### PR TITLE
Release v0.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,19 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+## [0.32.0](https://github.com/open-telemetry/otel-arrow/releases/tag/v0.32.0) - 2025-01-24
+
+- Make a generic `AttributesStore` in pkg/arrow. [#276](https://github.com/open-telemetry/otel-arrow/pull/276)
 - Update to v0.117.0 collector dependencies. [#277](https://github.com/open-telemetry/otel-arrow/pull/277), [#279](https://github.com/open-telemetry/otel-arrow/pull/279)
 - Deprecate local versions of `fileexporter` and `filereceiver` in favor of upstream components with related README changes. [#232](https://github.com/open-telemetry/otel-arrow/issues/232)
+- Made an incremental step towards deprecating `MetricsLevel` usage in the project. [#283](https://github.com/open-telemetry/otel-arrow/pull/283)
 
 ## [0.31.0](https://github.com/open-telemetry/otel-arrow/releases/tag/v0.31.0) - 2024-11-19
 
 - Update to v0.114.0 collector dependencies. [#274](https://github.com/open-telemetry/otel-arrow/pull/274)
 - Empty SpanID bug-fix. [#273](https://github.com/open-telemetry/otel-arrow/pull/273)
 
-## [0.30.0](https://github.com/open-telemetry/otel-arrow/releases/tag/v0.3029.0) - 2024-11-06
+## [0.30.0](https://github.com/open-telemetry/otel-arrow/releases/tag/v0.30.0) - 2024-11-06
 
 - Update to v0.113.0 collector dependencies. [#269](https://github.com/open-telemetry/otel-arrow/pull/269)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Make a generic `AttributesStore` in pkg/arrow. [#276](https://github.com/open-telemetry/otel-arrow/pull/276)
 - Update to v0.117.0 collector dependencies. [#277](https://github.com/open-telemetry/otel-arrow/pull/277), [#279](https://github.com/open-telemetry/otel-arrow/pull/279)
-- Deprecate local versions of `fileexporter` and `filereceiver` in favor of upstream components with related README changes. [#232](https://github.com/open-telemetry/otel-arrow/issues/232)
+- Deprecate local versions of `fileexporter` and `filereceiver` in favor of upstream components with related README changes. [#278](https://github.com/open-telemetry/otel-arrow/pull/278)
 - Made an incremental step towards deprecating `MetricsLevel` usage in the project. [#283](https://github.com/open-telemetry/otel-arrow/pull/283)
 
 ## [0.31.0](https://github.com/open-telemetry/otel-arrow/releases/tag/v0.31.0) - 2024-11-19

--- a/collector/cmd/otelarrowcol/components.go
+++ b/collector/cmd/otelarrowcol/components.go
@@ -77,8 +77,8 @@ func components() (otelcol.Factories, error) {
 		return otelcol.Factories{}, err
 	}
 	factories.ProcessorModules = make(map[component.Type]string, len(factories.Processors))
-	factories.ProcessorModules[concurrentbatchprocessor.NewFactory().Type()] = "github.com/open-telemetry/otel-arrow/collector/processor/concurrentbatchprocessor v0.31.0"
-	factories.ProcessorModules[obfuscationprocessor.NewFactory().Type()] = "github.com/open-telemetry/otel-arrow/collector/processor/obfuscationprocessor v0.31.0"
+	factories.ProcessorModules[concurrentbatchprocessor.NewFactory().Type()] = "github.com/open-telemetry/otel-arrow/collector/processor/concurrentbatchprocessor v0.32.0"
+	factories.ProcessorModules[obfuscationprocessor.NewFactory().Type()] = "github.com/open-telemetry/otel-arrow/collector/processor/obfuscationprocessor v0.32.0"
 
 	factories.Connectors, err = connector.MakeFactoryMap(
 	)

--- a/collector/cmd/otelarrowcol/go.mod
+++ b/collector/cmd/otelarrowcol/go.mod
@@ -14,8 +14,8 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.117.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver v0.117.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver v0.117.0
-	github.com/open-telemetry/otel-arrow/collector/processor/concurrentbatchprocessor v0.31.0
-	github.com/open-telemetry/otel-arrow/collector/processor/obfuscationprocessor v0.31.0
+	github.com/open-telemetry/otel-arrow/collector/processor/concurrentbatchprocessor v0.32.0
+	github.com/open-telemetry/otel-arrow/collector/processor/obfuscationprocessor v0.32.0
 	go.opentelemetry.io/collector/component v0.117.0
 	go.opentelemetry.io/collector/confmap v1.23.0
 	go.opentelemetry.io/collector/confmap/provider/envprovider v1.23.0

--- a/collector/cmd/otelarrowcol/main.go
+++ b/collector/cmd/otelarrowcol/main.go
@@ -20,7 +20,7 @@ func main() {
 	info := component.BuildInfo{
 		Command:     "otelarrowcol",
 		Description: "OpenTelemetry Protocol with Apache Arrow development collector, for testing and evaluation",
-		Version:     "0.31.0",
+		Version:     "0.32.0",
 	}
 
 	set := otelcol.CollectorSettings{

--- a/collector/otelarrowcol-build.yaml
+++ b/collector/otelarrowcol-build.yaml
@@ -17,7 +17,7 @@ dist:
 
   # Note: this version number is replaced to match the current release using `sed`
   # during the release process, see ../../../RELEASING.md.
-  version: 0.31.0
+  version: 0.32.0
 
   # Project-internal use: Directory path required for the `make
   # genotelarrowcol`, which the Dockerfile also recognizes.
@@ -43,8 +43,8 @@ receivers:
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.117.0
 
 processors:
-  - gomod: github.com/open-telemetry/otel-arrow/collector/processor/concurrentbatchprocessor v0.31.0
-  - gomod: github.com/open-telemetry/otel-arrow/collector/processor/obfuscationprocessor v0.31.0
+  - gomod: github.com/open-telemetry/otel-arrow/collector/processor/concurrentbatchprocessor v0.32.0
+  - gomod: github.com/open-telemetry/otel-arrow/collector/processor/obfuscationprocessor v0.32.0
 
 extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.117.0

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,7 +3,7 @@
 
 module-sets:
   beta:
-    version: v0.31.0
+    version: v0.32.0
     modules:
       - github.com/open-telemetry/otel-arrow
       - github.com/open-telemetry/otel-arrow/collector/cmd/otelarrowcol


### PR DESCRIPTION
- Make a generic `AttributesStore` in pkg/arrow. [#276](https://github.com/open-telemetry/otel-arrow/pull/276)
- Update to v0.117.0 collector dependencies. [#277](https://github.com/open-telemetry/otel-arrow/pull/277), [#279](https://github.com/open-telemetry/otel-arrow/pull/279)
- Deprecate local versions of `fileexporter` and `filereceiver` in favor of upstream components with related README changes. [#278](https://github.com/open-telemetry/otel-arrow/pull/278)
- Made an incremental step towards deprecating `MetricsLevel` usage in the project. [#283](https://github.com/open-telemetry/otel-arrow/pull/283)