### PR TITLE
(concurrentbatchprocessor): Allow re-use of the pending slice

### DIFF
--- a/collector/processor/concurrentbatchprocessor/batch_processor.go
+++ b/collector/processor/concurrentbatchprocessor/batch_processor.go
@@ -372,12 +372,9 @@ func (b *shard) sendItems(trigger trigger) {
 				ctx:    b.pending[0].parentCtx,
 			})
 
-			// complete response sent so b.pending[0] can be popped from queue.
-			if len(b.pending) > 1 {
-				b.pending = b.pending[1:]
-			} else {
-				b.pending = []pendingItem{}
-			}
+			// Shift the pending array, to allow it to be re-used.
+			copy(b.pending[0:len(b.pending)-1], b.pending[1:])
+			b.pending = b.pending[:len(b.pending)-1]
 		}
 	}
 

--- a/collector/processor/concurrentbatchprocessor/batch_processor.go
+++ b/collector/processor/concurrentbatchprocessor/batch_processor.go
@@ -372,8 +372,10 @@ func (b *shard) sendItems(trigger trigger) {
 				ctx:    b.pending[0].parentCtx,
 			})
 
-			// Shift the pending array, to allow it to be re-used.
+			// Shift the pending array, to allow it to be re-used
+			// instead of re-allocated.
 			copy(b.pending[0:len(b.pending)-1], b.pending[1:])
+			b.pending[len(b.pending)-1] = pendingItem{}
 			b.pending = b.pending[:len(b.pending)-1]
 		}
 	}


### PR DESCRIPTION
This avoids a pitfall in which we repeatedly re-slice `b.pending` to `b.pending[1:]`, which causes the slice to be re-allocated instead of re-used. To re-use the slice, shift its contents by one, zero the final element, and shorten it by one.