### PR TITLE
Split experimental and core Rust CI

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -11,10 +11,12 @@ on:
     paths-ignore:
       - 'rust/**'
       - .github/workflows/rust-ci.yml
+      - .github/workflows/rust-experimental.yml
   pull_request:
     paths-ignore:
       - 'rust/**'
       - .github/workflows/rust-ci.yml
+      - .github/workflows/rust-experimental.yml
 
 jobs:
 

--- a/.github/workflows/rust-audit.yml
+++ b/.github/workflows/rust-audit.yml
@@ -6,8 +6,7 @@ on:
   push:
     branches: [main]
     paths:
-      - 'rust/beaubourg/Cargo.toml'
-      - 'rust/otel-arrow-rust/Cargo.toml'
+      - 'rust/otap-dataflow/Cargo.toml'
   schedule:
     - cron: '0 2 * * 1' # run at 2 AM UTC every Monday
 
@@ -16,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        folder: [beaubourg, otel-arrow-rust]
+        folder: [otap-dataflow]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -79,7 +79,9 @@ jobs:
           toolchain: stable
           components: clippy
       - name: cargo clippy ${{ matrix.folder }}
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        # To not block initial checkin of CI, removing build break on warnings for now
+        # TODO: re-enable '-- -D warnings' when we have fixed all clippy warnings
+        run: cargo clippy --all-targets --all-features
         working-directory: ./rust/${{ matrix.folder }}
 
 #  coverage:

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -79,9 +79,7 @@ jobs:
           toolchain: stable
           components: clippy
       - name: cargo clippy ${{ matrix.folder }}
-        # To not block initial checkin of CI, removing build break on warnings for now
-        # TODO: re-enable '-- -D warnings' when we have fixed all clippy warnings
-        run: cargo clippy --all-targets --all-features
+        run: cargo clippy --all-targets --all-features -- -D warnings
         working-directory: ./rust/${{ matrix.folder }}
 
 #  coverage:

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,3 +1,5 @@
+# This workflow is for running CI on core components of the repository.
+# It has stricter checks than Rust-Experimental to ensure that the core components are stable, compliant, and reliable.
 name: Rust-CI
 permissions:
   contents: read
@@ -7,11 +9,11 @@ on:
   # only for changes in the rust directory
   push:
     paths:
-      - 'rust/**'
+      - 'rust/otap-dataflow/**'
       - .github/workflows/rust-ci.yml
   pull_request:
     paths:
-      - 'rust/**'
+      - 'rust/otap-dataflow/**'
       - .github/workflows/rust-ci.yml
 
 env:
@@ -22,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        folder: [beaubourg, otel-arrow-rust, experimental/query_abstraction, experimental/syslog-cef-receivers]
+        folder: [otap-dataflow]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -42,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        folder: [beaubourg, otel-arrow-rust, experimental/query_abstraction, experimental/syslog-cef-receivers]
+        folder: [otap-dataflow]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -63,7 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        folder: [beaubourg, otel-arrow-rust, experimental/query_abstraction, experimental/syslog-cef-receivers]
+        folder: [otap-dataflow]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -106,7 +108,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        folder: [beaubourg, otel-arrow-rust, experimental/query_abstraction, experimental/syslog-cef-receivers]
+        folder: [otap-dataflow]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -147,7 +149,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        folder: [beaubourg, otel-arrow-rust, experimental/query_abstraction, experimental/syslog-cef-receivers]
+        folder: [otap-dataflow]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -167,7 +169,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        folder: [beaubourg, otel-arrow-rust, experimental/query_abstraction, experimental/syslog-cef-receivers]
+        folder: [otap-dataflow]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -181,4 +183,24 @@ jobs:
           toolchain: stable
       - name: cargo doc ${{ matrix.folder }}
         run: cargo doc --no-deps
+        working-directory: ./rust/${{ matrix.folder }}
+
+  structure_check:
+    strategy:
+      fail-fast: false
+      matrix:
+        folder: [otap-dataflow]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: true
+      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0 # latest on /master branch as of 2025-04-02
+        with:
+          toolchain: stable
+      - name: cargo xtask ${{ matrix.folder }}
+        run: cargo xtask structure-check
         working-directory: ./rust/${{ matrix.folder }}

--- a/.github/workflows/rust-experimental.yml
+++ b/.github/workflows/rust-experimental.yml
@@ -11,16 +11,15 @@ on:
     paths:
       - 'rust/**'
       - .github/workflows/rust-experimental.yml
-    paths-ignore:
       # otap-dataflow is covered by the main Rust-CI workflow
-      - 'rust/otap-dataflow/**'
+      - '!rust/otap-dataflow/**'
   pull_request:
     paths:
       - 'rust/**'
       - .github/workflows/rust-experimental.yml
-    paths-ignore:
       # otap-dataflow is covered by the main Rust-CI workflow
-      - 'rust/otap-dataflow/**'
+      - '!rust/otap-dataflow/**'
+      
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust-experimental.yml
+++ b/.github/workflows/rust-experimental.yml
@@ -1,0 +1,47 @@
+# This workflow is for running CI on experimental Rust code in the repository.
+# It is much slimmer than the Rust-CI workflow and doesn't require the same level of maturity.
+name: Rust-Experimental
+permissions:
+  contents: read
+
+on:
+  # run this job on every push and pull request
+  # only for changes in the rust directory
+  push:
+    paths:
+      - 'rust/**'
+      - .github/workflows/rust-experimental.yml
+    paths-ignore:
+      # otap-dataflow is covered by the main Rust-CI workflow
+      - 'rust/otap-dataflow/**'
+  pull_request:
+    paths:
+      - 'rust/**'
+      - .github/workflows/rust-experimental.yml
+    paths-ignore:
+      # otap-dataflow is covered by the main Rust-CI workflow
+      - 'rust/otap-dataflow/**'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        folder: [beaubourg, otel-arrow-rust, experimental/query_abstraction, experimental/syslog-cef-receivers]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: true
+      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0 # latest on /master branch as of 2025-04-02
+        with:
+          toolchain: stable
+      - name: cargo test ${{ matrix.folder }}
+        run: cargo test
+        working-directory: ./rust/${{ matrix.folder }}

--- a/.github/workflows/rust-experimental.yml
+++ b/.github/workflows/rust-experimental.yml
@@ -44,3 +44,88 @@ jobs:
       - name: cargo test ${{ matrix.folder }}
         run: cargo test
         working-directory: ./rust/${{ matrix.folder }}
+
+  fmt:
+    strategy:
+      fail-fast: false
+      matrix:
+        folder: [beaubourg, otel-arrow-rust, experimental/query_abstraction, experimental/syslog-cef-receivers]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: true
+      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0 # latest on /master branch as of 2025-04-02
+        with:
+          toolchain: nightly
+          components: rustfmt
+      - name: cargo fmt ${{ matrix.folder }}
+        run: cargo fmt --all -- --check 
+        working-directory: ./rust/${{ matrix.folder }}
+
+  clippy:
+    strategy:
+      fail-fast: false
+      matrix:
+        folder: [beaubourg, otel-arrow-rust, experimental/query_abstraction, experimental/syslog-cef-receivers]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: true
+      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0 # latest on /master branch as of 2025-04-02
+        with:
+          toolchain: stable
+          components: clippy
+      - name: cargo clippy ${{ matrix.folder }}
+        # To not block initial checkin of CI, removing build break on warnings for now
+        # TODO: re-enable '-- -D warnings' when we have fixed all clippy warnings
+        run: cargo clippy --all-targets --all-features
+        working-directory: ./rust/${{ matrix.folder }}
+
+  cargo_deny:
+    strategy:
+      fail-fast: false
+      matrix:
+        folder: [beaubourg, otel-arrow-rust, experimental/query_abstraction, experimental/syslog-cef-receivers]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: true
+      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0 # latest on /master branch as of 2025-04-02
+        with:
+          toolchain: stable
+      - name: advisories
+        if: '!cancelled()'
+        uses: EmbarkStudios/cargo-deny-action@34899fc7ba81ca6268d5947a7a16b4649013fea1 # v2.0.11
+        with:
+          command: check advisories
+          manifest-path: ./rust/${{ matrix.folder }}/Cargo.toml
+      - name: licenses
+        if: '!cancelled()'
+        uses: EmbarkStudios/cargo-deny-action@34899fc7ba81ca6268d5947a7a16b4649013fea1 # v2.0.11
+        with:
+          command: check licenses
+          manifest-path: ./rust/${{ matrix.folder }}/Cargo.toml
+      - name: bans
+        if: '!cancelled()'
+        uses: EmbarkStudios/cargo-deny-action@34899fc7ba81ca6268d5947a7a16b4649013fea1 # v2.0.11
+        with:
+          command: check bans
+          manifest-path: ./rust/${{ matrix.folder }}/Cargo.toml
+      - name: sources
+        if: '!cancelled()'
+        uses: EmbarkStudios/cargo-deny-action@34899fc7ba81ca6268d5947a7a16b4649013fea1 # v2.0.11
+        with:
+          command: check sources
+          manifest-path: ./rust/${{ matrix.folder }}/Cargo.toml

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # OpenTelemetry Protocol with Apache Arrow
 
 [![Slack](https://img.shields.io/badge/slack-@cncf/otel/arrow-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C07S4Q67LTF)
-[![Go-CI](https://github.com/drewrelmas/otel-arrow/actions/workflows/go-ci.yml/badge.svg)](https://github.com/drewrelmas/otel-arrow/actions/workflows/go-ci.yml)
-[![Rust-CI](https://github.com/drewrelmas/otel-arrow/actions/workflows/rust-ci.yml/badge.svg)](https://github.com/drewrelmas/otel-arrow/actions/workflows/rust-ci.yml)
+[![Go-CI](https://github.com/open-telemetry/otel-arrow/actions/workflows/go-ci.yml/badge.svg)](https://github.com/open-telemetry/otel-arrow/actions/workflows/go-ci.yml)
+[![Rust-CI](https://github.com/open-telemetry/otel-arrow/actions/workflows/rust-ci.yml/badge.svg)](https://github.com/open-telemetry/otel-arrow/actions/workflows/rust-ci.yml)
+[![Rust-Experimental](https://github.com/open-telemetry/otel-arrow/actions/workflows/rust-experimental.yml/badge.svg)](https://github.com/open-telemetry/otel-arrow/actions/workflows/rust-experimental.yml)
 [![OpenSSF Scorecard for otel-arrow](https://api.scorecard.dev/projects/github.com/open-telemetry/otel-arrow/badge)](https://scorecard.dev/viewer/?uri=github.com/open-telemetry/otel-arrow)
 
 The [OpenTelemetry Protocol with Apache

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,16 @@
+# Rust components
+
+This folder contains various Rust projects of varying stages of maturity.
+
+The `otap-dataflow/` folder contains the main deliverable of Phase 2 of the
+otel-arrow project, [as mentioned in its README](./otap-dataflow/README.md).
+
+All other folders are either experimental or initial donations of components
+that have yet to be incorporated into the main library.
+
+| Folder          | Type                | CI Workflow(s)    |
+|-----------------|---------------------|-------------------|
+| beaubourg       | 🤝 Contributed Code | [![Rust-Experimental](https://github.com/open-telemetry/otel-arrow/actions/workflows/rust-experimental.yml/badge.svg)](https://github.com/open-telemetry/otel-arrow/actions/workflows/rust-experimental.yml) |
+| experimental    | 🧪 Prototype        | [![Rust-Experimental](https://github.com/open-telemetry/otel-arrow/actions/workflows/rust-experimental.yml/badge.svg)](https://github.com/open-telemetry/otel-arrow/actions/workflows/rust-experimental.yml) |
+| otap-dataflow   | 🏗️ Core Component   | [![Rust-CI](https://github.com/open-telemetry/otel-arrow/actions/workflows/rust-ci.yml/badge.svg)](https://github.com/open-telemetry/otel-arrow/actions/workflows/rust-ci.yml)          |
+| otel-arrow-rust | 🤝 Contributed Code | [![Rust-Experimental](https://github.com/open-telemetry/otel-arrow/actions/workflows/rust-experimental.yml/badge.svg)](https://github.com/open-telemetry/otel-arrow/actions/workflows/rust-experimental.yml) |


### PR DESCRIPTION
Addresses #354

This PR splits the CI workflow steps performed for experimental projects versus the main core component.

Rust-CI
- test
- fmt
- clippy
- deny
- bench
- doc
- coverage (todo)
- custom xtask checks

Rust-Experimental
- test
- fmt
- clippy
- deny