### PR TITLE
Subtract 0-5% of max_stream_lifetime, when set; support unlimited max_stream_lifetime

### DIFF
--- a/collector/exporter/otelarrowexporter/internal/arrow/exporter_test.go
+++ b/collector/exporter/otelarrowexporter/internal/arrow/exporter_test.go
@@ -566,3 +566,14 @@ func TestArrowExporterHeaders(t *testing.T) {
 	require.Equal(t, expectOutput, actualOutput)
 	require.NoError(t, tc.exporter.Shutdown(bg))
 }
+
+func TestAddJitter(t *testing.T) {
+	require.Equal(t, time.Duration(0), addJitter(0))
+
+	// Expect no more than 5% less in each trial.
+	for i := 0; i < 100; i++ {
+		x := addJitter(20 * time.Minute)
+		require.LessOrEqual(t, 19*time.Minute, x)
+		require.Less(t, x, 20*time.Minute)
+	}
+}


### PR DESCRIPTION
As discussed in https://github.com/grpc/grpc-go/issues/6504, the client should add jitter when configuring `max_connection_age_grace` because we expect each stream will create a new connection. Since connection storms will not be spread automatically by gRPC in this case, apply client jitter.

Part of #6.
