### PR TITLE
Remove randomness in go tests to address flaky codecov

### DIFF
--- a/pkg/benchmark/dataset/synthetic_dataset.go
+++ b/pkg/benchmark/dataset/synthetic_dataset.go
@@ -15,7 +15,6 @@
 package dataset
 
 import (
-	"math/rand"
 	"strings"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -61,8 +60,7 @@ type FakeMetricsDataset struct {
 }
 
 func NewFakeMetricsDataset(size int) *FakeMetricsDataset {
-	//#nosec G404 -- This is a false positive, this random number generator is not used for test purposes
-	entropy := datagen.NewTestEntropy(int64(rand.Uint64()))
+	entropy := datagen.NewTestEntropy()
 	return &FakeMetricsDataset{len: size, generator: datagen.NewMetricsGenerator(entropy, entropy.NewStandardResourceAttributes(), entropy.NewStandardInstrumentationScopes())}
 }
 
@@ -83,8 +81,7 @@ type FakeLogsDataset struct {
 }
 
 func NewFakeLogsDataset(size int) *FakeLogsDataset {
-	//#nosec G404 -- This is a false positive, this random number generator is not used for test purposes
-	entropy := datagen.NewTestEntropy(int64(rand.Uint64()))
+	entropy := datagen.NewTestEntropy()
 	return &FakeLogsDataset{len: size, generator: datagen.NewLogsGenerator(entropy, entropy.NewStandardResourceAttributes(), entropy.NewStandardInstrumentationScopes())}
 }
 
@@ -113,8 +110,7 @@ type FakeTraceDataset struct {
 }
 
 func NewFakeTraceDataset(size int) *FakeTraceDataset {
-	//#nosec G404 -- This is a false positive, this random number generator is not used for test purposes
-	entropy := datagen.NewTestEntropy(int64(rand.Uint64()))
+	entropy := datagen.NewTestEntropy()
 	return &FakeTraceDataset{len: size, generator: datagen.NewTracesGenerator(entropy, entropy.NewStandardResourceAttributes(), entropy.NewStandardInstrumentationScopes())}
 }
 

--- a/pkg/datagen/data_generator.go
+++ b/pkg/datagen/data_generator.go
@@ -49,9 +49,8 @@ type TestEntropy struct {
 	start int64
 }
 
-func NewTestEntropy(seed int64) TestEntropy {
-	//#nosec G404 -- This is a false positive, this random number generator is not used for test purposes
-	rng := rand.New(rand.NewSource(seed))
+func NewTestEntropy() TestEntropy {
+	rng := rand.New(rand.NewSource(42))
 
 	// let the start time happen in 2022 as the first rng draw.
 	start := time.Date(2022, time.January, 1, 0, 0, 0, 0, time.UTC).

--- a/pkg/otel/arrow_record/producer_consumer_test.go
+++ b/pkg/otel/arrow_record/producer_consumer_test.go
@@ -17,7 +17,6 @@ package arrow_record
 import (
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"testing"
 	"time"
 
@@ -41,7 +40,7 @@ import (
 func FuzzConsumerTraces(f *testing.F) {
 	const numSeeds = 5
 
-	ent := datagen.NewTestEntropy(12345)
+	ent := datagen.NewTestEntropy()
 
 	for i := 0; i < numSeeds; i++ {
 		func() {
@@ -100,7 +99,7 @@ func FuzzConsumerTraces(f *testing.F) {
 func FuzzProducerTraces2(f *testing.F) {
 	const numSeeds = 5
 
-	ent := datagen.NewTestEntropy(12345)
+	ent := datagen.NewTestEntropy()
 
 	for i := 0; i < numSeeds; i++ {
 		dg := datagen.NewTracesGenerator(
@@ -154,7 +153,7 @@ func FuzzProducerTraces2(f *testing.F) {
 func FuzzProducerTraces1(f *testing.F) {
 	const numSeeds = 5
 
-	ent := datagen.NewTestEntropy(12345)
+	ent := datagen.NewTestEntropy()
 
 	dg := datagen.NewTracesGenerator(
 		ent,
@@ -198,7 +197,7 @@ func FuzzProducerTraces1(f *testing.F) {
 }
 
 func TestProducerConsumerTraces(t *testing.T) {
-	ent := datagen.NewTestEntropy(int64(rand.Uint64())) //nolint:gosec // only used for testing
+	ent := datagen.NewTestEntropy()
 
 	stdTesting := assert.NewStdUnitTest(t)
 
@@ -271,7 +270,7 @@ func TestProducerConsumerTraces(t *testing.T) {
 }
 
 func TestProducerConsumerLogs(t *testing.T) {
-	ent := datagen.NewTestEntropy(int64(rand.Uint64())) //nolint:gosec // only used for testing
+	ent := datagen.NewTestEntropy()
 
 	stdTesting := assert.NewStdUnitTest(t)
 
@@ -325,7 +324,7 @@ func TestProducerConsumerLogs(t *testing.T) {
 }
 
 func TestProducerConsumerMetrics(t *testing.T) {
-	ent := datagen.NewTestEntropy(int64(rand.Uint64())) //nolint:gosec // only used for testing
+	ent := datagen.NewTestEntropy()
 
 	stdTesting := assert.NewStdUnitTest(t)
 

--- a/pkg/otel/logs/validation_test.go
+++ b/pkg/otel/logs/validation_test.go
@@ -53,7 +53,7 @@ var (
 func TestLogsEncodingDecoding(t *testing.T) {
 	t.Parallel()
 
-	entropy := datagen.NewTestEntropy(int64(rand.Uint64())) //nolint:gosec	// only used for testing
+	entropy := datagen.NewTestEntropy()
 	logsGen := datagen.NewLogsGenerator(entropy, entropy.NewStandardResourceAttributes(), entropy.NewStandardInstrumentationScopes())
 
 	expectedRequest := plogotlp.NewExportRequestFromLogs(logsGen.Generate(5000, 100))
@@ -68,7 +68,7 @@ func TestLogsEncodingDecoding(t *testing.T) {
 func TestInvalidLogsDecoding(t *testing.T) {
 	t.Parallel()
 
-	entropy := datagen.NewTestEntropy(int64(rand.Uint64())) //nolint:gosec	// only used for testing
+	entropy := datagen.NewTestEntropy()
 	logsGen := datagen.NewLogsGenerator(entropy, entropy.NewStandardResourceAttributes(), entropy.NewStandardInstrumentationScopes())
 
 	expectedRequest := plogotlp.NewExportRequestFromLogs(logsGen.Generate(100, 100))
@@ -126,7 +126,7 @@ func MultiRoundOfCheckEncodeMessUpDecode(
 	t *testing.T,
 	expectedRequest plogotlp.ExportRequest,
 ) {
-	rng := rand.New(rand.NewSource(int64(rand.Uint64())))
+	rng := rand.New(rand.NewSource(42))
 
 	for i := 0; i < 100; i++ {
 		CheckEncodeMessUpDecode(t, expectedRequest, rng)

--- a/pkg/otel/metrics/validation_test.go
+++ b/pkg/otel/metrics/validation_test.go
@@ -113,7 +113,7 @@ func TestExponentialHistograms(t *testing.T) {
 }
 
 func MetricsGenerator() *datagen.MetricsGenerator {
-	entropy := datagen.NewTestEntropy(int64(rand.Uint64())) //nolint:gosec // only used for testing
+	entropy := datagen.NewTestEntropy()
 
 	dg := datagen.NewDataGenerator(entropy, entropy.NewStandardResourceAttributes(), entropy.NewStandardInstrumentationScopes()).
 		WithConfig(datagen.Config{
@@ -175,7 +175,7 @@ func CheckEncodeDecode(t *testing.T, expectedRequest pmetricotlp.ExportRequest) 
 // records in order to test the robustness of the conversion. In this situation,
 // the conversion can generate errors, but should never panic.
 func MultiRoundOfCheckEncodeMessUpDecode(t *testing.T, expectedRequest pmetricotlp.ExportRequest) {
-	rng := rand.New(rand.NewSource(int64(rand.Uint64())))
+	rng := rand.New(rand.NewSource(42))
 
 	for i := 0; i < 100; i++ {
 		OneRoundOfMessUpArrowRecords(t, expectedRequest, rng)

--- a/pkg/otel/traces/validation_test.go
+++ b/pkg/otel/traces/validation_test.go
@@ -54,7 +54,7 @@ var ProducerStats = stats.NewProducerStats()
 func TestTracesEncodingDecoding(t *testing.T) {
 	t.Parallel()
 
-	entropy := datagen.NewTestEntropy(int64(rand.Uint64())) //nolint:gosec // only used for testing
+	entropy := datagen.NewTestEntropy()
 
 	tracesGen := datagen.NewTracesGenerator(
 		entropy,
@@ -70,7 +70,7 @@ func TestTracesEncodingDecoding(t *testing.T) {
 func TestRandomTracesEncodingDecoding(t *testing.T) {
 	t.Parallel()
 
-	entropy := datagen.NewTestEntropy(int64(rand.Uint64())) //nolint:gosec // only used for testing
+	entropy := datagen.NewTestEntropy()
 
 	tracesGen := datagen.NewTracesGenerator(
 		entropy,
@@ -270,7 +270,7 @@ func TestCustom2TracesEncodingDecoding(t *testing.T) {
 func TestInvalidTracesDecoding(t *testing.T) {
 	t.Parallel()
 
-	entropy := datagen.NewTestEntropy(int64(rand.Uint64())) //nolint:gosec // only used for testing
+	entropy := datagen.NewTestEntropy()
 
 	tracesGen := datagen.NewTracesGenerator(entropy, entropy.NewStandardResourceAttributes(), entropy.NewStandardInstrumentationScopes())
 
@@ -330,7 +330,7 @@ func MultiRoundOfCheckEncodeMessUpDecode(
 	t *testing.T,
 	expectedRequest ptraceotlp.ExportRequest,
 ) {
-	rng := rand.New(rand.NewSource(int64(rand.Uint64())))
+	rng := rand.New(rand.NewSource(42))
 
 	for i := 0; i < 100; i++ {
 		CheckEncodeMessUpDecode(t, expectedRequest, rng)

--- a/tools/logs_gen/main.go
+++ b/tools/logs_gen/main.go
@@ -18,13 +18,10 @@
 package main
 
 import (
-	"crypto/rand"
 	"encoding/json"
 	"flag"
 	"io"
 	"log"
-	"math"
-	"math/big"
 	"os"
 	"path"
 
@@ -128,12 +125,7 @@ func main() {
 	}
 
 	// Generate the dataset.
-	v, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
-	if err != nil {
-		log.Fatalf("Failed to generate random number - %v", err)
-	}
-
-	entropy := datagen.NewTestEntropy(v.Int64())
+	entropy := datagen.NewTestEntropy()
 	generator := datagen.NewLogsGenerator(entropy, entropy.NewStandardResourceAttributes(), entropy.NewStandardInstrumentationScopes())
 
 	// set default output file name

--- a/tools/metrics_gen/main.go
+++ b/tools/metrics_gen/main.go
@@ -15,13 +15,10 @@
 package main
 
 import (
-	"crypto/rand"
 	"encoding/json"
 	"flag"
 	"io"
 	"log"
-	"math"
-	"math/big"
 	"os"
 	"path"
 
@@ -128,12 +125,7 @@ func main() {
 	}
 
 	// Generate the dataset.
-	v, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
-	if err != nil {
-		log.Fatalf("Failed to generate random number - %v", err)
-	}
-	entropy := datagen.NewTestEntropy(v.Int64())
-
+	entropy := datagen.NewTestEntropy()
 	generator := datagen.NewMetricsGenerator(entropy, entropy.NewStandardResourceAttributes(), entropy.NewStandardInstrumentationScopes())
 
 	// set default output file name

--- a/tools/trace_gen/main.go
+++ b/tools/trace_gen/main.go
@@ -15,13 +15,10 @@
 package main
 
 import (
-	"crypto/rand"
 	"encoding/json"
 	"flag"
 	"io"
 	"log"
-	"math"
-	"math/big"
 	"os"
 	"path"
 
@@ -126,11 +123,7 @@ func main() {
 	}
 
 	// Generate the dataset.
-	v, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
-	if err != nil {
-		log.Fatalf("Failed to generate random number - %v", err)
-	}
-	entropy := datagen.NewTestEntropy(v.Int64())
+	entropy := datagen.NewTestEntropy()
 	generator := datagen.NewTracesGenerator(entropy, entropy.NewStandardResourceAttributes(), entropy.NewStandardInstrumentationScopes())
 
 	// set default output file name


### PR DESCRIPTION
Attempt at addressing #529

According to various [codecov readings](https://app.codecov.io/gh/open-telemetry/otel-arrow/pull/554/indirect-changes), the discrepancy in our codecov is often in various error conditions of different `pkg/otel` files.

![image](https://github.com/user-attachments/assets/66e6b96a-3449-4227-bb3c-a4f2ac07fa69)

This PR was a result of a brief look into the test infrastructure there and noting several usages of `rng` with a seed of type `rand.Uint64`. Out of curiosity I removed them and ran checked coverage multiple times locally, and found it stabilizes at reproducible numbers.

I am not entirely sure how important true entropy is in testing the go modules compared to seeded entropy, looking for insights from @jmacd and @lquerel who wrote most of it.

