### PR TITLE
feat: support decoding list/map attributes

### DIFF
--- a/rust/otel-arrow-rust/Cargo.toml
+++ b/rust/otel-arrow-rust/Cargo.toml
@@ -14,6 +14,7 @@ derive = []
 [dependencies]
 arrow = "53"
 arrow-ipc = { version = "53", features = ["zstd"] }
+ciborium = "0.2.2"
 lazy_static = "1.5"
 num_enum = "0.7"
 otlp-derive = { path = "./src/pdata/otlp/derive" }

--- a/rust/otel-arrow-rust/src/error.rs
+++ b/rust/otel-arrow-rust/src/error.rs
@@ -16,7 +16,7 @@ use arrow::datatypes::DataType;
 use arrow::error::ArrowError;
 use num_enum::TryFromPrimitiveError;
 use snafu::{Location, Snafu};
-use std::backtrace::Backtrace;
+use std::{backtrace::Backtrace, num::TryFromIntError};
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -61,9 +61,33 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("Currently attribute store value type: {} is not supported", type_name))]
-    UnsupportedAttributeValue {
-        type_name: String,
+    #[snafu(display("Invalid bytes for serialized attribute value"))]
+    InvalidSerializedAttributeBytes {
+        source: ciborium::de::Error<std::io::Error>,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Invalid serialized integer attribute value"))]
+    InvalidSerializedIntAttributeValue {
+        source: TryFromIntError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display(
+        "Invalid serialized map key type, expected: String, actual: {:?}",
+        actual
+    ))]
+    InvalidSerializedMapKeyType {
+        actual: ciborium::Value,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Serialized attribute {:?} is not supported", actual))]
+    UnsupportedSerializedAttributeValue {
+        actual: ciborium::Value,
         #[snafu(implicit)]
         location: Location,
     },

--- a/rust/otel-arrow-rust/src/otlp/attributes.rs
+++ b/rust/otel-arrow-rust/src/otlp/attributes.rs
@@ -10,6 +10,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod cbor;
 pub mod decoder;
 mod parent_id;
 pub mod store;

--- a/rust/otel-arrow-rust/src/otlp/attributes/cbor.rs
+++ b/rust/otel-arrow-rust/src/otlp/attributes/cbor.rs
@@ -1,0 +1,80 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error::{self, Error, Result};
+use crate::proto::opentelemetry::common::v1::any_value::Value;
+use crate::proto::opentelemetry::common::v1::{AnyValue, ArrayValue, KeyValue, KeyValueList};
+use snafu::ResultExt;
+
+/// Decode bytes from a serialized attribute into pcommon value.
+/// This should be used for values in the `ser` column of attributes
+/// and Log bodies.
+pub fn decode_pcommon_val(input: &[u8]) -> Result<Option<Value>> {
+    let decoded_val = ciborium::from_reader::<ciborium::Value, &[u8]>(input)
+        .context(error::InvalidSerializedAttributeBytesSnafu)?;
+
+    MaybeValue::try_from(decoded_val).map(Into::into)
+}
+
+// `MaybeValue` is a thin wrapper around `Option<Value>`. We use this so we to
+// avoid violating the coherence rule when implementing TryFrom.
+struct MaybeValue(Option<Value>);
+
+impl From<MaybeValue> for Option<Value> {
+    fn from(value: MaybeValue) -> Self {
+        value.0
+    }
+}
+
+impl TryFrom<ciborium::Value> for MaybeValue {
+    type Error = Error;
+
+    fn try_from(value: ciborium::Value) -> Result<Self> {
+        let val = match value {
+            ciborium::Value::Null => None,
+            ciborium::Value::Text(string_val) => Some(Value::StringValue(string_val)),
+            ciborium::Value::Float(double_val) => Some(Value::DoubleValue(double_val)),
+            ciborium::Value::Bytes(bytes_val) => Some(Value::BytesValue(bytes_val)),
+            ciborium::Value::Bool(bool_val) => Some(Value::BoolValue(bool_val)),
+            ciborium::Value::Integer(int_val) => Some(Value::IntValue(
+                int_val
+                    .try_into()
+                    .context(error::InvalidSerializedIntAttributeValueSnafu)?,
+            )),
+            ciborium::Value::Array(array_vals) => {
+                let vals: Result<Vec<_>> = array_vals
+                    .into_iter()
+                    .map(|element| match Self::try_from(element) {
+                        Ok(val) => Ok(AnyValue { value: val.into() }),
+                        Err(e) => Err(e),
+                    })
+                    .collect();
+
+                Some(Value::ArrayValue(ArrayValue { values: vals? }))
+            }
+            ciborium::Value::Map(map_vals) => {
+                let kvs: Result<Vec<_>> = map_vals
+                    .into_iter()
+                    .map(|(k, v)| {
+                        if let ciborium::Value::Text(key) = k {
+                            match Self::try_from(v) {
+                                Ok(val) => Ok(KeyValue::new(key, AnyValue { value: val.into() })),
+                                Err(e) => Err(e),
+                            }
+                        } else {
+                            error::InvalidSerializedMapKeyTypeSnafu { actual: k }.fail()
+                        }
+                    })
+                    .collect();
+
+                Some(Value::KvlistValue(KeyValueList::new(kvs?)))
+            }
+
+            other => {
+                return error::UnsupportedSerializedAttributeValueSnafu { actual: other }.fail();
+            }
+        };
+
+        Ok(Self(val))
+    }
+}

--- a/rust/otel-arrow-rust/src/otlp/logs.rs
+++ b/rust/otel-arrow-rust/src/otlp/logs.rs
@@ -21,7 +21,7 @@ use crate::proto::opentelemetry::common::v1::AnyValue;
 use crate::proto::opentelemetry::common::v1::any_value::Value;
 use crate::schema::consts;
 
-use super::attributes::store::AttributeValueType;
+use super::attributes::{cbor, store::AttributeValueType};
 
 pub mod related_data;
 
@@ -111,10 +111,9 @@ struct LogBodyArrays<'a> {
     double: Option<&'a Float64Array>,
     bool: Option<&'a BooleanArray>,
     bytes: Option<ByteArrayAccessor<'a>>,
-    // _ser is for serialized value type of AnyValue including "kvlist" and "array"
-    //
-    // TODO: see https://github.com/open-telemetry/otel-arrow/issues/384
-    _ser: Option<ByteArrayAccessor<'a>>,
+
+    // ser is for serialized value type of AnyValue including "kvlist" and "array"
+    ser: Option<ByteArrayAccessor<'a>>,
 }
 
 impl NullableArrayAccessor for LogBodyArrays<'_> {
@@ -134,15 +133,18 @@ impl NullableArrayAccessor for LogBodyArrays<'_> {
             }
         };
 
+        if value_type == AttributeValueType::Slice || value_type == AttributeValueType::Map {
+            let bytes = self.ser.value_at(idx)?;
+            let decode_result = cbor::decode_pcommon_val(&bytes).transpose()?;
+            return Some(decode_result.map(|val| AnyValue { value: Some(val) }));
+        }
+
         let value = match value_type {
             AttributeValueType::Str => Value::StringValue(self.str.value_at_or_default(idx)),
             AttributeValueType::Int => Value::IntValue(self.int.value_at_or_default(idx)),
             AttributeValueType::Double => Value::DoubleValue(self.double.value_at_or_default(idx)),
             AttributeValueType::Bool => Value::BoolValue(self.bool.value_at_or_default(idx)),
             AttributeValueType::Bytes => Value::BytesValue(self.bytes.value_at_or_default(idx)),
-            // TODO: see https://github.com/open-telemetry/otel-arrow/issues/384
-            // 1. handle slice
-            // 2. handle map
             _ => {
                 // silently ignore unknown types to avoid DOS attacks
                 return None;
@@ -166,7 +168,7 @@ impl<'a> TryFrom<&'a StructArray> for LogBodyArrays<'a> {
             double: column_accessor.primitive_column_op(consts::ATTRIBUTE_DOUBLE)?,
             bool: column_accessor.bool_column_op(consts::ATTRIBUTE_BOOL)?,
             bytes: column_accessor.byte_array_column_op(consts::ATTRIBUTE_BYTES)?,
-            _ser: column_accessor.byte_array_column_op(consts::ATTRIBUTE_SER)?,
+            ser: column_accessor.byte_array_column_op(consts::ATTRIBUTE_SER)?,
         })
     }
 }

--- a/rust/otel-arrow-rust/src/validation/otlp.rs
+++ b/rust/otel-arrow-rust/src/validation/otlp.rs
@@ -310,4 +310,13 @@ mod tests {
         )
         .await
     }
+
+    #[tokio::test]
+    async fn test_otap_logs_serialized_bodies() {
+        run_single_round_trip_test::<OTLPLogsInputType, OTAPLogsOutputType, _>(
+            testdata::logs::create_request_with_serialized_bodies,
+            None, // Expect success
+        )
+        .await
+    }
 }


### PR DESCRIPTION
Add support for complex list/map types when decoding Log bodies and attributes. This introduces a module called `attributes::cbor` which has the helper method `decode_pcommon_val` for deserializing the bytes to `proto::opentelemetry::common::v1::any_value::Value`.

`ciborium` crate is used for serialization. The motivating factor for choice is their [`Value`](https://docs.rs/ciborium/0.2.2/ciborium/enum.Value.html) type, which makes it easy to handle dynamic value type.

Adds coverage of this decoding behaviour in our round-trip validation tests.