### PR TITLE
Add PayloadCompression field, set zstd at gRPC level and disable at Arrow level by default

### DIFF
--- a/collector/exporter/otelarrowexporter/config.go
+++ b/collector/exporter/otelarrowexporter/config.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/open-telemetry/otel-arrow/pkg/config"
 	"google.golang.org/grpc"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configcompression"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
@@ -22,6 +24,7 @@ type Config struct {
 
 	configgrpc.GRPCClientSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
 
+	// Arrow includes settings specific to OTel Arrow.
 	Arrow ArrowSettings `mapstructure:"arrow"`
 
 	// UserDialOptions cannot be configured via `mapstructure`
@@ -34,11 +37,29 @@ type Config struct {
 // ArrowSettings includes whether Arrow is enabled and the number of
 // concurrent Arrow streams.
 type ArrowSettings struct {
-	Disabled           bool          `mapstructure:"disabled"`
-	NumStreams         int           `mapstructure:"num_streams"`
-	DisableDowngrade   bool          `mapstructure:"disable_downgrade"`
-	EnableMixedSignals bool          `mapstructure:"enable_mixed_signals"`
-	MaxStreamLifetime  time.Duration `mapstructure:"max_stream_lifetime"`
+	// Disabled prevents registering the OTel Arrow service.
+	Disabled bool `mapstructure:"disabled"`
+
+	// NumStreams determines the number of OTel Arrow streams.
+	NumStreams int `mapstructure:"num_streams"`
+
+	// DisableDowngrade prevents this exporter from fallback back to
+	// standard OTLP.
+	DisableDowngrade bool `mapstructure:"disable_downgrade"`
+
+	// EnableMixedSignals allows the use of multi-signal streams.
+	EnableMixedSignals bool `mapstructure:"enable_mixed_signals"`
+
+	// MaxStreamLifetime should be set to less than the value of
+	// grpc: keepalive: max_connection_age_grace plus the timeout.
+	MaxStreamLifetime time.Duration `mapstructure:"max_stream_lifetime"`
+
+	// PayloadCompression is applied on the Arrow IPC stream
+	// internally and may have different results from using
+	// gRPC-level compression.  This is disabled by default, since
+	// gRPC-level compression is enabled by default.  This can be
+	// set to "zstd" to turn on Arrow-Zstd compression.
+	PayloadCompression configcompression.CompressionType `mapstructure:"payload_compression"`
 }
 
 var _ component.Config = (*Config)(nil)
@@ -65,5 +86,24 @@ func (cfg *ArrowSettings) Validate() error {
 		return fmt.Errorf("max stream life must be > 0: %d", cfg.MaxStreamLifetime)
 	}
 
+	// The cfg.PayloadCompression field is validated by the underlying library,
+	// but we only support Zstd or none.
+	switch cfg.PayloadCompression {
+	case "none", "", configcompression.Zstd:
+	default:
+		return fmt.Errorf("unsupported payload compression: %s", cfg.PayloadCompression)
+	}
 	return nil
+}
+
+func (cfg *ArrowSettings) ToArrowProducerOptions() (arrowOpts []config.Option) {
+	switch cfg.PayloadCompression {
+	case configcompression.Zstd:
+		arrowOpts = append(arrowOpts, config.WithZstd())
+	case "none", "":
+		arrowOpts = append(arrowOpts, config.WithNoZstd())
+	default:
+		// Should have failed in validate, nothing we can do.
+	}
+	return
 }

--- a/collector/exporter/otelarrowexporter/factory.go
+++ b/collector/exporter/otelarrowexporter/factory.go
@@ -52,6 +52,10 @@ func createDefaultConfig() component.Config {
 		Arrow: ArrowSettings{
 			NumStreams:        runtime.NumCPU(),
 			MaxStreamLifetime: time.Hour,
+
+			// PayloadCompression is off by default because gRPC
+			// compression is on by default, above.
+			PayloadCompression: "",
 		},
 	}
 }

--- a/collector/exporter/otelarrowexporter/factory.go
+++ b/collector/exporter/otelarrowexporter/factory.go
@@ -44,8 +44,8 @@ func createDefaultConfig() component.Config {
 		QueueSettings:   exporterhelper.NewDefaultQueueSettings(),
 		GRPCClientSettings: configgrpc.GRPCClientSettings{
 			Headers: map[string]configopaque.String{},
-			// Default to gzip compression
-			Compression: configcompression.Gzip,
+			// Default to zstd compression
+			Compression: configcompression.Zstd,
 			// We almost read 0 bytes, so no need to tune ReadBufferSize.
 			WriteBufferSize: 512 * 1024,
 		},

--- a/collector/exporter/otelarrowexporter/factory_test.go
+++ b/collector/exporter/otelarrowexporter/factory_test.go
@@ -33,8 +33,13 @@ func TestCreateDefaultConfig(t *testing.T) {
 	assert.Equal(t, ocfg.RetrySettings, exporterhelper.NewDefaultRetrySettings())
 	assert.Equal(t, ocfg.QueueSettings, exporterhelper.NewDefaultQueueSettings())
 	assert.Equal(t, ocfg.TimeoutSettings, exporterhelper.NewDefaultTimeoutSettings())
-	assert.Equal(t, ocfg.Compression, configcompression.Gzip)
-	assert.Equal(t, ocfg.Arrow, ArrowSettings{Disabled: false, NumStreams: runtime.NumCPU(), MaxStreamLifetime: time.Hour})
+	assert.Equal(t, ocfg.Compression, configcompression.Zstd)
+	assert.Equal(t, ocfg.Arrow, ArrowSettings{
+		Disabled:           false,
+		NumStreams:         runtime.NumCPU(),
+		MaxStreamLifetime:  time.Hour,
+		PayloadCompression: "",
+	})
 }
 
 func TestCreateMetricsExporter(t *testing.T) {

--- a/collector/exporter/otelarrowexporter/otlp.go
+++ b/collector/exporter/otelarrowexporter/otlp.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	arrowPkg "github.com/apache/arrow/go/v12/arrow"
+	"github.com/open-telemetry/otel-arrow/pkg/config"
 	arrowRecord "github.com/open-telemetry/otel-arrow/pkg/otel/arrow_record"
 	"go.uber.org/multierr"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
@@ -132,7 +133,10 @@ func (e *baseExporter) start(ctx context.Context, host component.Host) (err erro
 		}
 
 		e.arrow = arrow.NewExporter(e.config.Arrow.MaxStreamLifetime, e.config.Arrow.NumStreams, e.config.Arrow.DisableDowngrade, e.settings.TelemetrySettings, e.callOptions, func() arrowRecord.ProducerAPI {
-			return arrowRecord.NewProducer()
+			// We configure the producer w/o Arrow-IPC compression because
+			// we have gRPC compression, and with gRPC compression we have
+			// existing instrumentation to monitor compression rate.
+			return arrowRecord.NewProducerWithOptions(config.WithNoZstd())
 		}, e.streamClientFactory(e.config, e.clientConn), perRPCCreds)
 
 		if err := e.arrow.Start(ctx); err != nil {

--- a/collector/exporter/otelarrowexporter/testdata/config.yaml
+++ b/collector/exporter/otelarrowexporter/testdata/config.yaml
@@ -1,5 +1,5 @@
 endpoint: "1.2.3.4:1234"
-compression: "gzip"
+compression: "none"
 tls:
   ca_file: /var/lib/mycert.pem
 timeout: 10s
@@ -30,3 +30,4 @@ arrow:
   disabled: false
   enable_mixed_signals: true
   max_stream_lifetime: 2h
+  payload_compression: "zstd"


### PR DESCRIPTION
We currently have two ways to configure compression.
This change makes the default settings to use zstd at the gRPC level and to disable zstd at the Arrow level.

The new field is called `PayloadCompression`. We will compare this configuration on production data before deciding to leave this the permanent default. Adding "Payload" to indicate that the `arrow_payloads` field is compressed by the library itself. This also leaves the option for the OTel-Arrow protocol to add separate compression for everything but the payload in the future.