### PR TITLE
Test Renovate Python upgrade behavior by pinning `requests` n-1 version

### DIFF
--- a/tools/pipeline_perf_test/orchestrator/requirements.txt
+++ b/tools/pipeline_perf_test/orchestrator/requirements.txt
@@ -1,7 +1,7 @@
 # Dependencies for the pipeline performance test orchestrator
 
 # General dependencies
-requests>=2.25.0
+requests==2.32.3
 pyyaml>=5.4.1
 pydantic>=2.11.4
 


### PR DESCRIPTION
Project is still considered vulnerable to the following:
- Warn: Project is vulnerable to: GHSA-9hjg-9r4m-mvj7
- Warn: Project is vulnerable to: GHSA-9wx4-h78v-vm56
- Warn: Project is vulnerable to: PYSEC-2023-74 / GHSA-j8r2-6x86-q33q

Offending package is Python `requests`: https://github.com/psf/requests

Trying to understand why Renovate doesn't seem to keep python deps up to date - suspecting it is because of the `>=` syntax usage. The Renovate log contains the following:
```json
{"depName":"requests","packageName":"requests","currentValue":">=2.25.0","datasource":"pypi","updates":[],"versioning":"pep440","warnings":[],"sourceUrl":"https://github.com/psf/requests","registryUrl":"https://pypi.org/pypi","homepage":"https://requests.readthedocs.io","changelogUrl":"https://github.com/psf/requests/blob/master/HISTORY.md","mostRecentTimestamp":"2025-06-09T16:43:05.000Z","currentVersion":"2.32.4","currentVersionTimestamp":"2025-06-09T16:43:05.000Z","currentVersionAgeInDays":43}
```

`"currentVersion":"2.32.4"` suggests that Renovate does detect the latest release, but doesn't feel a need to update it because the `requirements` file has `>=2.25.0` which is technically satisfied.

In order to keep code scanner happy, think it is important to have Renovate do regular updates to versions listed here. Testing the theory by pinning `requests` to n-1 release (`2.32.3`) in the hopes that Renovate understands and sends an update to `2.32.4`.

If it works, should use `==` for all python dependencies.