### PR TITLE
Add Pest grammars for KQL and OTTL supporting Filter and Extend

### DIFF
--- a/rust/experimental/query_abstraction/deny.toml
+++ b/rust/experimental/query_abstraction/deny.toml
@@ -64,9 +64,9 @@ ignore = [
 allow = [
     "MIT",
     "Apache-2.0",
-    #"Apache-2.0 WITH LLVM-exception",
-    "BSD-3-Clause",
-    "Zlib"
+    # TODO: Confirm legal use of Unicode-3.0
+    # See https://github.com/open-telemetry/otel-arrow/issues/313
+    "Unicode-3.0"
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the

--- a/rust/experimental/query_abstraction/kql_plugin/Cargo.toml
+++ b/rust/experimental/query_abstraction/kql_plugin/Cargo.toml
@@ -5,3 +5,5 @@ edition = "2021"
 
 [dependencies]
 intermediate_language = { verison = "0.1.0", path = "../intermediate_language" }
+pest = "2.8"
+pest_derive = "2.8"

--- a/rust/experimental/query_abstraction/kql_plugin/src/kql.pest
+++ b/rust/experimental/query_abstraction/kql_plugin/src/kql.pest
@@ -1,0 +1,106 @@
+// These two special rules, when defined, are implicitly allowed at:
+// - at every sequence (split by ~)
+// - between every repetition (+ or *)
+// Atomics (marked with @) are excluded
+// See https://pest.rs/book/grammars/syntax.html#implicit-whitespace
+WHITESPACE = _{ " " }
+COMMENT = _{ "/*" ~ (!"*/" ~ ANY)* ~ "*/" }
+
+// Basic tokens
+// ----------------------------------------------
+true_token = @{ "true" }
+false_token = @{ "false" }
+integer_token = @{ 
+    "-"?
+    ~ ("0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*)
+}
+string_token = @{ "\"" ~ (!"\"" ~ ANY)* ~ "\"" }
+equals_token = @{ "==" }
+not_equals_token = @{ "!=" }
+comma_token = @{ "," }
+and_token = @{ "and" }
+or_token = @{ "or" }
+greater_than_token = @{ ">" ~ !"=" }
+less_than_token = @{ "<" ~ !"=" }
+greater_than_or_equal_to_token = @{ ">=" }
+less_than_or_equal_to_token = @{ "<=" }
+open_paren_token = @{ "(" }
+close_paren_token = @{ ")" }
+not_token = @{ "not" }
+where_token = @{ "where" }
+// ----------------------------------------------
+
+// Basic Grammar
+// ----------------------------------------------
+literal = { true_token | false_token | integer_token | string_token }
+identifier = @{ ("_" | ASCII_ALPHANUMERIC)+ }
+
+expression_base = { identifier | literal | enclosed_expression }
+
+enclosed_expression = { open_paren_token ~ expression ~ close_paren_token }
+
+not_expression = { not_token ~ enclosed_expression }
+and_expression = { expression_base ~ (and_token ~ expression)+ }
+or_expression = { expression_base ~  (or_token ~ expression)+ }
+
+equals_expression = { expression_base ~ equals_token ~ expression }
+not_equals_expression = { expression_base ~ not_equals_token ~ expression }
+greater_than_expression = { expression_base ~ greater_than_token ~ expression }
+less_than_expression = { expression_base ~ less_than_token ~ expression }
+greater_than_or_equal_to_expression = { expression_base ~ greater_than_or_equal_to_token ~ expression }
+less_than_or_equal_to_expression = { expression_base ~ less_than_or_equal_to_token ~ expression }
+
+boolean_expression = {
+    not_expression
+    | and_expression
+    | or_expression
+}
+
+comparison_expression = {
+    equals_expression
+    | not_equals_expression
+    | greater_than_expression
+    | less_than_expression
+    | greater_than_or_equal_to_expression
+    | less_than_or_equal_to_expression
+}
+
+conditional_expression = {
+    boolean_expression
+    | comparison_expression
+}
+
+expression = { 
+    conditional_expression
+    | enclosed_expression
+    | literal
+    | identifier 
+}
+// ----------------------------------------------
+
+// KQL-specific Tokens
+// ----------------------------------------------
+assignment_token = @{ "=" ~ !"=" }
+extend_token = @{ "extend" }
+pipe_token = @{ "|" ~ !"|" }
+// ----------------------------------------------
+
+// KQL-specific Grammar
+// ----------------------------------------------
+assignment_expression = { identifier ~ assignment_token ~ expression }
+
+filter_expression = { where_token ~ conditional_expression }
+extend_expression = { extend_token ~ assignment_expression ~ (comma_token ~ assignment_expression)* }
+
+logical_expression = {
+    filter_expression
+    | extend_expression
+}
+
+statement = { pipe_token ~ logical_expression }
+
+query = { 
+    SOI ~ identifier ~ EOI
+    | SOI ~ identifier ~ (NEWLINE* ~ statement)+ ~ NEWLINE* ~ EOI
+}
+// ----------------------------------------------

--- a/rust/experimental/query_abstraction/kql_plugin/src/kql.pest
+++ b/rust/experimental/query_abstraction/kql_plugin/src/kql.pest
@@ -39,7 +39,6 @@ expression_base = { identifier | literal | enclosed_expression }
 
 enclosed_expression = { open_paren_token ~ expression ~ close_paren_token }
 
-not_expression = { not_token ~ enclosed_expression }
 and_expression = { expression_base ~ (and_token ~ expression)+ }
 or_expression = { expression_base ~  (or_token ~ expression)+ }
 
@@ -50,12 +49,10 @@ less_than_expression = { expression_base ~ less_than_token ~ expression }
 greater_than_or_equal_to_expression = { expression_base ~ greater_than_or_equal_to_token ~ expression }
 less_than_or_equal_to_expression = { expression_base ~ less_than_or_equal_to_token ~ expression }
 
-boolean_expression = {
-    not_expression
-    | and_expression
+binary_logical_expression = {
+    and_expression
     | or_expression
 }
-
 comparison_expression = {
     equals_expression
     | not_equals_expression
@@ -64,14 +61,16 @@ comparison_expression = {
     | greater_than_or_equal_to_expression
     | less_than_or_equal_to_expression
 }
+negated_expression = { not_token ~ enclosed_expression }
 
-conditional_expression = {
-    boolean_expression
+predicate = {
+    binary_logical_expression
     | comparison_expression
+    | negated_expression
 }
 
 expression = { 
-    conditional_expression
+    predicate
     | enclosed_expression
     | literal
     | identifier 
@@ -89,15 +88,10 @@ pipe_token = @{ "|" ~ !"|" }
 // ----------------------------------------------
 assignment_expression = { identifier ~ assignment_token ~ expression }
 
-filter_expression = { where_token ~ conditional_expression }
-extend_expression = { extend_token ~ assignment_expression ~ (comma_token ~ assignment_expression)* }
+filter_statement = { where_token ~ predicate }
+extend_statement = { extend_token ~ assignment_expression ~ (comma_token ~ assignment_expression)* }
 
-logical_expression = {
-    filter_expression
-    | extend_expression
-}
-
-statement = { pipe_token ~ logical_expression }
+statement = { pipe_token ~ (filter_statement | extend_statement) }
 
 query = { 
     SOI ~ identifier ~ EOI

--- a/rust/experimental/query_abstraction/kql_plugin/src/kql_parser.rs
+++ b/rust/experimental/query_abstraction/kql_plugin/src/kql_parser.rs
@@ -1,0 +1,151 @@
+use pest_derive::Parser;
+
+#[derive(Parser)]
+#[grammar = "kql.pest"]
+#[allow(dead_code)] // Remove this line when the parser is used
+pub struct KqlParser;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pest::Parser;
+
+    #[test]
+    fn test_true_token() {
+        assert!(KqlParser::parse(Rule::true_token, "true").is_ok());
+        assert!(KqlParser::parse(Rule::true_token, "false").is_err());
+        assert!(KqlParser::parse(Rule::true_token, "tru").is_err());
+    }
+
+    #[test]
+    fn test_false_token() {
+        assert!(KqlParser::parse(Rule::false_token, "false").is_ok());
+        assert!(KqlParser::parse(Rule::false_token, "true").is_err());
+        assert!(KqlParser::parse(Rule::false_token, "fals").is_err());
+    }
+
+    #[test]
+    fn test_integer_token() {
+        assert!(KqlParser::parse(Rule::integer_token, "123").is_ok());
+        assert!(KqlParser::parse(Rule::integer_token, ".53").is_err());
+        assert!(KqlParser::parse(Rule::integer_token, "abc").is_err());
+    }
+
+    #[test]
+    fn test_string_token() {
+        assert!(KqlParser::parse(Rule::string_token, r#""hello""#).is_ok());
+        assert!(KqlParser::parse(Rule::string_token, r#""hello"#).is_err());
+        assert!(KqlParser::parse(Rule::string_token, r#"hello""#).is_err());
+        assert!(KqlParser::parse(Rule::string_token, r#""""#).is_ok());
+    }
+
+    #[test]
+    fn test_identifier() {
+        assert!(KqlParser::parse(Rule::identifier, "abc").is_ok());
+        assert!(KqlParser::parse(Rule::identifier, "abc_123").is_ok());
+        assert!(KqlParser::parse(Rule::identifier, "_abc").is_ok());
+        assert!(KqlParser::parse(Rule::identifier, "123abc").is_ok());
+    }
+
+    #[test]
+    fn test_comparison_expression() {
+        assert!(KqlParser::parse(Rule::comparison_expression, "x == 42").is_ok());
+        assert!(KqlParser::parse(Rule::comparison_expression, r#"x != "hello""#).is_ok());
+        assert!(KqlParser::parse(Rule::comparison_expression, "x = 42").is_err());
+        assert!(KqlParser::parse(Rule::comparison_expression, "== 42").is_err());
+
+        assert!(KqlParser::parse(Rule::comparison_expression, "x > 5").is_ok());
+        assert!(KqlParser::parse(Rule::comparison_expression, "x < 5").is_ok());
+        assert!(KqlParser::parse(Rule::comparison_expression, "y <= 10").is_ok());
+        assert!(KqlParser::parse(Rule::comparison_expression, "y >= 10").is_ok());
+    }
+
+    #[test]
+    fn test_boolean_expression() {
+        assert!(KqlParser::parse(Rule::boolean_expression, "a and b").is_ok());
+        assert!(KqlParser::parse(Rule::boolean_expression, "a and").is_err());
+        assert!(KqlParser::parse(Rule::boolean_expression, "a or b").is_ok());
+        assert!(KqlParser::parse(Rule::boolean_expression, "or b").is_err());
+        assert!(KqlParser::parse(Rule::boolean_expression, "not(a)").is_ok());
+        assert!(KqlParser::parse(Rule::boolean_expression, "not a").is_err());
+        assert!(KqlParser::parse(Rule::boolean_expression, "!a").is_err());
+
+        assert!(KqlParser::parse(Rule::boolean_expression, "not(a and b)").is_ok());
+        assert!(KqlParser::parse(Rule::boolean_expression, "(a and b) or (c and d)").is_ok());
+        assert!(KqlParser::parse(Rule::boolean_expression, "a or (b and c)").is_ok());
+        assert!(KqlParser::parse(Rule::boolean_expression, "a and b and c").is_ok());
+    }
+
+    #[test]
+    fn test_expression() {
+        assert!(KqlParser::parse(Rule::expression, "(a and b)").is_ok());
+        assert!(KqlParser::parse(Rule::expression, "a and b").is_ok());
+        assert!(KqlParser::parse(Rule::expression, "x == 42").is_ok());
+        assert!(KqlParser::parse(Rule::expression, "my_variable").is_ok());
+        assert!(KqlParser::parse(Rule::expression, "42").is_ok());
+        assert!(KqlParser::parse(Rule::expression, "(y > 24) and z == 10").is_ok());
+    }
+
+    #[test]
+    fn test_filter_expression() {
+        assert!(KqlParser::parse(Rule::filter_expression, "where x == 42").is_ok());
+        assert!(KqlParser::parse(Rule::filter_expression, r#"where x != "hello""#).is_ok());
+        assert!(KqlParser::parse(Rule::filter_expression, "where x == 42 and y > 24").is_ok());
+        assert!(KqlParser::parse(Rule::filter_expression, "where x == 42 or not(y > 24)").is_ok());
+        assert!(KqlParser::parse(Rule::filter_expression, "where x = 42").is_err());
+        assert!(KqlParser::parse(Rule::filter_expression, "x == 42").is_err());
+    }
+
+    #[test]
+    fn test_extend_expression() {
+        assert!(KqlParser::parse(Rule::extend_expression, "extend x = 42").is_ok());
+        assert!(KqlParser::parse(Rule::extend_expression, "extend x=42").is_ok());
+        assert!(KqlParser::parse(Rule::extend_expression, r#"extend y = "hello""#).is_ok());
+        assert!(KqlParser::parse(Rule::extend_expression, "extend x = 42, y = 24").is_ok());
+        assert!(KqlParser::parse(Rule::extend_expression, "extend x = y > 24").is_ok());
+        assert!(
+            KqlParser::parse(Rule::extend_expression, "extend x = (y > 24) and z == 10").is_ok()
+        );
+        assert!(KqlParser::parse(Rule::extend_expression, "extend x == 42").is_err());
+        assert!(KqlParser::parse(Rule::extend_expression, "x = 42").is_err());
+    }
+
+    #[test]
+    fn test_pipe_token() {
+        assert!(KqlParser::parse(Rule::pipe_token, "|").is_ok());
+        assert!(KqlParser::parse(Rule::pipe_token, "||").is_err());
+        assert!(KqlParser::parse(Rule::pipe_token, " | ").is_err());
+    }
+
+    #[test]
+    fn test_statement() {
+        assert!(KqlParser::parse(Rule::statement, "| where x == 42").is_ok());
+        assert!(KqlParser::parse(Rule::statement, r#"| extend y = "hello""#).is_ok());
+        assert!(KqlParser::parse(Rule::statement, "| x == 42").is_err());
+        assert!(KqlParser::parse(Rule::statement, "| extend x == 42").is_err());
+        assert!(KqlParser::parse(Rule::statement, "| where x = 42").is_err());
+        assert!(KqlParser::parse(Rule::statement, "extend x = 42").is_err());
+        assert!(KqlParser::parse(Rule::statement, "|| extend x = 42").is_err());
+    }
+
+    #[test]
+    fn test_query() {
+        assert!(KqlParser::parse(Rule::query, "my_table").is_ok());
+        assert!(KqlParser::parse(Rule::query, "my_table | where x == 42").is_ok());
+        assert!(KqlParser::parse(
+            Rule::query,
+            r#"my_table | extend y = "hello" | where y != "world""#
+        )
+        .is_ok());
+        assert!(KqlParser::parse(Rule::query, "my_table | where x = 42").is_err());
+        assert!(KqlParser::parse(Rule::query, "my_table | extend x == 42").is_err());
+        assert!(KqlParser::parse(Rule::query, "my_table | extend x = 42 | where x == 42").is_ok());
+        assert!(KqlParser::parse(Rule::query, "my_table | extend x = 42 | x == 42").is_err());
+        assert!(KqlParser::parse(Rule::query, "my_table where x == 42").is_err());
+        let multiline_query = r#"my_table
+            | where x == 42
+            | extend y = "hello"
+            | where y != "world""#;
+        assert!(KqlParser::parse(Rule::query, multiline_query).is_ok());
+    }
+}

--- a/rust/experimental/query_abstraction/kql_plugin/src/kql_parser.rs
+++ b/rust/experimental/query_abstraction/kql_plugin/src/kql_parser.rs
@@ -61,19 +61,25 @@ mod tests {
     }
 
     #[test]
-    fn test_boolean_expression() {
-        assert!(KqlParser::parse(Rule::boolean_expression, "a and b").is_ok());
-        assert!(KqlParser::parse(Rule::boolean_expression, "a and").is_err());
-        assert!(KqlParser::parse(Rule::boolean_expression, "a or b").is_ok());
-        assert!(KqlParser::parse(Rule::boolean_expression, "or b").is_err());
-        assert!(KqlParser::parse(Rule::boolean_expression, "not(a)").is_ok());
-        assert!(KqlParser::parse(Rule::boolean_expression, "not a").is_err());
-        assert!(KqlParser::parse(Rule::boolean_expression, "!a").is_err());
+    fn test_binary_logical_expression() {
+        assert!(KqlParser::parse(Rule::binary_logical_expression, "a and b").is_ok());
+        assert!(KqlParser::parse(Rule::binary_logical_expression, "a and").is_err());
+        assert!(KqlParser::parse(Rule::binary_logical_expression, "a or b").is_ok());
+        assert!(KqlParser::parse(Rule::binary_logical_expression, "or b").is_err());
 
-        assert!(KqlParser::parse(Rule::boolean_expression, "not(a and b)").is_ok());
-        assert!(KqlParser::parse(Rule::boolean_expression, "(a and b) or (c and d)").is_ok());
-        assert!(KqlParser::parse(Rule::boolean_expression, "a or (b and c)").is_ok());
-        assert!(KqlParser::parse(Rule::boolean_expression, "a and b and c").is_ok());
+        assert!(
+            KqlParser::parse(Rule::binary_logical_expression, "(a and b) or (c and d)").is_ok()
+        );
+        assert!(KqlParser::parse(Rule::binary_logical_expression, "a or (b and c)").is_ok());
+        assert!(KqlParser::parse(Rule::binary_logical_expression, "a and b and c").is_ok());
+    }
+
+    #[test]
+    fn test_negated_expression() {
+        assert!(KqlParser::parse(Rule::negated_expression, "not(a)").is_ok());
+        assert!(KqlParser::parse(Rule::negated_expression, "not(a and b)").is_ok());
+        assert!(KqlParser::parse(Rule::negated_expression, "not a").is_err());
+        assert!(KqlParser::parse(Rule::negated_expression, "!a").is_err());
     }
 
     #[test]
@@ -87,27 +93,27 @@ mod tests {
     }
 
     #[test]
-    fn test_filter_expression() {
-        assert!(KqlParser::parse(Rule::filter_expression, "where x == 42").is_ok());
-        assert!(KqlParser::parse(Rule::filter_expression, r#"where x != "hello""#).is_ok());
-        assert!(KqlParser::parse(Rule::filter_expression, "where x == 42 and y > 24").is_ok());
-        assert!(KqlParser::parse(Rule::filter_expression, "where x == 42 or not(y > 24)").is_ok());
-        assert!(KqlParser::parse(Rule::filter_expression, "where x = 42").is_err());
-        assert!(KqlParser::parse(Rule::filter_expression, "x == 42").is_err());
+    fn test_filter_statement() {
+        assert!(KqlParser::parse(Rule::filter_statement, "where x == 42").is_ok());
+        assert!(KqlParser::parse(Rule::filter_statement, r#"where x != "hello""#).is_ok());
+        assert!(KqlParser::parse(Rule::filter_statement, "where x == 42 and y > 24").is_ok());
+        assert!(KqlParser::parse(Rule::filter_statement, "where x == 42 or not(y > 24)").is_ok());
+        assert!(KqlParser::parse(Rule::filter_statement, "where x = 42").is_err());
+        assert!(KqlParser::parse(Rule::filter_statement, "x == 42").is_err());
     }
 
     #[test]
-    fn test_extend_expression() {
-        assert!(KqlParser::parse(Rule::extend_expression, "extend x = 42").is_ok());
-        assert!(KqlParser::parse(Rule::extend_expression, "extend x=42").is_ok());
-        assert!(KqlParser::parse(Rule::extend_expression, r#"extend y = "hello""#).is_ok());
-        assert!(KqlParser::parse(Rule::extend_expression, "extend x = 42, y = 24").is_ok());
-        assert!(KqlParser::parse(Rule::extend_expression, "extend x = y > 24").is_ok());
+    fn test_extend_statement() {
+        assert!(KqlParser::parse(Rule::extend_statement, "extend x = 42").is_ok());
+        assert!(KqlParser::parse(Rule::extend_statement, "extend x=42").is_ok());
+        assert!(KqlParser::parse(Rule::extend_statement, r#"extend y = "hello""#).is_ok());
+        assert!(KqlParser::parse(Rule::extend_statement, "extend x = 42, y = 24").is_ok());
+        assert!(KqlParser::parse(Rule::extend_statement, "extend x = y > 24").is_ok());
         assert!(
-            KqlParser::parse(Rule::extend_expression, "extend x = (y > 24) and z == 10").is_ok()
+            KqlParser::parse(Rule::extend_statement, "extend x = (y > 24) and z == 10").is_ok()
         );
-        assert!(KqlParser::parse(Rule::extend_expression, "extend x == 42").is_err());
-        assert!(KqlParser::parse(Rule::extend_expression, "x = 42").is_err());
+        assert!(KqlParser::parse(Rule::extend_statement, "extend x == 42").is_err());
+        assert!(KqlParser::parse(Rule::extend_statement, "x = 42").is_err());
     }
 
     #[test]

--- a/rust/experimental/query_abstraction/kql_plugin/src/kql_plugin.rs
+++ b/rust/experimental/query_abstraction/kql_plugin/src/kql_plugin.rs
@@ -1,9 +1,12 @@
+use crate::kql_parser::{KqlParser, Rule};
 use intermediate_language::{grammar_objects::Query, query_processor::QueryProcessor};
+use pest::Parser;
 
 pub struct KqlPlugin;
 
 impl QueryProcessor for KqlPlugin {
-    fn process_query(_input: &str) -> Query {
+    fn process_query(input: &str) -> Query {
+        let _ = KqlParser::parse(Rule::query, input);
         todo!()
     }
 }

--- a/rust/experimental/query_abstraction/kql_plugin/src/lib.rs
+++ b/rust/experimental/query_abstraction/kql_plugin/src/lib.rs
@@ -1,1 +1,2 @@
+mod kql_parser;
 pub mod kql_plugin;

--- a/rust/experimental/query_abstraction/ottl_plugin/Cargo.toml
+++ b/rust/experimental/query_abstraction/ottl_plugin/Cargo.toml
@@ -5,3 +5,5 @@ edition = "2021"
 
 [dependencies]
 intermediate_language = { verison = "0.1.0", path = "../intermediate_language" }
+pest = "2.8"
+pest_derive = "2.8"

--- a/rust/experimental/query_abstraction/ottl_plugin/src/lib.rs
+++ b/rust/experimental/query_abstraction/ottl_plugin/src/lib.rs
@@ -1,1 +1,2 @@
+mod ottl_parser;
 pub mod ottl_plugin;

--- a/rust/experimental/query_abstraction/ottl_plugin/src/ottl.pest
+++ b/rust/experimental/query_abstraction/ottl_plugin/src/ottl.pest
@@ -39,7 +39,6 @@ expression_base = { identifier | literal | enclosed_expression }
 
 enclosed_expression = { open_paren_token ~ expression ~ close_paren_token }
 
-not_expression = { not_token ~ enclosed_expression }
 and_expression = { expression_base ~ (and_token ~ expression)+ }
 or_expression = { expression_base ~  (or_token ~ expression)+ }
 
@@ -50,12 +49,10 @@ less_than_expression = { expression_base ~ less_than_token ~ expression }
 greater_than_or_equal_to_expression = { expression_base ~ greater_than_or_equal_to_token ~ expression }
 less_than_or_equal_to_expression = { expression_base ~ less_than_or_equal_to_token ~ expression }
 
-boolean_expression = {
-    not_expression
-    | and_expression
+binary_logical_expression = {
+    and_expression
     | or_expression
 }
-
 comparison_expression = {
     equals_expression
     | not_equals_expression
@@ -64,14 +61,16 @@ comparison_expression = {
     | greater_than_or_equal_to_expression
     | less_than_or_equal_to_expression
 }
+negated_expression = { not_token ~ enclosed_expression }
 
-conditional_expression = {
-    boolean_expression
+predicate = {
+    binary_logical_expression
     | comparison_expression
+    | negated_expression
 }
 
 expression = { 
-    conditional_expression
+    predicate
     | enclosed_expression
     | literal
     | identifier 
@@ -95,20 +94,20 @@ set_token = @{ "set" }
 set_tuple = { identifier ~ comma_token ~ expression }
 set_with_paren = { set_token ~ open_paren_token ~ set_tuple ~ close_paren_token }
 
-filter_expression = { dash_token ~ single_quote_token ~ conditional_expression ~ single_quote_token }
-extend_expression = { dash_token ~ set_with_paren ~ (where_token ~ conditional_expression)? }
+filter_statement = { dash_token ~ single_quote_token ~ predicate ~ single_quote_token }
+extend_statement = { dash_token ~ set_with_paren ~ (where_token ~ predicate)? }
 
 filter_query = {
     filter_token ~ NEWLINE? 
     ~ logs_token ~ NEWLINE? 
     ~ log_record_token ~ NEWLINE? 
-    ~ (NEWLINE* ~filter_expression)+
+    ~ (NEWLINE* ~ filter_statement)+
 }
 
 transform_query = {
     transform_token ~ NEWLINE?
     ~ log_statements_token ~ NEWLINE?
-    ~ (NEWLINE* ~ extend_expression)+
+    ~ (NEWLINE* ~ extend_statement)+
 }
 
 query = { 

--- a/rust/experimental/query_abstraction/ottl_plugin/src/ottl.pest
+++ b/rust/experimental/query_abstraction/ottl_plugin/src/ottl.pest
@@ -1,0 +1,118 @@
+// These two special rules, when defined, are implicitly allowed at:
+// - at every sequence (split by ~)
+// - between every repetition (+ or *)
+// Atomics (marked with @) are excluded
+// See https://pest.rs/book/grammars/syntax.html#implicit-whitespace
+WHITESPACE = _{ " " }
+COMMENT = _{ "/*" ~ (!"*/" ~ ANY)* ~ "*/" }
+
+// Basic tokens
+// ----------------------------------------------
+true_token = @{ "true" }
+false_token = @{ "false" }
+integer_token = @{ 
+    "-"?
+    ~ ("0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*)
+}
+string_token = @{ "\"" ~ (!"\"" ~ ANY)* ~ "\"" }
+equals_token = @{ "==" }
+not_equals_token = @{ "!=" }
+comma_token = @{ "," }
+and_token = @{ "and" }
+or_token = @{ "or" }
+greater_than_token = @{ ">" ~ !"=" }
+less_than_token = @{ "<" ~ !"=" }
+greater_than_or_equal_to_token = @{ ">=" }
+less_than_or_equal_to_token = @{ "<=" }
+open_paren_token = @{ "(" }
+close_paren_token = @{ ")" }
+not_token = @{ "not" }
+where_token = @{ "where" }
+// ----------------------------------------------
+
+// Basic Grammar
+// ----------------------------------------------
+literal = { true_token | false_token | integer_token | string_token }
+identifier = @{ ("_" | ASCII_ALPHANUMERIC)+ }
+
+expression_base = { identifier | literal | enclosed_expression }
+
+enclosed_expression = { open_paren_token ~ expression ~ close_paren_token }
+
+not_expression = { not_token ~ enclosed_expression }
+and_expression = { expression_base ~ (and_token ~ expression)+ }
+or_expression = { expression_base ~  (or_token ~ expression)+ }
+
+equals_expression = { expression_base ~ equals_token ~ expression }
+not_equals_expression = { expression_base ~ not_equals_token ~ expression }
+greater_than_expression = { expression_base ~ greater_than_token ~ expression }
+less_than_expression = { expression_base ~ less_than_token ~ expression }
+greater_than_or_equal_to_expression = { expression_base ~ greater_than_or_equal_to_token ~ expression }
+less_than_or_equal_to_expression = { expression_base ~ less_than_or_equal_to_token ~ expression }
+
+boolean_expression = {
+    not_expression
+    | and_expression
+    | or_expression
+}
+
+comparison_expression = {
+    equals_expression
+    | not_equals_expression
+    | greater_than_expression
+    | less_than_expression
+    | greater_than_or_equal_to_expression
+    | less_than_or_equal_to_expression
+}
+
+conditional_expression = {
+    boolean_expression
+    | comparison_expression
+}
+
+expression = { 
+    conditional_expression
+    | enclosed_expression
+    | literal
+    | identifier 
+}
+// ----------------------------------------------
+
+// OTTL-specific Tokens
+// ----------------------------------------------
+dash_token = @{ "-" ~ !"-" }
+single_quote_token = @{ "'" }
+filter_token = @{ "filter:" }
+transform_token = @{ "transform:" }
+logs_token = @{ "logs:" }
+log_record_token = @{ "log_record:" }
+log_statements_token = @{ "log_statements:" }
+set_token = @{ "set" }
+// ----------------------------------------------
+
+// OTTL-specific Grammar
+// ----------------------------------------------
+set_tuple = { identifier ~ comma_token ~ expression }
+set_with_paren = { set_token ~ open_paren_token ~ set_tuple ~ close_paren_token }
+
+filter_expression = { dash_token ~ single_quote_token ~ conditional_expression ~ single_quote_token }
+extend_expression = { dash_token ~ set_with_paren ~ (where_token ~ conditional_expression)? }
+
+filter_query = {
+    filter_token ~ NEWLINE? 
+    ~ logs_token ~ NEWLINE? 
+    ~ log_record_token ~ NEWLINE? 
+    ~ (NEWLINE* ~filter_expression)+
+}
+
+transform_query = {
+    transform_token ~ NEWLINE?
+    ~ log_statements_token ~ NEWLINE?
+    ~ (NEWLINE* ~ extend_expression)+
+}
+
+query = { 
+    SOI ~ filter_query ~ NEWLINE* ~ EOI
+    | SOI ~ transform_query ~ NEWLINE* ~ EOI
+}
+// ----------------------------------------------

--- a/rust/experimental/query_abstraction/ottl_plugin/src/ottl_parser.rs
+++ b/rust/experimental/query_abstraction/ottl_plugin/src/ottl_parser.rs
@@ -61,19 +61,25 @@ mod tests {
     }
 
     #[test]
-    fn test_boolean_expression() {
-        assert!(OttlParser::parse(Rule::boolean_expression, "a and b").is_ok());
-        assert!(OttlParser::parse(Rule::boolean_expression, "a and").is_err());
-        assert!(OttlParser::parse(Rule::boolean_expression, "a or b").is_ok());
-        assert!(OttlParser::parse(Rule::boolean_expression, "or b").is_err());
-        assert!(OttlParser::parse(Rule::boolean_expression, "not(a)").is_ok());
-        assert!(OttlParser::parse(Rule::boolean_expression, "not a").is_err());
-        assert!(OttlParser::parse(Rule::boolean_expression, "!a").is_err());
+    fn test_binary_logical_expression() {
+        assert!(OttlParser::parse(Rule::binary_logical_expression, "a and b").is_ok());
+        assert!(OttlParser::parse(Rule::binary_logical_expression, "a and").is_err());
+        assert!(OttlParser::parse(Rule::binary_logical_expression, "a or b").is_ok());
+        assert!(OttlParser::parse(Rule::binary_logical_expression, "or b").is_err());
 
-        assert!(OttlParser::parse(Rule::boolean_expression, "not(a and b)").is_ok());
-        assert!(OttlParser::parse(Rule::boolean_expression, "(a and b) or (c and d)").is_ok());
-        assert!(OttlParser::parse(Rule::boolean_expression, "a or (b and c)").is_ok());
-        assert!(OttlParser::parse(Rule::boolean_expression, "a and b and c").is_ok());
+        assert!(
+            OttlParser::parse(Rule::binary_logical_expression, "(a and b) or (c and d)").is_ok()
+        );
+        assert!(OttlParser::parse(Rule::binary_logical_expression, "a or (b and c)").is_ok());
+        assert!(OttlParser::parse(Rule::binary_logical_expression, "a and b and c").is_ok());
+    }
+
+    #[test]
+    fn test_negated_expression() {
+        assert!(OttlParser::parse(Rule::negated_expression, "not(a)").is_ok());
+        assert!(OttlParser::parse(Rule::negated_expression, "not(a and b)").is_ok());
+        assert!(OttlParser::parse(Rule::negated_expression, "not a").is_err());
+        assert!(OttlParser::parse(Rule::negated_expression, "!a").is_err());
     }
 
     #[test]
@@ -87,37 +93,36 @@ mod tests {
     }
 
     #[test]
-    fn test_filter_expression() {
-        assert!(OttlParser::parse(Rule::filter_expression, "- 'x == 42'").is_ok());
-        assert!(OttlParser::parse(Rule::filter_expression, r#"- 'x != "hello"'"#).is_ok());
-        assert!(OttlParser::parse(Rule::filter_expression, "- 'x == 42 and y > 24'").is_ok());
-        assert!(OttlParser::parse(Rule::filter_expression, "- 'x == 42 or not(y > 24)'").is_ok());
-        assert!(OttlParser::parse(Rule::filter_expression, "- 'x = 42").is_err());
-        assert!(OttlParser::parse(Rule::filter_expression, "- x = 42").is_err());
-        assert!(OttlParser::parse(Rule::filter_expression, "'x == 42'").is_err());
+    fn test_filter_statement() {
+        assert!(OttlParser::parse(Rule::filter_statement, "- 'x == 42'").is_ok());
+        assert!(OttlParser::parse(Rule::filter_statement, r#"- 'x != "hello"'"#).is_ok());
+        assert!(OttlParser::parse(Rule::filter_statement, "- 'x == 42 and y > 24'").is_ok());
+        assert!(OttlParser::parse(Rule::filter_statement, "- 'x == 42 or not(y > 24)'").is_ok());
+        assert!(OttlParser::parse(Rule::filter_statement, "- 'x = 42").is_err());
+        assert!(OttlParser::parse(Rule::filter_statement, "x = 42").is_err());
     }
 
     #[test]
-    fn test_extend_expression() {
-        assert!(OttlParser::parse(Rule::extend_expression, "- set(x, 42)").is_ok());
-        assert!(OttlParser::parse(Rule::extend_expression, "- set(x,42)").is_ok());
-        assert!(OttlParser::parse(Rule::extend_expression, r#"- set(y, "hello")"#).is_ok());
-        assert!(OttlParser::parse(Rule::extend_expression, "- set (x, y > 24)").is_ok());
-        assert!(OttlParser::parse(Rule::extend_expression, "- set (x, (y > 24))").is_ok());
-        assert!(OttlParser::parse(Rule::extend_expression, "- set(x, 42) where y > 24").is_ok());
-        assert!(OttlParser::parse(Rule::extend_expression, "- set(x, 42) where (y > 24)").is_ok());
+    fn test_extend_statement() {
+        assert!(OttlParser::parse(Rule::extend_statement, "- set(x, 42)").is_ok());
+        assert!(OttlParser::parse(Rule::extend_statement, "- set(x,42)").is_ok());
+        assert!(OttlParser::parse(Rule::extend_statement, r#"- set(y, "hello")"#).is_ok());
+        assert!(OttlParser::parse(Rule::extend_statement, "- set (x, y > 24)").is_ok());
+        assert!(OttlParser::parse(Rule::extend_statement, "- set (x, (y > 24))").is_ok());
+        assert!(OttlParser::parse(Rule::extend_statement, "- set(x, 42) where y > 24").is_ok());
+        assert!(OttlParser::parse(Rule::extend_statement, "- set(x, 42) where (y > 24)").is_ok());
         assert!(
-            OttlParser::parse(Rule::extend_expression, "- set(x, y > 24) where z == 10").is_ok()
+            OttlParser::parse(Rule::extend_statement, "- set(x, y > 24) where z == 10").is_ok()
         );
         assert!(
-            OttlParser::parse(Rule::extend_expression, "- set(x, y > 24 and (z == 10))").is_ok()
+            OttlParser::parse(Rule::extend_statement, "- set(x, y > 24 and (z == 10))").is_ok()
         );
         assert!(
-            OttlParser::parse(Rule::extend_expression, "- set(x, (y > 24) and z == 10)").is_ok()
+            OttlParser::parse(Rule::extend_statement, "- set(x, (y > 24) and z == 10)").is_ok()
         );
-        assert!(OttlParser::parse(Rule::extend_expression, "set(x, 42").is_err());
-        assert!(OttlParser::parse(Rule::extend_expression, "- set(x = 42").is_err());
-        assert!(OttlParser::parse(Rule::extend_expression, "- (x, 42").is_err());
+        assert!(OttlParser::parse(Rule::extend_statement, "- set(x, 42").is_err());
+        assert!(OttlParser::parse(Rule::extend_statement, "- set(x = 42").is_err());
+        assert!(OttlParser::parse(Rule::extend_statement, "(x, 42").is_err());
     }
 
     #[test]

--- a/rust/experimental/query_abstraction/ottl_plugin/src/ottl_parser.rs
+++ b/rust/experimental/query_abstraction/ottl_plugin/src/ottl_parser.rs
@@ -1,0 +1,174 @@
+use pest_derive::Parser;
+
+#[derive(Parser)]
+#[grammar = "ottl.pest"]
+#[allow(dead_code)] // Remove this line when the parser is used
+pub struct OttlParser;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pest::Parser;
+
+    #[test]
+    fn test_true_token() {
+        assert!(OttlParser::parse(Rule::true_token, "true").is_ok());
+        assert!(OttlParser::parse(Rule::true_token, "false").is_err());
+        assert!(OttlParser::parse(Rule::true_token, "tru").is_err());
+    }
+
+    #[test]
+    fn test_false_token() {
+        assert!(OttlParser::parse(Rule::false_token, "false").is_ok());
+        assert!(OttlParser::parse(Rule::false_token, "true").is_err());
+        assert!(OttlParser::parse(Rule::false_token, "fals").is_err());
+    }
+
+    #[test]
+    fn test_integer_token() {
+        assert!(OttlParser::parse(Rule::integer_token, "123").is_ok());
+        assert!(OttlParser::parse(Rule::integer_token, ".53").is_err());
+        assert!(OttlParser::parse(Rule::integer_token, "abc").is_err());
+    }
+
+    #[test]
+    fn test_string_token() {
+        assert!(OttlParser::parse(Rule::string_token, r#""hello""#).is_ok());
+        assert!(OttlParser::parse(Rule::string_token, r#""hello"#).is_err());
+        assert!(OttlParser::parse(Rule::string_token, r#"hello""#).is_err());
+        assert!(OttlParser::parse(Rule::string_token, r#""""#).is_ok());
+    }
+
+    #[test]
+    fn test_identifier() {
+        assert!(OttlParser::parse(Rule::identifier, "abc").is_ok());
+        assert!(OttlParser::parse(Rule::identifier, "abc_123").is_ok());
+        assert!(OttlParser::parse(Rule::identifier, "_abc").is_ok());
+        assert!(OttlParser::parse(Rule::identifier, "123abc").is_ok());
+    }
+
+    #[test]
+    fn test_comparison_expression() {
+        assert!(OttlParser::parse(Rule::comparison_expression, "x == 42").is_ok());
+        assert!(OttlParser::parse(Rule::comparison_expression, r#"x != "hello""#).is_ok());
+        assert!(OttlParser::parse(Rule::comparison_expression, "x = 42").is_err());
+        assert!(OttlParser::parse(Rule::comparison_expression, "== 42").is_err());
+
+        assert!(OttlParser::parse(Rule::comparison_expression, "x > 5").is_ok());
+        assert!(OttlParser::parse(Rule::comparison_expression, "x < 5").is_ok());
+        assert!(OttlParser::parse(Rule::comparison_expression, "y <= 10").is_ok());
+        assert!(OttlParser::parse(Rule::comparison_expression, "y >= 10").is_ok());
+    }
+
+    #[test]
+    fn test_boolean_expression() {
+        assert!(OttlParser::parse(Rule::boolean_expression, "a and b").is_ok());
+        assert!(OttlParser::parse(Rule::boolean_expression, "a and").is_err());
+        assert!(OttlParser::parse(Rule::boolean_expression, "a or b").is_ok());
+        assert!(OttlParser::parse(Rule::boolean_expression, "or b").is_err());
+        assert!(OttlParser::parse(Rule::boolean_expression, "not(a)").is_ok());
+        assert!(OttlParser::parse(Rule::boolean_expression, "not a").is_err());
+        assert!(OttlParser::parse(Rule::boolean_expression, "!a").is_err());
+
+        assert!(OttlParser::parse(Rule::boolean_expression, "not(a and b)").is_ok());
+        assert!(OttlParser::parse(Rule::boolean_expression, "(a and b) or (c and d)").is_ok());
+        assert!(OttlParser::parse(Rule::boolean_expression, "a or (b and c)").is_ok());
+        assert!(OttlParser::parse(Rule::boolean_expression, "a and b and c").is_ok());
+    }
+
+    #[test]
+    fn test_expression() {
+        assert!(OttlParser::parse(Rule::expression, "(a and b)").is_ok());
+        assert!(OttlParser::parse(Rule::expression, "a and b").is_ok());
+        assert!(OttlParser::parse(Rule::expression, "x == 42").is_ok());
+        assert!(OttlParser::parse(Rule::expression, "my_variable").is_ok());
+        assert!(OttlParser::parse(Rule::expression, "42").is_ok());
+        assert!(OttlParser::parse(Rule::expression, "(y > 24) and z == 10").is_ok());
+    }
+
+    #[test]
+    fn test_filter_expression() {
+        assert!(OttlParser::parse(Rule::filter_expression, "- 'x == 42'").is_ok());
+        assert!(OttlParser::parse(Rule::filter_expression, r#"- 'x != "hello"'"#).is_ok());
+        assert!(OttlParser::parse(Rule::filter_expression, "- 'x == 42 and y > 24'").is_ok());
+        assert!(OttlParser::parse(Rule::filter_expression, "- 'x == 42 or not(y > 24)'").is_ok());
+        assert!(OttlParser::parse(Rule::filter_expression, "- 'x = 42").is_err());
+        assert!(OttlParser::parse(Rule::filter_expression, "- x = 42").is_err());
+        assert!(OttlParser::parse(Rule::filter_expression, "'x == 42'").is_err());
+    }
+
+    #[test]
+    fn test_extend_expression() {
+        assert!(OttlParser::parse(Rule::extend_expression, "- set(x, 42)").is_ok());
+        assert!(OttlParser::parse(Rule::extend_expression, "- set(x,42)").is_ok());
+        assert!(OttlParser::parse(Rule::extend_expression, r#"- set(y, "hello")"#).is_ok());
+        assert!(OttlParser::parse(Rule::extend_expression, "- set (x, y > 24)").is_ok());
+        assert!(OttlParser::parse(Rule::extend_expression, "- set (x, (y > 24))").is_ok());
+        assert!(OttlParser::parse(Rule::extend_expression, "- set(x, 42) where y > 24").is_ok());
+        assert!(OttlParser::parse(Rule::extend_expression, "- set(x, 42) where (y > 24)").is_ok());
+        assert!(
+            OttlParser::parse(Rule::extend_expression, "- set(x, y > 24) where z == 10").is_ok()
+        );
+        assert!(
+            OttlParser::parse(Rule::extend_expression, "- set(x, y > 24 and (z == 10))").is_ok()
+        );
+        assert!(
+            OttlParser::parse(Rule::extend_expression, "- set(x, (y > 24) and z == 10)").is_ok()
+        );
+        assert!(OttlParser::parse(Rule::extend_expression, "set(x, 42").is_err());
+        assert!(OttlParser::parse(Rule::extend_expression, "- set(x = 42").is_err());
+        assert!(OttlParser::parse(Rule::extend_expression, "- (x, 42").is_err());
+    }
+
+    #[test]
+    fn test_dash_token() {
+        assert!(OttlParser::parse(Rule::dash_token, "-").is_ok());
+        assert!(OttlParser::parse(Rule::dash_token, "--").is_err());
+        assert!(OttlParser::parse(Rule::dash_token, " - ").is_err());
+    }
+
+    #[test]
+    fn test_filter_query() {
+        assert!(
+            OttlParser::parse(Rule::filter_query, "filter: logs: log_record: - 'x == 42'").is_ok()
+        );
+        assert!(
+            OttlParser::parse(Rule::filter_query, "filter: logs: log_record: - 'x = 42'").is_err()
+        );
+        assert!(OttlParser::parse(
+            Rule::filter_query,
+            "filter: logs: log_record: - 'x == 42' - 'y == true'"
+        )
+        .is_ok());
+        let multiline_query = r#"filter:
+        logs:
+        log_record:
+        - 'x == 5'
+        - 'y == true'"#;
+        assert!(OttlParser::parse(Rule::filter_query, multiline_query).is_ok());
+    }
+
+    #[test]
+    fn test_transform_query() {
+        assert!(OttlParser::parse(
+            Rule::transform_query,
+            "transform: log_statements: - set(x, 42)"
+        )
+        .is_ok());
+        assert!(OttlParser::parse(
+            Rule::transform_query,
+            "transform: log_statements: - set(x = 42)"
+        )
+        .is_err());
+        assert!(OttlParser::parse(
+            Rule::transform_query,
+            r#"transform: log_statements: - set(x, 42) where someColumn == "blue""#
+        )
+        .is_ok());
+        let multiline_query = r#"transform:
+        log_statements:
+        - set(x, 42)
+        - set(y, 42) where someColumn == "blue""#;
+        assert!(OttlParser::parse(Rule::transform_query, multiline_query).is_ok());
+    }
+}

--- a/rust/experimental/query_abstraction/ottl_plugin/src/ottl_plugin.rs
+++ b/rust/experimental/query_abstraction/ottl_plugin/src/ottl_plugin.rs
@@ -1,9 +1,12 @@
+use crate::ottl_parser::{OttlParser, Rule};
 use intermediate_language::{grammar_objects::Query, query_processor::QueryProcessor};
+use pest::Parser;
 
 pub struct OttlPlugin;
 
 impl QueryProcessor for OttlPlugin {
-    fn process_query(_input: &str) -> Query {
+    fn process_query(input: &str) -> Query {
+        let _ = OttlParser::parse(Rule::query, input);
         todo!()
     }
 }


### PR DESCRIPTION
Following #320, adding basic [Pest](https://github.com/pest-parser/pest) grammar files to support `Filter` and `Extend` in both KQL and OTTL.

Pest is a popular Rust crate in the [parser-tooling](https://lib.rs/parsing) category.

The best intuition for seeing this works can be found looking at the `KqlParser` and `OttlParser` tests:

> Note - KQL allows both `Filter` (where) and `Extend` statements together
```rust
let multiline_query = r#"my_table
    | where x == 42
    | extend y = "hello"
    | where y != "world""#;
assert!(KqlParser::parse(Rule::query, multiline_query).is_ok());
```

> Note - OTTL has separate grammar for `Filter` and `Extend` (transform) statements

```rust
let multiline_query = r#"filter:
logs:
log_record:
- 'x == 5'
- 'y == true'"#;
assert!(OttlParser::parse(Rule::filter_query, multiline_query).is_ok());
```

```rust
let multiline_query = r#"transform:
log_statements:
- set(x, 42)
- set(y, 42) where someColumn == "blue""#;
assert!(OttlParser::parse(Rule::transform_query, multiline_query).is_ok());
```

The PR after this one will implement `process_query` for `KqlPlugin` and `OttlPlugin` - actually transforming successfully parsed input to IL grammar objects.