### PR TITLE
(otelarrowreceiver): add updown counters to track number of bytes and items pending

### DIFF
--- a/collector/receiver/otelarrowreceiver/internal/arrow/arrow.go
+++ b/collector/receiver/otelarrowreceiver/internal/arrow/arrow.go
@@ -500,13 +500,10 @@ func (r *Receiver) processRecords(ctx context.Context, method string, arrowConsu
 				err = multierr.Append(err,
 					r.Metrics().ConsumeMetrics(ctx, metrics),
 				)
-
-				// Once ConsumeMetrics returns we can decrement
-				// the updown counters as this memory will no
-				// longer be held by the receiver.
-				r.recvInFlightBytes.Add(ctx, -sz)
-				r.recvInFlightItems.Add(ctx, -int64(items))
 			}
+			// entire request has been processed, decrement counter.
+			r.recvInFlightBytes.Add(ctx, -uncompSize)
+			r.recvInFlightItems.Add(ctx, int64(-numPts))
 		}
 		r.obsrecv.EndMetricsOp(ctx, streamFormat, numPts, err)
 		return err
@@ -536,13 +533,10 @@ func (r *Receiver) processRecords(ctx context.Context, method string, arrowConsu
 				err = multierr.Append(err,
 					r.Logs().ConsumeLogs(ctx, logs),
 				)
-
-				// Once ConsumeLogs returns we can decrement
-				// the updown counters as this memory will no
-				// longer be held by the receiver.
-				r.recvInFlightBytes.Add(ctx, -sz)
-				r.recvInFlightItems.Add(ctx, int64(-items))
 			}
+			// entire request has been processed, decrement counter.
+			r.recvInFlightBytes.Add(ctx, -uncompSize)
+			r.recvInFlightItems.Add(ctx, int64(-numLogs))
 		}
 		r.obsrecv.EndLogsOp(ctx, streamFormat, numLogs, err)
 		return err
@@ -573,13 +567,11 @@ func (r *Receiver) processRecords(ctx context.Context, method string, arrowConsu
 				err = multierr.Append(err,
 					r.Traces().ConsumeTraces(ctx, traces),
 				)
-
-				// Once ConsumeTraces returns we can decrement
-				// the updown counters as this memory will no
-				// longer be held by the receiver.
-				r.recvInFlightBytes.Add(ctx, -sz)
-				r.recvInFlightItems.Add(ctx, int64(-items))
 			}
+
+			// entire request has been processed, decrement counter.
+			r.recvInFlightBytes.Add(ctx, -uncompSize)
+			r.recvInFlightItems.Add(ctx, int64(-numSpans))
 		}
 		r.obsrecv.EndTracesOp(ctx, streamFormat, numSpans, err)
 		return err

--- a/collector/receiver/otelarrowreceiver/internal/arrow/arrow.go
+++ b/collector/receiver/otelarrowreceiver/internal/arrow/arrow.go
@@ -467,7 +467,9 @@ func (r *Receiver) processRecords(ctx context.Context, method string, arrowConsu
 			// is instrumented this way.
 			var sized netstats.SizesStruct
 			sized.Method = method
-			sized.Length = uncompSize
+			if r.telemetry.MetricsLevel > configtelemetry.LevelNormal {
+				sized.Length = uncompSize
+			}
 			r.netReporter.CountReceive(ctx, sized)
 			r.netReporter.SetSpanSizeAttributes(ctx, sized)
 		}()
@@ -494,9 +496,7 @@ func (r *Receiver) processRecords(ctx context.Context, method string, arrowConsu
 				r.recvInFlightItems.Add(ctx, int64(items))
 
 				numPts += items
-				if r.telemetry.MetricsLevel > configtelemetry.LevelNormal {
-					uncompSize += sz
-				}
+				uncompSize += sz
 				err = multierr.Append(err,
 					r.Metrics().ConsumeMetrics(ctx, metrics),
 				)
@@ -527,9 +527,7 @@ func (r *Receiver) processRecords(ctx context.Context, method string, arrowConsu
 				r.recvInFlightBytes.Add(ctx, sz)
 				r.recvInFlightItems.Add(ctx, int64(items))
 				numLogs += items
-				if r.telemetry.MetricsLevel > configtelemetry.LevelNormal {
-					uncompSize += sz
-				}
+				uncompSize += sz
 				err = multierr.Append(err,
 					r.Logs().ConsumeLogs(ctx, logs),
 				)
@@ -561,9 +559,7 @@ func (r *Receiver) processRecords(ctx context.Context, method string, arrowConsu
 				r.recvInFlightItems.Add(ctx, int64(items))
 
 				numSpans += items
-				if r.telemetry.MetricsLevel > configtelemetry.LevelNormal {
-					uncompSize += sz
-				}
+				uncompSize += sz
 				err = multierr.Append(err,
 					r.Traces().ConsumeTraces(ctx, traces),
 				)

--- a/collector/receiver/otelarrowreceiver/internal/arrow/arrow_test.go
+++ b/collector/receiver/otelarrowreceiver/internal/arrow/arrow_test.go
@@ -336,7 +336,7 @@ func (ctc *commonTestCase) start(newConsumer func() arrowRecord.ConsumerAPI, opt
 	})
 	require.NoError(ctc.T, err)
 
-	rcvr := New(
+	rcvr, err := New(
 		ctc.consumers,
 		rc,
 		obsrecv,
@@ -345,6 +345,7 @@ func (ctc *commonTestCase) start(newConsumer func() arrowRecord.ConsumerAPI, opt
 		newConsumer,
 		netstats.Noop{},
 	)
+	require.NoError(ctc.T, err)
 	go func() {
 		ctc.streamErr <- rcvr.ArrowTraces(ctc.stream)
 	}()

--- a/collector/receiver/otelarrowreceiver/otelarrow.go
+++ b/collector/receiver/otelarrowreceiver/otelarrow.go
@@ -114,7 +114,7 @@ func (r *otelArrowReceiver) startProtocolServers(host component.Host) error {
 		}
 	}
 
-	r.arrowReceiver = arrow.New(arrow.Consumers(r), r.settings, r.obsrepGRPC, r.cfg.GRPC, authServer, func() arrowRecord.ConsumerAPI {
+	r.arrowReceiver, err = arrow.New(arrow.Consumers(r), r.settings, r.obsrepGRPC, r.cfg.GRPC, authServer, func() arrowRecord.ConsumerAPI {
 		var opts []arrowRecord.Option
 		if r.cfg.Arrow.MemoryLimitMiB != 0 {
 			// in which case the default is selected in the arrowRecord package.
@@ -125,6 +125,10 @@ func (r *otelArrowReceiver) startProtocolServers(host component.Host) error {
 		}
 		return arrowRecord.NewConsumer(opts...)
 	}, r.netReporter)
+
+	if err != nil {
+		return err
+	}
 
 	if r.tracesReceiver != nil {
 		ptraceotlp.RegisterGRPCServer(r.serverGRPC, r.tracesReceiver)


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/otel-arrow/issues/148

This PR adds two metrics to track the number of items and bytes that are pending in the receiver. Specifically when used with the `concurrentbatchprocessor` requests can be have a long lifetime in receiver due to the in flight byte limiter in the `concurrentbatchprocessor`. 