### PR TITLE
Perf - switch docker interaction to use api client library

### DIFF
--- a/tools/pipeline_perf_test/orchestrator/lib/process/deployed_process/docker.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/process/deployed_process/docker.py
@@ -77,7 +77,7 @@ class DockerProcess(DeployedProcess):
             while not stop_event.is_set():
                 try:
                     stat_data = container.stats(stream=False)
-                    
+
                     # CPU usage calculation
                     cpu_stats = stat_data['cpu_stats']
                     precpu_stats = stat_data['precpu_stats']

--- a/tools/pipeline_perf_test/orchestrator/lib/process/deployed_process/docker.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/process/deployed_process/docker.py
@@ -17,38 +17,45 @@ Key Features:
 Intended to be used by the orchestration layer to deploy, monitor, and manage containerized
 components.
 """
-import subprocess
 import threading
 import time
 
-from ..stats import ProcessStats, parse_mem_to_mib
+import docker
+from docker.errors import NotFound, APIError
+
+from ..stats import ProcessStats
 from .base import DeployedProcess
 
 class DockerProcess(DeployedProcess):
     """Class to manage Docker processes like containers"""
 
-    def __init__(self, container_id: str):
+    def __init__(self, container_id: str, client: docker.DockerClient, log_cli: bool=False):
         super().__init__("docker")
         self.container_id = container_id
         self.monitoring_thread = None
         self.stop_monitoring_event = threading.Event()
+        self.log_cli = log_cli
+        self._client = client
 
     def shutdown(self) -> None:
         """Gracefully shutdown and remove the Docker container"""
         if self.container_id:
             try:
-                # First stop the container if it's still running
-                print(f"Stopping Docker container: {self.container_id}")
-                stop_cmd = ["docker", "stop", self.container_id]
-                subprocess.run(stop_cmd, check=True, capture_output=True, text=True)
+                container = self._client.containers.get(self.container_id)
 
-                # Then remove the container
+                print(f"Stopping Docker container: {self.container_id}")
+                if self.log_cli:
+                    print(f"CLI_COMMAND = docker stop -t 10 {self.container_id}")
+                container.stop(timeout=10)  # default is 10 seconds
+
                 print(f"Removing Docker container: {self.container_id}")
-                rm_cmd = ["docker", "rm", "-f", self.container_id]
-                subprocess.run(rm_cmd, check=True, capture_output=True, text=True)
-            except subprocess.CalledProcessError as e:
+                if self.log_cli:
+                    print(f"CLI_COMMAND = docker rm -f {self.container_id}")
+                container.remove(force=True)
+            except NotFound:
+                print(f"Container {self.container_id} not found. It may have already been removed.")
+            except APIError as e:
                 print(f"Error stopping/removing Docker container: {e}")
-                print(f"Error output: {e.stderr}")
 
     def start_monitoring(self, interval: float) -> None:
         """
@@ -61,31 +68,45 @@ class DockerProcess(DeployedProcess):
                     stats: ProcessStats,
                     stop_event: threading.Event,
                     interval: float = 1.0):
+            try:
+                container = self._client.containers.get(container_id)
+            except APIError as e:
+                print(f"Could not retrieve container {container_id}: {e}")
+                return
+
             while not stop_event.is_set():
                 try:
-                    cmd = ["docker", "stats", container_id, "--no-stream", "--format",
-                        "{{.Container}} {{.CPUPerc}} {{.MemUsage}}"]
-                    result = subprocess.check_output(cmd, text=True).strip()
-                    if result:
-                        parts = result.split()
-                        # Example: ['11e99006dc11', '87.54%', '21.84MiB', '/', '7.662GiB']
-                        cpu_str = parts[1]
-                        cpu = float(cpu_str.strip('%')) / 100.0
-                        mem_used_str = parts[2]
-                        mem_mb = parse_mem_to_mib(mem_used_str)
+                    stat_data = container.stats(stream=False)
+                    
+                    # CPU usage calculation
+                    cpu_stats = stat_data['cpu_stats']
+                    precpu_stats = stat_data['precpu_stats']
+                    cpu_delta = cpu_stats['cpu_usage']['total_usage'] - precpu_stats['cpu_usage']['total_usage']
+                    system_delta = cpu_stats['system_cpu_usage'] - precpu_stats['system_cpu_usage']
 
-                        stats.add_sample(cpu, mem_mb)
-                        # Can add a flag to turn this on or off later
-                        print(f"Monitored Container ({container_id[:12]}) Cur. CPU: {cpu:.2f} "
-                              f"({stats.get_summary_string('cpu')}) Cur Mem: {mem_mb:.2f} "
-                              f"({stats.get_summary_string('mem')})")
-                        time.sleep(interval)
-                except subprocess.CalledProcessError as e:
+                    cpu_usage = 0.0
+                    if system_delta > 0.0 and cpu_delta > 0.0:
+                        num_cpus = len(cpu_stats['cpu_usage'].get('percpu_usage', [])) or cpu_stats['online_cpus']
+                        cpu_usage = (cpu_delta / system_delta) * num_cpus
+
+                    # Memory usage in MiB
+                    mem_usage = stat_data['memory_stats']['usage']
+                    mem_mb = mem_usage / (1024 * 1024)
+
+                    stats.add_sample(cpu_usage, mem_mb)
+                    print(f"Monitored Container ({container_id[:12]}) Cur. CPU (#Cores): {cpu_usage:.2f} "
+                          f"({stats.get_summary_string('cpu')}) Cur Mem (MiB): {mem_mb:.2f} "
+                          f"({stats.get_summary_string('mem')})")
+
+                    time.sleep(interval)
+
+                except APIError as e:
                     print(f"Error collecting stats for container {container_id}: {e}")
                     break
                 except Exception as e:
                     print(f"Unexpected error while monitoring {container_id}: {e}")
                     break
+
         print(f"Starting monitoring for Docker container: {self.container_id[:12]}")
         monitor_args = {
             "container_id": self.container_id,

--- a/tools/pipeline_perf_test/orchestrator/lib/process/utils/docker.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/process/utils/docker.py
@@ -11,19 +11,65 @@ These utilities abstract lower-level Docker CLI operations to simplify higher-le
 orchestration.
 """
 import os
-import subprocess
+from dataclasses import dataclass
 from typing import Optional, Dict, List
 
+import docker
+from docker.errors import BuildError, APIError, DockerException, NotFound
+
 from ..deployed_process.docker import DockerProcess
+
+
+@dataclass
+class VolumeMount:
+    host_path: str
+    container_path: str
+    mode: str = 'rw'
+
+
+@dataclass
+class PortBinding:
+    container_port: int
+    host_port: int
+    protocol: str = "tcp"
+    host_ip: str = "0.0.0.0"
+
+
+def build_volume_dict(volume_mounts: list[VolumeMount]) -> dict:
+    """Map a list of VolumeMounts to the format expected by docker api"
+    
+    Args:
+        - volume_mounts: a list of VolumeMount objects specifying mount configs
+    """
+    return {
+        vm.host_path: {'bind': vm.container_path, 'mode': vm.mode}
+        for vm in volume_mounts
+    }
+
+
+def build_port_bindings(bindings: list[PortBinding]) -> dict:
+    """Map a list of PortBindings to the format expected by docker api"
+    
+    Args:
+        - bindings: a list of PortBindings objects specifying port mapping configs
+    """
+    result = {}
+    for b in bindings:
+        key = f"{b.container_port}/{b.protocol}"
+        result[key] = (b.host_ip, b.host_port)
+    return result
+
 
 def launch_container(
     image_name: str,
     container_name: str,
-    ports: Optional[Dict[str, str]] = None,
+    client: docker.DockerClient,
+    ports: Optional[List[PortBinding]] = None,
     network: Optional[str] = None,
     command_args: Optional[List[str]] = None,
-    volumes: Optional[Dict[str, str]] = None,
-    environment: Optional[Dict[str, str]] = None
+    volume_mounts: Optional[List[VolumeMount]] = None,
+    environment: Optional[Dict[str, str]] = None,
+    log_cli: bool = False,
 ) -> DockerProcess:
     """
     Launch a Docker container
@@ -31,135 +77,208 @@ def launch_container(
     Args:
         image_name: Docker image name with tag
         container_name: name for the container
+        client: docker api client
         ports: Port mappings from host to container
         network: Docker network to connect to
         command_args: Additional command arguments to pass to the container
         volumes: Volume mounts from host to container
         environment: Environment variables to pass to the container
+        log_cli: Enable logging the equivalent cli command
 
     Returns:
         DockerProcess: Object representing the launched container
     """
     print(f"Starting {container_name} service using Docker image: {image_name}...")
 
-    # Construct the Docker command
-    cmd = ["docker", "run", "-d"]
+    # Prepare port bindings
+    port_bindings = build_port_bindings(ports) if ports else None
 
-    # Add container name
-    cmd.extend(["--name", container_name])
+    # Prepare volume bindings
+    volume_bindings = build_volume_dict(volume_mounts) if volume_mounts else {}
 
-    # Add network if specified
-    if network:
-        cmd.extend(["--network", network])
+    if log_cli:
+        port_parts = [
+            f"-p {p.host_ip}:{p.host_port}:{p.container_port}/{p.protocol}"
+            for p in ports or []
+        ]
+        volume_parts = [
+            f"-v {v.host_path}:{v.container_path}:{v.mode}"
+            for v in volume_mounts or []
+        ]
+        env_parts = [
+            f"-e {key}={value}"
+            for key, value in (environment or {}).items()
+        ]
+        args_str = " ".join(command_args) if command_args else ""
+        parts = [
+            "docker run -d",
+            f"--name {container_name}",
+            f"--network {network}",
+            *port_parts,
+            *volume_parts,
+            *env_parts,
+            image_name,
+            args_str
+        ]
+        cli_command = " ".join(part for part in parts if part.strip())
+        print(f"CLI_COMMAND = {cli_command}")
 
-    # Add port mappings
-    if ports:
-        for host_port, container_port in ports.items():
-            cmd.extend(["-p", f"{host_port}:{container_port}"])
-
-    # Add volume mounts if provided
-    if volumes:
-        for host_path, container_path in volumes.items():
-            cmd.extend(["-v", f"{host_path}:{container_path}"])
-
-    # Add environment variables if provided
-    if environment:
-        for var_name, var_value in environment.items():
-            cmd.extend(["-e", f"{var_name}={var_value}"])
-
-    # Add the image name
-    cmd.append(image_name)
-
-    # Add any additional command arguments
-    if command_args:
-        cmd.extend(command_args)
-
-    # Run the Docker container
     try:
-        # Start the container and get its ID
-        print(f"Running command: {' '.join(cmd)}")
-        container_id = subprocess.check_output(cmd, text=True).strip()
-        print(f"Docker container started with ID: {container_id}")
-
-        # Return a TargetProcess object
-        return DockerProcess(
-            container_id=container_id
+        container = client.containers.run(
+            image=image_name,
+            name=container_name,
+            detach=True,
+            network=network,
+            ports=port_bindings,
+            volumes=volume_bindings,
+            environment=environment,
+            command=command_args
         )
-    except subprocess.CalledProcessError as e:
+        print(f"Docker container started with ID: {container.id}")
+        return DockerProcess(container_id=container.id, client=client, log_cli=log_cli)
+    except DockerException as e:
         print(f"Error launching Docker container: {e}")
-        print(f"Error output: {e.stderr if hasattr(e, 'stderr') else 'No error output'}")
         raise
 
 
-
-def build_docker_image(image_name: str, dockerfile_dir: str) -> str:
+def build_docker_image(
+        image_name: str,
+        dockerfile_dir: str,
+        client: docker.DockerClient,
+        log_build: bool=False,
+        log_cli: bool = False,
+    ) -> str:
     """
     Build a Docker image locally
 
     Args:
         image_name: Name and tag for the Docker image (e.g. "backend-service:latest")
         dockerfile_dir: Directory containing the Dockerfile
+        client: docker api client
+        log_cli: Enable logging the equivalent cli command
 
     Returns:
         str: Name of the built image
     """
     print(f"Building Docker image '{image_name}'...")
 
-    # Get the absolute path to the directory
     dir_path = os.path.abspath(dockerfile_dir)
 
-    # Build the Docker image
+    if log_cli:
+        print(f"CLI_COMMAND = docker build -t {image_name} {dir_path}")
+
     try:
-        cmd = ["docker", "build", "-t", image_name, dir_path]
-        result = subprocess.run(cmd, check=True, capture_output=True, text=True)
-        print(f"Successfully built Docker image: {image_name}")
+        image, build_logs = client.images.build(path=dir_path, tag=image_name, rm=True)
+
+        if log_build:
+            for chunk in build_logs:
+                if 'stream' in chunk:
+                    print(chunk['stream'].strip())
+
+        print(f"Successfully built Docker image: {image.tags}")
         return image_name
-    except subprocess.CalledProcessError as e:
+    except (BuildError, APIError) as e:
         print(f"Error building Docker image '{image_name}': {e}")
-        print(f"Error output: {e.stderr}")
         raise
 
 
-def get_docker_logs(container_id: str) -> str:
+def get_docker_logs(container_id: str, client: docker.DockerClient, log_cli: bool = False) -> str:
     """
     Get logs from a Docker container
 
     Args:
         container_id: ID or name of the Docker container
+        client: docker api client
+        log_cli: Enable logging the equivalent cli command
 
     Returns:
         str: Container logs or empty string if error
     """
+    if log_cli:
+        print(f"CLI_COMMAND = docker logs {container_id}")
     try:
-        cmd = ["docker", "logs", container_id]
-        logs = subprocess.check_output(cmd, text=True)
-        return logs
-    except subprocess.CalledProcessError as e:
+        container = client.containers.get(container_id)
+        logs = container.logs(stdout=True, stderr=True, stream=False, timestamps=False)
+        return logs.decode("utf-8") if isinstance(logs, bytes) else str(logs)
+    except (NotFound, APIError) as e:
         print(f"Error getting Docker container logs: {e}")
-        print(f"Error output: {e.stderr if hasattr(e, 'stderr') else 'No error output'}")
         return ""
 
 
-def cleanup_docker_containers(container_names: List[str]) -> None:
+def cleanup_docker_containers(container_names: List[str], client: docker.DockerClient, log_cli: bool = False) -> None:
     """
     Remove any existing Docker containers with the specified names
 
     Args:
         container_names: List of container names to clean up
+        client: docker api client
+        log_cli: Enable logging the equivalent cli command
+
     """
     print(f"Cleaning up any existing Docker containers with names: {container_names}")
 
     for name in container_names:
         try:
-            # Check if the container exists
-            inspect_cmd = ["docker", "ps", "-a", "-q", "-f", f"name={name}"]
-            container_id = subprocess.run(inspect_cmd, check=True, capture_output=True, text=True).stdout.strip()
+            # Try to get the container by name
+            container = client.containers.get(name)
+            print(f"Removing existing container: {name} (ID: {container.id})")
+            if log_cli:
+                print(f"CLI_COMMAND = docker rm -f {name}")
+            container.remove(force=True)
+        except NotFound:
+            print(f"Container '{name}' not found. Skipping.")
+        except APIError as e:
+            print(f"Error removing container '{name}': {e}. Skipping.")
 
-            if container_id:
-                # Container exists, remove it forcefully
-                print(f"Removing existing container: {name} (ID: {container_id})")
-                rm_cmd = ["docker", "rm", "-f", name]
-                subprocess.run(rm_cmd, check=True, capture_output=True, text=True)
-        except subprocess.CalledProcessError as e:
-            print(f"Error checking/removing container '{name}': {e}")
-            # Continue with other containers
+
+def create_docker_network(network_name: str, client: docker.DockerClient, log_cli: bool = False) -> bool:
+    """
+    Creates a Docker network using the Docker SDK. If the network already exists, it will be reused.
+
+    Args:
+        network_name: a string representing the name of the docker network to use
+        client: docker api client
+        log_cli: Enable logging the equivalent cli command
+    
+    Returns:
+        boolean value indicating if the network is newly created (true) or existing (false)
+    """
+    try:
+        # Check if the network already exists
+        existing_networks = client.networks.list(names=[network_name])
+        if existing_networks:
+            print(f"Using existing Docker network: {network_name}")
+            return False
+
+        # Create the network
+        if log_cli:
+            print(f"CLI_COMMAND = docker network create {network_name}")
+        client.networks.create(name=network_name)
+        print(f"Created Docker network: {network_name}")
+    except APIError as e:
+        print(f"Error creating network: {e}")
+        raise
+
+    return True
+
+
+def delete_docker_network(network_name: str, client: docker.DockerClient, log_cli: bool = False) -> None:
+    """
+    Deletes a Docker network using the Docker SDK.
+    Args:
+        network_name: a string representing the name of the docker network to use
+        client: docker api client
+        log_cli: Enable logging the equivalent cli command
+    If the network does not exist, it will print a warning.
+    """
+    try:
+        network = client.networks.get(network_name)
+        if log_cli:
+            print(f"CLI_COMMAND = docker network rm -f {network_name}")
+        network.remove()
+        print(f"Deleted Docker network: {network_name}")
+    except NotFound:
+        print(f"Docker network '{network_name}' not found.")
+    except APIError as e:
+        print(f"Error removing Docker network: {e}")
+        raise

--- a/tools/pipeline_perf_test/orchestrator/lib/process/utils/docker.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/process/utils/docker.py
@@ -37,7 +37,7 @@ class PortBinding:
 
 def build_volume_dict(volume_mounts: list[VolumeMount]) -> dict:
     """Map a list of VolumeMounts to the format expected by docker api"
-    
+
     Args:
         - volume_mounts: a list of VolumeMount objects specifying mount configs
     """
@@ -49,7 +49,7 @@ def build_volume_dict(volume_mounts: list[VolumeMount]) -> dict:
 
 def build_port_bindings(bindings: list[PortBinding]) -> dict:
     """Map a list of PortBindings to the format expected by docker api"
-    
+
     Args:
         - bindings: a list of PortBindings objects specifying port mapping configs
     """
@@ -239,7 +239,7 @@ def create_docker_network(network_name: str, client: docker.DockerClient, log_cl
         network_name: a string representing the name of the docker network to use
         client: docker api client
         log_cli: Enable logging the equivalent cli command
-    
+
     Returns:
         boolean value indicating if the network is newly created (true) or existing (false)
     """

--- a/tools/pipeline_perf_test/orchestrator/orchestrator.py
+++ b/tools/pipeline_perf_test/orchestrator/orchestrator.py
@@ -1,4 +1,4 @@
-"""Orchestrator is the primary entrypoint for pipeline perf test benchmarking.
+r"""Orchestrator is the primary entrypoint for pipeline perf test benchmarking.
 
 This script orchestrates performance testing for OpenTelemetry (OTel) pipelines by deploying test
 environments  either using Docker or Kubernetes. It sets up and manages test resources, executes
@@ -56,7 +56,9 @@ import time
 from datetime import datetime
 
 # This will get cleaned up when we refactor the test control flow, but for now just import lots of stuff.
-from lib.process.utils.docker import cleanup_docker_containers, build_docker_image, launch_container, get_docker_logs
+import docker
+from lib.process.utils.docker import VolumeMount, PortBinding, cleanup_docker_containers
+from lib.process.utils.docker import build_docker_image, launch_container, get_docker_logs, create_docker_network, delete_docker_network
 from lib.process.utils.kubernetes import create_k8s_namespace, deploy_kubernetes_resources, run_k8s_loadgen, setup_k8s_port_forwarding
 from lib.report.report import get_report_string, parse_logs_for_sent_count
 
@@ -65,6 +67,7 @@ def main():
     parser.add_argument("--duration", type=int, default=10, help="Duration to perform perf test in seconds")
     parser.add_argument("--keep-resources", action="store_true", help="Don't delete resources after test. Useful for debugging.")
     parser.add_argument("--results-dir", type=str, default="./results", help="Directory to store test results")
+    parser.add_argument("--log-cli-commands", action="store_true", help="Log the equivalent docker / kubetcl cli commands executed. Useful for debugging.")
 
     # Deployment target choice
     parser.add_argument("--deployment-target", type=str, choices=["docker", "kubernetes"], default="docker",
@@ -110,69 +113,78 @@ def main():
     try:
         print("\nRunning perf tests...")
 
+        docker_client = None
+        if not args.skip_backend_build or not args.skip_loadgen_build:
+            print("Building container images(s)...")
+            docker_client = docker.from_env()
+            # Build the backend Docker image if not skipped
+            backend_image = "backend-service:latest"
+            if not args.skip_backend_build:
+                backend_image = build_docker_image(backend_image, "backend", docker_client, log_cli=args.log_cli_commands)
+            else:
+                print(f"Using existing backend image: {backend_image}")
+
+            # Build the loadgen Docker image if not skipped
+            loadgen_image = "otel-loadgen:latest"
+            if not args.skip_loadgen_build:
+                loadgen_image = build_docker_image(loadgen_image, "load_generator", docker_client, log_cli=args.log_cli_commands)
+
         if args.deployment_target == "docker":
+            if not docker_client:
+                docker_client = docker.from_env()
             # Clean up any existing containers with the same names we'll use
-            cleanup_docker_containers(["backend-service", "otel-collector", "otel-loadgen"])
+            cleanup_docker_containers(["backend-service", "otel-collector", "otel-loadgen"], docker_client, log_cli=args.log_cli_commands)
 
             # Docker deployment flow
             # Create a Docker network for inter-container communication
             network = "perf-test-network"
-            try:
-                subprocess.run(["docker", "network", "create", network], check=True, capture_output=True)
-                print(f"Created Docker network: {network}")
-                network_created = True
-            except subprocess.CalledProcessError as e:
-                if "already exists" not in str(e.stderr):
-                    print(f"Error creating network: {e}")
-                    print(f"Error output: {e.stderr}")
-                    raise
-                print(f"Using existing Docker network: {network}")
+            network_created = create_docker_network(network, docker_client, log_cli=args.log_cli_commands)
 
-            # Build the backend Docker image if not skipped
-            backend_image = "backend-service:latest"
-            if not args.skip_backend_build:
-                backend_image = build_docker_image(backend_image, "backend")
-            else:
-                print(f"Using existing backend image: {backend_image}")
 
+            backend_ports = [
+                PortBinding(container_port=5317, host_port=5317),
+                PortBinding(container_port=5000, host_port=5000),
+            ]
             # Launch the backend service as a Docker container
             backend_process = launch_container(
                 image_name=backend_image,
                 container_name="backend-service",
-                ports={"5317": "5317", "5000": "5000"},
-                network=network
+                client=docker_client,
+                ports=backend_ports,
+                network=network,
+                log_cli=args.log_cli_commands
             )
 
             # Give it a moment to initialize
             time.sleep(2)
 
             # Prepare collector config mounting
-            collector_volumes = {}
             collector_cmd_args = []
             abs_config_path = os.path.abspath(args.collector_config)
             config_dir = os.path.dirname(abs_config_path)
             config_filename = os.path.basename(abs_config_path)
-            collector_volumes[config_dir] = "/etc/otel/config:ro"
+            collector_volumes = [VolumeMount(config_dir,"/etc/otel/config","ro")]
             collector_cmd_args = ["--config", f"/etc/otel/config/{config_filename}"]
 
+
+            collector_ports = [
+                PortBinding(container_port=4317, host_port=4317),
+            ]
             # Launch the collector
             collector_image = "otel/opentelemetry-collector:latest"
             target_process = launch_container(
                 image_name=collector_image,
                 container_name="otel-collector",
-                ports={"4317": "4317"},
+                client=docker_client,
+                ports=collector_ports,
                 network=network,
-                volumes=collector_volumes,
-                command_args=collector_cmd_args
+                volume_mounts=collector_volumes,
+                command_args=collector_cmd_args,
+                log_cli=args.log_cli_commands
             )
 
             # Give it a moment to initialize
             time.sleep(2)
-
-            # Build the loadgen Docker image if not skipped
-            loadgen_image = "otel-loadgen:latest"
-            if not args.skip_loadgen_build:
-                loadgen_image = build_docker_image(loadgen_image, "load_generator")
 
             # Run the load generator using Docker
             print("Starting load generator using Docker...")
@@ -182,9 +194,11 @@ def main():
             loadgen_process = launch_container(
                 image_name=loadgen_image,
                 container_name="otel-loadgen",
+                client=docker_client,
                 network=network,
                 environment=loadgen_env,
-                command_args=["--duration", str(args.duration)]
+                command_args=["--duration", str(args.duration)],
+                log_cli=args.log_cli_commands
             )
 
             # Start monitoring once the load generator is built and launched
@@ -194,39 +208,29 @@ def main():
             # Wait for the loadgen container to finish (it runs for the specified duration)
             print(f"Waiting for load generator to finish (running for {args.duration}s)...")
 
-            try:
-                # Let the load run for the specified duration
-                time.sleep(args.duration)
-                # Stop monitoring immediately to avoid recording idle stats.
-                # Eventually this should be based on active signaling that the test load is done rather than timers.
-                target_process.stop_monitoring()
-                # Add 5 seconds buffer
-                time.sleep(5)
-                target_process_stats = target_process.get_stats()
+            # Let the load run for the specified duration
+            time.sleep(args.duration)
+            # Stop monitoring immediately to avoid recording idle stats.
+            # Eventually this should be based on active signaling that the test load is done rather than timers.
+            target_process.stop_monitoring()
+            # Add 5 seconds buffer
+            time.sleep(5)
+            target_process_stats = target_process.get_stats()
 
-                # Get logs from the container (which should have finished by now)
-                print("Getting logs from load generator container...")
-                logs = get_docker_logs(loadgen_process.container_id)
+            # Get logs from the container (which should have finished by now)
+            print("Getting logs from load generator container...")
+            logs = get_docker_logs(loadgen_process.container_id, docker_client, log_cli=args.log_cli_commands)
 
-                # Parse the output to extract logs sent count and failed count
-                logs_sent_count, logs_failed_count = parse_logs_for_sent_count(logs)
+            # Parse the output to extract logs sent count and failed count
+            logs_sent_count, logs_failed_count = parse_logs_for_sent_count(logs)
 
-                if logs_sent_count > 0:
-                    print(f"Load generator completed. Sent {logs_sent_count} logs, Failed {logs_failed_count} logs")
-
-            except subprocess.CalledProcessError as e:
-                print(f"Error getting logs from load generator container: {e}")
+            if logs_sent_count > 0:
+                print(f"Load generator completed. Sent {logs_sent_count} logs, Failed {logs_failed_count} logs")
+            else:
                 logs_sent_count = -1
                 logs_failed_count = 0
 
         else:
-            # Build the backend Docker image if not skipped
-            backend_image = "backend-service:latest"
-            if not args.skip_backend_build:
-                backend_image = build_docker_image(backend_image, "backend")
-            else:
-                print(f"Using existing backend image: {backend_image}")
-
             # Create namespace if it doesn't exist
             if not create_k8s_namespace(args.k8s_namespace):
                 print("Failed to create or confirm Kubernetes namespace. Exiting.")
@@ -317,10 +321,7 @@ def main():
                 if loadgen_process:
                     loadgen_process.shutdown()
                 if network_created:
-                    try:
-                        subprocess.run(["docker", "network", "rm", "perf-test-network"], check=True, capture_output=True)
-                    except subprocess.CalledProcessError as e:
-                        print(f"Error removing Docker network: {e}")
+                    delete_docker_network(network, docker_client)
             else:
                 # Cleanup Kubernetes resources
                 # First terminate port forwarding if it's active


### PR DESCRIPTION
This PR switches out the subprocess based docker CLI calls to use the python docker api client library. A new flag is added to enable printing equivalent CLI commands for all interactions to assist with debugging.

Functionality should be equivalent to previous version, biggest change is moving away from the string based process metrics parsing and relying on the stats api results directly.

Small additional refactor to group any image building as the first step to make client initialization logic more friendly.