### PR TITLE
Add decoding of OTAP Traces from OTLP Bytes

### DIFF
--- a/rust/otap-dataflow/crates/otap/src/encoder.rs
+++ b/rust/otap-dataflow/crates/otap/src/encoder.rs
@@ -952,7 +952,9 @@ mod test {
     use arrow::datatypes::{
         DataType, Field, Fields, Float64Type, Schema, TimeUnit, UInt8Type, UInt16Type, UInt64Type,
     };
+
     use otap_df_pdata_views::otlp::bytes::logs::RawLogsData;
+    use otap_df_pdata_views::otlp::bytes::traces::RawTraceData;
     use otel_arrow_rust::otlp::attributes::cbor::decode_pcommon_val;
     use otel_arrow_rust::otlp::attributes::store::AttributeValueType;
     use otel_arrow_rust::proto::opentelemetry::common::v1::{
@@ -962,6 +964,11 @@ mod test {
         LogRecord, LogRecordFlags, LogsData, ResourceLogs, ScopeLogs, SeverityNumber,
     };
     use otel_arrow_rust::proto::opentelemetry::resource::v1::Resource;
+    use otel_arrow_rust::proto::opentelemetry::trace::v1::{
+        ResourceSpans, ScopeSpans, Span, Status, TracesData,
+        span::{Event, Link, SpanKind},
+        status::StatusCode,
+    };
     use otel_arrow_rust::schema::{FieldExt, SpanId, TraceId, consts, no_nulls};
     use prost::Message;
 
@@ -3721,14 +3728,13 @@ mod test {
         _test_attributes_all_field_types_generic(RawLogsData::new(&logs_data_bytes));
     }
 
-    #[test]
-    fn test_spans_proto_struct() {
-        use otel_arrow_rust::proto::opentelemetry::trace::v1::*;
-
+    // TODO revist the imports here ...
+    fn _generate_traces_data_all_fields() -> TracesData {
         let a_trace_id: TraceId = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
         let a_span_id: SpanId = [17, 18, 19, 20, 21, 22, 23, 24];
         let a_parent_span_id: SpanId = [27, 28, 19, 20, 21, 22, 23, 24];
-        let traces_data = TracesData::new(vec![
+
+        TracesData::new(vec![
             ResourceSpans::build(
                 Resource::build(vec![KeyValue::new(
                     "attr1",
@@ -3762,10 +3768,10 @@ mod test {
                     .dropped_attributes_count(7u32)
                     .dropped_events_count(11u32)
                     .dropped_links_count(29u32)
-                    .kind(span::SpanKind::Consumer)
-                    .status(Status::new("something happened", status::StatusCode::Error))
+                    .kind(SpanKind::Consumer)
+                    .status(Status::new("something happened", StatusCode::Error))
                     .events(vec![
-                        span::Event::build("an_event", 456u64)
+                        Event::build("an_event", 456u64)
                             .attributes(vec![KeyValue::new(
                                 "event_attr1",
                                 AnyValue::new_string("hi"),
@@ -3774,7 +3780,7 @@ mod test {
                             .finish(),
                     ])
                     .links(vec![
-                        span::Link::build(a_trace_id.to_vec(), a_span_id.to_vec())
+                        Link::build(a_trace_id.to_vec(), a_span_id.to_vec())
                             .trace_state("some link state")
                             .dropped_attributes_count(567u32)
                             .flags(7u32)
@@ -3789,13 +3795,22 @@ mod test {
                 .finish(),
             ])
             .finish(),
-        ]);
+        ])
+    }
 
-        let otap_batch = encode_spans_otap_batch(&traces_data).unwrap();
+    fn _test_traces_data_all_fields<T>(traces_view: &T)
+    where
+        T: TracesView,
+    {
+        let a_trace_id: TraceId = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+        let a_span_id: SpanId = [17, 18, 19, 20, 21, 22, 23, 24];
+        let a_parent_span_id: SpanId = [27, 28, 19, 20, 21, 22, 23, 24];
+
+        let otap_batch = encode_spans_otap_batch(traces_view).unwrap();
 
         let expected_span_batch = RecordBatch::try_new(
             Arc::new(Schema::new(vec![
-                Field::new("id", DataType::UInt16, true),
+                Field::new("id", DataType::UInt16, true).with_plain_encoding(),
                 Field::new(
                     "resource",
                     DataType::Struct(
@@ -4034,7 +4049,7 @@ mod test {
                 // kind
                 Arc::new(DictionaryArray::<UInt8Type>::new(
                     UInt8Array::from(vec![0]),
-                    Arc::new(Int32Array::from(vec![span::SpanKind::Consumer as i32])),
+                    Arc::new(Int32Array::from(vec![SpanKind::Consumer as i32])),
                 )),
                 // dropped_attributes_count
                 Arc::new(UInt32Array::from(vec![7])) as ArrayRef,
@@ -4056,7 +4071,7 @@ mod test {
                         )),
                         Arc::new(DictionaryArray::<UInt8Type>::new(
                             UInt8Array::from(vec![0]),
-                            Arc::new(Int32Array::from(vec![status::StatusCode::Error as i32])),
+                            Arc::new(Int32Array::from(vec![StatusCode::Error as i32])),
                         )) as ArrayRef,
                     ),
                     // status message
@@ -4084,8 +4099,8 @@ mod test {
 
         let expected_events_batch = RecordBatch::try_new(
             Arc::new(Schema::new(vec![
-                Field::new("id", DataType::UInt32, true),
-                Field::new("parent_id", DataType::UInt16, false),
+                Field::new("id", DataType::UInt32, true).with_plain_encoding(),
+                Field::new("parent_id", DataType::UInt16, false).with_plain_encoding(),
                 Field::new(
                     "time_unix_nano",
                     DataType::Timestamp(TimeUnit::Nanosecond, None),
@@ -4121,8 +4136,8 @@ mod test {
 
         let expected_links_batch = RecordBatch::try_new(
             Arc::new(Schema::new(vec![
-                Field::new("id", DataType::UInt32, true),
-                Field::new("parent_id", DataType::UInt16, false),
+                Field::new("id", DataType::UInt32, true).with_plain_encoding(),
+                Field::new("parent_id", DataType::UInt16, false).with_plain_encoding(),
                 Field::new(
                     "trace_id",
                     DataType::Dictionary(
@@ -4266,6 +4281,20 @@ mod test {
         let link_attrs_rb = otap_batch.get(ArrowPayloadType::SpanLinkAttrs).unwrap();
         compare_record_batches(link_attrs_rb, &expected_link_attrs_batch);
         assert_eq!(link_attrs_rb, &expected_link_attrs_batch);
+    }
+
+    #[test]
+    fn test_spans_all_fields_proto_struct() {
+        let traces_view = _generate_traces_data_all_fields();
+        _test_traces_data_all_fields(&traces_view);
+    }
+
+    #[test]
+    fn test_traces_all_fields_proto_bytes() {
+        let traces_data = _generate_traces_data_all_fields();
+        let mut traces_data_bytes = vec![];
+        traces_data.encode(&mut traces_data_bytes).unwrap();
+        _test_traces_data_all_fields(&RawTraceData::new(&traces_data_bytes));
     }
 
     /// I'm a small helper function for examining differences between expected and under-test

--- a/rust/otap-dataflow/crates/otap/src/encoder.rs
+++ b/rust/otap-dataflow/crates/otap/src/encoder.rs
@@ -3728,7 +3728,6 @@ mod test {
         _test_attributes_all_field_types_generic(RawLogsData::new(&logs_data_bytes));
     }
 
-    // TODO revist the imports here ...
     fn _generate_traces_data_all_fields() -> TracesData {
         let a_trace_id: TraceId = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
         let a_span_id: SpanId = [17, 18, 19, 20, 21, 22, 23, 24];

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -664,6 +664,7 @@ mod test {
                 })
                 .spans(vec![
                     Span::build(u128::to_be_bytes(1), u64::to_be_bytes(1), "albert", 1u64)
+                        .end_time_unix_nano(4u64)
                         .status(Status::new("status1", StatusCode::Ok))
                         .attributes(vec![KeyValue::new("key", AnyValue::new_string("val1"))])
                         .links(vec![
@@ -694,6 +695,7 @@ mod test {
                         ])
                         .finish(),
                     Span::build(u128::to_be_bytes(2), u64::to_be_bytes(2), "terry", 2u64)
+                        .end_time_unix_nano(3u64)
                         .status(Status::new("status1", StatusCode::Ok))
                         .attributes(vec![KeyValue::new("key", AnyValue::new_string("val2"))])
                         .links(vec![
@@ -734,6 +736,7 @@ mod test {
                 })
                 .spans(vec![
                     Span::build(u128::to_be_bytes(3), u64::to_be_bytes(3), "albert", 3u64)
+                        .end_time_unix_nano(4u64)
                         .status(Status::new("status1", StatusCode::Ok))
                         .attributes(vec![KeyValue::new("key", AnyValue::new_string("val1"))])
                         .links(vec![
@@ -749,6 +752,7 @@ mod test {
                         ])
                         .finish(),
                     Span::build(u128::to_be_bytes(4), u64::to_be_bytes(4), "terry", 4u64)
+                        .end_time_unix_nano(5u64)
                         .status(Status::new("status1", StatusCode::Ok))
                         .attributes(vec![KeyValue::new("key", AnyValue::new_string("val4"))])
                         .links(vec![

--- a/rust/otap-dataflow/crates/pdata-views/src/otlp/bytes.rs
+++ b/rust/otap-dataflow/crates/pdata-views/src/otlp/bytes.rs
@@ -8,3 +8,4 @@ pub mod consts;
 pub mod decode;
 pub mod logs;
 pub mod resource;
+pub mod traces;

--- a/rust/otap-dataflow/crates/pdata-views/src/otlp/bytes/common.rs
+++ b/rust/otap-dataflow/crates/pdata-views/src/otlp/bytes/common.rs
@@ -17,8 +17,8 @@ use crate::otlp::bytes::consts::field_num::common::{
 use crate::otlp::bytes::consts::wire_types;
 use crate::otlp::bytes::decode::{
     FieldRanges, ProtoBytesParser, RepeatedFieldProtoBytesParser,
-    from_option_nonzero_range_to_primitive, read_fixed64, read_len_delim, read_varint,
-    to_nonzero_range,
+    from_option_nonzero_range_to_primitive, read_dropped_count, read_fixed64, read_len_delim,
+    read_varint, to_nonzero_range,
 };
 use crate::views::common::{AnyValueView, AttributeView, InstrumentationScopeView, ValueType};
 
@@ -523,17 +523,10 @@ impl InstrumentationScopeView for RawInstrumentationScope<'_> {
 
     #[inline]
     fn dropped_attributes_count(&self) -> u32 {
-        if let Some(slice) = self
+        let slice = self
             .bytes_parser
-            .advance_to_find_field(INSTRUMENTATION_DROPPED_ATTRIBUTES_COUNT)
-        {
-            if let Some((val, _)) = read_varint(slice, 0) {
-                return val as u32;
-            }
-        }
-
-        // default = 0 = no dropped attributes
-        0
+            .advance_to_find_field(INSTRUMENTATION_DROPPED_ATTRIBUTES_COUNT);
+        read_dropped_count(slice)
     }
 
     #[inline]

--- a/rust/otap-dataflow/crates/pdata-views/src/otlp/bytes/consts.rs
+++ b/rust/otap-dataflow/crates/pdata-views/src/otlp/bytes/consts.rs
@@ -70,4 +70,49 @@ pub mod field_num {
         pub const RESOURCE_ATTRIBUTES: u64 = 1;
         pub const RESOURCE_DROPPED_ATTRIBUTES_COUNT: u64 = 2;
     }
+
+    #[allow(missing_docs)]
+    pub mod traces {
+        pub const TRACES_DATA_RESOURCE_SPANS: u64 = 1;
+
+        pub const RESOURCE_SPANS_RESOURCE: u64 = 1;
+        pub const RESOURCE_SPANS_SCOPE_SPANS: u64 = 2;
+        pub const RESOURCE_SPANS_SCHEMA_URL: u64 = 3;
+
+        pub const SCOPE_SPANS_SCOPE: u64 = 1;
+        pub const SCOPE_SPANS_SPANS: u64 = 2;
+        pub const SCOPE_SPANS_SCHEMA_URL: u64 = 3;
+
+        pub const SPAN_TRACE_ID: u64 = 1;
+        pub const SPAN_SPAN_ID: u64 = 2;
+        pub const SPAN_TRACE_STATE: u64 = 3;
+        pub const SPAN_PARENT_SPAN_ID: u64 = 4;
+        pub const SPAN_NAME: u64 = 5;
+        pub const SPAN_KIND: u64 = 6;
+        pub const SPAN_START_TIME_UNIX_NANO: u64 = 7;
+        pub const SPAN_END_TIME_UNIX_NANO: u64 = 8;
+        pub const SPAN_ATTRIBUTES: u64 = 9;
+        pub const SPAN_DROPPED_ATTRIBUTES_COUNT: u64 = 10;
+        pub const SPAN_EVENTS: u64 = 11;
+        pub const SPAN_DROPPED_EVENTS_COUNT: u64 = 12;
+        pub const SPAN_LINKS: u64 = 13;
+        pub const SPAN_DROPPED_LINKS_COUNT: u64 = 14;
+        pub const SPAN_STATUS: u64 = 15;
+        pub const SPAN_FLAGS: u64 = 16;
+
+        pub const SPAN_EVENT_TIME_UNIX_NANO: u64 = 1;
+        pub const SPAN_EVENT_NAME: u64 = 2;
+        pub const SPAN_EVENT_ATTRIBUTES: u64 = 3;
+        pub const SPAN_EVENT_DROPPED_ATTRIBUTES_COUNTS: u64 = 4;
+
+        pub const SPAN_LINK_TRACE_ID: u64 = 1;
+        pub const SPAN_LINK_SPAN_ID: u64 = 2;
+        pub const SPAN_LINK_TRACE_STATE: u64 = 3;
+        pub const SPAN_LINK_ATTRIBUTES: u64 = 4;
+        pub const SPAN_LINK_DROPPED_ATTRIBUTES_COUNT: u64 = 5;
+        pub const SPAN_LINK_FLAGS: u64 = 6;
+
+        pub const SPAN_STATUS_MESSAGE: u64 = 2;
+        pub const SPAN_STATUS_CODE: u64 = 3;
+    }
 }

--- a/rust/otap-dataflow/crates/pdata-views/src/otlp/bytes/decode.rs
+++ b/rust/otap-dataflow/crates/pdata-views/src/otlp/bytes/decode.rs
@@ -379,3 +379,18 @@ pub fn read_fixed64(buf: &[u8], pos: usize) -> Option<(&[u8], usize)> {
     let slice = &buf[pos..end];
     Some((slice, end))
 }
+
+/// Fields like dropped_attributes_count, dropped_events_count and dropped_links count have
+/// all have this common logic where they're encoded as varints and interpreted to be zero if the
+/// field is missing. This helper encapsulates that logic
+#[inline]
+#[must_use]
+pub fn read_dropped_count(buf: Option<&[u8]>) -> u32 {
+    match buf {
+        Some(slice) => match read_varint(slice, 0) {
+            Some((val, _)) => val as u32,
+            None => 0,
+        },
+        None => 0,
+    }
+}

--- a/rust/otap-dataflow/crates/pdata-views/src/otlp/bytes/decode.rs
+++ b/rust/otap-dataflow/crates/pdata-views/src/otlp/bytes/decode.rs
@@ -380,9 +380,9 @@ pub fn read_fixed64(buf: &[u8], pos: usize) -> Option<(&[u8], usize)> {
     Some((slice, end))
 }
 
-/// Fields like dropped_attributes_count, dropped_events_count and dropped_links count have
-/// all have this common logic where they're encoded as varints and interpreted to be zero if the
-/// field is missing. This helper encapsulates that logic
+/// Fields like dropped_attributes_count, dropped_events_count and dropped_links count all have
+/// this common logic where they're encoded as varints and interpreted to be zero if the field
+/// is missing. This helper encapsulates that logic
 #[inline]
 #[must_use]
 pub fn read_dropped_count(buf: Option<&[u8]>) -> u32 {

--- a/rust/otap-dataflow/crates/pdata-views/src/otlp/bytes/resource.rs
+++ b/rust/otap-dataflow/crates/pdata-views/src/otlp/bytes/resource.rs
@@ -15,7 +15,7 @@ use crate::{
         },
         decode::{
             FieldRanges, ProtoBytesParser, RepeatedFieldProtoBytesParser,
-            from_option_nonzero_range_to_primitive, read_varint, to_nonzero_range,
+            from_option_nonzero_range_to_primitive, read_dropped_count, to_nonzero_range,
         },
     },
     views::resource::ResourceView,
@@ -105,16 +105,9 @@ impl ResourceView for RawResource<'_> {
 
     #[inline]
     fn dropped_attributes_count(&self) -> u32 {
-        if let Some(slice) = self
+        let slice = self
             .bytes_parser
-            .advance_to_find_field(RESOURCE_DROPPED_ATTRIBUTES_COUNT)
-        {
-            if let Some((val, _)) = read_varint(slice, 0) {
-                return val as u32;
-            }
-        }
-
-        // default = 0 = no attributes dropped
-        0
+            .advance_to_find_field(RESOURCE_DROPPED_ATTRIBUTES_COUNT);
+        read_dropped_count(slice)
     }
 }

--- a/rust/otap-dataflow/crates/pdata-views/src/otlp/bytes/traces.rs
+++ b/rust/otap-dataflow/crates/pdata-views/src/otlp/bytes/traces.rs
@@ -1,0 +1,943 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module contains the implementation of the pdata View traits for serialized OTLP protobuf
+//! bytes for the messages defined in trace.proto
+
+use std::{cell::Cell, num::NonZeroUsize};
+
+use otel_arrow_rust::{
+    proto::opentelemetry::trace::v1::{span::SpanKind, status::StatusCode},
+    schema::{SpanId, TraceId},
+};
+
+use crate::otlp::bytes::common::{KeyValueIter, RawInstrumentationScope, RawKeyValue};
+use crate::otlp::bytes::consts::field_num::traces::{
+    RESOURCE_SPANS_RESOURCE, RESOURCE_SPANS_SCHEMA_URL, RESOURCE_SPANS_SCOPE_SPANS,
+    SCOPE_SPANS_SCHEMA_URL, SCOPE_SPANS_SCOPE, SCOPE_SPANS_SPANS, SPAN_ATTRIBUTES,
+    SPAN_DROPPED_ATTRIBUTES_COUNT, SPAN_DROPPED_EVENTS_COUNT, SPAN_DROPPED_LINKS_COUNT,
+    SPAN_END_TIME_UNIX_NANO, SPAN_EVENT_ATTRIBUTES, SPAN_EVENT_DROPPED_ATTRIBUTES_COUNTS,
+    SPAN_EVENT_NAME, SPAN_EVENT_TIME_UNIX_NANO, SPAN_EVENTS, SPAN_FLAGS, SPAN_KIND,
+    SPAN_LINK_ATTRIBUTES, SPAN_LINK_DROPPED_ATTRIBUTES_COUNT, SPAN_LINK_FLAGS, SPAN_LINK_SPAN_ID,
+    SPAN_LINK_TRACE_ID, SPAN_LINK_TRACE_STATE, SPAN_LINKS, SPAN_NAME, SPAN_PARENT_SPAN_ID,
+    SPAN_SPAN_ID, SPAN_START_TIME_UNIX_NANO, SPAN_STATUS, SPAN_STATUS_CODE, SPAN_STATUS_MESSAGE,
+    SPAN_TRACE_ID, SPAN_TRACE_STATE, TRACES_DATA_RESOURCE_SPANS,
+};
+use crate::otlp::bytes::consts::wire_types;
+use crate::otlp::bytes::decode::{
+    FieldRanges, ProtoBytesParser, RepeatedFieldProtoBytesParser,
+    from_option_nonzero_range_to_primitive, read_dropped_count, read_len_delim, read_varint,
+    to_nonzero_range,
+};
+use crate::otlp::bytes::resource::RawResource;
+use crate::views::trace::{
+    EventView, LinkView, ResourceSpansView, ScopeSpansView, SpanView, StatusView, TracesView,
+};
+
+/// Implementation of [`TracesView`] backed by protobuf serialized `TracesData` message
+pub struct RawTraceData<'a> {
+    buf: &'a [u8],
+}
+
+impl<'a> RawTraceData<'a> {
+    /// Create a new [`RawTraceData`] instance
+    #[must_use]
+    pub fn new(buf: &'a [u8]) -> Self {
+        Self { buf }
+    }
+}
+
+/// Implementation of [`ResourceSpansView`] backed by protobuf serialized `ResourceSpans` message
+pub struct RawResourceSpans<'a> {
+    byte_parser: ProtoBytesParser<'a, ResourceSpansFieldRanges>,
+}
+
+/// Known field offsets within byte buffer for fields in `ResourceSpans` message
+pub struct ResourceSpansFieldRanges {
+    resource: Cell<Option<(NonZeroUsize, NonZeroUsize)>>,
+    schema_url: Cell<Option<(NonZeroUsize, NonZeroUsize)>>,
+    first_scope_spans: Cell<Option<(NonZeroUsize, NonZeroUsize)>>,
+}
+
+impl FieldRanges for ResourceSpansFieldRanges {
+    fn new() -> Self {
+        Self {
+            resource: Cell::new(None),
+            schema_url: Cell::new(None),
+            first_scope_spans: Cell::new(None),
+        }
+    }
+
+    fn get_field_range(&self, field_num: u64) -> Option<(usize, usize)> {
+        let range = match field_num {
+            RESOURCE_SPANS_RESOURCE => self.resource.get(),
+            RESOURCE_SPANS_SCHEMA_URL => self.schema_url.get(),
+            RESOURCE_SPANS_SCOPE_SPANS => self.first_scope_spans.get(),
+            _ => return None,
+        };
+
+        from_option_nonzero_range_to_primitive(range)
+    }
+
+    fn set_field_range(&self, field_num: u64, wire_type: u64, start: usize, end: usize) {
+        let range = match to_nonzero_range(start, end) {
+            Some(range) => range,
+            None => return,
+        };
+
+        if wire_type == wire_types::LEN {
+            match field_num {
+                RESOURCE_SPANS_RESOURCE => self.resource.set(Some(range)),
+                RESOURCE_SPANS_SCHEMA_URL => self.schema_url.set(Some(range)),
+                RESOURCE_SPANS_SCOPE_SPANS => {
+                    if self.first_scope_spans.get().is_none() {
+                        self.first_scope_spans.set(Some(range));
+                    }
+                }
+                _ => { /* ignore  */ }
+            }
+        }
+    }
+}
+
+/// Implementation of the [`ScopeSpansView`] backed by protobuf serialized `ScopeSpans` message
+pub struct RawScopeSpans<'a> {
+    byte_parser: ProtoBytesParser<'a, ScopeSpansFieldRanges>,
+}
+
+/// Known field offsets within byte buffer for fields in `ScopeSpans` message
+pub struct ScopeSpansFieldRanges {
+    scope: Cell<Option<(NonZeroUsize, NonZeroUsize)>>,
+    schema_url: Cell<Option<(NonZeroUsize, NonZeroUsize)>>,
+    first_span: Cell<Option<(NonZeroUsize, NonZeroUsize)>>,
+}
+
+impl FieldRanges for ScopeSpansFieldRanges {
+    fn new() -> Self {
+        Self {
+            scope: Cell::new(None),
+            schema_url: Cell::new(None),
+            first_span: Cell::new(None),
+        }
+    }
+
+    fn get_field_range(&self, field_num: u64) -> Option<(usize, usize)> {
+        let range = match field_num {
+            SCOPE_SPANS_SCOPE => self.scope.get(),
+            SCOPE_SPANS_SCHEMA_URL => self.schema_url.get(),
+            SCOPE_SPANS_SPANS => self.first_span.get(),
+            _ => return None,
+        };
+
+        from_option_nonzero_range_to_primitive(range)
+    }
+
+    fn set_field_range(&self, field_num: u64, wire_type: u64, start: usize, end: usize) {
+        let range = match to_nonzero_range(start, end) {
+            Some(range) => range,
+            None => return,
+        };
+
+        if wire_type == wire_types::LEN {
+            match field_num {
+                SCOPE_SPANS_SCOPE => self.scope.set(Some(range)),
+                SCOPE_SPANS_SCHEMA_URL => self.schema_url.set(Some(range)),
+                SCOPE_SPANS_SPANS => {
+                    if self.first_span.get().is_none() {
+                        self.first_span.set(Some(range));
+                    }
+                }
+                _ => { /* ignore  */ }
+            }
+        }
+    }
+}
+
+/// Implementation of [`SpanView`] backed by protobuf serialized `Span` message
+pub struct RawSpan<'a> {
+    bytes_parser: ProtoBytesParser<'a, SpanFieldRanges>,
+}
+
+/// Known field offsets within byte buffer for fields in `Span` message
+pub struct SpanFieldRanges {
+    scalar_fields: [Cell<Option<(NonZeroUsize, NonZeroUsize)>>; 17],
+    first_attribute: Cell<Option<(NonZeroUsize, NonZeroUsize)>>,
+    first_event: Cell<Option<(NonZeroUsize, NonZeroUsize)>>,
+    first_link: Cell<Option<(NonZeroUsize, NonZeroUsize)>>,
+}
+
+impl FieldRanges for SpanFieldRanges {
+    fn new() -> Self {
+        Self {
+            scalar_fields: std::array::from_fn(|_| Cell::new(None)),
+            first_attribute: Cell::new(None),
+            first_event: Cell::new(None),
+            first_link: Cell::new(None),
+        }
+    }
+
+    fn get_field_range(&self, field_num: u64) -> Option<(usize, usize)> {
+        let range = match field_num {
+            SPAN_ATTRIBUTES => self.first_attribute.get(),
+            SPAN_EVENTS => self.first_event.get(),
+            SPAN_LINKS => self.first_link.get(),
+            _ => self
+                .scalar_fields
+                .get(field_num as usize)
+                .and_then(|c| c.get()),
+        };
+
+        from_option_nonzero_range_to_primitive(range)
+    }
+
+    fn set_field_range(&self, field_num: u64, wire_type: u64, start: usize, end: usize) {
+        const WIRE_TYPES: [u64; 17] = [
+            0,
+            wire_types::LEN,     // trace_id = 1
+            wire_types::LEN,     // span_id = 2
+            wire_types::LEN,     // trace_state = 3
+            wire_types::LEN,     // parent_span_id = 4
+            wire_types::LEN,     // name = 5
+            wire_types::VARINT,  // kind = 6
+            wire_types::FIXED64, // start_time_unix_nano = 7
+            wire_types::FIXED64, // end_time_unix_nano = 8
+            wire_types::LEN,     // attributes = 9
+            wire_types::VARINT,  // dropped_attributes_count = 10
+            wire_types::LEN,     // events = 11,
+            wire_types::VARINT,  // dropped_events_count = 12
+            wire_types::LEN,     // links = 13
+            wire_types::VARINT,  // dropped_links_count = 14,
+            wire_types::LEN,     // status = 15
+            wire_types::FIXED32, // flags = 16
+        ];
+
+        let range = match to_nonzero_range(start, end) {
+            Some(range) => Some(range),
+            None => return,
+        };
+
+        match field_num {
+            SPAN_ATTRIBUTES => {
+                if self.first_attribute.get().is_none() && wire_type == wire_types::LEN {
+                    self.first_attribute.set(range)
+                }
+            }
+            SPAN_EVENTS => {
+                if self.first_event.get().is_none() && wire_type == wire_types::LEN {
+                    self.first_event.set(range)
+                }
+            }
+            SPAN_LINKS => {
+                if self.first_link.get().is_none() && wire_type == wire_types::LEN {
+                    self.first_link.set(range)
+                }
+            }
+            _ => {
+                let idx = field_num as usize;
+                if wire_type == WIRE_TYPES[idx] {
+                    self.scalar_fields[idx].set(range)
+                }
+            }
+        }
+    }
+}
+
+/// Implementation of [`EventView`] backed by protobuf serialized span `Event` message
+pub struct RawSpanEvent<'a> {
+    bytes_parser: ProtoBytesParser<'a, SpanEventFieldRanges>,
+}
+
+/// Known field offsets within byte buffer for fields in span `Event` message
+pub struct SpanEventFieldRanges {
+    time_unix_nano: Cell<Option<(NonZeroUsize, NonZeroUsize)>>,
+    name: Cell<Option<(NonZeroUsize, NonZeroUsize)>>,
+    dropped_attributes_count: Cell<Option<(NonZeroUsize, NonZeroUsize)>>,
+    first_attribute: Cell<Option<(NonZeroUsize, NonZeroUsize)>>,
+}
+
+impl FieldRanges for SpanEventFieldRanges {
+    fn new() -> Self {
+        Self {
+            time_unix_nano: Cell::new(None),
+            name: Cell::new(None),
+            dropped_attributes_count: Cell::new(None),
+            first_attribute: Cell::new(None),
+        }
+    }
+
+    fn get_field_range(&self, field_num: u64) -> Option<(usize, usize)> {
+        let range = match field_num {
+            SPAN_EVENT_TIME_UNIX_NANO => self.time_unix_nano.get(),
+            SPAN_EVENT_NAME => self.name.get(),
+            SPAN_EVENT_DROPPED_ATTRIBUTES_COUNTS => self.dropped_attributes_count.get(),
+            SPAN_EVENT_ATTRIBUTES => self.first_attribute.get(),
+            _ => return None,
+        };
+
+        from_option_nonzero_range_to_primitive(range)
+    }
+
+    fn set_field_range(&self, field_num: u64, wire_type: u64, start: usize, end: usize) {
+        let range = match to_nonzero_range(start, end) {
+            Some(range) => range,
+            None => return,
+        };
+
+        match field_num {
+            SPAN_EVENT_TIME_UNIX_NANO => {
+                if wire_type == wire_types::FIXED64 {
+                    self.time_unix_nano.set(Some(range))
+                }
+            }
+            SPAN_EVENT_NAME => {
+                if wire_type == wire_types::LEN {
+                    self.name.set(Some(range))
+                }
+            }
+            SPAN_EVENT_DROPPED_ATTRIBUTES_COUNTS => {
+                if wire_type == wire_types::VARINT {
+                    self.dropped_attributes_count.set(Some(range))
+                }
+            }
+            SPAN_EVENT_ATTRIBUTES => {
+                if self.first_attribute.get().is_none() && wire_type == wire_types::LEN {
+                    self.first_attribute.set(Some(range))
+                }
+            }
+            _ => { /* ignore */ }
+        }
+    }
+}
+
+/// Implementation of [`LinkView`] backed by protobuf serialized span `Link` message
+pub struct RawSpanLink<'a> {
+    bytes_parser: ProtoBytesParser<'a, SpanLinkFieldRanges>,
+}
+
+/// Known field offsets within byte buffer for fields in span `Link` message
+pub struct SpanLinkFieldRanges {
+    trace_id: Cell<Option<(NonZeroUsize, NonZeroUsize)>>,
+    span_id: Cell<Option<(NonZeroUsize, NonZeroUsize)>>,
+    trace_state: Cell<Option<(NonZeroUsize, NonZeroUsize)>>,
+    dropped_attributes_count: Cell<Option<(NonZeroUsize, NonZeroUsize)>>,
+    flags: Cell<Option<(NonZeroUsize, NonZeroUsize)>>,
+    first_attribute: Cell<Option<(NonZeroUsize, NonZeroUsize)>>,
+}
+
+impl FieldRanges for SpanLinkFieldRanges {
+    fn new() -> Self {
+        Self {
+            trace_id: Cell::new(None),
+            span_id: Cell::new(None),
+            trace_state: Cell::new(None),
+            dropped_attributes_count: Cell::new(None),
+            flags: Cell::new(None),
+            first_attribute: Cell::new(None),
+        }
+    }
+
+    fn get_field_range(&self, field_num: u64) -> Option<(usize, usize)> {
+        let range = match field_num {
+            SPAN_LINK_TRACE_ID => self.trace_id.get(),
+            SPAN_LINK_SPAN_ID => self.span_id.get(),
+            SPAN_LINK_TRACE_STATE => self.trace_state.get(),
+            SPAN_LINK_DROPPED_ATTRIBUTES_COUNT => self.dropped_attributes_count.get(),
+            SPAN_LINK_FLAGS => self.flags.get(),
+            SPAN_LINK_ATTRIBUTES => self.first_attribute.get(),
+            _ => return None,
+        };
+
+        from_option_nonzero_range_to_primitive(range)
+    }
+
+    fn set_field_range(&self, field_num: u64, wire_type: u64, start: usize, end: usize) {
+        let range = match to_nonzero_range(start, end) {
+            Some(range) => range,
+            None => return,
+        };
+
+        match field_num {
+            SPAN_LINK_TRACE_ID => {
+                if wire_type == wire_types::LEN {
+                    self.trace_id.set(Some(range))
+                }
+            }
+            SPAN_LINK_SPAN_ID => {
+                if wire_type == wire_types::LEN {
+                    self.span_id.set(Some(range))
+                }
+            }
+            SPAN_LINK_TRACE_STATE => {
+                if wire_type == wire_types::LEN {
+                    self.trace_state.set(Some(range))
+                }
+            }
+            SPAN_LINK_DROPPED_ATTRIBUTES_COUNT => {
+                if wire_type == wire_types::VARINT {
+                    self.dropped_attributes_count.set(Some(range))
+                }
+            }
+            SPAN_LINK_FLAGS => {
+                if wire_type == wire_types::FIXED32 {
+                    self.flags.set(Some(range))
+                }
+            }
+            SPAN_LINK_ATTRIBUTES => {
+                if self.first_attribute.get().is_none() && wire_type == wire_types::LEN {
+                    self.first_attribute.set(Some(range))
+                }
+            }
+            _ => { /* ignore */ }
+        }
+    }
+}
+
+/// Implementation of [`StatusView`] backed by protobuf serialized span `Status` message
+pub struct RawSpanStatus<'a> {
+    bytes_parser: ProtoBytesParser<'a, SpanStatusFieldRanges>,
+}
+
+struct SpanStatusFieldRanges {
+    message: Cell<Option<(NonZeroUsize, NonZeroUsize)>>,
+    code: Cell<Option<(NonZeroUsize, NonZeroUsize)>>,
+}
+
+impl FieldRanges for SpanStatusFieldRanges {
+    fn new() -> Self {
+        Self {
+            message: Cell::new(None),
+            code: Cell::new(None),
+        }
+    }
+
+    fn get_field_range(&self, field_num: u64) -> Option<(usize, usize)> {
+        let range = match field_num {
+            SPAN_STATUS_MESSAGE => self.message.get(),
+            SPAN_STATUS_CODE => self.code.get(),
+            _ => None,
+        };
+
+        from_option_nonzero_range_to_primitive(range)
+    }
+
+    fn set_field_range(&self, field_num: u64, wire_type: u64, start: usize, end: usize) {
+        let range = match to_nonzero_range(start, end) {
+            Some(range) => range,
+            None => return,
+        };
+
+        match field_num {
+            SPAN_STATUS_MESSAGE => {
+                if wire_type == wire_types::LEN {
+                    self.message.set(Some(range))
+                }
+            }
+            SPAN_STATUS_CODE => {
+                if wire_type == wire_types::VARINT {
+                    self.message.set(Some(range))
+                }
+            }
+            _ => { /* ignore */ }
+        }
+    }
+}
+
+/* ───────────────────────────── ADAPTER ITERATORS ─────────────────────── */
+
+/// Iterator of ResourceSpans - produces implementation of `ResourceSpans` view from byte array
+/// containing serialized `TracesData` message
+pub struct ResourceSpansIter<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Iterator for ResourceSpansIter<'a> {
+    type Item = RawResourceSpans<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.pos < self.buf.len() {
+            let (tag, next_pos) = read_varint(self.buf, self.pos)?;
+            self.pos = next_pos;
+            let field = tag >> 3;
+            let wire_type = tag & 7;
+            if field == TRACES_DATA_RESOURCE_SPANS && wire_type == wire_types::LEN {
+                let (slice, next_pos) = read_len_delim(self.buf, self.pos)?;
+                self.pos = next_pos;
+                return Some(RawResourceSpans {
+                    byte_parser: ProtoBytesParser::new(slice),
+                });
+            }
+        }
+
+        None
+    }
+}
+
+/// Iterator of ScopeSpans - produces implementation of `ResourceSpans` view from byte array
+/// containing a serialized ResourceSpans message
+pub struct ScopeSpansIter<'a> {
+    byte_parser: RepeatedFieldProtoBytesParser<'a, ResourceSpansFieldRanges>,
+}
+
+impl<'a> Iterator for ScopeSpansIter<'a> {
+    type Item = RawScopeSpans<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let slice = self.byte_parser.next()?;
+
+        Some(RawScopeSpans {
+            byte_parser: ProtoBytesParser::new(slice),
+        })
+    }
+}
+
+/// Iterator of Span - produces implementation of `Span` view from byte array containing a
+/// serialized ScopeSpans message
+pub struct SpanIter<'a> {
+    byte_parser: RepeatedFieldProtoBytesParser<'a, ScopeSpansFieldRanges>,
+}
+
+impl<'a> Iterator for SpanIter<'a> {
+    type Item = RawSpan<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let slice = self.byte_parser.next()?;
+
+        Some(RawSpan {
+            bytes_parser: ProtoBytesParser::new(slice),
+        })
+    }
+}
+
+/// Iterator of span Event - produces implementation of span `Event` view from byte array
+/// serialized Span message
+pub struct SpanEventIter<'a> {
+    byte_parser: RepeatedFieldProtoBytesParser<'a, SpanFieldRanges>,
+}
+
+impl<'a> Iterator for SpanEventIter<'a> {
+    type Item = RawSpanEvent<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let slice = self.byte_parser.next()?;
+
+        Some(RawSpanEvent {
+            bytes_parser: ProtoBytesParser::new(slice),
+        })
+    }
+}
+
+/// Iterator of span Link - produces implementation of span `Link` view from byte array
+/// serialized Span message
+pub struct SpanLinkIter<'a> {
+    byte_parser: RepeatedFieldProtoBytesParser<'a, SpanFieldRanges>,
+}
+
+impl<'a> Iterator for SpanLinkIter<'a> {
+    type Item = RawSpanLink<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let slice = self.byte_parser.next()?;
+
+        Some(RawSpanLink {
+            bytes_parser: ProtoBytesParser::new(slice),
+        })
+    }
+}
+
+/* ───────────────────────────── TRAIT IMPLEMENTATIONS ─────────────────── */
+impl TracesView for RawTraceData<'_> {
+    type ResourceSpans<'res>
+        = RawResourceSpans<'res>
+    where
+        Self: 'res;
+
+    type ResourcesIter<'res>
+        = ResourceSpansIter<'res>
+    where
+        Self: 'res;
+
+    #[inline]
+    fn resources(&self) -> Self::ResourcesIter<'_> {
+        ResourceSpansIter {
+            buf: self.buf,
+            pos: 0,
+        }
+    }
+}
+
+impl ResourceSpansView for RawResourceSpans<'_> {
+    type Resource<'res>
+        = RawResource<'res>
+    where
+        Self: 'res;
+
+    type ScopeSpans<'scp>
+        = RawScopeSpans<'scp>
+    where
+        Self: 'scp;
+
+    type ScopesIter<'scp>
+        = ScopeSpansIter<'scp>
+    where
+        Self: 'scp;
+
+    #[inline]
+    fn resource(&self) -> Option<Self::Resource<'_>> {
+        let slice = self
+            .byte_parser
+            .advance_to_find_field(RESOURCE_SPANS_RESOURCE)?;
+
+        Some(RawResource::new(ProtoBytesParser::new(slice)))
+    }
+
+    #[inline]
+    fn schema_url(&self) -> Option<crate::views::common::Str<'_>> {
+        let slice = self
+            .byte_parser
+            .advance_to_find_field(RESOURCE_SPANS_SCHEMA_URL)?;
+
+        std::str::from_utf8(slice).ok()
+    }
+
+    #[inline]
+    fn scopes(&self) -> Self::ScopesIter<'_> {
+        ScopeSpansIter {
+            byte_parser: RepeatedFieldProtoBytesParser::from_byte_parser(
+                &self.byte_parser,
+                RESOURCE_SPANS_SCOPE_SPANS,
+                wire_types::LEN,
+            ),
+        }
+    }
+}
+
+impl ScopeSpansView for RawScopeSpans<'_> {
+    type Span<'sp>
+        = RawSpan<'sp>
+    where
+        Self: 'sp;
+
+    type SpanIter<'sp>
+        = SpanIter<'sp>
+    where
+        Self: 'sp;
+
+    type Scope<'scp>
+        = RawInstrumentationScope<'scp>
+    where
+        Self: 'scp;
+
+    #[inline]
+    fn schema_url(&self) -> Option<crate::views::common::Str<'_>> {
+        let slice = self
+            .byte_parser
+            .advance_to_find_field(SCOPE_SPANS_SCHEMA_URL)?;
+        std::str::from_utf8(slice).ok()
+    }
+
+    #[inline]
+    fn scope(&self) -> Option<Self::Scope<'_>> {
+        let slice = self.byte_parser.advance_to_find_field(SCOPE_SPANS_SCOPE)?;
+        Some(RawInstrumentationScope::new(ProtoBytesParser::new(slice)))
+    }
+
+    #[inline]
+    fn spans(&self) -> Self::SpanIter<'_> {
+        SpanIter {
+            byte_parser: RepeatedFieldProtoBytesParser::from_byte_parser(
+                &self.byte_parser,
+                SCOPE_SPANS_SPANS,
+                wire_types::LEN,
+            ),
+        }
+    }
+}
+
+impl SpanView for RawSpan<'_> {
+    type Attribute<'att>
+        = RawKeyValue<'att>
+    where
+        Self: 'att;
+
+    type AttributeIter<'att>
+        = KeyValueIter<'att, SpanFieldRanges>
+    where
+        Self: 'att;
+
+    type Event<'ev>
+        = RawSpanEvent<'ev>
+    where
+        Self: 'ev;
+
+    type EventsIter<'ev>
+        = SpanEventIter<'ev>
+    where
+        Self: 'ev;
+
+    type Link<'ln>
+        = RawSpanLink<'ln>
+    where
+        Self: 'ln;
+
+    type LinksIter<'ln>
+        = SpanLinkIter<'ln>
+    where
+        Self: 'ln;
+
+    type Status<'st>
+        = RawSpanStatus<'st>
+    where
+        Self: 'st;
+
+    #[inline]
+    fn attributes(&self) -> Self::AttributeIter<'_> {
+        KeyValueIter::new(RepeatedFieldProtoBytesParser::from_byte_parser(
+            &self.bytes_parser,
+            SPAN_ATTRIBUTES,
+            wire_types::LEN,
+        ))
+    }
+
+    #[inline]
+    fn dropped_attributes_count(&self) -> u32 {
+        let slice = self
+            .bytes_parser
+            .advance_to_find_field(SPAN_DROPPED_ATTRIBUTES_COUNT);
+        read_dropped_count(slice)
+    }
+
+    #[inline]
+    fn dropped_events_count(&self) -> u32 {
+        let slice = self
+            .bytes_parser
+            .advance_to_find_field(SPAN_DROPPED_EVENTS_COUNT);
+        read_dropped_count(slice)
+    }
+
+    #[inline]
+    fn dropped_links_count(&self) -> u32 {
+        let slice = self
+            .bytes_parser
+            .advance_to_find_field(SPAN_DROPPED_LINKS_COUNT);
+        read_dropped_count(slice)
+    }
+
+    #[inline]
+    fn end_time_unix_nano(&self) -> Option<u64> {
+        let slice = self
+            .bytes_parser
+            .advance_to_find_field(SPAN_END_TIME_UNIX_NANO)?;
+        let byte_arr: [u8; 8] = slice.try_into().ok()?;
+        Some(u64::from_le_bytes(byte_arr))
+    }
+
+    #[inline]
+    fn events(&self) -> Self::EventsIter<'_> {
+        SpanEventIter {
+            byte_parser: RepeatedFieldProtoBytesParser::from_byte_parser(
+                &self.bytes_parser,
+                SPAN_EVENTS,
+                wire_types::LEN,
+            ),
+        }
+    }
+
+    #[inline]
+    fn flags(&self) -> Option<u32> {
+        let slice = self.bytes_parser.advance_to_find_field(SPAN_FLAGS)?;
+        let byte_arr: [u8; 4] = slice.try_into().ok()?;
+        Some(u32::from_le_bytes(byte_arr))
+    }
+
+    #[inline]
+    fn kind(&self) -> i32 {
+        self.bytes_parser
+            .advance_to_find_field(SPAN_KIND)
+            .and_then(|slice| read_varint(slice, 0))
+            .map(|(var, _)| SpanKind::try_from(var as i32).unwrap_or(SpanKind::Unspecified))
+            .unwrap_or(SpanKind::Unspecified) as i32
+    }
+
+    #[inline]
+    fn links(&self) -> Self::LinksIter<'_> {
+        SpanLinkIter {
+            byte_parser: RepeatedFieldProtoBytesParser::from_byte_parser(
+                &self.bytes_parser,
+                SPAN_LINKS,
+                wire_types::LEN,
+            ),
+        }
+    }
+
+    #[inline]
+    fn name(&self) -> Option<crate::views::common::Str<'_>> {
+        let slice = self.bytes_parser.advance_to_find_field(SPAN_NAME)?;
+        std::str::from_utf8(slice).ok()
+    }
+
+    #[inline]
+    fn parent_span_id(&self) -> Option<&SpanId> {
+        self.bytes_parser
+            .advance_to_find_field(SPAN_PARENT_SPAN_ID)
+            .and_then(|slice| slice.try_into().ok())
+    }
+
+    #[inline]
+    fn span_id(&self) -> Option<&SpanId> {
+        self.bytes_parser
+            .advance_to_find_field(SPAN_SPAN_ID)
+            .and_then(|slice| slice.try_into().ok())
+    }
+
+    #[inline]
+    fn start_time_unix_nano(&self) -> Option<u64> {
+        let slice = self
+            .bytes_parser
+            .advance_to_find_field(SPAN_START_TIME_UNIX_NANO)?;
+        let byte_arr: [u8; 8] = slice.try_into().ok()?;
+        Some(u64::from_le_bytes(byte_arr))
+    }
+
+    #[inline]
+    fn status(&self) -> Option<Self::Status<'_>> {
+        let slice = self.bytes_parser.advance_to_find_field(SPAN_STATUS)?;
+        Some(RawSpanStatus {
+            bytes_parser: ProtoBytesParser::new(slice),
+        })
+    }
+
+    #[inline]
+    fn trace_id(&self) -> Option<&TraceId> {
+        self.bytes_parser
+            .advance_to_find_field(SPAN_TRACE_ID)
+            .and_then(|slice| slice.try_into().ok())
+    }
+
+    #[inline]
+    fn trace_state(&self) -> Option<crate::views::common::Str<'_>> {
+        let slice = self.bytes_parser.advance_to_find_field(SPAN_TRACE_STATE)?;
+        std::str::from_utf8(slice).ok()
+    }
+}
+
+impl EventView for RawSpanEvent<'_> {
+    type Attribute<'att>
+        = RawKeyValue<'att>
+    where
+        Self: 'att;
+
+    type AttributeIter<'att>
+        = KeyValueIter<'att, SpanEventFieldRanges>
+    where
+        Self: 'att;
+
+    #[inline]
+    fn attributes(&self) -> Self::AttributeIter<'_> {
+        KeyValueIter::new(RepeatedFieldProtoBytesParser::from_byte_parser(
+            &self.bytes_parser,
+            SPAN_EVENT_ATTRIBUTES,
+            wire_types::LEN,
+        ))
+    }
+
+    #[inline]
+    fn dropped_attributes_count(&self) -> u32 {
+        let slice = self
+            .bytes_parser
+            .advance_to_find_field(SPAN_EVENT_DROPPED_ATTRIBUTES_COUNTS);
+        read_dropped_count(slice)
+    }
+
+    #[inline]
+    fn name(&self) -> Option<crate::views::common::Str<'_>> {
+        let slice = self.bytes_parser.advance_to_find_field(SPAN_EVENT_NAME)?;
+        std::str::from_utf8(slice).ok()
+    }
+
+    #[inline]
+    fn time_unix_nano(&self) -> Option<u64> {
+        let slice = self
+            .bytes_parser
+            .advance_to_find_field(SPAN_EVENT_TIME_UNIX_NANO)?;
+        let byte_arr: [u8; 8] = slice.try_into().ok()?;
+        Some(u64::from_le_bytes(byte_arr))
+    }
+}
+
+impl LinkView for RawSpanLink<'_> {
+    type Attribute<'att>
+        = RawKeyValue<'att>
+    where
+        Self: 'att;
+
+    type AttributeIter<'att>
+        = KeyValueIter<'att, SpanLinkFieldRanges>
+    where
+        Self: 'att;
+
+    #[inline]
+    fn attributes(&self) -> Self::AttributeIter<'_> {
+        KeyValueIter::new(RepeatedFieldProtoBytesParser::from_byte_parser(
+            &self.bytes_parser,
+            SPAN_LINK_ATTRIBUTES,
+            wire_types::LEN,
+        ))
+    }
+
+    #[inline]
+    fn dropped_attributes_count(&self) -> u32 {
+        let slice = self
+            .bytes_parser
+            .advance_to_find_field(SPAN_LINK_DROPPED_ATTRIBUTES_COUNT);
+        read_dropped_count(slice)
+    }
+
+    #[inline]
+    fn trace_id(&self) -> Option<&TraceId> {
+        self.bytes_parser
+            .advance_to_find_field(SPAN_LINK_TRACE_ID)
+            .and_then(|slice| slice.try_into().ok())
+    }
+
+    #[inline]
+    fn span_id(&self) -> Option<&SpanId> {
+        self.bytes_parser
+            .advance_to_find_field(SPAN_LINK_SPAN_ID)
+            .and_then(|slice| slice.try_into().ok())
+    }
+
+    #[inline]
+    fn trace_state(&self) -> Option<crate::views::common::Str<'_>> {
+        let slice = self
+            .bytes_parser
+            .advance_to_find_field(SPAN_LINK_TRACE_STATE)?;
+        std::str::from_utf8(slice).ok()
+    }
+
+    #[inline]
+    fn flags(&self) -> Option<u32> {
+        let slice = self.bytes_parser.advance_to_find_field(SPAN_LINK_FLAGS)?;
+        let byte_arr: [u8; 4] = slice.try_into().ok()?;
+        Some(u32::from_le_bytes(byte_arr))
+    }
+}
+
+impl StatusView for RawSpanStatus<'_> {
+    #[inline]
+    fn status_code(&self) -> i32 {
+        self.bytes_parser
+            .advance_to_find_field(SPAN_STATUS_CODE)
+            .and_then(|slice| read_varint(slice, 0))
+            .map(|(var, _)| var as i32)
+            .unwrap_or(StatusCode::Unset as i32)
+    }
+
+    #[inline]
+    fn message(&self) -> Option<crate::views::common::Str<'_>> {
+        let slice = self
+            .bytes_parser
+            .advance_to_find_field(SPAN_STATUS_MESSAGE)?;
+        std::str::from_utf8(slice).ok()
+    }
+}

--- a/rust/otel-arrow-rust/src/encode/record/traces.rs
+++ b/rust/otel-arrow-rust/src/encode/record/traces.rs
@@ -21,7 +21,7 @@ use crate::{
         },
         logs::{ResourceBuilder, ScopeBuilder},
     },
-    schema::{SpanId, TraceId, consts},
+    schema::{FieldExt, SpanId, TraceId, consts},
 };
 
 /// Record batch builder for traces
@@ -244,7 +244,7 @@ impl TracesRecordBatchBuilder {
         // SAFETY: `expect` is safe here because `AdaptiveArrayBuilder` guarantees that for
         // non-optional arrays, `finish()` will always return an array, even if it is empty.
         let array = self.id.finish().expect("finish returns `Some(array)`");
-        fields.push(Field::new(consts::ID, array.data_type().clone(), true));
+        fields.push(Field::new(consts::ID, array.data_type().clone(), true).with_plain_encoding());
         columns.push(array);
 
         let resource = self.resource.finish()?;
@@ -494,7 +494,7 @@ impl EventsRecordBatchBuilder {
         // SAFETY: `expect` is safe here because `AdaptiveArrayBuilder` guarantees that for
         // non-optional arrays, `finish()` will always return an array, even if it is empty.
         let array = self.id.finish().expect("finish returns `Some(array)`");
-        fields.push(Field::new(consts::ID, array.data_type().clone(), true));
+        fields.push(Field::new(consts::ID, array.data_type().clone(), true).with_plain_encoding());
         columns.push(array);
 
         // SAFETY: `expect` is safe here because `AdaptiveArrayBuilder` guarantees that for
@@ -503,11 +503,9 @@ impl EventsRecordBatchBuilder {
             .parent_id
             .finish()
             .expect("finish returns `Some(array)`");
-        fields.push(Field::new(
-            consts::PARENT_ID,
-            array.data_type().clone(),
-            false,
-        ));
+        fields.push(
+            Field::new(consts::PARENT_ID, array.data_type().clone(), false).with_plain_encoding(),
+        );
         columns.push(array);
 
         // SAFETY: `expect` is safe here because `AdaptiveArrayBuilder` guarantees that for
@@ -659,7 +657,7 @@ impl LinksRecordBatchBuilder {
         // SAFETY: `expect` is safe here because `AdaptiveArrayBuilder` guarantees that for
         // non-optional arrays, `finish()` will always return an array, even if it is empty.
         let array = self.id.finish().expect("finish returns `Some(array)`");
-        fields.push(Field::new(consts::ID, array.data_type().clone(), true));
+        fields.push(Field::new(consts::ID, array.data_type().clone(), true).with_plain_encoding());
         columns.push(array);
 
         // SAFETY: `expect` is safe here because `AdaptiveArrayBuilder` guarantees that for
@@ -668,11 +666,9 @@ impl LinksRecordBatchBuilder {
             .parent_id
             .finish()
             .expect("finish returns `Some(array)`");
-        fields.push(Field::new(
-            consts::PARENT_ID,
-            array.data_type().clone(),
-            false,
-        ));
+        fields.push(
+            Field::new(consts::PARENT_ID, array.data_type().clone(), false).with_plain_encoding(),
+        );
         columns.push(array);
 
         // SAFETY: `expect` is safe here because `AdaptiveArrayBuilder` guarantees that for

--- a/rust/otel-arrow-rust/src/otlp/traces.rs
+++ b/rust/otel-arrow-rust/src/otlp/traces.rs
@@ -214,9 +214,10 @@ pub fn traces_from(traces_otap_batch: OtapArrowRecords) -> Result<ExportTraceSer
             .unwrap_or_default();
         current_span.start_time_unix_nano =
             spans_arrays.start_time_unix_nano.value_at_or_default(idx) as u64;
-        current_span.end_time_unix_nano += spans_arrays
-            .duration_time_unix_nano
-            .value_at_or_default(idx) as u64;
+        current_span.end_time_unix_nano = current_span.start_time_unix_nano
+            + spans_arrays
+                .duration_time_unix_nano
+                .value_at_or_default(idx) as u64;
         current_span.dropped_attributes_count = spans_arrays
             .dropped_attributes_count
             .value_at_or_default(idx);

--- a/rust/otel-arrow-rust/src/otlp/traces.rs
+++ b/rust/otel-arrow-rust/src/otlp/traces.rs
@@ -214,10 +214,9 @@ pub fn traces_from(traces_otap_batch: OtapArrowRecords) -> Result<ExportTraceSer
             .unwrap_or_default();
         current_span.start_time_unix_nano =
             spans_arrays.start_time_unix_nano.value_at_or_default(idx) as u64;
-        current_span.end_time_unix_nano = current_span.end_time_unix_nano
-            + spans_arrays
-                .duration_time_unix_nano
-                .value_at_or_default(idx) as u64;
+        current_span.end_time_unix_nano += spans_arrays
+            .duration_time_unix_nano
+            .value_at_or_default(idx) as u64;
         current_span.dropped_attributes_count = spans_arrays
             .dropped_attributes_count
             .value_at_or_default(idx);


### PR DESCRIPTION
Resolves: https://github.com/open-telemetry/otel-arrow/issues/388 
Part of: https://github.com/open-telemetry/otel-arrow/issues/878

Changes:
- Implements the PData Views for Traces for OTLP bytes messages
- Implements the conversion from OTLP Bytes for Traces pdata
- Handle the plain encoded IDs when decoding Traces OTAP batches to OTLP
