### PR TITLE
Count the in-flight metric after acquire succeeds

### DIFF
--- a/collector/processor/concurrentbatchprocessor/batch_processor.go
+++ b/collector/processor/concurrentbatchprocessor/batch_processor.go
@@ -361,10 +361,11 @@ func (b *shard) sendItems(trigger trigger) {
 }
 
 func (bp *batchProcessor) countAcquire(ctx context.Context, bytes int64) error {
-	if bp.telemetry.batchInFlightBytes != nil {
+	err := bp.sem.Acquire(ctx, bytes)
+	if err == nil && bp.telemetry.batchInFlightBytes != nil {
 		bp.telemetry.batchInFlightBytes.Add(ctx, bytes, bp.telemetry.processorAttrOption)
 	}
-	return bp.sem.Acquire(ctx, bytes)
+	return err
 }
 
 func (bp *batchProcessor) countRelease(bytes int64) {


### PR DESCRIPTION
Fixes a leak in the in_flight_bytes accounting by not counting the bytes until after the semaphore is acquired.

We will want to add some kind of limit around the receiver's in-flight bytes.