### PR TITLE
Lint fixes from open collector-contrib PRs.

### DIFF
--- a/collector/exporter/otelarrowexporter/internal/arrow/exporter.go
+++ b/collector/exporter/otelarrowexporter/internal/arrow/exporter.go
@@ -311,7 +311,7 @@ func (e *Exporter) SendAndWait(ctx context.Context, data any) (bool, error) {
 	}
 
 	for {
-		writer := e.ready.nextWriter(ctx)
+		writer := e.ready.nextWriter()
 
 		if writer == nil {
 			return false, nil // a downgraded connection

--- a/collector/exporter/otelarrowexporter/internal/arrow/prioritizer.go
+++ b/collector/exporter/otelarrowexporter/internal/arrow/prioritizer.go
@@ -35,7 +35,7 @@ const (
 type streamPrioritizer interface {
 	// nextWriter gets the next stream writer.  In case the exporter
 	// was downgraded, returns nil.
-	nextWriter(context.Context) streamWriter
+	nextWriter() streamWriter
 
 	// downgrade is called with the root context of the exporter,
 	// and may block indefinitely.  this allows the prioritizer to

--- a/collector/exporter/otelarrowexporter/internal/arrow/stream.go
+++ b/collector/exporter/otelarrowexporter/internal/arrow/stream.go
@@ -247,7 +247,7 @@ func (s *Stream) run(ctx context.Context, dc doneCancel, streamClient StreamClie
 // the caller waiting on its error channel.
 func (s *Stream) write(ctx context.Context) (retErr error) {
 	// always close send()
-	defer s.client.CloseSend()
+	defer func() { _ = s.client.CloseSend() }()
 
 	// headers are encoding using hpack, reusing a buffer on each call.
 	var hdrsBuf bytes.Buffer

--- a/collector/exporter/otelarrowexporter/internal/arrow/stream_test.go
+++ b/collector/exporter/otelarrowexporter/internal/arrow/stream_test.go
@@ -117,15 +117,11 @@ func (tc *streamTestCase) connectTestStream(h testChannel) func(context.Context,
 
 // get returns the stream via the prioritizer it is registered with.
 func (tc *streamTestCase) mustGet() streamWriter {
-	stream := tc.prioritizer.nextWriter(context.Background())
+	stream := tc.prioritizer.nextWriter()
 	if stream == nil {
 		panic("unexpected nil stream")
 	}
 	return stream
-}
-
-func (tc *streamTestCase) get() streamWriter {
-	return tc.prioritizer.nextWriter(context.Background())
 }
 
 func (tc *streamTestCase) mustSendAndWait() error {

--- a/collector/receiver/otelarrowreceiver/config_test.go
+++ b/collector/receiver/otelarrowreceiver/config_test.go
@@ -97,7 +97,7 @@ func TestUnmarshalConfigUnix(t *testing.T) {
 				GRPC: configgrpc.ServerConfig{
 					NetAddr: confignet.AddrConfig{
 						Endpoint:  "/tmp/grpc_otlp.sock",
-						Transport: "unix",
+						Transport: confignet.TransportTypeUnix,
 					},
 					ReadBufferSize: 512 * 1024,
 				},

--- a/collector/receiver/otelarrowreceiver/factory.go
+++ b/collector/receiver/otelarrowreceiver/factory.go
@@ -19,7 +19,7 @@ import (
 const (
 	defaultGRPCEndpoint = "0.0.0.0:4317"
 
-	defaultMemoryLimitMiB = 128
+	defaultMemoryLimitMiB    = 128
 	defaultAdmissionLimitMiB = defaultMemoryLimitMiB / 2
 )
 
@@ -46,7 +46,7 @@ func createDefaultConfig() component.Config {
 				ReadBufferSize: 512 * 1024,
 			},
 			Arrow: ArrowConfig{
-				MemoryLimitMiB: defaultMemoryLimitMiB,
+				MemoryLimitMiB:    defaultMemoryLimitMiB,
 				AdmissionLimitMiB: defaultAdmissionLimitMiB,
 			},
 		},


### PR DESCRIPTION
Minor lint fixes needed to keep the two code-bases in sync.
- Remove unused context argument from nextWriter()
- Do not name a field `N`
- Fix unused variable `rnd`
- Harden the stream-lifetime test w/ use of context
- Etc.
