### PR TITLE
Use gRPC Status codes in the Arrow exporter

### DIFF
--- a/collector/exporter/otelarrowexporter/internal/arrow/bestofn.go
+++ b/collector/exporter/otelarrowexporter/internal/arrow/bestofn.go
@@ -9,6 +9,9 @@ import (
 	"runtime"
 	"sort"
 	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // bestOfNPrioritizer is a prioritizer that selects a less-loaded stream to write.
@@ -114,7 +117,7 @@ func (lp *bestOfNPrioritizer) sendAndWait(ctx context.Context, errCh <-chan erro
 	case <-lp.done:
 		return ErrStreamRestarting
 	case <-ctx.Done():
-		return context.Canceled
+		return status.Errorf(codes.Canceled, "stream wait: %v", ctx.Err())
 	case lp.input <- wri:
 		return waitForWrite(ctx, errCh, lp.done)
 	}

--- a/collector/exporter/otelarrowexporter/internal/arrow/exporter.go
+++ b/collector/exporter/otelarrowexporter/internal/arrow/exporter.go
@@ -20,7 +20,9 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/status"
 )
 
 // Exporter is 1:1 with exporter, isolates arrow-specific
@@ -255,6 +257,12 @@ func (e *Exporter) runArrowStream(ctx context.Context, dc doneCancel, state *str
 //
 // consumer should fall back to standard OTLP, (true, nil)
 func (e *Exporter) SendAndWait(ctx context.Context, data any) (bool, error) {
+	select {
+	case <-ctx.Done():
+		return false, status.Errorf(codes.Canceled, "incoming context: %v", ctx.Err())
+	default:
+	}
+
 	errCh := make(chan error, 1)
 
 	// Note that if the OTLP exporter's gRPC Headers field was
@@ -340,7 +348,7 @@ func waitForWrite(ctx context.Context, errCh <-chan error, down <-chan struct{})
 	select {
 	case <-ctx.Done():
 		// This caller's context timed out.
-		return ctx.Err()
+		return status.Errorf(codes.Canceled, "send wait: %v", ctx.Err())
 	case <-down:
 		return ErrStreamRestarting
 	case err := <-errCh:

--- a/collector/exporter/otelarrowexporter/internal/arrow/exporter_test.go
+++ b/collector/exporter/otelarrowexporter/internal/arrow/exporter_test.go
@@ -6,7 +6,6 @@ package arrow
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -31,7 +30,9 @@ import (
 	"go.uber.org/zap/zaptest"
 	"golang.org/x/net/http2/hpack"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 var AllPrioritizers = []PrioritizerName{LeastLoadedPrioritizer, LeastLoadedTwoPrioritizer}
@@ -278,7 +279,10 @@ func TestArrowExporterTimeout(t *testing.T) {
 			sent, err := tc.exporter.SendAndWait(ctx, twoTraces)
 			require.True(t, sent)
 			require.Error(t, err)
-			require.True(t, errors.Is(err, context.Canceled))
+
+			stat, is := status.FromError(err)
+			require.True(t, is, "is a gRPC status")
+			require.Equal(t, codes.Canceled, stat.Code())
 
 			require.NoError(t, tc.exporter.Shutdown(ctx))
 		})
@@ -406,7 +410,10 @@ func TestArrowExporterConnectTimeout(t *testing.T) {
 			}()
 			_, err := tc.exporter.SendAndWait(ctx, twoTraces)
 			require.Error(t, err)
-			require.True(t, errors.Is(err, context.Canceled))
+
+			stat, is := status.FromError(err)
+			require.True(t, is, "is a gRPC status error: %v", err)
+			require.Equal(t, codes.Canceled, stat.Code())
 
 			require.NoError(t, tc.exporter.Shutdown(bg))
 		})
@@ -489,7 +496,10 @@ func TestArrowExporterStreamRace(t *testing.T) {
 			// This blocks until the cancelation.
 			_, err := tc.exporter.SendAndWait(callctx, twoTraces)
 			require.Error(t, err)
-			require.True(t, errors.Is(err, context.Canceled))
+
+			stat, is := status.FromError(err)
+			require.True(t, is, "is a gRPC status error: %v", err)
+			require.Equal(t, codes.Canceled, stat.Code())
 		}()
 	}
 


### PR DESCRIPTION
Part of #210.

Mainly, changes the use of `fmt.Errorf()` and bare `context.Context.Err()` values, uses gRPC-Go's `status.Errorf()` to wrap the error with a code that gRPC and its consumers recognize.

Secondly, re-order and rename of the fields passed to the "arrow stream error" log statement, so that it matches the Reciever. This is used as the basis of a test for logging consistency and was otherwise an unintentional disagreement ("which" and "where")