### PR TITLE
Reduce dependency on MetricsLevel throughout otel-arrow

### DIFF
--- a/collector/processor/concurrentbatchprocessor/batch_processor_test.go
+++ b/collector/processor/concurrentbatchprocessor/batch_processor_test.go
@@ -27,7 +27,6 @@ import (
 	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
-	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/exporter"
@@ -160,7 +159,6 @@ func TestBatchProcessorUnbrokenParentContextSingle(t *testing.T) {
 	require.NoError(t, err)
 
 	processorSet := processortest.NewNopSettings()
-	processorSet.MetricsLevel = configtelemetry.LevelDetailed
 	processorSet.TracerProvider = tp
 	bp, err := newBatchTracesProcessor(processorSet, next, cfg)
 	require.NoError(t, err)
@@ -232,7 +230,6 @@ func TestBatchProcessorUnbrokenParentContextMultiple(t *testing.T) {
 	require.NoError(t, err)
 
 	processorSet := processortest.NewNopSettings()
-	processorSet.MetricsLevel = configtelemetry.LevelDetailed
 	processorSet.TracerProvider = tp
 	bp, err := newBatchTracesProcessor(processorSet, next, cfg)
 	require.NoError(t, err)
@@ -324,7 +321,6 @@ func TestBatchProcessorSpansDelivered(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.SendBatchSize = 128
 	creationSet := processortest.NewNopSettings()
-	creationSet.MetricsLevel = configtelemetry.LevelDetailed
 	batcher, err := newBatchTracesProcessor(creationSet, sink, cfg)
 	require.NoError(t, err)
 	require.NoError(t, batcher.Start(bg, componenttest.NewNopHost()))
@@ -370,7 +366,6 @@ func TestBatchProcessorSpansDeliveredEnforceBatchSize(t *testing.T) {
 	cfg.SendBatchSize = 128
 	cfg.SendBatchMaxSize = 130
 	creationSet := processortest.NewNopSettings()
-	creationSet.MetricsLevel = configtelemetry.LevelDetailed
 	batcher, err := newBatchTracesProcessor(creationSet, sink, cfg)
 	require.NoError(t, err)
 	require.NoError(t, batcher.Start(bg, componenttest.NewNopHost()))
@@ -422,7 +417,6 @@ func testBatchProcessorTracesSentBySize(t *testing.T, early bool) {
 	cfg.Timeout = 500 * time.Millisecond
 	cfg.EarlyReturn = early
 	creationSet := tel.NewSettings()
-	creationSet.MetricsLevel = configtelemetry.LevelDetailed
 	batcher, err := newBatchTracesProcessor(creationSet, sink, cfg)
 	require.NoError(t, err)
 
@@ -557,7 +551,6 @@ func testBatchProcessorTracesSentByMaxSize(t *testing.T, early bool) {
 	cfg.Timeout = 500 * time.Millisecond
 	cfg.EarlyReturn = early
 	creationSet := tel.NewSettings()
-	creationSet.MetricsLevel = configtelemetry.LevelDetailed
 	batcher, err := newBatchTracesProcessor(creationSet, sink, cfg)
 	require.NoError(t, err)
 
@@ -717,7 +710,6 @@ func testBatchProcessorSentByTimeout(t *testing.T, early bool) {
 	spansPerRequest := 10
 
 	creationSet := processortest.NewNopSettings()
-	creationSet.MetricsLevel = configtelemetry.LevelDetailed
 	batcher, err := newBatchTracesProcessor(creationSet, sink, cfg)
 	require.NoError(t, err)
 
@@ -765,7 +757,6 @@ func TestBatchProcessorTraceSendWhenClosing(t *testing.T) {
 	sink := new(consumertest.TracesSink)
 
 	creationSet := processortest.NewNopSettings()
-	creationSet.MetricsLevel = configtelemetry.LevelDetailed
 	batcher, err := newBatchTracesProcessor(creationSet, sink, &cfg)
 	require.NoError(t, err)
 	require.NoError(t, batcher.Start(bg, componenttest.NewNopHost()))
@@ -799,7 +790,6 @@ func TestBatchMetricProcessor_ReceivingData(t *testing.T) {
 
 	bg := context.Background()
 	creationSet := processortest.NewNopSettings()
-	creationSet.MetricsLevel = configtelemetry.LevelDetailed
 	batcher, err := newBatchMetricsProcessor(creationSet, sink, &cfg)
 	require.NoError(t, err)
 	require.NoError(t, batcher.Start(bg, componenttest.NewNopHost()))
@@ -856,7 +846,6 @@ func TestBatchMetricProcessorBatchSize(t *testing.T) {
 	sink := new(consumertest.MetricsSink)
 
 	creationSet := tel.NewSettings()
-	creationSet.MetricsLevel = configtelemetry.LevelDetailed
 	batcher, err := newBatchMetricsProcessor(creationSet, sink, &cfg)
 	require.NoError(t, err)
 
@@ -1004,7 +993,6 @@ func testBatchMetricsProcessor_Timeout(t *testing.T, early bool) {
 	sink := new(consumertest.MetricsSink)
 
 	creationSet := processortest.NewNopSettings()
-	creationSet.MetricsLevel = configtelemetry.LevelDetailed
 	batcher, err := newBatchMetricsProcessor(creationSet, sink, &cfg)
 	require.NoError(t, err)
 	var wg sync.WaitGroup
@@ -1052,7 +1040,6 @@ func TestBatchMetricProcessor_Shutdown(t *testing.T) {
 	sink := new(consumertest.MetricsSink)
 
 	creationSet := processortest.NewNopSettings()
-	creationSet.MetricsLevel = configtelemetry.LevelDetailed
 	batcher, err := newBatchMetricsProcessor(creationSet, sink, &cfg)
 	require.NoError(t, err)
 	require.NoError(t, batcher.Start(bg, componenttest.NewNopHost()))
@@ -1152,7 +1139,6 @@ func runMetricsProcessorBenchmark(b *testing.B, cfg Config) {
 	ctx := context.Background()
 	sink := new(metricsSink)
 	creationSet := processortest.NewNopSettings()
-	creationSet.MetricsLevel = configtelemetry.LevelDetailed
 	metricsPerRequest := 1000
 	batcher, err := newBatchMetricsProcessor(creationSet, sink, &cfg)
 	require.NoError(b, err)
@@ -1201,7 +1187,6 @@ func TestBatchLogProcessor_ReceivingData(t *testing.T) {
 	sink := new(consumertest.LogsSink)
 
 	creationSet := processortest.NewNopSettings()
-	creationSet.MetricsLevel = configtelemetry.LevelDetailed
 	batcher, err := newBatchLogsProcessor(creationSet, sink, &cfg)
 	require.NoError(t, err)
 	require.NoError(t, batcher.Start(bg, componenttest.NewNopHost()))
@@ -1256,7 +1241,6 @@ func TestBatchLogProcessor_BatchSize(t *testing.T) {
 	sink := new(consumertest.LogsSink)
 
 	creationSet := tel.NewSettings()
-	creationSet.MetricsLevel = configtelemetry.LevelDetailed
 	batcher, err := newBatchLogsProcessor(creationSet, sink, &cfg)
 	require.NoError(t, err)
 
@@ -1384,7 +1368,6 @@ func testBatchLogsProcessor_Timeout(t *testing.T, early bool) {
 	sink := new(consumertest.LogsSink)
 
 	creationSet := processortest.NewNopSettings()
-	creationSet.MetricsLevel = configtelemetry.LevelDetailed
 	batcher, err := newBatchLogsProcessor(creationSet, sink, &cfg)
 	require.NoError(t, err)
 
@@ -1432,7 +1415,6 @@ func TestBatchLogProcessor_Shutdown(t *testing.T) {
 	sink := new(consumertest.LogsSink)
 
 	creationSet := processortest.NewNopSettings()
-	creationSet.MetricsLevel = configtelemetry.LevelDetailed
 	batcher, err := newBatchLogsProcessor(creationSet, sink, &cfg)
 	require.NoError(t, err)
 	require.NoError(t, batcher.Start(bg, componenttest.NewNopHost()))
@@ -1541,7 +1523,6 @@ func TestBatchProcessorSpansBatchedByMetadata(t *testing.T) {
 	cfg.Timeout = 1 * time.Second
 	cfg.MetadataKeys = []string{"token1", "token2"}
 	creationSet := processortest.NewNopSettings()
-	creationSet.MetricsLevel = configtelemetry.LevelDetailed
 	batcher, err := newBatchTracesProcessor(creationSet, sink, cfg)
 	bg := context.Background()
 	require.NoError(t, err)
@@ -1686,7 +1667,6 @@ func TestBatchZeroConfig(t *testing.T) {
 	const logsPerRequest = 10
 	sink := new(consumertest.LogsSink)
 	creationSet := processortest.NewNopSettings()
-	creationSet.MetricsLevel = configtelemetry.LevelDetailed
 	batcher, err := newBatchLogsProcessor(creationSet, sink, &cfg)
 	require.NoError(t, err)
 	require.NoError(t, batcher.Start(bg, componenttest.NewNopHost()))
@@ -1731,7 +1711,6 @@ func TestBatchSplitOnly(t *testing.T) {
 
 	sink := new(consumertest.LogsSink)
 	creationSet := processortest.NewNopSettings()
-	creationSet.MetricsLevel = configtelemetry.LevelDetailed
 	batcher, err := newBatchLogsProcessor(creationSet, sink, &cfg)
 	require.NoError(t, err)
 	require.NoError(t, batcher.Start(bg, componenttest.NewNopHost()))
@@ -1764,7 +1743,6 @@ func TestBatchProcessorEmptyBatch(t *testing.T) {
 	requestCount := 5
 
 	creationSet := processortest.NewNopSettings()
-	creationSet.MetricsLevel = configtelemetry.LevelDetailed
 	batcher, err := newBatchTracesProcessor(creationSet, sink, cfg)
 	require.NoError(t, err)
 	require.NoError(t, batcher.Start(context.Background(), componenttest.NewNopHost()))
@@ -1805,7 +1783,6 @@ func TestErrorPropagation(t *testing.T) {
 		sink := errorSink{err: proto}
 
 		creationSet := processortest.NewNopSettings()
-		creationSet.MetricsLevel = configtelemetry.LevelDetailed
 		cfg := createDefaultConfig().(*Config)
 		batcher, err := newBatchLogsProcessor(creationSet, sink, cfg)
 
@@ -1920,7 +1897,6 @@ func TestBatchProcessorEarlyReturn(t *testing.T) {
 	cfg.EarlyReturn = true
 	cfg.Timeout = time.Minute
 	creationSet := processortest.NewNopSettings()
-	creationSet.MetricsLevel = configtelemetry.LevelDetailed
 	batcher, err := newBatchTracesProcessor(creationSet, sink, cfg)
 	require.NoError(t, err)
 

--- a/collector/processor/concurrentbatchprocessor/metrics.go
+++ b/collector/processor/concurrentbatchprocessor/metrics.go
@@ -10,7 +10,6 @@ import (
 	"go.opentelemetry.io/otel/metric"
 
 	"github.com/open-telemetry/otel-arrow/collector/processor/concurrentbatchprocessor/internal/metadata"
-	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/processor"
 )
 
@@ -22,8 +21,6 @@ const (
 )
 
 type batchProcessorTelemetry struct {
-	detailed bool
-
 	exportCtx context.Context
 
 	processorAttr    attribute.Set
@@ -45,7 +42,6 @@ func newBatchProcessorTelemetry(set processor.Settings, currentMetadataCardinali
 
 	return &batchProcessorTelemetry{
 		exportCtx:        context.Background(),
-		detailed:         set.MetricsLevel == configtelemetry.LevelDetailed,
 		telemetryBuilder: telemetryBuilder,
 		processorAttr:    attrs,
 	}, nil

--- a/pkg/otel/arrow_record/consumer.go
+++ b/pkg/otel/arrow_record/consumer.go
@@ -160,13 +160,11 @@ func NewConsumer(opts ...Option) *Consumer {
 		schemaResetCounter: noop.Int64Counter{},
 		memoryCounter:      noop.Int64UpDownCounter{},
 	}
-	if cfg.metricsLevel >= configtelemetry.LevelNormal {
-		meter := cfg.meterProvider.Meter("otel-arrow/pkg/otel/arrow_record")
+	meter := cfg.meterProvider.Meter("otel-arrow/pkg/otel/arrow_record")
 
-		c.recordsCounter = mustWarn(meter.Int64Counter("arrow_batch_records"))
-		c.schemaResetCounter = mustWarn(meter.Int64Counter("arrow_schema_resets"))
-		c.memoryCounter = mustWarn(meter.Int64UpDownCounter("arrow_memory_inuse"))
-	}
+	c.recordsCounter = mustWarn(meter.Int64Counter("arrow_batch_records"))
+	c.schemaResetCounter = mustWarn(meter.Int64Counter("arrow_schema_resets"))
+	c.memoryCounter = mustWarn(meter.Int64UpDownCounter("arrow_memory_inuse"))
 	return c
 }
 
@@ -185,9 +183,6 @@ func mustWarn[T any](t T, err error) T {
 }
 
 func (c *Consumer) metricOpts(kvs ...attribute.KeyValue) []metric.AddOption {
-	if c.metricsLevel < configtelemetry.LevelNormal {
-		return nil
-	}
 	return []metric.AddOption{
 		metric.WithAttributes(kvs...),
 	}

--- a/pkg/otel/arrow_record/consumer.go
+++ b/pkg/otel/arrow_record/consumer.go
@@ -126,6 +126,16 @@ func WithMeterProvider(p metric.MeterProvider, l configtelemetry.Level) Option {
 	}
 }
 
+// WithMeterProviderAlt configures an OTel metrics provider.  If none is
+// configured, the global meter provider will be used.
+// This is an alternative to WithMeterProvider, and will eventually be
+// the only option to remove dependency on configtelemetry.Level.
+func WithMeterProviderAlt(p metric.MeterProvider) Option {
+	return func(cfg *Config) {
+		cfg.meterProvider = p
+	}
+}
+
 type streamConsumer struct {
 	bufReader   *bytes.Reader
 	ipcReader   *ipc.Reader

--- a/pkg/otel/arrow_record/consumer.go
+++ b/pkg/otel/arrow_record/consumer.go
@@ -18,9 +18,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"log"
-	"math/rand"
 
 	"github.com/apache/arrow/go/v17/arrow/ipc"
 	"github.com/apache/arrow/go/v17/arrow/memory"
@@ -93,11 +91,6 @@ type Consumer struct {
 	schemaResetCounter metric.Int64Counter
 	// tracks allocator.Inuse()
 	memoryCounter metric.Int64UpDownCounter
-
-	// uniqueAttr is set to an 8-byte hex digit string with
-	// 32-bits of randomness, applied to all metric events
-	// when MetricsLevel is > Detailed (i.e., above detailed).
-	uniqueAttr attribute.KeyValue
 }
 
 type Config struct {
@@ -162,7 +155,6 @@ func NewConsumer(opts ...Option) *Consumer {
 	c := &Consumer{
 		Config:             cfg,
 		allocator:          allocator,
-		uniqueAttr:         attribute.String("stream_unique", fmt.Sprintf("%08x", rand.Uint32())),
 		streamConsumers:    make(map[string]*streamConsumer),
 		recordsCounter:     noop.Int64Counter{},
 		schemaResetCounter: noop.Int64Counter{},
@@ -195,9 +187,6 @@ func mustWarn[T any](t T, err error) T {
 func (c *Consumer) metricOpts(kvs ...attribute.KeyValue) []metric.AddOption {
 	if c.metricsLevel < configtelemetry.LevelNormal {
 		return nil
-	}
-	if c.metricsLevel > configtelemetry.LevelDetailed {
-		kvs = append(kvs, c.uniqueAttr)
 	}
 	return []metric.AddOption{
 		metric.WithAttributes(kvs...),

--- a/pkg/otel/arrow_record/consumer.go
+++ b/pkg/otel/arrow_record/consumer.go
@@ -151,7 +151,6 @@ func NewConsumer(opts ...Option) *Consumer {
 		memLimit:      defaultMemoryLimit,
 		tracesConfig:  arrow.DefaultConfig(),
 		meterProvider: otel.GetMeterProvider(),
-		metricsLevel:  configtelemetry.LevelNormal,
 	}
 	for _, opt := range opts {
 		opt(&cfg)


### PR DESCRIPTION
Related to issue #280 

Also see https://github.com/open-telemetry/opentelemetry-collector/issues/11061 and https://github.com/open-telemetry/opentelemetry-collector/pull/12143

There is a movement to remove `MetricsLevel` from the Collector's `TelemetrySettings`, which is used explicitly in various places in the otel-arrow project.

In addition to the 'dead code' identified in #280, this PR aims to remove other instances of reference to `MetricsLevel`.

In one case this is not currently possible because a component in `opentelemetry-collector-contrib` depends on an `otel-arrow arrow_record` function signature including `MetricsLevel`, see [otelarrowreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/c4abcb96bb70ab37135217614a96f309ea6c88d9/receiver/otelarrowreceiver/otelarrow.go#L145). Instead, introduced a temporary `WithMeterProviderAlt` without that paramater that should become the new default implementation once the Contrib component is updated accordingly.