### PR TITLE
Perf - support hook execution and runtime data on test framework elements.

### DIFF
--- a/tools/pipeline_perf_test/orchestrator/lib/core/component/__init__.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/component/__init__.py
@@ -1,1 +1,6 @@
 """Initialization for the core.component package."""
+
+from .component import Component, ComponentPhase
+from .component_data import ComponentData
+
+__all__ = ["Component", "ComponentPhase", "ComponentData"]

--- a/tools/pipeline_perf_test/orchestrator/lib/core/component/component_data.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/component/component_data.py
@@ -7,7 +7,7 @@ metrics (as arbitrary key-value pairs) and runtime information, allowing consist
 representation of component state for reporting, analysis, or serialization.
 
 The `ComponentData` class provides a `from_component` factory method to construct
-instances directly from a `LifecycleComponent` and a `TestExecutionContext`.
+instances directly from a `Component` and a `TestExecutionContext`.
 
 Typical usage:
     data = ComponentData.from_component(component, context)
@@ -17,10 +17,10 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, TYPE_CHECKING
 
 from ..context.test_contexts import TestExecutionContext
-from .runtime import ComponentRuntime
+from ..runtime.runtime import Runtime
 
 if TYPE_CHECKING:
-    from .lifecycle_component import LifecycleComponent
+    from .component import Component
 
 
 @dataclass
@@ -28,11 +28,11 @@ class ComponentData:
     """The class holds data about a component including arbitrary runtime data and metrics"""
 
     metrics: Dict[str, Any] = field(default_factory=dict)
-    runtime: ComponentRuntime = None
+    runtime: Runtime = None
 
     @classmethod
     def from_component(
-        cls, component: "LifecycleComponent", context: TestExecutionContext
+        cls, component: "Component", context: TestExecutionContext
     ) -> "ComponentData":
         """Create a ComponentData instance from a component and context."""
         return cls(

--- a/tools/pipeline_perf_test/orchestrator/lib/core/context/__init__.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/context/__init__.py
@@ -1,16 +1,29 @@
 """Initialization for the core.context package."""
 
 from .base import BaseContext
+from ..context.component_hook_context import (
+    ComponentHookContext,
+    HookableComponentPhase,
+)
+from ..context.test_element_hook_context import (
+    TestElementHookContext,
+    HookableTestPhase,
+)
 from .test_contexts import (
-    BaseContext,
     TestSuiteContext,
     TestExecutionContext,
     TestStepContext,
+    TestFrameworkElementContext,
 )
 
 __all__ = [
     "BaseContext",
+    "ComponentHookContext",
+    "HookableComponentPhase",
     "TestSuiteContext",
     "TestExecutionContext",
     "TestStepContext",
+    "TestFrameworkElementContext",
+    "TestElementHookContext",
+    "HookableTestPhase",
 ]

--- a/tools/pipeline_perf_test/orchestrator/lib/core/context/base.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/context/base.py
@@ -16,7 +16,8 @@ from typing import Dict, List, Optional, TYPE_CHECKING
 
 
 if TYPE_CHECKING:
-    from ..component.lifecycle_component import LifecycleComponent
+    from ..test_framework.test_suite import TestSuite
+    from ..component.component import Component
 
 
 class ExecutionStatus(str, Enum):
@@ -51,6 +52,7 @@ class BaseContext:
 
     @property
     def duration(self) -> Optional[float]:
+        """Duration of the context between start/stop calls or none if not run/stopped."""
         if self.start_time is not None and self.end_time is not None:
             return self.end_time - self.start_time
         return None
@@ -64,7 +66,7 @@ class BaseContext:
         self.child_contexts.append(ctx)
         ctx.parent_ctx = self
 
-    def get_components(self) -> Dict[str, "LifecycleComponent"]:
+    def get_components(self) -> Dict[str, "Component"]:
         """Get the components from the root context.
 
         Returns: The dict of components, indexed by component name.
@@ -73,7 +75,7 @@ class BaseContext:
             return self.parent_ctx.get_components()
         raise NotImplementedError("This context does not support get_components")
 
-    def get_component_by_name(self, name: str) -> Optional["LifecycleComponent"]:
+    def get_component_by_name(self, name: str) -> Optional["Component"]:
         """Get a component instance by the name of the component (from the root context).
 
         Args:
@@ -85,20 +87,11 @@ class BaseContext:
             return self.parent_ctx.get_component(name)
         raise NotImplementedError("This context does not support get_component_by_name")
 
-    def get_client(
-        self, name: str, client_factory: Optional[callable] = None
-    ) -> object:
-        """
-        Retrieve a client from the root context, creating it if it does not exist.
-
-        name: The name of the client.
-        client_factory: A factory function to create the client if it does not exist.
-
-        return: The client object.
-        """
+    def get_test_suite(self) -> Optional["TestSuite"]:
+        """Get the root test suite object from a given context."""
         if hasattr(self, "parent_ctx"):
-            return self.parent_ctx.get_client(name, client_factory)
-        raise NotImplementedError("This context does not support get_client")
+            return self.parent_ctx.get_test_suite()
+        raise NotImplementedError("This context does not support get_test_suite")
 
     def log(self, message: str):
         """

--- a/tools/pipeline_perf_test/orchestrator/lib/core/context/component_hook_context.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/context/component_hook_context.py
@@ -1,0 +1,93 @@
+"""
+Module: component_hook_context
+
+This module defines context structures and enumerations related to hook execution
+during the lifecycle of a test component. It supports component-level lifecycle hooks
+that can be triggered before or after specific phases such as deployment, configuration,
+start, stop, and monitoring.
+
+The `HookableComponentPhase` enum enumerates all supported lifecycle stages at which
+hooks may be registered and executed. This provides fine-grained control for extending
+behavior across the component's lifecycle.
+
+The `ComponentHookContext` class provides structured context during the execution of a
+hook, including access to the test step and component under orchestration. It allows
+strategies and plugins to introspect and interact with the current hook execution.
+
+Typical use cases include:
+    - Injecting behavior before a component is deployed (e.g., validation or mocking).
+    - Collecting diagnostics after a component has been stopped.
+    - Triggering monitoring setup during component startup.
+
+Enums:
+    HookableComponentPhase: Enumerates all phases of the component lifecycle that support hook execution.
+
+Classes:
+    ComponentHookContext(BaseContext): Context object passed to component lifecycle hooks, giving access
+                                       to the parent test step and the associated component instance.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional, TYPE_CHECKING
+
+from .base import BaseContext
+from .test_contexts import TestStepContext
+
+if TYPE_CHECKING:
+    from ..component.component import Component
+
+
+class HookableComponentPhase(Enum):
+    """
+    Enum representing the various phases in the lifecycle of a component which support hooks.
+
+    These phases correspond to different stages of the component's lifecycle, where hooks can be registered
+    and executed to perform actions before or after a phase is executed. These phases help manage the
+    orchestration of components during test execution.
+
+    Phases include:
+        - PRE_CONFIGURE, POST_CONFIGURE
+        - PRE_DEPLOY, POST_DEPLOY
+        - PRE_START, POST_START
+        - PRE_STOP, POST_STOP
+        - PRE_DESTROY, POST_DESTROY
+        - PRE_START_MONITORING, POST_START_MONITORING
+        - PRE_STOP_MONITORING, POST_STOP_MONITORING
+    """
+
+    PRE_CONFIGURE = "pre_configure"
+    POST_CONFIGURE = "post_configure"
+    PRE_DEPLOY = "pre_deploy"
+    POST_DEPLOY = "post_deploy"
+    PRE_START = "pre_start"
+    POST_START = "post_start"
+    PRE_STOP = "pre_stop"
+    POST_STOP = "post_stop"
+    PRE_DESTROY = "pre_destroy"
+    POST_DESTROY = "post_destroy"
+    PRE_START_MONITORING = "pre_start_monitoring"
+    POST_START_MONITORING = "post_start_monitoring"
+    PRE_STOP_MONITORING = "pre_stop_monitoring"
+    POST_STOP_MONITORING = "post_stop_monitoring"
+
+
+@dataclass
+class ComponentHookContext(BaseContext):
+    """
+    Holds state for a component hook execution.
+    """
+
+    parent_ctx: Optional["TestStepContext"] = None
+    phase: Optional["HookableComponentPhase"] = None
+
+    def get_step_component(self) -> Optional["Component"]:
+        """Fetches the component instance on which this hook is firing.
+
+        Returns: the component instance or none.
+        """
+        if self.parent_ctx is None:
+            raise RuntimeError(
+                "LifecycleHookContext.parent_ctx must be set to access the step component."
+            )
+        return self.parent_ctx.step.component

--- a/tools/pipeline_perf_test/orchestrator/lib/core/context/test_element_hook_context.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/context/test_element_hook_context.py
@@ -1,0 +1,71 @@
+"""
+Module: test_element_hook_context
+
+This module defines data structures and enums that support lifecycle hooks for test framework elements.
+These hooks enable actions to be performed automatically before or after key phases of a test's execution.
+
+Hookable lifecycle phases are defined using the `HookableTestPhase` enum, allowing for consistent
+integration points such as before a test runs or after it completes.
+
+The `TestLifecycleHookContext` class extends the base context and provides structured access to information
+about the current test phase and its associated framework element. This context object is passed to hook
+strategies for introspection and action.
+
+Typical use cases include:
+    - Injecting setup logic before a test runs.
+    - Executing cleanup or result validation after a test finishes.
+    - Dynamically altering behavior based on the test phase or test element metadata.
+
+Enums:
+    HookableTestPhase: Defines supported lifecycle phases where hooks can be executed.
+
+Classes:
+    TestLifecycleHookContext(BaseContext): Context object passed to lifecycle hooks, containing phase
+                                           and optional reference to the test framework element.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional, TYPE_CHECKING
+
+from .base import BaseContext
+from .test_contexts import TestFrameworkElementContext
+
+if TYPE_CHECKING:
+    from ..test_framework.test_element import TestLifecyclePhase, TestFrameworkElement
+
+
+class HookableTestPhase(Enum):
+    """This class represents the phases of a test framework element which can accept hooks."""
+
+    PRE_RUN = "pre_run"
+    POST_RUN = "post_run"
+
+
+@dataclass
+class TestElementHookContext(BaseContext):
+    """
+    Context object used during test lifecycle hooks to provide information
+    about the current phase and its associated test framework element.
+
+    This context is passed to hook strategies executed during specific
+    lifecycle phases (e.g., pre-run, post-run). It allows the hook to
+    access the broader test context and the test element involved in the phase.
+
+    Attributes:
+        parent_ctx (Optional[TestFrameworkElementContext]): Reference to the parent test element's context.
+        phase (Optional[TestLifecyclePhase]): The lifecycle phase during which the hook is executed.
+
+    Methods:
+        get_test_element() -> Optional[TestFrameworkElement]:
+            Returns the test element associated with the current context, if available.
+    """
+
+    parent_ctx: Optional["TestFrameworkElementContext"] = None
+    phase: Optional["TestLifecyclePhase"] = None
+
+    def get_test_element(self) -> Optional["TestFrameworkElement"]:
+        """Returns the test element associated with the current context, if available."""
+        if self.parent_ctx is None:
+            return None
+        return self.parent_ctx.get_test_element()

--- a/tools/pipeline_perf_test/orchestrator/lib/core/runtime/__init__.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/runtime/__init__.py
@@ -1,0 +1,5 @@
+"""Initialization for the core.runtime package."""
+
+from ..runtime.runtime import Runtime
+
+__all__ = ["Runtime"]

--- a/tools/pipeline_perf_test/orchestrator/lib/core/runtime/runtime.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/runtime/runtime.py
@@ -1,9 +1,9 @@
 """
-runtime.py
+component_runtime.py
 
-This module defines the `ComponentRuntime` class, which provides a flexible and
+This module defines the `Runtime` class, which provides a flexible and
 plugin-extensible mechanism for storing runtime information associated with a
-component during its lifecycle.
+component or element during its lifecycle.
 
 Runtime data is namespaced using string keys (e.g., strategy names), allowing
 different strategies or plugins to attach their own execution-specific state
@@ -25,8 +25,8 @@ across multiple strategies.
 from typing import Callable, Dict, Any
 
 
-class ComponentRuntime:
-    """Holds runtime info for a component in a plugin-extensible way."""
+class Runtime:
+    """Holds runtime info for a component or test element in a plugin-extensible way."""
 
     _data: Dict[str, Any]  # strategy_name -> plugin-defined state
 

--- a/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/__init__.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/__init__.py
@@ -1,11 +1,16 @@
 """Initialization for the core.test_framework package."""
 
+from .test_data import TestData
 from .test_definition import TestDefinition
 from .test_step import TestStep
 from .test_suite import TestSuite
+from .test_element import TestFrameworkElement, TestLifecyclePhase
 
 __all__ = [
+    "TestData",
+    "TestFrameworkElement",
     "TestSuite",
     "TestDefinition",
     "TestStep",
+    "TestLifecyclePhase",
 ]

--- a/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_data.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_data.py
@@ -1,3 +1,22 @@
+"""
+Module: test_data
+
+This module defines the `TestData` class, a container for storing information about a test run.
+It aggregates execution context and per-component data to support reporting, validation, and
+post-execution analysis.
+
+The `TestData` object is typically populated during or after test execution and passed to
+reporting strategies or other consumers that require a structured view of test results.
+
+Use cases include:
+    - Collecting metrics or artifacts from individual test components.
+    - Generating structured reports based on the test execution context.
+    - Providing a unified data interface to post-processing tools or hooks.
+
+Classes:
+    TestData: Stores the test execution context and associated component-level data.
+"""
+
 from dataclasses import dataclass, field
 from typing import Dict
 

--- a/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_definition.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_definition.py
@@ -1,7 +1,7 @@
 """
 Module: test_definition
 
-This module defines the `TestDefinition` class, which encapsulates a test scenario in a load generation
+This module defines the `TestDefinition` class, which encapsulates a test scenario in a
 testbed. The `TestDefinition` class allows for defining a sequence of test steps, executing them, and
 reporting the results through specified reporting strategies.
 
@@ -15,31 +15,29 @@ Classes:
 from typing import List, Optional, TYPE_CHECKING
 
 from ..component.component_data import ComponentData
-from ..context.base import ExecutionStatus
+from ..context.base import ExecutionStatus, BaseContext
 from ..context.test_contexts import TestExecutionContext, TestStepContext
 from .test_data import TestData
 from .test_step import TestStep
+from .test_element import TestFrameworkElement
+from ..context.test_element_hook_context import HookableTestPhase
 
 if TYPE_CHECKING:
     from ..strategies.reporting_strategy import ReportingStrategy
 
 
-class TestDefinition:
+class TestDefinition(TestFrameworkElement):
     """
-    A class that defines a test scenario, including its steps and reporting strategies.
-
-    The `TestDefinition` class encapsulates the details of a test, including the steps to execute and
-    the reporting strategies to use after the test has run. It provides the functionality to run the test,
-    aggregate monitoring data from components, and report the results using different strategies.
+    Defines a test scenario composed of sequential steps and reporting strategies.
 
     Attributes:
-        name (str): The name of the test.
-        steps (List[TestStep]): A list of test steps to be executed in sequence.
-        reporting_strategies (List[ReportingStrategy]): A list of reporting strategies used to report results.
+        name (str): The test's name.
+        steps (List[TestStep]): Ordered list of test steps.
+        reporting_strategies (List[ReportingStrategy]): Strategies for reporting test results.
 
     Methods:
-        run(context): Executes the test, runs the test steps, and reports results using the specified strategies.
-        aggregate_monitoring_data(context): Collects and aggregates monitoring data from all components.
+        run(ctx): Executes all steps and applies reporting strategies.
+        get_test_data(ctx) Compile and return a TestData object from components and steps.
     """
 
     def __init__(
@@ -57,25 +55,26 @@ class TestDefinition:
             reporting_strategies (List[ReportingStrategy], optional): A list of reporting strategies to apply
                                                                      after the test. Defaults to an empty list.
         """
+        super().__init__()
         self.name = name
         self.steps = steps
         self.reporting_strategies = reporting_strategies or []
-        self.context = None
 
-    def run(self, context: TestExecutionContext):
+    def run(self, ctx: Optional[BaseContext] = None) -> None:
         """
-        Executes the test by running all its steps and then reporting the results.
-
-        This method prints the test name, executes each test step in sequence, and collects aggregated monitoring
-        data from all components. Afterward, it reports the aggregated results using the provided reporting strategies.
+        Runs the test by executing steps and any pre/post run hooks.
 
         Args:
-            context (TestExecutionContext): The context that contains all the components and relevant data for the test.
+            ctx (TestExecutionContext): The test execution context.
         """
-        print(f"Running test: {self.name}")
+
+        assert isinstance(ctx, TestExecutionContext), "Expected TestExecutionContext"
+        self._run_hooks(HookableTestPhase.PRE_RUN, ctx)
+
         for step in self.steps:
             step_ctx = TestStepContext(name=step.name, step=step)
-            context.add_child_ctx(step_ctx)
+            ctx.add_child_ctx(step_ctx)
+
             try:
                 step_ctx.start()
                 step.run(step_ctx)
@@ -85,10 +84,11 @@ class TestDefinition:
                 step_ctx.status = ExecutionStatus.ERROR
                 step_ctx.error = e
                 step_ctx.log(f"Step '{step.name}' failed: {e}")
-                # TODO: Depending on policy: raise or continue
-                raise
+                raise  # or continue, based on policy
             finally:
                 step_ctx.end()
+
+        self._run_hooks(HookableTestPhase.POST_RUN, ctx)
 
     def get_test_data(self, ctx: TestExecutionContext) -> TestData:
         """

--- a/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_element.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_element.py
@@ -1,0 +1,125 @@
+"""
+Module: test_element
+
+This module defines the `TestFrameworkElement` abstract base class and supporting
+constructs that represent units of test execution within a test orchestration system.
+
+The test framework element is the foundational abstraction for anything that can be
+executed in a test such as a test case, test suite, or a test step. It supports
+execution hooks that can be attached to various phases of the test lifecycle,
+allowing users to inject behavior before or after execution (e.g., setup, validation,
+cleanup).
+
+The module also defines enums for lifecycle phases and mechanisms to run registered hooks.
+
+Key Concepts:
+    - Lifecycle Phases: Defined via `TestLifecyclePhase`, represent execution stages.
+    - Hook Integration: Hooks conforming to `HookStrategy` can be attached and run dynamically.
+
+Typical usage:
+    - Subclass `TestFrameworkElement` and implement the `run` method.
+    - Attach hooks using `add_hook` to customize behavior for different lifecycle phases.
+
+Enums:
+    TestLifecyclePhase: Represents core phases in a test element's execution.
+
+Classes:
+    TestFrameworkElement (ABC): Base class for all testable elements in the framework,
+                                with support for lifecycle hook execution.
+"""
+
+from abc import ABC, abstractmethod
+from enum import Enum
+from collections import defaultdict
+from typing import Optional, List, Dict, Callable, Any
+
+from ..context.test_element_hook_context import (
+    HookableTestPhase,
+    TestElementHookContext,
+)
+from ..strategies.hook_strategy import HookStrategy
+from ..context.base import BaseContext
+from ..context.test_contexts import TestFrameworkElementContext
+from ..context.base import ExecutionStatus
+from ..runtime import Runtime
+
+
+class TestLifecyclePhase(Enum):
+    """
+    Enum representing the various primary phases in the lifecycle of a TestFrameworkElement.
+
+    These phases help manage the orchestration of components during test execution.
+
+    Phases include:
+        - RUN        (Run the test suite/definition/step)
+    """
+
+    RUN = "run"
+
+
+class TestFrameworkElement(ABC):
+    """
+    Abstract base class for test elements within the orchestrator.
+    """
+
+    def __init__(self) -> None:
+        self._hooks: Dict[HookableTestPhase, List[HookStrategy]] = defaultdict(list)
+        self.runtime: Runtime = Runtime()
+
+    def add_hook(self, phase: HookableTestPhase, hook: HookStrategy) -> None:
+        """Register hooks to trigger at the specified phase of the element.
+
+        Args:
+            phase: The hookable phase of the test element (e.g. pre_run, post_run)
+            hook: The hook strategy to execute.
+        """
+        self._hooks[phase].append(hook)
+
+    def _run_hooks(
+        self, phase: HookableTestPhase, ctx: "TestFrameworkElementContext"
+    ) -> None:
+        """Run hooks for the specified phase with provided context.
+
+        Args:
+            phase: The hookable phase of the test element (e.g. pre_run, post_run)
+            ctx: The context for the current test element.
+        """
+        for hook in self._hooks.get(phase, []):
+            hook_context = TestElementHookContext(
+                phase=phase, name=f"{hook.__class__.__name__} ({phase.value})"
+            )
+            ctx.add_child_ctx(hook_context)
+            try:
+                hook_context.start()
+                hook.execute(hook_context)
+                if hook_context.status == ExecutionStatus.RUNNING:
+                    hook_context.status = ExecutionStatus.SUCCESS
+            except Exception as e:  # pylint: disable=broad-except
+                hook_context.status = ExecutionStatus.ERROR
+                hook_context.error = e
+                hook_context.log(f"Hook failed: {e}")
+                break
+            finally:
+                hook_context.end()
+
+    def get_or_create_runtime(self, namespace: str, factory: Callable[[], Any]) -> Any:
+        """Get an existing runtime data structure or initialize a new one.
+
+        Args:
+            namespace: The namespace to get/create data for.
+            factory: The initialization method if no namespace data exists.
+        """
+        return self.runtime.get_or_create(namespace, factory)
+
+    def set_runtime_data(self, namespace: str, data: Any):
+        """Set the data value on the component's runtime with the specified namespace.
+
+        Args:
+            namespace: The namespace to set the data value on.
+            data: The data to set.
+        """
+        self.runtime.set(namespace, data)
+
+    @abstractmethod
+    def run(self, ctx: Optional[BaseContext] = None):
+        """Run the test element logic."""

--- a/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_suite.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_suite.py
@@ -13,18 +13,19 @@ Classes:
     context to each test.
 """
 
-from typing import List, Dict, TYPE_CHECKING
+from typing import List, Dict, Optional, TYPE_CHECKING
 
-from ...core.context.base import ExecutionStatus
+from ...core.context.base import ExecutionStatus, BaseContext
 from .test_definition import TestDefinition
 from ..context.test_contexts import TestSuiteContext, TestExecutionContext
-
+from .test_element import TestFrameworkElement
+from ..context.test_element_hook_context import HookableTestPhase
 
 if TYPE_CHECKING:
-    from ..component.lifecycle_component import LifecycleComponent
+    from ..component.component import Component
 
 
-class TestSuite:
+class TestSuite(TestFrameworkElement):
     """
     A test suite class for managing and executing a series of tests on a set of components.
 
@@ -40,9 +41,7 @@ class TestSuite:
         run(): Executes all the tests in the test suite, providing each test with the necessary context.
     """
 
-    def __init__(
-        self, tests: List[TestDefinition], components: Dict[str, "LifecycleComponent"]
-    ):
+    def __init__(self, tests: List[TestDefinition], components: Dict[str, "Component"]):
         """
         Initializes the test suite with a list of tests and a dictionary of components.
 
@@ -53,6 +52,7 @@ class TestSuite:
             tests (List[TestDefinition]): The list of test definitions to be executed in the test suite.
             components (Dict[str, Component]): A dictionary of components to be used in the tests.
         """
+        super().__init__()
         self.tests = tests
         self.components = components
         # TODO: support a name field on TestSuite
@@ -60,15 +60,20 @@ class TestSuite:
         for k, v in components.items():
             self.context.add_component(k, v)
 
-    def run(self):
+    def run(self, _ctx: Optional[BaseContext] = None) -> None:
         """
         Run all tests in the test suite.
 
         This method iterates through the list of tests and runs each one, passing the context object
         to each test. The context provides access to the components, allowing the test to interact
         with them as needed.
+
+        Args:
+            _ctx: unused context object, defaults to None.
         """
+        self.context.test_suite = self
         self.context.start()
+        self._run_hooks(HookableTestPhase.PRE_RUN, self.context)
         for test_definition in self.tests:
             test_execution_context = TestExecutionContext(
                 name=test_definition.name, test_definition=test_definition
@@ -92,5 +97,6 @@ class TestSuite:
             for strategy in test_definition.reporting_strategies:
                 strategy.report(test_data)
         # TODO: Support policy based status (fail if any test fails, etc)
+        self._run_hooks(HookableTestPhase.POST_RUN, self.context)
         self.context.status = ExecutionStatus.SUCCESS
         self.context.end()


### PR DESCRIPTION
This change refactors hook and runtime classes and adds support for them on Test Elements (Test Suite, Test, Test Step).  This will allow us to e.g. run global hooks in order to e.g. deploy infrastructure without having to tie it to a particular component. Change also includes restructuring to provide more uniformity between component and test element naming, and introduces  base classes for test elements and their associated context classes.

- Rename LifecycleComponent -> Component
- Rename LifecyclePhase -> ComponentPhase
- Rename HookableLifecyclePhase -> HookableComponentPhase
- Rename LifecycleHookContext -> ComponentHookContext
- Move ComponentHookContext, HookableComponentPhase -> lib.core.context
- Rename ComponentRuntime -> Runtime 
- Move Runtime to lib.core.runtime (new).
- Add TestFrameworkElement as a base for all Test Element classes (TestSuite, TestDefinition, TestStep)
- Added TestFrameworkElementContext as a base for all Test Element related contexts.
- Added TestElementHookContext, HookableTestPhase in lib.core.context

This should be the last major change to the core. Config factory to follow, then various strategy implementations. #467 