### PR TITLE
[query-engine] Add parsing for KQL summarize expression

### DIFF
--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/bridge.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/bridge.rs
@@ -287,8 +287,6 @@ fn process_log_record_results(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
     use super::*;
 
     use bytes::BytesMut;
@@ -464,24 +462,7 @@ mod tests {
             ResourceLogs::new().with_scope_logs(ScopeLogs::new().with_log_record(LogRecord::new())),
         );
 
-        /* todo: Use KQL when parsing is done:
         let pipeline = parse_kql_query_into_pipeline("source | summarize Count = count()").unwrap();
-        */
-        let pipeline = PipelineExpressionBuilder::new(" ")
-            .with_expressions(vec![DataExpression::Summary(SummaryDataExpression::new(
-                QueryLocation::new_fake(),
-                HashMap::new(),
-                HashMap::from([(
-                    "Count".into(),
-                    AggregationExpression::new(
-                        QueryLocation::new_fake(),
-                        AggregationFunction::Count,
-                        None,
-                    ),
-                )]),
-            ))])
-            .build()
-            .unwrap();
 
         let (included_records, dropped_records) =
             process_export_logs_service_request_using_pipeline(

--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/tests/otlp_kql_recordset.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/tests/otlp_kql_recordset.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use data_engine_expressions::*;
 use data_engine_recordset::*;
 use data_engine_recordset_otlp_bridge::*;
@@ -92,26 +90,9 @@ fn test_summarize_count_only() {
         ),
     );
 
-    /* todo: Use KQL when parsing is done:
     let query = "source | summarize Count = count()";
 
-    let pipeline = data_engine_recordset_otlp_bridge::parse_kql_query_into_pipeline(query).unwrap();*/
-
-    let pipeline = PipelineExpressionBuilder::new(" ")
-        .with_expressions(vec![DataExpression::Summary(SummaryDataExpression::new(
-            QueryLocation::new_fake(),
-            HashMap::new(),
-            HashMap::from([(
-                "Count".into(),
-                AggregationExpression::new(
-                    QueryLocation::new_fake(),
-                    AggregationFunction::Count,
-                    None,
-                ),
-            )]),
-        ))])
-        .build()
-        .unwrap();
+    let pipeline = data_engine_recordset_otlp_bridge::parse_kql_query_into_pipeline(query).unwrap();
 
     let engine = RecordSetEngine::new_with_options(
         RecordSetEngineOptions::new()
@@ -162,37 +143,9 @@ fn test_summarize_count_and_group_by() {
         ),
     );
 
-    /* todo: Use KQL when parsing is done:
     let query = "source | summarize Count = count() by Body";
 
-    let pipeline = data_engine_recordset_otlp_bridge::parse_kql_query_into_pipeline(query).unwrap();*/
-
-    let pipeline = PipelineExpressionBuilder::new(" ")
-        .with_expressions(vec![DataExpression::Summary(SummaryDataExpression::new(
-            QueryLocation::new_fake(),
-            HashMap::from([(
-                "Body".into(),
-                ScalarExpression::Source(SourceScalarExpression::new(
-                    QueryLocation::new_fake(),
-                    ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
-                        StaticScalarExpression::String(StringScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            "Body",
-                        )),
-                    )]),
-                )),
-            )]),
-            HashMap::from([(
-                "Count".into(),
-                AggregationExpression::new(
-                    QueryLocation::new_fake(),
-                    AggregationFunction::Count,
-                    None,
-                ),
-            )]),
-        ))])
-        .build()
-        .unwrap();
+    let pipeline = data_engine_recordset_otlp_bridge::parse_kql_query_into_pipeline(query).unwrap();
 
     let engine = RecordSetEngine::new_with_options(
         RecordSetEngineOptions::new()

--- a/rust/experimental/query_engine/kql-parser/src/aggregate_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/aggregate_expressions.rs
@@ -1,0 +1,158 @@
+use data_engine_expressions::*;
+use data_engine_parser_abstractions::*;
+use pest::iterators::Pair;
+
+use crate::{Rule, scalar_expression::parse_scalar_expression};
+
+pub(crate) fn parse_aggregate_assignment_expression(
+    aggregate_assignment_expression_rule: Pair<Rule>,
+    state: &ParserState,
+) -> Result<(Box<str>, AggregationExpression), ParserError> {
+    let mut aggregate_assignment_rules = aggregate_assignment_expression_rule.into_inner();
+
+    let destination_rule = aggregate_assignment_rules.next().unwrap();
+    let destination_rule_str = destination_rule.as_str();
+
+    let aggregation_expression =
+        parse_aggregate_expression(aggregate_assignment_rules.next().unwrap(), state)?;
+
+    Ok((destination_rule_str.into(), aggregation_expression))
+}
+
+fn parse_aggregate_expression(
+    aggregate_expression_rule: Pair<Rule>,
+    state: &ParserState,
+) -> Result<AggregationExpression, ParserError> {
+    let query_location = to_query_location(&aggregate_expression_rule);
+
+    let aggregate = match aggregate_expression_rule.as_rule() {
+        Rule::average_aggregate_expression => AggregationExpression::new(
+            query_location,
+            AggregationFunction::Average,
+            Some(parse_scalar_expression(aggregate_expression_rule, state)?),
+        ),
+        Rule::count_aggregate_expression => {
+            AggregationExpression::new(query_location, AggregationFunction::Count, None)
+        }
+        Rule::maximum_aggregate_expression => AggregationExpression::new(
+            query_location,
+            AggregationFunction::Maximum,
+            Some(parse_scalar_expression(aggregate_expression_rule, state)?),
+        ),
+        Rule::minimum_aggregate_expression => AggregationExpression::new(
+            query_location,
+            AggregationFunction::Minimum,
+            Some(parse_scalar_expression(aggregate_expression_rule, state)?),
+        ),
+        Rule::sum_aggregate_expression => AggregationExpression::new(
+            query_location,
+            AggregationFunction::Sum,
+            Some(parse_scalar_expression(aggregate_expression_rule, state)?),
+        ),
+        _ => panic!("Unexpected rule in aggregate_expression: {aggregate_expression_rule}"),
+    };
+
+    Ok(aggregate)
+}
+
+#[cfg(test)]
+mod tests {
+    use pest::Parser;
+
+    use crate::KqlPestParser;
+
+    use super::*;
+
+    #[test]
+    fn test_parse_aggregate_assignment_expression() {
+        let run_test_success = |input: &str, expected: (Box<str>, AggregationExpression)| {
+            println!("Testing: {input}");
+
+            let state = ParserState::new(input);
+
+            let mut result =
+                KqlPestParser::parse(Rule::aggregate_assignment_expression, input).unwrap();
+
+            let expression =
+                parse_aggregate_assignment_expression(result.next().unwrap(), &state).unwrap();
+
+            assert_eq!(expected, expression);
+        };
+
+        run_test_success(
+            "Count = count()",
+            (
+                "Count".into(),
+                AggregationExpression::new(
+                    QueryLocation::new_fake(),
+                    AggregationFunction::Count,
+                    None,
+                ),
+            ),
+        );
+    }
+
+    #[test]
+    fn test_parse_aggregate_expression() {
+        let run_test_success = |input: &str, expected: AggregationExpression| {
+            println!("Testing: {input}");
+
+            let state = ParserState::new(input);
+
+            let mut result = KqlPestParser::parse(Rule::aggregate_expression, input).unwrap();
+
+            let expression = parse_aggregate_expression(result.next().unwrap(), &state).unwrap();
+
+            assert_eq!(expected, expression);
+        };
+
+        run_test_success(
+            "avg(1)",
+            AggregationExpression::new(
+                QueryLocation::new_fake(),
+                AggregationFunction::Average,
+                Some(ScalarExpression::Static(StaticScalarExpression::Integer(
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+                ))),
+            ),
+        );
+
+        run_test_success(
+            "count()",
+            AggregationExpression::new(QueryLocation::new_fake(), AggregationFunction::Count, None),
+        );
+
+        run_test_success(
+            "max(1)",
+            AggregationExpression::new(
+                QueryLocation::new_fake(),
+                AggregationFunction::Maximum,
+                Some(ScalarExpression::Static(StaticScalarExpression::Integer(
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+                ))),
+            ),
+        );
+
+        run_test_success(
+            "min(1)",
+            AggregationExpression::new(
+                QueryLocation::new_fake(),
+                AggregationFunction::Minimum,
+                Some(ScalarExpression::Static(StaticScalarExpression::Integer(
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+                ))),
+            ),
+        );
+
+        run_test_success(
+            "sum(1)",
+            AggregationExpression::new(
+                QueryLocation::new_fake(),
+                AggregationFunction::Sum,
+                Some(ScalarExpression::Static(StaticScalarExpression::Integer(
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+                ))),
+            ),
+        );
+    }
+}

--- a/rust/experimental/query_engine/kql-parser/src/kql.pest
+++ b/rust/experimental/query_engine/kql-parser/src/kql.pest
@@ -147,12 +147,52 @@ project_keep_expression = { "project-keep" ~ (identifier_or_pattern_literal|acce
 project_away_expression = { "project-away" ~ (identifier_or_pattern_literal|accessor_expression) ~ ("," ~ (identifier_or_pattern_literal|accessor_expression))* }
 where_expression = { "where" ~ logical_expression }
 
+average_aggregate_expression = {
+	"avg" ~ "(" ~ scalar_expression ~ ")"
+}
+count_aggregate_expression = {
+	"count" ~ "(" ~ ")"
+}
+maximum_aggregate_expression = {
+	"max" ~ "(" ~ scalar_expression ~ ")"
+}
+minimum_aggregate_expression = {
+	"min" ~ "(" ~ scalar_expression ~ ")"
+}
+sum_aggregate_expression = {
+	"sum" ~ "(" ~ scalar_expression ~ ")"
+}
+
+aggregate_expression = _{
+	average_aggregate_expression
+	| count_aggregate_expression
+    | maximum_aggregate_expression
+    | minimum_aggregate_expression
+    | sum_aggregate_expression
+}
+
+aggregate_assignment_expression = {
+	identifier_literal ~ "=" ~ aggregate_expression
+}
+
+group_by_expression = {
+	identifier_literal ~ ("=" ~ scalar_expression)?
+}
+
+summarize_expression = {
+	"summarize"
+    	~ (aggregate_assignment_expression ~ ("," ~ aggregate_assignment_expression)*)?
+        ~ ("by" ~ group_by_expression ~ ("," ~ group_by_expression)*)?
+        ~ ("|" ~ tabular_expressions)*
+}
+
 tabular_expressions = _{
     extend_expression
     | project_expression
     | project_keep_expression
     | project_away_expression
     | where_expression
+    | summarize_expression
 }
 
 tabular_expression = {

--- a/rust/experimental/query_engine/kql-parser/src/lib.rs
+++ b/rust/experimental/query_engine/kql-parser/src/lib.rs
@@ -1,3 +1,4 @@
+pub(crate) mod aggregate_expressions;
 pub(crate) mod date_utils;
 pub(crate) mod kql_parser;
 pub(crate) mod logical_expressions;


### PR DESCRIPTION
Relates to #722

## Changes

* Adds support in the KQL parser for the `summarize` expression