### PR TITLE
Perf - remaining core telemetry support

### DIFF
--- a/tools/pipeline_perf_test/orchestrator/lib/core/component/component.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/component/component.py
@@ -15,11 +15,15 @@ Classes:
 
 from abc import ABC, abstractmethod
 from collections import defaultdict
+from contextlib import nullcontext
 from enum import Enum
-from typing import Callable, Dict, List, Any
+from typing import Callable, Dict, List, Any, Optional
 
+from opentelemetry.trace import Status, StatusCode
+
+from ..errors.error_handler import handle_with_policy
 from ..runtime.runtime import Runtime
-from ..context.base import ExecutionStatus
+from ..context.base import ExecutionStatus, BaseContext
 from ..context.test_contexts import TestStepContext, TestExecutionContext
 from ..strategies.hook_strategy import HookStrategy
 from ..context.component_hook_context import (
@@ -84,6 +88,8 @@ class Component(ABC):
         collect_monitoring_data(): Abstract method to be implemented by subclasses to collect monitoring data for the component.
     """
 
+    name: Optional[str] = None
+
     def __init__(self):
         """
         Initializes the Component instance by setting up an empty hook registry.
@@ -132,6 +138,67 @@ class Component(ABC):
         """
         self._hooks[phase].append(hook)
 
+    def _maybe_trace(
+        self, ctx: TestStepContext, name: str, phase: HookableComponentPhase
+    ):
+        """
+        Optionally creates a tracing context for a specific component lifecycle phase.
+
+        Args:
+            ctx (TestStepContext): The context object containing tracing and span information.
+            name (str): The base name for the tracing span (e.g., component name or operation).
+            phase (HookableComponentPhase): The lifecycle phase to include in the span name.
+
+        Returns:
+            ContextManager: A tracing context manager if tracing is active, otherwise a no-op context.
+        """
+        tracer = ctx.get_tracer("component")
+        if tracer and ctx.span:
+            return tracer.start_as_current_span(f"{name}: {phase.value}")
+        return nullcontext()
+
+    def _with_span(self, ctx: "BaseContext", name: str, callable_fn, *args, **kwargs):
+        """
+        Wrap a callable function execution within a named tracing span.
+
+        This method attempts to create and start a tracing span with the given `name`
+        using the tracer retrieved from the provided context. If tracing is active and
+        the current span is recording, the callable function is executed within the
+        scope of the span. Any exceptions raised during the callable's execution are
+        recorded in the span, and the span status is set to error accordingly.
+
+        If tracing is not active or the span is not recording, the callable is simply
+        executed without tracing.
+
+        Args:
+            ctx (BaseContext): Context object providing tracing capabilities and
+                the current active span.
+            name (str): The name of the tracing span to create.
+            callable_fn (Callable): The function to be executed within the span.
+            *args: Positional arguments to pass to the callable function.
+            **kwargs: Keyword arguments to pass to the callable function.
+
+        Returns:
+            Any: The return value of the callable function.
+
+        Raises:
+            Exception: Propagates any exceptions raised by the callable function after
+                recording them in the tracing span.
+        """
+        tracer = ctx.get_tracer("component")
+        if tracer and ctx.span and ctx.span.is_recording():
+            with tracer.start_as_current_span(name) as span:
+                try:
+                    res = callable_fn(*args, **kwargs)
+                    span.set_status(StatusCode.OK)
+                    return res
+                except Exception as e:
+                    span.record_exception(e)
+                    span.set_status(Status(StatusCode.ERROR, str(e)))
+                    raise
+        else:
+            return callable_fn(*args, **kwargs)
+
     def _run_hooks(self, phase: HookableComponentPhase, ctx: TestStepContext):
         """
         Executes all hooks that are registered for a specified lifecycle phase.
@@ -141,57 +208,116 @@ class Component(ABC):
         Args:
             phase (HookableComponentPhase): The lifecycle phase during which to run the hooks (e.g., PRE_CONFIGURE, POST_CONFIGURE).
         """
-        ctx.log(f"Running hooks for phase: {phase.value}")
-        for hook in self._hooks.get(phase, []):
-            hook_context = ComponentHookContext(
-                phase=phase, name=f"{hook.__class__.__name__} ({phase.value})"
+        hooks = self._hooks.get(phase, [])
+        if not hooks:
+            return
+        with self._maybe_trace(
+            ctx, f"Run Component Hooks ({self.name})", phase
+        ) as span:
+            logger = ctx.get_logger(__name__)
+
+            logger.debug(
+                "Running %d component hooks for phase: %s", len(hooks), phase.value
             )
-            ctx.add_child_ctx(hook_context)
-            try:
-                hook_context.start()
-                hook.execute(hook_context)
-                if hook_context.status == ExecutionStatus.RUNNING:
-                    hook_context.status = ExecutionStatus.SUCCESS
-            except Exception as e:  # pylint: disable=broad-except
-                hook_context.status = ExecutionStatus.ERROR
-                hook_context.error = e
-                hook_context.log(f"Hook failed: {e}")
-                break
-            finally:
-                hook_context.end()
+            for hook in hooks:
+                hook_context = ComponentHookContext(
+                    phase=phase,
+                    name=f"{hook.__class__.__name__} ({phase.value})",
+                    parent_ctx=ctx,
+                )
+                ctx.add_child_ctx(hook_context)
+                with hook_context:
+                    hook_logger = hook_context.get_logger(__name__)
+                    try:
+                        hook_logger.debug("Executing main hook logic...")
+                        handle_with_policy(
+                            hook_context,
+                            lambda h=hook, hc=hook_context: h.execute(hc),
+                            hook.config.on_error,
+                        )
+                        if hook_context.status == ExecutionStatus.RUNNING:
+                            hook_context.status = ExecutionStatus.SUCCESS
+                    except Exception as e:  # pylint: disable=broad-except
+                        hook_context.status = ExecutionStatus.ERROR
+                        hook_context.error = e
+                        hook_logger.error(f"Hook failed: {e}")
+                        span.set_status(
+                            Status(StatusCode.ERROR, "Fatal Child Hook Failure")
+                        )
+                        raise
+            span.set_status(StatusCode.OK)
 
     @abstractmethod
-    def configure(self, ctx: TestStepContext):
+    def _configure(self, ctx: TestStepContext):
         """Abstract method for configuring the component."""
 
+    def configure(self, ctx: TestStepContext):
+        return self._with_span(
+            ctx, f"Configure Component ({self.name})", self._configure, ctx
+        )
+
     @abstractmethod
-    def deploy(self, ctx: TestStepContext):
+    def _deploy(self, ctx: TestStepContext):
         """Abstract method for deploying the component (spawn a process or start a container/deployment)."""
 
+    def deploy(self, ctx: TestStepContext):
+        return self._with_span(
+            ctx, f"Deploy Component ({self.name})", self._deploy, ctx
+        )
+
     @abstractmethod
-    def start(self, ctx: TestStepContext):
+    def _start(self, ctx: TestStepContext):
         """Abstract method for starting the component's execution behavior."""
 
-    @abstractmethod
-    def stop(self, ctx: TestStepContext):
-        """Abstract method for stopping the component's execution behavior."""
+    def start(self, ctx: TestStepContext):
+        return self._with_span(ctx, f"Start Component ({self.name})", self._start, ctx)
 
     @abstractmethod
-    def destroy(self, ctx: TestStepContext):
+    def _stop(self, ctx: TestStepContext):
+        """Abstract method for stopping the component's execution behavior."""
+
+    def stop(self, ctx: TestStepContext):
+        return self._with_span(ctx, f"Stop Component ({self.name})", self._stop, ctx)
+
+    @abstractmethod
+    def _destroy(self, ctx: TestStepContext):
         """Abstract method for destroying the component (e.g. kill process, stop/remove container).
 
         The specific signals (term/kill) and container cleanup (stop vs rm) will be dictated and
         configured by the strategy implementation and lifecycle hooks.
         """
 
+    def destroy(self, ctx: TestStepContext):
+        return self._with_span(
+            ctx, f"Destroy Component ({self.name})", self._destroy, ctx
+        )
+
     @abstractmethod
-    def start_monitoring(self, ctx: TestStepContext):
+    def _start_monitoring(self, ctx: TestStepContext):
         """Abstract method to start monitoring the component."""
 
-    @abstractmethod
-    def stop_monitoring(self, ctx: TestStepContext):
-        """Abstract method to stop monitoring the component."""
+    def start_monitoring(self, ctx: TestStepContext):
+        return self._with_span(
+            ctx, f"Start Monitoring ({self.name})", self._start_monitoring, ctx
+        )
 
     @abstractmethod
-    def collect_monitoring_data(self, ctx: TestExecutionContext):
+    def _stop_monitoring(self, ctx: TestStepContext):
+        """Abstract method to stop monitoring the component."""
+
+    def stop_monitoring(self, ctx: TestStepContext):
+        return self._with_span(
+            ctx, f"Stop Monitoring ({self.name})", self._stop_monitoring, ctx
+        )
+
+    @abstractmethod
+    def _collect_monitoring_data(self, ctx: TestExecutionContext):
         """Abstract method to collect monitoring data for the component."""
+
+    def collect_monitoring_data(self, ctx: TestExecutionContext):
+        return self._with_span(
+            ctx,
+            f"Collect Monitoring Data ({self.name})",
+            self._collect_monitoring_data,
+            ctx,
+        )

--- a/tools/pipeline_perf_test/orchestrator/lib/core/component/component_data.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/component/component_data.py
@@ -16,10 +16,10 @@ Typical usage:
 from dataclasses import dataclass, field
 from typing import Any, Dict, TYPE_CHECKING
 
-from ..context.test_contexts import TestExecutionContext
 from ..runtime.runtime import Runtime
 
 if TYPE_CHECKING:
+    from ..context.test_contexts import TestExecutionContext
     from .component import Component
 
 
@@ -32,7 +32,7 @@ class ComponentData:
 
     @classmethod
     def from_component(
-        cls, component: "Component", context: TestExecutionContext
+        cls, component: "Component", context: "TestExecutionContext"
     ) -> "ComponentData":
         """Create a ComponentData instance from a component and context."""
         return cls(

--- a/tools/pipeline_perf_test/orchestrator/lib/core/errors/__init__.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/errors/__init__.py
@@ -1,0 +1,5 @@
+"""Initialization for the core.errors package."""
+
+from .error_handler import OnErrorConfig, handle_with_policy
+
+__all__ = ["OnErrorConfig", "handle_with_policy"]

--- a/tools/pipeline_perf_test/orchestrator/lib/core/errors/error_handler.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/errors/error_handler.py
@@ -1,0 +1,77 @@
+"""
+Error handling utilities for test components and plugin execution.
+
+This module defines a configuration model and a helper function for managing
+error handling behavior in test or plugin execution contexts. It supports
+retry policies, optional continuation after failure, and integration with
+logging and tracing systems.
+
+Classes:
+    OnErrorConfig: Defines retry and continuation settings for error handling.
+
+Functions:
+    handle_with_policy: Wraps a callable with retry logic and error handling
+    based on a provided OnErrorConfig.
+"""
+
+import time
+from typing import Optional
+from pydantic import BaseModel, Field
+from opentelemetry.trace import StatusCode, Status
+from ..context.base import BaseContext, ExecutionStatus
+
+
+class OnErrorConfig(BaseModel):
+    """Base configuration model for handling error state in test components / plugins."""
+
+    retries: Optional[int] = 0
+    retry_delay_seconds: Optional[int] = 10
+    continue_: Optional[bool] = Field(default=False, alias="continue")
+
+
+def handle_with_policy(ctx: BaseContext, func, on_error: OnErrorConfig):
+    """
+    Executes a function with retry and error-handling policy defined by `on_error`.
+
+    This utility function wraps a callable in retry logic, retrying it upon exceptions
+    based on the provided configuration. If retries are exhausted, the function either
+    raises the exception or logs it and continues execution, depending on the `continue_`
+    flag in the `on_error` config.
+
+    Args:
+        ctx (BaseContext): Execution context providing logger, status, and span tracing.
+        func (Callable): The function to execute with retry and error handling.
+        on_error (OnErrorConfig): Configuration for retry attempts, delay, and continue behavior.
+
+    Returns:
+        The return value of `func()` if successful or if `on_error.continue_` is True after failure.
+        Otherwise, re-raises the final exception after exhausting retries.
+
+    Raises:
+        Exception: The last raised exception if retries are exhausted and `continue_` is False.
+    """
+
+    logger = ctx.get_logger(__name__)
+    retries = on_error.retries
+    should_continue = on_error.continue_
+
+    for attempt in range(retries + 1):
+        try:
+            return func()
+        except Exception as e:
+            if attempt < retries:
+                logger.warning(f"[Attempt {attempt+1}] Retrying after error: {e}")
+                time.sleep(on_error.retry_delay_seconds)
+                continue
+            if should_continue:
+                logger.warning(f"Continuing after failure: {e}")
+                ctx.status = ExecutionStatus.ERROR
+                ctx.span.set_status(
+                    Status(
+                        StatusCode.ERROR,
+                        f"Failed after {retries+1} attempts, continuing per config.",
+                    )
+                )
+                return
+            logger.error(f"Fatal error after {retries+1} attempts: {e}")
+            raise

--- a/tools/pipeline_perf_test/orchestrator/lib/core/strategies/base.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/strategies/base.py
@@ -1,0 +1,11 @@
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+from ..errors.error_handler import OnErrorConfig
+
+
+class BaseStrategyConfig(BaseModel):
+    """Base model for all Strategy configs."""
+
+    on_error: Optional[OnErrorConfig] = Field(default_factory=OnErrorConfig)

--- a/tools/pipeline_perf_test/orchestrator/lib/core/strategies/configuration_strategy.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/strategies/configuration_strategy.py
@@ -21,14 +21,12 @@ Classes:
 """
 
 from abc import ABC, abstractmethod
-
-from pydantic import BaseModel
-
 from ..component.component import Component
 from ..context.test_contexts import TestStepContext
+from .base import BaseStrategyConfig
 
 
-class ConfigurationStrategyConfig(BaseModel):
+class ConfigurationStrategyConfig(BaseStrategyConfig):
     """Base model for Configuration Strategy config, passed to strategy init."""
 
 

--- a/tools/pipeline_perf_test/orchestrator/lib/core/strategies/deployment_strategy.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/strategies/deployment_strategy.py
@@ -20,13 +20,12 @@ Classes:
 
 from abc import ABC, abstractmethod
 
-from pydantic import BaseModel
-
 from ..component.component import Component
 from ..context.test_contexts import TestStepContext
+from .base import BaseStrategyConfig
 
 
-class DeploymentStrategyConfig(BaseModel):
+class DeploymentStrategyConfig(BaseStrategyConfig):
     """Base model for Deployment Strategy config, passed to strategy init."""
 
 

--- a/tools/pipeline_perf_test/orchestrator/lib/core/strategies/execution_strategy.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/strategies/execution_strategy.py
@@ -20,13 +20,12 @@ Classes:
 
 from abc import ABC, abstractmethod
 
-from pydantic import BaseModel
-
 from ..component.component import Component
 from ..context.test_contexts import TestStepContext
+from .base import BaseStrategyConfig
 
 
-class ExecutionStrategyConfig(BaseModel):
+class ExecutionStrategyConfig(BaseStrategyConfig):
     """Base model for Execution Strategy config, passed to strategy init."""
 
 

--- a/tools/pipeline_perf_test/orchestrator/lib/core/strategies/hook_strategy.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/strategies/hook_strategy.py
@@ -16,15 +16,13 @@ Classes:
     HookStrategy (ABC): Abstract interface for executing a hook with access to runtime context.
 """
 
-from typing import Optional
 from abc import ABC, abstractmethod
 
-from pydantic import BaseModel
-
 from ..context.base import BaseContext
+from .base import BaseStrategyConfig
 
 
-class HookStrategyConfig(BaseModel):
+class HookStrategyConfig(BaseStrategyConfig):
     """Base model for Execution Strategy config, passed to strategy init."""
 
 

--- a/tools/pipeline_perf_test/orchestrator/lib/core/strategies/monitoring_strategy.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/strategies/monitoring_strategy.py
@@ -15,13 +15,12 @@ Classes:
 
 from abc import ABC, abstractmethod
 
-from pydantic import BaseModel
-
 from ..component.component import Component
 from ..context.test_contexts import TestStepContext, TestExecutionContext
+from .base import BaseStrategyConfig
 
 
-class MonitoringStrategyConfig(BaseModel):
+class MonitoringStrategyConfig(BaseStrategyConfig):
     """Base model for Monitoring Strategy config, passed to strategy init."""
 
 

--- a/tools/pipeline_perf_test/orchestrator/lib/core/strategies/reporting_strategy.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/strategies/reporting_strategy.py
@@ -20,12 +20,11 @@ Classes:
 from abc import ABC, abstractmethod
 from typing import Any, Dict
 
-from pydantic import BaseModel
-
 from ..test_framework.test_data import TestData
+from .base import BaseStrategyConfig
 
 
-class ReportingStrategyConfig(BaseModel):
+class ReportingStrategyConfig(BaseStrategyConfig):
     """Base model for Reporting Strategy config, passed to strategy init."""
 
 

--- a/tools/pipeline_perf_test/orchestrator/lib/core/telemetry/log.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/telemetry/log.py
@@ -1,0 +1,42 @@
+"""
+Custom logging handler that integrates Python logging with OpenTelemetry tracing.
+
+This module defines a logging handler that attaches log records as events
+to the current active OpenTelemetry span, allowing for improved traceability
+across distributed systems.
+"""
+
+import logging
+from opentelemetry.trace import get_current_span, Span
+
+
+class SpanAwareLogHandler(logging.Handler):
+    """
+    Logging handler that enriches the current OpenTelemetry span with log events.
+
+    If a span is active and recording, log records are added to it as events.
+    Certain custom keys (those starting with 'test.') are also included as attributes.
+    """
+
+    def emit(self, record: logging.LogRecord):
+        """
+        Emit a log record as an OpenTelemetry span event if a span is active.
+
+        Args:
+            record (logging.LogRecord): The log record to process.
+        """
+        span: Span = get_current_span()
+        if span and span.is_recording():
+
+            record_dict = record.__dict__.copy()
+
+            attributes = {
+                "log.severity": record.levelname,
+                "log.message": record.getMessage(),
+                "logger.name": record.name,
+            }
+            for key in list(record_dict.keys()):
+                if "test." in key:
+                    attributes[key] = record_dict[key]
+
+            span.add_event(name="log", attributes=attributes)

--- a/tools/pipeline_perf_test/orchestrator/lib/core/telemetry/test_event.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/telemetry/test_event.py
@@ -1,0 +1,39 @@
+from enum import Enum
+
+
+class TestEvent(Enum):
+    """Enum of Test Framework lifecycle events."""
+
+    # === Suite-level Events ===
+    SUITE_START = "suite_start"
+    SUITE_END = "suite_end"
+
+    # === Test-level Events ===
+    TEST_START = "test_start"
+    TEST_SUCCESS = "test_success"
+    TEST_ERROR = "test_error"
+    TEST_END = "test_end"
+
+    # === Step-level Events ===
+    STEP_START = "step_start"
+    STEP_EXECUTE_START = "step_execute_start"
+    STEP_EXECUTE_END = "step_execute_end"
+    STEP_SUCCESS = "step_success"
+    STEP_ERROR = "step_error"
+    STEP_END = "step_end"
+
+    # === Hooks ===
+    HOOK_START = "hook_start"
+    HOOK_END = "hook_end"
+
+    # === Strategy Invocation ===
+    STRATEGY_START = "strategy_start"
+    STRATEGY_END = "strategy_end"
+
+    # === Reporting ===
+    REPORTING_START = "reporting_start"
+    REPORTING_END = "reporting_end"
+
+    def namespaced(self, namespace="test_framework"):
+        """Return a string representation of the enum, prefixed with namespace"""
+        return f"{namespace}.{self.value}"

--- a/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_data.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_data.py
@@ -18,15 +18,17 @@ Classes:
 """
 
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import Dict, TYPE_CHECKING
 
 from ..component.component_data import ComponentData
-from ..context.test_contexts import TestExecutionContext
+
+if TYPE_CHECKING:
+    from ..context.test_contexts import TestExecutionContext
 
 
 @dataclass
 class TestData:
     """This class holds data about the test run, generally to be consumed by a reporting strategy."""
 
-    context: TestExecutionContext
+    context: "TestExecutionContext"
     component_data: Dict[str, ComponentData] = field(default_factory=dict)

--- a/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_step.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_step.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel
 from ..context.base import BaseContext
 from ..context.test_contexts import TestStepContext
 from ..context.test_element_hook_context import HookableTestPhase
+from ..telemetry.test_event import TestEvent
 from .test_element import TestFrameworkElement
 
 if TYPE_CHECKING:
@@ -108,6 +109,11 @@ class TestStep(TestFrameworkElement):
         """
         assert isinstance(ctx, TestStepContext), "Expected TestExecutionContext"
 
+        logger = ctx.get_logger(__name__)
         self._run_hooks(HookableTestPhase.PRE_RUN, ctx)
+        ctx.record_event(TestEvent.STEP_EXECUTE_START.namespaced())
+        logger.info("Executing main step action...")
         self.action.execute(ctx)
+        logger.debug("Main step action complete...")
+        ctx.record_event(TestEvent.STEP_EXECUTE_END.namespaced())
         self._run_hooks(HookableTestPhase.POST_RUN, ctx)

--- a/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_suite.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/test_framework/test_suite.py
@@ -102,8 +102,6 @@ class TestSuite(TestFrameworkElement):
                         test_execution_context.status = ExecutionStatus.ERROR
                         test_execution_context.error = e
                         logger.error("Test %s failed %s", test_definition.name, e)
-                        # test_execution_context.log(f"Test '{test_definition.name}' failed: {e}")
-                        # TODO: Depending on policy: break or continue
                         raise
 
                 logger.debug(
@@ -113,6 +111,5 @@ class TestSuite(TestFrameworkElement):
                 test_data = test_definition.get_test_data(test_execution_context)
                 for strategy in test_definition.reporting_strategies:
                     strategy.report(test_data)
-            # TODO: Support policy based status (fail if any test fails, etc)
             self._run_hooks(HookableTestPhase.POST_RUN, self.context)
             self.context.status = ExecutionStatus.SUCCESS


### PR DESCRIPTION
This adds the actual logging and span instrumentation to core test components, and introduces centralized plugin error handling. Misc config base models, and other accumulated nit/todo fixes as well.

