### PR TITLE
pkg: Create generic AttributesStore

### DIFF
--- a/pkg/otel/common/otlp/resource.go
+++ b/pkg/otel/common/otlp/resource.go
@@ -48,7 +48,7 @@ func NewResourceIdsFromSchema(schema *arrow.Schema) (*ResourceIds, error) {
 	}, nil
 }
 
-func UpdateResourceFromRecord(r pcommon.Resource, record arrow.Record, row int, resIds *ResourceIds, attrsStore *Attributes16Store) (schemaUrl string, err error) {
+func UpdateResourceFromRecord(r pcommon.Resource, record arrow.Record, row int, resIds *ResourceIds, attrsStore *AttributesStore[uint16]) (schemaUrl string, err error) {
 	resArr, err := arrowutils.StructFromRecord(record, resIds.Resource, row)
 	if err != nil {
 		return "", werror.WrapWithContext(err, map[string]interface{}{"row": row})

--- a/pkg/otel/common/otlp/scope.go
+++ b/pkg/otel/common/otlp/scope.go
@@ -55,7 +55,7 @@ func UpdateScopeFromRecord(
 	record arrow.Record,
 	row int,
 	ids *ScopeIds,
-	attrsStore *Attributes16Store,
+	attrsStore *AttributesStore[uint16],
 ) error {
 	scopeArray, err := arrowutils.StructFromRecord(record, ids.Scope, row)
 	if err != nil {

--- a/pkg/otel/logs/otlp/related_data.go
+++ b/pkg/otel/logs/otlp/related_data.go
@@ -30,17 +30,17 @@ import (
 type (
 	RelatedData struct {
 		LogRecordID           uint16
-		ResAttrMapStore       *otlp.Attributes16Store
-		ScopeAttrMapStore     *otlp.Attributes16Store
-		LogRecordAttrMapStore *otlp.Attributes16Store
+		ResAttrMapStore       *otlp.AttributesStore[uint16]
+		ScopeAttrMapStore     *otlp.AttributesStore[uint16]
+		LogRecordAttrMapStore *otlp.AttributesStore[uint16]
 	}
 )
 
 func NewRelatedData() *RelatedData {
 	return &RelatedData{
-		ResAttrMapStore:       otlp.NewAttributes16Store(),
-		ScopeAttrMapStore:     otlp.NewAttributes16Store(),
-		LogRecordAttrMapStore: otlp.NewAttributes16Store(),
+		ResAttrMapStore:       otlp.NewAttributesStore[uint16](),
+		ScopeAttrMapStore:     otlp.NewAttributesStore[uint16](),
+		LogRecordAttrMapStore: otlp.NewAttributesStore[uint16](),
 	}
 }
 
@@ -62,17 +62,17 @@ func RelatedDataFrom(records []*record_message.RecordMessage) (relatedData *Rela
 	for _, record := range records {
 		switch record.PayloadType() {
 		case colarspb.ArrowPayloadType_RESOURCE_ATTRS:
-			err = otlp.Attributes16StoreFrom(record.Record(), relatedData.ResAttrMapStore)
+			err = otlp.AttributesStoreFrom[uint16](record.Record(), relatedData.ResAttrMapStore)
 			if err != nil {
 				return nil, nil, werror.Wrap(err)
 			}
 		case colarspb.ArrowPayloadType_SCOPE_ATTRS:
-			err = otlp.Attributes16StoreFrom(record.Record(), relatedData.ScopeAttrMapStore)
+			err = otlp.AttributesStoreFrom[uint16](record.Record(), relatedData.ScopeAttrMapStore)
 			if err != nil {
 				return nil, nil, werror.Wrap(err)
 			}
 		case colarspb.ArrowPayloadType_LOG_ATTRS:
-			err = otlp.Attributes16StoreFrom(record.Record(), relatedData.LogRecordAttrMapStore)
+			err = otlp.AttributesStoreFrom[uint16](record.Record(), relatedData.LogRecordAttrMapStore)
 			if err != nil {
 				return nil, nil, werror.Wrap(err)
 			}

--- a/pkg/otel/metrics/otlp/ehistogram.go
+++ b/pkg/otel/metrics/otlp/ehistogram.go
@@ -149,7 +149,7 @@ func SchemaToEHistogramIDs(schema *arrow.Schema) (*EHistogramDataPointIDs, error
 //
 // Important Note: This function doesn't take ownership of the record. The
 // caller is responsible for releasing it.
-func EHistogramDataPointsStoreFrom(record arrow.Record, exemplarsStore *ExemplarsStore, attrsStore *otlp.Attributes32Store) (*EHistogramDataPointsStore, error) {
+func EHistogramDataPointsStoreFrom(record arrow.Record, exemplarsStore *ExemplarsStore, attrsStore *otlp.AttributesStore[uint32]) (*EHistogramDataPointsStore, error) {
 	store := &EHistogramDataPointsStore{
 		dataPointsByID: make(map[uint16]pmetric.ExponentialHistogramDataPointSlice),
 	}

--- a/pkg/otel/metrics/otlp/exemplar.go
+++ b/pkg/otel/metrics/otlp/exemplar.go
@@ -107,7 +107,7 @@ func (s *ExemplarsStore) ExemplarsByID(ID uint32) pmetric.ExemplarSlice {
 // caller is responsible for releasing it.
 func ExemplarsStoreFrom(
 	record arrow.Record,
-	attrsStore *otlp.Attributes32Store,
+	attrsStore *otlp.AttributesStore[uint32],
 ) (*ExemplarsStore, error) {
 	store := &ExemplarsStore{
 		exemplarsByIDs: make(map[uint32]pmetric.ExemplarSlice),

--- a/pkg/otel/metrics/otlp/histogram.go
+++ b/pkg/otel/metrics/otlp/histogram.go
@@ -136,7 +136,7 @@ func SchemaToHistogramIDs(schema *arrow.Schema) (*HistogramDataPointIDs, error) 
 //
 // Important Note: This function doesn't take ownership of the record. The
 // caller is responsible for releasing it.
-func HistogramDataPointsStoreFrom(record arrow.Record, exemplarsStore *ExemplarsStore, attrsStore *otlp.Attributes32Store) (*HistogramDataPointsStore, error) {
+func HistogramDataPointsStoreFrom(record arrow.Record, exemplarsStore *ExemplarsStore, attrsStore *otlp.AttributesStore[uint32]) (*HistogramDataPointsStore, error) {
 	store := &HistogramDataPointsStore{
 		dataPointsByID: make(map[uint16]pmetric.HistogramDataPointSlice),
 	}

--- a/pkg/otel/metrics/otlp/number_data_point.go
+++ b/pkg/otel/metrics/otlp/number_data_point.go
@@ -20,7 +20,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	arrowutils "github.com/open-telemetry/otel-arrow/pkg/arrow"
-	otlp "github.com/open-telemetry/otel-arrow/pkg/otel/common/otlp"
+	"github.com/open-telemetry/otel-arrow/pkg/otel/common/otlp"
 	"github.com/open-telemetry/otel-arrow/pkg/otel/constants"
 	"github.com/open-telemetry/otel-arrow/pkg/werror"
 )
@@ -107,7 +107,7 @@ func SchemaToNDPIDs(schema *arrow.Schema) (*NumberDataPointIDs, error) {
 //
 // Important Note: This function doesn't take ownership of the record. The
 // caller is responsible for releasing it.
-func NumberDataPointsStoreFrom(record arrow.Record, exemplarsStore *ExemplarsStore, attrsStore *otlp.Attributes32Store) (*NumberDataPointsStore, error) {
+func NumberDataPointsStoreFrom(record arrow.Record, exemplarsStore *ExemplarsStore, attrsStore *otlp.AttributesStore[uint32]) (*NumberDataPointsStore, error) {
 	store := &NumberDataPointsStore{
 		dataPointsByID: make(map[uint16]pmetric.NumberDataPointSlice),
 	}

--- a/pkg/otel/metrics/otlp/related_data.go
+++ b/pkg/otel/metrics/otlp/related_data.go
@@ -30,15 +30,15 @@ type (
 		MetricID uint16
 
 		// Attributes stores
-		ResAttrMapStore                *otlp.Attributes16Store
-		ScopeAttrMapStore              *otlp.Attributes16Store
-		NumberDPAttrsStore             *otlp.Attributes32Store
-		SummaryAttrsStore              *otlp.Attributes32Store
-		HistogramAttrsStore            *otlp.Attributes32Store
-		ExpHistogramAttrsStore         *otlp.Attributes32Store
-		NumberDPExemplarAttrsStore     *otlp.Attributes32Store
-		HistogramExemplarAttrsStore    *otlp.Attributes32Store
-		ExpHistogramExemplarAttrsStore *otlp.Attributes32Store
+		ResAttrMapStore                *otlp.AttributesStore[uint16]
+		ScopeAttrMapStore              *otlp.AttributesStore[uint16]
+		NumberDPAttrsStore             *otlp.AttributesStore[uint32]
+		SummaryAttrsStore              *otlp.AttributesStore[uint32]
+		HistogramAttrsStore            *otlp.AttributesStore[uint32]
+		ExpHistogramAttrsStore         *otlp.AttributesStore[uint32]
+		NumberDPExemplarAttrsStore     *otlp.AttributesStore[uint32]
+		HistogramExemplarAttrsStore    *otlp.AttributesStore[uint32]
+		ExpHistogramExemplarAttrsStore *otlp.AttributesStore[uint32]
 
 		// Metric stores
 		NumberDataPointsStore     *NumberDataPointsStore
@@ -55,15 +55,15 @@ type (
 
 func NewRelatedData() *RelatedData {
 	return &RelatedData{
-		ResAttrMapStore:                otlp.NewAttributes16Store(),
-		ScopeAttrMapStore:              otlp.NewAttributes16Store(),
-		NumberDPAttrsStore:             otlp.NewAttributes32Store(),
-		SummaryAttrsStore:              otlp.NewAttributes32Store(),
-		HistogramAttrsStore:            otlp.NewAttributes32Store(),
-		ExpHistogramAttrsStore:         otlp.NewAttributes32Store(),
-		NumberDPExemplarAttrsStore:     otlp.NewAttributes32Store(),
-		HistogramExemplarAttrsStore:    otlp.NewAttributes32Store(),
-		ExpHistogramExemplarAttrsStore: otlp.NewAttributes32Store(),
+		ResAttrMapStore:                otlp.NewAttributesStore[uint16](),
+		ScopeAttrMapStore:              otlp.NewAttributesStore[uint16](),
+		NumberDPAttrsStore:             otlp.NewAttributesStore[uint32](),
+		SummaryAttrsStore:              otlp.NewAttributesStore[uint32](),
+		HistogramAttrsStore:            otlp.NewAttributesStore[uint32](),
+		ExpHistogramAttrsStore:         otlp.NewAttributesStore[uint32](),
+		NumberDPExemplarAttrsStore:     otlp.NewAttributesStore[uint32](),
+		HistogramExemplarAttrsStore:    otlp.NewAttributesStore[uint32](),
+		ExpHistogramExemplarAttrsStore: otlp.NewAttributesStore[uint32](),
 
 		NumberDataPointsStore:     NewNumberDataPointsStore(),
 		SummaryDataPointsStore:    NewSummaryDataPointsStore(),
@@ -101,32 +101,32 @@ func RelatedDataFrom(records []*record_message.RecordMessage) (relatedData *Rela
 	for _, record := range records {
 		switch record.PayloadType() {
 		case colarspb.ArrowPayloadType_RESOURCE_ATTRS:
-			err = otlp.Attributes16StoreFrom(record.Record(), relatedData.ResAttrMapStore)
+			err = otlp.AttributesStoreFrom(record.Record(), relatedData.ResAttrMapStore)
 			if err != nil {
 				return nil, nil, werror.Wrap(err)
 			}
 		case colarspb.ArrowPayloadType_SCOPE_ATTRS:
-			err = otlp.Attributes16StoreFrom(record.Record(), relatedData.ScopeAttrMapStore)
+			err = otlp.AttributesStoreFrom(record.Record(), relatedData.ScopeAttrMapStore)
 			if err != nil {
 				return nil, nil, werror.Wrap(err)
 			}
 		case colarspb.ArrowPayloadType_NUMBER_DP_ATTRS:
-			err = otlp.Attributes32StoreFrom(record.Record(), relatedData.NumberDPAttrsStore)
+			err = otlp.AttributesStoreFrom(record.Record(), relatedData.NumberDPAttrsStore)
 			if err != nil {
 				return nil, nil, werror.Wrap(err)
 			}
 		case colarspb.ArrowPayloadType_SUMMARY_DP_ATTRS:
-			err = otlp.Attributes32StoreFrom(record.Record(), relatedData.SummaryAttrsStore)
+			err = otlp.AttributesStoreFrom(record.Record(), relatedData.SummaryAttrsStore)
 			if err != nil {
 				return nil, nil, werror.Wrap(err)
 			}
 		case colarspb.ArrowPayloadType_HISTOGRAM_DP_ATTRS:
-			err = otlp.Attributes32StoreFrom(record.Record(), relatedData.HistogramAttrsStore)
+			err = otlp.AttributesStoreFrom(record.Record(), relatedData.HistogramAttrsStore)
 			if err != nil {
 				return nil, nil, werror.Wrap(err)
 			}
 		case colarspb.ArrowPayloadType_EXP_HISTOGRAM_DP_ATTRS:
-			err = otlp.Attributes32StoreFrom(record.Record(), relatedData.ExpHistogramAttrsStore)
+			err = otlp.AttributesStoreFrom(record.Record(), relatedData.ExpHistogramAttrsStore)
 			if err != nil {
 				return nil, nil, werror.Wrap(err)
 			}
@@ -171,17 +171,17 @@ func RelatedDataFrom(records []*record_message.RecordMessage) (relatedData *Rela
 			}
 			expHistogramDBExRec = record
 		case colarspb.ArrowPayloadType_NUMBER_DP_EXEMPLAR_ATTRS:
-			err = otlp.Attributes32StoreFrom(record.Record(), relatedData.NumberDPExemplarAttrsStore)
+			err = otlp.AttributesStoreFrom[uint32](record.Record(), relatedData.NumberDPExemplarAttrsStore)
 			if err != nil {
 				return nil, nil, werror.Wrap(err)
 			}
 		case colarspb.ArrowPayloadType_HISTOGRAM_DP_EXEMPLAR_ATTRS:
-			err = otlp.Attributes32StoreFrom(record.Record(), relatedData.HistogramExemplarAttrsStore)
+			err = otlp.AttributesStoreFrom[uint32](record.Record(), relatedData.HistogramExemplarAttrsStore)
 			if err != nil {
 				return nil, nil, werror.Wrap(err)
 			}
 		case colarspb.ArrowPayloadType_EXP_HISTOGRAM_DP_EXEMPLAR_ATTRS:
-			err = otlp.Attributes32StoreFrom(record.Record(), relatedData.ExpHistogramExemplarAttrsStore)
+			err = otlp.AttributesStoreFrom[uint32](record.Record(), relatedData.ExpHistogramExemplarAttrsStore)
 			if err != nil {
 				return nil, nil, werror.Wrap(err)
 			}

--- a/pkg/otel/metrics/otlp/summary.go
+++ b/pkg/otel/metrics/otlp/summary.go
@@ -114,7 +114,7 @@ func SchemaToSummaryIDs(schema *arrow.Schema) (*SummaryDataPointIDs, error) {
 //
 // Important Note: This function doesn't take ownership of the record. The
 // caller is responsible for releasing it.
-func SummaryDataPointsStoreFrom(record arrow.Record, attrsStore *otlp.Attributes32Store) (*SummaryDataPointsStore, error) {
+func SummaryDataPointsStoreFrom(record arrow.Record, attrsStore *otlp.AttributesStore[uint32]) (*SummaryDataPointsStore, error) {
 	store := &SummaryDataPointsStore{
 		dataPointsByID: make(map[uint16]pmetric.SummaryDataPointSlice),
 	}

--- a/pkg/otel/traces/otlp/event.go
+++ b/pkg/otel/traces/otlp/event.go
@@ -76,7 +76,7 @@ func (s *SpanEventsStore) EventsByID(ID uint16) []*ptrace.SpanEvent {
 // caller is responsible for releasing it.
 func SpanEventsStoreFrom(
 	record arrow.Record,
-	attrsStore *otlp.Attributes32Store,
+	attrsStore *otlp.AttributesStore[uint32],
 	conf *tarrow.EventConfig,
 ) (*SpanEventsStore, error) {
 	store := &SpanEventsStore{

--- a/pkg/otel/traces/otlp/link.go
+++ b/pkg/otel/traces/otlp/link.go
@@ -23,7 +23,7 @@ import (
 
 	arrowutils "github.com/open-telemetry/otel-arrow/pkg/arrow"
 	carrow "github.com/open-telemetry/otel-arrow/pkg/otel/common/arrow"
-	otlp "github.com/open-telemetry/otel-arrow/pkg/otel/common/otlp"
+	"github.com/open-telemetry/otel-arrow/pkg/otel/common/otlp"
 	"github.com/open-telemetry/otel-arrow/pkg/otel/constants"
 	tarrow "github.com/open-telemetry/otel-arrow/pkg/otel/traces/arrow"
 	"github.com/open-telemetry/otel-arrow/pkg/werror"
@@ -77,7 +77,7 @@ func (s *SpanLinksStore) LinksByID(ID uint16) []*ptrace.SpanLink {
 // caller is responsible for releasing it.
 func SpanLinksStoreFrom(
 	record arrow.Record,
-	attrsStore *otlp.Attributes32Store,
+	attrsStore *otlp.AttributesStore[uint32],
 	conf *tarrow.LinkConfig,
 ) (*SpanLinksStore, error) {
 	store := &SpanLinksStore{

--- a/pkg/otel/traces/otlp/related_data.go
+++ b/pkg/otel/traces/otlp/related_data.go
@@ -31,11 +31,11 @@ import (
 type (
 	RelatedData struct {
 		SpanID                uint16
-		ResAttrMapStore       *otlp.Attributes16Store
-		ScopeAttrMapStore     *otlp.Attributes16Store
-		SpanAttrMapStore      *otlp.Attributes16Store
-		SpanEventAttrMapStore *otlp.Attributes32Store
-		SpanLinkAttrMapStore  *otlp.Attributes32Store
+		ResAttrMapStore       *otlp.AttributesStore[uint16]
+		ScopeAttrMapStore     *otlp.AttributesStore[uint16]
+		SpanAttrMapStore      *otlp.AttributesStore[uint16]
+		SpanEventAttrMapStore *otlp.AttributesStore[uint32]
+		SpanLinkAttrMapStore  *otlp.AttributesStore[uint32]
 		SpanEventsStore       *SpanEventsStore
 		SpanLinksStore        *SpanLinksStore
 	}
@@ -43,11 +43,11 @@ type (
 
 func NewRelatedData(conf *arrow.Config) *RelatedData {
 	return &RelatedData{
-		ResAttrMapStore:       otlp.NewAttributes16Store(),
-		ScopeAttrMapStore:     otlp.NewAttributes16Store(),
-		SpanAttrMapStore:      otlp.NewAttributes16Store(),
-		SpanEventAttrMapStore: otlp.NewAttributes32Store(),
-		SpanLinkAttrMapStore:  otlp.NewAttributes32Store(),
+		ResAttrMapStore:       otlp.NewAttributesStore[uint16](),
+		ScopeAttrMapStore:     otlp.NewAttributesStore[uint16](),
+		SpanAttrMapStore:      otlp.NewAttributesStore[uint16](),
+		SpanEventAttrMapStore: otlp.NewAttributesStore[uint32](),
+		SpanLinkAttrMapStore:  otlp.NewAttributesStore[uint32](),
 		SpanEventsStore:       NewSpanEventsStore(conf.Event),
 		SpanLinksStore:        NewSpanLinksStore(),
 	}
@@ -75,7 +75,7 @@ func RelatedDataFrom(records []*record_message.RecordMessage, conf *arrow.Config
 	for _, record := range records {
 		switch record.PayloadType() {
 		case colarspb.ArrowPayloadType_RESOURCE_ATTRS:
-			err = otlp.Attributes16StoreFrom(
+			err = otlp.AttributesStoreFrom[uint16](
 				record.Record(),
 				relatedData.ResAttrMapStore,
 			)
@@ -83,12 +83,12 @@ func RelatedDataFrom(records []*record_message.RecordMessage, conf *arrow.Config
 				return nil, nil, werror.Wrap(err)
 			}
 		case colarspb.ArrowPayloadType_SCOPE_ATTRS:
-			err = otlp.Attributes16StoreFrom(record.Record(), relatedData.ScopeAttrMapStore)
+			err = otlp.AttributesStoreFrom[uint16](record.Record(), relatedData.ScopeAttrMapStore)
 			if err != nil {
 				return nil, nil, werror.Wrap(err)
 			}
 		case colarspb.ArrowPayloadType_SPAN_ATTRS:
-			err = otlp.Attributes16StoreFrom(record.Record(), relatedData.SpanAttrMapStore)
+			err = otlp.AttributesStoreFrom[uint16](record.Record(), relatedData.SpanAttrMapStore)
 			if err != nil {
 				return nil, nil, werror.Wrap(err)
 			}
@@ -98,7 +98,7 @@ func RelatedDataFrom(records []*record_message.RecordMessage, conf *arrow.Config
 			}
 			spanEventRecord = record
 		case colarspb.ArrowPayloadType_SPAN_EVENT_ATTRS:
-			err = otlp.Attributes32StoreFrom(record.Record(), relatedData.SpanEventAttrMapStore)
+			err = otlp.AttributesStoreFrom[uint32](record.Record(), relatedData.SpanEventAttrMapStore)
 			if err != nil {
 				return nil, nil, werror.Wrap(err)
 			}
@@ -108,7 +108,7 @@ func RelatedDataFrom(records []*record_message.RecordMessage, conf *arrow.Config
 			}
 			spanLinkRecord = record
 		case colarspb.ArrowPayloadType_SPAN_LINK_ATTRS:
-			err = otlp.Attributes32StoreFrom(record.Record(), relatedData.SpanLinkAttrMapStore)
+			err = otlp.AttributesStoreFrom[uint32](record.Record(), relatedData.SpanLinkAttrMapStore)
 			if err != nil {
 				return nil, nil, werror.Wrap(err)
 			}


### PR DESCRIPTION
Rather than creating many implementations of the AttributesStore per type, let's use the new Go generic types.

Starting to use this code as a library I was wondering if this was possible. Turns out it is.
