### PR TITLE
[otap-dataflow] Fix broken test otap-df-{otlp,otap} test_fake_signal_receiver()

### DIFF
--- a/rust/otap-dataflow/crates/otap/src/fake_data_generator.rs
+++ b/rust/otap-dataflow/crates/otap/src/fake_data_generator.rs
@@ -603,7 +603,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // https://github.com/open-telemetry/otel-arrow/issues/964
     fn test_fake_signal_receiver() {
         let test_runtime = TestRuntime::new();
 

--- a/rust/otap-dataflow/crates/otlp/src/fake_signal_receiver/attributes.rs
+++ b/rust/otap-dataflow/crates/otlp/src/fake_signal_receiver/attributes.rs
@@ -213,7 +213,7 @@ pub fn get_attribute_name_value(attribute: &Attribute) -> KeyValue {
                     AnyValue::new_array(vec![AnyValue::new_bool(true), AnyValue::new_bool(false)])
                 }
             };
-            KeyValue::new(format!("{name}.key"), value)
+            KeyValue::new(name, value)
         }
     }
 }

--- a/rust/otap-dataflow/crates/otlp/src/fake_signal_receiver/receiver.rs
+++ b/rust/otap-dataflow/crates/otlp/src/fake_signal_receiver/receiver.rs
@@ -545,7 +545,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // https://github.com/open-telemetry/otel-arrow/issues/964
     fn test_fake_signal_receiver() {
         let test_runtime = TestRuntime::new();
         let registry_path = VirtualDirectoryPath::GitRepo {


### PR DESCRIPTION
Fixes test issue described in https://github.com/open-telemetry/otel-arrow/issues/964

caused by formatted key in attributes.rs which led to a comparison fail when checking attributes against the resolved registry
