### PR TITLE
[collector/netstats] Move span API calls into Count methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Unreleased
 
 - Jitter is applied to once per process, not once per stream. [#199](https://github.com/open-telemetry/otel-arrow/pull/199)
+- Network statistics tracing instrumentation simplified. [#201](https://github.com/open-telemetry/otel-arrow/pull/201)
 
 ## [0.23.0](https://github.com/open-telemetry/otel-arrow/releases/tag/v0.23.0) - 2024-05-09
 

--- a/collector/exporter/otelarrowexporter/internal/arrow/stream.go
+++ b/collector/exporter/otelarrowexporter/internal/arrow/stream.go
@@ -351,13 +351,10 @@ func (s *Stream) encodeAndSend(wri writeItem, hdrsBuf *bytes.Buffer, hdrsEnc *hp
 	// unreliable for arrow transport, so we instrument it
 	// directly here.  Only the primary direction of transport
 	// is instrumented this way.
-	if wri.uncompSize != 0 {
-		var sized netstats.SizesStruct
-		sized.Method = s.method
-		sized.Length = int64(wri.uncompSize)
-		s.netReporter.CountSend(ctx, sized)
-		s.netReporter.SetSpanSizeAttributes(ctx, sized)
-	}
+	var sized netstats.SizesStruct
+	sized.Method = s.method
+	sized.Length = int64(wri.uncompSize)
+	s.netReporter.CountSend(ctx, sized)
 
 	if err := s.client.Send(batch); err != nil {
 		// The error will be sent to errCh during cleanup for this stream.

--- a/collector/netstats/handler.go
+++ b/collector/netstats/handler.go
@@ -60,7 +60,6 @@ func (h statsHandler) HandleRPC(ctx context.Context, rs stats.RPCStats) {
 		}
 		ss.WireLength = int64(s.WireLength)
 		h.rep.CountReceive(ctx, ss)
-		h.rep.SetSpanSizeAttributes(ctx, ss)
 
 	case *stats.OutPayload:
 		var ss SizesStruct
@@ -70,7 +69,6 @@ func (h statsHandler) HandleRPC(ctx context.Context, rs stats.RPCStats) {
 		}
 		ss.WireLength = int64(s.WireLength)
 		h.rep.CountSend(ctx, ss)
-		h.rep.SetSpanSizeAttributes(ctx, ss)
 	}
 }
 

--- a/collector/netstats/netstats.go
+++ b/collector/netstats/netstats.go
@@ -60,6 +60,8 @@ type NetworkReporter struct {
 	compSizeHisto metric.Int64Histogram
 }
 
+var _ Interface = &NetworkReporter{}
+
 // SizesStruct is used to pass uncompressed on-wire message lengths to
 // the CountSend() and CountReceive() methods.
 type SizesStruct struct {
@@ -79,7 +81,10 @@ type Interface interface {
 	// CountSend reports inbound bytes.
 	CountReceive(ctx context.Context, ss SizesStruct)
 
-	// SetSpanAttributes takes a context and adds attributes to the associated span.
+	// SetSpanAttributes is a No-Op. Deprecated.  Remove uses of
+	// this function as the same functionality is included in
+	// CountSend/CountReceive.  Remove this after the collector-contrib
+	// components have been updated to not reference this method.
 	SetSpanSizeAttributes(ctx context.Context, ss SizesStruct)
 }
 
@@ -208,16 +213,27 @@ func (rep *NetworkReporter) CountSend(ctx context.Context, ss SizesStruct) {
 		return
 	}
 
+	span := trace.SpanFromContext(ctx)
 	attrs := metric.WithAttributes(rep.staticAttr, attribute.String("method", ss.Method))
 
-	if rep.isExporter && ss.WireLength > 0 {
-		rep.compSizeHisto.Record(ctx, ss.WireLength, attrs)
+	if ss.Length > 0 {
+		if rep.sentBytes != nil {
+			rep.sentBytes.Add(ctx, ss.Length, attrs)
+		}
+		if span.IsRecording() {
+			span.SetAttributes(attribute.Int64("sent_uncompressed", ss.Length))
+		}
 	}
-	if rep.sentBytes != nil && ss.Length > 0 {
-		rep.sentBytes.Add(ctx, ss.Length, attrs)
-	}
-	if rep.sentWireBytes != nil && ss.WireLength > 0 {
-		rep.sentWireBytes.Add(ctx, ss.WireLength, attrs)
+	if ss.WireLength > 0 {
+		if rep.isExporter && rep.compSizeHisto != nil {
+			rep.compSizeHisto.Record(ctx, ss.WireLength, attrs)
+		}
+		if rep.sentWireBytes != nil {
+			rep.sentWireBytes.Add(ctx, ss.WireLength, attrs)
+		}
+		if span.IsRecording() {
+			span.SetAttributes(attribute.Int64("sent_compressed", ss.WireLength))
+		}
 	}
 }
 
@@ -230,41 +246,29 @@ func (rep *NetworkReporter) CountReceive(ctx context.Context, ss SizesStruct) {
 		return
 	}
 
-	attrs := metric.WithAttributes(rep.staticAttr, attribute.String("method", ss.Method))
-	if !rep.isExporter && ss.WireLength > 0 {
-		rep.compSizeHisto.Record(ctx, ss.WireLength, attrs)
-	}
-	if rep.recvBytes != nil && ss.Length > 0 {
-		rep.recvBytes.Add(ctx, ss.Length, attrs)
-	}
-	if rep.recvWireBytes != nil && ss.WireLength > 0 {
-		rep.recvWireBytes.Add(ctx, ss.WireLength, attrs)
-	}
-}
-
-func (rep *NetworkReporter) SetSpanSizeAttributes(ctx context.Context, ss SizesStruct) {
-	if rep == nil {
-		return
-	}
-
 	span := trace.SpanFromContext(ctx)
-
-	var compressedName string
-	var uncompressedName string
-	// set attribute name based on exporter vs receiver
-	if rep.isExporter {
-		compressedName = "stream_client_compressed_bytes_sent"
-		uncompressedName = "stream_client_uncompressed_bytes_sent"
-	} else { // receiver attributes
-		compressedName = "stream_server_compressed_bytes_recv"
-		uncompressedName = "stream_server_uncompressed_bytes_recv"
-	}
+	attrs := metric.WithAttributes(rep.staticAttr, attribute.String("method", ss.Method))
 
 	if ss.Length > 0 {
-		span.SetAttributes(attribute.Int(uncompressedName, int(ss.Length)))
+		if rep.recvBytes != nil {
+			rep.recvBytes.Add(ctx, ss.Length, attrs)
+		}
+		if span.IsRecording() {
+			span.SetAttributes(attribute.Int64("received_uncompressed", ss.Length))
+		}
 	}
-
 	if ss.WireLength > 0 {
-		span.SetAttributes(attribute.Int(compressedName, int(ss.WireLength)))
+		if !rep.isExporter && rep.compSizeHisto != nil {
+			rep.compSizeHisto.Record(ctx, ss.WireLength, attrs)
+		}
+		if rep.recvWireBytes != nil {
+			rep.recvWireBytes.Add(ctx, ss.WireLength, attrs)
+		}
+		if span.IsRecording() {
+			span.SetAttributes(attribute.Int64("received_compressed", ss.WireLength))
+		}
 	}
 }
+
+// SetSpanSizeAttributes is a no-op.
+func (*NetworkReporter) SetSpanSizeAttributes(ctx context.Context, ss SizesStruct) {}

--- a/collector/receiver/otelarrowreceiver/internal/arrow/arrow.go
+++ b/collector/receiver/otelarrowreceiver/internal/arrow/arrow.go
@@ -614,11 +614,8 @@ func (r *Receiver) processRecords(ctx context.Context, method string, arrowConsu
 			// is instrumented this way.
 			var sized netstats.SizesStruct
 			sized.Method = method
-			if r.telemetry.MetricsLevel > configtelemetry.LevelNormal {
-				sized.Length = uncompSize
-			}
+			sized.Length = uncompSize
 			r.netReporter.CountReceive(ctx, sized)
-			r.netReporter.SetSpanSizeAttributes(ctx, sized)
 		}()
 	}
 


### PR DESCRIPTION
This is a simplification.

We can instrument the same information with fewer API calls, and I had encountered this as a readability problem in the exporter / receiver.  Since CountSend and CountReceive already see the four parameters correctly, and since the Span already has a name indicative of whether it is exporter or receiver, we can report the span attributes from inside the Count methods using fixed attribute names.

The exporter and receiver code avoids use of MetricsLevel to gate calls into the netstats code, so that span instrumentation is independent of metrics detail. Netstats is level-aware, so this is not a change in observability.

To avoid complicating release cycles with collector-contrib, I've left behind a no-op interface which can be removed after several release cycles.