### PR TITLE
Perf - improve loadgen and few nits

### DIFF
--- a/tools/pipeline_perf_test/load_generator/loadgen-manifest.yaml
+++ b/tools/pipeline_perf_test/load_generator/loadgen-manifest.yaml
@@ -24,8 +24,8 @@ spec:
         - "{{DURATION}}"  # This will be replaced by the orchestrator
         resources:
           requests:
-            cpu: 100m
-            memory: 100Mi
+            cpu: "2"
+            memory: 1000Mi
           limits:
-            cpu: 500m
-            memory: 500Mi
+            cpu: "4"
+            memory: 1000Mi

--- a/tools/pipeline_perf_test/load_generator/loadgen.py
+++ b/tools/pipeline_perf_test/load_generator/loadgen.py
@@ -2,13 +2,18 @@ import os
 import grpc
 import time
 import argparse
+import threading
+import concurrent.futures
 from opentelemetry.proto.collector.logs.v1 import logs_service_pb2_grpc, logs_service_pb2
 from opentelemetry.proto.logs.v1 import logs_pb2
 from opentelemetry.proto.common.v1 import common_pb2
 
 def create_log_record():
+    # Using a hardcoded timestamp (May 14, 2025 12:00:00 UTC in nanoseconds)
+    # This avoids the system call overhead of time.time_ns()
+    hardcoded_time_ns = 1747065600000000000
     return logs_pb2.LogRecord(
-        time_unix_nano=int(time.time_ns()),
+        time_unix_nano=hardcoded_time_ns,
         severity_text="INFO",
         severity_number=9,
         body=common_pb2.AnyValue(string_value="This is a test log message"),
@@ -24,20 +29,15 @@ def create_log_record():
         ],
     )
 
-def main():
-    parser = argparse.ArgumentParser(description="Loadgen for OTLP logs")
-    parser.add_argument("--duration", type=int, default=15, help="Duration in seconds (default: 15)")
-    parser.add_argument("--batch-size", type=int, default=100, help="Number of logs per batch (default: 100)")
-    args = parser.parse_args()
-
+def worker_thread(thread_id, args, end_time):
+    """Worker thread function that sends logs to the collector."""
     endpoint = os.getenv("OTLP_ENDPOINT", "localhost:4317")
     channel = grpc.insecure_channel(endpoint)
     stub = logs_service_pb2_grpc.LogsServiceStub(channel)
-
-    end_time = time.time() + args.duration
-
+    
     sent = 0
     failed = 0
+    
     while time.time() < end_time:
         log_batch = [create_log_record() for _ in range(args.batch_size)]
         scope_logs = logs_pb2.ScopeLogs(log_records=log_batch)
@@ -52,10 +52,33 @@ def main():
             sent += args.batch_size
         except Exception as e:
             failed += args.batch_size
-            print(f"Failed to send log batch: {e}")
+            print(f"Thread {thread_id}: Failed to send log batch: {e}")
+            
+    return sent, failed
 
-    print(f"LOADGEN_LOGS_SENT: {sent}")
-    print(f"LOADGEN_LOGS_FAILED: {failed}")
+def main():
+    parser = argparse.ArgumentParser(description="Loadgen for OTLP logs")
+    parser.add_argument("--duration", type=int, default=15, help="Duration in seconds (default: 15)")
+    parser.add_argument("--batch-size", type=int, default=10000, help="Number of logs per batch (default: 10000)")
+    parser.add_argument("--threads", type=int, default=8, help="Number of worker threads (default: 8)")
+    args = parser.parse_args()
+
+    end_time = time.time() + args.duration
+    
+    # Create and start worker threads
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.threads) as executor:
+        futures = [executor.submit(worker_thread, i, args, end_time) for i in range(args.threads)]
+        
+        # Wait for all threads to complete
+        total_sent = 0
+        total_failed = 0
+        for future in concurrent.futures.as_completed(futures):
+            sent, failed = future.result()
+            total_sent += sent
+            total_failed += failed
+    
+    print(f"LOADGEN_LOGS_SENT: {total_sent}")
+    print(f"LOADGEN_LOGS_FAILED: {total_failed}")
 
 if __name__ == "__main__":
     main()

--- a/tools/pipeline_perf_test/orchestrator/orchestrator.py
+++ b/tools/pipeline_perf_test/orchestrator/orchestrator.py
@@ -749,6 +749,14 @@ def main():
         # Calculate logs sent rate (based on attempted sends, not successful ones)
         total_logs_attempted = logs_sent_count + logs_failed_count
         logs_sent_rate = total_logs_attempted / duration if duration > 0 else 0
+        
+        # Format rate for human readability (K/sec or M/sec)
+        if logs_sent_rate >= 1000000:
+            formatted_rate = f"{logs_sent_rate/1000000:.2f}M/sec"
+        elif logs_sent_rate >= 1000:
+            formatted_rate = f"{logs_sent_rate/1000:.2f}K/sec"
+        else:
+            formatted_rate = f"{logs_sent_rate:.2f}/sec"
 
         # Calculate percentage of logs lost
         logs_lost_percentage = (total_logs_lost / total_logs_attempted * 100) if total_logs_attempted > 0 else 0
@@ -760,7 +768,7 @@ def main():
         print(f"Logs received by backend: {logs_received_backend_count}")
         print(f"Logs lost in transit: {transit_lost}")
         print(f"Duration: {duration:.2f} seconds")
-        print(f"Logs attempt rate: {logs_sent_rate:.2f} logs/second")
+        print(f"Logs attempt rate: {formatted_rate} ({logs_sent_rate:.2f} logs/second)")
         print(f"Total logs lost: {total_logs_lost} ({logs_lost_percentage:.2f}% of attempted logs)")
 
         # Write results to file
@@ -782,7 +790,7 @@ def main():
             f.write(f"- Logs received by backend: {logs_received_backend_count}\n")
             f.write(f"- Logs lost in transit: {transit_lost}\n")
             f.write(f"- Duration: {duration:.2f} seconds\n")
-            f.write(f"- Logs attempt rate: {logs_sent_rate:.2f} logs/second\n")
+            f.write(f"- Logs attempt rate: {formatted_rate} ({logs_sent_rate:.2f} logs/second)\n")
             f.write(f"- Total logs lost: {total_logs_lost} (failed at loadgen + lost in transit)\n")
             f.write(f"- Percentage of logs lost: {logs_lost_percentage:.2f}%\n")
 


### PR DESCRIPTION
While we expect to replace the simple loadgen with something more sophisticated in the future, this PR improves the current loadgen in a few ways:
1. Sends OTLP request from multiple threads (configurable), to better saturate Collectors.
2. Avoid sys call to get time(), and use hardcoded value to avoid wasting time!
3. More human readable output of throughput.
4. For K8s, more cpu/memory for loadtest in the example k8s manifest.