### PR TITLE
Disable the stream_unique metric attribute at Detailed level

### DIFF
--- a/pkg/otel/arrow_record/consumer.go
+++ b/pkg/otel/arrow_record/consumer.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"math/rand"
 
 	"github.com/apache/arrow/go/v12/arrow/ipc"
 	"github.com/apache/arrow/go/v12/arrow/memory"
@@ -89,10 +88,6 @@ type Consumer struct {
 	schemaResetCounter metric.Int64Counter
 	// tracks allocator.Inuse()
 	memoryCounter metric.Int64UpDownCounter
-
-	// uniqueAttr is set to an 8-byte hex digit string with
-	// 32-bits of randomness, applied to all metric events.
-	uniqueAttr attribute.KeyValue
 }
 
 type Config struct {
@@ -157,7 +152,6 @@ func NewConsumer(opts ...Option) *Consumer {
 	c := &Consumer{
 		Config:             cfg,
 		allocator:          allocator,
-		uniqueAttr:         attribute.String("stream_unique", fmt.Sprintf("%08x", rand.Uint32())),
 		streamConsumers:    make(map[string]*streamConsumer),
 		recordsCounter:     noop.Int64Counter{},
 		schemaResetCounter: noop.Int64Counter{},
@@ -190,9 +184,6 @@ func mustWarn[T any](t T, err error) T {
 func (c *Consumer) metricOpts(kvs ...attribute.KeyValue) []metric.AddOption {
 	if c.metricsLevel < configtelemetry.LevelNormal {
 		return nil
-	}
-	if c.metricsLevel == configtelemetry.LevelDetailed {
-		kvs = append(kvs, c.uniqueAttr)
 	}
 	return []metric.AddOption{
 		metric.WithAttributes(kvs...),


### PR DESCRIPTION
This field has caused a (predictable) cardinality explosion in our internal pipeline monitoring setup. This leaves the feature in but disabled at Detailed level. While the collectorconfig package won't parse a value greater than Detailed, callers can still pass `Detailed+1` to enable.