### PR TITLE
test: added validation test for logs decoding otap to otlp

### DIFF
--- a/rust/otel-arrow-rust/src/otlp/attributes/store.rs
+++ b/rust/otel-arrow-rust/src/otlp/attributes/store.rs
@@ -81,10 +81,16 @@ where
         let value_type_arr = get_u8_array(rb, consts::ATTRIBUTE_TYPE)?;
 
         let value_str_arr = StringArrayAccessor::try_new_for_column(rb, consts::ATTRIBUTE_STR)?;
-        let value_int_arr = Int64ArrayAccessor::try_new_for_column(rb, consts::ATTRIBUTE_INT)?;
+        let value_int_arr = rb
+            .column_by_name(consts::ATTRIBUTE_INT)
+            .map(Int64ArrayAccessor::try_new)
+            .transpose()?;
         let value_double_arr = get_f64_array_opt(rb, consts::ATTRIBUTE_DOUBLE)?;
         let value_bool_arr = get_bool_array_opt(rb, consts::ATTRIBUTE_BOOL)?;
-        let value_bytes_arr = ByteArrayAccessor::try_new_for_column(rb, consts::ATTRIBUTE_BYTES)?;
+        let value_bytes_arr = rb
+            .column_by_name(consts::ATTRIBUTE_BYTES)
+            .map(ByteArrayAccessor::try_new)
+            .transpose()?;
 
         for idx in 0..rb.num_rows() {
             let key = key_arr.value_at_or_default(idx);

--- a/rust/otel-arrow-rust/src/otlp/logs.rs
+++ b/rust/otel-arrow-rust/src/otlp/logs.rs
@@ -288,6 +288,13 @@ pub fn logs_from(
         if let Some(body_val) = logs_arrays.body.value_at(idx) {
             current_log_record.body = Some(body_val?)
         }
+
+        if let Some(attrs) = related_data
+            .log_record_attr_map_store
+            .attribute_by_id(delta_id)
+        {
+            current_log_record.attributes = attrs.to_vec();
+        }
     }
 
     Ok(logs)

--- a/rust/otel-arrow-rust/src/validation/otap.rs
+++ b/rust/otel-arrow-rust/src/validation/otap.rs
@@ -6,9 +6,16 @@
 // been made signal-generic, and it only supports an Output type (not
 // an Input type).
 
-use crate::proto::opentelemetry::arrow::v1::{
-    BatchArrowRecords, BatchStatus, StatusCode,
-    arrow_metrics_service_server::{ArrowMetricsService, ArrowMetricsServiceServer},
+use crate::{
+    Consumer,
+    proto::opentelemetry::{
+        arrow::v1::{
+            BatchArrowRecords, BatchStatus, StatusCode,
+            arrow_logs_service_server::{ArrowLogsService, ArrowLogsServiceServer},
+            arrow_metrics_service_server::{ArrowMetricsService, ArrowMetricsServiceServer},
+        },
+        collector::logs::v1::ExportLogsServiceRequest,
+    },
 };
 
 use crate::proto::opentelemetry::collector::metrics::v1::ExportMetricsServiceRequest;
@@ -22,6 +29,8 @@ use tonic::{Request, Response, Status};
 
 use super::error;
 use snafu::{OptionExt, ResultExt};
+
+const OTAP_PROTOCOL_NAME: &str = "otelarrow"; // matches the exporter and receiver name
 
 /// OTAP metrics service type for testing the OTAP-to-OTLP conversion
 /// for metrics in this crate.
@@ -72,18 +81,7 @@ impl ArrowMetricsService for OTAPMetricsAdapter {
                 let status_result = match process_arrow_metrics(batch, related_data, receiver).await
                 {
                     Ok(_) => (StatusCode::Ok, "Successfully processed".to_string()),
-                    Err(e) => {
-                        // Truncate the error message to 100 code points
-                        // There are no std helpers for this (on purpose)
-                        let err_msg = e.to_string();
-                        let upto = err_msg
-                            .char_indices()
-                            .map(|(i, _)| i)
-                            .nth(100)
-                            .unwrap_or(err_msg.len());
-
-                        (StatusCode::InvalidArgument, err_msg[..upto].to_string())
-                    }
+                    Err(e) => (StatusCode::InvalidArgument, truncate_error(e.to_string())),
                 };
 
                 tx.send(Ok(BatchStatus {
@@ -124,7 +122,7 @@ impl ServiceOutputType for OTAPMetricsOutputType {
     }
 
     fn protocol() -> &'static str {
-        "otelarrow" // matches the exporter and receiver name
+        OTAP_PROTOCOL_NAME
     }
 
     fn create_server(
@@ -191,4 +189,112 @@ async fn process_arrow_metrics(
     }
 
     Ok(())
+}
+
+// OTAP logs service type for testing the OTAP-to-OTLP conversion
+#[derive(Debug)]
+#[cfg(test)]
+pub struct OTAPLogsOutputType;
+
+#[cfg(test)]
+pub struct OTAPLogsAdapter {
+    receiver: TestReceiver<ExportLogsServiceRequest>,
+}
+
+#[cfg(test)]
+impl OTAPLogsAdapter {
+    fn new(receiver: TestReceiver<ExportLogsServiceRequest>) -> Self {
+        Self { receiver }
+    }
+}
+
+#[tonic::async_trait]
+impl ArrowLogsService for OTAPLogsAdapter {
+    type ArrowLogsStream =
+        Pin<Box<dyn Stream<Item = Result<BatchStatus, Status>> + Send + 'static>>;
+    async fn arrow_logs(
+        &self,
+        request: Request<tonic::Streaming<BatchArrowRecords>>,
+    ) -> Result<Response<Self::ArrowLogsStream>, Status> {
+        let mut input_stream = request.into_inner();
+        let receiver = self.receiver.clone();
+
+        let (tx, rx) = tokio::sync::mpsc::channel(100);
+
+        tokio::spawn(async move {
+            let mut consumer = Consumer::default();
+            while let Ok(Some(mut batch)) = input_stream.message().await {
+                let status_result = match consumer.consume_logs_batches(&mut batch) {
+                    Ok(otlp_logs) => {
+                        receiver
+                            .process_export_request::<ExportLogsServiceRequest>(
+                                Request::new(otlp_logs),
+                                "logs",
+                            )
+                            .await
+                            .context(error::TonicStatusSnafu)
+                            .unwrap();
+
+                        (StatusCode::Ok, "Successfully processed".to_string())
+                    }
+                    Err(e) => (StatusCode::InvalidArgument, truncate_error(e.to_string())),
+                };
+
+                let tx_result = tx
+                    .send(Ok(BatchStatus {
+                        batch_id: batch.batch_id,
+                        status_code: status_result.0 as i32,
+                        status_message: status_result.1,
+                    }))
+                    .await;
+
+                if tx_result.is_err() {
+                    break;
+                }
+            }
+        });
+
+        let output_stream = tokio_stream::wrappers::ReceiverStream::new(rx);
+        Ok(Response::new(
+            Box::pin(output_stream) as Self::ArrowLogsStream
+        ))
+    }
+}
+
+impl ServiceOutputType for OTAPLogsOutputType {
+    type Request = ExportLogsServiceRequest;
+    type Server = ArrowLogsServiceServer<OTAPLogsAdapter>;
+
+    fn signal() -> &'static str {
+        "logs"
+    }
+
+    fn protocol() -> &'static str {
+        OTAP_PROTOCOL_NAME
+    }
+
+    fn create_server(
+        receiver: TestReceiver<Self::Request>,
+        incoming: ShutdownableTcpListenerStream,
+    ) -> tokio::task::JoinHandle<error::Result<()>> {
+        tokio::spawn(async move {
+            let adapter = OTAPLogsAdapter::new(receiver);
+            Server::builder()
+                .add_service(ArrowLogsServiceServer::new(adapter))
+                .serve_with_incoming(incoming)
+                .await
+                .context(error::TonicTransportSnafu)
+        })
+    }
+}
+
+// Truncate the error message to 100 code points
+fn truncate_error(err_msg: String) -> String {
+    let upto = err_msg
+        .char_indices()
+        .map(|(i, _)| i)
+        .nth(100)
+        .unwrap_or(err_msg.len());
+
+    err_msg[..upto].to_string()
 }

--- a/rust/otel-arrow-rust/src/validation/otlp.rs
+++ b/rust/otel-arrow-rust/src/validation/otlp.rs
@@ -301,4 +301,13 @@ mod tests {
         )
         .await;
     }
+
+    #[tokio::test]
+    async fn test_otap_logs_single_request() {
+        run_single_round_trip_test::<OTLPLogsInputType, OTAPLogsOutputType, _>(
+            testdata::logs::create_single_request,
+            None, // Expect success
+        )
+        .await
+    }
 }

--- a/rust/otel-arrow-rust/src/validation/testdata.rs
+++ b/rust/otel-arrow-rust/src/validation/testdata.rs
@@ -88,13 +88,20 @@ pub mod logs {
     pub fn create_single_request() -> ExportLogsServiceRequest {
         let timestamp = 1619712000000000000u64;
 
-        let log_record = LogRecord::build(timestamp, SeverityNumber::Info, "test_log")
+        // TODO after we support event_name, set this to non-empty string
+        // to ensure we correctly decode it
+        // https://github.com/open-telemetry/otel-arrow/issues/422
+        let event_name = "";
+
+        let log_record = LogRecord::build(timestamp, SeverityNumber::Info, event_name)
             .severity_text("INFO")
             .body(AnyValue::new_string(format!("Test log message")))
             .attributes(vec![KeyValue::new(
                 "test.attribute",
                 AnyValue::new_string("test value"),
             )])
+            .trace_id((0u8..16u8).into_iter().collect::<Vec<u8>>())
+            .span_id((0u8..8u8).into_iter().collect::<Vec<u8>>())
             .finish();
 
         ExportLogsServiceRequest::new(vec![


### PR DESCRIPTION
Adds a validation test decoding logs from OTAP to OTLP.

Also corrects a few issues found in the decoder found by tests
- `log_attrs` columns `int` and `bytes` should be optional
- `from_logs` method should set the attributes on the Log record

