### PR TITLE
[query-engine] Simplify KQL logical expression rules

### DIFF
--- a/rust/experimental/query_engine/kql-parser/src/kql.pest
+++ b/rust/experimental/query_engine/kql-parser/src/kql.pest
@@ -80,7 +80,7 @@ scalar_expression = {
 
 comparison_expression = { scalar_expression ~ (equals_token|not_equals_token|greater_than_token|greater_than_or_equal_to_token|less_than_token|less_than_or_equal_to_token) ~ scalar_expression }
 logical_expressions = _{ comparison_expression|scalar_expression }
-logical_expression = { (logical_expressions|("(" ~ logical_expression ~ ")")) ~ ((and_token|or_token) ~ logical_expression)* }
+logical_expression = { logical_expressions ~ ((and_token|or_token) ~ logical_expressions)* }
 
 assignment_expression = { accessor_expression ~ "=" ~ scalar_expression }
 

--- a/rust/experimental/query_engine/kql-parser/src/kql_parser.rs
+++ b/rust/experimental/query_engine/kql-parser/src/kql_parser.rs
@@ -374,12 +374,12 @@ pub(crate) fn parse_logical_expression(
 
         let chain_rule = rule.unwrap();
         match chain_rule.as_rule() {
-            Rule::and_token => chain_rules.push(ChainedLogicalExpression::And(
-                parse_logical_expression(logical_rules.next().unwrap(), state)?,
-            )),
-            Rule::or_token => chain_rules.push(ChainedLogicalExpression::Or(
-                parse_logical_expression(logical_rules.next().unwrap(), state)?,
-            )),
+            Rule::and_token => chain_rules.push(ChainedLogicalExpression::And(parse_rule(
+                logical_rules.next().unwrap(),
+            )?)),
+            Rule::or_token => chain_rules.push(ChainedLogicalExpression::Or(parse_rule(
+                logical_rules.next().unwrap(),
+            )?)),
             _ => panic!("Unexpected rule in chain_rule: {}", chain_rule),
         }
     }
@@ -3377,7 +3377,7 @@ mod parse_tests {
                 assert_eq!(expected_id, id);
                 assert_eq!(expected_msg, msg);
             } else {
-                panic!("Expected SyntaxError");
+                panic!("Expected QueryLanguageDiagnostic");
             }
         };
 
@@ -3444,7 +3444,7 @@ mod parse_tests {
                 assert_eq!(expected_id, id);
                 assert_eq!(expected_msg, msg);
             } else {
-                panic!("Expected SyntaxError");
+                panic!("Expected QueryLanguageDiagnostic");
             }
         };
 


### PR DESCRIPTION
## Changes

* Simplify the KQL logical expression pest rules