### PR TITLE
Add moh-osman3 as approver to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,6 +12,6 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @lquerel @jmacd
+* @lquerel @jmacd @moh-osman3
 
 CODEOWNERS @lquerel @jmacd


### PR DESCRIPTION
@moh-osman3 is already in https://github.com/orgs/open-telemetry/teams/arrow-approvers/members
adding to CODEOWNERS makes his approval actually count in presubmit checks.