### PR TITLE
fix: flakey shutdown timeout test

### DIFF
--- a/rust/otap-dataflow/crates/engine/src/exporter.rs
+++ b/rust/otap-dataflow/crates/engine/src/exporter.rs
@@ -353,9 +353,11 @@ mod tests {
     }
 
     /// Validation closure that checks the expected counter values
-    fn validation_procedure()
-    -> impl FnOnce(TestContext<TestMsg>) -> std::pin::Pin<Box<dyn Future<Output = ()>>> {
-        |ctx| {
+    fn validation_procedure<T>() -> impl FnOnce(
+        TestContext<TestMsg>,
+        Result<(), Error<T>>,
+    ) -> std::pin::Pin<Box<dyn Future<Output = ()>>> {
+        |ctx, _| {
             Box::pin(async move {
                 ctx.counters().assert(
                     3, // timer tick
@@ -488,6 +490,7 @@ mod tests {
 
         // 5. Now, should receive the Shutdown message itself
         let msg5 = channel.recv().await.unwrap();
+        // println!("msg5 = {:?}", msg5);
         assert!(matches!(
             msg5,
             Message::Control(ControlMsg::Shutdown { .. })

--- a/rust/otap-dataflow/crates/engine/src/message.rs
+++ b/rust/otap-dataflow/crates/engine/src/message.rs
@@ -208,16 +208,6 @@ impl<PData> MessageChannel<PData> {
 
             // Draining mode: Shutdown pending
             if let Some(dl) = self.shutting_down_deadline {
-                // If the deadline has passed, emit the pending Shutdown now.
-                if Instant::now() >= dl {
-                    let shutdown = self
-                        .pending_shutdown
-                        .take()
-                        .expect("pending_shutdown must exist");
-                    self.shutdown();
-                    return Ok(Message::Control(shutdown));
-                }
-
                 if sleep_until_deadline.is_none() {
                     // Create a sleep timer for the deadline
                     sleep_until_deadline = Some(Box::pin(sleep_until(dl)));

--- a/rust/otap-dataflow/crates/otap/src/otap_exporter.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_exporter.rs
@@ -201,6 +201,7 @@ mod tests {
         arrow_traces_service_server::ArrowTracesServiceServer,
     };
     use otap_df_config::node::NodeUserConfig;
+    use otap_df_engine::error::Error;
     use otap_df_engine::exporter::ExporterWrapper;
     use otap_df_engine::testing::exporter::TestContext;
     use otap_df_engine::testing::exporter::TestRuntime;
@@ -258,9 +259,14 @@ mod tests {
     /// Validation closure that checks the expected counter values
     fn validation_procedure(
         mut receiver: tokio::sync::mpsc::Receiver<OTAPData>,
-    ) -> impl FnOnce(TestContext<OTAPData>) -> std::pin::Pin<Box<dyn Future<Output = ()>>> {
-        |_| {
+    ) -> impl FnOnce(
+        TestContext<OTAPData>,
+        Result<(), Error<OTAPData>>,
+    ) -> std::pin::Pin<Box<dyn Future<Output = ()>>> {
+        |_, exporter_result| {
             Box::pin(async move {
+                assert!(exporter_result.is_ok());
+
                 // check that the message was properly sent from the exporter
                 let metrics_received = timeout(Duration::from_secs(3), receiver.recv())
                     .await

--- a/rust/otap-dataflow/crates/otap/src/otap_exporter.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_exporter.rs
@@ -264,7 +264,7 @@ mod tests {
 
     /// Validation closure that checks the expected counter values
     fn validation_procedure(
-        mut receiver: tokio::sync::mpsc::Receiver<OTAPData>,
+        mut receiver: tokio::sync::mpsc::Receiver<OtapPdata>,
     ) -> impl FnOnce(
         TestContext<OtapPdata>,
         Result<(), Error<OtapPdata>>,

--- a/rust/otap-dataflow/crates/otap/src/parquet_exporter.rs
+++ b/rust/otap-dataflow/crates/otap/src/parquet_exporter.rs
@@ -234,12 +234,6 @@ mod test {
                 .await
                 .expect("Failed to send  logs message");
 
-                // wait a little bit before sending the shutdown message because
-                // in most test cases here, we want the exporter to handle to write
-                // messages before shutdown
-                // tokio::time::sleep(Duration::from_millis(1000)).await;
-                tokio::task::yield_now().await;
-
                 ctx.send_shutdown(shutdown_timeout, "test completed")
                     .await
                     .unwrap();

--- a/rust/otap-dataflow/crates/otap/src/parquet_exporter.rs
+++ b/rust/otap-dataflow/crates/otap/src/parquet_exporter.rs
@@ -424,7 +424,7 @@ mod test {
                             assert_eq!(&node, "test_exporter");
                             assert_eq!(error.kind(), ErrorKind::TimedOut);
                         },
-                        Err(e) => panic!("{}", format!("received unexpected error: {:?}. Expected IoError caused by timeout", e))
+                        Err(e) => panic!("{}", format!("received unexpected error: {e:?}. Expected IoError caused by timeout"))
                     }
                 })
             });

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -54,7 +54,7 @@
 //! ```
 //!
 //! Internally, conversions are happening using various utility functions:
-//! ```no_run
+//! ```text
 //!                                      ┌───────────────────────┐                                            
 //!                                      │                       │                                            
 //!                                      │      OTLP Bytes       │                                            

--- a/rust/otap-dataflow/crates/otap/src/perf_exporter/exporter.rs
+++ b/rust/otap-dataflow/crates/otap/src/perf_exporter/exporter.rs
@@ -595,6 +595,7 @@ mod tests {
         ArrowPayload, ArrowPayloadType, BatchArrowRecords,
     };
     use fluke_hpack::Encoder;
+    use otap_df_engine::error::Error;
     use otap_df_engine::exporter::ExporterWrapper;
     use otap_df_engine::testing::exporter::TestContext;
     use otap_df_engine::testing::exporter::TestRuntime;
@@ -712,9 +713,14 @@ mod tests {
     /// Validation closure that checks the expected counter values
     fn validation_procedure(
         output_file: String,
-    ) -> impl FnOnce(TestContext<OTAPData>) -> std::pin::Pin<Box<dyn Future<Output = ()>>> {
-        |_| {
+    ) -> impl FnOnce(
+        TestContext<OTAPData>,
+        Result<(), Error<OTAPData>>,
+    ) -> std::pin::Pin<Box<dyn Future<Output = ()>>> {
+        |_, exporter_result| {
             Box::pin(async move {
+                assert!(exporter_result.is_ok());
+
                 // get a file to read and validate the output
                 // open file
                 // read the output file

--- a/rust/otap-dataflow/crates/otlp/src/debug_exporter/exporter.rs
+++ b/rust/otap-dataflow/crates/otlp/src/debug_exporter/exporter.rs
@@ -433,6 +433,7 @@ mod tests {
         create_otlp_log, create_otlp_metric, create_otlp_profile, create_otlp_trace,
     };
 
+    use otap_df_engine::error::Error;
     use otap_df_engine::exporter::ExporterWrapper;
     use otap_df_engine::testing::exporter::TestContext;
     use otap_df_engine::testing::exporter::TestRuntime;
@@ -485,9 +486,14 @@ mod tests {
     /// Validation closure that checks the expected counter values
     fn validation_procedure(
         output_file: String,
-    ) -> impl FnOnce(TestContext<OTLPData>) -> std::pin::Pin<Box<dyn Future<Output = ()>>> {
-        |_| {
+    ) -> impl FnOnce(
+        TestContext<OTLPData>,
+        Result<(), Error<OTLPData>>,
+    ) -> std::pin::Pin<Box<dyn Future<Output = ()>>> {
+        |_, exporter_result| {
             Box::pin(async move {
+                assert!(exporter_result.is_ok());
+
                 // get a file to read and validate the output
                 // open file
                 // read the output file

--- a/rust/otap-dataflow/crates/otlp/src/otlp_batch_processor.rs
+++ b/rust/otap-dataflow/crates/otlp/src/otlp_batch_processor.rs
@@ -1813,6 +1813,7 @@ mod integration_tests {
     use std::io::Write;
     use std::rc::Rc;
     use std::time::Duration;
+    use tokio::io::AsyncWriteExt;
 
     fn wrap_local<P>(processor: P) -> ProcessorWrapper<OTLPData>
     where
@@ -1826,13 +1827,25 @@ mod integration_tests {
     }
 
     // Helper: Write string to a file
-    fn log_to_file(s: &str) {
-        let mut f = OpenOptions::new()
+    async fn log_to_file(s: &str) {
+        let mut f = tokio::fs::OpenOptions::new()
             .create(true)
             .append(true)
             .open("/tmp/generic_batch_proc_test.json")
+            .await
             .expect("could not open /tmp file for writing");
-        writeln!(f, "{s}\n").expect("Write failed");
+
+        _ = f
+            .write(&format!("{s}\n").encode_to_vec())
+            .await
+            .expect("write failed");
+
+        // let mut f = OpenOptions::new()
+        //     .create(true)
+        //     .append(true)
+        //     .open("/tmp/generic_batch_proc_test.json")
+        //     .expect("could not open /tmp file for writing");
+        // writeln!(f, "{s}\n").expect("Write failed");
     }
 
     fn sample_trace() -> ExportTraceServiceRequest {

--- a/rust/otap-dataflow/crates/otlp/src/otlp_batch_processor.rs
+++ b/rust/otap-dataflow/crates/otlp/src/otlp_batch_processor.rs
@@ -1813,7 +1813,6 @@ mod integration_tests {
     use std::io::Write;
     use std::rc::Rc;
     use std::time::Duration;
-    use tokio::io::AsyncWriteExt;
 
     fn wrap_local<P>(processor: P) -> ProcessorWrapper<OTLPData>
     where
@@ -1827,25 +1826,13 @@ mod integration_tests {
     }
 
     // Helper: Write string to a file
-    async fn log_to_file(s: &str) {
-        let mut f = tokio::fs::OpenOptions::new()
+    fn log_to_file(s: &str) {
+        let mut f = OpenOptions::new()
             .create(true)
             .append(true)
             .open("/tmp/generic_batch_proc_test.json")
-            .await
             .expect("could not open /tmp file for writing");
-
-        _ = f
-            .write(&format!("{s}\n").encode_to_vec())
-            .await
-            .expect("write failed");
-
-        // let mut f = OpenOptions::new()
-        //     .create(true)
-        //     .append(true)
-        //     .open("/tmp/generic_batch_proc_test.json")
-        //     .expect("could not open /tmp file for writing");
-        // writeln!(f, "{s}\n").expect("Write failed");
+        writeln!(f, "{s}\n").expect("Write failed");
     }
 
     fn sample_trace() -> ExportTraceServiceRequest {


### PR DESCRIPTION
fixes: https://github.com/open-telemetry/otel-arrow/issues/759

Fixes the flakey shutdown timeout test in parquet_exporter.

Before this change, the test was passing a `ControlMsg::Shutdown(Duration::ZERO)`, which would cause the channel to send a shutdown message to the exporter without trying to drain pdata. Most of the time, this would mean that calling `writer.flush()` would instantly finish because there were no buffered writes, and we wouldn't hit the timeout error. But occasionally, the timeout future would complete first for some reason and the test would fail.

Obviously we want to make this more reliable, while also testing the proper timeout behaviour. To do this, we need to invoke the drain mechanism to buffer some writes, in order that parquet exporter's `writer.flush()` method takes longer than the shutdown timeout.

To do this, we need a reliable way to invoke the drain mechanism. We do this by passing `ControlMsg::Shutdown(Duration::from_nanos(1))`, which will cause the `MessageChannel` to initiate drain behaviour. Also, we augment the behaviour at start of the `MessageChannel` control loop where if `shutting_down_deadline` is `Some`, we always initiate draining first. This gives a more reliable shutdown experience, because otherwise there's unknown behaviour related to how long the control loop iteration takes, how long the shutdown timeout is, and whether or not we attempt to drain pdata before sending the shutdown control message.

Also, in order to validate that the exporter returns the expected result the test harness now passes the returned `Result` into the validation procedure callback.