### PR TITLE
(concurrentbatchprocessor): add in-flight byte limit to producer queue

### DIFF
--- a/collector/cmd/otelarrowcol/go.mod
+++ b/collector/cmd/otelarrowcol/go.mod
@@ -4,11 +4,7 @@ module github.com/open-telemetry/otel-arrow/collector/cmd/otelarrowcol
 
 go 1.21
 
-<<<<<<< HEAD
 toolchain go1.21.3
-=======
-toolchain go1.21.4
->>>>>>> e367aca (add config, semaphore, fix unit tests)
 
 require (
 	github.com/lightstep/telemetry-generator/generatorreceiver v0.15.0
@@ -175,18 +171,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-<<<<<<< HEAD
-
-
-
-
-
-
-
-
-
-
-=======
 replace github.com/open-telemetry/otel-arrow => ../../..
 
 replace github.com/open-telemetry/otel-arrow/collector => ../../
@@ -195,4 +179,3 @@ replace github.com/open-telemetry/otel-arrow/collector => ../../
 replace cloud.google.com/go => cloud.google.com/go v0.110.2
 
 replace github.com/lightstep/telemetry-generator/generatorreceiver => ../../../../telemetry-generator/generatorreceiver/
->>>>>>> e367aca (add config, semaphore, fix unit tests)

--- a/collector/cmd/otelarrowcol/go.mod
+++ b/collector/cmd/otelarrowcol/go.mod
@@ -170,12 +170,3 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/open-telemetry/otel-arrow => ../../..
-
-replace github.com/open-telemetry/otel-arrow/collector => ../../
-
-// ambiguous import: found package cloud.google.com/go/compute/metadata in multiple modules
-replace cloud.google.com/go => cloud.google.com/go v0.110.2
-
-replace github.com/lightstep/telemetry-generator/generatorreceiver => ../../../../telemetry-generator/generatorreceiver/

--- a/collector/cmd/otelarrowcol/go.mod
+++ b/collector/cmd/otelarrowcol/go.mod
@@ -4,7 +4,11 @@ module github.com/open-telemetry/otel-arrow/collector/cmd/otelarrowcol
 
 go 1.21
 
+<<<<<<< HEAD
 toolchain go1.21.3
+=======
+toolchain go1.21.4
+>>>>>>> e367aca (add config, semaphore, fix unit tests)
 
 require (
 	github.com/lightstep/telemetry-generator/generatorreceiver v0.15.0
@@ -171,6 +175,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
+<<<<<<< HEAD
 
 
 
@@ -181,3 +186,13 @@ require (
 
 
 
+=======
+replace github.com/open-telemetry/otel-arrow => ../../..
+
+replace github.com/open-telemetry/otel-arrow/collector => ../../
+
+// ambiguous import: found package cloud.google.com/go/compute/metadata in multiple modules
+replace cloud.google.com/go => cloud.google.com/go v0.110.2
+
+replace github.com/lightstep/telemetry-generator/generatorreceiver => ../../../../telemetry-generator/generatorreceiver/
+>>>>>>> e367aca (add config, semaphore, fix unit tests)

--- a/collector/cmd/otelarrowcol/go.sum
+++ b/collector/cmd/otelarrowcol/go.sum
@@ -695,8 +695,6 @@ github.com/labstack/gommon v0.3.1/go.mod h1:uW6kP17uPlLJsD3ijUYn3/M5bAxtlZhMI6m3
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
 github.com/leodido/go-urn v1.2.1/go.mod h1:zt4jvISO2HfUBqxjfIshjdMTYS56ZS/qv49ictyFfxY=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
-github.com/lightstep/telemetry-generator/generatorreceiver v0.15.0 h1:gYEMyJHTSczSIRbkiVYQDH1ScQxyQKNgXJG3WarmtOE=
-github.com/lightstep/telemetry-generator/generatorreceiver v0.15.0/go.mod h1:pXv7/nt9MWXKio5S2deXbgq0q8JEKvm8IWJTLpNolqQ=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=

--- a/collector/examples/generator/hipster_shop.yaml
+++ b/collector/examples/generator/hipster_shop.yaml
@@ -566,19 +566,19 @@ rootRoutes:
     tracesPerHour: 1400
   - service: frontend
     route: /shipping
-    tracesPerHour: 4800
+    tracesPerHour: 480
   - service: frontend
     route: /currency
-    tracesPerHour: 2000
+    tracesPerHour: 200
   - service: frontend
     route: /checkout
-    tracesPerHour: 4800
+    tracesPerHour: 480
   - service: iOS
     route: /api/make-payment
-    tracesPerHour: 4800
+    tracesPerHour: 480
   - service: android  
     route: /api/make-payment
-    tracesPerHour: 4800
+    tracesPerHour: 480
 
 config:
   kubernetes:

--- a/collector/examples/generator/hipster_shop.yaml
+++ b/collector/examples/generator/hipster_shop.yaml
@@ -566,19 +566,19 @@ rootRoutes:
     tracesPerHour: 1400
   - service: frontend
     route: /shipping
-    tracesPerHour: 480
+    tracesPerHour: 4800
   - service: frontend
     route: /currency
-    tracesPerHour: 200
+    tracesPerHour: 2000
   - service: frontend
     route: /checkout
-    tracesPerHour: 480
+    tracesPerHour: 4800
   - service: iOS
     route: /api/make-payment
-    tracesPerHour: 480
+    tracesPerHour: 4800
   - service: android  
     route: /api/make-payment
-    tracesPerHour: 480
+    tracesPerHour: 4800
 
 config:
   kubernetes:

--- a/collector/processor/concurrentbatchprocessor/batch_processor.go
+++ b/collector/processor/concurrentbatchprocessor/batch_processor.go
@@ -565,7 +565,12 @@ func (bt *batchTraces) sizeBytes(data any) int {
 	return bt.sizer.TracesSize(data.(ptrace.Traces))
 }
 
-func (bt *batchTraces) export(ctx context.Context, req any) error {
+func (bt *batchTraces) export(ctx context.Context, req any) (retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			retErr = errors.New(r.(string))
+		}
+	}()
 	td := req.(ptrace.Traces)
 	return bt.nextConsumer.ConsumeTraces(ctx, td)
 }
@@ -605,7 +610,12 @@ func (bm *batchMetrics) sizeBytes(data any) int {
 	return bm.sizer.MetricsSize(data.(pmetric.Metrics))
 }
 
-func (bm *batchMetrics) export(ctx context.Context, req any) error {
+func (bm *batchMetrics) export(ctx context.Context, req any) (retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			retErr = errors.New(r.(string))
+		}
+	}()
 	md := req.(pmetric.Metrics)
 	return bm.nextConsumer.ConsumeMetrics(ctx, md)
 }
@@ -657,7 +667,12 @@ func (bl *batchLogs) sizeBytes(data any) int {
 	return bl.sizer.LogsSize(data.(plog.Logs))
 }
 
-func (bl *batchLogs) export(ctx context.Context, req any) error {
+func (bl *batchLogs) export(ctx context.Context, req any) (retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			retErr = errors.New(r.(string))
+		}
+	}()
 	ld := req.(plog.Logs)
 	return bl.nextConsumer.ConsumeLogs(ctx, ld)
 }

--- a/collector/processor/concurrentbatchprocessor/batch_processor.go
+++ b/collector/processor/concurrentbatchprocessor/batch_processor.go
@@ -362,8 +362,6 @@ func (b *shard) sendItems(trigger trigger) {
 
 func (b *shard) consumeAndWait(ctx context.Context, data any) error {
 	respCh := make(chan error, 1)
-	// TODO: add a semaphore to only write to channel if sizeof(data) keeps
-	// us below some configured inflight byte limit.
 	item := dataItem{
 		data:       data,
 		responseCh: respCh,
@@ -379,7 +377,7 @@ func (b *shard) consumeAndWait(ctx context.Context, data any) error {
 	}
 
 	bytes := int64(b.batch.sizeBytes(data))
-	err := b.sem.Acquire(b.exportCtx, bytes)
+	err := b.sem.Acquire(ctx, bytes)
 	if err != nil {
 		return err
 	}

--- a/collector/processor/concurrentbatchprocessor/batch_processor_test.go
+++ b/collector/processor/concurrentbatchprocessor/batch_processor_test.go
@@ -206,7 +206,7 @@ func TestBatchProcessorLogsPanicRecover(t *testing.T) {
 	require.NoError(t, bp.Shutdown(context.Background()))
 }
 
-func (b *shard) blockStart(done chan int) {
+func blockStart(b *shard, done chan int) {
 	var items []dataItem
 	for {
 		select {
@@ -249,7 +249,7 @@ func newBlockingBatchProcessor(set processor.CreateSettings, cfg *Config, batchF
 
 	b.processor.goroutines.Add(1)
 	done := make(chan int, 1)
-	go b.blockStart(done)
+	go blockStart(b, done)
 
 	bp.batcher = &singleShardBatcher{batcher: b}
 

--- a/collector/processor/concurrentbatchprocessor/batch_processor_test.go
+++ b/collector/processor/concurrentbatchprocessor/batch_processor_test.go
@@ -84,7 +84,7 @@ func TestBatchProcessorSpansDelivered(t *testing.T) {
 	sink := new(consumertest.TracesSink)
 	cfg := createDefaultConfig().(*Config)
 	cfg.SendBatchSize = 128
-	cfg.Timeout = 5 * time.Second
+	cfg.Timeout = 10 * time.Second
 	creationSet := processortest.NewNopCreateSettings()
 	creationSet.MetricsLevel = configtelemetry.LevelDetailed
 	batcher, err := newBatchTracesProcessor(creationSet, sink, cfg, true)
@@ -345,6 +345,7 @@ func TestBatchProcessorTraceSendWhenClosing(t *testing.T) {
 	cfg := Config{
 		Timeout:       3 * time.Second,
 		SendBatchSize: 1000,
+		MaxInFlightBytes: defaultMaxBytes,
 	}
 	sink := new(consumertest.TracesSink)
 
@@ -379,6 +380,7 @@ func TestBatchMetricProcessor_ReceivingData(t *testing.T) {
 	cfg := Config{
 		Timeout:       200 * time.Millisecond,
 		SendBatchSize: 50,
+		MaxInFlightBytes: defaultMaxBytes,
 	}
 
 	requestCount := 100
@@ -444,6 +446,7 @@ func testBatchMetricProcessorBatchSize(t *testing.T, tel testTelemetry, useOtel 
 	cfg := Config{
 		Timeout:       2 * time.Second,
 		SendBatchSize: 50,
+		MaxInFlightBytes: defaultMaxBytes,
 	}
 
 	requestCount := 100
@@ -505,7 +508,7 @@ func TestBatchMetrics_UnevenBatchMaxSize(t *testing.T) {
 
 	batchMetrics.add(md)
 	require.Equal(t, dataPointsPerMetric*metricsCount, batchMetrics.dataPointCount)
-	sent, _, req := batchMetrics.splitBatch(ctx, sendBatchMaxSize, true)
+	sent, req := batchMetrics.splitBatch(ctx, sendBatchMaxSize, true)
 	sendErr := batchMetrics.export(ctx, req)
 	require.NoError(t, sendErr)
 	require.Equal(t, sendBatchMaxSize, sent)
@@ -517,6 +520,7 @@ func TestBatchMetricsProcessor_Timeout(t *testing.T) {
 	cfg := Config{
 		Timeout:       100 * time.Millisecond,
 		SendBatchSize: 101,
+		MaxInFlightBytes: defaultMaxBytes,
 	}
 	requestCount := 5
 	metricsPerRequest := 10
@@ -562,6 +566,7 @@ func TestBatchMetricProcessor_Shutdown(t *testing.T) {
 	cfg := Config{
 		Timeout:       3 * time.Second,
 		SendBatchSize: 1000,
+		MaxInFlightBytes: defaultMaxBytes,
 	}
 	requestCount := 5
 	metricsPerRequest := 10
@@ -654,6 +659,7 @@ func BenchmarkBatchMetricProcessor(b *testing.B) {
 	cfg := Config{
 		Timeout:       100 * time.Millisecond,
 		SendBatchSize: 2000,
+		MaxInFlightBytes: defaultMaxBytes,
 	}
 	runMetricsProcessorBenchmark(b, cfg)
 }
@@ -664,6 +670,7 @@ func BenchmarkMultiBatchMetricProcessor(b *testing.B) {
 		Timeout:       100 * time.Millisecond,
 		SendBatchSize: 2000,
 		MetadataKeys:  []string{"test", "test2"},
+		MaxInFlightBytes: defaultMaxBytes,
 	}
 	runMetricsProcessorBenchmark(b, cfg)
 }
@@ -713,6 +720,7 @@ func TestBatchLogProcessor_ReceivingData(t *testing.T) {
 	cfg := Config{
 		Timeout:       200 * time.Millisecond,
 		SendBatchSize: 50,
+		MaxInFlightBytes: defaultMaxBytes,
 	}
 
 	requestCount := 100
@@ -778,6 +786,7 @@ func testBatchLogProcessorBatchSize(t *testing.T, tel testTelemetry, useOtel boo
 	cfg := Config{
 		Timeout:       2 * time.Second,
 		SendBatchSize: 50,
+		MaxInFlightBytes: defaultMaxBytes,
 	}
 
 	requestCount := 100
@@ -829,6 +838,7 @@ func TestBatchLogsProcessor_Timeout(t *testing.T) {
 	cfg := Config{
 		Timeout:       3 * time.Second,
 		SendBatchSize: 100,
+		MaxInFlightBytes: defaultMaxBytes,
 	}
 	requestCount := 5
 	logsPerRequest := 10
@@ -874,6 +884,7 @@ func TestBatchLogProcessor_Shutdown(t *testing.T) {
 	cfg := Config{
 		Timeout:       3 * time.Second,
 		SendBatchSize: 1000,
+		MaxInFlightBytes: defaultMaxBytes,
 	}
 	requestCount := 5
 	logsPerRequest := 10
@@ -1140,7 +1151,9 @@ func TestBatchProcessorMetadataCardinalityLimit(t *testing.T) {
 func TestBatchZeroConfig(t *testing.T) {
 	// This is a no-op configuration. No need for a timer, no
 	// minimum, no mxaimum, just a pass through.
-	cfg := Config{}
+	cfg := Config{
+		MaxInFlightBytes: defaultMaxBytes,
+	}
 
 	require.NoError(t, cfg.Validate())
 
@@ -1182,6 +1195,7 @@ func TestBatchSplitOnly(t *testing.T) {
 
 	cfg := Config{
 		SendBatchMaxSize: maxBatch,
+		MaxInFlightBytes: defaultMaxBytes,
 	}
 
 	require.NoError(t, cfg.Validate())

--- a/collector/processor/concurrentbatchprocessor/batch_processor_test.go
+++ b/collector/processor/concurrentbatchprocessor/batch_processor_test.go
@@ -306,7 +306,7 @@ func TestBatchProcessorCancelContext(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return bp.batcher.(*singleShardBatcher).batcher.sem.TryAcquire(int64(cfg.MaxInFlightBytes))
 	}, 5 * time.Second, 10 * time.Millisecond)
-	require.NoError(t, batcher.Shutdown(context.Background()))
+	require.NoError(t, bp.Shutdown(context.Background()))
 }
 
 func TestBatchProcessorSpansDelivered(t *testing.T) {

--- a/collector/processor/concurrentbatchprocessor/batch_processor_test.go
+++ b/collector/processor/concurrentbatchprocessor/batch_processor_test.go
@@ -87,7 +87,11 @@ func (pc *panicConsumer) ConsumeTraces(ctx context.Context, td ptrace.Traces) er
 	panic("testing panic")
 	return nil
 }
-func (pc *panicConsumer) ConsumeMetrics(ctx context.Context, td pmetric.Metrics) error {
+func (pc *panicConsumer) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
+	panic("testing panic")
+	return nil
+}
+func (pc *panicConsumer) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 	panic("testing panic")
 	return nil
 }
@@ -166,13 +170,13 @@ func TestBatchProcessorMetricsPanicRecover(t *testing.T) {
 	require.NoError(t, bp.Shutdown(context.Background()))
 }
 
-func TestBatchProcessorMetricsPanicRecover(t *testing.T) {
+func TestBatchProcessorLogsPanicRecover(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.SendBatchSize = 128
 	cfg.Timeout = 10 * time.Second
 	creationSet := processortest.NewNopCreateSettings()
 	creationSet.MetricsLevel = configtelemetry.LevelDetailed
-	bp, err := newBatchMetricsProcessor(creationSet, &panicConsumer{}, cfg, true)
+	bp, err := newBatchLogsProcessor(creationSet, &panicConsumer{}, cfg, true)
 
 	require.NoError(t, err)
 	require.NoError(t, bp.Start(context.Background(), componenttest.NewNopHost()))
@@ -190,7 +194,7 @@ func TestBatchProcessorMetricsPanicRecover(t *testing.T) {
 		ld.ResourceLogs().At(0).CopyTo(sentResourceLogs.AppendEmpty())
 		wg.Add(1)
 		go func() {
-			err = batcher.ConsumeLogs(context.Background(), ld)
+			err = bp.ConsumeLogs(context.Background(), ld)
 			assert.Contains(t, err.Error(), "testing panic")
 			wg.Done()
 		}()

--- a/collector/processor/concurrentbatchprocessor/batch_processor_test.go
+++ b/collector/processor/concurrentbatchprocessor/batch_processor_test.go
@@ -306,6 +306,7 @@ func TestBatchProcessorCancelContext(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return bp.batcher.(*singleShardBatcher).batcher.sem.TryAcquire(int64(cfg.MaxInFlightBytes))
 	}, 5 * time.Second, 10 * time.Millisecond)
+	require.NoError(t, batcher.Shutdown(context.Background()))
 }
 
 func TestBatchProcessorSpansDelivered(t *testing.T) {

--- a/collector/processor/concurrentbatchprocessor/batch_processor_test.go
+++ b/collector/processor/concurrentbatchprocessor/batch_processor_test.go
@@ -289,7 +289,7 @@ func TestBatchProcessorCancelContext(t *testing.T) {
 	require.Eventually(t, func() bool {
 		numSpans := requestCount * spansPerRequest
 		return bc.getItemsWaiting() == numSpans
-	}, 5 * time.Second, 10 * time.Millisecond)
+	}, 5*time.Second, 10*time.Millisecond)
 
 	// semaphore should be fully acquired at this point.
 	assert.False(t, bp.batcher.(*singleShardBatcher).batcher.sem.TryAcquire(int64(1)))
@@ -315,7 +315,7 @@ func TestBatchProcessorCancelContext(t *testing.T) {
 	// Semaphore should be released once all responses are returned. Confirm we can acquire MaxInFlightBytes bytes.
 	require.Eventually(t, func() bool {
 		return bp.batcher.(*singleShardBatcher).batcher.sem.TryAcquire(int64(cfg.MaxInFlightBytes))
-	}, 5 * time.Second, 10 * time.Millisecond)
+	}, 5*time.Second, 10*time.Millisecond)
 	require.NoError(t, bp.Shutdown(context.Background()))
 }
 
@@ -527,9 +527,9 @@ func testBatchProcessorSentBySizeWithMaxSize(t *testing.T, tel testTelemetry, us
 	require.EqualValues(t, expectedBatchesNum, len(receivedTraces))
 
 	tel.assertMetrics(t, expectedMetrics{
-		sendCount:      float64(expectedBatchesNum),
-		sendSizeSum:    float64(sink.SpanCount()),
-		sizeTrigger:    math.Floor(float64(totalSpans) / float64(sendBatchMaxSize)),
+		sendCount:   float64(expectedBatchesNum),
+		sendSizeSum: float64(sink.SpanCount()),
+		sizeTrigger: math.Floor(float64(totalSpans) / float64(sendBatchMaxSize)),
 	})
 }
 
@@ -582,8 +582,8 @@ func TestBatchProcessorSentByTimeout(t *testing.T) {
 
 func TestBatchProcessorTraceSendWhenClosing(t *testing.T) {
 	cfg := Config{
-		Timeout:       3 * time.Second,
-		SendBatchSize: 1000,
+		Timeout:          3 * time.Second,
+		SendBatchSize:    1000,
 		MaxInFlightBytes: defaultMaxBytes,
 	}
 	sink := new(consumertest.TracesSink)
@@ -617,8 +617,8 @@ func TestBatchMetricProcessor_ReceivingData(t *testing.T) {
 	// Instantiate the batch processor with low config values to test data
 	// gets sent through the processor.
 	cfg := Config{
-		Timeout:       200 * time.Millisecond,
-		SendBatchSize: 50,
+		Timeout:          200 * time.Millisecond,
+		SendBatchSize:    50,
 		MaxInFlightBytes: defaultMaxBytes,
 	}
 
@@ -683,8 +683,8 @@ func testBatchMetricProcessorBatchSize(t *testing.T, tel testTelemetry, useOtel 
 	// Instantiate the batch processor with low config values to test data
 	// gets sent through the processor.
 	cfg := Config{
-		Timeout:       2 * time.Second,
-		SendBatchSize: 50,
+		Timeout:          2 * time.Second,
+		SendBatchSize:    50,
 		MaxInFlightBytes: defaultMaxBytes,
 	}
 
@@ -757,8 +757,8 @@ func TestBatchMetrics_UnevenBatchMaxSize(t *testing.T) {
 
 func TestBatchMetricsProcessor_Timeout(t *testing.T) {
 	cfg := Config{
-		Timeout:       100 * time.Millisecond,
-		SendBatchSize: 101,
+		Timeout:          100 * time.Millisecond,
+		SendBatchSize:    101,
 		MaxInFlightBytes: defaultMaxBytes,
 	}
 	requestCount := 5
@@ -803,8 +803,8 @@ func TestBatchMetricsProcessor_Timeout(t *testing.T) {
 
 func TestBatchMetricProcessor_Shutdown(t *testing.T) {
 	cfg := Config{
-		Timeout:       3 * time.Second,
-		SendBatchSize: 1000,
+		Timeout:          3 * time.Second,
+		SendBatchSize:    1000,
 		MaxInFlightBytes: defaultMaxBytes,
 	}
 	requestCount := 5
@@ -896,8 +896,8 @@ func BenchmarkTraceSizeSpanCount(b *testing.B) {
 func BenchmarkBatchMetricProcessor(b *testing.B) {
 	b.StopTimer()
 	cfg := Config{
-		Timeout:       100 * time.Millisecond,
-		SendBatchSize: 2000,
+		Timeout:          100 * time.Millisecond,
+		SendBatchSize:    2000,
 		MaxInFlightBytes: defaultMaxBytes,
 	}
 	runMetricsProcessorBenchmark(b, cfg)
@@ -906,9 +906,9 @@ func BenchmarkBatchMetricProcessor(b *testing.B) {
 func BenchmarkMultiBatchMetricProcessor(b *testing.B) {
 	b.StopTimer()
 	cfg := Config{
-		Timeout:       100 * time.Millisecond,
-		SendBatchSize: 2000,
-		MetadataKeys:  []string{"test", "test2"},
+		Timeout:          100 * time.Millisecond,
+		SendBatchSize:    2000,
+		MetadataKeys:     []string{"test", "test2"},
 		MaxInFlightBytes: defaultMaxBytes,
 	}
 	runMetricsProcessorBenchmark(b, cfg)
@@ -957,8 +957,8 @@ func TestBatchLogProcessor_ReceivingData(t *testing.T) {
 	// Instantiate the batch processor with low config values to test data
 	// gets sent through the processor.
 	cfg := Config{
-		Timeout:       200 * time.Millisecond,
-		SendBatchSize: 50,
+		Timeout:          200 * time.Millisecond,
+		SendBatchSize:    50,
 		MaxInFlightBytes: defaultMaxBytes,
 	}
 
@@ -1023,8 +1023,8 @@ func testBatchLogProcessorBatchSize(t *testing.T, tel testTelemetry, useOtel boo
 	// Instantiate the batch processor with low config values to test data
 	// gets sent through the processor.
 	cfg := Config{
-		Timeout:       2 * time.Second,
-		SendBatchSize: 50,
+		Timeout:          2 * time.Second,
+		SendBatchSize:    50,
 		MaxInFlightBytes: defaultMaxBytes,
 	}
 
@@ -1075,8 +1075,8 @@ func testBatchLogProcessorBatchSize(t *testing.T, tel testTelemetry, useOtel boo
 
 func TestBatchLogsProcessor_Timeout(t *testing.T) {
 	cfg := Config{
-		Timeout:       3 * time.Second,
-		SendBatchSize: 100,
+		Timeout:          3 * time.Second,
+		SendBatchSize:    100,
 		MaxInFlightBytes: defaultMaxBytes,
 	}
 	requestCount := 5
@@ -1121,8 +1121,8 @@ func TestBatchLogsProcessor_Timeout(t *testing.T) {
 
 func TestBatchLogProcessor_Shutdown(t *testing.T) {
 	cfg := Config{
-		Timeout:       3 * time.Second,
-		SendBatchSize: 1000,
+		Timeout:          3 * time.Second,
+		SendBatchSize:    1000,
 		MaxInFlightBytes: defaultMaxBytes,
 	}
 	requestCount := 5
@@ -1377,7 +1377,7 @@ func TestBatchProcessorMetadataCardinalityLimit(t *testing.T) {
 	})
 
 	wg.Add(1)
-	go func()  {
+	go func() {
 		err := batcher.ConsumeTraces(ctx, td)
 		assert.ErrorIs(t, err, errTooManyBatchers)
 		wg.Done()

--- a/collector/processor/concurrentbatchprocessor/config.go
+++ b/collector/processor/concurrentbatchprocessor/config.go
@@ -44,6 +44,10 @@ type Config struct {
 	// batcher instances that will be created through a distinct
 	// combination of MetadataKeys.
 	MetadataCardinalityLimit uint32 `mapstructure:"metadata_cardinality_limit"`
+
+	// MaxInFlightBytes limits the number of bytes in queue waiting to be
+	// processed by the senders.
+	MaxInFlightBytes uint32 `mapstructure:"max_in_flight_bytes"`
 }
 
 var _ component.Config = (*Config)(nil)

--- a/collector/processor/concurrentbatchprocessor/config_test.go
+++ b/collector/processor/concurrentbatchprocessor/config_test.go
@@ -35,6 +35,7 @@ func TestUnmarshalConfig(t *testing.T) {
 			SendBatchMaxSize:         uint32(11000),
 			Timeout:                  time.Second * 10,
 			MetadataCardinalityLimit: 1000,
+			MaxInFlightBytes:         12345,
 		}, cfg)
 }
 

--- a/collector/processor/concurrentbatchprocessor/factory.go
+++ b/collector/processor/concurrentbatchprocessor/factory.go
@@ -18,6 +18,8 @@ const (
 
 	defaultSendBatchSize = uint32(8192)
 	defaultTimeout       = 200 * time.Millisecond
+	// default inflight bytes is 2 MiB
+	defaultMaxBytes      = 2 * 1048576
 
 	// defaultMetadataCardinalityLimit should be set to the number
 	// of metadata configurations the user expects to submit to
@@ -43,6 +45,7 @@ func createDefaultConfig() component.Config {
 	return &Config{
 		SendBatchSize:            defaultSendBatchSize,
 		Timeout:                  defaultTimeout,
+		MaxInFlightBytes:         defaultMaxBytes,
 		MetadataCardinalityLimit: defaultMetadataCardinalityLimit,
 	}
 }

--- a/collector/processor/concurrentbatchprocessor/testdata/config.yaml
+++ b/collector/processor/concurrentbatchprocessor/testdata/config.yaml
@@ -1,3 +1,4 @@
 timeout: 10s
 send_batch_size: 10000
 send_batch_max_size: 11000
+max_in_flight_bytes: 12345


### PR DESCRIPTION
This PR adds a new config option in the `concurrentbatchprocessor` named `max_in_flight_bytes`. This config option will be used by processor to control admission (using a semaphore) into the producer queue based on the size of requests.

Fixes #80.
Fixes #11.