### PR TITLE
Schedule monthly docker digest updates with Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -47,6 +47,15 @@
       ]
     },
     {
+      // update docker digest hashes only once a month
+      // reduces frequency of digest-only updates
+      "groupName": "docker digest updates",
+      "matchUpdateTypes": ["digest"],
+      "schedule": [
+        "before 8am on the first day of the month"
+      ]
+    },
+    {
       // group together all golang package updates
       // note that these changes often cannot be taken as-is
       // need to run genotelarrowcol again manually


### PR DESCRIPTION
Updates Renovate config to reduce the number of Docker Digest PRs we get. Since these don't follow SemVer, Renovate spawns a PR for every push (see #681, #679, #678, #676, #675, #589, etc). It should be fine to group these together on a regular schedule.