### PR TITLE
Release v0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+## [0.26.0](https://github.com/open-telemetry/otel-arrow/releases/tag/v0.26.0) - 2024-09-06
+
 - Concurrent batch processor: tracing improvements. [#238](https://github.com/open-telemetry/otel-arrow/pull/238), [#241](https://github.com/open-telemetry/otel-arrow/pull/241)
 - Update to latest OTel-Collector & OTel-Go dependencies.  Remove collector packages now included in collector-contrib/internal/otelarrow. [#245](https://github.com/open-telemetry/otel-arrow/pull/245)
 - Concurrent batch processor: remove support for in-flight limits. [#247](https://github.com/open-telemetry/otel-arrow/pull/248)
 
-## [0.25.0](https://github.com/open-telemetry/otel-arrow/releases/tag/v0.24.0) - 2024-07-17
+## [0.25.0](https://github.com/open-telemetry/otel-arrow/releases/tag/v0.25.0) - 2024-07-17
 
 - Wrap concurrentbatchprocessor errors [#235](https://github.com/open-telemetry/otel-arrow/pull/235)
 - Update to OTel-Collector v0.105.0, which includes the OTel-Arrow components. [#233](https://github.com/open-telemetry/otel-arrow/pull/233)

--- a/collector/cmd/otelarrowcol/go.mod
+++ b/collector/cmd/otelarrowcol/go.mod
@@ -12,11 +12,11 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.108.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.108.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver v0.108.0
-	github.com/open-telemetry/otel-arrow/collector/connector/validationconnector v0.25.0
-	github.com/open-telemetry/otel-arrow/collector/exporter/fileexporter v0.25.0
-	github.com/open-telemetry/otel-arrow/collector/processor/concurrentbatchprocessor v0.25.0
-	github.com/open-telemetry/otel-arrow/collector/processor/obfuscationprocessor v0.25.0
-	github.com/open-telemetry/otel-arrow/collector/receiver/filereceiver v0.25.0
+	github.com/open-telemetry/otel-arrow/collector/connector/validationconnector v0.26.0
+	github.com/open-telemetry/otel-arrow/collector/exporter/fileexporter v0.26.0
+	github.com/open-telemetry/otel-arrow/collector/processor/concurrentbatchprocessor v0.26.0
+	github.com/open-telemetry/otel-arrow/collector/processor/obfuscationprocessor v0.26.0
+	github.com/open-telemetry/otel-arrow/collector/receiver/filereceiver v0.26.0
 	go.opentelemetry.io/collector/component v0.108.1
 	go.opentelemetry.io/collector/confmap v1.14.1
 	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.108.1
@@ -92,7 +92,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/otelarrow v0.108.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.108.0 // indirect
-	github.com/open-telemetry/otel-arrow v0.25.0 // indirect
+	github.com/open-telemetry/otel-arrow v0.26.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.21 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect

--- a/collector/cmd/otelarrowcol/main.go
+++ b/collector/cmd/otelarrowcol/main.go
@@ -21,7 +21,7 @@ func main() {
 	info := component.BuildInfo{
 		Command:     "otelarrowcol",
 		Description: "OpenTelemetry Protocol with Apache Arrow development collector, for testing and evaluation",
-		Version:     "0.25.0",
+		Version:     "0.26.0",
 	}
 
 	set := otelcol.CollectorSettings{

--- a/collector/connector/validationconnector/go.mod
+++ b/collector/connector/validationconnector/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.6
 
 require (
-	github.com/open-telemetry/otel-arrow v0.25.0
+	github.com/open-telemetry/otel-arrow v0.26.0
 	go.opentelemetry.io/collector v0.105.0
 	go.opentelemetry.io/collector/component v0.105.0
 	go.opentelemetry.io/collector/connector v0.105.0

--- a/collector/otelarrowcol-build.yaml
+++ b/collector/otelarrowcol-build.yaml
@@ -17,7 +17,7 @@ dist:
 
   # Note: this version number is replaced to match the current release using `sed`
   # during the release process, see ../../../RELEASING.md.
-  version: 0.25.0
+  version: 0.26.0
 
   # Note: This should match the version of the core and contrib
   # collector components used below (e.g., the debugexporter and
@@ -36,23 +36,23 @@ exporters:
 
   - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.108.1
   - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.108.1
-  - gomod: github.com/open-telemetry/otel-arrow/collector/exporter/fileexporter v0.25.0
+  - gomod: github.com/open-telemetry/otel-arrow/collector/exporter/fileexporter v0.26.0
 
 receivers:
   # This is the core OpenTelemetry Protocol with Apache Arrow receiver
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver v0.108.0
 
-  - gomod: github.com/open-telemetry/otel-arrow/collector/receiver/filereceiver v0.25.0
+  - gomod: github.com/open-telemetry/otel-arrow/collector/receiver/filereceiver v0.26.0
   # Users wanting the OTLP/HTTP Receiver will use the otlp receiver.
   # Users wanting OTLP/gRPC may use the otelarrowreceiver.
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.108.1
 
 processors:
-  - gomod: github.com/open-telemetry/otel-arrow/collector/processor/concurrentbatchprocessor v0.25.0
-  - gomod: github.com/open-telemetry/otel-arrow/collector/processor/obfuscationprocessor v0.25.0
+  - gomod: github.com/open-telemetry/otel-arrow/collector/processor/concurrentbatchprocessor v0.26.0
+  - gomod: github.com/open-telemetry/otel-arrow/collector/processor/obfuscationprocessor v0.26.0
 
 connectors:
-  - gomod: github.com/open-telemetry/otel-arrow/collector/connector/validationconnector v0.25.0
+  - gomod: github.com/open-telemetry/otel-arrow/collector/connector/validationconnector v0.26.0
 
 extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.108.0

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,7 +3,7 @@
 
 module-sets:
   beta:
-    version: v0.25.0
+    version: v0.26.0
     modules:
       - github.com/open-telemetry/otel-arrow
       - github.com/open-telemetry/otel-arrow/collector/cmd/otelarrowcol


### PR DESCRIPTION
- Concurrent batch processor: tracing improvements. [#238](https://github.com/open-telemetry/otel-arrow/pull/238), [#241](https://github.com/open-telemetry/otel-arrow/pull/241)
- Update to latest OTel-Collector & OTel-Go dependencies.  Remove collector packages now included in collector-contrib/internal/otelarrow. [#245](https://github.com/open-telemetry/otel-arrow/pull/245)
- Concurrent batch processor: remove support for in-flight limits. [#247](https://github.com/open-telemetry/otel-arrow/pull/248)
