### PR TITLE
Properly place Renovate ignorePaths config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,6 +11,8 @@
     "docker:pinDigests",
     "helpers:pinGitHubActionDigestsToSemver"
   ],
+  // this directory has generated code, don't send updates to it
+  "ignorePaths": ["collector/cmd/otelarrowcol/**"],
   "packageRules": [
     {
       // reduces the number of Renovate PRs
@@ -33,10 +35,6 @@
       "schedule": [
         "before 8am on Monday"
       ]
-    },
-    {
-      // this directory has generated code, don't send updates to it
-      "ignorePaths": ["collector/cmd/otelarrowcol/**]
     },
     {
       // group together all github action workflow changes


### PR DESCRIPTION
#624 had an invalid Renovate config - `ignorePaths` doesn't go inside `packageRules`. 

Used [Renovate Config Validator tool](https://docs.renovatebot.com/config-validation/#config-validation) to prove this fix locally.

Opened #635 to track work to avoid recurrence of this problem.

Fixes #630.