### PR TITLE
Perf - Orchestrator context refactor and component implementation

### DIFF
--- a/tools/pipeline_perf_test/orchestrator/lib/core/component/runtime.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/component/runtime.py
@@ -1,0 +1,21 @@
+from typing import Callable, Dict, Any
+
+
+class ComponentRuntime:
+    """Holds runtime info for a component in a plugin-extensible way."""
+
+    _data: Dict[str, Any]  # strategy_name -> plugin-defined state
+
+    def __init__(self):
+        self._data = {}
+
+    def set(self, namespace: str, data: Any):
+        self._data[namespace] = data
+
+    def get(self, namespace: str) -> Any:
+        return self._data.get(namespace)
+
+    def get_or_create(self, namespace: str, factory: Callable[[], Any]) -> Any:
+        if namespace not in self._data:
+            self._data[namespace] = factory()
+        return self._data[namespace]

--- a/tools/pipeline_perf_test/orchestrator/lib/core/context/base.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/context/base.py
@@ -5,8 +5,15 @@ This module provides the BaseContext class which provides shared fields common t
 different implementations of Contexts throughout the orchestrator.
 """
 
+import json
+import time
+
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Dict, List, Optional, TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from ..component.lifecycle_component import LifecycleComponent
 
 
 @dataclass
@@ -15,15 +22,90 @@ class BaseContext:
     Base context class which includes common timing, status, metadata fields.
     """
 
-    status: Optional[str] = field(init=False)
-    error: Optional[Exception] = field(init=False)
-    start_time: Optional[float] = field(init=False)
-    end_time: Optional[float] = field(init=False)
-    metadata: dict = field(default_factory=dict, init=False)
+    name: Optional[str] = None
+    status: Optional[str] = None
+    error: Optional[Exception] = None
+    start_time: Optional[float] = None
+    end_time: Optional[float] = None
+    metadata: dict = field(default_factory=dict)
 
-    # Prevent initialization ordering errors for non-default fields in inheriting class.
-    def __post_init__(self):
-        self.status = None
-        self.error = None
-        self.start_time = None
-        self.end_time = None
+    parent_ctx: Optional["BaseContext"] = None
+    child_contexts: List["BaseContext"] = field(default_factory=list)
+
+    def add_child_ctx(self, ctx: "BaseContext"):
+        """Add a context to the list of children on the calling context and set the parent on the child.
+
+        Args:
+            ctx: The context to append to the list of children.
+        """
+        self.child_contexts.append(ctx)
+        ctx.parent_ctx = self
+
+    def get_components(self) -> Dict[str, "LifecycleComponent"]:
+        """Get the components from the root context.
+
+        Returns: The dict of components, indexed by component name.
+        """
+        if hasattr(self, "parent_ctx"):
+            return self.parent_ctx.get_components()
+        raise NotImplementedError("This context does not support get_components")
+
+    def get_component_by_name(self, name: str) -> Optional["LifecycleComponent"]:
+        """Get a component instance by the name of the component (from the root context).
+
+        Args:
+            name: The name of the component to return
+
+        Returns: The named component or none if not found.
+        """
+        if hasattr(self, "parent_ctx"):
+            return self.parent_ctx.get_component(name)
+        raise NotImplementedError("This context does not support get_component_by_name")
+
+    def get_client(
+        self, name: str, client_factory: Optional[callable] = None
+    ) -> object:
+        """
+        Retrieve a client from the root context, creating it if it does not exist.
+
+        name: The name of the client.
+        client_factory: A factory function to create the client if it does not exist.
+
+        return: The client object.
+        """
+        if hasattr(self, "parent_ctx"):
+            return self.parent_ctx.get_client(name, client_factory)
+        raise NotImplementedError("This context does not support get_client")
+
+    def log(self, message: str):
+        """
+        Logs a message both to the logger and stores it in the context log list.
+
+        Args:
+            message: the message to log
+        """
+        msg_dict = {"ctx_type": self.__class__.__name__, "message": message}
+        if self.name:
+            msg_dict["name"] = self.name
+        if self.status:
+            msg_dict["status"] = self.status
+        duration = (
+            self.end_time - self.start_time
+            if self.start_time and self.end_time
+            else None
+        )
+        if duration:
+            msg_dict["duration"] = f"{duration:.4f}"
+
+        log_entry = f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] {json.dumps(msg_dict)}"
+        print(log_entry)
+
+    def start(self):
+        """Mark start of context (e.g., for timing)."""
+        self.log("Context Starting...")
+        self.start_time = time.time()
+
+    def end(self):
+        """Mark end of context and log duration."""
+        self.end_time = time.time()
+        self.log("Context Ended")

--- a/tools/pipeline_perf_test/orchestrator/lib/core/strategies/configuration_strategy.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/strategies/configuration_strategy.py
@@ -21,6 +21,9 @@ Classes:
 
 from abc import ABC, abstractmethod
 
+from ..component.lifecycle_component import LifecycleComponent
+from ..test_framework.test_context import TestStepContext
+
 
 class ConfigurationStrategy(ABC):
     """
@@ -30,14 +33,15 @@ class ConfigurationStrategy(ABC):
     is applied to a given component.
 
     Methods:
-        start(component): Apply configuration to the specified component.
+        start(component, ctx): Apply configuration to the specified component.
     """
 
     @abstractmethod
-    def start(self, component):
+    def start(self, component: LifecycleComponent, ctx: TestStepContext):
         """
         Start configuration for the given component.
 
         Args:
             component: The component instance to configure.
+            ctx: The current execution context for the containing test step.
         """

--- a/tools/pipeline_perf_test/orchestrator/lib/core/strategies/deployment_strategy.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/strategies/deployment_strategy.py
@@ -19,22 +19,27 @@ Classes:
 
 from abc import ABC, abstractmethod
 
+from ..component.lifecycle_component import LifecycleComponent
+from ..test_framework.test_context import TestStepContext
+
 
 class DeploymentStrategy(ABC):
     @abstractmethod
-    def start(self, component):
+    def start(self, component: LifecycleComponent, ctx: TestStepContext):
         """
         Deploy the component to the target environment.
 
         Args:
             component: The component instance to deploy.
+            ctx: The current execution context for the containing test step.
         """
 
     @abstractmethod
-    def stop(self, component):
+    def stop(self, component: LifecycleComponent, ctx: TestStepContext):
         """
         Tear down and remove the deployed component.
 
         Args:
             component: The component instance to destroy.
+            ctx: The current execution context for the containing test step.
         """

--- a/tools/pipeline_perf_test/orchestrator/lib/core/strategies/execution_strategy.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/strategies/execution_strategy.py
@@ -19,6 +19,9 @@ Classes:
 
 from abc import ABC, abstractmethod
 
+from ..component.lifecycle_component import LifecycleComponent
+from ..test_framework.test_context import TestStepContext
+
 
 class ExecutionStrategy(ABC):
     """
@@ -29,24 +32,26 @@ class ExecutionStrategy(ABC):
     of a component's main workload or behavior.
 
     Methods:
-        start(component): Begin execution of the component's workload.
-        stop(component): Stop execution of the component's workload.
+        start(component, ctx): Begin execution of the component's workload.
+        stop(component, ctx): Stop execution of the component's workload.
     """
 
     @abstractmethod
-    def start(self, component):
+    def start(self, component: LifecycleComponent, ctx: TestStepContext):
         """
         Start executing the component's workload.
 
         Args:
             component: The component instance to execute.
+            ctx: The current execution context for the containing test step.
         """
 
     @abstractmethod
-    def stop(self, component):
+    def stop(self, component: LifecycleComponent, ctx: TestStepContext):
         """
         Stop executing the component's workload.
 
         Args:
             component: The component instance to stop.
+            ctx: The current execution context for the containing test step.
         """

--- a/tools/pipeline_perf_test/orchestrator/lib/core/strategies/monitoring_strategy.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/strategies/monitoring_strategy.py
@@ -19,6 +19,9 @@ Classes:
 
 from abc import ABC, abstractmethod
 
+from ..component.lifecycle_component import LifecycleComponent
+from ..test_framework.test_context import TestStepContext, TestExecutionContext
+
 
 class MonitoringStrategy(ABC):
     """
@@ -29,33 +32,43 @@ class MonitoringStrategy(ABC):
     data for a given component.
 
     Methods:
-        start(): Begin the monitoring process for the component.
-        stop(): Stop the monitoring process.
-        collect(): Collect and return monitoring data as a dictionary.
+        start(component, ctx): Begin the monitoring process for the component.
+        stop(component, ctx): Stop the monitoring process.
+        collect(component, ctx): Collect and return monitoring data as a dictionary.
     """
 
     @abstractmethod
-    def start(self):
+    def start(self, component: LifecycleComponent, ctx: TestStepContext):
         """
         Start the monitoring process.
 
         This method initializes and starts the collection of monitoring data for the component.
+        Args:
+            component: The component instance to stop.
+            ctx: The current execution context for the containing test step.
         """
 
     @abstractmethod
-    def stop(self):
+    def stop(self, component: LifecycleComponent, ctx: TestStepContext):
         """
         Stop the monitoring process.
 
         This method shuts down any active monitoring and ensures data collection is concluded.
+        Args:
+            component: The component instance to stop.
+            ctx: The current execution context for the containing test step.
         """
 
     @abstractmethod
-    def collect(self) -> dict:
+    def collect(self, component: LifecycleComponent, ctx: TestExecutionContext) -> dict:
         """
         Collect and return monitoring data.
 
         This method aggregates and returns the collected monitoring data as a dictionary.
+
+        Args:
+            component: The component instance to stop.
+            ctx: The current execution context for the containing test step.
 
         Returns:
             dict: A dictionary of collected monitoring data.

--- a/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_step.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_step.py
@@ -12,9 +12,13 @@ Classes:
 """
 
 import time
-from typing import Any, Callable
+from typing import Any, Callable, Optional, TYPE_CHECKING
 
 from .test_context import TestStepContext
+
+
+if TYPE_CHECKING:
+    from ..component.lifecycle_component import LifecycleComponent
 
 
 class TestStep:
@@ -32,7 +36,12 @@ class TestStep:
         run(context): Executes the action associated with the test step, providing the context to the action.
     """
 
-    def __init__(self, name: str, action: Callable[[TestStepContext], Any]):
+    def __init__(
+        self,
+        name: str,
+        action: Callable[[TestStepContext], Any],
+        component: Optional["LifecycleComponent"] = None,
+    ):
         """
         Initializes a test step with a name and an associated action.
 
@@ -42,6 +51,7 @@ class TestStep:
         """
         self.name = name
         self.action = action
+        self.component = component
 
     def run(self, context: TestStepContext):
         """
@@ -56,18 +66,5 @@ class TestStep:
         Returns:
             The result of the action execution, which is whatever is returned by the action callable.
         """
-        print(f"Running step: {self.name}")
-        result = None
-        context.start_time = time.time()
-        try:
-            result = self.action(context)
-            context.status = "success"
-        except Exception as e:
-            context.status = "error"
-            context.error = e
-            print(f"Error in step '{self.name}': {e}")
-            raise  # Optional: re-raise to propagate to the test level
-        finally:
-            context.end_time = time.time()
 
-        return result
+        return self.action(context)

--- a/tools/pipeline_perf_test/orchestrator/lib/impl/__init__.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/impl/__init__.py
@@ -1,0 +1,1 @@
+"""Initialization for the impl package."""

--- a/tools/pipeline_perf_test/orchestrator/lib/impl/component/__init__.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/impl/component/__init__.py
@@ -1,0 +1,1 @@
+"""Initialization for the impl.component package."""

--- a/tools/pipeline_perf_test/orchestrator/lib/impl/component/managed_component.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/impl/component/managed_component.py
@@ -30,6 +30,7 @@ LifecycleHookStrategy = Literal["append", "replace"]
 
 
 class LifecycleHooks(BaseModel):
+    """Base configuration model that specifies a lifecycle hook to set on a component"""
     pre: Optional[List[str]] = Field(
         default_factory=list, description="Commands to run before start/stop"
     )
@@ -40,7 +41,8 @@ class LifecycleHooks(BaseModel):
     post_strategy: LifecycleHookStrategy = "append"
 
 
-class ManagedComponentActioConfig(BaseModel):
+class ManagedComponentActionConfig(BaseModel):
+    """Base configuration model that specifies an action to invoke on a component"""
     type: Literal["component_action"]
     target: str
     action: LifecyclePhase

--- a/tools/pipeline_perf_test/orchestrator/lib/impl/component/managed_component.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/impl/component/managed_component.py
@@ -1,0 +1,219 @@
+"""
+Module: managed_component
+
+Each `ManagedComponent` represents a managed entity in the system, such as a service or
+application instance. The managed_component supports full lifecycle management (configure,
+deploy, start, stop, destroy), implemented through strategy patterns.
+
+Classes:
+    ManagedComponent: Represents a lifecycle-managed testbed component with pluggable
+               deployment and monitoring strategies.
+"""
+
+from pydantic import BaseModel, Field
+from typing import Any, Callable, List, Optional, Union, Literal
+
+from ..strategies.monitoring.composite_monitoring_strategy import (
+    CompositeMonitoringStrategy,
+)
+from ...core.component.runtime import ComponentRuntime
+from ...core.component.lifecycle_component import (
+    LifecycleComponent,
+    HookableLifecyclePhase,
+    LifecyclePhase,
+)
+from ..strategies.deployment.docker import DockerDeploymentConfig
+from ...core.test_framework.test_context import TestStepContext, TestExecutionContext
+
+
+LifecycleHookStrategy = Literal["append", "replace"]
+
+
+class LifecycleHooks(BaseModel):
+    pre: Optional[List[str]] = Field(
+        default_factory=list, description="Commands to run before start/stop"
+    )
+    pre_strategy: LifecycleHookStrategy = "append"
+    post: Optional[List[str]] = Field(
+        default_factory=list, description="Commands to run after start/stop"
+    )
+    post_strategy: LifecycleHookStrategy = "append"
+
+
+class ManagedComponentActioConfig(BaseModel):
+    type: Literal["component_action"]
+    target: str
+    action: LifecyclePhase
+
+
+class ManagedComponentConfiguration(BaseModel):
+    """Base configuration model for the ManagedComponent class"""
+
+    configure_hooks: Optional[LifecycleHooks] = Field(default_factory=LifecycleHooks)
+    deploy_hooks: Optional[LifecycleHooks] = Field(default_factory=LifecycleHooks)
+    start_hooks: Optional[LifecycleHooks] = Field(default_factory=LifecycleHooks)
+    stop_hooks: Optional[LifecycleHooks] = Field(default_factory=LifecycleHooks)
+    destroy_hooks: Optional[LifecycleHooks] = Field(default_factory=LifecycleHooks)
+    start_monitoring_hooks: Optional[LifecycleHooks] = Field(
+        default_factory=LifecycleHooks
+    )
+    stop_monitoring_hooks: Optional[LifecycleHooks] = Field(
+        default_factory=LifecycleHooks
+    )
+
+    deployment: Optional[Union[DockerDeploymentConfig]]
+
+    # placeholders
+    configuration: Optional[str] = None
+    execution: Optional[str] = None
+    monitoring: Optional[List[str]] = []
+
+
+class ManagedComponent(LifecycleComponent):
+    """
+    An orchestrated component that encapsulates deployment, configuration, and monitoring logic.
+
+    Attributes:
+        name (str): Name of the component.
+        deployment: A deployment strategy instance responsible for managing deployment operations.
+        monitoring (CompositeMonitoringStrategy): Composite strategy for managing monitoring implementations.
+        config: Optional configuration strategy used to configure the component.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        config: ManagedComponentConfiguration,
+    ):
+        """
+        Initialize the Component.
+
+        Args:
+            name (str): Identifier for the component.
+            config_strategy: Configuration strategy applied during configure phase.
+            deployment_strategy: Strategy object responsible for deploying the component.
+            execution_strategy: Strategy object responsible for component logic execution.
+            monitoring_strategies (List[MonitoringStrategy]): List of monitoring strategies to be applied.
+        """
+        super().__init__()
+        self.name: str = name
+        self.component_config: ManagedComponentConfiguration = config
+        self.runtime: ComponentRuntime = ComponentRuntime()
+
+        deployment_strategy = config.deployment.create() if config.deployment else None
+        config_strategy = (
+            config.configuration.create() if config.configuration else None
+        )
+        execution_strategy = config.execution.create() if config.execution else None
+        monitoring_strategies = [m.create() for m in config.monitoring or []]
+        self.configuration = config_strategy
+        self.deployment = deployment_strategy
+        self.execution_strategy = execution_strategy
+        self.monitoring = CompositeMonitoringStrategy(monitoring_strategies)
+
+        if self.deployment.default_hooks:
+            for hook_phase in self.deployment.default_hooks:
+                for hook in self.deployment.default_hooks[hook_phase]:
+                    self.add_hook(hook_phase, hook)
+
+    def get_or_create_runtime(self, namespace: str, factory: Callable[[], Any]) -> Any:
+        """Get an existing runtime data structure or initialize a new one.
+
+        Args:
+            namespace: The namespace to get/create data for.
+            factory: The initialization method if no namespace data exists.
+        """
+        return self.runtime.get_or_create(namespace, factory)
+
+    def set_runtime_data(self, namespace: str, data: Any):
+        """Set the data value on the component's runtime with the specified namespace.
+
+        Args:
+            namespace: The namespace to set the data value on.
+            data: The data to set.
+        """
+        self.runtime.set(namespace, data)
+
+    def get_component_config(self) -> BaseModel:
+        """Get the component's configuration model.
+
+        Returns: a BaseModel describing the configuration of the component.
+        """
+        return self.component_config
+
+    def configure(self, ctx: TestStepContext):
+        """
+        Apply configuration to the component using the configured strategy, if present.
+        Executes lifecycle hooks before and after the configuration.
+        """
+        self._run_hooks(HookableLifecyclePhase.PRE_CONFIGURE, ctx)
+        if self.configuration:
+            self.configuration.start(self, ctx)
+        self._run_hooks(HookableLifecyclePhase.POST_CONFIGURE, ctx)
+
+    def deploy(self, ctx: TestStepContext):
+        """
+        Deploy the component using the specified deployment strategy.
+        Executes lifecycle hooks before and after deployment.
+        """
+        self._run_hooks(HookableLifecyclePhase.PRE_DEPLOY, ctx)
+        if self.deployment:
+            self.deployment.start(self, ctx)
+        self._run_hooks(HookableLifecyclePhase.POST_DEPLOY, ctx)
+
+    def start(self, ctx: TestStepContext):
+        """
+        Start the deployed component using the execution strategy.
+        Executes lifecycle hooks before and after starting.
+        """
+        self._run_hooks(HookableLifecyclePhase.PRE_START, ctx)
+        if self.execution_strategy:
+            self.execution_strategy.start(self, ctx)
+        self._run_hooks(HookableLifecyclePhase.POST_START, ctx)
+
+    def stop(self, ctx: TestStepContext):
+        """
+        Stop the running component using the execution strategy.
+        Executes lifecycle hooks before and after stopping.
+        """
+        self._run_hooks(HookableLifecyclePhase.PRE_STOP, ctx)
+        if self.execution_strategy:
+            self.execution_strategy.stop(self, ctx)
+        self._run_hooks(HookableLifecyclePhase.POST_STOP, ctx)
+
+    def destroy(self, ctx: TestStepContext):
+        """
+        Tear down and clean up the component using the deployment strategy.
+        Executes lifecycle hooks before and after destruction.
+        """
+        self._run_hooks(HookableLifecyclePhase.PRE_DESTROY, ctx)
+        if self.deployment:
+            self.deployment.stop(self, ctx)
+        self._run_hooks(HookableLifecyclePhase.POST_DESTROY, ctx)
+
+    def start_monitoring(self, ctx: TestStepContext):
+        """
+        Start all monitoring strategies associated with the component.
+        Executes lifecycle hooks before and after monitoring startup.
+        """
+        self._run_hooks(HookableLifecyclePhase.PRE_START_MONITORING, ctx)
+        self.monitoring.start(self, ctx)
+        self._run_hooks(HookableLifecyclePhase.POST_START_MONITORING, ctx)
+
+    def stop_monitoring(self, ctx: TestStepContext):
+        """
+        Stop all monitoring strategies associated with the component.
+        Executes lifecycle hooks before and after monitoring shutdown.
+        """
+        self._run_hooks(HookableLifecyclePhase.PRE_STOP_MONITORING, ctx)
+        self.monitoring.stop(self, ctx)
+        self._run_hooks(HookableLifecyclePhase.POST_STOP_MONITORING, ctx)
+
+    def collect_monitoring_data(self, ctx: TestExecutionContext) -> dict:
+        """
+        Collect and return monitoring data from all configured monitoring strategies.
+
+        Returns:
+            dict: Aggregated monitoring data.
+        """
+        return self.monitoring.collect(self, ctx)

--- a/tools/pipeline_perf_test/orchestrator/lib/impl/strategies/__init__.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/impl/strategies/__init__.py
@@ -1,0 +1,1 @@
+"""Initialization for the impl.strategies package."""

--- a/tools/pipeline_perf_test/orchestrator/lib/impl/strategies/deployment/__init__.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/impl/strategies/deployment/__init__.py
@@ -1,0 +1,1 @@
+"""Initialization for the impl.strategies.execution package."""

--- a/tools/pipeline_perf_test/orchestrator/lib/impl/strategies/deployment/docker.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/impl/strategies/deployment/docker.py
@@ -1,0 +1,189 @@
+from typing import Dict, List, Literal, Optional, Union
+
+import docker
+from pydantic import BaseModel, Field
+
+from ....core.strategies.deployment_strategy import DeploymentStrategy
+from ....core.test_framework.test_context import TestStepContext
+from ....core.component.lifecycle_component import (
+    LifecycleHookContext,
+    HookableLifecyclePhase,
+)
+
+
+class DockerRuntime(BaseModel):
+    container_id: Optional[str] = None
+
+
+class BuildConfig(BaseModel):
+    """Base Model for docker container build settings."""
+
+    context: str
+    dockerfile: Optional[str] = None
+    args: Optional[Dict[str, str]] = None
+    target: Optional[str] = None
+
+
+class PortMapping(BaseModel):
+    """Base Model for docker container port settings."""
+
+    published: Union[int, str]
+    target: Union[int, str]
+
+
+class VolumeMapping(BaseModel):
+    """Base Model for docker container volume settings."""
+
+    source: str
+    target: str
+    read_only: Optional[bool] = False
+
+
+class DockerDeploymentConfig(BaseModel):
+    """Base Model for docker docker deployment settings."""
+
+    type: Literal["docker"]
+    build: Optional[BuildConfig] = Field(
+        None, description="Build configuration if building locally"
+    )
+    image: Optional[str] = Field(None, description="Docker image to use")
+    environment: Optional[Dict[str, str]] = None
+    ports: Optional[List[Union[str, PortMapping]]] = None
+    volumes: Optional[List[Union[str, VolumeMapping]]] = None
+    network: Optional[str] = None
+
+    # TODO: move this to use a factory / registry.
+    def create(self) -> DeploymentStrategy:
+        return DockerDeployment(config=self)
+
+
+class DockerDeployment(DeploymentStrategy):
+    """Manages component container lifecycle using docker on the local host."""
+
+    def __init__(self, config: DockerDeploymentConfig):
+        self.config = config
+        self.default_hooks = {
+            HookableLifecyclePhase.PRE_DEPLOY: [
+                build_docker_image,
+                create_docker_network,
+            ],
+            HookableLifecyclePhase.PRE_DESTROY: [get_docker_logs],
+            HookableLifecyclePhase.POST_DESTROY: [delete_docker_network],
+        }
+
+    def start(self, component, context: TestStepContext):
+        # dummy impl
+        context.log(f"Starting Docker container for {component.name}")
+        runtime = get_docker_runtime(context)
+        runtime.container_id = "123456789"
+        set_docker_runtime_data(context, runtime)
+
+    def stop(self, component, context: TestStepContext):
+        # dummy impl
+        runtime = get_docker_runtime(context)
+        context.log(
+            f"Stopping Docker container for {component.name}, with ID: {runtime.container_id}"
+        )
+
+
+def create_docker_client() -> object:
+    """Initialize a docker client from the environment"""
+    return docker.from_env()
+
+
+def get_docker_config(ctx: LifecycleHookContext) -> Optional[DockerDeploymentConfig]:
+    """Get the deployment strategy config for the component and ensure it's a docker deployment.
+
+    Args:
+        ctx: The context for the hook that's currently firing.
+
+    Returns: The DockerDeploymentConfig instance if valid, else None.
+    """
+    component = ctx.get_step_component()
+    if not component:
+        ctx.log("No component found in context.")
+        return None
+    deployment = getattr(component.component_config, "deployment", None)
+    if not isinstance(deployment, DockerDeploymentConfig):
+        ctx.log(
+            f"Deployment config is not DockerDeploymentConfig: {type(deployment).__name__}"
+        )
+        return None
+
+    return deployment
+
+
+def get_docker_runtime(
+    ctx: Union[LifecycleHookContext, TestStepContext],
+) -> DockerRuntime:
+    """Get runtime docker information from the context.
+
+    Args:
+        ctx: The current context
+
+    Returns: The existing docker runtime or a new one"""
+    component = ctx.get_step_component()
+    if not component:
+        ctx.log("No component found in context.")
+        return None
+    return component.get_or_create_runtime("docker", DockerRuntime)
+
+
+def set_docker_runtime_data(
+    ctx: Union[LifecycleHookContext, TestStepContext], data: DockerRuntime
+):
+    """Get runtime docker information from the context.
+
+    Args:
+        ctx: The current context
+
+    Returns: The existing docker runtime or a new one"""
+    component = ctx.get_step_component()
+    if not component:
+        ctx.log("No component found in context.")
+        return None
+    return component.set_runtime_data("docker", data)
+
+
+def build_docker_image(ctx: LifecycleHookContext):
+    _client = ctx.get_client("docker", create_docker_client)
+    conf = get_docker_config(ctx)
+    if not conf:
+        return
+    # dummy impl
+    ctx.log(f"docker build -t {conf.image} (other args available in conf.build) )")
+
+
+def create_docker_network(ctx: LifecycleHookContext):
+    _client = ctx.get_client("docker", create_docker_client)
+    conf = get_docker_config(ctx)
+    if not conf:
+        return
+    # dummy impl
+    ctx.log(f"docker network create: {conf.deployment.network}")
+
+
+def delete_docker_network(ctx: LifecycleHookContext):
+    _client = ctx.get_client("docker", create_docker_client)
+    conf = get_docker_config(ctx)
+    if not conf:
+        return
+    if not conf.network:
+        ctx.log("Default network in use, skip removal")
+        return
+    # dummy impl
+    ctx.log(f"docker network rm: {conf.network}")
+
+
+def get_docker_logs(ctx: LifecycleHookContext):
+    # dummy impl
+    runtime = get_docker_runtime(ctx)
+    ctx.log(f"docker logs {runtime.container_id}")
+
+
+# def launch_container(
+# def build_docker_image(
+# def get_docker_logs(container_id: str, client: docker.DockerClient, log_cli: bool = False) -> str:
+# def cleanup_docker_containers(container_names: List[str], client: docker.DockerClient, log_cli: bool = False) -> None:
+# def create_docker_network(network_name: str, client: docker.DockerClient, log_cli: bool = False) -> bool:
+# def delete_docker_network(network_name: str, client: docker.DockerClient, log_cli: bool = False) -> None:

--- a/tools/pipeline_perf_test/orchestrator/requirements.txt
+++ b/tools/pipeline_perf_test/orchestrator/requirements.txt
@@ -3,6 +3,7 @@
 # General dependencies
 requests>=2.25.0
 pyyaml>=5.4.1
+pydantic>=2.11.4
 
 # Docker management
 docker>=5.0.0


### PR DESCRIPTION
Sorry about the size... wanted to include a couple implementations to illustrate how things will fit together (can trim them out and focus on the core changes if preferred).

- Refactor contexts to support various plugin needs (store clients, additional helper methods, basic logging / timing / state support)
- Add component runtime data registry to support component scoped info that crosses test / step / hook bounds (e.g. container / process IDs).
- Added pydantic for configuration spec / validation.
- Add ManagedComponent implementation of Lifecycle component (other might include static component for e.g. long lived cloud services) - implements all the lifecycle methods and invokes hooks.
- Add example docker deployment strategy with dummy methods that approximate the data needs of the real version (container ids, configuration, client, etc) - next PR will include real implementation.

