### PR TITLE
[query-engine] Add protobuf reader and writer to bridge

### DIFF
--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/lib.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/lib.rs
@@ -1,1 +1,5 @@
+#![allow(dead_code)]
 
+pub(crate) mod serializer;
+
+pub use serializer::serializer_error::SerializerError;

--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/serializer/mod.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/serializer/mod.rs
@@ -1,0 +1,73 @@
+pub(crate) mod protobuf_reader;
+pub(crate) mod protobuf_writer;
+pub(crate) mod serializer_error;
+
+const TAG_TYPE_BITS: u32 = 3;
+const TAG_TYPE_MASK: u32 = (1u32 << TAG_TYPE_BITS as usize) - 1;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct ProtobufTag {
+    field_number: u32,
+    wire_type: ProtobufWireType,
+}
+
+impl ProtobufTag {
+    /// Extract wire type and field number from integer tag
+    pub fn new(value: u32) -> Result<ProtobufTag, serializer_error::SerializerError> {
+        let wire_type = ProtobufWireType::new(value & TAG_TYPE_MASK);
+        if wire_type.is_none() {
+            return Err(serializer_error::SerializerError::UnknownWireType(
+                value & TAG_TYPE_MASK,
+            ));
+        }
+        let field_number = value >> TAG_TYPE_BITS;
+        if field_number == 0 {
+            return Err(serializer_error::SerializerError::InvalidFieldNumber(
+                field_number,
+            ));
+        }
+        Ok(ProtobufTag {
+            field_number,
+            wire_type: wire_type.unwrap(),
+        })
+    }
+}
+
+/// All supported "wire types" are listed in this enum.
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+pub enum ProtobufWireType {
+    /// Variable-length integer
+    Varint = 0,
+    /// 64-bit field (e. g. `fixed64` or `double`)
+    Fixed64 = 1,
+    /// Length-delimited field
+    LengthDelimited = 2,
+    /// Groups are not supported in rust-protobuf
+    StartGroup = 3,
+    /// Groups are not supported in rust-protobuf
+    EndGroup = 4,
+    /// 32-bit field (e. g. `fixed32` or `float`)
+    Fixed32 = 5,
+}
+
+impl ProtobufWireType {
+    fn new(n: u32) -> Option<ProtobufWireType> {
+        match n {
+            0 => Some(ProtobufWireType::Varint),
+            1 => Some(ProtobufWireType::Fixed64),
+            2 => Some(ProtobufWireType::LengthDelimited),
+            3 => Some(ProtobufWireType::StartGroup),
+            4 => Some(ProtobufWireType::EndGroup),
+            5 => Some(ProtobufWireType::Fixed32),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ProtobufField {
+    Varint { field_number: u32, value: u64 },
+    Fixed32 { field_number: u32, value: u32 },
+    Fixed64 { field_number: u32, value: u64 },
+    LengthDelimited { field_number: u32, value: Vec<u8> },
+}

--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/serializer/protobuf_reader.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/serializer/protobuf_reader.rs
@@ -1,0 +1,207 @@
+use bytes::Buf;
+
+use crate::{serializer::*, *};
+
+pub struct ProtobufReader<'a> {
+    data: &'a [u8],
+}
+
+impl<'a> ProtobufReader<'a> {
+    pub fn new(protobuf_data: &'a [u8]) -> ProtobufReader<'a> {
+        Self {
+            data: protobuf_data,
+        }
+    }
+
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    #[inline(always)]
+    pub fn read_tag(&mut self) -> Result<ProtobufTag, SerializerError> {
+        let v = self.read_varint64()? as u32;
+        let tag = ProtobufTag::new(v)?;
+        if matches!(
+            tag.wire_type,
+            ProtobufWireType::StartGroup | ProtobufWireType::EndGroup
+        ) {
+            Err(SerializerError::Deprecated("group wire type"))
+        } else {
+            Ok(tag)
+        }
+    }
+
+    #[inline(always)]
+    pub fn read_field(&mut self, tag: ProtobufTag) -> Result<ProtobufField, SerializerError> {
+        Ok(match tag.wire_type {
+            ProtobufWireType::Varint => ProtobufField::Varint {
+                field_number: tag.field_number,
+                value: self.read_varint64()?,
+            },
+            ProtobufWireType::Fixed64 => ProtobufField::Fixed64 {
+                field_number: tag.field_number,
+                value: self.read_fixed64()?,
+            },
+            ProtobufWireType::LengthDelimited => ProtobufField::LengthDelimited {
+                field_number: tag.field_number,
+                value: self.read_bytes()?.to_vec(),
+            },
+            ProtobufWireType::Fixed32 => ProtobufField::Fixed32 {
+                field_number: tag.field_number,
+                value: self.read_fixed32()?,
+            },
+            _ => panic!("WireType not supported"),
+        })
+    }
+
+    #[inline(always)]
+    pub fn read_message<F>(&mut self, read_message: F) -> Result<bool, SerializerError>
+    where
+        F: FnOnce(ProtobufReader) -> Result<(), SerializerError>,
+    {
+        let message = self.read_bytes()?;
+        if message.is_empty() {
+            Ok(false)
+        } else {
+            read_message(ProtobufReader::new(message))?;
+
+            Ok(true)
+        }
+    }
+
+    #[inline(always)]
+    pub fn read_bytes(&mut self) -> Result<&[u8], SerializerError> {
+        let length = self.read_varint64()? as usize;
+        if length == 0 {
+            Ok(&[])
+        } else {
+            if self.data.len() < length {
+                return Err(SerializerError::UnexpectedEndOfBuffer);
+            }
+
+            unsafe {
+                let result = self.data.get_unchecked(0..length);
+
+                self.data = &self.data[length..];
+
+                Ok(result)
+            }
+        }
+    }
+
+    #[inline(always)]
+    pub fn read_string(&mut self) -> Result<String, SerializerError> {
+        String::from_utf8(self.read_bytes()?.to_vec())
+            .map_err(|e| SerializerError::Utf8(e.utf8_error()))
+    }
+
+    #[inline(always)]
+    fn read_u8(&mut self) -> Result<u8, SerializerError> {
+        self.data
+            .try_get_u8()
+            .map_err(|_| SerializerError::UnexpectedEndOfBuffer)
+    }
+
+    #[inline(always)]
+    pub fn read_bool(&mut self) -> Result<bool, SerializerError> {
+        self.read_u8().map(|r| r != 0)
+    }
+
+    #[inline(always)]
+    pub fn read_double(&mut self) -> Result<f64, SerializerError> {
+        let mut buffer = [0x00; 8];
+        self.data
+            .try_copy_to_slice(&mut buffer)
+            .map_err(|_| SerializerError::UnexpectedEndOfBuffer)?;
+        Ok(f64::from_le_bytes(buffer))
+    }
+
+    #[inline(always)]
+    pub fn read_int64(&mut self) -> Result<i64, SerializerError> {
+        Ok(self.read_varint64()? as i64)
+    }
+
+    #[inline(always)]
+    pub fn read_fixed32(&mut self) -> Result<u32, SerializerError> {
+        let mut buffer = [0x00; 4];
+        self.data
+            .try_copy_to_slice(&mut buffer)
+            .map_err(|_| SerializerError::UnexpectedEndOfBuffer)?;
+        Ok(u32::from_le_bytes(buffer))
+    }
+
+    #[inline(always)]
+    pub fn read_fixed64(&mut self) -> Result<u64, SerializerError> {
+        let mut buffer = [0x00; 8];
+        self.data
+            .try_copy_to_slice(&mut buffer)
+            .map_err(|_| SerializerError::UnexpectedEndOfBuffer)?;
+        Ok(u64::from_le_bytes(buffer))
+    }
+
+    pub fn read_varint64(&mut self) -> Result<u64, SerializerError> {
+        let mut buffer = [0x00; 10];
+        let size = std::cmp::min(self.data.len(), 10);
+        if size == 0 {
+            return Err(SerializerError::UnexpectedEndOfBuffer);
+        }
+
+        unsafe {
+            buffer
+                .get_unchecked_mut(..size)
+                .copy_from_slice(self.data.get_unchecked(..size));
+
+            let mut ptr = buffer.as_ptr();
+
+            let b = *ptr;
+            if b & 0x80 == 0 {
+                self.data = &self.data[1..];
+                return Ok(b as u64);
+            }
+
+            let mut value = (b as u64) & 0x7f;
+            let mut count = 1;
+            let mut shift = 7;
+            while count < size {
+                ptr = ptr.add(1);
+
+                let b = *ptr;
+                value |= ((b & 0x7f) as u64) << shift;
+                if b & 0x80 == 0 {
+                    self.data = &self.data[count + 1..];
+                    return Ok(value);
+                }
+
+                count += 1;
+                shift += 7;
+            }
+        }
+
+        Err(SerializerError::UnexpectedEndOfBuffer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_read_varint32() {
+        let run_test = |value: &[u8], expected: u64| {
+            let mut reader = ProtobufReader::new(value);
+
+            assert_eq!(expected, reader.read_varint64().unwrap());
+        };
+
+        run_test(&[0], 0);
+        run_test(&[0x80, 0x80, 0x80, 0], 0);
+        run_test(&[1], 1);
+        run_test(&[0x7F], 127);
+        run_test(&[0xFF, 0xFF, 0xFF, 0x7F], 268435455);
+        run_test(
+            &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F],
+            u64::MAX,
+        );
+    }
+}

--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/serializer/protobuf_writer.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/serializer/protobuf_writer.rs
@@ -1,0 +1,244 @@
+use bytes::{BufMut, Bytes, BytesMut};
+
+use crate::{serializer::*, *};
+
+const RESERVATION_SIZE_IN_BYTES: usize = 4;
+
+pub struct ProtobufWriter {
+    data: BytesMut,
+}
+
+impl ProtobufWriter {
+    pub fn new(initial_capacity: usize) -> ProtobufWriter {
+        ProtobufWriter {
+            data: BytesMut::with_capacity(initial_capacity),
+        }
+    }
+
+    #[inline(always)]
+    pub fn write_field(&mut self, field: &ProtobufField) {
+        match field {
+            ProtobufField::Varint {
+                field_number,
+                value,
+            } => {
+                self.write_tag(*field_number, ProtobufWireType::Varint);
+                self.write_varint64(*value);
+            }
+            ProtobufField::Fixed32 {
+                field_number,
+                value,
+            } => {
+                self.write_fixed32_field(*field_number, *value);
+            }
+            ProtobufField::Fixed64 {
+                field_number,
+                value,
+            } => {
+                self.write_fixed64_field(*field_number, *value);
+            }
+            ProtobufField::LengthDelimited {
+                field_number,
+                value,
+            } => {
+                self.write_bytes_field(*field_number, value);
+            }
+        }
+    }
+
+    #[inline(always)]
+    pub fn write_fixed64_field(&mut self, field_number: u32, v: u64) {
+        self.write_tag(field_number, ProtobufWireType::Fixed64);
+        self.data.put_u64_le(v);
+    }
+
+    #[inline(always)]
+    pub fn write_fixed32_field(&mut self, field_number: u32, v: u32) {
+        self.write_tag(field_number, ProtobufWireType::Fixed32);
+        self.data.put_u32_le(v);
+    }
+
+    #[inline(always)]
+    pub fn write_bytes_field(&mut self, field_number: u32, bytes: &[u8]) {
+        self.write_tag(field_number, ProtobufWireType::LengthDelimited);
+        self.write_varint32(bytes.len() as u32);
+        self.data.extend_from_slice(bytes);
+    }
+
+    #[inline(always)]
+    pub fn write_int64_field(&mut self, field_number: u32, v: i64) {
+        self.write_tag(field_number, ProtobufWireType::Varint);
+        self.write_varint64(v as u64);
+    }
+
+    #[inline(always)]
+    pub fn write_int32_field(&mut self, field_number: u32, v: i32) {
+        self.write_tag(field_number, ProtobufWireType::Varint);
+        self.write_varint32(v as u32);
+    }
+
+    #[inline(always)]
+    pub fn write_double_field(&mut self, field_number: u32, v: f64) {
+        self.write_tag(field_number, ProtobufWireType::Fixed64);
+        self.data.put_f64_le(v);
+    }
+
+    #[inline(always)]
+    pub fn write_bool_field(&mut self, field_number: u32, v: bool) {
+        self.write_tag(field_number, ProtobufWireType::Varint);
+        self.data.put_u8(if v { 1 } else { 0 });
+    }
+
+    #[inline(always)]
+    pub fn write_string_field(&mut self, field_number: u32, s: &str) {
+        self.write_bytes_field(field_number, s.as_bytes());
+    }
+
+    pub fn write_message_field<F>(
+        &mut self,
+        field_number: u32,
+        write_message: F,
+    ) -> Result<(), SerializerError>
+    where
+        F: FnOnce(&mut Self) -> Result<(), SerializerError>,
+    {
+        self.write_tag(field_number, ProtobufWireType::LengthDelimited);
+
+        let reservation_position = self.reserve_varint32();
+
+        write_message(self)?;
+
+        self.write_reserved_varint32(
+            reservation_position,
+            (self.get_position() - reservation_position - RESERVATION_SIZE_IN_BYTES) as u32,
+        )
+    }
+
+    pub fn freeze(self) -> Bytes {
+        self.data.freeze()
+    }
+
+    #[inline(always)]
+    fn get_position(&self) -> usize {
+        self.data.len()
+    }
+
+    #[inline(always)]
+    fn write_varint64(&mut self, mut v: u64) {
+        let mut buffer = [0x00; 10];
+        let mut count = 0;
+        unsafe {
+            let mut ptr = buffer.as_mut_ptr();
+            while v > 0x7F {
+                *ptr = ((v as u8) & 0x7F) | 0x80;
+                ptr = ptr.add(1);
+                count += 1;
+                v >>= 7;
+            }
+            *ptr = v as u8;
+        }
+        self.data.extend_from_slice(&buffer[0..(count + 1)]);
+    }
+
+    #[inline(always)]
+    fn write_varint32(&mut self, mut v: u32) {
+        let mut buffer = [0x00; 5];
+        let mut count = 0;
+        unsafe {
+            let mut ptr = buffer.as_mut_ptr();
+            while v > 0x7F {
+                *ptr = ((v as u8) & 0x7F) | 0x80;
+                ptr = ptr.add(1);
+                count += 1;
+                v >>= 7;
+            }
+            *ptr = v as u8;
+        }
+        self.data.extend_from_slice(&buffer[0..(count + 1)]);
+    }
+
+    #[inline(always)]
+    fn write_tag(&mut self, field_number: u32, wire_type: ProtobufWireType) {
+        self.write_varint32((field_number << TAG_TYPE_BITS) | (wire_type as u32));
+    }
+
+    #[inline(always)]
+    fn reserve_varint32(&mut self) -> usize {
+        let position = self.data.len();
+        self.data.extend_from_slice(&[0, 0, 0, 0]);
+        position
+    }
+
+    #[inline(always)]
+    fn write_reserved_varint32(
+        &mut self,
+        position: usize,
+        mut v: u32,
+    ) -> Result<(), SerializerError> {
+        if v > 268435455 {
+            return Err(SerializerError::Message(
+                "Cannot write u32 greater than 268435455 using write_reserved_varint32",
+            ));
+        }
+        let mut buffer: [u8; RESERVATION_SIZE_IN_BYTES] = [0x80, 0x80, 0x80, 0x00];
+        unsafe {
+            let mut ptr = buffer.as_mut_ptr();
+            while v > 0x7F {
+                *ptr |= (v as u8) & 0x7F;
+                ptr = ptr.add(1);
+                v >>= 7;
+            }
+            *ptr |= v as u8;
+        }
+        self.data[position..position + RESERVATION_SIZE_IN_BYTES].copy_from_slice(&buffer);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::serializer::protobuf_reader::ProtobufReader;
+
+    use super::*;
+
+    #[test]
+    fn test_reserve_varint32() {
+        let run_test = |value: u32, expected: &[u8]| {
+            let mut writer = ProtobufWriter::new(0);
+
+            let position = writer.reserve_varint32();
+
+            assert_eq!(RESERVATION_SIZE_IN_BYTES, writer.get_position());
+
+            writer.write_reserved_varint32(position, value).unwrap();
+
+            let bytes = writer.freeze();
+
+            assert_eq!(expected, &bytes);
+
+            let mut reader = ProtobufReader::new(&bytes);
+
+            assert_eq!(value, reader.read_varint64().unwrap() as u32);
+        };
+
+        run_test(0, &[0x80, 0x80, 0x80, 0x00]);
+
+        run_test(1, &[0x81, 0x80, 0x80, 0x00]);
+
+        run_test(300, &[0xAC, 0x82, 0x80, 0x00]);
+
+        run_test(127, &[0xFF, 0x80, 0x80, 0x00]);
+
+        run_test(128, &[0x80, 0x81, 0x80, 0x00]);
+
+        run_test(16383, &[0xFF, 0xFF, 0x80, 0x00]);
+
+        run_test(16384, &[0x80, 0x80, 0x81, 0x00]);
+
+        run_test(2097151, &[0xFF, 0xFF, 0xFF, 0x00]);
+
+        run_test(2097152, &[0x80, 0x80, 0x80, 0x01]);
+
+        run_test(268435455, &[0xFF, 0xFF, 0xFF, 0x7F]);
+    }
+}

--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/serializer/serializer_error.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/serializer/serializer_error.rs
@@ -1,0 +1,35 @@
+use std::str::Utf8Error;
+
+use thiserror::Error;
+
+use crate::serializer::ProtobufWireType;
+
+#[derive(Error, Debug)]
+pub enum SerializerError {
+    #[error(
+        "Unexpected tag encountered with field number '{field_number}' and wire type '{wire_type:?}' while parsing {while_parsing}"
+    )]
+    UnexpectedTag {
+        while_parsing: &'static str,
+        field_number: u32,
+        wire_type: ProtobufWireType,
+    },
+
+    #[error("Unexpected wire type '{0}' encountered")]
+    UnknownWireType(u32),
+
+    #[error("Unexpected field number '{0}' encountered")]
+    InvalidFieldNumber(u32),
+
+    #[error("Unexpected end of buffer encountered")]
+    UnexpectedEndOfBuffer,
+
+    #[error("Encountered feature '{0}' which has been deprecated")]
+    Deprecated(&'static str),
+
+    #[error("Encountered UTF8 error '{0}' while parsing a string")]
+    Utf8(Utf8Error),
+
+    #[error("{0}")]
+    Message(&'static str),
+}


### PR DESCRIPTION
## Changes

* Adds code to read & write protobuf messages

## Details

This will be used in the bridge to take protobuf OTLP messages and deserialize them directly onto structs the query engine can process natively and then serialize the results as protobuf OTLP messages on the way out.