### PR TITLE
OTel-Arrow components: trace Arrow stream send/recv and propagate trace context

### DIFF
--- a/collector/exporter/otelarrowexporter/internal/arrow/stream.go
+++ b/collector/exporter/otelarrowexporter/internal/arrow/stream.go
@@ -54,7 +54,9 @@ type Stream struct {
 
 	// telemetry are a copy of the exporter's telemetry settings
 	telemetry component.TelemetrySettings
-	tracer    trace.Tracer
+
+	// tracer is used to create a span describing the export.
+	tracer trace.Tracer
 
 	// client uses the exporter's grpc.ClientConn.  this is
 	// initially nil only set when ArrowStream() calls meaning the
@@ -102,7 +104,7 @@ func newStream(
 	perRPCCredentials credentials.PerRPCCredentials,
 	netReporter netstats.Interface,
 ) *Stream {
-	tracer := telemetry.TracerProvider.Tracer("otel-arrow")
+	tracer := telemetry.TracerProvider.Tracer("otel-arrow-exporter")
 	return &Stream{
 		producer:          producer,
 		prioritizer:       prioritizer,


### PR DESCRIPTION
Adds tracing support. This will enable diagnosis of pipeline stalls when they happen, which we believe is caused by a downstream component that we will be able to identify with traces enabled.

TESTED=manual & unittests

Test configuration like
```
receivers:
  otelarrow/1:
    protocols:
      grpc:
        endpoint: 127.0.0.1:4317
  otelarrow/2:
    protocols:
      grpc:
        endpoint: 127.0.0.1:4319

exporters:
  otelarrow:
    endpoint: 127.0.0.1:4319
    wait_for_ready: true
    tls:
      insecure: true
    sending_queue:
      enabled: false

  debug:
    # Uncomment this to print actual data.
    verbosity: detailed

service:
  pipelines:
    traces/1:
      receivers: [otelarrow/1]
      processors: []
      exporters: [otelarrow]
    traces/2:
      receivers: [otelarrow/2]
      processors: []
      exporters: [debug]

  telemetry:
    resource:
      "service.name": "simple-gateway"
    traces:
      propagators: [tracecontext]
      processors:
        - batch:
            exporter:
              otlp:
                protocol: grpc/protobuf
                endpoint: 127.0.0.1:4319
    logs:
      level: info
```