### PR TITLE
Set default read-all permissions for Labeler workflow

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,4 +1,7 @@
 name: "Pull Request Labeler"
+
+permissions: read-all
+
 on:
 - pull_request_target
 


### PR DESCRIPTION
Address code scanning alert. Following GitHub best practices - supposed to have minimal read-all permission at top level of each workflow.