### PR TITLE
fix clippy CI for otel-arrow-rust

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -108,7 +108,7 @@ jobs:
         with:
           toolchain: stable
           components: clippy
-      - name: cargo clippy ${{ matrix.folder }} --all-targets
+      - name: cargo clippy ${{ matrix.folder }}
         # beaubourg is a reference implementation without active development, so don't break the build on warnings
         run: |
           if [ "${{ matrix.folder }}" = "beaubourg" ]; then


### PR DESCRIPTION
Some changes got merged in that had clippy issues in the benches target. 

Currently is causing failures on this PR https://github.com/open-telemetry/otel-arrow/pull/565 because otap-dataflow uses `xtask check` which does include the `--all-targets` flag