### PR TITLE
fix: golang OTAP decoding logs handles optional trace ID and span ID columns

### DIFF
--- a/go/pkg/otel/logs/otlp/logs.go
+++ b/go/pkg/otel/logs/otlp/logs.go
@@ -133,14 +133,14 @@ func LogsFrom(record arrow.Record, relatedData *RelatedData) (plog.Logs, error) 
 		if err != nil {
 			return logs, werror.WrapWithContext(err, map[string]interface{}{"row": row})
 		}
-		if len(traceID) != 16 {
+		if traceID != nil && len(traceID) != 16 {
 			return logs, werror.WrapWithContext(common.ErrInvalidTraceIDLength, map[string]interface{}{"row": row, "traceID": traceID})
 		}
 		spanID, err := arrowutils.FixedSizeBinaryFromRecord(record, logRecordIDs.SpanID, row)
 		if err != nil {
 			return logs, werror.WrapWithContext(err, map[string]interface{}{"row": row})
 		}
-		if len(spanID) != 8 {
+		if spanID != nil && len(spanID) != 8 {
 			return logs, werror.WrapWithContext(common.ErrInvalidSpanIDLength, map[string]interface{}{"row": row, "spanID": spanID})
 		}
 

--- a/go/pkg/otel/logs/validation_test.go
+++ b/go/pkg/otel/logs/validation_test.go
@@ -109,7 +109,7 @@ func TestDecodingWithMissingOptionalTraceSpanIdFields(t *testing.T) {
 	require.Equal(t, 1, len(columnIndices))
 	spanIdColumnIndex := columnIndices[0]
 
-	// for column we're going to remove because traceID will get removed first below
+	// adjust index of column we're going to remove because traceID will get removed first below
 	if spanIdColumnIndex > traceIdColumnIndex {
 		spanIdColumnIndex -= 1
 	}


### PR DESCRIPTION
Fixes: #951 