### PR TITLE
[otap-dataflow] move otap datagen test files to fixtures.rs and perf exporter test refactor

### DIFF
--- a/rust/otap-dataflow/crates/otap/src/fixtures.rs
+++ b/rust/otap-dataflow/crates/otap/src/fixtures.rs
@@ -1,19 +1,20 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::sync::Arc;
-
 use arrow::array::{
     ArrowPrimitiveType, FixedSizeBinaryArray, PrimitiveArray, RecordBatch, StringArray,
     TimestampNanosecondArray, UInt8Array,
 };
 use arrow::datatypes::{DataType, Field, Schema, TimeUnit, UInt16Type, UInt32Type};
 use arrow_ipc::writer::StreamWriter;
+use fluke_hpack::Encoder;
 use otel_arrow_rust::otlp::attributes::store::AttributeValueType;
 use otel_arrow_rust::proto::opentelemetry::arrow::v1::BatchArrowRecords;
 use otel_arrow_rust::proto::opentelemetry::arrow::v1::{ArrowPayload, ArrowPayloadType};
 use otel_arrow_rust::schema::consts::{self, metadata};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 pub struct SimpleDataGenOptions {
     pub id_offset: u16,
@@ -22,6 +23,7 @@ pub struct SimpleDataGenOptions {
     pub with_main_record_attrs: bool,
     pub with_resource_attrs: bool,
     pub with_scope_attrs: bool,
+    pub with_timestamp_header: bool,
 
     pub ids_decoded: bool,
 
@@ -63,6 +65,7 @@ impl Default for SimpleDataGenOptions {
             with_main_record_attrs: true,
             with_resource_attrs: true,
             with_scope_attrs: true,
+            with_timestamp_header: true,
             ids_decoded: true,
             traces_options: None,
             metrics_options: None,
@@ -139,10 +142,31 @@ pub fn create_simple_logs_arrow_record_batches(options: SimpleDataGenOptions) ->
         });
     }
 
+    let mut headers = Vec::new();
+    if options.with_timestamp_header {
+        let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+        let secs = timestamp.as_secs().to_string();
+        let nanos = timestamp.subsec_nanos().to_string();
+        let timestamp_string = format!("{secs}:{nanos}");
+
+        headers.push((b"timestamp".to_vec(), timestamp_string.into_bytes()));
+    }
+
+    let encoded_headers = if !headers.is_empty() {
+        let mut encoder = Encoder::new();
+        let borrowed_headers: Vec<(&[u8], &[u8])> = headers
+            .iter()
+            .map(|(k, v)| (k.as_slice(), v.as_slice()))
+            .collect();
+        encoder.encode(borrowed_headers)
+    } else {
+        Vec::new()
+    };
+
     BatchArrowRecords {
         batch_id: 0,
         arrow_payloads,
-        headers: Vec::default(),
+        headers: encoded_headers,
     }
 }
 

--- a/rust/otap-dataflow/crates/otap/src/fixtures.rs
+++ b/rust/otap-dataflow/crates/otap/src/fixtures.rs
@@ -142,16 +142,6 @@ pub fn create_simple_logs_arrow_record_batches(options: SimpleDataGenOptions) ->
         });
     }
 
-    let mut headers = Vec::new();
-    if options.with_timestamp_header {
-        let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-        let secs = timestamp.as_secs().to_string();
-        let nanos = timestamp.subsec_nanos().to_string();
-        let timestamp_string = format!("{secs}:{nanos}");
-
-        headers.push((b"timestamp".to_vec(), timestamp_string.into_bytes()));
-    }
-
     let encoded_headers = generate_encoded_headers(&options);
 
     BatchArrowRecords {

--- a/rust/otap-dataflow/crates/otap/src/lib.rs
+++ b/rust/otap-dataflow/crates/otap/src/lib.rs
@@ -37,6 +37,9 @@ pub mod fake_data_generator;
 #[cfg(test)]
 mod mock;
 
+#[cfg(test)]
+mod fixtures;
+
 /// Signal-type router processor (OTAP-based)
 pub mod signal_type_router;
 

--- a/rust/otap-dataflow/crates/otap/src/parquet_exporter.rs
+++ b/rust/otap-dataflow/crates/otap/src/parquet_exporter.rs
@@ -205,7 +205,7 @@ mod test {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use datagen::SimpleDataGenOptions;
+    use fixtures::SimpleDataGenOptions;
     use futures::StreamExt;
     use otap_df_config::node::NodeUserConfig;
     use otap_df_engine::exporter::ExporterWrapper;
@@ -214,7 +214,7 @@ mod test {
     use parquet::arrow::async_reader::ParquetRecordBatchStreamBuilder;
     use tokio::fs::File;
 
-    pub mod datagen;
+    use crate::fixtures;
 
     fn logs_scenario(
         num_rows: usize,
@@ -223,7 +223,7 @@ mod test {
         move |ctx| {
             Box::pin(async move {
                 let otap_batch = OtapArrowBytes::ArrowLogs(
-                    datagen::create_simple_logs_arrow_record_batches(SimpleDataGenOptions {
+                    fixtures::create_simple_logs_arrow_record_batches(SimpleDataGenOptions {
                         num_rows,
                         ..Default::default()
                     }),
@@ -442,7 +442,7 @@ mod test {
 
         let num_rows = 100;
         let otap_batch = OtapArrowBytes::ArrowTraces(
-            datagen::create_simple_trace_arrow_record_batches(SimpleDataGenOptions {
+            fixtures::create_simple_trace_arrow_record_batches(SimpleDataGenOptions {
                 num_rows,
                 traces_options: Some(Default::default()),
                 ..Default::default()
@@ -502,7 +502,7 @@ mod test {
 
         let num_rows = 100;
         let otap_batch = OtapArrowBytes::ArrowMetrics(
-            datagen::create_simple_metrics_arrow_record_batches(SimpleDataGenOptions {
+            fixtures::create_simple_metrics_arrow_record_batches(SimpleDataGenOptions {
                 num_rows,
                 metrics_options: Some(Default::default()),
                 ..Default::default()

--- a/rust/otap-dataflow/crates/otap/src/parquet_exporter/idgen.rs
+++ b/rust/otap-dataflow/crates/otap/src/parquet_exporter/idgen.rs
@@ -233,9 +233,8 @@ pub mod test {
     use otel_arrow_rust::schema::consts::metadata;
     use otel_arrow_rust::schema::get_schema_metadata;
 
-    use crate::parquet_exporter::test::datagen::SimpleDataGenOptions;
+    use crate::fixtures::{SimpleDataGenOptions, create_simple_logs_arrow_record_batches};
 
-    use super::super::test::datagen::create_simple_logs_arrow_record_batches;
     use super::*;
 
     #[test]

--- a/rust/otap-dataflow/crates/otap/src/parquet_exporter/writer.rs
+++ b/rust/otap-dataflow/crates/otap/src/parquet_exporter/writer.rs
@@ -385,10 +385,8 @@ mod test {
     use parquet::arrow::ParquetRecordBatchStreamBuilder;
     use tokio::fs::File;
 
-    use crate::parquet_exporter::{
-        partition::PartitionAttributeValue,
-        test::datagen::{SimpleDataGenOptions, create_simple_logs_arrow_record_batches},
-    };
+    use crate::fixtures::{SimpleDataGenOptions, create_simple_logs_arrow_record_batches};
+    use crate::parquet_exporter::partition::PartitionAttributeValue;
 
     fn to_logs_record_batch(mut bar: BatchArrowRecords) -> OtapArrowRecords {
         let mut consumer = Consumer::default();

--- a/rust/otap-dataflow/crates/otap/src/perf_exporter/README.md
+++ b/rust/otap-dataflow/crates/otap/src/perf_exporter/README.md
@@ -6,6 +6,7 @@ This crate will contain the implementation of the perf exporter.
 
 ## Example Output
 
+```text
 ====================Pipeline Report====================
     - arrow records throughput          : 0.00 arrow-records/s
     - average pipeline latency          : 0.00 s
@@ -65,3 +66,4 @@ Network Interface: anpi0
     - total errors on received          : 0 B
     - errors on transmitted             : 0 B/s
     - total errors on transmitted       : 0 B
+```

--- a/rust/otap-dataflow/crates/otap/src/perf_exporter/exporter.rs
+++ b/rust/otap-dataflow/crates/otap/src/perf_exporter/exporter.rs
@@ -649,7 +649,7 @@ async fn display_report_pipeline(
     writer
         .write(&format!(
             "\t- average pipeline latency          : {:.2} s\n",
-            average_pipeline_latency * 1000.0,
+            average_pipeline_latency,
         ))
         .await?;
 
@@ -694,72 +694,26 @@ async fn display_report_pipeline(
 #[cfg(test)]
 mod tests {
 
+    use crate::fixtures::{
+        SimpleDataGenOptions, create_simple_logs_arrow_record_batches,
+        create_simple_metrics_arrow_record_batches, create_simple_trace_arrow_record_batches,
+    };
     use crate::grpc::OtapArrowBytes;
     use crate::pdata::OtapPdata;
     use crate::perf_exporter::config::Config;
     use crate::perf_exporter::exporter::{OTAP_PERF_EXPORTER_URN, PerfExporter};
-    use fluke_hpack::Encoder;
     use otap_df_config::node::NodeUserConfig;
     use otap_df_engine::error::Error;
     use otap_df_engine::exporter::ExporterWrapper;
     use otap_df_engine::testing::exporter::TestContext;
     use otap_df_engine::testing::exporter::TestRuntime;
-    use otel_arrow_rust::proto::opentelemetry::arrow::v1::{
-        ArrowPayload, ArrowPayloadType, BatchArrowRecords,
-    };
+    use std::collections::HashMap;
     use std::fs::{File, remove_file};
     use std::future::Future;
     use std::io::{BufReader, prelude::*};
     use std::sync::Arc;
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use tempfile::NamedTempFile;
     use tokio::time::{Duration, sleep};
-
-    const TRACES_BATCH_ID: i64 = 0;
-    const LOGS_BATCH_ID: i64 = 1;
-    const METRICS_BATCH_ID: i64 = 2;
-    const ROW_SIZE: usize = 10;
-    const MESSAGE_LEN: usize = 5;
-
-    pub fn create_batch_arrow_record_helper(
-        batch_id: i64,
-        payload_type: ArrowPayloadType,
-        message_len: usize,
-        row_size: usize,
-    ) -> BatchArrowRecords {
-        // init arrow payload vec
-        let mut arrow_payloads = Vec::new();
-        // create ArrowPayload objects and add to the vector
-        for _ in 0..message_len {
-            let arrow_payload_object = ArrowPayload {
-                schema_id: "0".to_string(),
-                r#type: payload_type as i32,
-                record: vec![1; row_size],
-            };
-            arrow_payloads.push(arrow_payload_object);
-        }
-
-        // create timestamp
-        // unix timestamp -> get secs and nano secs -> format string as secs:nanos -> create byte array &[u8]
-        // decoding will do the opposite to get the latency
-        let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-
-        let secs = timestamp.as_secs().to_string();
-        let nanos = timestamp.subsec_nanos().to_string();
-
-        // string formatted with timestamp secs : timestamp subsec_nanos
-        let timestamp_string = format!("{secs}:{nanos}");
-        let timestamp_bytes = timestamp_string.as_bytes();
-
-        // convert time to
-        let headers = vec![(b"timestamp" as &[u8], timestamp_bytes)];
-        let mut encoder = Encoder::new();
-        let encoded_headers = encoder.encode(headers);
-        BatchArrowRecords {
-            batch_id,
-            arrow_payloads,
-            headers: encoded_headers,
-        }
-    }
 
     /// Test closure that simulates a typical test scenario by sending timer ticks, config,
     /// data message, and shutdown control messages.
@@ -769,25 +723,25 @@ mod tests {
         |ctx| {
             Box::pin(async move {
                 // send some messages to the exporter to calculate pipeline statistics
-                for _ in 0..3 {
-                    let traces_batch_data = create_batch_arrow_record_helper(
-                        TRACES_BATCH_ID,
-                        ArrowPayloadType::Spans,
-                        MESSAGE_LEN,
-                        ROW_SIZE,
-                    );
-                    let logs_batch_data = create_batch_arrow_record_helper(
-                        LOGS_BATCH_ID,
-                        ArrowPayloadType::Logs,
-                        MESSAGE_LEN,
-                        ROW_SIZE,
-                    );
-                    let metrics_batch_data = create_batch_arrow_record_helper(
-                        METRICS_BATCH_ID,
-                        ArrowPayloadType::UnivariateMetrics,
-                        MESSAGE_LEN,
-                        ROW_SIZE,
-                    );
+                for i in 0..3 {
+                    let traces_batch_data =
+                        create_simple_trace_arrow_record_batches(SimpleDataGenOptions {
+                            id_offset: 0 * i + 0,
+                            num_rows: 5,
+                            ..Default::default()
+                        });
+                    let logs_batch_data =
+                        create_simple_logs_arrow_record_batches(SimpleDataGenOptions {
+                            id_offset: 1 * i + 1,
+                            num_rows: 5,
+                            ..Default::default()
+                        });
+                    let metrics_batch_data =
+                        create_simple_metrics_arrow_record_batches(SimpleDataGenOptions {
+                            id_offset: 2 * i + 2,
+                            num_rows: 5,
+                            ..Default::default()
+                        });
                     // // Send a data message
                     ctx.send_pdata(OtapArrowBytes::ArrowTraces(traces_batch_data).into())
                         .await
@@ -837,6 +791,37 @@ mod tests {
                 for line in reader.lines() {
                     lines.push(line.unwrap());
                 }
+
+                // Check lines with batch / signal counts for correct values
+                let prefixes = vec![
+                    ("total_otlp", "\t- total otlp signal received"),
+                    ("total_pdata", "\t- total pdata batch received"),
+                ];
+                // Map to store the last match per pattern
+                let mut last_values: HashMap<&str, u32> = HashMap::new();
+                for line in &lines {
+                    for (key, prefix) in &prefixes {
+                        if line.starts_with(prefix) {
+                            if let Some((_prefix, value_str)) = line.split_once(":") {
+                                if let Ok(value) = value_str.trim().parse::<u32>() {
+                                    _ = last_values.insert(*key, value);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // 3 * 3 batches of 5 signals each = 9 batches, 45 signals
+                assert_eq!(
+                    last_values.get("total_otlp"),
+                    Some(&45),
+                    "Expected total otlp signal received to be 45"
+                );
+                assert_eq!(
+                    last_values.get("total_pdata"),
+                    Some(&9),
+                    "Expected total pdata batch received to be 9"
+                );
 
                 // report contains message throughput
                 let message_throughput_line = &lines[1];
@@ -899,7 +884,8 @@ mod tests {
     fn test_exporter_local() {
         let test_runtime = TestRuntime::new();
         let config = Config::new(1000, 0.3, true, true, true, true, true);
-        let output_file = "perf_output.txt".to_string();
+        let temp_file = NamedTempFile::new().expect("Failed to create temp file");
+        let output_file = temp_file.path().to_str().unwrap().to_string();
         let node_config = Arc::new(NodeUserConfig::new_exporter_config(OTAP_PERF_EXPORTER_URN));
         let exporter = ExporterWrapper::local(
             PerfExporter::new(config, Some(output_file.clone())),
@@ -911,8 +897,5 @@ mod tests {
             .set_exporter(exporter)
             .run_test(scenario())
             .run_validation(validation_procedure(output_file.clone()));
-
-        // remove the created file, prevent accidental check in of report
-        remove_file(output_file).expect("Failed to remove file\n");
     }
 }

--- a/rust/otap-dataflow/crates/otap/src/perf_exporter/exporter.rs
+++ b/rust/otap-dataflow/crates/otap/src/perf_exporter/exporter.rs
@@ -708,7 +708,7 @@ mod tests {
     use otap_df_engine::testing::exporter::TestContext;
     use otap_df_engine::testing::exporter::TestRuntime;
     use std::collections::HashMap;
-    use std::fs::{File, remove_file};
+    use std::fs::File;
     use std::future::Future;
     use std::io::{BufReader, prelude::*};
     use std::sync::Arc;

--- a/rust/otap-dataflow/crates/otap/src/perf_exporter/exporter.rs
+++ b/rust/otap-dataflow/crates/otap/src/perf_exporter/exporter.rs
@@ -726,19 +726,19 @@ mod tests {
                 for i in 0..3 {
                     let traces_batch_data =
                         create_simple_trace_arrow_record_batches(SimpleDataGenOptions {
-                            id_offset: 0 * i + 0,
+                            id_offset: 3 * i,
                             num_rows: 5,
                             ..Default::default()
                         });
                     let logs_batch_data =
                         create_simple_logs_arrow_record_batches(SimpleDataGenOptions {
-                            id_offset: 1 * i + 1,
+                            id_offset: 3 * i + 1,
                             num_rows: 5,
                             ..Default::default()
                         });
                     let metrics_batch_data =
                         create_simple_metrics_arrow_record_batches(SimpleDataGenOptions {
-                            id_offset: 2 * i + 2,
+                            id_offset: 3 * i + 2,
                             num_rows: 5,
                             ..Default::default()
                         });


### PR DESCRIPTION
Fixes #927.

This PR moves the parquet_exporter/test/datagen.rs code into the main otap library for shared test fixtures.

- Added header generation via options to all create_simple_*_arrow_record_batches functions
- Added config option for timestamp header generation (default true)
- Refactor of the perf_exporter tests to leverage the new fixtures.