### PR TITLE
Enable codecov in Rust-CI for core Rust component

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -106,7 +106,7 @@ jobs:
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
         working-directory: ./rust/${{ matrix.folder }}
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
+        uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d # v5.4.2
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -84,25 +84,33 @@ jobs:
         run: cargo clippy --all-targets --all-features
         working-directory: ./rust/${{ matrix.folder }}
 
-#  coverage:
-#    name: Code coverage
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout repository
-#        uses: actions/checkout@v2
-#        with:
-#          submodules: true
-#
-#      - name: Install stable toolchain
-#        uses: actions-rs/toolchain@v1
-#        with:
-#          toolchain: stable
-#          override: true
-#      - name: Run cargo-tarpaulin
-#        uses: actions-rs/tarpaulin@v0.1
-#        with:
-#          version: '0.15.0'
-#          args: '--exclude-files vendor/ -- --test-threads 1'
+  coverage:
+    strategy:
+      fail-fast: false
+      matrix:
+        folder: [otap-dataflow]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: true
+      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0 # latest on /master branch as of 2025-04-02
+        with:
+          toolchain: stable
+      - name: install cargo-llvm-cov
+        uses: taiki-e/install-action@5075451c95db43b063f20f0c8fef04c04d5bf0ba # cargo-llvm-cov
+      - name: cargo llvm-cov
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+        working-directory: ./rust/${{ matrix.folder }}
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          fail_ci_if_error: true
   
   cargo_deny:
     strategy:

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,8 @@
+comment:
+  layout: "header, diff, flags, components"
+
+component_management:
+  individual_components:
+    - component_id: "otap-dataflow"
+      paths:
+        - "rust/otap-dataflow/"

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -3,6 +3,7 @@ comment:
 
 component_management:
   individual_components:
-    - component_id: "otap-dataflow"
+    - component_id: "otap_dataflow"
+      name: "otap-dataflow"
       paths:
         - "rust/otap-dataflow/"

--- a/rust/otap-dataflow/README.md
+++ b/rust/otap-dataflow/README.md
@@ -1,8 +1,8 @@
 # OTAP Pipeline Library
 
 [![build](https://github.com/open-telemetry/otel-arrow/actions/workflows/rust-ci.yml/badge.svg)](https://github.com/open-telemetry/otel-arrow/actions/workflows/rust-ci.yml)
-[![codecov](https://codecov.io/gh/open-telemetry/otel-arrow/graph/badge.svg?token=tmWKFoMT2G)](https://codecov.io/gh/open-telemetry/otel-arrow)
 [![build](https://github.com/open-telemetry/otel-arrow/actions/workflows/rust-audit.yml/badge.svg)](https://github.com/open-telemetry/otel-arrow/actions/workflows/rust-audit.yml)
+[![codecov](https://codecov.io/gh/open-telemetry/otel-arrow/graph/badge.svg?token=tmWKFoMT2G&component=otap-dataflow)](https://codecov.io/gh/open-telemetry/otel-arrow)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Slack](https://img.shields.io/badge/Slack-OTEL_Arrow-purple)](https://cloud-native.slack.com/archives/C07S4Q67LTF)
 


### PR DESCRIPTION
Enable codecoverage for projects included in Rust-CI workflow. This only covers a small portion of the repository, but is a start.

Partially addresses #106.