### PR TITLE
[query-engine] Improve validation in KQL string function parsing

### DIFF
--- a/rust/experimental/query_engine/kql-parser/src/scalar_string_function_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_string_function_expressions.rs
@@ -11,11 +11,28 @@ pub(crate) fn parse_strlen_expression(
     let query_location = to_query_location(&strlen_expression_rule);
 
     let mut strlen_rules = strlen_expression_rule.into_inner();
-    let inner_expression = strlen_rules.next().unwrap();
+
+    let inner_expression_rule = strlen_rules.next().unwrap();
+    let inner_expression_rule_location = to_query_location(&inner_expression_rule);
+    let inner_expression = parse_scalar_expression(inner_expression_rule, state)?;
+
+    let inner_expression_value_type_result = inner_expression
+        .try_resolve_value_type(state.get_pipeline())
+        .map_err(|e| ParserError::from(&e))?;
+
+    if let Some(v) = inner_expression_value_type_result
+        && v != ValueType::String
+    {
+        return Err(ParserError::QueryLanguageDiagnostic {
+            location: inner_expression_rule_location,
+            diagnostic_id: "KS141",
+            message: "The expression must have one of the types: string or dynamic".into(),
+        });
+    }
 
     Ok(ScalarExpression::Length(LengthScalarExpression::new(
         query_location,
-        parse_scalar_expression(inner_expression, state)?,
+        inner_expression,
     )))
 }
 
@@ -26,19 +43,41 @@ pub(crate) fn parse_replace_string_expression(
     let query_location = to_query_location(&replace_string_expression_rule);
 
     let mut replace_string_rules = replace_string_expression_rule.into_inner();
-    let haystack_expression = replace_string_rules.next().unwrap();
-    let needle_expression = replace_string_rules.next().unwrap();
-    let replacement_expression = replace_string_rules.next().unwrap();
 
-    Ok(ScalarExpression::Text(TextScalarExpression::Replace(
+    return Ok(ScalarExpression::Text(TextScalarExpression::Replace(
         ReplaceTextScalarExpression::new(
             query_location,
-            parse_scalar_expression(haystack_expression, state)?,
-            parse_scalar_expression(needle_expression, state)?,
-            parse_scalar_expression(replacement_expression, state)?,
+            parse_and_validate_string_rule(replace_string_rules.next().unwrap(), state)?,
+            parse_and_validate_string_rule(replace_string_rules.next().unwrap(), state)?,
+            parse_and_validate_string_rule(replace_string_rules.next().unwrap(), state)?,
             false, // case_insensitive - set to false for KQL
         ),
-    )))
+    )));
+
+    fn parse_and_validate_string_rule(
+        rule: Pair<Rule>,
+        state: &ParserState,
+    ) -> Result<ScalarExpression, ParserError> {
+        let location = to_query_location(&rule);
+
+        let scalar = parse_scalar_expression(rule, state)?;
+
+        let scalar_value_type_result = scalar
+            .try_resolve_value_type(state.get_pipeline())
+            .map_err(|e| ParserError::from(&e))?;
+
+        if let Some(v) = scalar_value_type_result
+            && v != ValueType::String
+        {
+            return Err(ParserError::QueryLanguageDiagnostic {
+                location,
+                diagnostic_id: "KS107",
+                message: "A value of type string expected".into(),
+            });
+        }
+
+        Ok(scalar)
+    }
 }
 
 pub(crate) fn parse_substring_expression(
@@ -49,11 +88,10 @@ pub(crate) fn parse_substring_expression(
 
     let mut substring_rules = substring_expression_rule.into_inner();
     let source_scalar = parse_scalar_expression(substring_rules.next().unwrap(), state)?;
-    let starting_index_scalar = parse_scalar_expression(substring_rules.next().unwrap(), state)?;
-    let length_scalar = substring_rules
-        .next()
-        .map(|v| parse_scalar_expression(v, state))
-        .transpose()?;
+
+    let starting_index_rule = substring_rules.next().unwrap();
+    let starting_index_rule_location = to_query_location(&starting_index_rule);
+    let starting_index_scalar = parse_scalar_expression(starting_index_rule, state)?;
 
     let starting_index_value_type_result = starting_index_scalar
         .try_resolve_value_type(state.get_pipeline())
@@ -63,26 +101,34 @@ pub(crate) fn parse_substring_expression(
         && v != ValueType::Integer
     {
         return Err(ParserError::QueryLanguageDiagnostic {
-            location: query_location,
+            location: starting_index_rule_location,
             diagnostic_id: "KS134",
             message: "The expression value must be an integer".into(),
         });
     }
 
-    if let Some(s) = length_scalar.as_ref() {
-        let length_scalar_value_type_result = s
+    let length_scalar = if let Some(length_rule) = substring_rules.next() {
+        let length_scalar_rule_location = to_query_location(&length_rule);
+        let length_scalar = parse_scalar_expression(length_rule, state)?;
+
+        let length_scalar_value_type_result = length_scalar
             .try_resolve_value_type(state.get_pipeline())
             .map_err(|e| ParserError::from(&e))?;
+
         if let Some(v) = length_scalar_value_type_result
             && v != ValueType::Integer
         {
             return Err(ParserError::QueryLanguageDiagnostic {
-                location: query_location,
+                location: length_scalar_rule_location,
                 diagnostic_id: "KS134",
                 message: "The expression value must be an integer".into(),
             });
         }
-    }
+
+        Some(length_scalar)
+    } else {
+        None
+    };
 
     Ok(ScalarExpression::Slice(SliceScalarExpression::new(
         query_location,
@@ -100,22 +146,24 @@ pub(crate) fn parse_parse_json_expression(
 
     let mut parse_json_rules = parse_json_expression_rule.into_inner();
 
-    let json_expression = parse_scalar_expression(parse_json_rules.next().unwrap(), state)?;
+    let inner_rule = parse_json_rules.next().unwrap();
+    let inner_rule_location = to_query_location(&inner_rule);
+    let inner_scalar = parse_scalar_expression(inner_rule, state)?;
 
-    if let Some(v) = json_expression
+    if let Some(v) = inner_scalar
         .try_resolve_value_type(state.get_pipeline())
         .map_err(|e| ParserError::from(&e))?
         && v != ValueType::String
     {
         return Err(ParserError::QueryLanguageDiagnostic {
-            location: query_location,
+            location: inner_rule_location,
             diagnostic_id: "KS107",
             message: "A value of type string expected".into(),
         });
     }
 
     let parse_json_scalar = ScalarExpression::Parse(ParseScalarExpression::Json(
-        ParseJsonScalarExpression::new(query_location, json_expression),
+        ParseJsonScalarExpression::new(query_location, inner_scalar),
     ));
 
     // Note: Call into try_resolve_static here is to try to validate the json
@@ -146,6 +194,7 @@ mod tests {
                 "replace_string(\"text\", \"old\", \"new\")",
                 "substring(\"hello world\", 0)",
                 "substring(\"hello world\", 0, 5)",
+                "parse_json(\"{\\\"key\\\": \\\"value\\\"}\")",
             ],
             &["!"],
         );
@@ -165,6 +214,28 @@ mod tests {
             assert_eq!(expected, expression);
         };
 
+        let run_test_failure = |input: &str, expected_id: &str, expected_msg: &str| {
+            println!("Testing: {input}");
+
+            let state = ParserState::new(input);
+
+            let mut result = KqlPestParser::parse(Rule::scalar_expression, input).unwrap();
+
+            let error = parse_scalar_expression(result.next().unwrap(), &state).unwrap_err();
+
+            if let ParserError::QueryLanguageDiagnostic {
+                location: _,
+                diagnostic_id: id,
+                message: msg,
+            } = error
+            {
+                assert_eq!(expected_id, id);
+                assert_eq!(expected_msg, msg);
+            } else {
+                panic!("Expected QueryLanguageDiagnostic");
+            }
+        };
+
         run_test_success(
             "strlen(\"hello\")",
             ScalarExpression::Length(LengthScalarExpression::new(
@@ -173,6 +244,12 @@ mod tests {
                     StringScalarExpression::new(QueryLocation::new_fake(), "hello"),
                 )),
             )),
+        );
+
+        run_test_failure(
+            "strlen(1)",
+            "KS141",
+            "The expression must have one of the types: string or dynamic",
         );
     }
 
@@ -188,6 +265,28 @@ mod tests {
             let expression = parse_scalar_expression(result.next().unwrap(), &state).unwrap();
 
             assert_eq!(expected, expression);
+        };
+
+        let run_test_failure = |input: &str, expected_id: &str, expected_msg: &str| {
+            println!("Testing: {input}");
+
+            let state = ParserState::new(input);
+
+            let mut result = KqlPestParser::parse(Rule::scalar_expression, input).unwrap();
+
+            let error = parse_scalar_expression(result.next().unwrap(), &state).unwrap_err();
+
+            if let ParserError::QueryLanguageDiagnostic {
+                location: _,
+                diagnostic_id: id,
+                message: msg,
+            } = error
+            {
+                assert_eq!(expected_id, id);
+                assert_eq!(expected_msg, msg);
+            } else {
+                panic!("Expected QueryLanguageDiagnostic");
+            }
         };
 
         run_test_success(
@@ -210,6 +309,22 @@ mod tests {
                     false, // case_insensitive
                 ),
             )),
+        );
+
+        run_test_failure(
+            "replace_string(1, 'hello', 'world')",
+            "KS107",
+            "A value of type string expected",
+        );
+        run_test_failure(
+            "replace_string('hello world', 1, 'world')",
+            "KS107",
+            "A value of type string expected",
+        );
+        run_test_failure(
+            "replace_string('hello world', 'hello', 1)",
+            "KS107",
+            "A value of type string expected",
         );
     }
 


### PR DESCRIPTION
## Changes

* Adds parameter validation in `strlen` and `replace_string`
* Adjust the query location to point to the inner expression instead of the root rule in `substring` and `parse_json`