### PR TITLE
feat: support metrics and traces in parquet exporter

### DIFF
--- a/rust/otap-dataflow/crates/otap/src/parquet_exporter/idgen.rs
+++ b/rust/otap-dataflow/crates/otap/src/parquet_exporter/idgen.rs
@@ -233,16 +233,16 @@ pub mod test {
     use otel_arrow_rust::schema::consts::metadata;
     use otel_arrow_rust::schema::get_schema_metadata;
 
-    use crate::parquet_exporter::test::datagen::SimpleLogDataGenOptions;
+    use crate::parquet_exporter::test::datagen::SimpleDataGenOptions;
 
-    use super::super::test::datagen::create_single_arrow_record_batch;
+    use super::super::test::datagen::create_simple_logs_arrow_record_batches;
     use super::*;
 
     #[test]
     fn test_partition_sequence_id_generator_logs() {
         let mut id_generator = PartitionSequenceIdGenerator::new();
 
-        let mut log_batch = create_single_arrow_record_batch(SimpleLogDataGenOptions {
+        let mut log_batch = create_simple_logs_arrow_record_batches(SimpleDataGenOptions {
             id_offset: 0,
             num_rows: 2,
             ..Default::default()
@@ -283,7 +283,7 @@ pub mod test {
         }
 
         // add a second batch
-        let mut log_batch = create_single_arrow_record_batch(SimpleLogDataGenOptions {
+        let mut log_batch = create_simple_logs_arrow_record_batches(SimpleDataGenOptions {
             id_offset: 0,
             num_rows: 2,
             ..Default::default()
@@ -327,7 +327,7 @@ pub mod test {
         id_generator.curr_max = u32::MAX - 5;
         let curr_partition_id = id_generator.part_id;
 
-        let mut log_batch = create_single_arrow_record_batch(SimpleLogDataGenOptions {
+        let mut log_batch = create_simple_logs_arrow_record_batches(SimpleDataGenOptions {
             id_offset: 0,
             num_rows: 10,
             ..Default::default()
@@ -358,7 +358,7 @@ pub mod test {
     fn test_partition_sequence_id_generator_decodes_ids() {
         let mut id_generator = PartitionSequenceIdGenerator::new();
 
-        let mut log_batch = create_single_arrow_record_batch(SimpleLogDataGenOptions {
+        let mut log_batch = create_simple_logs_arrow_record_batches(SimpleDataGenOptions {
             id_offset: 0,
             num_rows: 3,
             ids_decoded: false,

--- a/rust/otap-dataflow/crates/otap/src/parquet_exporter/idgen.rs
+++ b/rust/otap-dataflow/crates/otap/src/parquet_exporter/idgen.rs
@@ -10,9 +10,8 @@ use arrow::array::{RecordBatch, UInt32Array};
 use arrow::compute::kernels::cast;
 use arrow::compute::kernels::numeric::add;
 use arrow::compute::max;
-use arrow::datatypes::{DataType, Field, Schema};
-use arrow::error::ArrowError;
-use otel_arrow_rust::otap::{OtapBatch, child_payload_types};
+use arrow::datatypes::{DataType, Field, Schema, UInt16Type, UInt32Type};
+use otel_arrow_rust::otap::OtapBatch;
 use otel_arrow_rust::proto::opentelemetry::arrow::v1::ArrowPayloadType;
 use otel_arrow_rust::schema::{consts, update_schema_metadata};
 use uuid::Uuid;
@@ -22,9 +21,6 @@ use uuid::Uuid;
 pub enum IdGeneratorError {
     #[error("Invalid record batch: {error}")]
     InvalidRecordBatch { error: String },
-
-    #[error("overflow")]
-    Overflow {},
 
     #[error("Unknown error occurred: {error}")]
     UnknownError { error: String },
@@ -75,70 +71,83 @@ impl PartitionSequenceIdGenerator {
             }
         })?;
 
-        loop {
-            match otap_batch {
-                OtapBatch::Logs(_) => {
-                    let logs_rb = match otap_batch.get(ArrowPayloadType::Logs) {
-                        Some(rb) => rb,
-                        // nothing to do -- this could mean an empty batch
-                        None => break,
-                    };
+        let payload_types = otap_batch.allowed_payload_types();
 
-                    let new_logs_rb = match self.add_offset_to_column(consts::ID, logs_rb) {
-                        Ok(rb) => rb,
-                        Err(IdGeneratorError::Overflow {}) => {
-                            // re-init the curr_offset with a new node_id
-                            self.init();
-                            continue;
-                        }
-                        Err(e) => return Err(e),
-                    };
-
-                    let new_logs_rb = update_schema_metadata(
-                        new_logs_rb,
-                        PARTITION_METADATA_KEY.into(),
-                        format!("{}", self.part_id),
-                    );
-
-                    // hang onto the max_id so we can update current offset later
-                    // safety: we've already added an ID column of type UInt32 to the record batch here
-                    // in the call to add_offset_to_column
-                    let id_col = new_logs_rb
-                        .column_by_name(consts::ID)
-                        .expect("expect id is in batch here");
-                    let id_col = id_col
-                        .as_any()
-                        .downcast_ref::<UInt32Array>()
-                        .expect("expect this is the datatype");
-                    let max_id = match max(id_col) {
-                        Some(max) => max,
-                        // this would be null if the id_col was all nulls, in which case
-                        // there shouldn't be any children and we can just break
-                        None => break,
-                    };
-
-                    otap_batch.set(ArrowPayloadType::Logs, new_logs_rb);
-
-                    for child_payload_type in child_payload_types(ArrowPayloadType::Logs) {
-                        if let Some(rb) = otap_batch.get(*child_payload_type) {
-                            let new_rb = self.add_offset_to_column(consts::PARENT_ID, rb)?;
-                            otap_batch.set(*child_payload_type, new_rb);
-                        }
-                    }
-
-                    self.curr_max += max_id;
-                    self.curr_max += 1;
-                }
-                _ => {
-                    // TODO -- for the other record batches, we'll need to refactor this to
-                    // traverse the structure of the tree of record batches recursively transform
-                    // the parent ID, update the children as well.
-                    // https://github.com/open-telemetry/otel-arrow/issues/503
-                    todo!("implement generate ids for other signal types")
+        // find the max ID in any of the record batches. We'll use this later on to increment
+        // curr_max and also check for overflows before incrementing all the IDs
+        let mut max_id = 0;
+        for payload_type in payload_types {
+            if let Some(id_column) = otap_batch
+                .get(*payload_type)
+                .and_then(|rb| rb.column_by_name(consts::ID))
+            {
+                let record_batch_max_id = match id_column.data_type() {
+                    DataType::UInt16 => max::<UInt16Type>(
+                        id_column
+                            .as_any()
+                            .downcast_ref()
+                            .expect("can downcast to UInt16Array"),
+                    )
+                    .map(|max| max as u32),
+                    DataType::UInt32 => max::<UInt32Type>(
+                        id_column
+                            .as_any()
+                            .downcast_ref()
+                            .expect("can downcast to UInt32Array"),
+                    ),
+                    _ => None,
+                };
+                if let Some(record_batch_max_id) = record_batch_max_id {
+                    max_id = max_id.max(record_batch_max_id)
                 }
             }
+        }
 
-            break;
+        // check if we'll overflow when we increment the IDs
+        if max_id.checked_add(self.curr_max).is_none() {
+            // if adding curr_max to some record batch would cause the id sequence to overflow,
+            // re-init self to begin writing to new partition
+            self.init();
+        }
+
+        // update IDs for all record batch types
+        for payload_type in payload_types {
+            if let Some(rb) = otap_batch.get(*payload_type) {
+                let rb = self.add_offset_to_column(consts::ID, rb)?;
+                let rb = self.add_offset_to_column(consts::PARENT_ID, &rb)?;
+                otap_batch.set(*payload_type, rb);
+            }
+
+            // update the schema metadata with the partition key on the main record batch
+            match payload_type {
+                ArrowPayloadType::Logs
+                | ArrowPayloadType::UnivariateMetrics
+                | ArrowPayloadType::Spans => {
+                    if let Some(main_rb) = otap_batch.get(*payload_type) {
+                        otap_batch.set(
+                            *payload_type,
+                            update_schema_metadata(
+                                main_rb,
+                                PARTITION_METADATA_KEY.into(),
+                                format!("{}", self.part_id),
+                            ),
+                        );
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        self.curr_max += max_id;
+        // try incrementing curr_max by 1 so the next batch won't have
+        // any overlapping IDs (batch IDs could start at 0)
+        match self.curr_max.checked_add(1) {
+            Some(new_curr_max) => {
+                self.curr_max = new_curr_max;
+            }
+            None => {
+                self.init();
+            }
         }
 
         Ok(())
@@ -153,9 +162,8 @@ impl PartitionSequenceIdGenerator {
         let id_column_index = match schema.index_of(column_name) {
             Ok(index) => index,
             Err(_) => {
-                return Err(IdGeneratorError::InvalidRecordBatch {
-                    error: format!("Did not find expected column {}", column_name),
-                });
+                // column doesn't exist, nothing to do
+                return Ok(record_batch.clone());
             }
         };
         let id_column = record_batch.column(id_column_index);
@@ -171,8 +179,6 @@ impl PartitionSequenceIdGenerator {
         };
         let new_id_col = match add(&UInt32Array::new_scalar(self.curr_max), &id_column) {
             Ok(col) => col,
-            // return error if overflows
-            Err(ArrowError::ArithmeticOverflow(_)) => return Err(IdGeneratorError::Overflow {}),
             Err(e) => {
                 return Err(IdGeneratorError::UnknownError {
                     error: format!("{}", e),
@@ -218,9 +224,13 @@ impl PartitionSequenceIdGenerator {
 
 #[cfg(test)]
 pub mod test {
+    use std::collections::HashMap;
+
+    use arrow::array::new_empty_array;
     use otel_arrow_rust::Consumer;
-    use otel_arrow_rust::otap::from_record_messages;
+    use otel_arrow_rust::otap::{Metrics, Traces, from_record_messages};
     use otel_arrow_rust::proto::opentelemetry::arrow::v1::ArrowPayloadType;
+    use otel_arrow_rust::schema::consts::metadata;
     use otel_arrow_rust::schema::get_schema_metadata;
 
     use crate::parquet_exporter::test::datagen::SimpleLogDataGenOptions;
@@ -388,5 +398,97 @@ pub mod test {
                 .unwrap();
             assert_eq!(parent_id_col, &expected_ids);
         }
+    }
+
+    #[test]
+    fn test_can_handle_u32_ids() {
+        let span_events = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new(consts::ID, DataType::UInt32, true).with_metadata(HashMap::from_iter(
+                    vec![(
+                        metadata::COLUMN_ENCODING.into(),
+                        metadata::encodings::PLAIN.into(),
+                    )],
+                )),
+            ])),
+            vec![Arc::new(UInt32Array::from_iter_values(vec![1, 2, 3]))],
+        )
+        .unwrap();
+
+        let span_event_attrs = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new(consts::PARENT_ID, DataType::UInt32, true).with_metadata(
+                    HashMap::from_iter(vec![(
+                        metadata::COLUMN_ENCODING.into(),
+                        metadata::encodings::PLAIN.into(),
+                    )]),
+                ),
+            ])),
+            vec![Arc::new(UInt32Array::from_iter_values(vec![1, 2, 3]))],
+        )
+        .unwrap();
+
+        let mut traces_batch = OtapBatch::Traces(Traces::default());
+        traces_batch.set(ArrowPayloadType::SpanEvents, span_events.clone());
+        traces_batch.set(ArrowPayloadType::SpanEventAttrs, span_event_attrs.clone());
+
+        let mut id_generator = PartitionSequenceIdGenerator::new();
+        id_generator.curr_max = 2;
+        _ = id_generator.generate_unique_ids(&mut traces_batch).unwrap();
+
+        let spans_events_result = traces_batch.get(ArrowPayloadType::SpanEvents).unwrap();
+        let id_column = spans_events_result
+            .column_by_name(consts::ID)
+            .unwrap()
+            .as_any()
+            .downcast_ref::<UInt32Array>()
+            .unwrap();
+        let expected_ids = UInt32Array::from_iter_values(vec![3, 4, 5]);
+        assert_eq!(id_column, &expected_ids);
+
+        let span_events_attrs_result = traces_batch.get(ArrowPayloadType::SpanEventAttrs).unwrap();
+        let parent_id_column = span_events_attrs_result
+            .column_by_name(consts::PARENT_ID)
+            .unwrap()
+            .as_any()
+            .downcast_ref::<UInt32Array>()
+            .unwrap();
+        let expected_parent_ids = UInt32Array::from_iter_values(vec![3, 4, 5]);
+        assert_eq!(parent_id_column, &expected_parent_ids);
+    }
+
+    #[test]
+    fn test_partition_sequence_id_generator_update_root_payload_metadata() {
+        // ensure that for other root payload types beyond logs, it also updates the metadata
+        let root_batch = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                consts::ID,
+                DataType::UInt16,
+                true,
+            )])),
+            vec![Arc::new(new_empty_array(&DataType::UInt16))],
+        )
+        .unwrap();
+
+        let mut traces_batch = OtapBatch::Traces(Traces::default());
+        traces_batch.set(ArrowPayloadType::Spans, root_batch.clone());
+        let mut id_generator = PartitionSequenceIdGenerator::new();
+        _ = id_generator.generate_unique_ids(&mut traces_batch).unwrap();
+        let spans_batch = traces_batch.get(ArrowPayloadType::Spans).unwrap();
+        let partition_id =
+            get_schema_metadata(spans_batch.schema_ref(), PARTITION_METADATA_KEY).unwrap();
+        assert_eq!(partition_id, &format!("{}", id_generator.part_id));
+
+        let mut metrics_batch = OtapBatch::Metrics(Metrics::default());
+        metrics_batch.set(ArrowPayloadType::UnivariateMetrics, root_batch.clone());
+        _ = id_generator
+            .generate_unique_ids(&mut metrics_batch)
+            .unwrap();
+        let spans_batch = metrics_batch
+            .get(ArrowPayloadType::UnivariateMetrics)
+            .unwrap();
+        let partition_id =
+            get_schema_metadata(spans_batch.schema_ref(), PARTITION_METADATA_KEY).unwrap();
+        assert_eq!(partition_id, &format!("{}", id_generator.part_id));
     }
 }

--- a/rust/otap-dataflow/crates/otap/src/parquet_exporter/test/datagen.rs
+++ b/rust/otap-dataflow/crates/otap/src/parquet_exporter/test/datagen.rs
@@ -4,111 +4,72 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use arrow::array::{RecordBatch, StringArray, TimestampNanosecondArray, UInt8Array, UInt16Array};
-use arrow::datatypes::{DataType, Field, Schema};
+use arrow::array::{ArrowPrimitiveType, NativeAdapter, PrimitiveArray, RecordBatch, StringArray, TimestampNanosecondArray, UInt16Array, UInt8Array};
+use arrow::datatypes::{DataType, Field, Schema, UInt16Type};
 use arrow_ipc::writer::StreamWriter;
 use otel_arrow_rust::otlp::attributes::store::AttributeValueType;
 use otel_arrow_rust::proto::opentelemetry::arrow::v1::BatchArrowRecords;
 use otel_arrow_rust::proto::opentelemetry::arrow::v1::{ArrowPayload, ArrowPayloadType};
 use otel_arrow_rust::schema::consts::{self, metadata};
 
-pub struct SimpleLogDataGenOptions {
+pub struct SimpleDataGenOptions {
     pub id_offset: u16,
     pub num_rows: usize,
 
-    pub with_log_attrs: bool,
+    pub with_main_record_attrs: bool,
     pub with_resource_attrs: bool,
     pub with_scope_attrs: bool,
 
     pub ids_decoded: bool,
+
+    pub traces_options: Option<SimpleTracesDataGenOptions>,
+}
+pub struct SimpleTracesDataGenOptions {
+    pub with_span_links: bool,
+    pub with_span_links_attrs: bool,
+    pub with_span_events: bool,
+    pub with_span_events_attrs: bool,
 }
 
-impl Default for SimpleLogDataGenOptions {
+impl Default for SimpleDataGenOptions {
     fn default() -> Self {
         Self {
             id_offset: 0,
             num_rows: 1,
-            with_log_attrs: true,
+            with_main_record_attrs: true,
             with_resource_attrs: true,
             with_scope_attrs: true,
             ids_decoded: true,
+            traces_options: None,
         }
     }
 }
 
-pub fn create_single_arrow_record_batch(options: SimpleLogDataGenOptions) -> BatchArrowRecords {
+impl Default for SimpleTracesDataGenOptions {
+    fn default() -> Self {
+        Self {
+            with_span_events: true,
+            with_span_events_attrs: true,
+            with_span_links: true,
+            with_span_links_attrs: true
+        }
+    }
+}
+
+
+
+pub fn create_simple_logs_arrow_record_batches(options: SimpleDataGenOptions) -> BatchArrowRecords {
     let mut arrow_payloads = vec![];
 
-    let ids_metadata = if options.ids_decoded {
-        HashMap::from_iter(vec![(
-            metadata::COLUMN_ENCODING.to_string(),
-            metadata::encodings::PLAIN.to_string(),
-        )])
-    } else {
-        HashMap::<String, String>::new()
-    };
-
-    let logs_schema = Arc::new(Schema::new(vec![
-        Field::new(consts::ID, DataType::UInt16, true).with_metadata(ids_metadata.clone()),
-        Field::new(
-            consts::TIME_UNIX_NANO,
-            DataType::Timestamp(arrow::datatypes::TimeUnit::Nanosecond, None),
-            true,
-        ),
-    ]));
-
-    let attr_schema = Arc::new(Schema::new(vec![
-        Field::new(consts::PARENT_ID, DataType::UInt16, false).with_metadata(ids_metadata.clone()),
-        Field::new(consts::ATTRIBUTE_TYPE, DataType::UInt8, false),
-        Field::new(consts::ATTRIBUTE_KEY, DataType::Utf8, false),
-        Field::new(consts::ATTRIBUTE_STR, DataType::Utf8, true),
-    ]));
-
-    let ids_array = Arc::new(UInt16Array::from_iter((0..options.num_rows).map(|i| {
-        if options.ids_decoded {
-            i as u16 + options.id_offset
-        } else {
-            1
-        }
-    })));
-
-    let logs_batch = RecordBatch::try_new(
-        logs_schema.clone(),
-        vec![
-            ids_array.clone(),
-            Arc::new(TimestampNanosecondArray::from_iter_values(
-                (0..options.num_rows).map(|_| 1748297321 * 1_000_000_000),
-            )),
-        ],
-    )
-    .unwrap();
-
+    let logs_batch = create_main_record_batch(&options);
     arrow_payloads.push(ArrowPayload {
         schema_id: "logs_schema_1".to_string(),
         r#type: ArrowPayloadType::Logs as i32,
         record: serialize(&logs_batch),
     });
 
-    if options.with_log_attrs {
-        let log_attrs_batch = RecordBatch::try_new(
-            attr_schema.clone(),
-            vec![
-                ids_array.clone(),
-                Arc::new(UInt8Array::from_iter_values(
-                    vec![AttributeValueType::Str; options.num_rows]
-                        .iter()
-                        .map(|i| *i as u8),
-                )),
-                Arc::new(StringArray::from_iter_values(
-                    (0..options.num_rows).map(|_| "log_attr"),
-                )),
-                Arc::new(StringArray::from_iter(
-                    (0..options.num_rows).map(|_| Some("log_val")),
-                )),
-            ],
-        )
-        .unwrap();
-
+    if options.with_main_record_attrs {
+        let log_attrs_batch = create_attributes_records_batch(&options);
         arrow_payloads.push(ArrowPayload {
             schema_id: "log_attrs_schema_1".to_string(),
             r#type: ArrowPayloadType::LogAttrs as i32,
@@ -117,25 +78,7 @@ pub fn create_single_arrow_record_batch(options: SimpleLogDataGenOptions) -> Bat
     }
 
     if options.with_resource_attrs {
-        let resource_attrs_batch = RecordBatch::try_new(
-            attr_schema.clone(),
-            vec![
-                ids_array.clone(),
-                Arc::new(UInt8Array::from_iter_values(
-                    vec![AttributeValueType::Str; options.num_rows]
-                        .iter()
-                        .map(|i| *i as u8),
-                )),
-                Arc::new(StringArray::from_iter_values(
-                    (0..options.num_rows).map(|_| "resource_attr"),
-                )),
-                Arc::new(StringArray::from_iter(
-                    (0..options.num_rows).map(|_| Some("resource_val")),
-                )),
-            ],
-        )
-        .unwrap();
-
+        let resource_attrs_batch = create_attributes_records_batch(&options);
         arrow_payloads.push(ArrowPayload {
             schema_id: "resource_attrs_schema_1".to_string(),
             r#type: ArrowPayloadType::ResourceAttrs as i32,
@@ -144,25 +87,7 @@ pub fn create_single_arrow_record_batch(options: SimpleLogDataGenOptions) -> Bat
     }
 
     if options.with_scope_attrs {
-        let scope_attrs_batch = RecordBatch::try_new(
-            attr_schema,
-            vec![
-                ids_array.clone(),
-                Arc::new(UInt8Array::from_iter_values(
-                    vec![AttributeValueType::Str; options.num_rows]
-                        .iter()
-                        .map(|i| *i as u8),
-                )),
-                Arc::new(StringArray::from_iter_values(
-                    (0..options.num_rows).map(|_| "scope_attr"),
-                )),
-                Arc::new(StringArray::from_iter(
-                    (0..options.num_rows).map(|_| Some("scope_val")),
-                )),
-            ],
-        )
-        .unwrap();
-
+        let scope_attrs_batch = create_attributes_records_batch(&options);
         arrow_payloads.push(ArrowPayload {
             schema_id: "scope_attrs_schema_1".to_string(),
             r#type: ArrowPayloadType::ScopeAttrs as i32,
@@ -175,6 +100,128 @@ pub fn create_single_arrow_record_batch(options: SimpleLogDataGenOptions) -> Bat
         arrow_payloads,
         headers: Vec::default(),
     }
+}
+
+pub fn create_simple_trace_arrow_record_batches(options: SimpleDataGenOptions) -> BatchArrowRecords {
+    let mut arrow_payloads = vec![];
+
+    let spans_batch = create_main_record_batch(&options);
+    arrow_payloads.push(ArrowPayload {
+        schema_id: "spans_schema_1".to_string(),
+        r#type: ArrowPayloadType::Spans as i32,
+        record: serialize(&spans_batch),
+    });
+
+    if options.with_main_record_attrs {
+        let log_attrs_batch = create_attributes_records_batch(&options);
+        arrow_payloads.push(ArrowPayload {
+            schema_id: "log_attrs_schema_1".to_string(),
+            r#type: ArrowPayloadType::SpanAttrs as i32,
+            record: serialize(&log_attrs_batch),
+        });
+    }
+
+    if options.with_resource_attrs {
+        let resource_attrs_batch = create_attributes_records_batch(&options);
+        arrow_payloads.push(ArrowPayload {
+            schema_id: "resource_attrs_schema_1".to_string(),
+            r#type: ArrowPayloadType::ResourceAttrs as i32,
+            record: serialize(&resource_attrs_batch),
+        });
+    }
+
+    if options.with_scope_attrs {
+        let scope_attrs_batch = create_attributes_records_batch(&options);
+        arrow_payloads.push(ArrowPayload {
+            schema_id: "scope_attrs_schema_1".to_string(),
+            r#type: ArrowPayloadType::ScopeAttrs as i32,
+            record: serialize(&scope_attrs_batch),
+        });
+    }
+
+    BatchArrowRecords {
+        batch_id: 0,
+        arrow_payloads,
+        headers: Vec::default(),
+    }
+}
+
+pub fn create_ids_metadata(options: &SimpleDataGenOptions) -> HashMap<String, String> {
+    if options.ids_decoded {
+        HashMap::from_iter(vec![(
+            metadata::COLUMN_ENCODING.to_string(),
+            metadata::encodings::PLAIN.to_string(),
+        )])
+    } else {
+        HashMap::<String, String>::new()
+    }
+}
+
+pub fn create_ids_array<T>(options: &SimpleDataGenOptions) -> Arc<PrimitiveArray<T>>
+where T: ArrowPrimitiveType,
+    NativeAdapter<T>: From<u16> {
+    Arc::new(PrimitiveArray::<T>::from_iter((0..options.num_rows).map(|i| {
+        if options.ids_decoded {
+            i as u16 + options.id_offset
+        } else {
+            1
+        }
+    })))
+}
+
+pub fn create_main_record_batch(options: &SimpleDataGenOptions) -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new(consts::ID, DataType::UInt16, true).with_metadata(create_ids_metadata(options)),
+        Field::new(
+            consts::TIME_UNIX_NANO,
+            DataType::Timestamp(arrow::datatypes::TimeUnit::Nanosecond, None),
+            true,
+        ),
+    ]));
+
+    RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            create_ids_array::<UInt16Type>(options),
+            Arc::new(TimestampNanosecondArray::from_iter_values(
+                (0..options.num_rows).map(|_| 1748297321 * 1_000_000_000),
+            )),
+        ],
+    )
+    .unwrap()
+}
+
+
+pub fn create_attributes_records_batch<T>(options: &SimpleDataGenOptions) -> RecordBatch
+where 
+    T: ArrowPrimitiveType,
+    NativeAdapter<T>: From<u16> 
+{
+    let attr_schema = Arc::new(Schema::new(vec![
+        Field::new(consts::PARENT_ID, DataType::UInt16, false).with_metadata(create_ids_metadata(&options)),
+        Field::new(consts::ATTRIBUTE_TYPE, DataType::UInt8, false),
+        Field::new(consts::ATTRIBUTE_KEY, DataType::Utf8, false),
+        Field::new(consts::ATTRIBUTE_STR, DataType::Utf8, true),
+    ]));
+
+    RecordBatch::try_new(
+        attr_schema.clone(),
+        vec![
+            create_ids_array::<T>(&options),
+            Arc::new(UInt8Array::from_iter_values(
+                vec![AttributeValueType::Str; options.num_rows]
+                    .iter()
+                    .map(|i| *i as u8),
+            )),
+            Arc::new(StringArray::from_iter_values(
+                (0..options.num_rows).map(|_| "log_attr"),
+            )),
+            Arc::new(StringArray::from_iter(
+                (0..options.num_rows).map(|_| Some("log_val")),
+            )),
+        ],
+    )
+    .unwrap()
 }
 
 fn serialize(record_batch: &RecordBatch) -> Vec<u8> {

--- a/rust/otap-dataflow/crates/otap/src/parquet_exporter/writer.rs
+++ b/rust/otap-dataflow/crates/otap/src/parquet_exporter/writer.rs
@@ -457,17 +457,19 @@ mod test {
         let object_store = Arc::new(LocalFileSystem::new_with_prefix(path).unwrap());
         let mut writer = WriterManager::new(object_store, None);
 
-        let batch1 =
-            to_logs_record_batch(create_simple_logs_arrow_record_batches(SimpleDataGenOptions {
+        let batch1 = to_logs_record_batch(create_simple_logs_arrow_record_batches(
+            SimpleDataGenOptions {
                 id_offset: 0,
                 ..Default::default()
-            }));
+            },
+        ));
 
-        let batch2 =
-            to_logs_record_batch(create_simple_logs_arrow_record_batches(SimpleDataGenOptions {
+        let batch2 = to_logs_record_batch(create_simple_logs_arrow_record_batches(
+            SimpleDataGenOptions {
                 id_offset: 1,
                 ..Default::default()
-            }));
+            },
+        ));
 
         writer
             .write(&[
@@ -520,11 +522,12 @@ mod test {
         let object_store = Arc::new(LocalFileSystem::new_with_prefix(path).unwrap());
         let mut writer = WriterManager::new(object_store, None);
 
-        let partition1_batch =
-            to_logs_record_batch(create_simple_logs_arrow_record_batches(SimpleDataGenOptions {
+        let partition1_batch = to_logs_record_batch(create_simple_logs_arrow_record_batches(
+            SimpleDataGenOptions {
                 id_offset: 0,
                 ..Default::default()
-            }));
+            },
+        ));
 
         let partition1_attrs = vec![
             PartitionAttribute {
@@ -537,11 +540,12 @@ mod test {
             },
         ];
 
-        let partition2_batch =
-            to_logs_record_batch(create_simple_logs_arrow_record_batches(SimpleDataGenOptions {
+        let partition2_batch = to_logs_record_batch(create_simple_logs_arrow_record_batches(
+            SimpleDataGenOptions {
                 id_offset: 1,
                 ..Default::default()
-            }));
+            },
+        ));
 
         let partition2_attrs = vec![
             PartitionAttribute {
@@ -623,17 +627,19 @@ mod test {
             }),
         );
 
-        let batch1 =
-            to_logs_record_batch(create_simple_logs_arrow_record_batches(SimpleDataGenOptions {
+        let batch1 = to_logs_record_batch(create_simple_logs_arrow_record_batches(
+            SimpleDataGenOptions {
                 id_offset: 0,
                 ..Default::default()
-            }));
+            },
+        ));
 
-        let batch2 =
-            to_logs_record_batch(create_simple_logs_arrow_record_batches(SimpleDataGenOptions {
+        let batch2 = to_logs_record_batch(create_simple_logs_arrow_record_batches(
+            SimpleDataGenOptions {
                 id_offset: 1,
                 ..Default::default()
-            }));
+            },
+        ));
 
         writer
             .write(&[
@@ -689,18 +695,20 @@ mod test {
             }),
         );
 
-        let batch1 =
-            to_logs_record_batch(create_simple_logs_arrow_record_batches(SimpleDataGenOptions {
+        let batch1 = to_logs_record_batch(create_simple_logs_arrow_record_batches(
+            SimpleDataGenOptions {
                 id_offset: 0,
                 ..Default::default()
-            }));
+            },
+        ));
 
-        let batch2 =
-            to_logs_record_batch(create_simple_logs_arrow_record_batches(SimpleDataGenOptions {
+        let batch2 = to_logs_record_batch(create_simple_logs_arrow_record_batches(
+            SimpleDataGenOptions {
                 id_offset: 1,
                 with_main_record_attrs: false,
                 ..Default::default()
-            }));
+            },
+        ));
         writer
             .write(&[
                 WriteBatch::new(0, &batch1, None),

--- a/rust/otap-dataflow/crates/otap/src/parquet_exporter/writer.rs
+++ b/rust/otap-dataflow/crates/otap/src/parquet_exporter/writer.rs
@@ -386,7 +386,7 @@ mod test {
 
     use crate::parquet_exporter::{
         partition::PartitionAttributeValue,
-        test::datagen::{SimpleLogDataGenOptions, create_single_arrow_record_batch},
+        test::datagen::{SimpleDataGenOptions, create_simple_logs_arrow_record_batches},
     };
 
     fn to_logs_record_batch(mut bar: BatchArrowRecords) -> OtapBatch {
@@ -403,8 +403,8 @@ mod test {
         let mut writer = WriterManager::new(object_store, None);
 
         // write some batch:
-        let otap_batch = to_logs_record_batch(create_single_arrow_record_batch(
-            SimpleLogDataGenOptions::default(),
+        let otap_batch = to_logs_record_batch(create_simple_logs_arrow_record_batches(
+            SimpleDataGenOptions::default(),
         ));
         writer
             .write(&[WriteBatch::new(0, &otap_batch, None)])
@@ -458,13 +458,13 @@ mod test {
         let mut writer = WriterManager::new(object_store, None);
 
         let batch1 =
-            to_logs_record_batch(create_single_arrow_record_batch(SimpleLogDataGenOptions {
+            to_logs_record_batch(create_simple_logs_arrow_record_batches(SimpleDataGenOptions {
                 id_offset: 0,
                 ..Default::default()
             }));
 
         let batch2 =
-            to_logs_record_batch(create_single_arrow_record_batch(SimpleLogDataGenOptions {
+            to_logs_record_batch(create_simple_logs_arrow_record_batches(SimpleDataGenOptions {
                 id_offset: 1,
                 ..Default::default()
             }));
@@ -521,7 +521,7 @@ mod test {
         let mut writer = WriterManager::new(object_store, None);
 
         let partition1_batch =
-            to_logs_record_batch(create_single_arrow_record_batch(SimpleLogDataGenOptions {
+            to_logs_record_batch(create_simple_logs_arrow_record_batches(SimpleDataGenOptions {
                 id_offset: 0,
                 ..Default::default()
             }));
@@ -538,7 +538,7 @@ mod test {
         ];
 
         let partition2_batch =
-            to_logs_record_batch(create_single_arrow_record_batch(SimpleLogDataGenOptions {
+            to_logs_record_batch(create_simple_logs_arrow_record_batches(SimpleDataGenOptions {
                 id_offset: 1,
                 ..Default::default()
             }));
@@ -624,13 +624,13 @@ mod test {
         );
 
         let batch1 =
-            to_logs_record_batch(create_single_arrow_record_batch(SimpleLogDataGenOptions {
+            to_logs_record_batch(create_simple_logs_arrow_record_batches(SimpleDataGenOptions {
                 id_offset: 0,
                 ..Default::default()
             }));
 
         let batch2 =
-            to_logs_record_batch(create_single_arrow_record_batch(SimpleLogDataGenOptions {
+            to_logs_record_batch(create_simple_logs_arrow_record_batches(SimpleDataGenOptions {
                 id_offset: 1,
                 ..Default::default()
             }));
@@ -690,15 +690,15 @@ mod test {
         );
 
         let batch1 =
-            to_logs_record_batch(create_single_arrow_record_batch(SimpleLogDataGenOptions {
+            to_logs_record_batch(create_simple_logs_arrow_record_batches(SimpleDataGenOptions {
                 id_offset: 0,
                 ..Default::default()
             }));
 
         let batch2 =
-            to_logs_record_batch(create_single_arrow_record_batch(SimpleLogDataGenOptions {
+            to_logs_record_batch(create_simple_logs_arrow_record_batches(SimpleDataGenOptions {
                 id_offset: 1,
-                with_log_attrs: false,
+                with_main_record_attrs: false,
                 ..Default::default()
             }));
         writer

--- a/rust/otel-arrow-rust/src/otap.rs
+++ b/rust/otel-arrow-rust/src/otap.rs
@@ -476,7 +476,7 @@ pub fn child_payload_types(payload_type: ArrowPayloadType) -> &'static [ArrowPay
             ArrowPayloadType::NumberDpAttrs,
             ArrowPayloadType::NumberDpExemplars,
         ],
-        ArrowPayloadType::NumberDpExemplarAttrs => &[ArrowPayloadType::NumberDpExemplarAttrs],
+        ArrowPayloadType::NumberDpExemplars => &[ArrowPayloadType::NumberDpExemplarAttrs],
         ArrowPayloadType::SummaryDataPoints => &[ArrowPayloadType::SummaryDpAttrs],
         ArrowPayloadType::HistogramDataPoints => &[
             ArrowPayloadType::HistogramDpAttrs,
@@ -485,10 +485,10 @@ pub fn child_payload_types(payload_type: ArrowPayloadType) -> &'static [ArrowPay
         ArrowPayloadType::HistogramDpExemplars => &[ArrowPayloadType::HistogramDpExemplarAttrs],
         ArrowPayloadType::ExpHistogramDataPoints => &[
             ArrowPayloadType::ExpHistogramDpAttrs,
-            ArrowPayloadType::ExpHistogramDpExemplarAttrs,
+            ArrowPayloadType::ExpHistogramDpExemplars,
         ],
 
-        ArrowPayloadType::ExpHistogramDpExemplarAttrs => {
+        ArrowPayloadType::ExpHistogramDpExemplars => {
             &[ArrowPayloadType::ExpHistogramDpExemplarAttrs]
         }
         ArrowPayloadType::MultivariateMetrics => {

--- a/rust/otel-arrow-rust/src/otap/transform.rs
+++ b/rust/otel-arrow-rust/src/otap/transform.rs
@@ -16,7 +16,7 @@ use snafu::{OptionExt, ResultExt};
 use crate::arrays::{NullableArrayAccessor, get_u8_array};
 use crate::error::{self, Result};
 use crate::otlp::attributes::{parent_id::ParentId, store::AttributeValueType};
-use crate::schema:: consts::{self, metadata};
+use crate::schema::consts::{self, metadata};
 use crate::schema::{get_field_metadata, update_field_metadata};
 
 pub fn remove_delta_encoding<T>(

--- a/rust/otel-arrow-rust/src/otap/transform.rs
+++ b/rust/otel-arrow-rust/src/otap/transform.rs
@@ -470,10 +470,10 @@ mod test {
     use std::collections::HashMap;
     use std::sync::Arc;
 
-    use crate::arrays::{get_string_array, get_u16_array, get_u32_array};
+    use crate::arrays::{get_u16_array, get_u32_array};
     use crate::error::Error;
     use crate::otlp::attributes::store::AttributeValueType;
-    use crate::schema::{get_field_metadata, get_schema_metadata};
+    use crate::schema::get_field_metadata;
 
     #[test]
     fn test_materialize_parent_id_for_attributes_val_change() {

--- a/rust/otel-arrow-rust/src/schema.rs
+++ b/rust/otel-arrow-rust/src/schema.rs
@@ -24,7 +24,7 @@ pub mod consts;
 /// Returns a new record batch with the new key/value updated in the schema metadata.
 #[must_use]
 pub fn update_schema_metadata(
-    record_batch: RecordBatch,
+    record_batch: &RecordBatch,
     key: String,
     value: String,
 ) -> RecordBatch {
@@ -37,6 +37,7 @@ pub fn update_schema_metadata(
     // safety: this should not fail, as we haven't changed the fields in the schema,
     // just the metadata, so the schema should be compatible with the columns
     record_batch
+        .clone()
         .with_schema(Arc::new(new_schema))
         .expect("can create record batch with same schema.")
 }


### PR DESCRIPTION
Completes: #503 

The bulk of the important changes here are in the `idgen` module, which was hard-coded to encode IDs for logs. The majority of the rest of the changes are to testing code (including the code that generates record batches for the tests).

I also removed the unused `sort_by_parent_id`. This was added for some experimental optimization to AttributeStore. We can add this back in the future if we decide we need it.