### PR TITLE
chore: Fix link to meeting notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ calendar](https://github.com/open-telemetry/community?tab=readme-ov-file#calenda
 for specific dates and for Zoom meeting links.
 
 Meeting notes are available as a public [Google
-doc](https://docs.google.com/document/d/1X-RPSOSDUUTD2-zrPRQ6YJ54i4JkHIgvAm5EoVhTzPs/edit?usp=sharing).
+doc](https://docs.google.com/document/d/1z8_Ra-ALDaYNa88mMj1gOZtOpLZLRk0-dZEmDjPmcUs).
 If you have trouble accessing the doc, please get in touch on
 [Slack](https://cloud-native.slack.com/archives/C07S4Q67LTF).
 


### PR DESCRIPTION
Picked the correct link from the Otel calendar's meeting invite. The current link was pointing to the wrong location.