### PR TITLE
[query-engine] Add clear transformation and support for parsing KQL project expressions

### DIFF
--- a/rust/experimental/query_engine/expressions/src/transform_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/transform_expressions.rs
@@ -1,8 +1,11 @@
+use std::collections::HashSet;
+
 use crate::{Expression, ImmutableValueExpression, MutableValueExpression, QueryLocation};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum TransformExpression {
     Set(SetTransformExpression),
+    Clear(ClearTransformExpression),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -35,6 +38,41 @@ impl SetTransformExpression {
 }
 
 impl Expression for SetTransformExpression {
+    fn get_query_location(&self) -> &QueryLocation {
+        &self.query_location
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ClearTransformExpression {
+    query_location: QueryLocation,
+    target: MutableValueExpression,
+    keys_to_keep: HashSet<Box<str>>,
+}
+
+impl ClearTransformExpression {
+    pub fn new(
+        query_location: QueryLocation,
+        target: MutableValueExpression,
+        keys_to_keep: HashSet<Box<str>>,
+    ) -> ClearTransformExpression {
+        Self {
+            query_location,
+            target,
+            keys_to_keep,
+        }
+    }
+
+    pub fn get_target(&self) -> &MutableValueExpression {
+        &self.target
+    }
+
+    pub fn get_keys_to_keep(&self) -> &HashSet<Box<str>> {
+        &self.keys_to_keep
+    }
+}
+
+impl Expression for ClearTransformExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
     }

--- a/rust/experimental/query_engine/kql-parser/src/kql.pest
+++ b/rust/experimental/query_engine/kql-parser/src/kql.pest
@@ -74,3 +74,4 @@ accessor_expression = { accessor ~ (("." ~ accessor)|accessor_index)* }
 assignment_expression = { accessor_expression ~ "=" ~ scalar_expression }
 
 extend_expression = { "extend" ~ assignment_expression ~ ("," ~ assignment_expression)* }
+project_expression = { "project" ~ (assignment_expression|accessor_expression) ~ ("," ~ (assignment_expression|accessor_expression))* }

--- a/rust/experimental/query_engine/parser-abstractions/src/parser_state.rs
+++ b/rust/experimental/query_engine/parser-abstractions/src/parser_state.rs
@@ -1,27 +1,25 @@
 use std::collections::HashSet;
 
-pub struct ParserState {
-    pub default_source_map_key: Option<Box<str>>,
+use data_engine_expressions::QueryLocation;
+
+pub struct ParserState<'a> {
+    query: &'a str,
+    default_source_map_key: Option<Box<str>>,
     pub attached_data_names: HashSet<Box<str>>,
     pub variable_names: HashSet<Box<str>>,
 }
 
-impl Default for ParserState {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl ParserState {
-    pub fn new() -> ParserState {
+impl<'a> ParserState<'a> {
+    pub fn new(query: &'a str) -> ParserState<'a> {
         Self {
+            query,
             default_source_map_key: None,
             attached_data_names: HashSet::new(),
             variable_names: HashSet::new(),
         }
     }
 
-    pub fn with_default_source_map_key_name(mut self, name: &str) -> ParserState {
+    pub fn with_default_source_map_key_name(mut self, name: &str) -> ParserState<'a> {
         if !name.is_empty() {
             self.default_source_map_key = Some(name.into());
         }
@@ -29,12 +27,26 @@ impl ParserState {
         self
     }
 
-    pub fn with_attached_data_names(mut self, names: &[&str]) -> ParserState {
+    pub fn with_attached_data_names(mut self, names: &[&str]) -> ParserState<'a> {
         for name in names {
             self.attached_data_names.insert((*name).into());
         }
 
         self
+    }
+
+    pub fn get_query(&self) -> &str {
+        self.query
+    }
+
+    pub fn get_query_slice(&self, query_location: &QueryLocation) -> &str {
+        let (start, end) = query_location.get_start_and_end_positions();
+
+        &self.query[start..end]
+    }
+
+    pub fn get_default_source_map_key(&self) -> Option<&str> {
+        self.default_source_map_key.as_ref().map(|f| f.as_ref())
     }
 
     pub fn push_variable_name(&mut self, name: &str) {


### PR DESCRIPTION
## Changes

* Support parsing KQL project expression onto `Set` & `Clear` transformations
* Add the raw query string to `ParserState` and a helper for getting query slice from a `QueryLocation`