### PR TITLE
[query-engine] Optimize KQL project-away parsing

### DIFF
--- a/rust/experimental/query_engine/expressions/src/transform_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/transform_expressions.rs
@@ -123,7 +123,12 @@ impl Expression for RemoveKeysTransformExpression {
 
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]
 pub enum MapKey {
+    /// A pattern used to resolve keys.
+    ///
+    /// Examples: `name*`, `*`, `*_value`
     Pattern(StringScalarExpression),
+
+    /// A static key value.
     Value(StringScalarExpression),
 }
 


### PR DESCRIPTION
## Changes

* KQL `project-away` parsing will now decide to use `RemoveKeys` over `ReduceMap` if the query is only referencing statically known top-level keys