### PR TITLE
[query-engine] Logging tweaks

### DIFF
--- a/rust/experimental/query_engine/engine-recordset/src/logical_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/logical_expressions.rs
@@ -16,7 +16,7 @@ pub fn execute_logical_expression<'a, TRecord: Record>(
                 execution_context.add_diagnostic_if_enabled(
                     RecordSetEngineDiagnosticLevel::Verbose,
                     logical_expression,
-                    || format!("Evaluated as: {b}"),
+                    || format!("Evaluated as: '{b}'"),
                 );
                 Ok(b)
             } else {
@@ -44,7 +44,7 @@ pub fn execute_logical_expression<'a, TRecord: Record>(
                     execution_context.add_diagnostic_if_enabled(
                         RecordSetEngineDiagnosticLevel::Verbose,
                         logical_expression,
-                        || format!("Evaluated as: {b}"),
+                        || format!("Evaluated as: '{b}'"),
                     );
                     Ok(b)
                 }
@@ -63,7 +63,7 @@ pub fn execute_logical_expression<'a, TRecord: Record>(
                     execution_context.add_diagnostic_if_enabled(
                         RecordSetEngineDiagnosticLevel::Verbose,
                         logical_expression,
-                        || format!("Evaluated as: {r}"),
+                        || format!("Evaluated as: '{r}'"),
                     );
                     Ok(r)
                 }
@@ -82,7 +82,7 @@ pub fn execute_logical_expression<'a, TRecord: Record>(
                     execution_context.add_diagnostic_if_enabled(
                         RecordSetEngineDiagnosticLevel::Verbose,
                         logical_expression,
-                        || format!("Evaluated as: {r}"),
+                        || format!("Evaluated as: '{r}'"),
                     );
                     Ok(r)
                 }
@@ -96,7 +96,7 @@ pub fn execute_logical_expression<'a, TRecord: Record>(
                     execution_context.add_diagnostic_if_enabled(
                         RecordSetEngineDiagnosticLevel::Verbose,
                         logical_expression,
-                        || format!("Evaluated as: {b}"),
+                        || format!("Evaluated as: '{b}'"),
                     );
                     Ok(b)
                 }
@@ -146,7 +146,7 @@ pub fn execute_logical_expression<'a, TRecord: Record>(
             execution_context.add_diagnostic_if_enabled(
                 RecordSetEngineDiagnosticLevel::Verbose,
                 logical_expression,
-                || format!("Evaluated as: {result}"),
+                || format!("Evaluated as: '{result}'"),
             );
 
             Ok(result)
@@ -165,7 +165,7 @@ pub fn execute_logical_expression<'a, TRecord: Record>(
                     execution_context.add_diagnostic_if_enabled(
                         RecordSetEngineDiagnosticLevel::Verbose,
                         logical_expression,
-                        || format!("Evaluated as: {b}"),
+                        || format!("Evaluated as: '{b}'"),
                     );
                     Ok(b)
                 }

--- a/rust/experimental/query_engine/engine-recordset/src/scalar_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/scalar_expressions.rs
@@ -31,7 +31,7 @@ where
             execution_context.add_diagnostic_if_enabled(
                 RecordSetEngineDiagnosticLevel::Verbose,
                 scalar_expression,
-                || format!("Evaluated as: {value}"),
+                || format!("Evaluated as: '{value}'"),
             );
 
             Ok(value)
@@ -49,7 +49,7 @@ where
                 execution_context.add_diagnostic_if_enabled(
                     RecordSetEngineDiagnosticLevel::Verbose,
                     scalar_expression,
-                    || format!("Evaluated as: {value}"),
+                    || format!("Evaluated as: '{value}'"),
                 );
 
                 Ok(value)
@@ -93,7 +93,7 @@ where
             execution_context.add_diagnostic_if_enabled(
                 RecordSetEngineDiagnosticLevel::Verbose,
                 scalar_expression,
-                || format!("Evaluated as: {value}"),
+                || format!("Evaluated as: '{value}'"),
             );
 
             Ok(value)
@@ -104,7 +104,7 @@ where
             execution_context.add_diagnostic_if_enabled(
                 RecordSetEngineDiagnosticLevel::Verbose,
                 scalar_expression,
-                || format!("Evaluated as: {value}"),
+                || format!("Evaluated as: '{value}'"),
             );
 
             Ok(ResolvedValue::Value(value))
@@ -181,7 +181,7 @@ where
             execution_context.add_diagnostic_if_enabled(
                 RecordSetEngineDiagnosticLevel::Verbose,
                 scalar_expression,
-                || format!("Evaluated as: {v}"),
+                || format!("Evaluated as: '{v}'"),
             );
 
             Ok(v)
@@ -192,7 +192,7 @@ where
             execution_context.add_diagnostic_if_enabled(
                 RecordSetEngineDiagnosticLevel::Verbose,
                 scalar_expression,
-                || format!("Evaluated as: {value}"),
+                || format!("Evaluated as: '{value}'"),
             );
 
             Ok(ResolvedValue::Computed(OwnedValue::Boolean(
@@ -206,7 +206,7 @@ where
                     execution_context.add_diagnostic_if_enabled(
                         RecordSetEngineDiagnosticLevel::Verbose,
                         scalar_expression,
-                        || format!("Evaluated as: {value}"),
+                        || format!("Evaluated as: '{value}'"),
                     );
 
                     return Ok(value);
@@ -216,7 +216,7 @@ where
             execution_context.add_diagnostic_if_enabled(
                 RecordSetEngineDiagnosticLevel::Verbose,
                 scalar_expression,
-                || "Evaluated as: null".into(),
+                || "Evaluated as: 'null'".into(),
             );
 
             Ok(ResolvedValue::Computed(OwnedValue::Null))
@@ -233,7 +233,7 @@ where
             execution_context.add_diagnostic_if_enabled(
                 RecordSetEngineDiagnosticLevel::Verbose,
                 scalar_expression,
-                || format!("Evaluated as: {inner_value}"),
+                || format!("Evaluated as: '{inner_value}'"),
             );
 
             Ok(inner_value)
@@ -249,7 +249,7 @@ where
                     execution_context.add_diagnostic_if_enabled(
                         RecordSetEngineDiagnosticLevel::Verbose,
                         scalar_expression,
-                        || format!("Evaluated as: {inner_value}"),
+                        || format!("Evaluated as: '{inner_value}'"),
                     );
 
                     return Ok(inner_value);
@@ -263,7 +263,7 @@ where
             execution_context.add_diagnostic_if_enabled(
                 RecordSetEngineDiagnosticLevel::Verbose,
                 scalar_expression,
-                || format!("Evaluated as: {inner_value}"),
+                || format!("Evaluated as: '{inner_value}'"),
             );
 
             Ok(inner_value)
@@ -299,9 +299,13 @@ where
                 }
                 ConvertScalarExpression::String(c) => {
                     let v = execute_scalar_expression(execution_context, c.get_inner_expression())?;
-
-                    if v.get_value_type() == ValueType::String {
+                    let value_type = v.get_value_type();
+                    if value_type == ValueType::String {
                         v
+                    } else if value_type == ValueType::Null {
+                        ResolvedValue::Computed(OwnedValue::String(StringValueStorage::new(
+                            "".into(),
+                        )))
                     } else {
                         let mut string_value = None;
                         v.to_value().convert_to_string(&mut |s| {
@@ -317,7 +321,7 @@ where
             execution_context.add_diagnostic_if_enabled(
                 RecordSetEngineDiagnosticLevel::Verbose,
                 scalar_expression,
-                || format!("Evaluated as: {value}"),
+                || format!("Evaluated as: '{value}'"),
             );
 
             Ok(value)
@@ -342,7 +346,7 @@ where
             execution_context.add_diagnostic_if_enabled(
                 RecordSetEngineDiagnosticLevel::Verbose,
                 scalar_expression,
-                || format!("Evaluated as: {v}"),
+                || format!("Evaluated as: '{v}'"),
             );
 
             Ok(v)
@@ -370,7 +374,7 @@ where
             execution_context.add_diagnostic_if_enabled(
                 RecordSetEngineDiagnosticLevel::Verbose,
                 scalar_expression,
-                || format!("Evaluated as: {v}"),
+                || format!("Evaluated as: '{v}'"),
             );
 
             Ok(v)
@@ -436,7 +440,7 @@ where
             execution_context.add_diagnostic_if_enabled(
                 RecordSetEngineDiagnosticLevel::Verbose,
                 scalar_expression,
-                || format!("Evaluated as: {v}"),
+                || format!("Evaluated as: '{v}'"),
             );
 
             Ok(v)

--- a/rust/experimental/query_engine/engine-recordset/src/value_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/value_expressions.rs
@@ -22,7 +22,7 @@ where
             execution_context.add_diagnostic_if_enabled(
                 RecordSetEngineDiagnosticLevel::Verbose,
                 immutable_value_expression,
-                || format!("Evaluated as: {value}"),
+                || format!("Evaluated as: '{value}'"),
             );
 
             Ok(value)

--- a/rust/experimental/query_engine/expressions/src/primitives/value.rs
+++ b/rust/experimental/query_engine/expressions/src/primitives/value.rs
@@ -94,7 +94,7 @@ impl Value<'_> {
             Value::Double(d) => d.to_string(action),
             Value::Integer(i) => i.to_string(action),
             Value::Map(m) => m.to_string(action),
-            Value::Null => (action)(""),
+            Value::Null => (action)("null"),
             Value::Regex(r) => r.to_string(action),
             Value::String(s) => (action)(s.get_value()),
         }

--- a/rust/experimental/query_engine/expressions/src/scalars/convert_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/convert_scalar_expression.rs
@@ -102,16 +102,27 @@ impl ConvertScalarExpression {
             }
             ConvertScalarExpression::String(c) => {
                 if let Some(v) = c.get_inner_expression().try_resolve_static(pipeline)? {
-                    let mut value = None;
-                    v.to_value().convert_to_string(&mut |s| {
-                        value = Some(StringScalarExpression::new(c.query_location.clone(), s));
-                    });
+                    let v = v.to_value();
+                    if let Value::Null = v {
+                        Ok(Some(ResolvedStaticScalarExpression::Value(
+                            StaticScalarExpression::String(StringScalarExpression::new(
+                                c.query_location.clone(),
+                                "",
+                            )),
+                        )))
+                    } else {
+                        let mut value = None;
 
-                    Ok(Some(ResolvedStaticScalarExpression::Value(
-                        StaticScalarExpression::String(
-                            value.expect("Inner value did not return a string"),
-                        ),
-                    )))
+                        v.convert_to_string(&mut |s| {
+                            value = Some(StringScalarExpression::new(c.query_location.clone(), s));
+                        });
+
+                        Ok(Some(ResolvedStaticScalarExpression::Value(
+                            StaticScalarExpression::String(
+                                value.expect("Inner value did not return a string"),
+                            ),
+                        )))
+                    }
                 } else {
                     Ok(None)
                 }
@@ -363,23 +374,33 @@ mod tests {
 
     #[test]
     pub fn test_string_try_resolve_static() {
-        let expression = ConvertScalarExpression::String(ConversionScalarExpression::new(
-            QueryLocation::new_fake(),
-            ScalarExpression::Static(StaticScalarExpression::Integer(
-                IntegerScalarExpression::new(QueryLocation::new_fake(), 18),
-            )),
-        ));
-
-        assert_eq!(
-            Some(Value::String(&StringScalarExpression::new(
+        let run_test = |input: StaticScalarExpression, expected: Value| {
+            let expression = ConvertScalarExpression::String(ConversionScalarExpression::new(
                 QueryLocation::new_fake(),
-                "18"
-            ))),
-            expression
-                .try_resolve_static(&Default::default())
-                .unwrap()
-                .as_ref()
-                .map(|v| v.to_value())
+                ScalarExpression::Static(input),
+            ));
+
+            let pipeline = Default::default();
+
+            let actual = expression.try_resolve_static(&pipeline).unwrap();
+
+            assert_eq!(Some(expected), actual.as_ref().map(|v| v.to_value()));
+        };
+
+        run_test(
+            StaticScalarExpression::Integer(IntegerScalarExpression::new(
+                QueryLocation::new_fake(),
+                18,
+            )),
+            Value::String(&StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "18",
+            )),
+        );
+
+        run_test(
+            StaticScalarExpression::Null(NullScalarExpression::new(QueryLocation::new_fake())),
+            Value::String(&StringScalarExpression::new(QueryLocation::new_fake(), "")),
         );
     }
 }


### PR DESCRIPTION
## Changes

* Reverts [this change](https://github.com/open-telemetry/otel-arrow/pull/829/files#diff-4ba0898c86bce0156158c29e56edd36aabc32a52dbbfd8884b38e6e4db43a499R97) which caused `null` to be indistinguishable from empty string in logging. Instead added special handling in `tostring` logic to resolve `null` as empty string.
* Adds `''` around values in "Evaluated as: {...}" logging to improve clarity