### PR TITLE
[query-engine] Add schema support to query engine parsers and support inner regex in reduce map

### DIFF
--- a/rust/experimental/query_engine/expressions/src/value_accessor.rs
+++ b/rust/experimental/query_engine/expressions/src/value_accessor.rs
@@ -44,6 +44,14 @@ impl ValueAccessor {
     pub fn push_selector(&mut self, selector: ScalarExpression) {
         self.selectors.push(selector)
     }
+
+    pub fn remove_selector(&mut self, index: usize) -> Option<ScalarExpression> {
+        if index >= self.selectors.len() {
+            return None;
+        }
+
+        Some(self.selectors.remove(index))
+    }
 }
 
 impl Default for ValueAccessor {

--- a/rust/experimental/query_engine/kql-parser/src/lib.rs
+++ b/rust/experimental/query_engine/kql-parser/src/lib.rs
@@ -14,3 +14,6 @@ pub use kql_parser::*;
 // parser-abstractions crate just to parse queries.
 pub use data_engine_parser_abstractions::Parser;
 pub use data_engine_parser_abstractions::ParserError;
+pub use data_engine_parser_abstractions::ParserMapKeySchema;
+pub use data_engine_parser_abstractions::ParserMapSchema;
+pub use data_engine_parser_abstractions::ParserOptions;

--- a/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
@@ -194,8 +194,8 @@ pub(crate) fn parse_real_expression(
 ///
 /// * If the root identifier is not `source` or something contained in either
 ///   attached names nor variables names we assume the user wants some default
-///   behavior. This is controlled by `default_source_map_key` on
-///   [`ParserState`].
+///   behavior. This is controlled by `source_keys` and `default_source_map_key`
+///   on [`ParserState`].
 ///
 ///   `unknown` -> `Source(MapKey("attributes"), MapKey("unknown"))`
 pub(crate) fn parse_accessor_expression(
@@ -209,15 +209,26 @@ pub(crate) fn parse_accessor_expression(
 
     let root_accessor_identity_rule = accessor_rules.next().unwrap();
 
+    let mut root_full_identifier_literal_complete = false;
+    let mut root_full_identifier_literal_depth = 0;
+    let mut root_full_identifier_literal = String::new();
+
     let root_accessor_identity = match root_accessor_identity_rule.as_rule() {
         Rule::string_literal => match parse_string_literal(root_accessor_identity_rule) {
-            StaticScalarExpression::String(v) => v,
+            StaticScalarExpression::String(v) => {
+                root_full_identifier_literal_complete = true;
+                v
+            }
             _ => panic!("Unexpected type returned from parse_string_literal"),
         },
-        Rule::identifier_literal => StringScalarExpression::new(
-            to_query_location(&root_accessor_identity_rule),
-            root_accessor_identity_rule.as_str(),
-        ),
+        Rule::identifier_literal => {
+            root_full_identifier_literal.push_str(root_accessor_identity_rule.as_str());
+
+            StringScalarExpression::new(
+                to_query_location(&root_accessor_identity_rule),
+                root_accessor_identity_rule.as_str(),
+            )
+        }
         _ => panic!("Unexpected rule in accessor_expression: {root_accessor_identity_rule}"),
     };
 
@@ -232,31 +243,40 @@ pub(crate) fn parse_accessor_expression(
         }
 
         let pair = accessor.unwrap();
-        match pair.as_rule() {
-            Rule::integer_literal => match parse_standard_integer_literal(pair)? {
-                StaticScalarExpression::Integer(v) => {
-                    let i = v.get_value();
+        let pair_value = pair.as_str();
+        let add_to_root_literal = match pair.as_rule() {
+            Rule::integer_literal => {
+                match parse_standard_integer_literal(pair)? {
+                    StaticScalarExpression::Integer(v) => {
+                        let i = v.get_value();
 
-                    if i < i32::MIN as i64 || i > i32::MAX as i64 {
-                        return Err(ParserError::SyntaxError(
-                            v.get_query_location().clone(),
-                            format!(
-                                "'{i}' value for array index is too large to fit into a 32bit value"
-                            ),
+                        if i < i32::MIN as i64 || i > i32::MAX as i64 {
+                            return Err(ParserError::SyntaxError(
+                                v.get_query_location().clone(),
+                                format!(
+                                    "'{i}' value for array index is too large to fit into a 32bit value"
+                                ),
+                            ));
+                        }
+
+                        value_accessor.push_selector(ScalarExpression::Static(
+                            StaticScalarExpression::Integer(v),
                         ));
                     }
-
-                    value_accessor.push_selector(ScalarExpression::Static(
-                        StaticScalarExpression::Integer(v),
-                    ));
+                    _ => panic!("Unexpected type returned from parse_standard_integer_literal"),
                 }
-                _ => panic!("Unexpected type returned from parse_standard_integer_literal"),
-            },
-            Rule::string_literal => match parse_string_literal(pair) {
-                StaticScalarExpression::String(v) => value_accessor
-                    .push_selector(ScalarExpression::Static(StaticScalarExpression::String(v))),
-                _ => panic!("Unexpected type returned from parse_string_literal"),
-            },
+
+                false
+            }
+            Rule::string_literal => {
+                match parse_string_literal(pair) {
+                    StaticScalarExpression::String(v) => value_accessor
+                        .push_selector(ScalarExpression::Static(StaticScalarExpression::String(v))),
+                    _ => panic!("Unexpected type returned from parse_string_literal"),
+                }
+
+                false
+            }
             Rule::identifier_literal => {
                 value_accessor.push_selector(ScalarExpression::Static(
                     StaticScalarExpression::String(StringScalarExpression::new(
@@ -264,6 +284,8 @@ pub(crate) fn parse_accessor_expression(
                         pair.as_str(),
                     )),
                 ));
+
+                true
             }
             Rule::scalar_expression => {
                 let scalar = parse_scalar_expression(pair, state)?;
@@ -305,31 +327,43 @@ pub(crate) fn parse_accessor_expression(
 
                     value_accessor.push_selector(scalar);
                 }
+
+                false
             }
             Rule::minus_token => {
                 negate_location = Some(to_query_location(&pair));
+                false
             }
             _ => panic!("Unexpected rule in accessor_expression: {pair}"),
+        };
+
+        if !root_full_identifier_literal_complete && add_to_root_literal {
+            root_full_identifier_literal_depth += 1;
+            root_full_identifier_literal.push('.');
+            root_full_identifier_literal.push_str(pair_value);
+        } else {
+            root_full_identifier_literal_complete = true;
         }
     }
 
     if root_accessor_identity.get_value() == "source" {
-        Ok(ScalarExpression::Source(SourceScalarExpression::new(
+        let value_type = get_value_type(state, &value_accessor);
+
+        Ok(ScalarExpression::Source(
+            SourceScalarExpression::new_with_value_type(query_location, value_accessor, value_type),
+        ))
+    } else if state.is_attached_data_defined(root_accessor_identity.get_value()) {
+        Ok(ScalarExpression::Attached(AttachedScalarExpression::new(
             query_location,
+            root_accessor_identity,
             value_accessor,
         )))
-    } else if state.is_attached_data_defined(root_accessor_identity.get_value()) {
-        return Ok(ScalarExpression::Attached(AttachedScalarExpression::new(
-            query_location,
-            root_accessor_identity,
-            value_accessor,
-        )));
     } else if state.is_variable_defined(root_accessor_identity.get_value()) {
-        return Ok(ScalarExpression::Variable(VariableScalarExpression::new(
+        Ok(ScalarExpression::Variable(VariableScalarExpression::new(
             query_location,
             root_accessor_identity,
             value_accessor,
-        )));
+        )))
     } else {
         // Note: If the accessor_expression is being used as a scalar it is
         // perfectly valid to return a static constant value. However accessors
@@ -362,16 +396,130 @@ pub(crate) fn parse_accessor_expression(
             }
         }
 
-        value_accessor.insert_selector(
-            0,
-            ScalarExpression::Static(StaticScalarExpression::String(root_accessor_identity)),
-        );
+        if let Some(schema) = state.get_source_schema() {
+            match schema.get_schema_for_key(root_accessor_identity.get_value()) {
+                Some(key) => {
+                    if value_accessor.has_selectors() {
+                        // Note: If we are selecting a well-defined key on the
+                        // source we can do some validation. If there are child
+                        // selectors they are only valid for maps and arrays.
+                        // This logic could be improved further to inspect the
+                        // next selector and see if it is a string (parent must
+                        // be a map) or an int (parent must be an array).
+                        if !matches!(
+                            key.get_value_type(),
+                            Some(ValueType::Map) | Some(ValueType::Array) | None
+                        ) {
+                            return Err(ParserError::SyntaxError(
+                                root_accessor_identity.get_query_location().clone(),
+                                format!(
+                                    "Cannot access into key '{}' which is defined as a '{:?}' type",
+                                    root_accessor_identity.get_value(),
+                                    key.get_value_type()
+                                ),
+                            ));
+                        }
+                    }
 
-        return Ok(ScalarExpression::Source(SourceScalarExpression::new(
-            query_location,
-            value_accessor,
-        )));
+                    value_accessor.insert_selector(
+                        0,
+                        ScalarExpression::Static(StaticScalarExpression::String(
+                            root_accessor_identity,
+                        )),
+                    );
+                }
+                None => {
+                    if let Some(default_map_key) = schema.get_default_map_key() {
+                        // Note: If the root is not found and we have a default
+                        // map we insert it into the expression. Let's say
+                        // default_source_map_key=attributes. And we have keys
+                        // source_keys[timestamp, body, attributes] defined. If
+                        // we see a selector "key1" we rewrite that as
+                        // "attributes.key1" so the search for "key1" looks into
+                        // the default map ("attributes" in this case).
+
+                        let root_location = root_accessor_identity.get_query_location().clone();
+
+                        if root_full_identifier_literal_depth > 0 {
+                            // Note: If we have a selector like "some.thing" it
+                            // will parse as [some][thing] by default. We know
+                            // we didn't find "some" as a defined key on source.
+                            // What this code does is for the lookup to the
+                            // default map (say attributes) we do
+                            // attributes["some.thing"] instead of
+                            // attributes["some"]["thing"].
+
+                            while root_full_identifier_literal_depth > 0 {
+                                value_accessor.remove_selector(0);
+                                root_full_identifier_literal_depth -= 1;
+                            }
+
+                            value_accessor.insert_selector(
+                                0,
+                                ScalarExpression::Static(StaticScalarExpression::String(
+                                    StringScalarExpression::new(
+                                        root_location.clone(),
+                                        root_full_identifier_literal.as_str(),
+                                    ),
+                                )),
+                            );
+                        } else {
+                            value_accessor.insert_selector(
+                                0,
+                                ScalarExpression::Static(StaticScalarExpression::String(
+                                    root_accessor_identity,
+                                )),
+                            );
+                        }
+
+                        value_accessor.insert_selector(
+                            0,
+                            ScalarExpression::Static(StaticScalarExpression::String(
+                                StringScalarExpression::new(root_location, default_map_key),
+                            )),
+                        );
+                    } else {
+                        return Err(ParserError::QueryLanguageDiagnostic {
+                            location: root_accessor_identity.get_query_location().clone(),
+                            diagnostic_id: "KS109",
+                            message: format!(
+                                "The name '{}' does not refer to any known column, table, variable or function",
+                                root_accessor_identity.get_value()
+                            ),
+                        });
+                    }
+                }
+            }
+        } else {
+            value_accessor.insert_selector(
+                0,
+                ScalarExpression::Static(StaticScalarExpression::String(root_accessor_identity)),
+            );
+        }
+
+        let value_type = get_value_type(state, &value_accessor);
+
+        Ok(ScalarExpression::Source(
+            SourceScalarExpression::new_with_value_type(query_location, value_accessor, value_type),
+        ))
     }
+}
+
+fn get_value_type(state: &ParserState, value_accessor: &ValueAccessor) -> Option<ValueType> {
+    let selectors = value_accessor.get_selectors();
+    let mut value_type = None;
+    if selectors.is_empty() {
+        value_type = Some(ValueType::Map);
+    } else if selectors.len() == 1
+        && let Some(schema) = state.get_source_schema()
+        && let ScalarExpression::Static(StaticScalarExpression::String(key)) =
+            selectors.first().unwrap()
+        && let Some(key_schema) = schema.get_schema_for_key(key.get_value())
+    {
+        value_type = key_schema.get_value_type();
+    }
+
+    value_type
 }
 
 #[cfg(test)]
@@ -988,29 +1136,157 @@ mod tests {
 
     #[test]
     fn test_parse_accessor_expression_implicit_source_and_default_map() {
-        let mut result = KqlPestParser::parse(Rule::accessor_expression, "subkey").unwrap();
+        let run_test = |query: &str, expected: &Vec<ScalarExpression>| {
+            let mut result = KqlPestParser::parse(Rule::accessor_expression, query).unwrap();
 
-        let expression = parse_accessor_expression(
-            result.next().unwrap(),
-            &ParserState::new_with_options(
-                "subkey",
-                ParserOptions::new().with_default_source_map_key_name("attributes"),
+            let expression = parse_accessor_expression(
+                result.next().unwrap(),
+                &ParserState::new_with_options(
+                    query,
+                    ParserOptions::new().with_source_map_schema(
+                        ParserMapSchema::new().set_default_map_key("attributes"),
+                    ),
+                ),
+                true,
+            )
+            .unwrap();
+
+            if let ScalarExpression::Source(s) = expression {
+                assert_eq!(expected, s.get_value_accessor().get_selectors());
+            } else {
+                panic!("Expected SourceScalarExpression");
+            }
+        };
+
+        run_test(
+            "subkey",
+            &vec![
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "attributes"),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "subkey"),
+                )),
+            ],
+        );
+
+        run_test(
+            "sub.key",
+            &vec![
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "attributes"),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "sub.key"),
+                )),
+            ],
+        );
+
+        run_test(
+            "sub.a.b['key1']",
+            &vec![
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "attributes"),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "sub.a.b"),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "key1"),
+                )),
+            ],
+        );
+    }
+
+    #[test]
+    fn test_parse_accessor_expression_implicit_source_and_souce_keys() {
+        let run_test_success = |query: &str, expected: SourceScalarExpression| {
+            let mut result = KqlPestParser::parse(Rule::accessor_expression, query).unwrap();
+
+            let expression = parse_accessor_expression(
+                result.next().unwrap(),
+                &ParserState::new_with_options(
+                    query,
+                    ParserOptions::new().with_source_map_schema(
+                        ParserMapSchema::new()
+                            .with_key_definition("int_key", ParserMapKeySchema::Integer)
+                            .with_key_definition("key_without_type", ParserMapKeySchema::Any),
+                    ),
+                ),
+                true,
+            )
+            .unwrap();
+
+            if let ScalarExpression::Source(s) = expression {
+                assert_eq!(expected, s);
+            } else {
+                panic!("Expected SourceScalarExpression");
+            }
+        };
+
+        let run_test_failure = |query: &str, expected_id: &str, expected_msg: &str| {
+            let mut result = KqlPestParser::parse(Rule::accessor_expression, query).unwrap();
+
+            let error = parse_accessor_expression(
+                result.next().unwrap(),
+                &ParserState::new_with_options(
+                    query,
+                    ParserOptions::new().with_source_map_schema(
+                        ParserMapSchema::new()
+                            .with_key_definition("int_key", ParserMapKeySchema::Integer)
+                            .with_key_definition("key_without_type", ParserMapKeySchema::Any),
+                    ),
+                ),
+                true,
+            )
+            .unwrap_err();
+
+            if let ParserError::QueryLanguageDiagnostic {
+                location: _,
+                diagnostic_id: id,
+                message: msg,
+            } = error
+            {
+                assert_eq!(expected_id, id);
+                assert_eq!(expected_msg, msg);
+            } else {
+                panic!("Expected QueryLanguageDiagnostic");
+            }
+        };
+
+        run_test_success(
+            "int_key",
+            SourceScalarExpression::new_with_value_type(
+                QueryLocation::new_fake(),
+                ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                    StaticScalarExpression::String(StringScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        "int_key",
+                    )),
+                )]),
+                Some(ValueType::Integer),
             ),
-            true,
-        )
-        .unwrap();
+        );
 
-        if let ScalarExpression::Source(s) = expression {
-            assert_eq!(
-                &[ScalarExpression::Static(StaticScalarExpression::String(
-                    StringScalarExpression::new(QueryLocation::new_fake(), "subkey")
-                ))]
-                .to_vec(),
-                s.get_value_accessor().get_selectors()
-            );
-        } else {
-            panic!("Expected SourceScalarExpression");
-        }
+        run_test_success(
+            "key_without_type",
+            SourceScalarExpression::new_with_value_type(
+                QueryLocation::new_fake(),
+                ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                    StaticScalarExpression::String(StringScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        "key_without_type",
+                    )),
+                )]),
+                None,
+            ),
+        );
+
+        run_test_failure(
+            "unknown_key",
+            "KS109",
+            "The name 'unknown_key' does not refer to any known column, table, variable or function",
+        );
     }
 
     #[test]

--- a/rust/experimental/query_engine/ottl-parser/src/lib.rs
+++ b/rust/experimental/query_engine/ottl-parser/src/lib.rs
@@ -10,3 +10,6 @@ pub use ottl_parser::*;
 // parser-abstractions crate just to parse queries.
 pub use data_engine_parser_abstractions::Parser;
 pub use data_engine_parser_abstractions::ParserError;
+pub use data_engine_parser_abstractions::ParserMapKeySchema;
+pub use data_engine_parser_abstractions::ParserMapSchema;
+pub use data_engine_parser_abstractions::ParserOptions;

--- a/rust/experimental/query_engine/parser-abstractions/src/parser.rs
+++ b/rust/experimental/query_engine/parser-abstractions/src/parser.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use data_engine_expressions::*;
 
@@ -16,22 +16,20 @@ pub trait Parser {
 }
 
 pub struct ParserOptions {
-    pub(crate) default_source_map_key: Option<Box<str>>,
+    pub(crate) source_map_schema: Option<ParserMapSchema>,
     pub(crate) attached_data_names: HashSet<Box<str>>,
 }
 
 impl ParserOptions {
     pub fn new() -> ParserOptions {
         Self {
-            default_source_map_key: None,
+            source_map_schema: None,
             attached_data_names: HashSet::new(),
         }
     }
 
-    pub fn with_default_source_map_key_name(mut self, name: &str) -> ParserOptions {
-        if !name.is_empty() {
-            self.default_source_map_key = Some(name.into());
-        }
+    pub fn with_source_map_schema(mut self, source_map_schema: ParserMapSchema) -> ParserOptions {
+        self.source_map_schema = Some(source_map_schema);
 
         self
     }
@@ -48,5 +46,86 @@ impl ParserOptions {
 impl Default for ParserOptions {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+pub struct ParserMapSchema {
+    keys: HashMap<Box<str>, ParserMapKeySchema>,
+    default_map_key: Option<Box<str>>,
+}
+
+impl ParserMapSchema {
+    pub fn new() -> ParserMapSchema {
+        Self {
+            keys: HashMap::new(),
+            default_map_key: None,
+        }
+    }
+
+    pub fn with_key_definition(
+        mut self,
+        name: &str,
+        schema: ParserMapKeySchema,
+    ) -> ParserMapSchema {
+        self.keys.insert(name.into(), schema);
+        self
+    }
+
+    pub fn set_default_map_key(mut self, name: &str) -> ParserMapSchema {
+        let definition = self
+            .keys
+            .entry(name.into())
+            .or_insert_with(|| ParserMapKeySchema::Map);
+        if definition.get_value_type() != Some(ValueType::Map) {
+            panic!("Map key was already defined for '{name}' as something other than a map");
+        }
+        self.default_map_key = Some(name.into());
+        self
+    }
+
+    pub fn get_schema_for_keys(&self) -> &HashMap<Box<str>, ParserMapKeySchema> {
+        &self.keys
+    }
+
+    pub fn get_schema_for_key(&self, name: &str) -> Option<&ParserMapKeySchema> {
+        self.keys.get(name)
+    }
+
+    pub fn get_default_map_key(&self) -> Option<&str> {
+        self.default_map_key.as_ref().map(|v| v.as_ref())
+    }
+}
+
+impl Default for ParserMapSchema {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub enum ParserMapKeySchema {
+    Any,
+    Array,
+    Boolean,
+    DateTime,
+    Double,
+    Integer,
+    Map,
+    Regex,
+    String,
+}
+
+impl ParserMapKeySchema {
+    pub fn get_value_type(&self) -> Option<ValueType> {
+        match self {
+            ParserMapKeySchema::Any => None,
+            ParserMapKeySchema::Array => Some(ValueType::Array),
+            ParserMapKeySchema::Boolean => Some(ValueType::Boolean),
+            ParserMapKeySchema::DateTime => Some(ValueType::DateTime),
+            ParserMapKeySchema::Double => Some(ValueType::Double),
+            ParserMapKeySchema::Integer => Some(ValueType::Integer),
+            ParserMapKeySchema::Map => Some(ValueType::Map),
+            ParserMapKeySchema::Regex => Some(ValueType::Regex),
+            ParserMapKeySchema::String => Some(ValueType::String),
+        }
     }
 }

--- a/rust/experimental/query_engine/parser-abstractions/src/parser_state.rs
+++ b/rust/experimental/query_engine/parser-abstractions/src/parser_state.rs
@@ -2,10 +2,10 @@ use std::collections::{HashMap, HashSet};
 
 use data_engine_expressions::*;
 
-use crate::{ParserError, ParserOptions};
+use crate::{ParserError, ParserMapSchema, ParserOptions};
 
 pub struct ParserState {
-    default_source_map_key: Option<Box<str>>,
+    source_map_schema: Option<ParserMapSchema>,
     attached_data_names: HashSet<Box<str>>,
     variable_names: HashSet<Box<str>>,
     constants: HashMap<Box<str>, (usize, ValueType)>,
@@ -19,7 +19,7 @@ impl ParserState {
 
     pub fn new_with_options(query: &str, options: ParserOptions) -> ParserState {
         Self {
-            default_source_map_key: options.default_source_map_key,
+            source_map_schema: options.source_map_schema,
             attached_data_names: options.attached_data_names,
             variable_names: HashSet::new(),
             constants: HashMap::new(),
@@ -39,8 +39,8 @@ impl ParserState {
         self.pipeline_builder.as_ref()
     }
 
-    pub fn get_default_source_map_key(&self) -> Option<&str> {
-        self.default_source_map_key.as_ref().map(|f| f.as_ref())
+    pub fn get_source_schema(&self) -> Option<&ParserMapSchema> {
+        self.source_map_schema.as_ref()
     }
 
     pub fn is_well_defined_identifier(&self, name: &str) -> bool {


### PR DESCRIPTION
Fixes #685

## Changes

* Introduces schema for the source record when parsing expressions
* Support inner regex patterns in reduce map
