### PR TITLE
[query-engine] Introduce Regex + remove constant folding in KQL parser

### DIFF
--- a/rust/experimental/query_engine/expressions/Cargo.toml
+++ b/rust/experimental/query_engine/expressions/Cargo.toml
@@ -12,4 +12,5 @@ rust-version.workspace = true
 caseless = "0.2.2"
 
 chrono = { workspace = true }
+regex = { workspace = true }
 thiserror = { workspace = true }

--- a/rust/experimental/query_engine/expressions/src/lib.rs
+++ b/rust/experimental/query_engine/expressions/src/lib.rs
@@ -16,7 +16,6 @@ pub use expression_error::ExpressionError;
 pub use pipeline_expression::PipelineExpression;
 
 pub use value_accessor::ValueAccessor;
-pub use value_accessor::ValueSelector;
 
 pub use data_expressions::*;
 pub use logical_expressions::*;

--- a/rust/experimental/query_engine/expressions/src/primitives/value.rs
+++ b/rust/experimental/query_engine/expressions/src/primitives/value.rs
@@ -632,6 +632,14 @@ mod tests {
             )),
             "2025-06-29T00:00:00Z",
         );
+
+        run_test_success(
+            Value::Regex(&RegexScalarExpression::new(
+                QueryLocation::new_fake(),
+                Regex::new(".*").unwrap(),
+            )),
+            ".*",
+        );
     }
 
     #[test]
@@ -829,6 +837,19 @@ mod tests {
             )),
             false,
             "String value 'hello world' on right side of equality operation could not be converted to DateTime",
+        );
+
+        run_test_success(
+            Value::Regex(&RegexScalarExpression::new(
+                QueryLocation::new_fake(),
+                Regex::new(".*").unwrap(),
+            )),
+            Value::Regex(&RegexScalarExpression::new(
+                QueryLocation::new_fake(),
+                Regex::new(".*").unwrap(),
+            )),
+            false,
+            true
         );
     }
 

--- a/rust/experimental/query_engine/expressions/src/primitives/value.rs
+++ b/rust/experimental/query_engine/expressions/src/primitives/value.rs
@@ -849,7 +849,7 @@ mod tests {
                 Regex::new(".*").unwrap(),
             )),
             false,
-            true
+            true,
         );
     }
 

--- a/rust/experimental/query_engine/expressions/src/primitives/value_type.rs
+++ b/rust/experimental/query_engine/expressions/src/primitives/value_type.rs
@@ -4,5 +4,6 @@ pub enum ValueType {
     Integer,
     DateTime,
     Double,
+    Regex,
     String,
 }

--- a/rust/experimental/query_engine/expressions/src/static_scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/static_scalar_expressions.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, FixedOffset};
+use regex::Regex;
 
 use crate::{Expression, QueryLocation, primitives::*};
 
@@ -16,6 +17,9 @@ pub enum StaticScalarExpression {
     /// Resolve a static integer value provided directly in a query.
     Integer(IntegerScalarExpression),
 
+    /// Resolve a static regex value provided directly in a query.
+    Regex(RegexScalarExpression),
+
     /// Resolve a static string value provided directly in a query.
     String(StringScalarExpression),
 }
@@ -27,6 +31,7 @@ impl StaticScalarExpression {
             StaticScalarExpression::DateTime(_) => ValueType::DateTime,
             StaticScalarExpression::Double(_) => ValueType::Double,
             StaticScalarExpression::Integer(_) => ValueType::Integer,
+            StaticScalarExpression::Regex(_) => ValueType::Regex,
             StaticScalarExpression::String(_) => ValueType::String,
         }
     }
@@ -39,6 +44,7 @@ impl Expression for StaticScalarExpression {
             StaticScalarExpression::DateTime(d) => d.get_query_location(),
             StaticScalarExpression::Double(d) => d.get_query_location(),
             StaticScalarExpression::Integer(i) => i.get_query_location(),
+            StaticScalarExpression::Regex(r) => r.get_query_location(),
             StaticScalarExpression::String(s) => s.get_query_location(),
         }
     }
@@ -155,7 +161,44 @@ impl IntegerValue for IntegerScalarExpression {
     }
 }
 
-#[derive(Debug, Clone, Eq, Hash, PartialEq)]
+#[derive(Debug, Clone)]
+pub struct RegexScalarExpression {
+    query_location: QueryLocation,
+    value: Regex,
+}
+
+impl RegexScalarExpression {
+    pub fn new(query_location: QueryLocation, value: Regex) -> RegexScalarExpression {
+        Self {
+            query_location,
+            value,
+        }
+    }
+
+    pub fn get_value(&self) -> &Regex {
+        &self.value
+    }
+}
+
+impl Expression for RegexScalarExpression {
+    fn get_query_location(&self) -> &QueryLocation {
+        &self.query_location
+    }
+}
+
+impl RegexValue for RegexScalarExpression {
+    fn get_value(&self) -> &Regex {
+        &self.value
+    }
+}
+
+impl PartialEq for RegexScalarExpression {
+    fn eq(&self, other: &Self) -> bool {
+        self.query_location == other.query_location && self.value.as_str() == other.value.as_str()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct StringScalarExpression {
     query_location: QueryLocation,
     value: Box<str>,

--- a/rust/experimental/query_engine/expressions/src/value_accessor.rs
+++ b/rust/experimental/query_engine/expressions/src/value_accessor.rs
@@ -1,43 +1,15 @@
-use crate::{IntegerScalarExpression, ScalarExpression, StringScalarExpression};
+use crate::ScalarExpression;
 
 /// Contains the rules used to resolve data from a target
 ///
 /// Notes:
 ///
-/// * Given a target such as `source` and selectors `MapKey('SubItem')`,
-///   `ArrayIndex(0)` evaluation would be equivalent to: `source.SubItem[0]`.
+/// * Given a target such as `source` and selectors `String('SubItem')`,
+///   `Integer(0)` evaluation would be equivalent to: `source.SubItem[0]`.
 /// * An empty set of selectors resolves the initial target.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ValueAccessor {
-    selectors: Vec<ValueSelector>,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum ValueSelector {
-    /// Resolve a value from an array using a static 32bit integer provided
-    /// directly in a query.
-    ///
-    /// Note: Negative values indicate access from the end of the array. For
-    /// example `-1` will select the last item.
-    ArrayIndex(IntegerScalarExpression),
-
-    /// Resolve a value from a map using a static string provided directly in a
-    /// query as the key.
-    ///
-    /// Note: Keys are case-sensitive.
-    MapKey(StringScalarExpression),
-
-    /// Resolve a value using a [`ScalarExpression`].
-    ///
-    /// Notes:
-    /// * If the [`ScalarExpression`] returns an integer an array index
-    ///   operation will be attempted. If the integer value is negative then the
-    ///   array index will be performed from the end of the array.
-    /// * If the [`ScalarExpression`] returns a string a map key operation will
-    ///   be attempted.
-    /// * If any other value type is returned by the [`ScalarExpression`] then
-    ///   no data will be resolved.
-    ScalarExpression(ScalarExpression),
+    selectors: Vec<ScalarExpression>,
 }
 
 impl ValueAccessor {
@@ -47,7 +19,7 @@ impl ValueAccessor {
         }
     }
 
-    pub fn new_with_selectors(selectors: Vec<ValueSelector>) -> ValueAccessor {
+    pub fn new_with_selectors(selectors: Vec<ScalarExpression>) -> ValueAccessor {
         let mut accessor = ValueAccessor::new();
 
         for selector in selectors {
@@ -61,15 +33,15 @@ impl ValueAccessor {
         !self.selectors.is_empty()
     }
 
-    pub fn get_selectors(&self) -> &Vec<ValueSelector> {
+    pub fn get_selectors(&self) -> &Vec<ScalarExpression> {
         &self.selectors
     }
 
-    pub fn insert_selector(&mut self, index: usize, selector: ValueSelector) {
+    pub fn insert_selector(&mut self, index: usize, selector: ScalarExpression) {
         self.selectors.insert(index, selector);
     }
 
-    pub fn push_selector(&mut self, selector: ValueSelector) {
+    pub fn push_selector(&mut self, selector: ScalarExpression) {
         self.selectors.push(selector)
     }
 }

--- a/rust/experimental/query_engine/kql-parser/src/logical_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/logical_expressions.rs
@@ -244,8 +244,11 @@ mod tests {
                 )),
                 ScalarExpression::Source(SourceScalarExpression::new(
                     QueryLocation::new_fake(),
-                    ValueAccessor::new_with_selectors(vec![ValueSelector::MapKey(
-                        StringScalarExpression::new(QueryLocation::new_fake(), "source_path"),
+                    ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                        StaticScalarExpression::String(StringScalarExpression::new(
+                            QueryLocation::new_fake(),
+                            "source_path",
+                        )),
                     )]),
                 )),
             )),
@@ -261,8 +264,11 @@ mod tests {
                 ScalarExpression::Attached(AttachedScalarExpression::new(
                     QueryLocation::new_fake(),
                     "resource",
-                    ValueAccessor::new_with_selectors(vec![ValueSelector::MapKey(
-                        StringScalarExpression::new(QueryLocation::new_fake(), "key"),
+                    ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                        StaticScalarExpression::String(StringScalarExpression::new(
+                            QueryLocation::new_fake(),
+                            "key",
+                        )),
                     )]),
                 )),
             )),
@@ -385,8 +391,11 @@ mod tests {
             "source.name",
             LogicalExpression::Scalar(ScalarExpression::Source(SourceScalarExpression::new(
                 QueryLocation::new_fake(),
-                ValueAccessor::new_with_selectors(vec![ValueSelector::MapKey(
-                    StringScalarExpression::new(QueryLocation::new_fake(), "name"),
+                ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                    StaticScalarExpression::String(StringScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        "name",
+                    )),
                 )]),
             ))),
         );
@@ -397,13 +406,11 @@ mod tests {
                 QueryLocation::new_fake(),
                 "resource",
                 ValueAccessor::new_with_selectors(vec![
-                    ValueSelector::MapKey(StringScalarExpression::new(
-                        QueryLocation::new_fake(),
-                        "attributes",
+                    ScalarExpression::Static(StaticScalarExpression::String(
+                        StringScalarExpression::new(QueryLocation::new_fake(), "attributes"),
                     )),
-                    ValueSelector::MapKey(StringScalarExpression::new(
-                        QueryLocation::new_fake(),
-                        "service.name",
+                    ScalarExpression::Static(StaticScalarExpression::String(
+                        StringScalarExpression::new(QueryLocation::new_fake(), "service.name"),
                     )),
                 ]),
             ))),
@@ -454,8 +461,11 @@ mod tests {
                 QueryLocation::new_fake(),
                 ScalarExpression::Source(SourceScalarExpression::new(
                     QueryLocation::new_fake(),
-                    ValueAccessor::new_with_selectors(vec![ValueSelector::MapKey(
-                        StringScalarExpression::new(QueryLocation::new_fake(), "SeverityText"),
+                    ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                        StaticScalarExpression::String(StringScalarExpression::new(
+                            QueryLocation::new_fake(),
+                            "SeverityText",
+                        )),
                     )]),
                 )),
                 ScalarExpression::Static(StaticScalarExpression::String(
@@ -489,8 +499,11 @@ mod tests {
                 QueryLocation::new_fake(),
                 ScalarExpression::Source(SourceScalarExpression::new(
                     QueryLocation::new_fake(),
-                    ValueAccessor::new_with_selectors(vec![ValueSelector::MapKey(
-                        StringScalarExpression::new(QueryLocation::new_fake(), "SeverityNumber"),
+                    ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                        StaticScalarExpression::String(StringScalarExpression::new(
+                            QueryLocation::new_fake(),
+                            "SeverityNumber",
+                        )),
                     )]),
                 )),
                 ScalarExpression::Static(StaticScalarExpression::Integer(

--- a/rust/experimental/query_engine/kql-parser/src/query_expression.rs
+++ b/rust/experimental/query_engine/kql-parser/src/query_expression.rs
@@ -123,8 +123,11 @@ mod tests {
                         )),
                         MutableValueExpression::Source(SourceScalarExpression::new(
                             QueryLocation::new_fake(),
-                            ValueAccessor::new_with_selectors(vec![ValueSelector::MapKey(
-                                StringScalarExpression::new(QueryLocation::new_fake(), "a"),
+                            ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                                StaticScalarExpression::String(StringScalarExpression::new(
+                                    QueryLocation::new_fake(),
+                                    "a",
+                                )),
                             )]),
                         )),
                     ),
@@ -150,8 +153,11 @@ mod tests {
                             )),
                             MutableValueExpression::Source(SourceScalarExpression::new(
                                 QueryLocation::new_fake(),
-                                ValueAccessor::new_with_selectors(vec![ValueSelector::MapKey(
-                                    StringScalarExpression::new(QueryLocation::new_fake(), "a"),
+                                ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                                    StaticScalarExpression::String(StringScalarExpression::new(
+                                        QueryLocation::new_fake(),
+                                        "a",
+                                    )),
                                 )]),
                             )),
                         ),
@@ -168,13 +174,17 @@ mod tests {
                             MutableValueExpression::Source(SourceScalarExpression::new(
                                 QueryLocation::new_fake(),
                                 ValueAccessor::new_with_selectors(vec![
-                                    ValueSelector::MapKey(StringScalarExpression::new(
-                                        QueryLocation::new_fake(),
-                                        "attributes",
+                                    ScalarExpression::Static(StaticScalarExpression::String(
+                                        StringScalarExpression::new(
+                                            QueryLocation::new_fake(),
+                                            "attributes",
+                                        ),
                                     )),
-                                    ValueSelector::MapKey(StringScalarExpression::new(
-                                        QueryLocation::new_fake(),
-                                        "attr",
+                                    ScalarExpression::Static(StaticScalarExpression::String(
+                                        StringScalarExpression::new(
+                                            QueryLocation::new_fake(),
+                                            "attr",
+                                        ),
                                     )),
                                 ]),
                             )),
@@ -200,8 +210,11 @@ mod tests {
                             )),
                             MutableValueExpression::Source(SourceScalarExpression::new(
                                 QueryLocation::new_fake(),
-                                ValueAccessor::new_with_selectors(vec![ValueSelector::MapKey(
-                                    StringScalarExpression::new(QueryLocation::new_fake(), "a"),
+                                ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                                    StaticScalarExpression::String(StringScalarExpression::new(
+                                        QueryLocation::new_fake(),
+                                        "a",
+                                    )),
                                 )]),
                             )),
                         ),
@@ -217,8 +230,11 @@ mod tests {
                             )),
                             MutableValueExpression::Source(SourceScalarExpression::new(
                                 QueryLocation::new_fake(),
-                                ValueAccessor::new_with_selectors(vec![ValueSelector::MapKey(
-                                    StringScalarExpression::new(QueryLocation::new_fake(), "b"),
+                                ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                                    StaticScalarExpression::String(StringScalarExpression::new(
+                                        QueryLocation::new_fake(),
+                                        "b",
+                                    )),
                                 )]),
                             )),
                         ),

--- a/rust/experimental/query_engine/kql-parser/src/scalar_conditional_function_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_conditional_function_expressions.rs
@@ -90,28 +90,5 @@ mod tests {
                 )),
             )),
         );
-
-        // Note: The inner statements get folded into constants.
-        run_test_success(
-            "iif(1 > 0, iif(true, 'a', 'b'), iff(false, 'c', 'd'))",
-            ScalarExpression::Conditional(ConditionalScalarExpression::new(
-                QueryLocation::new_fake(),
-                LogicalExpression::GreaterThan(GreaterThanLogicalExpression::new(
-                    QueryLocation::new_fake(),
-                    ScalarExpression::Static(StaticScalarExpression::Integer(
-                        IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
-                    )),
-                    ScalarExpression::Static(StaticScalarExpression::Integer(
-                        IntegerScalarExpression::new(QueryLocation::new_fake(), 0),
-                    )),
-                )),
-                ScalarExpression::Static(StaticScalarExpression::String(
-                    StringScalarExpression::new(QueryLocation::new_fake(), "a"),
-                )),
-                ScalarExpression::Static(StaticScalarExpression::String(
-                    StringScalarExpression::new(QueryLocation::new_fake(), "d"),
-                )),
-            )),
-        );
     }
 }

--- a/rust/experimental/query_engine/kql-parser/src/shared_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/shared_expressions.rs
@@ -160,8 +160,11 @@ mod tests {
                 )),
                 MutableValueExpression::Source(SourceScalarExpression::new(
                     QueryLocation::new_fake(),
-                    ValueAccessor::new_with_selectors(vec![ValueSelector::MapKey(
-                        StringScalarExpression::new(QueryLocation::new_fake(), "new_attribute"),
+                    ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                        StaticScalarExpression::String(StringScalarExpression::new(
+                            QueryLocation::new_fake(),
+                            "new_attribute",
+                        )),
                     )]),
                 )),
             )),


### PR DESCRIPTION
## Changes

* Remove constant folding of scalar expressions inside KQL parser
* Introduce regex static value and use that for pattern matching in key lists

## Details

I'm working on running the new `PipelineExpression` in the recordset engine. The constant folding has some issues. It works fine generally but how things fold the query location for the USE of the constant is lost and only the constant definition location is retained. This makes proper diagnostics impossible. Also we _always_ copy the constant. For large constants (maps, arrays, big strings) we probably don't want to make those copies and instead perform a lookup to the constant definition. To address this constant folding really needs to move from KQL Parser into Expressions proper. I'll do that as a follow-up. The big benefit to do that besides fixing the issues is all parsers should be able to benefit from the folding optimizations without having to do any work.

Also refactored selector lists. Where there were dedicated Key/Array variants I simplified to just scalars. For patterns, I introduced Regex normalization. Having the Regex lets engines code a single pathway instead of having to figure out what the string pattern represents and evaluate what is effectively a string without any contract.