### PR TITLE
add uncompressed bytes to receiver and exporter span attributes

### DIFF
--- a/collector/exporter/otelarrowexporter/internal/arrow/stream.go
+++ b/collector/exporter/otelarrowexporter/internal/arrow/stream.go
@@ -340,6 +340,10 @@ func (s *Stream) encodeAndSend(wri writeItem, hdrsBuf *bytes.Buffer, hdrsEnc *hp
 	ctx, span := s.tracer.Start(wri.parent, "otel_arrow_stream_send")
 	defer span.End()
 
+	var err error
+	defer func() {
+		s.netReporter.SetSpanAttributes(ctx, err, attribute.Int("stream_client_uncompressed_request_size", wri.uncompSize))
+	}
 	// Get the global propagator, to inject context.  When there
 	// are no fields, it's a no-op propagator implementation and
 	// we can skip the allocations inside this block.

--- a/collector/exporter/otelarrowexporter/internal/arrow/stream.go
+++ b/collector/exporter/otelarrowexporter/internal/arrow/stream.go
@@ -337,16 +337,15 @@ func (s *Stream) write(ctx context.Context) error {
 	}
 }
 
-func (s *Stream) encodeAndSend(wri writeItem, hdrsBuf *bytes.Buffer, hdrsEnc *hpack.Encoder) error {
+func (s *Stream) encodeAndSend(wri writeItem, hdrsBuf *bytes.Buffer, hdrsEnc *hpack.Encoder) (retErr error) {
 	ctx, span := s.tracer.Start(wri.parent, "otel_arrow_stream_send")
 	defer span.End()
 
-	var err error
 	defer func() {
 		// Set span status if an error is returned.
-		if err != nil {
+		if retErr != nil {
 			span := trace.SpanFromContext(ctx)
-			span.SetStatus(otelcodes.Error, err.Error())
+			span.SetStatus(otelcodes.Error, retErr.Error())
 		}
 	}()
 	// Get the global propagator, to inject context.  When there

--- a/collector/netstats/handler.go
+++ b/collector/netstats/handler.go
@@ -60,6 +60,7 @@ func (h statsHandler) HandleRPC(ctx context.Context, rs stats.RPCStats) {
 		}
 		ss.WireLength = int64(s.WireLength)
 		h.rep.CountReceive(ctx, ss)
+		h.rep.SetSpanSizeAttributes(ctx, ss)
 
 	case *stats.OutPayload:
 		var ss SizesStruct
@@ -69,6 +70,7 @@ func (h statsHandler) HandleRPC(ctx context.Context, rs stats.RPCStats) {
 		}
 		ss.WireLength = int64(s.WireLength)
 		h.rep.CountSend(ctx, ss)
+		h.rep.SetSpanSizeAttributes(ctx, ss)
 	}
 }
 

--- a/collector/netstats/netstats.go
+++ b/collector/netstats/netstats.go
@@ -8,8 +8,8 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/trace"
 	noopmetric "go.opentelemetry.io/otel/metric/noop"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/multierr"
 
 	"go.opentelemetry.io/collector/config/configtelemetry"
@@ -88,8 +88,8 @@ type Noop struct{}
 
 var _ Interface = Noop{}
 
-func (Noop) CountSend(ctx context.Context, ss SizesStruct)    {}
-func (Noop) CountReceive(ctx context.Context, ss SizesStruct) {}
+func (Noop) CountSend(ctx context.Context, ss SizesStruct)             {}
+func (Noop) CountReceive(ctx context.Context, ss SizesStruct)          {}
 func (Noop) SetSpanSizeAttributes(ctx context.Context, ss SizesStruct) {}
 
 const (

--- a/collector/netstats/netstats.go
+++ b/collector/netstats/netstats.go
@@ -7,7 +7,6 @@ import (
 	"context"
 
 	"go.opentelemetry.io/otel/attribute"
-	otelcodes "go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	noopmetric "go.opentelemetry.io/otel/metric/noop"
@@ -82,9 +81,6 @@ type Interface interface {
 
 	// SetSpanAttributes takes a context and adds attributes to the associated span.
 	SetSpanSizeAttributes(ctx context.Context, ss SizesStruct)
-
-	// SetSpanError set span status explicitly, if there is an non-nil error provided.
-	SetSpanError(ctx context.Context, err error)
 }
 
 // Noop is a no-op implementation of Interface.
@@ -95,7 +91,6 @@ var _ Interface = Noop{}
 func (Noop) CountSend(ctx context.Context, ss SizesStruct)    {}
 func (Noop) CountReceive(ctx context.Context, ss SizesStruct) {}
 func (Noop) SetSpanSizeAttributes(ctx context.Context, ss SizesStruct) {}
-func (Noop) SetSpanError(ctx context.Context, err error) {}
 
 const (
 	bytesUnit           = "bytes"
@@ -272,13 +267,4 @@ func (rep *NetworkReporter) SetSpanSizeAttributes(ctx context.Context, ss SizesS
 	if ss.WireLength > 0 {
 		span.SetAttributes(attribute.Int(compressedName, int(ss.WireLength)))
 	}
-}
-
-func (rep *NetworkReporter) SetSpanError(ctx context.Context, err error) {
-	if err == nil {
-		return
-	}
-
-	span := trace.SpanFromContext(ctx)
-	span.SetStatus(otelcodes.Error, err.Error())
 }

--- a/collector/netstats/netstats_test.go
+++ b/collector/netstats/netstats_test.go
@@ -137,16 +137,16 @@ func testNetStatsExporter(t *testing.T, level configtelemetry.Level, expect map[
 
 func TestNetStatsSetSpanAttrs(t *testing.T) {
 	tests := []struct {
-		name          string
-		attrs []attribute.KeyValue
-		isExporter    bool
-		length int
+		name       string
+		attrs      []attribute.KeyValue
+		isExporter bool
+		length     int
 		wireLength int
 	}{
 		{
-			name: "set exporter attributes",
+			name:       "set exporter attributes",
 			isExporter: true,
-			length: 1234567,
+			length:     1234567,
 			wireLength: 123,
 			attrs: []attribute.KeyValue{
 				attribute.Int("stream_client_uncompressed_bytes_sent", 1234567),
@@ -154,9 +154,9 @@ func TestNetStatsSetSpanAttrs(t *testing.T) {
 			},
 		},
 		{
-			name: "set receiver attributes",
+			name:       "set receiver attributes",
 			isExporter: false,
-			length: 8901234,
+			length:     8901234,
 			wireLength: 890,
 			attrs: []attribute.KeyValue{
 				attribute.Int("stream_server_uncompressed_bytes_recv", 8901234),
@@ -167,7 +167,7 @@ func TestNetStatsSetSpanAttrs(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			enr := &NetworkReporter{
-				isExporter:    tc.isExporter,
+				isExporter: tc.isExporter,
 			}
 
 			tp := sdktrace.NewTracerProvider()

--- a/collector/receiver/otelarrowreceiver/internal/arrow/arrow.go
+++ b/collector/receiver/otelarrowreceiver/internal/arrow/arrow.go
@@ -373,7 +373,7 @@ func (r *Receiver) anyStream(serverStream anyStreamServer, method string) (retEr
 	}
 }
 
-func (r *Receiver) processAndConsume(ctx context.Context, method string, arrowConsumer arrowRecord.ConsumerAPI, req *arrowpb.BatchArrowRecords, serverStream anyStreamServer, authErr error) error {
+func (r *Receiver) processAndConsume(ctx context.Context, method string, arrowConsumer arrowRecord.ConsumerAPI, req *arrowpb.BatchArrowRecords, serverStream anyStreamServer, authErr error) (retErr error) {
 	var err error
 
 	ctx, span := r.tracer.Start(ctx, "otel_arrow_stream_recv")
@@ -381,9 +381,9 @@ func (r *Receiver) processAndConsume(ctx context.Context, method string, arrowCo
 
 	defer func() {
 		// Set span status if an error is returned.
-		if err != nil {
+		if retErr != nil {
 			span := trace.SpanFromContext(ctx)
-			span.SetStatus(otelcodes.Error, err.Error())
+			span.SetStatus(otelcodes.Error, retErr.Error())
 		}
 	}()
 


### PR DESCRIPTION
This PR adds a new method to the netstats reporter, called `SetSpanAttributes`. This method adds uncompressed request size as an attribute to the provided span and explicitly sets the span status in the case of an error. This method is used to track errors for both `server.Send` and `client.Send`  grpc  operations.