### PR TITLE
Perf - Add loadgenerator api server mode

### DIFF
--- a/tools/pipeline_perf_test/load_generator/requirements.txt
+++ b/tools/pipeline_perf_test/load_generator/requirements.txt
@@ -1,7 +1,4 @@
-docker
-psutil
-requests
-kubernetes
-pyyaml
-grpcio
-opentelemetry-proto
+grpcio>=1.73.1
+opentelemetry-proto>=1.34.1
+pydantic>=2.11.4
+Flask>=3.1.1

--- a/tools/pipeline_perf_test/load_generator/tox.ini
+++ b/tools/pipeline_perf_test/load_generator/tox.ini
@@ -1,0 +1,27 @@
+[tox]
+envlist = lint, type, format
+
+
+[flake8]
+max-line-length = 88
+
+
+[testenv:lint]
+description = Run flake8 for linting
+deps = flake8
+commands = flake8 ./
+
+
+[testenv:type]
+description = Run mypy for type checking
+deps =
+    -rrequirements.txt
+    mypy
+commands = mypy --check-untyped-defs ./
+
+
+[testenv:format]
+description = Check formatting with black (non-destructive)
+skip_install = true
+deps = black
+commands = black ./


### PR DESCRIPTION
 This refactor of the loadgenerator adds the ability to run in server mode. This allows us to re-configure load properties on the fly without having to re-launch the container. **Existing one-off cli mode behavior is unchanged.**

- Add config class for shared (cli + api) options (body / attribute / batch size / num threads)
- Refactor main logic into LoadGenerator class
- Add flask routes for /start /stop /metrics
- Refactor parser to support --serve, move default values and help string for shared config items to pydantic class
- Add prometheus compatible endpoint for load metrics
- Add tox.ini and run+fix format / lint / typing