### PR TITLE
Upgrade arrow and arrow-ipc to v55

### DIFF
--- a/rust/otel-arrow-rust/Cargo.toml
+++ b/rust/otel-arrow-rust/Cargo.toml
@@ -22,8 +22,8 @@ trace = []
 derive = []
 
 [dependencies]
-arrow = "53"
-arrow-ipc = { version = "53", features = ["zstd"] }
+arrow = "55"
+arrow-ipc = { version = "55", features = ["zstd"] }
 ciborium = "0.2.2"
 lazy_static = "1.5"
 num_enum = "0.7"


### PR DESCRIPTION
Manual replacement for #460 and #461. Those Renovate PRs don't pass CI because the upgrades must be done together.

An inner dependency of Arrow had a breaking change - for more information see [arrow-rs #7196](https://github.com/apache/arrow-rs/issues/7196).