### PR TITLE
(concurrentbatchprocessor): Fix deadlock, test EarlyReturn feature

### DIFF
--- a/collector/processor/concurrentbatchprocessor/batch_processor.go
+++ b/collector/processor/concurrentbatchprocessor/batch_processor.go
@@ -375,9 +375,12 @@ func (b *shard) sendItems(trigger trigger) {
 				ctx:    b.pending[0].parentCtx,
 			})
 
-			// Shift the pending array, to allow it to be re-used.
-			copy(b.pending[0:len(b.pending)-1], b.pending[1:])
-			b.pending = b.pending[:len(b.pending)-1]
+			// complete response sent so b.pending[0] can be popped from queue.
+			if len(b.pending) > 1 {
+				b.pending = b.pending[1:]
+			} else {
+				b.pending = []pendingItem{}
+			}
 		}
 	}
 


### PR DESCRIPTION
This tests and fixes a deadlock in the concurrent batch processor, one that was especially easy to see with EarlyReturn=true, however exists either way. The bug was introduced in https://github.com/open-telemetry/otel-arrow/pull/251 when it removed a `defer func()` from `consumeAndWait()` by mistake.

This is now covered by testing. This is fixed w/o a `defer func() { ... }`. The older code was both counting responses and updating a semaphore. Now that we only count responses and do not update a semaphore, there is no need to defer. The batcher will avoid sending to the waiter when the waiter's context is canceled.