### PR TITLE
Fix import

### DIFF
--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -49,7 +49,7 @@ thiserror = "2.0.12"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_cbor = "0.11.2"
 serde_json = { version = "1.0.140" }
-tokio = { version = "1.46.1", features = ["rt", "time", "net", "io-util", "sync", "macros", "rt-multi-thread", "fs"] }
+tokio = { version = "1.46.1", features = ["rt", "time", "net", "io-util", "sync", "macros", "rt-multi-thread", "fs", "io-std"] }
 uuid = { version = "1.17.0", features = ["v4"] }
 async-trait = "0.1.88"
 futures = "0.3.31"

--- a/rust/otap-dataflow/crates/engine/src/effect_handler.rs
+++ b/rust/otap-dataflow/crates/engine/src/effect_handler.rs
@@ -28,8 +28,8 @@ impl EffectHandlerCore {
     /// This method provides a standardized way for all nodes in the pipeline
     /// to output informational messages without blocking the async runtime.
     pub(crate) async fn info(&self, message: &str) {
-        use tokio::io::{AsyncWriteExt, stdout};
-        let mut out = stdout();
+        use tokio::io::AsyncWriteExt;
+        let mut out = tokio::io::stdout();
         let formatted_message = format!("{message}\n");
         // Ignore write errors as they're typically not recoverable for stdout
         let _ = out.write_all(formatted_message.as_bytes()).await;

--- a/rust/otap-dataflow/crates/engine/src/effect_handler.rs
+++ b/rust/otap-dataflow/crates/engine/src/effect_handler.rs
@@ -28,8 +28,8 @@ impl EffectHandlerCore {
     /// This method provides a standardized way for all nodes in the pipeline
     /// to output informational messages without blocking the async runtime.
     pub(crate) async fn info(&self, message: &str) {
-        use tokio::io::AsyncWriteExt;
-        let mut out = tokio::io::stdout();
+        use tokio::io::{AsyncWriteExt, stdout};
+        let mut out = stdout();
         let formatted_message = format!("{message}\n");
         // Ignore write errors as they're typically not recoverable for stdout
         let _ = out.write_all(formatted_message.as_bytes()).await;


### PR DESCRIPTION
Follow-up to #785 

<img width="1867" height="1095" alt="image" src="https://github.com/user-attachments/assets/91fb340b-4d2e-4143-9084-83f58b1040dc" />


## Changes
- Fix import of `tokio::io::stdout` in effect handler's `info` method