### PR TITLE
Avoid work for already-canceled requests

### DIFF
--- a/collector/exporter/otelarrowexporter/internal/arrow/exporter.go
+++ b/collector/exporter/otelarrowexporter/internal/arrow/exporter.go
@@ -257,7 +257,7 @@ func (e *Exporter) runArrowStream(ctx context.Context, dc doneCancel, state *str
 //
 // consumer should fall back to standard OTLP, (true, nil)
 func (e *Exporter) SendAndWait(ctx context.Context, data any) (bool, error) {
-	// If the incoming context is already cancaled, return the
+	// If the incoming context is already canceled, return the
 	// same error condition a unary gRPC or HTTP exporter would do.
 	select {
 	case <-ctx.Done():

--- a/collector/exporter/otelarrowexporter/internal/arrow/exporter.go
+++ b/collector/exporter/otelarrowexporter/internal/arrow/exporter.go
@@ -20,7 +20,9 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/status"
 )
 
 // Exporter is 1:1 with exporter, isolates arrow-specific
@@ -255,6 +257,14 @@ func (e *Exporter) runArrowStream(ctx context.Context, dc doneCancel, state *str
 //
 // consumer should fall back to standard OTLP, (true, nil)
 func (e *Exporter) SendAndWait(ctx context.Context, data any) (bool, error) {
+	// If the incoming context is already cancaled, return the
+	// same error condition a unary gRPC or HTTP exporter would do.
+	select {
+	case <-ctx.Done():
+		return false, status.Errorf(codes.Canceled, "context done before send: %v", ctx.Err())
+	default:
+	}
+
 	errCh := make(chan error, 1)
 
 	// Note that if the OTLP exporter's gRPC Headers field was

--- a/collector/exporter/otelarrowexporter/internal/arrow/exporter_test.go
+++ b/collector/exporter/otelarrowexporter/internal/arrow/exporter_test.go
@@ -31,7 +31,9 @@ import (
 	"go.uber.org/zap/zaptest"
 	"golang.org/x/net/http2/hpack"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 var AllPrioritizers = []PrioritizerName{LeastLoadedPrioritizer, LeastLoadedTwoPrioritizer}
@@ -279,6 +281,13 @@ func TestArrowExporterTimeout(t *testing.T) {
 			require.True(t, sent)
 			require.Error(t, err)
 			require.True(t, errors.Is(err, context.Canceled))
+
+			// Repeat the request, will get immediate timeout.
+			sent, err = tc.exporter.SendAndWait(ctx, twoTraces)
+			stat, is := status.FromError(err)
+			require.True(t, is, "is a gRPC status error: %v", err)
+			require.Equal(t, "context done before send: context canceled", stat.Message())
+			require.Equal(t, codes.Canceled, stat.Code())
 
 			require.NoError(t, tc.exporter.Shutdown(ctx))
 		})

--- a/collector/exporter/otelarrowexporter/internal/arrow/exporter_test.go
+++ b/collector/exporter/otelarrowexporter/internal/arrow/exporter_test.go
@@ -286,7 +286,7 @@ func TestArrowExporterTimeout(t *testing.T) {
 
 			// Repeat the request, will get immediate timeout.
 			sent, err = tc.exporter.SendAndWait(ctx, twoTraces)
-			stat, is := status.FromError(err)
+			stat, is = status.FromError(err)
 			require.True(t, is, "is a gRPC status error: %v", err)
 			require.Equal(t, "context done before send: context canceled", stat.Message())
 			require.Equal(t, codes.Canceled, stat.Code())


### PR DESCRIPTION
This is consistent with gRPC behavior for unary exporters, as with for HTTP exporters.
It also helps us test with realistic conditions in the new integration test of #210.

https://grpc.io/docs/guides/deadlines/ explains why the default behavior is the way it is for unary gRPC. This is also the case for Golang's net/http client, which is used for the OTLP/HTTP exporter. Therefore, it seems the right thing to do for Arrow as well. Further, if we were to support extending the deadline on purpose, it would belong in the exporterhelper code (IMO).