### PR TITLE
Pin actions/download-artifact to SemVer hash

### DIFF
--- a/.github/workflows/pipeline-perf-test.yml
+++ b/.github/workflows/pipeline-perf-test.yml
@@ -63,7 +63,7 @@ jobs:
           - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
           - name: Download benchmark artifacts
-            uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
+            uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
             with:
               pattern: benchmark-results-*
               merge-multiple: true


### PR DESCRIPTION
Manual replacement for #492

In order to properly update on SemVer release instead of every commit with embedded changelog, need the fully qualified `v4.3.0` on the end.