### PR TITLE
Implement process_query for KqlPlugin

### DIFF
--- a/rust/experimental/query_abstraction/intermediate_language/src/grammar_objects.rs
+++ b/rust/experimental/query_abstraction/intermediate_language/src/grammar_objects.rs
@@ -40,32 +40,28 @@ pub enum Expression {
     Identifier(Identifier),
     Literal(Literal),
     Predicate(Predicate),
+    EnclosedExpression(Box<Expression>),
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Predicate {
     BinaryLogicalExpression(BinaryLogicalExpression),
     ComparisonExpression(ComparisonExpression),
-    NegatedExpression(NegatedExpression),
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct NegatedExpression {
-    expression: Box<Predicate>,
+    NegatedExpression(Box<Expression>),
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct BinaryLogicalExpression {
-    left: Box<Expression>,
-    boolean_operator: BooleanOperator,
-    right: Box<Expression>,
+    pub left: Box<Expression>,
+    pub boolean_operator: BooleanOperator,
+    pub right: Box<Expression>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ComparisonExpression {
-    left: Box<Expression>,
-    comparison_operator: ComparisonOperator,
-    right: Box<Expression>,
+    pub left: Box<Expression>,
+    pub comparison_operator: ComparisonOperator,
+    pub right: Box<Expression>,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/rust/experimental/query_abstraction/intermediate_language/src/query_processor.rs
+++ b/rust/experimental/query_abstraction/intermediate_language/src/query_processor.rs
@@ -1,5 +1,26 @@
 use crate::grammar_objects::*;
+use std::error::Error;
+use std::fmt;
+
+#[derive(Debug)]
+pub enum QueryError {
+    ParseError(String),
+    ProcessingError(String),
+}
+
+impl fmt::Display for QueryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            QueryError::ParseError(msg) => write!(f, "KQL Parse Error: {}", msg),
+            QueryError::ProcessingError(msg) => write!(f, "KQL Processing Error: {}", msg),
+        }
+    }
+}
+
+impl Error for QueryError {}
+
+pub type QueryResult<T> = Result<T, QueryError>;
 
 pub trait QueryProcessor {
-    fn process_query(input: &str) -> Query;
+    fn process_query(input: &str) -> Result<Query, QueryError>;
 }

--- a/rust/experimental/query_abstraction/intermediate_language/src/query_processor.rs
+++ b/rust/experimental/query_abstraction/intermediate_language/src/query_processor.rs
@@ -11,8 +11,8 @@ pub enum QueryError {
 impl fmt::Display for QueryError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            QueryError::ParseError(msg) => write!(f, "KQL Parse Error: {}", msg),
-            QueryError::ProcessingError(msg) => write!(f, "KQL Processing Error: {}", msg),
+            QueryError::ParseError(msg) => write!(f, "Parse Error: {}", msg),
+            QueryError::ProcessingError(msg) => write!(f, "Processing Error: {}", msg),
         }
     }
 }

--- a/rust/experimental/query_abstraction/kql_plugin/src/kql_plugin.rs
+++ b/rust/experimental/query_abstraction/kql_plugin/src/kql_plugin.rs
@@ -1,272 +1,378 @@
 use crate::kql_parser::{KqlParser, Rule};
-use intermediate_language::{grammar_objects::*, query_processor::QueryProcessor};
+use intermediate_language::{
+    grammar_objects::*,
+    query_processor::{QueryError, QueryProcessor, QueryResult},
+};
 use pest::{iterators::Pair, Parser};
 
+/// `KqlPlugin`` implements the `QueryProcessor` trait for KQL (Kusto Query Language)
 pub struct KqlPlugin;
 
 impl QueryProcessor for KqlPlugin {
-    fn process_query(input: &str) -> Query {
-        let mut source = "".to_string();
-        let mut statements: Vec<Statement> = Vec::new();
-        let query = KqlParser::parse(Rule::query, input)
-            .expect("Failed to parse query")
+    fn process_query(input: &str) -> Result<Query, QueryError> {
+        let parsed_query = KqlParser::parse(Rule::query, input)
+            .map_err(|e| QueryError::ParseError(e.to_string()))?
             .next()
-            .unwrap();
+            .ok_or_else(|| QueryError::ParseError("Empty query".to_string()))?;
 
-        for query_piece in query.clone().into_inner() {
+        let mut source = String::new();
+        let mut statements = Vec::new();
+
+        for query_piece in parsed_query.into_inner() {
             match query_piece.as_rule() {
                 Rule::identifier => {
                     source = query_piece.as_str().to_string();
                 }
                 Rule::statement => {
-                    statements.extend(process_statement(query_piece));
+                    statements.extend(Self::process_statement(query_piece)?);
                 }
                 Rule::EOI => (),
-                _ => handle_unexpected_rule("query", query_piece),
-            }
-        }
-
-        Query { source, statements }
-    }
-}
-
-fn process_statement(statement: Pair<Rule>) -> Vec<Statement> {
-    let mut statements: Vec<Statement> = Vec::new();
-    for statement_piece in statement.into_inner() {
-        match statement_piece.as_rule() {
-            Rule::pipe_token => continue,
-            Rule::filter_statement => {
-                let filter_statement = statement_piece.into_inner();
-                for filter_piece in filter_statement {
-                    match filter_piece.as_rule() {
-                        Rule::where_token => continue,
-                        Rule::predicate => {
-                            statements.push(Statement::Filter(process_predicate(filter_piece)));
-                        }
-                        _ => handle_unexpected_rule("filter_statement", filter_piece),
-                    }
+                _ => {
+                    return Err(QueryError::ProcessingError(format!(
+                        "Unexpected rule: '{:?}' found processing parent object: 'query'",
+                        query_piece.as_rule()
+                    )))
                 }
             }
-            Rule::extend_statement => {
-                let extend_statement = statement_piece.into_inner();
-                for extend_piece in extend_statement {
-                    match extend_piece.as_rule() {
-                        Rule::extend_token | Rule::comma_token => continue,
-                        Rule::assignment_expression => {
-                            let (identifier, value) = process_assignment(extend_piece);
-                            statements.push(Statement::Extend(identifier, value, None));
-                        }
-                        _ => handle_unexpected_rule("extend_statement", extend_piece),
-                    }
+        }
+
+        Ok(Query { source, statements })
+    }
+}
+
+impl KqlPlugin {
+    /// Process a statement, returning a vector of Statement objects
+    fn process_statement(statement: Pair<Rule>) -> QueryResult<Vec<Statement>> {
+        let mut statements = Vec::new();
+
+        for statement_piece in statement.into_inner() {
+            match statement_piece.as_rule() {
+                Rule::pipe_token => continue,
+                Rule::filter_statement => {
+                    Self::process_filter_statement(statement_piece, &mut statements)?;
+                }
+                Rule::extend_statement => {
+                    Self::process_extend_statement(statement_piece, &mut statements)?;
+                }
+                _ => {
+                    return Err(QueryError::ProcessingError(format!(
+                        "Unexpected rule: '{:?}' found processing parent object: 'statement'",
+                        statement_piece.as_rule()
+                    )))
                 }
             }
-            _ => handle_unexpected_rule("statement", statement_piece),
         }
-    }
-    if statements.is_empty() {
-        panic!("Expected a valid statement but none was found");
-    }
-    statements
-}
 
-fn process_predicate(predicate: Pair<Rule>) -> Predicate {
-    for predicate_piece in predicate.into_inner() {
-        match predicate_piece.as_rule() {
-            Rule::binary_logical_expression => {
-                return Predicate::BinaryLogicalExpression(process_binary_logical_expression(
-                    predicate_piece,
-                ));
-            }
-            Rule::comparison_expression => {
-                return Predicate::ComparisonExpression(process_comparison_expression(
-                    predicate_piece,
-                ));
-            }
-            Rule::negated_expression => {
-                return Predicate::NegatedExpression(Box::new(process_negated_expression(
-                    predicate_piece,
-                )));
-            }
-            _ => handle_unexpected_rule("predicate", predicate_piece),
+        if statements.is_empty() {
+            return Err(QueryError::ProcessingError(
+                "Expected a valid statement but none was found".to_string(),
+            ));
         }
-    }
-    unreachable!("Expected a valid predicate but none was found");
-}
 
-fn process_assignment(assignment: Pair<Rule>) -> (Identifier, Expression) {
-    let mut identifier = Identifier {
-        name: "".to_string(),
-    }; // Placeholder for actual value
-    let mut value = Expression::Literal(Literal::Int(0)); // Placeholder for actual value
-    for assignment_piece in assignment.into_inner() {
-        match assignment_piece.as_rule() {
-            Rule::identifier => identifier = process_identifier(assignment_piece),
-            Rule::assignment_token => continue,
-            Rule::expression => {
-                value = process_expression(assignment_piece);
-            }
-            _ => handle_unexpected_rule("assignment", assignment_piece),
-        }
+        Ok(statements)
     }
-    (identifier, value)
-}
 
-fn process_binary_logical_expression(
-    binary_logical_expression: Pair<Rule>,
-) -> BinaryLogicalExpression {
-    for expression_piece in binary_logical_expression.into_inner() {
-        match expression_piece.as_rule() {
-            Rule::and_expression | Rule::or_expression => {
-                let mut left = Expression::Literal(Literal::Int(0)); // Placeholder for actual value
-                let mut right = Expression::Literal(Literal::Int(0)); // Placeholder for actual value
-                let mut boolean_operator = BooleanOperator::And; // Default value
-                let logical_expression = expression_piece.into_inner();
-                for logical_piece in logical_expression {
-                    match logical_piece.as_rule() {
-                        Rule::expression_base => {
-                            left = process_expression(logical_piece);
-                        }
-                        Rule::expression => {
-                            right = process_expression(logical_piece);
-                        }
-                        Rule::and_token => boolean_operator = BooleanOperator::And,
-                        Rule::or_token => boolean_operator = BooleanOperator::Or,
-                        _ => handle_unexpected_rule("logical_expression", logical_piece),
-                    }
+    /// Process a filter statement and add it to the statements vector
+    fn process_filter_statement(
+        filter_statement: Pair<Rule>,
+        statements: &mut Vec<Statement>,
+    ) -> QueryResult<()> {
+        for filter_piece in filter_statement.into_inner() {
+            match filter_piece.as_rule() {
+                Rule::where_token => continue,
+                Rule::predicate => {
+                    statements.push(Statement::Filter(Self::process_predicate(filter_piece)?));
                 }
-                return BinaryLogicalExpression {
-                    left: Box::new(left),
-                    boolean_operator,
-                    right: Box::new(right),
-                };
-            }
-            _ => handle_unexpected_rule("binary_logical_expression", expression_piece),
-        }
-    }
-    unreachable!("Expected a valid binary logical expression but none was found");
-}
-
-fn process_comparison_expression(comparison_expression: Pair<Rule>) -> ComparisonExpression {
-    for expression_piece in comparison_expression.into_inner() {
-        match expression_piece.as_rule() {
-            Rule::equals_expression
-            | Rule::not_equals_expression
-            | Rule::greater_than_expression
-            | Rule::less_than_expression
-            | Rule::greater_than_or_equal_to_expression
-            | Rule::less_than_or_equal_to_expression => {
-                let mut left = Expression::Literal(Literal::Int(0)); // Placeholder for actual value
-                let mut right = Expression::Literal(Literal::Int(0)); // Placeholder for actual value
-                let mut comparison_operator = ComparisonOperator::Equal; // Default value
-                let comparison_expression = expression_piece.into_inner();
-                for comparison_piece in comparison_expression {
-                    match comparison_piece.as_rule() {
-                        Rule::expression_base => {
-                            left = process_expression(comparison_piece);
-                        }
-                        Rule::expression => {
-                            right = process_expression(comparison_piece);
-                        }
-                        Rule::equals_token => comparison_operator = ComparisonOperator::Equal,
-                        Rule::not_equals_token => {
-                            comparison_operator = ComparisonOperator::NotEqual
-                        }
-                        Rule::greater_than_token => {
-                            comparison_operator = ComparisonOperator::GreaterThan
-                        }
-                        Rule::less_than_token => comparison_operator = ComparisonOperator::LessThan,
-                        Rule::greater_than_or_equal_to_token => {
-                            comparison_operator = ComparisonOperator::GreaterThanOrEqual
-                        }
-                        Rule::less_than_or_equal_to_token => {
-                            comparison_operator = ComparisonOperator::LessThanOrEqual
-                        }
-                        _ => handle_unexpected_rule("comparison_expression", comparison_piece),
-                    }
+                _ => {
+                    return Err(QueryError::ProcessingError(format!(
+                    "Unexpected rule: '{:?}' found processing parent object: 'filter_statement'",
+                    filter_piece.as_rule()
+                )))
                 }
-                return ComparisonExpression {
-                    left: Box::new(left),
-                    comparison_operator,
-                    right: Box::new(right),
-                };
             }
-            _ => handle_unexpected_rule("comparison_expression", expression_piece),
+        }
+        Ok(())
+    }
+
+    /// Process an extend statement and add it to the statements vector
+    fn process_extend_statement(
+        extend_statement: Pair<Rule>,
+        statements: &mut Vec<Statement>,
+    ) -> QueryResult<()> {
+        for extend_piece in extend_statement.into_inner() {
+            match extend_piece.as_rule() {
+                Rule::extend_token | Rule::comma_token => continue,
+                Rule::assignment_expression => {
+                    let (identifier, value) = Self::process_assignment(extend_piece)?;
+                    statements.push(Statement::Extend(identifier, value, None));
+                }
+                _ => {
+                    return Err(QueryError::ProcessingError(format!(
+                    "Unexpected rule: '{:?}' found processing parent object: 'extend_statement'",
+                    extend_piece.as_rule()
+                )))
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Process a predicate, returning a Predicate object
+    fn process_predicate(predicate: Pair<Rule>) -> QueryResult<Predicate> {
+        for predicate_piece in predicate.into_inner() {
+            match predicate_piece.as_rule() {
+                Rule::binary_logical_expression => {
+                    return Ok(Predicate::BinaryLogicalExpression(
+                        Self::process_binary_logical_expression(predicate_piece)?,
+                    ));
+                }
+                Rule::comparison_expression => {
+                    return Ok(Predicate::ComparisonExpression(
+                        Self::process_comparison_expression(predicate_piece)?,
+                    ));
+                }
+                Rule::negated_expression => {
+                    return Ok(Predicate::NegatedExpression(Box::new(
+                        Self::process_negated_expression(predicate_piece)?,
+                    )));
+                }
+                _ => {
+                    return Err(QueryError::ProcessingError(format!(
+                        "Unexpected rule: '{:?}' found processing parent object: 'predicate'",
+                        predicate_piece.as_rule()
+                    )))
+                }
+            }
+        }
+        Err(QueryError::ProcessingError(
+            "Expected a valid predicate but none was found".to_string(),
+        ))
+    }
+
+    /// Process an assignment expression, returning an identifier and value
+    fn process_assignment(assignment: Pair<Rule>) -> QueryResult<(Identifier, Expression)> {
+        let mut identifier = Identifier {
+            name: String::new(),
+        };
+        let mut value = None;
+
+        for assignment_piece in assignment.into_inner() {
+            match assignment_piece.as_rule() {
+                Rule::identifier => identifier = Self::process_identifier(assignment_piece),
+                Rule::assignment_token => continue,
+                Rule::expression => {
+                    value = Some(Self::process_expression(assignment_piece)?);
+                }
+                _ => {
+                    return Err(QueryError::ProcessingError(format!(
+                        "Unexpected rule: '{:?}' found processing parent object: 'assignment'",
+                        assignment_piece.as_rule()
+                    )))
+                }
+            }
+        }
+
+        let value = value.ok_or_else(|| {
+            QueryError::ProcessingError("Missing value in assignment expression".to_string())
+        })?;
+
+        Ok((identifier, value))
+    }
+
+    fn process_binary_logical_expression(
+        binary_logical_expression: Pair<Rule>,
+    ) -> QueryResult<BinaryLogicalExpression> {
+        for expression_piece in binary_logical_expression.into_inner() {
+            match expression_piece.as_rule() {
+                Rule::and_expression | Rule::or_expression => {
+                    let mut left = Expression::Literal(Literal::Int(0)); // Placeholder for actual value
+                    let mut right = Expression::Literal(Literal::Int(0)); // Placeholder for actual value
+                    let mut boolean_operator = BooleanOperator::And; // Default value
+                    let logical_expression = expression_piece.into_inner();
+                    for logical_piece in logical_expression {
+                        match logical_piece.as_rule() {
+                            Rule::expression_base => {
+                                left = Self::process_expression(logical_piece)?;
+                            }
+                            Rule::expression => {
+                                right = Self::process_expression(logical_piece)?;
+                            }
+                            Rule::and_token => boolean_operator = BooleanOperator::And,
+                            Rule::or_token => boolean_operator = BooleanOperator::Or,
+                            _ => return Err(QueryError::ProcessingError(format!(
+                                "Unexpected rule: '{:?}' found processing parent object: 'logical_expression'",
+                                logical_piece.as_rule()
+                            ))),
+                        }
+                    }
+                    return Ok(BinaryLogicalExpression {
+                        left: Box::new(left),
+                        boolean_operator,
+                        right: Box::new(right),
+                    });
+                }
+                _ => return Err(QueryError::ProcessingError(format!(
+                    "Unexpected rule: '{:?}' found processing parent object: 'binary_logical_expression'",
+                    expression_piece.as_rule()
+                ))),
+            }
+        }
+        Err(QueryError::ProcessingError(
+            "Expected a valid binary logical expression but none was found".to_string(),
+        ))
+    }
+
+    fn process_comparison_expression(
+        comparison_expression: Pair<Rule>,
+    ) -> QueryResult<ComparisonExpression> {
+        for expression_piece in comparison_expression.into_inner() {
+            match expression_piece.as_rule() {
+                Rule::equals_expression
+                | Rule::not_equals_expression
+                | Rule::greater_than_expression
+                | Rule::less_than_expression
+                | Rule::greater_than_or_equal_to_expression
+                | Rule::less_than_or_equal_to_expression => {
+                    let mut left = Expression::Literal(Literal::Int(0)); // Placeholder for actual value
+                    let mut right = Expression::Literal(Literal::Int(0)); // Placeholder for actual value
+                    let mut comparison_operator = ComparisonOperator::Equal; // Default value
+                    let comparison_expression = expression_piece.into_inner();
+                    for comparison_piece in comparison_expression {
+                        match comparison_piece.as_rule() {
+                            Rule::expression_base => {
+                                left = Self::process_expression(comparison_piece)?;
+                            }
+                            Rule::expression => {
+                                right = Self::process_expression(comparison_piece)?;
+                            }
+                            Rule::equals_token => comparison_operator = ComparisonOperator::Equal,
+                            Rule::not_equals_token => {
+                                comparison_operator = ComparisonOperator::NotEqual
+                            }
+                            Rule::greater_than_token => {
+                                comparison_operator = ComparisonOperator::GreaterThan
+                            }
+                            Rule::less_than_token => comparison_operator = ComparisonOperator::LessThan,
+                            Rule::greater_than_or_equal_to_token => {
+                                comparison_operator = ComparisonOperator::GreaterThanOrEqual
+                            }
+                            Rule::less_than_or_equal_to_token => {
+                                comparison_operator = ComparisonOperator::LessThanOrEqual
+                            }
+                            _ => return Err(QueryError::ProcessingError(format!(
+                                "Unexpected rule: '{:?}' found processing parent object: 'comparison_expression'",
+                                comparison_piece.as_rule()
+                            ))),
+                        }
+                    }
+                    return Ok(ComparisonExpression {
+                        left: Box::new(left),
+                        comparison_operator,
+                        right: Box::new(right),
+                    });
+                }
+                _ => return Err(QueryError::ProcessingError(format!(
+                    "Unexpected rule: '{:?}' found processing parent object: 'comparison_expression'",
+                    expression_piece.as_rule()
+                ))),
+            }
+        }
+        Err(QueryError::ProcessingError(
+            "Expected a valid comparison expression but none was found".to_string(),
+        ))
+    }
+
+    fn process_negated_expression(negated_expression: Pair<Rule>) -> QueryResult<Expression> {
+        for negated_piece in negated_expression.into_inner() {
+            match negated_piece.as_rule() {
+                Rule::not_token => continue,
+                Rule::enclosed_expression => {
+                    return Ok(Self::process_enclosed_expression(negated_piece)?)
+                }
+                _ => {
+                    return Err(QueryError::ProcessingError(format!(
+                    "Unexpected rule: '{:?}' found processing parent object: 'negated_expression'",
+                    negated_piece.as_rule()
+                )))
+                }
+            }
+        }
+        Err(QueryError::ProcessingError(
+            "Expected a valid negated expression but none was found".to_string(),
+        ))
+    }
+
+    fn process_enclosed_expression(enclosed_expression: Pair<Rule>) -> QueryResult<Expression> {
+        for enclosed_piece in enclosed_expression.into_inner() {
+            match enclosed_piece.as_rule() {
+                Rule::open_paren_token | Rule::close_paren_token => continue,
+                Rule::expression => {
+                    return Ok(Self::process_expression(enclosed_piece)?);
+                }
+                _ => {
+                    return Err(QueryError::ProcessingError(format!(
+                    "Unexpected rule: '{:?}' found processing parent object: 'enclosed_expression'",
+                    enclosed_piece.as_rule()
+                )))
+                }
+            }
+        }
+        Err(QueryError::ProcessingError(
+            "Expected a valid enclosed expression but none was found".to_string(),
+        ))
+    }
+
+    fn process_expression(expression: Pair<Rule>) -> QueryResult<Expression> {
+        for expression_piece in expression.into_inner() {
+            match expression_piece.as_rule() {
+                Rule::predicate => {
+                    return Ok(Expression::Predicate(Self::process_predicate(
+                        expression_piece,
+                    )?));
+                }
+                Rule::enclosed_expression => {
+                    return Ok(Expression::EnclosedExpression(Box::new(
+                        Self::process_enclosed_expression(expression_piece)?,
+                    )));
+                }
+                Rule::literal => {
+                    return Ok(Expression::Literal(Self::process_literal(expression_piece)));
+                }
+                Rule::identifier => {
+                    return Ok(Expression::Identifier(Self::process_identifier(
+                        expression_piece,
+                    )));
+                }
+                _ => {
+                    return Err(QueryError::ProcessingError(format!(
+                        "Unexpected rule: '{:?}' found processing parent object: 'expression'",
+                        expression_piece.as_rule()
+                    )))
+                }
+            }
+        }
+        Err(QueryError::ProcessingError(
+            "Expected a valid expression but none was found".to_string(),
+        ))
+    }
+
+    fn process_identifier(identifier: Pair<Rule>) -> Identifier {
+        Identifier {
+            name: identifier.as_str().to_string(),
         }
     }
-    unreachable!("Expected a valid comparison expression but none was found");
-}
 
-fn process_negated_expression(negated_expression: Pair<Rule>) -> Expression {
-    for negated_piece in negated_expression.into_inner() {
-        match negated_piece.as_rule() {
-            Rule::not_token => continue,
-            Rule::enclosed_expression => return process_enclosed_expression(negated_piece),
-            _ => handle_unexpected_rule("negated_expression", negated_piece),
+    fn process_literal(literal: Pair<Rule>) -> Literal {
+        if let Ok(value) = literal.as_str().parse::<i32>() {
+            return Literal::Int(value);
+        } else if literal.as_str() == "true" {
+            return Literal::Bool(true);
+        } else if literal.as_str() == "false" {
+            return Literal::Bool(false);
+        } else {
+            return Literal::String(literal.as_str().trim_matches('"').to_string());
         }
     }
-    unreachable!("Expected a valid negated expression but none was found");
-}
-
-fn process_enclosed_expression(enclosed_expression: Pair<Rule>) -> Expression {
-    for enclosed_piece in enclosed_expression.into_inner() {
-        match enclosed_piece.as_rule() {
-            Rule::open_paren_token | Rule::close_paren_token => continue,
-            Rule::expression => {
-                return process_expression(enclosed_piece);
-            }
-            _ => handle_unexpected_rule("enclosed_expression", enclosed_piece),
-        }
-    }
-    unreachable!("Expected a valid enclosed expression but none was found");
-}
-
-fn process_expression(expression: Pair<Rule>) -> Expression {
-    for expression_piece in expression.into_inner() {
-        match expression_piece.as_rule() {
-            Rule::predicate => {
-                return Expression::Predicate(process_predicate(expression_piece));
-            }
-            Rule::enclosed_expression => {
-                return Expression::EnclosedExpression(Box::new(process_enclosed_expression(
-                    expression_piece,
-                )));
-            }
-            Rule::literal => {
-                return Expression::Literal(process_literal(expression_piece));
-            }
-            Rule::identifier => {
-                return Expression::Identifier(process_identifier(expression_piece));
-            }
-            _ => handle_unexpected_rule("expression", expression_piece),
-        }
-    }
-    unreachable!("Expected a valid expression but none was found");
-}
-
-fn process_identifier(identifier: Pair<Rule>) -> Identifier {
-    Identifier {
-        name: identifier.as_str().to_string(),
-    }
-}
-
-fn process_literal(literal: Pair<Rule>) -> Literal {
-    if let Ok(value) = literal.as_str().parse::<i32>() {
-        return Literal::Int(value);
-    } else if literal.as_str() == "true" {
-        return Literal::Bool(true);
-    } else if literal.as_str() == "false" {
-        return Literal::Bool(false);
-    } else {
-        return Literal::String(literal.as_str().trim_matches('"').to_string());
-    }
-}
-
-fn handle_unexpected_rule(parent_object: &str, found_rule: Pair<Rule>) {
-    panic!(
-        "Unexpected rule: '{:?}' found processing parent object: '{:?}'",
-        found_rule.as_rule(),
-        parent_object
-    );
 }
 
 #[cfg(test)]
@@ -279,21 +385,21 @@ mod tests {
             .unwrap()
             .next()
             .unwrap();
-        let result = process_literal(literal);
+        let result = KqlPlugin::process_literal(literal);
         assert_eq!(result, Literal::Int(42));
 
         let literal = KqlParser::parse(Rule::literal, "true")
             .unwrap()
             .next()
             .unwrap();
-        let result = process_literal(literal);
+        let result = KqlPlugin::process_literal(literal);
         assert_eq!(result, Literal::Bool(true));
 
         let literal = KqlParser::parse(Rule::literal, "\"hello\"")
             .unwrap()
             .next()
             .unwrap();
-        let result = process_literal(literal);
+        let result = KqlPlugin::process_literal(literal);
         assert_eq!(result, Literal::String("hello".to_string()));
     }
 
@@ -303,7 +409,7 @@ mod tests {
             .unwrap()
             .next()
             .unwrap();
-        let result = process_identifier(identifier);
+        let result = KqlPlugin::process_identifier(identifier);
         assert_eq!(result.name, "my_variable");
     }
 
@@ -313,7 +419,7 @@ mod tests {
             .unwrap()
             .next()
             .unwrap();
-        let result = process_expression(expression);
+        let result = KqlPlugin::process_expression(expression).unwrap();
         assert_eq!(
             result,
             Expression::Predicate(Predicate::ComparisonExpression(ComparisonExpression {
@@ -326,14 +432,13 @@ mod tests {
         );
     }
 
-    
     #[test]
     fn test_process_expression_enclosed_expression() {
         let expression = KqlParser::parse(Rule::expression, "(x == 42)")
             .unwrap()
             .next()
             .unwrap();
-        let result = process_expression(expression);
+        let result = KqlPlugin::process_expression(expression).unwrap();
         assert_eq!(
             result,
             Expression::EnclosedExpression(Box::new(Expression::Predicate(
@@ -354,21 +459,17 @@ mod tests {
             .unwrap()
             .next()
             .unwrap();
-        let result = process_expression(expression);
-        assert_eq!(
-            result,
-            Expression::Literal(Literal::Int(42))
-        );
+        let result = KqlPlugin::process_expression(expression).unwrap();
+        assert_eq!(result, Expression::Literal(Literal::Int(42)));
     }
 
-    
     #[test]
     fn test_process_expression_identifier() {
         let expression = KqlParser::parse(Rule::expression, "my_variable")
             .unwrap()
             .next()
             .unwrap();
-        let result = process_expression(expression);
+        let result = KqlPlugin::process_expression(expression).unwrap();
         assert_eq!(
             result,
             Expression::Identifier(Identifier {
@@ -383,7 +484,7 @@ mod tests {
             .unwrap()
             .next()
             .unwrap();
-        let result = process_enclosed_expression(expression);
+        let result = KqlPlugin::process_enclosed_expression(expression).unwrap();
         assert_eq!(
             result,
             Expression::Predicate(Predicate::ComparisonExpression(ComparisonExpression {
@@ -402,18 +503,16 @@ mod tests {
             .unwrap()
             .next()
             .unwrap();
-        let result = process_negated_expression(expression);
+        let result = KqlPlugin::process_negated_expression(expression).unwrap();
         assert_eq!(
             result,
-            Expression::Predicate(
-                Predicate::ComparisonExpression(ComparisonExpression {
-                    left: Box::new(Expression::Identifier(Identifier {
-                        name: "x".to_string(),
-                    })),
-                    comparison_operator: ComparisonOperator::Equal,
-                    right: Box::new(Expression::Literal(Literal::Int(42))),
-                })
-            )
+            Expression::Predicate(Predicate::ComparisonExpression(ComparisonExpression {
+                left: Box::new(Expression::Identifier(Identifier {
+                    name: "x".to_string(),
+                })),
+                comparison_operator: ComparisonOperator::Equal,
+                right: Box::new(Expression::Literal(Literal::Int(42))),
+            }))
         );
     }
 
@@ -423,7 +522,7 @@ mod tests {
             .unwrap()
             .next()
             .unwrap();
-        let result = process_comparison_expression(expression);
+        let result = KqlPlugin::process_comparison_expression(expression).unwrap();
         assert_eq!(
             result,
             ComparisonExpression {
@@ -442,7 +541,7 @@ mod tests {
             .unwrap()
             .next()
             .unwrap();
-        let result = process_comparison_expression(expression);
+        let result = KqlPlugin::process_comparison_expression(expression).unwrap();
         assert_eq!(
             result,
             ComparisonExpression {
@@ -461,7 +560,7 @@ mod tests {
             .unwrap()
             .next()
             .unwrap();
-        let result = process_comparison_expression(expression);
+        let result = KqlPlugin::process_comparison_expression(expression).unwrap();
         assert_eq!(
             result,
             ComparisonExpression {
@@ -480,7 +579,7 @@ mod tests {
             .unwrap()
             .next()
             .unwrap();
-        let result = process_comparison_expression(expression);
+        let result = KqlPlugin::process_comparison_expression(expression).unwrap();
         assert_eq!(
             result,
             ComparisonExpression {
@@ -499,7 +598,7 @@ mod tests {
             .unwrap()
             .next()
             .unwrap();
-        let result = process_comparison_expression(expression);
+        let result = KqlPlugin::process_comparison_expression(expression).unwrap();
         assert_eq!(
             result,
             ComparisonExpression {
@@ -518,7 +617,7 @@ mod tests {
             .unwrap()
             .next()
             .unwrap();
-        let result = process_comparison_expression(expression);
+        let result = KqlPlugin::process_comparison_expression(expression).unwrap();
         assert_eq!(
             result,
             ComparisonExpression {
@@ -537,7 +636,7 @@ mod tests {
             .unwrap()
             .next()
             .unwrap();
-        let result = process_binary_logical_expression(expression);
+        let result = KqlPlugin::process_binary_logical_expression(expression).unwrap();
         assert_eq!(
             result,
             BinaryLogicalExpression {
@@ -558,7 +657,7 @@ mod tests {
             .unwrap()
             .next()
             .unwrap();
-        let result = process_binary_logical_expression(expression);
+        let result = KqlPlugin::process_binary_logical_expression(expression).unwrap();
         assert_eq!(
             result,
             BinaryLogicalExpression {
@@ -582,32 +681,36 @@ mod tests {
         .unwrap()
         .next()
         .unwrap();
-        let result = process_binary_logical_expression(expression);
+        let result = KqlPlugin::process_binary_logical_expression(expression).unwrap();
         assert_eq!(
             result,
             BinaryLogicalExpression {
                 left: Box::new(Expression::EnclosedExpression(Box::new(
                     Expression::Predicate(Predicate::BinaryLogicalExpression(
                         BinaryLogicalExpression {
-                            left: Box::new(Expression::EnclosedExpression(Box::new(Expression::Predicate(
-                                Predicate::ComparisonExpression(ComparisonExpression {
-                                    left: Box::new(Expression::Identifier(Identifier {
-                                        name: "x".to_string(),
-                                    })),
-                                    comparison_operator: ComparisonOperator::Equal,
-                                    right: Box::new(Expression::Literal(Literal::Int(42))),
-                                })
-                            )))),
+                            left: Box::new(Expression::EnclosedExpression(Box::new(
+                                Expression::Predicate(Predicate::ComparisonExpression(
+                                    ComparisonExpression {
+                                        left: Box::new(Expression::Identifier(Identifier {
+                                            name: "x".to_string(),
+                                        })),
+                                        comparison_operator: ComparisonOperator::Equal,
+                                        right: Box::new(Expression::Literal(Literal::Int(42))),
+                                    }
+                                ))
+                            ))),
                             boolean_operator: BooleanOperator::And,
-                            right: Box::new(Expression::EnclosedExpression(Box::new(Expression::Predicate(
-                                Predicate::ComparisonExpression(ComparisonExpression {
-                                    left: Box::new(Expression::Identifier(Identifier {
-                                        name: "y".to_string(),
-                                    })),
-                                    comparison_operator: ComparisonOperator::Equal,
-                                    right: Box::new(Expression::Literal(Literal::Int(24))),
-                                })
-                            )))),
+                            right: Box::new(Expression::EnclosedExpression(Box::new(
+                                Expression::Predicate(Predicate::ComparisonExpression(
+                                    ComparisonExpression {
+                                        left: Box::new(Expression::Identifier(Identifier {
+                                            name: "y".to_string(),
+                                        })),
+                                        comparison_operator: ComparisonOperator::Equal,
+                                        right: Box::new(Expression::Literal(Literal::Int(24))),
+                                    }
+                                ))
+                            ))),
                         }
                     ))
                 ))),
@@ -631,7 +734,7 @@ mod tests {
             .unwrap()
             .next()
             .unwrap();
-        let (identifier, value) = process_assignment(assignment);
+        let (identifier, value) = KqlPlugin::process_assignment(assignment).unwrap();
         assert_eq!(identifier.name, "x");
         assert_eq!(value, Expression::Literal(Literal::Int(42)));
     }
@@ -642,7 +745,7 @@ mod tests {
             .unwrap()
             .next()
             .unwrap();
-        let result = process_predicate(predicate);
+        let result = KqlPlugin::process_predicate(predicate).unwrap();
         assert_eq!(
             result,
             Predicate::BinaryLogicalExpression(BinaryLogicalExpression {
@@ -663,7 +766,7 @@ mod tests {
             .unwrap()
             .next()
             .unwrap();
-        let result = process_predicate(predicate);
+        let result = KqlPlugin::process_predicate(predicate).unwrap();
         assert_eq!(
             result,
             Predicate::ComparisonExpression(ComparisonExpression {
@@ -682,7 +785,7 @@ mod tests {
             .unwrap()
             .next()
             .unwrap();
-        let result = process_predicate(predicate);
+        let result = KqlPlugin::process_predicate(predicate).unwrap();
         assert_eq!(
             result,
             Predicate::NegatedExpression(Box::new(Expression::Predicate(
@@ -703,29 +806,29 @@ mod tests {
             .unwrap()
             .next()
             .unwrap();
-        let result = process_predicate(predicate);
+        let result = KqlPlugin::process_predicate(predicate).unwrap();
         assert_eq!(
             result,
             Predicate::BinaryLogicalExpression(BinaryLogicalExpression {
-                left: Box::new(Expression::EnclosedExpression(Box::new(Expression::Predicate(
-                    Predicate::ComparisonExpression(ComparisonExpression {
+                left: Box::new(Expression::EnclosedExpression(Box::new(
+                    Expression::Predicate(Predicate::ComparisonExpression(ComparisonExpression {
                         left: Box::new(Expression::Identifier(Identifier {
                             name: "x".to_string(),
                         })),
                         comparison_operator: ComparisonOperator::Equal,
                         right: Box::new(Expression::Literal(Literal::Int(42))),
-                    })
-                )))),
+                    }))
+                ))),
                 boolean_operator: BooleanOperator::And,
-                right: Box::new(Expression::EnclosedExpression(Box::new(Expression::Predicate(
-                    Predicate::ComparisonExpression(ComparisonExpression {
+                right: Box::new(Expression::EnclosedExpression(Box::new(
+                    Expression::Predicate(Predicate::ComparisonExpression(ComparisonExpression {
                         left: Box::new(Expression::Identifier(Identifier {
                             name: "y".to_string(),
                         })),
                         comparison_operator: ComparisonOperator::Equal,
                         right: Box::new(Expression::Literal(Literal::Int(24))),
-                    })
-                )))),
+                    }))
+                ))),
             })
         );
     }
@@ -736,16 +839,18 @@ mod tests {
             .unwrap()
             .next()
             .unwrap();
-        let result = process_statement(statement);
+        let result = KqlPlugin::process_statement(statement).unwrap();
         assert_eq!(
             result,
-            vec![Statement::Filter(Predicate::ComparisonExpression(ComparisonExpression {
-                left: Box::new(Expression::Identifier(Identifier {
-                    name: "x".to_string(),
-                })),
-                comparison_operator: ComparisonOperator::Equal,
-                right: Box::new(Expression::Literal(Literal::Int(42))),
-            }))]
+            vec![Statement::Filter(Predicate::ComparisonExpression(
+                ComparisonExpression {
+                    left: Box::new(Expression::Identifier(Identifier {
+                        name: "x".to_string(),
+                    })),
+                    comparison_operator: ComparisonOperator::Equal,
+                    right: Box::new(Expression::Literal(Literal::Int(42))),
+                }
+            ))]
         );
     }
 
@@ -755,7 +860,7 @@ mod tests {
             .unwrap()
             .next()
             .unwrap();
-        let result = process_statement(statement);
+        let result = KqlPlugin::process_statement(statement).unwrap();
         assert_eq!(
             result,
             vec![Statement::Extend(
@@ -774,7 +879,7 @@ mod tests {
             .unwrap()
             .next()
             .unwrap();
-        let result = process_statement(statement);
+        let result = KqlPlugin::process_statement(statement).unwrap();
         assert_eq!(
             result,
             vec![
@@ -799,42 +904,46 @@ mod tests {
     #[test]
     fn test_process_query() {
         let input = "my_table | where my_variable == 5";
-        let query = KqlPlugin::process_query(input);
+        let result = KqlPlugin::process_query(input);
+        assert!(result.is_ok());
+        let query = result.unwrap();
         assert_eq!(
             query,
             Query {
                 source: "my_table".to_string(),
-                statements: vec![Statement::Filter(
-                    Predicate::ComparisonExpression(ComparisonExpression {
+                statements: vec![Statement::Filter(Predicate::ComparisonExpression(
+                    ComparisonExpression {
                         left: Box::new(Expression::Identifier(Identifier {
                             name: "my_variable".to_string(),
                         })),
                         comparison_operator: ComparisonOperator::Equal,
                         right: Box::new(Expression::Literal(Literal::Int(5))),
-                    })
-                )]
+                    }
+                ))]
             }
-        )
+        );
     }
 
     #[test]
     fn test_process_query_multi_line() {
         let input = "my_table 
         | where my_variable == 5";
-        let query = KqlPlugin::process_query(input);
+        let result = KqlPlugin::process_query(input);
+        assert!(result.is_ok());
+        let query = result.unwrap();
         assert_eq!(
             query,
             Query {
                 source: "my_table".to_string(),
-                statements: vec![Statement::Filter(
-                    Predicate::ComparisonExpression(ComparisonExpression {
+                statements: vec![Statement::Filter(Predicate::ComparisonExpression(
+                    ComparisonExpression {
                         left: Box::new(Expression::Identifier(Identifier {
                             name: "my_variable".to_string(),
                         })),
                         comparison_operator: ComparisonOperator::Equal,
                         right: Box::new(Expression::Literal(Literal::Int(5))),
-                    })
-                )]
+                    }
+                ))]
             }
         );
     }
@@ -847,7 +956,9 @@ mod tests {
         | where not(z >= 10)
         | extend new_column = true, another_new_column = (another_variable == 100)
         "#;
-        let query = KqlPlugin::process_query(input);
+        let result = KqlPlugin::process_query(input);
+        assert!(result.is_ok());
+        let query = result.unwrap();
         assert_eq!(
             query,
             Query {
@@ -909,17 +1020,15 @@ mod tests {
                         Identifier {
                             name: "another_new_column".to_string(),
                         },
-                        Expression::EnclosedExpression(Box::new(
-                            Expression::Predicate(Predicate::ComparisonExpression(
-                                ComparisonExpression {
-                                    left: Box::new(Expression::Identifier(Identifier {
-                                        name: "another_variable".to_string(),
-                                    })),
-                                    comparison_operator: ComparisonOperator::Equal,
-                                    right: Box::new(Expression::Literal(Literal::Int(100))),
-                                }
-                            ))
-                        )),
+                        Expression::EnclosedExpression(Box::new(Expression::Predicate(
+                            Predicate::ComparisonExpression(ComparisonExpression {
+                                left: Box::new(Expression::Identifier(Identifier {
+                                    name: "another_variable".to_string(),
+                                })),
+                                comparison_operator: ComparisonOperator::Equal,
+                                right: Box::new(Expression::Literal(Literal::Int(100))),
+                            })
+                        ))),
                         None
                     )
                 ]

--- a/rust/experimental/query_abstraction/kql_plugin/src/kql_plugin.rs
+++ b/rust/experimental/query_abstraction/kql_plugin/src/kql_plugin.rs
@@ -1035,4 +1035,22 @@ mod tests {
             }
         );
     }
+
+    #[test]
+    fn test_process_query_expect_parsing_error() {
+        let invalid_inputs = vec![
+            "my_table | where my_variable == 5 |",
+            "| where my_variable == 5",
+            "my_table | where == 5",
+            "my_table | where my_variable = 5",
+            "my_table | extend x = 42, y =",
+            "my_table | extend x = 42, y = 24,",
+        ];
+
+        for input in invalid_inputs {
+            let result = KqlPlugin::process_query(input);
+            assert!(result.is_err(), "Expected error for input: {}", input);
+            assert!(matches!(result, Err(QueryError::ParseError(_))));
+        }
+    }
 }

--- a/rust/experimental/query_abstraction/kql_plugin/src/kql_plugin.rs
+++ b/rust/experimental/query_abstraction/kql_plugin/src/kql_plugin.rs
@@ -1,12 +1,929 @@
 use crate::kql_parser::{KqlParser, Rule};
-use intermediate_language::{grammar_objects::Query, query_processor::QueryProcessor};
-use pest::Parser;
+use intermediate_language::{grammar_objects::*, query_processor::QueryProcessor};
+use pest::{iterators::Pair, Parser};
 
 pub struct KqlPlugin;
 
 impl QueryProcessor for KqlPlugin {
     fn process_query(input: &str) -> Query {
-        let _ = KqlParser::parse(Rule::query, input);
-        todo!()
+        let mut source = "".to_string();
+        let mut statements: Vec<Statement> = Vec::new();
+        let query = KqlParser::parse(Rule::query, input)
+            .expect("Failed to parse query")
+            .next()
+            .unwrap();
+
+        for query_piece in query.clone().into_inner() {
+            match query_piece.as_rule() {
+                Rule::identifier => {
+                    source = query_piece.as_str().to_string();
+                }
+                Rule::statement => {
+                    statements.extend(process_statement(query_piece));
+                }
+                Rule::EOI => (),
+                _ => handle_unexpected_rule("query", query_piece),
+            }
+        }
+
+        Query { source, statements }
+    }
+}
+
+fn process_statement(statement: Pair<Rule>) -> Vec<Statement> {
+    let mut statements: Vec<Statement> = Vec::new();
+    for statement_piece in statement.into_inner() {
+        match statement_piece.as_rule() {
+            Rule::pipe_token => continue,
+            Rule::filter_statement => {
+                let filter_statement = statement_piece.into_inner();
+                for filter_piece in filter_statement {
+                    match filter_piece.as_rule() {
+                        Rule::where_token => continue,
+                        Rule::predicate => {
+                            statements.push(Statement::Filter(process_predicate(filter_piece)));
+                        }
+                        _ => handle_unexpected_rule("filter_statement", filter_piece),
+                    }
+                }
+            }
+            Rule::extend_statement => {
+                let extend_statement = statement_piece.into_inner();
+                for extend_piece in extend_statement {
+                    match extend_piece.as_rule() {
+                        Rule::extend_token | Rule::comma_token => continue,
+                        Rule::assignment_expression => {
+                            let (identifier, value) = process_assignment(extend_piece);
+                            statements.push(Statement::Extend(identifier, value, None));
+                        }
+                        _ => handle_unexpected_rule("extend_statement", extend_piece),
+                    }
+                }
+            }
+            _ => handle_unexpected_rule("statement", statement_piece),
+        }
+    }
+    if statements.is_empty() {
+        panic!("Expected a valid statement but none was found");
+    }
+    statements
+}
+
+fn process_predicate(predicate: Pair<Rule>) -> Predicate {
+    for predicate_piece in predicate.into_inner() {
+        match predicate_piece.as_rule() {
+            Rule::binary_logical_expression => {
+                return Predicate::BinaryLogicalExpression(process_binary_logical_expression(
+                    predicate_piece,
+                ));
+            }
+            Rule::comparison_expression => {
+                return Predicate::ComparisonExpression(process_comparison_expression(
+                    predicate_piece,
+                ));
+            }
+            Rule::negated_expression => {
+                return Predicate::NegatedExpression(Box::new(process_negated_expression(
+                    predicate_piece,
+                )));
+            }
+            _ => handle_unexpected_rule("predicate", predicate_piece),
+        }
+    }
+    unreachable!("Expected a valid predicate but none was found");
+}
+
+fn process_assignment(assignment: Pair<Rule>) -> (Identifier, Expression) {
+    let mut identifier = Identifier {
+        name: "".to_string(),
+    }; // Placeholder for actual value
+    let mut value = Expression::Literal(Literal::Int(0)); // Placeholder for actual value
+    for assignment_piece in assignment.into_inner() {
+        match assignment_piece.as_rule() {
+            Rule::identifier => identifier = process_identifier(assignment_piece),
+            Rule::assignment_token => continue,
+            Rule::expression => {
+                value = process_expression(assignment_piece);
+            }
+            _ => handle_unexpected_rule("assignment", assignment_piece),
+        }
+    }
+    (identifier, value)
+}
+
+fn process_binary_logical_expression(
+    binary_logical_expression: Pair<Rule>,
+) -> BinaryLogicalExpression {
+    for expression_piece in binary_logical_expression.into_inner() {
+        match expression_piece.as_rule() {
+            Rule::and_expression | Rule::or_expression => {
+                let mut left = Expression::Literal(Literal::Int(0)); // Placeholder for actual value
+                let mut right = Expression::Literal(Literal::Int(0)); // Placeholder for actual value
+                let mut boolean_operator = BooleanOperator::And; // Default value
+                let logical_expression = expression_piece.into_inner();
+                for logical_piece in logical_expression {
+                    match logical_piece.as_rule() {
+                        Rule::expression_base => {
+                            left = process_expression(logical_piece);
+                        }
+                        Rule::expression => {
+                            right = process_expression(logical_piece);
+                        }
+                        Rule::and_token => boolean_operator = BooleanOperator::And,
+                        Rule::or_token => boolean_operator = BooleanOperator::Or,
+                        _ => handle_unexpected_rule("logical_expression", logical_piece),
+                    }
+                }
+                return BinaryLogicalExpression {
+                    left: Box::new(left),
+                    boolean_operator,
+                    right: Box::new(right),
+                };
+            }
+            _ => handle_unexpected_rule("binary_logical_expression", expression_piece),
+        }
+    }
+    unreachable!("Expected a valid binary logical expression but none was found");
+}
+
+fn process_comparison_expression(comparison_expression: Pair<Rule>) -> ComparisonExpression {
+    for expression_piece in comparison_expression.into_inner() {
+        match expression_piece.as_rule() {
+            Rule::equals_expression
+            | Rule::not_equals_expression
+            | Rule::greater_than_expression
+            | Rule::less_than_expression
+            | Rule::greater_than_or_equal_to_expression
+            | Rule::less_than_or_equal_to_expression => {
+                let mut left = Expression::Literal(Literal::Int(0)); // Placeholder for actual value
+                let mut right = Expression::Literal(Literal::Int(0)); // Placeholder for actual value
+                let mut comparison_operator = ComparisonOperator::Equal; // Default value
+                let comparison_expression = expression_piece.into_inner();
+                for comparison_piece in comparison_expression {
+                    match comparison_piece.as_rule() {
+                        Rule::expression_base => {
+                            left = process_expression(comparison_piece);
+                        }
+                        Rule::expression => {
+                            right = process_expression(comparison_piece);
+                        }
+                        Rule::equals_token => comparison_operator = ComparisonOperator::Equal,
+                        Rule::not_equals_token => {
+                            comparison_operator = ComparisonOperator::NotEqual
+                        }
+                        Rule::greater_than_token => {
+                            comparison_operator = ComparisonOperator::GreaterThan
+                        }
+                        Rule::less_than_token => comparison_operator = ComparisonOperator::LessThan,
+                        Rule::greater_than_or_equal_to_token => {
+                            comparison_operator = ComparisonOperator::GreaterThanOrEqual
+                        }
+                        Rule::less_than_or_equal_to_token => {
+                            comparison_operator = ComparisonOperator::LessThanOrEqual
+                        }
+                        _ => handle_unexpected_rule("comparison_expression", comparison_piece),
+                    }
+                }
+                return ComparisonExpression {
+                    left: Box::new(left),
+                    comparison_operator,
+                    right: Box::new(right),
+                };
+            }
+            _ => handle_unexpected_rule("comparison_expression", expression_piece),
+        }
+    }
+    unreachable!("Expected a valid comparison expression but none was found");
+}
+
+fn process_negated_expression(negated_expression: Pair<Rule>) -> Expression {
+    for negated_piece in negated_expression.into_inner() {
+        match negated_piece.as_rule() {
+            Rule::not_token => continue,
+            Rule::enclosed_expression => return process_enclosed_expression(negated_piece),
+            _ => handle_unexpected_rule("negated_expression", negated_piece),
+        }
+    }
+    unreachable!("Expected a valid negated expression but none was found");
+}
+
+fn process_enclosed_expression(enclosed_expression: Pair<Rule>) -> Expression {
+    for enclosed_piece in enclosed_expression.into_inner() {
+        match enclosed_piece.as_rule() {
+            Rule::open_paren_token | Rule::close_paren_token => continue,
+            Rule::expression => {
+                return process_expression(enclosed_piece);
+            }
+            _ => handle_unexpected_rule("enclosed_expression", enclosed_piece),
+        }
+    }
+    unreachable!("Expected a valid enclosed expression but none was found");
+}
+
+fn process_expression(expression: Pair<Rule>) -> Expression {
+    for expression_piece in expression.into_inner() {
+        match expression_piece.as_rule() {
+            Rule::predicate => {
+                return Expression::Predicate(process_predicate(expression_piece));
+            }
+            Rule::enclosed_expression => {
+                return Expression::EnclosedExpression(Box::new(process_enclosed_expression(
+                    expression_piece,
+                )));
+            }
+            Rule::literal => {
+                return Expression::Literal(process_literal(expression_piece));
+            }
+            Rule::identifier => {
+                return Expression::Identifier(process_identifier(expression_piece));
+            }
+            _ => handle_unexpected_rule("expression", expression_piece),
+        }
+    }
+    unreachable!("Expected a valid expression but none was found");
+}
+
+fn process_identifier(identifier: Pair<Rule>) -> Identifier {
+    Identifier {
+        name: identifier.as_str().to_string(),
+    }
+}
+
+fn process_literal(literal: Pair<Rule>) -> Literal {
+    if let Ok(value) = literal.as_str().parse::<i32>() {
+        return Literal::Int(value);
+    } else if literal.as_str() == "true" {
+        return Literal::Bool(true);
+    } else if literal.as_str() == "false" {
+        return Literal::Bool(false);
+    } else {
+        return Literal::String(literal.as_str().trim_matches('"').to_string());
+    }
+}
+
+fn handle_unexpected_rule(parent_object: &str, found_rule: Pair<Rule>) {
+    panic!(
+        "Unexpected rule: '{:?}' found processing parent object: '{:?}'",
+        found_rule.as_rule(),
+        parent_object
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_process_literal() {
+        let literal = KqlParser::parse(Rule::literal, "42")
+            .unwrap()
+            .next()
+            .unwrap();
+        let result = process_literal(literal);
+        assert_eq!(result, Literal::Int(42));
+
+        let literal = KqlParser::parse(Rule::literal, "true")
+            .unwrap()
+            .next()
+            .unwrap();
+        let result = process_literal(literal);
+        assert_eq!(result, Literal::Bool(true));
+
+        let literal = KqlParser::parse(Rule::literal, "\"hello\"")
+            .unwrap()
+            .next()
+            .unwrap();
+        let result = process_literal(literal);
+        assert_eq!(result, Literal::String("hello".to_string()));
+    }
+
+    #[test]
+    fn test_process_identifier() {
+        let identifier = KqlParser::parse(Rule::identifier, "my_variable")
+            .unwrap()
+            .next()
+            .unwrap();
+        let result = process_identifier(identifier);
+        assert_eq!(result.name, "my_variable");
+    }
+
+    #[test]
+    fn test_process_expression_predicate() {
+        let expression = KqlParser::parse(Rule::expression, "x == 42")
+            .unwrap()
+            .next()
+            .unwrap();
+        let result = process_expression(expression);
+        assert_eq!(
+            result,
+            Expression::Predicate(Predicate::ComparisonExpression(ComparisonExpression {
+                left: Box::new(Expression::Identifier(Identifier {
+                    name: "x".to_string(),
+                })),
+                comparison_operator: ComparisonOperator::Equal,
+                right: Box::new(Expression::Literal(Literal::Int(42))),
+            }))
+        );
+    }
+
+    
+    #[test]
+    fn test_process_expression_enclosed_expression() {
+        let expression = KqlParser::parse(Rule::expression, "(x == 42)")
+            .unwrap()
+            .next()
+            .unwrap();
+        let result = process_expression(expression);
+        assert_eq!(
+            result,
+            Expression::EnclosedExpression(Box::new(Expression::Predicate(
+                Predicate::ComparisonExpression(ComparisonExpression {
+                    left: Box::new(Expression::Identifier(Identifier {
+                        name: "x".to_string(),
+                    })),
+                    comparison_operator: ComparisonOperator::Equal,
+                    right: Box::new(Expression::Literal(Literal::Int(42))),
+                })
+            )))
+        );
+    }
+
+    #[test]
+    fn test_process_expression_literal() {
+        let expression = KqlParser::parse(Rule::expression, "42")
+            .unwrap()
+            .next()
+            .unwrap();
+        let result = process_expression(expression);
+        assert_eq!(
+            result,
+            Expression::Literal(Literal::Int(42))
+        );
+    }
+
+    
+    #[test]
+    fn test_process_expression_identifier() {
+        let expression = KqlParser::parse(Rule::expression, "my_variable")
+            .unwrap()
+            .next()
+            .unwrap();
+        let result = process_expression(expression);
+        assert_eq!(
+            result,
+            Expression::Identifier(Identifier {
+                name: "my_variable".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn test_process_enclosed_expression() {
+        let expression = KqlParser::parse(Rule::enclosed_expression, "(x == 42)")
+            .unwrap()
+            .next()
+            .unwrap();
+        let result = process_enclosed_expression(expression);
+        assert_eq!(
+            result,
+            Expression::Predicate(Predicate::ComparisonExpression(ComparisonExpression {
+                left: Box::new(Expression::Identifier(Identifier {
+                    name: "x".to_string(),
+                })),
+                comparison_operator: ComparisonOperator::Equal,
+                right: Box::new(Expression::Literal(Literal::Int(42))),
+            }))
+        );
+    }
+
+    #[test]
+    fn test_process_negated_expression() {
+        let expression = KqlParser::parse(Rule::negated_expression, "not(x == 42)")
+            .unwrap()
+            .next()
+            .unwrap();
+        let result = process_negated_expression(expression);
+        assert_eq!(
+            result,
+            Expression::Predicate(
+                Predicate::ComparisonExpression(ComparisonExpression {
+                    left: Box::new(Expression::Identifier(Identifier {
+                        name: "x".to_string(),
+                    })),
+                    comparison_operator: ComparisonOperator::Equal,
+                    right: Box::new(Expression::Literal(Literal::Int(42))),
+                })
+            )
+        );
+    }
+
+    #[test]
+    fn test_process_comparison_expression_equals() {
+        let expression = KqlParser::parse(Rule::comparison_expression, "x == 42")
+            .unwrap()
+            .next()
+            .unwrap();
+        let result = process_comparison_expression(expression);
+        assert_eq!(
+            result,
+            ComparisonExpression {
+                left: Box::new(Expression::Identifier(Identifier {
+                    name: "x".to_string(),
+                })),
+                comparison_operator: ComparisonOperator::Equal,
+                right: Box::new(Expression::Literal(Literal::Int(42))),
+            }
+        );
+    }
+
+    #[test]
+    fn test_process_comparison_expression_not_equals() {
+        let expression = KqlParser::parse(Rule::comparison_expression, "x != 42")
+            .unwrap()
+            .next()
+            .unwrap();
+        let result = process_comparison_expression(expression);
+        assert_eq!(
+            result,
+            ComparisonExpression {
+                left: Box::new(Expression::Identifier(Identifier {
+                    name: "x".to_string(),
+                })),
+                comparison_operator: ComparisonOperator::NotEqual,
+                right: Box::new(Expression::Literal(Literal::Int(42))),
+            }
+        );
+    }
+
+    #[test]
+    fn test_process_comparison_expression_greater_than() {
+        let expression = KqlParser::parse(Rule::comparison_expression, "x > 42")
+            .unwrap()
+            .next()
+            .unwrap();
+        let result = process_comparison_expression(expression);
+        assert_eq!(
+            result,
+            ComparisonExpression {
+                left: Box::new(Expression::Identifier(Identifier {
+                    name: "x".to_string(),
+                })),
+                comparison_operator: ComparisonOperator::GreaterThan,
+                right: Box::new(Expression::Literal(Literal::Int(42))),
+            }
+        );
+    }
+
+    #[test]
+    fn test_process_comparison_expression_less_than() {
+        let expression = KqlParser::parse(Rule::comparison_expression, "x < 42")
+            .unwrap()
+            .next()
+            .unwrap();
+        let result = process_comparison_expression(expression);
+        assert_eq!(
+            result,
+            ComparisonExpression {
+                left: Box::new(Expression::Identifier(Identifier {
+                    name: "x".to_string(),
+                })),
+                comparison_operator: ComparisonOperator::LessThan,
+                right: Box::new(Expression::Literal(Literal::Int(42))),
+            }
+        );
+    }
+
+    #[test]
+    fn test_process_comparison_expression_greater_than_or_equal_to() {
+        let expression = KqlParser::parse(Rule::comparison_expression, "x >= 42")
+            .unwrap()
+            .next()
+            .unwrap();
+        let result = process_comparison_expression(expression);
+        assert_eq!(
+            result,
+            ComparisonExpression {
+                left: Box::new(Expression::Identifier(Identifier {
+                    name: "x".to_string(),
+                })),
+                comparison_operator: ComparisonOperator::GreaterThanOrEqual,
+                right: Box::new(Expression::Literal(Literal::Int(42))),
+            }
+        );
+    }
+
+    #[test]
+    fn test_process_comparison_expression_less_than_or_equal_to() {
+        let expression = KqlParser::parse(Rule::comparison_expression, "x <= 42")
+            .unwrap()
+            .next()
+            .unwrap();
+        let result = process_comparison_expression(expression);
+        assert_eq!(
+            result,
+            ComparisonExpression {
+                left: Box::new(Expression::Identifier(Identifier {
+                    name: "x".to_string(),
+                })),
+                comparison_operator: ComparisonOperator::LessThanOrEqual,
+                right: Box::new(Expression::Literal(Literal::Int(42))),
+            }
+        );
+    }
+
+    #[test]
+    fn test_process_binary_logical_expression_and() {
+        let expression = KqlParser::parse(Rule::binary_logical_expression, "x and y")
+            .unwrap()
+            .next()
+            .unwrap();
+        let result = process_binary_logical_expression(expression);
+        assert_eq!(
+            result,
+            BinaryLogicalExpression {
+                left: Box::new(Expression::Identifier(Identifier {
+                    name: "x".to_string(),
+                })),
+                boolean_operator: BooleanOperator::And,
+                right: Box::new(Expression::Identifier(Identifier {
+                    name: "y".to_string(),
+                })),
+            }
+        );
+    }
+
+    #[test]
+    fn test_process_binary_logical_expression_or() {
+        let expression = KqlParser::parse(Rule::binary_logical_expression, "x or y")
+            .unwrap()
+            .next()
+            .unwrap();
+        let result = process_binary_logical_expression(expression);
+        assert_eq!(
+            result,
+            BinaryLogicalExpression {
+                left: Box::new(Expression::Identifier(Identifier {
+                    name: "x".to_string(),
+                })),
+                boolean_operator: BooleanOperator::Or,
+                right: Box::new(Expression::Identifier(Identifier {
+                    name: "y".to_string(),
+                })),
+            }
+        );
+    }
+
+    #[test]
+    fn test_process_binary_logical_expression_nested() {
+        let expression = KqlParser::parse(
+            Rule::binary_logical_expression,
+            "((x == 42) and (y == 24)) or z == 10",
+        )
+        .unwrap()
+        .next()
+        .unwrap();
+        let result = process_binary_logical_expression(expression);
+        assert_eq!(
+            result,
+            BinaryLogicalExpression {
+                left: Box::new(Expression::EnclosedExpression(Box::new(
+                    Expression::Predicate(Predicate::BinaryLogicalExpression(
+                        BinaryLogicalExpression {
+                            left: Box::new(Expression::EnclosedExpression(Box::new(Expression::Predicate(
+                                Predicate::ComparisonExpression(ComparisonExpression {
+                                    left: Box::new(Expression::Identifier(Identifier {
+                                        name: "x".to_string(),
+                                    })),
+                                    comparison_operator: ComparisonOperator::Equal,
+                                    right: Box::new(Expression::Literal(Literal::Int(42))),
+                                })
+                            )))),
+                            boolean_operator: BooleanOperator::And,
+                            right: Box::new(Expression::EnclosedExpression(Box::new(Expression::Predicate(
+                                Predicate::ComparisonExpression(ComparisonExpression {
+                                    left: Box::new(Expression::Identifier(Identifier {
+                                        name: "y".to_string(),
+                                    })),
+                                    comparison_operator: ComparisonOperator::Equal,
+                                    right: Box::new(Expression::Literal(Literal::Int(24))),
+                                })
+                            )))),
+                        }
+                    ))
+                ))),
+                boolean_operator: BooleanOperator::Or,
+                right: Box::new(Expression::Predicate(Predicate::ComparisonExpression(
+                    ComparisonExpression {
+                        left: Box::new(Expression::Identifier(Identifier {
+                            name: "z".to_string(),
+                        })),
+                        comparison_operator: ComparisonOperator::Equal,
+                        right: Box::new(Expression::Literal(Literal::Int(10))),
+                    }
+                ))),
+            }
+        );
+    }
+
+    #[test]
+    fn test_process_assignment_simple() {
+        let assignment = KqlParser::parse(Rule::assignment_expression, "x = 42")
+            .unwrap()
+            .next()
+            .unwrap();
+        let (identifier, value) = process_assignment(assignment);
+        assert_eq!(identifier.name, "x");
+        assert_eq!(value, Expression::Literal(Literal::Int(42)));
+    }
+
+    #[test]
+    fn test_process_predicate_binary_logical_expression() {
+        let predicate = KqlParser::parse(Rule::predicate, "x and y")
+            .unwrap()
+            .next()
+            .unwrap();
+        let result = process_predicate(predicate);
+        assert_eq!(
+            result,
+            Predicate::BinaryLogicalExpression(BinaryLogicalExpression {
+                left: Box::new(Expression::Identifier(Identifier {
+                    name: "x".to_string(),
+                })),
+                boolean_operator: BooleanOperator::And,
+                right: Box::new(Expression::Identifier(Identifier {
+                    name: "y".to_string(),
+                })),
+            })
+        );
+    }
+
+    #[test]
+    fn test_process_predicate_comparison_expression() {
+        let predicate = KqlParser::parse(Rule::predicate, "x == 42")
+            .unwrap()
+            .next()
+            .unwrap();
+        let result = process_predicate(predicate);
+        assert_eq!(
+            result,
+            Predicate::ComparisonExpression(ComparisonExpression {
+                left: Box::new(Expression::Identifier(Identifier {
+                    name: "x".to_string(),
+                })),
+                comparison_operator: ComparisonOperator::Equal,
+                right: Box::new(Expression::Literal(Literal::Int(42))),
+            })
+        );
+    }
+
+    #[test]
+    fn test_process_predicate_negated_expression() {
+        let predicate = KqlParser::parse(Rule::predicate, "not(x == 42)")
+            .unwrap()
+            .next()
+            .unwrap();
+        let result = process_predicate(predicate);
+        assert_eq!(
+            result,
+            Predicate::NegatedExpression(Box::new(Expression::Predicate(
+                Predicate::ComparisonExpression(ComparisonExpression {
+                    left: Box::new(Expression::Identifier(Identifier {
+                        name: "x".to_string(),
+                    })),
+                    comparison_operator: ComparisonOperator::Equal,
+                    right: Box::new(Expression::Literal(Literal::Int(42))),
+                })
+            )))
+        );
+    }
+
+    #[test]
+    fn test_process_predicate_nested_binary_logical_expression() {
+        let predicate = KqlParser::parse(Rule::predicate, "(x == 42) and (y == 24)")
+            .unwrap()
+            .next()
+            .unwrap();
+        let result = process_predicate(predicate);
+        assert_eq!(
+            result,
+            Predicate::BinaryLogicalExpression(BinaryLogicalExpression {
+                left: Box::new(Expression::EnclosedExpression(Box::new(Expression::Predicate(
+                    Predicate::ComparisonExpression(ComparisonExpression {
+                        left: Box::new(Expression::Identifier(Identifier {
+                            name: "x".to_string(),
+                        })),
+                        comparison_operator: ComparisonOperator::Equal,
+                        right: Box::new(Expression::Literal(Literal::Int(42))),
+                    })
+                )))),
+                boolean_operator: BooleanOperator::And,
+                right: Box::new(Expression::EnclosedExpression(Box::new(Expression::Predicate(
+                    Predicate::ComparisonExpression(ComparisonExpression {
+                        left: Box::new(Expression::Identifier(Identifier {
+                            name: "y".to_string(),
+                        })),
+                        comparison_operator: ComparisonOperator::Equal,
+                        right: Box::new(Expression::Literal(Literal::Int(24))),
+                    })
+                )))),
+            })
+        );
+    }
+
+    #[test]
+    fn test_process_statement_filter_statement() {
+        let statement = KqlParser::parse(Rule::statement, "| where x == 42")
+            .unwrap()
+            .next()
+            .unwrap();
+        let result = process_statement(statement);
+        assert_eq!(
+            result,
+            vec![Statement::Filter(Predicate::ComparisonExpression(ComparisonExpression {
+                left: Box::new(Expression::Identifier(Identifier {
+                    name: "x".to_string(),
+                })),
+                comparison_operator: ComparisonOperator::Equal,
+                right: Box::new(Expression::Literal(Literal::Int(42))),
+            }))]
+        );
+    }
+
+    #[test]
+    fn test_process_statement_extend_statement() {
+        let statement = KqlParser::parse(Rule::statement, "| extend x = 42")
+            .unwrap()
+            .next()
+            .unwrap();
+        let result = process_statement(statement);
+        assert_eq!(
+            result,
+            vec![Statement::Extend(
+                Identifier {
+                    name: "x".to_string(),
+                },
+                Expression::Literal(Literal::Int(42)),
+                None
+            )]
+        );
+    }
+
+    #[test]
+    fn test_process_statement_extend_statement_multiple() {
+        let statement = KqlParser::parse(Rule::statement, "| extend x = 42, y = 24")
+            .unwrap()
+            .next()
+            .unwrap();
+        let result = process_statement(statement);
+        assert_eq!(
+            result,
+            vec![
+                Statement::Extend(
+                    Identifier {
+                        name: "x".to_string(),
+                    },
+                    Expression::Literal(Literal::Int(42)),
+                    None
+                ),
+                Statement::Extend(
+                    Identifier {
+                        name: "y".to_string(),
+                    },
+                    Expression::Literal(Literal::Int(24)),
+                    None
+                )
+            ]
+        );
+    }
+
+    #[test]
+    fn test_process_query() {
+        let input = "my_table | where my_variable == 5";
+        let query = KqlPlugin::process_query(input);
+        assert_eq!(
+            query,
+            Query {
+                source: "my_table".to_string(),
+                statements: vec![Statement::Filter(
+                    Predicate::ComparisonExpression(ComparisonExpression {
+                        left: Box::new(Expression::Identifier(Identifier {
+                            name: "my_variable".to_string(),
+                        })),
+                        comparison_operator: ComparisonOperator::Equal,
+                        right: Box::new(Expression::Literal(Literal::Int(5))),
+                    })
+                )]
+            }
+        )
+    }
+
+    #[test]
+    fn test_process_query_multi_line() {
+        let input = "my_table 
+        | where my_variable == 5";
+        let query = KqlPlugin::process_query(input);
+        assert_eq!(
+            query,
+            Query {
+                source: "my_table".to_string(),
+                statements: vec![Statement::Filter(
+                    Predicate::ComparisonExpression(ComparisonExpression {
+                        left: Box::new(Expression::Identifier(Identifier {
+                            name: "my_variable".to_string(),
+                        })),
+                        comparison_operator: ComparisonOperator::Equal,
+                        right: Box::new(Expression::Literal(Literal::Int(5))),
+                    })
+                )]
+            }
+        );
+    }
+
+    #[test]
+    fn test_process_query_complex() {
+        let input = r#"my_table 
+        | where my_variable == 5
+        | where (x < 42) and (y > 24)
+        | where not(z >= 10)
+        | extend new_column = true, another_new_column = (another_variable == 100)
+        "#;
+        let query = KqlPlugin::process_query(input);
+        assert_eq!(
+            query,
+            Query {
+                source: "my_table".to_string(),
+                statements: vec![
+                    Statement::Filter(Predicate::ComparisonExpression(ComparisonExpression {
+                        left: Box::new(Expression::Identifier(Identifier {
+                            name: "my_variable".to_string(),
+                        })),
+                        comparison_operator: ComparisonOperator::Equal,
+                        right: Box::new(Expression::Literal(Literal::Int(5))),
+                    })),
+                    Statement::Filter(Predicate::BinaryLogicalExpression(
+                        BinaryLogicalExpression {
+                            left: Box::new(Expression::EnclosedExpression(Box::new(
+                                Expression::Predicate(Predicate::ComparisonExpression(
+                                    ComparisonExpression {
+                                        left: Box::new(Expression::Identifier(Identifier {
+                                            name: "x".to_string(),
+                                        })),
+                                        comparison_operator: ComparisonOperator::LessThan,
+                                        right: Box::new(Expression::Literal(Literal::Int(42))),
+                                    }
+                                ))
+                            ))),
+                            boolean_operator: BooleanOperator::And,
+                            right: Box::new(Expression::EnclosedExpression(Box::new(
+                                Expression::Predicate(Predicate::ComparisonExpression(
+                                    ComparisonExpression {
+                                        left: Box::new(Expression::Identifier(Identifier {
+                                            name: "y".to_string(),
+                                        })),
+                                        comparison_operator: ComparisonOperator::GreaterThan,
+                                        right: Box::new(Expression::Literal(Literal::Int(24))),
+                                    }
+                                ))
+                            ))),
+                        }
+                    )),
+                    Statement::Filter(Predicate::NegatedExpression(Box::new(
+                        Expression::Predicate(Predicate::ComparisonExpression(
+                            ComparisonExpression {
+                                left: Box::new(Expression::Identifier(Identifier {
+                                    name: "z".to_string(),
+                                })),
+                                comparison_operator: ComparisonOperator::GreaterThanOrEqual,
+                                right: Box::new(Expression::Literal(Literal::Int(10))),
+                            }
+                        ))
+                    ))),
+                    Statement::Extend(
+                        Identifier {
+                            name: "new_column".to_string(),
+                        },
+                        Expression::Literal(Literal::Bool(true)),
+                        None
+                    ),
+                    Statement::Extend(
+                        Identifier {
+                            name: "another_new_column".to_string(),
+                        },
+                        Expression::EnclosedExpression(Box::new(
+                            Expression::Predicate(Predicate::ComparisonExpression(
+                                ComparisonExpression {
+                                    left: Box::new(Expression::Identifier(Identifier {
+                                        name: "another_variable".to_string(),
+                                    })),
+                                    comparison_operator: ComparisonOperator::Equal,
+                                    right: Box::new(Expression::Literal(Literal::Int(100))),
+                                }
+                            ))
+                        )),
+                        None
+                    )
+                ]
+            }
+        );
     }
 }

--- a/rust/experimental/query_abstraction/ottl_plugin/src/ottl.pest
+++ b/rust/experimental/query_abstraction/ottl_plugin/src/ottl.pest
@@ -1,4 +1,4 @@
-// KQL Grammar is heavily influenced by the following source:
+// OTTL Grammar is heavily influenced by the following source:
 // https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/LANGUAGE.md
 
 // These two special rules, when defined, are implicitly allowed at:

--- a/rust/experimental/query_abstraction/ottl_plugin/src/ottl_plugin.rs
+++ b/rust/experimental/query_abstraction/ottl_plugin/src/ottl_plugin.rs
@@ -1,11 +1,14 @@
 use crate::ottl_parser::{OttlParser, Rule};
-use intermediate_language::{grammar_objects::Query, query_processor::QueryProcessor};
+use intermediate_language::{
+    grammar_objects::Query,
+    query_processor::{QueryError, QueryProcessor},
+};
 use pest::Parser;
 
 pub struct OttlPlugin;
 
 impl QueryProcessor for OttlPlugin {
-    fn process_query(input: &str) -> Query {
+    fn process_query(input: &str) -> Result<Query, QueryError> {
         let _ = OttlParser::parse(Rule::query, input);
         todo!()
     }


### PR DESCRIPTION
This PR includes some incidental changes outside of just `KqlPlugin`
* Minor changes in `grammar_objects` to reduce overhead and expose needed members
* Addition of `QueryResult` and `QueryError` in `intermediate_language` to better follow Rust patterns around success and failure

The main bulk of the changes are in `KqlPlugin` which can now build full IL representation of `Filter` and `Extend` KQL queries. The fullest example of this may be found in `test_process_query_complex`:

```rust
let input = r#"my_table 
| where my_variable == 5
| where (x < 42) and (y > 24)
| where not(z >= 10)
| extend new_column = true, another_new_column = (another_variable == 100)
"#;
```
-->
```rust
// Full depth omitted for brevity
Query
├── Statement::Filter
|   └── Predicate::ComparisonExpression
|       ├── Expression::Identifier(...)
|       ├── ComparisonOperator::Equals
|       └── Expression::Literal(...)
├── Statement::Filter
|   └── Predicate::BinaryLogicalExpression(...)
├── Statement::Filter
|   └── Predicate::NegatedExpression(...)
├── Statement::Extend
|   ├── Expression::Identifier(...)
|   └── Expression::Literal(...)
└── Statement::Extend
    ├── Expression::Identifier(...)
    └── Expression::EnclosedExpression(...)
```

Implementation for `OttlPlugin` coming in separate PR, wanted to get this merged first!