### PR TITLE
[query-engine] Introduce PipelineExpressionBuilder

### DIFF
--- a/rust/experimental/query_engine/expressions/src/expression.rs
+++ b/rust/experimental/query_engine/expressions/src/expression.rs
@@ -20,6 +20,9 @@ impl QueryLocation {
         line_number: usize,
         column_number: usize,
     ) -> QueryLocation {
+        assert!(line_number >= 1);
+        assert!(column_number >= 1);
+
         Self {
             start,
             end,

--- a/rust/experimental/query_engine/expressions/src/lib.rs
+++ b/rust/experimental/query_engine/expressions/src/lib.rs
@@ -14,7 +14,7 @@ pub use expression::Expression;
 pub use expression::QueryLocation;
 pub use expression_error::ExpressionError;
 pub use pipeline_expression::PipelineExpression;
-
+pub use pipeline_expression::PipelineExpressionBuilder;
 pub use value_accessor::ValueAccessor;
 
 pub use data_expressions::*;

--- a/rust/experimental/query_engine/expressions/src/pipeline_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/pipeline_expression.rs
@@ -1,40 +1,88 @@
-use crate::{DataExpression, Expression, QueryLocation};
+use crate::{DataExpression, Expression, ExpressionError, QueryLocation};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct PipelineExpression {
+    query: Box<str>,
     query_location: QueryLocation,
     expressions: Vec<DataExpression>,
 }
 
 impl PipelineExpression {
-    pub fn new(query_location: QueryLocation) -> PipelineExpression {
+    pub(crate) fn new(query: &str) -> PipelineExpression {
         Self {
-            query_location,
+            query: query.into(),
+            query_location: QueryLocation::new(0, query.len(), 1, 1),
             expressions: Vec::new(),
         }
     }
 
-    pub fn new_with_expressions(
-        query_location: QueryLocation,
-        expressions: Vec<DataExpression>,
-    ) -> PipelineExpression {
-        Self {
-            query_location,
-            expressions,
-        }
+    pub fn get_query(&self) -> &str {
+        &self.query
+    }
+
+    pub fn get_query_slice(&self, query_location: &QueryLocation) -> &str {
+        let (start, end) = query_location.get_start_and_end_positions();
+
+        &self.query[start..end]
     }
 
     pub fn get_expressions(&self) -> &[DataExpression] {
         &self.expressions
     }
 
-    pub fn push_expression(&mut self, expression: DataExpression) {
+    pub(crate) fn push_expression(&mut self, expression: DataExpression) {
         self.expressions.push(expression);
+    }
+
+    pub(crate) fn optimize(&mut self) -> Result<(), Vec<ExpressionError>> {
+        // todo: Implement constant folding and other optimizations
+        Ok(())
     }
 }
 
 impl Expression for PipelineExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
+    }
+}
+
+pub struct PipelineExpressionBuilder {
+    pipeline: PipelineExpression,
+}
+
+impl PipelineExpressionBuilder {
+    pub fn new(query: &str) -> PipelineExpressionBuilder {
+        PipelineExpressionBuilder::new_with_expressions(query, Vec::new())
+    }
+
+    pub fn new_with_expressions(
+        query: &str,
+        expressions: Vec<DataExpression>,
+    ) -> PipelineExpressionBuilder {
+        let mut s = Self {
+            pipeline: PipelineExpression::new(query),
+        };
+
+        for expression in expressions {
+            s.push_expression(expression);
+        }
+
+        s
+    }
+
+    pub fn push_expression(&mut self, expression: DataExpression) {
+        self.pipeline.push_expression(expression);
+    }
+
+    pub fn build(self) -> Result<PipelineExpression, Vec<ExpressionError>> {
+        let mut p = self.pipeline;
+        p.optimize()?;
+        Ok(p)
+    }
+}
+
+impl AsRef<PipelineExpression> for PipelineExpressionBuilder {
+    fn as_ref(&self) -> &PipelineExpression {
+        &self.pipeline
     }
 }

--- a/rust/experimental/query_engine/kql-parser/src/kql_parser.rs
+++ b/rust/experimental/query_engine/kql-parser/src/kql_parser.rs
@@ -1,6 +1,5 @@
 use data_engine_expressions::*;
 use data_engine_parser_abstractions::*;
-use pest::Parser;
 use pest_derive::Parser;
 
 use crate::query_expression::parse_query;
@@ -9,38 +8,15 @@ use crate::query_expression::parse_query;
 #[grammar = "kql.pest"]
 pub(crate) struct KqlParser;
 
-pub fn parse(query: &str) -> Result<PipelineExpression, ParserError> {
+pub fn parse(query: &str) -> Result<PipelineExpression, Vec<ParserError>> {
     parse_with_options(query, ParserOptions::new())
 }
 
 pub fn parse_with_options(
     query: &str,
     options: ParserOptions,
-) -> Result<PipelineExpression, ParserError> {
-    let mut state = ParserState::new_with_options(query, options);
-
-    let parse_result = KqlParser::parse(Rule::query, query);
-
-    if parse_result.is_err() {
-        let pest_error = parse_result.unwrap_err();
-
-        let (start, end) = match pest_error.location {
-            pest::error::InputLocation::Pos(p) => (0, p),
-            pest::error::InputLocation::Span(s) => s,
-        };
-
-        let (line, column) = match pest_error.line_col {
-            pest::error::LineColLocation::Pos(p) => p,
-            pest::error::LineColLocation::Span(l, _) => l,
-        };
-
-        return Err(ParserError::SyntaxNotSupported(
-            QueryLocation::new(start, end, line, column),
-            pest_error.variant.message().into(),
-        ));
-    }
-
-    parse_query(parse_result.unwrap().next().unwrap(), &mut state)
+) -> Result<PipelineExpression, Vec<ParserError>> {
+    parse_query(query, options)
 }
 
 #[cfg(test)]
@@ -49,6 +25,7 @@ mod tests {
 
     #[test]
     pub fn test_parse() {
+        assert!(parse("a").is_ok());
         assert!(parse("let a = 1").is_err());
         assert!(parse("i | extend a = 1 i | extend b = 2").is_err());
     }

--- a/rust/experimental/query_engine/kql-parser/src/query_expression.rs
+++ b/rust/experimental/query_engine/kql-parser/src/query_expression.rs
@@ -1,117 +1,144 @@
 use data_engine_expressions::*;
 use data_engine_parser_abstractions::*;
-use pest::iterators::Pair;
+use pest::Parser;
 
 use crate::{
-    Rule, shared_expressions::parse_let_expression, tabular_expressions::parse_tabular_expression,
+    KqlParser, Rule, shared_expressions::parse_let_expression,
+    tabular_expressions::parse_tabular_expression,
 };
 
 pub(crate) fn parse_query(
-    query_rule: Pair<Rule>,
-    state: &mut ParserState,
-) -> Result<PipelineExpression, ParserError> {
-    let query_location = to_query_location(&query_rule);
+    query: &str,
+    options: ParserOptions,
+) -> Result<PipelineExpression, Vec<ParserError>> {
+    let mut errors = Vec::new();
 
-    let query_rules = query_rule.into_inner();
+    let mut state = ParserState::new_with_options(query, options);
 
-    let mut pipeline = PipelineExpression::new(query_location);
+    let parse_result = KqlParser::parse(Rule::query, query);
+
+    if parse_result.is_err() {
+        let pest_error = parse_result.unwrap_err();
+
+        let (start, end) = match pest_error.location {
+            pest::error::InputLocation::Pos(p) => (0, p),
+            pest::error::InputLocation::Span(s) => s,
+        };
+
+        let (line, column) = match pest_error.line_col {
+            pest::error::LineColLocation::Pos(p) => p,
+            pest::error::LineColLocation::Span(l, _) => l,
+        };
+
+        errors.push(ParserError::SyntaxNotSupported(
+            QueryLocation::new(start, end, line, column),
+            pest_error.variant.message().into(),
+        ));
+
+        return Err(errors);
+    }
+
+    let query_rules = parse_result.unwrap().next().unwrap().into_inner();
 
     for rule in query_rules {
         match rule.as_rule() {
-            Rule::let_expression => {
-                let let_expression = parse_let_expression(rule, state)?;
+            Rule::let_expression => match parse_let_expression(rule, &state) {
+                Ok(let_expression) => {
+                    let mut validated = false;
 
-                let mut validated = false;
+                    if let TransformExpression::Set(s) = &let_expression {
+                        if let MutableValueExpression::Variable(v) = s.get_destination() {
+                            let name = v.get_name();
 
-                if let TransformExpression::Set(s) = &let_expression {
-                    if let MutableValueExpression::Variable(v) = s.get_destination() {
-                        let name = v.get_name();
-
-                        if let ImmutableValueExpression::Scalar(ScalarExpression::Static(s)) =
-                            s.get_source()
-                        {
-                            state.push_constant(name, s.clone());
-                            validated = true;
+                            if let ImmutableValueExpression::Scalar(ScalarExpression::Static(s)) =
+                                s.get_source()
+                            {
+                                state.push_constant(name, s.clone());
+                                validated = true;
+                            }
                         }
                     }
-                }
 
-                if !validated {
-                    panic!("Unexpected let_expression encountered");
+                    if !validated {
+                        panic!("Unexpected let_expression encountered");
+                    }
                 }
-            }
-            Rule::tabular_expression => {
-                let expressions = parse_tabular_expression(rule, state)?;
-
-                for e in expressions {
-                    pipeline.push_expression(e);
+                Err(e) => errors.push(e),
+            },
+            Rule::tabular_expression => match parse_tabular_expression(rule, &state) {
+                Ok(expressions) => {
+                    for e in expressions {
+                        state.push_expression(e);
+                    }
                 }
-            }
+                Err(e) => errors.push(e),
+            },
             Rule::EOI => {}
             _ => panic!("Unexpected rule in query: {rule}"),
         }
     }
 
-    Ok(pipeline)
+    if !errors.is_empty() {
+        return Err(errors);
+    }
+
+    match state.build() {
+        Ok(p) => Ok(p),
+        Err(e) => {
+            for err in e {
+                errors.push(ParserError::SyntaxError(
+                    err.get_query_location().clone(),
+                    err.to_string(),
+                ));
+            }
+            Err(errors)
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use pest::Parser;
-
-    use crate::KqlParser;
-
     use super::*;
 
     #[test]
     pub fn test_parse_query() {
         let run_test_success = |input: &str, expected: PipelineExpression| {
-            let mut state = ParserState::new(input);
-
-            state.push_variable_name("variable");
-
-            let mut result = KqlParser::parse(Rule::query, input).unwrap();
-
-            let expression = parse_query(result.next().unwrap(), &mut state).unwrap();
+            let expression = parse_query(input, Default::default()).unwrap();
 
             assert_eq!(expected, expression);
         };
 
         let run_test_failure = |input: &str, expected_id: &str, expected_msg: &str| {
-            let mut state = ParserState::new(input);
-
-            state.push_variable_name("variable");
-
-            let mut result = KqlParser::parse(Rule::query, input).unwrap();
-
-            let error = parse_query(result.next().unwrap(), &mut state).unwrap_err();
+            let errors = parse_query(input, Default::default()).unwrap_err();
 
             if let ParserError::QueryLanguageDiagnostic {
                 location: _,
                 diagnostic_id: id,
                 message: msg,
-            } = error
+            } = &errors[0]
             {
-                assert_eq!(expected_id, id);
+                assert_eq!(expected_id, *id);
                 assert_eq!(expected_msg, msg);
             } else {
                 panic!("Expected QueryLanguageDiagnostic");
             }
         };
 
-        run_test_success("", PipelineExpression::new(QueryLocation::new_fake()));
+        run_test_success("", PipelineExpressionBuilder::new("").build().unwrap());
 
         // Note: The let statement becomes an unreferenced constant so the whole
         // expression essentially becomes a no-op.
         run_test_success(
             "let var1 = 1;",
-            PipelineExpression::new(QueryLocation::new_fake()),
+            PipelineExpressionBuilder::new("let var1 = 1;")
+                .build()
+                .unwrap(),
         );
 
         run_test_success(
             "i | extend a = 1",
-            PipelineExpression::new_with_expressions(
-                QueryLocation::new_fake(),
+            PipelineExpressionBuilder::new_with_expressions(
+                "i | extend a = 1",
                 vec![DataExpression::Transform(TransformExpression::Set(
                     SetTransformExpression::new(
                         QueryLocation::new_fake(),
@@ -132,15 +159,17 @@ mod tests {
                         )),
                     ),
                 ))],
-            ),
+            )
+            .build()
+            .unwrap(),
         );
 
         // Note: This test folds the constants and ends up as if it was written:
         // "source | extend a = 1, attributes['attr'] = 1".
         run_test_success(
             "let var1 = 1; let var2 = 'attr'; source | extend a = var1, attributes[var2] = 1;",
-            PipelineExpression::new_with_expressions(
-                QueryLocation::new_fake(),
+            PipelineExpressionBuilder::new_with_expressions(
+                "let var1 = 1; let var2 = 'attr'; source | extend a = var1, attributes[var2] = 1;",
                 vec![
                     DataExpression::Transform(TransformExpression::Set(
                         SetTransformExpression::new(
@@ -191,13 +220,15 @@ mod tests {
                         ),
                     )),
                 ],
-            ),
+            )
+            .build()
+            .unwrap(),
         );
 
         run_test_success(
             "i | extend a = 1; i_other | extend b = 2;",
-            PipelineExpression::new_with_expressions(
-                QueryLocation::new_fake(),
+            PipelineExpressionBuilder::new_with_expressions(
+                "i | extend a = 1; i_other | extend b = 2;",
                 vec![
                     DataExpression::Transform(TransformExpression::Set(
                         SetTransformExpression::new(
@@ -240,7 +271,9 @@ mod tests {
                         ),
                     )),
                 ],
-            ),
+            )
+            .build()
+            .unwrap(),
         );
 
         run_test_failure(

--- a/rust/experimental/query_engine/parser-abstractions/src/parser_state.rs
+++ b/rust/experimental/query_engine/parser-abstractions/src/parser_state.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use data_engine_expressions::{QueryLocation, StaticScalarExpression};
+use data_engine_expressions::*;
 
 pub struct ParserOptions {
     default_source_map_key: Option<Box<str>>,
@@ -38,37 +38,39 @@ impl Default for ParserOptions {
     }
 }
 
-pub struct ParserState<'a> {
-    query: &'a str,
+pub struct ParserState {
     default_source_map_key: Option<Box<str>>,
     attached_data_names: HashSet<Box<str>>,
     variable_names: HashSet<Box<str>>,
     constants: HashMap<Box<str>, StaticScalarExpression>,
+    pipeline_builder: PipelineExpressionBuilder,
 }
 
-impl<'a> ParserState<'a> {
-    pub fn new(query: &'a str) -> ParserState<'a> {
+impl ParserState {
+    pub fn new(query: &str) -> ParserState {
         ParserState::new_with_options(query, ParserOptions::new())
     }
 
-    pub fn new_with_options(query: &'a str, options: ParserOptions) -> ParserState<'a> {
+    pub fn new_with_options(query: &str, options: ParserOptions) -> ParserState {
         Self {
-            query,
             default_source_map_key: options.default_source_map_key,
             attached_data_names: options.attached_data_names,
             variable_names: HashSet::new(),
             constants: HashMap::new(),
+            pipeline_builder: PipelineExpressionBuilder::new(query),
         }
     }
 
     pub fn get_query(&self) -> &str {
-        self.query
+        self.get_pipeline().get_query()
     }
 
     pub fn get_query_slice(&self, query_location: &QueryLocation) -> &str {
-        let (start, end) = query_location.get_start_and_end_positions();
+        self.get_pipeline().get_query_slice(query_location)
+    }
 
-        &self.query[start..end]
+    pub fn get_pipeline(&self) -> &PipelineExpression {
+        self.pipeline_builder.as_ref()
     }
 
     pub fn get_default_source_map_key(&self) -> Option<&str> {
@@ -100,5 +102,13 @@ impl<'a> ParserState<'a> {
 
     pub fn push_constant(&mut self, name: &str, value: StaticScalarExpression) {
         self.constants.insert(name.into(), value);
+    }
+
+    pub fn push_expression(&mut self, expression: DataExpression) {
+        self.pipeline_builder.push_expression(expression)
+    }
+
+    pub fn build(self) -> Result<PipelineExpression, Vec<ExpressionError>> {
+        self.pipeline_builder.build()
     }
 }


### PR DESCRIPTION
## Changes

* Introduce `PipelineExpressionBuilder` and refactor KQL parser to use it

## Details

The main goal here is to introduce `PipelineExpression.optimize()` which is invoked as the last step before the `PipelineExpression` is returned. This gives us a spot to introduce constant folding and other optimizations, validations, etc., when queries are being parsed or when pipelines are manually constructed (if someone wanted to do that).