### PR TITLE
[query-engine] Support referencing map accessors in kql project expression

### DIFF
--- a/rust/experimental/query_engine/kql-parser/src/kql_parser.rs
+++ b/rust/experimental/query_engine/kql-parser/src/kql_parser.rs
@@ -649,6 +649,9 @@ pub(crate) fn parse_project_expression(
 
     let mut expressions = Vec::new();
 
+    // `map_key_tree` is used to accumulate selectors from source expressions and
+    // generate clear-keys transforms, ensuring proper handling of map keys in the
+    // project expression parsing flow.
     let mut map_key_tree = MapKeyTree::new();
 
     for rule in project_rules {

--- a/rust/experimental/query_engine/kql-parser/src/kql_parser.rs
+++ b/rust/experimental/query_engine/kql-parser/src/kql_parser.rs
@@ -2164,7 +2164,7 @@ mod parse_tests {
         );
 
         run_test_success(
-            "extend body.nested.field = 1",
+            "extend body.nested[0] = 1",
             vec![TransformExpression::Set(SetTransformExpression::new(
                 QueryLocation::new_fake(),
                 ImmutableValueExpression::Scalar(ScalarExpression::Static(
@@ -2184,9 +2184,9 @@ mod parse_tests {
                             QueryLocation::new_fake(),
                             "nested",
                         )),
-                        ValueSelector::MapKey(StringScalarExpression::new(
+                        ValueSelector::ArrayIndex(IntegerScalarExpression::new(
                             QueryLocation::new_fake(),
-                            "field",
+                            0,
                         )),
                     ]),
                 )),
@@ -2712,7 +2712,7 @@ mod parse_tests {
         );
 
         run_test_success(
-            "project-away key1, body.nested, attributes['key2'], source.attributes['key3'], body.other_nested",
+            "project-away key1, body.nested, attributes['key2'], source.attributes['key3'], body.other_nested[0]",
             vec![
                 TransformExpression::Remove(RemoveTransformExpression::new(
                     QueryLocation::new_fake(),
@@ -2742,6 +2742,10 @@ mod parse_tests {
                             ValueSelector::MapKey(StringScalarExpression::new(
                                 QueryLocation::new_fake(),
                                 "other_nested",
+                            )),
+                            ValueSelector::ArrayIndex(IntegerScalarExpression::new(
+                                QueryLocation::new_fake(),
+                                0,
                             )),
                         ]),
                     )),

--- a/rust/experimental/query_engine/kql-parser/src/lib.rs
+++ b/rust/experimental/query_engine/kql-parser/src/lib.rs
@@ -1,4 +1,5 @@
 pub(crate) mod date_utils;
 pub(crate) mod kql_parser;
+pub(crate) mod map_key_tree;
 
 pub use kql_parser::*;

--- a/rust/experimental/query_engine/kql-parser/src/map_key_tree.rs
+++ b/rust/experimental/query_engine/kql-parser/src/map_key_tree.rs
@@ -1,0 +1,106 @@
+use std::collections::HashMap;
+
+use data_engine_expressions::*;
+
+pub(crate) struct MapKeyTree {
+    children: HashMap<Box<str>, MapKeyTree>,
+}
+
+impl MapKeyTree {
+    pub fn new() -> MapKeyTree {
+        Self {
+            children: HashMap::new(),
+        }
+    }
+
+    pub fn push_selectors(
+        &mut self,
+        default_source_map_key: Option<&str>,
+        selectors: &[ValueSelector],
+    ) -> bool {
+        if selectors.is_empty() {
+            return false;
+        }
+
+        self.push_selectors_recursive(default_source_map_key, &mut selectors.iter())
+    }
+
+    pub fn build_clear_keys_expressions(
+        &mut self,
+        query_location: &QueryLocation,
+        expressions: &mut Vec<TransformExpression>,
+    ) {
+        self.build_clear_keys_expressions_recursive(
+            query_location,
+            expressions,
+            ValueAccessor::new(),
+        );
+    }
+
+    fn push_selectors_recursive(
+        &mut self,
+        default_source_map_key: Option<&str>,
+        selectors: &mut std::slice::Iter<ValueSelector>,
+    ) -> bool {
+        if let Some(selector) = selectors.next() {
+            if let ValueSelector::MapKey(k) = selector {
+                let key = k.get_value();
+                if Some(key) == default_source_map_key {
+                    // Note: If the root key is the default_source_map_key value
+                    // it is stripped away. Given some accessor list like key1,
+                    // source.attributes[key2], attributes[key3] when
+                    // default_source_map_key=attributes we want the root key
+                    // list to be: key1, key2, key3.
+                    return self.push_selectors_recursive(None, selectors);
+                }
+                let child = self.children.entry(key.into()).or_insert(MapKeyTree::new());
+                return child.push_selectors_recursive(None, selectors);
+            } else {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    fn build_clear_keys_expressions_recursive(
+        &mut self,
+        query_location: &QueryLocation,
+        expressions: &mut Vec<TransformExpression>,
+        value_accessor: ValueAccessor,
+    ) {
+        if self.children.is_empty() {
+            return;
+        }
+
+        let keys_to_keep = self
+            .children
+            .keys()
+            .map(|v| SourceKey::Identifier(StringScalarExpression::new(query_location.clone(), v)))
+            .collect();
+
+        expressions.push(TransformExpression::ClearKeys(
+            ClearKeysTransformExpression::new(
+                query_location.clone(),
+                MutableValueExpression::Source(SourceScalarExpression::new(
+                    query_location.clone(),
+                    value_accessor.clone(),
+                )),
+                keys_to_keep,
+            ),
+        ));
+
+        for (name, child) in &mut self.children {
+            let mut selectors = value_accessor.get_selectors().clone();
+            selectors.push(ValueSelector::MapKey(StringScalarExpression::new(
+                query_location.clone(),
+                name,
+            )));
+            child.build_clear_keys_expressions_recursive(
+                query_location,
+                expressions,
+                ValueAccessor::new_with_selectors(selectors),
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Changes

* Allow referencing map accessors in KQL `project`

## Details

Currently you can do things like...

```
extend body.complex_thing = [expression]
project-away body.complex_thing
```

But if you do...

`project body.complex_thing`

There will be an error saying you can only reference top-level keys in `project`.

What this PR does is bring `project` into parity with `extend` and `project-away` for keys. Arrays need additional work.