### PR TITLE
[query-engine] Add basic transformation expressions into recordset engine

### DIFF
--- a/rust/experimental/query_engine/engine-recordset/src/transform_expressions/clear_transformation_expression.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/transform_expressions/clear_transformation_expression.rs
@@ -1,0 +1,120 @@
+use std::cell::OnceCell;
+
+use crate::{
+    error::Error, execution_context::*, expression::*,
+    logical_expressions::logical_expression::LogicalExpression,
+};
+
+use super::transformation_expression::TransformationExpressionInternal;
+
+#[derive(Debug)]
+pub struct ClearTransformationExpression {
+    id: usize,
+    predicate: Option<Box<dyn LogicalExpression>>,
+    hash: OnceCell<ExpressionHash>,
+}
+
+impl Expression for ClearTransformationExpression {
+    fn get_id(&self) -> usize {
+        self.id
+    }
+
+    fn get_hash(&self) -> &ExpressionHash {
+        self.hash.get_or_init(|| {
+            ExpressionHash::new(|h| {
+                h.add_bytes(b"clear");
+                if self.predicate.is_some() {
+                    h.add_bytes(b"predicate:");
+                    h.add_bytes(self.predicate.as_ref().unwrap().get_hash().get_bytes());
+                }
+            })
+        })
+    }
+
+    fn write_debug(
+        &self,
+        execution_context: &dyn ExecutionContext,
+        heading: &'static str,
+        level: i32,
+        output: &mut String,
+    ) {
+        let padding = "\t".repeat(level as usize);
+
+        output.push_str(&padding);
+        output.push_str(heading);
+        output.push_str("clear (\n");
+
+        if self.predicate.is_some() {
+            self.predicate.as_ref().unwrap().write_debug(
+                execution_context,
+                "predicate: ",
+                level + 1,
+                output,
+            );
+        }
+
+        output.push_str(&padding);
+        output.push_str(")\n");
+
+        execution_context.write_debug_comments_for_expression(self, output, &padding);
+    }
+}
+
+impl TransformationExpressionInternal for ClearTransformationExpression {
+    fn evaluate<'a, 'b>(&'a self, execution_context: &dyn ExecutionContext<'b>) -> Result<(), Error>
+    where
+        'a: 'b,
+    {
+        if self.predicate.is_some()
+            && !self
+                .predicate
+                .as_ref()
+                .unwrap()
+                .evaluate(execution_context)?
+        {
+            execution_context.add_message_for_expression(
+                self,
+                ExpressionMessage::info(
+                    "ClearTransformationExpression evaluation skipped".to_string(),
+                ),
+            );
+
+            return Ok(());
+        }
+
+        execution_context.clear();
+
+        execution_context.add_message_for_expression(
+            self,
+            ExpressionMessage::info("ClearTransformationExpression DataRecord cleared".to_string()),
+        );
+
+        Ok(())
+    }
+}
+
+impl Default for ClearTransformationExpression {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ClearTransformationExpression {
+    pub fn new() -> ClearTransformationExpression {
+        Self {
+            id: get_next_id(),
+            predicate: None,
+            hash: OnceCell::new(),
+        }
+    }
+
+    pub fn new_with_predicate(
+        predicate: impl LogicalExpression + 'static,
+    ) -> ClearTransformationExpression {
+        Self {
+            id: get_next_id(),
+            predicate: Some(Box::new(predicate)),
+            hash: OnceCell::new(),
+        }
+    }
+}

--- a/rust/experimental/query_engine/engine-recordset/src/transform_expressions/mod.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/transform_expressions/mod.rs
@@ -1,0 +1,11 @@
+pub(crate) mod clear_transformation_expression;
+pub(crate) mod move_transformation_expression;
+pub(crate) mod remove_transformation_expression;
+pub(crate) mod set_transformation_expression;
+pub(crate) mod transformation_expression;
+
+pub use clear_transformation_expression::ClearTransformationExpression;
+pub use move_transformation_expression::MoveTransformationExpression;
+pub use remove_transformation_expression::RemoveTransformationExpression;
+pub use set_transformation_expression::SetTransformationExpression;
+pub use transformation_expression::TransformationExpression;

--- a/rust/experimental/query_engine/engine-recordset/src/transform_expressions/move_transformation_expression.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/transform_expressions/move_transformation_expression.rs
@@ -1,0 +1,194 @@
+use std::cell::OnceCell;
+
+use crate::{
+    data::data_record_resolver::*, error::Error, execution_context::ExecutionContext,
+    expression::*, logical_expressions::logical_expression::LogicalExpression,
+    value_expressions::value_expression::MutatableValueExpression,
+};
+
+use super::transformation_expression::TransformationExpressionInternal;
+
+#[derive(Debug)]
+pub struct MoveTransformationExpression {
+    id: usize,
+    destination: Box<dyn MutatableValueExpression>,
+    source: Box<dyn MutatableValueExpression>,
+    predicate: Option<Box<dyn LogicalExpression>>,
+    hash: OnceCell<ExpressionHash>,
+}
+
+impl Expression for MoveTransformationExpression {
+    fn get_id(&self) -> usize {
+        self.id
+    }
+
+    fn get_hash(&self) -> &ExpressionHash {
+        self.hash.get_or_init(|| {
+            ExpressionHash::new(|h| {
+                h.add_bytes(b"move");
+                if self.predicate.is_some() {
+                    h.add_bytes(b"predicate:");
+                    h.add_bytes(self.predicate.as_ref().unwrap().get_hash().get_bytes());
+                }
+                h.add_bytes(b"destination:");
+                h.add_bytes(self.destination.get_hash().get_bytes());
+                h.add_bytes(b"source:");
+                h.add_bytes(self.source.get_hash().get_bytes());
+            })
+        })
+    }
+
+    fn write_debug(
+        &self,
+        execution_context: &dyn ExecutionContext,
+        heading: &'static str,
+        level: i32,
+        output: &mut String,
+    ) {
+        let padding = "\t".repeat(level as usize);
+
+        output.push_str(&padding);
+        output.push_str(heading);
+        output.push_str("move (\n");
+
+        if self.predicate.is_some() {
+            self.predicate.as_ref().unwrap().write_debug(
+                execution_context,
+                "predicate: ",
+                level + 1,
+                output,
+            );
+
+            output.push_str(&padding);
+            output.push_str(" ,\n");
+        }
+
+        self.destination
+            .write_debug(execution_context, "destination: ", level + 1, output);
+
+        output.push_str(&padding);
+        output.push_str(" ,\n");
+
+        self.source
+            .write_debug(execution_context, "source: ", level + 1, output);
+
+        output.push_str(&padding);
+        output.push_str(")\n");
+
+        execution_context.write_debug_comments_for_expression(self, output, &padding);
+    }
+}
+
+impl TransformationExpressionInternal for MoveTransformationExpression {
+    fn evaluate<'a, 'b>(&'a self, execution_context: &dyn ExecutionContext<'b>) -> Result<(), Error>
+    where
+        'a: 'b,
+    {
+        if self.predicate.is_some()
+            && !self
+                .predicate
+                .as_ref()
+                .unwrap()
+                .evaluate(execution_context)?
+        {
+            execution_context.add_message_for_expression(
+                self,
+                ExpressionMessage::info(
+                    "MoveTransformationExpression evaluation skipped".to_string(),
+                ),
+            );
+
+            return Ok(());
+        }
+
+        match self.source.remove_any_value(execution_context) {
+            DataRecordRemoveAnyValueResult::NotFound => {
+                execution_context.add_message_for_expression(
+                    self,
+                    ExpressionMessage::warn(
+                        "MoveTransformationExpression AnyValue to write into the destination not found".to_string()));
+            }
+            DataRecordRemoveAnyValueResult::NotSupported(message) => {
+                execution_context.add_message_for_expression(
+                    self,
+                    ExpressionMessage::warn(
+                        format!("MoveTransformationExpression AnyValue to write into the destination could not be mutated: {message}").to_string()));
+            }
+            DataRecordRemoveAnyValueResult::Removed(any_value) => {
+                execution_context.add_message_for_expression(
+                    self,
+                    ExpressionMessage::info(
+                        "MoveTransformationExpression removed AnyValue from source".to_string(),
+                    ),
+                );
+
+                match self.destination.set_any_value(execution_context, any_value) {
+                    DataRecordSetAnyValueResult::NotSupported(message) => {
+                        execution_context.add_message_for_expression(
+                            self,
+                            ExpressionMessage::warn(
+                                format!("MoveTransformationExpression AnyValue destination does not support set operation: {message}")));
+                    }
+                    DataRecordSetAnyValueResult::NotFound => {
+                        execution_context.add_message_for_expression(
+                            self,
+                            ExpressionMessage::warn(
+                                "MoveTransformationExpression AnyValue destination was not found"
+                                    .to_string(),
+                            ),
+                        );
+                    }
+                    DataRecordSetAnyValueResult::Created => {
+                        execution_context.add_message_for_expression(
+                            self,
+                            ExpressionMessage::info(
+                                "MoveTransformationExpression AnyValue created at destination"
+                                    .to_string(),
+                            ),
+                        );
+                    }
+                    DataRecordSetAnyValueResult::Updated(_) => {
+                        execution_context.add_message_for_expression(
+                            self,
+                            ExpressionMessage::info(
+                                "MoveTransformationExpression AnyValue updated in destination"
+                                    .to_string(),
+                            ),
+                        );
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl MoveTransformationExpression {
+    pub fn new(
+        destination: impl MutatableValueExpression + 'static,
+        source: impl MutatableValueExpression + 'static,
+    ) -> MoveTransformationExpression {
+        Self {
+            id: get_next_id(),
+            destination: Box::new(destination),
+            source: Box::new(source),
+            predicate: None,
+            hash: OnceCell::new(),
+        }
+    }
+
+    pub fn new_with_predicate(
+        destination: impl MutatableValueExpression + 'static,
+        source: impl MutatableValueExpression + 'static,
+        predicate: impl LogicalExpression + 'static,
+    ) -> MoveTransformationExpression {
+        Self {
+            id: get_next_id(),
+            destination: Box::new(destination),
+            source: Box::new(source),
+            predicate: Some(Box::new(predicate)),
+            hash: OnceCell::new(),
+        }
+    }
+}

--- a/rust/experimental/query_engine/engine-recordset/src/transform_expressions/remove_transformation_expression.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/transform_expressions/remove_transformation_expression.rs
@@ -1,0 +1,145 @@
+use std::cell::OnceCell;
+
+use crate::{
+    data::data_record_resolver::*, error::Error, execution_context::*, expression::*,
+    logical_expressions::logical_expression::LogicalExpression,
+    value_expressions::value_expression::*,
+};
+
+use super::transformation_expression::TransformationExpressionInternal;
+
+#[derive(Debug)]
+pub struct RemoveTransformationExpression {
+    id: usize,
+    target: Box<dyn MutatableValueExpression>,
+    predicate: Option<Box<dyn LogicalExpression>>,
+    hash: OnceCell<ExpressionHash>,
+}
+
+impl Expression for RemoveTransformationExpression {
+    fn get_id(&self) -> usize {
+        self.id
+    }
+
+    fn get_hash(&self) -> &ExpressionHash {
+        self.hash.get_or_init(|| {
+            ExpressionHash::new(|h| {
+                h.add_bytes(b"remove");
+                if self.predicate.is_some() {
+                    h.add_bytes(b"predicate:");
+                    h.add_bytes(self.predicate.as_ref().unwrap().get_hash().get_bytes());
+                }
+                h.add_bytes(b"target:");
+                h.add_bytes(self.target.get_hash().get_bytes());
+            })
+        })
+    }
+
+    fn write_debug(
+        &self,
+        execution_context: &dyn ExecutionContext,
+        heading: &'static str,
+        level: i32,
+        output: &mut String,
+    ) {
+        let padding = "\t".repeat(level as usize);
+
+        output.push_str(&padding);
+        output.push_str(heading);
+        output.push_str("remove (\n");
+
+        if self.predicate.is_some() {
+            self.predicate.as_ref().unwrap().write_debug(
+                execution_context,
+                "predicate: ",
+                level + 1,
+                output,
+            );
+
+            output.push_str(&padding);
+            output.push_str(" ,\n");
+        }
+
+        self.target
+            .write_debug(execution_context, "target: ", level + 1, output);
+
+        output.push_str(&padding);
+        output.push_str(")\n");
+
+        execution_context.write_debug_comments_for_expression(self, output, &padding);
+    }
+}
+
+impl TransformationExpressionInternal for RemoveTransformationExpression {
+    fn evaluate<'a, 'b>(&'a self, execution_context: &dyn ExecutionContext<'b>) -> Result<(), Error>
+    where
+        'a: 'b,
+    {
+        if self.predicate.is_some()
+            && !self
+                .predicate
+                .as_ref()
+                .unwrap()
+                .evaluate(execution_context)?
+        {
+            execution_context.add_message_for_expression(
+                self,
+                ExpressionMessage::info(
+                    "RemoveTransformationExpression evaluation skipped".to_string(),
+                ),
+            );
+
+            return Ok(());
+        }
+
+        match self.target.remove_any_value(execution_context) {
+            DataRecordRemoveAnyValueResult::NotFound => {
+                execution_context.add_message_for_expression(
+                    self,
+                    ExpressionMessage::info(
+                        "RemoveTransformationExpression AnyValue not found".to_string(),
+                    ),
+                );
+            }
+            DataRecordRemoveAnyValueResult::NotSupported(message) => {
+                execution_context.add_message_for_expression(
+                    self,
+                    ExpressionMessage::warn(
+                        format!("RemoveTransformationExpression AnyValue could not be mutated: {message}").to_string()));
+            }
+            DataRecordRemoveAnyValueResult::Removed(_) => {
+                execution_context.add_message_for_expression(
+                    self,
+                    ExpressionMessage::info(
+                        "RemoveTransformationExpression AnyValue removed from target".to_string(),
+                    ),
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl RemoveTransformationExpression {
+    pub fn new(target: impl MutatableValueExpression + 'static) -> RemoveTransformationExpression {
+        Self {
+            id: get_next_id(),
+            target: Box::new(target),
+            predicate: None,
+            hash: OnceCell::new(),
+        }
+    }
+
+    pub fn new_with_predicate(
+        target: impl MutatableValueExpression + 'static,
+        predicate: impl LogicalExpression + 'static,
+    ) -> RemoveTransformationExpression {
+        Self {
+            id: get_next_id(),
+            target: Box::new(target),
+            predicate: Some(Box::new(predicate)),
+            hash: OnceCell::new(),
+        }
+    }
+}

--- a/rust/experimental/query_engine/engine-recordset/src/transform_expressions/set_transformation_expression.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/transform_expressions/set_transformation_expression.rs
@@ -1,0 +1,201 @@
+use std::cell::OnceCell;
+
+use crate::{
+    data::data_record_resolver::*, error::Error, execution_context::*, expression::*,
+    logical_expressions::logical_expression::LogicalExpression, primitives::any_value::AnyValue,
+    value_expressions::value_expression::*,
+};
+
+use super::transformation_expression::TransformationExpressionInternal;
+
+#[derive(Debug)]
+pub struct SetTransformationExpression {
+    id: usize,
+    destination: Box<dyn MutatableValueExpression>,
+    value: Box<dyn ValueExpression>,
+    predicate: Option<Box<dyn LogicalExpression>>,
+    hash: OnceCell<ExpressionHash>,
+}
+
+impl Expression for SetTransformationExpression {
+    fn get_id(&self) -> usize {
+        self.id
+    }
+
+    fn get_hash(&self) -> &ExpressionHash {
+        self.hash.get_or_init(|| {
+            ExpressionHash::new(|h| {
+                h.add_bytes(b"set");
+                if self.predicate.is_some() {
+                    h.add_bytes(b"predicate:");
+                    h.add_bytes(self.predicate.as_ref().unwrap().get_hash().get_bytes());
+                }
+                h.add_bytes(b"destination:");
+                h.add_bytes(self.destination.get_hash().get_bytes());
+                h.add_bytes(b"value:");
+                h.add_bytes(self.value.get_hash().get_bytes());
+            })
+        })
+    }
+
+    fn write_debug(
+        &self,
+        execution_context: &dyn ExecutionContext,
+        heading: &'static str,
+        level: i32,
+        output: &mut String,
+    ) {
+        let padding = "\t".repeat(level as usize);
+
+        output.push_str(&padding);
+        output.push_str(heading);
+        output.push_str("set (\n");
+
+        if self.predicate.is_some() {
+            self.predicate.as_ref().unwrap().write_debug(
+                execution_context,
+                "predicate: ",
+                level + 1,
+                output,
+            );
+
+            output.push_str(&padding);
+            output.push_str(" ,\n");
+        }
+
+        self.destination
+            .write_debug(execution_context, "destination: ", level + 1, output);
+
+        output.push_str(&padding);
+        output.push_str(" ,\n");
+
+        self.value
+            .write_debug(execution_context, "value: ", level + 1, output);
+
+        output.push_str(&padding);
+        output.push_str(")\n");
+
+        execution_context.write_debug_comments_for_expression(self, output, &padding);
+    }
+}
+
+impl TransformationExpressionInternal for SetTransformationExpression {
+    fn evaluate<'a, 'b>(&'a self, execution_context: &dyn ExecutionContext<'b>) -> Result<(), Error>
+    where
+        'a: 'b,
+    {
+        if self.predicate.is_some()
+            && !self
+                .predicate
+                .as_ref()
+                .unwrap()
+                .evaluate(execution_context)?
+        {
+            execution_context.add_message_for_expression(
+                self,
+                ExpressionMessage::info(
+                    "SetTransformationExpression evaluation skipped".to_string(),
+                ),
+            );
+
+            return Ok(());
+        }
+
+        let mut result = Err(Error::ExpressionError(
+            self.get_id(),
+            Error::NotEvaluated.into(),
+        ));
+
+        let mut value: Option<AnyValue> = None;
+
+        self.value.read_any_value(
+            execution_context,
+            &mut DataRecordAnyValueReadClosureCallback::new(|v| {
+                result = Ok(());
+
+                match v {
+                    DataRecordReadAnyValueResult::NotFound => {
+                        execution_context.add_message_for_expression(
+                            self,
+                            ExpressionMessage::warn(
+                                "SetTransformationExpression AnyValue to write into the destination not found".to_string()));
+                    },
+                    DataRecordReadAnyValueResult::Found(any_value) => {
+                        value = Some(any_value.clone())
+                    },
+                }
+            }));
+
+        if value.is_none() {
+            return result;
+        }
+
+        match self
+            .destination
+            .set_any_value(execution_context, value.unwrap())
+        {
+            DataRecordSetAnyValueResult::NotSupported(message) => {
+                execution_context.add_message_for_expression(
+                    self,
+                    ExpressionMessage::warn(
+                        format!("SetTransformationExpression AnyValue destination does not support set operation: {message}")));
+            }
+            DataRecordSetAnyValueResult::NotFound => {
+                execution_context.add_message_for_expression(
+                    self,
+                    ExpressionMessage::warn(
+                        "SetTransformationExpression AnyValue destination was not found"
+                            .to_string(),
+                    ),
+                );
+            }
+            DataRecordSetAnyValueResult::Created => {
+                execution_context.add_message_for_expression(
+                    self,
+                    ExpressionMessage::info(
+                        "SetTransformationExpression AnyValue created at destination".to_string(),
+                    ),
+                );
+            }
+            DataRecordSetAnyValueResult::Updated(_) => {
+                execution_context.add_message_for_expression(
+                    self,
+                    ExpressionMessage::info(
+                        "SetTransformationExpression AnyValue updated in destination".to_string(),
+                    ),
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl SetTransformationExpression {
+    pub fn new(
+        destination: impl MutatableValueExpression + 'static,
+        value: impl ValueExpression + 'static,
+    ) -> SetTransformationExpression {
+        Self {
+            id: get_next_id(),
+            destination: Box::new(destination),
+            value: Box::new(value),
+            predicate: None,
+            hash: OnceCell::new(),
+        }
+    }
+
+    pub fn new_with_predicate(
+        destination: impl MutatableValueExpression + 'static,
+        value: impl ValueExpression + 'static,
+        predicate: impl LogicalExpression + 'static,
+    ) -> SetTransformationExpression {
+        Self {
+            id: get_next_id(),
+            destination: Box::new(destination),
+            value: Box::new(value),
+            predicate: Some(Box::new(predicate)),
+            hash: OnceCell::new(),
+        }
+    }
+}

--- a/rust/experimental/query_engine/engine-recordset/src/transform_expressions/transformation_expression.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/transform_expressions/transformation_expression.rs
@@ -1,0 +1,15 @@
+use crate::{error::Error, execution_context::ExecutionContext, expression::Expression};
+
+#[allow(private_bounds)]
+pub trait TransformationExpression: TransformationExpressionInternal {}
+
+impl<T: ?Sized + TransformationExpressionInternal> TransformationExpression for T {}
+
+pub(crate) trait TransformationExpressionInternal: Expression {
+    fn evaluate<'a, 'b>(
+        &'a self,
+        execution_context: &dyn ExecutionContext<'b>,
+    ) -> Result<(), Error>
+    where
+        'a: 'b;
+}


### PR DESCRIPTION
## Changes

* Adds basic transformation expressions (set, remove, move, clear) into recordset engine