### PR TITLE
Specify jinja2 version in requirements.txt

### DIFF
--- a/tools/pipeline_perf_test/orchestrator/requirements.txt
+++ b/tools/pipeline_perf_test/orchestrator/requirements.txt
@@ -19,5 +19,5 @@ opentelemetry-proto>=1.12.0
 prometheus_client>=0.22.0
 pandas>=2.2.3
 pyarrow>=20.0.0
-jinja2
+jinja2>=3.1.6
 tabulate>=0.9.0


### PR DESCRIPTION
Hopefully resolving some code scanning warnings, this is the one python dependency without a version specified. Adding version should also make it in-scope for Renovate bot.