### PR TITLE
[query-engine] String slice improvements

### DIFF
--- a/rust/experimental/query_engine/engine-recordset/src/scalar_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/scalar_expressions.rs
@@ -1952,7 +1952,7 @@ mod tests {
 
             let actual = execute_scalar_expression(&execution_context, &expression).unwrap();
 
-            assert_eq!(expected, actual.to_value());
+            assert_eq!(expected.to_string(), actual.to_value().to_string());
         }
 
         fn run_test_failure(input: SliceScalarExpression, expected: ExpressionError) {

--- a/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
@@ -1118,9 +1118,8 @@ impl SliceScalarExpression {
 
                     // Note: We only return statically small string slices. The
                     // idea here is to prevent expansion of the expression tree
-                    // for large values. This could potentially be improved by
-                    // promoting common slices to constants automatically and
-                    // then referencing them when a slice is requested.
+                    // for large values. At runtime a slice of a string is just
+                    // a pointer to some data.
                     if range_end_exclusive - range_start_inclusive > 32 {
                         Ok(None)
                     } else {


### PR DESCRIPTION
Relates to #868

## Changes

* Improve the string slice in recordset engine to point to the inner string instead of making a copy