### PR TITLE
Prepare release v0.2

### DIFF
--- a/collector/cmd/otelarrowcol/build.yaml
+++ b/collector/cmd/otelarrowcol/build.yaml
@@ -4,7 +4,7 @@ dist:
   description: Development OTel-Arrow Collector binary, testing only.
 
   # Note: this is replaced to match the current release using `sed`
-  version: 0.1.0
+  version: 0.2.0
 
   # Note: This should match the version of the core collector components used below
   otelcol_version: 0.83.0
@@ -15,15 +15,15 @@ exporters:
   - import: go.opentelemetry.io/collector/exporter/otlphttpexporter
     gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.83.0
   - import: github.com/open-telemetry/otel-arrow/collector/exporter/otelarrowexporter
-    gomod: github.com/open-telemetry/otel-arrow/collector v0.1.0
+    gomod: github.com/open-telemetry/otel-arrow/collector v0.2.0
   - import: github.com/open-telemetry/otel-arrow/collector/exporter/fileexporter
-    gomod: github.com/open-telemetry/otel-arrow/collector v0.1.0
+    gomod: github.com/open-telemetry/otel-arrow/collector v0.2.0
 
 receivers:
   - import: github.com/open-telemetry/otel-arrow/collector/receiver/otelarrowreceiver
-    gomod: github.com/open-telemetry/otel-arrow/collector v0.1.0
+    gomod: github.com/open-telemetry/otel-arrow/collector v0.2.0
   - import: github.com/open-telemetry/otel-arrow/collector/receiver/filereceiver
-    gomod: github.com/open-telemetry/otel-arrow/collector v0.1.0
+    gomod: github.com/open-telemetry/otel-arrow/collector v0.2.0
   - import: github.com/lightstep/telemetry-generator/generatorreceiver
     gomod: github.com/lightstep/telemetry-generator/generatorreceiver v0.13.0
 
@@ -33,13 +33,13 @@ processors:
   - import: go.opentelemetry.io/collector/processor/memorylimiterprocessor
     gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.83.0
   - import: github.com/open-telemetry/otel-arrow/collector/processor/experimentprocessor
-    gomod: github.com/open-telemetry/otel-arrow/collector v0.1.0
+    gomod: github.com/open-telemetry/otel-arrow/collector v0.2.0
   - import: github.com/open-telemetry/otel-arrow/collector/processor/obfuscationprocessor
-    gomod: github.com/open-telemetry/otel-arrow/collector v0.1.0
+    gomod: github.com/open-telemetry/otel-arrow/collector v0.2.0
 
 connectors:
   - import: github.com/open-telemetry/otel-arrow/collector/connector/validationconnector
-    gomod: github.com/open-telemetry/otel-arrow/collector v0.1.0
+    gomod: github.com/open-telemetry/otel-arrow/collector v0.2.0
 
 extensions:
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension

--- a/collector/cmd/otelarrowcol/go.mod
+++ b/collector/cmd/otelarrowcol/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/lightstep/telemetry-generator/generatorreceiver v0.13.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.83.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.83.0
-	github.com/open-telemetry/otel-arrow/collector v0.1.0
+	github.com/open-telemetry/otel-arrow/collector v0.2.0
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/collector v0.83.0
 	go.opentelemetry.io/collector/component v0.83.0
@@ -81,7 +81,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mostynb/go-grpc-compression v1.2.0 // indirect
-	github.com/open-telemetry/otel-arrow v0.1.0 // indirect
+	github.com/open-telemetry/otel-arrow v0.2.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.17 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect

--- a/collector/cmd/otelarrowcol/main.go
+++ b/collector/cmd/otelarrowcol/main.go
@@ -18,7 +18,7 @@ func main() {
 	info := component.BuildInfo{
 		Command:     "otelarrowcol",
 		Description: "Development OTel-Arrow Collector binary, testing only.",
-		Version:     "0.1.0",
+		Version:     "0.2.0",
 	}
 
 	if err := run(otelcol.CollectorSettings{BuildInfo: info, Factories: factories}); err != nil {

--- a/collector/go.mod
+++ b/collector/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/mock v1.6.0
 	github.com/klauspost/compress v1.16.7
-	github.com/open-telemetry/otel-arrow v0.1.0
+	github.com/open-telemetry/otel-arrow v0.2.0
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/collector v0.83.0
 	go.opentelemetry.io/collector/component v0.83.0

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,7 +3,7 @@
 
 module-sets:
   beta:
-    version: v0.1.0
+    version: v0.2.0
     modules:
       - github.com/open-telemetry/otel-arrow
       - github.com/open-telemetry/otel-arrow/collector


### PR DESCRIPTION
Includes #13, #20, #21, #22, #23.
Releasing often - this makes it easier to integrate for `go.mod` users.