### PR TITLE
Backport from otel-colletor-contrib HEAD

### DIFF
--- a/collector/exporter/otelarrowexporter/config.go
+++ b/collector/exporter/otelarrowexporter/config.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/open-telemetry/otel-arrow/collector/compression/zstd"
-	"github.com/open-telemetry/otel-arrow/collector/exporter/otelarrowexporter/internal/arrow"
 	"github.com/open-telemetry/otel-arrow/pkg/config"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configcompression"
@@ -16,6 +15,8 @@ import (
 	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"google.golang.org/grpc"
+
+	"github.com/open-telemetry/otel-arrow/collector/exporter/otelarrowexporter/internal/arrow"
 )
 
 // Config defines configuration for OTLP exporter.

--- a/collector/exporter/otelarrowexporter/config_test.go
+++ b/collector/exporter/otelarrowexporter/config_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/open-telemetry/otel-arrow/collector/compression/zstd"
-	"github.com/open-telemetry/otel-arrow/collector/exporter/otelarrowexporter/internal/arrow"
 	"github.com/open-telemetry/otel-arrow/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,6 +22,8 @@ import (
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
+
+	"github.com/open-telemetry/otel-arrow/collector/exporter/otelarrowexporter/internal/arrow"
 )
 
 func TestUnmarshalDefaultConfig(t *testing.T) {

--- a/collector/exporter/otelarrowexporter/factory.go
+++ b/collector/exporter/otelarrowexporter/factory.go
@@ -67,14 +67,14 @@ func createDefaultConfig() component.Config {
 	}
 }
 
-func (oce *baseExporter) helperOptions() []exporterhelper.Option {
+func (exp *baseExporter) helperOptions() []exporterhelper.Option {
 	return []exporterhelper.Option{
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
-		exporterhelper.WithTimeout(oce.config.TimeoutSettings),
-		exporterhelper.WithRetry(oce.config.RetryConfig),
-		exporterhelper.WithQueue(oce.config.QueueSettings),
-		exporterhelper.WithStart(oce.start),
-		exporterhelper.WithShutdown(oce.shutdown),
+		exporterhelper.WithTimeout(exp.config.TimeoutSettings),
+		exporterhelper.WithRetry(exp.config.RetryConfig),
+		exporterhelper.WithQueue(exp.config.QueueSettings),
+		exporterhelper.WithStart(exp.start),
+		exporterhelper.WithShutdown(exp.shutdown),
 	}
 }
 
@@ -97,13 +97,13 @@ func createTracesExporter(
 	set exporter.CreateSettings,
 	cfg component.Config,
 ) (exporter.Traces, error) {
-	oce, err := newExporter(cfg, set, createArrowTracesStream)
+	exp, err := newExporter(cfg, set, createArrowTracesStream)
 	if err != nil {
 		return nil, err
 	}
-	return exporterhelper.NewTracesExporter(ctx, oce.settings, oce.config,
-		oce.pushTraces,
-		oce.helperOptions()...,
+	return exporterhelper.NewTracesExporter(ctx, exp.settings, exp.config,
+		exp.pushTraces,
+		exp.helperOptions()...,
 	)
 }
 
@@ -116,13 +116,13 @@ func createMetricsExporter(
 	set exporter.CreateSettings,
 	cfg component.Config,
 ) (exporter.Metrics, error) {
-	oce, err := newExporter(cfg, set, createArrowMetricsStream)
+	exp, err := newExporter(cfg, set, createArrowMetricsStream)
 	if err != nil {
 		return nil, err
 	}
-	return exporterhelper.NewMetricsExporter(ctx, oce.settings, oce.config,
-		oce.pushMetrics,
-		oce.helperOptions()...,
+	return exporterhelper.NewMetricsExporter(ctx, exp.settings, exp.config,
+		exp.pushMetrics,
+		exp.helperOptions()...,
 	)
 }
 
@@ -135,12 +135,12 @@ func createLogsExporter(
 	set exporter.CreateSettings,
 	cfg component.Config,
 ) (exporter.Logs, error) {
-	oce, err := newExporter(cfg, set, createArrowLogsStream)
+	exp, err := newExporter(cfg, set, createArrowLogsStream)
 	if err != nil {
 		return nil, err
 	}
-	return exporterhelper.NewLogsExporter(ctx, oce.settings, oce.config,
-		oce.pushLogs,
-		oce.helperOptions()...,
+	return exporterhelper.NewLogsExporter(ctx, exp.settings, exp.config,
+		exp.pushLogs,
+		exp.helperOptions()...,
 	)
 }

--- a/collector/exporter/otelarrowexporter/factory_test.go
+++ b/collector/exporter/otelarrowexporter/factory_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/open-telemetry/otel-arrow/collector/compression/zstd"
-	"github.com/open-telemetry/otel-arrow/collector/exporter/otelarrowexporter/internal/arrow"
 	"github.com/open-telemetry/otel-arrow/collector/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,6 +22,8 @@ import (
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/exporter/exportertest"
+
+	"github.com/open-telemetry/otel-arrow/collector/exporter/otelarrowexporter/internal/arrow"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {

--- a/collector/exporter/otelarrowexporter/internal/metadata/generated_status.go
+++ b/collector/exporter/otelarrowexporter/internal/metadata/generated_status.go
@@ -4,8 +4,6 @@ package metadata
 
 import (
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/trace"
 )
 
 var (
@@ -17,11 +15,3 @@ const (
 	MetricsStability = component.StabilityLevelDevelopment
 	LogsStability    = component.StabilityLevelDevelopment
 )
-
-func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter("otelcol/otelarrow")
-}
-
-func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer("otelcol/otelarrow")
-}

--- a/collector/exporter/otelarrowexporter/otelarrow_test.go
+++ b/collector/exporter/otelarrowexporter/otelarrow_test.go
@@ -988,6 +988,8 @@ func testSendArrowTraces(t *testing.T, clientWaitForReady, streamServiceAvailabl
 	md := rcv.getMetadata()
 	require.EqualValues(t, []string{"arrow"}, md.Get("callerid"))
 	require.EqualValues(t, expectedHeader, md.Get("header"))
+
+	rcv.srv.GracefulStop()
 }
 
 func okStatusFor(id int64) *arrowpb.BatchStatus {
@@ -1131,6 +1133,8 @@ func TestSendArrowFailedTraces(t *testing.T) {
 	assert.EqualValues(t, int32(2), rcv.totalItems.Load())
 	assert.EqualValues(t, int32(1), rcv.requestCount.Load())
 	assert.EqualValues(t, td, rcv.getLastRequest())
+
+	rcv.srv.GracefulStop()
 }
 
 func TestUserDialOptions(t *testing.T) {

--- a/collector/receiver/otelarrowreceiver/config.go
+++ b/collector/receiver/otelarrowreceiver/config.go
@@ -24,16 +24,6 @@ type ArrowConfig struct {
 	// passing through, they will see ResourceExhausted errors.
 	MemoryLimitMiB uint64 `mapstructure:"memory_limit_mib"`
 
-	// AdmissionLimitMiB limits the number of requests that are received by the stream based on
-	// request size information available. Request size is used to control how much traffic we admit
-	// for processing, but does not control how much memory is used during request processing.
-	AdmissionLimitMiB uint64 `mapstructure:"admission_limit_mib"`
-
-	// WaiterLimit is the limit on the number of waiters waiting to be processed and consumed.
-	// This is a dimension of memory limiting to ensure waiters are not consuming an
-	// unexpectedly large amount of memory in the arrow receiver.
-	WaiterLimit int64 `mapstructure:"waiter_limit"`
-
 	// Zstd settings apply to OTel-Arrow use of gRPC specifically.
 	Zstd zstd.DecoderConfig `mapstructure:"zstd"`
 }

--- a/collector/receiver/otelarrowreceiver/config_test.go
+++ b/collector/receiver/otelarrowreceiver/config_test.go
@@ -77,9 +77,7 @@ func TestUnmarshalConfig(t *testing.T) {
 					},
 				},
 				Arrow: ArrowConfig{
-					MemoryLimitMiB:    123,
-					AdmissionLimitMiB: 80,
-					WaiterLimit:       100,
+					MemoryLimitMiB: 123,
 				},
 			},
 		}, cfg)
@@ -103,9 +101,7 @@ func TestUnmarshalConfigUnix(t *testing.T) {
 					ReadBufferSize: 512 * 1024,
 				},
 				Arrow: ArrowConfig{
-					MemoryLimitMiB:    defaultMemoryLimitMiB,
-					AdmissionLimitMiB: defaultAdmissionLimitMiB,
-					WaiterLimit:       defaultWaiterLimit,
+					MemoryLimitMiB: defaultMemoryLimitMiB,
 				},
 			},
 		}, cfg)

--- a/collector/receiver/otelarrowreceiver/factory.go
+++ b/collector/receiver/otelarrowreceiver/factory.go
@@ -19,15 +19,13 @@ import (
 const (
 	defaultGRPCEndpoint = "0.0.0.0:4317"
 
-	defaultMemoryLimitMiB    = 128
-	defaultAdmissionLimitMiB = defaultMemoryLimitMiB / 2
-	defaultWaiterLimit       = 1000
+	defaultMemoryLimitMiB = 128
 )
 
-// NewFactory creates a new OTLP receiver factory.
+// NewFactory creates a new OTel-Arrow receiver factory.
 func NewFactory() receiver.Factory {
 	return receiver.NewFactory(
-		component.MustNewType(metadata.Type),
+		metadata.Type,
 		createDefaultConfig,
 		receiver.WithTraces(createTraces, metadata.TracesStability),
 		receiver.WithMetrics(createMetrics, metadata.MetricsStability),
@@ -47,9 +45,7 @@ func createDefaultConfig() component.Config {
 				ReadBufferSize: 512 * 1024,
 			},
 			Arrow: ArrowConfig{
-				MemoryLimitMiB:    defaultMemoryLimitMiB,
-				AdmissionLimitMiB: defaultAdmissionLimitMiB,
-				WaiterLimit:       defaultWaiterLimit,
+				MemoryLimitMiB: defaultMemoryLimitMiB,
 			},
 		},
 	}

--- a/collector/receiver/otelarrowreceiver/internal/arrow/arrow.go
+++ b/collector/receiver/otelarrowreceiver/internal/arrow/arrow.go
@@ -8,11 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
-	"runtime"
-	"strconv"
 	"strings"
-	"sync"
 
 	arrowpb "github.com/open-telemetry/otel-arrow/api/experimental/arrow/v1"
 	"github.com/open-telemetry/otel-arrow/collector/netstats"
@@ -41,9 +37,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
-
-	"github.com/open-telemetry/otel-arrow/collector/admission"
 )
 
 const (
@@ -82,8 +75,6 @@ type Receiver struct {
 	recvInFlightBytes    metric.Int64UpDownCounter
 	recvInFlightItems    metric.Int64UpDownCounter
 	recvInFlightRequests metric.Int64UpDownCounter
-	boundedQueue         *admission.BoundedQueue
-	inFlightWG           sync.WaitGroup
 }
 
 // New creates a new Receiver reference.
@@ -94,21 +85,19 @@ func New(
 	gsettings configgrpc.ServerConfig,
 	authServer auth.Server,
 	newConsumer func() arrowRecord.ConsumerAPI,
-	bq *admission.BoundedQueue,
 	netReporter netstats.Interface,
 ) (*Receiver, error) {
 	tracer := set.TelemetrySettings.TracerProvider.Tracer("otel-arrow-receiver")
 	var errors, err error
 	recv := &Receiver{
-		Consumers:    cs,
-		obsrecv:      obsrecv,
-		telemetry:    set.TelemetrySettings,
-		tracer:       tracer,
-		authServer:   authServer,
-		newConsumer:  newConsumer,
-		gsettings:    gsettings,
-		netReporter:  netReporter,
-		boundedQueue: bq,
+		Consumers:   cs,
+		obsrecv:     obsrecv,
+		telemetry:   set.TelemetrySettings,
+		tracer:      tracer,
+		authServer:  authServer,
+		newConsumer: newConsumer,
+		gsettings:   gsettings,
+		netReporter: netReporter,
 	}
 
 	meter := recv.telemetry.MeterProvider.Meter(scopeName)
@@ -340,16 +329,10 @@ type anyStreamServer interface {
 	grpc.ServerStream
 }
 
-type batchResp struct {
-	addr           net.Addr
-	id             int64
-	err            error
-	bytesToRelease int64
-}
-
 func (r *Receiver) anyStream(serverStream anyStreamServer, method string) (retErr error) {
 	streamCtx := serverStream.Context()
 	ac := r.newConsumer()
+	hrcv := newHeaderReceiver(serverStream.Context(), r.authServer, r.gsettings.IncludeMetadata)
 
 	defer func() {
 		if err := recover(); err != nil {
@@ -367,199 +350,48 @@ func (r *Receiver) anyStream(serverStream anyStreamServer, method string) (retEr
 		}
 	}()
 
-	doneCtx, doneCancel := context.WithCancel(streamCtx)
-	defer doneCancel()
-	streamErrCh := make(chan error, 2)
-	pendingCh := make(chan batchResp, runtime.NumCPU())
-
-	go func() {
-		err := r.srvReceiveLoop(doneCtx, serverStream, pendingCh, method, ac)
-		streamErrCh <- err
-	}()
-
-	// WG is used to ensure main thread only returns once sender is finished sending responses for all requests.
-	var senderWG sync.WaitGroup
-	senderWG.Add(1)
-	go func() {
-		err := r.srvSendLoop(doneCtx, serverStream, pendingCh)
-		streamErrCh <- err
-		senderWG.Done()
-	}()
-
-	select {
-	case <-doneCtx.Done():
-		senderWG.Wait()
-		return status.Error(codes.Canceled, "server stream shutdown")
-	case retErr = <-streamErrCh:
-		doneCancel()
-		senderWG.Wait()
-		return
-	}
-}
-
-func (r *Receiver) recvOne(ctx context.Context, serverStream anyStreamServer, hrcv *headerReceiver, pendingCh chan<- batchResp, method string, ac arrowRecord.ConsumerAPI) (retErr error) {
-	r.inFlightWG.Add(1)
-	defer func() {
-		if retErr != nil {
-			r.inFlightWG.Done() // not processed
-			r.logStreamError(retErr)
-		}
-	}()
-
-	// Receive a batch corresponding with one ptrace.Traces, pmetric.Metrics,
-	// or plog.Logs item.
-	req, err := serverStream.Recv()
-
-	if err != nil {
-		if errors.Is(err, io.EOF) {
-			return status.Error(codes.Canceled, "client stream shutdown")
-		} else if errors.Is(err, context.Canceled) {
-			return status.Error(codes.Canceled, "server stream shutdown")
-		}
-		return err
-	}
-
-	// Check for optional headers and set the incoming context.
-	thisCtx, authHdrs, err := hrcv.combineHeaders(ctx, req.GetHeaders())
-	if err != nil {
-		// Failing to parse the incoming headers breaks the stream.
-		return fmt.Errorf("arrow metadata error: %w", err)
-	}
-	var prevAcquiredBytes int
-	uncompSizeStr, sizeHeaderFound := authHdrs["otlp-pdata-size"]
-	if !sizeHeaderFound || len(uncompSizeStr) == 0 {
-		// This is a compressed size so make sure to acquire the difference when request is decompressed.
-		prevAcquiredBytes = proto.Size(req)
-	} else {
-		prevAcquiredBytes, err = strconv.Atoi(uncompSizeStr[0])
+	for {
+		// Receive a batch corresponding with one ptrace.Traces, pmetric.Metrics,
+		// or plog.Logs item.
+		req, err := serverStream.Recv()
 		if err != nil {
-			return fmt.Errorf("failed to convert string to request size: %w", err)
-		}
-	}
-	// bounded queue to memory limit based on incoming uncompressed request size and waiters.
-	// Acquire will fail immediately if there are too many waiters,
-	// or will otherwise block until timeout or enough memory becomes available.
-	err = r.boundedQueue.Acquire(ctx, int64(prevAcquiredBytes))
-	if err != nil {
-		return fmt.Errorf("breaking stream: %w", err)
-	}
+			// This includes the case where a client called CloseSend(), in
+			// which case we see an EOF error here.
+			r.logStreamError(err)
 
-	resp := batchResp{
-		addr:           hrcv.connInfo.Addr,
-		id:             req.GetBatchId(),
-		bytesToRelease: int64(prevAcquiredBytes),
-	}
-
-	var authErr error
-	if r.authServer != nil {
-		var newCtx context.Context
-		if newCtx, err = r.authServer.Authenticate(thisCtx, authHdrs); err != nil {
-			authErr = err
-		} else {
-			thisCtx = newCtx
-		}
-	}
-
-	// processAndConsume will process and send an error to the sender loop
-	go func() {
-		defer r.inFlightWG.Done() // done processing
-		err = r.processAndConsume(thisCtx, method, ac, req, authErr, resp, sizeHeaderFound)
-		resp.err = err
-		pendingCh <- resp
-	}()
-
-	return nil
-}
-
-func (r *Receiver) srvReceiveLoop(ctx context.Context, serverStream anyStreamServer, pendingCh chan<- batchResp, method string, ac arrowRecord.ConsumerAPI) (retErr error) {
-	hrcv := newHeaderReceiver(ctx, r.authServer, r.gsettings.IncludeMetadata)
-	for {
-		select {
-		case <-ctx.Done():
-			return status.Error(codes.Canceled, "server stream shutdown")
-		default:
-			err := r.recvOne(ctx, serverStream, hrcv, pendingCh, method, ac)
-			if err != nil {
-				return err
+			if errors.Is(err, io.EOF) {
+				return status.Error(codes.Canceled, "client stream shutdown")
+			} else if errors.Is(err, context.Canceled) {
+				return status.Error(codes.Canceled, "server stream shutdown")
 			}
-		}
-	}
-}
-
-func (r *Receiver) sendOne(serverStream anyStreamServer, resp batchResp) error {
-	// Note: Statuses can be batched, but we do not take
-	// advantage of this feature.
-	status := &arrowpb.BatchStatus{
-		BatchId: resp.id,
-	}
-	if resp.err == nil {
-		status.StatusCode = arrowpb.StatusCode_OK
-	} else {
-		status.StatusMessage = resp.err.Error()
-		switch {
-		case errors.Is(resp.err, arrowRecord.ErrConsumerMemoryLimit):
-			r.telemetry.Logger.Error("arrow resource exhausted", zap.Error(resp.err))
-			status.StatusCode = arrowpb.StatusCode_RESOURCE_EXHAUSTED
-		case consumererror.IsPermanent(resp.err):
-			r.telemetry.Logger.Error("arrow data error", zap.Error(resp.err))
-			status.StatusCode = arrowpb.StatusCode_INVALID_ARGUMENT
-		default:
-			r.telemetry.Logger.Debug("arrow consumer error", zap.Error(resp.err))
-			status.StatusCode = arrowpb.StatusCode_UNAVAILABLE
-		}
-	}
-
-	err := serverStream.Send(status)
-	if err != nil {
-		r.logStreamError(err)
-		return err
-	}
-
-	err = r.boundedQueue.Release(resp.bytesToRelease)
-	if err != nil {
-		r.logStreamError(err)
-		return err
-	}
-
-	return nil
-}
-
-func (r *Receiver) flushSender(serverStream anyStreamServer, pendingCh <-chan batchResp) error {
-	var err error
-	// wait for all in flight requests to successfully be processed or fail.
-	r.inFlightWG.Wait()
-	for {
-		select {
-		case resp := <-pendingCh:
-			err = r.sendOne(serverStream, resp)
-			if err != nil {
-				return err
-			}
-		default:
-			// Currently nothing left in pendingCh.
-			return nil
-		}
-	}
-}
-
-func (r *Receiver) srvSendLoop(ctx context.Context, serverStream anyStreamServer, pendingCh <-chan batchResp) error {
-	var err error
-	for {
-		select {
-		case <-ctx.Done():
-			err = r.flushSender(serverStream, pendingCh)
-			// err := multierr.Append(err, ctx.Err())
 			return err
-		case resp := <-pendingCh:
-			err = r.sendOne(serverStream, resp)
-			if err != nil {
-				return err
+		}
+
+		// Check for optional headers and set the incoming context.
+		thisCtx, authHdrs, err := hrcv.combineHeaders(streamCtx, req.GetHeaders())
+		if err != nil {
+			// Failing to parse the incoming headers breaks the stream.
+			r.telemetry.Logger.Error("arrow metadata error", zap.Error(err))
+			return err
+		}
+
+		var authErr error
+		if r.authServer != nil {
+			var newCtx context.Context
+			if newCtx, err = r.authServer.Authenticate(thisCtx, authHdrs); err != nil {
+				authErr = err
+			} else {
+				thisCtx = newCtx
 			}
+		}
+
+		if err := r.processAndConsume(thisCtx, method, ac, req, serverStream, authErr); err != nil {
+			return err
 		}
 	}
 }
 
-func (r *Receiver) processAndConsume(ctx context.Context, method string, arrowConsumer arrowRecord.ConsumerAPI, req *arrowpb.BatchArrowRecords, authErr error, response batchResp, sizeHeaderFound bool) error {
+func (r *Receiver) processAndConsume(ctx context.Context, method string, arrowConsumer arrowRecord.ConsumerAPI, req *arrowpb.BatchArrowRecords, serverStream anyStreamServer, authErr error) (retErr error) {
 	var err error
 
 	ctx, span := r.tracer.Start(ctx, "otel_arrow_stream_recv")
@@ -569,9 +401,9 @@ func (r *Receiver) processAndConsume(ctx context.Context, method string, arrowCo
 	defer func() {
 		r.recvInFlightRequests.Add(ctx, -1)
 		// Set span status if an error is returned.
-		if err != nil {
+		if retErr != nil {
 			span := trace.SpanFromContext(ctx)
-			span.SetStatus(otelcodes.Error, err.Error())
+			span.SetStatus(otelcodes.Error, retErr.Error())
 		}
 	}()
 
@@ -580,17 +412,44 @@ func (r *Receiver) processAndConsume(ctx context.Context, method string, arrowCo
 	if authErr != nil {
 		err = authErr
 	} else {
-		err = r.processRecords(ctx, method, arrowConsumer, req, response, sizeHeaderFound)
+		err = r.processRecords(ctx, method, arrowConsumer, req)
 	}
 
-	return err
+	// Note: Statuses can be batched, but we do not take
+	// advantage of this feature.
+	status := &arrowpb.BatchStatus{
+		BatchId: req.GetBatchId(),
+	}
+	if err == nil {
+		status.StatusCode = arrowpb.StatusCode_OK
+	} else {
+		status.StatusMessage = err.Error()
+		switch {
+		case errors.Is(err, arrowRecord.ErrConsumerMemoryLimit):
+			r.telemetry.Logger.Error("arrow resource exhausted", zap.Error(err))
+			status.StatusCode = arrowpb.StatusCode_RESOURCE_EXHAUSTED
+		case consumererror.IsPermanent(err):
+			r.telemetry.Logger.Error("arrow data error", zap.Error(err))
+			status.StatusCode = arrowpb.StatusCode_INVALID_ARGUMENT
+		default:
+			r.telemetry.Logger.Debug("arrow consumer error", zap.Error(err))
+			status.StatusCode = arrowpb.StatusCode_UNAVAILABLE
+		}
+	}
+
+	err = serverStream.Send(status)
+	if err != nil {
+		r.logStreamError(err)
+		return err
+	}
+	return nil
 }
 
 // processRecords returns an error and a boolean indicating whether
 // the error (true) was from processing the data (i.e., invalid
 // argument) or (false) from the consuming pipeline.  The boolean is
 // not used when success (nil error) is returned.
-func (r *Receiver) processRecords(ctx context.Context, method string, arrowConsumer arrowRecord.ConsumerAPI, records *arrowpb.BatchArrowRecords, response batchResp, sizeHeaderFound bool) error {
+func (r *Receiver) processRecords(ctx context.Context, method string, arrowConsumer arrowRecord.ConsumerAPI, records *arrowpb.BatchArrowRecords) error {
 	payloads := records.GetArrowPayloads()
 	if len(payloads) == 0 {
 		return nil
@@ -639,15 +498,6 @@ func (r *Receiver) processRecords(ctx context.Context, method string, arrowConsu
 					r.Metrics().ConsumeMetrics(ctx, metrics),
 				)
 			}
-
-			acquireErr := r.acquireAdditionalBytes(ctx, uncompSize, response, sizeHeaderFound)
-
-			if acquireErr != nil {
-				err = multierr.Append(err, acquireErr)
-				// if acquireAdditionalBytes() failed then the previously acquired bytes were already released i.e. nothing to releaes.
-				return err
-			}
-
 			// entire request has been processed, decrement counter.
 			r.recvInFlightBytes.Add(ctx, -uncompSize)
 			r.recvInFlightItems.Add(ctx, int64(-numPts))
@@ -679,15 +529,6 @@ func (r *Receiver) processRecords(ctx context.Context, method string, arrowConsu
 					r.Logs().ConsumeLogs(ctx, logs),
 				)
 			}
-
-			acquireErr := r.acquireAdditionalBytes(ctx, uncompSize, response, sizeHeaderFound)
-
-			if acquireErr != nil {
-				err = multierr.Append(err, acquireErr)
-				// if acquireAdditionalBytes() failed then the previously acquired bytes were already released i.e. nothing to releaes.
-				return err
-			}
-
 			// entire request has been processed, decrement counter.
 			r.recvInFlightBytes.Add(ctx, -uncompSize)
 			r.recvInFlightItems.Add(ctx, int64(-numLogs))
@@ -721,14 +562,6 @@ func (r *Receiver) processRecords(ctx context.Context, method string, arrowConsu
 				)
 			}
 
-			acquireErr := r.acquireAdditionalBytes(ctx, uncompSize, response, sizeHeaderFound)
-
-			if acquireErr != nil {
-				err = multierr.Append(err, acquireErr)
-				// if acquireAdditionalBytes() failed then the previously acquired bytes were already released i.e. nothing to releaes.
-				return err
-			}
-
 			// entire request has been processed, decrement counter.
 			r.recvInFlightBytes.Add(ctx, -uncompSize)
 			r.recvInFlightItems.Add(ctx, int64(-numSpans))
@@ -739,44 +572,4 @@ func (r *Receiver) processRecords(ctx context.Context, method string, arrowConsu
 	default:
 		return ErrUnrecognizedPayload
 	}
-}
-
-func (r *Receiver) acquireAdditionalBytes(ctx context.Context, uncompSize int64, response batchResp, sizeHeaderFound bool) error {
-	diff := uncompSize - response.bytesToRelease
-
-	var err error
-	if diff != 0 {
-		if sizeHeaderFound {
-			var clientAddr string
-			if response.addr != nil {
-				clientAddr = response.addr.String()
-			}
-			// a mismatch between header set by exporter and the uncompSize just calculated.
-			r.telemetry.Logger.Debug("mismatch between uncompressed size in receiver and otlp-pdata-size header", zap.String("client-address", clientAddr), zap.Int("uncompsize", int(uncompSize)), zap.Int("otlp-pdata-size", int(response.bytesToRelease)))
-		} else if diff < 0 {
-			// proto.Size() on compressed request was greater than pdata uncompressed size.
-			r.telemetry.Logger.Debug("uncompressed size is less than compressed size", zap.Int("uncompressed", int(uncompSize)), zap.Int("compressed", int(response.bytesToRelease)))
-		}
-
-		if diff > 0 {
-			// diff > 0 means we previously acquired too few bytes initially and we need to correct this. Release previously
-			// acquired bytes to prevent deadlock and reacquire the uncompressed size we just calculated.
-			// Note: No need to release and reacquire bytes if diff < 0 because this has less impact and no reason to potentially block
-			// a request that is in flight by reacquiring the correct size.
-			err = r.boundedQueue.Release(response.bytesToRelease)
-			if err != nil {
-				return err
-			}
-
-			err = r.boundedQueue.Acquire(ctx, uncompSize)
-			if err != nil {
-				response.bytesToRelease = int64(0)
-			} else {
-				response.bytesToRelease = uncompSize
-			}
-		}
-
-	}
-
-	return err
 }

--- a/collector/receiver/otelarrowreceiver/internal/metadata/generated_status.go
+++ b/collector/receiver/otelarrowreceiver/internal/metadata/generated_status.go
@@ -6,9 +6,12 @@ import (
 	"go.opentelemetry.io/collector/component"
 )
 
+var (
+	Type = component.MustNewType("otelarrow")
+)
+
 const (
-	Type             = "otelarrow"
-	MetricsStability = component.StabilityLevelDevelopment
 	TracesStability  = component.StabilityLevelDevelopment
+	MetricsStability = component.StabilityLevelDevelopment
 	LogsStability    = component.StabilityLevelDevelopment
 )

--- a/collector/receiver/otelarrowreceiver/otelarrow.go
+++ b/collector/receiver/otelarrowreceiver/otelarrow.go
@@ -24,7 +24,6 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
-	"github.com/open-telemetry/otel-arrow/collector/admission"
 	"github.com/open-telemetry/otel-arrow/collector/receiver/otelarrowreceiver/internal/arrow"
 	"github.com/open-telemetry/otel-arrow/collector/receiver/otelarrowreceiver/internal/logs"
 	"github.com/open-telemetry/otel-arrow/collector/receiver/otelarrowreceiver/internal/metrics"
@@ -114,7 +113,6 @@ func (r *otelArrowReceiver) startProtocolServers(host component.Host) error {
 			return err
 		}
 	}
-	bq :=  admission.NewBoundedQueue(int64(r.cfg.Arrow.AdmissionLimitMiB<<20), r.cfg.Arrow.WaiterLimit)
 
 	r.arrowReceiver, err = arrow.New(arrow.Consumers(r), r.settings, r.obsrepGRPC, r.cfg.GRPC, authServer, func() arrowRecord.ConsumerAPI {
 		var opts []arrowRecord.Option
@@ -126,7 +124,7 @@ func (r *otelArrowReceiver) startProtocolServers(host component.Host) error {
 			opts = append(opts, arrowRecord.WithMeterProvider(r.settings.TelemetrySettings.MeterProvider, r.settings.TelemetrySettings.MetricsLevel))
 		}
 		return arrowRecord.NewConsumer(opts...)
-	}, bq, r.netReporter)
+	}, r.netReporter)
 
 	if err != nil {
 		return err

--- a/collector/receiver/otelarrowreceiver/otelarrow_test.go
+++ b/collector/receiver/otelarrowreceiver/otelarrow_test.go
@@ -49,7 +49,7 @@ import (
 
 const otlpReceiverName = "receiver_test"
 
-var testReceiverID = component.NewIDWithName(component.MustNewType(componentMetadata.Type), otlpReceiverName)
+var testReceiverID = component.NewIDWithName(componentMetadata.Type, otlpReceiverName)
 
 func TestGRPCNewPortAlreadyUsed(t *testing.T) {
 	addr := testutil.GetAvailableLocalAddress(t)


### PR DESCRIPTION
Automated content generation: 
Copy diffs from the collector-contrib repository back into this repo, avoiding divergence.

From https://github.com/open-telemetry/opentelemetry-collector-contrib/commit/726ffec310654866f7c3a1b668eec288e36c09e5.