### PR TITLE
Add support for non-recurring timer events

### DIFF
--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -53,7 +53,7 @@ serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_cbor = "0.11.2"
 serde_json = { version = "1.0.142" }
 serde_yaml = "0.9.34+deprecated"        # Deprecated, but no good alternative yet
-tokio = { version = "1.46.1", features = ["rt", "time", "net", "io-util", "sync", "macros", "rt-multi-thread", "fs", "io-std"] }
+tokio = { version = "1.46.1", features = ["rt", "time", "net", "io-util", "sync", "macros", "rt-multi-thread", "fs", "io-std", "test-util"] }
 uuid = { version = "1.17.0", features = ["v4"] }
 async-trait = "0.1.88"
 futures = "0.3.31"

--- a/rust/otap-dataflow/crates/engine/src/control.rs
+++ b/rust/otap-dataflow/crates/engine/src/control.rs
@@ -9,6 +9,7 @@ use crate::shared::message::{SharedReceiver, SharedSender};
 use otap_df_channel::error::SendError;
 use otap_df_config::NodeId;
 use std::time::Duration;
+use tokio::time::Instant;
 
 /// Control messages sent by the pipeline engine to nodes to manage their behavior,
 /// configuration, and lifecycle.
@@ -74,7 +75,14 @@ pub enum PipelineControlMsg {
         /// Duration of the timer interval.
         duration: Duration,
     },
-    /// Requests cancellation of a periodic timer for the specified node.
+    /// Requests the pipeline engine to start a non-recurring timer for the specified node.
+    RunAtTimer {
+        /// Identifier of the node for which the timer is being started.
+        node_id: NodeId,
+        /// Instant when to run.
+        when: Instant,
+    },
+    /// Requests cancellation of a periodic or non-recurring timer for the specified node.
     CancelTimer {
         /// Identifier of the node for which the timer is being canceled.
         node_id: NodeId,

--- a/rust/otap-dataflow/crates/engine/src/local/exporter.rs
+++ b/rust/otap-dataflow/crates/engine/src/local/exporter.rs
@@ -39,6 +39,7 @@ use async_trait::async_trait;
 use otap_df_config::NodeId;
 use std::marker::PhantomData;
 use std::time::Duration;
+use tokio::time::Instant;
 
 /// A trait for egress exporters (!Send definition).
 #[async_trait( ? Send)]
@@ -124,6 +125,17 @@ impl<PData> EffectHandler<PData> {
         duration: Duration,
     ) -> Result<TimerCancelHandle, Error<PData>> {
         self.core.start_periodic_timer(duration).await
+    }
+
+    /// Schedules a cancellable non-recurring timer that emits TimerTick at the specified time.
+    /// Returns a handle that can be used to cancel the timer.
+    ///
+    /// Current limitation: Only one timer can be started by an exporter at a time.
+    pub async fn run_timer_at(
+        &self,
+        when: Instant,
+    ) -> Result<TimerCancelHandle, Error<PData>> {
+        self.core.run_at_timer(when).await
     }
 
     // More methods will be added in the future as needed.

--- a/rust/otap-dataflow/crates/engine/src/local/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/local/processor.rs
@@ -39,6 +39,7 @@ use async_trait::async_trait;
 use otap_df_config::{NodeId, PortName};
 use std::collections::HashMap;
 use std::time::Duration;
+use tokio::time::Instant;
 
 /// A trait for processors in the pipeline (!Send definition).
 #[async_trait(?Send)]
@@ -195,6 +196,17 @@ impl<PData> EffectHandler<PData> {
         duration: Duration,
     ) -> Result<TimerCancelHandle, Error<PData>> {
         self.core.start_periodic_timer(duration).await
+    }
+
+    /// Schedules a cancellable non-recurring timer that emits TimerTick at the specified time.
+    /// Returns a handle that can be used to cancel the timer.
+    ///
+    /// Current limitation: Only one timer can be started by a processor at a time.
+    pub async fn run_timer_at(
+        &self,
+        when: Instant,
+    ) -> Result<TimerCancelHandle, Error<PData>> {
+        self.core.run_at_timer(when).await
     }
 
     // More methods will be added in the future as needed.

--- a/rust/otap-dataflow/crates/engine/src/local/receiver.rs
+++ b/rust/otap-dataflow/crates/engine/src/local/receiver.rs
@@ -42,6 +42,7 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::time::Duration;
 use tokio::net::{TcpListener, UdpSocket};
+use tokio::time::Instant;
 
 /// A trait for ingress receivers (!Send definition).
 ///
@@ -251,6 +252,16 @@ impl<PData> EffectHandler<PData> {
         duration: Duration,
     ) -> Result<TimerCancelHandle, Error<PData>> {
         self.core.start_periodic_timer(duration).await
+    }
+
+    /// Schedules a cancellable non-recurring timer that emits TimerTick at the specified time.
+    ///
+    /// Current limitation: Only one timer can be started by a receiver at a time.
+    pub async fn run_timer_at(
+        &self,
+        when: Instant,
+    ) -> Result<TimerCancelHandle, Error<PData>> {
+        self.core.run_at_timer(when).await
     }
 
     // More methods will be added in the future as needed.

--- a/rust/otap-dataflow/crates/engine/src/shared/exporter.rs
+++ b/rust/otap-dataflow/crates/engine/src/shared/exporter.rs
@@ -244,5 +244,16 @@ impl<PData> EffectHandler<PData> {
         self.core.start_periodic_timer(duration).await
     }
 
+    /// Schedules a cancellable non-recurring timer that emits TimerTick at the specified time.
+    /// Returns a handle that can be used to cancel the timer.
+    ///
+    /// Current limitation: Only one timer can be started by an exporter at a time.
+    pub async fn run_timer_at(
+        &self,
+        when: Instant,
+    ) -> Result<TimerCancelHandle, Error<PData>> {
+        self.core.run_at_timer(when).await
+    }
+
     // More methods will be added in the future as needed.
 }

--- a/rust/otap-dataflow/crates/engine/src/shared/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/shared/processor.rs
@@ -38,6 +38,7 @@ use async_trait::async_trait;
 use otap_df_config::{NodeId, PortName};
 use std::collections::HashMap;
 use std::time::Duration;
+use tokio::time::Instant;
 
 /// A trait for processors in the pipeline (Send definition).
 #[async_trait]
@@ -185,6 +186,17 @@ impl<PData> EffectHandler<PData> {
         duration: Duration,
     ) -> Result<TimerCancelHandle, Error<PData>> {
         self.core.start_periodic_timer(duration).await
+    }
+
+    /// Schedules a cancellable non-recurring timer that emits TimerTick at the specified time.
+    /// Returns a handle that can be used to cancel the timer.
+    ///
+    /// Current limitation: Only one timer can be started by a processor at a time.
+    pub async fn run_timer_at(
+        &self,
+        when: Instant,
+    ) -> Result<TimerCancelHandle, Error<PData>> {
+        self.core.run_at_timer(when).await
     }
 
     // More methods will be added in the future as needed.

--- a/rust/otap-dataflow/crates/engine/src/shared/receiver.rs
+++ b/rust/otap-dataflow/crates/engine/src/shared/receiver.rs
@@ -42,6 +42,7 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::time::Duration;
 use tokio::net::TcpListener;
+use tokio::time::Instant;
 
 /// A trait for ingress receivers (Send definition).
 ///
@@ -203,6 +204,17 @@ impl<PData> EffectHandler<PData> {
         duration: Duration,
     ) -> Result<TimerCancelHandle, Error<PData>> {
         self.core.start_periodic_timer(duration).await
+    }
+
+    /// Schedules a cancellable non-recurring timer that emits TimerTick at the specified time.
+    /// Returns a handle that can be used to cancel the timer.
+    ///
+    /// Current limitation: Only one timer can be started by a receiver at a time.
+    pub async fn run_timer_at(
+        &self,
+        when: Instant,
+    ) -> Result<TimerCancelHandle, Error<PData>> {
+        self.core.run_at_timer(when).await
     }
 
     // More methods will be added in the future as needed.


### PR DESCRIPTION
This is partly a test of whether I understand the existing style and code base :-)

Part of #919, a prerequisite for the approach described in the conversation quoted there.

----

As an aside, the `#[allow(dead_code)]` annotations have confused me for a while. I noticed something new in this PR:

I had added run_at_timer() in the effect handler: looked like dead code
I had added run_at_timer() in tests: still looked like dead code
I had added run_at_timer() in each of the local and shared components: no longer dead code

Actually still dead code, by my understanding of the logic. How come adding unused code in a sub-module causes the code to appear used?