### PR TITLE
Require commit_sha when running push-release workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -89,6 +89,7 @@ jobs:
 
       - name: Create release branch and commit changes
         if: '!inputs.dry_run'
+        id: commit
         run: |
           # Configure git for otelbot
           git config user.name otelbot
@@ -96,6 +97,11 @@ jobs:
 
           # Use script to create branch and commit
           ./.github/workflows/scripts/create-release-branch.sh "${{ inputs.version }}" --push
+          
+          # Output the commit SHA for reference
+          COMMIT_SHA=$(git rev-parse HEAD)
+          echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
+          echo "Release commit SHA: $COMMIT_SHA"
 
       - name: Create pull request
         if: '!inputs.dry_run'
@@ -112,6 +118,8 @@ jobs:
 
           This PR prepares the repository for release v${{ inputs.version }}.
 
+          **Release Commit SHA:** \`${{ steps.commit.outputs.commit_sha }}\`
+
           ### Changes included:
           - Updated CHANGELOG.md with release notes
           - Updated collector/otelarrowcol-build.yaml version to v${{ inputs.version }}
@@ -125,7 +133,7 @@ jobs:
           - [ ] Confirm all tests pass
           - [ ] Ready to merge and tag release
 
-          After merging this PR, run the **Push Release** workflow to create git tags and publish the GitHub release.
+          After merging this PR, run the **Push Release** workflow with the merge commit SHA to create git tags and publish the GitHub release.
           EOF
 
           # Create the pull request using GitHub CLI
@@ -147,8 +155,11 @@ jobs:
             echo ""
             echo "Next steps:"
             echo "1. Review and merge the pull request: https://github.com/open-telemetry/otel-arrow/pulls"
-            echo "2. After merging, run the 'Push Release' workflow to create git tags and GitHub release"
+            echo "2. After merging, run the 'Push Release' workflow with the merge commit SHA"
             echo ""
             echo "Release branch: otelbot/release-v${{ inputs.version }}"
             echo "Release version: v${{ inputs.version }}"
+            echo "Release commit SHA: ${{ steps.commit.outputs.commit_sha }}"
+            echo ""
+            echo "**Important:** Use the merge commit SHA when running Push Release to ensure consistency"
           fi

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -7,6 +7,10 @@ on:
         description: 'Release version to tag and publish (e.g., 0.40.0)'
         required: true
         type: string
+      commit_sha:
+        description: 'Commit SHA to tag (from the merged prepare-release PR)'
+        required: true
+        type: string
       dry_run:
         description: 'Dry run mode (just show what would happen)'
         required: true
@@ -27,15 +31,34 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          ref: ${{ github.ref }}
+          ref: ${{ inputs.commit_sha }}
 
-      - name: Validate inputs
+      - name: Validate commit and inputs
         run: |
           # Validate version format
           if [[ ! "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Error: Version must be in format X.Y.Z (e.g., 0.40.0)"
             exit 1
           fi
+
+          # Validate commit SHA exists
+          if ! git cat-file -e "${{ inputs.commit_sha }}"; then
+            echo "Error: Commit SHA ${{ inputs.commit_sha }} does not exist"
+            exit 1
+          fi
+          
+          echo "Using specified commit SHA: ${{ inputs.commit_sha }}"
+          CURRENT_SHA=$(git rev-parse HEAD)
+          if [ "$CURRENT_SHA" != "${{ inputs.commit_sha }}" ]; then
+            echo "Error: Current HEAD ($CURRENT_SHA) does not match specified commit (${{ inputs.commit_sha }})"
+            echo "This should not happen with the checkout action, please check the workflow"
+            exit 1
+          fi
+
+          # Display current commit info
+          echo "Current commit SHA: $(git rev-parse HEAD)"
+          echo "Current commit message: $(git log -1 --pretty=format:'%s')"
+          echo "Current commit author: $(git log -1 --pretty=format:'%an <%ae>')"
 
       - name: Verify release preparation
         run: |
@@ -46,12 +69,14 @@ jobs:
             exit 1
           fi
 
-          # Check if repository is clean
-          if [ -n "$(git status --porcelain)" ]; then
-            echo "Error: Repository has uncommitted changes"
-            git status
+          # Verify the collector version was updated
+          if ! grep -q "version: ${{ inputs.version }}" collector/otelarrowcol-build.yaml; then
+            echo "Error: collector/otelarrowcol-build.yaml does not contain version ${{ inputs.version }}"
+            echo "Make sure the prepare release changes were properly merged"
             exit 1
           fi
+
+          echo "✓ Release preparation verification passed"
 
       - name: Get last released version
         id: last_version
@@ -100,6 +125,7 @@ jobs:
           echo ""
           echo "Planned operations:"
           echo "- Version to tag: v${{ inputs.version }}"
+          echo "- Commit to tag: $(git rev-parse HEAD)"
           echo "- Last version: v${{ steps.last_version.outputs.last_version }}"
           echo "--------------------------------"
           echo "Git tags that would be created:"
@@ -130,6 +156,10 @@ jobs:
           git config user.name otelbot
           git config user.email 197425009+otelbot@users.noreply.github.com
 
+          # Ensure we're on the correct commit
+          CURRENT_SHA=$(git rev-parse HEAD)
+          echo "Tagging commit: $CURRENT_SHA"
+
           # Create main release tag
           git tag -a "v${{ inputs.version }}" -m "Release v${{ inputs.version }}"
 
@@ -137,7 +167,7 @@ jobs:
           git tag -a "go/v${{ inputs.version }}" -m "Release go/v${{ inputs.version }}"
           git tag -a "collector/cmd/otelarrowcol/v${{ inputs.version }}" -m "Release collector/cmd/otelarrowcol/v${{ inputs.version }}"
 
-          echo "Created tags:"
+          echo "Created tags on commit $CURRENT_SHA:"
           git tag --list "v${{ inputs.version }}"
           git tag --list "*v${{ inputs.version }}"
 
@@ -186,15 +216,18 @@ jobs:
 
       - name: Summary
         run: |
+          CURRENT_SHA=$(git rev-parse HEAD)
           if [ "${{ inputs.dry_run }}" = "true" ]; then
             echo ":heavy_check_mark: Dry run completed successfully"
             echo "No changes were made to the repository"
+            echo "Would tag commit: $CURRENT_SHA"
             echo "Review the planned changes above and run again without dry-run when ready"
           else
             echo ":heavy_check_mark: Release published successfully"
             echo ""
             echo "Release details:"
             echo "- Version: v${{ inputs.version }}"
+            echo "- Tagged commit: $CURRENT_SHA"
             echo "- GitHub release: https://github.com/open-telemetry/otel-arrow/releases/tag/v${{ inputs.version }}"
             echo ""
             echo "Git tags created:"


### PR DESCRIPTION
Related to #737

I'm wondering if it is good practice to require specific commit SHA during push-release. Want to limit the chance that changes are merged **between** the prepare-release PR and maintainer running the push-release workflow. If that happens, they would not be represented in the Changelog and increase risk of the release.