### PR TITLE
feat: add ability to generate OTAP messages

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,4 +1,8 @@
 otlp_*.pg
+otlp_*.pb
+otlp_*.json.zst
+otap_*.pb
+otap_*.json.zst
 hipstershop_*.pb
 generated_otlp_*.pb
 

--- a/tools/logs_gen/main.go
+++ b/tools/logs_gen/main.go
@@ -19,6 +19,7 @@ package main
 
 import (
 	"crypto/rand"
+	"encoding/json"
 	"flag"
 	"io"
 	"log"
@@ -31,14 +32,16 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
 
 	"github.com/open-telemetry/otel-arrow/pkg/datagen"
+	"github.com/open-telemetry/otel-arrow/pkg/otel/arrow_record"
 )
 
 var help = flag.Bool("help", false, "Show help")
-var outputFile = "./data/otlp_logs.pb"
+var outputFile = ""
 var batchSize = 20
 var format = "proto"
+var otap = false
 
-func writeJSON(file *os.File, batchsize int, generator *datagen.LogsGenerator) {
+func writeJSON(file *os.File, batchsize int, useOtap bool, generator *datagen.LogsGenerator) {
 	fw, err := zstd.NewWriter(file)
 	if err != nil {
 		log.Fatal("error creating compressed writer", err)
@@ -46,12 +49,25 @@ func writeJSON(file *os.File, batchsize int, generator *datagen.LogsGenerator) {
 	defer fw.Close()
 
 	for i := 0; i < batchSize; i++ {
-		request := plogotlp.NewExportRequestFromLogs(generator.Generate(1, 100))
+		var msg []byte
 
-		// Marshal the request to bytes.
-		msg, err := request.MarshalJSON()
-		if err != nil {
-			log.Fatal("marshaling error: ", err)
+		if useOtap {
+			producer := arrow_record.NewProducer()
+			bar, err := producer.BatchArrowRecordsFromLogs(generator.Generate(1, 100))
+			if err != nil {
+				log.Fatal("error creating batch arrow records: ", err)
+			}
+			msg, err = json.Marshal(bar)
+			if err != nil {
+				log.Fatal("marshaling error: ", err)
+			}
+		} else {
+			request := plogotlp.NewExportRequestFromLogs(generator.Generate(1, 100))
+			var err error
+			msg, err = request.MarshalJSON()
+			if err != nil {
+				log.Fatal("marshaling error: ", err)
+			}
 		}
 		if _, err := fw.Write(msg); err != nil {
 			log.Fatal("writing error: ", err)
@@ -64,16 +80,31 @@ func writeJSON(file *os.File, batchsize int, generator *datagen.LogsGenerator) {
 	fw.Flush()
 }
 
-func writeProto(file *os.File, batchsize int, generator *datagen.LogsGenerator) {
-	request := plogotlp.NewExportRequestFromLogs(generator.Generate(batchSize, 100))
-	// Marshal the request to bytes.
-	msg, err := request.MarshalProto()
-	if err != nil {
-		log.Fatal("marshaling error: ", err)
-	}
-	// Write protobuf to file
-	err = os.WriteFile(outputFile, msg, 0600)
+func writeProto(file *os.File, batchsize int, useOtap bool, generator *datagen.LogsGenerator) {
+	logs := generator.Generate(batchSize, 100)
+	var msg []byte
 
+	if useOtap {
+		producer := arrow_record.NewProducer()
+		bar, err := producer.BatchArrowRecordsFromLogs(logs)
+		if err != nil {
+			log.Fatal("error creating batch arrow records: ", err)
+		}
+		msg, err = json.Marshal(bar)
+		if err != nil {
+			log.Fatal("marshaling error: ", err)
+		}
+	} else {
+		request := plogotlp.NewExportRequestFromLogs(generator.Generate(batchSize, 100))
+		var err error
+		msg, err = request.MarshalProto()
+		if err != nil {
+			log.Fatal("marshaling error: ", err)
+		}
+	}
+
+	// Write protobuf to file
+	_, err := file.Write(msg)
 	if err != nil {
 		log.Fatal("write error: ", err)
 	}
@@ -84,6 +115,7 @@ func main() {
 	flag.StringVar(&outputFile, "output", outputFile, "Output file")
 	flag.IntVar(&batchSize, "batchsize", batchSize, "Batch size")
 	flag.StringVar(&format, "format", format, "file format")
+	flag.BoolVar(&otap, "otap", otap, "Use OTAP format. If true, generated files will contain OTAP messages. Otherwise, they will contain OTLP messages. Default is false.")
 
 	// Parse the flag
 	flag.Parse()
@@ -103,6 +135,22 @@ func main() {
 	entropy := datagen.NewTestEntropy(v.Int64())
 	generator := datagen.NewLogsGenerator(entropy, entropy.NewStandardResourceAttributes(), entropy.NewStandardInstrumentationScopes())
 
+	// set default output file name
+	if outputFile == "" {
+		outputFile = "./data/"
+		if otap {
+			outputFile += "otap_logs"
+		} else {
+			outputFile += "otlp_logs"
+		}
+
+		if format == "json" {
+			outputFile += ".json.zst"
+		} else {
+			outputFile += ".pb"
+		}
+	}
+
 	if _, err := os.Stat(outputFile); os.IsNotExist(err) {
 		err = os.MkdirAll(path.Dir(outputFile), 0700)
 		if err != nil {
@@ -113,11 +161,10 @@ func main() {
 	if err != nil {
 		log.Fatal("failed to open file: ", err)
 	}
-
 	if format == "json" {
-		writeJSON(f, batchSize, generator)
+		writeJSON(f, batchSize, otap, generator)
 	} else { // proto
-		writeProto(f, batchSize, generator)
+		writeProto(f, batchSize, otap, generator)
 	}
 
 }


### PR DESCRIPTION
We have some Go programs in the tools directory that can be used to generate sample telemetry data (`tools/logs_gen/main.go`, `tools/metrics_gen/main.go` & `tools/traces_gen/main.go`). Currently these tools only generate data in OTLP protocol format.

I thought it might be useful to have a way to generate OTAP telemetry data as well. This PR adds an additional flag to each of these programs (`-otap`) which will have them generate telemetry data in the OTAP format.

This also corrects the logic around the default filename. Before this change, the default file name was as follows if the user does not pass the `-output` flag (the `-format` flag had no bearing over the file extension):
- logs_gen = `otlp_logs.pb`
- metrics_gen = `otlp_metrics.pb`
- traces_gen = `otlp_traces.json`

This PR generates a more sensible default output filename taking into account the protocol (OTAP/OTLP), the telemetry type and the filetype (protobuf/compressed json)
