### PR TITLE
Perf - Backend tox support and misc fixes

### DIFF
--- a/tools/pipeline_perf_test/backend/requirements.txt
+++ b/tools/pipeline_perf_test/backend/requirements.txt
@@ -1,3 +1,3 @@
-grpcio
-flask
-opentelemetry-proto
+grpcio>=1.73.1
+Flask>=3.1.1
+opentelemetry-proto>=1.34.1

--- a/tools/pipeline_perf_test/backend/tox.ini
+++ b/tools/pipeline_perf_test/backend/tox.ini
@@ -1,0 +1,27 @@
+[tox]
+envlist = lint, type, format
+
+
+[flake8]
+max-line-length = 88
+
+
+[testenv:lint]
+description = Run flake8 for linting
+deps = flake8
+commands = flake8 ./
+
+
+[testenv:type]
+description = Run mypy for type checking
+deps =
+    -rrequirements.txt
+    mypy
+commands = mypy --check-untyped-defs ./
+
+
+[testenv:format]
+description = Check formatting with black (non-destructive)
+skip_install = true
+deps = black
+commands = black ./


### PR DESCRIPTION
This PR adds tox to the perf backend as well as a few minor tweaks. No behavioral changes other than what's noted below:

- Adds an additional prometheus compatible metrics endpoint at /prom_metrics (we can remove the old one after we migrate to new framework)
- Adds tox support, fixes  for lint, formatter, typing
- Switch flask thread to daemon mode to prevent blocking on tear-down, explicit grpc server stop on interrupt