### PR TITLE
[query-engine] Refactor static resolution API

### DIFF
--- a/rust/experimental/query_engine/expressions/src/logical_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/logical_expressions.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Expression, ExpressionError, PipelineExpression, QueryLocation, ResolvedStaticScalarExpression,
-    ScalarExpression,
+    Expression, ExpressionError, PipelineExpression, QueryLocation, ScalarExpression,
+    resolved_static_scalar_expression::ResolvedStaticScalarExpression,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -34,7 +34,7 @@ pub enum LogicalExpression {
 }
 
 impl LogicalExpression {
-    pub fn try_resolve_static<'a, 'b, 'c>(
+    pub(crate) fn try_resolve_static<'a, 'b, 'c>(
         &'a self,
         pipeline: &'b PipelineExpression,
     ) -> Result<Option<ResolvedStaticScalarExpression<'c>>, ExpressionError>

--- a/rust/experimental/query_engine/expressions/src/scalars/statics/mod.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/statics/mod.rs
@@ -1,7 +1,9 @@
 pub(crate) mod array_scalar_expression;
 pub(crate) mod map_scalar_expression;
+pub(crate) mod resolved_static_scalar_expression;
 pub(crate) mod static_scalar_expressions;
 
 pub use array_scalar_expression::*;
 pub use map_scalar_expression::*;
+pub use resolved_static_scalar_expression::*;
 pub use static_scalar_expressions::*;

--- a/rust/experimental/query_engine/expressions/src/scalars/statics/resolved_static_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/statics/resolved_static_scalar_expression.rs
@@ -20,9 +20,11 @@ impl ResolvedStaticScalarExpression<'_> {
             ResolvedStaticScalarExpression::Value(s) => s.to_value(),
         }
     }
+}
 
-    #[cfg(test)]
-    pub fn as_ref(&self) -> &StaticScalarExpression {
+#[cfg(test)]
+impl AsRef<StaticScalarExpression> for ResolvedStaticScalarExpression<'_> {
+    fn as_ref(&self) -> &StaticScalarExpression {
         match self {
             ResolvedStaticScalarExpression::Reference(s) => s,
             ResolvedStaticScalarExpression::Value(s) => s,

--- a/rust/experimental/query_engine/expressions/src/scalars/statics/resolved_static_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/statics/resolved_static_scalar_expression.rs
@@ -1,0 +1,31 @@
+use crate::{StaticScalarExpression, Value, ValueType};
+
+#[derive(Debug)]
+pub enum ResolvedStaticScalarExpression<'a> {
+    Reference(&'a StaticScalarExpression),
+    Value(StaticScalarExpression),
+}
+
+impl ResolvedStaticScalarExpression<'_> {
+    pub fn get_value_type(&self) -> ValueType {
+        match self {
+            ResolvedStaticScalarExpression::Reference(s) => s.get_value_type(),
+            ResolvedStaticScalarExpression::Value(s) => s.get_value_type(),
+        }
+    }
+
+    pub fn to_value(&self) -> Value {
+        match self {
+            ResolvedStaticScalarExpression::Reference(s) => s.to_value(),
+            ResolvedStaticScalarExpression::Value(s) => s.to_value(),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn as_ref(&self) -> &StaticScalarExpression {
+        match self {
+            ResolvedStaticScalarExpression::Reference(s) => s,
+            ResolvedStaticScalarExpression::Value(s) => s,
+        }
+    }
+}

--- a/rust/experimental/query_engine/kql-parser/src/tabular_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/tabular_expressions.rs
@@ -495,9 +495,9 @@ fn get_root_map_key_from_source_scalar_expression(
     if selectors.len() == 1 {
         let first = selectors.first().unwrap();
         if let Some(s) = first
-            .try_resolve_static(state.get_pipeline())
+            .try_resolve_value_type(state.get_pipeline())
             .map_err(|e| ParserError::from(&e))?
-            && let StaticScalarExpression::String(_) = s.as_ref()
+            && s == ValueType::String
         {
             return Ok(Some(first.clone()));
         } else {
@@ -514,7 +514,7 @@ fn get_root_map_key_from_source_scalar_expression(
             .unwrap()
             .try_resolve_static(state.get_pipeline())
             .map_err(|e| ParserError::from(&e))?
-            && let StaticScalarExpression::String(k) = s.as_ref()
+            && let Value::String(k) = s.to_value()
         {
             let root_key = k.get_value();
 


### PR DESCRIPTION
## Changes

* Moved `ResolvedStaticScalarExpression` to its own file in expressions
* Tweaked `ResolvedStaticScalarExpression` API to use the `Value` API instead of interacting with `StaticScalarExpression` directly
* Made a lot of the static resolution API internal

## Details

Really just some random cleanup and refactoring I've done while working on getting expressions up and running in recordset engine.