### PR TITLE
[query-engine] Support KQL case-insensitive equality

### DIFF
--- a/rust/experimental/query_engine/engine-recordset2/src/logical_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset2/src/logical_expressions.rs
@@ -38,7 +38,7 @@ pub fn execute_logical_expression<'a, TRecord: Record>(
                 e.get_query_location(),
                 &left.to_value(),
                 &right.to_value(),
-                false,
+                e.get_case_insensitive(),
             ) {
                 Ok(b) => {
                     execution_context.add_diagnostic_if_enabled(
@@ -222,6 +222,7 @@ mod tests {
                 ScalarExpression::Static(StaticScalarExpression::Boolean(
                     BooleanScalarExpression::new(QueryLocation::new_fake(), true),
                 )),
+                false,
             )),
             true,
         );
@@ -229,14 +230,30 @@ mod tests {
         run_test(
             LogicalExpression::EqualTo(EqualToLogicalExpression::new(
                 QueryLocation::new_fake(),
-                ScalarExpression::Static(StaticScalarExpression::Boolean(
-                    BooleanScalarExpression::new(QueryLocation::new_fake(), true),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "VALUE"),
                 )),
-                ScalarExpression::Static(StaticScalarExpression::Boolean(
-                    BooleanScalarExpression::new(QueryLocation::new_fake(), false),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "value"),
                 )),
+                false,
             )),
             false,
+        );
+
+        // Test case-insensitive string equality
+        run_test(
+            LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                QueryLocation::new_fake(),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "VALUE"),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "value"),
+                )),
+                true,
+            )),
+            true,
         );
     }
 

--- a/rust/experimental/query_engine/engine-recordset2/src/scalar_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset2/src/scalar_expressions.rs
@@ -786,6 +786,7 @@ mod tests {
                     ScalarExpression::Static(StaticScalarExpression::Integer(
                         IntegerScalarExpression::new(QueryLocation::new_fake(), 18),
                     )),
+                    false,
                 ))
                 .into(),
             ),

--- a/rust/experimental/query_engine/expressions/src/logical_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/logical_expressions.rs
@@ -133,6 +133,7 @@ pub struct EqualToLogicalExpression {
     query_location: QueryLocation,
     left: ScalarExpression,
     right: ScalarExpression,
+    case_insensitive: bool,
 }
 
 impl EqualToLogicalExpression {
@@ -140,12 +141,18 @@ impl EqualToLogicalExpression {
         query_location: QueryLocation,
         left: ScalarExpression,
         right: ScalarExpression,
+        case_insensitive: bool,
     ) -> EqualToLogicalExpression {
         Self {
             query_location,
             left,
             right,
+            case_insensitive,
         }
+    }
+
+    pub fn get_case_insensitive(&self) -> bool {
+        self.case_insensitive
     }
 
     pub fn get_left(&self) -> &ScalarExpression {

--- a/rust/experimental/query_engine/kql-parser/src/kql.pest
+++ b/rust/experimental/query_engine/kql-parser/src/kql.pest
@@ -16,7 +16,9 @@ plus_token = { "+" }
 positive_infinity_token = { "+inf" }
 negative_infinity_token = { "-inf" }
 equals_token = @{ "==" }
+equals_insensitive_token = @{ "=~" }
 not_equals_token = @{ "!=" }
+not_equals_insensitive_token = @{ "!~" }
 greater_than_token = @{ ">" ~ !"=" }
 greater_than_or_equal_to_token = @{ ">=" }
 less_than_token = @{ "<" ~ !"=" }
@@ -94,7 +96,7 @@ scalar_expression = {
     | ("(" ~ logical_expression ~ ")")
 }
 
-comparison_expression = { scalar_expression ~ (equals_token|not_equals_token|greater_than_token|greater_than_or_equal_to_token|less_than_token|less_than_or_equal_to_token) ~ scalar_expression }
+comparison_expression = { scalar_expression ~ (equals_token|equals_insensitive_token|not_equals_token|not_equals_insensitive_token|greater_than_token|greater_than_or_equal_to_token|less_than_token|less_than_or_equal_to_token) ~ scalar_expression }
 logical_expressions = _{ comparison_expression|scalar_expression }
 logical_expression = { logical_expressions ~ ((and_token|or_token) ~ logical_expressions)* }
 

--- a/rust/experimental/query_engine/kql-parser/src/logical_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/logical_expressions.rs
@@ -33,11 +33,32 @@ pub(crate) fn parse_comparison_expression(
             query_location,
             left,
             right,
+            false,
         ))),
+        Rule::equals_insensitive_token => Ok(LogicalExpression::EqualTo(
+            EqualToLogicalExpression::new(query_location, left, right, true),
+        )),
+
         Rule::not_equals_token => Ok(LogicalExpression::Not(NotLogicalExpression::new(
             query_location.clone(),
-            LogicalExpression::EqualTo(EqualToLogicalExpression::new(query_location, left, right)),
+            LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                query_location,
+                left,
+                right,
+                false,
+            )),
         ))),
+        Rule::not_equals_insensitive_token => {
+            Ok(LogicalExpression::Not(NotLogicalExpression::new(
+                query_location.clone(),
+                LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                    query_location,
+                    left,
+                    right,
+                    true,
+                )),
+            )))
+        }
 
         Rule::greater_than_token => Ok(LogicalExpression::GreaterThan(
             GreaterThanLogicalExpression::new(query_location, left, right),
@@ -165,7 +186,9 @@ mod tests {
             Rule::comparison_expression,
             &[
                 "1 == 1",
+                "1 =~ 1",
                 "(1) != true",
+                "1 !~ true",
                 "(1==1) > false",
                 "1 >= 1",
                 "1 < 1",
@@ -204,6 +227,42 @@ mod tests {
                 ScalarExpression::Static(StaticScalarExpression::String(
                     StringScalarExpression::new(QueryLocation::new_fake(), "hello world"),
                 )),
+                false,
+            )),
+        );
+
+        run_test(
+            "variable =~ 'hello world'",
+            LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                QueryLocation::new_fake(),
+                ScalarExpression::Variable(VariableScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    StringScalarExpression::new(QueryLocation::new_fake(), "variable"),
+                    ValueAccessor::new(),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "hello world"),
+                )),
+                true,
+            )),
+        );
+
+        run_test(
+            "variable !~ 'hello world'",
+            LogicalExpression::Not(NotLogicalExpression::new(
+                QueryLocation::new_fake(),
+                LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                    QueryLocation::new_fake(),
+                    ScalarExpression::Variable(VariableScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        StringScalarExpression::new(QueryLocation::new_fake(), "variable"),
+                        ValueAccessor::new(),
+                    )),
+                    ScalarExpression::Static(StaticScalarExpression::String(
+                        StringScalarExpression::new(QueryLocation::new_fake(), "hello world"),
+                    )),
+                    true,
+                )),
             )),
         );
 
@@ -222,12 +281,14 @@ mod tests {
                             ScalarExpression::Static(StaticScalarExpression::Boolean(
                                 BooleanScalarExpression::new(QueryLocation::new_fake(), true),
                             )),
+                            false,
                         ))
                         .into(),
                     ),
                     ScalarExpression::Static(StaticScalarExpression::Boolean(
                         BooleanScalarExpression::new(QueryLocation::new_fake(), true),
                     )),
+                    false,
                 )),
             )),
         );
@@ -307,6 +368,7 @@ mod tests {
                             ScalarExpression::Static(StaticScalarExpression::Boolean(
                                 BooleanScalarExpression::new(QueryLocation::new_fake(), true),
                             )),
+                            false,
                         ))
                         .into(),
                     ),
@@ -434,6 +496,7 @@ mod tests {
                 ScalarExpression::Static(StaticScalarExpression::String(
                     StringScalarExpression::new(QueryLocation::new_fake(), "hello world"),
                 )),
+                false,
             )),
         );
 
@@ -449,6 +512,7 @@ mod tests {
                 ScalarExpression::Static(StaticScalarExpression::String(
                     StringScalarExpression::new(QueryLocation::new_fake(), "hello world"),
                 )),
+                false,
             )),
         );
 
@@ -468,6 +532,7 @@ mod tests {
                 ScalarExpression::Static(StaticScalarExpression::String(
                     StringScalarExpression::new(QueryLocation::new_fake(), "Info"),
                 )),
+                false,
             )),
         )));
 
@@ -488,6 +553,7 @@ mod tests {
                 ScalarExpression::Static(StaticScalarExpression::String(
                     StringScalarExpression::new(QueryLocation::new_fake(), "hello world"),
                 )),
+                false,
             )),
         );
 

--- a/rust/experimental/query_engine/kql-parser/src/scalar_expression.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_expression.rs
@@ -170,6 +170,7 @@ mod tests {
                     ScalarExpression::Static(StaticScalarExpression::Boolean(
                         BooleanScalarExpression::new(QueryLocation::new_fake(), true),
                     )),
+                    false,
                 ))
                 .into(),
             ),


### PR DESCRIPTION
Relates to #722

## Changes

* Adds support for `=~` and `!~` KQL operators