### PR TITLE
[concurrentbatchprocessor] Allow max_in_flight_size_mib to be set to zero to disable inflight limit

### DIFF
--- a/collector/processor/concurrentbatchprocessor/README.md
+++ b/collector/processor/concurrentbatchprocessor/README.md
@@ -9,7 +9,8 @@ The differences in this component, relative to that component are:
    until the request returns with success or an error status code.
 2. Maximim in-flight-bytes setting.  This component measures the
    in-memory size of each request it admits to the pipeline and
-   otherwise stalls requests until they timeout.
+   otherwise stalls requests until they timeout.  This function is
+   disabled by `max_in_flight_size_mib: 0`.
 3. Unlimited concurrency: this component will start as many goroutines
    as needed to send batches through the pipeline.
    

--- a/collector/processor/concurrentbatchprocessor/config.go
+++ b/collector/processor/concurrentbatchprocessor/config.go
@@ -46,7 +46,7 @@ type Config struct {
 	MetadataCardinalityLimit uint32 `mapstructure:"metadata_cardinality_limit"`
 
 	// MaxInFlightSizeMiB limits the number of bytes in queue waiting to be
-	// processed by the senders.
+	// processed by the senders.  If zero, this functionality is disabled.
 	MaxInFlightSizeMiB uint32 `mapstructure:"max_in_flight_size_mib"`
 }
 
@@ -67,9 +67,6 @@ func (cfg *Config) Validate() error {
 	}
 	if cfg.Timeout < 0 {
 		return errors.New("timeout must be greater or equal to 0")
-	}
-	if cfg.MaxInFlightSizeMiB <= 0 {
-		return errors.New("max_in_flight_size_mib must be greater than 0")
 	}
 	return nil
 }

--- a/collector/processor/concurrentbatchprocessor/config_test.go
+++ b/collector/processor/concurrentbatchprocessor/config_test.go
@@ -74,8 +74,3 @@ func TestValidateConfig_InvalidTimeout(t *testing.T) {
 	}
 	assert.Error(t, cfg.Validate())
 }
-
-func TestValidateConfig_InvalidZero(t *testing.T) {
-	cfg := &Config{}
-	assert.Error(t, cfg.Validate())
-}


### PR DESCRIPTION
For OTel-Arrow, we now prefer to limit admitted bytes in the receiver.  Allow the function to be disabled in the CBP.
([Refer to this for reciever admission control](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/otelarrowreceiver/README.md#arrow-specific-configuration).)
