### PR TITLE
[otap-dataflow] add criterion initial structure and benchmark test 

### DIFF
--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
-members = [ "benchmarks",
+members = [ 
+    "benchmarks",
     "crates/*",
     "xtask"
 ]
@@ -20,7 +21,7 @@ serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.139"
 tokio = { version = "1.43.0", features = ["rt", "time", "net", "io-util", "sync", "macros", "rt-multi-thread"] }
 async-trait = "0.1.86"
-criterion = "0.5"
+criterion = "0.5.1"
 
 [workspace.lints.rust]
 # General compatibility lints

--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [
+members = [ "benchmarks",
     "crates/*",
     "xtask"
 ]
@@ -20,6 +20,7 @@ serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.139"
 tokio = { version = "1.43.0", features = ["rt", "time", "net", "io-util", "sync", "macros", "rt-multi-thread"] }
 async-trait = "0.1.86"
+criterion = "0.5"
 
 [workspace.lints.rust]
 # General compatibility lints

--- a/rust/otap-dataflow/README.md
+++ b/rust/otap-dataflow/README.md
@@ -44,23 +44,23 @@ TBD (Explain why Rust, why Arrow, ...)
 
 ```text
 .
-├── Cargo.toml
-├── crates
-│   ├── channel        # Async Channel Implementations
-│   ├── config         # Pipeline Configuration Model
-│   ├── engine         # Async Pipeline Engine
-│   ├── otap           # OTAP Nodes
-│   └── otlp           # OTLP Nodes
-├── docs               # Documentation
-├── examples           # Rust Examples
-├── src                # Main library source code
-├── xtask              # Xtask for project management
-└── examples           # Examples or demo applications
+|-- Cargo.toml
+|-- crates
+|   |-- channel        # Async Channel Implementations
+|   |-- config         # Pipeline Configuration Model
+|   |-- engine         # Async Pipeline Engine
+|   |-- otap           # OTAP Nodes
+|   |-- otlp           # OTLP Nodes
+|-- docs               # Documentation
+|-- examples           # Rust Examples
+|-- src                # Main library source code
+|-- xtask              # Xtask for project management
+|-- examples           # Examples or demo applications
 ```
 
-## 🚀 Quickstart Guide
+## Quickstart Guide
 
-### 📥 Installation
+### Installation
 
 TBD
 
@@ -75,7 +75,7 @@ TBD
 - [Architecture](docs/architecture.md)
 - [Glossary](docs/glossary.md)
 
-## 🛠️ Development Setup
+## Development Setup
 
 **Requirements**:
 
@@ -102,7 +102,7 @@ cargo test --workspace
 cargo run --example <example_name>
 ```
 
-## 🧩 Contributing
+## Contributing
 
 - [Contribution Guidelines](CONTRIBUTING.md)
 - Code of Conduct (TBD)

--- a/rust/otap-dataflow/benchmarks/Cargo.toml
+++ b/rust/otap-dataflow/benchmarks/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "benchmarks"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+publish.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+tokio.workspace = true
+serde_json.workspace = true
+
+otap-df-config = { path = "../crates/config" }
+
+[dev-dependencies]
+criterion = { workspace = true, features = ["html_reports", "async_tokio"] }
+
+[lints]
+workspace = true
+
+[[bench]]
+name = "config"
+harness = false

--- a/rust/otap-dataflow/benchmarks/README.md
+++ b/rust/otap-dataflow/benchmarks/README.md
@@ -3,19 +3,30 @@
 **Status:** 🚧 *Work in Progress*
 
 ## Benches
-This workspace includes **Criterion-based micro-benchmarks** for the `otap-dataflow` crates. These benchmarks help evaluate and track the performance of individual components and cross-cutting functionality over time.
 
+This workspace includes **Criterion-based micro-benchmarks** for the
+`otap-dataflow` crates. These benchmarks help evaluate and track the
+performance of individual components and cross-cutting functionality over time.
 
 ### 📁 Bench Directory Structure
 
-All benchmarks are defined under the `benchmarks/benches/` directory. The organization mirrors the structure of the crates in `crates/`:
+All benchmarks are defined under the `benchmarks/benches/` directory.
+The organization mirrors the structure of the crates in `crates/`:
 
 - 📦 **Crate-specific benchmarks**:  
-  Located in subdirectories named after the crate, e.g., `benchmarks/benches/config/` for `crates/config`.
+  Located in subdirectories named after the crate, e.g.,
+  `benchmarks/benches/config/` for `crates/config`.
 
 - 🔄 **Cross-crate or e2e benchmarks**:  
-  General-purpose or integration-style benchmarks that span multiple crates may be placed in directories such as `benchmarks/benches/e2e/`.
+  General-purpose or integration-style benchmarks that span multiple
+  crates may be placed in directories such as `benchmarks/benches/e2e/`.
 
+> Note: crate specific tests in the root benchmarks directory (rather
+> than in the specific crate) allows for single-command invocations
+> which include extra criterion flags (e.g. --no-plot --output-format bencher).
+> If, moving these out at some point - additional scripting may be required.
+> More detail:
+> [here](https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options)
 
 ### ➕ Adding New Benchmarks
 
@@ -30,9 +41,10 @@ Example:
 otap-df-config = { path = "../crates/config" }
 ```
 
-
 #### 2. Add a [[bench]] entry for the benchmark target
-This declares the benchmark file and disables the default test harness (as required by Criterion):
+
+This declares the benchmark file and disables the default test harness
+(as required by Criterion):
 
 ```toml
 [[bench]]
@@ -43,6 +55,7 @@ harness = false
 This will expect a file at: `benchmarks/benches/config/main.rs`
 
 #### 3. Create the benchmark file
+
 Use Criterion’s macro-based structure. Example:
 
 ```rust
@@ -57,11 +70,12 @@ criterion_group!(benches, bench_some_function);
 criterion_main!(benches);
 ```
 
-
 ### 🏃 Running Benchmarks
+
 From the workspace root:
 
 ```bash
 cargo bench -p benchmarks
 ```
+
 ---

--- a/rust/otap-dataflow/benchmarks/README.md
+++ b/rust/otap-dataflow/benchmarks/README.md
@@ -1,0 +1,67 @@
+# 📈 Benchmarks
+
+**Status:** 🚧 *Work in Progress*
+
+## Benches
+This workspace includes **Criterion-based micro-benchmarks** for the `otap-dataflow` crates. These benchmarks help evaluate and track the performance of individual components and cross-cutting functionality over time.
+
+
+### 📁 Bench Directory Structure
+
+All benchmarks are defined under the `benchmarks/benches/` directory. The organization mirrors the structure of the crates in `crates/`:
+
+- 📦 **Crate-specific benchmarks**:  
+  Located in subdirectories named after the crate, e.g., `benchmarks/benches/config/` for `crates/config`.
+
+- 🔄 **Cross-crate or e2e benchmarks**:  
+  General-purpose or integration-style benchmarks that span multiple crates may be placed in directories such as `benchmarks/benches/e2e/`.
+
+
+### ➕ Adding New Benchmarks
+
+To add a benchmark for a new crate:
+
+#### 1. Add the crate as a dependency in `benchmarks/Cargo.toml`
+
+Example:
+
+```toml
+[dependencies]
+otap-df-config = { path = "../crates/config" }
+```
+
+
+#### 2. Add a [[bench]] entry for the benchmark target
+This declares the benchmark file and disables the default test harness (as required by Criterion):
+
+```toml
+[[bench]]
+name = "config"
+harness = false
+```
+
+This will expect a file at: `benchmarks/benches/config/main.rs`
+
+#### 3. Create the benchmark file
+Use Criterion’s macro-based structure. Example:
+
+```rust
+use criterion::{criterion_group, criterion_main, Criterion};
+use otap_df_config::some_function;
+
+fn bench_some_function(c: &mut Criterion) {
+    c.bench_function("some_function", |b| b.iter(|| some_function()));
+}
+
+criterion_group!(benches, bench_some_function);
+criterion_main!(benches);
+```
+
+
+### 🏃 Running Benchmarks
+From the workspace root:
+
+```bash
+cargo bench -p benchmarks
+```
+---

--- a/rust/otap-dataflow/benchmarks/README.md
+++ b/rust/otap-dataflow/benchmarks/README.md
@@ -1,6 +1,6 @@
-# 📈 Benchmarks
+# Benchmarks
 
-**Status:** 🚧 *Work in Progress*
+**Status:** *Work in Progress*
 
 ## Benches
 
@@ -8,16 +8,16 @@ This workspace includes **Criterion-based micro-benchmarks** for the
 `otap-dataflow` crates. These benchmarks help evaluate and track the
 performance of individual components and cross-cutting functionality over time.
 
-### 📁 Bench Directory Structure
+### Bench Directory Structure
 
 All benchmarks are defined under the `benchmarks/benches/` directory.
 The organization mirrors the structure of the crates in `crates/`:
 
-- 📦 **Crate-specific benchmarks**:  
+- **Crate-specific benchmarks**:
   Located in subdirectories named after the crate, e.g.,
   `benchmarks/benches/config/` for `crates/config`.
 
-- 🔄 **Cross-crate or e2e benchmarks**:  
+- **Cross-crate or e2e benchmarks**:
   General-purpose or integration-style benchmarks that span multiple
   crates may be placed in directories such as `benchmarks/benches/e2e/`.
 
@@ -28,7 +28,7 @@ The organization mirrors the structure of the crates in `crates/`:
 > More detail:
 > [here](https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options)
 
-### ➕ Adding New Benchmarks
+### Adding New Benchmarks
 
 To add a benchmark for a new crate:
 
@@ -56,7 +56,7 @@ This will expect a file at: `benchmarks/benches/config/main.rs`
 
 #### 3. Create the benchmark file
 
-Use Criterion’s macro-based structure. Example:
+Use Criterion's macro-based structure. Example:
 
 ```rust
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -70,7 +70,7 @@ criterion_group!(benches, bench_some_function);
 criterion_main!(benches);
 ```
 
-### 🏃 Running Benchmarks
+### Running Benchmarks
 
 From the workspace root:
 

--- a/rust/otap-dataflow/benchmarks/benches/config/main.rs
+++ b/rust/otap-dataflow/benchmarks/benches/config/main.rs
@@ -6,7 +6,7 @@ use criterion::{
     BatchSize, BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::WallTime,
 };
 
-use otap_df_config::{PipelineDag, NodeKind, SignalType};
+use otap_df_config::{NodeKind, PipelineDag, SignalType};
 
 #[allow(missing_docs)]
 pub mod bench_entry {

--- a/rust/otap-dataflow/benchmarks/benches/config/main.rs
+++ b/rust/otap-dataflow/benchmarks/benches/config/main.rs
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Benchmark tests for config implementations
+
+use criterion::{
+    BatchSize, BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::WallTime,
+};
+
+use otap_df_config::{PipelineDag, NodeKind, SignalType};
+
+#[allow(missing_docs)]
+pub mod bench_entry {
+    use super::*;
+
+    // optimize_chains benchmark function
+    fn optimize_chains(c: &mut Criterion) {
+        let mut group: BenchmarkGroup<'_, WallTime> = c.benchmark_group("config");
+
+        let _ = group.bench_function("optimize_chains", |b| {
+            b.iter_batched(
+                || {
+                    let dataflow_dag = create_pipeline_dag();
+                    Box::new(dataflow_dag)
+                },
+                |mut dataflow_dag| {
+                    dataflow_dag.optimize_chains();
+                },
+                BatchSize::SmallInput,
+            );
+        });
+        group.finish();
+    }
+
+    // create_pipeline_dag creates a pipeline dag with some configuration for optimization benchmarks
+    fn create_pipeline_dag() -> PipelineDag {
+        let mut dag = PipelineDag::new();
+
+        // --------------------------------------------------
+        // TRACES pipeline
+        // --------------------------------------------------
+        dag.add_node(
+            "receiver_otlp_traces",
+            NodeKind::Receiver,
+            SignalType::Traces,
+            SignalType::Traces,
+            serde_json::from_str(r#"{"desc": "OTLP trace receiver"}"#).unwrap_or_default(),
+        )
+        .expect("Should be able to add node");
+        dag.add_node(
+            "processor_batch_traces",
+            NodeKind::Processor,
+            SignalType::Traces,
+            SignalType::Traces,
+            serde_json::from_str(r#"{"name": "batch_traces"}"#).unwrap_or_default(),
+        )
+        .expect("Should be able to add node");
+        dag.add_node(
+            "processor_resource_traces",
+            NodeKind::Processor,
+            SignalType::Traces,
+            SignalType::Traces,
+            serde_json::from_str(r#"{"name": "resource_traces"}"#).unwrap_or_default(),
+        )
+        .expect("Should be able to add node");
+        // This was previously a "connector", now it's just a Processor that changes input->output
+        dag.add_node(
+            "processor_traces_to_metrics",
+            NodeKind::Processor,
+            SignalType::Traces,
+            SignalType::Metrics,
+            serde_json::from_str(r#"{"desc": "convert traces to metrics"}"#).unwrap_or_default(),
+        )
+        .expect("Should be able to add node");
+        dag.add_node(
+            "exporter_otlp_traces",
+            NodeKind::Exporter,
+            SignalType::Traces,
+            SignalType::Traces,
+            serde_json::from_str(r#"{"desc": "OTLP trace exporter"}"#).unwrap_or_default(),
+        )
+        .expect("Should be able to add node");
+        // Traces edges
+        dag.add_edge("receiver_otlp_traces", "processor_batch_traces");
+        dag.add_edge("processor_batch_traces", "processor_resource_traces");
+        dag.add_edge("processor_resource_traces", "processor_traces_to_metrics");
+        dag.add_edge("processor_resource_traces", "exporter_otlp_traces");
+
+        // --------------------------------------------------
+        // METRICS pipeline
+        // --------------------------------------------------
+        dag.add_node(
+            "receiver_otlp_metrics",
+            NodeKind::Receiver,
+            SignalType::Metrics,
+            SignalType::Metrics,
+            serde_json::from_str(r#"{"desc": "OTLP metric receiver"}"#).unwrap_or_default(),
+        )
+        .expect("Should be able to add node");
+        dag.add_node(
+            "processor_batch_metrics",
+            NodeKind::Processor,
+            SignalType::Metrics,
+            SignalType::Metrics,
+            serde_json::from_str(r#"{"name": "batch_metrics"}"#).unwrap_or_default(),
+        )
+        .expect("Should be able to add node");
+        // This was previously a "connector_metrics_to_events"
+        dag.add_node(
+            "processor_metrics_to_events",
+            NodeKind::Processor,
+            SignalType::Metrics,
+            SignalType::Logs,
+            serde_json::from_str(r#"{"desc": "convert metrics to events"}"#).unwrap_or_default(),
+        )
+        .expect("Should be able to add node");
+        dag.add_node(
+            "exporter_prometheus",
+            NodeKind::Exporter,
+            SignalType::Metrics,
+            SignalType::Metrics,
+            serde_json::from_str(r#"{"desc": "Prometheus exporter"}"#).unwrap_or_default(),
+        )
+        .expect("Should be able to add node");
+        dag.add_node(
+            "exporter_otlp_metrics",
+            NodeKind::Exporter,
+            SignalType::Metrics,
+            SignalType::Metrics,
+            serde_json::from_str(r#"{"desc": "OTLP metric exporter"}"#).unwrap_or_default(),
+        )
+        .expect("Should be able to add node");
+        // Edges
+        dag.add_edge("receiver_otlp_metrics", "processor_batch_metrics");
+        dag.add_edge("processor_batch_metrics", "processor_metrics_to_events");
+        dag.add_edge("processor_batch_metrics", "exporter_prometheus");
+        dag.add_edge("processor_batch_metrics", "exporter_otlp_metrics");
+        // Also from traces->metrics
+        dag.add_edge("processor_traces_to_metrics", "processor_batch_metrics");
+
+        // --------------------------------------------------
+        // LOGS pipeline
+        // --------------------------------------------------
+        dag.add_node(
+            "receiver_filelog",
+            NodeKind::Receiver,
+            SignalType::Logs,
+            SignalType::Logs,
+            serde_json::from_str(r#"{"desc": "file log receiver"}"#).unwrap_or_default(),
+        )
+        .expect("Should be able to add node");
+        dag.add_node(
+            "receiver_syslog",
+            NodeKind::Receiver,
+            SignalType::Logs,
+            SignalType::Logs,
+            serde_json::from_str(r#"{"desc": "syslog receiver"}"#).unwrap_or_default(),
+        )
+        .expect("Should be able to add node");
+        dag.add_node(
+            "processor_filter_logs",
+            NodeKind::Processor,
+            SignalType::Logs,
+            SignalType::Logs,
+            serde_json::from_str(r#"{"name": "filter_logs"}"#).unwrap_or_default(),
+        )
+        .expect("Should be able to add node");
+        // formerly "connector_logs_to_events"
+        dag.add_node(
+            "processor_logs_to_events",
+            NodeKind::Processor,
+            SignalType::Logs,
+            SignalType::Logs,
+            serde_json::from_str(r#"{"desc": "convert logs to events"}"#).unwrap_or_default(),
+        )
+        .expect("Should be able to add node");
+        dag.add_node(
+            "exporter_otlp_logs",
+            NodeKind::Exporter,
+            SignalType::Logs,
+            SignalType::Logs,
+            serde_json::from_str(r#"{"desc": "OTLP log exporter"}"#).unwrap_or_default(),
+        )
+        .expect("Should be able to add node");
+        // Edges
+        dag.add_edge("receiver_filelog", "processor_filter_logs");
+        dag.add_edge("receiver_syslog", "processor_filter_logs");
+        dag.add_edge("processor_filter_logs", "processor_logs_to_events");
+        dag.add_edge("processor_filter_logs", "exporter_otlp_logs");
+
+        // --------------------------------------------------
+        // EVENTS pipeline
+        // --------------------------------------------------
+        dag.add_node(
+            "receiver_some_events",
+            NodeKind::Receiver,
+            SignalType::Logs,
+            SignalType::Logs,
+            serde_json::from_str(r#"{"desc": "custom event receiver"}"#).unwrap_or_default(),
+        )
+        .expect("Should be able to add node");
+        dag.add_node(
+            "processor_enrich_events",
+            NodeKind::Processor,
+            SignalType::Logs,
+            SignalType::Logs,
+            serde_json::from_str(r#"{"name": "enrich_events"}"#).unwrap_or_default(),
+        )
+        .expect("Should be able to add node");
+        dag.add_node(
+            "exporter_queue_events",
+            NodeKind::Exporter,
+            SignalType::Logs,
+            SignalType::Logs,
+            serde_json::from_str(r#"{"desc": "push events to queue"}"#).unwrap_or_default(),
+        )
+        .expect("Should be able to add node");
+        // Edges
+        dag.add_edge("receiver_some_events", "processor_enrich_events");
+        dag.add_edge("processor_enrich_events", "exporter_queue_events");
+        // logs->events and metrics->events feed here
+        dag.add_edge("processor_logs_to_events", "processor_enrich_events");
+        dag.add_edge("processor_metrics_to_events", "processor_enrich_events");
+        dag
+    }
+
+    criterion_group!(
+        name = benches;
+        config = Criterion::default()
+            .warm_up_time(std::time::Duration::from_secs(1))
+            .measurement_time(std::time::Duration::from_secs(2));
+        targets = optimize_chains
+    );
+}
+
+criterion_main!(bench_entry::benches,);


### PR DESCRIPTION
- Add benchmarks top level directory under otap-dataflow

    - Criterion micro-benchmark definitions all located under benches/
    - Eventual e2e load test definitions leveraging the testbed efforts in https://github.com/open-telemetry/otel-arrow/issues/377 in another subdirectory
- Add example benchmark test for otap-df-config::optimize_pipeline

Pipeline integrations and test-result persistence in future PRs.