### PR TITLE
[query-engine] Add support for KQL `parse` and `matches regex`

### DIFF
--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/tests/otlp_kql_recordset.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/tests/otlp_kql_recordset.rs
@@ -433,8 +433,7 @@ fn test_parse_function() {
 
     let query = "source | parse Attributes['message'] with \"Event:\" resourceName:string";
 
-    let pipeline =
-        data_engine_recordset_otlp_bridge::parse_kql_query_into_pipeline(&query).unwrap();
+    let pipeline = data_engine_recordset_otlp_bridge::parse_kql_query_into_pipeline(query).unwrap();
 
     let engine = RecordSetEngine::new_with_options(
         RecordSetEngineOptions::new()
@@ -493,8 +492,7 @@ fn test_matches_regex_function() {
 
     let query = "source | where Attributes['message'] matches regex 'Event: .*'";
 
-    let pipeline =
-        data_engine_recordset_otlp_bridge::parse_kql_query_into_pipeline(&query).unwrap();
+    let pipeline = data_engine_recordset_otlp_bridge::parse_kql_query_into_pipeline(query).unwrap();
 
     let engine = RecordSetEngine::new_with_options(
         RecordSetEngineOptions::new()

--- a/rust/experimental/query_engine/engine-recordset/src/scalars/text_scalar_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/scalars/text_scalar_expressions.rs
@@ -53,6 +53,164 @@ where
 
             Ok(v)
         }
+        TextScalarExpression::Match(m) => {
+            // Execute the input expression to get the string to match
+            let input_value =
+                execute_scalar_expression(execution_context, m.get_input_expression())?;
+            let input_string = match input_value.to_value() {
+                Value::String(s) => s.get_value(),
+                _ => {
+                    return Err(ExpressionError::ValidationFailure(
+                        m.get_query_location().clone(),
+                        format!(
+                            "Text match input must be a string, got: '{:?}'",
+                            input_value.get_value_type()
+                        ),
+                    ));
+                }
+            };
+
+            // Execute the pattern expression to get the regex
+            let pattern_value = execute_scalar_expression(execution_context, m.get_pattern())?;
+            let pattern_string = match pattern_value.to_value() {
+                Value::String(s) => s.get_value(),
+                _ => {
+                    return Err(ExpressionError::ValidationFailure(
+                        m.get_query_location().clone(),
+                        format!(
+                            "Text match pattern must be a string, got: '{:?}'",
+                            pattern_value.get_value_type()
+                        ),
+                    ));
+                }
+            };
+
+            // Compile the regex pattern
+            let regex = match regex::Regex::new(pattern_string) {
+                Ok(regex) => regex,
+                Err(e) => {
+                    return Err(ExpressionError::ValidationFailure(
+                        m.get_query_location().clone(),
+                        format!("Invalid regex pattern '{}': {}", pattern_string, e),
+                    ));
+                }
+            };
+
+            // Check if the regex matches the input string
+            let matches = regex.is_match(input_string);
+
+            let v = ResolvedValue::Computed(OwnedValue::Boolean(BooleanValueStorage::new(matches)));
+
+            execution_context.add_diagnostic_if_enabled(
+                RecordSetEngineDiagnosticLevel::Verbose,
+                text_scalar_expression,
+                || format!("Evaluated as: '{v}'"),
+            );
+
+            Ok(v)
+        }
+        TextScalarExpression::Extract(e) => {
+            // Execute the input expression to get the string to parse
+            let input_value =
+                execute_scalar_expression(execution_context, e.get_input_expression())?;
+            let input_string = match input_value.to_value() {
+                Value::String(s) => s.get_value(),
+                _ => {
+                    return Err(ExpressionError::ValidationFailure(
+                        e.get_query_location().clone(),
+                        format!(
+                            "Text extract input must be a string, got: '{:?}'",
+                            input_value.get_value_type()
+                        ),
+                    ));
+                }
+            };
+
+            // Execute the pattern expression to get the regex
+            let pattern_value =
+                execute_scalar_expression(execution_context, e.get_pattern_expression())?;
+            let pattern_string = match pattern_value.to_value() {
+                Value::String(s) => s.get_value(),
+                _ => {
+                    return Err(ExpressionError::ValidationFailure(
+                        e.get_query_location().clone(),
+                        format!(
+                            "Text extract pattern must be a string, got: '{:?}'",
+                            pattern_value.get_value_type()
+                        ),
+                    ));
+                }
+            };
+
+            // Execute the capture name or index expression
+            let capture_value =
+                execute_scalar_expression(execution_context, e.get_capture_name_or_index())?;
+
+            // Compile the regex pattern
+            let regex = match regex::Regex::new(pattern_string) {
+                Ok(regex) => regex,
+                Err(err) => {
+                    return Err(ExpressionError::ValidationFailure(
+                        e.get_query_location().clone(),
+                        format!("Invalid regex pattern '{}': {}", pattern_string, err),
+                    ));
+                }
+            };
+
+            // Apply the regex to the input string and extract the capture group
+            let v = if let Some(captures) = regex.captures(input_string) {
+                match capture_value.to_value() {
+                    Value::String(s) => {
+                        // Named capture group
+                        let capture_name = s.get_value();
+                        if let Some(matched) = captures.name(capture_name) {
+                            ResolvedValue::Computed(OwnedValue::String(StringValueStorage::new(
+                                matched.as_str().into(),
+                            )))
+                        } else {
+                            // Named capture group not found - return empty string
+                            ResolvedValue::Computed(OwnedValue::String(StringValueStorage::new(
+                                "".into(),
+                            )))
+                        }
+                    }
+                    Value::Integer(i) => {
+                        // Indexed capture group
+                        let index = i.get_value() as usize;
+                        if let Some(matched) = captures.get(index) {
+                            ResolvedValue::Computed(OwnedValue::String(StringValueStorage::new(
+                                matched.as_str().into(),
+                            )))
+                        } else {
+                            // Indexed capture group not found - return empty string
+                            ResolvedValue::Computed(OwnedValue::String(StringValueStorage::new(
+                                "".into(),
+                            )))
+                        }
+                    }
+                    _ => {
+                        return Err(ExpressionError::ValidationFailure(
+                            e.get_query_location().clone(),
+                            format!(
+                                "Text extract capture name or index must be a string or integer, got: '{:?}'",
+                                capture_value.get_value_type()
+                            ),
+                        ));
+                    }
+                }
+            } else {
+                // No match found - return empty string
+                ResolvedValue::Computed(OwnedValue::String(StringValueStorage::new("".into())))
+            };
+
+            execution_context.add_diagnostic_if_enabled(
+                RecordSetEngineDiagnosticLevel::Verbose,
+                text_scalar_expression,
+                || format!("Evaluated as: '{v}'"),
+            );
+
+            Ok(v)
+        }
     }
 }
 
@@ -360,6 +518,259 @@ mod tests {
                 QueryLocation::new_fake(),
                 "dog dog dog", // All variants of "cat" replaced
             )),
+        );
+    }
+
+    #[test]
+    fn test_execute_extract_text_scalar_expression() {
+        fn run_test(
+            input: ScalarExpression,
+            pattern: ScalarExpression,
+            capture: ScalarExpression,
+            expected: Value,
+        ) {
+            let e = ScalarExpression::Text(TextScalarExpression::Extract(
+                ExtractTextScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    input,
+                    pattern,
+                    capture,
+                ),
+            ));
+
+            let mut test = TestExecutionContext::new();
+            let execution_context = test.create_execution_context();
+            let result = execute_scalar_expression(&execution_context, &e).unwrap();
+
+            assert_eq!(result.to_value(), expected);
+        }
+
+        // Test named capture group extraction
+        run_test(
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "John Smith age 30",
+            ))),
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                r"(?P<name>\w+) (?P<lastname>\w+) age (?P<age>\d+)",
+            ))),
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "name",
+            ))),
+            Value::String(&StringValueStorage::new("John".into())),
+        );
+
+        // Test another named capture group
+        run_test(
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "John Smith age 30",
+            ))),
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                r"(?P<name>\w+) (?P<lastname>\w+) age (?P<age>\d+)",
+            ))),
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "age",
+            ))),
+            Value::String(&StringValueStorage::new("30".into())),
+        );
+
+        // Test indexed capture group (1 = first capture group)
+        run_test(
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "John Smith age 30",
+            ))),
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                r"(\w+) (\w+) age (\d+)",
+            ))),
+            ScalarExpression::Static(StaticScalarExpression::Integer(
+                IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+            )),
+            Value::String(&StringValueStorage::new("John".into())),
+        );
+
+        // Test indexed capture group (3 = third capture group)
+        run_test(
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "John Smith age 30",
+            ))),
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                r"(\w+) (\w+) age (\d+)",
+            ))),
+            ScalarExpression::Static(StaticScalarExpression::Integer(
+                IntegerScalarExpression::new(QueryLocation::new_fake(), 3),
+            )),
+            Value::String(&StringValueStorage::new("30".into())),
+        );
+
+        // Test non-existent named capture group - should return empty string
+        run_test(
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "John Smith age 30",
+            ))),
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                r"(?P<name>\w+) (?P<lastname>\w+) age (?P<age>\d+)",
+            ))),
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "nonexistent",
+            ))),
+            Value::String(&StringValueStorage::new("".into())),
+        );
+
+        // Test non-existent indexed capture group - should return empty string
+        run_test(
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "John Smith age 30",
+            ))),
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                r"(\w+) (\w+) age (\d+)",
+            ))),
+            ScalarExpression::Static(StaticScalarExpression::Integer(
+                IntegerScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    5, // Index 5 doesn't exist
+                ),
+            )),
+            Value::String(&StringValueStorage::new("".into())),
+        );
+
+        // Test no match - should return empty string
+        run_test(
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "This doesn't match",
+            ))),
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                r"(\w+) (\w+) age (\d+)",
+            ))),
+            ScalarExpression::Static(StaticScalarExpression::Integer(
+                IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+            )),
+            Value::String(&StringValueStorage::new("".into())),
+        );
+    }
+
+    #[test]
+    fn test_execute_match_text_scalar_expression() {
+        fn run_test(input: ScalarExpression, pattern: ScalarExpression, expected: bool) {
+            let e = ScalarExpression::Text(TextScalarExpression::Match(
+                MatchTextScalarExpression::new(QueryLocation::new_fake(), input, pattern),
+            ));
+
+            let mut test = TestExecutionContext::new();
+
+            let execution_context = test.create_execution_context();
+
+            let actual = execute_scalar_expression(&execution_context, &e).unwrap();
+            assert_eq!(
+                Value::Boolean(&BooleanValueStorage::new(expected)),
+                actual.to_value()
+            );
+        }
+
+        // Basic regex match - should match
+        run_test(
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "Event: NotifySliceRelease",
+            ))),
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "Event: .*",
+            ))),
+            true,
+        );
+
+        // Basic regex match - should not match
+        run_test(
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "Warning: Something happened",
+            ))),
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "Event: .*",
+            ))),
+            false,
+        );
+
+        // Case sensitive match
+        run_test(
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "hello world",
+            ))),
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "^[a-z ]+$",
+            ))),
+            true,
+        );
+
+        // Case sensitive match - should fail
+        run_test(
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "Hello World",
+            ))),
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "^[a-z ]+$",
+            ))),
+            false,
+        );
+
+        // Complex regex with character classes
+        run_test(
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "user123@example.com",
+            ))),
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                r"^[a-zA-Z0-9]+@[a-zA-Z0-9]+\.[a-zA-Z]{2,}$",
+            ))),
+            true,
+        );
+
+        // Empty string match
+        run_test(
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "",
+            ))),
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "^$",
+            ))),
+            true,
+        );
+
+        // No match
+        run_test(
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "This doesn't match anything",
+            ))),
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "^\\d+$",
+            ))),
+            false,
         );
     }
 }

--- a/rust/experimental/query_engine/kql-parser/src/kql.pest
+++ b/rust/experimental/query_engine/kql-parser/src/kql.pest
@@ -167,7 +167,7 @@ parse_expression = { "parse" ~ ("kind" ~ "=" ~ parse_kind)? ~ ("flags" ~ "=" ~ s
 parse_kind = { "simple" | "regex" | "relaxed" }
 parse_pattern = { parse_pattern_element ~ (parse_pattern_element)* }
 parse_pattern_element = { "*" | string_literal | parse_column_spec }
-parse_column_spec = { identifier_literal ~ ":" ~ identifier_literal }
+parse_column_spec = { identifier_literal ~ (":" ~ identifier_literal)? }
 
 average_aggregate_expression = {
     "avg" ~ "(" ~ scalar_expression ~ ")"

--- a/rust/experimental/query_engine/kql-parser/src/kql.pest
+++ b/rust/experimental/query_engine/kql-parser/src/kql.pest
@@ -37,6 +37,7 @@ not_has_token = @{ "!has" }
 not_has_cs_token = @{ "!has_cs" }
 not_in_token = @{ "!in" }
 not_in_insensitive_token = @{ "!in~" }
+matches_regex_token = { "matches" ~ "regex" }
 statement_end_token = { &";" }
 
 // Literals
@@ -149,7 +150,7 @@ scalar_expression = {
 }
 
 comparison_expression = {
-    scalar_expression ~ (not_contains_cs_token|not_contains_token|not_has_cs_token|not_has_token|contains_cs_token|contains_token|has_cs_token|has_token|equals_token|equals_insensitive_token|not_equals_token|not_equals_insensitive_token|greater_than_token|greater_than_or_equal_to_token|less_than_token|less_than_or_equal_to_token) ~ scalar_expression
+    scalar_expression ~ (not_contains_cs_token|not_contains_token|not_has_cs_token|not_has_token|contains_cs_token|contains_token|has_cs_token|has_token|equals_token|equals_insensitive_token|not_equals_token|not_equals_insensitive_token|greater_than_token|greater_than_or_equal_to_token|less_than_token|less_than_or_equal_to_token|matches_regex_token) ~ scalar_expression
     | scalar_expression ~ (not_in_insensitive_token|not_in_token|in_insensitive_token|in_token) ~ "(" ~ scalar_expression ~ ("," ~ scalar_expression)* ~ ")"
 }
 logical_expressions = _{ comparison_expression|scalar_expression }
@@ -162,6 +163,11 @@ project_expression = { "project" ~ (assignment_expression|accessor_expression) ~
 project_keep_expression = { "project-keep" ~ (identifier_or_pattern_literal|accessor_expression) ~ ("," ~ (identifier_or_pattern_literal|accessor_expression))* }
 project_away_expression = { "project-away" ~ (identifier_or_pattern_literal|accessor_expression) ~ ("," ~ (identifier_or_pattern_literal|accessor_expression))* }
 where_expression = { "where" ~ logical_expression }
+parse_expression = { "parse" ~ ("kind" ~ "=" ~ parse_kind)? ~ ("flags" ~ "=" ~ string_literal)? ~ scalar_expression ~ "with" ~ parse_pattern }
+parse_kind = { "simple" | "regex" | "relaxed" }
+parse_pattern = { parse_pattern_element ~ (parse_pattern_element)* }
+parse_pattern_element = { "*" | string_literal | parse_column_spec }
+parse_column_spec = { identifier_literal ~ ":" ~ identifier_literal }
 
 average_aggregate_expression = {
     "avg" ~ "(" ~ scalar_expression ~ ")"
@@ -208,6 +214,7 @@ tabular_expressions = _{
     | project_keep_expression
     | project_away_expression
     | where_expression
+    | parse_expression
     | summarize_expression
 }
 

--- a/rust/experimental/query_engine/kql-parser/src/tabular_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/tabular_expressions.rs
@@ -2592,11 +2592,20 @@ mod tests {
 
         // Test optional column types (should default to string when not specified)
         run_test("parse EventText with \"data:\" field", vec!["field"]);
-        run_test("parse EventText with \"*\" col1 \"*\" col2:int", vec!["col1", "col2"]);
-        run_test("parse EventText with \"name:\" userName \", id:\" userId:long", vec!["userName", "userId"]);
+        run_test(
+            "parse EventText with \"*\" col1 \"*\" col2:int",
+            vec!["col1", "col2"],
+        );
+        run_test(
+            "parse EventText with \"name:\" userName \", id:\" userId:long",
+            vec!["userName", "userId"],
+        );
 
         // Test that unsupported column types still default to string (no conversion)
-        run_test("parse EventText with \"data:\" field:unknown", vec!["field"]);
+        run_test(
+            "parse EventText with \"data:\" field:unknown",
+            vec!["field"],
+        );
 
         // Test grammar errors
         for invalid in ["parse", "parse EventText", "parse with \"*\" col:string"] {


### PR DESCRIPTION
Part of #722

Implements [parse](https://learn.microsoft.com/kusto/query/parse-operator?view=microsoft-fabric) and [matches regex](https://learn.microsoft.com/kusto/query/matches-regex-operator?view=microsoft-fabric).