### PR TITLE
Replace memory_limit with memory_limit_mib

### DIFF
--- a/collector/receiver/otelarrowreceiver/config.go
+++ b/collector/receiver/otelarrowreceiver/config.go
@@ -45,8 +45,8 @@ type Protocols struct {
 
 // ArrowSettings support configuring the Arrow receiver.
 type ArrowSettings struct {
-	// MemoryLimit is deprecated, use MemoryLimitMiB.
-	MemoryLimit uint64 `mapstructure:"memory_limit"`
+	// DeprecatedMemoryLimit is deprecated, use MemoryLimitMiB.
+	DeprecatedMemoryLimit uint64 `mapstructure:"memory_limit"`
 
 	// MemoryLimitMiB is the size of a shared memory region used
 	// by all Arrow streams, in MiB.  When too much load is
@@ -71,13 +71,13 @@ func (cfg *Config) Validate() error {
 	if cfg.Arrow != nil && cfg.GRPC == nil {
 		return errors.New("must specify at gRPC protocol when using the OTLP Arrow receiver")
 	}
-	if cfg.Arrow.MemoryLimit != 0 && cfg.Arrow.MemoryLimitMiB != 0 {
+	if cfg.Arrow.DeprecatedMemoryLimit != 0 && cfg.Arrow.MemoryLimitMiB != 0 {
 		return errors.New("memory_limit is deprected, use only memory_limit_mib")
 	}
-	if cfg.Arrow.MemoryLimit != 0 {
+	if cfg.Arrow.DeprecatedMemoryLimit != 0 {
 		// Round up
-		cfg.Arrow.MemoryLimitMiB = (cfg.Arrow.MemoryLimit - 1 + 1<<20) >> 20
-		cfg.Arrow.MemoryLimit = 0
+		cfg.Arrow.MemoryLimitMiB = (cfg.Arrow.DeprecatedMemoryLimit - 1 + 1<<20) >> 20
+		cfg.Arrow.DeprecatedMemoryLimit = 0
 	}
 	return nil
 }

--- a/collector/receiver/otelarrowreceiver/config.go
+++ b/collector/receiver/otelarrowreceiver/config.go
@@ -72,7 +72,7 @@ func (cfg *Config) Validate() error {
 		return errors.New("must specify at gRPC protocol when using the OTLP Arrow receiver")
 	}
 	if cfg.Arrow.DeprecatedMemoryLimit != 0 && cfg.Arrow.MemoryLimitMiB != 0 {
-		return errors.New("memory_limit is deprected, use only memory_limit_mib")
+		return errors.New("memory_limit is deprecated, use only memory_limit_mib")
 	}
 	if cfg.Arrow.DeprecatedMemoryLimit != 0 {
 		// Round up

--- a/collector/receiver/otelarrowreceiver/config.go
+++ b/collector/receiver/otelarrowreceiver/config.go
@@ -16,9 +16,11 @@ import (
 )
 
 const (
-	// Protocol values.
-	protoGRPC = "protocols::grpc"
-	protoHTTP = "protocols::http"
+	// Confmap values.
+	protoGRPC                = "protocols::grpc"
+	protoHTTP                = "protocols::http"
+	protoArrowOldMemoryLimit = "protocols::arrow::memory_limit"
+	protoArrowMemoryLimitMiB = "protocols::arrow::memory_limit_mib"
 )
 
 type httpServerSettings struct {
@@ -43,10 +45,13 @@ type Protocols struct {
 
 // ArrowSettings support configuring the Arrow receiver.
 type ArrowSettings struct {
-	// MemoryLimit is the size of a shared memory region used by
-	// all Arrow streams.  When too much load is passing through, they
-	// will see ResourceExhausted errors.
+	// MemoryLimit is deprecated, use MemoryLimitMiB.
 	MemoryLimit uint64 `mapstructure:"memory_limit"`
+
+	// MemoryLimitMiB is the size of a shared memory region used
+	// by all Arrow streams, in MiB.  When too much load is
+	// passing through, they will see ResourceExhausted errors.
+	MemoryLimitMiB uint64 `mapstructure:"memory_limit_mib"`
 }
 
 // Config defines configuration for OTel Arrow receiver.
@@ -65,6 +70,14 @@ func (cfg *Config) Validate() error {
 	}
 	if cfg.Arrow != nil && cfg.GRPC == nil {
 		return errors.New("must specify at gRPC protocol when using the OTLP Arrow receiver")
+	}
+	if cfg.Arrow.MemoryLimit != 0 && cfg.Arrow.MemoryLimitMiB != 0 {
+		return errors.New("memory_limit is deprected, use only memory_limit_mib")
+	}
+	if cfg.Arrow.MemoryLimit != 0 {
+		// Round up
+		cfg.Arrow.MemoryLimitMiB = (cfg.Arrow.MemoryLimit - 1 + 1<<20) >> 20
+		cfg.Arrow.MemoryLimit = 0
 	}
 	return nil
 }
@@ -85,6 +98,12 @@ func (cfg *Config) Unmarshal(conf *confmap.Conf) error {
 	//   if !conf.IsSet(protoGRPC) {
 	//   	cfg.GRPC = nil
 	//   }
+
+	// Allow the deprecated field, when explicitly set, to unset
+	// the new default value.
+	if conf.IsSet(protoArrowOldMemoryLimit) && !conf.IsSet(protoArrowMemoryLimitMiB) {
+		cfg.Arrow.MemoryLimitMiB = 0
+	}
 
 	if !conf.IsSet(protoHTTP) {
 		cfg.HTTP = nil

--- a/collector/receiver/otelarrowreceiver/config_test.go
+++ b/collector/receiver/otelarrowreceiver/config_test.go
@@ -75,6 +75,29 @@ func TestUnmarshalConfigOnlyHTTPEmptyMap(t *testing.T) {
 	assert.Equal(t, defaultOnlyHTTP, cfg)
 }
 
+func TestUnmarshalOldMemoryLimitConfig(t *testing.T) {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "oldmemlimit.yaml"))
+	require.NoError(t, err)
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
+	assert.NoError(t, component.UnmarshalConfig(cm, cfg))
+	expectCfg := factory.CreateDefaultConfig().(*Config)
+	// The number in config is <1MB, so Validate() rounds up.
+	expectCfg.Arrow.MemoryLimitMiB = 1
+	expectCfg.HTTP = nil
+	assert.NoError(t, cfg.(*Config).Validate())
+	assert.Equal(t, expectCfg, cfg)
+}
+
+func TestUnmarshalBothMemoryLimitConfig(t *testing.T) {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "bothmemlimit.yaml"))
+	require.NoError(t, err)
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
+	assert.NoError(t, component.UnmarshalConfig(cm, cfg))
+	assert.Error(t, cfg.(*Config).Validate())
+}
+
 func TestUnmarshalConfig(t *testing.T) {
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
 	require.NoError(t, err)
@@ -132,7 +155,7 @@ func TestUnmarshalConfig(t *testing.T) {
 					LogsURLPath:    "/log/ingest",
 				},
 				Arrow: &ArrowSettings{
-					MemoryLimit: 123456,
+					MemoryLimitMiB: 123,
 				},
 			},
 		}, cfg)
@@ -164,7 +187,7 @@ func TestUnmarshalConfigUnix(t *testing.T) {
 					LogsURLPath:    defaultLogsURLPath,
 				},
 				Arrow: &ArrowSettings{
-					MemoryLimit: defaultMemoryLimit,
+					MemoryLimitMiB: defaultMemoryLimitMiB,
 				},
 			},
 		}, cfg)

--- a/collector/receiver/otelarrowreceiver/factory.go
+++ b/collector/receiver/otelarrowreceiver/factory.go
@@ -25,7 +25,7 @@ const (
 	defaultMetricsURLPath = "/v1/metrics"
 	defaultLogsURLPath    = "/v1/logs"
 
-	defaultMemoryLimit = 128 << 20 // 128MB
+	defaultMemoryLimitMiB = 128
 )
 
 // NewFactory creates a new OTLP receiver factory.
@@ -59,7 +59,7 @@ func createDefaultConfig() component.Config {
 				LogsURLPath:    defaultLogsURLPath,
 			},
 			Arrow: &ArrowSettings{
-				MemoryLimit: defaultMemoryLimit,
+				MemoryLimitMiB: defaultMemoryLimitMiB,
 			},
 		},
 	}

--- a/collector/receiver/otelarrowreceiver/otlp.go
+++ b/collector/receiver/otelarrowreceiver/otlp.go
@@ -150,9 +150,9 @@ func (r *otlpReceiver) startProtocolServers(host component.Host) error {
 
 			r.arrowReceiver = arrow.New(arrow.Consumers(r), r.settings, r.obsrepGRPC, r.cfg.GRPC, authServer, func() arrowRecord.ConsumerAPI {
 				var opts []arrowRecord.Option
-				if r.cfg.Arrow.MemoryLimit != 0 {
+				if r.cfg.Arrow.MemoryLimitMiB != 0 {
 					// in which case the default is selected in the arrowRecord package.
-					opts = append(opts, arrowRecord.WithMemoryLimit(r.cfg.Arrow.MemoryLimit))
+					opts = append(opts, arrowRecord.WithMemoryLimit(r.cfg.Arrow.MemoryLimitMiB<<20))
 				}
 				if r.settings.TelemetrySettings.MeterProvider != nil {
 					opts = append(opts, arrowRecord.WithMeterProvider(r.settings.TelemetrySettings.MeterProvider, r.settings.TelemetrySettings.MetricsLevel))

--- a/collector/receiver/otelarrowreceiver/testdata/bothmemlimit.yaml
+++ b/collector/receiver/otelarrowreceiver/testdata/bothmemlimit.yaml
@@ -1,0 +1,4 @@
+protocols:
+  arrow:
+    memory_limit: 123456000
+    memory_limit_mib: 123

--- a/collector/receiver/otelarrowreceiver/testdata/config.yaml
+++ b/collector/receiver/otelarrowreceiver/testdata/config.yaml
@@ -44,4 +44,4 @@ protocols:
     metrics_url_path: /v2/metrics
     logs_url_path: log/ingest
   arrow:
-    memory_limit: 123456
+    memory_limit_mib: 123

--- a/collector/receiver/otelarrowreceiver/testdata/oldmemlimit.yaml
+++ b/collector/receiver/otelarrowreceiver/testdata/oldmemlimit.yaml
@@ -1,0 +1,4 @@
+protocols:
+  arrow:
+    # This has to be rounded up to 1MB
+    memory_limit: 123456


### PR DESCRIPTION
While adding compression settings, I noticed the receiver Arrow.MemoryLimit is a non-standard configuration for large sizes, which are generally configured with a `_mib` suffix for MiB. Before introducing more consistency issues, I've fixed it w/ compatibility support. When the old value is configured it will be rounded up to the next MiB and used instead of the new field.

Part of #35.
