### PR TITLE
Potential fix for code scanning alert no. 1: Size computation for allocation may overflow

### DIFF
--- a/pkg/benchmark/compression.go
+++ b/pkg/benchmark/compression.go
@@ -57,6 +57,9 @@ func (c *Lz4CompressionAlgo) Compress(data []byte) ([]byte, error) {
 }
 
 func (c *Lz4CompressionAlgo) Decompress(data []byte) ([]byte, error) {
+	if len(data) > (1<<30)/10 { // Ensure len(data) is within a safe range
+		return nil, fmt.Errorf("data too large to decompress")
+	}
 	decompressed := make([]byte, 10*len(data))
 
 	n, err := lz4.UncompressBlock(data, decompressed)


### PR DESCRIPTION
Potential fix for [https://github.com/open-telemetry/otel-arrow/security/code-scanning/1](https://github.com/open-telemetry/otel-arrow/security/code-scanning/1)

To fix the problem, we need to ensure that the size computation for the allocation does not overflow. This can be achieved by validating the size of `data` before performing the multiplication. If the size of `data` is too large, we should return an error to prevent the overflow.

1. Add a check to ensure that `len(data)` is within a safe range before performing the multiplication.
2. If `len(data)` exceeds the safe range, return an error indicating that the data is too large to process.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
