### PR TITLE
[query-engine] Add support for KQL parse_json expression

### DIFF
--- a/rust/experimental/query_engine/kql-parser/src/kql.pest
+++ b/rust/experimental/query_engine/kql-parser/src/kql.pest
@@ -124,10 +124,12 @@ conversion_expressions = _{
 strlen_expression = { "strlen" ~ "(" ~ scalar_expression ~ ")" }
 replace_string_expression = { "replace_string" ~ "(" ~ scalar_expression ~ "," ~ scalar_expression ~ "," ~ scalar_expression ~ ")" }
 substring_expression = { "substring" ~ "(" ~ scalar_expression ~ "," ~ scalar_expression ~ ("," ~ scalar_expression)? ~ ")" }
+parse_json_expression = { "parse_json" ~ "(" ~ scalar_expression ~ ")" }
 string_expressions = _{
     strlen_expression
     | replace_string_expression
     | substring_expression
+    | parse_json_expression
 }
 
 scalar_expression = {

--- a/rust/experimental/query_engine/kql-parser/src/scalar_expression.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_expression.rs
@@ -34,6 +34,7 @@ pub(crate) fn parse_scalar_expression(
         Rule::strlen_expression => parse_strlen_expression(scalar_rule, state)?,
         Rule::replace_string_expression => parse_replace_string_expression(scalar_rule, state)?,
         Rule::substring_expression => parse_substring_expression(scalar_rule, state)?,
+        Rule::parse_json_expression => parse_parse_json_expression(scalar_rule, state)?,
         Rule::true_literal | Rule::false_literal => {
             ScalarExpression::Static(parse_standard_bool_literal(scalar_rule))
         }

--- a/rust/experimental/query_engine/kql-parser/src/scalar_string_function_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_string_function_expressions.rs
@@ -92,6 +92,43 @@ pub(crate) fn parse_substring_expression(
     )))
 }
 
+pub(crate) fn parse_parse_json_expression(
+    parse_json_expression_rule: Pair<Rule>,
+    state: &ParserState,
+) -> Result<ScalarExpression, ParserError> {
+    let query_location = to_query_location(&parse_json_expression_rule);
+
+    let mut parse_json_rules = parse_json_expression_rule.into_inner();
+
+    let json_expression = parse_scalar_expression(parse_json_rules.next().unwrap(), state)?;
+
+    if let Some(v) = json_expression
+        .try_resolve_value_type(state.get_pipeline())
+        .map_err(|e| ParserError::from(&e))?
+        && v != ValueType::String
+    {
+        return Err(ParserError::QueryLanguageDiagnostic {
+            location: query_location,
+            diagnostic_id: "KS107",
+            message: "A value of type string expected".into(),
+        });
+    }
+
+    let parse_json_scalar = ScalarExpression::Parse(ParseScalarExpression::Json(
+        ParseJsonScalarExpression::new(query_location, json_expression),
+    ));
+
+    // Note: Call into try_resolve_static here is to try to validate the json
+    // string and bubble up any errors. It can be removed if/when expression
+    // tree gets constant folding which should automatically call into
+    // try_resolve_static.
+    parse_json_scalar
+        .try_resolve_static(state.get_pipeline())
+        .map_err(|e| ParserError::from(&e))?;
+
+    Ok(parse_json_scalar)
+}
+
 #[cfg(test)]
 mod tests {
     use pest::Parser;
@@ -252,6 +289,71 @@ mod tests {
             "substring('asdf', 0, '0')",
             "KS134",
             "The expression value must be an integer",
+        );
+    }
+
+    #[test]
+    fn test_parse_parse_json_expression() {
+        let run_test_success = |input: &str, expected: ScalarExpression| {
+            println!("Testing: {input}");
+
+            let state = ParserState::new(input);
+
+            let mut result = KqlPestParser::parse(Rule::scalar_expression, input).unwrap();
+
+            let expression = parse_scalar_expression(result.next().unwrap(), &state).unwrap();
+
+            assert_eq!(expected, expression);
+        };
+
+        let run_test_failure = |input: &str, expected_id: Option<&str>, expected_msg: &str| {
+            println!("Testing: {input}");
+
+            let state = ParserState::new(input);
+
+            let mut result = KqlPestParser::parse(Rule::scalar_expression, input).unwrap();
+
+            let error = parse_scalar_expression(result.next().unwrap(), &state).unwrap_err();
+
+            if let Some(eid) = expected_id {
+                if let ParserError::QueryLanguageDiagnostic {
+                    location: _,
+                    diagnostic_id: id,
+                    message: msg,
+                } = error
+                {
+                    assert_eq!(eid, id);
+                    assert_eq!(expected_msg, msg);
+                } else {
+                    panic!("Expected QueryLanguageDiagnostic");
+                }
+            } else if let ParserError::SyntaxError(_, msg) = error {
+                assert_eq!(expected_msg, msg);
+            } else {
+                panic!("Unexpected error");
+            }
+        };
+
+        run_test_success(
+            "parse_json('\"hello\"')",
+            ScalarExpression::Parse(ParseScalarExpression::Json(ParseJsonScalarExpression::new(
+                QueryLocation::new_fake(),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "\"hello\""),
+                )),
+            ))),
+        );
+
+        run_test_failure(
+            "parse_json(0)",
+            Some("KS107"),
+            "A value of type string expected",
+        );
+
+        run_test_failure(
+            "parse_json('[')",
+            None,
+            "Input could not be parsed as JSON: EOF while parsing a list at line 1 column 1",
         );
     }
 }


### PR DESCRIPTION
Relates to #722

## Changes

* Adds parsing of KQL `parse_json` expression onto `ParseJsonScalarExpression`