### PR TITLE
[query-engine] Implement constant folding of scalar expressions in KQL parser

### DIFF
--- a/rust/experimental/query_engine/kql-parser/src/scalar_conditional_function_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_conditional_function_expressions.rs
@@ -104,35 +104,11 @@ mod tests {
                         IntegerScalarExpression::new(QueryLocation::new_fake(), 0),
                     )),
                 )),
-                ScalarExpression::Conditional(ConditionalScalarExpression::new(
-                    QueryLocation::new_fake(),
-                    LogicalExpression::Scalar(ScalarExpression::Static(
-                        StaticScalarExpression::Boolean(BooleanScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            true,
-                        )),
-                    )),
-                    ScalarExpression::Static(StaticScalarExpression::String(
-                        StringScalarExpression::new(QueryLocation::new_fake(), "a"),
-                    )),
-                    ScalarExpression::Static(StaticScalarExpression::String(
-                        StringScalarExpression::new(QueryLocation::new_fake(), "b"),
-                    )),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "a"),
                 )),
-                ScalarExpression::Conditional(ConditionalScalarExpression::new(
-                    QueryLocation::new_fake(),
-                    LogicalExpression::Scalar(ScalarExpression::Static(
-                        StaticScalarExpression::Boolean(BooleanScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            false,
-                        )),
-                    )),
-                    ScalarExpression::Static(StaticScalarExpression::String(
-                        StringScalarExpression::new(QueryLocation::new_fake(), "c"),
-                    )),
-                    ScalarExpression::Static(StaticScalarExpression::String(
-                        StringScalarExpression::new(QueryLocation::new_fake(), "d"),
-                    )),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "d"),
                 )),
             )),
         );

--- a/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
@@ -1088,20 +1088,8 @@ mod tests {
             ScalarExpression::Source(SourceScalarExpression::new(
                 QueryLocation::new_fake(),
                 ValueAccessor::new_with_selectors(vec![ValueSelector::ScalarExpression(
-                    ScalarExpression::Conditional(ConditionalScalarExpression::new(
-                        QueryLocation::new_fake(),
-                        LogicalExpression::Scalar(ScalarExpression::Static(
-                            StaticScalarExpression::Boolean(BooleanScalarExpression::new(
-                                QueryLocation::new_fake(),
-                                true,
-                            )),
-                        )),
-                        ScalarExpression::Static(StaticScalarExpression::Integer(
-                            IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
-                        )),
-                        ScalarExpression::Static(StaticScalarExpression::Integer(
-                            IntegerScalarExpression::new(QueryLocation::new_fake(), 0),
-                        )),
+                    ScalarExpression::Static(StaticScalarExpression::Integer(
+                        IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
                     )),
                 )]),
             )),

--- a/rust/experimental/query_engine/parser-abstractions/src/parser_error.rs
+++ b/rust/experimental/query_engine/parser-abstractions/src/parser_error.rs
@@ -1,4 +1,4 @@
-use data_engine_expressions::QueryLocation;
+use data_engine_expressions::{ExpressionError, QueryLocation};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -15,4 +15,7 @@ pub enum ParserError {
         diagnostic_id: &'static str,
         message: String,
     },
+
+    #[error("{0}")]
+    ExpressionError(ExpressionError),
 }


### PR DESCRIPTION
## Changes

* Implement constant folding of scalar expressions in KQL parser

## Details

Example `iff(true, 0, 1)` is going to always evaluate as `0` so it gets replaced with just `Static(Integer(0))`.