### PR TITLE
[PerfTest] Perf Test Suite for dataflow engine otlp logs

### DIFF
--- a/tools/pipeline_perf_test/backend/backend.py
+++ b/tools/pipeline_perf_test/backend/backend.py
@@ -13,6 +13,7 @@ Intended for testing or development purposes where a mock OTLP log collector is 
 """
 
 import asyncio
+import os
 import signal
 import sys
 import grpc  # type: ignore
@@ -23,8 +24,8 @@ from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import (
 )
 
 # Constants for ports
-FLASK_PORT = 5000
-GRPC_PORT = 5317
+FLASK_PORT = int(os.getenv('FLASK_PORT', 5000))
+GRPC_PORT = int(os.getenv('GRPC_PORT', 5317))
 
 app = Flask(__name__)
 received_logs = 0
@@ -32,10 +33,10 @@ received_logs_lock = asyncio.Lock()  # Async lock to guard the received_logs
 grpc_server = None
 
 
-def handle_signal(signal, frame):
+async def handle_signal(signal, frame):
     print("Received signal to terminate, stopping gRPC server.")
     if grpc_server:
-        grpc_server.stop(0)
+        await grpc_server.stop(0)
     sys.exit(0)
 
 

--- a/tools/pipeline_perf_test/backend/tests/test_receiver.py
+++ b/tools/pipeline_perf_test/backend/tests/test_receiver.py
@@ -73,9 +73,10 @@ async def test_prom_metrics_returns_prometheus_format():
     assert response == "received_logs 1000"
 
 
-def test_handle_signal_calls_exit(monkeypatch):
+@pytest.mark.asyncio
+async def test_handle_signal_calls_exit(monkeypatch):
     monkeypatch.setattr(sys, "exit", mock.Mock())
 
-    handle_signal(signal.SIGINT, None)
+    await handle_signal(signal.SIGINT, None)
 
     sys.exit.assert_called_once_with(0)

--- a/tools/pipeline_perf_test/orchestrator/lib/impl/strategies/execution/pipeline_perf_loadgen.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/impl/strategies/execution/pipeline_perf_loadgen.py
@@ -25,6 +25,7 @@ components:
       pipeline_perf_loadgen:
         endpoint:  "http://localhost:5001/"
         threads: 1
+        target_rate: 10000
         body_size: 25
         num_attributes: 2
         attribute_value_size: 15
@@ -61,6 +62,7 @@ class PipelinePerfLoadgenConfig(ExecutionStrategyConfig):
         endpoint (Optional[str]): Base URL of the load generator service. Defaults to
             "http://localhost:5001/".
         threads (Optional[int]): Number of concurrent threads to simulate. Defaults to 1.
+        target_rate (Optional[int]): Number of messages / sec to target. Defaults to None.
         body_size (Optional[int]): Size of the request body payload. Defaults to 25.
         num_attributes (Optional[int]): Number of attributes included in each load event.
             Defaults to 2.
@@ -70,6 +72,7 @@ class PipelinePerfLoadgenConfig(ExecutionStrategyConfig):
 
     endpoint: Optional[str] = "http://localhost:5001/"
     threads: Optional[int] = 1
+    target_rate: Optional[int] = None
     body_size: Optional[int] = 25
     num_attributes: Optional[int] = 2
     attribute_value_size: Optional[int] = 15
@@ -107,6 +110,7 @@ components:
       pipeline_perf_loadgen:
         endpoint:  "http://localhost:5001/"
         threads: 1
+        target_rate: 10000
         body_size: 25
         num_attributes: 2
         attribute_value_size: 15
@@ -143,6 +147,7 @@ components:
             json={
                 "threads": self.config.threads,
                 "body_size": self.config.body_size,
+                "target_rate": self.config.target_rate,
                 "num_attributes": self.config.num_attributes,
                 "attribute_value_size": self.config.attribute_value_size,
                 "batch_size": self.config.batch_size,

--- a/tools/pipeline_perf_test/test_suites/dataflow_engine_e2e_logs/README.md
+++ b/tools/pipeline_perf_test/test_suites/dataflow_engine_e2e_logs/README.md
@@ -1,0 +1,60 @@
+# Pipeline Performance Test - Dataflow Engine with OTLP Logs
+
+This repository contains a performance testing suite to evaluate the dataflow
+engine's handling of OTLP logs.
+
+## Prerequisites
+
+Before running the tests, you need to set up a virtual environment and install
+the required dependencies.
+
+### 1. Set Up a Virtual Environment
+
+If you don't already have a virtual environment for Python, you can create one
+using the following commands:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate  # On Windows use: .venv\Scripts\activate
+```
+
+### 2. Install Dependencies
+
+After activating your virtual environment, install the required dependencies for
+the project:
+
+```bash
+pip install -r ./otel-arrow/tools/pipeline_perf_test/orchestrator/requirements.txt
+```
+
+This will install all the necessary Python packages, including dependencies for
+orchestrating and running performance tests.
+
+### 3. Download Otel Collector Binary
+
+This suite uses subprocess-based deployment, so an otel-collector is required at
+the expected path.
+
+See [Collector Installation](https://opentelemetry.io/docs/collector/installation/).
+
+The defaults are set as follows (you can modify line 31 of the test-suite-comparison
+with your path).
+
+```yaml
+    deployment:
+      process:
+        # Path to your otel collector binary
+        command: /tmp/otelcol --config ./test_suites/dataflow_engine_e2e_logs/collector-config-without-batch-processor.yaml
+```
+
+## Running the Test Suite
+
+The test suite is executed using the run_orchestrator.py script. This script
+will orchestrate the deployment, execution, monitoring, and reporting phases
+of the test based on the configuration file.
+
+To run the test suite, execute the following command:
+
+```bash
+python ./otel-arrow/tools/pipeline_perf_test/orchestrator/run_orchestrator.py --config ./test_suites/dataflow_engine_e2e_logs/test-suite-comparison.yaml --debug
+```

--- a/tools/pipeline_perf_test/test_suites/dataflow_engine_e2e_logs/collector-config-without-batch-processor.yaml
+++ b/tools/pipeline_perf_test/test_suites/dataflow_engine_e2e_logs/collector-config-without-batch-processor.yaml
@@ -1,0 +1,25 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+exporters:
+  otlp:
+    endpoint: localhost:1235
+    tls:
+      insecure: true
+
+service:
+  telemetry:
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: '0.0.0.0'
+                port: 8888
+  pipelines:
+    logs:
+      receivers: [otlp]
+      exporters: [otlp]

--- a/tools/pipeline_perf_test/test_suites/dataflow_engine_e2e_logs/test-suite-comparison.yaml
+++ b/tools/pipeline_perf_test/test_suites/dataflow_engine_e2e_logs/test-suite-comparison.yaml
@@ -1,0 +1,340 @@
+name: Test Dataflow Engine With OTLP Logs
+# Components are the individual systems, services, or tools that are involved in your test environment
+components:
+  # Components are named and specify how they are configured, deployed, executed, and monitored.
+  load-generator:
+    # A deployment strategy describes how the component is created and destroyed.
+    deployment:
+      process:
+        command: python ./load_generator/loadgen.py --serve
+        environment:
+          - OTLP_ENDPOINT=localhost:4317
+    # An execution strategy describes start / stop logic to apply to the component.
+    execution:
+      # The pipeline_perf_loadgen strategy calls the start/stop api endpoint on the load-generator
+      # with the specified parameters.
+      pipeline_perf_loadgen:
+        threads: 1
+        target_rate: 100000
+        batch_size: 1000
+    # A monitoring strategy describes how the component should be monitored.
+    monitoring:
+      # The process_component monitoring strategy uses the psutil lib to monitoring container cpu, memory, network.
+      process_component: {}
+      # The prometheus monitoring strategy calls the specified endpoint periodically to record metrics.
+      prometheus:
+        endpoint: http://localhost:5001/metrics
+  otel-collector:
+    deployment:
+      process:
+        # Path to your otel collector binary
+        command: /tmp/otelcol --config ./test_suites/dataflow_engine_e2e_logs/collector-config-without-batch-processor.yaml
+    monitoring:
+      # The process_component monitoring strategy uses the psutil lib to monitoring container cpu, memory, network.
+      process_component: {}
+  dataflow-engine:
+    deployment:
+      process:
+        command: ../../rust/otap-dataflow/target/debug/examples/engine
+    monitoring:
+      process_component: {}
+  backend-service:
+    deployment:
+      process:
+        command: GRPC_PORT=1235 python ./backend/backend.py
+    monitoring:
+      process_component: {}
+      prometheus:
+        endpoint: http://localhost:5000/prom_metrics
+
+# The "tests" section describes 1 or more tests to execute when the suite is run.
+tests:
+    # Tests are named, and contain "steps" and "hooks" (optional) which describe the execution flow.
+  - name: Test OTLP Logs - Dataflow Engine
+    # Each step describes an "action" and hooks (optional)
+    steps:
+      - name: Deploy All
+        action:
+          # The multi_component_action invokes the specified phase on 1 or more components, here deploying
+          # all components using their deployment strategy configs.
+          multi_component_action:
+            phase: deploy
+            targets:
+              - load-generator
+              - backend-service
+              - dataflow-engine
+      - name: Monitor All
+        action:
+          multi_component_action:
+            phase: start_monitoring
+            targets:
+              - load-generator
+              - backend-service
+              - dataflow-engine
+      - name: Wait For Processes
+        action:
+          # The "wait" action pauses for the specified time before continuing.
+          wait:
+            delay_seconds: 5
+      - name: Start Load Generator
+        action:
+          # The component_action invokes the specified phase on 1 component, here starting the load from
+          # the load-generator component using it's execution strategy.
+          component_action:
+            phase: start
+            target: load-generator
+      - name: Wait For Stability
+        action:
+          wait:
+            delay_seconds: 5
+      - name: Observe Load
+        action:
+          wait:
+            delay_seconds: 10
+        # Hooks are applied before/after step (or test or suite) logic to further customize
+        # execution flow as needed.
+        hooks:
+          # These hooks are used to mark start/end of the observation window where we expect
+          # the test to be in a "steady state".
+          run:
+            pre:
+                # The record_event hook emits a custom span event before the test step runs
+                # with the name "observation_start" and other metadata attributes applied
+                # by the framework (test name, suite name, step name, etc)
+              - record_event:
+                  name: observation_start
+            post:
+              - record_event:
+                  name: observation_stop
+      - name: Stop Load Generator
+        action:
+          component_action:
+            phase: stop
+            target: load-generator
+      - name: Wait For Drain
+        action:
+          wait:
+            delay_seconds: 5
+      - name: Stop Monitoring All
+        action:
+          multi_component_action:
+            phase: stop_monitoring
+            targets:
+              - load-generator
+              - backend-service
+              - dataflow-engine
+      - name: Destroy All
+        action:
+          multi_component_action:
+            phase: destroy
+            targets:
+              - load-generator
+              - backend-service
+              - dataflow-engine
+
+  - name: Test OTLP Logs - Otel Collector
+    # Each step describes an "action" and hooks (optional)
+    steps:
+      - name: Deploy All
+        action:
+          # The multi_component_action invokes the specified phase on 1 or more components, here deploying
+          # all components using their deployment strategy configs.
+          multi_component_action:
+            phase: deploy
+            targets:
+              - load-generator
+              - backend-service
+              - otel-collector
+      - name: Monitor All
+        action:
+          multi_component_action:
+            phase: start_monitoring
+            targets:
+              - load-generator
+              - backend-service
+              - otel-collector
+      - name: Wait For Processes
+        action:
+          # The "wait" action pauses for the specified time before continuing.
+          wait:
+            delay_seconds: 5
+      - name: Start Load Generator
+        action:
+          # The component_action invokes the specified phase on 1 component, here starting the load from
+          # the load-generator component using it's execution strategy.
+          component_action:
+            phase: start
+            target: load-generator
+      - name: Wait For Stability
+        action:
+          wait:
+            delay_seconds: 5
+      - name: Observe Load
+        action:
+          wait:
+            delay_seconds: 10
+        # Hooks are applied before/after step (or test or suite) logic to further customize
+        # execution flow as needed.
+        hooks:
+          # These hooks are used to mark start/end of the observation window where we expect
+          # the test to be in a "steady state".
+          run:
+            pre:
+                # The record_event hook emits a custom span event before the test step runs
+                # with the name "observation_start" and other metadata attributes applied
+                # by the framework (test name, suite name, step name, etc)
+              - record_event:
+                  name: observation_start
+            post:
+              - record_event:
+                  name: observation_stop
+      - name: Stop Load Generator
+        action:
+          component_action:
+            phase: stop
+            target: load-generator
+      - name: Wait For Drain
+        action:
+          wait:
+            delay_seconds: 5
+      - name: Stop Monitoring All
+        action:
+          multi_component_action:
+            phase: stop_monitoring
+            targets:
+              - load-generator
+              - backend-service
+              - otel-collector
+      - name: Destroy All
+        action:
+          multi_component_action:
+            phase: destroy
+            targets:
+              - load-generator
+              - backend-service
+              - otel-collector
+
+# Test Suite Hooks (Before / After All Tests)
+hooks:
+  run:
+    pre:
+      # Build the dataflow-engine prior to all test execution.
+      - run_command:
+          command: cd ../../rust/otap-dataflow && cargo build --all-targets
+    post:
+        # This report type collects e.g. logs sent / lost / rate /etc.
+        # We declare it once for each test by adjusting
+        # the start and stop event window.
+      - pipeline_perf_report:
+          name: Perf - Dataflow Engine
+          system_under_test: dataflow-engine
+          output:
+            - format:
+                template: {}
+              destination:
+                console: {}
+          # Start and end events to set report window.
+          between_events:
+            # We use the test start/end events instead of a narrower window to make sure
+            # we get readings from all components before load starts sending.
+            start:
+              name: test_framework.test_start
+              attributes:
+                test.name: Test OTLP Logs - Dataflow Engine
+            end:
+              name: test_framework.test_end
+              attributes:
+                test.name: Test OTLP Logs - Dataflow Engine
+      - pipeline_perf_report:
+          name: Perf - Otel Collector
+          system_under_test: dataflow-engine
+          output:
+            - format:
+                template: {}
+              destination:
+                console: {}
+          # Start and end events to set report window.
+          between_events:
+            # We use the test start/end events instead of a narrower window to make sure
+            # we get readings from all components before load starts sending.
+            start:
+              name: test_framework.test_start
+              attributes:
+                test.name: Test OTLP Logs - Otel Collector
+            end:
+              name: test_framework.test_end
+              attributes:
+                test.name: Test OTLP Logs - Otel Collector
+        # The process report gathers cpu / memory values for the specified components.
+        # Again we declare 1 for each test.
+      - process_report:
+          name: Process - Dataflow Engine
+          output:
+            - format:
+                template: {}
+              destination:
+                console: {}
+          # Only report on the specified components here (or leave empty for all)
+          components:
+            - load-generator
+            - dataflow-engine
+            - backend-service
+          # Start and end events to set report window.
+          between_events:
+            # We use the custom start/end events here because we're measuring 'gauge' values.
+            # We're ok missing initial readings (where it's warming up), and only want the
+            # cpu/memory measurements "at stable load".
+            start:
+              name: observation_start
+              attributes:
+                test.name: Test OTLP Logs - Dataflow Engine
+            end:
+              name: observation_stop
+              attributes:
+                test.name: Test OTLP Logs - Dataflow Engine
+
+      - process_report:
+          name: Process - OTEL Collector
+          output:
+            - format:
+                template: {}
+              destination:
+                console: {}
+          # Only report on the specified components here (or leave empty for all)
+          components:
+            - load-generator
+            - otel-collector
+            - backend-service
+          # Start and end events to set report window.
+          between_events:
+            # We use the custom start/end events here because we're measuring 'gauge' values.
+            # We're ok missing initial readings (where it's warming up), and only want the
+            # cpu/memory measurements "at stable load".
+            start:
+              name: observation_start
+              attributes:
+                test.name: Test OTLP Logs - Otel Collector
+            end:
+              name: observation_stop
+              attributes:
+                test.name: Test OTLP Logs - Otel Collector
+      - comparison_report:
+          name: Compare Process
+          reports:
+            - Process - Dataflow Engine
+            - Process - OTEL Collector
+          output:
+            - format:
+                template: {}
+              destination:
+                console: {}
+      - comparison_report:
+          name: Compare Otel Collector
+          reports:
+            - Perf - Dataflow Engine
+            - Perf - Otel Collector
+          output:
+            - format:
+                template: {}
+              destination:
+                console: {}


### PR DESCRIPTION
This adds an initial perf test suite for the single-threaded, un-optimized, dataflow engine to compare otlp logs performance with the go collector running in a similar configuration. It includes a few small fixes to backend / orchestrator to support additional knobs needed.

- add test_suites/dataflow_engine_e2e_logs - workflow with constant rate (100k log/sec) load to the dataflow engine and otel collector with comparable configuration.
- Add support for constant rate log generation in orchestrator's pipeline_perf log exection strategy.
- Add support for env based port selection in backend.py to support dataflow engine example default otlp out port.
- Fix missing await in backend.py shutdown handler
- Fix pipeline perf report to provide more accurate send/receive avg rate calculations.

Related to #798 