### PR TITLE
Release v0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## [0.36.0](https://github.com/open-telemetry/otel-arrow/releases/tag/v0.36.0) - 2025-06-09
+
 - Remove `concurrentbatch` and `obfuscation` processors.
   [#409](https://github.com/open-telemetry/otel-arrow/pull/409)
 - OTAP AttributeStore parent_id encoding cleanup.

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,7 +3,7 @@
 
 module-sets:
   beta:
-    version: v0.35.0
+    version: v0.36.0
     modules:
       - github.com/open-telemetry/otel-arrow
       - github.com/open-telemetry/otel-arrow/collector/cmd/otelarrowcol


### PR DESCRIPTION
Primary motivation for this release (besides the fact it has been 2 months since preceeding one) is confirming code movement performed #413 doesn't adversely affect our ability to update our Golang components.

# Changelog

- Remove `concurrentbatch` and `obfuscation` processors. [#409](https://github.com/open-telemetry/otel-arrow/pull/409)
- OTAP AttributeStore parent_id encoding cleanup. [#431](https://github.com/open-telemetry/otel-arrow/pull/431)
- Upgrade Go to 1.24.3. [#440](https://github.com/open-telemetry/otel-arrow/pull/440), [#508](https://github.com/open-telemetry/otel-arrow/pull/508)
- Fix time unit of `DurationTimeUnixNano` to `Duration_ns` in Traces. [#517](https://github.com/open-telemetry/otel-arrow/pull/517)
- Upgrade to v0.127.0 / v1.33.0 of collector dependencies. [#526](https://github.com/open-telemetry/otel-arrow/pull/526)