### PR TITLE
Golang: Add -coverpkg=./...

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -26,4 +26,4 @@ component_management:
     - component_id: "otel_arrow_go"
       name: "otel-arrow-go"
       paths:
-        - "go/pkg/otel/"
+        - "go/"

--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -26,4 +26,4 @@ component_management:
     - component_id: "otel_arrow_go"
       name: "otel-arrow-go"
       paths:
-        - "go/"
+        - "go/pkg/otel/"

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -26,8 +26,8 @@ jobs:
         with:
           go-version: "1.23"
       - name: Run tests with coverage
-        run: go test -cover -coverprofile=coverage.txt -covermode=atomic ./${{ matrix.folder}}/...
-        working-directory: ./go
+        run: go test -cover -coverprofile=coverage.txt -covermode=atomic -coverpkg=./${{ matrix.folder}}/... ./${{ matrix.folder}}/...
+        working-directory: ./go/pkg/otel
       - name: Upload to codecov.io
         uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d # v5.4.2
         env:

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -26,8 +26,8 @@ jobs:
         with:
           go-version: "1.23"
       - name: Run tests with coverage
-        run: go test -cover -coverprofile=coverage.txt -covermode=atomic -coverpkg=./... ./${{ matrix.folder}}/...
-        working-directory: ./go/pkg/otel
+        run: go test -cover -coverprofile=coverage.txt -covermode=atomic -coverpkg=./... ./...
+        working-directory: ./go/${{ matrix.folder }}
       - name: Upload to codecov.io
         uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d # v5.4.2
         env:

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           go-version: "1.23"
       - name: Run tests with coverage
-        run: go test -cover -coverprofile=coverage.txt -covermode=atomic -coverpkg=./${{ matrix.folder}}/... ./${{ matrix.folder}}/...
+        run: go test -cover -coverprofile=coverage.txt -covermode=atomic -coverpkg=./... ./${{ matrix.folder}}/...
         working-directory: ./go/pkg/otel
       - name: Upload to codecov.io
         uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d # v5.4.2


### PR DESCRIPTION
This should improve Golang test coverage to be more realistic, because the Golang OTAP implementation uses many packages, and a few packages exercise many others. With this package layout, -coverpkg=./... is sensible.

Results: 53% of go/pkg/otel covered, was 16% before