### PR TITLE
chore: Cancel inprogress CI runs for Rust workflow

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -7,6 +7,11 @@ on: [push, pull_request]
 env:
   CARGO_TERM_COLOR: always
 
+# Cancel in-progress runs on new commits to same PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test_and_coverage:
     strategy:


### PR DESCRIPTION
https://github.com/open-telemetry/otel-arrow/pull/421 ,  extending to Rust-CI. With this, all non-trivial workflows have this enabled - Go-CI, Rust-CI, PerfTest-CI