### PR TITLE
Enable gomodTidy in Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,6 +20,9 @@
        "schedule": ["before 8am on Monday"]
      }
    ],
+   "postUpdateOptions": [
+     "gomodTidy"
+   ]
    "labels": [
      "dependencies"
    ]

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,29 +1,31 @@
 {
-   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-   "extends": [
-     "config:recommended",
-     "docker:pinDigests",
-     "helpers:pinGitHubActionDigestsToSemver"
-   ],
-   "packageRules": [
-     {
-       // reduces the number of Renovate PRs
-       // (patch updates are typically non-breaking)
-       "groupName": "all patch versions",
-       "matchUpdateTypes": ["patch"],
-       "schedule": ["before 8am every weekday"]
-     },
-     {
-       // avoids these Renovate PRs from trickling in throughout the week
-       // (consolidating the review process)
-       "matchUpdateTypes": ["minor", "major"],
-       "schedule": ["before 8am on Monday"]
-     }
-   ],
-   "postUpdateOptions": [
-     "gomodTidy"
-   ]
-   "labels": [
-     "dependencies"
-   ]
- }
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "docker:pinDigests",
+    "helpers:pinGitHubActionDigestsToSemver"
+  ],
+  "packageRules": [
+    {
+      // reduces the number of Renovate PRs
+      // (patch updates are typically non-breaking)
+      "groupName": "all patch versions",
+      "matchUpdateTypes": ["patch"],
+      "schedule": ["before 8am every weekday"]
+    },
+    {
+      // avoids these Renovate PRs from trickling in throughout the week
+      // (consolidating the review process)
+      "matchUpdateTypes": ["minor", "major"],
+      "schedule": ["before 8am on Monday"]
+    }
+  ],
+  "postUpdateOptions": [
+    // see https://docs.renovatebot.com/golang/#module-tidying
+    // go modules may require running go mod tidy to pass CI
+    "gomodTidy"
+  ]
+  "labels": [
+    "dependencies"
+  ]
+}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,21 +10,30 @@
       // reduces the number of Renovate PRs
       // (patch updates are typically non-breaking)
       "groupName": "all patch versions",
-      "matchUpdateTypes": ["patch"],
-      "schedule": ["before 8am every weekday"]
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      "schedule": [
+        "before 8am every weekday"
+      ]
     },
     {
       // avoids these Renovate PRs from trickling in throughout the week
       // (consolidating the review process)
-      "matchUpdateTypes": ["minor", "major"],
-      "schedule": ["before 8am on Monday"]
+      "matchUpdateTypes": [
+        "minor",
+        "major"
+      ],
+      "schedule": [
+        "before 8am on Monday"
+      ]
     }
   ],
   "postUpdateOptions": [
     // see https://docs.renovatebot.com/golang/#module-tidying
     // go modules may require running go mod tidy to pass CI
     "gomodTidy"
-  ]
+  ],
   "labels": [
     "dependencies"
   ]


### PR DESCRIPTION
Renovate's Go dependency updates may fail and require manual intervention: [see this job run](https://github.com/open-telemetry/otel-arrow/actions/runs/15024100098/job/42220415019?pr=419) of #419.

>go: updates to go.mod needed; to update it:
	go mod tidy

Renovate does support also running `go mod tidy` itself via opt-in config, see https://docs.renovatebot.com/golang/#module-tidying.

Hopefully merging this will lead to automatic Go dependency updates passing CI from the start.

**Note: Also did some `json` formatting in vscode, but only real content added are lines 32-36.**