### PR TITLE
[otap-dataflow] Use const methods when possible

### DIFF
--- a/rust/otap-dataflow/crates/engine/src/control.rs
+++ b/rust/otap-dataflow/crates/engine/src/control.rs
@@ -103,7 +103,7 @@ pub trait Controllable {
 impl NodeControlMsg {
     /// Returns `true` if this control message is a shutdown request.
     #[must_use]
-    pub fn is_shutdown(&self) -> bool {
+    pub const fn is_shutdown(&self) -> bool {
         matches!(self, NodeControlMsg::Shutdown { .. })
     }
 }

--- a/rust/otap-dataflow/crates/engine/src/message.rs
+++ b/rust/otap-dataflow/crates/engine/src/message.rs
@@ -69,19 +69,19 @@ impl<Data> Message<Data> {
 
     /// Checks if this message is a data message.
     #[must_use]
-    pub fn is_data(&self) -> bool {
+    pub const fn is_data(&self) -> bool {
         matches!(self, Message::PData(..))
     }
 
     /// Checks if this message is a control message.
     #[must_use]
-    pub fn is_control(&self) -> bool {
+    pub const fn is_control(&self) -> bool {
         matches!(self, Message::Control(..))
     }
 
     /// Checks if this message is a shutdown control message.
     #[must_use]
-    pub fn is_shutdown(&self) -> bool {
+    pub const fn is_shutdown(&self) -> bool {
         matches!(self, Message::Control(NodeControlMsg::Shutdown { .. }))
     }
 }

--- a/rust/otap-dataflow/crates/otap/src/perf_exporter/config.rs
+++ b/rust/otap-dataflow/crates/otap/src/perf_exporter/config.rs
@@ -82,37 +82,37 @@ impl Config {
     }
     /// check the frequency interval
     #[must_use]
-    pub fn frequency(&self) -> u64 {
+    pub const fn frequency(&self) -> u64 {
         self.frequency
     }
     /// check if self_usage is enabled
     #[must_use]
-    pub fn self_usage(&self) -> bool {
+    pub const fn self_usage(&self) -> bool {
         self.self_usage
     }
     /// check if cpu_usage is enabled
     #[must_use]
-    pub fn cpu_usage(&self) -> bool {
+    pub const fn cpu_usage(&self) -> bool {
         self.cpu_usage
     }
     /// check if mem_usage is enabled
     #[must_use]
-    pub fn mem_usage(&self) -> bool {
+    pub const fn mem_usage(&self) -> bool {
         self.mem_usage
     }
     /// check if disk_usage is enabled
     #[must_use]
-    pub fn disk_usage(&self) -> bool {
+    pub const fn disk_usage(&self) -> bool {
         self.disk_usage
     }
     /// check if io_usage is enabled
     #[must_use]
-    pub fn io_usage(&self) -> bool {
+    pub const fn io_usage(&self) -> bool {
         self.io_usage
     }
     /// get the smoothing factor
     #[must_use]
-    pub fn smoothing_factor(&self) -> f32 {
+    pub const fn smoothing_factor(&self) -> f32 {
         self.smoothing_factor
     }
 }

--- a/rust/otap-dataflow/crates/otlp/src/compression.rs
+++ b/rust/otap-dataflow/crates/otlp/src/compression.rs
@@ -22,7 +22,7 @@ impl CompressionMethod {
     /// map the compression method to the proper tonic compression encoding equivalent
     /// use the CompressionMethod enum to abstract from tonic
     #[must_use]
-    pub fn map_to_compression_encoding(&self) -> CompressionEncoding {
+    pub const fn map_to_compression_encoding(&self) -> CompressionEncoding {
         match *self {
             CompressionMethod::Gzip => CompressionEncoding::Gzip,
             CompressionMethod::Zstd => CompressionEncoding::Zstd,

--- a/rust/otap-dataflow/crates/otlp/src/debug_exporter/config.rs
+++ b/rust/otap-dataflow/crates/otlp/src/debug_exporter/config.rs
@@ -35,7 +35,7 @@ impl Config {
     }
     /// check the frequency interval
     #[must_use]
-    pub fn verbosity(&self) -> Verbosity {
+    pub const fn verbosity(&self) -> Verbosity {
         self.verbosity
     }
 }

--- a/rust/otap-dataflow/crates/otlp/src/fake_signal_receiver/config.rs
+++ b/rust/otap-dataflow/crates/otlp/src/fake_signal_receiver/config.rs
@@ -91,13 +91,13 @@ impl ScenarioStep {
 
     /// return the number of batches to generate
     #[must_use]
-    pub fn get_batches_to_generate(&self) -> u64 {
+    pub const fn get_batches_to_generate(&self) -> u64 {
         self.batches_to_generate
     }
 
     /// return the delay in ms
     #[must_use]
-    pub fn get_delay_between_batches_ms(&self) -> u64 {
+    pub const fn get_delay_between_batches_ms(&self) -> u64 {
         self.delay_between_batches_ms
     }
 }
@@ -121,12 +121,12 @@ impl Load {
 
     /// Provide a reference to the vector of scenario steps
     #[must_use]
-    pub fn resource_count(&self) -> usize {
+    pub const fn resource_count(&self) -> usize {
         self.resource_count
     }
     /// Provide a reference to the vector of scenario steps
     #[must_use]
-    pub fn scope_count(&self) -> usize {
+    pub const fn scope_count(&self) -> usize {
         self.scope_count
     }
 }

--- a/rust/otap-dataflow/crates/pdata-views/src/views/metrics.rs
+++ b/rust/otap-dataflow/crates/pdata-views/src/views/metrics.rs
@@ -471,7 +471,7 @@ impl DataPointFlags {
     /// explicitly missing data in a series, as for an equivalent to the Prometheus "staleness
     /// marker".
     #[must_use]
-    pub fn no_recorded_value(&self) -> bool {
+    pub const fn no_recorded_value(&self) -> bool {
         self.0 & 1 != 0
     }
 


### PR DESCRIPTION
## Changes
- Use `const` methods when possible

Making these methods const provides several benefits:

- Compile-time evaluation: These methods can now be evaluated at compile time when called with const arguments
- Performance: Potentially better optimization by the compiler
- API clarity: Signals to users that these methods are pure functions with no side effects
- Future-proofing: Ready for more advanced const evaluation features in future Rust versions