### PR TITLE
Re-group Go mod dependency updates after subfolder move

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -62,7 +62,7 @@
       // to properly update collector/cmd/otelarrowcol
       // grouping them together reduces pain of this manual work
       "groupName": "golang module dependencies",
-      "matchFileNames": ["go.mod"],
+      "matchFileNames": ["go/go.mod"],
       "schedule": [
         "before 8am on Monday"
       ]


### PR DESCRIPTION
#574 moved the repository's main go module code into the `go/` subfolder. This change adjusts Renovate config to continue grouping Go dep updates together, the working behavior before the subfolder move.

Realized this was an issue because Renovate opened #712, #713, and #714 which should all be together.