### PR TITLE
GitHub Actions fixes after Go+Rust refactor

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -1,6 +1,8 @@
 name: Go-CI
 permissions:
   contents: read
+  # needed for codeql 
+  security-events: write
 
 on: [push, pull_request]
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # OpenTelemetry Protocol with Apache Arrow
 
 [![Slack](https://img.shields.io/badge/slack-@cncf/otel/arrow-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C07S4Q67LTF)
-[![Build](https://github.com/open-telemetry/otel-arrow/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/open-telemetry/otel-arrow/actions/workflows/ci.yml)
+[![Go-CI](https://github.com/drewrelmas/otel-arrow/actions/workflows/go-ci.yml/badge.svg)](https://github.com/drewrelmas/otel-arrow/actions/workflows/go-ci.yml)
+[![Rust-CI](https://github.com/drewrelmas/otel-arrow/actions/workflows/rust-ci.yml/badge.svg)](https://github.com/drewrelmas/otel-arrow/actions/workflows/rust-ci.yml)
 [![OpenSSF Scorecard for otel-arrow](https://api.scorecard.dev/projects/github.com/open-telemetry/otel-arrow/badge)](https://scorecard.dev/viewer/?uri=github.com/open-telemetry/otel-arrow)
 
 The [OpenTelemetry Protocol with Apache


### PR DESCRIPTION
There were a few undiscovered issued in #302 
1. Status badge in README.md became outdated
1. Go-CI action which uses `codeql` became unable to write, likely due to missing [security-events: write permission](https://github.com/github/codeql-action?tab=readme-ov-file#workflow-permissions)
1. Rust-CI Clippy step fails build on `/main` branch with warnings even though it passes in CI build

This PR addresses (1) and (2), still trying to find a solution for (3)