### PR TITLE
More panic handling for receiver; print Error, not Debug

### DIFF
--- a/collector/exporter/otelarrowexporter/internal/arrow/exporter.go
+++ b/collector/exporter/otelarrowexporter/internal/arrow/exporter.go
@@ -34,7 +34,9 @@ type Exporter struct {
 
 	// maxStreamLifetime is a limit on duration for streams.  A
 	// slight "jitter" is applied relative to this value on a
-	// per-stream basis.
+	// per-stream basis.  TODO: move this field to workstate
+	// so it's not re-initialized on each stream. the jitter is
+	// averaged away by re-evaluating.
 	maxStreamLifetime time.Duration
 
 	// disableDowngrade prevents downgrade from occurring, supports


### PR DESCRIPTION
This will help explain a crash we've seen internally -- it appears that unless Debug-level logging is enabled, we are not likely to see any indication when a panic happens inside the receiver. In v0.22.0 and earlier, this would be logged and recovered. With the changes in v0.23.0, these panics would interrupt the process because not all goroutines support panic recovery. 

If the summary above holds, it means that the errors we've seen were not caused by v0.23.0 but were pre-existing conditions, and the only regression in v0.23.0 was not to recover from the panic.