### PR TITLE
Backport exporter changes from collector-contrib

### DIFF
--- a/collector/exporter/otelarrowexporter/config.go
+++ b/collector/exporter/otelarrowexporter/config.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/open-telemetry/otel-arrow/collector/compression/zstd"
-	"github.com/open-telemetry/otel-arrow/collector/exporter/otelarrowexporter/internal/arrow"
 	"github.com/open-telemetry/otel-arrow/pkg/config"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configcompression"
@@ -16,6 +15,8 @@ import (
 	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"google.golang.org/grpc"
+
+	"github.com/open-telemetry/otel-arrow/collector/exporter/otelarrowexporter/internal/arrow"
 )
 
 // Config defines configuration for OTLP exporter.

--- a/collector/exporter/otelarrowexporter/config_test.go
+++ b/collector/exporter/otelarrowexporter/config_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/open-telemetry/otel-arrow/collector/compression/zstd"
-	"github.com/open-telemetry/otel-arrow/collector/exporter/otelarrowexporter/internal/arrow"
 	"github.com/open-telemetry/otel-arrow/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,6 +22,8 @@ import (
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
+
+	"github.com/open-telemetry/otel-arrow/collector/exporter/otelarrowexporter/internal/arrow"
 )
 
 func TestUnmarshalDefaultConfig(t *testing.T) {

--- a/collector/exporter/otelarrowexporter/factory.go
+++ b/collector/exporter/otelarrowexporter/factory.go
@@ -67,14 +67,14 @@ func createDefaultConfig() component.Config {
 	}
 }
 
-func (oce *baseExporter) helperOptions() []exporterhelper.Option {
+func (exp *baseExporter) helperOptions() []exporterhelper.Option {
 	return []exporterhelper.Option{
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
-		exporterhelper.WithTimeout(oce.config.TimeoutSettings),
-		exporterhelper.WithRetry(oce.config.RetryConfig),
-		exporterhelper.WithQueue(oce.config.QueueSettings),
-		exporterhelper.WithStart(oce.start),
-		exporterhelper.WithShutdown(oce.shutdown),
+		exporterhelper.WithTimeout(exp.config.TimeoutSettings),
+		exporterhelper.WithRetry(exp.config.RetryConfig),
+		exporterhelper.WithQueue(exp.config.QueueSettings),
+		exporterhelper.WithStart(exp.start),
+		exporterhelper.WithShutdown(exp.shutdown),
 	}
 }
 
@@ -97,13 +97,13 @@ func createTracesExporter(
 	set exporter.CreateSettings,
 	cfg component.Config,
 ) (exporter.Traces, error) {
-	oce, err := newExporter(cfg, set, createArrowTracesStream)
+	exp, err := newExporter(cfg, set, createArrowTracesStream)
 	if err != nil {
 		return nil, err
 	}
-	return exporterhelper.NewTracesExporter(ctx, oce.settings, oce.config,
-		oce.pushTraces,
-		oce.helperOptions()...,
+	return exporterhelper.NewTracesExporter(ctx, exp.settings, exp.config,
+		exp.pushTraces,
+		exp.helperOptions()...,
 	)
 }
 
@@ -116,13 +116,13 @@ func createMetricsExporter(
 	set exporter.CreateSettings,
 	cfg component.Config,
 ) (exporter.Metrics, error) {
-	oce, err := newExporter(cfg, set, createArrowMetricsStream)
+	exp, err := newExporter(cfg, set, createArrowMetricsStream)
 	if err != nil {
 		return nil, err
 	}
-	return exporterhelper.NewMetricsExporter(ctx, oce.settings, oce.config,
-		oce.pushMetrics,
-		oce.helperOptions()...,
+	return exporterhelper.NewMetricsExporter(ctx, exp.settings, exp.config,
+		exp.pushMetrics,
+		exp.helperOptions()...,
 	)
 }
 
@@ -135,12 +135,12 @@ func createLogsExporter(
 	set exporter.CreateSettings,
 	cfg component.Config,
 ) (exporter.Logs, error) {
-	oce, err := newExporter(cfg, set, createArrowLogsStream)
+	exp, err := newExporter(cfg, set, createArrowLogsStream)
 	if err != nil {
 		return nil, err
 	}
-	return exporterhelper.NewLogsExporter(ctx, oce.settings, oce.config,
-		oce.pushLogs,
-		oce.helperOptions()...,
+	return exporterhelper.NewLogsExporter(ctx, exp.settings, exp.config,
+		exp.pushLogs,
+		exp.helperOptions()...,
 	)
 }

--- a/collector/exporter/otelarrowexporter/factory_test.go
+++ b/collector/exporter/otelarrowexporter/factory_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/open-telemetry/otel-arrow/collector/compression/zstd"
-	"github.com/open-telemetry/otel-arrow/collector/exporter/otelarrowexporter/internal/arrow"
 	"github.com/open-telemetry/otel-arrow/collector/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,6 +22,8 @@ import (
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/exporter/exportertest"
+
+	"github.com/open-telemetry/otel-arrow/collector/exporter/otelarrowexporter/internal/arrow"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {

--- a/collector/exporter/otelarrowexporter/internal/metadata/generated_status.go
+++ b/collector/exporter/otelarrowexporter/internal/metadata/generated_status.go
@@ -4,8 +4,6 @@ package metadata
 
 import (
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/trace"
 )
 
 var (
@@ -17,11 +15,3 @@ const (
 	MetricsStability = component.StabilityLevelDevelopment
 	LogsStability    = component.StabilityLevelDevelopment
 )
-
-func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter("otelcol/otelarrow")
-}
-
-func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer("otelcol/otelarrow")
-}

--- a/collector/exporter/otelarrowexporter/otelarrow_test.go
+++ b/collector/exporter/otelarrowexporter/otelarrow_test.go
@@ -988,6 +988,8 @@ func testSendArrowTraces(t *testing.T, clientWaitForReady, streamServiceAvailabl
 	md := rcv.getMetadata()
 	require.EqualValues(t, []string{"arrow"}, md.Get("callerid"))
 	require.EqualValues(t, expectedHeader, md.Get("header"))
+
+	rcv.srv.GracefulStop()
 }
 
 func okStatusFor(id int64) *arrowpb.BatchStatus {
@@ -1131,6 +1133,8 @@ func TestSendArrowFailedTraces(t *testing.T) {
 	assert.EqualValues(t, int32(2), rcv.totalItems.Load())
 	assert.EqualValues(t, int32(1), rcv.requestCount.Load())
 	assert.EqualValues(t, td, rcv.getLastRequest())
+
+	rcv.srv.GracefulStop()
 }
 
 func TestUserDialOptions(t *testing.T) {


### PR DESCRIPTION
Automated content generation:
Copy diffs from the collector-contrib repository back into this repo's otelarrowexporter, avoiding divergence.

From https://github.com/open-telemetry/opentelemetry-collector-contrib/commit/726ffec310654866f7c3a1b668eec288e36c09e5.