### PR TITLE
[query-engine] Re-export Parser API in parser crates

### DIFF
--- a/rust/experimental/query_engine/kql-parser/src/lib.rs
+++ b/rust/experimental/query_engine/kql-parser/src/lib.rs
@@ -9,3 +9,8 @@ pub(crate) mod shared_expressions;
 pub(crate) mod tabular_expressions;
 
 pub use kql_parser::*;
+
+// Note: Re-export Parser API surface so users don't need to also depend on
+// parser-abstractions crate just to parse queries.
+pub use data_engine_parser_abstractions::Parser;
+pub use data_engine_parser_abstractions::ParserError;

--- a/rust/experimental/query_engine/ottl-parser/src/lib.rs
+++ b/rust/experimental/query_engine/ottl-parser/src/lib.rs
@@ -4,3 +4,8 @@ pub(crate) mod scalar_primitive_expression;
 
 pub use data_engine_parser_abstractions::parse_standard_bool_literal;
 pub use ottl_parser::*;
+
+// Note: Re-export Parser API surface so users don't need to also depend on
+// parser-abstractions crate just to parse queries.
+pub use data_engine_parser_abstractions::Parser;
+pub use data_engine_parser_abstractions::ParserError;


### PR DESCRIPTION
## Changes

* Re-export `Parser` & `ParserError` in kql and ottl parser crates

## Details

We have this [Parser](https://github.com/open-telemetry/otel-arrow/blob/4f55ba7eb4abfe5f57177d15603df0e86b23f47a/rust/experimental/query_engine/parser-abstractions/src/parser.rs#L7) trait which is the entry point for parsing KQL or OTTL queries.

In order to call these traits users have to bring them into scope which currently means depending on the `parser-abstractions` crate. What this change does is makes them part of the public API in the KQL & OTTL crates so users don't need to worry about `parser-abstractions`.

I feel like this is a good thing to do but I'm also new to Rust 😄 It may be something which gets reverted later but I thought it was worth trying out.