### PR TITLE
(otelarrowreceiver): remove obsreporttest package

### DIFF
--- a/collector/receiver/otelarrowreceiver/otelarrow_test.go
+++ b/collector/receiver/otelarrowreceiver/otelarrow_test.go
@@ -42,7 +42,6 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/extension/auth"
-	"go.opentelemetry.io/collector/obsreport/obsreporttest"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
@@ -176,7 +175,7 @@ func TestOTLPReceiverGRPCTracesIngestTest(t *testing.T) {
 	addr := testutil.GetAvailableLocalAddress(t)
 	td := testdata.GenerateTraces(1)
 
-	tt, err := obsreporttest.SetupTelemetry(testReceiverID)
+	tt, err := componenttest.SetupTelemetry(testReceiverID)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 


### PR DESCRIPTION
Remove a deprecated package that is removed completely from collector `v0.97.0` (https://github.com/open-telemetry/opentelemetry-collector/pull/9724). This seems to be blocking a collector upgrade.

Attempt to upgrade collector to v0.97.0 results in 
```
go: found github.com/open-telemetry/otel-arrow/collector/receiver/filereceiver in github.com/open-telemetry/otel-arrow/collector/receiver/filereceiver v0.18.0
go: found github.com/open-telemetry/otel-arrow/collector/receiver/otelarrowreceiver in github.com/open-telemetry/otel-arrow/collector/receiver/otelarrowreceiver v0.18.0
go: finding module for package go.opentelemetry.io/collector/obsreport/obsreporttest
go: github.com/open-telemetry/otel-arrow/collector/cmd/otelarrowcol imports
        github.com/open-telemetry/otel-arrow/collector/receiver/otelarrowreceiver tested by
        github.com/open-telemetry/otel-arrow/collector/receiver/otelarrowreceiver.test imports
        go.opentelemetry.io/collector/obsreport/obsreporttest: module go.opentelemetry.io/collector@latest found (v0.97.0), but does not contain package go.opentelemetry.io/collector/obsreport/obsreporttest
```