### PR TITLE
Update the contributing section in the main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ calendar](https://github.com/open-telemetry/community?tab=readme-ov-file#calenda
 for specific dates and for Zoom meeting links.
 
 Meeting notes are available as a public [Google
-doc](TBD).
+doc](https://docs.google.com/document/d/1X-RPSOSDUUTD2-zrPRQ6YJ54i4JkHIgvAm5EoVhTzPs/edit?usp=sharing).
 If you have trouble accessing the doc, please get in touch on
 [Slack](https://cloud-native.slack.com/archives/C07S4Q67LTF).
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ you're more than welcome to participate!
 
 - [Alex Boten](https://github.com/codeboten), Honeycomb
 - [Drew Relmas](https://github.com/drewrelmas), Microsoft
-- [Moh Osman](https://github.com/Kielek)
+- [Moh Osman](https://github.com/moh-osman3), ServiceNow
 
 ### Thanks to all the people who have contributed
 

--- a/README.md
+++ b/README.md
@@ -201,8 +201,8 @@ For more details, see the following [benchmark results](docs/benchmarks.md) page
 For information about contributing to the project see:
 [CONTRIBUTING.md](./CONTRIBUTING.md).
 
-We meet weekly on Tuesdays, and the time of the meeting alternates between 9AM
-PT and 4PM PT. The meeting is subject to change depending on contributors'
+We meet every-other-week on Thursdays, at 8AM PT. The meeting is subject to change 
+depending on contributors'
 availability. Check the [OpenTelemetry community
 calendar](https://github.com/open-telemetry/community?tab=readme-ov-file#calendar)
 for specific dates and for Zoom meeting links.

--- a/README.md
+++ b/README.md
@@ -196,14 +196,45 @@ be higher for traffic predominantly containing multivariate metrics.
 
 For more details, see the following [benchmark results](docs/benchmarks.md) page.
 
-### Contributing
+## Contributing
 
-Pull requests are welcome. For major changes, please open an issue
-first to discuss what you would like to change.  For more information, please
-read [CONTRIBUTING.md][].
+For information about contributing to the project see:
+[CONTRIBUTING.md](./CONTRIBUTING.md).
 
-## License
+We meet weekly on Tuesdays, and the time of the meeting alternates between 9AM
+PT and 4PM PT. The meeting is subject to change depending on contributors'
+availability. Check the [OpenTelemetry community
+calendar](https://github.com/open-telemetry/community?tab=readme-ov-file#calendar)
+for specific dates and for Zoom meeting links.
 
-OpenTelemetry Protocol with Apache Arrow Protocol Adapter is licensed under Apache 2.0.
+Meeting notes are available as a public [Google
+doc](TBD).
+If you have trouble accessing the doc, please get in touch on
+[Slack](https://cloud-native.slack.com/archives/C07S4Q67LTF).
 
-[CONTRIBUTING.md]: ./CONTRIBUTING.md
+The meeting is open for all to join. We invite everyone to join our meeting,
+regardless of your experience level. Whether you're a seasoned OpenTelemetry
+developer, just starting your journey, or simply curious about the work we do,
+you're more than welcome to participate!
+
+[Maintainers](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#maintainer)
+([@open-telemetry/arrow-maintainers](https://github.com/orgs/open-telemetry/teams/arrow-maintainers)):
+
+- [Joshua MacDonald](https://github.com/jmacd), Microsoft
+- [Laurent Qu&#xE9;rel](https://github.com/lquerel), F5
+
+[Approvers](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver)
+([@open-telemetry/arrow-approvers](https://github.com/orgs/open-telemetry/teams/arrow-approvers)):
+
+- [Alex Boten](https://github.com/codeboten), Honeycomb
+- [Drew Relmas](https://github.com/drewrelmas), Microsoft
+- [Moh Osman](https://github.com/Kielek)
+
+### Thanks to all the people who have contributed
+
+[![contributors](https://contributors-img.web.app/image?repo=open-telemetry/otel-arrow)](https://github.com/open-telemetry/otel-arrow/graphs/contributors)
+
+## References
+
+- [OpenTelemetry Project](https://opentelemetry.io/)
+- [OpenTelemetry Specification](https://github.com/open-telemetry/opentelemetry-specification)

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ For more details, see the following [benchmark results](docs/benchmarks.md) page
 For information about contributing to the project see:
 [CONTRIBUTING.md](./CONTRIBUTING.md).
 
-We meet every-other-week on Thursdays, at 8AM PT. The meeting is subject to change 
+We meet every other Thursday at 8AM PT. The meeting is subject to change 
 depending on contributors'
 availability. Check the [OpenTelemetry community
 calendar](https://github.com/open-telemetry/community?tab=readme-ov-file#calendar)


### PR DESCRIPTION
Updated the contributing section to better align with other OpenTelemetry repositories.
Removed the license section as it is already covered on the repo home page:

![image](https://github.com/user-attachments/assets/af4c7030-2e94-44dc-9f80-b2cc83ee5f44)
