### PR TITLE
[Editorial] Standardize README content to include repository maintainers and approvers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,34 +181,6 @@ to upgrade this repository is:
 3. Regenerate `otelarrowcol` via `make genotelarrowcol`
 4. Run `go work sync` to update the other modules with fresh dependencies.
 
-## OpenTelemetry-Arrow Team
-
-It takes a team to keep a repository like this functioning.  We use
-the OpenTelemetry the [Maintainer][MAINTAINERROLE] and
-[Approver][APPROVERROLE] roles to organize our work.
-
-The current [OpenTelemetry-Arrow maintainers
-(@open-telemetry/arrow-maintainers)][MAINTAINERS] are:
-
-- [Laurent Qu&#xE9;rel](https://github.com/lquerel), F5
-- [Joshua MacDonald](https://github.com/jmacd), Microsoft
-- [Drew Relmas](https://github.com/drewrelmas), Microsoft
-
-The current [OpenTelemetry-Arrow approvers
-(@open-telemetry/arrow-approvers)][APPROVERS] are:
-
-- [Lei Huang](https://github.com/v0y4g3r), Greptime
-- [Albert Lockett](https://github.com/albertlockett), F5
-
-The people who filled these roles in the past:
-
-- [Moh Osman](https://github.com/moh-osman3)
-- [Alex Boten](https://github.com/codeboten)
-
-Thanks to all the contributors!
-
-[![OpenTelemetry-Arrow contributors](https://contributors-img.web.app/image?repo=open-telemetry/otel-arrow)](https://github.com/open-telemetry/otel-arrow/graphs/contributors)
-
 [RELEASING.md]: ./RELEASING.md
 [OTCDOCS]: https://opentelemetry.io/docs/collector/
 [OTCGH]: https://github.com/open-telemetry/opentelemetry-collector

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,7 +195,3 @@ to upgrade this repository is:
     https://github.com/open-telemetry/opentelemetry-collector/receiver/otlpreceiver
 [OTLPEXPORTER]:
     https://github.com/open-telemetry/opentelemetry-collector/exporter/otlpexporter
-[APPROVERS]: https://github.com/orgs/open-telemetry/teams/arrow-approvers
-[MAINTAINERS]: https://github.com/orgs/open-telemetry/teams/arrow-maintainers
-[MAINTAINERROLE]: https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#maintainer
-[APPROVERROLE]: https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver

--- a/README.md
+++ b/README.md
@@ -237,6 +237,33 @@ regardless of your experience level. Whether you're a seasoned OpenTelemetry
 developer, just starting your journey, or simply curious about the work we do,
 you're more than welcome to participate!
 
+### Maintainers
+
+- [Laurent Qu&#xE9;rel](https://github.com/lquerel), F5
+- [Joshua MacDonald](https://github.com/jmacd), Microsoft
+- [Drew Relmas](https://github.com/drewrelmas), Microsoft
+
+For more information about the maintainer role, see the [community
+repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#maintainer).
+
+### Approvers
+
+- [Lei Huang](https://github.com/v0y4g3r), Greptime
+- [Albert Lockett](https://github.com/albertlockett), F5
+
+For more information about the approver role, see the [community
+repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver).
+
+### Emeritus Approvers
+
+- [Moh Osman](https://github.com/moh-osman3)
+- [Alex Boten](https://github.com/codeboten)
+
+### Thanks to all of our contributors
+
+[![OpenTelemetry-Arrow
+contributors](https://contributors-img.web.app/image?repo=open-telemetry/otel-arrow)](https://github.com/open-telemetry/otel-arrow/graphs/contributors)
+
 ## References
 
 - [OpenTelemetry Project](https://opentelemetry.io/)


### PR DESCRIPTION
See [community #2830](https://github.com/open-telemetry/community/issues/2830) - ask is to clearly display repository maintainer/approver teams on Readme.