### PR TITLE
(obfuscation processor): obfuscate some span string fields that were missed

### DIFF
--- a/collector/processor/obfuscationprocessor/processor.go
+++ b/collector/processor/obfuscationprocessor/processor.go
@@ -142,10 +142,13 @@ func (o *obfuscation) processResourceSpan(ctx context.Context, rs ptrace.Resourc
 		ils := rs.ScopeSpans().At(j)
 		ilsScopeAttrs := ils.Scope().Attributes()
 		o.processAttrs(ctx, ilsScopeAttrs)
+		ils.Scope().SetName(o.encryptString(ils.Scope().Name()))
+		ils.Scope().SetVersion(o.encryptString(ils.Scope().Version()))
 
 		for k := 0; k < ils.Spans().Len(); k++ {
 			span := ils.Spans().At(k)
 			span.SetName(o.encryptString(span.Name()))
+			span.Status().SetMessage(o.encryptString(span.Status().Message()))
 			spanAttrs := span.Attributes()
 
 			// Attributes can also be part of span

--- a/collector/processor/obfuscationprocessor/processor_test.go
+++ b/collector/processor/obfuscationprocessor/processor_test.go
@@ -71,9 +71,12 @@ func setupSpanWithAttrs() ptrace.Traces {
 
 	ss := rs.ScopeSpans().AppendEmpty()
 	ss.Scope().Attributes().PutStr("scope-attr", scopeAttrVal)
+	ss.Scope().SetName("dummy name")
+	ss.Scope().SetVersion("dummy version")
 
 	span := ss.Spans().AppendEmpty()
 	span.SetName("operationA")
+	span.Status().SetMessage("dummy error message")
 	span.Attributes().PutStr("span-attr", spanAttrVal)
 	span.Attributes().PutEmptyBytes(byteIDKey).FromRaw(byteIDVal)
 	mp := span.Attributes().PutEmptyMap("complex-span-attr")
@@ -102,10 +105,13 @@ func validateTraceAttrs(t *testing.T, expected map[string]pair, traces ptrace.Tr
 			scopeVal, ok := ss.Scope().Attributes().Get(expected["scope-attr"].key)
 			assert.True(t, ok)
 			assert.Equal(t, expected["scope-attr"].val.AsString(), scopeVal.AsString())
+			assert.Equal(t, expected["sensitive-key-name"].val.AsString(), ss.Scope().Name())
+			assert.Equal(t, expected["sensitive-version"].val.AsString(), ss.Scope().Version())
 
 			for k := 0; k < ss.Spans().Len(); k++ {
 				// validate span attributes
 				span := ss.Spans().At(k)
+				assert.Equal(t, expected["status-message"].val.AsString(), span.Status().Message())
 				val, ok := span.Attributes().Get(expected["span-attr"].key)
 				assert.True(t, ok)
 				assert.Equal(t, expected["span-attr"].val.AsString(), val.AsString())
@@ -185,6 +191,9 @@ func TestProcessTraces(t *testing.T) {
 		"complex-span-attr": cryptPair(processor, "complex-span-attr", csVal),
 		"byte-id":           cryptPair(processor, "byte-id", bVal),
 		"span-event-name":   cryptPair(processor, "span-event-name", pcommon.NewValueStr(eventName)),
+		"sensitive-key-name": cryptPair(processor, "sensitive-key-name", pcommon.NewValueStr("dummy name")),
+		"sensitive-version": cryptPair(processor, "sensitive-version", pcommon.NewValueStr("dummy version")),
+		"status-message": cryptPair(processor, "status-message", pcommon.NewValueStr("dummy error message")),
 	}
 
 	processedTraces, err := processor.processTraces(context.Background(), traces)


### PR DESCRIPTION
This PR fixes obfuscation for some span fields that were missed when this was initially implemented. This will now obfuscate string values for `.ScopeSpans.Scope.Name`, `.ScopeSpans.Scope.Version`, and `.Span.Status.Message`.