### PR TITLE
[query-engine] Parse KQL let expression and query statements

### DIFF
--- a/rust/experimental/query_engine/expressions/src/lib.rs
+++ b/rust/experimental/query_engine/expressions/src/lib.rs
@@ -1,6 +1,7 @@
 pub(crate) mod data_expressions;
 pub(crate) mod expression;
 pub(crate) mod logical_expressions;
+pub(crate) mod pipeline_expression;
 pub(crate) mod scalar_expressions;
 pub(crate) mod static_scalar_expressions;
 pub(crate) mod transform_expressions;
@@ -9,6 +10,7 @@ pub(crate) mod value_expressions;
 
 pub use expression::Expression;
 pub use expression::QueryLocation;
+pub use pipeline_expression::PipelineExpression;
 
 pub use value_accessor::ValueAccessor;
 pub use value_accessor::ValueSelector;

--- a/rust/experimental/query_engine/expressions/src/pipeline_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/pipeline_expression.rs
@@ -14,6 +14,16 @@ impl PipelineExpression {
         }
     }
 
+    pub fn new_with_expressions(
+        query_location: QueryLocation,
+        expressions: Vec<DataExpression>,
+    ) -> PipelineExpression {
+        Self {
+            query_location,
+            expressions,
+        }
+    }
+
     pub fn push_expression(&mut self, expression: DataExpression) {
         self.expressions.push(expression);
     }

--- a/rust/experimental/query_engine/expressions/src/pipeline_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/pipeline_expression.rs
@@ -1,0 +1,26 @@
+use crate::{DataExpression, Expression, QueryLocation};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PipelineExpression {
+    query_location: QueryLocation,
+    expressions: Vec<DataExpression>,
+}
+
+impl PipelineExpression {
+    pub fn new(query_location: QueryLocation) -> PipelineExpression {
+        Self {
+            query_location,
+            expressions: Vec::new(),
+        }
+    }
+
+    pub fn push_expression(&mut self, expression: DataExpression) {
+        self.expressions.push(expression);
+    }
+}
+
+impl Expression for PipelineExpression {
+    fn get_query_location(&self) -> &QueryLocation {
+        &self.query_location
+    }
+}

--- a/rust/experimental/query_engine/kql-parser/src/kql.pest
+++ b/rust/experimental/query_engine/kql-parser/src/kql.pest
@@ -109,5 +109,5 @@ query_expressions = _{
 }
 
 query = {
-    SOI ~ query_expressions ~ (";" ~ query_expressions)* ~ ";"? ~ EOI
+    SOI ~ (query_expressions ~ (";" ~ query_expressions)* ~ ";"?)? ~ EOI
 }

--- a/rust/experimental/query_engine/kql-parser/src/kql.pest
+++ b/rust/experimental/query_engine/kql-parser/src/kql.pest
@@ -23,6 +23,7 @@ less_than_token = @{ "<" ~ !"=" }
 less_than_or_equal_to_token = @{ "<=" }
 and_token = @{ "and" }
 or_token = @{ "or" }
+statement_end_token = { &";" }
 
 // Literals
 true_literal = @{ "true" | "True" | "TRUE" }
@@ -90,7 +91,7 @@ project_away_expression = { "project-away" ~ (identifier_or_pattern_literal|acce
 where_expression = { "where" ~ logical_expression }
 
 tabular_expressions = _{
-	extend_expression
+    extend_expression
     | project_expression
     | project_keep_expression
     | project_away_expression
@@ -98,5 +99,15 @@ tabular_expressions = _{
 }
 
 tabular_expression = {
-	identifier_literal ~ ("|" ~ tabular_expressions)*
+    identifier_literal ~ ("|" ~ tabular_expressions)*
+}
+
+let_expression = { "let" ~ identifier_literal ~ "=" ~ scalar_expression ~ statement_end_token }
+
+query_expressions = _{
+    let_expression|tabular_expression
+}
+
+query = {
+    SOI ~ query_expressions ~ (";" ~ query_expressions)* ~ ";"? ~ EOI
 }

--- a/rust/experimental/query_engine/kql-parser/src/kql_parser.rs
+++ b/rust/experimental/query_engine/kql-parser/src/kql_parser.rs
@@ -1178,7 +1178,7 @@ pub fn parse_with_options(
 
         return Err(ParserError::SyntaxNotSupported(
             QueryLocation::new(start, end, line, column),
-            pest_error.to_string(),
+            pest_error.variant.message().into(),
         ));
     }
 

--- a/rust/experimental/query_engine/parser-abstractions/src/parser_state.rs
+++ b/rust/experimental/query_engine/parser-abstractions/src/parser_state.rs
@@ -2,6 +2,42 @@ use std::collections::HashSet;
 
 use data_engine_expressions::QueryLocation;
 
+pub struct ParserOptions {
+    default_source_map_key: Option<Box<str>>,
+    attached_data_names: HashSet<Box<str>>,
+}
+
+impl ParserOptions {
+    pub fn new() -> ParserOptions {
+        Self {
+            default_source_map_key: None,
+            attached_data_names: HashSet::new(),
+        }
+    }
+
+    pub fn with_default_source_map_key_name(mut self, name: &str) -> ParserOptions {
+        if !name.is_empty() {
+            self.default_source_map_key = Some(name.into());
+        }
+
+        self
+    }
+
+    pub fn with_attached_data_names(mut self, names: &[&str]) -> ParserOptions {
+        for name in names {
+            self.attached_data_names.insert((*name).into());
+        }
+
+        self
+    }
+}
+
+impl Default for ParserOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 pub struct ParserState<'a> {
     query: &'a str,
     default_source_map_key: Option<Box<str>>,
@@ -11,28 +47,16 @@ pub struct ParserState<'a> {
 
 impl<'a> ParserState<'a> {
     pub fn new(query: &'a str) -> ParserState<'a> {
+        ParserState::new_with_options(query, ParserOptions::new())
+    }
+
+    pub fn new_with_options(query: &'a str, options: ParserOptions) -> ParserState<'a> {
         Self {
             query,
-            default_source_map_key: None,
-            attached_data_names: HashSet::new(),
+            default_source_map_key: options.default_source_map_key,
+            attached_data_names: options.attached_data_names,
             variable_names: HashSet::new(),
         }
-    }
-
-    pub fn with_default_source_map_key_name(mut self, name: &str) -> ParserState<'a> {
-        if !name.is_empty() {
-            self.default_source_map_key = Some(name.into());
-        }
-
-        self
-    }
-
-    pub fn with_attached_data_names(mut self, names: &[&str]) -> ParserState<'a> {
-        for name in names {
-            self.attached_data_names.insert((*name).into());
-        }
-
-        self
     }
 
     pub fn get_query(&self) -> &str {


### PR DESCRIPTION
## Changes

* Support parsing KQL `let` expressions as `Set` transformations
* Add top-level query parsing onto `PipelineExpression`s