### PR TITLE
[query-engine] Add name API on expression

### DIFF
--- a/rust/experimental/query_engine/expressions/src/data_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/data_expressions.rs
@@ -16,6 +16,13 @@ impl Expression for DataExpression {
             DataExpression::Transform(t) => t.get_query_location(),
         }
     }
+
+    fn get_name(&self) -> &'static str {
+        match self {
+            DataExpression::Discard(_) => "DataExpression(Discard)",
+            DataExpression::Transform(_) => "DataExpression(Transform)",
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -46,5 +53,9 @@ impl DiscardDataExpression {
 impl Expression for DiscardDataExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
+    }
+
+    fn get_name(&self) -> &'static str {
+        "DiscardDataExpression"
     }
 }

--- a/rust/experimental/query_engine/expressions/src/expression.rs
+++ b/rust/experimental/query_engine/expressions/src/expression.rs
@@ -7,6 +7,8 @@ use crate::ExpressionError;
 
 pub trait Expression: Debug {
     fn get_query_location(&self) -> &QueryLocation;
+
+    fn get_name(&self) -> &'static str;
 }
 
 #[derive(Debug, Clone, Eq)]

--- a/rust/experimental/query_engine/expressions/src/logical_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/logical_expressions.rs
@@ -65,6 +65,17 @@ impl Expression for LogicalExpression {
             LogicalExpression::Chain(c) => c.get_query_location(),
         }
     }
+
+    fn get_name(&self) -> &'static str {
+        match self {
+            LogicalExpression::Scalar(_) => "LogicalExpression(Scalar)",
+            LogicalExpression::EqualTo(_) => "LogicalExpression(EqualTo)",
+            LogicalExpression::GreaterThan(_) => "LogicalExpression(GreaterThan)",
+            LogicalExpression::GreaterThanOrEqualTo(_) => "LogicalExpression(GreaterThanOrEqualTo)",
+            LogicalExpression::Not(_) => "LogicalExpression(Not)",
+            LogicalExpression::Chain(_) => "LogicalExpression(Chain)",
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -104,6 +115,10 @@ impl ChainLogicalExpression {
 impl Expression for ChainLogicalExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
+    }
+
+    fn get_name(&self) -> &'static str {
+        "ChainLogicalExpression"
     }
 }
 
@@ -146,6 +161,10 @@ impl Expression for EqualToLogicalExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
     }
+
+    fn get_name(&self) -> &'static str {
+        "EqualToLogicalExpression"
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -180,6 +199,10 @@ impl GreaterThanLogicalExpression {
 impl Expression for GreaterThanLogicalExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
+    }
+
+    fn get_name(&self) -> &'static str {
+        "GreaterThanLogicalExpression"
     }
 }
 
@@ -216,6 +239,10 @@ impl Expression for GreaterThanOrEqualToLogicalExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
     }
+
+    fn get_name(&self) -> &'static str {
+        "GreaterThanOrEqualToLogicalExpression"
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -243,5 +270,9 @@ impl NotLogicalExpression {
 impl Expression for NotLogicalExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
+    }
+
+    fn get_name(&self) -> &'static str {
+        "NotLogicalExpression"
     }
 }

--- a/rust/experimental/query_engine/expressions/src/pipeline_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/pipeline_expression.rs
@@ -65,6 +65,10 @@ impl Expression for PipelineExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
     }
+
+    fn get_name(&self) -> &'static str {
+        "PipelineExpression"
+    }
 }
 
 pub struct PipelineExpressionBuilder {

--- a/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
@@ -91,6 +91,19 @@ impl Expression for ScalarExpression {
             ScalarExpression::Conditional(c) => c.get_query_location(),
         }
     }
+
+    fn get_name(&self) -> &'static str {
+        match self {
+            ScalarExpression::Source(_) => "ScalarExpression(Source)",
+            ScalarExpression::Attached(_) => "ScalarExpression(Attached)",
+            ScalarExpression::Variable(_) => "ScalarExpression(Variable)",
+            ScalarExpression::Static(s) => s.get_name(),
+            ScalarExpression::Negate(_) => "ScalarExpression(Negate)",
+            ScalarExpression::Logical(_) => "ScalarExpression(Logical)",
+            ScalarExpression::Conditional(_) => "ScalarExpression(Conditional)",
+            ScalarExpression::Constant(c) => c.get_name(),
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -140,6 +153,10 @@ impl Expression for SourceScalarExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
     }
+
+    fn get_name(&self) -> &'static str {
+        "SourceScalarExpression"
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -175,6 +192,10 @@ impl Expression for AttachedScalarExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
     }
+
+    fn get_name(&self) -> &'static str {
+        "AttachedScalarExpression"
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -209,6 +230,10 @@ impl VariableScalarExpression {
 impl Expression for VariableScalarExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
+    }
+
+    fn get_name(&self) -> &'static str {
+        "VariableScalarExpression"
     }
 }
 
@@ -283,6 +308,13 @@ impl Expression for ConstantScalarExpression {
             ConstantScalarExpression::Copy(c) => c.get_query_location(),
         }
     }
+
+    fn get_name(&self) -> &'static str {
+        match self {
+            ConstantScalarExpression::Reference(_) => "ConstantScalar(Reference)",
+            ConstantScalarExpression::Copy(_) => "ConstantScalar(Copy)",
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -318,6 +350,10 @@ impl Expression for ReferenceConstantScalarExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
     }
+
+    fn get_name(&self) -> &'static str {
+        "ReferenceConstantScalarExpression"
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -352,6 +388,10 @@ impl CopyConstantScalarExpression {
 impl Expression for CopyConstantScalarExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
+    }
+
+    fn get_name(&self) -> &'static str {
+        "CopyConstantScalarExpression"
     }
 }
 
@@ -426,6 +466,10 @@ impl NegateScalarExpression {
 impl Expression for NegateScalarExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
+    }
+
+    fn get_name(&self) -> &'static str {
+        "NegateScalarExpression"
     }
 }
 
@@ -529,6 +573,10 @@ impl ConditionalScalarExpression {
 impl Expression for ConditionalScalarExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
+    }
+
+    fn get_name(&self) -> &'static str {
+        "ConditionalScalarExpression"
     }
 }
 

--- a/rust/experimental/query_engine/expressions/src/scalars/statics/array_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/statics/array_scalar_expression.rs
@@ -24,6 +24,10 @@ impl Expression for ArrayScalarExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
     }
+
+    fn get_name(&self) -> &'static str {
+        "ArrayScalarExpression"
+    }
 }
 
 impl ArrayValue for ArrayScalarExpression {

--- a/rust/experimental/query_engine/expressions/src/scalars/statics/map_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/statics/map_scalar_expression.rs
@@ -24,6 +24,10 @@ impl Expression for MapScalarExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
     }
+
+    fn get_name(&self) -> &'static str {
+        "MapScalarExpression"
+    }
 }
 
 impl MapValue for MapScalarExpression {

--- a/rust/experimental/query_engine/expressions/src/scalars/statics/static_scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/statics/static_scalar_expressions.rs
@@ -77,6 +77,20 @@ impl Expression for StaticScalarExpression {
             StaticScalarExpression::String(s) => s.get_query_location(),
         }
     }
+
+    fn get_name(&self) -> &'static str {
+        match self {
+            StaticScalarExpression::Array(_) => "StaticScalar(Array)",
+            StaticScalarExpression::Boolean(_) => "StaticScalar(Boolean)",
+            StaticScalarExpression::DateTime(_) => "StaticScalar(DateTime)",
+            StaticScalarExpression::Double(_) => "StaticScalar(Double)",
+            StaticScalarExpression::Integer(_) => "StaticScalar(Integer)",
+            StaticScalarExpression::Map(_) => "StaticScalar(Map)",
+            StaticScalarExpression::Null(_) => "StaticScalar(Null)",
+            StaticScalarExpression::String(_) => "StaticScalar(String)",
+            StaticScalarExpression::Regex(_) => "StaticScalar(Regex)",
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -97,6 +111,10 @@ impl BooleanScalarExpression {
 impl Expression for BooleanScalarExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
+    }
+
+    fn get_name(&self) -> &'static str {
+        "BooleanScalarExpression"
     }
 }
 
@@ -128,6 +146,10 @@ impl Expression for DateTimeScalarExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
     }
+
+    fn get_name(&self) -> &'static str {
+        "DateTimeScalarExpression"
+    }
 }
 
 impl DateTimeValue for DateTimeScalarExpression {
@@ -154,6 +176,10 @@ impl DoubleScalarExpression {
 impl Expression for DoubleScalarExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
+    }
+
+    fn get_name(&self) -> &'static str {
+        "DoubleScalarExpression"
     }
 }
 
@@ -182,6 +208,10 @@ impl Expression for IntegerScalarExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
     }
+
+    fn get_name(&self) -> &'static str {
+        "IntegerScalarExpression"
+    }
 }
 
 impl IntegerValue for IntegerScalarExpression {
@@ -204,6 +234,10 @@ impl NullScalarExpression {
 impl Expression for NullScalarExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
+    }
+
+    fn get_name(&self) -> &'static str {
+        "NullScalarExpression"
     }
 }
 
@@ -229,6 +263,10 @@ impl RegexScalarExpression {
 impl Expression for RegexScalarExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
+    }
+
+    fn get_name(&self) -> &'static str {
+        "RegexScalarExpression"
     }
 }
 
@@ -262,6 +300,10 @@ impl StringScalarExpression {
 impl Expression for StringScalarExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
+    }
+
+    fn get_name(&self) -> &'static str {
+        "StringScalarExpression"
     }
 }
 

--- a/rust/experimental/query_engine/expressions/src/transform_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/transform_expressions.rs
@@ -30,6 +30,15 @@ impl Expression for TransformExpression {
             TransformExpression::RemoveMapKeys(r) => r.get_query_location(),
         }
     }
+
+    fn get_name(&self) -> &'static str {
+        match self {
+            TransformExpression::Set(_) => "Transform(Set)",
+            TransformExpression::Remove(_) => "Transform(Set)",
+            TransformExpression::ReduceMap(r) => r.get_name(),
+            TransformExpression::RemoveMapKeys(r) => r.get_name(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -65,6 +74,10 @@ impl Expression for SetTransformExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
     }
+
+    fn get_name(&self) -> &'static str {
+        "SetTransformExpression"
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -93,6 +106,10 @@ impl Expression for RemoveTransformExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
     }
+
+    fn get_name(&self) -> &'static str {
+        "RemoveTransformExpression"
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -109,6 +126,13 @@ impl Expression for RemoveMapKeysTransformExpression {
         match self {
             RemoveMapKeysTransformExpression::Remove(m) => m.get_query_location(),
             RemoveMapKeysTransformExpression::Retain(m) => m.get_query_location(),
+        }
+    }
+
+    fn get_name(&self) -> &'static str {
+        match self {
+            RemoveMapKeysTransformExpression::Remove(_) => "RemoveMapKeysTransform(Remove)",
+            RemoveMapKeysTransformExpression::Retain(_) => "RemoveMapKeysTransform(Retain)",
         }
     }
 }
@@ -146,6 +170,10 @@ impl Expression for MapKeyListExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
     }
+
+    fn get_name(&self) -> &'static str {
+        "MapKeyListExpression"
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -162,6 +190,13 @@ impl Expression for ReduceMapTransformExpression {
         match self {
             ReduceMapTransformExpression::Remove(m) => m.get_query_location(),
             ReduceMapTransformExpression::Retain(m) => m.get_query_location(),
+        }
+    }
+
+    fn get_name(&self) -> &'static str {
+        match self {
+            ReduceMapTransformExpression::Remove(_) => "ReduceTransform(Remove)",
+            ReduceMapTransformExpression::Retain(_) => "ReduceTransform(Retain)",
         }
     }
 }
@@ -250,5 +285,9 @@ impl MapSelectionExpression {
 impl Expression for MapSelectionExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
+    }
+
+    fn get_name(&self) -> &'static str {
+        "MapSelectionExpression"
     }
 }


### PR DESCRIPTION
## Changes

* Introduces an API for getting the name of an expression

## Details

I'm using this in diagnostic output. Currently looks like this:

```
ln   1: let t = true;
                [Verbose] StaticScalar(Boolean): Constant defined with id '0'
ln   2: source
ln   3:  | where t or false
                      [Verbose] LogicalExpression(Scalar): Evaluation skipped due to logical OR short-circuit
                 [Verbose] ConstantScalar(Reference): Resolved constant with id '0' on line 1 at column 9 as: true
                 [Verbose] LogicalExpression(Scalar): Evaluated as: true
                 [Verbose] LogicalExpression(Chain): Evaluated as: true
           [Verbose] LogicalExpression(Not): Evaluated as: false
           [Verbose] DiscardDataExpression: Record included
```