### PR TITLE
[query-engine] Support constants in expressions

### DIFF
--- a/rust/experimental/query_engine/expressions/src/logical_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/logical_expressions.rs
@@ -1,4 +1,7 @@
-use crate::{Expression, ExpressionError, QueryLocation, ScalarExpression, StaticScalarExpression};
+use crate::{
+    Expression, ExpressionError, PipelineExpression, QueryLocation, ResolvedStaticScalarExpression,
+    ScalarExpression,
+};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum LogicalExpression {
@@ -31,9 +34,16 @@ pub enum LogicalExpression {
 }
 
 impl LogicalExpression {
-    pub fn try_resolve_static(&self) -> Result<Option<StaticScalarExpression>, ExpressionError> {
+    pub fn try_resolve_static<'a, 'b, 'c>(
+        &'a self,
+        pipeline: &'b PipelineExpression,
+    ) -> Result<Option<ResolvedStaticScalarExpression<'c>>, ExpressionError>
+    where
+        'a: 'c,
+        'b: 'c,
+    {
         match self {
-            LogicalExpression::Scalar(s) => s.try_resolve_static(),
+            LogicalExpression::Scalar(s) => s.try_resolve_static(pipeline),
             // todo: Implement static resolution of logicals:
             LogicalExpression::EqualTo(_) => Ok(None),
             LogicalExpression::GreaterThan(_) => Ok(None),

--- a/rust/experimental/query_engine/expressions/src/primitives/value_type.rs
+++ b/rust/experimental/query_engine/expressions/src/primitives/value_type.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ValueType {
     Boolean,
     Integer,

--- a/rust/experimental/query_engine/kql-parser/src/logical_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/logical_expressions.rs
@@ -87,12 +87,9 @@ pub(crate) fn parse_logical_expression(
                     if let ScalarExpression::Logical(l) = scalar {
                         Ok(*l)
                     } else {
-                        let value_type_result = scalar.try_resolve_value_type();
+                        let value_type_result = scalar.try_resolve_value_type(state.get_pipeline());
                         if let Err(e) = value_type_result {
-                            return Err(ParserError::SyntaxError(
-                                e.get_query_location().clone(),
-                                e.to_string(),
-                            ));
+                            return Err(ParserError::from(&e));
                         }
                         if let Some(t) = value_type_result.unwrap()
                             && t != ValueType::Boolean

--- a/rust/experimental/query_engine/parser-abstractions/src/parser_error.rs
+++ b/rust/experimental/query_engine/parser-abstractions/src/parser_error.rs
@@ -1,4 +1,4 @@
-use data_engine_expressions::QueryLocation;
+use data_engine_expressions::{ExpressionError, QueryLocation};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -15,4 +15,10 @@ pub enum ParserError {
         diagnostic_id: &'static str,
         message: String,
     },
+}
+
+impl From<&ExpressionError> for ParserError {
+    fn from(value: &ExpressionError) -> Self {
+        ParserError::SyntaxError(value.get_query_location().clone(), value.to_string())
+    }
 }


### PR DESCRIPTION
Relates to #684

## Changes

* Support constants in expressions

## Details

This solves the issue mentioned on #684 where we previously lost the information about WHERE constants were referenced in the expression tree. Now the tree owns the constants and understands where they are being used.

Note: This PR does not bring back constant folding. Currently referenced constants are always a lookup operation. In a follow-up PR I'll bring back (among other things) constant folding where small constants get copied where they are used (to avoid the lookup cost).