### PR TITLE
Set the default balancer name to round_robin

### DIFF
--- a/collector/exporter/otelarrowexporter/config_test.go
+++ b/collector/exporter/otelarrowexporter/config_test.go
@@ -75,7 +75,7 @@ func TestUnmarshalConfig(t *testing.T) {
 					Timeout:             30 * time.Second,
 				},
 				WriteBufferSize: 512 * 1024,
-				BalancerName:    "round_robin",
+				BalancerName:    "experimental",
 				Auth:            &configauth.Authentication{AuthenticatorID: component.NewID("nop")},
 			},
 			Arrow: ArrowSettings{

--- a/collector/exporter/otelarrowexporter/config_test.go
+++ b/collector/exporter/otelarrowexporter/config_test.go
@@ -19,16 +19,18 @@ import (
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configtls"
-	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
 
 func TestUnmarshalDefaultConfig(t *testing.T) {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "default.yaml"))
+	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, component.UnmarshalConfig(confmap.New(), cfg))
+	assert.NoError(t, component.UnmarshalConfig(cm, cfg))
 	assert.Equal(t, factory.CreateDefaultConfig(), cfg)
+	assert.Equal(t, "round_robin", cfg.(*Config).GRPCClientSettings.BalancerName)
 }
 
 func TestUnmarshalConfig(t *testing.T) {

--- a/collector/exporter/otelarrowexporter/factory.go
+++ b/collector/exporter/otelarrowexporter/factory.go
@@ -48,6 +48,11 @@ func createDefaultConfig() component.Config {
 			Compression: configcompression.Zstd,
 			// We almost read 0 bytes, so no need to tune ReadBufferSize.
 			WriteBufferSize: 512 * 1024,
+			// The `configgrpc` default is pick_first,
+			// which is not great for OTel Arrow exporters
+			// because it concentrates load at a single
+			// destination.
+			BalancerName: "round_robin",
 		},
 		Arrow: ArrowSettings{
 			NumStreams:        runtime.NumCPU(),

--- a/collector/exporter/otelarrowexporter/testdata/config.yaml
+++ b/collector/exporter/otelarrowexporter/testdata/config.yaml
@@ -24,7 +24,7 @@ keepalive:
   time: 20s
   timeout: 30s
   permit_without_stream: true
-balancer_name: "round_robin"
+balancer_name: "experimental"
 arrow:
   num_streams: 2
   disabled: false

--- a/collector/exporter/otelarrowexporter/testdata/default.yaml
+++ b/collector/exporter/otelarrowexporter/testdata/default.yaml
@@ -1,0 +1,1 @@
+# when nothing is set


### PR DESCRIPTION
Here at Lightstep we think that round_robin is a reasonably good default load balancer for OTel Arrow, while `pick_first` is what we get without setting something in this field. `pick_first` is not a reasonably good default load balancer for OTel Arrow. This change was documented in #29 already.

Fixes #32. 