### PR TITLE
[query-engine] Support constants in KQL accessor expressions

### DIFF
--- a/rust/experimental/query_engine/kql-parser/src/scalar_expression.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_expression.rs
@@ -24,7 +24,7 @@ pub(crate) fn parse_scalar_expression(
         Rule::double_literal => ScalarExpression::Static(parse_double_literal(scalar_rule)?),
         Rule::integer_literal => ScalarExpression::Static(parse_integer_literal(scalar_rule)?),
         Rule::string_literal => ScalarExpression::Static(parse_string_literal(scalar_rule)),
-        Rule::accessor_expression => parse_accessor_expression(scalar_rule, state)?,
+        Rule::accessor_expression => parse_accessor_expression(scalar_rule, state, true)?,
         Rule::logical_expression => {
             let l = parse_logical_expression(scalar_rule, state)?;
 

--- a/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
@@ -246,6 +246,7 @@ pub(crate) fn parse_real_expression(
 pub(crate) fn parse_accessor_expression(
     accessor_expression_rule: Pair<Rule>,
     state: &ParserState,
+    allow_root_scalar: bool,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&accessor_expression_rule);
 
@@ -297,29 +298,35 @@ pub(crate) fn parse_accessor_expression(
             }
             Rule::scalar_expression => {
                 let scalar = parse_scalar_expression(pair, state)?;
-                let value = scalar.to_value();
 
-                if negate_location.is_some() {
-                    if value.is_some() && !matches!(value, Some(Value::Integer(_))) {
-                        return Err(ParserError::QueryLanguageDiagnostic {
-                            location: scalar.get_query_location().clone(),
-                            diagnostic_id: "KS141",
-                            message: "The expression must have the type int".into(),
-                        });
-                    }
+                // Note: If the returned scalar is a statically known string or
+                // integer we fold it into a MapKey or ArrayIndex. Otherwise we
+                // return an error that the value is invalid for an accessor
+                // expression.
+                if let ScalarExpression::Static(s) = &scalar {
+                    if let StaticScalarExpression::String(str) = s {
+                        if negate_location.is_some() {
+                            return Err(ParserError::QueryLanguageDiagnostic {
+                                location: scalar.get_query_location().clone(),
+                                diagnostic_id: "KS141",
+                                message: "The expression must have the type int".into(),
+                            });
+                        }
 
-                    value_accessor.push_selector(ValueSelector::ScalarExpression(
-                        ScalarExpression::Negate(NegateScalarExpression::new(
-                            negate_location.unwrap(),
-                            scalar,
-                        )),
-                    ));
-                    negate_location = None;
-                } else {
-                    if value.is_some()
-                        && !matches!(value, Some(Value::Integer(_)))
-                        && !matches!(value, Some(Value::String(_)))
-                    {
+                        value_accessor.push_selector(ValueSelector::MapKey(str.clone()));
+                    } else if let StaticScalarExpression::Integer(i) = s {
+                        if negate_location.is_some() {
+                            value_accessor.push_selector(ValueSelector::ArrayIndex(
+                                IntegerScalarExpression::new(
+                                    negate_location.unwrap(),
+                                    -i.get_value(),
+                                ),
+                            ));
+                            negate_location = None;
+                        } else {
+                            value_accessor.push_selector(ValueSelector::ArrayIndex(i.clone()));
+                        }
+                    } else {
                         return Err(ParserError::QueryLanguageDiagnostic {
                             location: scalar.get_query_location().clone(),
                             diagnostic_id: "KS141",
@@ -327,8 +334,40 @@ pub(crate) fn parse_accessor_expression(
                                 .into(),
                         });
                     }
+                } else {
+                    let value = scalar.to_value();
 
-                    value_accessor.push_selector(ValueSelector::ScalarExpression(scalar));
+                    if negate_location.is_some() {
+                        if value.is_some() && !matches!(value, Some(Value::Integer(_))) {
+                            return Err(ParserError::QueryLanguageDiagnostic {
+                                location: scalar.get_query_location().clone(),
+                                diagnostic_id: "KS141",
+                                message: "The expression must have the type int".into(),
+                            });
+                        }
+
+                        value_accessor.push_selector(ValueSelector::ScalarExpression(
+                            ScalarExpression::Negate(NegateScalarExpression::new(
+                                negate_location.unwrap(),
+                                scalar,
+                            )),
+                        ));
+                        negate_location = None;
+                    } else {
+                        if value.is_some()
+                            && !matches!(value, Some(Value::Integer(_)))
+                            && !matches!(value, Some(Value::String(_)))
+                        {
+                            return Err(ParserError::QueryLanguageDiagnostic {
+                                location: scalar.get_query_location().clone(),
+                                diagnostic_id: "KS141",
+                                message: "The expression must have one of the types: int or string"
+                                    .into(),
+                            });
+                        }
+
+                        value_accessor.push_selector(ValueSelector::ScalarExpression(scalar));
+                    }
                 }
             }
             Rule::minus_token => {
@@ -356,6 +395,29 @@ pub(crate) fn parse_accessor_expression(
             value_accessor,
         )));
     } else {
+        // Note: If the accessor_expression is being used as a scalar it is
+        // perfectly valid to return a static constant value. However accessors
+        // can also be used in extend & project* expressions where the behavior
+        // needs to change such that a static is invalid at the root. Example:
+        // * iff(const_bool, const_val1, const_val2): This is a nested scalar
+        //   expression. const_bool, const_val1, and const_val2 should be
+        //   resolved to their values.
+        // * extend const_str = 1: This expression needs to execute as
+        //   source['const_str'] = 1 so the const_str is not evaluated.
+        if allow_root_scalar {
+            if let Some(constant) = state.try_get_constant(root_accessor_identity) {
+                if value_accessor.has_selectors() {
+                    // Note: It is not currently supported to access into a constant.
+                    // This is because statics are currently simple things like string,
+                    // bool, double, float, datetime. If it becomes possible to have a
+                    // static map or array this should be supported.
+                    panic!("Accessor into a constant value encountered")
+                }
+
+                return Ok(ScalarExpression::Static(constant.clone()));
+            }
+        }
+
         value_accessor.insert_selector(
             0,
             ValueSelector::MapKey(StringScalarExpression::new(
@@ -895,6 +957,7 @@ mod tests {
         let expression = parse_accessor_expression(
             result.next().unwrap(),
             &ParserState::new("source.subkey['array'][0]"),
+            true,
         )
         .unwrap();
 
@@ -931,7 +994,7 @@ mod tests {
 
         state.push_variable_name("var");
 
-        let expression = parse_accessor_expression(result.next().unwrap(), &state).unwrap();
+        let expression = parse_accessor_expression(result.next().unwrap(), &state, true).unwrap();
 
         if let ScalarExpression::Source(s) = expression {
             assert_eq!(
@@ -980,6 +1043,7 @@ mod tests {
                 "subkey",
                 ParserOptions::new().with_default_source_map_key_name("attributes"),
             ),
+            true,
         )
         .unwrap();
 
@@ -1008,6 +1072,7 @@ mod tests {
                 "resource['~at\\'tr~']",
                 ParserOptions::new().with_attached_data_names(&["resource"]),
             ),
+            true,
         )
         .unwrap();
 
@@ -1034,7 +1099,7 @@ mod tests {
 
         state.push_variable_name("a");
 
-        let expression = parse_accessor_expression(result.next().unwrap(), &state).unwrap();
+        let expression = parse_accessor_expression(result.next().unwrap(), &state, true).unwrap();
 
         if let ScalarExpression::Variable(v) = expression {
             assert_eq!("a", v.get_name());
@@ -1052,13 +1117,43 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_accessor_expression_with_scalars() {
+    fn test_parse_accessor_expression_with_scalars_and_allow_root_scalars() {
         let run_test_success = |input: &str, expected: ScalarExpression| {
             let mut result = KqlParser::parse(Rule::accessor_expression, input).unwrap();
 
-            let state = ParserState::new(input);
+            let mut state = ParserState::new(input);
 
-            let expression = parse_accessor_expression(result.next().unwrap(), &state).unwrap();
+            state.push_constant(
+                "const_int",
+                StaticScalarExpression::Integer(IntegerScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    1,
+                )),
+            );
+            state.push_constant(
+                "const_bool_true",
+                StaticScalarExpression::Boolean(BooleanScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    true,
+                )),
+            );
+            state.push_constant(
+                "const_bool_false",
+                StaticScalarExpression::Boolean(BooleanScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    false,
+                )),
+            );
+            state.push_constant(
+                "const_str",
+                StaticScalarExpression::String(StringScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    "hello world",
+                )),
+            );
+
+            let expression =
+                parse_accessor_expression(result.next().unwrap(), &state, true).unwrap();
 
             assert_eq!(expected, expression);
         };
@@ -1066,9 +1161,39 @@ mod tests {
         let run_test_failure = |input: &str, expected_id: &str, expected_msg: &str| {
             let mut result = KqlParser::parse(Rule::accessor_expression, input).unwrap();
 
-            let state = ParserState::new(input);
+            let mut state = ParserState::new(input);
 
-            let error = parse_accessor_expression(result.next().unwrap(), &state).unwrap_err();
+            state.push_constant(
+                "const_int",
+                StaticScalarExpression::Integer(IntegerScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    1,
+                )),
+            );
+            state.push_constant(
+                "const_bool_true",
+                StaticScalarExpression::Boolean(BooleanScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    true,
+                )),
+            );
+            state.push_constant(
+                "const_bool_false",
+                StaticScalarExpression::Boolean(BooleanScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    false,
+                )),
+            );
+            state.push_constant(
+                "const_str",
+                StaticScalarExpression::String(StringScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    "hello world",
+                )),
+            );
+
+            let error =
+                parse_accessor_expression(result.next().unwrap(), &state, true).unwrap_err();
 
             if let ParserError::QueryLanguageDiagnostic {
                 location: _,
@@ -1084,13 +1209,57 @@ mod tests {
         };
 
         run_test_success(
-            "source[iif(true, 1, 0)]",
+            "const_str",
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "hello world",
+            ))),
+        );
+
+        run_test_success(
+            "const_int",
+            ScalarExpression::Static(StaticScalarExpression::Integer(
+                IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+            )),
+        );
+
+        // Note: The inner scalars referencing constants are folded into static
+        // lookups in this test.
+        run_test_success(
+            "source[const_str][const_int]",
             ScalarExpression::Source(SourceScalarExpression::new(
                 QueryLocation::new_fake(),
-                ValueAccessor::new_with_selectors(vec![ValueSelector::ScalarExpression(
-                    ScalarExpression::Static(StaticScalarExpression::Integer(
-                        IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+                ValueAccessor::new_with_selectors(vec![
+                    ValueSelector::MapKey(StringScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        "hello world",
                     )),
+                    ValueSelector::ArrayIndex(IntegerScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        1,
+                    )),
+                ]),
+            )),
+        );
+
+        // Note: The inner scalar is folded into a constant in this test.
+        run_test_success(
+            "source[iif(const_bool_false, 'a', const_str)]",
+            ScalarExpression::Source(SourceScalarExpression::new(
+                QueryLocation::new_fake(),
+                ValueAccessor::new_with_selectors(vec![ValueSelector::MapKey(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "hello world"),
+                )]),
+            )),
+        );
+
+        // Note: The inner scalar is folded into a constant in this test.
+        run_test_success(
+            "source[-iif(const_bool_true, const_int, 0)]",
+            ScalarExpression::Source(SourceScalarExpression::new(
+                QueryLocation::new_fake(),
+                ValueAccessor::new_with_selectors(vec![ValueSelector::ArrayIndex(
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), -1),
                 )]),
             )),
         );
@@ -1105,6 +1274,67 @@ mod tests {
             "sub[-('attr')]",
             "KS141",
             "The expression must have the type int",
+        );
+
+        run_test_failure(
+            "source[const_bool_true]",
+            "KS141",
+            "The expression must have one of the types: int or string",
+        );
+
+        run_test_failure(
+            "source[-const_str]",
+            "KS141",
+            "The expression must have the type int",
+        );
+    }
+
+    #[test]
+    fn test_parse_accessor_expression_with_scalars_and_disallow_root_scalars() {
+        let run_test_success = |input: &str, expected: ScalarExpression| {
+            let mut result = KqlParser::parse(Rule::accessor_expression, input).unwrap();
+
+            let mut state = ParserState::new(input);
+
+            state.push_constant(
+                "const_str",
+                StaticScalarExpression::String(StringScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    "hello world",
+                )),
+            );
+
+            let expression =
+                parse_accessor_expression(result.next().unwrap(), &state, false).unwrap();
+
+            assert_eq!(expected, expression);
+        };
+
+        run_test_success(
+            "const_str",
+            ScalarExpression::Source(SourceScalarExpression::new(
+                QueryLocation::new_fake(),
+                ValueAccessor::new_with_selectors(vec![ValueSelector::MapKey(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "const_str"),
+                )]),
+            )),
+        );
+
+        run_test_success(
+            "const_str[const_str]",
+            ScalarExpression::Source(SourceScalarExpression::new(
+                QueryLocation::new_fake(),
+                ValueAccessor::new_with_selectors(vec![
+                    ValueSelector::MapKey(StringScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        "const_str",
+                    )),
+                    ValueSelector::MapKey(StringScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        "hello world",
+                    )),
+                ]),
+            )),
         );
     }
 }

--- a/rust/experimental/query_engine/kql-parser/src/shared_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/shared_expressions.rs
@@ -20,7 +20,9 @@ pub(crate) fn parse_assignment_expression(
     let destination_rule_str = destination_rule.as_str();
 
     let accessor = match destination_rule.as_rule() {
-        Rule::accessor_expression => parse_accessor_expression(destination_rule, state)?,
+        // Note: Root-level static accessors are not valid in an assignment
+        // expression so allow_root_scalar=false is passed here.
+        Rule::accessor_expression => parse_accessor_expression(destination_rule, state, false)?,
         _ => panic!(
             "Unexpected rule in assignment_expression: {}",
             destination_rule


### PR DESCRIPTION
## Changes

* Support constants in KQL accessor expressions
* Handle cases in extend & project statements where accessor expressions have special meaning