### PR TITLE
Release v0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+## [0.34.0](https://github.com/open-telemetry/otel-arrow/releases/tag/v0.34.0) - 2025-02-25
+
 - Upgrade to v0.120.0 of collector dependencies. [#292](https://github.com/open-telemetry/otel-arrow/pull/292)
 
 ## [0.33.0](https://github.com/open-telemetry/otel-arrow/releases/tag/v0.33.0) - 2025-02-06

--- a/collector/cmd/otelarrowcol/main.go
+++ b/collector/cmd/otelarrowcol/main.go
@@ -20,7 +20,7 @@ func main() {
 	info := component.BuildInfo{
 		Command:     "otelarrowcol",
 		Description: "OpenTelemetry Protocol with Apache Arrow development collector, for testing and evaluation",
-		Version:     "0.33.0",
+		Version:     "0.34.0",
 	}
 
 	set := otelcol.CollectorSettings{

--- a/collector/otelarrowcol-build.yaml
+++ b/collector/otelarrowcol-build.yaml
@@ -17,7 +17,7 @@ dist:
 
   # Note: this version number is replaced to match the current release using `sed`
   # during the release process, see ../../../RELEASING.md.
-  version: 0.33.0
+  version: 0.34.0
 
   # Project-internal use: Directory path required for the `make
   # genotelarrowcol`, which the Dockerfile also recognizes.
@@ -43,8 +43,8 @@ receivers:
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.120.0
 
 processors:
-  - gomod: github.com/open-telemetry/otel-arrow/collector/processor/concurrentbatchprocessor v0.33.0
-  - gomod: github.com/open-telemetry/otel-arrow/collector/processor/obfuscationprocessor v0.33.0
+  - gomod: github.com/open-telemetry/otel-arrow/collector/processor/concurrentbatchprocessor v0.34.0
+  - gomod: github.com/open-telemetry/otel-arrow/collector/processor/obfuscationprocessor v0.34.0
 
 extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.120.0

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,7 +3,7 @@
 
 module-sets:
   beta:
-    version: v0.33.0
+    version: v0.34.0
     modules:
       - github.com/open-telemetry/otel-arrow
       - github.com/open-telemetry/otel-arrow/collector/cmd/otelarrowcol


### PR DESCRIPTION
- Upgrade to v0.120.0 of collector dependencies. [#292](https://github.com/open-telemetry/otel-arrow/pull/292)
