### PR TITLE
chore: Optimize workflows by cancelling stale runs

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -4,6 +4,11 @@ permissions:
 
 on: [push, pull_request]
 
+# Cancel in-progress runs on new commits to same PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   test_and_coverage:


### PR DESCRIPTION
This PR adds concurrency configuration to the Go-CI GitHub workflow (can expand to all other non-trivial CI checks, if all agree) to automatically cancel in-progress runs when new commits are pushed to the same PR or branch, as its pointless to continue the run when new code is pushed.

reference:
https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#concurrency

Similar effort in Otel Rust repo: https://github.com/open-telemetry/opentelemetry-rust/issues/2335