### PR TITLE
[query-engine] Rename Clear -> ClearKeys and add doc comments

### DIFF
--- a/rust/experimental/query_engine/expressions/src/transform_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/transform_expressions.rs
@@ -7,10 +7,23 @@ use crate::{
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum TransformExpression {
+    /// Set data transformation.
     Set(SetTransformExpression),
+
+    /// Remove data transformation.
     Remove(RemoveTransformExpression),
+
+    /// Remove keys transformation.
+    ///
+    /// Note: Remove keys is a specialized form of the remove transformation
+    /// which takes a target map and a list of keys to be removed.
     RemoveKeys(RemoveKeysTransformExpression),
-    Clear(ClearTransformExpression),
+
+    /// Clear keys transformation.
+    ///
+    /// Note: Clear keys is used to remove all keys from a target map with an
+    /// optional list of keys to retain.
+    ClearKeys(ClearKeysTransformExpression),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -112,18 +125,18 @@ impl Expression for RemoveKeysTransformExpression {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct ClearTransformExpression {
+pub struct ClearKeysTransformExpression {
     query_location: QueryLocation,
     target: MutableValueExpression,
     keys_to_keep: HashSet<SourceKey>,
 }
 
-impl ClearTransformExpression {
+impl ClearKeysTransformExpression {
     pub fn new(
         query_location: QueryLocation,
         target: MutableValueExpression,
         keys_to_keep: HashSet<SourceKey>,
-    ) -> ClearTransformExpression {
+    ) -> ClearKeysTransformExpression {
         Self {
             query_location,
             target,
@@ -140,7 +153,7 @@ impl ClearTransformExpression {
     }
 }
 
-impl Expression for ClearTransformExpression {
+impl Expression for ClearKeysTransformExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
     }

--- a/rust/experimental/query_engine/expressions/src/value_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/value_expressions.rs
@@ -2,12 +2,21 @@ use crate::{ScalarExpression, SourceScalarExpression, VariableScalarExpression};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum MutableValueExpression {
+    /// Source value.
+    ///
+    /// Note: Source may refer to the source itself (root) or data on the source
+    /// accessed via [`crate::ValueAccessor`] selectors.
     Source(SourceScalarExpression),
 
+    /// Variable value.
+    ///
+    /// Note: Variable may refer to the variable itself (root) or data on the
+    /// variable accessed via [`crate::ValueAccessor`] selectors.
     Variable(VariableScalarExpression),
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum ImmutableValueExpression {
+    /// Scalar value.
     Scalar(ScalarExpression),
 }

--- a/rust/experimental/query_engine/kql-parser/src/kql_parser.rs
+++ b/rust/experimental/query_engine/kql-parser/src/kql_parser.rs
@@ -714,14 +714,16 @@ pub(crate) fn parse_project_expression(
         }
     }
 
-    expressions.push(TransformExpression::Clear(ClearTransformExpression::new(
-        query_location.clone(),
-        MutableValueExpression::Source(SourceScalarExpression::new(
-            query_location,
-            ValueAccessor::new(),
-        )),
-        keys_to_keep,
-    )));
+    expressions.push(TransformExpression::ClearKeys(
+        ClearKeysTransformExpression::new(
+            query_location.clone(),
+            MutableValueExpression::Source(SourceScalarExpression::new(
+                query_location,
+                ValueAccessor::new(),
+            )),
+            keys_to_keep,
+        ),
+    ));
 
     Ok(expressions)
 }
@@ -786,14 +788,16 @@ pub(crate) fn parse_project_keep_expression(
         }
     }
 
-    Ok(TransformExpression::Clear(ClearTransformExpression::new(
-        query_location.clone(),
-        MutableValueExpression::Source(SourceScalarExpression::new(
-            query_location,
-            ValueAccessor::new(),
-        )),
-        keys_to_keep,
-    )))
+    Ok(TransformExpression::ClearKeys(
+        ClearKeysTransformExpression::new(
+            query_location.clone(),
+            MutableValueExpression::Source(SourceScalarExpression::new(
+                query_location,
+                ValueAccessor::new(),
+            )),
+            keys_to_keep,
+        ),
+    ))
 }
 
 #[allow(dead_code)]
@@ -2201,38 +2205,42 @@ mod parse_tests {
 
         run_test_success(
             "project key1",
-            vec![TransformExpression::Clear(ClearTransformExpression::new(
-                QueryLocation::new_fake(),
-                MutableValueExpression::Source(SourceScalarExpression::new(
+            vec![TransformExpression::ClearKeys(
+                ClearKeysTransformExpression::new(
                     QueryLocation::new_fake(),
-                    ValueAccessor::new(),
-                )),
-                HashSet::from([SourceKey::Identifier(StringScalarExpression::new(
-                    QueryLocation::new_fake(),
-                    "key1",
-                ))]),
-            ))],
+                    MutableValueExpression::Source(SourceScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        ValueAccessor::new(),
+                    )),
+                    HashSet::from([SourceKey::Identifier(StringScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        "key1",
+                    ))]),
+                ),
+            )],
         );
 
         run_test_success(
             "project key1, key2",
-            vec![TransformExpression::Clear(ClearTransformExpression::new(
-                QueryLocation::new_fake(),
-                MutableValueExpression::Source(SourceScalarExpression::new(
+            vec![TransformExpression::ClearKeys(
+                ClearKeysTransformExpression::new(
                     QueryLocation::new_fake(),
-                    ValueAccessor::new(),
-                )),
-                HashSet::from([
-                    SourceKey::Identifier(StringScalarExpression::new(
+                    MutableValueExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
-                        "key1",
+                        ValueAccessor::new(),
                     )),
-                    SourceKey::Identifier(StringScalarExpression::new(
-                        QueryLocation::new_fake(),
-                        "key2",
-                    )),
-                ]),
-            ))],
+                    HashSet::from([
+                        SourceKey::Identifier(StringScalarExpression::new(
+                            QueryLocation::new_fake(),
+                            "key1",
+                        )),
+                        SourceKey::Identifier(StringScalarExpression::new(
+                            QueryLocation::new_fake(),
+                            "key2",
+                        )),
+                    ]),
+                ),
+            )],
         );
 
         run_test_success(
@@ -2254,7 +2262,7 @@ mod parse_tests {
                         )]),
                     )),
                 )),
-                TransformExpression::Clear(ClearTransformExpression::new(
+                TransformExpression::ClearKeys(ClearKeysTransformExpression::new(
                     QueryLocation::new_fake(),
                     MutableValueExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -2312,7 +2320,7 @@ mod parse_tests {
                         ]),
                     )),
                 )),
-                TransformExpression::Clear(ClearTransformExpression::new(
+                TransformExpression::ClearKeys(ClearKeysTransformExpression::new(
                     QueryLocation::new_fake(),
                     MutableValueExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -2408,7 +2416,7 @@ mod parse_tests {
 
         run_test_success(
             "project-keep key*",
-            TransformExpression::Clear(ClearTransformExpression::new(
+            TransformExpression::ClearKeys(ClearKeysTransformExpression::new(
                 QueryLocation::new_fake(),
                 MutableValueExpression::Source(SourceScalarExpression::new(
                     QueryLocation::new_fake(),
@@ -2423,7 +2431,7 @@ mod parse_tests {
 
         run_test_success(
             "project-keep *key*value*, *, key1, attributes['key2'], source.attributes['key3']",
-            TransformExpression::Clear(ClearTransformExpression::new(
+            TransformExpression::ClearKeys(ClearKeysTransformExpression::new(
                 QueryLocation::new_fake(),
                 MutableValueExpression::Source(SourceScalarExpression::new(
                     QueryLocation::new_fake(),


### PR DESCRIPTION
Follow-up to https://github.com/open-telemetry/otel-arrow/pull/615#discussion_r2155476636

## Changes

* Add doc comments where it was missing on expression definitions
* Rename Clear -> ClearKeys to fit in better with RemoveKeys