### PR TITLE
Release v0.31.0

### DIFF
--- a/collector/cmd/otelarrowcol/go.mod
+++ b/collector/cmd/otelarrowcol/go.mod
@@ -12,10 +12,10 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.113.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.113.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver v0.113.0
-	github.com/open-telemetry/otel-arrow/collector/exporter/fileexporter v0.30.0
-	github.com/open-telemetry/otel-arrow/collector/processor/concurrentbatchprocessor v0.30.0
-	github.com/open-telemetry/otel-arrow/collector/processor/obfuscationprocessor v0.30.0
-	github.com/open-telemetry/otel-arrow/collector/receiver/filereceiver v0.30.0
+	github.com/open-telemetry/otel-arrow/collector/exporter/fileexporter v0.31.0
+	github.com/open-telemetry/otel-arrow/collector/processor/concurrentbatchprocessor v0.31.0
+	github.com/open-telemetry/otel-arrow/collector/processor/obfuscationprocessor v0.31.0
+	github.com/open-telemetry/otel-arrow/collector/receiver/filereceiver v0.31.0
 	go.opentelemetry.io/collector/component v0.114.0
 	go.opentelemetry.io/collector/confmap v1.20.0
 	go.opentelemetry.io/collector/confmap/provider/envprovider v1.17.0
@@ -92,7 +92,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/grpcutil v0.113.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/otelarrow v0.113.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.113.0 // indirect
-	github.com/open-telemetry/otel-arrow v0.29.0 // indirect
+	github.com/open-telemetry/otel-arrow v0.31.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.21 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect

--- a/collector/cmd/otelarrowcol/main.go
+++ b/collector/cmd/otelarrowcol/main.go
@@ -20,7 +20,7 @@ func main() {
 	info := component.BuildInfo{
 		Command:     "otelarrowcol",
 		Description: "OpenTelemetry Protocol with Apache Arrow development collector, for testing and evaluation",
-		Version:     "0.30.0",
+		Version:     "0.31.0",
 	}
 
 	set := otelcol.CollectorSettings{

--- a/collector/otelarrowcol-build.yaml
+++ b/collector/otelarrowcol-build.yaml
@@ -17,7 +17,7 @@ dist:
 
   # Note: this version number is replaced to match the current release using `sed`
   # during the release process, see ../../../RELEASING.md.
-  version: 0.30.0
+  version: 0.31.0
 
   # Project-internal use: Directory path required for the `make
   # genotelarrowcol`, which the Dockerfile also recognizes.
@@ -31,20 +31,20 @@ exporters:
 
   - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.113.0
   - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.113.0
-  - gomod: github.com/open-telemetry/otel-arrow/collector/exporter/fileexporter v0.30.0
+  - gomod: github.com/open-telemetry/otel-arrow/collector/exporter/fileexporter v0.31.0
 
 receivers:
   # This is the core OpenTelemetry Protocol with Apache Arrow receiver
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver v0.113.0
 
-  - gomod: github.com/open-telemetry/otel-arrow/collector/receiver/filereceiver v0.30.0
+  - gomod: github.com/open-telemetry/otel-arrow/collector/receiver/filereceiver v0.31.0
   # Users wanting the OTLP/HTTP Receiver will use the otlp receiver.
   # Users wanting OTLP/gRPC may use the otelarrowreceiver.
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.113.0
 
 processors:
-  - gomod: github.com/open-telemetry/otel-arrow/collector/processor/concurrentbatchprocessor v0.30.0
-  - gomod: github.com/open-telemetry/otel-arrow/collector/processor/obfuscationprocessor v0.30.0
+  - gomod: github.com/open-telemetry/otel-arrow/collector/processor/concurrentbatchprocessor v0.31.0
+  - gomod: github.com/open-telemetry/otel-arrow/collector/processor/obfuscationprocessor v0.31.0
 
 extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.113.0

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,7 +3,7 @@
 
 module-sets:
   beta:
-    version: v0.30.0
+    version: v0.31.0
     modules:
       - github.com/open-telemetry/otel-arrow
       - github.com/open-telemetry/otel-arrow/collector/cmd/otelarrowcol


### PR DESCRIPTION
- Update to v0.114.0 collector dependencies. [#274](https://github.com/open-telemetry/otel-arrow/pull/274)
- Empty SpanID bug-fix. [#273](https://github.com/open-telemetry/otel-arrow/pull/273)
