### PR TITLE
Call IPCReader.Err() after reader loop

### DIFF
--- a/pkg/otel/common/arrow/allocator.go
+++ b/pkg/otel/common/arrow/allocator.go
@@ -45,7 +45,7 @@ type LimitError struct {
 
 var _ error = LimitError{}
 
-var limitRegexp = regexp.MustCompile(`allocation size exceeds limit: requested (\d+) out of (\d+) \(in-use=(\d+)\)`)
+var limitRegexp = regexp.MustCompile(`memory limit exceeded: requested (\d+) out of (\d+) \(in-use=(\d+)\)`)
 
 // NewLimitErrorFromError extracts a formatted limit error.
 //
@@ -72,7 +72,7 @@ func NewLimitErrorFromError(err error) (error, bool) {
 }
 
 func (le LimitError) Error() string {
-	return fmt.Sprintf("allocation size exceeds limit: requested %d out of %d (in-use=%d)", le.Request, le.Limit, le.Inuse)
+	return fmt.Sprintf("memory limit exceeded: requested %d out of %d (in-use=%d)", le.Request, le.Limit, le.Inuse)
 }
 
 func (_ LimitError) Is(tgt error) bool {

--- a/pkg/otel/common/arrow/allocator_test.go
+++ b/pkg/otel/common/arrow/allocator_test.go
@@ -48,7 +48,7 @@ func TestLimitedAllocatorUnformatted(t *testing.T) {
 	}()
 	require.NotNil(t, capture)
 	require.True(t, errors.Is(capture.(error), LimitError{}))
-	require.Equal(t, "allocation size exceeds limit: requested 1 out of 1000000 (in-use=1000000)", capture.(error).Error())
+	require.Equal(t, "memory limit exceeded: requested 1 out of 1000000 (in-use=1000000)", capture.(error).Error())
 
 	limit.Free(b)
 


### PR DESCRIPTION
Part of #210.

This updates memory-limit error handling because, prior to this fix, there were two fallbacks.

(1) the use of os.Stderr to print the message that we had lost
(2) a test for the expected number of records to match

The first is now removed (i.e. no printing to os.Stderr). The second is now an internal error.

The consumer is expected to test for the memory limit error explicitly (e.g., and handle it as ResourceExhausted). A new function is added to do this (NewLimitErrorFromError) that parses the message using a regexp. An upstream issue report and PR will be filed with Arrow-Go to overcome this in the future.

See https://github.com/apache/arrow/pull/41989.