### PR TITLE
Update component names to "otelarrow"

### DIFF
--- a/collector/examples/bridge/edge-collector.yaml
+++ b/collector/examples/bridge/edge-collector.yaml
@@ -1,18 +1,18 @@
 receivers:
-  # otlp/standard is a standard OTLP receiver.
-  otlp/standard:
+  # otelarrow/standard is an OTelArrow receiver.
+  otelarrow/standard:
     protocols:
       grpc:
-        # Port 4318 is the standard port for OTLP/gRPC.
-        endpoint: 127.0.0.1:4318
+        # Port 4317 is the standard port for OTLP/gRPC.
+        endpoint: 127.0.0.1:4317
 
 processors:
   # The batch processor will benefit pipelines with small export sizes.
   batch:
 
 exporters:
-  # otlp/arrow is an OTLP-Arrow exporter.
-  otlp/arrow:
+  # otelarrow/arrow is an OTel-Arrow exporter.
+  otelarrow/arrow:
     # For the sample configuration, the other side of the bridge
     # runs on port 8100.
     endpoint: 127.0.0.1:8100
@@ -48,13 +48,13 @@ exporters:
 service:
   pipelines:
     traces:
-      receivers: [otlp/standard]
+      receivers: [otelarrow/standard]
       processors: [batch]
-      exporters: [otlp/arrow]
+      exporters: [otelarrow/arrow]
     metrics:
-      receivers: [otlp/standard]
+      receivers: [otelarrow/standard]
       processors: [batch]
-      exporters: [otlp/arrow]
+      exporters: [otelarrow/arrow]
 
   telemetry:
     resource:

--- a/collector/examples/loopback/config.yaml
+++ b/collector/examples/loopback/config.yaml
@@ -1,11 +1,11 @@
 receivers:
-  # otlp/stdin is for regular traffic on the default gRPC port
-  otlp/stdin:
+  # otelarrow/stdin is for regular traffic on the default gRPC port
+  otelarrow/stdin:
     protocols:
       grpc:
-        endpoint: 127.0.0.1:4318
-  # otlp/loopback receives OTLP-Arrow traffic on port 4000
-  otlp/loopback:
+        endpoint: 127.0.0.1:4317
+  # otelarrow/loopback receives OTLP-Arrow traffic on port 4000
+  otelarrow/loopback:
     protocols:
       grpc:
         endpoint: 127.0.0.1:4000
@@ -19,19 +19,19 @@ processors:
   experiment:
     table:
     - weight: 1
-      exporters: [otlp/arrowout, logging/debug]
+      exporters: [otelarrow/arrowout, logging/debug]
     - weight: 2
-      exporters: [otlp/stdout, logging/info]
+      exporters: [otelarrow/stdout, logging/info]
 
 exporters:
-  # otlp/stdout sends standard OTLP to an external destination
-  otlp/stdout:
+  # otelarrow/stdout sends standard OTLP to an external destination
+  otelarrow/stdout:
     endpoint: ingest.lightstep.com:443
     headers:
       lightstep-access-token: "${LIGHTSTEP_ACCESS_TOKEN}"
 
-  # otlp/arrowout sends standard OTLP to an external destination
-  otlp/arrowout:
+  # otelarrow/arrowout sends standard OTLP to an external destination
+  otelarrow/arrowout:
     endpoint: 127.0.0.1:4000
     # wait_for_ready ensures the exporter doesn't fallback to standard
     # OTLP because the exporter has not started.
@@ -52,16 +52,16 @@ service:
     # the normal traces pipeline either routes directly to the
     # standard output or via the loopback.  it prints an info.
     traces/normal:
-      receivers: [otlp/stdin]
+      receivers: [otelarrow/stdin]
       processors: [batch, experiment]
-      exporters: [logging/info, otlp/stdout, otlp/arrowout]
+      exporters: [logging/info, otelarrow/stdout, otelarrow/arrowout]
 
     # experiment processes data send via Arrow through the loopback.
     # it prints a debug log.
     traces/experiment:
-      receivers: [otlp/loopback]
+      receivers: [otelarrow/loopback]
       processors: [batch]
-      exporters: [logging/debug, otlp/stdout]
+      exporters: [logging/debug, otelarrow/stdout]
 
   telemetry:
     metrics:

--- a/collector/examples/metadata-bridge/edge-collector.yaml
+++ b/collector/examples/metadata-bridge/edge-collector.yaml
@@ -1,10 +1,10 @@
 receivers:
-  # otlp/standard is a standard OTLP receiver.
-  otlp/standard:
+  # otelarrow/standard is a standard OTLP receiver.
+  otelarrow/standard:
     protocols:
       grpc:
-        # Port 4318 is the standard port for OTLP/gRPC.
-        endpoint: 127.0.0.1:4318
+        # Port 4317 is the standard port for OTLP/gRPC.
+        endpoint: 127.0.0.1:4317
 
         # include_metadata is required for the receiver to pass
         # per-request metadata through the pipeline, in order for the
@@ -33,7 +33,7 @@ extensions:
 exporters:
   # The OTLP/Arrow exporter sends to a local corresponding with
   # saas-collector.yaml.
-  otlp/arrow:
+  otelarrow/arrow:
     endpoint: 127.0.0.1:5000
 
     # For demonstration purposes, use an insecure port.  This would
@@ -84,9 +84,9 @@ service:
   extensions: [headers_setter, basicauth]
   pipelines:
     traces:
-      receivers: [otlp/standard]
+      receivers: [otelarrow/standard]
       processors: []
-      exporters: [logging, otlp/arrow]
+      exporters: [logging, otelarrow/arrow]
 
   telemetry:
     # Enable a prometheus /metrics endpoint on :8888

--- a/collector/examples/metadata-bridge/saas-collector.yaml
+++ b/collector/examples/metadata-bridge/saas-collector.yaml
@@ -1,7 +1,7 @@
 receivers:
-  # otlp is an OTLP-Arrow receiver that will operate as the SaaS-side
+  # otelarrow is an OTLP-Arrow receiver that will operate as the SaaS-side
   # of the bridge.
-  otlp:
+  otelarrow:
     protocols:
       grpc:
         # Port 5000 is the endpoint used in edge-collector.
@@ -56,7 +56,7 @@ service:
   extensions: [headers_setter, basicauth]
   pipelines:
     traces:
-      receivers: [otlp]
+      receivers: [otelarrow]
       processors: []
       exporters: [logging, otlphttp]
 

--- a/collector/examples/recorder/README.md
+++ b/collector/examples/recorder/README.md
@@ -18,7 +18,7 @@ Arrow in the recording step, e.g.,:
 
 ```
 exporters:
-  otlp/forward:
+  otelarrow/forward:
     arrow:
       enabled: false
 ```

--- a/collector/examples/recorder/replay.yaml
+++ b/collector/examples/recorder/replay.yaml
@@ -1,26 +1,24 @@
 receivers:
-  otlp/na:
+  otelarrow/first:
     protocols:
       grpc:
-        endpoint: 127.0.0.1:9099
-  otlp/second:
+        endpoint: 127.0.0.1:8081
+  otelarrow/second:
     protocols:
       grpc:
-        endpoint: 127.0.0.1:6000
+        endpoint: 127.0.0.1:8082
       arrow:
         disabled: false
   file/first_metrics:
     path: "first.metrics.json"
     throttle: 0
-
-  # not supported
-  # file/first_traces:
-  #   path: "first.traces.json"
-  #   throttle: 0
+  file/first_traces:
+    path: "first.traces.json"
+    throttle: 0
         
 exporters:
-  otlp/forward:
-    endpoint: 127.0.0.1:6000
+  otelarrow/forward:
+    endpoint: 127.0.0.1:8082
     wait_for_ready: true
     arrow:
       disabled: false
@@ -44,20 +42,20 @@ exporters:
 service:
   pipelines:
     traces/first:
-      receivers: [otlp/na] # @@@ should be file/first_traces, traces not supported
+      receivers: [file/first_traces]
       processors: []
-      exporters: [logging/first, otlp/forward]
+      exporters: [logging/first, otelarrow/forward]
     metrics/first:
       receivers: [file/first_metrics]
       processors: []
-      exporters: [logging/first, otlp/forward]
+      exporters: [logging/first, otelarrow/forward]
 
     traces/second:
-      receivers: [otlp/second]
+      receivers: [otelarrow/second]
       processors: []
       exporters: [logging/second, file/second_traces]
     metrics/second:
-      receivers: [otlp/second]
+      receivers: [otelarrow/second]
       processors: []
       exporters: [logging/second, file/second_metrics]
       

--- a/collector/examples/recorder/target.yaml
+++ b/collector/examples/recorder/target.yaml
@@ -14,14 +14,14 @@ receivers:
   otelarrow/second:
     protocols:
       grpc:
-        endpoint: 127.0.0.1:5000
+        endpoint: 127.0.0.1:8081
       arrow:
         disabled: false
 
 exporters:
   otelarrow/forward:
     # Data is forwarded via Arrow to this receiver.
-    endpoint: 127.0.0.1:5000
+    endpoint: 127.0.0.1:8081
     wait_for_ready: true
     arrow:
       disabled: false

--- a/collector/examples/recorder/target.yaml
+++ b/collector/examples/recorder/target.yaml
@@ -1,22 +1,25 @@
 receivers:
-  # Send test data to the first pipeline.
-  otlp/first:
+  # Send test data to the first pipeline using standard OTel ports
+  # 4317 and 4318.
+  otelarrow/first:
     protocols:
       grpc:
+        endpoint: 127.0.0.1:4317
+      http:
         endpoint: 127.0.0.1:4318
       arrow:
         disabled: false
 
   # Data will be repeated to the second pipeline via Arrow.
-  otlp/second:
+  otelarrow/second:
     protocols:
       grpc:
         endpoint: 127.0.0.1:5000
       arrow:
         disabled: false
-        
+
 exporters:
-  otlp/forward:
+  otelarrow/forward:
     # Data is forwarded via Arrow to this receiver.
     endpoint: 127.0.0.1:5000
     wait_for_ready: true
@@ -46,20 +49,20 @@ exporters:
 service:
   pipelines:
     traces/first:
-      receivers: [otlp/first]
+      receivers: [otelarrow/first]
       processors: []
-      exporters: [logging/first, file/first_traces, otlp/forward]
+      exporters: [logging/first, file/first_traces, otelarrow/forward]
     metrics/first:
-      receivers: [otlp/first]
+      receivers: [otelarrow/first]
       processors: []
-      exporters: [logging/first, file/first_metrics, otlp/forward]
+      exporters: [logging/first, file/first_metrics, otelarrow/forward]
 
     traces/second:
-      receivers: [otlp/second]
+      receivers: [otelarrow/second]
       processors: []
       exporters: [logging/second, file/second_traces]
     metrics/second:
-      receivers: [otlp/second]
+      receivers: [otelarrow/second]
       processors: []
       exporters: [logging/second, file/second_metrics]
       

--- a/collector/examples/synthesize/replay.yaml
+++ b/collector/examples/synthesize/replay.yaml
@@ -1,5 +1,5 @@
 receivers:
-  otlp/loopback:
+  otelarrow/loopback:
     protocols:
       grpc:
         endpoint: 127.0.0.1:4000
@@ -16,7 +16,7 @@ receivers:
     format: json
 
 exporters:
-  otlp/arrow:
+  otelarrow/arrow:
     endpoint: 127.0.0.1:4000
     wait_for_ready: true
     tls:
@@ -67,16 +67,16 @@ service:
 
     traces/validate:
       receivers: [validation/expect/traces]
-      exporters: [validation/verify/traces, otlp/arrow]
+      exporters: [validation/verify/traces, otelarrow/arrow]
     metrics/validate:
       receivers: [validation/expect/metrics]
-      exporters: [validation/verify/metrics, otlp/arrow]
+      exporters: [validation/verify/metrics, otelarrow/arrow]
 
     traces/loop:
-      receivers: [otlp/loopback]
+      receivers: [otelarrow/loopback]
       exporters: [validation/verify/traces]
     metrics/loop:
-      receivers: [otlp/loopback]
+      receivers: [otelarrow/loopback]
       exporters: [validation/verify/metrics]
       
     traces/output:

--- a/collector/gen/exporter/otlpexporter/factory.go
+++ b/collector/gen/exporter/otlpexporter/factory.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	// The value of "type" key in configuration.
-	typeStr = "otlp"
+	typeStr = "otelarrow"
 )
 
 // NewFactory creates a factory for OTLP exporter.

--- a/collector/gen/receiver/otlpreceiver/factory.go
+++ b/collector/gen/receiver/otlpreceiver/factory.go
@@ -6,17 +6,17 @@ package otlpreceiver // import "github.com/open-telemetry/otel-arrow/collector/g
 import (
 	"context"
 
+	"github.com/open-telemetry/otel-arrow/collector/gen/internal/sharedcomponent"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/consumer"
-	"github.com/open-telemetry/otel-arrow/collector/gen/internal/sharedcomponent"
 	"go.opentelemetry.io/collector/receiver"
 )
 
 const (
-	typeStr = "otlp"
+	typeStr = "otelarrow"
 
 	defaultGRPCEndpoint = "0.0.0.0:4317"
 	defaultHTTPEndpoint = "0.0.0.0:4318"


### PR DESCRIPTION
This is the fourth step documented in https://github.com/open-telemetry/otel-arrow/issues/3.
While revising the example yamls for this change, also corrected a historical error. The OTel standard gRPC port is 4317, not 4318 -- correct this error.