### PR TITLE
Improve cargo deny invocation for isolated logging

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -10,9 +10,11 @@ on:
   push:
     paths-ignore:
       - 'rust/**'
+      - .github/workflows/rust-ci.yml
   pull_request:
     paths-ignore:
       - 'rust/**'
+      - .github/workflows/rust-ci.yml
 
 jobs:
 

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -95,22 +95,36 @@ jobs:
       fail-fast: false
       matrix:
         folder: [beaubourg, otel-arrow-rust]
-        checks: 
-          - advisories
-          - bans licenses sources
     runs-on: ubuntu-latest
-    # Prevent sudden announcement of a new advisory from failing ci:
-    continue-on-error: ${{ matrix.checks == 'advisories' }}
     steps:
       - uses: actions/checkout@v4
       - uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: dtolnay/rust-toolchain@stable
-      - name: cargo deny check ${{ matrix.checks}}
+      - name: advisories
+        if: '!cancelled()'
         uses: EmbarkStudios/cargo-deny-action@v2
         with:
-          command: check ${{ matrix.checks }}
+          command: check advisories
+          manifest-path: ./rust/${{ matrix.folder }}/Cargo.toml
+      - name: licenses
+        if: '!cancelled()'
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check licenses
+          manifest-path: ./rust/${{ matrix.folder }}/Cargo.toml
+      - name: bans
+        if: '!cancelled()'
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check bans
+          manifest-path: ./rust/${{ matrix.folder }}/Cargo.toml
+      - name: sources
+        if: '!cancelled()'
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check sources
           manifest-path: ./rust/${{ matrix.folder }}/Cargo.toml
 
   bench:

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -8,9 +8,11 @@ on:
   push:
     paths:
       - 'rust/**'
+      - .github/workflows/rust-ci.yml
   pull_request:
     paths:
       - 'rust/**'
+      - .github/workflows/rust-ci.yml
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -93,15 +93,22 @@ jobs:
       fail-fast: false
       matrix:
         folder: [beaubourg, otel-arrow-rust]
+        checks: 
+          - advisories
+          - bans licenses sources
     runs-on: ubuntu-latest
+    # Prevent sudden announcement of a new advisory from failing ci:
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
     steps:
       - uses: actions/checkout@v4
       - uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: dtolnay/rust-toolchain@stable
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - name: cargo deny check ${{ matrix.checks}}
+        uses: EmbarkStudios/cargo-deny-action@v2
         with:
+          command: check ${{ matrix.checks }}
           manifest-path: ./rust/${{ matrix.folder }}/Cargo.toml
 
   bench:


### PR DESCRIPTION
See https://github.com/EmbarkStudios/cargo-deny-action?tab=readme-ov-file#recommended-pipeline-if-using-advisories-to-avoid-sudden-breakages

Took inspiration from the above to restructure cargo deny invocation. Desired state:
- Only 1 cargo_deny job for each `/rust` subfolder
- Isolated cargo_deny steps inside that job that always run independently of others

In this way, we aviud exponentially increasing the number of running jobs but ALSO can see isolated error messages for each portion of the cargo deny workflow (advisories vs licenses vs ...)

![image](https://github.com/user-attachments/assets/7cf836e7-5455-4e4c-b5d5-709722bb8fe8)
