### PR TITLE
[otap-dataflow] Micro optimizations for the view implementations

### DIFF
--- a/rust/otap-dataflow/crates/otap/src/encoder.rs
+++ b/rust/otap-dataflow/crates/otap/src/encoder.rs
@@ -79,14 +79,14 @@ where
                 // set the resource
                 logs.resource.append_id(Some(curr_resource_id));
                 logs.resource
-                    .append_schema_url(resource_schema_url.as_deref());
+                    .append_schema_url(resource_schema_url);
                 logs.resource
                     .append_dropped_attributes_count(resource_dropped_attrs_count);
 
                 // set the scope
                 logs.scope.append_id(Some(curr_scope_id));
-                logs.scope.append_name(scope_name.as_deref());
-                logs.scope.append_version(scope_version.as_deref());
+                logs.scope.append_name(scope_name);
+                logs.scope.append_version(scope_version);
                 logs.scope
                     .append_dropped_attributes_count(scope_dropped_attributes_count);
 
@@ -94,9 +94,9 @@ where
                 logs.append_observed_time_unix_nano(
                     log_record.observed_time_unix_nano().map(|v| v as i64),
                 );
-                logs.append_schema_url(scope_schema_url.as_deref());
+                logs.append_schema_url(scope_schema_url);
                 logs.append_severity_number(log_record.severity_number());
-                logs.append_severity_text(log_record.severity_text().as_deref());
+                logs.append_severity_text(log_record.severity_text());
                 logs.append_dropped_attributes_count(log_record.dropped_attributes_count());
                 logs.append_flags(log_record.flags());
                 logs.append_trace_id(log_record.trace_id())?;
@@ -106,7 +106,7 @@ where
                     match body.value_type() {
                         ValueType::String => {
                             logs.body
-                                .append_str(&body.as_string().expect("body to be string"));
+                                .append_str(body.as_string().expect("body to be string"));
                         }
                         ValueType::Double => {
                             logs.body
@@ -200,12 +200,12 @@ where
     KV: AttributeView,
 {
     let key = kv.key();
-    attribute_rb_builder.append_key(&key);
+    attribute_rb_builder.append_key(key);
 
     if let Some(val) = kv.value() {
         match val.value_type() {
             ValueType::String => {
-                attribute_rb_builder.append_str(&val.as_string().expect("value to be string"));
+                attribute_rb_builder.append_str(val.as_string().expect("value to be string"));
             }
             ValueType::Int64 => {
                 attribute_rb_builder.append_int(val.as_int64().expect("value to be int64"))

--- a/rust/otap-dataflow/crates/otap/src/encoder.rs
+++ b/rust/otap-dataflow/crates/otap/src/encoder.rs
@@ -78,8 +78,7 @@ where
             for log_record in scope_logs.log_records() {
                 // set the resource
                 logs.resource.append_id(Some(curr_resource_id));
-                logs.resource
-                    .append_schema_url(resource_schema_url);
+                logs.resource.append_schema_url(resource_schema_url);
                 logs.resource
                     .append_dropped_attributes_count(resource_dropped_attrs_count);
 

--- a/rust/otap-dataflow/crates/pdata-views/src/otlp/bytes/logs.rs
+++ b/rust/otap-dataflow/crates/pdata-views/src/otlp/bytes/logs.rs
@@ -4,7 +4,6 @@
 //! This module contains the implementation of the pdata View traits for serialized OTLP protobuf
 //! bytes for messages defined in logs.proto
 
-use std::borrow::Cow;
 use std::cell::Cell;
 use std::num::NonZeroUsize;
 
@@ -196,6 +195,7 @@ impl FieldRanges for LogFieldOffsets {
         }
     }
 
+    #[inline]
     fn get_field_range(&self, field_num: u64) -> Option<(usize, usize)> {
         let range = if field_num == LOG_RECORD_ATTRIBUTES {
             self.first_attribute.get()
@@ -290,6 +290,7 @@ impl LogsDataView for RawLogsData<'_> {
     where
         Self: 'a;
 
+    #[inline]
     fn resources(&self) -> Self::ResourcesIter<'_> {
         ResourceLogsIter {
             buf: self.buf,
@@ -312,6 +313,7 @@ impl ResourceLogsView for RawResourceLogs<'_> {
     where
         Self: 'scp;
 
+    #[inline]
     fn resource(&self) -> Option<Self::Resource<'_>> {
         let slice = self
             .byte_parser
@@ -320,13 +322,15 @@ impl ResourceLogsView for RawResourceLogs<'_> {
         Some(RawResource::new(ProtoBytesParser::new(slice)))
     }
 
+    #[inline]
     fn schema_url(&self) -> Option<crate::views::common::Str<'_>> {
         let slice = self
             .byte_parser
             .advance_to_find_field(RESOURCE_LOGS_SCHEMA_URL)?;
-        std::str::from_utf8(slice).ok().map(Cow::Borrowed)
+        std::str::from_utf8(slice).ok()
     }
 
+    #[inline]
     fn scopes(&self) -> Self::ScopesIter<'_> {
         ScopeLogsIter {
             // field_index: 0,
@@ -354,6 +358,7 @@ impl ScopeLogsView for RawScopeLogs<'_> {
     where
         Self: 'scp;
 
+    #[inline]
     fn log_records(&self) -> Self::LogRecordsIter<'_> {
         LogRecordsIter {
             byte_parser: RepeatedFieldProtoBytesParser::from_byte_parser(
@@ -364,13 +369,15 @@ impl ScopeLogsView for RawScopeLogs<'_> {
         }
     }
 
+    #[inline]
     fn schema_url(&self) -> Option<crate::views::common::Str<'_>> {
         let slice = self
             .byte_parser
             .advance_to_find_field(SCOPE_LOGS_SCHEMA_URL)?;
-        std::str::from_utf8(slice).ok().map(Cow::Borrowed)
+        std::str::from_utf8(slice).ok()
     }
 
+    #[inline]
     fn scope(&self) -> Option<Self::Scope<'_>> {
         let slice = self.byte_parser.advance_to_find_field(SCOPE_LOG_SCOPE)?;
         Some(RawInstrumentationScope::new(ProtoBytesParser::new(slice)))
@@ -393,6 +400,7 @@ impl LogRecordView for RawLogRecord<'_> {
     where
         Self: 'bod;
 
+    #[inline]
     fn attributes(&self) -> Self::AttributeIter<'_> {
         KeyValueIter::new(RepeatedFieldProtoBytesParser::from_byte_parser(
             &self.bytes_parser,
@@ -401,12 +409,14 @@ impl LogRecordView for RawLogRecord<'_> {
         ))
     }
 
+    #[inline]
     fn body(&self) -> Option<Self::Body<'_>> {
         self.bytes_parser
             .advance_to_find_field(LOG_RECORD_BODY)
             .map(RawAnyValue::new)
     }
 
+    #[inline]
     fn dropped_attributes_count(&self) -> u32 {
         match self
             .bytes_parser
@@ -420,12 +430,14 @@ impl LogRecordView for RawLogRecord<'_> {
         }
     }
 
+    #[inline]
     fn flags(&self) -> Option<u32> {
         let slice = self.bytes_parser.advance_to_find_field(LOG_RECORD_FLAGS)?;
         let byte_arr: [u8; 4] = slice.try_into().ok()?;
         Some(u32::from_le_bytes(byte_arr))
     }
 
+    #[inline]
     fn observed_time_unix_nano(&self) -> Option<u64> {
         let slice = self
             .bytes_parser
@@ -434,6 +446,7 @@ impl LogRecordView for RawLogRecord<'_> {
         Some(u64::from_le_bytes(byte_arr))
     }
 
+    #[inline]
     fn severity_number(&self) -> Option<i32> {
         let slice = self
             .bytes_parser
@@ -442,17 +455,20 @@ impl LogRecordView for RawLogRecord<'_> {
         Some(val as i32)
     }
 
+    #[inline]
     fn severity_text(&self) -> Option<crate::views::common::Str<'_>> {
         let slice = self
             .bytes_parser
             .advance_to_find_field(LOG_RECORD_SEVERITY_TEXT)?;
-        std::str::from_utf8(slice).ok().map(Cow::Borrowed)
+        std::str::from_utf8(slice).ok()
     }
 
+    #[inline]
     fn span_id(&self) -> Option<&[u8]> {
         self.bytes_parser.advance_to_find_field(LOG_RECORD_SPAN_ID)
     }
 
+    #[inline]
     fn time_unix_nano(&self) -> Option<u64> {
         let slice = self
             .bytes_parser
@@ -461,6 +477,7 @@ impl LogRecordView for RawLogRecord<'_> {
         Some(u64::from_le_bytes(byte_arr))
     }
 
+    #[inline]
     fn trace_id(&self) -> Option<&[u8]> {
         self.bytes_parser.advance_to_find_field(LOG_RECORD_TRACE_ID)
     }

--- a/rust/otap-dataflow/crates/pdata-views/src/otlp/bytes/resource.rs
+++ b/rust/otap-dataflow/crates/pdata-views/src/otlp/bytes/resource.rs
@@ -48,6 +48,7 @@ impl FieldRanges for ResourceFieldOffsets {
         }
     }
 
+    #[inline]
     fn get_field_range(&self, field_num: u64) -> Option<(usize, usize)> {
         let range = match field_num {
             RESOURCE_ATTRIBUTES => self.first_attribute.get(),
@@ -58,6 +59,7 @@ impl FieldRanges for ResourceFieldOffsets {
         from_option_nonzero_range_to_primitive(range)
     }
 
+    #[inline]
     fn set_field_range(&self, field_num: u64, wire_type: u64, start: usize, end: usize) {
         let range = match to_nonzero_range(start, end) {
             Some(range) => Some(range),
@@ -92,6 +94,7 @@ impl ResourceView for RawResource<'_> {
     where
         Self: 'att;
 
+    #[inline]
     fn attributes(&self) -> Self::AttributesIter<'_> {
         KeyValueIter::new(RepeatedFieldProtoBytesParser::from_byte_parser(
             &self.bytes_parser,
@@ -100,6 +103,7 @@ impl ResourceView for RawResource<'_> {
         ))
     }
 
+    #[inline]
     fn dropped_attributes_count(&self) -> u32 {
         if let Some(slice) = self
             .bytes_parser

--- a/rust/otap-dataflow/crates/pdata-views/src/otlp/proto/common.rs
+++ b/rust/otap-dataflow/crates/pdata-views/src/otlp/proto/common.rs
@@ -4,8 +4,6 @@
 //! This module contains the implementation of the pdata View traits for proto message structs
 //! from otlp common.proto.
 
-use std::borrow::Cow;
-
 use otel_arrow_rust::proto::opentelemetry::common::v1::{
     AnyValue, InstrumentationScope, KeyValue, any_value,
 };
@@ -112,6 +110,7 @@ impl<'a> AnyValueView<'a> for ObjAny<'a> {
     where
         Self: 'att;
 
+    #[inline]
     fn value_type(&self) -> ValueType {
         match self.0.value.as_ref() {
             Some(val) => val.into(),
@@ -119,6 +118,7 @@ impl<'a> AnyValueView<'a> for ObjAny<'a> {
         }
     }
 
+    #[inline]
     fn as_bool(&self) -> Option<bool> {
         self.0.value.as_ref().and_then(|v| match v {
             any_value::Value::BoolValue(b) => Some(*b),
@@ -126,6 +126,7 @@ impl<'a> AnyValueView<'a> for ObjAny<'a> {
         })
     }
 
+    #[inline]
     fn as_bytes(&self) -> Option<&[u8]> {
         self.0.value.as_ref().and_then(|v| match v {
             any_value::Value::BytesValue(b) => Some(b.as_slice()),
@@ -133,6 +134,7 @@ impl<'a> AnyValueView<'a> for ObjAny<'a> {
         })
     }
 
+    #[inline]
     fn as_double(&self) -> Option<f64> {
         self.0.value.as_ref().and_then(|v| match v {
             any_value::Value::DoubleValue(f) => Some(*f),
@@ -140,6 +142,7 @@ impl<'a> AnyValueView<'a> for ObjAny<'a> {
         })
     }
 
+    #[inline]
     fn as_int64(&self) -> Option<i64> {
         self.0.value.as_ref().and_then(|v| match v {
             any_value::Value::IntValue(i) => Some(*i),
@@ -147,13 +150,15 @@ impl<'a> AnyValueView<'a> for ObjAny<'a> {
         })
     }
 
+    #[inline]
     fn as_string(&self) -> Option<Str<'_>> {
         self.0.value.as_ref().and_then(|v| match v {
-            any_value::Value::StringValue(s) => Some(Cow::Borrowed(s.as_str())),
+            any_value::Value::StringValue(s) => Some(s.as_str()),
             _ => None,
         })
     }
 
+    #[inline]
     fn as_array(&self) -> Option<Self::ArrayIter<'_>> {
         if let Some(any_value::Value::ArrayValue(ref vec)) = self.0.value {
             let values = &vec.values;
@@ -163,6 +168,7 @@ impl<'a> AnyValueView<'a> for ObjAny<'a> {
         }
     }
 
+    #[inline]
     fn as_kvlist(&self) -> Option<Self::KeyValueIter<'_>> {
         if let Some(any_value::Value::KvlistValue(ref vec)) = self.0.value {
             let vals = &vec.values;
@@ -193,10 +199,12 @@ impl AttributeView for ObjKeyValue<'_> {
     where
         Self: 'val;
 
+    #[inline]
     fn key(&self) -> Str<'_> {
-        Cow::Borrowed(self.key)
+        self.key
     }
 
+    #[inline]
     fn value(&self) -> Option<Self::Val<'_>> {
         self.val
     }
@@ -212,26 +220,30 @@ impl InstrumentationScopeView for ObjInstrumentationScope<'_> {
     where
         Self: 'b;
 
+    #[inline]
     fn name(&self) -> Option<Str<'_>> {
         if !self.inner.name.is_empty() {
-            Some(Cow::Borrowed(self.inner.name.as_str()))
+            Some(self.inner.name.as_str())
         } else {
             None
         }
     }
 
+    #[inline]
     fn version(&self) -> Option<Str<'_>> {
         if !self.inner.version.is_empty() {
-            Some(Cow::Borrowed(self.inner.version.as_str()))
+            Some(self.inner.version.as_str())
         } else {
             None
         }
     }
 
+    #[inline]
     fn attributes(&self) -> Self::AttributeIter<'_> {
         KeyValueIter::new(self.inner.attributes.iter())
     }
 
+    #[inline]
     fn dropped_attributes_count(&self) -> u32 {
         self.inner.dropped_attributes_count
     }

--- a/rust/otap-dataflow/crates/pdata-views/src/otlp/proto/logs.rs
+++ b/rust/otap-dataflow/crates/pdata-views/src/otlp/proto/logs.rs
@@ -4,8 +4,6 @@
 //! This module contains the implementation of the pdata View traits for proto message structs
 //! from otlp logs.proto.
 
-use std::borrow::Cow;
-
 use otel_arrow_rust::proto::opentelemetry::logs::v1::{
     LogRecord, LogsData, ResourceLogs, ScopeLogs,
 };
@@ -129,22 +127,25 @@ impl ResourceLogsView for ObjResourceLogs<'_> {
     where
         Self: 'b;
 
+    #[inline]
     fn resource(&self) -> Option<Self::Resource<'_>> {
         self.inner.resource.as_ref().map(ObjResource::new)
     }
 
+    #[inline]
     fn scopes(&self) -> Self::ScopesIter<'_> {
         ScopeIter {
             it: self.inner.scope_logs.iter(),
         }
     }
 
+    #[inline]
     fn schema_url(&self) -> Option<Str<'_>> {
         let schema_url = self.inner.schema_url.as_str();
         if schema_url.is_empty() {
             None
         } else {
-            Some(Cow::Borrowed(schema_url))
+            Some(schema_url)
         }
     }
 }
@@ -165,22 +166,25 @@ impl ScopeLogsView for ObjScope<'_> {
     where
         Self: 'b;
 
+    #[inline]
     fn scope(&self) -> Option<Self::Scope<'_>> {
         self.inner.scope.as_ref().map(ObjInstrumentationScope::new)
     }
 
+    #[inline]
     fn log_records(&self) -> Self::LogRecordsIter<'_> {
         LogRecordIter {
             it: self.inner.log_records.iter(),
         }
     }
 
+    #[inline]
     fn schema_url(&self) -> Option<Str<'_>> {
         let schema_url = self.inner.schema_url.as_str();
         if schema_url.is_empty() {
             None
         } else {
-            Some(Cow::Borrowed(schema_url))
+            Some(schema_url)
         }
     }
 }
@@ -201,6 +205,7 @@ impl LogRecordView for ObjLogRecord<'_> {
     where
         Self: 'bod;
 
+    #[inline]
     fn time_unix_nano(&self) -> Option<u64> {
         if self.inner.time_unix_nano != 0 {
             Some(self.inner.time_unix_nano)
@@ -209,6 +214,7 @@ impl LogRecordView for ObjLogRecord<'_> {
         }
     }
 
+    #[inline]
     fn observed_time_unix_nano(&self) -> Option<u64> {
         if self.inner.observed_time_unix_nano != 0 {
             Some(self.inner.observed_time_unix_nano)
@@ -217,6 +223,7 @@ impl LogRecordView for ObjLogRecord<'_> {
         }
     }
 
+    #[inline]
     fn severity_number(&self) -> Option<i32> {
         if self.inner.severity_number != 0 {
             Some(self.inner.severity_number)
@@ -225,26 +232,31 @@ impl LogRecordView for ObjLogRecord<'_> {
         }
     }
 
+    #[inline]
     fn severity_text(&self) -> Option<Str<'_>> {
         if !self.inner.severity_text.is_empty() {
-            Some(Cow::Borrowed(self.inner.severity_text.as_str()))
+            Some(self.inner.severity_text.as_str())
         } else {
             None
         }
     }
 
+    #[inline]
     fn body(&self) -> Option<Self::Body<'_>> {
         self.inner.body.as_ref().map(ObjAny)
     }
 
+    #[inline]
     fn attributes(&self) -> Self::AttributeIter<'_> {
         KeyValueIter::new(self.inner.attributes.iter())
     }
 
+    #[inline]
     fn dropped_attributes_count(&self) -> u32 {
         self.inner.dropped_attributes_count
     }
 
+    #[inline]
     fn flags(&self) -> Option<u32> {
         if self.inner.flags != 0 {
             Some(self.inner.flags)
@@ -253,6 +265,7 @@ impl LogRecordView for ObjLogRecord<'_> {
         }
     }
 
+    #[inline]
     fn trace_id(&self) -> Option<&[u8]> {
         if is_valid_trace_id(&self.inner.trace_id) {
             Some(self.inner.trace_id.as_slice())
@@ -261,6 +274,7 @@ impl LogRecordView for ObjLogRecord<'_> {
         }
     }
 
+    #[inline]
     fn span_id(&self) -> Option<&[u8]> {
         if is_valid_span_id(&self.inner.span_id) {
             Some(self.inner.span_id.as_slice())

--- a/rust/otap-dataflow/crates/pdata-views/src/otlp/proto/resource.rs
+++ b/rust/otap-dataflow/crates/pdata-views/src/otlp/proto/resource.rs
@@ -38,10 +38,12 @@ impl ResourceView for ObjResource<'_> {
     where
         Self: 'b;
 
+    #[inline]
     fn attributes(&self) -> Self::AttributesIter<'_> {
         KeyValueIter::new(self.inner.attributes.iter())
     }
 
+    #[inline]
     fn dropped_attributes_count(&self) -> u32 {
         self.inner.dropped_attributes_count
     }

--- a/rust/otap-dataflow/crates/pdata-views/src/views/common.rs
+++ b/rust/otap-dataflow/crates/pdata-views/src/views/common.rs
@@ -8,11 +8,9 @@
 //! an analogous proto message, but are available as common return types for other View trait
 //! implementations
 
-use std::borrow::Cow;
-
-/// Switch this to `std::borrow::Cow<'src, str>` if/when you want lossy UTF-8.
-/// Note: String::from_utf8_lossy returns Cow<'src, str> which is not zero-cost.
-pub type Str<'src> = Cow<'src, str>;
+/// All current implementations only use borrowed strings from the underlying data.
+/// If lossy UTF-8 support is needed in the future, this can be reverted to `Cow<'src, str>`.
+pub type Str<'src> = &'src str;
 
 /// View for AnyValue
 pub trait AnyValueView<'val> {
@@ -41,9 +39,9 @@ pub trait AnyValueView<'val> {
     fn value_type(&self) -> ValueType;
 
     /* ---------- scalar ---------- */
-    /// Get the value as a boolean. returns None if the value_type is not `String`
+    /// Get the value as an &str. returns None if the value_type is not `String`
     fn as_string(&self) -> Option<Str<'_>>;
-    /// Get the value as a string. returns `None` if value_type is not `Bool`
+    /// Get the value as a boolean. returns `None` if value_type is not `Bool`
     fn as_bool(&self) -> Option<bool>;
     /// Get the value as int64. returns `None` if the value_type is not an `Int64`
     fn as_int64(&self) -> Option<i64>;


### PR DESCRIPTION
## Changes
A few micro-optimizations for the view implementations
- Use `&str` instead of `Cow<'a,str>` 
- Add `#[inline]` to all the methods that are used when encoding data to OTAP
- For the bytes implementation, update the `advance_to_find_field` method to
  - Enter the loop only if the field is not already cached
  - Use a simpler check `field == field_num` instead of calling `get_field_range` to know when to return

I made the first two changes to both the prost and the bytes implementation to have a fair comparison.

For the bytes representation, these changes showed a ~5% improvement in the traversal benchmarks and ~3.5% for the encoding benchmarks.