### PR TITLE
[query-engine] Add basic logical expressions into recordset engine

### DIFF
--- a/rust/experimental/query_engine/engine-recordset/src/logical_expressions/equal_to_logical_expression.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/logical_expressions/equal_to_logical_expression.rs
@@ -1,0 +1,98 @@
+use std::cell::OnceCell;
+
+use crate::{
+    error::Error, execution_context::ExecutionContext, expression::*,
+    value_expressions::value_expression::ValueExpression,
+};
+
+use super::logical_expression::{LogicalExpressionInternal, equals};
+
+#[derive(Debug)]
+pub struct EqualToLogicalExpression {
+    id: usize,
+    left: Box<dyn ValueExpression>,
+    right: Box<dyn ValueExpression>,
+    hash: OnceCell<ExpressionHash>,
+}
+
+impl EqualToLogicalExpression {
+    pub fn new(
+        left: impl ValueExpression + 'static,
+        right: impl ValueExpression + 'static,
+    ) -> EqualToLogicalExpression {
+        Self {
+            id: get_next_id(),
+            left: Box::new(left),
+            right: Box::new(right),
+            hash: OnceCell::new(),
+        }
+    }
+}
+
+impl Expression for EqualToLogicalExpression {
+    fn get_id(&self) -> usize {
+        self.id
+    }
+
+    fn get_hash(&self) -> &ExpressionHash {
+        self.hash.get_or_init(|| {
+            ExpressionHash::new(|h| {
+                h.add_bytes(b"equal_to");
+                h.add_bytes(b"left:");
+                h.add_bytes(self.left.get_hash().get_bytes());
+                h.add_bytes(b"right:");
+                h.add_bytes(self.right.get_hash().get_bytes());
+            })
+        })
+    }
+
+    fn write_debug(
+        &self,
+        execution_context: &dyn ExecutionContext,
+        heading: &'static str,
+        level: i32,
+        output: &mut String,
+    ) {
+        let padding = "\t".repeat(level as usize);
+
+        output.push_str(&padding);
+        output.push_str(heading);
+        output.push_str("equal_to (\n");
+
+        self.left
+            .write_debug(execution_context, "left: ", level + 1, output);
+        output.push_str(&padding);
+        output.push_str(" ,\n");
+
+        self.right
+            .write_debug(execution_context, "right: ", level + 1, output);
+        output.push_str(&padding);
+        output.push_str(")\n");
+
+        execution_context.write_debug_comments_for_expression(self, output, &padding);
+    }
+}
+
+impl LogicalExpressionInternal for EqualToLogicalExpression {
+    fn evaluate<'a, 'b>(
+        &'a self,
+        execution_context: &dyn ExecutionContext<'b>,
+    ) -> Result<bool, Error>
+    where
+        'a: 'b,
+    {
+        let equal = equals(
+            execution_context,
+            self.get_id(),
+            self.left.as_ref(),
+            self.right.as_ref(),
+        )?;
+
+        execution_context.add_message_for_expression(
+            self,
+            ExpressionMessage::info(
+                either!(equal => "EqualToLogicalExpression evaluated as true"; "EqualToLogicalExpression evaluated as false").to_string()));
+
+        Ok(equal)
+    }
+}

--- a/rust/experimental/query_engine/engine-recordset/src/logical_expressions/greater_than_logical_expression.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/logical_expressions/greater_than_logical_expression.rs
@@ -1,0 +1,98 @@
+use std::cell::OnceCell;
+
+use crate::{
+    error::Error, execution_context::ExecutionContext, expression::*,
+    value_expressions::value_expression::ValueExpression,
+};
+
+use super::logical_expression::{LogicalExpressionInternal, compare};
+
+#[derive(Debug)]
+pub struct GreaterThanLogicalExpression {
+    id: usize,
+    left: Box<dyn ValueExpression>,
+    right: Box<dyn ValueExpression>,
+    hash: OnceCell<ExpressionHash>,
+}
+
+impl GreaterThanLogicalExpression {
+    pub fn new(
+        left: impl ValueExpression + 'static,
+        right: impl ValueExpression + 'static,
+    ) -> GreaterThanLogicalExpression {
+        Self {
+            id: get_next_id(),
+            left: Box::new(left),
+            right: Box::new(right),
+            hash: OnceCell::new(),
+        }
+    }
+}
+
+impl Expression for GreaterThanLogicalExpression {
+    fn get_id(&self) -> usize {
+        self.id
+    }
+
+    fn get_hash(&self) -> &ExpressionHash {
+        self.hash.get_or_init(|| {
+            ExpressionHash::new(|h| {
+                h.add_bytes(b"greater_than");
+                h.add_bytes(b"left:");
+                h.add_bytes(self.left.get_hash().get_bytes());
+                h.add_bytes(b"right:");
+                h.add_bytes(self.right.get_hash().get_bytes());
+            })
+        })
+    }
+
+    fn write_debug(
+        &self,
+        execution_context: &dyn ExecutionContext,
+        heading: &'static str,
+        level: i32,
+        output: &mut String,
+    ) {
+        let padding = "\t".repeat(level as usize);
+
+        output.push_str(&padding);
+        output.push_str(heading);
+        output.push_str("greater_than (\n");
+
+        self.left
+            .write_debug(execution_context, "left: ", level + 1, output);
+        output.push_str(&padding);
+        output.push_str(" ,\n");
+
+        self.right
+            .write_debug(execution_context, "right: ", level + 1, output);
+        output.push_str(&padding);
+        output.push_str(")\n");
+
+        execution_context.write_debug_comments_for_expression(self, output, &padding);
+    }
+}
+
+impl LogicalExpressionInternal for GreaterThanLogicalExpression {
+    fn evaluate<'a, 'b>(
+        &'a self,
+        execution_context: &dyn ExecutionContext<'b>,
+    ) -> Result<bool, Error>
+    where
+        'a: 'b,
+    {
+        let result = compare(
+            execution_context,
+            self.get_id(),
+            self.left.as_ref(),
+            self.right.as_ref(),
+        )?;
+
+        execution_context.add_message_for_expression(
+            self,
+            ExpressionMessage::info(
+                either!(result > 0 => "GreaterThanLogicalExpression evaluated as true"; "GreaterThanLogicalExpression evaluated as false").to_string()));
+
+        Ok(result > 0)
+    }
+}

--- a/rust/experimental/query_engine/engine-recordset/src/logical_expressions/greater_than_or_equal_to_logical_expression.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/logical_expressions/greater_than_or_equal_to_logical_expression.rs
@@ -1,0 +1,98 @@
+use std::cell::OnceCell;
+
+use crate::{
+    error::Error, execution_context::ExecutionContext, expression::*,
+    value_expressions::value_expression::ValueExpression,
+};
+
+use super::logical_expression::{LogicalExpressionInternal, compare};
+
+#[derive(Debug)]
+pub struct GreaterThanOrEqualToLogicalExpression {
+    id: usize,
+    left: Box<dyn ValueExpression>,
+    right: Box<dyn ValueExpression>,
+    hash: OnceCell<ExpressionHash>,
+}
+
+impl GreaterThanOrEqualToLogicalExpression {
+    pub fn new(
+        left: impl ValueExpression + 'static,
+        right: impl ValueExpression + 'static,
+    ) -> GreaterThanOrEqualToLogicalExpression {
+        Self {
+            id: get_next_id(),
+            left: Box::new(left),
+            right: Box::new(right),
+            hash: OnceCell::new(),
+        }
+    }
+}
+
+impl Expression for GreaterThanOrEqualToLogicalExpression {
+    fn get_id(&self) -> usize {
+        self.id
+    }
+
+    fn get_hash(&self) -> &ExpressionHash {
+        self.hash.get_or_init(|| {
+            ExpressionHash::new(|h| {
+                h.add_bytes(b"greater_than_or_equal_to");
+                h.add_bytes(b"left:");
+                h.add_bytes(self.left.get_hash().get_bytes());
+                h.add_bytes(b"right:");
+                h.add_bytes(self.right.get_hash().get_bytes());
+            })
+        })
+    }
+
+    fn write_debug(
+        &self,
+        execution_context: &dyn ExecutionContext,
+        heading: &'static str,
+        level: i32,
+        output: &mut String,
+    ) {
+        let padding = "\t".repeat(level as usize);
+
+        output.push_str(&padding);
+        output.push_str(heading);
+        output.push_str("greater_than_or_equal_to (\n");
+
+        self.left
+            .write_debug(execution_context, "left: ", level + 1, output);
+        output.push_str(&padding);
+        output.push_str(" ,\n");
+
+        self.right
+            .write_debug(execution_context, "right: ", level + 1, output);
+        output.push_str(&padding);
+        output.push_str(")\n");
+
+        execution_context.write_debug_comments_for_expression(self, output, &padding);
+    }
+}
+
+impl LogicalExpressionInternal for GreaterThanOrEqualToLogicalExpression {
+    fn evaluate<'a, 'b>(
+        &'a self,
+        execution_context: &dyn ExecutionContext<'b>,
+    ) -> Result<bool, Error>
+    where
+        'a: 'b,
+    {
+        let result = compare(
+            execution_context,
+            self.get_id(),
+            self.left.as_ref(),
+            self.right.as_ref(),
+        )?;
+
+        execution_context.add_message_for_expression(
+            self,
+            ExpressionMessage::info(
+                either!(result >= 0 => "GreaterThanOrEqualToLogicalExpression evaluated as true"; "GreaterThanOrEqualToLogicalExpression evaluated as false").to_string()));
+
+        Ok(result >= 0)
+    }
+}

--- a/rust/experimental/query_engine/engine-recordset/src/logical_expressions/less_than_logical_expression.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/logical_expressions/less_than_logical_expression.rs
@@ -1,0 +1,98 @@
+use std::cell::OnceCell;
+
+use crate::{
+    error::Error, execution_context::ExecutionContext, expression::*,
+    value_expressions::value_expression::ValueExpression,
+};
+
+use super::logical_expression::{LogicalExpressionInternal, compare};
+
+#[derive(Debug)]
+pub struct LessThanLogicalExpression {
+    id: usize,
+    left: Box<dyn ValueExpression>,
+    right: Box<dyn ValueExpression>,
+    hash: OnceCell<ExpressionHash>,
+}
+
+impl LessThanLogicalExpression {
+    pub fn new(
+        left: impl ValueExpression + 'static,
+        right: impl ValueExpression + 'static,
+    ) -> LessThanLogicalExpression {
+        Self {
+            id: get_next_id(),
+            left: Box::new(left),
+            right: Box::new(right),
+            hash: OnceCell::new(),
+        }
+    }
+}
+
+impl Expression for LessThanLogicalExpression {
+    fn get_id(&self) -> usize {
+        self.id
+    }
+
+    fn get_hash(&self) -> &ExpressionHash {
+        self.hash.get_or_init(|| {
+            ExpressionHash::new(|h| {
+                h.add_bytes(b"less_than");
+                h.add_bytes(b"left:");
+                h.add_bytes(self.left.get_hash().get_bytes());
+                h.add_bytes(b"right:");
+                h.add_bytes(self.right.get_hash().get_bytes());
+            })
+        })
+    }
+
+    fn write_debug(
+        &self,
+        execution_context: &dyn ExecutionContext,
+        heading: &'static str,
+        level: i32,
+        output: &mut String,
+    ) {
+        let padding = "\t".repeat(level as usize);
+
+        output.push_str(&padding);
+        output.push_str(heading);
+        output.push_str("less_than (\n");
+
+        self.left
+            .write_debug(execution_context, "left: ", level + 1, output);
+        output.push_str(&padding);
+        output.push_str(" ,\n");
+
+        self.right
+            .write_debug(execution_context, "right: ", level + 1, output);
+        output.push_str(&padding);
+        output.push_str(")\n");
+
+        execution_context.write_debug_comments_for_expression(self, output, &padding);
+    }
+}
+
+impl LogicalExpressionInternal for LessThanLogicalExpression {
+    fn evaluate<'a, 'b>(
+        &'a self,
+        execution_context: &dyn ExecutionContext<'b>,
+    ) -> Result<bool, Error>
+    where
+        'a: 'b,
+    {
+        let result = compare(
+            execution_context,
+            self.get_id(),
+            self.left.as_ref(),
+            self.right.as_ref(),
+        )?;
+
+        execution_context.add_message_for_expression(
+            self,
+            ExpressionMessage::info(
+                either!(result < 0 => "LessThanLogicalExpression evaluated as true"; "LessThanLogicalExpression evaluated as false").to_string()));
+
+        Ok(result < 0)
+    }
+}

--- a/rust/experimental/query_engine/engine-recordset/src/logical_expressions/less_than_or_equal_to_logical_expression.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/logical_expressions/less_than_or_equal_to_logical_expression.rs
@@ -1,0 +1,98 @@
+use std::cell::OnceCell;
+
+use crate::{
+    error::Error, execution_context::ExecutionContext, expression::*,
+    value_expressions::value_expression::ValueExpression,
+};
+
+use super::logical_expression::{LogicalExpressionInternal, compare};
+
+#[derive(Debug)]
+pub struct LessThanOrEqualToLogicalExpression {
+    id: usize,
+    left: Box<dyn ValueExpression>,
+    right: Box<dyn ValueExpression>,
+    hash: OnceCell<ExpressionHash>,
+}
+
+impl LessThanOrEqualToLogicalExpression {
+    pub fn new(
+        left: impl ValueExpression + 'static,
+        right: impl ValueExpression + 'static,
+    ) -> LessThanOrEqualToLogicalExpression {
+        Self {
+            id: get_next_id(),
+            left: Box::new(left),
+            right: Box::new(right),
+            hash: OnceCell::new(),
+        }
+    }
+}
+
+impl Expression for LessThanOrEqualToLogicalExpression {
+    fn get_id(&self) -> usize {
+        self.id
+    }
+
+    fn get_hash(&self) -> &ExpressionHash {
+        self.hash.get_or_init(|| {
+            ExpressionHash::new(|h| {
+                h.add_bytes(b"less_than_or_equal_to");
+                h.add_bytes(b"left:");
+                h.add_bytes(self.left.get_hash().get_bytes());
+                h.add_bytes(b"right:");
+                h.add_bytes(self.right.get_hash().get_bytes());
+            })
+        })
+    }
+
+    fn write_debug(
+        &self,
+        execution_context: &dyn ExecutionContext,
+        heading: &'static str,
+        level: i32,
+        output: &mut String,
+    ) {
+        let padding = "\t".repeat(level as usize);
+
+        output.push_str(&padding);
+        output.push_str(heading);
+        output.push_str("less_than_or_equal_to (\n");
+
+        self.left
+            .write_debug(execution_context, "left: ", level + 1, output);
+        output.push_str(&padding);
+        output.push_str(" ,\n");
+
+        self.right
+            .write_debug(execution_context, "right: ", level + 1, output);
+        output.push_str(&padding);
+        output.push_str(")\n");
+
+        execution_context.write_debug_comments_for_expression(self, output, &padding);
+    }
+}
+
+impl LogicalExpressionInternal for LessThanOrEqualToLogicalExpression {
+    fn evaluate<'a, 'b>(
+        &'a self,
+        execution_context: &dyn ExecutionContext<'b>,
+    ) -> Result<bool, Error>
+    where
+        'a: 'b,
+    {
+        let result = compare(
+            execution_context,
+            self.get_id(),
+            self.left.as_ref(),
+            self.right.as_ref(),
+        )?;
+
+        execution_context.add_message_for_expression(
+            self,
+            ExpressionMessage::info(
+                either!(result <= 0 => "LessThanOrEqualToLogicalExpression evaluated as true"; "LessThanOrEqualToLogicalExpression evaluated as false").to_string()));
+
+        Ok(result <= 0)
+    }
+}

--- a/rust/experimental/query_engine/engine-recordset/src/logical_expressions/logical_expression.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/logical_expressions/logical_expression.rs
@@ -1,0 +1,117 @@
+use crate::{
+    error::Error,
+    execution_context::ExecutionContext,
+    expression::Expression,
+    primitives::any_value::AnyValue,
+    value_expressions::value_expression::{self, ValueExpression},
+};
+
+#[allow(private_bounds)]
+pub trait LogicalExpression: LogicalExpressionInternal {}
+
+impl<T: ?Sized + LogicalExpressionInternal> LogicalExpression for T {}
+
+pub(crate) trait LogicalExpressionInternal: Expression {
+    fn evaluate<'a, 'b>(
+        &'a self,
+        execution_context: &dyn ExecutionContext<'b>,
+    ) -> Result<bool, Error>
+    where
+        'a: 'b;
+}
+
+pub(crate) fn compare<'a, 'b>(
+    execution_context: &dyn ExecutionContext<'b>,
+    expression_id: usize,
+    left_value_expr: &'a dyn ValueExpression,
+    right_value_expr: &'a dyn ValueExpression,
+) -> Result<i32, Error>
+where
+    'a: 'b,
+{
+    let mut result = Err(Error::ExpressionError(
+        expression_id,
+        Error::NotEvaluated.into(),
+    ));
+
+    value_expression::resolve_values(
+        execution_context,
+        left_value_expr,
+        right_value_expr,
+        |left_value: Option<&AnyValue>, right_value: Option<&AnyValue>| {
+            if left_value.is_none() {
+                result = Err(Error::new_expression_not_supported(
+                    expression_id,
+                    "NullValue type on left side of comparison expression is not supported",
+                ));
+                return;
+            }
+
+            if right_value.is_none() {
+                let null_value = AnyValue::NullValue;
+                result = left_value
+                    .unwrap()
+                    .compare(execution_context, expression_id, &null_value);
+                return;
+            }
+
+            result =
+                left_value
+                    .unwrap()
+                    .compare(execution_context, expression_id, right_value.unwrap());
+        },
+    );
+
+    result
+}
+
+pub(crate) fn equals<'a, 'b>(
+    execution_context: &dyn ExecutionContext<'b>,
+    expression_id: usize,
+    left_value_expr: &'a dyn ValueExpression,
+    right_value_expr: &'a dyn ValueExpression,
+) -> Result<bool, Error>
+where
+    'a: 'b,
+{
+    let mut result = Err(Error::ExpressionError(
+        expression_id,
+        Error::NotEvaluated.into(),
+    ));
+
+    value_expression::resolve_values(
+        execution_context,
+        left_value_expr,
+        right_value_expr,
+        |left_value: Option<&AnyValue>, right_value: Option<&AnyValue>| {
+            let left_is_none = left_value.is_none();
+            let right_is_none = right_value.is_none();
+
+            if left_is_none && right_is_none {
+                result = Ok(true);
+                return;
+            }
+
+            if left_is_none {
+                let null_value = AnyValue::NullValue;
+                result = null_value.equals(execution_context, expression_id, right_value.unwrap());
+                return;
+            }
+
+            if right_is_none {
+                let null_value = AnyValue::NullValue;
+                result = left_value
+                    .unwrap()
+                    .equals(execution_context, expression_id, &null_value);
+                return;
+            }
+
+            result =
+                left_value
+                    .unwrap()
+                    .equals(execution_context, expression_id, right_value.unwrap());
+        },
+    );
+
+    result
+}

--- a/rust/experimental/query_engine/engine-recordset/src/logical_expressions/logical_group_expression.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/logical_expressions/logical_group_expression.rs
@@ -1,0 +1,197 @@
+use std::{cell::OnceCell, collections::LinkedList};
+
+use crate::{error::Error, execution_context::ExecutionContext, expression::*};
+
+use super::logical_expression::*;
+
+#[derive(Debug)]
+pub struct LogicalGroupExpression {
+    id: usize,
+    first_expression: Box<dyn LogicalExpression>,
+    expressions: LinkedList<LogicalGroupExpressionValue>,
+    chain_type: LogicalGroupExpressionChain,
+    hash: OnceCell<ExpressionHash>,
+}
+
+impl LogicalGroupExpression {
+    pub fn new(first_expression: impl LogicalExpression + 'static) -> LogicalGroupExpression {
+        Self {
+            id: get_next_id(),
+            first_expression: Box::new(first_expression),
+            expressions: LinkedList::new(),
+            chain_type: LogicalGroupExpressionChain::None,
+            hash: OnceCell::new(),
+        }
+    }
+
+    pub fn add_logical_expression_with_and(
+        &mut self,
+        expression: impl LogicalExpression + 'static,
+    ) {
+        self.add(LogicalGroupExpressionValue::AndExpression(Box::new(
+            expression,
+        )));
+    }
+
+    pub fn add_logical_expression_with_or(&mut self, expression: impl LogicalExpression + 'static) {
+        self.add(LogicalGroupExpressionValue::OrExpression(Box::new(
+            expression,
+        )));
+    }
+
+    fn add(&mut self, expression: LogicalGroupExpressionValue) {
+        let chain_type = match expression {
+            LogicalGroupExpressionValue::AndExpression(_) => LogicalGroupExpressionChain::AndChain,
+            LogicalGroupExpressionValue::OrExpression(_) => LogicalGroupExpressionChain::OrChain,
+        };
+
+        if self.chain_type != LogicalGroupExpressionChain::MixedChain {
+            if self.chain_type == LogicalGroupExpressionChain::None {
+                self.chain_type = chain_type;
+            } else if self.chain_type != chain_type {
+                self.chain_type = LogicalGroupExpressionChain::MixedChain;
+            }
+        }
+
+        self.expressions.push_back(expression);
+    }
+}
+
+impl Expression for LogicalGroupExpression {
+    fn get_id(&self) -> usize {
+        self.id
+    }
+
+    fn get_hash(&self) -> &ExpressionHash {
+        self.hash.get_or_init(|| {
+            ExpressionHash::new(|h| {
+                h.add_bytes(b"logical_group");
+                h.add_bytes(b"expressions:");
+                h.add_bytes(self.first_expression.get_hash().get_bytes());
+                for expression in self.expressions.iter() {
+                    match expression {
+                        LogicalGroupExpressionValue::AndExpression(e) => {
+                            h.add_bytes(b"&&");
+                            h.add_bytes(e.get_hash().get_bytes());
+                        }
+                        LogicalGroupExpressionValue::OrExpression(e) => {
+                            h.add_bytes(b"||");
+                            h.add_bytes(e.get_hash().get_bytes());
+                        }
+                    }
+                }
+            })
+        })
+    }
+
+    fn write_debug(
+        &self,
+        execution_context: &dyn ExecutionContext,
+        _heading: &'static str,
+        level: i32,
+        output: &mut String,
+    ) {
+        let padding = "\t".repeat(level as usize);
+
+        output.push_str(&padding);
+        output.push_str("(\n");
+
+        self.first_expression
+            .write_debug(execution_context, "", level + 1, output);
+
+        for expression in self.expressions.iter() {
+            let inner_expression_operation_type;
+            let inner_expression;
+            match expression {
+                LogicalGroupExpressionValue::AndExpression(e) => {
+                    inner_expression_operation_type = LogicalGroupExpressionChain::AndChain;
+                    inner_expression = e;
+                }
+                LogicalGroupExpressionValue::OrExpression(e) => {
+                    inner_expression_operation_type = LogicalGroupExpressionChain::OrChain;
+                    inner_expression = e;
+                }
+            }
+
+            output.push_str(&padding);
+            output.push(' ');
+            match inner_expression_operation_type {
+                LogicalGroupExpressionChain::AndChain => output.push_str("&&"),
+                LogicalGroupExpressionChain::OrChain => output.push_str("||"),
+                _ => panic!(),
+            }
+            output.push('\n');
+
+            inner_expression.write_debug(execution_context, "", level + 1, output);
+        }
+
+        output.push_str(&padding);
+        output.push_str(")\n");
+
+        execution_context.write_debug_comments_for_expression(self, output, &padding);
+    }
+}
+
+impl LogicalExpressionInternal for LogicalGroupExpression {
+    fn evaluate<'a, 'b>(
+        &'a self,
+        execution_context: &dyn ExecutionContext<'b>,
+    ) -> Result<bool, Error>
+    where
+        'a: 'b,
+    {
+        let mut result = self.first_expression.evaluate(execution_context)?;
+        let chain_type = self.chain_type;
+
+        for expression in self.expressions.iter() {
+            if !result && chain_type == LogicalGroupExpressionChain::AndChain {
+                execution_context.add_message_for_expression(
+                    self,
+                    ExpressionMessage::info("LogicalGroupExpression AND chain clause evaluated as false and short-circuited".to_string()));
+                break;
+            }
+
+            if result && chain_type == LogicalGroupExpressionChain::OrChain {
+                execution_context.add_message_for_expression(
+                    self,
+                    ExpressionMessage::info("LogicalGroupExpression OR chain clause evaluated as true and short-circuited".to_string()));
+                break;
+            }
+
+            match expression {
+                LogicalGroupExpressionValue::AndExpression(e) => {
+                    result = result && e.evaluate(execution_context)?;
+                }
+                LogicalGroupExpressionValue::OrExpression(e) => {
+                    result = result || e.evaluate(execution_context)?;
+                }
+            }
+        }
+
+        execution_context.add_message_for_expression(
+            self,
+            ExpressionMessage::info(
+                either!(result => "LogicalGroupExpressionn evaluated as true"; "LogicalGroupExpression evaluated as false").to_string()));
+
+        Ok(result)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum LogicalGroupExpressionValue {
+    AndExpression(Box<dyn LogicalExpression>),
+    OrExpression(Box<dyn LogicalExpression>),
+}
+
+#[derive(
+    Debug,     // enables formatting in "{:?}"
+    Clone,     // required by Copy
+    Copy,      // enables copy-by-value semantics
+    PartialEq, // enables value equality (==)
+)]
+enum LogicalGroupExpressionChain {
+    None = 0,
+    AndChain = 1,
+    OrChain = 2,
+    MixedChain = 3,
+}

--- a/rust/experimental/query_engine/engine-recordset/src/logical_expressions/mod.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/logical_expressions/mod.rs
@@ -1,0 +1,17 @@
+pub(crate) mod equal_to_logical_expression;
+pub(crate) mod greater_than_logical_expression;
+pub(crate) mod greater_than_or_equal_to_logical_expression;
+pub(crate) mod less_than_logical_expression;
+pub(crate) mod less_than_or_equal_to_logical_expression;
+pub(crate) mod logical_expression;
+pub(crate) mod logical_group_expression;
+pub(crate) mod not_equal_to_logical_expression;
+
+pub use equal_to_logical_expression::EqualToLogicalExpression;
+pub use greater_than_logical_expression::GreaterThanLogicalExpression;
+pub use greater_than_or_equal_to_logical_expression::GreaterThanOrEqualToLogicalExpression;
+pub use less_than_logical_expression::LessThanLogicalExpression;
+pub use less_than_or_equal_to_logical_expression::LessThanOrEqualToLogicalExpression;
+pub use logical_expression::LogicalExpression;
+pub use logical_group_expression::LogicalGroupExpression;
+pub use not_equal_to_logical_expression::NotEqualToLogicalExpression;

--- a/rust/experimental/query_engine/engine-recordset/src/logical_expressions/not_equal_to_logical_expression.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/logical_expressions/not_equal_to_logical_expression.rs
@@ -1,0 +1,98 @@
+use std::cell::OnceCell;
+
+use crate::{
+    error::Error, execution_context::ExecutionContext, expression::*,
+    value_expressions::value_expression::ValueExpression,
+};
+
+use super::logical_expression::{LogicalExpressionInternal, equals};
+
+#[derive(Debug)]
+pub struct NotEqualToLogicalExpression {
+    id: usize,
+    left: Box<dyn ValueExpression>,
+    right: Box<dyn ValueExpression>,
+    hash: OnceCell<ExpressionHash>,
+}
+
+impl NotEqualToLogicalExpression {
+    pub fn new(
+        left: impl ValueExpression + 'static,
+        right: impl ValueExpression + 'static,
+    ) -> NotEqualToLogicalExpression {
+        Self {
+            id: get_next_id(),
+            left: Box::new(left),
+            right: Box::new(right),
+            hash: OnceCell::new(),
+        }
+    }
+}
+
+impl Expression for NotEqualToLogicalExpression {
+    fn get_id(&self) -> usize {
+        self.id
+    }
+
+    fn get_hash(&self) -> &ExpressionHash {
+        self.hash.get_or_init(|| {
+            ExpressionHash::new(|h| {
+                h.add_bytes(b"not_equal_to");
+                h.add_bytes(b"left:");
+                h.add_bytes(self.left.get_hash().get_bytes());
+                h.add_bytes(b"right:");
+                h.add_bytes(self.right.get_hash().get_bytes());
+            })
+        })
+    }
+
+    fn write_debug(
+        &self,
+        execution_context: &dyn ExecutionContext,
+        heading: &'static str,
+        level: i32,
+        output: &mut String,
+    ) {
+        let padding = "\t".repeat(level as usize);
+
+        output.push_str(&padding);
+        output.push_str(heading);
+        output.push_str("not_equal_to (\n");
+
+        self.left
+            .write_debug(execution_context, "left: ", level + 1, output);
+        output.push_str(&padding);
+        output.push_str(" ,");
+
+        self.right
+            .write_debug(execution_context, "right: ", level + 1, output);
+        output.push_str(&padding);
+        output.push_str(")\n");
+
+        execution_context.write_debug_comments_for_expression(self, output, &padding);
+    }
+}
+
+impl LogicalExpressionInternal for NotEqualToLogicalExpression {
+    fn evaluate<'a, 'b>(
+        &'a self,
+        execution_context: &dyn ExecutionContext<'b>,
+    ) -> Result<bool, Error>
+    where
+        'a: 'b,
+    {
+        let equal = equals(
+            execution_context,
+            self.get_id(),
+            self.left.as_ref(),
+            self.right.as_ref(),
+        )?;
+
+        execution_context.add_message_for_expression(
+            self,
+            ExpressionMessage::info(
+                either!(!equal => "NotEqualToLogicalExpression evaluated as true"; "NotEqualToLogicalExpression evaluated as false").to_string()));
+
+        Ok(!equal)
+    }
+}


### PR DESCRIPTION
## Changes

* Adds basic logical expressions (`==`, `!=`, `>`, `>=`, `<`, `<=`) into recordset engine