### PR TITLE
[query-engine] Introduce ReduceMap expression and update KQL project

### DIFF
--- a/rust/experimental/query_engine/expressions/src/transform_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/transform_expressions.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use crate::{
     Expression, ImmutableValueExpression, MutableValueExpression, QueryLocation,
-    StringScalarExpression,
+    StringScalarExpression, ValueAccessor, ValueSelector,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -24,6 +24,9 @@ pub enum TransformExpression {
     /// Note: Clear keys is used to remove all keys from a target map with an
     /// optional list of keys to retain.
     ClearKeys(ClearKeysTransformExpression),
+
+    /// Remove data from a target map.
+    ReduceMap(ReduceMapTransformExpression),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -163,4 +166,138 @@ impl Expression for ClearKeysTransformExpression {
 pub enum SourceKey {
     Identifier(StringScalarExpression),
     Pattern(StringScalarExpression),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ReduceMapTransformExpression {
+    Keep(KeepMapReductionExpression),
+    Remove(RemoveMapReductionExpression),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum MapSelector {
+    KeyPattern(StringScalarExpression),
+    Key(StringScalarExpression),
+    ValueAccessor(ValueAccessor),
+}
+
+pub trait MapReductionExpression: Expression {
+    fn get_target(&self) -> &MutableValueExpression;
+
+    fn get_selectors(&self) -> &Vec<MapSelector>;
+
+    fn push_selector(&mut self, selector: MapSelector);
+
+    fn push_value_accessor(&mut self, value_accessor: &ValueAccessor) -> bool {
+        let selectors = value_accessor.get_selectors();
+        if selectors.is_empty() {
+            return false;
+        }
+
+        if selectors.len() == 1 {
+            match selectors.first().unwrap() {
+                ValueSelector::ArrayIndex(_) => return false,
+                ValueSelector::MapKey(s) => self.push_selector(MapSelector::Key(s.clone())),
+                ValueSelector::ScalarExpression(_) => {
+                    self.push_selector(MapSelector::ValueAccessor(value_accessor.clone()))
+                }
+            }
+        } else {
+            self.push_selector(MapSelector::ValueAccessor(value_accessor.clone()));
+        }
+
+        true
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct KeepMapReductionExpression {
+    query_location: QueryLocation,
+    target: MutableValueExpression,
+    selectors: Vec<MapSelector>,
+}
+
+impl KeepMapReductionExpression {
+    pub fn new(
+        query_location: QueryLocation,
+        target: MutableValueExpression,
+    ) -> KeepMapReductionExpression {
+        Self {
+            query_location,
+            target,
+            selectors: Vec::new(),
+        }
+    }
+
+    pub fn new_with_selectors(
+        query_location: QueryLocation,
+        target: MutableValueExpression,
+        selectors: Vec<MapSelector>,
+    ) -> KeepMapReductionExpression {
+        Self {
+            query_location,
+            target,
+            selectors,
+        }
+    }
+}
+
+impl Expression for KeepMapReductionExpression {
+    fn get_query_location(&self) -> &QueryLocation {
+        &self.query_location
+    }
+}
+
+impl MapReductionExpression for KeepMapReductionExpression {
+    fn get_target(&self) -> &MutableValueExpression {
+        &self.target
+    }
+
+    fn get_selectors(&self) -> &Vec<MapSelector> {
+        &self.selectors
+    }
+
+    fn push_selector(&mut self, selector: MapSelector) {
+        self.selectors.push(selector)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RemoveMapReductionExpression {
+    query_location: QueryLocation,
+    target: MutableValueExpression,
+    selectors: Vec<MapSelector>,
+}
+
+impl RemoveMapReductionExpression {
+    pub fn new(
+        query_location: QueryLocation,
+        target: MutableValueExpression,
+    ) -> RemoveMapReductionExpression {
+        Self {
+            query_location,
+            target,
+            selectors: Vec::new(),
+        }
+    }
+}
+
+impl Expression for RemoveMapReductionExpression {
+    fn get_query_location(&self) -> &QueryLocation {
+        &self.query_location
+    }
+}
+
+impl MapReductionExpression for RemoveMapReductionExpression {
+    fn get_target(&self) -> &MutableValueExpression {
+        &self.target
+    }
+
+    fn get_selectors(&self) -> &Vec<MapSelector> {
+        &self.selectors
+    }
+
+    fn push_selector(&mut self, selector: MapSelector) {
+        self.selectors.push(selector)
+    }
 }

--- a/rust/experimental/query_engine/expressions/src/transform_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/transform_expressions.rs
@@ -171,10 +171,10 @@ pub enum SourceKey {
 #[derive(Debug, Clone, PartialEq)]
 pub enum ReduceMapTransformExpression {
     /// A map reduction providing the data to keep. All other data is removed.
-    Keep(MapReductionExpression),
+    Keep(MapSelectionExpression),
 
     /// A map reduction providing the data to remove. All other data is retained.
-    Remove(MapReductionExpression),
+    Remove(MapSelectionExpression),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -193,17 +193,17 @@ pub enum MapSelector {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct MapReductionExpression {
+pub struct MapSelectionExpression {
     query_location: QueryLocation,
     target: MutableValueExpression,
     selectors: Vec<MapSelector>,
 }
 
-impl MapReductionExpression {
+impl MapSelectionExpression {
     pub fn new(
         query_location: QueryLocation,
         target: MutableValueExpression,
-    ) -> MapReductionExpression {
+    ) -> MapSelectionExpression {
         Self {
             query_location,
             target,
@@ -215,7 +215,7 @@ impl MapReductionExpression {
         query_location: QueryLocation,
         target: MutableValueExpression,
         selectors: Vec<MapSelector>,
-    ) -> MapReductionExpression {
+    ) -> MapSelectionExpression {
         Self {
             query_location,
             target,
@@ -257,7 +257,7 @@ impl MapReductionExpression {
     }
 }
 
-impl Expression for MapReductionExpression {
+impl Expression for MapSelectionExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
     }

--- a/rust/experimental/query_engine/expressions/src/transform_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/transform_expressions.rs
@@ -171,10 +171,10 @@ pub enum SourceKey {
 #[derive(Debug, Clone, PartialEq)]
 pub enum ReduceMapTransformExpression {
     /// A map reduction providing the data to keep. All other data is removed.
-    Keep(KeepMapReductionExpression),
+    Keep(MapReductionExpression),
 
     /// A map reduction providing the data to remove. All other data is retained.
-    Remove(RemoveMapReductionExpression),
+    Remove(MapReductionExpression),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -192,14 +192,50 @@ pub enum MapSelector {
     ValueAccessor(ValueAccessor),
 }
 
-pub trait MapReductionExpression: Expression {
-    fn get_target(&self) -> &MutableValueExpression;
+#[derive(Debug, Clone, PartialEq)]
+pub struct MapReductionExpression {
+    query_location: QueryLocation,
+    target: MutableValueExpression,
+    selectors: Vec<MapSelector>,
+}
 
-    fn get_selectors(&self) -> &Vec<MapSelector>;
+impl MapReductionExpression {
+    pub fn new(
+        query_location: QueryLocation,
+        target: MutableValueExpression,
+    ) -> MapReductionExpression {
+        Self {
+            query_location,
+            target,
+            selectors: Vec::new(),
+        }
+    }
 
-    fn push_selector(&mut self, selector: MapSelector);
+    pub fn new_with_selectors(
+        query_location: QueryLocation,
+        target: MutableValueExpression,
+        selectors: Vec<MapSelector>,
+    ) -> MapReductionExpression {
+        Self {
+            query_location,
+            target,
+            selectors,
+        }
+    }
 
-    fn push_value_accessor(&mut self, value_accessor: &ValueAccessor) -> bool {
+    pub fn get_target(&self) -> &MutableValueExpression {
+        &self.target
+    }
+
+    pub fn get_selectors(&self) -> &Vec<MapSelector> {
+        &self.selectors
+    }
+
+    pub fn push_selector(&mut self, selector: MapSelector) {
+        self.selectors.push(selector)
+    }
+
+    pub fn push_value_accessor(&mut self, value_accessor: &ValueAccessor) -> bool {
         let selectors = value_accessor.get_selectors();
         if selectors.is_empty() {
             return false;
@@ -221,94 +257,8 @@ pub trait MapReductionExpression: Expression {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub struct KeepMapReductionExpression {
-    query_location: QueryLocation,
-    target: MutableValueExpression,
-    selectors: Vec<MapSelector>,
-}
-
-impl KeepMapReductionExpression {
-    pub fn new(
-        query_location: QueryLocation,
-        target: MutableValueExpression,
-    ) -> KeepMapReductionExpression {
-        Self {
-            query_location,
-            target,
-            selectors: Vec::new(),
-        }
-    }
-
-    pub fn new_with_selectors(
-        query_location: QueryLocation,
-        target: MutableValueExpression,
-        selectors: Vec<MapSelector>,
-    ) -> KeepMapReductionExpression {
-        Self {
-            query_location,
-            target,
-            selectors,
-        }
-    }
-}
-
-impl Expression for KeepMapReductionExpression {
+impl Expression for MapReductionExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
-    }
-}
-
-impl MapReductionExpression for KeepMapReductionExpression {
-    fn get_target(&self) -> &MutableValueExpression {
-        &self.target
-    }
-
-    fn get_selectors(&self) -> &Vec<MapSelector> {
-        &self.selectors
-    }
-
-    fn push_selector(&mut self, selector: MapSelector) {
-        self.selectors.push(selector)
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct RemoveMapReductionExpression {
-    query_location: QueryLocation,
-    target: MutableValueExpression,
-    selectors: Vec<MapSelector>,
-}
-
-impl RemoveMapReductionExpression {
-    pub fn new(
-        query_location: QueryLocation,
-        target: MutableValueExpression,
-    ) -> RemoveMapReductionExpression {
-        Self {
-            query_location,
-            target,
-            selectors: Vec::new(),
-        }
-    }
-}
-
-impl Expression for RemoveMapReductionExpression {
-    fn get_query_location(&self) -> &QueryLocation {
-        &self.query_location
-    }
-}
-
-impl MapReductionExpression for RemoveMapReductionExpression {
-    fn get_target(&self) -> &MutableValueExpression {
-        &self.target
-    }
-
-    fn get_selectors(&self) -> &Vec<MapSelector> {
-        &self.selectors
-    }
-
-    fn push_selector(&mut self, selector: MapSelector) {
-        self.selectors.push(selector)
     }
 }

--- a/rust/experimental/query_engine/expressions/src/transform_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/transform_expressions.rs
@@ -170,14 +170,25 @@ pub enum SourceKey {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum ReduceMapTransformExpression {
+    /// A map reduction providing the data to keep. All other data is removed.
     Keep(KeepMapReductionExpression),
+
+    /// A map reduction providing the data to remove. All other data is retained.
     Remove(RemoveMapReductionExpression),
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum MapSelector {
+    /// Top-level key pattern.
     KeyPattern(StringScalarExpression),
+
+    /// Static top-level key.
     Key(StringScalarExpression),
+
+    /// A [`ValueAccessor`] representing a path to data on the map.
+    ///
+    /// Note: The [`ValueAccessor`] could refer to top-level keys or nested
+    /// elements.
     ValueAccessor(ValueAccessor),
 }
 

--- a/rust/experimental/query_engine/kql-parser/src/kql_parser.rs
+++ b/rust/experimental/query_engine/kql-parser/src/kql_parser.rs
@@ -649,7 +649,7 @@ pub(crate) fn parse_project_expression(
 
     let mut expressions = Vec::new();
 
-    let mut map_reduce = KeepMapReductionExpression::new(
+    let mut map_reduce = MapReductionExpression::new(
         query_location.clone(),
         MutableValueExpression::Source(SourceScalarExpression::new(
             query_location,
@@ -2242,7 +2242,7 @@ mod parse_tests {
         run_test_success(
             "project key1",
             vec![TransformExpression::ReduceMap(
-                ReduceMapTransformExpression::Keep(KeepMapReductionExpression::new_with_selectors(
+                ReduceMapTransformExpression::Keep(MapReductionExpression::new_with_selectors(
                     QueryLocation::new_fake(),
                     MutableValueExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -2259,7 +2259,7 @@ mod parse_tests {
         run_test_success(
             "project key1, key2",
             vec![TransformExpression::ReduceMap(
-                ReduceMapTransformExpression::Keep(KeepMapReductionExpression::new_with_selectors(
+                ReduceMapTransformExpression::Keep(MapReductionExpression::new_with_selectors(
                     QueryLocation::new_fake(),
                     MutableValueExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -2299,7 +2299,7 @@ mod parse_tests {
                     )),
                 )),
                 TransformExpression::ReduceMap(ReduceMapTransformExpression::Keep(
-                    KeepMapReductionExpression::new_with_selectors(
+                    MapReductionExpression::new_with_selectors(
                         QueryLocation::new_fake(),
                         MutableValueExpression::Source(SourceScalarExpression::new(
                             QueryLocation::new_fake(),
@@ -2365,7 +2365,7 @@ mod parse_tests {
                     )),
                 )),
                 TransformExpression::ReduceMap(ReduceMapTransformExpression::Keep(
-                    KeepMapReductionExpression::new_with_selectors(
+                    MapReductionExpression::new_with_selectors(
                         QueryLocation::new_fake(),
                         MutableValueExpression::Source(SourceScalarExpression::new(
                             QueryLocation::new_fake(),
@@ -2405,7 +2405,7 @@ mod parse_tests {
         run_test_success(
             "project body['complex'], source.body.nested[0], body[variable]",
             vec![TransformExpression::ReduceMap(
-                ReduceMapTransformExpression::Keep(KeepMapReductionExpression::new_with_selectors(
+                ReduceMapTransformExpression::Keep(MapReductionExpression::new_with_selectors(
                     QueryLocation::new_fake(),
                     MutableValueExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -2480,7 +2480,7 @@ mod parse_tests {
                     )),
                 )),
                 TransformExpression::ReduceMap(ReduceMapTransformExpression::Keep(
-                    KeepMapReductionExpression::new_with_selectors(
+                    MapReductionExpression::new_with_selectors(
                         QueryLocation::new_fake(),
                         MutableValueExpression::Source(SourceScalarExpression::new(
                             QueryLocation::new_fake(),

--- a/rust/experimental/query_engine/kql-parser/src/kql_parser.rs
+++ b/rust/experimental/query_engine/kql-parser/src/kql_parser.rs
@@ -649,7 +649,7 @@ pub(crate) fn parse_project_expression(
 
     let mut expressions = Vec::new();
 
-    let mut map_reduce = MapReductionExpression::new(
+    let mut map_selection = MapSelectionExpression::new(
         query_location.clone(),
         MutableValueExpression::Source(SourceScalarExpression::new(
             query_location,
@@ -669,7 +669,7 @@ pub(crate) fn parse_project_expression(
                         MutableValueExpression::Source(s) => {
                             let accessor = s.get_value_accessor();
 
-                            if !map_reduce.push_value_accessor(accessor) {
+                            if !map_selection.push_value_accessor(accessor) {
                                 let location = s.get_query_location();
                                 return Err(ParserError::SyntaxError(
                                     location.clone(),
@@ -706,7 +706,7 @@ pub(crate) fn parse_project_expression(
                 if let ScalarExpression::Source(s) = &accessor_expression {
                     let accessor = s.get_value_accessor();
 
-                    if !map_reduce.push_value_accessor(accessor) {
+                    if !map_selection.push_value_accessor(accessor) {
                         let location = s.get_query_location();
                         return Err(ParserError::SyntaxError(
                             location.clone(),
@@ -731,7 +731,7 @@ pub(crate) fn parse_project_expression(
     }
 
     expressions.push(TransformExpression::ReduceMap(
-        ReduceMapTransformExpression::Keep(map_reduce),
+        ReduceMapTransformExpression::Keep(map_selection),
     ));
 
     Ok(expressions)
@@ -2242,7 +2242,7 @@ mod parse_tests {
         run_test_success(
             "project key1",
             vec![TransformExpression::ReduceMap(
-                ReduceMapTransformExpression::Keep(MapReductionExpression::new_with_selectors(
+                ReduceMapTransformExpression::Keep(MapSelectionExpression::new_with_selectors(
                     QueryLocation::new_fake(),
                     MutableValueExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -2259,7 +2259,7 @@ mod parse_tests {
         run_test_success(
             "project key1, key2",
             vec![TransformExpression::ReduceMap(
-                ReduceMapTransformExpression::Keep(MapReductionExpression::new_with_selectors(
+                ReduceMapTransformExpression::Keep(MapSelectionExpression::new_with_selectors(
                     QueryLocation::new_fake(),
                     MutableValueExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -2299,7 +2299,7 @@ mod parse_tests {
                     )),
                 )),
                 TransformExpression::ReduceMap(ReduceMapTransformExpression::Keep(
-                    MapReductionExpression::new_with_selectors(
+                    MapSelectionExpression::new_with_selectors(
                         QueryLocation::new_fake(),
                         MutableValueExpression::Source(SourceScalarExpression::new(
                             QueryLocation::new_fake(),
@@ -2365,7 +2365,7 @@ mod parse_tests {
                     )),
                 )),
                 TransformExpression::ReduceMap(ReduceMapTransformExpression::Keep(
-                    MapReductionExpression::new_with_selectors(
+                    MapSelectionExpression::new_with_selectors(
                         QueryLocation::new_fake(),
                         MutableValueExpression::Source(SourceScalarExpression::new(
                             QueryLocation::new_fake(),
@@ -2405,7 +2405,7 @@ mod parse_tests {
         run_test_success(
             "project body['complex'], source.body.nested[0], body[variable]",
             vec![TransformExpression::ReduceMap(
-                ReduceMapTransformExpression::Keep(MapReductionExpression::new_with_selectors(
+                ReduceMapTransformExpression::Keep(MapSelectionExpression::new_with_selectors(
                     QueryLocation::new_fake(),
                     MutableValueExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -2480,7 +2480,7 @@ mod parse_tests {
                     )),
                 )),
                 TransformExpression::ReduceMap(ReduceMapTransformExpression::Keep(
-                    MapReductionExpression::new_with_selectors(
+                    MapSelectionExpression::new_with_selectors(
                         QueryLocation::new_fake(),
                         MutableValueExpression::Source(SourceScalarExpression::new(
                             QueryLocation::new_fake(),


### PR DESCRIPTION
## Changes

* Introduce `ReduceMap` expression and use that to drive KQL `project` expressions

## Details

My first attempt at this was #620. Worked fine for map accessors. Could work for array accessors. But those are statically known in the query. What I realized is that design would just not work at all for accessors which reference something that is not known until evaluation. For example `body[my_variable]` could resolve a string (map key) or int (array index) or some other scalar (error).

What this PR is doing is adding a `ReduceMap` operation which is able to express a) patterns, b) static keys, and c) accessor expressions. My plan is to use this for `project`, `project-keep`, and `project-away` and then remove `ClearKeys`.