### PR TITLE
Wrap the error used in concurrentbatchprocessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+- Wrap concurrentbatchprocessor errors [#235](https://github.com/open-telemetry/otel-arrow/pull/235)
 - Update to OTel-Collector v0.105.0, which includes the OTel-Arrow components. [#233](https://github.com/open-telemetry/otel-arrow/pull/233)
 - Remove the primary exporter/receiver components, update references and documentation. [#230](https://github.com/open-telemetry/otel-arrow/pull/230)
 - Update to Arrow v17. [#231](https://github.com/open-telemetry/otel-arrow/pull/231)

--- a/collector/processor/concurrentbatchprocessor/batch_processor.go
+++ b/collector/processor/concurrentbatchprocessor/batch_processor.go
@@ -154,6 +154,10 @@ func (ce countedError) Error() string {
 	return fmt.Sprintf("batch error: %s", ce.err.Error())
 }
 
+func (ce countedError) Unwrap() error {
+	return ce.err
+}
+
 var _ consumer.Traces = (*batchProcessor)(nil)
 var _ consumer.Metrics = (*batchProcessor)(nil)
 var _ consumer.Logs = (*batchProcessor)(nil)


### PR DESCRIPTION
A missing `func (_) Unwrap() error` makes the receiver not able to unwrap the exporter errors. 

Fixes #234.
