### PR TITLE
Address regression in OpenSSF Token-Permissions

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -1,14 +1,15 @@
 name: Go-CI
 permissions:
   contents: read
-  # needed for codeql
-  security-events: write
 
 on: [push, pull_request]
 
 jobs:
 
   build_test:
+    permissions:
+      # needed for codeql
+      security-events: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/pipeline-perf-test.yml
+++ b/.github/workflows/pipeline-perf-test.yml
@@ -1,4 +1,6 @@
 name: Pipeline Performance Tests
+permissions:
+  contents: read
 
 on:
     push:


### PR DESCRIPTION
Related to #289

I noticed an unexpected drop in [OpenSSF Scorecard results](https://scorecard.dev/viewer/?uri=github.com/open-telemetry/otel-arrow) - one of which is the Token-Permissions category.

Details include the following warnings:
> Warn: topLevel 'security-events' permission set to 'write': .github/workflows/go-ci.yml:5
Warn: no topLevel permission defined: .github/workflows/pipeline-perf-test.yml:1

This PR:
* Restricts `security-events: write` to single job in `Go-CI`
* Adds an explicit `contents: read` into `Pipeline Performance Tests` per best practice