### PR TITLE
Orchestrator refactor phase2

### DIFF
--- a/tools/pipeline_perf_test/orchestrator/lib/core/component/__init__.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/component/__init__.py
@@ -1,0 +1,1 @@
+"""Initialization for the core.component package."""

--- a/tools/pipeline_perf_test/orchestrator/lib/core/component/lifecycle_component.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/component/lifecycle_component.py
@@ -36,7 +36,7 @@ class LifecyclePhase(Enum):
     """
     Enum representing the various phases in the lifecycle of a component.
 
-    These phases correspond to different stages of the component’s lifecycle, where hooks can be registered
+    These phases correspond to different stages of the component's lifecycle, where hooks can be registered
     and executed to perform actions before or after a phase is executed. These phases help manage the
     orchestration of components during test execution.
 

--- a/tools/pipeline_perf_test/orchestrator/lib/core/component/lifecycle_component.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/component/lifecycle_component.py
@@ -1,0 +1,177 @@
+"""
+Module: lifecycle_component
+
+This module defines the abstract base class `LifecycleComponent`, which serves as a blueprint for components
+in a load generation test orchestrator. It provides hooks for various lifecycle phases such as configuration,
+deployment, starting, stopping, and destruction, allowing for custom behavior during these phases.
+
+Components derived from `LifecycleComponent` must implement the lifecycle methods (`configure`, `deploy`,
+`start`, `stop`, and `destroy`) and can register hooks to be executed at specific points in the lifecycle.
+
+Classes:
+    LifecyclePhase: An enumeration of the different phases in the lifecycle of a component.
+    LifecycleComponent: An abstract base class that defines the structure for components with lifecycle hooks.
+"""
+
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable, Dict, List, Optional, Any
+
+from ..context.base import BaseContext
+
+
+@dataclass
+class LifecycleHookContext(BaseContext):
+    """
+    Holds state for a test hook execution.
+    """
+
+    component: Optional["LifecycleComponent"] = None
+    phase: Optional["LifecyclePhase"] = None
+
+
+class LifecyclePhase(Enum):
+    """
+    Enum representing the various phases in the lifecycle of a component.
+
+    These phases correspond to different stages of the component’s lifecycle, where hooks can be registered
+    and executed to perform actions before or after a phase is executed. These phases help manage the
+    orchestration of components during test execution.
+
+    Phases include:
+        - PRE_CONFIGURE, POST_CONFIGURE
+        - PRE_DEPLOY, POST_DEPLOY
+        - PRE_START, POST_START
+        - PRE_STOP, POST_STOP
+        - PRE_DESTROY, POST_DESTROY
+        - PRE_START_MONITORING, POST_START_MONITORING
+        - PRE_STOP_MONITORING, POST_STOP_MONITORING
+    """
+
+    PRE_CONFIGURE = "pre_configure"
+    POST_CONFIGURE = "post_configure"
+    PRE_DEPLOY = "pre_deploy"
+    POST_DEPLOY = "post_deploy"
+    PRE_START = "pre_start"
+    POST_START = "post_start"
+    PRE_STOP = "pre_stop"
+    POST_STOP = "post_stop"
+    PRE_DESTROY = "pre_destroy"
+    POST_DESTROY = "post_destroy"
+    PRE_START_MONITORING = "pre_start_monitoring"
+    POST_START_MONITORING = "post_start_monitoring"
+    PRE_STOP_MONITORING = "pre_stop_monitoring"
+    POST_STOP_MONITORING = "post_stop_monitoring"
+
+
+class LifecycleComponent(ABC):
+    """
+    Abstract base class for components within a load generation test orchestrator.
+
+    This class provides a mechanism for registering and executing hooks at various lifecycle phases, allowing
+    subclasses to define specific behaviors during phases such as configuration, deployment, starting, stopping,
+    and destruction. Subclasses are required to implement the lifecycle methods (`configure`, `deploy`, `start`,
+    `stop`, and `destroy`).
+
+    Components can register hooks that will be executed during specific lifecycle phases. Hooks are callable
+    functions that are executed when a particular phase occurs, enabling custom actions at various points in the
+    lifecycle.
+
+    Attributes:
+        _hooks (Dict[LifecyclePhase, List[Callable]]): A registry of hooks for each lifecycle phase,
+                                                       where the key is the phase and the value is a list of
+                                                       callable functions to execute during that phase.
+
+    Methods:
+        add_hook(phase, hook): Registers a hook function to be executed during a specified lifecycle phase.
+        _run_hooks(phase): Executes all hooks that have been registered for a specified lifecycle phase.
+        configure(): Abstract method to be implemented by subclasses for configuring the component.
+        deploy(): Abstract method to be implemented by subclasses for deploying the component.
+        start(): Abstract method to be implemented by subclasses for starting the component.
+        stop(): Abstract method to be implemented by subclasses for stopping the component.
+        destroy(): Abstract method to be implemented by subclasses for destroying the component.
+        start_monitoring(): Abstract method to be implemented by subclasses to start monitoring the component.
+        stop_monitoring(): Abstract method to be implemented by subclasses to stop monitoring the component.
+        collect_monitoring_data(): Abstract method to be implemented by subclasses to collect monitoring data for the component.
+    """
+
+    def __init__(self):
+        """
+        Initializes the LifecycleComponent instance by setting up an empty hook registry.
+
+        The hook registry maps lifecycle phases to lists of hook functions (callables). Hooks
+        can be added to different phases, and when those phases are triggered, the corresponding hooks will
+        be executed.
+        """
+        self._hooks: Dict[
+            LifecyclePhase, List[Callable[[LifecycleHookContext], Any]]
+        ] = defaultdict(list)
+
+    def add_hook(
+        self, phase: LifecyclePhase, hook: Callable[[LifecycleHookContext], Any]
+    ):
+        """
+        Registers a hook to be executed during a specific lifecycle phase.
+
+        Hooks allow you to define custom behavior during various lifecycle phases, such as configuring
+        the component, deploying it, starting or stopping it, and more. Each hook is a callable function.
+
+        Args:
+            phase (LifecyclePhase): The lifecycle phase during which the hook should be executed.
+                                     Example phases are "pre_configure", "post_configure", "pre_deploy", etc.
+            hook (Callable): A function to be executed during the specified lifecycle phase.
+
+        Example:
+            component.add_hook(LifecyclePhase.PRE_DEPLOY, lambda: print("Preparing deployment..."))
+        """
+        self._hooks[phase].append(hook)
+
+    def _run_hooks(self, phase: LifecyclePhase):
+        """
+        Executes all hooks that are registered for a specified lifecycle phase.
+
+        This method iterates through the list of hooks registered for the given phase and calls each hook function.
+
+        Args:
+            phase (LifecyclePhase): The lifecycle phase during which to run the hooks (e.g., PRE_CONFIGURE, POST_CONFIGURE).
+        """
+        hook_context = LifecycleHookContext(
+            component=self,
+            phase=phase,
+        )
+        for hook in self._hooks.get(phase, []):
+            hook(hook_context)
+
+    @abstractmethod
+    def configure(self):
+        """Abstract method for configuring the component."""
+
+    @abstractmethod
+    def deploy(self):
+        """Abstract method for deploying the component."""
+
+    @abstractmethod
+    def start(self):
+        """Abstract method for starting the component."""
+
+    @abstractmethod
+    def stop(self):
+        """Abstract method for stopping the component."""
+
+    @abstractmethod
+    def destroy(self):
+        """Abstract method for destroying the component."""
+
+    @abstractmethod
+    def start_monitoring(self):
+        """Abstract method to start monitoring the component."""
+
+    @abstractmethod
+    def stop_monitoring(self):
+        """Abstract method to stop monitoring the component."""
+
+    @abstractmethod
+    def collect_monitoring_data(self):
+        """Abstract method to collect monitoring data for the component."""

--- a/tools/pipeline_perf_test/orchestrator/lib/core/strategies/__init__.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/strategies/__init__.py
@@ -1,0 +1,17 @@
+"""Initialization for the core.strategies package."""
+
+from .monitoring_strategy import MonitoringStrategy
+from .deployment_strategy import DeploymentStrategy
+from .configuration_strategy import ConfigurationStrategy
+from .execution_strategy import ExecutionStrategy
+from .reporting_strategy import ReportingStrategy, DestinationStrategy, FormatStrategy
+
+__all__ = [
+    "MonitoringStrategy",
+    "DeploymentStrategy",
+    "ConfigurationStrategy",
+    "ExecutionStrategy",
+    "ReportingStrategy",
+    "DestinationStrategy",
+    "FormatStrategy",
+]

--- a/tools/pipeline_perf_test/orchestrator/lib/core/strategies/configuration_strategy.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/strategies/configuration_strategy.py
@@ -1,0 +1,43 @@
+"""
+Module: config_strategy
+
+This module defines the abstract base class `ConfigStrategy`, which is used to implement
+pluggable configuration behaviors for components in the load generator testbed.
+
+The `ConfigStrategy` interface allows components to be configured in a flexible and
+extensible way. Implementations of this class should define how configuration is
+applied to a given component, enabling support for various configuration mechanisms
+(e.g., file-based config, environment variables, remote config services, etc.).
+
+Typical concrete implementations of this interface might include:
+    - FileConfig: Writes configs to a file on disk
+    - ManifestConfig: Generates k8s manifests for application to a cluster
+    - RemoteConfig: Reads configs from a remote location and applies them
+
+Classes:
+    ConfigStrategy (ABC): Abstract base class that declares the `start` method,
+                          which must be implemented by all concrete configuration strategies.
+"""
+
+from abc import ABC, abstractmethod
+
+
+class ConfigurationStrategy(ABC):
+    """
+    Abstract base class for component configuration strategies.
+
+    Subclasses should implement the `start` method to define how configuration
+    is applied to a given component.
+
+    Methods:
+        start(component): Apply configuration to the specified component.
+    """
+
+    @abstractmethod
+    def start(self, component):
+        """
+        Start configuration for the given component.
+
+        Args:
+            component: The component instance to configure.
+        """

--- a/tools/pipeline_perf_test/orchestrator/lib/core/strategies/deployment_strategy.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/strategies/deployment_strategy.py
@@ -1,0 +1,40 @@
+"""
+Module: deployment_strategy
+
+This module defines the abstract base class `DeploymentStrategy`, which provides
+a common interface for managing the lifecycle of components in the load generator testbed.
+
+The `DeploymentStrategy` interface enables pluggable deployment mechanisms, allowing
+different deployment backends (e.g., Docker, Kubernetes, local processes) to be used
+interchangeably. This design supports extensibility and modular deployment logic.
+
+Typical concrete implementations of this interface include:
+    - DockerDeployment: Deploys and manages components in Docker containers.
+    - K8sDeployment: Deploys components as Kubernetes Pods or Deployments.
+    - ProcessDeployment: Manages components as local OS processes.
+
+Classes:
+    DeploymentStrategy (ABC): Abstract base class for defining component deployment behavior.
+"""
+
+from abc import ABC, abstractmethod
+
+
+class DeploymentStrategy(ABC):
+    @abstractmethod
+    def start(self, component):
+        """
+        Deploy the component to the target environment.
+
+        Args:
+            component: The component instance to deploy.
+        """
+
+    @abstractmethod
+    def stop(self, component):
+        """
+        Tear down and remove the deployed component.
+
+        Args:
+            component: The component instance to destroy.
+        """

--- a/tools/pipeline_perf_test/orchestrator/lib/core/strategies/execution_strategy.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/strategies/execution_strategy.py
@@ -1,0 +1,52 @@
+"""
+Module: execution_strategy
+
+This module defines the `ExecutionStrategy` abstract base class, which provides a unified
+interface for controlling the execution behavior of testbed components in a load generation
+environment.
+
+Execution strategies encapsulate how a component runs or behaves at runtime. This separation
+of concerns allows different execution modes to be applied to the same deployment and configuration
+mechanisms.
+
+Typical implementations of this interface include:
+    - GenerateLoad: Starts a component that actively generates load (e.g., otlp, arrow, etc).
+    - ReceiveLoad: Starts a component that passively receives load (e.g., validating otlp receiver).
+
+Classes:
+    ExecutionStrategy (ABC): Abstract interface for starting and stopping a component’s workload execution.
+"""
+
+from abc import ABC, abstractmethod
+
+
+class ExecutionStrategy(ABC):
+    """
+    Abstract base class for execution strategies.
+
+    Execution strategies define how a component behaves when it is running.
+    This interface is responsible for triggering and controlling runtime execution
+    of a component’s main workload or behavior.
+
+    Methods:
+        start(component): Begin execution of the component’s workload.
+        stop(component): Stop execution of the component’s workload.
+    """
+
+    @abstractmethod
+    def start(self, component):
+        """
+        Start executing the component's workload.
+
+        Args:
+            component: The component instance to execute.
+        """
+
+    @abstractmethod
+    def stop(self, component):
+        """
+        Stop executing the component's workload.
+
+        Args:
+            component: The component instance to stop.
+        """

--- a/tools/pipeline_perf_test/orchestrator/lib/core/strategies/execution_strategy.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/strategies/execution_strategy.py
@@ -14,7 +14,7 @@ Typical implementations of this interface include:
     - ReceiveLoad: Starts a component that passively receives load (e.g., validating otlp receiver).
 
 Classes:
-    ExecutionStrategy (ABC): Abstract interface for starting and stopping a component’s workload execution.
+    ExecutionStrategy (ABC): Abstract interface for starting and stopping a component's workload execution.
 """
 
 from abc import ABC, abstractmethod
@@ -26,11 +26,11 @@ class ExecutionStrategy(ABC):
 
     Execution strategies define how a component behaves when it is running.
     This interface is responsible for triggering and controlling runtime execution
-    of a component’s main workload or behavior.
+    of a component's main workload or behavior.
 
     Methods:
-        start(component): Begin execution of the component’s workload.
-        stop(component): Stop execution of the component’s workload.
+        start(component): Begin execution of the component's workload.
+        stop(component): Stop execution of the component's workload.
     """
 
     @abstractmethod

--- a/tools/pipeline_perf_test/orchestrator/lib/core/strategies/monitoring_strategy.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/strategies/monitoring_strategy.py
@@ -1,0 +1,63 @@
+"""
+Module: monitoring_strategy
+
+This module defines the `MonitoringStrategy` abstract base class, which provides
+a common interface for monitoring components in a load generation testbed.
+
+Monitoring strategies are responsible for gathering, starting, and stopping monitoring
+for components during tests. This can involve collecting performance metrics, logging,
+or gathering any relevant statistics or insights from the component.
+
+Typical implementations of this interface include:
+    - ResourceMonitoring: Monitors system resources such as CPU, memory, and network usage.
+    - HealthMonitoring: Monitors the health and availability of the component (e.g., via heartbeats).
+    - ResourceLogging: Monitors the application’s logs from file, docker, k8s.
+
+Classes:
+    MonitoringStrategy (ABC): Abstract base class for all monitoring strategies.
+"""
+
+from abc import ABC, abstractmethod
+from typing import List
+
+
+class MonitoringStrategy(ABC):
+    """
+    Abstract base class for monitoring strategies.
+
+    Monitoring strategies define how to start, stop, and collect data from a component’s monitoring
+    system. Concrete implementations should specify how to track, log, and aggregate monitoring
+    data for a given component.
+
+    Methods:
+        start(): Begin the monitoring process for the component.
+        stop(): Stop the monitoring process.
+        collect(): Collect and return monitoring data as a dictionary.
+    """
+
+    @abstractmethod
+    def start(self):
+        """
+        Start the monitoring process.
+
+        This method initializes and starts the collection of monitoring data for the component.
+        """
+
+    @abstractmethod
+    def stop(self):
+        """
+        Stop the monitoring process.
+
+        This method shuts down any active monitoring and ensures data collection is concluded.
+        """
+
+    @abstractmethod
+    def collect(self) -> dict:
+        """
+        Collect and return monitoring data.
+
+        This method aggregates and returns the collected monitoring data as a dictionary.
+
+        Returns:
+            dict: A dictionary of collected monitoring data.
+        """

--- a/tools/pipeline_perf_test/orchestrator/lib/core/strategies/monitoring_strategy.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/strategies/monitoring_strategy.py
@@ -11,7 +11,7 @@ or gathering any relevant statistics or insights from the component.
 Typical implementations of this interface include:
     - ResourceMonitoring: Monitors system resources such as CPU, memory, and network usage.
     - HealthMonitoring: Monitors the health and availability of the component (e.g., via heartbeats).
-    - ResourceLogging: Monitors the application’s logs from file, docker, k8s.
+    - ResourceLogging: Monitors the application's logs from file, docker, k8s.
 
 Classes:
     MonitoringStrategy (ABC): Abstract base class for all monitoring strategies.
@@ -25,7 +25,7 @@ class MonitoringStrategy(ABC):
     """
     Abstract base class for monitoring strategies.
 
-    Monitoring strategies define how to start, stop, and collect data from a component’s monitoring
+    Monitoring strategies define how to start, stop, and collect data from a component's monitoring
     system. Concrete implementations should specify how to track, log, and aggregate monitoring
     data for a given component.
 

--- a/tools/pipeline_perf_test/orchestrator/lib/core/strategies/reporting_strategy.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/strategies/reporting_strategy.py
@@ -1,0 +1,103 @@
+"""
+Module: reporting_strategy
+
+This module defines a set of abstract base classes that provide an interface for reporting strategies
+in a load generation testbed. The goal of these strategies is to format, output, and report aggregated
+monitoring and test data in various ways.
+
+The three key components in this module are:
+    - `FormatStrategy`: Defines how aggregated data should be formatted into a specific structure (e.g., JSON, CSV, etc.).
+    - `DestinationStrategy`: Defines where and how the formatted data should be output (e.g., to a file, console, or external service).
+    - `ReportingStrategy`: Integrates the formatting and output strategies to generate and report test data.
+
+Classes:
+    FormatStrategy (ABC): Interface for strategies that format aggregated test data.
+    DestinationStrategy (ABC): Interface for strategies that determine where and how to output formatted data.
+    ReportingStrategy (ABC): Interface for strategies that combine formatting and output to report aggregated data.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Dict, Any
+
+
+class FormatStrategy(ABC):
+    """
+    Abstract base class for data formatting strategies.
+
+    The `FormatStrategy` class defines how aggregated test data should be formatted into a specific
+    structure (e.g., JSON, CSV). Implementations should specify the format that best suits the reporting
+    needs for the testbed.
+
+    Methods:
+        format(aggregated_data): Format the aggregated test data into a desired structure.
+
+    Args:
+        aggregated_data (Dict[str, Dict[str, any]]): The data to be formatted, typically containing metrics
+                                                      or test results organized by component and metric name.
+
+    Returns:
+        str: The formatted data as a string.
+    """
+
+    @abstractmethod
+    def format(self, aggregated_data: Dict[str, Dict[str, Any]]) -> str:
+        """
+        Format the aggregated test data.
+
+        Args:
+            aggregated_data (Dict[str, Dict[str, any]]): The data to format.
+
+        Returns:
+            str: The formatted data as a string.
+        """
+
+
+class DestinationStrategy(ABC):
+    """
+    Abstract base class for data output strategies.
+
+    The `DestinationStrategy` class defines where and how the formatted data should be sent, such as
+    outputting to a file, the console, or an external service. Concrete implementations will specify
+    the exact destination behavior.
+
+    Methods:
+        output(formatted_data): Output the formatted data to a specified destination.
+
+    Args:
+        formatted_data (str): The data to output, typically in the form of a string after being formatted.
+    """
+
+    @abstractmethod
+    def output(self, formatted_data: str):
+        """
+        Output the formatted data.
+
+        Args:
+            formatted_data (str): The formatted data to be sent to the destination.
+        """
+
+
+class ReportingStrategy(ABC):
+    """
+    Abstract base class for reporting strategies.
+
+    The `ReportingStrategy` class integrates the formatting and destination strategies to generate
+    and report test data. This could involve formatting the aggregated data and sending it to a
+    designated output, such as a log, file, or monitoring system.
+
+    Methods:
+        report(aggregated_data): Format and output the aggregated test data.
+
+    Args:
+        aggregated_data (Dict[str, Dict[str, any]]): The data to be reported, typically containing metrics
+                                                      or test results organized by component and metric name.
+    """
+
+    @abstractmethod
+    def report(self, aggregated_data: Dict[str, Dict[str, Any]]):
+        """
+        Generate and report test data by formatting and outputting the aggregated data.
+
+        Args:
+            aggregated_data (Dict[str, Dict[str, any]]): The aggregated data to format and report.
+        """


### PR DESCRIPTION
follow up to #466 (for #467)

This PR adds additional classes for component management, as described in the diagram below. A follow-on PR(s) will begin moving the existing logic to this new structure, but no functionality change for now.

![structure](https://github.com/user-attachments/assets/2490262d-a11d-4f82-a7e3-c3f4f7689692)
