### PR TITLE
(concurrentbatchprocessor): adds suffix, changes setting from max_in_flight_bytes to max_in_flight_bytes_mib

### DIFF
--- a/collector/processor/concurrentbatchprocessor/batch_processor.go
+++ b/collector/processor/concurrentbatchprocessor/batch_processor.go
@@ -166,7 +166,7 @@ func newBatchProcessor(set processor.CreateSettings, cfg *Config, batchFunc func
 		shutdownC:        make(chan struct{}, 1),
 		metadataKeys:     mks,
 		metadataLimit:    int(cfg.MetadataCardinalityLimit),
-		sem:              semaphore.NewWeighted(int64(cfg.MaxInFlightBytes)),
+		sem:              semaphore.NewWeighted(int64(cfg.MaxInFlightBytesMiB)),
 	}
 	if len(bp.metadataKeys) == 0 {
 		bp.batcher = &singleShardBatcher{batcher: bp.newShard(nil)}

--- a/collector/processor/concurrentbatchprocessor/config.go
+++ b/collector/processor/concurrentbatchprocessor/config.go
@@ -47,6 +47,9 @@ type Config struct {
 
 	// MaxInFlightBytes limits the number of bytes in queue waiting to be
 	// processed by the senders.
+	MaxInFlightBytesMiB uint32 `mapstructure:"max_in_flight_bytes_mib"`
+
+	// Deprecated: Use MaxInFlightBytesMiB instead.
 	MaxInFlightBytes uint32 `mapstructure:"max_in_flight_bytes"`
 }
 
@@ -67,6 +70,15 @@ func (cfg *Config) Validate() error {
 	}
 	if cfg.Timeout < 0 {
 		return errors.New("timeout must be greater or equal to 0")
+	}
+
+	// remove this check once MaxInFlightBytes is removed.
+	if cfg.MaxInFlightBytes != 0 {
+		return errors.New("max_in_flight_bytes is deprecated, use max_in_flight_bytes_mib instead")
+	}
+
+	if cfg.MaxInFlightBytesMiB < 0 {
+		return errors.New("max_in_flight_bytes_mib must be greater than or equal to 0")
 	}
 	return nil
 }

--- a/collector/processor/concurrentbatchprocessor/config_test.go
+++ b/collector/processor/concurrentbatchprocessor/config_test.go
@@ -35,7 +35,7 @@ func TestUnmarshalConfig(t *testing.T) {
 			SendBatchMaxSize:         uint32(11000),
 			Timeout:                  time.Second * 10,
 			MetadataCardinalityLimit: 1000,
-			MaxInFlightBytes:         12345,
+			MaxInFlightBytesMiB:      12345,
 		}, cfg)
 }
 

--- a/collector/processor/concurrentbatchprocessor/factory.go
+++ b/collector/processor/concurrentbatchprocessor/factory.go
@@ -19,7 +19,7 @@ const (
 	defaultSendBatchSize = uint32(8192)
 	defaultTimeout       = 200 * time.Millisecond
 	// default inflight bytes is 2 MiB
-	defaultMaxBytes      = 2 * 1048576
+	defaultMaxBytes = 2 * 1048576
 
 	// defaultMetadataCardinalityLimit should be set to the number
 	// of metadata configurations the user expects to submit to
@@ -45,7 +45,7 @@ func createDefaultConfig() component.Config {
 	return &Config{
 		SendBatchSize:            defaultSendBatchSize,
 		Timeout:                  defaultTimeout,
-		MaxInFlightBytes:         defaultMaxBytes,
+		MaxInFlightBytesMiB:      defaultMaxBytes,
 		MetadataCardinalityLimit: defaultMetadataCardinalityLimit,
 	}
 }

--- a/collector/processor/concurrentbatchprocessor/testdata/config.yaml
+++ b/collector/processor/concurrentbatchprocessor/testdata/config.yaml
@@ -1,4 +1,4 @@
 timeout: 10s
 send_batch_size: 10000
 send_batch_max_size: 11000
-max_in_flight_bytes: 12345
+max_in_flight_bytes_mib: 12345


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/otel-arrow/issues/109