### PR TITLE
[query-engine] Support regex parse expression

### DIFF
--- a/rust/experimental/query_engine/engine-recordset/src/primitives/owned_value.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/primitives/owned_value.rs
@@ -18,52 +18,55 @@ pub enum OwnedValue {
 }
 
 impl OwnedValue {
-    pub fn from_json(input: &str) -> Option<OwnedValue> {
+    pub fn from_json(
+        query_location: &QueryLocation,
+        input: &str,
+    ) -> Result<OwnedValue, ExpressionError> {
         return match serde_json::from_str::<serde_json::Value>(input) {
-            Ok(v) => from_value(v),
-            Err(_) => None,
+            Ok(v) => from_value(query_location, v),
+            Err(e) => Err(ExpressionError::ParseError(
+                query_location.clone(),
+                format!("Input could not be parsed as JSON: {e}"),
+            )),
         };
 
-        fn from_value(value: serde_json::Value) -> Option<OwnedValue> {
+        fn from_value(
+            query_location: &QueryLocation,
+            value: serde_json::Value,
+        ) -> Result<OwnedValue, ExpressionError> {
             match value {
-                serde_json::Value::Null => Some(OwnedValue::Null),
-                serde_json::Value::Bool(b) => {
-                    Some(OwnedValue::Boolean(BooleanValueStorage::new(b)))
-                }
+                serde_json::Value::Null => Ok(OwnedValue::Null),
+                serde_json::Value::Bool(b) => Ok(OwnedValue::Boolean(BooleanValueStorage::new(b))),
                 serde_json::Value::Number(n) => {
                     if let Some(i) = n.as_i64() {
-                        Some(OwnedValue::Integer(IntegerValueStorage::new(i)))
+                        Ok(OwnedValue::Integer(IntegerValueStorage::new(i)))
                     } else {
-                        n.as_f64()
+                        match n
+                            .as_f64()
                             .map(|f| OwnedValue::Double(DoubleValueStorage::new(f)))
+                        {
+                            Some(v) => Ok(v),
+                            None => Err(ExpressionError::ParseError(
+                                query_location.clone(),
+                                format!("Input '{n}' could not be parsed as a number"),
+                            )),
+                        }
                     }
                 }
-                serde_json::Value::String(s) => {
-                    Some(OwnedValue::String(StringValueStorage::new(s)))
-                }
+                serde_json::Value::String(s) => Ok(OwnedValue::String(StringValueStorage::new(s))),
                 serde_json::Value::Array(v) => {
                     let mut values = Vec::new();
                     for value in v {
-                        match from_value(value) {
-                            Some(s) => {
-                                values.push(s);
-                            }
-                            None => return None,
-                        }
+                        values.push(from_value(query_location, value)?);
                     }
-                    Some(OwnedValue::Array(ArrayValueStorage::new(values)))
+                    Ok(OwnedValue::Array(ArrayValueStorage::new(values)))
                 }
                 serde_json::Value::Object(m) => {
                     let mut values = HashMap::new();
                     for (key, value) in m {
-                        match from_value(value) {
-                            Some(s) => {
-                                values.insert(key.into(), s);
-                            }
-                            None => return None,
-                        }
+                        values.insert(key.into(), from_value(query_location, value)?);
                     }
-                    Some(OwnedValue::Map(MapValueStorage::new(values)))
+                    Ok(OwnedValue::Map(MapValueStorage::new(values)))
                 }
             }
         }
@@ -138,9 +141,9 @@ mod tests {
     #[test]
     pub fn test_from_json() {
         let run_test = |input: &str| {
-            let value = OwnedValue::from_json(input);
+            let value = OwnedValue::from_json(&QueryLocation::new_fake(), input).unwrap();
 
-            assert_eq!(Some(input.into()), value.map(|v| v.to_value().to_string()));
+            assert_eq!(input, value.to_value().to_string());
         };
 
         run_test("true");

--- a/rust/experimental/query_engine/engine-recordset/src/scalars/mod.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/scalars/mod.rs
@@ -1,7 +1,9 @@
 pub(crate) mod math_scalar_expressions;
+pub(crate) mod parse_scalar_expressions;
 pub(crate) mod scalar_expressions;
 pub(crate) mod temporal_scalar_expressions;
 
 pub use math_scalar_expressions::*;
+pub use parse_scalar_expressions::*;
 pub use scalar_expressions::*;
 pub use temporal_scalar_expressions::*;

--- a/rust/experimental/query_engine/engine-recordset/src/scalars/parse_scalar_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/scalars/parse_scalar_expressions.rs
@@ -1,0 +1,189 @@
+use data_engine_expressions::*;
+
+use crate::{execution_context::*, scalars::execute_scalar_expression, *};
+
+pub fn execute_parse_scalar_expression<'a, 'b, 'c, TRecord: Record>(
+    execution_context: &'b ExecutionContext<'a, '_, '_, TRecord>,
+    parse_scalar_expression: &'a ParseScalarExpression,
+) -> Result<ResolvedValue<'c>, ExpressionError>
+where
+    'a: 'c,
+    'b: 'c,
+{
+    let v = match parse_scalar_expression {
+        ParseScalarExpression::Json(p) => {
+            let inner_value =
+                execute_scalar_expression(execution_context, p.get_inner_expression())?;
+
+            let value = inner_value.to_value();
+
+            match value {
+                Value::String(s) => ResolvedValue::Computed(OwnedValue::from_json(
+                    p.get_query_location(),
+                    s.get_value(),
+                )?),
+                _ => {
+                    return Err(ExpressionError::ParseError(
+                        p.get_query_location().clone(),
+                        format!(
+                            "Input of '{:?}' type could not be pased as JSON",
+                            value.get_value_type()
+                        ),
+                    ));
+                }
+            }
+        }
+        ParseScalarExpression::Regex(p) => {
+            let pattern_value = execute_scalar_expression(execution_context, p.get_pattern())?;
+
+            let options_value = if let Some(o) = p.get_options() {
+                Some(execute_scalar_expression(execution_context, o)?)
+            } else {
+                None
+            };
+
+            let regex = match (pattern_value, options_value) {
+                (pattern, None) => {
+                    Value::parse_regex(p.get_query_location(), &pattern.to_value(), None)?
+                }
+                (pattern, Some(options)) => Value::parse_regex(
+                    p.get_query_location(),
+                    &pattern.to_value(),
+                    Some(&options.to_value()),
+                )?,
+            };
+
+            ResolvedValue::Computed(OwnedValue::Regex(RegexValueStorage::new(regex)))
+        }
+    };
+
+    execution_context.add_diagnostic_if_enabled(
+        RecordSetEngineDiagnosticLevel::Verbose,
+        parse_scalar_expression,
+        || format!("Evaluated as: {v}"),
+    );
+
+    Ok(v)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    pub fn test_execute_parse_json_scalar_expression() {
+        fn run_test_success(input: &str, expected_value: Value) {
+            let expression = ScalarExpression::Parse(ParseScalarExpression::Json(
+                ParseJsonScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    ScalarExpression::Static(StaticScalarExpression::String(
+                        StringScalarExpression::new(QueryLocation::new_fake(), input),
+                    )),
+                ),
+            ));
+
+            let mut test = TestExecutionContext::new();
+
+            let execution_context = test.create_execution_context();
+
+            let actual_value = execute_scalar_expression(&execution_context, &expression).unwrap();
+            assert_eq!(expected_value, actual_value.to_value());
+        }
+
+        fn run_test_failure(input: &str) {
+            let expression = ScalarExpression::Parse(ParseScalarExpression::Json(
+                ParseJsonScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    ScalarExpression::Static(StaticScalarExpression::String(
+                        StringScalarExpression::new(QueryLocation::new_fake(), input),
+                    )),
+                ),
+            ));
+
+            let mut test = TestExecutionContext::new();
+
+            let execution_context = test.create_execution_context();
+
+            let actual_value =
+                execute_scalar_expression(&execution_context, &expression).unwrap_err();
+            assert!(matches!(actual_value, ExpressionError::ParseError(_, _)));
+        }
+
+        run_test_success(
+            "18",
+            Value::Integer(&IntegerScalarExpression::new(QueryLocation::new_fake(), 18)),
+        );
+        run_test_failure("hello world");
+    }
+
+    #[test]
+    pub fn test_execute_parse_regex_scalar_expression() {
+        fn run_test_success(pattern: ScalarExpression, options: Option<ScalarExpression>) {
+            let expression = ScalarExpression::Parse(ParseScalarExpression::Regex(
+                ParseRegexScalarExpression::new(QueryLocation::new_fake(), pattern, options),
+            ));
+
+            let mut test = TestExecutionContext::new();
+
+            let execution_context = test.create_execution_context();
+
+            let actual_value = execute_scalar_expression(&execution_context, &expression).unwrap();
+            assert_eq!(ValueType::Regex, actual_value.get_value_type());
+        }
+
+        fn run_test_failure(pattern: ScalarExpression, options: Option<ScalarExpression>) {
+            let expression = ScalarExpression::Parse(ParseScalarExpression::Regex(
+                ParseRegexScalarExpression::new(QueryLocation::new_fake(), pattern, options),
+            ));
+
+            let mut test = TestExecutionContext::new();
+
+            let execution_context = test.create_execution_context();
+
+            execute_scalar_expression(&execution_context, &expression).unwrap_err();
+        }
+
+        run_test_success(
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                ".*",
+            ))),
+            None,
+        );
+
+        run_test_success(
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                ".*",
+            ))),
+            Some(ScalarExpression::Static(StaticScalarExpression::String(
+                StringScalarExpression::new(QueryLocation::new_fake(), "i"),
+            ))),
+        );
+
+        run_test_failure(
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "(",
+            ))),
+            None,
+        );
+
+        run_test_failure(
+            ScalarExpression::Static(StaticScalarExpression::Null(NullScalarExpression::new(
+                QueryLocation::new_fake(),
+            ))),
+            None,
+        );
+
+        run_test_failure(
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                ".*",
+            ))),
+            Some(ScalarExpression::Static(StaticScalarExpression::Null(
+                NullScalarExpression::new(QueryLocation::new_fake()),
+            ))),
+        );
+    }
+}

--- a/rust/experimental/query_engine/expressions/src/expression_error.rs
+++ b/rust/experimental/query_engine/expressions/src/expression_error.rs
@@ -9,6 +9,9 @@ pub enum ExpressionError {
 
     #[error("{1}")]
     ValidationFailure(QueryLocation, String),
+
+    #[error("{1}")]
+    ParseError(QueryLocation, String),
 }
 
 impl ExpressionError {
@@ -16,6 +19,7 @@ impl ExpressionError {
         match self {
             ExpressionError::TypeMismatch(l, _) => l,
             ExpressionError::ValidationFailure(l, _) => l,
+            ExpressionError::ParseError(l, _) => l,
         }
     }
 }

--- a/rust/experimental/query_engine/expressions/src/scalars/mod.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/mod.rs
@@ -1,11 +1,13 @@
 pub(crate) mod convert_scalar_expression;
 pub(crate) mod math_scalar_expression;
+pub(crate) mod parse_scalar_expression;
 pub(crate) mod scalar_expressions;
 pub(crate) mod statics;
 pub(crate) mod temporal_scalar_expression;
 
 pub use convert_scalar_expression::*;
 pub use math_scalar_expression::*;
+pub use parse_scalar_expression::*;
 pub use scalar_expressions::*;
 pub use statics::*;
 pub use temporal_scalar_expression::*;

--- a/rust/experimental/query_engine/expressions/src/scalars/parse_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/parse_scalar_expression.rs
@@ -1,0 +1,369 @@
+use crate::*;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ParseScalarExpression {
+    /// Parses an inner string scalar value as JSON and returns a Map, Array,
+    /// Integer, Double, or Null value, or returns an error for invalid input.
+    Json(ParseJsonScalarExpression),
+
+    /// Parses an inner string scalar value into a Regex value or returns an
+    /// error for invalid input.
+    Regex(ParseRegexScalarExpression),
+}
+
+impl ParseScalarExpression {
+    pub(crate) fn try_resolve_value_type(
+        &self,
+        pipeline: &PipelineExpression,
+    ) -> Result<Option<ValueType>, ExpressionError> {
+        match self {
+            ParseScalarExpression::Json(p) => p.try_resolve_value_type(pipeline),
+            ParseScalarExpression::Regex(p) => p.try_resolve_value_type(pipeline),
+        }
+    }
+
+    pub(crate) fn try_resolve_static<'a, 'b, 'c>(
+        &'a self,
+        pipeline: &'b PipelineExpression,
+    ) -> Result<Option<ResolvedStaticScalarExpression<'c>>, ExpressionError>
+    where
+        'a: 'c,
+        'b: 'c,
+    {
+        match self {
+            ParseScalarExpression::Json(p) => p.try_resolve_static(pipeline),
+            ParseScalarExpression::Regex(p) => p.try_resolve_static(pipeline),
+        }
+    }
+}
+
+impl Expression for ParseScalarExpression {
+    fn get_query_location(&self) -> &QueryLocation {
+        match self {
+            ParseScalarExpression::Json(p) => p.get_query_location(),
+            ParseScalarExpression::Regex(p) => p.get_query_location(),
+        }
+    }
+
+    fn get_name(&self) -> &'static str {
+        match self {
+            ParseScalarExpression::Json(_) => "ParseScalar(Json)",
+            ParseScalarExpression::Regex(_) => "ParseScalar(Regex)",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParseJsonScalarExpression {
+    query_location: QueryLocation,
+    inner_expression: Box<ScalarExpression>,
+}
+
+impl ParseJsonScalarExpression {
+    pub fn new(
+        query_location: QueryLocation,
+        inner_expression: ScalarExpression,
+    ) -> ParseJsonScalarExpression {
+        Self {
+            query_location,
+            inner_expression: inner_expression.into(),
+        }
+    }
+
+    pub fn get_inner_expression(&self) -> &ScalarExpression {
+        &self.inner_expression
+    }
+
+    pub(crate) fn try_resolve_value_type(
+        &self,
+        pipeline: &PipelineExpression,
+    ) -> Result<Option<ValueType>, ExpressionError> {
+        Ok(self
+            .try_resolve_static(pipeline)?
+            .map(|v| v.get_value_type()))
+    }
+
+    pub(crate) fn try_resolve_static(
+        &self,
+        pipeline: &PipelineExpression,
+    ) -> Result<Option<ResolvedStaticScalarExpression<'_>>, ExpressionError> {
+        match self.inner_expression.try_resolve_static(pipeline)? {
+            Some(v) => Ok(Some(ResolvedStaticScalarExpression::Value(
+                if let Value::String(s) = v.to_value() {
+                    StaticScalarExpression::from_json(self.query_location.clone(), s.get_value())?
+                } else {
+                    return Err(ExpressionError::ParseError(
+                        self.get_query_location().clone(),
+                        format!(
+                            "Input of '{:?}' type could not be pased as JSON",
+                            v.get_value_type()
+                        ),
+                    ));
+                },
+            ))),
+            None => Ok(None),
+        }
+    }
+}
+
+impl Expression for ParseJsonScalarExpression {
+    fn get_query_location(&self) -> &QueryLocation {
+        &self.query_location
+    }
+
+    fn get_name(&self) -> &'static str {
+        "ParseJsonScalarExpression"
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParseRegexScalarExpression {
+    query_location: QueryLocation,
+    pattern: Box<ScalarExpression>,
+    options: Option<Box<ScalarExpression>>,
+}
+
+impl ParseRegexScalarExpression {
+    pub fn new(
+        query_location: QueryLocation,
+        pattern: ScalarExpression,
+        options: Option<ScalarExpression>,
+    ) -> ParseRegexScalarExpression {
+        Self {
+            query_location,
+            pattern: pattern.into(),
+            options: options.map(|v| v.into()),
+        }
+    }
+
+    pub fn get_pattern(&self) -> &ScalarExpression {
+        &self.pattern
+    }
+
+    pub fn get_options(&self) -> Option<&ScalarExpression> {
+        self.options.as_deref()
+    }
+
+    pub(crate) fn try_resolve_value_type(
+        &self,
+        pipeline: &PipelineExpression,
+    ) -> Result<Option<ValueType>, ExpressionError> {
+        Ok(self
+            .try_resolve_static(pipeline)?
+            .map(|v| v.get_value_type()))
+    }
+
+    pub(crate) fn try_resolve_static(
+        &self,
+        pipeline: &PipelineExpression,
+    ) -> Result<Option<ResolvedStaticScalarExpression<'_>>, ExpressionError> {
+        let pattern = self.pattern.try_resolve_static(pipeline)?;
+
+        let options = if let Some(o) = &self.options {
+            match o.try_resolve_static(pipeline)? {
+                Some(v) => Some(v),
+                None => return Ok(None),
+            }
+        } else {
+            None
+        };
+
+        let regex = match (pattern, options) {
+            (Some(pattern), None) => {
+                Value::parse_regex(&self.query_location, &pattern.to_value(), None)?
+            }
+            (Some(pattern), Some(options)) => Value::parse_regex(
+                &self.query_location,
+                &pattern.to_value(),
+                Some(&options.to_value()),
+            )?,
+            _ => {
+                return Ok(None);
+            }
+        };
+
+        Ok(Some(ResolvedStaticScalarExpression::Value(
+            StaticScalarExpression::Regex(RegexScalarExpression::new(
+                self.query_location.clone(),
+                regex,
+            )),
+        )))
+    }
+}
+
+impl Expression for ParseRegexScalarExpression {
+    fn get_query_location(&self) -> &QueryLocation {
+        &self.query_location
+    }
+
+    fn get_name(&self) -> &'static str {
+        "ParseRegexScalarExpression"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    pub fn test_parse_json_scalar_expression_try_resolve() {
+        fn run_test_success(input: &str, expected_value: Value) {
+            let pipeline = Default::default();
+
+            let expression = ParseJsonScalarExpression::new(
+                QueryLocation::new_fake(),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), input),
+                )),
+            );
+
+            let actual_type = expression.try_resolve_value_type(&pipeline).unwrap();
+            assert_eq!(Some(expected_value.get_value_type()), actual_type);
+
+            let actual_value = expression.try_resolve_static(&pipeline).unwrap();
+            assert_eq!(
+                Some(expected_value),
+                actual_value.as_ref().map(|v| v.to_value())
+            );
+        }
+
+        fn run_test_failure(input: &str) {
+            let pipeline = Default::default();
+
+            let expression = ParseJsonScalarExpression::new(
+                QueryLocation::new_fake(),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), input),
+                )),
+            );
+
+            let actual_type_error = expression.try_resolve_value_type(&pipeline).unwrap_err();
+            assert!(matches!(
+                actual_type_error,
+                ExpressionError::ParseError(_, _)
+            ));
+
+            let actual_value_error = expression.try_resolve_static(&pipeline).unwrap_err();
+            assert!(matches!(
+                actual_value_error,
+                ExpressionError::ParseError(_, _)
+            ));
+        }
+
+        run_test_success(
+            "18",
+            Value::Integer(&IntegerScalarExpression::new(QueryLocation::new_fake(), 18)),
+        );
+        run_test_failure("hello world");
+    }
+
+    #[test]
+    pub fn test_parse_regex_scalar_expression_try_resolve() {
+        fn run_test_success(
+            pattern: ScalarExpression,
+            options: Option<ScalarExpression>,
+            expected: Option<ValueType>,
+        ) {
+            let pipeline = Default::default();
+
+            let expression =
+                ParseRegexScalarExpression::new(QueryLocation::new_fake(), pattern, options);
+
+            let actual_type = expression.try_resolve_value_type(&pipeline).unwrap();
+            assert_eq!(expected, actual_type);
+
+            let actual_value = expression
+                .try_resolve_static(&pipeline)
+                .unwrap()
+                .map(|v| v.get_value_type());
+            assert_eq!(expected, actual_value);
+        }
+
+        fn run_test_failure(pattern: ScalarExpression, options: Option<ScalarExpression>) {
+            let pipeline = Default::default();
+
+            let expression =
+                ParseRegexScalarExpression::new(QueryLocation::new_fake(), pattern, options);
+
+            expression.try_resolve_value_type(&pipeline).unwrap_err();
+
+            expression.try_resolve_static(&pipeline).unwrap_err();
+        }
+
+        run_test_success(
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "[^a]ello world",
+            ))),
+            None,
+            Some(ValueType::Regex),
+        );
+
+        run_test_success(
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "hello world",
+            ))),
+            Some(ScalarExpression::Static(StaticScalarExpression::String(
+                StringScalarExpression::new(QueryLocation::new_fake(), "i"),
+            ))),
+            Some(ValueType::Regex),
+        );
+
+        run_test_success(
+            ScalarExpression::Source(SourceScalarExpression::new(
+                QueryLocation::new_fake(),
+                ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                    StaticScalarExpression::String(StringScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        "key1",
+                    )),
+                )]),
+            )),
+            None,
+            None,
+        );
+
+        run_test_success(
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "[^a]ello world",
+            ))),
+            Some(ScalarExpression::Source(SourceScalarExpression::new(
+                QueryLocation::new_fake(),
+                ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                    StaticScalarExpression::String(StringScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        "key1",
+                    )),
+                )]),
+            ))),
+            None,
+        );
+
+        run_test_failure(
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "(",
+            ))),
+            None,
+        );
+
+        run_test_failure(
+            ScalarExpression::Static(StaticScalarExpression::Null(NullScalarExpression::new(
+                QueryLocation::new_fake(),
+            ))),
+            None,
+        );
+
+        run_test_failure(
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                ".*",
+            ))),
+            Some(ScalarExpression::Static(StaticScalarExpression::Null(
+                NullScalarExpression::new(QueryLocation::new_fake()),
+            ))),
+        );
+    }
+}

--- a/rust/experimental/query_engine/expressions/src/scalars/statics/static_scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/statics/static_scalar_expressions.rs
@@ -36,51 +36,58 @@ pub enum StaticScalarExpression {
 }
 
 impl StaticScalarExpression {
-    pub fn from_json(query_location: QueryLocation, input: &str) -> Option<StaticScalarExpression> {
+    pub fn from_json(
+        query_location: QueryLocation,
+        input: &str,
+    ) -> Result<StaticScalarExpression, ExpressionError> {
         return match serde_json::from_str::<serde_json::Value>(input) {
-            Ok(v) => from_value(&query_location, v),
-            Err(_) => None,
+            Ok(v) => Ok(from_value(&query_location, v)?),
+            Err(e) => Err(ExpressionError::ParseError(
+                query_location,
+                format!("Input could not be parsed as JSON: {e}"),
+            )),
         };
 
         fn from_value(
             query_location: &QueryLocation,
             value: serde_json::Value,
-        ) -> Option<StaticScalarExpression> {
+        ) -> Result<StaticScalarExpression, ExpressionError> {
             match value {
-                serde_json::Value::Null => Some(StaticScalarExpression::Null(
+                serde_json::Value::Null => Ok(StaticScalarExpression::Null(
                     NullScalarExpression::new(query_location.clone()),
                 )),
-                serde_json::Value::Bool(b) => Some(StaticScalarExpression::Boolean(
+                serde_json::Value::Bool(b) => Ok(StaticScalarExpression::Boolean(
                     BooleanScalarExpression::new(query_location.clone(), b),
                 )),
                 serde_json::Value::Number(n) => {
                     if let Some(i) = n.as_i64() {
-                        Some(StaticScalarExpression::Integer(
+                        Ok(StaticScalarExpression::Integer(
                             IntegerScalarExpression::new(query_location.clone(), i),
                         ))
                     } else {
-                        n.as_f64().map(|f| {
+                        match n.as_f64().map(|f| {
                             StaticScalarExpression::Double(DoubleScalarExpression::new(
                                 query_location.clone(),
                                 f,
                             ))
-                        })
+                        }) {
+                            Some(s) => Ok(s),
+                            None => Err(ExpressionError::ParseError(
+                                query_location.clone(),
+                                format!("Input '{n}' could not be parsed as a number"),
+                            )),
+                        }
                     }
                 }
-                serde_json::Value::String(s) => Some(StaticScalarExpression::String(
+                serde_json::Value::String(s) => Ok(StaticScalarExpression::String(
                     StringScalarExpression::new(query_location.clone(), &s),
                 )),
                 serde_json::Value::Array(v) => {
                     let mut values = Vec::new();
                     for value in v {
-                        match from_value(query_location, value) {
-                            Some(s) => {
-                                values.push(s);
-                            }
-                            None => return None,
-                        }
+                        values.push(from_value(query_location, value)?);
                     }
-                    Some(StaticScalarExpression::Array(ArrayScalarExpression::new(
+                    Ok(StaticScalarExpression::Array(ArrayScalarExpression::new(
                         query_location.clone(),
                         values,
                     )))
@@ -88,14 +95,9 @@ impl StaticScalarExpression {
                 serde_json::Value::Object(m) => {
                     let mut values = HashMap::new();
                     for (key, value) in m {
-                        match from_value(query_location, value) {
-                            Some(s) => {
-                                values.insert(key.into(), s);
-                            }
-                            None => return None,
-                        }
+                        values.insert(key.into(), from_value(query_location, value)?);
                     }
-                    Some(StaticScalarExpression::Map(MapScalarExpression::new(
+                    Ok(StaticScalarExpression::Map(MapScalarExpression::new(
                         query_location.clone(),
                         values,
                     )))
@@ -378,9 +380,10 @@ mod tests {
     #[test]
     pub fn test_from_json() {
         let run_test = |input: &str| {
-            let value = StaticScalarExpression::from_json(QueryLocation::new_fake(), input);
+            let value =
+                StaticScalarExpression::from_json(QueryLocation::new_fake(), input).unwrap();
 
-            assert_eq!(Some(input.into()), value.map(|v| v.to_value().to_string()));
+            assert_eq!(input, value.to_value().to_string());
         };
 
         run_test("true");


### PR DESCRIPTION
Relates to #722

## Changes

* Refactor parse json into a parse group
* Add regex parsing into the group