### PR TITLE
[Perf] add optional load_generator rate limit

### DIFF
--- a/tools/pipeline_perf_test/load_generator/tests/test_config.py
+++ b/tools/pipeline_perf_test/load_generator/tests/test_config.py
@@ -1,0 +1,45 @@
+import sys
+import os
+import pytest
+from pydantic import ValidationError
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from loadgen import LoadGenConfig  # noqa: E402
+
+
+def test_valid_config():
+    config = LoadGenConfig(
+        body_size=30,
+        num_attributes=3,
+        attribute_value_size=20,
+        batch_size=1000,
+        threads=2,
+        target_rate=5000,
+    )
+    assert config.body_size == 30
+    assert config.target_rate == 5000
+
+
+@pytest.mark.parametrize(
+    "field, value",
+    [
+        ("body_size", 0),
+        ("num_attributes", -1),
+        ("attribute_value_size", 0),
+        ("batch_size", 0),
+        ("threads", 0),
+    ],
+)
+def test_invalid_config_values(field, value):
+    kwargs = {
+        "body_size": 25,
+        "num_attributes": 2,
+        "attribute_value_size": 15,
+        "batch_size": 5000,
+        "threads": 4,
+        "target_rate": 1000,
+    }
+    kwargs[field] = value
+    with pytest.raises(ValidationError):
+        LoadGenConfig(**kwargs)

--- a/tools/pipeline_perf_test/load_generator/tests/test_flask_api.py
+++ b/tools/pipeline_perf_test/load_generator/tests/test_flask_api.py
@@ -1,0 +1,111 @@
+import sys
+import os
+import time
+import pytest
+
+# Add root dir to sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from loadgen import app  # noqa: E402
+
+
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        yield client
+
+
+def test_start_with_valid_config(client):
+    config = {
+        "body_size": 10,
+        "num_attributes": 2,
+        "attribute_value_size": 10,
+        "batch_size": 2,
+        "threads": 1,
+        "target_rate": 100,
+    }
+
+    resp = client.post("/start", json=config)
+    assert resp.status_code == 200
+    assert resp.get_json()["status"] == "started"
+
+    # Let it run a little
+    time.sleep(0.2)
+    client.post("/stop")
+
+
+def test_start_with_invalid_config(client):
+    invalid_config = {
+        "body_size": -1,  # Invalid
+        "num_attributes": 2,
+        "attribute_value_size": 10,
+        "batch_size": 2,
+        "threads": 1,
+        "target_rate": 100,
+    }
+
+    resp = client.post("/start", json=invalid_config)
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+
+def test_double_start_is_rejected(client):
+    config = {
+        "body_size": 10,
+        "num_attributes": 1,
+        "attribute_value_size": 10,
+        "batch_size": 2,
+        "threads": 1,
+    }
+
+    resp1 = client.post("/start", json=config)
+    assert resp1.status_code == 200
+
+    resp2 = client.post("/start", json=config)
+    assert resp2.status_code == 400
+    assert "error" in resp2.get_json()
+
+    client.post("/stop")
+
+
+def test_stop_endpoint(client):
+    config = {
+        "body_size": 10,
+        "num_attributes": 1,
+        "attribute_value_size": 10,
+        "batch_size": 1,
+        "threads": 1,
+    }
+
+    client.post("/start", json=config)
+    time.sleep(0.1)
+    resp = client.post("/stop")
+    assert resp.status_code == 200
+    assert resp.get_json()["status"] == "stopped"
+
+
+def test_metrics_endpoint(client):
+    config = {
+        "body_size": 10,
+        "num_attributes": 1,
+        "attribute_value_size": 10,
+        "batch_size": 2,
+        "threads": 1,
+    }
+
+    client.post("/start", json=config)
+    time.sleep(0.2)
+    client.post("/stop")
+
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+
+    # Metrics returned as plain text
+    body = resp.data.decode("utf-8")
+    lines = body.splitlines()
+    keys = [line.split()[0] for line in lines]
+
+    assert "sent" in keys
+    assert "failed" in keys
+    assert "bytes_sent" in keys

--- a/tools/pipeline_perf_test/load_generator/tests/test_log_record.py
+++ b/tools/pipeline_perf_test/load_generator/tests/test_log_record.py
@@ -1,0 +1,37 @@
+import sys
+import os
+
+# Add root dir to sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from loadgen import LoadGenerator  # noqa: E402
+
+
+def test_create_log_record_structure():
+    generator = LoadGenerator()
+    body_size = 50
+    num_attributes = 3
+    attribute_value_size = 20
+
+    record = generator.create_log_record(
+        body_size=body_size,
+        num_attributes=num_attributes,
+        attribute_value_size=attribute_value_size,
+    )
+
+    # Check that record is a LogRecord
+    assert record.body.string_value is not None
+    assert len(record.body.string_value) == body_size
+
+    # Check attribute count
+    assert len(record.attributes) == num_attributes
+
+    # Check each attribute key and value
+    for i, attr in enumerate(record.attributes, start=1):
+        assert attr.key == f"attribute.{i}"
+        assert attr.value.string_value is not None
+        assert len(attr.value.string_value) == attribute_value_size
+
+    # Severity checks
+    assert record.severity_text == "INFO"
+    assert record.severity_number > 0

--- a/tools/pipeline_perf_test/load_generator/tests/test_worker_thread.py
+++ b/tools/pipeline_perf_test/load_generator/tests/test_worker_thread.py
@@ -1,0 +1,115 @@
+import sys
+import os
+import time
+import threading
+from unittest.mock import MagicMock, patch
+
+# Add root dir to sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from loadgen import LoadGenerator  # noqa: E402
+
+
+@patch("loadgen.grpc.insecure_channel")
+@patch("loadgen.logs_service_pb2_grpc.LogsServiceStub")
+def test_worker_thread_sends_logs(mock_stub_class, mock_channel):
+    generator = LoadGenerator()
+
+    # Mock stub and its Export method
+    mock_stub = MagicMock()
+    mock_stub.Export.return_value = None
+    mock_stub_class.return_value = mock_stub
+
+    # Set up args for the worker thread
+    args = {
+        "body_size": 10,
+        "num_attributes": 1,
+        "attribute_value_size": 5,
+        "batch_size": 3,
+        "threads": 1,
+        "target_rate": None,
+    }
+
+    # Start the thread and stop it shortly after
+    generator.stop_event.clear()
+    thread = threading.Thread(target=generator.worker_thread, args=(0, args))
+    thread.start()
+
+    # Let the worker send at least once
+    time.sleep(0.2)
+    generator.stop_event.set()
+    thread.join()
+
+    # Verify Export was called
+    assert mock_stub.Export.called
+    assert generator.metrics["sent"] >= 3
+    assert generator.metrics["bytes_sent"] > 0
+    assert generator.metrics["failed"] == 0
+
+
+@patch("loadgen.grpc.insecure_channel")
+@patch("loadgen.logs_service_pb2_grpc.LogsServiceStub")
+def test_worker_thread_handles_export_failure(mock_stub_class, mock_channel):
+    generator = LoadGenerator()
+
+    # Simulate gRPC Export failure
+    mock_stub = MagicMock()
+    mock_stub.Export.side_effect = Exception("gRPC failed")
+    mock_stub_class.return_value = mock_stub
+
+    args = {
+        "body_size": 10,
+        "num_attributes": 1,
+        "attribute_value_size": 5,
+        "batch_size": 2,
+        "threads": 1,
+        "target_rate": None,
+    }
+
+    generator.stop_event.clear()
+    thread = threading.Thread(target=generator.worker_thread, args=(0, args))
+    thread.start()
+
+    time.sleep(0.2)
+    generator.stop_event.set()
+    thread.join()
+
+    assert generator.metrics["failed"] >= 2
+
+
+@patch("loadgen.grpc.insecure_channel")
+@patch("loadgen.logs_service_pb2_grpc.LogsServiceStub")
+def test_worker_thread_rate_limiting_and_late_batches(mock_stub_class, mock_channel):
+    generator = LoadGenerator()
+
+    # Mock stub with delay to simulate late sending
+    def slow_export(request):
+        time.sleep(0.3)  # delay > interval causes batch to be late
+        return None
+
+    mock_stub = MagicMock()
+    mock_stub.Export.side_effect = slow_export
+    mock_stub_class.return_value = mock_stub
+
+    args = {
+        "body_size": 5,
+        "num_attributes": 1,
+        "attribute_value_size": 5,
+        "batch_size": 2,
+        "threads": 1,
+        "target_rate": 10,  # 10 logs/sec => batch every 0.2s
+    }
+
+    generator.stop_event.clear()
+    thread = threading.Thread(target=generator.worker_thread, args=(0, args))
+    thread.start()
+
+    # Wait for a few iterations
+    time.sleep(0.7)
+    generator.stop_event.set()
+    thread.join()
+
+    # Because slow_export takes longer than allowed interval,
+    # late_batches should increase
+    assert generator.metrics["late_batches"] > 0
+    assert generator.metrics["sent"] >= 2

--- a/tools/pipeline_perf_test/load_generator/tox.ini
+++ b/tools/pipeline_perf_test/load_generator/tox.ini
@@ -25,3 +25,11 @@ description = Check formatting with black (non-destructive)
 skip_install = true
 deps = black
 commands = black ./
+
+[testenv:test]
+description = Run unit tests with pytest
+deps =
+    -rrequirements.txt
+    pytest
+commands =
+    pytest


### PR DESCRIPTION
This PR introduces an optional "target_rate" flag / config item that will cause the loadgenerator worker threads to attempt to hit a specific rate of messages/sec. Default behavior in cli / server mode is unchanged.

- Add "target_rate" cli argument and config field, which will throttle threads when set
- Add "late_batches" metric for tracking where sends are failing to reach the target rate
- Add logic to compute per-worker-thread send intervals, and apply simple sleep based throttles
- Add light testing for configs, message format, worker behavior, and flask server

Support for orchestrator execution strategy to specify rate limiting will come in a subsequent PR