### PR TITLE
[query-engine] Static value refactor

### DIFF
--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/attached_records.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/attached_records.rs
@@ -27,13 +27,9 @@ impl AttachedRecords for OtlpAttachedRecords<'_> {
     }
 }
 
-impl AsValue for Resource {
-    fn get_value_type(&self) -> ValueType {
-        ValueType::Map
-    }
-
-    fn to_value(&self) -> Value {
-        Value::Map(self)
+impl AsStaticValue for Resource {
+    fn to_static_value(&self) -> StaticValue {
+        StaticValue::Map(self)
     }
 }
 
@@ -50,9 +46,9 @@ impl MapValue for Resource {
         key == "Attributes"
     }
 
-    fn get(&self, key: &str) -> Option<&(dyn AsValue + 'static)> {
+    fn get(&self, key: &str) -> Option<&(dyn AsStaticValue + 'static)> {
         if key == "Attributes" {
-            return Some(&self.attributes as &dyn AsValue);
+            return Some(&self.attributes as &dyn AsStaticValue);
         }
 
         None
@@ -63,13 +59,9 @@ impl MapValue for Resource {
     }
 }
 
-impl AsValue for InstrumentationScope {
-    fn get_value_type(&self) -> ValueType {
-        ValueType::Map
-    }
-
-    fn to_value(&self) -> Value {
-        Value::Map(self)
+impl AsStaticValue for InstrumentationScope {
+    fn to_static_value(&self) -> StaticValue {
+        StaticValue::Map(self)
     }
 }
 
@@ -86,11 +78,11 @@ impl MapValue for InstrumentationScope {
         matches!(key, "Attributes" | "Name" | "Version")
     }
 
-    fn get(&self, key: &str) -> Option<&(dyn AsValue + 'static)> {
+    fn get(&self, key: &str) -> Option<&(dyn AsStaticValue + 'static)> {
         match key {
-            "Attributes" => Some(&self.attributes as &dyn AsValue),
-            "Name" => self.name.as_ref().map(|v| v as &dyn AsValue),
-            "Version" => self.version.as_ref().map(|v| v as &dyn AsValue),
+            "Attributes" => Some(&self.attributes as &dyn AsStaticValue),
+            "Name" => self.name.as_ref().map(|v| v as &dyn AsStaticValue),
+            "Version" => self.version.as_ref().map(|v| v as &dyn AsStaticValue),
             _ => None,
         }
     }

--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/attached_records.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/attached_records.rs
@@ -48,7 +48,7 @@ impl MapValue for Resource {
 
     fn get(&self, key: &str) -> Option<&(dyn AsStaticValue + 'static)> {
         if key == "Attributes" {
-            return Some(&self.attributes as &dyn AsStaticValue);
+            return Some(&self.attributes);
         }
 
         None
@@ -80,7 +80,7 @@ impl MapValue for InstrumentationScope {
 
     fn get(&self, key: &str) -> Option<&(dyn AsStaticValue + 'static)> {
         match key {
-            "Attributes" => Some(&self.attributes as &dyn AsStaticValue),
+            "Attributes" => Some(&self.attributes),
             "Name" => self.name.as_ref().map(|v| v as &dyn AsStaticValue),
             "Version" => self.version.as_ref().map(|v| v as &dyn AsStaticValue),
             _ => None,

--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/bridge.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/bridge.rs
@@ -193,7 +193,7 @@ fn process_log_record_results(
         if let Some(d) = diagnostic_output {
             log_record.attributes.get_values_mut().insert(
                 "query_engine.output".into(),
-                AnyValue::Native(OtlpAnyValue::StringValue(ValueStorage::new(d))),
+                AnyValue::Native(OtlpAnyValue::StringValue(StringValueStorage::new(d))),
             );
         }
 

--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/logs.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/logs.rs
@@ -88,7 +88,7 @@ impl MapValue for LogRecord {
 
     fn get(&self, key: &str) -> Option<&(dyn AsStaticValue + 'static)> {
         match key {
-            "Attributes" => Some(&self.attributes as &dyn AsStaticValue),
+            "Attributes" => Some(&self.attributes),
             "Timestamp" => self.timestamp.as_ref().map(|v| v as &dyn AsStaticValue),
             "ObservedTimestamp" => self
                 .observed_timestamp

--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/proto/common.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/proto/common.rs
@@ -1,8 +1,6 @@
 use std::{collections::HashMap, mem};
 
-use chrono::{DateTime, FixedOffset};
 use data_engine_recordset::*;
-use regex::Regex;
 
 use data_engine_expressions::*;
 
@@ -10,8 +8,8 @@ use crate::serializer::ProtobufField;
 
 #[derive(Debug, Clone)]
 pub struct InstrumentationScope {
-    pub name: Option<ValueStorage<String>>,
-    pub version: Option<ValueStorage<String>>,
+    pub name: Option<StringValueStorage>,
+    pub version: Option<StringValueStorage>,
     pub attributes: MapValueStorage<AnyValue>,
     pub(crate) extra_fields: Vec<ProtobufField>,
 }
@@ -33,12 +31,12 @@ impl InstrumentationScope {
     }
 
     pub fn with_name(mut self, value: String) -> InstrumentationScope {
-        self.name = Some(ValueStorage::new(value));
+        self.name = Some(StringValueStorage::new(value));
         self
     }
 
     pub fn with_version(mut self, value: String) -> InstrumentationScope {
-        self.version = Some(ValueStorage::new(value));
+        self.version = Some(StringValueStorage::new(value));
         self
     }
 
@@ -57,56 +55,38 @@ pub enum AnyValue {
     Extended(ExtendedValue),
 }
 
-impl AsValue for AnyValue {
-    fn get_value_type(&self) -> ValueType {
+impl AsStaticValueMut for AnyValue {
+    fn to_static_value_mut(&mut self) -> Option<StaticValueMut> {
         match self {
-            AnyValue::Null => ValueType::Null,
             AnyValue::Native(n) => match n {
-                OtlpAnyValue::StringValue(_) => ValueType::String,
-                OtlpAnyValue::BoolValue(_) => ValueType::Boolean,
-                OtlpAnyValue::IntValue(_) => ValueType::Integer,
-                OtlpAnyValue::DoubleValue(_) => ValueType::Double,
-                OtlpAnyValue::ArrayValue(_) => ValueType::Array,
-                OtlpAnyValue::KvlistValue(_) => ValueType::Map,
-                OtlpAnyValue::BytesValue(_) => ValueType::Array,
+                OtlpAnyValue::StringValue(s) => Some(StaticValueMut::String(s)),
+                OtlpAnyValue::ArrayValue(a) => Some(StaticValueMut::Array(a)),
+                OtlpAnyValue::KvlistValue(m) => Some(StaticValueMut::Map(m)),
+                OtlpAnyValue::BytesValue(b) => Some(StaticValueMut::Array(b)),
+                _ => None,
             },
-            AnyValue::Extended(e) => match e {
-                ExtendedValue::DateTime(_) => ValueType::DateTime,
-                ExtendedValue::Regex(_) => ValueType::Regex,
-            },
-        }
-    }
-
-    fn to_value(&self) -> Value {
-        match self {
-            AnyValue::Null => Value::Null,
-            AnyValue::Native(n) => match n {
-                OtlpAnyValue::StringValue(s) => Value::String(s),
-                OtlpAnyValue::BoolValue(b) => Value::Boolean(b),
-                OtlpAnyValue::IntValue(i) => Value::Integer(i),
-                OtlpAnyValue::DoubleValue(d) => Value::Double(d),
-                OtlpAnyValue::ArrayValue(a) => Value::Array(a),
-                OtlpAnyValue::KvlistValue(m) => Value::Map(m),
-                OtlpAnyValue::BytesValue(b) => Value::Array(b),
-            },
-            AnyValue::Extended(e) => match e {
-                ExtendedValue::DateTime(d) => Value::DateTime(d),
-                ExtendedValue::Regex(r) => Value::Regex(r),
-            },
+            _ => None,
         }
     }
 }
 
-impl AsValueMut for AnyValue {
-    fn to_value_mut(&mut self) -> Option<ValueMut> {
+impl AsStaticValue for AnyValue {
+    fn to_static_value(&self) -> StaticValue {
         match self {
+            AnyValue::Null => StaticValue::Null,
             AnyValue::Native(n) => match n {
-                OtlpAnyValue::ArrayValue(a) => Some(ValueMut::Array(a)),
-                OtlpAnyValue::KvlistValue(m) => Some(ValueMut::Map(m)),
-                OtlpAnyValue::BytesValue(b) => Some(ValueMut::Array(b)),
-                _ => None,
+                OtlpAnyValue::StringValue(s) => StaticValue::String(s),
+                OtlpAnyValue::BoolValue(b) => StaticValue::Boolean(b),
+                OtlpAnyValue::IntValue(i) => StaticValue::Integer(i),
+                OtlpAnyValue::DoubleValue(d) => StaticValue::Double(d),
+                OtlpAnyValue::ArrayValue(a) => StaticValue::Array(a),
+                OtlpAnyValue::KvlistValue(m) => StaticValue::Map(m),
+                OtlpAnyValue::BytesValue(b) => StaticValue::Array(b),
             },
-            _ => None,
+            AnyValue::Extended(e) => match e {
+                ExtendedValue::DateTime(d) => StaticValue::DateTime(d),
+                ExtendedValue::Regex(r) => StaticValue::Regex(r),
+            },
         }
     }
 }
@@ -122,7 +102,7 @@ impl ValueSource<AnyValue> for AnyValue {
                         if let Value::Integer(i) = v {
                             let v = i.get_value();
                             if v >= u8::MIN as i64 && v <= u8::MAX as i64 {
-                                byte_values.push(ValueStorage::new(v as u8));
+                                byte_values.push(IntegerValueStorage::new(v as u8));
                                 return true;
                             }
                         }
@@ -162,7 +142,7 @@ impl ValueSource<AnyValue> for AnyValue {
                 OtlpAnyValue::BytesValue(mut b) => OwnedValue::Array(ArrayValueStorage::new(
                     b.values
                         .drain(..)
-                        .map(|v| OwnedValue::Integer(ValueStorage::new(v.get_value())))
+                        .map(|v| OwnedValue::Integer(IntegerValueStorage::new(v.get_value())))
                         .collect(),
                 )),
             },
@@ -176,16 +156,16 @@ impl ValueSource<AnyValue> for AnyValue {
 
 #[derive(Debug, Clone)]
 pub enum ExtendedValue {
-    DateTime(ValueStorage<DateTime<FixedOffset>>),
-    Regex(ValueStorage<Regex>),
+    DateTime(DateTimeValueStorage),
+    Regex(RegexValueStorage),
 }
 
 #[derive(Debug, Clone)]
 pub enum OtlpAnyValue {
-    StringValue(ValueStorage<String>),
-    BoolValue(ValueStorage<bool>),
-    IntValue(ValueStorage<i64>),
-    DoubleValue(ValueStorage<f64>),
+    StringValue(StringValueStorage),
+    BoolValue(BooleanValueStorage),
+    IntValue(IntegerValueStorage<i64>),
+    DoubleValue(DoubleValueStorage<f64>),
     ArrayValue(ArrayValueStorage<AnyValue>),
     KvlistValue(MapValueStorage<AnyValue>),
     BytesValue(ByteArrayValueStorage),
@@ -193,30 +173,32 @@ pub enum OtlpAnyValue {
 
 #[derive(Debug, Clone)]
 pub struct ByteArrayValueStorage {
-    values: Vec<ValueStorage<u8>>,
+    values: Vec<IntegerValueStorage<u8>>,
 }
 
 impl ByteArrayValueStorage {
-    pub fn new(values: Vec<ValueStorage<u8>>) -> ByteArrayValueStorage {
+    pub fn new(values: Vec<IntegerValueStorage<u8>>) -> ByteArrayValueStorage {
         Self { values }
     }
 
-    pub fn get_values(&self) -> &Vec<ValueStorage<u8>> {
+    pub fn get_values(&self) -> &Vec<IntegerValueStorage<u8>> {
         &self.values
     }
 
-    pub fn get_values_mut(&mut self) -> &mut Vec<ValueStorage<u8>> {
+    pub fn get_values_mut(&mut self) -> &mut Vec<IntegerValueStorage<u8>> {
         &mut self.values
     }
 }
 
-impl AsValue for ByteArrayValueStorage {
-    fn get_value_type(&self) -> ValueType {
-        ValueType::Array
+impl AsStaticValue for ByteArrayValueStorage {
+    fn to_static_value(&self) -> StaticValue {
+        StaticValue::Array(self)
     }
+}
 
-    fn to_value(&self) -> Value {
-        Value::Array(self)
+impl AsStaticValueMut for ByteArrayValueStorage {
+    fn to_static_value_mut(&mut self) -> Option<StaticValueMut> {
+        Some(StaticValueMut::Array(self))
     }
 }
 
@@ -229,8 +211,8 @@ impl ArrayValue for ByteArrayValueStorage {
         self.values.len()
     }
 
-    fn get(&self, index: usize) -> Option<&(dyn AsValue + 'static)> {
-        self.values.get(index).map(|v| v as &dyn AsValue)
+    fn get(&self, index: usize) -> Option<&(dyn AsStaticValue + 'static)> {
+        self.values.get(index).map(|v| v as &dyn AsStaticValue)
     }
 
     fn get_items(&self, item_callback: &mut dyn IndexValueCallback) -> bool {
@@ -241,12 +223,6 @@ impl ArrayValue for ByteArrayValueStorage {
         }
 
         true
-    }
-}
-
-impl AsValueMut for ByteArrayValueStorage {
-    fn to_value_mut(&mut self) -> Option<ValueMut> {
-        Some(ValueMut::Array(self))
     }
 }
 
@@ -261,9 +237,9 @@ impl ArrayValueMut for ByteArrayValueStorage {
             if v >= u8::MIN as i64 && v <= u8::MAX as i64 {
                 match self.values.get_mut(index) {
                     Some(slot) => {
-                        let old = mem::replace(slot, ValueStorage::new(v as u8));
+                        let old = mem::replace(slot, IntegerValueStorage::new(v as u8));
                         return ValueMutWriteResult::Updated(OwnedValue::Integer(
-                            ValueStorage::new(old.get_value()),
+                            IntegerValueStorage::new(old.get_value()),
                         ));
                     }
                     None => {
@@ -283,7 +259,7 @@ impl ArrayValueMut for ByteArrayValueStorage {
         if let Value::Integer(i) = value.to_value() {
             let v = i.get_value();
             if v >= u8::MIN as i64 && v <= u8::MAX as i64 {
-                self.values.push(ValueStorage::new(v as u8));
+                self.values.push(IntegerValueStorage::new(v as u8));
                 return ValueMutWriteResult::Created;
             }
         }
@@ -302,7 +278,7 @@ impl ArrayValueMut for ByteArrayValueStorage {
         if let Value::Integer(i) = value.to_value() {
             let v = i.get_value();
             if v >= u8::MIN as i64 && v <= u8::MAX as i64 {
-                self.values.insert(index, ValueStorage::new(v as u8));
+                self.values.insert(index, IntegerValueStorage::new(v as u8));
                 return ValueMutWriteResult::Created;
             }
         }
@@ -320,13 +296,15 @@ impl ArrayValueMut for ByteArrayValueStorage {
 
         let old = self.values.remove(index);
 
-        ValueMutRemoveResult::Removed(OwnedValue::Integer(ValueStorage::new(old.get_value())))
+        ValueMutRemoveResult::Removed(OwnedValue::Integer(IntegerValueStorage::new(
+            old.get_value(),
+        )))
     }
 
     fn retain(&mut self, item_callback: &mut dyn IndexValueMutCallback) {
         let mut index = 0;
-        self.values.retain(|v| {
-            let r = item_callback.next(index, InnerValue::Value(v));
+        self.values.retain_mut(|v| {
+            let r = item_callback.next(index, v);
             index += 1;
             r
         });

--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/proto/common.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/proto/common.rs
@@ -91,8 +91,8 @@ impl AsStaticValue for AnyValue {
     }
 }
 
-impl ValueSource<AnyValue> for AnyValue {
-    fn from_owned(value: OwnedValue) -> AnyValue {
+impl From<OwnedValue> for AnyValue {
+    fn from(value: OwnedValue) -> Self {
         match value {
             OwnedValue::Array(a) => {
                 if a.len() > 0 {
@@ -128,9 +128,11 @@ impl ValueSource<AnyValue> for AnyValue {
             OwnedValue::String(s) => AnyValue::Native(OtlpAnyValue::StringValue(s)),
         }
     }
+}
 
-    fn to_owned(self) -> OwnedValue {
-        match self {
+impl From<AnyValue> for OwnedValue {
+    fn from(val: AnyValue) -> Self {
+        match val {
             AnyValue::Null => OwnedValue::Null,
             AnyValue::Native(n) => match n {
                 OtlpAnyValue::StringValue(s) => OwnedValue::String(s),

--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/proto/logs.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/proto/logs.rs
@@ -76,16 +76,16 @@ pub struct LogRecord {
     pub(crate) resource_id: Option<usize>,
     pub(crate) scope_id: Option<usize>,
     pub(crate) diagnostic_level: Option<RecordSetEngineDiagnosticLevel>,
-    pub timestamp: Option<ValueStorage<DateTime<FixedOffset>>>,
-    pub observed_timestamp: Option<ValueStorage<DateTime<FixedOffset>>>,
-    pub severity_number: Option<ValueStorage<i32>>,
-    pub severity_text: Option<ValueStorage<String>>,
+    pub timestamp: Option<DateTimeValueStorage>,
+    pub observed_timestamp: Option<DateTimeValueStorage>,
+    pub severity_number: Option<IntegerValueStorage<i32>>,
+    pub severity_text: Option<StringValueStorage>,
     pub body: Option<AnyValue>,
     pub attributes: MapValueStorage<AnyValue>,
-    pub flags: Option<ValueStorage<u32>>,
+    pub flags: Option<IntegerValueStorage<u32>>,
     pub trace_id: Option<ByteArrayValueStorage>,
     pub span_id: Option<ByteArrayValueStorage>,
-    pub event_name: Option<ValueStorage<String>>,
+    pub event_name: Option<StringValueStorage>,
     pub(crate) extra_fields: Vec<ProtobufField>,
 }
 
@@ -116,32 +116,36 @@ impl LogRecord {
     }
 
     pub fn with_timestamp(mut self, value: DateTime<FixedOffset>) -> LogRecord {
-        self.timestamp = Some(ValueStorage::new(value));
+        self.timestamp = Some(DateTimeValueStorage::new(value));
         self
     }
 
     pub fn with_timestamp_unix_nanos(mut self, value: u64) -> LogRecord {
-        self.timestamp = Some(ValueStorage::new(Utc.timestamp_nanos(value as i64).into()));
+        self.timestamp = Some(DateTimeValueStorage::new(
+            Utc.timestamp_nanos(value as i64).into(),
+        ));
         self
     }
 
     pub fn with_observed_timestamp(mut self, value: DateTime<FixedOffset>) -> LogRecord {
-        self.observed_timestamp = Some(ValueStorage::new(value));
+        self.observed_timestamp = Some(DateTimeValueStorage::new(value));
         self
     }
 
     pub fn with_observed_timestamp_unix_nanos(mut self, value: u64) -> LogRecord {
-        self.observed_timestamp = Some(ValueStorage::new(Utc.timestamp_nanos(value as i64).into()));
+        self.observed_timestamp = Some(DateTimeValueStorage::new(
+            Utc.timestamp_nanos(value as i64).into(),
+        ));
         self
     }
 
     pub fn with_severity_number(mut self, value: i32) -> LogRecord {
-        self.severity_number = Some(ValueStorage::new(value));
+        self.severity_number = Some(IntegerValueStorage::new(value));
         self
     }
 
     pub fn with_severity_text(mut self, value: String) -> LogRecord {
-        self.severity_text = Some(ValueStorage::new(value));
+        self.severity_text = Some(StringValueStorage::new(value));
         self
     }
 
@@ -158,26 +162,26 @@ impl LogRecord {
     }
 
     pub fn with_flags(mut self, value: u32) -> LogRecord {
-        self.flags = Some(ValueStorage::new(value));
+        self.flags = Some(IntegerValueStorage::new(value));
         self
     }
 
     pub fn with_trace_id(mut self, value: Vec<u8>) -> LogRecord {
         self.trace_id = Some(ByteArrayValueStorage::new(
-            value.iter().map(|v| ValueStorage::new(*v)).collect(),
+            value.iter().map(|v| IntegerValueStorage::new(*v)).collect(),
         ));
         self
     }
 
     pub fn with_span_id(mut self, value: Vec<u8>) -> LogRecord {
         self.span_id = Some(ByteArrayValueStorage::new(
-            value.iter().map(|v| ValueStorage::new(*v)).collect(),
+            value.iter().map(|v| IntegerValueStorage::new(*v)).collect(),
         ));
         self
     }
 
     pub fn with_event_name(mut self, value: String) -> LogRecord {
-        self.event_name = Some(ValueStorage::new(value));
+        self.event_name = Some(StringValueStorage::new(value));
         self
     }
 }

--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/serializer/otlp_writer.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/serializer/otlp_writer.rs
@@ -327,7 +327,7 @@ mod tests {
         run_test(
             (
                 "key1",
-                AnyValue::Native(crate::OtlpAnyValue::StringValue(ValueStorage::new(
+                AnyValue::Native(crate::OtlpAnyValue::StringValue(StringValueStorage::new(
                     "value1".into(),
                 ))),
             ),
@@ -355,7 +355,7 @@ mod tests {
         run_test(AnyValue::Null, OtlpAnyValue { value: None });
 
         run_test(
-            AnyValue::Native(crate::OtlpAnyValue::StringValue(ValueStorage::new(
+            AnyValue::Native(crate::OtlpAnyValue::StringValue(StringValueStorage::new(
                 "".into(),
             ))),
             OtlpAnyValue {
@@ -364,7 +364,7 @@ mod tests {
         );
 
         run_test(
-            AnyValue::Native(crate::OtlpAnyValue::StringValue(ValueStorage::new(
+            AnyValue::Native(crate::OtlpAnyValue::StringValue(StringValueStorage::new(
                 "hello world".into(),
             ))),
             OtlpAnyValue {
@@ -373,42 +373,50 @@ mod tests {
         );
 
         run_test(
-            AnyValue::Native(crate::OtlpAnyValue::BoolValue(ValueStorage::new(true))),
+            AnyValue::Native(crate::OtlpAnyValue::BoolValue(BooleanValueStorage::new(
+                true,
+            ))),
             OtlpAnyValue {
                 value: Some(OtlpValue::BoolValue(true)),
             },
         );
 
         run_test(
-            AnyValue::Native(crate::OtlpAnyValue::BoolValue(ValueStorage::new(false))),
+            AnyValue::Native(crate::OtlpAnyValue::BoolValue(BooleanValueStorage::new(
+                false,
+            ))),
             OtlpAnyValue {
                 value: Some(OtlpValue::BoolValue(false)),
             },
         );
 
         run_test(
-            AnyValue::Native(crate::OtlpAnyValue::IntValue(ValueStorage::new(18))),
+            AnyValue::Native(crate::OtlpAnyValue::IntValue(IntegerValueStorage::new(18))),
             OtlpAnyValue {
                 value: Some(OtlpValue::IntValue(18)),
             },
         );
 
         run_test(
-            AnyValue::Native(crate::OtlpAnyValue::IntValue(ValueStorage::new(-18))),
+            AnyValue::Native(crate::OtlpAnyValue::IntValue(IntegerValueStorage::new(-18))),
             OtlpAnyValue {
                 value: Some(OtlpValue::IntValue(-18)),
             },
         );
 
         run_test(
-            AnyValue::Native(crate::OtlpAnyValue::DoubleValue(ValueStorage::new(18.0))),
+            AnyValue::Native(crate::OtlpAnyValue::DoubleValue(DoubleValueStorage::new(
+                18.0,
+            ))),
             OtlpAnyValue {
                 value: Some(OtlpValue::DoubleValue(18.0)),
             },
         );
 
         run_test(
-            AnyValue::Native(crate::OtlpAnyValue::DoubleValue(ValueStorage::new(-18.0))),
+            AnyValue::Native(crate::OtlpAnyValue::DoubleValue(DoubleValueStorage::new(
+                -18.0,
+            ))),
             OtlpAnyValue {
                 value: Some(OtlpValue::DoubleValue(-18.0)),
             },
@@ -427,7 +435,7 @@ mod tests {
             AnyValue::Native(crate::OtlpAnyValue::ArrayValue(ArrayValueStorage::new(
                 vec![
                     AnyValue::Null,
-                    AnyValue::Native(crate::OtlpAnyValue::IntValue(ValueStorage::new(18))),
+                    AnyValue::Native(crate::OtlpAnyValue::IntValue(IntegerValueStorage::new(18))),
                 ],
             ))),
             OtlpAnyValue {
@@ -460,7 +468,9 @@ mod tests {
                     ("key1".into(), AnyValue::Null),
                     (
                         "key2".into(),
-                        AnyValue::Native(crate::OtlpAnyValue::IntValue(ValueStorage::new(18))),
+                        AnyValue::Native(crate::OtlpAnyValue::IntValue(IntegerValueStorage::new(
+                            18,
+                        ))),
                     ),
                 ]),
             ))),
@@ -497,7 +507,10 @@ mod tests {
 
         run_test(
             AnyValue::Native(crate::OtlpAnyValue::BytesValue(ByteArrayValueStorage::new(
-                vec![ValueStorage::new(0x00), ValueStorage::new(0xFF)],
+                vec![
+                    IntegerValueStorage::new(0x00),
+                    IntegerValueStorage::new(0xFF),
+                ],
             ))),
             OtlpAnyValue {
                 value: Some(OtlpValue::BytesValue(vec![0x00, 0xFF])),
@@ -507,7 +520,9 @@ mod tests {
         // Extended
         let now = Utc::now();
         run_test(
-            AnyValue::Extended(ExtendedValue::DateTime(ValueStorage::new(now.into()))),
+            AnyValue::Extended(ExtendedValue::DateTime(DateTimeValueStorage::new(
+                now.into(),
+            ))),
             OtlpAnyValue {
                 value: Some(OtlpValue::StringValue(
                     now.to_rfc3339_opts(SecondsFormat::AutoSi, true),
@@ -516,7 +531,7 @@ mod tests {
         );
 
         run_test(
-            AnyValue::Extended(ExtendedValue::Regex(ValueStorage::new(
+            AnyValue::Extended(ExtendedValue::Regex(RegexValueStorage::new(
                 Regex::new(".*").unwrap(),
             ))),
             OtlpAnyValue {
@@ -552,7 +567,9 @@ mod tests {
                     ("key1".into(), AnyValue::Null),
                     (
                         "key2".into(),
-                        AnyValue::Native(crate::OtlpAnyValue::IntValue(ValueStorage::new(18))),
+                        AnyValue::Native(crate::OtlpAnyValue::IntValue(IntegerValueStorage::new(
+                            18,
+                        ))),
                     ),
                 ])),
                 extra_fields: Vec::new(),
@@ -623,8 +640,8 @@ mod tests {
 
         run_test(
             InstrumentationScope {
-                name: Some(ValueStorage::new("name".into())),
-                version: Some(ValueStorage::new("version".into())),
+                name: Some(StringValueStorage::new("name".into())),
+                version: Some(StringValueStorage::new("version".into())),
                 attributes: MapValueStorage::new(HashMap::new()),
                 extra_fields: Vec::new(),
             },
@@ -644,7 +661,9 @@ mod tests {
                     ("key1".into(), AnyValue::Null),
                     (
                         "key2".into(),
-                        AnyValue::Native(crate::OtlpAnyValue::IntValue(ValueStorage::new(18))),
+                        AnyValue::Native(crate::OtlpAnyValue::IntValue(IntegerValueStorage::new(
+                            18,
+                        ))),
                     ),
                 ])),
                 extra_fields: Vec::new(),
@@ -758,7 +777,7 @@ mod tests {
                 .with_attribute("key1", AnyValue::Null)
                 .with_attribute(
                     "key2",
-                    AnyValue::Native(crate::OtlpAnyValue::IntValue(ValueStorage::new(18))),
+                    AnyValue::Native(crate::OtlpAnyValue::IntValue(IntegerValueStorage::new(18))),
                 ),
             OtlpLogRecord {
                 time_unix_nano: 0,

--- a/rust/experimental/query_engine/engine-recordset/src/engine.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/engine.rs
@@ -193,7 +193,7 @@ pub trait RecordSet<TRecord: Record>: Debug {
         F: FnMut(Option<&dyn AttachedRecords>, TRecord);
 }
 
-pub trait Record: MapValueMut {
+pub trait Record: MapValueMut + AsStaticValue {
     fn get_timestamp(&self) -> Option<SystemTime>;
 
     fn get_observed_timestamp(&self) -> Option<SystemTime>;

--- a/rust/experimental/query_engine/engine-recordset/src/primitives/owned_value.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/primitives/owned_value.rs
@@ -1,58 +1,42 @@
-use chrono::{DateTime, FixedOffset};
 use data_engine_expressions::*;
-use regex::Regex;
 
 use crate::*;
 
 #[derive(Debug, Clone)]
 pub enum OwnedValue {
     Array(ArrayValueStorage<OwnedValue>),
-    Boolean(ValueStorage<bool>),
-    DateTime(ValueStorage<DateTime<FixedOffset>>),
-    Double(ValueStorage<f64>),
-    Integer(ValueStorage<i64>),
+    Boolean(BooleanValueStorage),
+    DateTime(DateTimeValueStorage),
+    Double(DoubleValueStorage<f64>),
+    Integer(IntegerValueStorage<i64>),
     Map(MapValueStorage<OwnedValue>),
     Null,
-    Regex(ValueStorage<Regex>),
-    String(ValueStorage<String>),
+    Regex(RegexValueStorage),
+    String(StringValueStorage),
 }
 
-impl AsValue for OwnedValue {
-    fn get_value_type(&self) -> ValueType {
+impl AsStaticValue for OwnedValue {
+    fn to_static_value(&self) -> StaticValue {
         match self {
-            OwnedValue::Array(_) => ValueType::Array,
-            OwnedValue::Boolean(_) => ValueType::Boolean,
-            OwnedValue::DateTime(_) => ValueType::DateTime,
-            OwnedValue::Double(_) => ValueType::Double,
-            OwnedValue::Integer(_) => ValueType::Integer,
-            OwnedValue::Map(_) => ValueType::Map,
-            OwnedValue::Null => ValueType::Null,
-            OwnedValue::Regex(_) => ValueType::Regex,
-            OwnedValue::String(_) => ValueType::String,
-        }
-    }
-
-    fn to_value(&self) -> Value {
-        match self {
-            OwnedValue::Array(a) => Value::Array(a),
-            OwnedValue::Boolean(b) => Value::Boolean(b),
-            OwnedValue::DateTime(d) => Value::DateTime(d),
-            OwnedValue::Double(v) => Value::Double(v),
-            OwnedValue::Integer(v) => Value::Integer(v),
-            OwnedValue::Map(m) => Value::Map(m),
-            OwnedValue::Null => Value::Null,
-            OwnedValue::Regex(r) => Value::Regex(r),
-            OwnedValue::String(s) => Value::String(s),
+            OwnedValue::Array(a) => StaticValue::Array(a),
+            OwnedValue::Boolean(b) => StaticValue::Boolean(b),
+            OwnedValue::DateTime(d) => StaticValue::DateTime(d),
+            OwnedValue::Double(d) => StaticValue::Double(d),
+            OwnedValue::Integer(i) => StaticValue::Integer(i),
+            OwnedValue::Map(m) => StaticValue::Map(m),
+            OwnedValue::Null => StaticValue::Null,
+            OwnedValue::Regex(r) => StaticValue::Regex(r),
+            OwnedValue::String(s) => StaticValue::String(s),
         }
     }
 }
 
-impl AsValueMut for OwnedValue {
-    fn to_value_mut(&mut self) -> Option<ValueMut> {
+impl AsStaticValueMut for OwnedValue {
+    fn to_static_value_mut(&mut self) -> Option<StaticValueMut> {
         match self {
-            OwnedValue::Array(a) => Some(ValueMut::Array(a)),
-            OwnedValue::Map(m) => Some(ValueMut::Map(m)),
-            OwnedValue::String(s) => Some(ValueMut::String(s)),
+            OwnedValue::Array(a) => Some(StaticValueMut::Array(a)),
+            OwnedValue::Map(m) => Some(StaticValueMut::Map(m)),
+            OwnedValue::String(s) => Some(StaticValueMut::String(s)),
             _ => None,
         }
     }

--- a/rust/experimental/query_engine/engine-recordset/src/primitives/resolved_value.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/primitives/resolved_value.rs
@@ -219,7 +219,7 @@ impl AsValue for ResolvedStringValue<'_> {
         match self {
             ResolvedStringValue::Value(v) => Value::String(*v),
             ResolvedStringValue::Borrowed(b) => Value::String(&**b),
-            ResolvedStringValue::Computed(c) => Value::String(c as &dyn StringValue),
+            ResolvedStringValue::Computed(c) => Value::String(c),
         }
     }
 }
@@ -261,7 +261,7 @@ impl AsValue for ResolvedRegexValue<'_> {
         match self {
             ResolvedRegexValue::Value(v) => Value::Regex(*v),
             ResolvedRegexValue::Borrowed(b) => Value::Regex(&**b),
-            ResolvedRegexValue::Computed(c) => Value::Regex(c as &dyn RegexValue),
+            ResolvedRegexValue::Computed(c) => Value::Regex(c),
         }
     }
 }

--- a/rust/experimental/query_engine/engine-recordset/src/primitives/value_mut.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/primitives/value_mut.rs
@@ -1,69 +1,32 @@
+use std::fmt::Debug;
+
 use data_engine_expressions::*;
 
 use crate::{OwnedValue, ResolvedValue};
 
 #[derive(Debug)]
-pub enum ValueMut<'a> {
+pub enum StaticValueMut<'a> {
     Array(&'a mut (dyn ArrayValueMut + 'static)),
     Map(&'a mut (dyn MapValueMut + 'static)),
     String(&'a mut (dyn StringValueMut + 'static)),
 }
 
-pub trait AsValueMut: AsValue {
-    fn to_value_mut(&mut self) -> Option<ValueMut>;
-}
-
-impl<'a> AsValue for ValueMut<'a> {
-    fn get_value_type(&self) -> ValueType {
+impl<'a> AsStaticValue for StaticValueMut<'a> {
+    fn to_static_value(&self) -> StaticValue {
         match self {
-            ValueMut::Array(_) => ValueType::Array,
-            ValueMut::Map(_) => ValueType::Map,
-            ValueMut::String(_) => ValueType::String,
-        }
-    }
-
-    fn to_value(&self) -> Value {
-        match self {
-            ValueMut::Array(a) => Value::Array(*a),
-            ValueMut::Map(b) => Value::Map(*b),
-            ValueMut::String(s) => Value::String(*s),
+            StaticValueMut::Array(a) => StaticValue::Array(*a),
+            StaticValueMut::Map(b) => StaticValue::Map(*b),
+            StaticValueMut::String(s) => StaticValue::String(*s),
         }
     }
 }
 
-#[derive(Debug)]
-pub enum InnerValue<'a> {
-    Value(&'a (dyn AsValue + 'static)),
-    ValueMut(&'a mut (dyn AsValueMut + 'static)),
-}
-
-impl AsValue for InnerValue<'_> {
-    fn get_value_type(&self) -> ValueType {
-        match self {
-            InnerValue::Value(v) => v.get_value_type(),
-            InnerValue::ValueMut(v) => v.get_value_type(),
-        }
-    }
-
-    fn to_value(&self) -> Value {
-        match self {
-            InnerValue::Value(v) => v.to_value(),
-            InnerValue::ValueMut(v) => v.to_value(),
-        }
-    }
-}
-
-impl AsValueMut for InnerValue<'_> {
-    fn to_value_mut(&mut self) -> Option<ValueMut> {
-        match self {
-            InnerValue::Value(_) => None,
-            InnerValue::ValueMut(v) => v.to_value_mut(),
-        }
-    }
+pub trait AsStaticValueMut: AsStaticValue {
+    fn to_static_value_mut(&mut self) -> Option<StaticValueMut>;
 }
 
 pub enum ValueMutGetResult<'a> {
-    Found(&'a mut (dyn AsValueMut + 'static)),
+    Found(&'a mut (dyn AsStaticValueMut + 'static)),
     NotFound,
     NotSupported(String),
 }
@@ -80,7 +43,7 @@ pub enum ValueMutRemoveResult {
     Removed(OwnedValue),
 }
 
-pub trait ArrayValueMut: ArrayValue + AsValueMut {
+pub trait ArrayValueMut: ArrayValue {
     fn get_mut(&mut self, index: usize) -> ValueMutGetResult;
 
     fn set(&mut self, index: usize, value: ResolvedValue) -> ValueMutWriteResult;
@@ -95,19 +58,19 @@ pub trait ArrayValueMut: ArrayValue + AsValueMut {
 }
 
 pub trait IndexValueMutCallback {
-    fn next(&mut self, index: usize, value: InnerValue) -> bool;
+    fn next(&mut self, index: usize, value: &mut (dyn AsStaticValueMut + 'static)) -> bool;
 }
 
 pub struct IndexValueMutClosureCallback<F>
 where
-    F: FnMut(usize, InnerValue) -> bool,
+    F: FnMut(usize, &mut (dyn AsStaticValueMut + 'static)) -> bool,
 {
     callback: F,
 }
 
 impl<F> IndexValueMutClosureCallback<F>
 where
-    F: FnMut(usize, InnerValue) -> bool,
+    F: FnMut(usize, &mut (dyn AsStaticValueMut + 'static)) -> bool,
 {
     pub fn new(callback: F) -> IndexValueMutClosureCallback<F> {
         Self { callback }
@@ -116,14 +79,14 @@ where
 
 impl<F> IndexValueMutCallback for IndexValueMutClosureCallback<F>
 where
-    F: FnMut(usize, InnerValue) -> bool,
+    F: FnMut(usize, &mut (dyn AsStaticValueMut + 'static)) -> bool,
 {
-    fn next(&mut self, index: usize, value: InnerValue) -> bool {
+    fn next(&mut self, index: usize, value: &mut (dyn AsStaticValueMut + 'static)) -> bool {
         (self.callback)(index, value)
     }
 }
 
-pub trait MapValueMut: MapValue + AsValueMut {
+pub trait MapValueMut: MapValue {
     fn get_mut(&mut self, key: &str) -> ValueMutGetResult;
 
     fn set(&mut self, key: &str, value: ResolvedValue) -> ValueMutWriteResult;
@@ -136,19 +99,19 @@ pub trait MapValueMut: MapValue + AsValueMut {
 }
 
 pub trait KeyValueMutCallback {
-    fn next(&mut self, key: &str, value: InnerValue) -> bool;
+    fn next(&mut self, key: &str, value: &mut (dyn AsStaticValueMut + 'static)) -> bool;
 }
 
 pub struct KeyValueMutClosureCallback<F>
 where
-    F: FnMut(&str, InnerValue) -> bool,
+    F: FnMut(&str, &mut (dyn AsStaticValueMut + 'static)) -> bool,
 {
     callback: F,
 }
 
 impl<F> KeyValueMutClosureCallback<F>
 where
-    F: FnMut(&str, InnerValue) -> bool,
+    F: FnMut(&str, &mut (dyn AsStaticValueMut + 'static)) -> bool,
 {
     pub fn new(callback: F) -> KeyValueMutClosureCallback<F> {
         Self { callback }
@@ -157,13 +120,13 @@ where
 
 impl<F> KeyValueMutCallback for KeyValueMutClosureCallback<F>
 where
-    F: FnMut(&str, InnerValue) -> bool,
+    F: FnMut(&str, &mut (dyn AsStaticValueMut + 'static)) -> bool,
 {
-    fn next(&mut self, key: &str, value: InnerValue) -> bool {
+    fn next(&mut self, key: &str, value: &mut (dyn AsStaticValueMut + 'static)) -> bool {
         (self.callback)(key, value)
     }
 }
 
-pub trait StringValueMut: StringValue + AsValueMut {
+pub trait StringValueMut: StringValue {
     fn get_value_mut(&mut self) -> &mut String;
 }

--- a/rust/experimental/query_engine/engine-recordset/src/primitives/value_storage.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/primitives/value_storage.rs
@@ -6,19 +6,87 @@ use regex::Regex;
 
 use crate::*;
 
-pub trait ValueSource<T>: AsValueMut {
+pub trait ValueSource<T>: AsStaticValue + AsStaticValueMut {
     fn from_owned(value: OwnedValue) -> T;
 
     fn to_owned(self) -> OwnedValue;
 }
 
 #[derive(Debug, Clone)]
-pub struct ValueStorage<T> {
+pub struct BooleanValueStorage {
+    value: bool,
+}
+
+impl BooleanValueStorage {
+    pub fn new(value: bool) -> BooleanValueStorage {
+        Self { value }
+    }
+
+    pub fn get_raw_value(&self) -> &bool {
+        &self.value
+    }
+
+    pub fn get_raw_value_mut(&mut self) -> &mut bool {
+        &mut self.value
+    }
+}
+
+impl BooleanValue for BooleanValueStorage {
+    fn get_value(&self) -> bool {
+        self.value
+    }
+}
+
+impl AsStaticValue for BooleanValueStorage {
+    fn to_static_value(&self) -> StaticValue {
+        StaticValue::Boolean(self)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DateTimeValueStorage {
+    value: DateTime<FixedOffset>,
+}
+
+impl DateTimeValueStorage {
+    pub fn new(value: DateTime<FixedOffset>) -> DateTimeValueStorage {
+        Self { value }
+    }
+
+    pub fn get_raw_value(&self) -> &DateTime<FixedOffset> {
+        &self.value
+    }
+
+    pub fn get_raw_value_mut(&mut self) -> &mut DateTime<FixedOffset> {
+        &mut self.value
+    }
+}
+
+impl DateTimeValue for DateTimeValueStorage {
+    fn get_value(&self) -> DateTime<FixedOffset> {
+        self.value
+    }
+}
+
+impl AsStaticValue for DateTimeValueStorage {
+    fn to_static_value(&self) -> StaticValue {
+        StaticValue::DateTime(self)
+    }
+}
+
+impl AsStaticValueMut for DateTimeValueStorage {
+    fn to_static_value_mut(&mut self) -> Option<StaticValueMut> {
+        None
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DoubleValueStorage<T: Into<f64> + Clone + Debug + 'static> {
     value: T,
 }
 
-impl<T> ValueStorage<T> {
-    pub fn new(value: T) -> ValueStorage<T> {
+impl<T: Into<f64> + Clone + Debug + 'static> DoubleValueStorage<T> {
+    pub fn new(value: T) -> DoubleValueStorage<T> {
         Self { value }
     }
 
@@ -26,180 +94,143 @@ impl<T> ValueStorage<T> {
         &self.value
     }
 
-    pub fn get_raw_value_mut(&mut self) -> &T {
+    pub fn get_raw_value_mut(&mut self) -> &mut T {
+        &mut self.value
+    }
+}
+
+impl<T: Into<f64> + Clone + Debug + 'static> DoubleValue for DoubleValueStorage<T> {
+    fn get_value(&self) -> f64 {
+        self.value.clone().into()
+    }
+}
+
+impl<T: Into<f64> + Clone + Debug + 'static> AsStaticValue for DoubleValueStorage<T> {
+    fn to_static_value(&self) -> StaticValue {
+        StaticValue::Double(self)
+    }
+}
+
+impl<T: Into<f64> + Clone + Debug + 'static> AsStaticValueMut for DoubleValueStorage<T> {
+    fn to_static_value_mut(&mut self) -> Option<StaticValueMut> {
+        None
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct IntegerValueStorage<T: Into<i64> + Clone + Debug + 'static> {
+    value: T,
+}
+
+impl<T: Into<i64> + Clone + Debug + 'static> IntegerValueStorage<T> {
+    pub fn new(value: T) -> IntegerValueStorage<T> {
+        Self { value }
+    }
+
+    pub fn get_raw_value(&self) -> &T {
         &self.value
     }
-}
 
-impl BooleanValue for ValueStorage<bool> {
-    fn get_value(&self) -> bool {
-        self.value
+    pub fn get_raw_value_mut(&mut self) -> &mut T {
+        &mut self.value
     }
 }
 
-impl AsValue for ValueStorage<bool> {
-    fn get_value_type(&self) -> ValueType {
-        ValueType::Boolean
-    }
-
-    fn to_value(&self) -> Value {
-        Value::Boolean(self)
-    }
-}
-
-impl IntegerValue for ValueStorage<i64> {
+impl<T: Into<i64> + Clone + Debug + 'static> IntegerValue for IntegerValueStorage<T> {
     fn get_value(&self) -> i64 {
-        self.value
+        self.value.clone().into()
     }
 }
 
-impl AsValue for ValueStorage<i64> {
-    fn get_value_type(&self) -> ValueType {
-        ValueType::Integer
-    }
-
-    fn to_value(&self) -> Value {
-        Value::Integer(self)
+impl<T: Into<i64> + Clone + Debug + 'static> AsStaticValue for IntegerValueStorage<T> {
+    fn to_static_value(&self) -> StaticValue {
+        StaticValue::Integer(self)
     }
 }
 
-impl IntegerValue for ValueStorage<i32> {
-    fn get_value(&self) -> i64 {
-        self.value as i64
+impl<T: Into<i64> + Clone + Debug + 'static> AsStaticValueMut for IntegerValueStorage<T> {
+    fn to_static_value_mut(&mut self) -> Option<StaticValueMut> {
+        None
     }
 }
 
-impl AsValue for ValueStorage<i32> {
-    fn get_value_type(&self) -> ValueType {
-        ValueType::Integer
+#[derive(Debug, Clone)]
+pub struct RegexValueStorage {
+    value: Regex,
+}
+
+impl RegexValueStorage {
+    pub fn new(value: Regex) -> RegexValueStorage {
+        Self { value }
     }
 
-    fn to_value(&self) -> Value {
-        Value::Integer(self)
+    pub fn get_raw_value(&self) -> &Regex {
+        &self.value
+    }
+
+    pub fn get_raw_value_mut(&mut self) -> &mut Regex {
+        &mut self.value
     }
 }
 
-impl IntegerValue for ValueStorage<u32> {
-    fn get_value(&self) -> i64 {
-        self.value as i64
-    }
-}
-
-impl AsValue for ValueStorage<u32> {
-    fn get_value_type(&self) -> ValueType {
-        ValueType::Integer
-    }
-
-    fn to_value(&self) -> Value {
-        Value::Integer(self)
-    }
-}
-
-impl IntegerValue for ValueStorage<u8> {
-    fn get_value(&self) -> i64 {
-        self.value as i64
-    }
-}
-
-impl AsValue for ValueStorage<u8> {
-    fn get_value_type(&self) -> ValueType {
-        ValueType::Integer
-    }
-
-    fn to_value(&self) -> Value {
-        Value::Integer(self)
-    }
-}
-
-impl DateTimeValue for ValueStorage<DateTime<FixedOffset>> {
-    fn get_value(&self) -> DateTime<FixedOffset> {
-        self.value
-    }
-}
-
-impl AsValue for ValueStorage<DateTime<FixedOffset>> {
-    fn get_value_type(&self) -> ValueType {
-        ValueType::DateTime
-    }
-
-    fn to_value(&self) -> Value {
-        Value::DateTime(self)
-    }
-}
-
-impl DoubleValue for ValueStorage<f64> {
-    fn get_value(&self) -> f64 {
-        self.value
-    }
-}
-
-impl AsValue for ValueStorage<f64> {
-    fn get_value_type(&self) -> ValueType {
-        ValueType::Double
-    }
-
-    fn to_value(&self) -> Value {
-        Value::Double(self)
-    }
-}
-
-impl DoubleValue for ValueStorage<f32> {
-    fn get_value(&self) -> f64 {
-        self.value as f64
-    }
-}
-
-impl AsValue for ValueStorage<f32> {
-    fn get_value_type(&self) -> ValueType {
-        ValueType::Double
-    }
-
-    fn to_value(&self) -> Value {
-        Value::Double(self)
-    }
-}
-
-impl RegexValue for ValueStorage<Regex> {
+impl RegexValue for RegexValueStorage {
     fn get_value(&self) -> &Regex {
         &self.value
     }
 }
 
-impl AsValue for ValueStorage<Regex> {
-    fn get_value_type(&self) -> ValueType {
-        ValueType::Regex
-    }
-
-    fn to_value(&self) -> Value {
-        Value::Regex(self)
+impl AsStaticValue for RegexValueStorage {
+    fn to_static_value(&self) -> StaticValue {
+        StaticValue::Regex(self)
     }
 }
 
-impl StringValue for ValueStorage<String> {
+impl AsStaticValueMut for RegexValueStorage {
+    fn to_static_value_mut(&mut self) -> Option<StaticValueMut> {
+        None
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct StringValueStorage {
+    value: String,
+}
+
+impl StringValueStorage {
+    pub fn new(value: String) -> StringValueStorage {
+        Self { value }
+    }
+
+    pub fn get_raw_value(&self) -> &String {
+        &self.value
+    }
+
+    pub fn get_raw_value_mut(&mut self) -> &mut String {
+        &mut self.value
+    }
+}
+
+impl StringValue for StringValueStorage {
     fn get_value(&self) -> &str {
         &self.value
     }
 }
 
-impl AsValue for ValueStorage<String> {
-    fn get_value_type(&self) -> ValueType {
-        ValueType::String
-    }
-
-    fn to_value(&self) -> Value {
-        Value::String(self)
-    }
-}
-
-impl StringValueMut for ValueStorage<String> {
+impl StringValueMut for StringValueStorage {
     fn get_value_mut(&mut self) -> &mut String {
         &mut self.value
     }
 }
 
-impl AsValueMut for ValueStorage<String> {
-    fn to_value_mut(&mut self) -> Option<ValueMut> {
-        Some(ValueMut::String(self))
+impl AsStaticValue for StringValueStorage {
+    fn to_static_value(&self) -> StaticValue {
+        StaticValue::String(self)
+    }
+}
+
+impl AsStaticValueMut for StringValueStorage {
+    fn to_static_value_mut(&mut self) -> Option<StaticValueMut> {
+        Some(StaticValueMut::String(self))
     }
 }
 
@@ -240,8 +271,8 @@ impl<T: ValueSource<T> + 'static> ArrayValue for ArrayValueStorage<T> {
         self.values.len()
     }
 
-    fn get(&self, index: usize) -> Option<&(dyn AsValue + 'static)> {
-        self.values.get(index).map(|v| v as &dyn AsValue)
+    fn get(&self, index: usize) -> Option<&(dyn AsStaticValue + 'static)> {
+        self.values.get(index).map(|v| v as &dyn AsStaticValue)
     }
 
     fn get_items(&self, item_callback: &mut dyn IndexValueCallback) -> bool {
@@ -255,27 +286,22 @@ impl<T: ValueSource<T> + 'static> ArrayValue for ArrayValueStorage<T> {
     }
 }
 
-impl<T: ValueSource<T> + 'static> AsValue for ArrayValueStorage<T> {
-    fn get_value_type(&self) -> ValueType {
-        ValueType::Array
+impl<T: ValueSource<T> + 'static> AsStaticValue for ArrayValueStorage<T> {
+    fn to_static_value(&self) -> StaticValue {
+        StaticValue::Array(self)
     }
+}
 
-    fn to_value(&self) -> Value {
-        Value::Array(self)
+impl<T: ValueSource<T> + 'static> AsStaticValueMut for ArrayValueStorage<T> {
+    fn to_static_value_mut(&mut self) -> Option<StaticValueMut> {
+        Some(StaticValueMut::Array(self))
     }
 }
 
 impl<T: ValueSource<T> + 'static> ArrayValueMut for ArrayValueStorage<T> {
     fn get_mut(&mut self, index: usize) -> ValueMutGetResult {
         if let Some(v) = self.values.get_mut(index) {
-            if v.to_value_mut().is_some() {
-                ValueMutGetResult::Found(v)
-            } else {
-                ValueMutGetResult::NotSupported(format!(
-                    "Cannot mutate '{:?}' value at index '{index}'",
-                    v.get_value_type()
-                ))
-            }
+            ValueMutGetResult::Found(v)
         } else {
             ValueMutGetResult::NotFound
         }
@@ -320,16 +346,10 @@ impl<T: ValueSource<T> + 'static> ArrayValueMut for ArrayValueStorage<T> {
     fn retain(&mut self, item_callback: &mut dyn IndexValueMutCallback) {
         let mut index = 0;
         self.values.retain_mut(|v| {
-            let r = item_callback.next(index, InnerValue::ValueMut(v));
+            let r = item_callback.next(index, v);
             index += 1;
             r
         });
-    }
-}
-
-impl<T: ValueSource<T> + 'static> AsValueMut for ArrayValueStorage<T> {
-    fn to_value_mut(&mut self) -> Option<ValueMut> {
-        Some(ValueMut::Array(self))
     }
 }
 
@@ -373,8 +393,8 @@ impl<T: ValueSource<T> + 'static> MapValue for MapValueStorage<T> {
         self.values.contains_key(key)
     }
 
-    fn get(&self, key: &str) -> Option<&(dyn AsValue + 'static)> {
-        self.values.get(key).map(|v| v as &dyn AsValue)
+    fn get(&self, key: &str) -> Option<&(dyn AsStaticValue + 'static)> {
+        self.values.get(key).map(|v| v as &dyn AsStaticValue)
     }
 
     fn get_items(&self, item_callback: &mut dyn KeyValueCallback) -> bool {
@@ -388,29 +408,22 @@ impl<T: ValueSource<T> + 'static> MapValue for MapValueStorage<T> {
     }
 }
 
-impl<T: ValueSource<T> + 'static> AsValue for MapValueStorage<T> {
-    fn get_value_type(&self) -> ValueType {
-        ValueType::Map
+impl<T: ValueSource<T> + 'static> AsStaticValue for MapValueStorage<T> {
+    fn to_static_value(&self) -> StaticValue {
+        StaticValue::Map(self)
     }
+}
 
-    fn to_value(&self) -> Value {
-        Value::Map(self)
+impl<T: ValueSource<T> + 'static> AsStaticValueMut for MapValueStorage<T> {
+    fn to_static_value_mut(&mut self) -> Option<StaticValueMut> {
+        Some(StaticValueMut::Map(self))
     }
 }
 
 impl<T: ValueSource<T> + 'static> MapValueMut for MapValueStorage<T> {
     fn get_mut(&mut self, key: &str) -> ValueMutGetResult {
         match self.values.get_mut(key) {
-            Some(v) => {
-                if v.to_value_mut().is_some() {
-                    ValueMutGetResult::Found(v)
-                } else {
-                    ValueMutGetResult::NotSupported(format!(
-                        "Cannot mutate '{:?}' value at key '{key}'",
-                        v.get_value_type()
-                    ))
-                }
-            }
+            Some(v) => ValueMutGetResult::Found(v),
             None => ValueMutGetResult::NotFound,
         }
     }
@@ -440,13 +453,6 @@ impl<T: ValueSource<T> + 'static> MapValueMut for MapValueStorage<T> {
     }
 
     fn retain(&mut self, item_callback: &mut dyn KeyValueMutCallback) {
-        self.values
-            .retain(|k, v| item_callback.next(k, InnerValue::ValueMut(v)));
-    }
-}
-
-impl<T: ValueSource<T> + 'static> AsValueMut for MapValueStorage<T> {
-    fn to_value_mut(&mut self) -> Option<ValueMut> {
-        Some(ValueMut::Map(self))
+        self.values.retain(|k, v| item_callback.next(k, v));
     }
 }

--- a/rust/experimental/query_engine/engine-recordset/src/test_helpers.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/test_helpers.rs
@@ -72,7 +72,7 @@ impl TestRecord {
         let mut values = self.values;
         values.insert(
             "Timestamp".into(),
-            OwnedValue::DateTime(ValueStorage::new(value)),
+            OwnedValue::DateTime(DateTimeValueStorage::new(value)),
         );
         Self { values }
     }
@@ -81,7 +81,7 @@ impl TestRecord {
         let mut values = self.values;
         values.insert(
             "ObservedTimestamp".into(),
-            OwnedValue::DateTime(ValueStorage::new(value)),
+            OwnedValue::DateTime(DateTimeValueStorage::new(value)),
         );
         Self { values }
     }
@@ -102,7 +102,7 @@ impl Default for TestRecord {
 impl Record for TestRecord {
     fn get_timestamp(&self) -> Option<SystemTime> {
         if let Some(OwnedValue::DateTime(d)) = self.values.get("Timestamp") {
-            Some(d.get_value().into())
+            Some((*d.get_raw_value()).into())
         } else {
             None
         }
@@ -110,7 +110,7 @@ impl Record for TestRecord {
 
     fn get_observed_timestamp(&self) -> Option<SystemTime> {
         if let Some(OwnedValue::DateTime(d)) = self.values.get("ObservedTimestamp") {
-            Some(d.get_value().into())
+            Some((*d.get_raw_value()).into())
         } else {
             None
         }
@@ -121,13 +121,9 @@ impl Record for TestRecord {
     }
 }
 
-impl AsValue for TestRecord {
-    fn get_value_type(&self) -> ValueType {
-        ValueType::Map
-    }
-
-    fn to_value(&self) -> Value {
-        Value::Map(self)
+impl AsStaticValue for TestRecord {
+    fn to_static_value(&self) -> StaticValue {
+        StaticValue::Map(self)
     }
 }
 
@@ -144,8 +140,8 @@ impl MapValue for TestRecord {
         self.values.contains_key(key)
     }
 
-    fn get(&self, key: &str) -> Option<&(dyn AsValue + 'static)> {
-        self.values.get(key).map(|v| v as &dyn AsValue)
+    fn get(&self, key: &str) -> Option<&(dyn AsStaticValue + 'static)> {
+        self.values.get(key).map(|v| v as &dyn AsStaticValue)
     }
 
     fn get_items(&self, item_callback: &mut dyn KeyValueCallback) -> bool {
@@ -159,17 +155,9 @@ impl MapValue for TestRecord {
     }
 }
 
-impl AsValueMut for TestRecord {
-    fn to_value_mut(&mut self) -> Option<ValueMut> {
-        Some(ValueMut::Map(self))
-    }
-}
-
 impl MapValueMut for TestRecord {
     fn get_mut(&mut self, key: &str) -> ValueMutGetResult {
-        if let Some(v) = self.values.get_mut(key)
-            && let Some(_) = v.to_value_mut()
-        {
+        if let Some(v) = self.values.get_mut(key) {
             ValueMutGetResult::Found(v)
         } else {
             ValueMutGetResult::NotFound
@@ -198,7 +186,6 @@ impl MapValueMut for TestRecord {
     }
 
     fn retain(&mut self, item_callback: &mut dyn KeyValueMutCallback) {
-        self.values
-            .retain(|k, v| item_callback.next(k, InnerValue::ValueMut(v)));
+        self.values.retain(|k, v| item_callback.next(k, v));
     }
 }

--- a/rust/experimental/query_engine/engine-recordset/src/test_helpers.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/test_helpers.rs
@@ -165,7 +165,7 @@ impl MapValueMut for TestRecord {
     }
 
     fn set(&mut self, key: &str, value: ResolvedValue) -> ValueMutWriteResult {
-        match self.values.insert(key.into(), value.to_owned()) {
+        match self.values.insert(key.into(), value.into()) {
             Some(old) => ValueMutWriteResult::Updated(old),
             None => ValueMutWriteResult::Created,
         }

--- a/rust/experimental/query_engine/engine-recordset/src/transform/reduce_map_transform_expression.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/transform/reduce_map_transform_expression.rs
@@ -32,7 +32,7 @@ pub fn execute_map_reduce_transform_expression<'a, TRecord: Record>(
             let target = execute_mutable_value_expression(execution_context, target)?;
 
             if let Some(ResolvedValueMut::Map(mut m)) = target {
-                m.retain(&mut KeyValueMutClosureCallback::new(|k, mut v| {
+                m.retain(&mut KeyValueMutClosureCallback::new(|k, v| {
                     for p in &reduction.key_patterns {
                         if p.get_value().is_match(k) {
                             execution_context.add_diagnostic_if_enabled(
@@ -45,9 +45,9 @@ pub fn execute_map_reduce_transform_expression<'a, TRecord: Record>(
                     }
 
                     if let Some(inner_reduction) = reduction.keys.get(&MapReductionKey::Key(k)) {
-                        let v = v.to_value_mut();
+                        let v = v.to_static_value_mut();
                         let remove = match v {
-                            Some(ValueMut::Map(m)) => {
+                            Some(StaticValueMut::Map(m)) => {
                                 if !inner_reduction.key_patterns.is_empty() || !inner_reduction.keys.is_empty() {
                                     execution_context.add_diagnostic_if_enabled(
                                         RecordSetEngineDiagnosticLevel::Verbose,
@@ -61,7 +61,7 @@ pub fn execute_map_reduce_transform_expression<'a, TRecord: Record>(
                                     true
                                 }
                             }
-                            Some(ValueMut::Array(a)) => {
+                            Some(StaticValueMut::Array(a)) => {
                                 if !inner_reduction.indices.is_empty() {
                                     execution_context.add_diagnostic_if_enabled(
                                         RecordSetEngineDiagnosticLevel::Verbose,
@@ -114,7 +114,7 @@ pub fn execute_map_reduce_transform_expression<'a, TRecord: Record>(
             let target = execute_mutable_value_expression(execution_context, target)?;
 
             if let Some(ResolvedValueMut::Map(mut m)) = target {
-                m.retain(&mut KeyValueMutClosureCallback::new(|k, mut v| {
+                m.retain(&mut KeyValueMutClosureCallback::new(|k, v| {
                     for p in &reduction.key_patterns {
                         if p.get_value().is_match(k) {
                             return true;
@@ -122,9 +122,9 @@ pub fn execute_map_reduce_transform_expression<'a, TRecord: Record>(
                     }
 
                     if let Some(inner_reduction) = reduction.keys.get(&MapReductionKey::Key(k)) {
-                        let v = v.to_value_mut();
+                        let v = v.to_static_value_mut();
                         match v {
-                            Some(ValueMut::Map(m)) => {
+                            Some(StaticValueMut::Map(m)) => {
                                 if !inner_reduction.key_patterns.is_empty() || !inner_reduction.keys.is_empty() {
                                     execution_context.add_diagnostic_if_enabled(
                                         RecordSetEngineDiagnosticLevel::Verbose,
@@ -134,7 +134,7 @@ pub fn execute_map_reduce_transform_expression<'a, TRecord: Record>(
                                     keep_in_map(execution_context, r, m, inner_reduction);
                                 }
                             }
-                            Some(ValueMut::Array(a)) => {
+                            Some(StaticValueMut::Array(a)) => {
                                 if !inner_reduction.indices.is_empty() {
                                     execution_context.add_diagnostic_if_enabled(
                                         RecordSetEngineDiagnosticLevel::Verbose,
@@ -408,7 +408,7 @@ fn remove_from_map<'a, TRecord: Record + 'static>(
     map: &mut dyn MapValueMut,
     reduction: &MapReduction<'_>,
 ) {
-    map.retain(&mut KeyValueMutClosureCallback::new(|k, mut v| {
+    map.retain(&mut KeyValueMutClosureCallback::new(|k, v| {
         if !reduction.key_patterns.is_empty() {
             for p in &reduction.key_patterns {
                 if p.get_value().is_match(k) {
@@ -423,9 +423,9 @@ fn remove_from_map<'a, TRecord: Record + 'static>(
         }
 
         if let Some(inner_reduction) = reduction.keys.get(&MapReductionKey::Key(k)) {
-            let v = v.to_value_mut();
+            let v = v.to_static_value_mut();
             let remove = match v {
-                Some(ValueMut::Map(m)) => {
+                Some(StaticValueMut::Map(m)) => {
                     if !inner_reduction.key_patterns.is_empty() || !inner_reduction.keys.is_empty() {
                         execution_context.add_diagnostic_if_enabled(
                             RecordSetEngineDiagnosticLevel::Verbose,
@@ -439,7 +439,7 @@ fn remove_from_map<'a, TRecord: Record + 'static>(
                         true
                     }
                 }
-                Some(ValueMut::Array(a)) => {
+                Some(StaticValueMut::Array(a)) => {
                     if !inner_reduction.indices.is_empty() {
                         execution_context.add_diagnostic_if_enabled(
                             RecordSetEngineDiagnosticLevel::Verbose,
@@ -499,11 +499,11 @@ fn remove_from_array<'a, TRecord: Record + 'static>(
         }
     }
 
-    array.retain(&mut IndexValueMutClosureCallback::new(|i, mut v| {
+    array.retain(&mut IndexValueMutClosureCallback::new(|i, v| {
         if let Some(inner_reduction) = elements.get(&i) {
-            let v = v.to_value_mut();
+            let v = v.to_static_value_mut();
             let remove = match v {
-                Some(ValueMut::Map(m)) => {
+                Some(StaticValueMut::Map(m)) => {
                     if !inner_reduction.key_patterns.is_empty() || !inner_reduction.keys.is_empty() {
                         execution_context.add_diagnostic_if_enabled(
                             RecordSetEngineDiagnosticLevel::Verbose,
@@ -517,7 +517,7 @@ fn remove_from_array<'a, TRecord: Record + 'static>(
                         true
                     }
                 }
-                Some(ValueMut::Array(a)) => {
+                Some(StaticValueMut::Array(a)) => {
                     if !inner_reduction.indices.is_empty() {
                         execution_context.add_diagnostic_if_enabled(
                             RecordSetEngineDiagnosticLevel::Verbose,
@@ -554,7 +554,7 @@ fn keep_in_map<'a, TRecord: Record + 'static>(
     map: &mut dyn MapValueMut,
     reduction: &MapReduction<'_>,
 ) {
-    map.retain(&mut KeyValueMutClosureCallback::new(|k, mut v| {
+    map.retain(&mut KeyValueMutClosureCallback::new(|k, v| {
         if !reduction.key_patterns.is_empty() {
             for p in &reduction.key_patterns {
                 if p.get_value().is_match(k) {
@@ -564,9 +564,9 @@ fn keep_in_map<'a, TRecord: Record + 'static>(
         }
 
         if let Some(inner_reduction) = reduction.keys.get(&MapReductionKey::Key(k)) {
-            let v = v.to_value_mut();
+            let v = v.to_static_value_mut();
             match v {
-                Some(ValueMut::Map(m)) => {
+                Some(StaticValueMut::Map(m)) => {
                     if !inner_reduction.key_patterns.is_empty() || !inner_reduction.keys.is_empty() {
                         execution_context.add_diagnostic_if_enabled(
                             RecordSetEngineDiagnosticLevel::Verbose,
@@ -576,7 +576,7 @@ fn keep_in_map<'a, TRecord: Record + 'static>(
                         keep_in_map(execution_context, expression, m, inner_reduction);
                     }
                 }
-                Some(ValueMut::Array(a)) => {
+                Some(StaticValueMut::Array(a)) => {
                     if !inner_reduction.indices.is_empty() {
                         execution_context.add_diagnostic_if_enabled(
                             RecordSetEngineDiagnosticLevel::Verbose,
@@ -632,11 +632,11 @@ fn keep_in_array<'a, TRecord: Record + 'static>(
         }
     }
 
-    array.retain(&mut IndexValueMutClosureCallback::new(|i, mut v| {
+    array.retain(&mut IndexValueMutClosureCallback::new(|i, v| {
         if let Some(inner_reduction) = elements.get(&i) {
-            let v = v.to_value_mut();
+            let v = v.to_static_value_mut();
             match v {
-                Some(ValueMut::Map(m)) => {
+                Some(StaticValueMut::Map(m)) => {
                     if !inner_reduction.key_patterns.is_empty() || !inner_reduction.keys.is_empty() {
                         execution_context.add_diagnostic_if_enabled(
                             RecordSetEngineDiagnosticLevel::Verbose,
@@ -646,7 +646,7 @@ fn keep_in_array<'a, TRecord: Record + 'static>(
                         keep_in_map(execution_context, expression, m, inner_reduction);
                     }
                 }
-                Some(ValueMut::Array(a)) => {
+                Some(StaticValueMut::Array(a)) => {
                     if !inner_reduction.indices.is_empty() {
                         execution_context.add_diagnostic_if_enabled(
                             RecordSetEngineDiagnosticLevel::Verbose,
@@ -688,29 +688,29 @@ mod tests {
                 OwnedValue::Map(MapValueStorage::new(HashMap::from([
                     (
                         "subkey1".into(),
-                        OwnedValue::String(ValueStorage::new("hello".into())),
+                        OwnedValue::String(StringValueStorage::new("hello".into())),
                     ),
                     (
                         "subkey2".into(),
-                        OwnedValue::String(ValueStorage::new("world".into())),
+                        OwnedValue::String(StringValueStorage::new("world".into())),
                     ),
                     (
                         "subkey3".into(),
-                        OwnedValue::String(ValueStorage::new("goodbye".into())),
+                        OwnedValue::String(StringValueStorage::new("goodbye".into())),
                     ),
                 ]))),
             )
             .with_key_value(
                 "key2".into(),
                 OwnedValue::Array(ArrayValueStorage::new(vec![
-                    OwnedValue::Integer(ValueStorage::new(1)),
-                    OwnedValue::Integer(ValueStorage::new(2)),
-                    OwnedValue::Integer(ValueStorage::new(3)),
+                    OwnedValue::Integer(IntegerValueStorage::new(1)),
+                    OwnedValue::Integer(IntegerValueStorage::new(2)),
+                    OwnedValue::Integer(IntegerValueStorage::new(3)),
                 ])),
             )
             .with_key_value(
                 "key_to_remove".into(),
-                OwnedValue::String(ValueStorage::new("key1".into())),
+                OwnedValue::String(StringValueStorage::new("key1".into())),
             );
 
         let run_test = |transform_expression| {
@@ -987,24 +987,24 @@ mod tests {
                 OwnedValue::Map(MapValueStorage::new(HashMap::from([
                     (
                         "subkey1".into(),
-                        OwnedValue::String(ValueStorage::new("hello".into())),
+                        OwnedValue::String(StringValueStorage::new("hello".into())),
                     ),
                     (
                         "subkey2".into(),
-                        OwnedValue::String(ValueStorage::new("world".into())),
+                        OwnedValue::String(StringValueStorage::new("world".into())),
                     ),
                     (
                         "subkey3".into(),
-                        OwnedValue::String(ValueStorage::new("goodbye".into())),
+                        OwnedValue::String(StringValueStorage::new("goodbye".into())),
                     ),
                 ]))),
             )
             .with_key_value(
                 "key2".into(),
                 OwnedValue::Array(ArrayValueStorage::new(vec![
-                    OwnedValue::Integer(ValueStorage::new(1)),
-                    OwnedValue::Integer(ValueStorage::new(2)),
-                    OwnedValue::Integer(ValueStorage::new(3)),
+                    OwnedValue::Integer(IntegerValueStorage::new(1)),
+                    OwnedValue::Integer(IntegerValueStorage::new(2)),
+                    OwnedValue::Integer(IntegerValueStorage::new(3)),
                 ])),
             );
 
@@ -1061,9 +1061,7 @@ mod tests {
         assert_eq!(2, result.len());
         assert!(result.contains_key("key1"));
 
-        if let Some(v) = result.get("key1").map(|v| v.to_value())
-            && let Value::Map(m) = v
-        {
+        if let Some(Value::Map(m)) = result.get("key1").map(|v| v.to_value()) {
             assert_eq!(0, m.len());
         } else {
             panic!()

--- a/rust/experimental/query_engine/engine-recordset/src/transform/transform_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/transform/transform_expressions.rs
@@ -352,7 +352,7 @@ fn resolve_map_destination<'a>(
             ResolvedValueMut::Map(m) => Some(m),
             ResolvedValueMut::MapKey { map, key } => RefMut::filter_map(map, |v| {
                 if let ValueMutGetResult::Found(v) = v.get_mut(key.get_value())
-                    && let Some(ValueMut::Map(m)) = v.to_value_mut()
+                    && let Some(StaticValueMut::Map(m)) = v.to_static_value_mut()
                 {
                     Some(m)
                 } else {
@@ -362,7 +362,7 @@ fn resolve_map_destination<'a>(
             .ok(),
             ResolvedValueMut::ArrayIndex { array, index } => RefMut::filter_map(array, |v| {
                 if let ValueMutGetResult::Found(v) = v.get_mut(index)
-                    && let Some(ValueMut::Map(m)) = v.to_value_mut()
+                    && let Some(StaticValueMut::Map(m)) = v.to_static_value_mut()
                 {
                     Some(m)
                 } else {
@@ -385,23 +385,23 @@ mod tests {
         let record = TestRecord::new()
             .with_key_value(
                 "key1".into(),
-                OwnedValue::String(ValueStorage::new("value1".into())),
+                OwnedValue::String(StringValueStorage::new("value1".into())),
             )
             .with_key_value(
                 "key2".into(),
                 OwnedValue::Array(ArrayValueStorage::new(vec![
-                    OwnedValue::Integer(ValueStorage::new(1)),
-                    OwnedValue::Integer(ValueStorage::new(2)),
-                    OwnedValue::Integer(ValueStorage::new(3)),
+                    OwnedValue::Integer(IntegerValueStorage::new(1)),
+                    OwnedValue::Integer(IntegerValueStorage::new(2)),
+                    OwnedValue::Integer(IntegerValueStorage::new(3)),
                 ])),
             )
             .with_key_value(
                 "key3".into(),
-                OwnedValue::String(ValueStorage::new("Hello world!".into())),
+                OwnedValue::String(StringValueStorage::new("Hello world!".into())),
             )
             .with_key_value(
                 "key4".into(),
-                OwnedValue::String(ValueStorage::new("key1".into())),
+                OwnedValue::String(StringValueStorage::new("key1".into())),
             );
 
         let run_test = |transform_expression| {
@@ -451,7 +451,7 @@ mod tests {
         )));
 
         assert_eq!(
-            Value::String(&ValueStorage::new("hello world".into())),
+            Value::String(&StringValueStorage::new("hello world".into())),
             result.get("key1").unwrap().to_value()
         );
 
@@ -486,7 +486,7 @@ mod tests {
         )));
 
         assert_eq!(
-            Value::String(&ValueStorage::new("Hello world!".into())),
+            Value::String(&StringValueStorage::new("Hello world!".into())),
             result.get("key1").unwrap().to_value()
         );
 
@@ -511,7 +511,7 @@ mod tests {
         )));
 
         assert_eq!(
-            Value::String(&ValueStorage::new("hello world".into())),
+            Value::String(&StringValueStorage::new("hello world".into())),
             result.get("new_key").unwrap().to_value()
         );
 
@@ -539,7 +539,7 @@ mod tests {
 
         if let Some(Value::Array(a)) = result.get("key2").map(|v| v.to_value()) {
             assert_eq!(
-                Value::String(&ValueStorage::new("hello world".into())),
+                Value::String(&StringValueStorage::new("hello world".into())),
                 a.get(0).unwrap().to_value()
             );
         } else {
@@ -570,7 +570,7 @@ mod tests {
 
         if let Some(Value::Array(a)) = result.get("key2").map(|v| v.to_value()) {
             assert_eq!(
-                Value::String(&ValueStorage::new("hello world".into())),
+                Value::String(&StringValueStorage::new("hello world".into())),
                 a.get(2).unwrap().to_value()
             );
         } else {
@@ -599,20 +599,22 @@ mod tests {
                 "var1",
                 ResolvedValue::Computed(OwnedValue::Map(MapValueStorage::new(HashMap::from([(
                     "subkey1".into(),
-                    OwnedValue::String(ValueStorage::new("hello world".into())),
+                    OwnedValue::String(StringValueStorage::new("hello world".into())),
                 )])))),
             );
 
             execution_context.get_variables().borrow_mut().set(
                 "var2",
-                ResolvedValue::Computed(OwnedValue::String(ValueStorage::new(
+                ResolvedValue::Computed(OwnedValue::String(StringValueStorage::new(
                     "Hello world!".into(),
                 ))),
             );
 
             execution_context.get_variables().borrow_mut().set(
                 "var3",
-                ResolvedValue::Computed(OwnedValue::String(ValueStorage::new("subkey1".into()))),
+                ResolvedValue::Computed(OwnedValue::String(StringValueStorage::new(
+                    "subkey1".into(),
+                ))),
             );
 
             if let DataExpression::Transform(t) = &pipeline.get_expressions()[0] {
@@ -650,7 +652,7 @@ mod tests {
 
         assert_eq!(4, result.len());
         assert_eq!(
-            OwnedValue::String(ValueStorage::new("hello world!".into())).to_value(),
+            OwnedValue::String(StringValueStorage::new("hello world!".into())).to_value(),
             result.get("var4").unwrap().to_value()
         );
 
@@ -673,7 +675,7 @@ mod tests {
 
         assert_eq!(3, result.len());
         assert_eq!(
-            OwnedValue::String(ValueStorage::new("Hello world!".into())).to_value(),
+            OwnedValue::String(StringValueStorage::new("Hello world!".into())).to_value(),
             result.get("var3").unwrap().to_value()
         );
 
@@ -695,7 +697,7 @@ mod tests {
 
         assert_eq!(3, result.len());
         assert_eq!(
-            OwnedValue::String(ValueStorage::new("goodebye world".into())).to_value(),
+            OwnedValue::String(StringValueStorage::new("goodebye world".into())).to_value(),
             result.get("var1").unwrap().to_value()
         );
 
@@ -760,14 +762,14 @@ mod tests {
         let record = TestRecord::new()
             .with_key_value(
                 "key1".into(),
-                OwnedValue::String(ValueStorage::new("value1".into())),
+                OwnedValue::String(StringValueStorage::new("value1".into())),
             )
             .with_key_value(
                 "key2".into(),
                 OwnedValue::Array(ArrayValueStorage::new(vec![
-                    OwnedValue::Integer(ValueStorage::new(1)),
-                    OwnedValue::Integer(ValueStorage::new(2)),
-                    OwnedValue::Integer(ValueStorage::new(3)),
+                    OwnedValue::Integer(IntegerValueStorage::new(1)),
+                    OwnedValue::Integer(IntegerValueStorage::new(2)),
+                    OwnedValue::Integer(IntegerValueStorage::new(3)),
                 ])),
             );
 
@@ -879,7 +881,7 @@ mod tests {
                 "var1",
                 ResolvedValue::Computed(OwnedValue::Map(MapValueStorage::new(HashMap::from([(
                     "subkey1".into(),
-                    OwnedValue::String(ValueStorage::new("hello world".into())),
+                    OwnedValue::String(StringValueStorage::new("hello world".into())),
                 )])))),
             );
 
@@ -912,19 +914,19 @@ mod tests {
         let record = TestRecord::new()
             .with_key_value(
                 "key1".into(),
-                OwnedValue::String(ValueStorage::new("value1".into())),
+                OwnedValue::String(StringValueStorage::new("value1".into())),
             )
             .with_key_value(
                 "key2".into(),
                 OwnedValue::Array(ArrayValueStorage::new(vec![
-                    OwnedValue::Integer(ValueStorage::new(1)),
-                    OwnedValue::Integer(ValueStorage::new(2)),
-                    OwnedValue::Integer(ValueStorage::new(3)),
+                    OwnedValue::Integer(IntegerValueStorage::new(1)),
+                    OwnedValue::Integer(IntegerValueStorage::new(2)),
+                    OwnedValue::Integer(IntegerValueStorage::new(3)),
                 ])),
             )
             .with_key_value(
                 "key_to_remove".into(),
-                OwnedValue::String(ValueStorage::new("key1".into())),
+                OwnedValue::String(StringValueStorage::new("key1".into())),
             );
 
         let run_test = |transform_expression| {

--- a/rust/experimental/query_engine/engine-recordset/src/value_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/value_expressions.rs
@@ -335,7 +335,7 @@ where
 
 fn select_from_as_value_mut<'a, 'b, 'c, TRecord: Record>(
     execution_context: &'b ExecutionContext<'a, '_, '_, TRecord>,
-    current_borrow: RefMut<'b, dyn AsValueMut + 'static>,
+    current_borrow: RefMut<'b, dyn AsStaticValueMut + 'static>,
     current_selector: (&'a ScalarExpression, ResolvedValue<'c>),
     remaining_selectors: Drain<(&'a ScalarExpression, ResolvedValue<'c>)>,
 ) -> Result<Option<ResolvedValueMut<'b, 'c>>, ExpressionError>
@@ -346,7 +346,7 @@ where
     match current_borrow.get_value_type() {
         ValueType::Array => {
             let next_borrow = RefMut::map(current_borrow, |v| {
-                if let Some(ValueMut::Array(a)) = v.to_value_mut() {
+                if let Some(StaticValueMut::Array(a)) = v.to_static_value_mut() {
                     a
                 } else {
                     panic!("Array was not returned from ValueMut")
@@ -362,7 +362,7 @@ where
         }
         ValueType::Map => {
             let next_borrow = RefMut::map(current_borrow, |v| {
-                if let Some(ValueMut::Map(m)) = v.to_value_mut() {
+                if let Some(StaticValueMut::Map(m)) = v.to_static_value_mut() {
                     m
                 } else {
                     panic!("Map was not returned from ValueMut")
@@ -445,7 +445,7 @@ mod tests {
                     "hello world",
                 )),
             )),
-            Value::String(&ValueStorage::new("hello world".into())),
+            Value::String(&StringValueStorage::new("hello world".into())),
         );
     }
 
@@ -454,14 +454,14 @@ mod tests {
         let record = TestRecord::new()
             .with_key_value(
                 "key1".into(),
-                OwnedValue::String(ValueStorage::new("value1".into())),
+                OwnedValue::String(StringValueStorage::new("value1".into())),
             )
             .with_key_value(
                 "key2".into(),
                 OwnedValue::Array(ArrayValueStorage::new(vec![
-                    OwnedValue::Integer(ValueStorage::new(1)),
-                    OwnedValue::Integer(ValueStorage::new(2)),
-                    OwnedValue::Integer(ValueStorage::new(3)),
+                    OwnedValue::Integer(IntegerValueStorage::new(1)),
+                    OwnedValue::Integer(IntegerValueStorage::new(2)),
+                    OwnedValue::Integer(IntegerValueStorage::new(3)),
                 ])),
             )
             .with_key_value(
@@ -510,7 +510,7 @@ mod tests {
             &|v| {
                 if let Some(ResolvedValueMut::MapKey { map: _, key }) = v {
                     assert_eq!(
-                        Value::String(&ValueStorage::new("key1".into())),
+                        Value::String(&StringValueStorage::new("key1".into())),
                         key.to_value()
                     );
                 } else {
@@ -535,7 +535,7 @@ mod tests {
             &|v| {
                 if let Some(ResolvedValueMut::MapKey { map: _, key }) = v {
                     assert_eq!(
-                        Value::String(&ValueStorage::new("sub-key".into())),
+                        Value::String(&StringValueStorage::new("sub-key".into())),
                         key.to_value()
                     );
                 } else {
@@ -608,14 +608,16 @@ mod tests {
 
                 variables.set(
                     "key1",
-                    ResolvedValue::Computed(OwnedValue::String(ValueStorage::new("value1".into()))),
+                    ResolvedValue::Computed(OwnedValue::String(StringValueStorage::new(
+                        "value1".into(),
+                    ))),
                 );
                 variables.set(
                     "key2",
                     ResolvedValue::Computed(OwnedValue::Array(ArrayValueStorage::new(vec![
-                        OwnedValue::Integer(ValueStorage::new(1)),
-                        OwnedValue::Integer(ValueStorage::new(2)),
-                        OwnedValue::Integer(ValueStorage::new(3)),
+                        OwnedValue::Integer(IntegerValueStorage::new(1)),
+                        OwnedValue::Integer(IntegerValueStorage::new(2)),
+                        OwnedValue::Integer(IntegerValueStorage::new(3)),
                     ]))),
                 );
                 variables.set(
@@ -640,7 +642,7 @@ mod tests {
             &|v| {
                 if let Some(ResolvedValueMut::MapKey { map: _, key }) = v {
                     assert_eq!(
-                        Value::String(&ValueStorage::new("key1".into())),
+                        Value::String(&StringValueStorage::new("key1".into())),
                         key.to_value()
                     );
                 } else {
@@ -664,7 +666,7 @@ mod tests {
             &|v| {
                 if let Some(ResolvedValueMut::MapKey { map: _, key }) = v {
                     assert_eq!(
-                        Value::String(&ValueStorage::new("key1".into())),
+                        Value::String(&StringValueStorage::new("key1".into())),
                         key.to_value()
                     );
                 } else {

--- a/rust/experimental/query_engine/expressions/src/primitives/array_value.rs
+++ b/rust/experimental/query_engine/expressions/src/primitives/array_value.rs
@@ -1,11 +1,13 @@
-use crate::{AsValue, ExpressionError, QueryLocation, Value};
+use std::fmt::Debug;
 
-pub trait ArrayValue: AsValue {
+use crate::*;
+
+pub trait ArrayValue: Debug {
     fn is_empty(&self) -> bool;
 
     fn len(&self) -> usize;
 
-    fn get(&self, index: usize) -> Option<&(dyn AsValue + 'static)>;
+    fn get(&self, index: usize) -> Option<&(dyn AsStaticValue + 'static)>;
 
     fn get_items(&self, item_callback: &mut dyn IndexValueCallback) -> bool;
 

--- a/rust/experimental/query_engine/expressions/src/primitives/map_value.rs
+++ b/rust/experimental/query_engine/expressions/src/primitives/map_value.rs
@@ -1,13 +1,15 @@
-use crate::{AsValue, ExpressionError, QueryLocation, Value};
+use std::fmt::Debug;
 
-pub trait MapValue: AsValue {
+use crate::*;
+
+pub trait MapValue: Debug {
     fn is_empty(&self) -> bool;
 
     fn len(&self) -> usize;
 
     fn contains_key(&self, key: &str) -> bool;
 
-    fn get(&self, key: &str) -> Option<&(dyn AsValue + 'static)>;
+    fn get(&self, key: &str) -> Option<&(dyn AsStaticValue + 'static)>;
 
     fn get_items(&self, item_callback: &mut dyn KeyValueCallback) -> bool;
 

--- a/rust/experimental/query_engine/expressions/src/primitives/value.rs
+++ b/rust/experimental/query_engine/expressions/src/primitives/value.rs
@@ -11,15 +11,15 @@ use crate::{
 
 #[derive(Debug, Clone)]
 pub enum Value<'a> {
-    Array(&'a (dyn ArrayValue + 'static)),
-    Boolean(&'a (dyn BooleanValue + 'static)),
-    DateTime(&'a (dyn DateTimeValue + 'static)),
-    Double(&'a (dyn DoubleValue + 'static)),
-    Integer(&'a (dyn IntegerValue + 'static)),
-    Map(&'a (dyn MapValue + 'static)),
+    Array(&'a dyn ArrayValue),
+    Boolean(&'a dyn BooleanValue),
+    DateTime(&'a dyn DateTimeValue),
+    Double(&'a dyn DoubleValue),
+    Integer(&'a dyn IntegerValue),
+    Map(&'a dyn MapValue),
     Null,
-    Regex(&'a (dyn RegexValue + 'static)),
-    String(&'a (dyn StringValue + 'static)),
+    Regex(&'a dyn RegexValue),
+    String(&'a dyn StringValue),
 }
 
 impl Value<'_> {
@@ -375,7 +375,54 @@ pub trait AsValue: Debug {
     fn to_value(&self) -> Value;
 }
 
-pub trait BooleanValue: AsValue {
+#[derive(Debug, Clone)]
+pub enum StaticValue<'a> {
+    Array(&'a (dyn ArrayValue + 'static)),
+    Boolean(&'a (dyn BooleanValue + 'static)),
+    DateTime(&'a (dyn DateTimeValue + 'static)),
+    Double(&'a (dyn DoubleValue + 'static)),
+    Integer(&'a (dyn IntegerValue + 'static)),
+    Map(&'a (dyn MapValue + 'static)),
+    Null,
+    Regex(&'a (dyn RegexValue + 'static)),
+    String(&'a (dyn StringValue + 'static)),
+}
+
+pub trait AsStaticValue: AsValue {
+    fn to_static_value(&self) -> StaticValue;
+}
+
+impl<T: AsStaticValue> AsValue for T {
+    fn get_value_type(&self) -> ValueType {
+        match self.to_static_value() {
+            StaticValue::Array(_) => ValueType::Array,
+            StaticValue::Boolean(_) => ValueType::Boolean,
+            StaticValue::DateTime(_) => ValueType::DateTime,
+            StaticValue::Double(_) => ValueType::Double,
+            StaticValue::Integer(_) => ValueType::Integer,
+            StaticValue::Map(_) => ValueType::Map,
+            StaticValue::Null => ValueType::Null,
+            StaticValue::Regex(_) => ValueType::Regex,
+            StaticValue::String(_) => ValueType::String,
+        }
+    }
+
+    fn to_value(&self) -> Value {
+        match self.to_static_value() {
+            StaticValue::Array(a) => Value::Array(a),
+            StaticValue::Boolean(b) => Value::Boolean(b),
+            StaticValue::DateTime(d) => Value::DateTime(d),
+            StaticValue::Double(d) => Value::Double(d),
+            StaticValue::Integer(i) => Value::Integer(i),
+            StaticValue::Map(m) => Value::Map(m),
+            StaticValue::Null => Value::Null,
+            StaticValue::Regex(r) => Value::Regex(r),
+            StaticValue::String(s) => Value::String(s),
+        }
+    }
+}
+
+pub trait BooleanValue: Debug {
     fn get_value(&self) -> bool;
 
     fn to_string(&self, action: &mut dyn FnMut(&str)) {
@@ -383,7 +430,7 @@ pub trait BooleanValue: AsValue {
     }
 }
 
-pub trait IntegerValue: AsValue {
+pub trait IntegerValue: Debug {
     fn get_value(&self) -> i64;
 
     fn to_string(&self, action: &mut dyn FnMut(&str)) {
@@ -391,7 +438,7 @@ pub trait IntegerValue: AsValue {
     }
 }
 
-pub trait DateTimeValue: AsValue {
+pub trait DateTimeValue: Debug {
     fn get_value(&self) -> DateTime<FixedOffset>;
 
     fn to_string(&self, action: &mut dyn FnMut(&str)) {
@@ -403,7 +450,7 @@ pub trait DateTimeValue: AsValue {
     }
 }
 
-pub trait DoubleValue: AsValue {
+pub trait DoubleValue: Debug {
     fn get_value(&self) -> f64;
 
     fn to_string(&self, action: &mut dyn FnMut(&str)) {
@@ -411,7 +458,7 @@ pub trait DoubleValue: AsValue {
     }
 }
 
-pub trait RegexValue: AsValue {
+pub trait RegexValue: Debug {
     fn get_value(&self) -> &Regex;
 
     fn to_string(&self, action: &mut dyn FnMut(&str)) {
@@ -419,7 +466,7 @@ pub trait RegexValue: AsValue {
     }
 }
 
-pub trait StringValue: AsValue {
+pub trait StringValue: Debug {
     fn get_value(&self) -> &str;
 }
 

--- a/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
@@ -914,7 +914,10 @@ mod tests {
                     StringScalarExpression::new(QueryLocation::new_fake(), "value"),
                 ))],
             ),
-            Some(StringScalarExpression::new(QueryLocation::new_fake(), "value").to_value()),
+            Some(Value::String(&StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "value",
+            ))),
         );
 
         // Test first expression is known null and second expression is known
@@ -930,7 +933,10 @@ mod tests {
                     )),
                 ],
             ),
-            Some(StringScalarExpression::new(QueryLocation::new_fake(), "value").to_value()),
+            Some(Value::String(&StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "value",
+            ))),
         );
 
         // Test first expression is known null and second expression is unknown

--- a/rust/experimental/query_engine/expressions/src/scalars/statics/array_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/statics/array_scalar_expression.rs
@@ -1,7 +1,4 @@
-use crate::{
-    ArrayValue, AsValue, Expression, IndexValueCallback, QueryLocation, StaticScalarExpression,
-    Value, ValueType,
-};
+use crate::*;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ArrayScalarExpression {
@@ -31,16 +28,6 @@ impl Expression for ArrayScalarExpression {
     }
 }
 
-impl AsValue for ArrayScalarExpression {
-    fn get_value_type(&self) -> ValueType {
-        ValueType::Array
-    }
-
-    fn to_value(&self) -> Value {
-        Value::Array(self)
-    }
-}
-
 impl ArrayValue for ArrayScalarExpression {
     fn is_empty(&self) -> bool {
         self.value.is_empty()
@@ -50,8 +37,8 @@ impl ArrayValue for ArrayScalarExpression {
         self.value.len()
     }
 
-    fn get(&self, index: usize) -> Option<&(dyn AsValue + 'static)> {
-        self.value.get(index).map(|v| v as &dyn AsValue)
+    fn get(&self, index: usize) -> Option<&(dyn AsStaticValue + 'static)> {
+        self.value.get(index).map(|v| v as &dyn AsStaticValue)
     }
 
     fn get_items(&self, item_callback: &mut dyn IndexValueCallback) -> bool {

--- a/rust/experimental/query_engine/expressions/src/scalars/statics/map_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/statics/map_scalar_expression.rs
@@ -1,9 +1,6 @@
 use std::collections::HashMap;
 
-use crate::{
-    AsValue, Expression, KeyValueCallback, MapValue, QueryLocation, StaticScalarExpression, Value,
-    ValueType,
-};
+use crate::*;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct MapScalarExpression {
@@ -33,16 +30,6 @@ impl Expression for MapScalarExpression {
     }
 }
 
-impl AsValue for MapScalarExpression {
-    fn get_value_type(&self) -> ValueType {
-        ValueType::Map
-    }
-
-    fn to_value(&self) -> Value {
-        Value::Map(self)
-    }
-}
-
 impl MapValue for MapScalarExpression {
     fn is_empty(&self) -> bool {
         self.value.is_empty()
@@ -56,8 +43,8 @@ impl MapValue for MapScalarExpression {
         self.value.contains_key(key)
     }
 
-    fn get(&self, key: &str) -> Option<&(dyn AsValue + 'static)> {
-        self.value.get(key).map(|v| v as &dyn AsValue)
+    fn get(&self, key: &str) -> Option<&(dyn AsStaticValue + 'static)> {
+        self.value.get(key).map(|v| v as &dyn AsStaticValue)
     }
 
     fn get_items(&self, item_callback: &mut dyn KeyValueCallback) -> bool {

--- a/rust/experimental/query_engine/expressions/src/scalars/statics/resolved_static_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/statics/resolved_static_scalar_expression.rs
@@ -1,4 +1,4 @@
-use crate::{AsValue, StaticScalarExpression, Value, ValueType};
+use crate::{AsStaticValue, StaticScalarExpression, StaticValue};
 
 #[derive(Debug)]
 pub enum ResolvedStaticScalarExpression<'a> {
@@ -6,18 +6,11 @@ pub enum ResolvedStaticScalarExpression<'a> {
     Value(StaticScalarExpression),
 }
 
-impl AsValue for ResolvedStaticScalarExpression<'_> {
-    fn get_value_type(&self) -> ValueType {
+impl AsStaticValue for ResolvedStaticScalarExpression<'_> {
+    fn to_static_value(&self) -> StaticValue {
         match self {
-            ResolvedStaticScalarExpression::Reference(s) => s.get_value_type(),
-            ResolvedStaticScalarExpression::Value(s) => s.get_value_type(),
-        }
-    }
-
-    fn to_value(&self) -> Value {
-        match self {
-            ResolvedStaticScalarExpression::Reference(s) => s.to_value(),
-            ResolvedStaticScalarExpression::Value(s) => s.to_value(),
+            ResolvedStaticScalarExpression::Reference(s) => s.to_static_value(),
+            ResolvedStaticScalarExpression::Value(s) => s.to_static_value(),
         }
     }
 }

--- a/rust/experimental/query_engine/expressions/src/scalars/statics/static_scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/statics/static_scalar_expressions.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, FixedOffset};
 use regex::Regex;
 
-use crate::{ArrayScalarExpression, Expression, MapScalarExpression, QueryLocation, primitives::*};
+use crate::*;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum StaticScalarExpression {
@@ -63,32 +63,18 @@ impl Expression for StaticScalarExpression {
     }
 }
 
-impl AsValue for StaticScalarExpression {
-    fn get_value_type(&self) -> ValueType {
+impl AsStaticValue for StaticScalarExpression {
+    fn to_static_value(&self) -> StaticValue {
         match self {
-            StaticScalarExpression::Array(_) => ValueType::Array,
-            StaticScalarExpression::Boolean(_) => ValueType::Boolean,
-            StaticScalarExpression::DateTime(_) => ValueType::DateTime,
-            StaticScalarExpression::Double(_) => ValueType::Double,
-            StaticScalarExpression::Integer(_) => ValueType::Integer,
-            StaticScalarExpression::Map(_) => ValueType::Map,
-            StaticScalarExpression::Null(_) => ValueType::Null,
-            StaticScalarExpression::Regex(_) => ValueType::Regex,
-            StaticScalarExpression::String(_) => ValueType::String,
-        }
-    }
-
-    fn to_value(&self) -> Value {
-        match self {
-            StaticScalarExpression::Array(a) => Value::Array(a),
-            StaticScalarExpression::Boolean(b) => Value::Boolean(b),
-            StaticScalarExpression::DateTime(d) => Value::DateTime(d),
-            StaticScalarExpression::Double(d) => Value::Double(d),
-            StaticScalarExpression::Integer(i) => Value::Integer(i),
-            StaticScalarExpression::Map(m) => Value::Map(m),
-            StaticScalarExpression::Null(_) => Value::Null,
-            StaticScalarExpression::Regex(r) => Value::Regex(r),
-            StaticScalarExpression::String(s) => Value::String(s),
+            StaticScalarExpression::Array(a) => StaticValue::Array(a),
+            StaticScalarExpression::Boolean(b) => StaticValue::Boolean(b),
+            StaticScalarExpression::DateTime(d) => StaticValue::DateTime(d),
+            StaticScalarExpression::Double(d) => StaticValue::Double(d),
+            StaticScalarExpression::Integer(i) => StaticValue::Integer(i),
+            StaticScalarExpression::Map(m) => StaticValue::Map(m),
+            StaticScalarExpression::Null(_) => StaticValue::Null,
+            StaticScalarExpression::Regex(r) => StaticValue::Regex(r),
+            StaticScalarExpression::String(s) => StaticValue::String(s),
         }
     }
 }
@@ -115,16 +101,6 @@ impl Expression for BooleanScalarExpression {
 
     fn get_name(&self) -> &'static str {
         "BooleanScalarExpression"
-    }
-}
-
-impl AsValue for BooleanScalarExpression {
-    fn get_value_type(&self) -> ValueType {
-        ValueType::Boolean
-    }
-
-    fn to_value(&self) -> Value {
-        Value::Boolean(self)
     }
 }
 
@@ -162,16 +138,6 @@ impl Expression for DateTimeScalarExpression {
     }
 }
 
-impl AsValue for DateTimeScalarExpression {
-    fn get_value_type(&self) -> ValueType {
-        ValueType::DateTime
-    }
-
-    fn to_value(&self) -> Value {
-        Value::DateTime(self)
-    }
-}
-
 impl DateTimeValue for DateTimeScalarExpression {
     fn get_value(&self) -> DateTime<FixedOffset> {
         self.value
@@ -200,16 +166,6 @@ impl Expression for DoubleScalarExpression {
 
     fn get_name(&self) -> &'static str {
         "DoubleScalarExpression"
-    }
-}
-
-impl AsValue for DoubleScalarExpression {
-    fn get_value_type(&self) -> ValueType {
-        ValueType::Double
-    }
-
-    fn to_value(&self) -> Value {
-        Value::Double(self)
     }
 }
 
@@ -244,16 +200,6 @@ impl Expression for IntegerScalarExpression {
     }
 }
 
-impl AsValue for IntegerScalarExpression {
-    fn get_value_type(&self) -> ValueType {
-        ValueType::Integer
-    }
-
-    fn to_value(&self) -> Value {
-        Value::Integer(self)
-    }
-}
-
 impl IntegerValue for IntegerScalarExpression {
     fn get_value(&self) -> i64 {
         self.value
@@ -278,16 +224,6 @@ impl Expression for NullScalarExpression {
 
     fn get_name(&self) -> &'static str {
         "NullScalarExpression"
-    }
-}
-
-impl AsValue for NullScalarExpression {
-    fn get_value_type(&self) -> ValueType {
-        ValueType::Null
-    }
-
-    fn to_value(&self) -> Value {
-        Value::Null
     }
 }
 
@@ -317,16 +253,6 @@ impl Expression for RegexScalarExpression {
 
     fn get_name(&self) -> &'static str {
         "RegexScalarExpression"
-    }
-}
-
-impl AsValue for RegexScalarExpression {
-    fn get_value_type(&self) -> ValueType {
-        ValueType::Regex
-    }
-
-    fn to_value(&self) -> Value {
-        Value::Regex(self)
     }
 }
 
@@ -364,16 +290,6 @@ impl Expression for StringScalarExpression {
 
     fn get_name(&self) -> &'static str {
         "StringScalarExpression"
-    }
-}
-
-impl AsValue for StringScalarExpression {
-    fn get_value_type(&self) -> ValueType {
-        ValueType::String
-    }
-
-    fn to_value(&self) -> Value {
-        Value::String(self)
     }
 }
 

--- a/rust/experimental/query_engine/expressions/src/transform_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/transform_expressions.rs
@@ -1,7 +1,4 @@
-use crate::{
-    AsValue, Expression, ImmutableValueExpression, MutableValueExpression, QueryLocation,
-    ScalarExpression, ValueAccessor, ValueType,
-};
+use crate::*;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum TransformExpression {


### PR DESCRIPTION
## Changes

* Rename `Value` and `ValueMut` -> `StaticValue` & `StaticValueMut`
* Re-introduce `Value` without `'static` requirement
* Use `From` \ `Into` for conversions instead of custom logic on `ValueSource<T>`
* Use blanket implementations of traits where possible to allow removal of a lot of code repating boilerplate things like `impl AsValue for [SomeType] { ... }`

## Details

The main thing this addresses is the `'static` on `Value`...

```rust
enum Value<'a>
{
   Array(&'a (dyn ArrayValue + 'static))
   ...
}
```

The `'static` there means the thing implementing the trait must be statically-known. It doesn't mean it needs a 'static` lifetime. One of the restrictions for something to be known statically is that it can't itself have a lifetime or contain any pointers.

What I'm working on is slice support in the engine. We want a scalar expression which will take a slice of a string or an array. To do this with decent perf you want the slice to hold a reference to the thing it is slicing. Problem is, the `'static` prohibits this.