### PR TITLE
[perf-exporter] fix perf otlp signal counting

### DIFF
--- a/rust/otap-dataflow/crates/otap/src/perf_exporter/exporter.rs
+++ b/rust/otap-dataflow/crates/otap/src/perf_exporter/exporter.rs
@@ -323,10 +323,11 @@ impl local::Exporter<OtapPdata> for PerfExporter {
                     received_arrow_records_count += batch.arrow_payloads.len() as u64;
                     total_received_arrow_records_count += batch.arrow_payloads.len() as u128;
                     // increment counters for otlp signals
-                    let batch_received_otlp_signal_count = match calculate_otlp_signal_count(&mut batch) {
-                        Ok(count) => count,
-                        Err(_) => 0, // Set to 0 if there's an error
-                    };
+                    let batch_received_otlp_signal_count =
+                        match calculate_otlp_signal_count(&mut batch) {
+                            Ok(count) => count,
+                            Err(_) => 0, // Set to 0 if there's an error
+                        };
                     received_otlp_signal_count += batch_received_otlp_signal_count;
                     total_received_otlp_signal_count += batch_received_otlp_signal_count as u128;
                 }

--- a/rust/otap-dataflow/crates/otap/src/perf_exporter/exporter.rs
+++ b/rust/otap-dataflow/crates/otap/src/perf_exporter/exporter.rs
@@ -826,7 +826,7 @@ mod tests {
     ) -> std::pin::Pin<Box<dyn Future<Output = ()>>> {
         |_, exporter_result| {
             Box::pin(async move {
-                assert!(exporter_result.is_ok(), "{}", exporter_result.unwrap_err());
+                assert!(exporter_result.is_ok());
 
                 // get a file to read and validate the output
                 // open file
@@ -851,7 +851,7 @@ mod tests {
                 assert!(total_msg_line.contains("- total arrow records received"),);
 
                 let otlp_signal_throughput_line = &lines[4];
-                assert!(otlp_signal_throughput_line.contains("- otlp signal throughput"));
+                assert!(otlp_signal_throughput_line.contains("- otlp signal throughput"),);
 
                 let total_otlp_signal_line = &lines[5];
                 assert!(total_otlp_signal_line.contains("- total otlp signal received"),);

--- a/rust/otap-dataflow/crates/otap/src/perf_exporter/exporter.rs
+++ b/rust/otap-dataflow/crates/otap/src/perf_exporter/exporter.rs
@@ -321,13 +321,14 @@ impl local::Exporter<OtapPdata> for PerfExporter {
 
                     // increment counters for received arrow payloads
                     received_arrow_records_count += batch.arrow_payloads.len() as u64;
-                    total_received_arrow_records_count += received_arrow_records_count as u128;
+                    total_received_arrow_records_count += batch.arrow_payloads.len() as u128;
                     // increment counters for otlp signals
-                    let received_otlp_signal_count = match calculate_otlp_signal_count(&mut batch) {
+                    let batch_received_otlp_signal_count = match calculate_otlp_signal_count(&mut batch) {
                         Ok(count) => count,
                         Err(_) => 0, // Set to 0 if there's an error
                     };
-                    total_received_otlp_signal_count += received_otlp_signal_count as u128;
+                    received_otlp_signal_count += batch_received_otlp_signal_count;
+                    total_received_otlp_signal_count += batch_received_otlp_signal_count as u128;
                 }
                 _ => {
                     return Err(Error::ExporterError {


### PR DESCRIPTION
Related to #927.

This PR updates the perf exporter calculations:
- Count otlp signals instead of bytes
- Increment total counters by current batch/signal size instead of accumulated batch/signal size for this interval on each new batch.

Will update tests in a subsequent PR (planning to move some code in parquet-exporter/tests around to support this, so splitting it up to keep it more manageable).