### PR TITLE
Isolate Go and Rust CIs by file path

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -4,7 +4,15 @@ permissions:
   # needed for codeql 
   security-events: write
 
-on: [push, pull_request]
+on: 
+  # run this job on every push and pull request
+  # ignore changes only in the rust directory
+  push:
+    paths-ignore:
+      - 'rust/**'
+  pull_request:
+    paths-ignore:
+      - 'rust/**'
 
 jobs:
 

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -2,7 +2,15 @@ name: Rust-CI
 permissions:
   contents: read
 
-on: [push, pull_request]
+on:
+  # run this job on every push and pull request
+  # only for changes in the rust directory
+  push:
+    paths:
+      - 'rust/**'
+  pull_request:
+    paths:
+      - 'rust/**'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Since #317 forecasts ongoing Rust-CI failures for the foreseeable future, it is convenient to only run Rust CI when the git diff actually touches something under the `rust/` directory (and vice-versa for the Go CI).

This will be a little cleaner in the future if all Go code is isolated under a `go/` directory. For now, the Go-CI will run if something outside of `rust/` is touched.

Will also help in cases like #311 which only touch Go code - hiding unrelated job failures.