### PR TITLE
Re-enable CI testing post-v0.11.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         go-version: "1.21"
 
     - name: Build all modules
-      run: make build || true
+      run: make build
 
     - name: Test all modules
-      run: make test || true
+      run: make test


### PR DESCRIPTION
The release process is currently operational, but it requires disabling CI during the release PR and immediately re-enabling it. Here is that step for v0.11.0.