### PR TITLE
[query-engine] Add basic value expressions to the recordset engine

### DIFF
--- a/rust/experimental/query_engine/engine-recordset/src/value_expressions/mod.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/value_expressions/mod.rs
@@ -1,0 +1,11 @@
+pub(crate) mod resolve_from_attached_value_expression;
+pub(crate) mod resolve_value_expression;
+pub(crate) mod static_value_expression;
+pub(crate) mod value_expression;
+pub(crate) mod variable_value_expression;
+
+pub use resolve_from_attached_value_expression::ResolveFromAttachedValueExpression;
+pub use resolve_value_expression::ResolveValueExpression;
+pub use static_value_expression::StaticValueExpression;
+pub use value_expression::{MutatableValueExpression, ValueExpression};
+pub use variable_value_expression::VariableValueExpression;

--- a/rust/experimental/query_engine/engine-recordset/src/value_expressions/resolve_from_attached_value_expression.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/value_expressions/resolve_from_attached_value_expression.rs
@@ -1,0 +1,122 @@
+use std::cell::OnceCell;
+
+use crate::{
+    data::data_record_resolver::*, error::Error, execution_context::*, expression::*,
+    primitives::*, value_path::ValuePath,
+};
+
+use super::value_expression::*;
+
+#[derive(Debug)]
+pub struct ResolveFromAttachedValueExpression {
+    id: usize,
+    name: StringValueData,
+    path: ValuePath,
+    hash: OnceCell<ExpressionHash>,
+}
+
+impl ResolveFromAttachedValueExpression {
+    pub fn new(name: &str, path: &str) -> Result<ResolveFromAttachedValueExpression, Error> {
+        Ok(Self {
+            id: get_next_id(),
+            name: StringValueData::new(name),
+            path: ValuePath::new(path)?,
+            hash: OnceCell::new(),
+        })
+    }
+
+    pub fn get_name(&self) -> &str {
+        self.name.get_value()
+    }
+
+    pub fn get_path(&self) -> &ValuePath {
+        &self.path
+    }
+}
+
+impl Expression for ResolveFromAttachedValueExpression {
+    fn get_id(&self) -> usize {
+        self.id
+    }
+
+    fn get_hash(&self) -> &ExpressionHash {
+        self.hash.get_or_init(|| {
+            ExpressionHash::new(|h| {
+                h.add_bytes(b"resolve_from_attached");
+                h.add_bytes(b"name:");
+                h.add_bytes(self.name.get_value().as_bytes());
+                h.add_bytes(b"path:");
+                h.add_bytes(self.path.get_raw_value().as_bytes());
+            })
+        })
+    }
+
+    fn write_debug(
+        &self,
+        execution_context: &dyn ExecutionContext,
+        heading: &'static str,
+        level: i32,
+        output: &mut String,
+    ) {
+        let padding = "\t".repeat(level as usize);
+
+        output.push_str(&padding);
+        output.push_str(heading);
+        output.push_str("resolve_from_attached (\n");
+
+        AnyValue::write_debug(&self.name, "name: ", level + 1, output);
+
+        output.push_str(&padding);
+        output.push_str(" ,\n");
+
+        output.push_str(&padding);
+        output.push_str("\tpath: ");
+        output.push_str(self.path.get_raw_value());
+        output.push('\n');
+
+        output.push_str(&padding);
+        output.push_str(")\n");
+
+        execution_context.write_debug_comments_for_expression(self, output, &padding);
+    }
+}
+
+impl ValueExpressionInternal for ResolveFromAttachedValueExpression {
+    fn read_any_value<'a, 'b>(
+        &'a self,
+        execution_context: &dyn ExecutionContext<'b>,
+        action: &mut dyn DataRecordAnyValueReadCallback,
+    ) where
+        'a: 'b,
+    {
+        execution_context.read_any_value_from_attached(
+            self.get_id(),
+            self.name.get_value(),
+            &self.path,
+            &mut DataRecordAnyValueReadClosureCallback::new(|v| {
+                match v {
+                    DataRecordReadAnyValueResult::NotFound => {
+                        execution_context.add_message_for_expression(
+                            self,
+                            ExpressionMessage::info(
+                                "ResolveFromAttachedValueExpression could not resolve a value"
+                                    .to_string(),
+                            ),
+                        );
+                    }
+                    DataRecordReadAnyValueResult::Found(any_value) => {
+                        execution_context.add_message_for_expression(
+                            self,
+                            ExpressionMessage::info(format!(
+                                "ResolveFromAttachedValueExpression resolved: {:?}",
+                                any_value
+                            )),
+                        );
+                    }
+                }
+
+                action.invoke_once(v);
+            }),
+        )
+    }
+}

--- a/rust/experimental/query_engine/engine-recordset/src/value_expressions/resolve_value_expression.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/value_expressions/resolve_value_expression.rs
@@ -1,0 +1,194 @@
+use std::cell::OnceCell;
+
+use crate::{
+    data::data_record_resolver::*, error::Error, execution_context::*, expression::*,
+    primitives::any_value::AnyValue, value_path::ValuePath,
+};
+
+use super::value_expression::*;
+
+#[derive(Debug)]
+pub struct ResolveValueExpression {
+    id: usize,
+    path: ValuePath,
+    hash: OnceCell<ExpressionHash>,
+}
+
+impl ResolveValueExpression {
+    pub fn new(path: &str) -> Result<ResolveValueExpression, Error> {
+        Ok(Self {
+            id: get_next_id(),
+            path: ValuePath::new(path)?,
+            hash: OnceCell::new(),
+        })
+    }
+
+    pub fn get_path(&self) -> &ValuePath {
+        &self.path
+    }
+}
+
+impl Expression for ResolveValueExpression {
+    fn get_id(&self) -> usize {
+        self.id
+    }
+
+    fn get_hash(&self) -> &ExpressionHash {
+        self.hash.get_or_init(|| {
+            ExpressionHash::new(|h| {
+                h.add_bytes(b"resolve");
+                h.add_bytes(b"path:");
+                h.add_bytes(self.path.get_raw_value().as_bytes());
+            })
+        })
+    }
+
+    fn write_debug(
+        &self,
+        execution_context: &dyn ExecutionContext,
+        heading: &'static str,
+        level: i32,
+        output: &mut String,
+    ) {
+        let padding = "\t".repeat(level as usize);
+
+        output.push_str(&padding);
+        output.push_str(heading);
+        output.push_str("resolve ( path: \"");
+
+        output.push_str(self.path.get_raw_value());
+
+        output.push_str("\" )\n");
+
+        execution_context.write_debug_comments_for_expression(self, output, &padding);
+    }
+}
+
+impl ValueExpressionInternal for ResolveValueExpression {
+    fn read_any_value<'a, 'b>(
+        &'a self,
+        execution_context: &dyn ExecutionContext<'b>,
+        action: &mut dyn DataRecordAnyValueReadCallback,
+    ) where
+        'a: 'b,
+    {
+        execution_context.read_any_value(
+            self.get_id(),
+            self,
+            &mut DataRecordAnyValueReadClosureCallback::new(|v| {
+                match v {
+                    DataRecordReadAnyValueResult::NotFound => {
+                        execution_context.add_message_for_expression(
+                            self,
+                            ExpressionMessage::info(
+                                "ResolveValueExpression could not resolve a value".to_string(),
+                            ),
+                        );
+                    }
+                    DataRecordReadAnyValueResult::Found(ref any_value) => {
+                        execution_context.add_message_for_expression(
+                            self,
+                            ExpressionMessage::info(format!(
+                                "ResolveValueExpression resolved: {:?}",
+                                any_value
+                            )),
+                        );
+                    }
+                }
+
+                action.invoke_once(v);
+            }),
+        )
+    }
+}
+
+impl MutatableValueExpressionInternal for ResolveValueExpression {
+    fn set_any_value<'a, 'b>(
+        &'a self,
+        execution_context: &dyn ExecutionContext<'b>,
+        value: AnyValue,
+    ) -> DataRecordSetAnyValueResult
+    where
+        'a: 'b,
+    {
+        let result = execution_context.set_any_value(self.get_id(), self, value);
+
+        match &result {
+            DataRecordSetAnyValueResult::NotSupported(message) => {
+                execution_context.add_message_for_expression(
+                    self,
+                    ExpressionMessage::warn(format!(
+                        "ResolveValueExpression set not supported: {message}"
+                    )),
+                );
+                result
+            }
+            DataRecordSetAnyValueResult::NotFound => {
+                execution_context.add_message_for_expression(
+                    self,
+                    ExpressionMessage::info("ResolveValueExpression value not found".to_string()),
+                );
+                result
+            }
+            DataRecordSetAnyValueResult::Created => {
+                execution_context.add_message_for_expression(
+                    self,
+                    ExpressionMessage::info("ResolveValueExpression created value".to_string()),
+                );
+                result
+            }
+            DataRecordSetAnyValueResult::Updated(old_value) => {
+                execution_context.add_message_for_expression(
+                    self,
+                    ExpressionMessage::info(format!(
+                        "ResolveValueExpression replaced value: {:?}",
+                        old_value
+                    )),
+                );
+                result
+            }
+        }
+    }
+
+    fn remove_any_value<'a, 'b>(
+        &'a self,
+        execution_context: &dyn ExecutionContext<'b>,
+    ) -> DataRecordRemoveAnyValueResult
+    where
+        'a: 'b,
+    {
+        let result = execution_context.remove_any_value(self.get_id(), self);
+
+        match &result {
+            DataRecordRemoveAnyValueResult::NotFound => {
+                execution_context.add_message_for_expression(
+                    self,
+                    ExpressionMessage::info(
+                        "ResolveValueExpression could not resolve a value".to_string(),
+                    ),
+                );
+                result
+            }
+            DataRecordRemoveAnyValueResult::NotSupported(message) => {
+                execution_context.add_message_for_expression(
+                    self,
+                    ExpressionMessage::warn(
+                        format!("ResolveValueExpression could not remove value: {message}")
+                            .to_string(),
+                    ),
+                );
+                result
+            }
+            DataRecordRemoveAnyValueResult::Removed(old_value) => {
+                execution_context.add_message_for_expression(
+                    self,
+                    ExpressionMessage::info(format!(
+                        "ResolveValueExpression removed: {:?}",
+                        old_value
+                    )),
+                );
+                result
+            }
+        }
+    }
+}

--- a/rust/experimental/query_engine/engine-recordset/src/value_expressions/static_value_expression.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/value_expressions/static_value_expression.rs
@@ -1,0 +1,80 @@
+use std::cell::OnceCell;
+
+use crate::{
+    data::data_record_resolver::*, execution_context::*, expression::*,
+    primitives::any_value::AnyValue,
+};
+
+use super::value_expression::*;
+
+#[derive(Debug)]
+pub struct StaticValueExpression {
+    id: usize,
+    value: AnyValue,
+    hash: OnceCell<ExpressionHash>,
+}
+
+impl StaticValueExpression {
+    pub fn new(value: AnyValue) -> StaticValueExpression {
+        Self {
+            id: get_next_id(),
+            value,
+            hash: OnceCell::new(),
+        }
+    }
+}
+
+impl Expression for StaticValueExpression {
+    fn get_id(&self) -> usize {
+        self.id
+    }
+
+    fn get_hash(&self) -> &ExpressionHash {
+        self.hash.get_or_init(|| {
+            ExpressionHash::new(|h| {
+                h.add_bytes(b"static");
+                h.add_bytes(b"value:");
+                AnyValue::add_hash_bytes(&self.value, h);
+            })
+        })
+    }
+
+    fn write_debug(
+        &self,
+        execution_context: &dyn ExecutionContext,
+        heading: &'static str,
+        level: i32,
+        output: &mut String,
+    ) {
+        let padding = "\t".repeat(level as usize);
+
+        output.push_str(&padding);
+        output.push_str(heading);
+        output.push_str("static ( value: ");
+
+        output.push_str(format!("{:?}", self.value).as_str());
+
+        output.push_str(" )\n");
+
+        execution_context.write_debug_comments_for_expression(self, output, &padding);
+    }
+}
+
+impl ValueExpressionInternal for StaticValueExpression {
+    fn read_any_value<'a, 'b>(
+        &'a self,
+        execution_context: &dyn ExecutionContext<'b>,
+        action: &mut dyn DataRecordAnyValueReadCallback,
+    ) where
+        'a: 'b,
+    {
+        let value = &self.value;
+
+        execution_context.add_message_for_expression(
+            self,
+            ExpressionMessage::info(format!("StaticValueExpression resolved: {:?}", value)),
+        );
+
+        action.invoke_once(DataRecordReadAnyValueResult::Found(value));
+    }
+}

--- a/rust/experimental/query_engine/engine-recordset/src/value_expressions/value_expression.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/value_expressions/value_expression.rs
@@ -1,0 +1,86 @@
+use crate::{
+    data::data_record_resolver::*, execution_context::*, expression::Expression,
+    primitives::any_value::AnyValue,
+};
+
+#[allow(private_bounds)]
+pub trait ValueExpression: ValueExpressionInternal {}
+
+impl<T: ?Sized + ValueExpressionInternal> ValueExpression for T {}
+
+pub(crate) trait ValueExpressionInternal: Expression {
+    fn read_any_value<'a, 'b>(
+        &'a self,
+        execution_context: &dyn ExecutionContext<'b>,
+        action: &mut dyn DataRecordAnyValueReadCallback,
+    ) where
+        'a: 'b;
+}
+
+#[allow(private_bounds)]
+pub trait MutatableValueExpression: MutatableValueExpressionInternal + ValueExpression {}
+
+impl<T: ?Sized + MutatableValueExpressionInternal> MutatableValueExpression for T {}
+
+pub(crate) trait MutatableValueExpressionInternal: ValueExpressionInternal {
+    fn set_any_value<'a, 'b>(
+        &'a self,
+        execution_context: &dyn ExecutionContext<'b>,
+        value: AnyValue,
+    ) -> DataRecordSetAnyValueResult
+    where
+        'a: 'b;
+
+    fn remove_any_value<'a, 'b>(
+        &'a self,
+        execution_context: &dyn ExecutionContext<'b>,
+    ) -> DataRecordRemoveAnyValueResult
+    where
+        'a: 'b;
+}
+
+pub(crate) fn resolve_values<'a, 'b, F>(
+    execution_context: &dyn ExecutionContext<'b>,
+    value1_expr: &'a dyn ValueExpression,
+    value2_expr: &'a dyn ValueExpression,
+    action: F,
+) where
+    'a: 'b,
+    F: FnOnce(Option<&AnyValue>, Option<&AnyValue>),
+{
+    value1_expr.read_any_value(
+        execution_context,
+        &mut DataRecordAnyValueReadClosureCallback::new(|v| {
+            match v {
+                DataRecordReadAnyValueResult::NotFound => {
+                    complete(execution_context, None, value2_expr, action)
+                }
+                DataRecordReadAnyValueResult::Found(any_value) => {
+                    complete(execution_context, Some(any_value), value2_expr, action)
+                }
+            };
+        }),
+    );
+
+    fn complete<'a, 'b, F>(
+        execution_context: &dyn ExecutionContext<'b>,
+        value1: Option<&AnyValue>,
+        value2_expr: &'a dyn ValueExpression,
+        action: F,
+    ) where
+        'a: 'b,
+        F: FnOnce(Option<&AnyValue>, Option<&AnyValue>),
+    {
+        value2_expr.read_any_value(
+            execution_context,
+            &mut DataRecordAnyValueReadClosureCallback::new(|v| {
+                match v {
+                    DataRecordReadAnyValueResult::NotFound => action(value1, None),
+                    DataRecordReadAnyValueResult::Found(any_value) => {
+                        action(value1, Some(any_value))
+                    }
+                };
+            }),
+        );
+    }
+}

--- a/rust/experimental/query_engine/engine-recordset/src/value_expressions/variable_value_expression.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/value_expressions/variable_value_expression.rs
@@ -1,0 +1,232 @@
+use std::{cell::OnceCell, collections::hash_map::Entry};
+
+use crate::{
+    data::data_record_resolver::*, error::Error, execution_context::*, expression::*,
+    primitives::any_value::AnyValue, value_path::ValuePath,
+};
+
+use super::value_expression::*;
+
+#[derive(Debug)]
+pub struct VariableValueExpression {
+    id: usize,
+    name: Box<str>,
+    path: Option<ValuePath>,
+    hash: OnceCell<ExpressionHash>,
+}
+
+impl VariableValueExpression {
+    pub fn new(name: &str) -> VariableValueExpression {
+        Self {
+            id: get_next_id(),
+            name: name.into(),
+            path: None,
+            hash: OnceCell::new(),
+        }
+    }
+
+    pub fn new_with_path(name: &str, path: &str) -> Result<VariableValueExpression, Error> {
+        Ok(Self {
+            id: get_next_id(),
+            name: name.into(),
+            path: Some(ValuePath::new(path)?),
+            hash: OnceCell::new(),
+        })
+    }
+
+    pub fn get_name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl Expression for VariableValueExpression {
+    fn get_id(&self) -> usize {
+        self.id
+    }
+
+    fn get_hash(&self) -> &ExpressionHash {
+        self.hash.get_or_init(|| {
+            ExpressionHash::new(|h| {
+                h.add_bytes(b"var");
+                h.add_bytes(b"name:");
+                h.add_bytes(self.name.as_bytes());
+                if self.path.is_some() {
+                    h.add_bytes(b"path:");
+                    h.add_bytes(self.path.as_ref().unwrap().get_raw_value().as_bytes());
+                }
+            })
+        })
+    }
+
+    fn write_debug(
+        &self,
+        execution_context: &dyn ExecutionContext,
+        heading: &'static str,
+        level: i32,
+        output: &mut String,
+    ) {
+        let padding = "\t".repeat(level as usize);
+
+        output.push_str(&padding);
+        output.push_str(heading);
+        output.push_str("var ( name: \"");
+
+        output.push_str(&self.name);
+        output.push('"');
+
+        if self.path.is_some() {
+            output.push_str(", path: \"");
+            output.push_str(self.path.as_ref().unwrap().get_raw_value());
+            output.push('"');
+        }
+
+        output.push_str(" )\n");
+
+        execution_context.write_debug_comments_for_expression(self, output, &padding);
+    }
+}
+
+impl ValueExpressionInternal for VariableValueExpression {
+    fn read_any_value<'a, 'b>(
+        &'a self,
+        execution_context: &dyn ExecutionContext<'b>,
+        action: &mut dyn DataRecordAnyValueReadCallback,
+    ) where
+        'a: 'b,
+    {
+        let variables = execution_context.get_variables().borrow();
+
+        let variable = variables.get(self.get_name());
+
+        match variable {
+            Some(any_value) => {
+                execution_context.add_message_for_expression(
+                    self,
+                    ExpressionMessage::info(format!(
+                        "VariableValueExpression resolved: {:?}",
+                        any_value
+                    )),
+                );
+
+                if self.path.is_some() {
+                    action.invoke_once(self.path.as_ref().unwrap().read(any_value));
+                } else {
+                    action.invoke_once(DataRecordReadAnyValueResult::Found(any_value));
+                }
+            }
+            None => {
+                execution_context.add_message_for_expression(
+                    self,
+                    ExpressionMessage::info(
+                        "VariableValueExpression could not resolve value".to_string(),
+                    ),
+                );
+                action.invoke_once(DataRecordReadAnyValueResult::NotFound);
+            }
+        }
+    }
+}
+
+impl MutatableValueExpressionInternal for VariableValueExpression {
+    fn set_any_value<'a, 'b>(
+        &'a self,
+        execution_context: &dyn ExecutionContext<'b>,
+        value: AnyValue,
+    ) -> DataRecordSetAnyValueResult
+    where
+        'a: 'b,
+    {
+        let mut variables = execution_context.get_variables().borrow_mut();
+
+        let variable = variables.entry(self.get_name().to_string());
+
+        match variable {
+            Entry::Occupied(mut occupied_entry) => {
+                let current_value = occupied_entry.get_mut();
+
+                if self.path.is_some() {
+                    return self.path.as_ref().unwrap().set(current_value, value);
+                }
+
+                let old_value = current_value.clone();
+                *current_value = value;
+
+                execution_context.add_message_for_expression(
+                    self,
+                    ExpressionMessage::info(format!(
+                        "VariableValueExpression replaced value: {:?}",
+                        old_value
+                    )),
+                );
+
+                DataRecordSetAnyValueResult::Updated(old_value)
+            }
+            Entry::Vacant(vacant_entry) => {
+                if self.path.is_some() {
+                    execution_context.add_message_for_expression(
+                        self,
+                        ExpressionMessage::warn("Cannot set into a null value".to_string()),
+                    );
+
+                    return DataRecordSetAnyValueResult::NotFound;
+                }
+
+                vacant_entry.insert(value);
+
+                execution_context.add_message_for_expression(
+                    self,
+                    ExpressionMessage::info("VariableValueExpression created value".to_string()),
+                );
+
+                DataRecordSetAnyValueResult::Created
+            }
+        }
+    }
+
+    fn remove_any_value<'a, 'b>(
+        &'a self,
+        execution_context: &dyn ExecutionContext<'b>,
+    ) -> DataRecordRemoveAnyValueResult
+    where
+        'a: 'b,
+    {
+        let mut variables = execution_context.get_variables().borrow_mut();
+
+        if self.path.is_some() {
+            match variables.get_mut(self.get_name()) {
+                Some(current_value) => {
+                    return self.path.as_ref().unwrap().remove(current_value);
+                }
+                None => {
+                    return DataRecordRemoveAnyValueResult::NotFound;
+                }
+            }
+        }
+
+        let variable = variables.remove(self.get_name());
+
+        match variable {
+            Some(any_value) => {
+                execution_context.add_message_for_expression(
+                    self,
+                    ExpressionMessage::info(format!(
+                        "VariableValueExpression removed value: {:?}",
+                        any_value
+                    )),
+                );
+
+                DataRecordRemoveAnyValueResult::Removed(any_value)
+            }
+            None => {
+                execution_context.add_message_for_expression(
+                    self,
+                    ExpressionMessage::info(
+                        "VariableValueExpression could not resolve value".to_string(),
+                    ),
+                );
+
+                DataRecordRemoveAnyValueResult::NotFound
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Changes

* Adds basic value expressions (resolve, resolve_from_attached, static, variable) into recordset engine