### PR TITLE
Try fixing Release body replacement

### DIFF
--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -163,7 +163,7 @@ jobs:
           RELEASE_CONTENT=$(cat /tmp/release_content.txt)
 
           # Create release body content
-          cat > /tmp/release_body.md << 'EOF'
+          cat > /tmp/release_body.md << EOF
           ## What's Changed
 
           ${RELEASE_CONTENT}


### PR DESCRIPTION
Attempt to fix #793. Hard to test on local fork because of token permissions.

This is the suspicion because of a similar issue fixed earlier in `prepare-release.yaml`. Apparently having `''` around EOF disables expansion.