### PR TITLE
Re-enable ci/cd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         go-version: "1.21"
 
     - name: Build all modules
-      run: make build || true
+      run: make build
 
     - name: Test all modules
-      run: make test || true
+      run: make test


### PR DESCRIPTION
This was disabled to release otel-arrow v0.23.0. Should be reenabled now that the release is out.