### PR TITLE
Rename docs-ci to repo-lint

### DIFF
--- a/.github/workflows/repo-lint.yaml
+++ b/.github/workflows/repo-lint.yaml
@@ -1,4 +1,6 @@
-name: Docs-CI
+# This workflow is for various linting tasks that act in bulk over the repository.
+# Scoped linting (i.e. code formatting) should be done in the respective language-specific workflows.
+name: Repo Lint
 
 permissions: read-all
 


### PR DESCRIPTION
Related to #373 - prep to handle that PR properly

Specifically, see [this comment](https://github.com/open-telemetry/otel-arrow/pull/373#discussion_r2076005379)

> Perhaps the convention is:
> * Operations that act on a specific subsection of code belong in \<Language\>-CI (since matrix list is already present there)
> * Operations that act on the repository as a whole (i.e. markdownlint and this sanitycheck script) can and should be combined together in Repo-Lint (or another name).