### PR TITLE
minor: use "https" in the submodule's url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "proto/opentelemetry-proto"]
 	path = proto/opentelemetry-proto
-	url = git@github.com:open-telemetry/opentelemetry-proto.git
-    update = none
+	url = https://github.com/open-telemetry/opentelemetry-proto.git


### PR DESCRIPTION
instead of "git@" to avoid having to set a ssh key to build otel-arrow-rust. it can be a little annoying for ci