### PR TITLE
chore: add `--all-targets` to `cargo xtask check`

### DIFF
--- a/rust/otap-dataflow/xtask/src/main.rs
+++ b/rust/otap-dataflow/xtask/src/main.rs
@@ -70,7 +70,17 @@ fn format_all() -> anyhow::Result<()> {
 
 fn clippy_all() -> anyhow::Result<()> {
     println!("🚀 Linting workspace with cargo clippy...");
-    run("cargo", &["clippy", "--workspace", "--", "-D", "warnings"])?;
+    run(
+        "cargo",
+        &[
+            "clippy",
+            "--workspace",
+            "--all-targets",
+            "--",
+            "-D",
+            "warnings",
+        ],
+    )?;
     println!("✅ Clippy linting passed without warnings.\n");
     Ok(())
 }


### PR DESCRIPTION
The impetus here is so we can see the clippy issues in tests as well with this command