### PR TITLE
Change default limit dictionary index size to 2^16

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -42,16 +42,18 @@ type Config struct {
 type Option func(*Config)
 
 // DefaultConfig returns a Config with the following default values:
-//  - Pool: memory.NewGoAllocator()
-//  - InitIndexSize: math.MaxUint16
-//  - LimitIndexSize: math.MaxUint32
-//  - Stats: false
-//  - Zstd: true
+//   - Pool: memory.NewGoAllocator()
+//   - InitIndexSize: math.MaxUint16
+//   - LimitIndexSize: math.MaxUint32
+//   - Stats: false
+//   - Zstd: true
 func DefaultConfig() *Config {
 	return &Config{
-		Pool:           memory.NewGoAllocator(),
-		InitIndexSize:  math.MaxUint16,
-		LimitIndexSize: math.MaxUint32,
+		Pool:          memory.NewGoAllocator(),
+		InitIndexSize: math.MaxUint16,
+		// The default dictionary index limit is set to 2^16 - 1
+		// to keep the overall memory usage of the encoder and decoder low.
+		LimitIndexSize: math.MaxUint16,
 		Stats:          false,
 		Zstd:           true,
 	}


### PR DESCRIPTION
Prior to this PR, by default, dictionaries could hold up to 2^32-1 entries, which can be quite large in terms of memory usage depending on the telemetry workload handled by the OTel Arrow Encoder.

This PR changes this limit from default to 2^16-1 to keep overall memory usage low.

A more sophisticated strategy could be based on calculating the entropy for each column to determine earlier when it is worth using or not a dictionary encoding for each column.