### PR TITLE
[perf] [hot-path] Optimize send_message methods on EffectHandler

### DIFF
--- a/rust/otap-dataflow/crates/engine/src/local/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/local/processor.rs
@@ -103,7 +103,7 @@ impl<PData> EffectHandler<PData> {
         default_port: Option<PortName>,
     ) -> Self {
         let core = EffectHandlerCore::new(node_id);
-        
+
         // Determine and cache the default sender
         let default_sender = if let Some(ref port) = default_port {
             msg_senders.get(port).cloned()

--- a/rust/otap-dataflow/crates/engine/src/local/receiver.rs
+++ b/rust/otap-dataflow/crates/engine/src/local/receiver.rs
@@ -122,8 +122,8 @@ pub struct EffectHandler<PData> {
     /// A sender used to forward messages from the receiver.
     /// Supports multiple named output ports.
     msg_senders: HashMap<PortName, LocalSender<PData>>,
-    /// Optional default port to use when calling send_message.
-    default_port: Option<PortName>,
+    /// Cached default sender for fast access in the hot path
+    default_sender: Option<LocalSender<PData>>,
 }
 
 /// Implementation for the `!Send` effect handler.
@@ -138,17 +138,20 @@ impl<PData> EffectHandler<PData> {
     ) -> Self {
         let mut core = EffectHandlerCore::new(node_id);
         core.set_pipeline_ctrl_msg_sender(node_request_sender);
-        let default_port = default_port.or_else(|| {
-            if msg_senders.len() == 1 {
-                msg_senders.keys().next().cloned()
-            } else {
-                None
-            }
-        });
+        
+        // Determine and cache the default sender
+        let default_sender = if let Some(ref port) = default_port {
+            msg_senders.get(port).cloned()
+        } else if msg_senders.len() == 1 {
+            msg_senders.values().next().cloned()
+        } else {
+            None
+        };
+        
         EffectHandler {
             core,
             msg_senders,
-            default_port,
+            default_sender,
         }
     }
 
@@ -173,18 +176,16 @@ impl<PData> EffectHandler<PData> {
     ///
     /// Returns an [`Error::ChannelSendError`] if the message could not be sent or [`Error::ReceiverError`]
     /// if the default port is not configured.
+    #[inline]
     pub async fn send_message(&self, data: PData) -> Result<(), Error<PData>> {
-        let port = if let Some(p) = &self.default_port {
-            p.clone()
-        } else {
-            return Err(Error::ReceiverError {
+        match &self.default_sender {
+            Some(sender) => sender.send(data).await.map_err(Error::ChannelSendError),
+            None => Err(Error::ReceiverError {
                 receiver: self.receiver_id(),
-                error:
-                    "Ambiguous default out port: multiple ports connected and no default configured"
-                        .to_string(),
-            });
-        };
-        self.send_message_to(port, data).await
+                error: "Ambiguous default out port: multiple ports connected and no default configured"
+                    .to_string(),
+            }),
+        }
     }
 
     /// Sends a message to a specific named out port.
@@ -193,23 +194,22 @@ impl<PData> EffectHandler<PData> {
     ///
     /// Returns a [`Error::ChannelSendError`] if the message could not be sent, or
     /// [`Error::ReceiverError`] if the port does not exist.
+    #[inline]
     pub async fn send_message_to<P>(&self, port: P, data: PData) -> Result<(), Error<PData>>
     where
         P: Into<PortName>,
     {
         let port_name: PortName = port.into();
-        let sender =
-            self.msg_senders
-                .get(&port_name)
-                .cloned()
-                .ok_or_else(|| Error::ReceiverError {
-                    receiver: self.receiver_id(),
-                    error: format!(
-                        "Unknown out port '{port_name}' for node {}",
-                        self.receiver_id()
-                    ),
-                })?;
-        sender.send(data).await.map_err(Error::ChannelSendError)
+        match self.msg_senders.get(&port_name) {
+            Some(sender) => sender.send(data).await.map_err(Error::ChannelSendError),
+            None => Err(Error::ReceiverError {
+                receiver: self.receiver_id(),
+                error: format!(
+                    "Unknown out port '{port_name}' for node {}",
+                    self.receiver_id()
+                ),
+            }),
+        }
     }
 
     /// Creates a non-blocking TCP listener on the given address with socket options defined by the

--- a/rust/otap-dataflow/crates/engine/src/local/receiver.rs
+++ b/rust/otap-dataflow/crates/engine/src/local/receiver.rs
@@ -138,7 +138,7 @@ impl<PData> EffectHandler<PData> {
     ) -> Self {
         let mut core = EffectHandlerCore::new(node_id);
         core.set_pipeline_ctrl_msg_sender(node_request_sender);
-        
+
         // Determine and cache the default sender
         let default_sender = if let Some(ref port) = default_port {
             msg_senders.get(port).cloned()
@@ -147,7 +147,7 @@ impl<PData> EffectHandler<PData> {
         } else {
             None
         };
-        
+
         EffectHandler {
             core,
             msg_senders,
@@ -182,8 +182,9 @@ impl<PData> EffectHandler<PData> {
             Some(sender) => sender.send(data).await.map_err(Error::ChannelSendError),
             None => Err(Error::ReceiverError {
                 receiver: self.receiver_id(),
-                error: "Ambiguous default out port: multiple ports connected and no default configured"
-                    .to_string(),
+                error:
+                    "Ambiguous default out port: multiple ports connected and no default configured"
+                        .to_string(),
             }),
         }
     }

--- a/rust/otap-dataflow/crates/engine/src/shared/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/shared/processor.rs
@@ -88,8 +88,8 @@ pub struct EffectHandler<PData> {
     /// A sender used to forward messages from the processor.
     /// Supports multiple named output ports.
     msg_senders: HashMap<PortName, SharedSender<PData>>,
-    /// Optional default port to use when calling send_message.
-    default_port: Option<PortName>,
+    /// Cached default sender for fast access in the hot path
+    default_sender: Option<SharedSender<PData>>,
 }
 
 /// Implementation for the `Send` effect handler.
@@ -102,17 +102,20 @@ impl<PData> EffectHandler<PData> {
         default_port: Option<PortName>,
     ) -> Self {
         let core = EffectHandlerCore::new(node_id);
-        let default_port = default_port.or_else(|| {
-            if msg_senders.len() == 1 {
-                msg_senders.keys().next().cloned()
-            } else {
-                None
-            }
-        });
+
+        // Determine and cache the default sender
+        let default_sender = if let Some(ref port) = default_port {
+            msg_senders.get(port).cloned()
+        } else if msg_senders.len() == 1 {
+            msg_senders.values().next().cloned()
+        } else {
+            None
+        };
+
         EffectHandler {
             core,
             msg_senders,
-            default_port,
+            default_sender,
         }
     }
 
@@ -133,39 +136,36 @@ impl<PData> EffectHandler<PData> {
     /// # Errors
     ///
     /// Returns an [`Error::ProcessorError`] if the message could not be routed to a port.
+    #[inline]
     pub async fn send_message(&self, data: PData) -> Result<(), Error<PData>> {
-        let port = if let Some(p) = &self.default_port {
-            p.clone()
-        } else {
-            return Err(Error::ProcessorError {
+        match &self.default_sender {
+            Some(sender) => sender.send(data).await.map_err(Error::ChannelSendError),
+            None => Err(Error::ProcessorError {
                 processor: self.processor_id(),
                 error:
                     "Ambiguous default out port: multiple ports connected and no default configured"
                         .to_string(),
-            });
-        };
-        self.send_message_to(port, data).await
+            }),
+        }
     }
 
     /// Sends a message to a specific named out port.
+    #[inline]
     pub async fn send_message_to<P>(&self, port: P, data: PData) -> Result<(), Error<PData>>
     where
         P: Into<PortName>,
     {
         let port_name: PortName = port.into();
-        let sender = match self.msg_senders.get(&port_name).cloned() {
-            Some(s) => s,
-            None => {
-                return Err(Error::ProcessorError {
-                    processor: self.processor_id(),
-                    error: format!(
-                        "Unknown out port '{port_name}' for node {}",
-                        self.processor_id()
-                    ),
-                });
-            }
-        };
-        sender.send(data).await.map_err(Error::ChannelSendError)
+        match self.msg_senders.get(&port_name) {
+            Some(sender) => sender.send(data).await.map_err(Error::ChannelSendError),
+            None => Err(Error::ProcessorError {
+                processor: self.processor_id(),
+                error: format!(
+                    "Unknown out port '{port_name}' for node {}",
+                    self.processor_id()
+                ),
+            }),
+        }
     }
 
     /// Print an info message to stdout.

--- a/rust/otap-dataflow/crates/engine/src/shared/receiver.rs
+++ b/rust/otap-dataflow/crates/engine/src/shared/receiver.rs
@@ -149,8 +149,9 @@ impl<PData> EffectHandler<PData> {
             Some(sender) => sender.send(data).await.map_err(Error::ChannelSendError),
             None => Err(Error::ReceiverError {
                 receiver: self.receiver_id(),
-                error: "Ambiguous default out port: multiple ports connected and no default configured"
-                    .to_string(),
+                error:
+                    "Ambiguous default out port: multiple ports connected and no default configured"
+                        .to_string(),
             }),
         }
     }


### PR DESCRIPTION
## Changes
- Receivers and Processors would send the messages to the next component in the pipeline using `EffectHandler::send_message` method
- This PR optimizes the send methods for both `local` and `shared` receiver and processor's effect handlers
   - Avoid `Hashmap` lookup on the hot-path by caching the default sender
   - Avoid cloning the port name for each send operation by using references
   - Avoid cloning the sender for send operation by using references