### PR TITLE
[query-engine] Adds support for KQL coalesce expression

### DIFF
--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/tests/otlp_kql_recordset.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/tests/otlp_kql_recordset.rs
@@ -358,3 +358,59 @@ fn test_substring_function() {
     run_test("substring(Attributes['greeting'], 6)", "world");
     run_test("substring(Attributes['greeting'], 0, 5)", "hello");
 }
+
+#[test]
+fn test_coalesce_function() {
+    let run_test = |statement: &str, expected: &str| {
+        let log = LogRecord::new()
+            .with_attribute("null_key1", AnyValue::Null)
+            .with_attribute(
+                "string_key1",
+                AnyValue::Native(OtlpAnyValue::StringValue(StringValueStorage::new(
+                    "hello world".into(),
+                ))),
+            );
+
+        let mut request = ExportLogsServiceRequest::new().with_resource_logs(
+            ResourceLogs::new().with_scope_logs(ScopeLogs::new().with_log_record(log)),
+        );
+
+        let pipeline = data_engine_recordset_otlp_bridge::parse_kql_query_into_pipeline(
+            format!("source | extend e = {statement}").as_str(),
+        )
+        .unwrap();
+
+        let engine = RecordSetEngine::new_with_options(
+            RecordSetEngineOptions::new()
+                .with_diagnostic_level(RecordSetEngineDiagnosticLevel::Verbose),
+        );
+
+        let results = process_records(&pipeline, &engine, &mut request);
+
+        assert_eq!(results.included_records.len(), 1);
+        assert_eq!(results.dropped_records.len(), 0);
+
+        let log = results.included_records.first().unwrap().get_record();
+
+        assert_eq!(
+            expected,
+            log.attributes.get("e").unwrap().to_value().to_string()
+        );
+    };
+
+    run_test("coalesce('hello', 'world')", "hello");
+    run_test("coalesce(Attributes['null_key1'], 'world')", "world");
+    run_test(
+        "coalesce(Attributes['null_key1'], Attributes['null_key1'], 'world')",
+        "world",
+    );
+    run_test(
+        "coalesce(Attributes['null_key1'], Attributes['null_key1'], Attributes['null_key1'])",
+        "null",
+    );
+    run_test(
+        "coalesce(Attributes['null_key1'], Attributes['string_key1'])",
+        "hello world",
+    );
+    run_test("coalesce(tolong('invalid'), 18)", "18");
+}

--- a/rust/experimental/query_engine/kql-parser/src/kql.pest
+++ b/rust/experimental/query_engine/kql-parser/src/kql.pest
@@ -92,8 +92,15 @@ accessor_expression = { accessor ~ (("." ~ accessor)|accessor_index)* }
 boolean_expression = _{ true_literal | false_literal }
 real_expression = { "real(" ~ (positive_infinity_token|negative_infinity_token|double_literal|integer_literal) ~ ")" }
 datetime_expression = { "datetime(" ~ (string_literal|datetime_literal) ~ ")" }
+
 conditional_expression = { ("iff"|"iif") ~ "(" ~ logical_expression ~ "," ~ scalar_expression ~ "," ~ scalar_expression ~ ")" }
 case_expression = { "case" ~ "(" ~ logical_expression ~ "," ~ scalar_expression ~ ("," ~ logical_expression ~ "," ~ scalar_expression)* ~ "," ~ scalar_expression ~ ")" }
+coalesce_expression = { "coalesce" ~ "(" ~ scalar_expression ~ "," ~ scalar_expression ~ ("," ~ scalar_expression)* ~ ")" }
+conditional_expressions = _{
+    conditional_expression
+    | case_expression
+    | coalesce_expression
+}
 
 tostring_expression = { "tostring" ~ "(" ~ scalar_expression ~ ")" }
 toint_expression = { "toint" ~ "(" ~ scalar_expression ~ ")" }
@@ -118,7 +125,7 @@ strlen_expression = { "strlen" ~ "(" ~ scalar_expression ~ ")" }
 replace_string_expression = { "replace_string" ~ "(" ~ scalar_expression ~ "," ~ scalar_expression ~ "," ~ scalar_expression ~ ")" }
 substring_expression = { "substring" ~ "(" ~ scalar_expression ~ "," ~ scalar_expression ~ ("," ~ scalar_expression)? ~ ")" }
 string_expressions = _{
-	strlen_expression
+    strlen_expression
     | replace_string_expression
     | substring_expression
 }
@@ -127,10 +134,9 @@ scalar_expression = {
     null_literal
     | real_expression
     | datetime_expression
-    | conditional_expression
+    | conditional_expressions
     | conversion_expressions
     | string_expressions
-    | case_expression
     | boolean_expression
     | double_literal
     | integer_literal

--- a/rust/experimental/query_engine/kql-parser/src/scalar_conditional_function_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_conditional_function_expressions.rs
@@ -85,6 +85,36 @@ pub(crate) fn parse_case_expression(
     )))
 }
 
+pub(crate) fn parse_coalesce_expression(
+    coalesce_expression_rule: Pair<Rule>,
+    state: &ParserState,
+) -> Result<ScalarExpression, ParserError> {
+    let query_location = to_query_location(&coalesce_expression_rule);
+
+    let mut coalesce_rules = coalesce_expression_rule.into_inner();
+
+    let mut expressions = Vec::new();
+
+    expressions.push(parse_scalar_expression(
+        coalesce_rules.next().unwrap(),
+        state,
+    )?);
+
+    expressions.push(parse_scalar_expression(
+        coalesce_rules.next().unwrap(),
+        state,
+    )?);
+
+    for e in coalesce_rules {
+        expressions.push(parse_scalar_expression(e, state)?);
+    }
+
+    Ok(ScalarExpression::Coalesce(CoalesceScalarExpression::new(
+        query_location,
+        expressions,
+    )))
+}
+
 #[cfg(test)]
 mod tests {
     use pest::Parser;
@@ -315,6 +345,52 @@ mod tests {
                 ScalarExpression::Static(StaticScalarExpression::Integer(
                     IntegerScalarExpression::new(QueryLocation::new_fake(), 3),
                 )),
+            )),
+        );
+    }
+
+    #[test]
+    fn test_parse_coalesce_expression() {
+        let run_test_success = |input: &str, expected: ScalarExpression| {
+            let state = ParserState::new(input);
+
+            let mut result = KqlPestParser::parse(Rule::scalar_expression, input).unwrap();
+
+            let expression = parse_scalar_expression(result.next().unwrap(), &state).unwrap();
+
+            assert_eq!(expected, expression);
+        };
+
+        run_test_success(
+            "coalesce('one', 'two')",
+            ScalarExpression::Coalesce(CoalesceScalarExpression::new(
+                QueryLocation::new_fake(),
+                vec![
+                    ScalarExpression::Static(StaticScalarExpression::String(
+                        StringScalarExpression::new(QueryLocation::new_fake(), "one"),
+                    )),
+                    ScalarExpression::Static(StaticScalarExpression::String(
+                        StringScalarExpression::new(QueryLocation::new_fake(), "two"),
+                    )),
+                ],
+            )),
+        );
+
+        run_test_success(
+            "coalesce('one', 'two', 'three')",
+            ScalarExpression::Coalesce(CoalesceScalarExpression::new(
+                QueryLocation::new_fake(),
+                vec![
+                    ScalarExpression::Static(StaticScalarExpression::String(
+                        StringScalarExpression::new(QueryLocation::new_fake(), "one"),
+                    )),
+                    ScalarExpression::Static(StaticScalarExpression::String(
+                        StringScalarExpression::new(QueryLocation::new_fake(), "two"),
+                    )),
+                    ScalarExpression::Static(StaticScalarExpression::String(
+                        StringScalarExpression::new(QueryLocation::new_fake(), "three"),
+                    )),
+                ],
             )),
         );
     }

--- a/rust/experimental/query_engine/kql-parser/src/scalar_expression.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_expression.rs
@@ -21,6 +21,8 @@ pub(crate) fn parse_scalar_expression(
             ScalarExpression::Static(parse_datetime_expression(scalar_rule)?)
         }
         Rule::conditional_expression => parse_conditional_expression(scalar_rule, state)?,
+        Rule::case_expression => parse_case_expression(scalar_rule, state)?,
+        Rule::coalesce_expression => parse_coalesce_expression(scalar_rule, state)?,
         Rule::tostring_expression => parse_tostring_expression(scalar_rule, state)?,
         Rule::toint_expression => parse_toint_expression(scalar_rule, state)?,
         Rule::tobool_expression => parse_tobool_expression(scalar_rule, state)?,
@@ -32,7 +34,6 @@ pub(crate) fn parse_scalar_expression(
         Rule::strlen_expression => parse_strlen_expression(scalar_rule, state)?,
         Rule::replace_string_expression => parse_replace_string_expression(scalar_rule, state)?,
         Rule::substring_expression => parse_substring_expression(scalar_rule, state)?,
-        Rule::case_expression => parse_case_expression(scalar_rule, state)?,
         Rule::true_literal | Rule::false_literal => {
             ScalarExpression::Static(parse_standard_bool_literal(scalar_rule))
         }


### PR DESCRIPTION
## Changes

* Adds support for parsing KQL `coalesce` onto `ScalarExpression::Coalesce`