### PR TITLE
OTAP AttributeStore parent_id encoding cleanup

### DIFF
--- a/go/pkg/otel/common/arrow/attributes.go
+++ b/go/pkg/otel/common/arrow/attributes.go
@@ -34,19 +34,6 @@ import (
 // ToDo Standard attributes (i.e. AttributesDT) will be removed in the future. They are still used as shared attributes in the metrics.
 // ToDo this file must be redistributed into `attributes_16.go` and `attributes_32.go` files.
 
-// ParentID encodings
-const (
-	// ParentIdNoEncoding stores the parent ID as is.
-	ParentIdNoEncoding = iota
-	// ParentIdDeltaEncoding stores the parent ID as a delta from the previous
-	// parent ID.
-	ParentIdDeltaEncoding
-	// ParentIdDeltaGroupEncoding stores the parent ID as a delta from the
-	// previous parent ID in the same group. A group is defined by the
-	// combination Key and Value.
-	ParentIdDeltaGroupEncoding
-)
-
 // Arrow data types used to build the attribute map.
 var (
 	// KDT is the Arrow key data type.

--- a/go/pkg/otel/common/schema/schema.go
+++ b/go/pkg/otel/common/schema/schema.go
@@ -35,9 +35,6 @@ const (
 
 	OptionalKey   = "#optional"
 	DictionaryKey = "#dictionary"
-	EncodingKey   = "encoding"
-
-	DeltaEncodingValue = "delta"
 )
 
 var (
@@ -55,8 +52,6 @@ func Metadata(keys ...MetadataKey) arrow.Metadata {
 			m[DictionaryKey] = "8"
 		case Dictionary16:
 			m[DictionaryKey] = "16"
-		case DeltaEncoding:
-			m[EncodingKey] = DeltaEncodingValue
 		}
 	}
 	return arrow.MetadataFrom(m)

--- a/go/pkg/otel/metrics/arrow/exemplar.go
+++ b/go/pkg/otel/metrics/arrow/exemplar.go
@@ -296,20 +296,9 @@ func NewExemplarParentIdEncoder(encoderType int) *ExemplarParentIdEncoder {
 }
 
 func (e *ExemplarParentIdEncoder) Encode(parentID uint32) uint32 {
-	switch e.encoderType {
-	case carrow.ParentIdNoEncoding:
-		return parentID
-	case carrow.ParentIdDeltaEncoding:
-		delta := parentID - e.prevParentID
-		e.prevParentID = parentID
-		return delta
-	case carrow.ParentIdDeltaGroupEncoding:
-		delta := parentID - e.prevParentID
-		e.prevParentID = parentID
-		return delta
-	default:
-		panic("Unknown parent ID encoding type.")
-	}
+	delta := parentID - e.prevParentID
+	e.prevParentID = parentID
+	return delta
 }
 
 // No sorting

--- a/rust/otel-arrow-rust/src/otlp/attributes/parent_id.rs
+++ b/rust/otel-arrow-rust/src/otlp/attributes/parent_id.rs
@@ -14,7 +14,6 @@ use crate::otlp::attributes::decoder::{
     Attrs16ParentIdDecoder, Attrs32ParentIdDecoder, AttrsParentIdDecoder,
 };
 use arrow::datatypes::{UInt16Type, UInt32Type};
-use num_enum::TryFromPrimitive;
 use std::hash::Hash;
 use std::ops::{Add, AddAssign};
 
@@ -38,19 +37,4 @@ impl ParentId for u32 {
     fn new_decoder() -> AttrsParentIdDecoder<Self> {
         Attrs32ParentIdDecoder::default()
     }
-}
-
-#[allow(clippy::enum_variant_names)]
-#[derive(Copy, Clone, Eq, PartialEq, Debug, TryFromPrimitive)]
-#[repr(u8)]
-pub enum ParentIdEncoding {
-    /// ParentIdNoEncoding stores the parent ID as is.
-    ParentIdNoEncoding = 0,
-    /// ParentIdDeltaEncoding stores the parent ID as a delta from the previous
-    /// parent ID.
-    ParentIdDeltaEncoding = 1,
-    /// ParentIdDeltaGroupEncoding stores the parent ID as a delta from the
-    /// previous parent ID in the same group. A group is defined by the
-    /// combination Key and Value.
-    ParentIdDeltaGroupEncoding = 2,
 }

--- a/rust/otel-arrow-rust/src/otlp/attributes/store.rs
+++ b/rust/otel-arrow-rust/src/otlp/attributes/store.rs
@@ -20,7 +20,6 @@ use crate::proto::opentelemetry::common::v1::any_value::Value;
 use crate::proto::opentelemetry::common::v1::{AnyValue, KeyValue};
 use crate::schema::consts;
 use arrow::array::{ArrowPrimitiveType, PrimitiveArray, RecordBatch};
-use arrow::datatypes::Schema;
 use num_enum::TryFromPrimitive;
 use snafu::{OptionExt, ResultExt};
 use std::collections::HashMap;
@@ -134,10 +133,6 @@ where
                 MaybeDictArrayAccessor::<PrimitiveArray<<T as ParentId>::ArrayType>>::try_new(
                     parent_id_arr,
                 )?;
-
-            // Curious, but looks like this is not used anywhere in otel-arrow
-            // See https://github.com/open-telemetry/otel-arrow/blob/985aa1500a012859cec44855e187eacf46eda7c8/pkg/otel/common/otlp/attributes.go#L134
-            let _delta_encoded = is_delta_encoded(rb.schema_ref());
             let mut parent_id_decoder = T::new_decoder();
 
             let parent_id = parent_id_decoder.decode(
@@ -173,17 +168,4 @@ impl FindOrAppendValue<Option<AnyValue>> for Vec<KeyValue> {
         });
         &mut self.last_mut().unwrap().value
     }
-}
-
-/// Key form
-const DELTA_ENCODING_KEY: &str = "encoding";
-const DELTA_ENCODING_VALUE: &str = "delta";
-
-/// Checks if parent id field is delta encoded from the metadata of schema.
-fn is_delta_encoded(schema: &Schema) -> bool {
-    schema
-        .metadata
-        .get(DELTA_ENCODING_KEY)
-        .map(|v| v == DELTA_ENCODING_VALUE)
-        .unwrap_or(false)
 }


### PR DESCRIPTION
Early in Phase 1, @lquerel did experiments with several attribute-set encoding schemes. We settled on a single strategy, but there is a bit of left-over in the implementation. This removes it in both Go and Rust implementations:

- Option to encode "delta_encoded" via schema metadata
- Choice of encoding mode "None" and "DeltaEncoding" are removed; the former "ParentIdDeltaGroupEncoding" remains