### PR TITLE
[query-engine] Refactor the code used to determine the value type of scalar expressions

### DIFF
--- a/rust/experimental/query_engine/expressions/src/scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/scalar_expressions.rs
@@ -278,7 +278,7 @@ impl ConditionalScalarExpression {
         }
 
         let true_e = self.true_expression.try_resolve_static()?;
-        let false_e = self.true_expression.try_resolve_static()?;
+        let false_e = self.false_expression.try_resolve_static()?;
 
         if true_e.is_some() && false_e.is_some() {
             let true_type = true_e.unwrap().get_value_type();
@@ -335,6 +335,196 @@ mod tests {
     use crate::BooleanScalarExpression;
 
     use super::*;
+
+    #[test]
+    pub fn try_resolve_value_type() {
+        let run_test_success = |expression: ScalarExpression, expected: Option<ValueType>| {
+            let actual = expression.try_resolve_value_type().unwrap();
+
+            assert_eq!(expected, actual)
+        };
+
+        run_test_success(
+            ScalarExpression::Attached(AttachedScalarExpression::new(
+                QueryLocation::new_fake(),
+                "resource",
+                ValueAccessor::new(),
+            )),
+            None,
+        );
+
+        run_test_success(
+            ScalarExpression::Source(SourceScalarExpression::new(
+                QueryLocation::new_fake(),
+                ValueAccessor::new(),
+            )),
+            None,
+        );
+
+        run_test_success(
+            ScalarExpression::Variable(VariableScalarExpression::new(
+                QueryLocation::new_fake(),
+                "var",
+                ValueAccessor::new(),
+            )),
+            None,
+        );
+
+        run_test_success(
+            ScalarExpression::Static(StaticScalarExpression::Boolean(
+                BooleanScalarExpression::new(QueryLocation::new_fake(), true),
+            )),
+            Some(ValueType::Boolean),
+        );
+
+        run_test_success(
+            ScalarExpression::Negate(NegateScalarExpression::new(
+                QueryLocation::new_fake(),
+                ScalarExpression::Static(StaticScalarExpression::Integer(
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+                )),
+            )),
+            Some(ValueType::Integer),
+        );
+
+        run_test_success(
+            ScalarExpression::Logical(
+                LogicalExpression::Scalar(ScalarExpression::Static(
+                    StaticScalarExpression::Boolean(BooleanScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        true,
+                    )),
+                ))
+                .into(),
+            ),
+            Some(ValueType::Boolean),
+        );
+
+        run_test_success(
+            ScalarExpression::Conditional(ConditionalScalarExpression::new(
+                QueryLocation::new_fake(),
+                LogicalExpression::Scalar(ScalarExpression::Static(
+                    StaticScalarExpression::Boolean(BooleanScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        true,
+                    )),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::Integer(
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+                )),
+                ScalarExpression::Source(SourceScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    ValueAccessor::new(),
+                )),
+            )),
+            Some(ValueType::Integer),
+        );
+    }
+
+    #[test]
+    pub fn test_conditional_try_resolve_value_type() {
+        let run_test_success = |expression: ConditionalScalarExpression,
+                                expected: Option<ValueType>| {
+            let actual = expression.try_resolve_value_type().unwrap();
+
+            assert_eq!(expected, actual)
+        };
+
+        run_test_success(
+            ConditionalScalarExpression::new(
+                QueryLocation::new_fake(),
+                LogicalExpression::Scalar(ScalarExpression::Source(SourceScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    ValueAccessor::new(),
+                ))),
+                ScalarExpression::Static(StaticScalarExpression::Integer(
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::Integer(
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 0),
+                )),
+            ),
+            Some(ValueType::Integer),
+        );
+
+        run_test_success(
+            ConditionalScalarExpression::new(
+                QueryLocation::new_fake(),
+                LogicalExpression::Scalar(ScalarExpression::Static(
+                    StaticScalarExpression::Boolean(BooleanScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        true,
+                    )),
+                )),
+                ScalarExpression::Source(SourceScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    ValueAccessor::new(),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::Integer(
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 0),
+                )),
+            ),
+            None,
+        );
+
+        run_test_success(
+            ConditionalScalarExpression::new(
+                QueryLocation::new_fake(),
+                LogicalExpression::Scalar(ScalarExpression::Static(
+                    StaticScalarExpression::Boolean(BooleanScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        false,
+                    )),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::Integer(
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+                )),
+                ScalarExpression::Source(SourceScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    ValueAccessor::new(),
+                )),
+            ),
+            None,
+        );
+
+        run_test_success(
+            ConditionalScalarExpression::new(
+                QueryLocation::new_fake(),
+                LogicalExpression::Scalar(ScalarExpression::Static(
+                    StaticScalarExpression::Boolean(BooleanScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        true,
+                    )),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::Integer(
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::Integer(
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 0),
+                )),
+            ),
+            Some(ValueType::Integer),
+        );
+
+        run_test_success(
+            ConditionalScalarExpression::new(
+                QueryLocation::new_fake(),
+                LogicalExpression::Scalar(ScalarExpression::Static(
+                    StaticScalarExpression::Boolean(BooleanScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        false,
+                    )),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::Integer(
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::Integer(
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 0),
+                )),
+            ),
+            Some(ValueType::Integer),
+        );
+    }
 
     #[test]
     pub fn test_try_resolve_static() {
@@ -434,15 +624,30 @@ mod tests {
     pub fn test_negate_try_resolve_static() {
         let run_test_success =
             |expression: NegateScalarExpression, expected: Option<StaticScalarExpression>| {
-                let actual = expression.try_resolve_static().unwrap();
+                let actual_static = expression.try_resolve_static().unwrap();
 
-                assert_eq!(expected, actual)
+                assert_eq!(expected, actual_static);
+                if actual_static.is_none() {
+                    assert_eq!(None, expression.try_resolve_value_type().unwrap());
+                } else {
+                    assert_eq!(
+                        ScalarExpression::Static(actual_static.unwrap())
+                            .try_resolve_value_type()
+                            .unwrap(),
+                        expression.try_resolve_value_type().unwrap()
+                    );
+                }
             };
 
         let run_test_failure = |expression: NegateScalarExpression| {
-            let actual = expression.try_resolve_static().unwrap_err();
-
-            assert!(matches!(actual, ExpressionError::TypeMismatch(_, _)));
+            assert!(matches!(
+                expression.try_resolve_static().unwrap_err(),
+                ExpressionError::TypeMismatch(_, _)
+            ));
+            assert!(matches!(
+                expression.try_resolve_value_type().unwrap_err(),
+                ExpressionError::TypeMismatch(_, _)
+            ));
         };
 
         run_test_success(

--- a/rust/experimental/query_engine/expressions/src/scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/scalar_expressions.rs
@@ -332,7 +332,7 @@ impl Expression for ConditionalScalarExpression {
 
 #[cfg(test)]
 mod tests {
-    use crate::BooleanScalarExpression;
+    use crate::{BooleanScalarExpression, StringScalarExpression};
 
     use super::*;
 
@@ -445,6 +445,25 @@ mod tests {
                 )),
             ),
             Some(ValueType::Integer),
+        );
+
+        // Note: Type is not resolved here because true & false branches return
+        // different types.
+        run_test_success(
+            ConditionalScalarExpression::new(
+                QueryLocation::new_fake(),
+                LogicalExpression::Scalar(ScalarExpression::Source(SourceScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    ValueAccessor::new(),
+                ))),
+                ScalarExpression::Static(StaticScalarExpression::Integer(
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "hello world"),
+                )),
+            ),
+            None,
         );
 
         run_test_success(

--- a/rust/experimental/query_engine/expressions/src/static_scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/static_scalar_expressions.rs
@@ -172,7 +172,7 @@ impl Expression for StringScalarExpression {
     }
 }
 
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum ValueType {
     Boolean,
     Integer,

--- a/rust/experimental/query_engine/expressions/src/static_scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/static_scalar_expressions.rs
@@ -21,13 +21,13 @@ pub enum StaticScalarExpression {
 }
 
 impl StaticScalarExpression {
-    pub fn to_value(&self) -> Value {
+    pub fn get_value_type(&self) -> ValueType {
         match self {
-            StaticScalarExpression::Boolean(b) => b.to_value(),
-            StaticScalarExpression::DateTime(d) => d.to_value(),
-            StaticScalarExpression::Double(d) => d.to_value(),
-            StaticScalarExpression::Integer(i) => i.to_value(),
-            StaticScalarExpression::String(s) => s.to_value(),
+            StaticScalarExpression::Boolean(_) => ValueType::Boolean,
+            StaticScalarExpression::DateTime(_) => ValueType::DateTime,
+            StaticScalarExpression::Double(_) => ValueType::Double,
+            StaticScalarExpression::Integer(_) => ValueType::Integer,
+            StaticScalarExpression::String(_) => ValueType::String,
         }
     }
 }
@@ -61,10 +61,6 @@ impl BooleanScalarExpression {
     pub fn get_value(&self) -> bool {
         self.value
     }
-
-    pub fn to_value(&self) -> Value {
-        Value::Boolean(self.get_value())
-    }
 }
 
 impl Expression for BooleanScalarExpression {
@@ -93,10 +89,6 @@ impl DateTimeScalarExpression {
     pub fn get_value(&self) -> DateTime<FixedOffset> {
         self.value
     }
-
-    pub fn to_value(&self) -> Value {
-        Value::DateTime(self.get_value())
-    }
 }
 
 impl Expression for DateTimeScalarExpression {
@@ -121,10 +113,6 @@ impl DoubleScalarExpression {
 
     pub fn get_value(&self) -> f64 {
         self.value
-    }
-
-    pub fn to_value(&self) -> Value {
-        Value::Double(self.get_value())
     }
 }
 
@@ -151,10 +139,6 @@ impl IntegerScalarExpression {
     pub fn get_value(&self) -> i64 {
         self.value
     }
-
-    pub fn to_value(&self) -> Value {
-        Value::Integer(self.get_value())
-    }
 }
 
 impl Expression for IntegerScalarExpression {
@@ -180,10 +164,6 @@ impl StringScalarExpression {
     pub fn get_value(&self) -> &str {
         &self.value
     }
-
-    pub fn to_value(&self) -> Value {
-        Value::String(self.get_value())
-    }
 }
 
 impl Expression for StringScalarExpression {
@@ -192,10 +172,11 @@ impl Expression for StringScalarExpression {
     }
 }
 
-pub enum Value<'a> {
-    Boolean(bool),
-    Integer(i64),
-    DateTime(DateTime<FixedOffset>),
-    Double(f64),
-    String(&'a str),
+#[derive(PartialEq)]
+pub enum ValueType {
+    Boolean,
+    Integer,
+    DateTime,
+    Double,
+    String,
 }

--- a/rust/experimental/query_engine/kql-parser/src/logical_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/logical_expressions.rs
@@ -87,8 +87,16 @@ pub(crate) fn parse_logical_expression(
                     if let ScalarExpression::Logical(l) = scalar {
                         Ok(*l)
                     } else {
-                        let value = scalar.to_value();
-                        if value.is_some() && !matches!(value, Some(Value::Boolean(_))) {
+                        let value_type_result = scalar.try_resolve_value_type();
+                        if let Err(e) = value_type_result {
+                            return Err(ParserError::SyntaxError(
+                                e.get_query_location().clone(),
+                                e.to_string(),
+                            ));
+                        }
+                        if let Some(t) = value_type_result.unwrap()
+                            && t != ValueType::Boolean
+                        {
                             return Err(ParserError::QueryLanguageDiagnostic {
                                 location: scalar.get_query_location().clone(),
                                 diagnostic_id: "KS141",


### PR DESCRIPTION
## Changes

* Remove the `to_value` code and replace it with `try_resolve_value_type`

## Details

I felt `to_value` was too restrictive for what was needed. It would return full values which really only works for static expressions. Consider something like `tolong([scalar])` or `tostring([scalar])`. With the new design we can determine the correct value type without having to evaluate the inner expressions at all. The value type is really all that is needed for the validation code calling this API. Full static values can still be resolved using `try_resolve_static`.