### PR TITLE
[otelarrowexporter] Deflake TestSendArrowTracesNotSupported

### DIFF
--- a/collector/exporter/otelarrowexporter/otelarrow_test.go
+++ b/collector/exporter/otelarrowexporter/otelarrow_test.go
@@ -935,10 +935,6 @@ func testSendArrowTraces(t *testing.T, clientWaitForReady, streamServiceAvailabl
 	require.NoError(t, err)
 	require.NotNil(t, exp)
 
-	defer func() {
-		assert.NoError(t, exp.Shutdown(context.Background()))
-	}()
-
 	type isUserCall struct{}
 
 	host := newHostWithExtensions(
@@ -956,6 +952,15 @@ func testSendArrowTraces(t *testing.T, clientWaitForReady, streamServiceAvailabl
 	assert.NoError(t, exp.Start(context.Background(), host))
 
 	rcv, _ := otelArrowTracesReceiverOnGRPCServer(ln, false)
+
+	defer func() {
+		// Shutdown before GracefulStop, because otherwise we
+		// wait for a full stream lifetime instead of closing
+		// after requests are served.
+		assert.NoError(t, exp.Shutdown(context.Background()))
+		rcv.srv.GracefulStop()
+	}()
+
 	if streamServiceAvailable {
 		rcv.startStreamMockArrowTraces(t, okStatusFor)
 	}
@@ -988,8 +993,6 @@ func testSendArrowTraces(t *testing.T, clientWaitForReady, streamServiceAvailabl
 	md := rcv.getMetadata()
 	require.EqualValues(t, []string{"arrow"}, md.Get("callerid"))
 	require.EqualValues(t, expectedHeader, md.Get("header"))
-
-	rcv.srv.GracefulStop()
 }
 
 func okStatusFor(id int64) *arrowpb.BatchStatus {


### PR DESCRIPTION
There is a test flake, seen here. I believe this is for failing to shutdown the service, which causes a 100s long run-time. This does not explain a deadlock, but we aren't sure that has happened, vs a timeout due to CPU shortage.

https://github.com/open-telemetry/otel-arrow/actions/runs/9180018006/job/25243494523