### PR TITLE
fix: Stack overflow when getting child types for multivariate metrics

### DIFF
--- a/rust/otel-arrow-rust/Cargo.toml
+++ b/rust/otel-arrow-rust/Cargo.toml
@@ -23,7 +23,7 @@ derive = []
 
 [dependencies]
 arrow = "55.2"
-arrow-ipc = { git = "https://github.com/JakeDern/arrow-rs.git", rev = "a0ea922882b4a8fca5eebe47fc0182ca9abf0955", features = ["zstd"] }
+arrow-ipc = { version = "55.2", features = ["zstd"] }
 ciborium = "0.2.2"
 lazy_static = "1.5"
 num_enum = "0.7"

--- a/rust/otel-arrow-rust/Cargo.toml
+++ b/rust/otel-arrow-rust/Cargo.toml
@@ -23,7 +23,7 @@ derive = []
 
 [dependencies]
 arrow = "55.2"
-arrow-ipc = { version = "55.2", features = ["zstd"] }
+arrow-ipc = { git = "https://github.com/JakeDern/arrow-rs.git", rev = "a0ea922882b4a8fca5eebe47fc0182ca9abf0955", features = ["zstd"] }
 ciborium = "0.2.2"
 lazy_static = "1.5"
 num_enum = "0.7"

--- a/rust/otel-arrow-rust/src/otap.rs
+++ b/rust/otel-arrow-rust/src/otap.rs
@@ -496,7 +496,7 @@ pub fn child_payload_types(payload_type: ArrowPayloadType) -> &'static [ArrowPay
             &[ArrowPayloadType::ExpHistogramDpExemplarAttrs]
         }
         ArrowPayloadType::MultivariateMetrics => {
-            child_payload_types(ArrowPayloadType::MultivariateMetrics)
+            child_payload_types(ArrowPayloadType::UnivariateMetrics)
         }
         _ => &[],
     }
@@ -514,6 +514,13 @@ mod test {
     use crate::otlp::attributes::store::AttributeValueType;
 
     use super::*;
+
+    #[test]
+    fn test_multivariate_metrics_child_types() {
+        let multivariate_types = child_payload_types(ArrowPayloadType::MultivariateMetrics);
+        let univariate_types = child_payload_types(ArrowPayloadType::UnivariateMetrics);
+        assert_eq!(multivariate_types, univariate_types)
+    }
 
     #[test]
     fn test_log_getset() {


### PR DESCRIPTION
Ran into a stack overflow when poking around with multivariate metrics types, I think the intent is for the types to be the same as Univariate for now, but let me know if not.