### PR TITLE
[perf] additional performance improvements for OTAP encoding

### DIFF
--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -16,16 +16,17 @@ publish = false
 rust-version = "1.86.0"
 
 [workspace.dependencies]
-arrow = "55"
-arrow-ipc = { version = "55", features=["zstd"] }
+arrow = "55.2"
+arrow-ipc = { version = "55.2", features=["zstd"] }
 ciborium = "0.2.2"
 futures-timer = "3.0"
 object_store = "0.12"
 otel-arrow-rust = { path = "../otel-arrow-rust"}
-parquet = { version = "55", default-features = false, features = ["arrow", "async", "object_store"]}
+parquet = { version = "55.2", default-features = false, features = ["arrow", "async", "object_store"]}
 tempfile = "3"
 thiserror = "2.0.12"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
+serde_cbor = "0.11.2"
 serde_json = { version = "1.0.140" }
 tokio = { version = "1.45.0", features = ["rt", "time", "net", "io-util", "sync", "macros", "rt-multi-thread"] }
 uuid = { version = "1.17.0", features = ["v4"] }

--- a/rust/otap-dataflow/crates/otap/Cargo.toml
+++ b/rust/otap-dataflow/crates/otap/Cargo.toml
@@ -45,6 +45,7 @@ prost = "0.13.5"
 tokio-stream = "0.1.17"
 async-stream = "0.3.6"
 thiserror = { workspace = true }
+serde_cbor = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 linkme = { workspace = true }

--- a/rust/otap-dataflow/crates/otap/src/encoder.rs
+++ b/rust/otap-dataflow/crates/otap/src/encoder.rs
@@ -249,7 +249,7 @@ where
                 }
             }
 
-            logs.scope.append_id_n(Some(curr_scope_id), scope_log_count);
+            logs.scope.append_id_n(curr_scope_id, scope_log_count);
             logs.scope.append_name_n(scope_name, scope_log_count);
             logs.scope.append_version_n(scope_version, scope_log_count);
             logs.scope
@@ -260,11 +260,9 @@ where
         }
 
         logs.resource
-            .append_id_n(Some(curr_resource_id), resource_log_count);
-
+            .append_id_n(curr_resource_id, resource_log_count);
         logs.resource
             .append_schema_url_n(resource_schema_url, resource_log_count);
-
         logs.resource
             .append_dropped_attributes_count_n(resource_dropped_attrs_count, resource_log_count);
     }

--- a/rust/otap-dataflow/crates/otap/src/encoder/cbor.rs
+++ b/rust/otap-dataflow/crates/otap/src/encoder/cbor.rs
@@ -50,7 +50,7 @@ where
     match source.value_type() {
         ValueType::String => {
             let s = source.as_string().expect("expected string");
-            serializer.serialize_str(s.as_ref())
+            serializer.serialize_str(s)
         }
         ValueType::Bool => {
             let b = source.as_bool().expect("expected bool");

--- a/rust/otap-dataflow/crates/otap/src/encoder/cbor.rs
+++ b/rust/otap-dataflow/crates/otap/src/encoder/cbor.rs
@@ -3,22 +3,93 @@
 
 use std::io::Write;
 
-use ciborium::{Value, value::Integer};
 use otap_df_pdata_views::views::common::{AnyValueView, AttributeView, ValueType};
+use serde::ser::{SerializeMap, SerializeSeq, Serializer};
+use serde_cbor::ser::IoWrite;
 
 use crate::encoder::error::Result;
 
-/// serialize the passed `AnyValue` view as bytes in cbor representation
+/// Adapter for serializing AnyValueView using Serde
+struct AnyValueSerializerWrapper<T>(pub T);
+
+impl<'a, T> serde::Serialize for AnyValueSerializerWrapper<T>
+where
+    T: AnyValueView<'a> + 'a,
+{
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serialize_any_value::<T, S>(&self.0, serializer)
+    }
+}
+
 pub fn serialize_any_values<'a, I, T, W>(source: I, writer: W) -> Result<()>
 where
     I: Iterator<Item = T>,
     T: AnyValueView<'a> + 'a,
     W: Write,
 {
-    let value = Value::Array(source.map(|val| cbor_value_from_any_value(&val)).collect());
-    ciborium::into_writer(&value, writer)?;
+    let mut serializer = serde_cbor::Serializer::new(IoWrite::new(writer));
+    let mut seq = serializer.serialize_seq(None)?;
+
+    for val in source {
+        seq.serialize_element(&AnyValueSerializerWrapper(val))?;
+    }
+    SerializeSeq::end(seq)?;
 
     Ok(())
+}
+
+/// serialize the passed `AnyValue` view as bytes in cbor representation
+fn serialize_any_value<'a, T, S>(source: &T, serializer: S) -> std::result::Result<S::Ok, S::Error>
+where
+    T: AnyValueView<'a> + 'a,
+    S: Serializer,
+{
+    match source.value_type() {
+        ValueType::String => {
+            let s = source.as_string().expect("expected string");
+            serializer.serialize_str(s.as_ref())
+        }
+        ValueType::Bool => {
+            let b = source.as_bool().expect("expected bool");
+            serializer.serialize_bool(b)
+        }
+        ValueType::Int64 => {
+            let i = source.as_int64().expect("expected int64");
+            serializer.serialize_i64(i)
+        }
+        ValueType::Double => {
+            let f = source.as_double().expect("expected f64");
+            serializer.serialize_f64(f)
+        }
+        ValueType::Bytes => {
+            let b = source.as_bytes().expect("expected bytes");
+            serializer.serialize_bytes(b)
+        }
+        ValueType::Empty => serializer.serialize_none(),
+        ValueType::Array => {
+            let children = source.as_array().expect("expected array");
+            let mut seq = serializer.serialize_seq(None)?;
+            for child in children {
+                seq.serialize_element(&AnyValueSerializerWrapper(child))?;
+            }
+            seq.end()
+        }
+        ValueType::KeyValueList => {
+            let kvlist = source.as_kvlist().expect("expected kvlist");
+            let mut map = serializer.serialize_map(None)?;
+            for kv in kvlist {
+                let key = kv.key();
+                match kv.value() {
+                    Some(v) => map.serialize_entry(&key, &AnyValueSerializerWrapper(v))?,
+                    None => map.serialize_entry(&key, &Option::<()>::None)?,
+                }
+            }
+            map.end()
+        }
+    }
 }
 
 /// serialize the passed list of key values as bytes in cbor representation
@@ -28,57 +99,18 @@ where
     T: AttributeView,
     W: Write,
 {
-    let value = cbor_value_from_kvlist(source);
-    ciborium::into_writer(&value, writer)?;
+    let mut serializer = serde_cbor::Serializer::new(IoWrite::new(writer));
+    let mut map = serializer.serialize_map(None)?;
+    for kv in source {
+        let key = kv.key();
+        match kv.value() {
+            Some(v) => map.serialize_entry(&key, &AnyValueSerializerWrapper(v))?,
+            None => map.serialize_entry(&key, &Option::<()>::None)?,
+        }
+    }
+    SerializeMap::end(map)?;
 
     Ok(())
-}
-
-/// convert the any value to cbor `Value`
-fn cbor_value_from_any_value<'a, T>(source: &T) -> Value
-where
-    T: AnyValueView<'a>,
-{
-    match source.value_type() {
-        ValueType::String => Value::Text(source.as_string().expect("body is string").to_string()),
-        ValueType::Bool => Value::Bool(source.as_bool().expect("body is bool")),
-        ValueType::Int64 => Value::Integer(Integer::from(source.as_int64().expect("body is int"))),
-        ValueType::Double => Value::Float(source.as_double().expect("body is float")),
-        ValueType::Bytes => Value::Bytes(source.as_bytes().expect("body is bytes").to_vec()),
-        ValueType::Array => {
-            let children = source
-                .as_array()
-                .expect("body is array")
-                .map(|val| cbor_value_from_any_value(&val))
-                .collect();
-            Value::Array(children)
-        }
-        ValueType::KeyValueList => {
-            cbor_value_from_kvlist(source.as_kvlist().expect("body is kvlist"))
-        }
-        ValueType::Empty => Value::Null,
-    }
-}
-
-/// convert the key-value pairs into cbor `Value`
-fn cbor_value_from_kvlist<I, T>(source: I) -> Value
-where
-    I: Iterator<Item = T>,
-    T: AttributeView,
-{
-    let children = source
-        .map(|kv| {
-            (
-                Value::Text(kv.key().to_string()),
-                match kv.value() {
-                    None => Value::Null,
-                    Some(val) => cbor_value_from_any_value(&val),
-                },
-            )
-        })
-        .collect();
-
-    Value::Map(children)
 }
 
 #[cfg(test)]

--- a/rust/otap-dataflow/crates/otap/src/encoder/error.rs
+++ b/rust/otap-dataflow/crates/otap/src/encoder/error.rs
@@ -24,3 +24,11 @@ impl From<ciborium::ser::Error<std::io::Error>> for Error {
         }
     }
 }
+
+impl From<serde_cbor::Error> for Error {
+    fn from(e: serde_cbor::Error) -> Self {
+        Self::CborError {
+            error: format!("{e}"),
+        }
+    }
+}

--- a/rust/otap-dataflow/deny.toml
+++ b/rust/otap-dataflow/deny.toml
@@ -74,7 +74,8 @@ ignore = [
     #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
-    { id="RUSTSEC-2024-0436", reason="unmaintained `paste` crate is a dependency of parquet"}
+    { id="RUSTSEC-2024-0436", reason="unmaintained `paste` crate is a dependency of parquet"},
+    { id="RUSTSEC-2021-0127", reason="`serde_cbor` is archived, but current implementation meets needs" }
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.

--- a/rust/otel-arrow-rust/Cargo.toml
+++ b/rust/otel-arrow-rust/Cargo.toml
@@ -22,8 +22,8 @@ trace = []
 derive = []
 
 [dependencies]
-arrow = "55"
-arrow-ipc = { version = "55", features = ["zstd"] }
+arrow = "55.2"
+arrow-ipc = { version = "55.2", features = ["zstd"] }
 ciborium = "0.2.2"
 lazy_static = "1.5"
 num_enum = "0.7"

--- a/rust/otel-arrow-rust/src/encode/record/array.rs
+++ b/rust/otel-arrow-rust/src/encode/record/array.rs
@@ -25,6 +25,7 @@ use arrow::datatypes::{
     TimestampNanosecondType, UInt8Type, UInt16Type, UInt32Type, UInt64Type,
 };
 use arrow::error::ArrowError;
+use paste::paste;
 
 use crate::arrays::NullableArrayAccessor;
 use crate::encode::record::array::dictionary::{
@@ -76,6 +77,9 @@ pub trait ArrayAppend: ArrayAppendNulls {
     type Native;
 
     fn append_value(&mut self, value: &Self::Native);
+
+    /// Append the value to the array builder `n` times
+    fn append_values(&mut self, value: &Self::Native, n: usize);
 }
 
 /// this trait implementation called by adaptive array builders on the base array builders to
@@ -107,6 +111,9 @@ pub trait ArrayAppendNulls {
 pub trait ArrayAppendStr {
     /// Append a value of type str to the builder
     fn append_str(&mut self, value: &str);
+
+    /// Append a value of type str to the builder `n` times
+    fn append_str_n(&mut self, value: &str, n: usize);
 }
 
 /// this trait can be implemented by types that can receive a value to append as a type of &[T].
@@ -119,6 +126,9 @@ pub trait ArrayAppendSlice {
     /// append a slice of T to the builder. Note that this does not append an individual
     /// element for each value in the slice, it appends the slice as a single row
     fn append_slice(&mut self, val: &[Self::Native]);
+
+    /// append the slice to the builder `n` times
+    fn append_slice_n(&mut self, val: &[Self::Native], n: usize);
 }
 
 /// Checked variant of ArrayAppendSlice for values that can return an error
@@ -296,10 +306,11 @@ where
     TD8: ArrayAppendNulls,
     TD16: ArrayAppendNulls,
 {
+    #[inline(always)]
     fn append_null(&mut self) {
         match &mut self.inner {
-            InnerBuilder::Native(builder) => builder.append_null(),
             InnerBuilder::Dictionary(builder) => builder.append_null(),
+            InnerBuilder::Native(builder) => builder.append_null(),
             InnerBuilder::Uninitialized(prefix) => prefix.append_null(),
         }
     }
@@ -313,145 +324,90 @@ where
     }
 }
 
-impl<T, TArgs, TN, TD8, TD16> AdaptiveArrayBuilder<T, TArgs, TN, TD8, TD16>
-where
-    T: Clone + PartialEq,
-    TArgs: Clone,
-    TN: ArrayBuilderConstructor<Args = TArgs> + ArrayAppendNulls + ArrayAppend<Native = T>,
-    TD8: ArrayBuilderConstructor<Args = TArgs>
-        + ArrayAppendNulls
-        + ConvertToNativeHelper
-        + DictionaryArrayAppend<Native = T>
-        + DictionaryBuilder<UInt8Type>
-        + UpdateDictionaryIndexInto<TD16>,
-    <TD8 as ConvertToNativeHelper>::Accessor: NullableArrayAccessor<Native = T> + 'static,
-    TD16: ArrayBuilderConstructor<Args = TArgs>
-        + ArrayAppendNulls
-        + ConvertToNativeHelper
-        + DictionaryArrayAppend<Native = T>
-        + DictionaryBuilder<UInt16Type>,
-    <TD16 as ConvertToNativeHelper>::Accessor: NullableArrayAccessor<Native = T> + 'static,
-{
-    // generic function to handle doing an append and upgrading the array. There are some types
-    // that have an optimized append mechanism, for example to avoid cloning str and slice so
-    // we try to use the optimized append functions here while having one generic function that
-    // contains logic for how/when to upgrade the inner builder
-    fn handle_append<FIsDefault, FNative, FDict, FRetry>(
-        &mut self,
-        is_default: FIsDefault,
-        default_value: &Option<T>,
-        mut append_native_fn: FNative,
-        mut append_dict_fn: FDict,
-        retry_append: FRetry,
-    ) where
-        FIsDefault: FnOnce() -> bool,
-        FNative: FnMut(&mut TN),
-        FDict: FnMut(
-            &mut AdaptiveDictionaryBuilder<TD8, TD16>,
-        ) -> Result<usize, DictionaryBuilderError>,
-        FRetry: FnOnce(&mut Self),
-    {
-        match &mut self.inner {
+// general macro  to handle doing an append and upgrading the array. There are some types
+// that have an optimized append mechanism, for example to avoid cloning str and slice so
+// we try to use the optimized append functions here while having one generic function that
+// contains logic for how/when to upgrade the inner builder
+macro_rules! handle_append {
+(
+        $self:ident,
+        $method:ident ( $($arg:expr),* ),
+        default_check = $default_check:expr,
+        retry = $retry:block
+    ) => {
+        match &mut $self.inner {
             InnerBuilder::Native(native_builder) => {
-                append_native_fn(native_builder);
+                native_builder.$method($($arg),*);
             }
             InnerBuilder::Dictionary(dictionary_builder) => {
-                match append_dict_fn(dictionary_builder) {
+                match dictionary_builder.$method($($arg),*) {
                     Ok(_) => {}
                     Err(DictionaryBuilderError::DictOverflow {}) => {
-                        let mut native = TN::new(self.inner_args.clone());
+                        let mut native = TN::new($self.inner_args.clone());
                         dictionary_builder.to_native(&mut native);
-                        self.inner = InnerBuilder::Native(native);
-                        retry_append(self);
+                        $self.inner = InnerBuilder::Native(native);
+                        $retry
                     }
                 }
             }
             InnerBuilder::Uninitialized(prefix) => {
-                if is_default() {
+                if $default_check {
                     prefix.append_value();
                 } else {
-                    let mut prefix = self.initialize_inner().expect("can get prefix");
-                    prefix.init_builder(self, default_value.clone());
-                    retry_append(self);
+                    let mut prefix = $self.initialize_inner().expect("can get prefix");
+                    prefix.init_builder($self, $self.default_value.clone());
+                    $retry
                 }
             }
         }
-    }
+    };
 }
 
-impl<T, TArgs, TN, TD8, TD16> AdaptiveArrayBuilder<T, TArgs, TN, TD8, TD16>
-where
-    T: Clone + PartialEq,
-    TArgs: Clone,
-    TN: ArrayBuilderConstructor<Args = TArgs> + ArrayAppendNulls + CheckedArrayAppend<Native = T>,
-    TD8: ArrayBuilderConstructor<Args = TArgs>
-        + ArrayAppendNulls
-        + ConvertToNativeHelper
-        + CheckedDictionaryArrayAppend<Native = T>
-        + DictionaryBuilder<UInt8Type>
-        + UpdateDictionaryIndexInto<TD16>,
-    <TD8 as ConvertToNativeHelper>::Accessor: NullableArrayAccessor<Native = T> + 'static,
-    TD16: ArrayBuilderConstructor<Args = TArgs>
-        + ArrayAppendNulls
-        + ConvertToNativeHelper
-        + CheckedDictionaryArrayAppend<Native = T>
-        + DictionaryBuilder<UInt16Type>,
-    <TD16 as ConvertToNativeHelper>::Accessor: NullableArrayAccessor<Native = T> + 'static,
-{
-    // generic function to handle doing an append and upgrading the array. There are some types
-    // that have an optimized append mechanism, for example to avoid cloning str and slice so
-    // we try to use the optimized append functions here while having one generic function that
-    // contains logic for how/when to upgrade the inner builder
-    fn handle_append_checked<FIsDefault, FNative, FDict, FRetry>(
-        &mut self,
-        is_default: FIsDefault,
-        default_value: &Option<T>,
-        mut append_native_fn: FNative,
-        mut append_dict_fn: FDict,
-        retry_append: FRetry,
-    ) -> Result<(), ArrowError>
-    where
-        FIsDefault: FnOnce() -> bool,
-        FNative: FnMut(&mut TN) -> Result<(), ArrowError>,
-        FDict: FnMut(
-            &mut AdaptiveDictionaryBuilder<TD8, TD16>,
-        ) -> Result<usize, checked::DictionaryBuilderError>,
-        FRetry: FnOnce(&mut Self) -> Result<(), ArrowError>,
-    {
-        match &mut self.inner {
-            InnerBuilder::Native(native_builder) => append_native_fn(native_builder),
-            InnerBuilder::Dictionary(dictionary_builder) => {
-                match append_dict_fn(dictionary_builder) {
-                    Ok(_) => {
-                        // append succeeded
-                        Ok(())
-                    }
-
-                    Err(checked::DictionaryBuilderError::DictOverflow {}) => {
-                        let mut native = TN::new(self.inner_args.clone());
-                        dictionary_builder.to_native_checked(&mut native)?;
-                        self.inner = InnerBuilder::Native(native);
-                        retry_append(self)
-                    }
-                    Err(checked::DictionaryBuilderError::CheckedBuilderError {
-                        source: arrow_error,
-                    }) => Err(arrow_error),
+macro_rules! handle_append_checked {
+    (
+        $self:ident,
+        $method:ident ( $($arg:expr),* ),
+        default_check = $default_check:expr,
+        retry = $retry:block
+    ) => {
+        paste! {
+            match &mut $self.inner {
+                InnerBuilder::Native(native_builder) => {
+                    native_builder.$method($($arg),*)
                 }
-            }
-            InnerBuilder::Uninitialized(prefix) => {
-                if is_default() {
-                    prefix.append_value();
-                    Ok(())
-                } else {
-                    // safety: initialize_inner will return the prefix if the inner variant is
-                    // `Uninitialized` which we've checked in the match here
-                    let mut prefix = self.initialize_inner().expect("can get prefix");
-                    prefix.init_builder_checked(self, default_value.clone())?;
-                    retry_append(self)
+                InnerBuilder::Dictionary(dictionary_builder) => {
+                    match dictionary_builder.[<$method _checked>]($($arg),*) {
+                        Ok(_) => {
+                            // append succeeded
+                            Ok(())
+                        }
+
+                        Err(checked::DictionaryBuilderError::DictOverflow {}) => {
+                            let mut native = TN::new($self.inner_args.clone());
+                            dictionary_builder.to_native_checked(&mut native)?;
+                            $self.inner = InnerBuilder::Native(native);
+                            $retry
+                        }
+                        Err(checked::DictionaryBuilderError::CheckedBuilderError {
+                            source: arrow_error,
+                        }) => Err(arrow_error),
+                    }
+                }
+                InnerBuilder::Uninitialized(prefix) => {
+                    if $default_check {
+                        prefix.append_value();
+                        Ok(())
+                    } else {
+                        // safety: initialize_inner will return the prefix if the inner variant is
+                        // `Uninitialized` which we've checked in the match here
+                        let mut prefix = $self.initialize_inner().expect("can get prefix");
+                        prefix.init_builder_checked($self, $self.default_value.clone())?;
+                        $retry
+                    }
                 }
             }
         }
-    }
+    };
 }
 
 impl<T, TArgs, TN, TD8, TD16> ArrayAppend for AdaptiveArrayBuilder<T, TArgs, TN, TD8, TD16>
@@ -477,20 +433,21 @@ where
 
     /// Append a value to the underlying builder
     fn append_value(&mut self, value: &T) {
-        // temporarily move the value of default_value to avoid borrowing self as mut and non-mut
-        // at the same time
-        let default_value = std::mem::take(&mut self.default_value);
-        let is_default = || Self::is_default_value(&default_value, value);
-        self.handle_append(
-            is_default,
-            &default_value,
-            |native| native.append_value(value),
-            |dict| dict.append_value(value),
-            |me| me.append_value(value),
+        handle_append!(
+            self,
+            append_value(value),
+            default_check = Self::is_default_value(&self.default_value, value),
+            retry = { self.append_value(value) }
         );
+    }
 
-        // restore the default value
-        self.default_value = default_value;
+    fn append_values(&mut self, value: &Self::Native, n: usize) {
+        handle_append!(
+            self,
+            append_values(value, n),
+            default_check = Self::is_default_value(&self.default_value, value),
+            retry = { self.append_values(value, n) }
+        );
     }
 }
 
@@ -518,35 +475,21 @@ where
     <TD16 as ConvertToNativeHelper>::Accessor: NullableArrayAccessor<Native = String> + 'static,
 {
     fn append_str(&mut self, value: &str) {
-        // the logic is duplicated here and in handle_append, but it turns out having the duplicated
-        // logic is a good performance gain and because appending strings is so common (e.g. this
-        // is called for all attr keys), it's worth it to have the code duplicated.
+        handle_append!(
+            self,
+            append_str(value),
+            default_check = Self::is_default_value(&self.default_value, &value),
+            retry = { self.append_str(value) }
+        );
+    }
 
-        match &mut self.inner {
-            InnerBuilder::Native(native_builder) => {
-                native_builder.append_str(value);
-            }
-            InnerBuilder::Dictionary(dictionary_builder) => {
-                match dictionary_builder.append_str(value) {
-                    Ok(_) => {}
-                    Err(DictionaryBuilderError::DictOverflow {}) => {
-                        let mut native = TN::new(self.inner_args.clone());
-                        dictionary_builder.to_native(&mut native);
-                        self.inner = InnerBuilder::Native(native);
-                        self.append_str(value); // retry
-                    }
-                }
-            }
-            InnerBuilder::Uninitialized(prefix) => {
-                if Self::is_default_value(&self.default_value, &value) {
-                    prefix.append_value();
-                } else {
-                    let mut prefix = self.initialize_inner().expect("can get prefix");
-                    prefix.init_builder(self, self.default_value.clone());
-                    self.append_str(value); // retry
-                }
-            }
-        }
+    fn append_str_n(&mut self, value: &str, n: usize) {
+        handle_append!(
+            self,
+            append_str_n(value, n),
+            default_check = Self::is_default_value(&self.default_value, &value),
+            retry = { self.append_str_n(value, n) }
+        );
     }
 }
 
@@ -578,19 +521,21 @@ where
     type Native = T;
 
     fn append_slice(&mut self, value: &[Self::Native]) {
-        // temporarily move the value of default_value to avoid borrowing self as mut and non-mut
-        // at the same time
-        let default_value = std::mem::take(&mut self.default_value);
-        let is_default = || Self::is_default_value(&default_value, &value);
-        self.handle_append(
-            is_default,
-            &default_value,
-            |native| native.append_slice(value),
-            |dict| dict.append_slice(value),
-            |me| me.append_slice(value),
-        );
-        // restore value of default value
-        self.default_value = default_value
+        handle_append!(
+            self,
+            append_slice(value),
+            default_check = Self::is_default_value(&self.default_value, &value),
+            retry = { self.append_slice(value) }
+        )
+    }
+
+    fn append_slice_n(&mut self, value: &[Self::Native], n: usize) {
+        handle_append!(
+            self,
+            append_slice_n(value, n),
+            default_check = Self::is_default_value(&self.default_value, &value),
+            retry = { self.append_slice_n(value, n) }
+        )
     }
 }
 
@@ -618,20 +563,12 @@ where
     /// Try to append a value to the underlying builder. This method may return an error if
     /// the value is not valid.
     fn append_value(&mut self, value: &T) -> Result<(), ArrowError> {
-        // temporarily move the value of default_value to avoid borrowing self as mut and non-mut
-        // at the same time
-        let default_value = std::mem::take(&mut self.default_value);
-        let is_default = || Self::is_default_value(&default_value, value);
-        let result = self.handle_append_checked(
-            is_default,
-            &default_value,
-            |native| native.append_value(value),
-            |dict| dict.append_value_checked(value),
-            |me| me.append_value(value),
+        let result = handle_append_checked!(
+            self,
+            append_value(value),
+            default_check = Self::is_default_value(&self.default_value, value),
+            retry = { self.append_value(value) }
         );
-
-        // restore the default value
-        self.default_value = default_value;
 
         result
     }
@@ -667,20 +604,12 @@ where
     /// Try to append a value to the underlying builder. This method may return an error if
     /// the value is not valid
     fn append_slice(&mut self, value: &[Self::Native]) -> Result<(), ArrowError> {
-        // temporarily move the value of default_value to avoid borrowing self as mut and non-mut
-        // at the same time
-        let default_value = std::mem::take(&mut self.default_value);
-        let is_default = || Self::is_default_value(&default_value, &value);
-        let result = self.handle_append_checked(
-            is_default,
-            &default_value,
-            |native| native.append_slice(value),
-            |dict| dict.append_slice_checked(value),
-            |me| me.append_slice(value),
+        let result = handle_append_checked!(
+            self,
+            append_slice(value),
+            default_check = Self::is_default_value(&self.default_value, &value),
+            retry = { self.append_slice(value) }
         );
-
-        // restore the default value
-        self.default_value = default_value;
 
         result
     }
@@ -892,7 +821,7 @@ pub mod test {
         builder.append_null();
         builder.append_value(&values[0]);
         builder.append_nulls(2);
-        builder.append_value(&values[1]);
+        builder.append_values(&values[1], 2);
 
         let result = builder.finish().unwrap();
         assert_eq!(
@@ -902,7 +831,7 @@ pub mod test {
                 Box::new(expected_data_type.clone())
             )
         );
-        assert_eq!(result.len(), 8);
+        assert_eq!(result.len(), 9);
 
         let dict_array = result
             .as_any()
@@ -919,7 +848,8 @@ pub mod test {
                 Some(0),
                 None,
                 None,
-                Some(1)
+                Some(1),
+                Some(1),
             ])
         );
         let dict_values = dict_array
@@ -941,9 +871,9 @@ pub mod test {
         builder.append_null();
         builder.append_value(&values[1]);
         builder.append_nulls(2);
-        builder.append_value(&values[1]);
+        builder.append_values(&values[1], 2);
         let result = builder.finish().unwrap();
-        assert_eq!(result.len(), 7);
+        assert_eq!(result.len(), 8);
         let array = result
             .as_any()
             .downcast_ref::<<TD8 as ConvertToNativeHelper>::Accessor>()
@@ -955,6 +885,7 @@ pub mod test {
         assert!(array.value_at(4).is_none());
         assert!(array.value_at(5).is_none());
         assert_eq!(array.value_at(6).unwrap(), values[1]);
+        assert_eq!(array.value_at(7).unwrap(), values[1]);
 
         // expect that when dictionary overflow happens, we get the native builder
         let mut builder = array_builder_factory(ArrayOptions {
@@ -1078,6 +1009,7 @@ pub mod test {
         builder.append_null();
         builder.append_str("foo");
         builder.append_str("baz");
+        builder.append_str_n("bar", 2);
         builder.append_nulls(2);
 
         let result = builder.finish().unwrap();
@@ -1085,7 +1017,7 @@ pub mod test {
             result.data_type(),
             &DataType::Dictionary(Box::new(DataType::UInt8), Box::new(DataType::Utf8))
         );
-        assert_eq!(result.len(), 7);
+        assert_eq!(result.len(), 9);
 
         let dict_array = result
             .as_any()
@@ -1094,7 +1026,17 @@ pub mod test {
         let dict_keys = dict_array.keys();
         assert_eq!(
             dict_keys,
-            &UInt8Array::from_iter(vec![Some(0), Some(1), None, Some(0), Some(2), None, None])
+            &UInt8Array::from_iter(vec![
+                Some(0),
+                Some(1),
+                None,
+                Some(0),
+                Some(2),
+                Some(1),
+                Some(1),
+                None,
+                None
+            ])
         );
         let dict_values = dict_array
             .values()
@@ -1164,6 +1106,7 @@ pub mod test {
         builder.append_null();
         builder.append_slice(b"foo");
         builder.append_slice(b"baz");
+        builder.append_slice_n(b"bar", 2);
         builder.append_nulls(2);
 
         let result = builder.finish().unwrap();
@@ -1171,7 +1114,7 @@ pub mod test {
             result.data_type(),
             &DataType::Dictionary(Box::new(DataType::UInt8), Box::new(DataType::Binary))
         );
-        assert_eq!(result.len(), 7);
+        assert_eq!(result.len(), 9);
 
         let dict_array = result
             .as_any()
@@ -1180,7 +1123,17 @@ pub mod test {
         let dict_keys = dict_array.keys();
         assert_eq!(
             dict_keys,
-            &UInt8Array::from_iter(vec![Some(0), Some(1), None, Some(0), Some(2), None, None])
+            &UInt8Array::from_iter(vec![
+                Some(0),
+                Some(1),
+                None,
+                Some(0),
+                Some(2),
+                Some(1),
+                Some(1),
+                None,
+                None
+            ])
         );
         let dict_values = dict_array
             .values()

--- a/rust/otel-arrow-rust/src/encode/record/array.rs
+++ b/rust/otel-arrow-rust/src/encode/record/array.rs
@@ -79,7 +79,7 @@ pub trait ArrayAppend: ArrayAppendNulls {
     fn append_value(&mut self, value: &Self::Native);
 
     /// Append the value to the array builder `n` times
-    fn append_values(&mut self, value: &Self::Native, n: usize);
+    fn append_value_n(&mut self, value: &Self::Native, n: usize);
 }
 
 /// this trait implementation called by adaptive array builders on the base array builders to
@@ -255,7 +255,6 @@ where
     {
         if let Some(default_val) = default_value {
             if default_val == value {
-                // prefix.append_value();
                 return true;
             }
         }
@@ -441,12 +440,12 @@ where
         );
     }
 
-    fn append_values(&mut self, value: &Self::Native, n: usize) {
+    fn append_value_n(&mut self, value: &Self::Native, n: usize) {
         handle_append!(
             self,
-            append_values(value, n),
+            append_value_n(value, n),
             default_check = Self::is_default_value(&self.default_value, value),
-            retry = { self.append_values(value, n) }
+            retry = { self.append_value_n(value, n) }
         );
     }
 }
@@ -817,7 +816,7 @@ pub mod test {
         builder.append_null();
         builder.append_value(&values[0]);
         builder.append_nulls(2);
-        builder.append_values(&values[1], 2);
+        builder.append_value_n(&values[1], 2);
 
         let result = builder.finish().unwrap();
         assert_eq!(
@@ -867,7 +866,7 @@ pub mod test {
         builder.append_null();
         builder.append_value(&values[1]);
         builder.append_nulls(2);
-        builder.append_values(&values[1], 2);
+        builder.append_value_n(&values[1], 2);
         let result = builder.finish().unwrap();
         assert_eq!(result.len(), 8);
         let array = result

--- a/rust/otel-arrow-rust/src/encode/record/array.rs
+++ b/rust/otel-arrow-rust/src/encode/record/array.rs
@@ -563,14 +563,12 @@ where
     /// Try to append a value to the underlying builder. This method may return an error if
     /// the value is not valid.
     fn append_value(&mut self, value: &T) -> Result<(), ArrowError> {
-        let result = handle_append_checked!(
+        handle_append_checked!(
             self,
             append_value(value),
             default_check = Self::is_default_value(&self.default_value, value),
             retry = { self.append_value(value) }
-        );
-
-        result
+        )
     }
 }
 
@@ -604,14 +602,12 @@ where
     /// Try to append a value to the underlying builder. This method may return an error if
     /// the value is not valid
     fn append_slice(&mut self, value: &[Self::Native]) -> Result<(), ArrowError> {
-        let result = handle_append_checked!(
+        handle_append_checked!(
             self,
             append_slice(value),
             default_check = Self::is_default_value(&self.default_value, &value),
             retry = { self.append_slice(value) }
-        );
-
-        result
+        )
     }
 }
 

--- a/rust/otel-arrow-rust/src/encode/record/array/binary.rs
+++ b/rust/otel-arrow-rust/src/encode/record/array/binary.rs
@@ -210,12 +210,14 @@ mod test {
         ArrayAppend::append_value(&mut binary_builder, &b"a".to_vec());
         ArrayAppend::append_value(&mut binary_builder, &b"b".to_vec());
         ArrayAppend::append_value(&mut binary_builder, &b"c".to_vec());
+        binary_builder.append_slice(b"d");
+        binary_builder.append_slice_n(b"e", 2);
 
         let result = ArrayBuilder::finish(&mut binary_builder);
 
         assert_eq!(result.data_type(), &DataType::Binary);
 
-        let expected = BinaryArray::from_iter_values(vec![b"a", b"b", b"c"]);
+        let expected = BinaryArray::from_iter_values(vec![b"a", b"b", b"c", b"d", b"e", b"e"]);
         assert_eq!(
             result.as_any().downcast_ref::<BinaryArray>().unwrap(),
             &expected

--- a/rust/otel-arrow-rust/src/encode/record/array/binary.rs
+++ b/rust/otel-arrow-rust/src/encode/record/array/binary.rs
@@ -28,7 +28,7 @@ impl ArrayAppend for BinaryBuilder {
     }
 
     #[inline(always)]
-    fn append_values(&mut self, value: &Self::Native, n: usize) {
+    fn append_value_n(&mut self, value: &Self::Native, n: usize) {
         for _ in 0..n {
             self.append_value(value);
         }

--- a/rust/otel-arrow-rust/src/encode/record/array/boolean.rs
+++ b/rust/otel-arrow-rust/src/encode/record/array/boolean.rs
@@ -41,11 +41,6 @@ impl AdaptiveBooleanArrayBuilder {
 
     pub fn append_value(&mut self, value: bool) {
         if self.inner.is_none() {
-            // TODO -- when we handle nulls here we need to keep track of how many
-            // nulls have been appended before the first value, and prefix this
-            // newly initialized array with that number of nulls
-            // https://github.com/open-telemetry/otel-arrow/issues/534
-
             self.inner = Some(BooleanBuilder::new());
             if self.nulls_prefix > 0 {
                 self.append_nulls(self.nulls_prefix);

--- a/rust/otel-arrow-rust/src/encode/record/array/dictionary.rs
+++ b/rust/otel-arrow-rust/src/encode/record/array/dictionary.rs
@@ -383,7 +383,7 @@ where
         }
     }
 
-    pub fn append_values(&mut self, value: &T, n: usize) -> Result<usize> {
+    pub fn append_value_n(&mut self, value: &T, n: usize) -> Result<usize> {
         loop {
             let append_result = match &mut self.variant {
                 DictIndexVariant::UInt8(dict_builder) => dict_builder.append_values(value, n),

--- a/rust/otel-arrow-rust/src/encode/record/array/fixed_size_binary.rs
+++ b/rust/otel-arrow-rust/src/encode/record/array/fixed_size_binary.rs
@@ -58,12 +58,7 @@ impl ArrayAppendNulls for FixedSizeBinaryBuilder {
     }
 
     fn append_nulls(&mut self, n: usize) {
-        // TODO - after the next release of arrow-rs we should revisit this and call append_nulls
-        // on the base builder. Waiting on these changes to be released:
-        // https://github.com/apache/arrow-rs/pull/7606
-        for _ in 0..n {
-            self.append_null();
-        }
+        self.append_nulls(n);
     }
 }
 
@@ -130,12 +125,7 @@ where
     }
 
     fn append_nulls(&mut self, n: usize) {
-        // TODO - after the next release of arrow-rs we should revisit this and call append_nulls
-        // on the base builder. Waiting on these changes to be released:
-        // https://github.com/apache/arrow-rs/pull/7606
-        for _ in 0..n {
-            self.append_null();
-        }
+        self.append_nulls(n);
     }
 }
 

--- a/rust/otel-arrow-rust/src/encode/record/array/prefix.rs
+++ b/rust/otel-arrow-rust/src/encode/record/array/prefix.rs
@@ -124,7 +124,7 @@ mod test {
             self.builder.append_value(*value);
         }
 
-        fn append_values(&mut self, value: &Self::Native, n: usize) {
+        fn append_value_n(&mut self, value: &Self::Native, n: usize) {
             self.builder.append_value_n(*value, n);
         }
     }

--- a/rust/otel-arrow-rust/src/encode/record/array/prefix.rs
+++ b/rust/otel-arrow-rust/src/encode/record/array/prefix.rs
@@ -123,6 +123,10 @@ mod test {
         fn append_value(&mut self, value: &Self::Native) {
             self.builder.append_value(*value);
         }
+
+        fn append_values(&mut self, value: &Self::Native, n: usize) {
+            self.builder.append_value_n(*value, n);
+        }
     }
 
     impl ArrayAppendNulls for TestArrayBuilder {

--- a/rust/otel-arrow-rust/src/encode/record/array/primitive.rs
+++ b/rust/otel-arrow-rust/src/encode/record/array/primitive.rs
@@ -28,7 +28,7 @@ where
         self.append_value(*value);
     }
 
-    fn append_values(&mut self, value: &Self::Native, n: usize) {
+    fn append_value_n(&mut self, value: &Self::Native, n: usize) {
         self.append_value_n(*value, n);
     }
 }

--- a/rust/otel-arrow-rust/src/encode/record/array/string.rs
+++ b/rust/otel-arrow-rust/src/encode/record/array/string.rs
@@ -203,12 +203,14 @@ mod test {
         ArrayAppend::append_value(&mut string_builder, &"a".to_string());
         ArrayAppend::append_value(&mut string_builder, &"b".to_string());
         ArrayAppend::append_value(&mut string_builder, &"c".to_string());
+        string_builder.append_str("d");
+        string_builder.append_str_n("e", 2);
 
         let result = ArrayBuilder::finish(&mut string_builder);
 
         assert_eq!(result.data_type(), &DataType::Utf8);
 
-        let expected = StringArray::from(vec!["a", "b", "c"]);
+        let expected = StringArray::from(vec!["a", "b", "c", "d", "e", "e"]);
         assert_eq!(
             result.as_any().downcast_ref::<StringArray>().unwrap(),
             &expected

--- a/rust/otel-arrow-rust/src/encode/record/array/string.rs
+++ b/rust/otel-arrow-rust/src/encode/record/array/string.rs
@@ -35,7 +35,7 @@ impl ArrayAppend for StringBuilder {
         self.append_value(value);
     }
 
-    fn append_values(&mut self, value: &Self::Native, n: usize) {
+    fn append_value_n(&mut self, value: &Self::Native, n: usize) {
         for _ in 0..n {
             self.append_value(value);
         }

--- a/rust/otel-arrow-rust/src/encode/record/logs.rs
+++ b/rust/otel-arrow-rust/src/encode/record/logs.rs
@@ -603,7 +603,7 @@ impl ResourceBuilder {
     /// Append the value of `id` to the builder `n` times
     pub fn append_id_n(&mut self, val: Option<u16>, n: usize) {
         if let Some(val) = val {
-            self.id.append_values(&val, n);
+            self.id.append_value_n(&val, n);
         } else {
             self.id.append_nulls(n);
         }
@@ -634,7 +634,7 @@ impl ResourceBuilder {
 
     /// Append a value to the `dropped_attributes_count` array `n` times
     pub fn append_dropped_attributes_count_n(&mut self, val: u32, n: usize) {
-        self.dropped_attributes_count.append_values(&val, n);
+        self.dropped_attributes_count.append_value_n(&val, n);
     }
 
     /// Finish this builder and build the resulting `StructArray` for the resource
@@ -723,7 +723,7 @@ impl ScopeBuilder {
     /// Append the value of `id` to the builder `n` times
     pub fn append_id_n(&mut self, val: Option<u16>, n: usize) {
         if let Some(val) = val {
-            self.id.append_values(&val, n);
+            self.id.append_value_n(&val, n);
         } else {
             self.id.append_nulls(n);
         }
@@ -772,7 +772,7 @@ impl ScopeBuilder {
 
     /// Append a value to the `dropped_attributes_count` array `n` times
     pub fn append_dropped_attributes_count_n(&mut self, val: u32, n: usize) {
-        self.dropped_attributes_count.append_values(&val, n);
+        self.dropped_attributes_count.append_value_n(&val, n);
     }
 
     /// Finish this builder and build the resulting `StructArray` for the scope

--- a/rust/otel-arrow-rust/src/encode/record/logs.rs
+++ b/rust/otel-arrow-rust/src/encode/record/logs.rs
@@ -155,6 +155,15 @@ impl LogsRecordBatchBuilder {
         }
     }
 
+    /// append a value to the `schema_url` array `n` times
+    pub fn append_schema_url_n(&mut self, val: Option<&str>, n: usize) {
+        if let Some(val) = val {
+            self.schema_url.append_str_n(val, n);
+        } else {
+            self.schema_url.append_nulls(n);
+        }
+    }
+
     /// append a value to the `severity_text` array
     pub fn append_severity_text(&mut self, val: Option<&str>) {
         if let Some(val) = val {
@@ -591,6 +600,15 @@ impl ResourceBuilder {
         }
     }
 
+    /// Append the value of `id` to the builder `n` times
+    pub fn append_id_n(&mut self, val: Option<u16>, n: usize) {
+        if let Some(val) = val {
+            self.id.append_values(&val, n);
+        } else {
+            self.id.append_nulls(n);
+        }
+    }
+
     /// Append a value to the `schema_url` array
     pub fn append_schema_url(&mut self, val: Option<&str>) {
         if let Some(val) = val {
@@ -600,9 +618,23 @@ impl ResourceBuilder {
         }
     }
 
+    /// Append a value to the `schema_url` array `n` times
+    pub fn append_schema_url_n(&mut self, val: Option<&str>, n: usize) {
+        if let Some(val) = val {
+            self.schema_url.append_str_n(val, n);
+        } else {
+            self.schema_url.append_nulls(n);
+        }
+    }
+
     /// Append a value to the `dropped_attributes_count` array
     pub fn append_dropped_attributes_count(&mut self, val: u32) {
         self.dropped_attributes_count.append_value(&val);
+    }
+
+    /// Append a value to the `dropped_attributes_count` array `n` times
+    pub fn append_dropped_attributes_count_n(&mut self, val: u32, n: usize) {
+        self.dropped_attributes_count.append_values(&val, n);
     }
 
     /// Finish this builder and build the resulting `StructArray` for the resource
@@ -688,12 +720,30 @@ impl ScopeBuilder {
         }
     }
 
+    /// Append the value of `id` to the builder `n` times
+    pub fn append_id_n(&mut self, val: Option<u16>, n: usize) {
+        if let Some(val) = val {
+            self.id.append_values(&val, n);
+        } else {
+            self.id.append_nulls(n);
+        }
+    }
+
     /// Append a value to the `name` array
     pub fn append_name(&mut self, val: Option<&str>) {
         if let Some(val) = val {
             self.name.append_str(val)
         } else {
             self.name.append_null();
+        }
+    }
+
+    /// Append a value to the `name` array n times
+    pub fn append_name_n(&mut self, val: Option<&str>, n: usize) {
+        if let Some(val) = val {
+            self.name.append_str_n(val, n);
+        } else {
+            self.name.append_nulls(n);
         }
     }
 
@@ -706,9 +756,23 @@ impl ScopeBuilder {
         }
     }
 
+    /// Append a value to the `version` array n times`
+    pub fn append_version_n(&mut self, val: Option<&str>, n: usize) {
+        if let Some(val) = val {
+            self.version.append_str_n(val, n);
+        } else {
+            self.version.append_nulls(n);
+        }
+    }
+
     /// Append a value to the `dropped_attributes_count` array
     pub fn append_dropped_attributes_count(&mut self, val: u32) {
         self.dropped_attributes_count.append_value(&val);
+    }
+
+    /// Append a value to the `dropped_attributes_count` array `n` times
+    pub fn append_dropped_attributes_count_n(&mut self, val: u32, n: usize) {
+        self.dropped_attributes_count.append_values(&val, n);
     }
 
     /// Finish this builder and build the resulting `StructArray` for the scope

--- a/rust/otel-arrow-rust/src/encode/record/logs.rs
+++ b/rust/otel-arrow-rust/src/encode/record/logs.rs
@@ -601,12 +601,8 @@ impl ResourceBuilder {
     }
 
     /// Append the value of `id` to the builder `n` times
-    pub fn append_id_n(&mut self, val: Option<u16>, n: usize) {
-        if let Some(val) = val {
-            self.id.append_value_n(&val, n);
-        } else {
-            self.id.append_nulls(n);
-        }
+    pub fn append_id_n(&mut self, val: u16, n: usize) {
+        self.id.append_value_n(&val, n);
     }
 
     /// Append a value to the `schema_url` array
@@ -721,12 +717,8 @@ impl ScopeBuilder {
     }
 
     /// Append the value of `id` to the builder `n` times
-    pub fn append_id_n(&mut self, val: Option<u16>, n: usize) {
-        if let Some(val) = val {
-            self.id.append_value_n(&val, n);
-        } else {
-            self.id.append_nulls(n);
-        }
+    pub fn append_id_n(&mut self, val: u16, n: usize) {
+        self.id.append_value_n(&val, n);
     }
 
     /// Append a value to the `name` array


### PR DESCRIPTION
### Changes:

**Benchmark improvements:**
- Adds a variety of batch sizes to the `otap_encoder` benchmark

**Performance improvements**
- Adaptive Array Builders:
  - Adds new methods to append multiple values to the array builders in a single method call. This is 
  - Use the optimized `append_nulls` implementation that was introduced in arrow-rs v52.2 https://github.com/apache/arrow-rs/pull/7606
  - Uses a macro to handle the append value logic instead of a method with callbacks instead of the generic `handle_append` method that took callback arguments. This improves performance on the hot path of `AdaptiveArrayBuilder::append_value / append_slice / etc.`
- Add additional inlines for some short, frequently called methods
- Array/KvList value serialization:
  - optimize CBOR serialization to remove heap allocations (previously we were allocating `vec` in several places when creating `ciborium::Value`, but now we use `serde_cbor::Serializer` to avoid the allocations)
  
### Benchmark Results:

Comparing benchmark **`encode_otap_logs_using_views/proto_bytes->views->OTAP`** on old code vs new. 

| batch size | old code | new code | % diff |
| --- | --- | --- | --- |
| resources=5,scopes=10,logs=5 | 23.571 us | 19.568 us | 16.98% |
| resources=1,scopes=1,logs=1000 | 74.841us | 61.622us | 17.66% |
| resources=1,scopes=1,logs=5000 | 3.6978ms | 3.0042ms | 18.75% |
| resources=1,scopes=1,logs=5000 | 7.3788ms | 6.0012ms | 18.67% |


Comparing **`encode_otap_logs_using_views/proto_bytes->views->OTAP`** with **`decode_proto_bytes/proto_bytes->prost`**.

| batch size | proto_bytes->prost | proto_bytes->views->OTAP | % diff |
| --- | --- | --- | --- |
| resources=5,scopes=10,logs=5 | 15.215us | 19.568 us | 28.61% |
| resources=1,scopes=1,logs=1000 | 55.204us | 61.622us | 11.63% |
| resources=1,scopes=1,logs=5000 | 2.7839ms | 3.0042ms | 7.91% |
| resources=1,scopes=1,logs=5000 | 5.5983ms | 6.0012ms | 7.20% |

Benchmark machine:
```
macOS 15.5 (24F74)
CPU: Apple M4 Pro
Memory: 24 GB
```

---

resolves: https://github.com/open-telemetry/otel-arrow/issues/534