### PR TITLE
Release v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+## [0.27.0](https://github.com/open-telemetry/otel-arrow/releases/tag/v0.27.0) - 2024-09-25
+
 - Concurrent batch processor: concurrency limit for legacy behavior or otherwise. [#254](https://github.com/open-telemetry/otel-arrow/pull/254)
 - Concurrent batch processor: EarlyReturn legacy compat feature. [#253](https://github.com/open-telemetry/otel-arrow/pull/253)
 - Concurrent batch processor: Synchronize with upstream; removes in-flight bytes metric, 

--- a/collector/cmd/otelarrowcol/go.mod
+++ b/collector/cmd/otelarrowcol/go.mod
@@ -12,10 +12,10 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.110.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.110.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver v0.110.0
-	github.com/open-telemetry/otel-arrow/collector/exporter/fileexporter v0.26.0
-	github.com/open-telemetry/otel-arrow/collector/processor/concurrentbatchprocessor v0.26.0
-	github.com/open-telemetry/otel-arrow/collector/processor/obfuscationprocessor v0.26.0
-	github.com/open-telemetry/otel-arrow/collector/receiver/filereceiver v0.26.0
+	github.com/open-telemetry/otel-arrow/collector/exporter/fileexporter v0.27.0
+	github.com/open-telemetry/otel-arrow/collector/processor/concurrentbatchprocessor v0.27.0
+	github.com/open-telemetry/otel-arrow/collector/processor/obfuscationprocessor v0.27.0
+	github.com/open-telemetry/otel-arrow/collector/receiver/filereceiver v0.27.0
 	go.opentelemetry.io/collector/component v0.110.0
 	go.opentelemetry.io/collector/confmap v1.16.0
 	go.opentelemetry.io/collector/confmap/provider/envprovider v1.16.0
@@ -91,7 +91,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/grpcutil v0.110.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/otelarrow v0.110.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.110.0 // indirect
-	github.com/open-telemetry/otel-arrow v0.26.0 // indirect
+	github.com/open-telemetry/otel-arrow v0.27.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.21 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect

--- a/collector/cmd/otelarrowcol/main.go
+++ b/collector/cmd/otelarrowcol/main.go
@@ -20,7 +20,7 @@ func main() {
 	info := component.BuildInfo{
 		Command:     "otelarrowcol",
 		Description: "OpenTelemetry Protocol with Apache Arrow development collector, for testing and evaluation",
-		Version:     "0.26.0",
+		Version:     "0.27.0",
 	}
 
 	set := otelcol.CollectorSettings{

--- a/collector/otelarrowcol-build.yaml
+++ b/collector/otelarrowcol-build.yaml
@@ -17,7 +17,7 @@ dist:
 
   # Note: this version number is replaced to match the current release using `sed`
   # during the release process, see ../../../RELEASING.md.
-  version: 0.26.0
+  version: 0.27.0
 
   # Note: This should match the version of the core and contrib
   # collector components used below (e.g., the debugexporter and
@@ -36,20 +36,20 @@ exporters:
 
   - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.110.0
   - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.110.0
-  - gomod: github.com/open-telemetry/otel-arrow/collector/exporter/fileexporter v0.26.0
+  - gomod: github.com/open-telemetry/otel-arrow/collector/exporter/fileexporter v0.27.0
 
 receivers:
   # This is the core OpenTelemetry Protocol with Apache Arrow receiver
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver v0.110.0
 
-  - gomod: github.com/open-telemetry/otel-arrow/collector/receiver/filereceiver v0.26.0
+  - gomod: github.com/open-telemetry/otel-arrow/collector/receiver/filereceiver v0.27.0
   # Users wanting the OTLP/HTTP Receiver will use the otlp receiver.
   # Users wanting OTLP/gRPC may use the otelarrowreceiver.
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.110.0
 
 processors:
-  - gomod: github.com/open-telemetry/otel-arrow/collector/processor/concurrentbatchprocessor v0.26.0
-  - gomod: github.com/open-telemetry/otel-arrow/collector/processor/obfuscationprocessor v0.26.0
+  - gomod: github.com/open-telemetry/otel-arrow/collector/processor/concurrentbatchprocessor v0.27.0
+  - gomod: github.com/open-telemetry/otel-arrow/collector/processor/obfuscationprocessor v0.27.0
 
 extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.110.0

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,7 +3,7 @@
 
 module-sets:
   beta:
-    version: v0.26.0
+    version: v0.27.0
     modules:
       - github.com/open-telemetry/otel-arrow
       - github.com/open-telemetry/otel-arrow/collector/cmd/otelarrowcol


### PR DESCRIPTION
- Concurrent batch processor: concurrency limit for legacy behavior or otherwise. [#254](https://github.com/open-telemetry/otel-arrow/pull/254)
- Concurrent batch processor: EarlyReturn legacy compat feature. [#253](https://github.com/open-telemetry/otel-arrow/pull/253)
- Concurrent batch processor: Synchronize with upstream; removes in-flight bytes metric, 
  removes panic recovery as unnecessary divergence. [#251](https://github.com/open-telemetry/otel-arrow/pull/251)
- Update collector dependencies to v0.110.0/v1.16.0; remove validation connector [#252](https://github.com/open-telemetry/otel-arrow/pull/252)
