### PR TITLE
Minor prepare-release fixes and script abstraction

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -23,102 +23,29 @@ jobs:
     environment: release
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-tags: true
 
       - name: Validate inputs
-        run: |
-          # Validate version format
-          if [[ ! "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Error: Version must be in format X.Y.Z (e.g., 0.40.0)"
-            exit 1
-          fi
-
-          # Check if repository is clean
-          if [ -n "$(git status --porcelain)" ]; then
-            echo "Error: Repository has uncommitted changes"
-            git status
-            exit 1
-          fi
+        run: ./.github/workflows/scripts/validate-version.sh "${{ inputs.version }}"
 
       - name: Get last released version
         id: last_version
         run: |
-          # Get the latest tag
-          LAST_TAG=$(git tag --list 'v*' --sort=-version:refname | head -n1)
-          if [ -z "$LAST_TAG" ]; then
-            echo "No previous tags found"
-            LAST_VERSION="0.0.0"
-          else
-            LAST_VERSION=${LAST_TAG#v}
-          fi
+          LAST_VERSION=$(./.github/workflows/scripts/get-last-version.sh --quiet)
           echo "last_version=$LAST_VERSION" >> $GITHUB_OUTPUT
           echo "Last released version: $LAST_VERSION"
           echo "New version: ${{ inputs.version }}"
 
       - name: Validate version increment
-        run: |
-          LAST_VERSION="${{ steps.last_version.outputs.last_version }}"
-          NEW_VERSION="${{ inputs.version }}"
-
-          # Simple version comparison (assumes semantic versioning)
-          if [ "$LAST_VERSION" != "0.0.0" ]; then
-            if ! printf '%s\n%s\n' "$LAST_VERSION" "$NEW_VERSION" | sort -V -C; then
-              echo "Error: New version $NEW_VERSION is not greater than last version $LAST_VERSION"
-              exit 1
-            fi
-          fi
+        run: ./.github/workflows/scripts/validate-version-increment.sh "${{ steps.last_version.outputs.last_version }}" "${{ inputs.version }}"
 
       - name: Extract changelog content
         id: changelog
-        run: |
-          # Extract content from ## Unreleased section
-          if [ ! -f "CHANGELOG.md" ]; then
-            echo "Error: CHANGELOG.md not found"
-            exit 1
-          fi
-
-          # Get unreleased content
-          UNRELEASED_CONTENT=$(awk '/^## Unreleased/,/^## \[/ {
-            if (/^## Unreleased/) next
-            if (/^## \[/) exit
-            print
-          }' CHANGELOG.md | sed '/^$/d')
-
-          if [ -z "$UNRELEASED_CONTENT" ]; then
-            echo "Error: No unreleased content found in CHANGELOG.md"
-            exit 1
-          fi
-
-          # Save to file for later use
-          echo "$UNRELEASED_CONTENT" > /tmp/changelog_content.txt
-          echo "Found changelog content:"
-          cat /tmp/changelog_content.txt
+        run: ./.github/workflows/scripts/extract-changelog.sh /tmp/changelog_content.txt
 
       - name: Update CHANGELOG.md
-        run: |
-          # Create new changelog with release section
-          RELEASE_DATE=$(date -u +"%Y-%m-%d")
-          NEW_VERSION="${{ inputs.version }}"
-
-          # Create temporary file with new content
-          {
-            # Keep everything up to ## Unreleased
-            awk '/^## Unreleased/ {print; exit}' CHANGELOG.md
-            echo ""
-
-            # Add new release section
-            echo "## [${NEW_VERSION}](https://github.com/open-telemetry/otel-arrow/releases/tag/v${NEW_VERSION}) - ${RELEASE_DATE}"
-            echo ""
-
-            # Add unreleased content
-            cat /tmp/changelog_content.txt
-            echo ""
-
-            # Add rest of changelog (starting from first existing release)
-            awk '/^## \[.*\]/ {found=1} found {print}' CHANGELOG.md
-          } > CHANGELOG.md.tmp
-
-          mv CHANGELOG.md.tmp CHANGELOG.md
-          echo "Updated CHANGELOG.md with release $NEW_VERSION"
+        run: ./.github/workflows/scripts/update-changelog.sh "${{ inputs.version }}" /tmp/changelog_content.txt
 
       - name: Dry run - Show planned changes
         if: inputs.dry_run
@@ -135,7 +62,7 @@ jobs:
 
           echo ""
           echo "Git operations that would occur:"
-          echo "  - Create branch: release-v${{ inputs.version }}"
+          echo "  - Create branch: otelbot/release-v${{ inputs.version }}"
           echo "  - Commit version updates"
           echo "  - Create pull request"
           echo ""
@@ -152,25 +79,12 @@ jobs:
       - name: Create release branch and commit changes
         if: '!inputs.dry_run'
         run: |
-          # Configure git
+          # Configure git for otelbot
           git config user.name otelbot
           git config user.email 197425009+otelbot@users.noreply.github.com
 
-          # Create and switch to release branch
-          git checkout -b "otelbot/release-v${{ inputs.version }}"
-
-          # Add all changes
-          git add .
-
-          # Commit changes
-          git commit -m "Prepare release v${{ inputs.version }}
-
-          - Update CHANGELOG.md with release notes for v${{ inputs.version }}
-
-          This commit prepares the repository for release v${{ inputs.version }}."
-
-          # Push branch
-          git push origin "otelbot/release-v${{ inputs.version }}"
+          # Use script to create branch and commit
+          ./.github/workflows/scripts/create-release-branch.sh "${{ inputs.version }}" --push
 
       - name: Create pull request
         if: '!inputs.dry_run'

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -14,11 +14,13 @@ on:
         default: true
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   prepare-release:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     environment: release
     steps:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Create GitHub App token
         if: '!inputs.dry_run'
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         id: app-token
         with:
           app-id: ${{ vars.OTELBOT_APP_ID }}

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Create GitHub App token
         if: '!inputs.dry_run'
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         id: app-token
         with:
           app-id: ${{ vars.OTELBOT_APP_ID }}

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -14,10 +14,12 @@ on:
         default: true
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   push-release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     environment: release
     steps:

--- a/.github/workflows/scripts/create-release-branch.sh
+++ b/.github/workflows/scripts/create-release-branch.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# create-release-branch.sh - Create release branch and commit changes
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+usage() {
+    echo "Usage: $0 <version> [--push]"
+    echo "  version: Release version (e.g., 0.40.0)"
+    echo "  --push: Push the branch to origin (optional)"
+    exit 1
+}
+
+if [ $# -lt 1 ]; then
+    usage
+fi
+
+VERSION="$1"
+PUSH_BRANCH=false
+
+if [ $# -eq 2 ] && [ "$2" = "--push" ]; then
+    PUSH_BRANCH=true
+fi
+
+BRANCH_NAME="otelbot/release-v$VERSION"
+
+echo -e "${YELLOW}Creating release branch and committing changes...${NC}"
+
+# Configure git (use current user config by default)
+if [ -z "$(git config user.name)" ] || [ -z "$(git config user.email)" ]; then
+    echo -e "${YELLOW}Warning: Git user name or email not configured${NC}"
+    echo "You may want to run:"
+    echo "  git config user.name 'Your Name'"
+    echo "  git config user.email 'your.email@example.com'"
+fi
+
+# Check if branch already exists
+if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
+    echo -e "${RED}Error: Branch $BRANCH_NAME already exists${NC}"
+    exit 1
+fi
+
+# Create and switch to release branch
+echo "Creating branch: $BRANCH_NAME"
+git checkout -b "$BRANCH_NAME"
+
+# Check if there are any changes to commit
+if [ -z "$(git status --porcelain)" ]; then
+    echo -e "${YELLOW}Warning: No changes to commit${NC}"
+    exit 0
+fi
+
+# Add all changes
+git add .
+
+# Commit changes
+git commit -m "Prepare release v$VERSION
+
+- Update CHANGELOG.md with release notes for v$VERSION
+
+This commit prepares the repository for release v$VERSION."
+
+echo -e "${GREEN}✓ Committed changes to branch $BRANCH_NAME${NC}"
+
+# Push branch if requested
+if [ "$PUSH_BRANCH" = true ]; then
+    echo "Pushing branch to origin..."
+    git push origin "$BRANCH_NAME"
+    echo -e "${GREEN}✓ Pushed branch to origin${NC}"
+fi
+
+echo -e "${GREEN}Release branch created successfully!${NC}"
+echo "Branch: $BRANCH_NAME"

--- a/.github/workflows/scripts/extract-changelog.sh
+++ b/.github/workflows/scripts/extract-changelog.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# extract-changelog.sh - Extract unreleased content from CHANGELOG.md
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+OUTPUT_FILE="${1:-/tmp/changelog_content.txt}"
+
+echo -e "${YELLOW}Extracting changelog content...${NC}"
+
+# Check if CHANGELOG.md exists
+if [ ! -f "CHANGELOG.md" ]; then
+    echo -e "${RED}Error: CHANGELOG.md not found${NC}"
+    exit 1
+fi
+
+# Get unreleased content
+UNRELEASED_CONTENT=$(awk '/^## Unreleased/,/^## \[/ {
+    if (/^## Unreleased/) next
+    if (/^## \[/) exit
+    print
+}' CHANGELOG.md | sed '/^$/d')
+
+if [ -z "$UNRELEASED_CONTENT" ]; then
+    echo -e "${RED}Error: No unreleased content found in CHANGELOG.md${NC}"
+    exit 1
+fi
+
+# Save to file
+echo "$UNRELEASED_CONTENT" > "$OUTPUT_FILE"
+
+echo -e "${GREEN}✓ Changelog content extracted to: $OUTPUT_FILE${NC}"
+echo "Content:"
+echo "----------------------------------------"
+cat "$OUTPUT_FILE"
+echo "----------------------------------------"

--- a/.github/workflows/scripts/get-last-version.sh
+++ b/.github/workflows/scripts/get-last-version.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# get-last-version.sh - Get the last released version from git tags
+
+set -euo pipefail
+
+# Colors for output
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Check if we want verbose output (default is verbose unless --quiet is passed)
+QUIET=false
+if [ $# -eq 1 ] && [ "$1" = "--quiet" ]; then
+    QUIET=true
+fi
+
+if [ "$QUIET" = false ]; then
+    echo -e "${YELLOW}Getting last released version...${NC}" >&2
+fi
+
+# Get the latest tag
+LAST_TAG=$(git tag --list 'v*' --sort=-version:refname | head -n1)
+
+if [ -z "$LAST_TAG" ]; then
+    if [ "$QUIET" = false ]; then
+        echo "No previous tags found" >&2
+    fi
+    LAST_VERSION="0.0.0"
+else
+    LAST_VERSION=${LAST_TAG#v}
+fi
+
+if [ "$QUIET" = false ]; then
+    echo -e "${GREEN}Last released version: $LAST_VERSION${NC}" >&2
+fi
+echo "$LAST_VERSION"

--- a/.github/workflows/scripts/update-changelog.sh
+++ b/.github/workflows/scripts/update-changelog.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# update-changelog.sh - Update CHANGELOG.md with new release section
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+usage() {
+    echo "Usage: $0 <version> [changelog_content_file]"
+    echo "  version: Release version (e.g., 0.40.0)"
+    echo "  changelog_content_file: File containing unreleased content (default: /tmp/changelog_content.txt)"
+    exit 1
+}
+
+if [ $# -lt 1 ]; then
+    usage
+fi
+
+NEW_VERSION="$1"
+CHANGELOG_CONTENT_FILE="${2:-/tmp/changelog_content.txt}"
+
+echo -e "${YELLOW}Updating CHANGELOG.md...${NC}"
+
+# Check if CHANGELOG.md exists
+if [ ! -f "CHANGELOG.md" ]; then
+    echo -e "${RED}Error: CHANGELOG.md not found${NC}"
+    exit 1
+fi
+
+# Check if changelog content file exists
+if [ ! -f "$CHANGELOG_CONTENT_FILE" ]; then
+    echo -e "${RED}Error: Changelog content file not found: $CHANGELOG_CONTENT_FILE${NC}"
+    exit 1
+fi
+
+# Create new changelog with release section
+RELEASE_DATE=$(date -u +"%Y-%m-%d")
+
+# Create temporary file with new content
+{
+    # Keep header content and unreleased section header
+    awk '/^## Unreleased/ {print; exit} {print}' CHANGELOG.md
+    echo ""
+
+    # Add new release section
+    echo "## [${NEW_VERSION}](https://github.com/open-telemetry/otel-arrow/releases/tag/v${NEW_VERSION}) - ${RELEASE_DATE}"
+    echo ""
+
+    # Add unreleased content
+    cat "$CHANGELOG_CONTENT_FILE"
+    echo ""
+
+    # Add rest of changelog (starting from first existing release)
+    awk '/^## \[.*\]/ {found=1} found {print}' CHANGELOG.md
+} > CHANGELOG.md.tmp
+
+mv CHANGELOG.md.tmp CHANGELOG.md
+echo -e "${GREEN}✓ Updated CHANGELOG.md with release $NEW_VERSION${NC}"

--- a/.github/workflows/scripts/validate-version-increment.sh
+++ b/.github/workflows/scripts/validate-version-increment.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# validate-version-increment.sh - Validate that new version is greater than last version
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+usage() {
+    echo "Usage: $0 <last_version> <new_version>"
+    echo "  last_version: Previous version (e.g., 0.39.0)"
+    echo "  new_version: New version (e.g., 0.40.0)"
+    exit 1
+}
+
+if [ $# -ne 2 ]; then
+    usage
+fi
+
+LAST_VERSION="$1"
+NEW_VERSION="$2"
+
+echo -e "${YELLOW}Validating version increment...${NC}"
+echo "Last version: $LAST_VERSION"
+echo "New version: $NEW_VERSION"
+
+# Simple version comparison (assumes semantic versioning)
+if [ "$LAST_VERSION" != "0.0.0" ]; then
+    if ! printf '%s\n%s\n' "$LAST_VERSION" "$NEW_VERSION" | sort -V -C; then
+        echo -e "${RED}Error: New version $NEW_VERSION is not greater than last version $LAST_VERSION${NC}"
+        exit 1
+    fi
+fi
+
+echo -e "${GREEN}✓ Version increment is valid${NC}"

--- a/.github/workflows/scripts/validate-version.sh
+++ b/.github/workflows/scripts/validate-version.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# validate-version.sh - Validate version format and repository state
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+usage() {
+    echo "Usage: $0 <version>"
+    echo "  version: Version in format X.Y.Z (e.g., 0.40.0)"
+    exit 1
+}
+
+if [ $# -ne 1 ]; then
+    usage
+fi
+
+VERSION="$1"
+
+echo -e "${YELLOW}Validating version and repository state...${NC}"
+
+# Validate version format
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo -e "${RED}Error: Version must be in format X.Y.Z (e.g., 0.40.0)${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}✓ Version format is valid: $VERSION${NC}"
+
+# Check if repository is clean
+if [ -n "$(git status --porcelain)" ]; then
+    echo -e "${RED}Error: Repository has uncommitted changes${NC}"
+    git status
+    exit 1
+fi
+
+echo -e "${GREEN}✓ Repository is clean${NC}"
+
+# Check if we're in a git repository
+if ! git rev-parse --git-dir > /dev/null 2>&1; then
+    echo -e "${RED}Error: Not in a git repository${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}✓ In a git repository${NC}"
+
+echo -e "${GREEN}All validations passed!${NC}"


### PR DESCRIPTION
Fixes after [first run of prepare-release workflow](https://github.com/open-telemetry/otel-arrow/actions/runs/16528210761/job/46746812345), follow-up to #739
- Use `fetch-tags` during checkout
- Fix changelog content addition (don't override start of file headers)
- Use scripts instead of inline to enable local testing
- Address security warnings:
  - Use joblevel permissions instead of toplevel
  - Pin `create-github-app-token` action to Hash version