### PR TITLE
[query-engine] Store variable and attached record names as StringScalarExpressions

### DIFF
--- a/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
@@ -575,7 +575,7 @@ mod tests {
         run_test_success(
             ScalarExpression::Attached(AttachedScalarExpression::new(
                 QueryLocation::new_fake(),
-                StringScalarExpression::new(QueryLocation::new_fake(), "resource".into()),
+                StringScalarExpression::new(QueryLocation::new_fake(), "resource"),
                 ValueAccessor::new(),
             )),
             None,
@@ -592,7 +592,7 @@ mod tests {
         run_test_success(
             ScalarExpression::Variable(VariableScalarExpression::new(
                 QueryLocation::new_fake(),
-                StringScalarExpression::new(QueryLocation::new_fake(), "var".into()),
+                StringScalarExpression::new(QueryLocation::new_fake(), "var"),
                 ValueAccessor::new(),
             )),
             None,
@@ -818,7 +818,7 @@ mod tests {
         run_test_success(
             ScalarExpression::Attached(AttachedScalarExpression::new(
                 QueryLocation::new_fake(),
-                StringScalarExpression::new(QueryLocation::new_fake(), "resource".into()),
+                StringScalarExpression::new(QueryLocation::new_fake(), "resource"),
                 ValueAccessor::new(),
             )),
             None,
@@ -835,7 +835,7 @@ mod tests {
         run_test_success(
             ScalarExpression::Variable(VariableScalarExpression::new(
                 QueryLocation::new_fake(),
-                StringScalarExpression::new(QueryLocation::new_fake(), "var".into()),
+                StringScalarExpression::new(QueryLocation::new_fake(), "var"),
                 ValueAccessor::new(),
             )),
             None,

--- a/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
@@ -138,24 +138,24 @@ impl Expression for SourceScalarExpression {
 #[derive(Debug, Clone, PartialEq)]
 pub struct AttachedScalarExpression {
     query_location: QueryLocation,
-    name: Box<str>,
+    name: StringScalarExpression,
     accessor: ValueAccessor,
 }
 
 impl AttachedScalarExpression {
     pub fn new(
         query_location: QueryLocation,
-        name: &str,
+        name: StringScalarExpression,
         accessor: ValueAccessor,
     ) -> AttachedScalarExpression {
         Self {
             query_location,
-            name: name.into(),
+            name,
             accessor,
         }
     }
 
-    pub fn get_name(&self) -> &str {
+    pub fn get_name(&self) -> &StringScalarExpression {
         &self.name
     }
 
@@ -177,24 +177,24 @@ impl Expression for AttachedScalarExpression {
 #[derive(Debug, Clone, PartialEq)]
 pub struct VariableScalarExpression {
     query_location: QueryLocation,
-    name: Box<str>,
+    name: StringScalarExpression,
     accessor: ValueAccessor,
 }
 
 impl VariableScalarExpression {
     pub fn new(
         query_location: QueryLocation,
-        name: &str,
+        name: StringScalarExpression,
         accessor: ValueAccessor,
     ) -> VariableScalarExpression {
         Self {
             query_location,
-            name: name.into(),
+            name,
             accessor,
         }
     }
 
-    pub fn get_name(&self) -> &str {
+    pub fn get_name(&self) -> &StringScalarExpression {
         &self.name
     }
 
@@ -575,7 +575,7 @@ mod tests {
         run_test_success(
             ScalarExpression::Attached(AttachedScalarExpression::new(
                 QueryLocation::new_fake(),
-                "resource",
+                StringScalarExpression::new(QueryLocation::new_fake(), "resource".into()),
                 ValueAccessor::new(),
             )),
             None,
@@ -592,7 +592,7 @@ mod tests {
         run_test_success(
             ScalarExpression::Variable(VariableScalarExpression::new(
                 QueryLocation::new_fake(),
-                "var",
+                StringScalarExpression::new(QueryLocation::new_fake(), "var".into()),
                 ValueAccessor::new(),
             )),
             None,
@@ -818,7 +818,7 @@ mod tests {
         run_test_success(
             ScalarExpression::Attached(AttachedScalarExpression::new(
                 QueryLocation::new_fake(),
-                "resource",
+                StringScalarExpression::new(QueryLocation::new_fake(), "resource".into()),
                 ValueAccessor::new(),
             )),
             None,
@@ -835,7 +835,7 @@ mod tests {
         run_test_success(
             ScalarExpression::Variable(VariableScalarExpression::new(
                 QueryLocation::new_fake(),
-                "var",
+                StringScalarExpression::new(QueryLocation::new_fake(), "var".into()),
                 ValueAccessor::new(),
             )),
             None,

--- a/rust/experimental/query_engine/kql-parser/src/logical_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/logical_expressions.rs
@@ -198,7 +198,7 @@ mod tests {
                 QueryLocation::new_fake(),
                 ScalarExpression::Variable(VariableScalarExpression::new(
                     QueryLocation::new_fake(),
-                    "variable",
+                    StringScalarExpression::new(QueryLocation::new_fake(), "variable".into()),
                     ValueAccessor::new(),
                 )),
                 ScalarExpression::Static(StaticScalarExpression::String(
@@ -260,7 +260,7 @@ mod tests {
                 )),
                 ScalarExpression::Attached(AttachedScalarExpression::new(
                     QueryLocation::new_fake(),
-                    "resource",
+                    StringScalarExpression::new(QueryLocation::new_fake(), "resource".into()),
                     ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
                         StaticScalarExpression::String(StringScalarExpression::new(
                             QueryLocation::new_fake(),
@@ -401,7 +401,7 @@ mod tests {
             "resource.attributes['service.name']",
             LogicalExpression::Scalar(ScalarExpression::Attached(AttachedScalarExpression::new(
                 QueryLocation::new_fake(),
-                "resource",
+                StringScalarExpression::new(QueryLocation::new_fake(), "resource".into()),
                 ValueAccessor::new_with_selectors(vec![
                     ScalarExpression::Static(StaticScalarExpression::String(
                         StringScalarExpression::new(QueryLocation::new_fake(), "attributes"),
@@ -417,7 +417,7 @@ mod tests {
             "variable",
             LogicalExpression::Scalar(ScalarExpression::Variable(VariableScalarExpression::new(
                 QueryLocation::new_fake(),
-                "variable",
+                StringScalarExpression::new(QueryLocation::new_fake(), "variable".into()),
                 ValueAccessor::new(),
             ))),
         );
@@ -428,7 +428,7 @@ mod tests {
                 QueryLocation::new_fake(),
                 ScalarExpression::Variable(VariableScalarExpression::new(
                     QueryLocation::new_fake(),
-                    "variable",
+                    StringScalarExpression::new(QueryLocation::new_fake(), "variable".into()),
                     ValueAccessor::new(),
                 )),
                 ScalarExpression::Static(StaticScalarExpression::String(
@@ -443,7 +443,7 @@ mod tests {
                 QueryLocation::new_fake(),
                 ScalarExpression::Variable(VariableScalarExpression::new(
                     QueryLocation::new_fake(),
-                    "variable",
+                    StringScalarExpression::new(QueryLocation::new_fake(), "variable".into()),
                     ValueAccessor::new(),
                 )),
                 ScalarExpression::Static(StaticScalarExpression::String(
@@ -482,7 +482,7 @@ mod tests {
                 QueryLocation::new_fake(),
                 ScalarExpression::Variable(VariableScalarExpression::new(
                     QueryLocation::new_fake(),
-                    "variable",
+                    StringScalarExpression::new(QueryLocation::new_fake(), "variable".into()),
                     ValueAccessor::new(),
                 )),
                 ScalarExpression::Static(StaticScalarExpression::String(

--- a/rust/experimental/query_engine/kql-parser/src/logical_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/logical_expressions.rs
@@ -198,7 +198,7 @@ mod tests {
                 QueryLocation::new_fake(),
                 ScalarExpression::Variable(VariableScalarExpression::new(
                     QueryLocation::new_fake(),
-                    StringScalarExpression::new(QueryLocation::new_fake(), "variable".into()),
+                    StringScalarExpression::new(QueryLocation::new_fake(), "variable"),
                     ValueAccessor::new(),
                 )),
                 ScalarExpression::Static(StaticScalarExpression::String(
@@ -260,7 +260,7 @@ mod tests {
                 )),
                 ScalarExpression::Attached(AttachedScalarExpression::new(
                     QueryLocation::new_fake(),
-                    StringScalarExpression::new(QueryLocation::new_fake(), "resource".into()),
+                    StringScalarExpression::new(QueryLocation::new_fake(), "resource"),
                     ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
                         StaticScalarExpression::String(StringScalarExpression::new(
                             QueryLocation::new_fake(),
@@ -401,7 +401,7 @@ mod tests {
             "resource.attributes['service.name']",
             LogicalExpression::Scalar(ScalarExpression::Attached(AttachedScalarExpression::new(
                 QueryLocation::new_fake(),
-                StringScalarExpression::new(QueryLocation::new_fake(), "resource".into()),
+                StringScalarExpression::new(QueryLocation::new_fake(), "resource"),
                 ValueAccessor::new_with_selectors(vec![
                     ScalarExpression::Static(StaticScalarExpression::String(
                         StringScalarExpression::new(QueryLocation::new_fake(), "attributes"),
@@ -417,7 +417,7 @@ mod tests {
             "variable",
             LogicalExpression::Scalar(ScalarExpression::Variable(VariableScalarExpression::new(
                 QueryLocation::new_fake(),
-                StringScalarExpression::new(QueryLocation::new_fake(), "variable".into()),
+                StringScalarExpression::new(QueryLocation::new_fake(), "variable"),
                 ValueAccessor::new(),
             ))),
         );
@@ -428,7 +428,7 @@ mod tests {
                 QueryLocation::new_fake(),
                 ScalarExpression::Variable(VariableScalarExpression::new(
                     QueryLocation::new_fake(),
-                    StringScalarExpression::new(QueryLocation::new_fake(), "variable".into()),
+                    StringScalarExpression::new(QueryLocation::new_fake(), "variable"),
                     ValueAccessor::new(),
                 )),
                 ScalarExpression::Static(StaticScalarExpression::String(
@@ -443,7 +443,7 @@ mod tests {
                 QueryLocation::new_fake(),
                 ScalarExpression::Variable(VariableScalarExpression::new(
                     QueryLocation::new_fake(),
-                    StringScalarExpression::new(QueryLocation::new_fake(), "variable".into()),
+                    StringScalarExpression::new(QueryLocation::new_fake(), "variable"),
                     ValueAccessor::new(),
                 )),
                 ScalarExpression::Static(StaticScalarExpression::String(
@@ -482,7 +482,7 @@ mod tests {
                 QueryLocation::new_fake(),
                 ScalarExpression::Variable(VariableScalarExpression::new(
                     QueryLocation::new_fake(),
-                    StringScalarExpression::new(QueryLocation::new_fake(), "variable".into()),
+                    StringScalarExpression::new(QueryLocation::new_fake(), "variable"),
                     ValueAccessor::new(),
                 )),
                 ScalarExpression::Static(StaticScalarExpression::String(

--- a/rust/experimental/query_engine/kql-parser/src/query_expression.rs
+++ b/rust/experimental/query_engine/kql-parser/src/query_expression.rs
@@ -49,7 +49,7 @@ pub(crate) fn parse_query(
 
                     if let TransformExpression::Set(s) = &let_expression {
                         if let MutableValueExpression::Variable(v) = s.get_destination() {
-                            let name = v.get_name();
+                            let name = v.get_name().get_value();
 
                             if let ImmutableValueExpression::Scalar(ScalarExpression::Static(s)) =
                                 s.get_source()

--- a/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
@@ -962,7 +962,7 @@ mod tests {
                     )),
                     ScalarExpression::Variable(VariableScalarExpression::new(
                         QueryLocation::new_fake(),
-                        StringScalarExpression::new(QueryLocation::new_fake(), "var".into()),
+                        StringScalarExpression::new(QueryLocation::new_fake(), "var"),
                         ValueAccessor::new()
                     )),
                     ScalarExpression::Negate(NegateScalarExpression::new(

--- a/rust/experimental/query_engine/kql-parser/src/shared_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/shared_expressions.rs
@@ -98,7 +98,7 @@ pub(crate) fn parse_let_expression(
         ImmutableValueExpression::Scalar(scalar),
         MutableValueExpression::Variable(VariableScalarExpression::new(
             identifier.get_query_location().clone(),
-            identifier.get_value(),
+            identifier,
             ValueAccessor::new(),
         )),
     )))
@@ -182,7 +182,7 @@ mod tests {
                 )),
                 MutableValueExpression::Variable(VariableScalarExpression::new(
                     QueryLocation::new_fake(),
-                    "variable",
+                    StringScalarExpression::new(QueryLocation::new_fake(), "variable".into()),
                     ValueAccessor::new(),
                 )),
             )),
@@ -253,7 +253,7 @@ mod tests {
                 )),
                 MutableValueExpression::Variable(VariableScalarExpression::new(
                     QueryLocation::new_fake(),
-                    "var1",
+                    StringScalarExpression::new(QueryLocation::new_fake(), "var1".into()),
                     ValueAccessor::new(),
                 )),
             )),

--- a/rust/experimental/query_engine/kql-parser/src/shared_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/shared_expressions.rs
@@ -182,7 +182,7 @@ mod tests {
                 )),
                 MutableValueExpression::Variable(VariableScalarExpression::new(
                     QueryLocation::new_fake(),
-                    StringScalarExpression::new(QueryLocation::new_fake(), "variable".into()),
+                    StringScalarExpression::new(QueryLocation::new_fake(), "variable"),
                     ValueAccessor::new(),
                 )),
             )),
@@ -253,7 +253,7 @@ mod tests {
                 )),
                 MutableValueExpression::Variable(VariableScalarExpression::new(
                     QueryLocation::new_fake(),
-                    StringScalarExpression::new(QueryLocation::new_fake(), "var1".into()),
+                    StringScalarExpression::new(QueryLocation::new_fake(), "var1"),
                     ValueAccessor::new(),
                 )),
             )),

--- a/rust/experimental/query_engine/kql-parser/src/tabular_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/tabular_expressions.rs
@@ -843,7 +843,10 @@ mod tests {
                     ImmutableValueExpression::Scalar(ScalarExpression::Variable(
                         VariableScalarExpression::new(
                             QueryLocation::new_fake(),
-                            "variable",
+                            StringScalarExpression::new(
+                                QueryLocation::new_fake(),
+                                "variable".into(),
+                            ),
                             ValueAccessor::new(),
                         ),
                     )),
@@ -923,7 +926,10 @@ mod tests {
                     ImmutableValueExpression::Scalar(ScalarExpression::Variable(
                         VariableScalarExpression::new(
                             QueryLocation::new_fake(),
-                            "variable",
+                            StringScalarExpression::new(
+                                QueryLocation::new_fake(),
+                                "variable".into(),
+                            ),
                             ValueAccessor::new(),
                         ),
                     )),
@@ -942,11 +948,17 @@ mod tests {
                     ImmutableValueExpression::Scalar(ScalarExpression::Attached(
                         AttachedScalarExpression::new(
                             QueryLocation::new_fake(),
-                            "resource",
+                            StringScalarExpression::new(
+                                QueryLocation::new_fake(),
+                                "resource".into(),
+                            ),
                             ValueAccessor::new_with_selectors(vec![ScalarExpression::Variable(
                                 VariableScalarExpression::new(
                                     QueryLocation::new_fake(),
-                                    "variable",
+                                    StringScalarExpression::new(
+                                        QueryLocation::new_fake(),
+                                        "variable".into(),
+                                    ),
                                     ValueAccessor::new(),
                                 ),
                             )]),
@@ -1025,7 +1037,10 @@ mod tests {
                             )),
                             ScalarExpression::Variable(VariableScalarExpression::new(
                                 QueryLocation::new_fake(),
-                                "variable",
+                                StringScalarExpression::new(
+                                    QueryLocation::new_fake(),
+                                    "variable".into(),
+                                ),
                                 ValueAccessor::new(),
                             )),
                         ])),
@@ -1256,7 +1271,10 @@ mod tests {
                             )),
                             ScalarExpression::Variable(VariableScalarExpression::new(
                                 QueryLocation::new_fake(),
-                                "variable",
+                                StringScalarExpression::new(
+                                    QueryLocation::new_fake(),
+                                    "variable".into(),
+                                ),
                                 ValueAccessor::new(),
                             )),
                         ])),
@@ -1450,7 +1468,10 @@ mod tests {
                             )),
                             ScalarExpression::Variable(VariableScalarExpression::new(
                                 QueryLocation::new_fake(),
-                                "variable",
+                                StringScalarExpression::new(
+                                    QueryLocation::new_fake(),
+                                    "variable".into(),
+                                ),
                                 ValueAccessor::new(),
                             )),
                         ])),
@@ -1520,7 +1541,10 @@ mod tests {
                         LogicalExpression::Scalar(ScalarExpression::Variable(
                             VariableScalarExpression::new(
                                 QueryLocation::new_fake(),
-                                "variable",
+                                StringScalarExpression::new(
+                                    QueryLocation::new_fake(),
+                                    "variable".into(),
+                                ),
                                 ValueAccessor::new(),
                             ),
                         )),

--- a/rust/experimental/query_engine/kql-parser/src/tabular_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/tabular_expressions.rs
@@ -843,10 +843,7 @@ mod tests {
                     ImmutableValueExpression::Scalar(ScalarExpression::Variable(
                         VariableScalarExpression::new(
                             QueryLocation::new_fake(),
-                            StringScalarExpression::new(
-                                QueryLocation::new_fake(),
-                                "variable",
-                            ),
+                            StringScalarExpression::new(QueryLocation::new_fake(), "variable"),
                             ValueAccessor::new(),
                         ),
                     )),
@@ -926,10 +923,7 @@ mod tests {
                     ImmutableValueExpression::Scalar(ScalarExpression::Variable(
                         VariableScalarExpression::new(
                             QueryLocation::new_fake(),
-                            StringScalarExpression::new(
-                                QueryLocation::new_fake(),
-                                "variable",
-                            ),
+                            StringScalarExpression::new(QueryLocation::new_fake(), "variable"),
                             ValueAccessor::new(),
                         ),
                     )),
@@ -948,10 +942,7 @@ mod tests {
                     ImmutableValueExpression::Scalar(ScalarExpression::Attached(
                         AttachedScalarExpression::new(
                             QueryLocation::new_fake(),
-                            StringScalarExpression::new(
-                                QueryLocation::new_fake(),
-                                "resource",
-                            ),
+                            StringScalarExpression::new(QueryLocation::new_fake(), "resource"),
                             ValueAccessor::new_with_selectors(vec![ScalarExpression::Variable(
                                 VariableScalarExpression::new(
                                     QueryLocation::new_fake(),
@@ -1037,10 +1028,7 @@ mod tests {
                             )),
                             ScalarExpression::Variable(VariableScalarExpression::new(
                                 QueryLocation::new_fake(),
-                                StringScalarExpression::new(
-                                    QueryLocation::new_fake(),
-                                    "variable",
-                                ),
+                                StringScalarExpression::new(QueryLocation::new_fake(), "variable"),
                                 ValueAccessor::new(),
                             )),
                         ])),
@@ -1271,10 +1259,7 @@ mod tests {
                             )),
                             ScalarExpression::Variable(VariableScalarExpression::new(
                                 QueryLocation::new_fake(),
-                                StringScalarExpression::new(
-                                    QueryLocation::new_fake(),
-                                    "variable",
-                                ),
+                                StringScalarExpression::new(QueryLocation::new_fake(), "variable"),
                                 ValueAccessor::new(),
                             )),
                         ])),
@@ -1468,10 +1453,7 @@ mod tests {
                             )),
                             ScalarExpression::Variable(VariableScalarExpression::new(
                                 QueryLocation::new_fake(),
-                                StringScalarExpression::new(
-                                    QueryLocation::new_fake(),
-                                    "variable",
-                                ),
+                                StringScalarExpression::new(QueryLocation::new_fake(), "variable"),
                                 ValueAccessor::new(),
                             )),
                         ])),
@@ -1541,10 +1523,7 @@ mod tests {
                         LogicalExpression::Scalar(ScalarExpression::Variable(
                             VariableScalarExpression::new(
                                 QueryLocation::new_fake(),
-                                StringScalarExpression::new(
-                                    QueryLocation::new_fake(),
-                                    "variable",
-                                ),
+                                StringScalarExpression::new(QueryLocation::new_fake(), "variable"),
                                 ValueAccessor::new(),
                             ),
                         )),

--- a/rust/experimental/query_engine/kql-parser/src/tabular_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/tabular_expressions.rs
@@ -845,7 +845,7 @@ mod tests {
                             QueryLocation::new_fake(),
                             StringScalarExpression::new(
                                 QueryLocation::new_fake(),
-                                "variable".into(),
+                                "variable",
                             ),
                             ValueAccessor::new(),
                         ),
@@ -928,7 +928,7 @@ mod tests {
                             QueryLocation::new_fake(),
                             StringScalarExpression::new(
                                 QueryLocation::new_fake(),
-                                "variable".into(),
+                                "variable",
                             ),
                             ValueAccessor::new(),
                         ),
@@ -950,14 +950,14 @@ mod tests {
                             QueryLocation::new_fake(),
                             StringScalarExpression::new(
                                 QueryLocation::new_fake(),
-                                "resource".into(),
+                                "resource",
                             ),
                             ValueAccessor::new_with_selectors(vec![ScalarExpression::Variable(
                                 VariableScalarExpression::new(
                                     QueryLocation::new_fake(),
                                     StringScalarExpression::new(
                                         QueryLocation::new_fake(),
-                                        "variable".into(),
+                                        "variable",
                                     ),
                                     ValueAccessor::new(),
                                 ),
@@ -1039,7 +1039,7 @@ mod tests {
                                 QueryLocation::new_fake(),
                                 StringScalarExpression::new(
                                     QueryLocation::new_fake(),
-                                    "variable".into(),
+                                    "variable",
                                 ),
                                 ValueAccessor::new(),
                             )),
@@ -1273,7 +1273,7 @@ mod tests {
                                 QueryLocation::new_fake(),
                                 StringScalarExpression::new(
                                     QueryLocation::new_fake(),
-                                    "variable".into(),
+                                    "variable",
                                 ),
                                 ValueAccessor::new(),
                             )),
@@ -1470,7 +1470,7 @@ mod tests {
                                 QueryLocation::new_fake(),
                                 StringScalarExpression::new(
                                     QueryLocation::new_fake(),
-                                    "variable".into(),
+                                    "variable",
                                 ),
                                 ValueAccessor::new(),
                             )),
@@ -1543,7 +1543,7 @@ mod tests {
                                 QueryLocation::new_fake(),
                                 StringScalarExpression::new(
                                     QueryLocation::new_fake(),
-                                    "variable".into(),
+                                    "variable",
                                 ),
                                 ValueAccessor::new(),
                             ),


### PR DESCRIPTION
## Changes

* Store variable and attached record names as `StringScalarExpression`s

## Details

Doing this allows them to be accessed using the `Value` API (like other things which also come from the query) and adds the location tracking for diagnostics