### PR TITLE
Perf - Orchestrator restructuring phase1

### DIFF
--- a/tools/pipeline_perf_test/orchestrator/lib/core/__init__.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/__init__.py
@@ -1,0 +1,1 @@
+"""Initialization for the core package."""

--- a/tools/pipeline_perf_test/orchestrator/lib/core/context/__init__.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/context/__init__.py
@@ -1,0 +1,6 @@
+"""Initialization for the core.context package."""
+from .base import BaseContext
+
+__all__ = [
+    "BaseContext",
+]

--- a/tools/pipeline_perf_test/orchestrator/lib/core/context/__init__.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/context/__init__.py
@@ -1,4 +1,5 @@
 """Initialization for the core.context package."""
+
 from .base import BaseContext
 
 __all__ = [

--- a/tools/pipeline_perf_test/orchestrator/lib/core/context/base.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/context/base.py
@@ -1,0 +1,27 @@
+"""
+Module: context
+
+This module provides the BaseContext class which provides shared fields common to
+different implementations of Contexts throughout the orchestrator.
+"""
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class BaseContext:
+    """
+    Base context class which includes common timing, status, metadata fields.
+    """
+    status: Optional[str] = field(init=False)
+    error: Optional[Exception] = field(init=False)
+    start_time: Optional[float] = field(init=False)
+    end_time: Optional[float] = field(init=False)
+    metadata: dict = field(default_factory=dict, init=False)
+
+    # Prevent initialization ordering errors for non-default fields in inheriting class.
+    def __post_init__(self):
+        self.status = None
+        self.error = None
+        self.start_time = None
+        self.end_time = None

--- a/tools/pipeline_perf_test/orchestrator/lib/core/context/base.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/context/base.py
@@ -4,6 +4,7 @@ Module: context
 This module provides the BaseContext class which provides shared fields common to
 different implementations of Contexts throughout the orchestrator.
 """
+
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -13,6 +14,7 @@ class BaseContext:
     """
     Base context class which includes common timing, status, metadata fields.
     """
+
     status: Optional[str] = field(init=False)
     error: Optional[Exception] = field(init=False)
     start_time: Optional[float] = field(init=False)

--- a/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/__init__.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/__init__.py
@@ -1,0 +1,14 @@
+"""Initialization for the core.test_framework package."""
+from .test_definition import TestDefinition
+from .test_step import TestStep
+from .test_suite import TestSuite
+from .test_context import TestSuiteContext, TestExecutionContext, TestStepContext
+
+__all__ = [
+    "TestSuite",
+    "TestDefinition",
+    "TestStep",
+    "TestSuiteContext",
+    "TestExecutionContext",
+    "TestStepContext"
+]

--- a/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/__init__.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/__init__.py
@@ -1,4 +1,5 @@
 """Initialization for the core.test_framework package."""
+
 from .test_definition import TestDefinition
 from .test_step import TestStep
 from .test_suite import TestSuite
@@ -10,5 +11,5 @@ __all__ = [
     "TestStep",
     "TestSuiteContext",
     "TestExecutionContext",
-    "TestStepContext"
+    "TestStepContext",
 ]

--- a/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_context.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_context.py
@@ -1,0 +1,79 @@
+"""
+Module: test_context
+
+This module defines the core context classes used for managing state and shared data throughout
+the lifecycle of a test suite execution. These context classes enable structured access to components
+and metadata at different granularities: suite-wide, per-test, and per-step.
+
+Classes:
+    TestSuiteContext:
+        Holds global state for a test suite run, including shared components and metadata.
+        Provides methods to register and retrieve components by name.
+
+    TestExecutionContext:
+        Represents the execution context for a single TestDefinition.
+        Tracks execution metadata (timing, status, errors) and maintains access to the suite-level context.
+        Allows per-test interaction with shared components.
+
+    TestStepContext:
+        Represents the execution context for an individual test step within a test.
+        Provides access to the parent test and suite contexts, as well as step-level status and metadata.
+
+Each context layer provides helper methods to retrieve components by name, ensuring consistent
+access across the execution lifecycle.
+"""
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, TYPE_CHECKING
+
+from ..component.lifecycle_component import LifecycleComponent
+from ..context.base import BaseContext
+
+if TYPE_CHECKING:
+    from .test_definition import TestDefinition
+    from .test_step import TestStep
+
+
+@dataclass
+class TestSuiteContext(BaseContext):
+    """
+    Holds global state for a test suite run, including all shared components.
+    """
+    components: Dict[str, LifecycleComponent] = field(default_factory=dict)
+    metadata: dict = field(default_factory=dict)
+
+    def add_component(self, name: str, component: LifecycleComponent):
+        "Add a component to the test suite context by name"
+        self.components[name] = component
+
+    def get_component(self, name: str) -> Optional[LifecycleComponent]:
+        "Cat a component from the test suite context by name"
+        return self.components.get(name)
+
+
+@dataclass
+class TestExecutionContext(BaseContext):
+    """
+    Context for executing a single TestDefinition, scoped per test.
+    """
+    test_definition: "TestDefinition"
+    suite_context: "TestSuiteContext"
+    step_contexts: List["TestStepContext"] = field(default_factory=list)
+
+    def get_component(self, name: str) -> Optional[LifecycleComponent]:
+        "Cat a component from the test suite context by name"
+        return self.suite_context.get_component(name)
+
+
+@dataclass
+class TestStepContext(BaseContext):
+    """
+    Context for an individual test step execution.
+    """
+    step: "TestStep"
+    test_definition: "TestDefinition"
+    test_context: "TestExecutionContext"
+
+    def get_component(self, name: str) -> Optional[LifecycleComponent]:
+        "Cat a component from the test suite context by name"
+        return self.test_context.suite_context.get_component(name)

--- a/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_context.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_context.py
@@ -22,6 +22,7 @@ Classes:
 Each context layer provides helper methods to retrieve components by name, ensuring consistent
 access across the execution lifecycle.
 """
+
 from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, TYPE_CHECKING
@@ -39,6 +40,7 @@ class TestSuiteContext(BaseContext):
     """
     Holds global state for a test suite run, including all shared components.
     """
+
     components: Dict[str, LifecycleComponent] = field(default_factory=dict)
     metadata: dict = field(default_factory=dict)
 
@@ -56,6 +58,7 @@ class TestExecutionContext(BaseContext):
     """
     Context for executing a single TestDefinition, scoped per test.
     """
+
     test_definition: "TestDefinition"
     suite_context: "TestSuiteContext"
     step_contexts: List["TestStepContext"] = field(default_factory=list)
@@ -70,6 +73,7 @@ class TestStepContext(BaseContext):
     """
     Context for an individual test step execution.
     """
+
     step: "TestStep"
     test_definition: "TestDefinition"
     test_context: "TestExecutionContext"

--- a/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_context.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_context.py
@@ -47,7 +47,7 @@ class TestSuiteContext(BaseContext):
         self.components[name] = component
 
     def get_component(self, name: str) -> Optional[LifecycleComponent]:
-        "Cat a component from the test suite context by name"
+        "Get a component from the test suite context by name"
         return self.components.get(name)
 
 
@@ -61,7 +61,7 @@ class TestExecutionContext(BaseContext):
     step_contexts: List["TestStepContext"] = field(default_factory=list)
 
     def get_component(self, name: str) -> Optional[LifecycleComponent]:
-        "Cat a component from the test suite context by name"
+        "Get a component from the test suite context by name"
         return self.suite_context.get_component(name)
 
 
@@ -75,5 +75,5 @@ class TestStepContext(BaseContext):
     test_context: "TestExecutionContext"
 
     def get_component(self, name: str) -> Optional[LifecycleComponent]:
-        "Cat a component from the test suite context by name"
+        "Get a component from the test suite context by name"
         return self.test_context.suite_context.get_component(name)

--- a/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_definition.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_definition.py
@@ -1,0 +1,117 @@
+"""
+Module: test_definition
+
+This module defines the `TestDefinition` class, which encapsulates a test scenario in a load generation
+testbed. The `TestDefinition` class allows for defining a sequence of test steps, executing them, and
+reporting the results through specified reporting strategies.
+
+The class provides the functionality to aggregate monitoring data during the test execution and apply
+different reporting strategies to the results.
+
+Classes:
+    TestDefinition: A class that defines a test, including the steps to run and the reporting strategies to use.
+"""
+import time
+from typing import List, Dict
+
+from .test_context import TestExecutionContext, TestStepContext
+from .test_step import TestStep
+from ..strategies.reporting_strategy import ReportingStrategy
+
+
+class TestDefinition:
+    """
+    A class that defines a test scenario, including its steps and reporting strategies.
+
+    The `TestDefinition` class encapsulates the details of a test, including the steps to execute and
+    the reporting strategies to use after the test has run. It provides the functionality to run the test,
+    aggregate monitoring data from components, and report the results using different strategies.
+
+    Attributes:
+        name (str): The name of the test.
+        steps (List[TestStep]): A list of test steps to be executed in sequence.
+        reporting_strategies (List[ReportingStrategy]): A list of reporting strategies used to report results.
+
+    Methods:
+        run(context): Executes the test, runs the test steps, and reports results using the specified strategies.
+        aggregate_monitoring_data(context): Collects and aggregates monitoring data from all components.
+    """
+    def __init__(self, name: str, steps: List[TestStep], reporting_strategies: List[ReportingStrategy] = None):
+        """
+        Initializes the test definition with the given name, steps, and reporting strategies.
+
+        Args:
+            name (str): The name of the test.
+            steps (List[TestStep]): A list of test steps to be executed in sequence.
+            reporting_strategies (List[ReportingStrategy], optional): A list of reporting strategies to apply
+                                                                     after the test. Defaults to an empty list.
+        """
+        self.name = name
+        self.steps = steps
+        self.reporting_strategies = reporting_strategies or []
+        self.context = None
+
+    def run(self, context: TestExecutionContext):
+        """
+        Executes the test by running all its steps and then reporting the results.
+
+        This method prints the test name, executes each test step in sequence, and collects aggregated monitoring
+        data from all components. Afterward, it reports the aggregated results using the provided reporting strategies.
+
+        Args:
+            context (Context): The context that contains all the components and relevant data for the test.
+        """
+        print(f"Running test: {self.name}")
+        context.start_time = time.time()
+        for step in self.steps:
+            step_ctx = TestStepContext(
+                step=step,
+                test_definition=self,
+                test_context=context,
+            )
+            try:
+                step_ctx.start_time = time.time()
+                step.run(step_ctx)
+                step_ctx.status = "success"
+            except Exception as e:
+                step_ctx.status = "error"
+                step_ctx.error = e
+                print(f"Step '{step.name}' failed: {e}")
+                #TODO: Depending on policy: break or continue
+                break
+            finally:
+                step_ctx.end_time = time.time()
+
+        context.step_contexts.append(step_ctx)
+        context.end_time = time.time()
+
+        # Report using all reporting strategies
+        aggregated_data = self.aggregate_monitoring_data(context)
+        for strategy in self.reporting_strategies:
+            strategy.report(aggregated_data)
+
+    def aggregate_monitoring_data(self, context) -> Dict[str, Dict[str, any]]:
+        """
+        Aggregates monitoring data from all components in the context.
+
+        This method collects monitoring data from each component in the provided context and combines it
+        into a single dictionary, where the keys are component names and the values are the respective
+        monitoring data.
+
+        Args:
+            context (Context): The context containing all components and their monitoring data.
+
+        Returns:
+            Dict[str, Dict[str, any]]: A dictionary of aggregated monitoring data, indexed by component name.
+        """
+        aggregated_data = {}
+
+        # Collect data from each component
+        for component_name, component in context.suite_context.components.items():
+            # Collect the monitoring data from the component
+            collected_data = component.collect_monitoring_data()
+
+            # Aggregate it by component name
+            aggregated_data[component_name] = collected_data
+
+        return aggregated_data

--- a/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_definition.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_definition.py
@@ -59,7 +59,7 @@ class TestDefinition:
         data from all components. Afterward, it reports the aggregated results using the provided reporting strategies.
 
         Args:
-            context (Context): The context that contains all the components and relevant data for the test.
+            context (TestExecutionContext): The context that contains all the components and relevant data for the test.
         """
         print(f"Running test: {self.name}")
         context.start_time = time.time()
@@ -99,7 +99,7 @@ class TestDefinition:
         monitoring data.
 
         Args:
-            context (Context): The context containing all components and their monitoring data.
+            context (TestExecutionContext): The context containing all components
 
         Returns:
             Dict[str, Dict[str, any]]: A dictionary of aggregated monitoring data, indexed by component name.

--- a/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_definition.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_definition.py
@@ -12,7 +12,7 @@ Classes:
     TestDefinition: A class that defines a test, including the steps to run and the reporting strategies to use.
 """
 import time
-from typing import List, Dict
+from typing import Any, Dict, List, Optional
 
 from .test_context import TestExecutionContext, TestStepContext
 from .test_step import TestStep
@@ -36,7 +36,7 @@ class TestDefinition:
         run(context): Executes the test, runs the test steps, and reports results using the specified strategies.
         aggregate_monitoring_data(context): Collects and aggregates monitoring data from all components.
     """
-    def __init__(self, name: str, steps: List[TestStep], reporting_strategies: List[ReportingStrategy] = None):
+    def __init__(self, name: str, steps: List[TestStep], reporting_strategies: Optional[List[ReportingStrategy]] = None):
         """
         Initializes the test definition with the given name, steps, and reporting strategies.
 
@@ -90,7 +90,7 @@ class TestDefinition:
         for strategy in self.reporting_strategies:
             strategy.report(aggregated_data)
 
-    def aggregate_monitoring_data(self, context) -> Dict[str, Dict[str, any]]:
+    def aggregate_monitoring_data(self, context) -> Dict[str, Dict[str, Any]]:
         """
         Aggregates monitoring data from all components in the context.
 

--- a/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_definition.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_definition.py
@@ -11,6 +11,7 @@ different reporting strategies to the results.
 Classes:
     TestDefinition: A class that defines a test, including the steps to run and the reporting strategies to use.
 """
+
 import time
 from typing import Any, Dict, List, Optional
 
@@ -36,7 +37,13 @@ class TestDefinition:
         run(context): Executes the test, runs the test steps, and reports results using the specified strategies.
         aggregate_monitoring_data(context): Collects and aggregates monitoring data from all components.
     """
-    def __init__(self, name: str, steps: List[TestStep], reporting_strategies: Optional[List[ReportingStrategy]] = None):
+
+    def __init__(
+        self,
+        name: str,
+        steps: List[TestStep],
+        reporting_strategies: Optional[List[ReportingStrategy]] = None,
+    ):
         """
         Initializes the test definition with the given name, steps, and reporting strategies.
 
@@ -77,7 +84,7 @@ class TestDefinition:
                 step_ctx.status = "error"
                 step_ctx.error = e
                 print(f"Step '{step.name}' failed: {e}")
-                #TODO: Depending on policy: break or continue
+                # TODO: Depending on policy: break or continue
                 break
             finally:
                 step_ctx.end_time = time.time()

--- a/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_step.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_step.py
@@ -30,13 +30,13 @@ class TestStep:
     Methods:
         run(context): Executes the action associated with the test step, providing the context to the action.
     """
-    def __init__(self, name: str, action: Callable):
+    def __init__(self, name: str, action: Callable[[TestStepContext], any]):
         """
         Initializes a test step with a name and an associated action.
 
         Args:
             name (str): The name of the test step.
-            action (Callable): A callable function that defines the action to execute when the test step is run.
+            action (Callable[[TestStepContext], any]): A callable function that defines the action to execute when the test step is run.
         """
         self.name = name
         self.action = action

--- a/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_step.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_step.py
@@ -11,7 +11,7 @@ Classes:
     TestStep: A class representing a single step in a test, which includes a name and an action to execute.
 """
 import time
-from typing import Callable
+from typing import Any, Callable
 
 from .test_context import TestStepContext
 
@@ -30,7 +30,7 @@ class TestStep:
     Methods:
         run(context): Executes the action associated with the test step, providing the context to the action.
     """
-    def __init__(self, name: str, action: Callable[[TestStepContext], any]):
+    def __init__(self, name: str, action: Callable[[TestStepContext], Any]):
         """
         Initializes a test step with a name and an associated action.
 

--- a/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_step.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_step.py
@@ -10,6 +10,7 @@ test steps are executed in sequence to complete a full test.
 Classes:
     TestStep: A class representing a single step in a test, which includes a name and an action to execute.
 """
+
 import time
 from typing import Any, Callable
 
@@ -30,6 +31,7 @@ class TestStep:
     Methods:
         run(context): Executes the action associated with the test step, providing the context to the action.
     """
+
     def __init__(self, name: str, action: Callable[[TestStepContext], Any]):
         """
         Initializes a test step with a name and an associated action.

--- a/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_step.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_step.py
@@ -1,0 +1,71 @@
+"""
+Module: test_step
+
+This module defines the `TestStep` class, which represents a single step in a test execution sequence.
+Each test step has a name and an associated action (a callable function) that is executed when the step is run.
+
+The `TestStep` class is designed to be used within the broader context of a test definition, where multiple
+test steps are executed in sequence to complete a full test.
+
+Classes:
+    TestStep: A class representing a single step in a test, which includes a name and an action to execute.
+"""
+import time
+from typing import Callable
+
+from .test_context import TestStepContext
+
+
+class TestStep:
+    """
+    Represents a single step in a test execution sequence.
+
+    A test step consists of a name and an associated action, which is a callable function that is executed
+    when the step is run. Test steps are typically used in a sequence to build up the logic for a complete test.
+
+    Attributes:
+        name (str): The name of the test step.
+        action (Callable): The action (a callable function) to be executed for this test step.
+
+    Methods:
+        run(context): Executes the action associated with the test step, providing the context to the action.
+    """
+    def __init__(self, name: str, action: Callable):
+        """
+        Initializes a test step with a name and an associated action.
+
+        Args:
+            name (str): The name of the test step.
+            action (Callable): A callable function that defines the action to execute when the test step is run.
+        """
+        self.name = name
+        self.action = action
+
+    def run(self, context: TestStepContext):
+        """
+        Executes the action associated with the test step.
+
+        This method prints the name of the test step and then runs the action, passing the provided context
+        to the action.
+
+        Args:
+            context (Context): The context containing data and components to be used during the step execution.
+
+        Returns:
+            The result of the action execution, which is whatever is returned by the action callable.
+        """
+        print(f"Running step: {self.name}")
+        result = None
+        context.start_time = time.time()
+        try:
+            result = self.action(context)
+            context.status = "success"
+        except Exception as e:
+            context.status = "error"
+            context.error = e
+            print(f"Error in step '{self.name}': {e}")
+            raise  # Optional: re-raise to propagate to the test level
+        finally:
+            context.end_time = time.time()
+
+        return result

--- a/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_suite.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_suite.py
@@ -24,13 +24,12 @@ class TestSuite:
     A test suite class for managing and executing a series of tests on a set of components.
 
     The `TestSuite` class is designed to execute a list of tests on a set of components. Each test is provided
-    with a `Context` that contains all components, enabling the test to interact with and manipulate the components
-    during execution.
+    with a `TestExecutionContext` that contains all components, enabling the test to interact with and
+    manipulate the components during execution.
 
     Attributes:
         tests (List[TestDefinition]): A list of test definitions that define the tests to run.
         components (Dict[str, Component]): A dictionary of components, indexed by their names.
-        context (Context): A context object that stores and manages the components for the test suite.
 
     Methods:
         run(): Executes all the tests in the test suite, providing each test with the necessary context.

--- a/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_suite.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_suite.py
@@ -12,6 +12,7 @@ Classes:
     TestSuite: A class that manages a collection of tests and components, runs the tests, and provides
     context to each test.
 """
+
 from typing import List, Dict
 
 from .test_definition import TestDefinition
@@ -34,7 +35,10 @@ class TestSuite:
     Methods:
         run(): Executes all the tests in the test suite, providing each test with the necessary context.
     """
-    def __init__(self, tests: List[TestDefinition], components: Dict[str, LifecycleComponent]):
+
+    def __init__(
+        self, tests: List[TestDefinition], components: Dict[str, LifecycleComponent]
+    ):
         """
         Initializes the test suite with a list of tests and a dictionary of components.
 
@@ -61,7 +65,6 @@ class TestSuite:
         """
         for test_definition in self.tests:
             test_execution_context = TestExecutionContext(
-                test_definition=test_definition,
-                suite_context=self.context
+                test_definition=test_definition, suite_context=self.context
             )
             test_definition.run(test_execution_context)

--- a/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_suite.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_suite.py
@@ -1,0 +1,68 @@
+"""
+Module: test_suite
+
+This module defines the `TestSuite` class, which is responsible for managing and running a series of tests
+on a set of components. It allows the execution of multiple tests in a sequence, providing the necessary
+context and components to each test.
+
+The `TestSuite` class organizes tests and components, managing their execution in a structured manner.
+Each test is provided with a context that includes all the components needed for the test to run.
+
+Classes:
+    TestSuite: A class that manages a collection of tests and components, runs the tests, and provides
+    context to each test.
+"""
+from typing import List, Dict
+
+from .test_definition import TestDefinition
+from ..component.lifecycle_component import LifecycleComponent
+from .test_context import TestSuiteContext, TestExecutionContext
+
+
+class TestSuite:
+    """
+    A test suite class for managing and executing a series of tests on a set of components.
+
+    The `TestSuite` class is designed to execute a list of tests on a set of components. Each test is provided
+    with a `Context` that contains all components, enabling the test to interact with and manipulate the components
+    during execution.
+
+    Attributes:
+        tests (List[TestDefinition]): A list of test definitions that define the tests to run.
+        components (Dict[str, Component]): A dictionary of components, indexed by their names.
+        context (Context): A context object that stores and manages the components for the test suite.
+
+    Methods:
+        run(): Executes all the tests in the test suite, providing each test with the necessary context.
+    """
+    def __init__(self, tests: List[TestDefinition], components: Dict[str, LifecycleComponent]):
+        """
+        Initializes the test suite with a list of tests and a dictionary of components.
+
+        This constructor sets up the test suite by storing the tests and components, and initializing
+        a `Context` to manage the components during test execution.
+
+        Args:
+            tests (List[TestDefinition]): The list of test definitions to be executed in the test suite.
+            components (Dict[str, Component]): A dictionary of components to be used in the tests.
+        """
+        self.tests = tests
+        self.components = components
+        self.context = TestSuiteContext()
+        for k, v in components.items():
+            self.context.add_component(k, v)
+
+    def run(self):
+        """
+        Run all tests in the test suite.
+
+        This method iterates through the list of tests and runs each one, passing the context object
+        to each test. The context provides access to the components, allowing the test to interact
+        with them as needed.
+        """
+        for test_definition in self.tests:
+            test_execution_context = TestExecutionContext(
+                test_definition=test_definition,
+                suite_context=self.context
+            )
+            test_definition.run(test_execution_context)


### PR DESCRIPTION
This is the first of several PRs that will perform additional refactoring on the orchestrator module, with the goal being to enhance / standardize the test and component orchestration and related control flows. The diagram below lays out roughly the planned structure (we'll continue to iterate on this). The first PR includes core Test*/Context models (left side of the diargram). The next PR will introduce the component / strategy models. And a final PR(s) will migrate the existing functionality over to this new structure.

![structure](https://github.com/user-attachments/assets/017d7e7d-fc7b-4d23-ba34-224cfb26633b)
