### PR TITLE
[query-engine] Refactor ParserState to not expose fields

### DIFF
--- a/rust/experimental/query_engine/kql-parser/src/kql_parser.rs
+++ b/rust/experimental/query_engine/kql-parser/src/kql_parser.rs
@@ -505,13 +505,13 @@ pub(crate) fn parse_accessor_expression(
             query_location,
             value_accessor,
         )))
-    } else if state.attached_data_names.contains(root_accessor_identity) {
+    } else if state.is_attached_data_defined(root_accessor_identity) {
         return Ok(ScalarExpression::Attached(AttachedScalarExpression::new(
             query_location,
             root_accessor_identity,
             value_accessor,
         )));
-    } else if state.variable_names.contains(root_accessor_identity) {
+    } else if state.is_variable_defined(root_accessor_identity) {
         return Ok(ScalarExpression::Variable(VariableScalarExpression::new(
             query_location,
             root_accessor_identity,

--- a/rust/experimental/query_engine/parser-abstractions/src/parser_state.rs
+++ b/rust/experimental/query_engine/parser-abstractions/src/parser_state.rs
@@ -5,8 +5,8 @@ use data_engine_expressions::QueryLocation;
 pub struct ParserState<'a> {
     query: &'a str,
     default_source_map_key: Option<Box<str>>,
-    pub attached_data_names: HashSet<Box<str>>,
-    pub variable_names: HashSet<Box<str>>,
+    attached_data_names: HashSet<Box<str>>,
+    variable_names: HashSet<Box<str>>,
 }
 
 impl<'a> ParserState<'a> {
@@ -47,6 +47,14 @@ impl<'a> ParserState<'a> {
 
     pub fn get_default_source_map_key(&self) -> Option<&str> {
         self.default_source_map_key.as_ref().map(|f| f.as_ref())
+    }
+
+    pub fn is_attached_data_defined(&self, name: &str) -> bool {
+        self.attached_data_names.contains(name)
+    }
+
+    pub fn is_variable_defined(&self, name: &str) -> bool {
+        self.variable_names.contains(name)
     }
 
     pub fn push_variable_name(&mut self, name: &str) {


### PR DESCRIPTION
nt