### PR TITLE
Document recent branch protection changes

### DIFF
--- a/.github/repository-settings.md
+++ b/.github/repository-settings.md
@@ -4,6 +4,19 @@ Maintainers are expected to maintain this log. This is required as per
 [OpenTelemetry Community
 guidelines](https://github.com/open-telemetry/community/blob/main/docs/how-to-configure-new-repository.md#collaborators-and-teams).
 
+## 2025-06-16
+
+- Configure branch protection for `**/**` branches to enable GitHub Copilot
+  Autofix and Coding Agent
+  - Uncheck 'require status checks to pass before merging' to allow commits on
+    branches by default.
+
+## 2025-06-05
+
+- Configure branch protection for `main` branch to enable Merge Queue:
+  - Disable 'Require branches to be up to date before merging', as Merge Queue
+    behavior handles this.
+
 ## 2025-05-12
 
 - Configure branch protection for `main` branch to 'Require' certain checks:


### PR DESCRIPTION
- Document merge queue change on `main` branch from earlier this month
- Document `**/**` branch change to uncheck require status checks
  - Enabled Copilot Autofix to create #604 
  - Does not affect `main` branch rule, that is still protected