### PR TITLE
Post v0.14.0: re-enable CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         go-version: "1.21"
 
     - name: Build all modules
-      run: make build || true
+      run: make build
 
     - name: Test all modules
-      run: make test || true
+      run: make test


### PR DESCRIPTION
Following the release process for v0.14.0.