### PR TITLE
[query-engine] Support static resolution of scalar expressions

### DIFF
--- a/rust/experimental/query_engine/expressions/Cargo.toml
+++ b/rust/experimental/query_engine/expressions/Cargo.toml
@@ -10,3 +10,4 @@ rust-version.workspace = true
 
 [dependencies]
 chrono = { workspace = true }
+thiserror = { workspace = true }

--- a/rust/experimental/query_engine/expressions/src/expression_error.rs
+++ b/rust/experimental/query_engine/expressions/src/expression_error.rs
@@ -1,0 +1,9 @@
+use thiserror::Error;
+
+use crate::QueryLocation;
+
+#[derive(Error, Debug)]
+pub enum ExpressionError {
+    #[error("{1}")]
+    TypeMismatch(QueryLocation, String),
+}

--- a/rust/experimental/query_engine/expressions/src/lib.rs
+++ b/rust/experimental/query_engine/expressions/src/lib.rs
@@ -1,5 +1,6 @@
 pub(crate) mod data_expressions;
 pub(crate) mod expression;
+pub(crate) mod expression_error;
 pub(crate) mod logical_expressions;
 pub(crate) mod pipeline_expression;
 pub(crate) mod scalar_expressions;
@@ -10,6 +11,7 @@ pub(crate) mod value_expressions;
 
 pub use expression::Expression;
 pub use expression::QueryLocation;
+pub use expression_error::ExpressionError;
 pub use pipeline_expression::PipelineExpression;
 
 pub use value_accessor::ValueAccessor;

--- a/rust/experimental/query_engine/expressions/src/logical_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/logical_expressions.rs
@@ -1,4 +1,4 @@
-use crate::{Expression, QueryLocation, ScalarExpression};
+use crate::{Expression, ExpressionError, QueryLocation, ScalarExpression, StaticScalarExpression};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum LogicalExpression {
@@ -6,7 +6,7 @@ pub enum LogicalExpression {
     /// scalar expression.
     ///
     /// Note: To be valid the inner expression should be a
-    /// [`ScalarExpression::Boolean`] value or a resolved
+    /// [`StaticScalarExpression::Boolean`] value or a resolved
     /// ([`ScalarExpression::Attached`], [`ScalarExpression::Source`], or
     /// [`ScalarExpression::Variable`]) value which is a boolean.
     Scalar(ScalarExpression),
@@ -28,6 +28,20 @@ pub enum LogicalExpression {
     /// Returns the result of a sequence of logical expressions chained using
     /// logical `AND(&&)` and/or `OR(||)` operations.
     Chain(ChainLogicalExpression),
+}
+
+impl LogicalExpression {
+    pub fn try_resolve_static(&self) -> Result<Option<StaticScalarExpression>, ExpressionError> {
+        match self {
+            LogicalExpression::Scalar(s) => s.try_resolve_static(),
+            // todo: Implement static resolution of logicals:
+            LogicalExpression::EqualTo(_) => Ok(None),
+            LogicalExpression::GreaterThan(_) => Ok(None),
+            LogicalExpression::GreaterThanOrEqualTo(_) => Ok(None),
+            LogicalExpression::Not(_) => Ok(None),
+            LogicalExpression::Chain(_) => Ok(None),
+        }
+    }
 }
 
 impl Expression for LogicalExpression {

--- a/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
@@ -1019,7 +1019,7 @@ mod tests {
                     "~at'tr~"
                 ))]
                 .to_vec(),
-                a.get_selectors()
+                a.get_value_accessor().get_selectors()
             );
         } else {
             panic!("Expected AttachedScalarExpression");
@@ -1044,7 +1044,7 @@ mod tests {
                     -1
                 ))]
                 .to_vec(),
-                v.get_selectors()
+                v.get_value_accessor().get_selectors()
             );
         } else {
             panic!("Expected VariableScalarExpression");


### PR DESCRIPTION
## Changes

* Add logic in expressions to resolve scalar expressions statically

## Details

What I'm working towards here is essentially constant folding where expressions which can be evaluated at compile time are replaced with the static values.