### PR TITLE
[query-engine] Adds parsing of KQL substring expression onto Slice query expression

### DIFF
--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/tests/otlp_kql_recordset.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/tests/otlp_kql_recordset.rs
@@ -317,3 +317,44 @@ fn test_replace_string_function() {
         )
     );
 }
+
+#[test]
+fn test_substring_function() {
+    let run_test = |statement: &str, expected: &str| {
+        let log = LogRecord::new().with_attribute(
+            "greeting",
+            AnyValue::Native(OtlpAnyValue::StringValue(StringValueStorage::new(
+                "hello world".into(),
+            ))),
+        );
+
+        let mut request = ExportLogsServiceRequest::new().with_resource_logs(
+            ResourceLogs::new().with_scope_logs(ScopeLogs::new().with_log_record(log)),
+        );
+
+        let pipeline = data_engine_recordset_otlp_bridge::parse_kql_query_into_pipeline(
+            format!("source | extend e = {statement}").as_str(),
+        )
+        .unwrap();
+
+        let engine = RecordSetEngine::new_with_options(
+            RecordSetEngineOptions::new()
+                .with_diagnostic_level(RecordSetEngineDiagnosticLevel::Verbose),
+        );
+
+        let results = process_records(&pipeline, &engine, &mut request);
+
+        assert_eq!(results.included_records.len(), 1);
+        assert_eq!(results.dropped_records.len(), 0);
+
+        let log = results.included_records.first().unwrap().get_record();
+
+        assert_eq!(
+            expected,
+            log.attributes.get("e").unwrap().to_value().to_string()
+        );
+    };
+
+    run_test("substring(Attributes['greeting'], 6)", "world");
+    run_test("substring(Attributes['greeting'], 0, 5)", "hello");
+}

--- a/rust/experimental/query_engine/kql-parser/src/kql.pest
+++ b/rust/experimental/query_engine/kql-parser/src/kql.pest
@@ -93,8 +93,6 @@ boolean_expression = _{ true_literal | false_literal }
 real_expression = { "real(" ~ (positive_infinity_token|negative_infinity_token|double_literal|integer_literal) ~ ")" }
 datetime_expression = { "datetime(" ~ (string_literal|datetime_literal) ~ ")" }
 conditional_expression = { ("iff"|"iif") ~ "(" ~ logical_expression ~ "," ~ scalar_expression ~ "," ~ scalar_expression ~ ")" }
-strlen_expression = { "strlen" ~ "(" ~ scalar_expression ~ ")" }
-replace_string_expression = { "replace_string" ~ "(" ~ scalar_expression ~ "," ~ scalar_expression ~ "," ~ scalar_expression ~ ")" }
 case_expression = { "case" ~ "(" ~ logical_expression ~ "," ~ scalar_expression ~ ("," ~ logical_expression ~ "," ~ scalar_expression)* ~ "," ~ scalar_expression ~ ")" }
 
 tostring_expression = { "tostring" ~ "(" ~ scalar_expression ~ ")" }
@@ -114,14 +112,22 @@ conversion_expressions = _{
     | todouble_expression
 }
 
+strlen_expression = { "strlen" ~ "(" ~ scalar_expression ~ ")" }
+replace_string_expression = { "replace_string" ~ "(" ~ scalar_expression ~ "," ~ scalar_expression ~ "," ~ scalar_expression ~ ")" }
+substring_expression = { "substring" ~ "(" ~ scalar_expression ~ "," ~ scalar_expression ~ ("," ~ scalar_expression)? ~ ")" }
+string_expressions = _{
+	strlen_expression
+    | replace_string_expression
+    | substring_expression
+}
+
 scalar_expression = {
     null_literal
     | real_expression
     | datetime_expression
     | conditional_expression
     | conversion_expressions
-    | strlen_expression
-    | replace_string_expression
+    | string_expressions
     | case_expression
     | boolean_expression
     | double_literal

--- a/rust/experimental/query_engine/kql-parser/src/lib.rs
+++ b/rust/experimental/query_engine/kql-parser/src/lib.rs
@@ -7,6 +7,7 @@ pub(crate) mod scalar_conditional_function_expressions;
 pub(crate) mod scalar_conversion_function_expressions;
 pub(crate) mod scalar_expression;
 pub(crate) mod scalar_primitive_expressions;
+pub(crate) mod scalar_string_function_expressions;
 pub(crate) mod shared_expressions;
 pub(crate) mod tabular_expressions;
 

--- a/rust/experimental/query_engine/kql-parser/src/scalar_expression.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_expression.rs
@@ -5,7 +5,7 @@ use pest::iterators::Pair;
 use crate::{
     Rule, logical_expressions::parse_logical_expression,
     scalar_conditional_function_expressions::*, scalar_conversion_function_expressions::*,
-    scalar_primitive_expressions::*,
+    scalar_primitive_expressions::*, scalar_string_function_expressions::*,
 };
 
 pub(crate) fn parse_scalar_expression(
@@ -30,6 +30,7 @@ pub(crate) fn parse_scalar_expression(
         Rule::todouble_expression => parse_todouble_expression(scalar_rule, state)?,
         Rule::strlen_expression => parse_strlen_expression(scalar_rule, state)?,
         Rule::replace_string_expression => parse_replace_string_expression(scalar_rule, state)?,
+        Rule::substring_expression => parse_substring_expression(scalar_rule, state)?,
         Rule::case_expression => parse_case_expression(scalar_rule, state)?,
         Rule::true_literal | Rule::false_literal => {
             ScalarExpression::Static(parse_standard_bool_literal(scalar_rule))
@@ -64,43 +65,6 @@ pub(crate) fn parse_scalar_expression(
     };
 
     Ok(scalar)
-}
-
-pub(crate) fn parse_strlen_expression(
-    strlen_expression_rule: Pair<Rule>,
-    state: &ParserState,
-) -> Result<ScalarExpression, ParserError> {
-    let query_location = to_query_location(&strlen_expression_rule);
-
-    let mut strlen_rules = strlen_expression_rule.into_inner();
-    let inner_expression = strlen_rules.next().unwrap();
-
-    Ok(ScalarExpression::Length(LengthScalarExpression::new(
-        query_location,
-        parse_scalar_expression(inner_expression, state)?,
-    )))
-}
-
-pub(crate) fn parse_replace_string_expression(
-    replace_string_expression_rule: Pair<Rule>,
-    state: &ParserState,
-) -> Result<ScalarExpression, ParserError> {
-    let query_location = to_query_location(&replace_string_expression_rule);
-
-    let mut replace_string_rules = replace_string_expression_rule.into_inner();
-    let haystack_expression = replace_string_rules.next().unwrap();
-    let needle_expression = replace_string_rules.next().unwrap();
-    let replacement_expression = replace_string_rules.next().unwrap();
-
-    Ok(ScalarExpression::Text(TextScalarExpression::Replace(
-        ReplaceTextScalarExpression::new(
-            query_location,
-            parse_scalar_expression(haystack_expression, state)?,
-            parse_scalar_expression(needle_expression, state)?,
-            parse_scalar_expression(replacement_expression, state)?,
-            false, // case_insensitive - set to false for KQL
-        ),
-    )))
 }
 
 #[cfg(test)]
@@ -138,8 +102,6 @@ mod tests {
                 "timespan(null)",
                 "guid(null)",
                 "dynamic(null)",
-                "strlen(\"hello\")",
-                "replace_string(\"text\", \"old\", \"new\")",
                 "tostring(\"hello\")",
                 "tostring(42)",
             ],
@@ -314,38 +276,6 @@ mod tests {
             ScalarExpression::Static(StaticScalarExpression::Null(NullScalarExpression::new(
                 QueryLocation::new_fake(),
             ))),
-        );
-
-        run_test_success(
-            "strlen(\"hello\")",
-            ScalarExpression::Length(LengthScalarExpression::new(
-                QueryLocation::new_fake(),
-                ScalarExpression::Static(StaticScalarExpression::String(
-                    StringScalarExpression::new(QueryLocation::new_fake(), "hello"),
-                )),
-            )),
-        );
-
-        run_test_success(
-            "replace_string(\"A magic trick can turn a cat into a dog\", \"cat\", \"hamster\")",
-            ScalarExpression::Text(TextScalarExpression::Replace(
-                ReplaceTextScalarExpression::new(
-                    QueryLocation::new_fake(),
-                    ScalarExpression::Static(StaticScalarExpression::String(
-                        StringScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            "A magic trick can turn a cat into a dog",
-                        ),
-                    )),
-                    ScalarExpression::Static(StaticScalarExpression::String(
-                        StringScalarExpression::new(QueryLocation::new_fake(), "cat"),
-                    )),
-                    ScalarExpression::Static(StaticScalarExpression::String(
-                        StringScalarExpression::new(QueryLocation::new_fake(), "hamster"),
-                    )),
-                    false, // case_insensitive
-                ),
-            )),
         );
 
         run_test_success(

--- a/rust/experimental/query_engine/kql-parser/src/scalar_string_function_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_string_function_expressions.rs
@@ -1,0 +1,257 @@
+use data_engine_expressions::*;
+use data_engine_parser_abstractions::*;
+use pest::iterators::Pair;
+
+use crate::{Rule, scalar_expression::parse_scalar_expression};
+
+pub(crate) fn parse_strlen_expression(
+    strlen_expression_rule: Pair<Rule>,
+    state: &ParserState,
+) -> Result<ScalarExpression, ParserError> {
+    let query_location = to_query_location(&strlen_expression_rule);
+
+    let mut strlen_rules = strlen_expression_rule.into_inner();
+    let inner_expression = strlen_rules.next().unwrap();
+
+    Ok(ScalarExpression::Length(LengthScalarExpression::new(
+        query_location,
+        parse_scalar_expression(inner_expression, state)?,
+    )))
+}
+
+pub(crate) fn parse_replace_string_expression(
+    replace_string_expression_rule: Pair<Rule>,
+    state: &ParserState,
+) -> Result<ScalarExpression, ParserError> {
+    let query_location = to_query_location(&replace_string_expression_rule);
+
+    let mut replace_string_rules = replace_string_expression_rule.into_inner();
+    let haystack_expression = replace_string_rules.next().unwrap();
+    let needle_expression = replace_string_rules.next().unwrap();
+    let replacement_expression = replace_string_rules.next().unwrap();
+
+    Ok(ScalarExpression::Text(TextScalarExpression::Replace(
+        ReplaceTextScalarExpression::new(
+            query_location,
+            parse_scalar_expression(haystack_expression, state)?,
+            parse_scalar_expression(needle_expression, state)?,
+            parse_scalar_expression(replacement_expression, state)?,
+            false, // case_insensitive - set to false for KQL
+        ),
+    )))
+}
+
+pub(crate) fn parse_substring_expression(
+    substring_expression_rule: Pair<Rule>,
+    state: &ParserState,
+) -> Result<ScalarExpression, ParserError> {
+    let query_location = to_query_location(&substring_expression_rule);
+
+    let mut substring_rules = substring_expression_rule.into_inner();
+    let source_scalar = parse_scalar_expression(substring_rules.next().unwrap(), state)?;
+    let starting_index_scalar = parse_scalar_expression(substring_rules.next().unwrap(), state)?;
+    let length_scalar = substring_rules
+        .next()
+        .map(|v| parse_scalar_expression(v, state))
+        .transpose()?;
+
+    let starting_index_value_type_result = starting_index_scalar
+        .try_resolve_value_type(state.get_pipeline())
+        .map_err(|e| ParserError::from(&e))?;
+
+    if let Some(v) = starting_index_value_type_result
+        && v != ValueType::Integer
+    {
+        return Err(ParserError::QueryLanguageDiagnostic {
+            location: query_location,
+            diagnostic_id: "KS134",
+            message: "The expression value must be an integer".into(),
+        });
+    }
+
+    if let Some(s) = length_scalar.as_ref() {
+        let length_scalar_value_type_result = s
+            .try_resolve_value_type(state.get_pipeline())
+            .map_err(|e| ParserError::from(&e))?;
+        if let Some(v) = length_scalar_value_type_result
+            && v != ValueType::Integer
+        {
+            return Err(ParserError::QueryLanguageDiagnostic {
+                location: query_location,
+                diagnostic_id: "KS134",
+                message: "The expression value must be an integer".into(),
+            });
+        }
+    }
+
+    Ok(ScalarExpression::Slice(SliceScalarExpression::new(
+        query_location,
+        source_scalar,
+        Some(starting_index_scalar),
+        length_scalar,
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use pest::Parser;
+
+    use crate::KqlPestParser;
+
+    use super::*;
+
+    #[test]
+    fn test_pest_parse_string_scalar_expression_rule() {
+        pest_test_helpers::test_pest_rule::<KqlPestParser, Rule>(
+            Rule::scalar_expression,
+            &[
+                "strlen(\"hello\")",
+                "replace_string(\"text\", \"old\", \"new\")",
+                "substring(\"hello world\", 0)",
+                "substring(\"hello world\", 0, 5)",
+            ],
+            &["!"],
+        );
+    }
+
+    #[test]
+    fn test_parse_strlen_expression() {
+        let run_test_success = |input: &str, expected: ScalarExpression| {
+            println!("Testing: {input}");
+
+            let state = ParserState::new(input);
+
+            let mut result = KqlPestParser::parse(Rule::scalar_expression, input).unwrap();
+
+            let expression = parse_scalar_expression(result.next().unwrap(), &state).unwrap();
+
+            assert_eq!(expected, expression);
+        };
+
+        run_test_success(
+            "strlen(\"hello\")",
+            ScalarExpression::Length(LengthScalarExpression::new(
+                QueryLocation::new_fake(),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "hello"),
+                )),
+            )),
+        );
+    }
+
+    #[test]
+    fn test_parse_replace_string_expression() {
+        let run_test_success = |input: &str, expected: ScalarExpression| {
+            println!("Testing: {input}");
+
+            let state = ParserState::new(input);
+
+            let mut result = KqlPestParser::parse(Rule::scalar_expression, input).unwrap();
+
+            let expression = parse_scalar_expression(result.next().unwrap(), &state).unwrap();
+
+            assert_eq!(expected, expression);
+        };
+
+        run_test_success(
+            "replace_string(\"A magic trick can turn a cat into a dog\", \"cat\", \"hamster\")",
+            ScalarExpression::Text(TextScalarExpression::Replace(
+                ReplaceTextScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    ScalarExpression::Static(StaticScalarExpression::String(
+                        StringScalarExpression::new(
+                            QueryLocation::new_fake(),
+                            "A magic trick can turn a cat into a dog",
+                        ),
+                    )),
+                    ScalarExpression::Static(StaticScalarExpression::String(
+                        StringScalarExpression::new(QueryLocation::new_fake(), "cat"),
+                    )),
+                    ScalarExpression::Static(StaticScalarExpression::String(
+                        StringScalarExpression::new(QueryLocation::new_fake(), "hamster"),
+                    )),
+                    false, // case_insensitive
+                ),
+            )),
+        );
+    }
+
+    #[test]
+    fn test_parse_substring_expression() {
+        let run_test_success = |input: &str, expected: ScalarExpression| {
+            println!("Testing: {input}");
+
+            let state = ParserState::new(input);
+
+            let mut result = KqlPestParser::parse(Rule::scalar_expression, input).unwrap();
+
+            let expression = parse_scalar_expression(result.next().unwrap(), &state).unwrap();
+
+            assert_eq!(expected, expression);
+        };
+
+        let run_test_failure = |input: &str, expected_id: &str, expected_msg: &str| {
+            println!("Testing: {input}");
+
+            let state = ParserState::new(input);
+
+            let mut result = KqlPestParser::parse(Rule::scalar_expression, input).unwrap();
+
+            let error = parse_scalar_expression(result.next().unwrap(), &state).unwrap_err();
+
+            if let ParserError::QueryLanguageDiagnostic {
+                location: _,
+                diagnostic_id: id,
+                message: msg,
+            } = error
+            {
+                assert_eq!(expected_id, id);
+                assert_eq!(expected_msg, msg);
+            } else {
+                panic!("Expected QueryLanguageDiagnostic");
+            }
+        };
+
+        run_test_success(
+            "substring('asdf', 0)",
+            ScalarExpression::Slice(SliceScalarExpression::new(
+                QueryLocation::new_fake(),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "asdf"),
+                )),
+                Some(ScalarExpression::Static(StaticScalarExpression::Integer(
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 0),
+                ))),
+                None,
+            )),
+        );
+
+        run_test_success(
+            "substring('asdf', 0, 1)",
+            ScalarExpression::Slice(SliceScalarExpression::new(
+                QueryLocation::new_fake(),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "asdf"),
+                )),
+                Some(ScalarExpression::Static(StaticScalarExpression::Integer(
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 0),
+                ))),
+                Some(ScalarExpression::Static(StaticScalarExpression::Integer(
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+                ))),
+            )),
+        );
+
+        run_test_failure(
+            "substring('asdf', '0')",
+            "KS134",
+            "The expression value must be an integer",
+        );
+
+        run_test_failure(
+            "substring('asdf', 0, '0')",
+            "KS134",
+            "The expression value must be an integer",
+        );
+    }
+}


### PR DESCRIPTION
Relates to #722

## Changes

* Parse KQL `substring` onto Slice expression