### PR TITLE
[query-engine] Allow scalar expressions in accessor expressions when parsing KQL

### DIFF
--- a/rust/experimental/query_engine/expressions/src/scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/scalar_expressions.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Expression, LogicalExpression, QueryLocation, StaticScalarExpression, ValueAccessor,
+    Expression, LogicalExpression, QueryLocation, StaticScalarExpression, Value, ValueAccessor,
     ValueSelector,
 };
 
@@ -41,16 +41,11 @@ pub enum ScalarExpression {
 }
 
 impl ScalarExpression {
-    pub fn is_bool_compatible(&self) -> bool {
-        match self {
-            ScalarExpression::Source(_) => true,
-            ScalarExpression::Attached(_) => true,
-            ScalarExpression::Variable(_) => true,
-            ScalarExpression::Static(s) => matches!(s, StaticScalarExpression::Boolean(_)),
-            ScalarExpression::Negate(_) => false,
-            ScalarExpression::Logical(_) => true,
-            ScalarExpression::Conditional(_) => true,
+    pub fn to_value(&self) -> Option<Value> {
+        if let ScalarExpression::Static(s) = self {
+            return Some(s.to_value());
         }
+        None
     }
 }
 

--- a/rust/experimental/query_engine/expressions/src/static_scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/static_scalar_expressions.rs
@@ -20,6 +20,18 @@ pub enum StaticScalarExpression {
     String(StringScalarExpression),
 }
 
+impl StaticScalarExpression {
+    pub fn to_value(&self) -> Value {
+        match self {
+            StaticScalarExpression::Boolean(b) => b.to_value(),
+            StaticScalarExpression::DateTime(d) => d.to_value(),
+            StaticScalarExpression::Double(d) => d.to_value(),
+            StaticScalarExpression::Integer(i) => i.to_value(),
+            StaticScalarExpression::String(s) => s.to_value(),
+        }
+    }
+}
+
 impl Expression for StaticScalarExpression {
     fn get_query_location(&self) -> &QueryLocation {
         match self {
@@ -49,6 +61,10 @@ impl BooleanScalarExpression {
     pub fn get_value(&self) -> bool {
         self.value
     }
+
+    pub fn to_value(&self) -> Value {
+        Value::Boolean(self.get_value())
+    }
 }
 
 impl Expression for BooleanScalarExpression {
@@ -77,6 +93,10 @@ impl DateTimeScalarExpression {
     pub fn get_value(&self) -> DateTime<FixedOffset> {
         self.value
     }
+
+    pub fn to_value(&self) -> Value {
+        Value::DateTime(self.get_value())
+    }
 }
 
 impl Expression for DateTimeScalarExpression {
@@ -101,6 +121,10 @@ impl DoubleScalarExpression {
 
     pub fn get_value(&self) -> f64 {
         self.value
+    }
+
+    pub fn to_value(&self) -> Value {
+        Value::Double(self.get_value())
     }
 }
 
@@ -127,6 +151,10 @@ impl IntegerScalarExpression {
     pub fn get_value(&self) -> i64 {
         self.value
     }
+
+    pub fn to_value(&self) -> Value {
+        Value::Integer(self.get_value())
+    }
 }
 
 impl Expression for IntegerScalarExpression {
@@ -152,10 +180,22 @@ impl StringScalarExpression {
     pub fn get_value(&self) -> &str {
         &self.value
     }
+
+    pub fn to_value(&self) -> Value {
+        Value::String(self.get_value())
+    }
 }
 
 impl Expression for StringScalarExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
     }
+}
+
+pub enum Value<'a> {
+    Boolean(bool),
+    Integer(i64),
+    DateTime(DateTime<FixedOffset>),
+    Double(f64),
+    String(&'a str),
 }

--- a/rust/experimental/query_engine/kql-parser/src/kql.pest
+++ b/rust/experimental/query_engine/kql-parser/src/kql.pest
@@ -56,7 +56,7 @@ identifier_literal = @{ ("_" | ASCII_ALPHA) ~ ("_" | ASCII_ALPHANUMERIC)* }
 identifier_or_pattern_literal = @{ ("_" | ASCII_ALPHA | "*") ~ ("_" | ASCII_ALPHANUMERIC | "*")* ~ !("["|".")}
 
 // Expressions
-accessor_index = _{ "[" ~ (integer_literal | string_literal | (minus_token? ~ accessor_expression)) ~ "]" }
+accessor_index = _{ "[" ~ (integer_literal | string_literal | (minus_token? ~ scalar_expression)) ~ "]" }
 accessor = _{ identifier_literal ~ accessor_index? }
 accessor_expression = { accessor ~ (("." ~ accessor)|accessor_index)* }
 

--- a/rust/experimental/query_engine/kql-parser/src/logical_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/logical_expressions.rs
@@ -87,7 +87,8 @@ pub(crate) fn parse_logical_expression(
                     if let ScalarExpression::Logical(l) = scalar {
                         Ok(*l)
                     } else {
-                        if !scalar.is_bool_compatible() {
+                        let value = scalar.to_value();
+                        if value.is_some() && !matches!(value, Some(Value::Boolean(_))) {
                             return Err(ParserError::QueryLanguageDiagnostic {
                                 location: scalar.get_query_location().clone(),
                                 diagnostic_id: "KS141",

--- a/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
@@ -828,6 +828,26 @@ mod tests {
         );
 
         pest_test_helpers::test_compound_pest_rule(
+            KqlParser::parse(Rule::accessor_expression, "abc['name']").unwrap(),
+            &[
+                (Rule::accessor_expression, "abc['name']"),
+                (Rule::identifier_literal, "abc"),
+                (Rule::string_literal, "'name'"),
+            ],
+        );
+
+        pest_test_helpers::test_compound_pest_rule(
+            KqlParser::parse(Rule::accessor_expression, "abc[-'name']").unwrap(),
+            &[
+                (Rule::accessor_expression, "abc[-'name']"),
+                (Rule::identifier_literal, "abc"),
+                (Rule::minus_token, "-"),
+                (Rule::scalar_expression, "'name'"),
+                (Rule::string_literal, "'name'"),
+            ],
+        );
+
+        pest_test_helpers::test_compound_pest_rule(
             KqlParser::parse(Rule::accessor_expression, "abc.name1.name2").unwrap(),
             &[
                 (Rule::accessor_expression, "abc.name1.name2"),


### PR DESCRIPTION
## Changes

* Allow full scalar expressions inside accessor expressions when parsing KQL