### PR TITLE
[query-engine] Remove unused timestamp fields from Record trait

### DIFF
--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/logs.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/logs.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, mem, time::SystemTime};
+use std::{collections::HashMap, mem};
 
 use data_engine_expressions::*;
 use data_engine_recordset::*;
@@ -31,16 +31,6 @@ impl RecordSet<LogRecord> for ExportLogsServiceRequest {
 }
 
 impl Record for LogRecord {
-    fn get_timestamp(&self) -> Option<SystemTime> {
-        self.timestamp.as_ref().map(|v| v.get_value().into())
-    }
-
-    fn get_observed_timestamp(&self) -> Option<SystemTime> {
-        self.observed_timestamp
-            .as_ref()
-            .map(|v| v.get_value().into())
-    }
-
     fn get_diagnostic_level(&self) -> Option<RecordSetEngineDiagnosticLevel> {
         self.diagnostic_level.clone()
     }

--- a/rust/experimental/query_engine/engine-recordset/src/engine.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/engine.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::HashMap,
     fmt::{Debug, Display, Write},
-    time::SystemTime,
 };
 
 use data_engine_expressions::*;
@@ -243,10 +242,6 @@ pub trait RecordSet<TRecord: Record>: Debug {
 }
 
 pub trait Record: MapValueMut + AsStaticValue {
-    fn get_timestamp(&self) -> Option<SystemTime>;
-
-    fn get_observed_timestamp(&self) -> Option<SystemTime>;
-
     fn get_diagnostic_level(&self) -> Option<RecordSetEngineDiagnosticLevel>;
 }
 

--- a/rust/experimental/query_engine/engine-recordset/src/test_helpers.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/test_helpers.rs
@@ -1,5 +1,5 @@
 #![cfg(test)]
-use std::{collections::HashMap, time::SystemTime};
+use std::collections::HashMap;
 
 use chrono::{DateTime, FixedOffset};
 use data_engine_expressions::*;
@@ -101,22 +101,6 @@ impl Default for TestRecord {
 }
 
 impl Record for TestRecord {
-    fn get_timestamp(&self) -> Option<SystemTime> {
-        if let Some(OwnedValue::DateTime(d)) = self.values.get("Timestamp") {
-            Some((*d.get_raw_value()).into())
-        } else {
-            None
-        }
-    }
-
-    fn get_observed_timestamp(&self) -> Option<SystemTime> {
-        if let Some(OwnedValue::DateTime(d)) = self.values.get("ObservedTimestamp") {
-            Some((*d.get_raw_value()).into())
-        } else {
-            None
-        }
-    }
-
     fn get_diagnostic_level(&self) -> Option<RecordSetEngineDiagnosticLevel> {
         None
     }


### PR DESCRIPTION
## Changes

* Remove unused timestamp fields from `Record` trait