### PR TITLE
Mark terminal version of otel-arrow module and bump to 0.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Downgrade Go to 1.23.0.
   [#569](https://github.com/open-telemetry/otel-arrow/pull/569)
 - Mark terminal version of `github.com/open-telemetry/otel-arrow` module.
-  [#572](https://github.com/open-telemetry/otel-arrow/pull/569)
+  [#572](https://github.com/open-telemetry/otel-arrow/pull/572)
+- Retract `github.com/open-telemetry/otel-arrow v0.37.0`.
+  [#572](https://github.com/open-telemetry/otel-arrow/pull/572)
 
 ## [0.37.0](https://github.com/open-telemetry/otel-arrow/releases/tag/v0.37.0) - 2025-06-10
 
@@ -33,6 +35,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   [#517](https://github.com/open-telemetry/otel-arrow/pull/517)
 - Upgrade to v0.127.0 / v1.33.0 of collector dependencies.
   [#526](https://github.com/open-telemetry/otel-arrow/pull/526)
+- Retract `github.com/open-telemetry/otel-arrow v0.36.0`.
+  [#567](https://github.com/open-telemetry/otel-arrow/pull/567)
 
 ## [0.35.0](https://github.com/open-telemetry/otel-arrow/releases/tag/v0.35.0) - 2025-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Downgrade Go to 1.23.0.
   [#569](https://github.com/open-telemetry/otel-arrow/pull/569)
+- Mark terminal version of `github.com/open-telemetry/otel-arrow` module. [#]
 
 ## [0.37.0](https://github.com/open-telemetry/otel-arrow/releases/tag/v0.37.0) - 2025-06-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## [0.38.0](https://github.com/open-telemetry/otel-arrow/releases/tag/v0.38.0) - 2025-06-10
+
 - Downgrade Go to 1.23.0.
   [#569](https://github.com/open-telemetry/otel-arrow/pull/569)
-- Mark terminal version of `github.com/open-telemetry/otel-arrow` module. [#]
+- Mark terminal version of `github.com/open-telemetry/otel-arrow` module.
+  [#572](https://github.com/open-telemetry/otel-arrow/pull/569)
 
 ## [0.37.0](https://github.com/open-telemetry/otel-arrow/releases/tag/v0.37.0) - 2025-06-10
 

--- a/collector/cmd/otelarrowcol/main.go
+++ b/collector/cmd/otelarrowcol/main.go
@@ -20,7 +20,7 @@ func main() {
 	info := component.BuildInfo{
 		Command:     "otelarrowcol",
 		Description: "OpenTelemetry Protocol with Apache Arrow development collector, for testing and evaluation",
-		Version:     "0.37.0",
+		Version:     "0.38.0",
 	}
 
 	set := otelcol.CollectorSettings{

--- a/collector/otelarrowcol-build.yaml
+++ b/collector/otelarrowcol-build.yaml
@@ -17,7 +17,7 @@ dist:
 
   # Note: this version number is replaced to match the current release using `sed`
   # during the release process, see ../../../RELEASING.md.
-  version: 0.37.0
+  version: 0.38.0
 
   # Project-internal use: Directory path required for the `make
   # genotelarrowcol`, which the Dockerfile also recognizes.

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: Terminal version of github.com/open-telemetry/otel-arrow, use github.com/open-telemetry/otel-arrow/go instead.
 module github.com/open-telemetry/otel-arrow
 
 go 1.23.0
@@ -55,4 +56,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-retract v0.36.0 // This version was released in the midst of a repository restructure causing incompatilibity between module name and source location.
+retract (
+	v0.37.0 // This version contained an upgrade to Go 1.24 which was incompatible with primary consumers.
+	v0.36.0 // This version was released in the midst of a repository restructure causing incompatilibity between module name and source location.
+)

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,7 +3,7 @@
 
 module-sets:
   beta:
-    version: v0.37.0
+    version: v0.38.0
     modules:
       - github.com/open-telemetry/otel-arrow
       - github.com/open-telemetry/otel-arrow/collector/cmd/otelarrowcol


### PR DESCRIPTION
Next step of https://github.com/open-telemetry/otel-arrow/issues/566 involves:
- Retract `v0.37.0` due to incompatibility with consumers (OpenTelemetry-Collector-Contrib)
- Mark terminal version of `github.com/open-telemetry/otel-arrow` module with deprecation notice
- Bump version to `v0.38.0`