### PR TITLE
Perf - Orchestrator, add configuration classes, factory, yaml loader

### DIFF
--- a/tools/pipeline_perf_test/orchestrator/lib/core/strategies/__init__.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/strategies/__init__.py
@@ -1,16 +1,26 @@
 """Initialization for the core.strategies package."""
 
-from .monitoring_strategy import MonitoringStrategy
-from .deployment_strategy import DeploymentStrategy
-from .configuration_strategy import ConfigurationStrategy
-from .execution_strategy import ExecutionStrategy
-from .reporting_strategy import ReportingStrategy, DestinationStrategy, FormatStrategy
+from .monitoring_strategy import MonitoringStrategy, MonitoringStrategyConfig
+from .deployment_strategy import DeploymentStrategy, DeploymentStrategyConfig
+from .configuration_strategy import ConfigurationStrategy, ConfigurationStrategyConfig
+from .execution_strategy import ExecutionStrategy, ExecutionStrategyConfig
+from .reporting_strategy import (
+    ReportingStrategy,
+    DestinationStrategy,
+    FormatStrategy,
+    ReportingStrategyConfig,
+)
 
 __all__ = [
+    "MonitoringStrategyConfig",
     "MonitoringStrategy",
+    "DeploymentStrategyConfig",
     "DeploymentStrategy",
+    "ConfigurationStrategyConfig",
     "ConfigurationStrategy",
+    "ExecutionStrategyConfig",
     "ExecutionStrategy",
+    "ReportingStrategyConfig",
     "ReportingStrategy",
     "DestinationStrategy",
     "FormatStrategy",

--- a/tools/pipeline_perf_test/orchestrator/lib/core/strategies/configuration_strategy.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/strategies/configuration_strategy.py
@@ -15,14 +15,21 @@ Typical concrete implementations of this interface might include:
     - RemoteConfig: Reads configs from a remote location and applies them
 
 Classes:
+    ConfigurationStrategyConfig(BaseModel): Base model for Configuration Strategy config.
     ConfigStrategy (ABC): Abstract base class that declares the `start` method,
                           which must be implemented by all concrete configuration strategies.
 """
 
 from abc import ABC, abstractmethod
 
-from ..component.lifecycle_component import LifecycleComponent
+from pydantic import BaseModel
+
+from ..component.component import Component
 from ..context.test_contexts import TestStepContext
+
+
+class ConfigurationStrategyConfig(BaseModel):
+    """Base model for Configuration Strategy config, passed to strategy init."""
 
 
 class ConfigurationStrategy(ABC):
@@ -37,7 +44,11 @@ class ConfigurationStrategy(ABC):
     """
 
     @abstractmethod
-    def start(self, component: LifecycleComponent, ctx: TestStepContext):
+    def __init__(self, config: ConfigurationStrategyConfig) -> None:
+        """All configuration strategies must be initialized with a config object."""
+
+    @abstractmethod
+    def start(self, component: Component, ctx: TestStepContext):
         """
         Start configuration for the given component.
 

--- a/tools/pipeline_perf_test/orchestrator/lib/core/strategies/deployment_strategy.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/strategies/deployment_strategy.py
@@ -14,18 +14,30 @@ Typical concrete implementations of this interface include:
     - ProcessDeployment: Manages components as local OS processes.
 
 Classes:
+    DeploymentStrategyConfig (BaseModel): Base class for strategy configs.
     DeploymentStrategy (ABC): Abstract base class for defining component deployment behavior.
 """
 
 from abc import ABC, abstractmethod
 
-from ..component.lifecycle_component import LifecycleComponent
+from pydantic import BaseModel
+
+from ..component.component import Component
 from ..context.test_contexts import TestStepContext
 
 
+class DeploymentStrategyConfig(BaseModel):
+    """Base model for Deployment Strategy config, passed to strategy init."""
+
+
 class DeploymentStrategy(ABC):
+
     @abstractmethod
-    def start(self, component: LifecycleComponent, ctx: TestStepContext):
+    def __init__(self, config: DeploymentStrategyConfig) -> None:
+        """All deployment strategies must be initialized with a config object."""
+
+    @abstractmethod
+    def start(self, component: Component, ctx: TestStepContext):
         """
         Deploy the component to the target environment.
 
@@ -35,7 +47,7 @@ class DeploymentStrategy(ABC):
         """
 
     @abstractmethod
-    def stop(self, component: LifecycleComponent, ctx: TestStepContext):
+    def stop(self, component: Component, ctx: TestStepContext):
         """
         Tear down and remove the deployed component.
 

--- a/tools/pipeline_perf_test/orchestrator/lib/core/strategies/execution_strategy.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/strategies/execution_strategy.py
@@ -14,13 +14,20 @@ Typical implementations of this interface include:
     - ReceiveLoad: Starts a component that passively receives load (e.g., validating otlp receiver).
 
 Classes:
+    ExecutionStrategyConfig(BaseModel):  Base model for Execution Strategy config.
     ExecutionStrategy (ABC): Abstract interface for starting and stopping a component's workload execution.
 """
 
 from abc import ABC, abstractmethod
 
-from ..component.lifecycle_component import LifecycleComponent
+from pydantic import BaseModel
+
+from ..component.component import Component
 from ..context.test_contexts import TestStepContext
+
+
+class ExecutionStrategyConfig(BaseModel):
+    """Base model for Execution Strategy config, passed to strategy init."""
 
 
 class ExecutionStrategy(ABC):
@@ -37,7 +44,11 @@ class ExecutionStrategy(ABC):
     """
 
     @abstractmethod
-    def start(self, component: LifecycleComponent, ctx: TestStepContext):
+    def __init__(self, config: ExecutionStrategyConfig) -> None:
+        """All execution strategies must be initialized with a config object."""
+
+    @abstractmethod
+    def start(self, component: Component, ctx: TestStepContext):
         """
         Start executing the component's workload.
 
@@ -47,7 +58,7 @@ class ExecutionStrategy(ABC):
         """
 
     @abstractmethod
-    def stop(self, component: LifecycleComponent, ctx: TestStepContext):
+    def stop(self, component: Component, ctx: TestStepContext):
         """
         Stop executing the component's workload.
 

--- a/tools/pipeline_perf_test/orchestrator/lib/core/strategies/hook_strategy.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/strategies/hook_strategy.py
@@ -1,0 +1,38 @@
+"""
+Module: hook_strategy
+
+This module defines the `HookStrategy` abstract base class, which provides a unified
+interface for implementing custom hooks that can be executed at various stages of
+a testbed or component lifecycle.
+
+Hook strategies encapsulate behavior that can be injected into specific points in the
+execution flow, such as setup, teardown, or validation phases. This allows for modular
+and reusable logic that interacts with the runtime context without modifying core
+execution strategies.
+
+
+Classes:
+    HookStrategyConfig(BaseModel): Base model for Hook Strategy config, passed to strategy init.
+    HookStrategy (ABC): Abstract interface for executing a hook with access to runtime context.
+"""
+
+from typing import Optional
+from abc import ABC, abstractmethod
+
+from pydantic import BaseModel
+
+from ..context.base import BaseContext
+
+
+class HookStrategyConfig(BaseModel):
+    """Base model for Execution Strategy config, passed to strategy init."""
+
+
+class HookStrategy(ABC):
+    @abstractmethod
+    def __init__(self, config: HookStrategyConfig):
+        """All hook strategies must be initialized with a config object."""
+
+    @abstractmethod
+    def execute(self, ctx: BaseContext) -> None:
+        """Execute the hook and pass it the current context."""

--- a/tools/pipeline_perf_test/orchestrator/lib/core/strategies/monitoring_strategy.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/strategies/monitoring_strategy.py
@@ -8,19 +8,21 @@ Monitoring strategies are responsible for gathering, starting, and stopping moni
 for components during tests. This can involve collecting performance metrics, logging,
 or gathering any relevant statistics or insights from the component.
 
-Typical implementations of this interface include:
-    - ResourceMonitoring: Monitors system resources such as CPU, memory, and network usage.
-    - HealthMonitoring: Monitors the health and availability of the component (e.g., via heartbeats).
-    - ResourceLogging: Monitors the application's logs from file, docker, k8s.
-
 Classes:
+    MonitoringStrategyConfig(BaseModel): Base class for configuring monitoring strategies.
     MonitoringStrategy (ABC): Abstract base class for all monitoring strategies.
 """
 
 from abc import ABC, abstractmethod
 
-from ..component.lifecycle_component import LifecycleComponent
+from pydantic import BaseModel
+
+from ..component.component import Component
 from ..context.test_contexts import TestStepContext, TestExecutionContext
+
+
+class MonitoringStrategyConfig(BaseModel):
+    """Base model for Monitoring Strategy config, passed to strategy init."""
 
 
 class MonitoringStrategy(ABC):
@@ -38,7 +40,11 @@ class MonitoringStrategy(ABC):
     """
 
     @abstractmethod
-    def start(self, component: LifecycleComponent, ctx: TestStepContext):
+    def __init__(self, config: MonitoringStrategyConfig) -> None:
+        """All monitoring strategies must be initialized with a config object."""
+
+    @abstractmethod
+    def start(self, component: Component, ctx: TestStepContext):
         """
         Start the monitoring process.
 
@@ -49,7 +55,7 @@ class MonitoringStrategy(ABC):
         """
 
     @abstractmethod
-    def stop(self, component: LifecycleComponent, ctx: TestStepContext):
+    def stop(self, component: Component, ctx: TestStepContext):
         """
         Stop the monitoring process.
 
@@ -60,7 +66,7 @@ class MonitoringStrategy(ABC):
         """
 
     @abstractmethod
-    def collect(self, component: LifecycleComponent, ctx: TestExecutionContext) -> dict:
+    def collect(self, component: Component, ctx: TestExecutionContext) -> dict:
         """
         Collect and return monitoring data.
 

--- a/tools/pipeline_perf_test/orchestrator/lib/core/strategies/reporting_strategy.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/strategies/reporting_strategy.py
@@ -11,15 +11,22 @@ The three key components in this module are:
     - `ReportingStrategy`: Integrates the formatting and output strategies to generate and report test data.
 
 Classes:
+    ReportingStrategyConfig(BaseModel) Base model for configuring reporting strategies.
     FormatStrategy (ABC): Interface for strategies that format aggregated test data.
     DestinationStrategy (ABC): Interface for strategies that determine where and how to output formatted data.
     ReportingStrategy (ABC): Interface for strategies that combine formatting and output to report aggregated data.
 """
 
 from abc import ABC, abstractmethod
-from typing import Dict, Any
+from typing import Any, Dict
+
+from pydantic import BaseModel
 
 from ..test_framework.test_data import TestData
+
+
+class ReportingStrategyConfig(BaseModel):
+    """Base model for Reporting Strategy config, passed to strategy init."""
 
 
 class FormatStrategy(ABC):
@@ -94,6 +101,10 @@ class ReportingStrategy(ABC):
         aggregated_data (Dict[str, Dict[str, any]]): The data to be reported, typically containing metrics
                                                       or test results organized by component and metric name.
     """
+
+    @abstractmethod
+    def __init__(self, config: ReportingStrategyConfig) -> None:
+        """All reporting strategies must be initialized with a config object."""
 
     @abstractmethod
     def report(self, test_data: TestData):

--- a/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/__init__.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/__init__.py
@@ -2,7 +2,7 @@
 
 from .test_data import TestData
 from .test_definition import TestDefinition
-from .test_step import TestStep
+from .test_step import TestStep, TestStepActionConfig, TestStepAction
 from .test_suite import TestSuite
 from .test_element import TestFrameworkElement, TestLifecyclePhase
 
@@ -12,5 +12,7 @@ __all__ = [
     "TestSuite",
     "TestDefinition",
     "TestStep",
+    "TestStepActionConfig",
+    "TestStepAction",
     "TestLifecyclePhase",
 ]

--- a/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_step.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_step.py
@@ -11,15 +11,43 @@ Classes:
     TestStep: A class representing a single step in a test, which includes a name and an action to execute.
 """
 
-from typing import Any, Callable, Optional, TYPE_CHECKING
+from abc import abstractmethod, ABC
+from typing import Optional, TYPE_CHECKING
+
+from pydantic import BaseModel
 
 from ..context.base import BaseContext
 from ..context.test_contexts import TestStepContext
-from .test_element import TestFrameworkElement
 from ..context.test_element_hook_context import HookableTestPhase
+from .test_element import TestFrameworkElement
 
 if TYPE_CHECKING:
     from ..component.component import Component
+
+
+class TestStepActionConfig(BaseModel):
+    """Base model for Test Step Action configs, passed to TestStepAction init."""
+
+
+class TestStepAction(ABC):
+    """
+    Abstract base class representing a test step action.
+
+    This class defines the interface for all test step actions that can be
+    performed in a testing framework. Each action must be initialized with
+    a configuration object and must implement an execution method that takes
+    the current test step context.
+
+    Subclasses are required to implement the __init__ and execute methods.
+    """
+
+    @abstractmethod
+    def __init__(self, config: TestStepActionConfig) -> None:
+        """All test step actions must be initialized with a config object."""
+
+    @abstractmethod
+    def execute(self, ctx: TestStepContext) -> None:
+        """Execute the step action and pass it the current context."""
 
 
 class TestStep(TestFrameworkElement):
@@ -31,7 +59,7 @@ class TestStep(TestFrameworkElement):
 
     Attributes:
         name (str): The name of the test step.
-        action (Callable): The action (a callable function) to be executed for this test step.
+        action (TestStepAction): The action to be executed for this test step.
 
     Methods:
         run(context): Executes the action associated with the test step, providing the context to the action.
@@ -40,7 +68,7 @@ class TestStep(TestFrameworkElement):
     def __init__(
         self,
         name: str,
-        action: Callable[[TestStepContext], Any],
+        action: TestStepAction,
         component: Optional["Component"] = None,
     ):
         """
@@ -49,10 +77,20 @@ class TestStep(TestFrameworkElement):
         Args:
             name (str): The name of the test step.
             action (Callable[[TestStepContext], any]): A callable function that defines the action to execute when the test step is run.
+            component: Optional component associated with the test step.
         """
         super().__init__()
         self.name = name
         self.action = action
+        self.component = component
+
+    def set_component(self, component):
+        """
+        Allows test actions to set the step target component at runtime.
+
+        Args:
+            component: The Component that is the target of a given step action.
+        """
         self.component = component
 
     def run(self, ctx: Optional[BaseContext] = None) -> None:
@@ -71,5 +109,5 @@ class TestStep(TestFrameworkElement):
         assert isinstance(ctx, TestStepContext), "Expected TestExecutionContext"
 
         self._run_hooks(HookableTestPhase.PRE_RUN, ctx)
-        self.action(ctx)
+        self.action.execute(ctx)
         self._run_hooks(HookableTestPhase.POST_RUN, ctx)

--- a/tools/pipeline_perf_test/orchestrator/lib/runner/__init__.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/runner/__init__.py
@@ -1,0 +1,24 @@
+"""Initialization for the lib.runner package."""
+
+from .registry import (
+    deployment_registry,
+    monitoring_registry,
+    reporting_registry,
+    configuration_registry,
+    execution_registry,
+    hook_registry,
+    test_step_action_registry,
+)
+from .schema.loader import load_config_from_file, load_config_from_string
+
+__all__ = [
+    "deployment_registry",
+    "monitoring_registry",
+    "reporting_registry",
+    "configuration_registry",
+    "execution_registry",
+    "hook_registry",
+    "test_step_action_registry",
+    "load_config_from_file",
+    "load_config_from_string",
+]

--- a/tools/pipeline_perf_test/orchestrator/lib/runner/factory.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/runner/factory.py
@@ -1,0 +1,255 @@
+"""
+factory.py
+
+This module provides factory functions for constructing core objects in the test
+framework from their configuration representations. These include managed components,
+test steps, test definitions, and entire test suites.
+
+Each factory function is responsible for:
+- Instantiating the appropriate element from its config model.
+- Building and injecting optional strategies (e.g., deployment, monitoring, execution).
+- Registering lifecycle hooks defined in the configuration.
+- Ensuring consistency and encapsulating construction logic.
+
+Functions:
+- build_managed_component: Creates a ManagedComponent from its configuration.
+- build_test_step: Creates a TestStep with action and hooks from its config.
+- build_test_definition: Builds a TestDefinition including steps and reporting strategies.
+- build_test_suite: Constructs a complete TestSuite with components, tests, and hooks.
+- register_hooks_from_config: Utility to attach pre/post hooks based on config and phase enums.
+- get_hookable_phase: Resolves enum members for lifecycle hook registration.
+
+This module centralizes framework object construction to promote modularity, reuse,
+and consistency across the system.
+"""
+
+from enum import Enum
+from typing import Type
+from ..core.context.component_hook_context import HookableComponentPhase
+from ..core.test_framework import (
+    TestSuite,
+    TestDefinition,
+    TestStep,
+    TestFrameworkElement,
+)
+from ..core.context.test_element_hook_context import HookableTestPhase
+from ..impl.component.managed_component import (
+    ManagedComponent,
+    ManagedComponentConfiguration,
+)
+from ..impl.strategies.monitoring.composite_monitoring_strategy import (
+    CompositeMonitoringStrategy,
+)
+
+from .schema.test_config import (
+    TestSuiteConfig,
+    TestDefinitionConfig,
+    TestStepConfig,
+)
+
+# Trigger all the default strategy / action registrations
+# pylint: disable=unused-import
+from ..impl import strategies  # Do not remove
+from ..impl import actions  # Do not remove
+
+
+def get_hookable_phase(enum_cls: Type[Enum], base_phase: str, timing: str) -> Enum:
+    """
+    Retrieve a specific enum member representing a hookable phase based on timing and phase name.
+
+    Args:
+        enum_cls (Type[Enum]): The enumeration class containing hookable phase members.
+        base_phase (str): The base name of the phase (e.g., "run").
+        timing (str): The timing of the hook relative to the phase (e.g., "pre", "post").
+
+    Returns:
+        Enum: The corresponding enum member (e.g., enum_cls["PRE_START"]).
+
+    Raises:
+        KeyError: If the constructed name does not match any member of the enum.
+    """
+    name = f"{timing.upper()}_{base_phase.upper()}"
+    return enum_cls[name]
+
+
+def register_hooks_from_config(
+    target: TestFrameworkElement | ManagedComponent,
+    config: (
+        ManagedComponentConfiguration
+        | TestSuiteConfig
+        | TestDefinitionConfig
+        | TestStepConfig
+    ),
+    enum_cls: Type[Enum],
+):
+    """
+    Registers lifecycle hooks from a configuration object onto a target element.
+
+    This function iterates over the hook phases defined in the configuration object,
+    builds the corresponding hook elements (both pre and post), and attaches them
+    to the appropriate lifecycle phase of the target element using the provided enum class.
+
+    The hookable phase is determined dynamically by combining the phase name (e.g., "start")
+    with a timing prefix ("pre" or "post"), and matching it against the given enum class
+    (e.g., enum_cls["PRE_START"]).
+
+    Args:
+        target (TestFrameworkElement | ManagedComponent): The object that will have hooks attached.
+        config (ManagedComponentConfiguration | TestSuiteConfig | TestDefinitionConfig | TestStepConfig):
+            The configuration containing hook definitions for different lifecycle phases.
+        enum_cls (Type[Enum]): Enum class representing hookable lifecycle phases.
+
+    Raises:
+        KeyError: If a generated hook phase name (e.g., "PRE_START") is not found in the enum.
+    """
+    for phase, hooks_config in config.hooks.items():
+        base_phase = phase.value  # e.g., "start", "deploy"
+
+        for hook_wrapper in hooks_config.pre:
+            hook = hook_wrapper.build_element()
+            lifecycle_phase = get_hookable_phase(enum_cls, base_phase, "pre")
+            target.add_hook(lifecycle_phase, hook)
+
+        for hook_wrapper in hooks_config.post:
+            hook = hook_wrapper.build_element()
+            lifecycle_phase = get_hookable_phase(enum_cls, base_phase, "post")
+            target.add_hook(lifecycle_phase, hook)
+
+
+def build_managed_component(
+    name: str, config: ManagedComponentConfiguration
+) -> ManagedComponent:
+    """
+    Constructs a ManagedComponent instance from its configuration.
+
+    This function builds and assembles various optional strategies defined in the
+    `ManagedComponentConfiguration`, including deployment, monitoring, configuration,
+    and execution strategies. It also registers any lifecycle hooks specified in
+    the configuration.
+
+    Args:
+        name (str): The name to assign to the managed component.
+        config (ManagedComponentConfiguration): The configuration object that defines
+            the component's behavior, strategies, and hooks.
+
+    Returns:
+        ManagedComponent: A fully constructed and hook-registered managed component.
+
+    Notes:
+        - If a strategy (e.g., deployment, configuration) is not specified in the config,
+          it will be set to None.
+        - The monitoring strategy supports multiple sub-strategies combined into a
+          CompositeMonitoringStrategy.
+        - Lifecycle hooks are registered using the `HookableComponentPhase` enum.
+    """
+    deployment = config.deployment.build_element() if config.deployment else None
+    monitoring = CompositeMonitoringStrategy(
+        strategies=[
+            strat.build_element() for _, strat in (config.monitoring or {}).items()
+        ]
+    )
+    configuration = (
+        config.configuration.build_element() if config.configuration else None
+    )
+    execution = config.execution.build_element() if config.execution else None
+
+    component = ManagedComponent(
+        name=name,
+        config=config,
+        deployment_strategy=deployment,
+        monitoring_strategy=monitoring,
+        configuration_strategy=configuration,
+        execution_strategy=execution,
+    )
+    register_hooks_from_config(component, config, HookableComponentPhase)
+    return component
+
+
+def build_test_step(config: TestStepConfig) -> TestStep:
+    """
+    Constructs a TestStep instance from its configuration.
+
+    This function initializes a TestStep using the provided configuration by:
+    - Building the action element defined in the config.
+    - Registering any pre- and post-execution hooks defined in the config using the
+      `HookableTestPhase` enum.
+
+    Args:
+        config (TestStepConfig): The configuration object defining the test step's
+            name, action, and associated hooks.
+
+    Returns:
+        TestStep: A fully initialized and hook-registered test step instance.
+    """
+    ts = TestStep(name=config.name, action=config.action.build_element())
+    register_hooks_from_config(ts, config, HookableTestPhase)
+    return ts
+
+
+def build_test_definition(config: TestDefinitionConfig) -> TestDefinition:
+    """
+    Constructs a TestDefinition instance from its configuration.
+
+    This function builds the individual test steps and reporting strategies defined
+    in the configuration, and registers any lifecycle hooks associated with the test
+    definition using the `HookableTestPhase` enum.
+
+    Steps:
+    - Each configured test step is built using `build_test_step`.
+    - Reporting strategies are built and aggregated.
+    - A TestDefinition object is instantiated with the name, steps, and strategies.
+    - Pre and post-execution hooks are registered.
+
+    Args:
+        config (TestDefinitionConfig): Configuration defining the test name, steps,
+            reporting strategies, and hooks.
+
+    Returns:
+        TestDefinition: A fully constructed and hook-registered test definition.
+    """
+    steps = [build_test_step(s) for s in config.steps or []]
+    reporting_strategies = []
+    for _, strat in config.reporting.items():
+        reporting_strategies.append(strat.build_element())
+
+    td = TestDefinition(
+        name=config.name, steps=steps, reporting_strategies=reporting_strategies
+    )
+    register_hooks_from_config(td, config, HookableTestPhase)
+    return td
+
+
+def build_test_suite(config: TestSuiteConfig) -> TestSuite:
+    """
+    Constructs a TestSuite instance from its configuration.
+
+    This function builds all managed components and test definitions defined
+    in the test suite configuration. It also registers any lifecycle hooks
+    using the `HookableTestPhase` enum.
+
+    Steps:
+    - For each component in the configuration, build a ManagedComponent using
+      `build_managed_component`.
+    - For each test definition, build a TestDefinition using `build_test_definition`.
+    - Create a TestSuite with the assembled components and tests.
+    - Register pre- and post-phase hooks defined in the suite config.
+
+    Args:
+        config (TestSuiteConfig): Configuration object defining the suite's
+            components, tests, and associated hooks.
+
+    Returns:
+        TestSuite: A fully constructed and hook-registered test suite instance.
+    """
+    components = {}
+    for component_name, component_def in config.components.items():
+        component = build_managed_component(component_name, component_def)
+        components[component_name] = component
+
+    tests = []
+    for test_def in config.tests:
+        tests.append(build_test_definition(test_def))
+
+    ts = TestSuite(components=components, tests=tests)
+    register_hooks_from_config(ts, config, HookableTestPhase)
+    return ts

--- a/tools/pipeline_perf_test/orchestrator/lib/runner/registry.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/runner/registry.py
@@ -1,0 +1,112 @@
+"""
+registry.py
+
+This module defines a flexible registry system for managing the mapping between
+string-based type identifiers and their corresponding element and configuration classes.
+It supports registration and lookup of components such as strategies, actions, and their
+configuration schemas.
+
+Core Concepts:
+- ElementRegistry: A base registry that maintains mappings for both element classes
+  and their associated configuration classes using decorators.
+- StrategyRegistry: A specialization of ElementRegistry for registering various strategy types.
+- TestStepActionRegistry: A specialization of ElementRegistry for test step actions.
+
+Usage:
+- Register classes using the `@register_class("type_name")` decorator.
+- Register config schemas using the `@register_config("type_name")` decorator.
+- Retrieve registered classes from `element` or `config` dictionaries.
+
+Defined Registries:
+- deployment_registry: For deployment strategies.
+- monitoring_registry: For monitoring strategies.
+- reporting_registry: For reporting strategies.
+- configuration_registry: For configuration strategies.
+- execution_registry: For execution strategies.
+- hook_registry: For hook strategies.
+- test_step_action_registry: For test step action implementations.
+
+This module centralizes and standardizes how extensible elements are registered and
+resolved dynamically by type name throughout the framework.
+"""
+
+from typing import Dict, Type, Callable, TypeVar
+
+
+T = TypeVar("T")
+ConfigT = TypeVar("ConfigT")
+
+
+class ElementRegistry:
+    """
+    Registry for mapping element and configuration type names to their classes.
+
+    Attributes:
+        element (Dict[str, Type]): Maps element type names to element classes.
+        config (Dict[str, Type]): Maps element type names to configuration classes.
+    """
+
+    def __init__(self):
+        """
+        Initialize empty registries for elements and configs.
+        """
+        self.element: Dict[str, Type] = {}
+        self.config: Dict[str, Type] = {}
+
+    def register_class(self, type_name: str) -> Callable[[Type[T]], Type[T]]:
+        """
+        Decorator to register a element class under a given type name.
+
+        Args:
+            type_name (str): The identifier to register the element class under.
+
+        Returns:
+            Callable[[Type[T]], Type[T]]: A decorator that registers the class and returns it unchanged.
+        """
+
+        def decorator(cls: Type[T]) -> Type[T]:
+            self.element[type_name] = cls
+            return cls
+
+        return decorator
+
+    def register_config(
+        self, type_name: str
+    ) -> Callable[[Type[ConfigT]], Type[ConfigT]]:
+        """
+        Decorator to register a configuration class under a given type name.
+
+        Args:
+            type_name (str): The identifier to register the config class under.
+
+        Returns:
+            Callable[[Type[ConfigT]], Type[ConfigT]]: A decorator that registers the class and returns it unchanged.
+        """
+
+        def decorator(cls: Type[ConfigT]) -> Type[ConfigT]:
+            self.config[type_name] = cls
+            return cls
+
+        return decorator
+
+
+class StrategyRegistry(ElementRegistry):
+    """
+    Registry for mapping strategy and configuration type names to their classes.
+    """
+
+
+class TestStepActionRegistry(ElementRegistry):
+    """
+    Registry for mapping strategy and configuration type names to their classes.
+    """
+
+
+# Domain-specific registries for different strategy categories
+deployment_registry = StrategyRegistry()
+monitoring_registry = StrategyRegistry()
+reporting_registry = StrategyRegistry()
+configuration_registry = StrategyRegistry()
+execution_registry = StrategyRegistry()
+hook_registry = StrategyRegistry()
+test_step_action_registry = TestStepActionRegistry()

--- a/tools/pipeline_perf_test/orchestrator/lib/runner/schema/__init__.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/runner/schema/__init__.py
@@ -1,0 +1,12 @@
+"""Initialization for the lib.runner.schema package."""
+
+from .loader import load_config_from_file, load_config_from_string
+from .test_config import TestStepConfig, TestDefinitionConfig, TestSuiteConfig
+
+__all__ = [
+    "load_config_from_file",
+    "load_config_from_string",
+    "TestStepConfig",
+    "TestDefinitionConfig",
+    "TestSuiteConfig"
+]

--- a/tools/pipeline_perf_test/orchestrator/lib/runner/schema/hook_config.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/runner/schema/hook_config.py
@@ -1,0 +1,41 @@
+"""
+hook_config.py
+
+This module defines the configuration schema for managing lifecycle hooks
+attached to components or test phases in the framework.
+
+Key Elements:
+- HooksConfig: A Pydantic model representing pre- and post-phase hooks that can
+  be applied to a component or test. Each phase supports a list of hook wrappers
+  and an associated strategy for how hooks should be added (e.g., append or replace).
+
+Types:
+- HookAddStrategy: A literal type defining allowed strategies for modifying the
+  existing hook list ("append" or "replace").
+
+Usage:
+- Use `HooksConfig` as part of higher-level configurations (e.g., test steps,
+  test definitions, components) to declaratively define lifecycle hooks.
+- Hooks are wrapped using `HookWrapper` to defer instantiation until build time.
+
+This configuration model enables flexible and declarative control over how hooks
+are injected into different phases of execution.
+"""
+
+from typing import List, Literal
+
+from pydantic import BaseModel, Field
+
+from ..wrappers import HookWrapper
+
+
+HookAddStrategy = Literal["append", "replace"]
+
+
+class HooksConfig(BaseModel):
+    """Base configuration model that specifies a hook to set on a component or test"""
+
+    pre: List[HookWrapper] = Field(default_factory=list)
+    pre_strategy: HookAddStrategy = "append"
+    post: List[HookWrapper] = Field(default_factory=list)
+    post_strategy: HookAddStrategy = "append"

--- a/tools/pipeline_perf_test/orchestrator/lib/runner/schema/loader.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/runner/schema/loader.py
@@ -1,0 +1,29 @@
+"""
+loader.py
+
+This module provides utility functions for loading a `TestSuiteConfig` from YAML sources.
+
+Functions:
+- load_config_from_file: Reads a YAML file from disk and parses it into a `TestSuiteConfig`.
+- load_config_from_string: Parses a YAML string directly into a `TestSuiteConfig`.
+
+These utilities support configuration-driven workflows, allowing test suites to be
+defined declaratively in YAML and loaded at runtime using Pydantic model validation.
+"""
+
+import yaml
+from pathlib import Path
+from .test_config import TestSuiteConfig
+
+
+def load_config_from_file(path: str | Path) -> TestSuiteConfig:
+    """Loads and parses a TestSuiteConfig from a YAML file."""
+    with open(path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    return TestSuiteConfig.model_validate(data)
+
+
+def load_config_from_string(yaml_str: str) -> TestSuiteConfig:
+    """Loads and parses a TestSuiteConfig from a YAML string."""
+    data = yaml.safe_load(yaml_str)
+    return TestSuiteConfig.model_validate(data)

--- a/tools/pipeline_perf_test/orchestrator/lib/runner/schema/test_config.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/runner/schema/test_config.py
@@ -1,0 +1,209 @@
+"""
+test_config.py
+
+Configuration Models for Test Suite, Test Definitions, and Test Steps
+
+This module contains configuration models used to define and manage the structure
+of a test suite, its individual tests, and the steps involved in each test. These
+models are designed using Pydantic's `BaseModel` to provide validation and parsing
+of test configurations.
+
+The following models are included:
+
+1. `TestStepConfig`: Represents the configuration for an individual test step.
+   - Defines the name, action, and hooks associated with each test step.
+   - Allows validation and parsing of the action section, ensuring correct action type and configuration.
+
+2. `TestDefinitionConfig`: Represents the configuration for a full test within a suite.
+   - Defines the test name, the list of steps involved, the reporting strategies, and lifecycle hooks.
+   - Parses and validates reporting strategies, ensuring each one is correctly configured.
+
+3. `TestSuiteConfig`: Represents the overall configuration for a test suite.
+   - Defines components, tests, and hooks for the entire test suite.
+   - Allows grouping of reusable components and sets up lifecycle hooks for the suite.
+
+"""
+
+from typing import Dict, List, Optional, Any
+from pydantic import BaseModel, model_validator, Field
+
+from ...impl.component.managed_component import (
+    ManagedComponentConfiguration,
+)
+from ..registry import reporting_registry, test_step_action_registry
+from ..wrappers import ReportingWrapper, TestStepActionWrapper
+from ...core.test_framework.test_element import TestLifecyclePhase
+from .hook_config import HooksConfig
+
+
+class TestStepConfig(BaseModel):
+    """
+    Represents the configuration for a single test step in a test framework.
+
+    Attributes:
+        name (str): The name of the test step.
+        action (TestStepActionWrapper): The action config to be performed during this test step, wrapped via TestStepActionWrapper.
+        hooks (Dict[TestLifecyclePhase, HooksConfig]): A dictionary of hooks that are applied at different points in the test lifecycle. The keys are lifecycle phases, and the values are the corresponding hook configurations.
+
+    Methods:
+        parse_action_section(cls, data: Any) -> Any:
+            A class method that validates and processes the 'action' section of the test step configuration. If the 'action' is provided as a dictionary, it wraps the configuration into the appropriate action class, ensuring the action type is valid.
+
+    Example:
+        test_step_config = TestStepConfig(
+            name="Step 1",
+            action=TestStepActionWrapper(element_type="action_type", config=config_data),
+            hooks={TestLifecyclePhase.START: start_hook_config}
+        )
+    """
+
+    name: str
+    action: TestStepActionWrapper
+    hooks: Dict[TestLifecyclePhase, HooksConfig] = Field(default_factory=dict)
+
+    @model_validator(mode="before")
+    @classmethod
+    def parse_action_section(cls, data: Any) -> Any:
+        """
+        A class method that validates and processes the 'action' section in the test step configuration.
+
+        This method checks if the 'action' field exists in the input `data` and whether it is provided as a dictionary.
+        If it is, the method iterates over the items in the dictionary, validates the action type,
+        creates the appropriate configuration object, and wraps it into a `TestStepActionWrapper`.
+
+        The wrapped action is then assigned back to the 'action' key in the `data` dictionary.
+
+        Args:
+            data (Any): The input data for the test step configuration, typically a dictionary.
+
+        Returns:
+            Any: The processed data, with the 'action' field updated to contain the wrapped action configuration.
+
+        Raises:
+            ValueError: If an unknown action type is encountered during processing.
+        """
+        action = data.get("action")
+
+        # If 'action' exists and is a dictionary, process it.
+        if action and isinstance(action, dict):
+            for action_type, config_data in action.items():
+                # Look up the corresponding configuration class for the action type.
+                config_cls = test_step_action_registry.config.get(action_type)
+
+                # If no configuration class is registered, raise an error.
+                if not config_cls:
+                    raise ValueError(f"Unknown test step action type: '{action_type}'")
+
+                # Instantiate the configuration class with the provided data.
+                action_config = config_cls(**config_data)
+
+                # Wrap the action configuration into a TestStepActionWrapper.
+                wrapped = TestStepActionWrapper(
+                    element_type=action_type, config=action_config
+                )
+
+            # Update the 'action' field in the input data with the wrapped configuration.
+            data["action"] = wrapped
+        return data
+
+
+class TestDefinitionConfig(BaseModel):
+    """
+    Base configuration model for defining a test, including its steps, reporting, and hooks.
+
+    Attributes:
+        name (str): The name of the test definition.
+        steps (Optional[List[TestStepConfig]]): A list of steps that define the sequence of actions for this test. Each step is configured via a `TestStepConfig`.
+        reporting (Optional[Dict[str, ReportingWrapper]]): A dictionary of reporting strategies to be applied during the test. The keys are reporting strategy types, and the values are the corresponding `ReportingWrapper` configurations.
+        hooks (Dict[TestLifecyclePhase, HooksConfig]): A dictionary of hooks applied at different phases of the test lifecycle. The keys represent lifecycle phases, and the values are the corresponding `HooksConfig`.
+
+    Methods:
+        parse_reporting_section(cls, data: Any) -> Any:
+            A class method that validates and processes the 'reporting' section of the test definition configuration. If the 'reporting' field is provided as a dictionary, it wraps each reporting strategy into the appropriate wrapper class, ensuring the strategy type is valid.
+
+    Example:
+        test_def_config = TestDefinitionConfig(
+            name="Test 1",
+            steps=[step_1_config, step_2_config],
+            reporting={"strategy_1": strategy_1_config, "strategy_2": strategy_2_config},
+            hooks={TestLifecyclePhase.START: start_hook_config, TestLifecyclePhase.END: end_hook_config}
+        )
+    """
+
+    name: str
+    steps: Optional[List[TestStepConfig]]
+    reporting: Optional[Dict[str, ReportingWrapper]]
+    hooks: Dict[TestLifecyclePhase, HooksConfig] = Field(default_factory=dict)
+
+    @model_validator(mode="before")
+    @classmethod
+    def parse_reporting_section(cls, data: Any) -> Any:
+        """
+        A class method that validates and processes the 'reporting' section in the test definition configuration.
+
+        This method checks if the 'reporting' field exists in the input `data` and whether it is provided as a dictionary.
+        If it is, the method iterates over the items in the dictionary, validates the reporting strategy type,
+        creates the corresponding configuration object, and wraps it into a `ReportingWrapper`.
+
+        The wrapped reporting strategies are then assigned back to the 'reporting' key in the `data` dictionary.
+
+        Args:
+            data (Any): The input data for the test definition configuration, typically a dictionary.
+
+        Returns:
+            Any: The processed data, with the 'reporting' field updated to contain the wrapped reporting strategies.
+
+        Raises:
+            ValueError: If an unknown reporting strategy type is encountered during processing.
+        """
+        reports = data.get("reporting")
+        if reports and isinstance(reports, dict):
+            parsed = {}
+            for strategy_type, config_data in reports.items():
+                # Look up the corresponding configuration class for the strategy type.
+                config_cls = reporting_registry.config.get(strategy_type)
+
+                # If no configuration class is registered for the strategy type, raise an error.
+                if not config_cls:
+                    raise ValueError(f"Unknown reporting strategy: '{strategy_type}'")
+
+                # Instantiate the configuration class with the provided data for this reporting strategy.
+                strategy_config = config_cls(**config_data)
+
+                # Wrap the strategy configuration into a ReportingWrapper and store it in the parsed dictionary.
+                parsed[strategy_type] = ReportingWrapper(
+                    element_type=strategy_type, config=strategy_config
+                )
+
+            # Update the 'reporting' field in the input data with the parsed and wrapped strategies.
+            data["reporting"] = parsed
+        return data
+
+
+class TestSuiteConfig(BaseModel):
+    """
+    Base configuration model for defining a test suite, including its components, tests, and lifecycle hooks.
+
+    Attributes:
+        components (Optional[Dict[str, ManagedComponentConfiguration]]):
+            A dictionary of reusable components used throughout the test suite.
+            The keys represent component names, and the values are their corresponding configurations.
+
+        tests (Optional[List[TestDefinitionConfig]]):
+            A list of test definitions that make up the test suite. Each test is defined using a `TestDefinitionConfig`.
+
+        hooks (Dict[TestLifecyclePhase, HooksConfig]):
+            A dictionary of lifecycle hooks to be executed at various phases of the test suite execution.
+            The keys are lifecycle phases (e.g., setup, teardown), and the values are `HooksConfig` objects.
+
+    Example:
+        suite_config = TestSuiteConfig(
+            components={"db": db_component_config, "api": api_component_config},
+            tests=[test_1_config, test_2_config],
+            hooks={TestLifecyclePhase.BEFORE_ALL: before_all_hook}
+        )
+    """
+
+    components: Optional[Dict[str, ManagedComponentConfiguration]]
+    tests: Optional[List[TestDefinitionConfig]]
+    hooks: Dict[TestLifecyclePhase, HooksConfig] = Field(default_factory=dict)

--- a/tools/pipeline_perf_test/orchestrator/lib/runner/wrappers.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/runner/wrappers.py
@@ -1,0 +1,242 @@
+"""
+wrappers.py
+
+This module provides generic wrapper classes for building element instances
+from configuration objects and type identifiers.
+
+Each wrapper class is parameterized by specific configuration and element types,
+and relies on a corresponding registry to resolve and instantiate the correct
+element implementation.
+
+Wrappers serve as a bridge between raw configuration data and fully constructed
+element objects, facilitating consistent parsing, validation, and instantiation
+across different element domains such as test actions, hooks, monitoring, reporting,
+configuration, and execution.
+"""
+
+from typing import Type, Dict, Generic, TypeVar
+from pydantic import BaseModel, model_validator
+
+from ..core.strategies.deployment_strategy import (
+    DeploymentStrategyConfig,
+    DeploymentStrategy,
+)
+from ..core.strategies.monitoring_strategy import (
+    MonitoringStrategyConfig,
+    MonitoringStrategy,
+)
+from ..core.strategies.reporting_strategy import (
+    ReportingStrategyConfig,
+    ReportingStrategy,
+)
+from ..core.strategies.hook_strategy import HookStrategyConfig, HookStrategy
+from ..core.strategies.execution_strategy import (
+    ExecutionStrategy,
+    ExecutionStrategyConfig,
+)
+from ..core.strategies.configuration_strategy import (
+    ConfigurationStrategy,
+    ConfigurationStrategyConfig,
+)
+from ..core.test_framework.test_step import TestStepActionConfig, TestStepAction
+from .registry import (
+    deployment_registry,
+    monitoring_registry,
+    reporting_registry,
+    configuration_registry,
+    execution_registry,
+    hook_registry,
+    test_step_action_registry,
+)
+
+ConfigType = TypeVar("ConfigType", bound=BaseModel)  # pylint: disable=invalid-name
+ElementType = TypeVar("ElementType")  # pylint: disable=invalid-name
+
+
+class ConfigurableWrapper(BaseModel, Generic[ConfigType, ElementType]):
+    """
+    Generic wrapper for building a instances from a type and config.
+
+    This class serves as a base for defining wrappers that take a
+    type identifier and a corresponding config object, and resolve
+    the actual class using a registry defined in subclasses.
+
+    Type Args:
+        ConfigType: The type of configuration model required by the strategy.
+        ElementType: The class type being constructed.
+
+    Attributes:
+        element_type (str): The key identifying which implementation to use.
+        config (ConfigType): The configuration object used to initialize the element.
+        _registry (Dict[str, Type[ElementType]]): A registry mapping element type
+            strings to concrete element classes. Must be defined in subclasses.
+    """
+
+    element_type: str
+    config: ConfigType
+
+    # Registry must be defined in subclasses
+    _registry: Dict[str, Type[ElementType]] = {}
+
+    def build_element(self) -> ElementType:
+        """
+        Instantiate the element based on the element type and config.
+
+        Returns:
+            ElementType: An instance of the resolved element class, initialized
+            with the provided configuration.
+
+        Raises:
+            ValueError: If no element class is registered for the given element type.
+        """
+        element_cls = self._registry.get(self.element_type)
+        if not element_cls:
+            raise ValueError(
+                f"No element class registered for type '{self.element_type}'"
+            )
+        return element_cls(self.config)
+
+
+class HookWrapper(ConfigurableWrapper[HookStrategyConfig, HookStrategy]):
+    """
+    Wrapper class for hook strategies, specialized with hook-specific config and strategy types.
+
+    This class uses the `hook_registry` to map strategy type strings to
+    concrete hook strategy classes and configurations.
+
+    Attributes:
+        _registry (Dict[str, Type[HookStrategy]]): Registry mapping hook strategy type
+            names to their corresponding classes, sourced from `hook_registry.strategy`.
+    """
+
+    _registry = hook_registry.element
+
+    @model_validator(mode="before")
+    @classmethod
+    def parse_keyed_strategy(cls, data: Dict) -> Dict:
+        """
+        Validate and parse input data into a normalized dictionary containing
+        `strategy_type` and `config` keys.
+
+        This validator supports two input formats:
+        - A dictionary already containing 'strategy_type' and 'config' keys.
+        - A single-key dictionary where the key is the strategy type and the value
+          is the config data dictionary.
+
+        Args:
+            data (Dict): Input data to parse, expected to follow one of the formats above.
+
+        Returns:
+            Dict: A dictionary with keys:
+                - 'strategy_type': The resolved strategy type string.
+                - 'config': An instantiated configuration object for that strategy.
+
+        Raises:
+            ValueError: If input is not a dict with exactly one strategy key,
+                        or if the strategy type is unknown (not in `hook_registry.config`).
+        """
+        if isinstance(data, dict) and "strategy_type" in data and "config" in data:
+            return data
+        if not isinstance(data, dict) or len(data) != 1:
+            raise ValueError("Hook must have exactly one strategy key")
+        strategy_type, config_data = next(iter(data.items()))
+        config_cls = hook_registry.config.get(strategy_type)
+        if not config_cls:
+            raise ValueError(f"Unknown hook strategy: '{strategy_type}'")
+        config = config_cls(**config_data)
+        return {
+            "element_type": strategy_type,
+            "config": config,
+        }
+
+
+class DeploymentWrapper(
+    ConfigurableWrapper[DeploymentStrategyConfig, DeploymentStrategy]
+):
+    _registry = deployment_registry.element
+
+    @model_validator(mode="before")
+    @classmethod
+    def parse_keyed_strategy(cls, data: Dict) -> Dict:
+        if isinstance(data, dict) and "strategy_type" in data and "config" in data:
+            return data
+        if not isinstance(data, dict) or len(data) != 1:
+            raise ValueError("Deployment must have exactly one strategy key")
+        element_type, config_data = next(iter(data.items()))
+        config_cls = deployment_registry.config.get(element_type)
+        if not config_cls:
+            raise ValueError(f"Unknown deployment strategy: '{element_type}'")
+        config = config_cls(**config_data)
+        return {
+            "element_type": element_type,
+            "config": config,
+        }
+
+
+class MonitoringWrapper(
+    ConfigurableWrapper[MonitoringStrategyConfig, MonitoringStrategy]
+):
+    """
+    Wrapper class for monitoring strategies, specialized with monitoring-specific config and strategy types.
+
+    Attributes:
+        _registry (Dict[str, Type[MonitoringStrategy]]): Registry mapping monitoring
+            strategy type strings to their corresponding classes, sourced from
+            `monitoring_registry.strategy`.
+    """
+
+    _registry = monitoring_registry.element
+
+
+class ReportingWrapper(ConfigurableWrapper[ReportingStrategyConfig, ReportingStrategy]):
+    """
+    Wrapper class for reporting strategies, specialized with reporting-specific config and strategy types.
+
+    Attributes:
+        _registry (Dict[str, Type[ReportingStrategy]]): Registry mapping reporting
+            strategy type strings to their corresponding classes, sourced from
+            `reporting_registry.strategy`.
+    """
+
+    _registry = reporting_registry.element
+
+
+class ConfigurationWrapper(
+    ConfigurableWrapper[ConfigurationStrategyConfig, ConfigurationStrategy]
+):
+    """
+    Wrapper class for configuration strategies, specialized with configuration-specific config and strategy types.
+
+    Attributes:
+        _registry (Dict[str, Type[ConfigurationStrategy]]): Registry mapping configuration
+            strategy type strings to their corresponding classes, sourced from
+            `configuration_registry.strategy`.
+    """
+
+    _registry = configuration_registry.element
+
+
+class ExecutionWrapper(ConfigurableWrapper[ExecutionStrategyConfig, ExecutionStrategy]):
+    """
+    Wrapper class for execution strategies, specialized with execution-specific config and strategy types.
+
+    Attributes:
+        _registry (Dict[str, Type[ExecutionStrategy]]): Registry mapping execution
+            strategy type strings to their corresponding classes, sourced from
+            `execution_registry.strategy`.
+    """
+
+    _registry = execution_registry.element
+
+
+class TestStepActionWrapper(ConfigurableWrapper[TestStepActionConfig, TestStepAction]):
+    """
+    Wrapper class for test step actions, specialized with execution-specific config and types.
+
+    Attributes:
+        _registry (Dict[str, Type[TestStepAction]]): Registry mapping execution
+            strategy type strings to their corresponding classes, sourced from
+            `execution_registry.strategy`.
+    """
+
+    _registry = test_step_action_registry.element


### PR DESCRIPTION
This adds requisite classes for representing and loading all orchestrator elements and execution logic declaratively in yaml. Support for pluggable strategies / test actions / hooks with config type checking.

- Add hook strategy base class
- Add base configuration classes for all strategies
- Add Test Step Action base class and config base
- Add registries (classes/configs registered via decorator) for elements that are highly pluggable (TestStepActions, Hooks, Strategies)
- Add wrappers with instantiation logic for all of the above config/element classes.
- Add factory logic which assembles base test framework objects and pluggable elements.

Config would look roughly like this:
```yaml
components:
  load-generator:
    deployment:
      docker:
        image: load_generator:latest
        network: testbed
        command: ["--threads", "1", "--duration", "5"]
        environment:
          - OTLP_ENDPOINT=otel-collector:4317
        build:
          context: ./load_generator
  otel-collector:
    deployment:
      docker:
        ...
  backend-service:
    deployment:
      docker:
        ...
    monitoring:
      docker_component:
        interval: 1

hooks:
  run:
    pre:
      - run_command:
          command: "./deploy_some_infra.sh"

tests:
  - name: Test Max Rate Logs
    reporting:
      pipeline_perf_report:
        load_generator: load-generator
        backend: backend-service
        system_under_test: otel-collector
    steps:
      - name: Deploy Backend
        action:
          component_action:
            phase: deploy
            target: backend-service
      - name: Wait For Backend
        action:
          wait:
            delay_seconds: 3
      ...
```