### PR TITLE
Update Node index to usize

### DIFF
--- a/rust/otap-dataflow/crates/engine/src/control.rs
+++ b/rust/otap-dataflow/crates/engine/src/control.rs
@@ -6,7 +6,6 @@
 //! configuration updates, and timer management.
 
 use crate::message::Sender;
-use crate::node::NodeIndex;
 use crate::shared::message::{SharedReceiver, SharedSender};
 use std::time::Duration;
 
@@ -70,14 +69,14 @@ pub enum PipelineControlMsg {
     /// Requests the pipeline engine to start a periodic timer for the specified node.
     StartTimer {
         /// Identifier of the node for which the timer is being started.
-        node_id: NodeIndex,
+        node_id: usize,
         /// Duration of the timer interval.
         duration: Duration,
     },
     /// Requests cancellation of a periodic timer for the specified node.
     CancelTimer {
         /// Identifier of the node for which the timer is being canceled.
-        node_id: NodeIndex,
+        node_id: usize,
     },
     /// Requests shutdown of the node request manager.
     Shutdown,

--- a/rust/otap-dataflow/crates/engine/src/effect_handler.rs
+++ b/rust/otap-dataflow/crates/engine/src/effect_handler.rs
@@ -5,7 +5,7 @@
 
 use crate::control::{PipelineControlMsg, PipelineCtrlMsgSender};
 use crate::error::Error;
-use crate::node::{NodeId, NodeIndex};
+use crate::node::NodeId;
 use otap_df_channel::error::SendError;
 use std::net::SocketAddr;
 use std::time::Duration;
@@ -175,7 +175,7 @@ impl EffectHandlerCore {
 
 /// Handle to cancel a running timer.
 pub struct TimerCancelHandle {
-    node_id: NodeIndex,
+    node_id: usize,
     pipeline_ctrl_msg_sender: PipelineCtrlMsgSender,
 }
 

--- a/rust/otap-dataflow/crates/engine/src/runtime_pipeline.rs
+++ b/rust/otap-dataflow/crates/engine/src/runtime_pipeline.rs
@@ -5,9 +5,7 @@
 
 use crate::control::{Controllable, NodeControlMsg, pipeline_ctrl_msg_channel};
 use crate::error::Error;
-use crate::node::{
-    Node, NodeDefs, NodeId, NodeIndex, NodeType, NodeWithPDataReceiver, NodeWithPDataSender,
-};
+use crate::node::{Node, NodeDefs, NodeId, NodeType, NodeWithPDataReceiver, NodeWithPDataSender};
 use crate::pipeline_ctrl::PipelineCtrlMsgManager;
 use crate::{exporter::ExporterWrapper, processor::ProcessorWrapper, receiver::ReceiverWrapper};
 
@@ -164,8 +162,8 @@ impl<PData: 'static + Debug + Clone> RuntimePipeline<PData> {
 
     /// Gets a reference to any node by its ID as a Node trait object
     #[must_use]
-    pub fn get_node(&self, node: NodeIndex) -> Option<&dyn Node> {
-        let ndef = self.nodes.get(node)?;
+    pub fn get_node(&self, node_id: usize) -> Option<&dyn Node> {
+        let ndef = self.nodes.get(node_id)?;
 
         match ndef.ntype {
             NodeType::Receiver => self.receivers.get(ndef.inner.index).map(|r| r as &dyn Node),
@@ -181,9 +179,9 @@ impl<PData: 'static + Debug + Clone> RuntimePipeline<PData> {
     #[must_use]
     pub fn get_mut_node_with_pdata_sender(
         &mut self,
-        node: NodeIndex,
+        node_id: usize,
     ) -> Option<&mut dyn NodeWithPDataSender<PData>> {
-        let ndef = self.nodes.get(node)?;
+        let ndef = self.nodes.get(node_id)?;
 
         match ndef.ntype {
             NodeType::Receiver => self
@@ -202,9 +200,9 @@ impl<PData: 'static + Debug + Clone> RuntimePipeline<PData> {
     #[must_use]
     pub fn get_mut_node_with_pdata_receiver(
         &mut self,
-        node: NodeIndex,
+        node_id: usize,
     ) -> Option<&mut dyn NodeWithPDataReceiver<PData>> {
-        let ndef = self.nodes.get(node)?;
+        let ndef = self.nodes.get(node_id)?;
 
         match ndef.ntype {
             NodeType::Receiver => None,


### PR DESCRIPTION
Follow up to https://github.com/open-telemetry/otel-arrow/pull/939#discussion_r2286670031

## Changes
- Update Node index to `usize` to look up the vec directly without converting from `u16`