### PR TITLE
[query-engine] Support expressions run against summary records

### DIFF
--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/bridge.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/bridge.rs
@@ -167,7 +167,7 @@ pub fn process_export_logs_service_request_using_pipeline(
 
     let mut included_records = None;
 
-    let has_summaries = !final_results.summaries.is_empty();
+    let has_summaries = !final_results.summaries.included_summaries.is_empty();
     let has_included_records = !final_results.included_records.is_empty();
     if has_summaries || has_included_records {
         if has_included_records {
@@ -180,53 +180,86 @@ pub fn process_export_logs_service_request_using_pipeline(
         if has_summaries {
             let mut log_records = Vec::new();
 
-            for summary in final_results.summaries {
-                let mut attributes: Vec<(Box<str>, AnyValue)> = Vec::with_capacity(
-                    summary.aggregation_values.len() + summary.group_by_values.len(),
-                );
+            for summary in final_results.summaries.included_summaries {
+                let diagnostics = summary.to_string();
 
-                for (key, value) in summary.group_by_values {
-                    attributes.push((key, value.into()));
-                }
+                if let Some(map) = summary.map {
+                    let mut attributes: Vec<(Box<str>, AnyValue)> =
+                        Vec::with_capacity(map.len() + 1);
 
-                for (key, value) in summary.aggregation_values {
-                    match value {
-                        SummaryAggregation::Average { count, sum } => {
-                            let avg = sum.to_double() / count as f64;
+                    attributes.extend(
+                        map.take_values()
+                            .drain()
+                            .map(|(key, value)| (key, value.into())),
+                    );
 
-                            attributes.push((
-                                key,
-                                AnyValue::Native(OtlpAnyValue::DoubleValue(
-                                    DoubleValueStorage::new(avg),
-                                )),
-                            ));
-                        }
-                        SummaryAggregation::Count(v) => {
-                            attributes.push((
-                                key,
-                                AnyValue::Native(OtlpAnyValue::IntValue(IntegerValueStorage::new(
-                                    v as i64,
-                                ))),
-                            ));
-                        }
-                        SummaryAggregation::Maximum(v) | SummaryAggregation::Minimum(v) => {
-                            attributes.push((key, v.into()));
-                        }
-                        SummaryAggregation::Sum(v) => {
-                            let v = match v {
-                                SummaryValue::Double(d) => AnyValue::Native(
-                                    OtlpAnyValue::DoubleValue(DoubleValueStorage::new(d)),
-                                ),
-                                SummaryValue::Integer(i) => AnyValue::Native(
-                                    OtlpAnyValue::IntValue(IntegerValueStorage::new(i)),
-                                ),
-                            };
-                            attributes.push((key, v));
+                    if !diagnostics.is_empty() {
+                        attributes.push((
+                            "query_engine.output".into(),
+                            AnyValue::Native(OtlpAnyValue::StringValue(StringValueStorage::new(
+                                diagnostics,
+                            ))),
+                        ));
+                    }
+
+                    log_records.push(LogRecord::new().with_attributes(attributes));
+                } else {
+                    let mut attributes: Vec<(Box<str>, AnyValue)> = Vec::with_capacity(
+                        summary.aggregation_values.len() + summary.group_by_values.len() + 1,
+                    );
+
+                    for (key, value) in summary.group_by_values {
+                        attributes.push((key, value.into()));
+                    }
+
+                    for (key, value) in summary.aggregation_values {
+                        match value {
+                            SummaryAggregation::Average { count, sum } => {
+                                let avg = sum.to_double() / count as f64;
+
+                                attributes.push((
+                                    key,
+                                    AnyValue::Native(OtlpAnyValue::DoubleValue(
+                                        DoubleValueStorage::new(avg),
+                                    )),
+                                ));
+                            }
+                            SummaryAggregation::Count(v) => {
+                                attributes.push((
+                                    key,
+                                    AnyValue::Native(OtlpAnyValue::IntValue(
+                                        IntegerValueStorage::new(v as i64),
+                                    )),
+                                ));
+                            }
+                            SummaryAggregation::Maximum(v) | SummaryAggregation::Minimum(v) => {
+                                attributes.push((key, v.into()));
+                            }
+                            SummaryAggregation::Sum(v) => {
+                                let v = match v {
+                                    SummaryValue::Double(d) => AnyValue::Native(
+                                        OtlpAnyValue::DoubleValue(DoubleValueStorage::new(d)),
+                                    ),
+                                    SummaryValue::Integer(i) => AnyValue::Native(
+                                        OtlpAnyValue::IntValue(IntegerValueStorage::new(i)),
+                                    ),
+                                };
+                                attributes.push((key, v));
+                            }
                         }
                     }
-                }
 
-                log_records.push(LogRecord::new().with_attributes(attributes));
+                    if !diagnostics.is_empty() {
+                        attributes.push((
+                            "query_engine.output".into(),
+                            AnyValue::Native(OtlpAnyValue::StringValue(StringValueStorage::new(
+                                diagnostics,
+                            ))),
+                        ));
+                    }
+
+                    log_records.push(LogRecord::new().with_attributes(attributes));
+                }
             }
 
             let summary_otlp = ResourceLogs::new().with_scope_logs(

--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/proto/common.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/proto/common.rs
@@ -187,7 +187,7 @@ impl ByteArrayValueStorage {
         Self { values }
     }
 
-    pub fn get_values(&self) -> &Vec<IntegerValueStorage<u8>> {
+    pub fn get_values(&self) -> &[IntegerValueStorage<u8>] {
         &self.values
     }
 

--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/tests/common/mod.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/tests/common/mod.rs
@@ -32,18 +32,47 @@ where
     }
 
     println!("Initialization:");
-    if final_results.get_diagnostics().is_empty() {
+    if final_results.diagnostics.is_empty() {
         println!("None")
     } else {
         println!("{final_results}");
     }
 
-    println!("Summaries:");
-    if final_results.summaries.is_empty() {
+    println!("Included summaries:");
+    if final_results.summaries.included_summaries.is_empty() {
         println!("None")
     } else {
-        for summary in &final_results.summaries {
-            println!("{summary:?}");
+        for included_summary in &final_results.summaries.included_summaries {
+            let diagnostics = included_summary.to_string();
+            if !diagnostics.is_empty() {
+                println!("{included_summary}");
+            }
+            println!(
+                "Id: {}, GroupBy: {:?}, Aggregation: {:?}, Map: {:?}",
+                included_summary.summary_id,
+                included_summary.group_by_values,
+                included_summary.aggregation_values,
+                included_summary.map
+            );
+        }
+    }
+
+    println!("Dropped summaries:");
+    if final_results.summaries.dropped_summaries.is_empty() {
+        println!("None")
+    } else {
+        for dropped_summary in &final_results.summaries.dropped_summaries {
+            let diagnostics = dropped_summary.to_string();
+            if !diagnostics.is_empty() {
+                println!("{dropped_summary}");
+            }
+            println!(
+                "Id: {}, GroupBy: {:?}, Aggregation: {:?}, Map: {:?}",
+                dropped_summary.summary_id,
+                dropped_summary.group_by_values,
+                dropped_summary.aggregation_values,
+                dropped_summary.map
+            );
         }
     }
 

--- a/rust/experimental/query_engine/engine-recordset/src/engine.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/engine.rs
@@ -5,6 +5,7 @@ use std::{
     cell::RefCell,
     collections::HashMap,
     fmt::{Debug, Display, Write},
+    marker::PhantomData,
 };
 
 use data_engine_expressions::*;
@@ -96,7 +97,7 @@ pub struct RecordSetEngineBatch<'a, 'b, 'c, TRecord: Record> {
     pipeline: &'a PipelineExpression,
     diagnostics: Vec<RecordSetEngineDiagnostic<'b>>,
     global_variables: RefCell<MapValueStorage<OwnedValue>>,
-    summaries: Summaries,
+    summaries: Summaries<'a>,
     included_records: Vec<RecordSetEngineRecord<'a, 'c, TRecord>>,
 }
 
@@ -171,7 +172,12 @@ where
         RecordSetEngineResults::new(
             self.pipeline,
             self.diagnostics,
-            self.summaries,
+            process_summaries(
+                self.engine.diagnostic_level.clone(),
+                &self.global_variables,
+                self.pipeline,
+                &self.summaries,
+            ),
             self.included_records,
             Vec::new(),
         )
@@ -205,79 +211,164 @@ where
             }
         }
 
-        for expression in self.pipeline.get_expressions() {
-            match expression {
-                DataExpression::Discard(d) => {
-                    if let Some(predicate) = d.get_predicate() {
-                        match execute_logical_expression(&execution_context, predicate) {
-                            Ok(logical_result) => {
-                                if !logical_result {
-                                    execution_context.add_diagnostic_if_enabled(
-                                        RecordSetEngineDiagnosticLevel::Verbose,
-                                        d,
-                                        || "Record included".into(),
-                                    );
-                                    continue;
-                                }
-                            }
-                            Err(e) => {
+        process_record(execution_context, self.pipeline.get_expressions())
+    }
+}
+
+fn process_record<'a, 'c, TRecord: Record + 'static>(
+    execution_context: ExecutionContext<'a, '_, 'c, TRecord>,
+    expressions: &'a [DataExpression],
+) -> RecordSetEngineResult<'a, 'c, TRecord> {
+    for expression in expressions {
+        match expression {
+            DataExpression::Discard(d) => {
+                if let Some(predicate) = d.get_predicate() {
+                    match execute_logical_expression(&execution_context, predicate) {
+                        Ok(logical_result) => {
+                            if !logical_result {
                                 execution_context.add_diagnostic_if_enabled(
-                                    RecordSetEngineDiagnosticLevel::Error,
+                                    RecordSetEngineDiagnosticLevel::Verbose,
                                     d,
-                                    || e.to_string(),
+                                    || "Record included".into(),
                                 );
-                                break;
+                                continue;
                             }
                         }
-                    }
-
-                    execution_context.add_diagnostic_if_enabled(
-                        RecordSetEngineDiagnosticLevel::Info,
-                        d,
-                        || "Record dropped".into(),
-                    );
-
-                    return RecordSetEngineResult::Drop(execution_context.into());
-                }
-                DataExpression::Summary(s) => {
-                    match execute_summary_data_expression(&execution_context, s) {
-                        Ok(_) => {
-                            execution_context.add_diagnostic_if_enabled(
-                                RecordSetEngineDiagnosticLevel::Info,
-                                s,
-                                || "Record summarized and dropped".into(),
-                            );
-
-                            return RecordSetEngineResult::Drop(execution_context.into());
-                        }
                         Err(e) => {
                             execution_context.add_diagnostic_if_enabled(
                                 RecordSetEngineDiagnosticLevel::Error,
-                                s,
+                                d,
                                 || e.to_string(),
                             );
                             break;
                         }
                     }
                 }
-                DataExpression::Transform(t) => {
-                    match execute_transform_expression(&execution_context, t) {
-                        Ok(_) => {}
-                        Err(e) => {
-                            execution_context.add_diagnostic_if_enabled(
-                                RecordSetEngineDiagnosticLevel::Error,
-                                t,
-                                || e.to_string(),
-                            );
-                            break;
-                        }
+
+                execution_context.add_diagnostic_if_enabled(
+                    RecordSetEngineDiagnosticLevel::Info,
+                    d,
+                    || "Record dropped".into(),
+                );
+
+                return RecordSetEngineResult::Drop(execution_context.into());
+            }
+            DataExpression::Summary(s) => {
+                match execute_summary_data_expression(&execution_context, s) {
+                    Ok(_) => {
+                        execution_context.add_diagnostic_if_enabled(
+                            RecordSetEngineDiagnosticLevel::Info,
+                            s,
+                            || "Record summarized and dropped".into(),
+                        );
+
+                        return RecordSetEngineResult::Drop(execution_context.into());
+                    }
+                    Err(e) => {
+                        execution_context.add_diagnostic_if_enabled(
+                            RecordSetEngineDiagnosticLevel::Error,
+                            s,
+                            || e.to_string(),
+                        );
+                        break;
+                    }
+                }
+            }
+            DataExpression::Transform(t) => {
+                match execute_transform_expression(&execution_context, t) {
+                    Ok(_) => {}
+                    Err(e) => {
+                        execution_context.add_diagnostic_if_enabled(
+                            RecordSetEngineDiagnosticLevel::Error,
+                            t,
+                            || e.to_string(),
+                        );
+                        break;
                     }
                 }
             }
         }
-
-        RecordSetEngineResult::Include(execution_context.into())
     }
+
+    RecordSetEngineResult::Include(execution_context.into())
+}
+
+fn process_summaries<'a, 'b>(
+    diagnostic_level: RecordSetEngineDiagnosticLevel,
+    global_variables: &RefCell<MapValueStorage<OwnedValue>>,
+    pipeline: &'a PipelineExpression,
+    summaries: &Summaries<'a>,
+) -> RecordSetEngineSummaryResults<'a, 'b>
+where
+    'a: 'b,
+{
+    let mut summaries = summaries.values.take();
+
+    let mut included_summaries = Vec::with_capacity(summaries.len());
+    let mut dropped_summaries = Vec::new();
+
+    for (id, summary) in summaries.drain() {
+        let post_expressions = summary.summary_data_expression.get_post_expressions();
+        if !post_expressions.is_empty() {
+            let map = summary.as_map();
+
+            // Note: Summary of a summary can produce at most a single record
+            let summaries = Summaries::new(1);
+
+            let execution_context = ExecutionContext::new(
+                diagnostic_level.clone(),
+                pipeline,
+                global_variables,
+                &summaries,
+                None,
+                Some(map),
+            );
+
+            match process_record(execution_context, post_expressions) {
+                RecordSetEngineResult::Drop(r) => {
+                    dropped_summaries.push(RecordSetEngineSummary::new(
+                        Some(pipeline),
+                        r.diagnostics,
+                        id,
+                        summary.group_by_values,
+                        summary.aggregation_values,
+                        Some(r.record),
+                    ));
+                }
+                RecordSetEngineResult::Include(r) => {
+                    included_summaries.push(RecordSetEngineSummary::new(
+                        Some(pipeline),
+                        r.diagnostics,
+                        id,
+                        summary.group_by_values,
+                        summary.aggregation_values,
+                        Some(r.record),
+                    ));
+                }
+            }
+
+            let results = process_summaries(
+                diagnostic_level.clone(),
+                global_variables,
+                pipeline,
+                &summaries,
+            );
+
+            included_summaries.extend(results.included_summaries);
+            dropped_summaries.extend(results.dropped_summaries);
+        } else {
+            included_summaries.push(RecordSetEngineSummary::new(
+                None,
+                Vec::new(),
+                id,
+                summary.group_by_values,
+                summary.aggregation_values,
+                None,
+            ));
+        }
+    }
+
+    RecordSetEngineSummaryResults::new(included_summaries, dropped_summaries)
 }
 
 pub trait RecordSet<TRecord: Record>: Debug {
@@ -323,7 +414,7 @@ impl<'a, 'b, TRecord: Record> RecordSetEngineRecord<'a, 'b, TRecord> {
         &self.record
     }
 
-    pub fn get_diagnostics(&self) -> &Vec<RecordSetEngineDiagnostic<'b>> {
+    pub fn get_diagnostics(&self) -> &[RecordSetEngineDiagnostic<'b>] {
         &self.diagnostics
     }
 
@@ -348,7 +439,7 @@ impl<TRecord: Record> Display for RecordSetEngineRecord<'_, '_, TRecord> {
 
 fn format_diagnostics(
     query: &str,
-    diagnostics: &Vec<RecordSetEngineDiagnostic<'_>>,
+    diagnostics: &[RecordSetEngineDiagnostic<'_>],
     f: &mut std::fmt::Formatter<'_>,
 ) -> std::fmt::Result {
     let mut lines: Vec<(&str, Vec<&RecordSetEngineDiagnostic<'_>>)> = Vec::new();
@@ -411,7 +502,7 @@ fn format_diagnostics(
 pub struct RecordSetEngineResults<'a, 'b, TRecord: Record> {
     pipeline: &'a PipelineExpression,
     pub diagnostics: Vec<RecordSetEngineDiagnostic<'b>>,
-    pub summaries: Vec<RecordSetEngineSummary>,
+    pub summaries: RecordSetEngineSummaryResults<'a, 'b>,
     pub included_records: Vec<RecordSetEngineRecord<'a, 'b, TRecord>>,
     pub dropped_records: Vec<RecordSetEngineRecord<'a, 'b, TRecord>>,
 }
@@ -420,14 +511,14 @@ impl<'a, 'b, TRecord: Record> RecordSetEngineResults<'a, 'b, TRecord> {
     pub(crate) fn new(
         pipeline: &'a PipelineExpression,
         diagnostics: Vec<RecordSetEngineDiagnostic<'b>>,
-        summaries: Summaries,
+        summaries: RecordSetEngineSummaryResults<'a, 'b>,
         included_records: Vec<RecordSetEngineRecord<'a, 'b, TRecord>>,
         dropped_records: Vec<RecordSetEngineRecord<'a, 'b, TRecord>>,
     ) -> RecordSetEngineResults<'a, 'b, TRecord> {
         Self {
             pipeline,
             diagnostics,
-            summaries: summaries.into(),
+            summaries,
             included_records,
             dropped_records,
         }
@@ -435,10 +526,6 @@ impl<'a, 'b, TRecord: Record> RecordSetEngineResults<'a, 'b, TRecord> {
 
     pub fn get_pipeline(&self) -> &PipelineExpression {
         self.pipeline
-    }
-
-    pub fn get_diagnostics(&self) -> &Vec<RecordSetEngineDiagnostic<'b>> {
-        &self.diagnostics
     }
 }
 
@@ -449,41 +536,63 @@ impl<TRecord: Record> Display for RecordSetEngineResults<'_, '_, TRecord> {
 }
 
 #[derive(Debug)]
-pub struct RecordSetEngineSummary {
-    pub summary_id: String,
-    pub group_by_values: Vec<(Box<str>, OwnedValue)>,
-    pub aggregation_values: HashMap<Box<str>, SummaryAggregation>,
+pub struct RecordSetEngineSummaryResults<'a, 'b> {
+    pub included_summaries: Vec<RecordSetEngineSummary<'a, 'b>>,
+    pub dropped_summaries: Vec<RecordSetEngineSummary<'a, 'b>>,
+    // Note: Marker used to not allow manual construction of the struct
+    marker: PhantomData<usize>,
 }
 
-impl RecordSetEngineSummary {
-    pub fn new(
-        summary_id: String,
-        group_by_values: Vec<(Box<str>, OwnedValue)>,
-        aggregation_values: HashMap<Box<str>, SummaryAggregation>,
-    ) -> RecordSetEngineSummary {
+impl<'a, 'b> RecordSetEngineSummaryResults<'a, 'b> {
+    pub(crate) fn new(
+        included_summaries: Vec<RecordSetEngineSummary<'a, 'b>>,
+        dropped_summaries: Vec<RecordSetEngineSummary<'a, 'b>>,
+    ) -> RecordSetEngineSummaryResults<'a, 'b> {
         Self {
-            summary_id,
-            group_by_values,
-            aggregation_values,
+            included_summaries,
+            dropped_summaries,
+            marker: Default::default(),
         }
     }
 }
 
-impl From<Summaries> for Vec<RecordSetEngineSummary> {
-    fn from(value: Summaries) -> Self {
-        let mut values = value.values.borrow_mut();
+#[derive(Debug)]
+pub struct RecordSetEngineSummary<'a, 'b> {
+    pipeline: Option<&'a PipelineExpression>,
+    pub diagnostics: Vec<RecordSetEngineDiagnostic<'b>>,
+    pub summary_id: String,
+    pub group_by_values: Vec<(Box<str>, OwnedValue)>,
+    pub aggregation_values: HashMap<Box<str>, SummaryAggregation>,
+    pub map: Option<MapValueStorage<OwnedValue>>,
+}
 
-        let mut results = Vec::with_capacity(values.len());
-
-        for (summary_id, summary) in values.drain() {
-            results.push(RecordSetEngineSummary::new(
-                summary_id,
-                summary.group_by_values,
-                summary.aggregation_values,
-            ));
+impl<'a, 'b> RecordSetEngineSummary<'a, 'b> {
+    pub(crate) fn new(
+        pipeline: Option<&'a PipelineExpression>,
+        diagnostics: Vec<RecordSetEngineDiagnostic<'b>>,
+        summary_id: String,
+        group_by_values: Vec<(Box<str>, OwnedValue)>,
+        aggregation_values: HashMap<Box<str>, SummaryAggregation>,
+        map: Option<MapValueStorage<OwnedValue>>,
+    ) -> RecordSetEngineSummary<'a, 'b> {
+        Self {
+            pipeline,
+            diagnostics,
+            summary_id,
+            group_by_values,
+            aggregation_values,
+            map,
         }
+    }
+}
 
-        results
+impl Display for RecordSetEngineSummary<'_, '_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(pipeline) = self.pipeline {
+            format_diagnostics(pipeline.get_query(), &self.diagnostics, f)
+        } else {
+            Ok(())
+        }
     }
 }
 
@@ -545,5 +654,154 @@ mod tests {
             ValueType::DateTime,
             record.get("now").unwrap().get_value_type()
         );
+    }
+
+    #[test]
+    fn test_engine_with_summary() {
+        let mut records = TestRecordSet::new(vec![
+            TestRecord::new().with_key_value(
+                "key1".into(),
+                OwnedValue::Integer(IntegerValueStorage::new(18)),
+            ),
+            TestRecord::new().with_key_value(
+                "key1".into(),
+                OwnedValue::Integer(IntegerValueStorage::new(18)),
+            ),
+            TestRecord::new().with_key_value(
+                "key1".into(),
+                OwnedValue::Integer(IntegerValueStorage::new(0)),
+            ),
+        ]);
+
+        let summary_expression = SummaryDataExpression::new(
+            QueryLocation::new_fake(),
+            HashMap::from([(
+                "key1".into(),
+                ScalarExpression::Source(SourceScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                        StaticScalarExpression::String(StringScalarExpression::new(
+                            QueryLocation::new_fake(),
+                            "key1",
+                        )),
+                    )]),
+                )),
+            )]),
+            HashMap::from([]),
+        );
+
+        let pipeline = PipelineExpressionBuilder::new(" ")
+            .with_expressions(vec![DataExpression::Summary(summary_expression)])
+            .build()
+            .unwrap();
+
+        let engine = RecordSetEngine::new();
+
+        let mut batch = engine.begin_batch(&pipeline).unwrap();
+
+        let dropped_records = batch.push_records(&mut records);
+
+        assert_eq!(3, dropped_records.len());
+
+        let results = batch.flush();
+
+        assert_eq!(2, results.summaries.included_summaries.len());
+        assert_eq!(0, results.summaries.dropped_summaries.len());
+        assert_eq!(0, results.included_records.len());
+        assert_eq!(0, results.dropped_records.len());
+    }
+
+    #[test]
+    fn test_engine_with_summary_and_pipeline() {
+        let mut records = TestRecordSet::new(vec![
+            TestRecord::new().with_key_value(
+                "key1".into(),
+                OwnedValue::Integer(IntegerValueStorage::new(18)),
+            ),
+            TestRecord::new().with_key_value(
+                "key1".into(),
+                OwnedValue::Integer(IntegerValueStorage::new(18)),
+            ),
+            TestRecord::new().with_key_value(
+                "key1".into(),
+                OwnedValue::Integer(IntegerValueStorage::new(0)),
+            ),
+        ]);
+
+        let summary_expression = SummaryDataExpression::new(
+            QueryLocation::new_fake(),
+            HashMap::from([(
+                "key1".into(),
+                ScalarExpression::Source(SourceScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                        StaticScalarExpression::String(StringScalarExpression::new(
+                            QueryLocation::new_fake(),
+                            "key1",
+                        )),
+                    )]),
+                )),
+            )]),
+            HashMap::from([]),
+        )
+        .with_post_expressions(vec![
+            DataExpression::Discard(
+                DiscardDataExpression::new(QueryLocation::new_fake()).with_predicate(
+                    LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                        QueryLocation::new_fake(),
+                        ScalarExpression::Source(SourceScalarExpression::new(
+                            QueryLocation::new_fake(),
+                            ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                                StaticScalarExpression::String(StringScalarExpression::new(
+                                    QueryLocation::new_fake(),
+                                    "key1",
+                                )),
+                            )]),
+                        )),
+                        ScalarExpression::Static(StaticScalarExpression::Integer(
+                            IntegerScalarExpression::new(QueryLocation::new_fake(), 0),
+                        )),
+                        false,
+                    )),
+                ),
+            ),
+            DataExpression::Transform(TransformExpression::Set(SetTransformExpression::new(
+                QueryLocation::new_fake(),
+                ImmutableValueExpression::Scalar(ScalarExpression::Static(
+                    StaticScalarExpression::Null(NullScalarExpression::new(
+                        QueryLocation::new_fake(),
+                    )),
+                )),
+                MutableValueExpression::Source(SourceScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                        StaticScalarExpression::String(StringScalarExpression::new(
+                            QueryLocation::new_fake(),
+                            "key2",
+                        )),
+                    )]),
+                )),
+            ))),
+        ]);
+
+        let pipeline = PipelineExpressionBuilder::new(" ")
+            .with_expressions(vec![DataExpression::Summary(summary_expression)])
+            .build()
+            .unwrap();
+
+        let engine = RecordSetEngine::new();
+
+        let mut batch = engine.begin_batch(&pipeline).unwrap();
+
+        let dropped_records = batch.push_records(&mut records);
+
+        assert_eq!(3, dropped_records.len());
+
+        let results = batch.flush();
+
+        assert_eq!(1, results.summaries.included_summaries.len());
+        assert_eq!(1, results.summaries.dropped_summaries.len());
+        assert_eq!(0, results.included_records.len());
+        assert_eq!(0, results.dropped_records.len());
     }
 }

--- a/rust/experimental/query_engine/engine-recordset/src/engine_diagnostic.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/engine_diagnostic.rs
@@ -56,7 +56,7 @@ pub struct RecordSetEngineDiagnostic<'a> {
 }
 
 impl<'a> RecordSetEngineDiagnostic<'a> {
-    pub fn new(
+    pub(crate) fn new(
         diagnostic_level: RecordSetEngineDiagnosticLevel,
         expression: &'a dyn Expression,
         message: String,

--- a/rust/experimental/query_engine/engine-recordset/src/primitives/value_storage.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/primitives/value_storage.rs
@@ -294,7 +294,7 @@ impl<T: EnumerableValueSource<T>> ArrayValueStorage<T> {
         ArrayValueStorage::<TTarget>::new(self.values.drain(..).map(|v| v.into().into()).collect())
     }
 
-    pub fn get_values(&self) -> &Vec<T> {
+    pub fn get_values(&self) -> &[T] {
         &self.values
     }
 
@@ -420,6 +420,10 @@ impl<T: EnumerableValueSource<T>> MapValueStorage<T> {
         &mut self.values
     }
 
+    pub fn take_values(self) -> HashMap<Box<str>, T> {
+        self.values
+    }
+
     pub fn into<TTarget: EnumerableValueSource<TTarget>>(mut self) -> MapValueStorage<TTarget> {
         MapValueStorage::<TTarget>::new(HashMap::from_iter(
             self.values.drain().map(|(k, v)| (k, v.into().into())),
@@ -501,5 +505,11 @@ impl<T: EnumerableValueSource<T>> MapValueMut for MapValueStorage<T> {
 
     fn retain(&mut self, item_callback: &mut dyn KeyValueMutCallback) {
         self.values.retain(|k, v| item_callback.next(k, v));
+    }
+}
+
+impl<T: EnumerableValueSource<T>> Record for MapValueStorage<T> {
+    fn get_diagnostic_level(&self) -> Option<RecordSetEngineDiagnosticLevel> {
+        None
     }
 }

--- a/rust/experimental/query_engine/engine-recordset/src/summary/summaries.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/summary/summaries.rs
@@ -9,20 +9,20 @@ use sha2::{Digest, Sha256};
 use crate::{execution_context::ExecutionContext, *};
 
 #[derive(Debug)]
-pub(crate) struct Summaries {
+pub(crate) struct Summaries<'a> {
     cardinality_limit: usize,
-    pub values: RefCell<HashMap<String, Summary>>,
+    pub values: RefCell<HashMap<String, Summary<'a>>>,
 }
 
-impl Summaries {
-    pub fn new(cardinality_limit: usize) -> Summaries {
+impl<'a> Summaries<'a> {
+    pub fn new(cardinality_limit: usize) -> Summaries<'a> {
         Self {
             cardinality_limit,
             values: RefCell::new(HashMap::new()),
         }
     }
 
-    pub fn create_or_update_summary<'a, T: Record>(
+    pub fn create_or_update_summary<T: Record>(
         &self,
         execution_context: &ExecutionContext<'a, '_, '_, T>,
         summary_data_expression: &'a SummaryDataExpression,
@@ -38,11 +38,7 @@ impl Summaries {
         let summary_data = values.get_mut(&summary_id);
 
         if let Some(summary) = summary_data {
-            summary.update(
-                execution_context,
-                summary_data_expression,
-                aggregation_values,
-            );
+            summary.update(execution_context, aggregation_values);
 
             execution_context.add_diagnostic_if_enabled(
                 RecordSetEngineDiagnosticLevel::Verbose,
@@ -63,6 +59,7 @@ impl Summaries {
         }
 
         let summary = Summary::new(
+            summary_data_expression,
             Vec::from_iter(group_by_values.drain(..).map(|(k, v)| (k, v.into()))),
             HashMap::from_iter(aggregation_values.drain().map(|(k, v)| (k, v.into()))),
         );
@@ -80,26 +77,28 @@ impl Summaries {
 }
 
 #[derive(Debug)]
-pub(crate) struct Summary {
+pub(crate) struct Summary<'a> {
+    pub summary_data_expression: &'a SummaryDataExpression,
     pub group_by_values: Vec<(Box<str>, OwnedValue)>,
     pub aggregation_values: HashMap<Box<str>, SummaryAggregation>,
 }
 
-impl Summary {
+impl<'a> Summary<'a> {
     pub fn new(
+        summary_data_expression: &'a SummaryDataExpression,
         group_by_values: Vec<(Box<str>, OwnedValue)>,
         aggregation_values: HashMap<Box<str>, SummaryAggregation>,
-    ) -> Summary {
+    ) -> Summary<'a> {
         Self {
+            summary_data_expression,
             group_by_values,
             aggregation_values,
         }
     }
 
-    pub(crate) fn update<'a, T: Record>(
+    pub(crate) fn update<T: Record>(
         &mut self,
         execution_context: &ExecutionContext<'a, '_, '_, T>,
-        summary_data_expression: &'a SummaryDataExpression,
         aggregation_values: HashMap<Box<str>, SummaryAggregationUpdate>,
     ) {
         for (key, aggregation) in aggregation_values {
@@ -132,7 +131,7 @@ impl Summary {
                     if let SummaryAggregationUpdate::Maximum(v) = aggregation {
                         let right_value = v.to_value();
                         match Value::compare_values(
-                            summary_data_expression.get_query_location(),
+                            self.summary_data_expression.get_query_location(),
                             &max.to_value(),
                             &right_value,
                         ) {
@@ -144,7 +143,7 @@ impl Summary {
                             Err(_) => {
                                 execution_context.add_diagnostic_if_enabled(
                                     RecordSetEngineDiagnosticLevel::Warn,
-                                    summary_data_expression,
+                                    self.summary_data_expression,
                                     || format!("Max aggregation cannot compare values of '{:?}' and '{:?}' types", max.get_value_type(), right_value.get_value_type()));
                             }
                         }
@@ -156,7 +155,7 @@ impl Summary {
                     if let SummaryAggregationUpdate::Minimum(v) = aggregation {
                         let right_value = v.to_value();
                         match Value::compare_values(
-                            summary_data_expression.get_query_location(),
+                            self.summary_data_expression.get_query_location(),
                             &min.to_value(),
                             &right_value,
                         ) {
@@ -168,7 +167,7 @@ impl Summary {
                             Err(_) => {
                                 execution_context.add_diagnostic_if_enabled(
                                     RecordSetEngineDiagnosticLevel::Warn,
-                                    summary_data_expression,
+                                    self.summary_data_expression,
                                     || format!("Min aggregation cannot compare values of '{:?}' and '{:?}' types", min.get_value_type(), right_value.get_value_type()));
                             }
                         }
@@ -190,7 +189,7 @@ impl Summary {
         }
     }
 
-    pub(crate) fn generate_id(group_by_values: &Vec<(Box<str>, ResolvedValue)>) -> String {
+    pub(crate) fn generate_id(group_by_values: &[(Box<str>, ResolvedValue)]) -> String {
         let mut hasher = Sha256::new();
 
         for (key, value) in group_by_values {
@@ -225,6 +224,48 @@ impl Summary {
         let bytes = &hash[..];
 
         hex::encode(bytes)
+    }
+
+    pub fn as_map(&self) -> MapValueStorage<OwnedValue> {
+        let mut values =
+            HashMap::with_capacity(self.group_by_values.len() + self.aggregation_values.len());
+
+        for (key, value) in &self.group_by_values {
+            values.insert(key.clone(), value.clone());
+        }
+
+        for (key, value) in &self.aggregation_values {
+            match value {
+                SummaryAggregation::Average { count, sum } => {
+                    let avg = sum.to_double() / *count as f64;
+
+                    values.insert(
+                        key.clone(),
+                        OwnedValue::Double(DoubleValueStorage::new(avg)),
+                    );
+                }
+                SummaryAggregation::Count(v) => {
+                    values.insert(
+                        key.clone(),
+                        OwnedValue::Integer(IntegerValueStorage::new(*v as i64)),
+                    );
+                }
+                SummaryAggregation::Maximum(v) | SummaryAggregation::Minimum(v) => {
+                    values.insert(key.clone(), v.clone());
+                }
+                SummaryAggregation::Sum(v) => {
+                    let v = match v {
+                        SummaryValue::Double(d) => OwnedValue::Double(DoubleValueStorage::new(*d)),
+                        SummaryValue::Integer(i) => {
+                            OwnedValue::Integer(IntegerValueStorage::new(*i))
+                        }
+                    };
+                    values.insert(key.clone(), v);
+                }
+            }
+        }
+
+        MapValueStorage::new(values)
     }
 }
 

--- a/rust/experimental/query_engine/engine-recordset/src/summary/summary_data_expression.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/summary/summary_data_expression.rs
@@ -144,7 +144,7 @@ mod tests {
     fn test_execute_summary_data_expression_group_by() {
         fn run_test(
             summary_data_expression: SummaryDataExpression,
-            assert: impl FnOnce(&Vec<RecordSetEngineSummary>),
+            assert: impl FnOnce(&[RecordSetEngineSummary]),
         ) {
             let record1 = TestRecord::new().with_key_value(
                 "key1".into(),
@@ -178,7 +178,7 @@ mod tests {
 
             let results = batch.flush();
 
-            let mut summaries = results.summaries;
+            let mut summaries = results.summaries.included_summaries;
 
             summaries.sort_by(|l, r| l.summary_id.cmp(&r.summary_id));
 
@@ -364,7 +364,7 @@ mod tests {
     fn test_execute_summary_data_expression_aggregation() {
         fn run_test(
             summary_data_expression: SummaryDataExpression,
-            assert: impl FnOnce(&Vec<RecordSetEngineSummary>),
+            assert: impl FnOnce(&[RecordSetEngineSummary]),
         ) {
             let record1 = TestRecord::new().with_key_value(
                 "key1".into(),
@@ -389,7 +389,7 @@ mod tests {
 
             let results = batch.flush();
 
-            let mut summaries = results.summaries;
+            let mut summaries = results.summaries.included_summaries;
 
             summaries.sort_by(|l, r| l.summary_id.cmp(&r.summary_id));
 

--- a/rust/experimental/query_engine/engine-recordset/src/value_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/value_expressions.rs
@@ -127,7 +127,7 @@ where
 fn capture_selector_values_for_mutable_write<'a, 'b, 'c, TRecord: Record>(
     execution_context: &'b ExecutionContext<'a, '_, '_, TRecord>,
     mutable_value_expression: &'a MutableValueExpression,
-    selectors: &'a Vec<ScalarExpression>,
+    selectors: &'a [ScalarExpression],
 ) -> Result<Vec<(&'a ScalarExpression, ResolvedValue<'c>)>, ExpressionError>
 where
     'a: 'c,

--- a/rust/experimental/query_engine/expressions/src/logical_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/logical_expressions.rs
@@ -112,7 +112,7 @@ impl ChainLogicalExpression {
             .push(ChainedLogicalExpression::And(expression));
     }
 
-    pub fn get_expressions(&self) -> (&LogicalExpression, &Vec<ChainedLogicalExpression>) {
+    pub fn get_expressions(&self) -> (&LogicalExpression, &[ChainedLogicalExpression]) {
         (&self.first_expression, &self.chain_expressions)
     }
 

--- a/rust/experimental/query_engine/expressions/src/pipeline_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/pipeline_expression.rs
@@ -38,7 +38,7 @@ impl PipelineExpression {
         self.constants.len() - 1
     }
 
-    pub fn get_constants(&self) -> &Vec<StaticScalarExpression> {
+    pub fn get_constants(&self) -> &[StaticScalarExpression] {
         &self.constants
     }
 

--- a/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
@@ -476,7 +476,7 @@ impl CoalesceScalarExpression {
         }
     }
 
-    pub fn get_expressions(&self) -> &Vec<ScalarExpression> {
+    pub fn get_expressions(&self) -> &[ScalarExpression] {
         &self.expressions
     }
 
@@ -662,7 +662,7 @@ impl CaseScalarExpression {
         }
     }
 
-    pub fn get_expressions_with_conditions(&self) -> &Vec<(LogicalExpression, ScalarExpression)> {
+    pub fn get_expressions_with_conditions(&self) -> &[(LogicalExpression, ScalarExpression)] {
         &self.expressions_with_conditions
     }
 
@@ -861,7 +861,7 @@ impl ListScalarExpression {
         }
     }
 
-    pub fn get_value_expressions(&self) -> &Vec<ScalarExpression> {
+    pub fn get_value_expressions(&self) -> &[ScalarExpression] {
         &self.value_expressions
     }
 

--- a/rust/experimental/query_engine/expressions/src/summary/summary_data_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/summary/summary_data_expression.rs
@@ -10,6 +10,7 @@ pub struct SummaryDataExpression {
     query_location: QueryLocation,
     group_by_expressions: Vec<(Box<str>, ScalarExpression)>,
     aggregation_expressions: Vec<(Box<str>, AggregationExpression)>,
+    pipeline: Option<PipelineExpression>,
 }
 
 impl SummaryDataExpression {
@@ -28,7 +29,13 @@ impl SummaryDataExpression {
             query_location,
             group_by_expressions,
             aggregation_expressions,
+            pipeline: None,
         }
+    }
+
+    pub fn with_pipeline(mut self, pipeline: PipelineExpression) -> Self {
+        self.pipeline = Some(pipeline);
+        self
     }
 
     pub fn get_group_by_expressions(&self) -> &Vec<(Box<str>, ScalarExpression)> {
@@ -37,6 +44,10 @@ impl SummaryDataExpression {
 
     pub fn get_aggregation_expressions(&self) -> &Vec<(Box<str>, AggregationExpression)> {
         &self.aggregation_expressions
+    }
+
+    pub fn get_pipeline(&self) -> Option<&PipelineExpression> {
+        self.pipeline.as_ref()
     }
 }
 

--- a/rust/experimental/query_engine/expressions/src/summary/summary_data_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/summary/summary_data_expression.rs
@@ -10,7 +10,7 @@ pub struct SummaryDataExpression {
     query_location: QueryLocation,
     group_by_expressions: Vec<(Box<str>, ScalarExpression)>,
     aggregation_expressions: Vec<(Box<str>, AggregationExpression)>,
-    pipeline: Option<PipelineExpression>,
+    post_expressions: Vec<DataExpression>,
 }
 
 impl SummaryDataExpression {
@@ -29,25 +29,29 @@ impl SummaryDataExpression {
             query_location,
             group_by_expressions,
             aggregation_expressions,
-            pipeline: None,
+            post_expressions: Vec::new(),
         }
     }
 
-    pub fn with_pipeline(mut self, pipeline: PipelineExpression) -> Self {
-        self.pipeline = Some(pipeline);
+    pub fn with_post_expressions(mut self, expressions: Vec<DataExpression>) -> Self {
+        self.post_expressions = expressions;
         self
     }
 
-    pub fn get_group_by_expressions(&self) -> &Vec<(Box<str>, ScalarExpression)> {
+    pub fn get_group_by_expressions(&self) -> &[(Box<str>, ScalarExpression)] {
         &self.group_by_expressions
     }
 
-    pub fn get_aggregation_expressions(&self) -> &Vec<(Box<str>, AggregationExpression)> {
+    pub fn get_aggregation_expressions(&self) -> &[(Box<str>, AggregationExpression)] {
         &self.aggregation_expressions
     }
 
-    pub fn get_pipeline(&self) -> Option<&PipelineExpression> {
-        self.pipeline.as_ref()
+    pub fn get_post_expressions(&self) -> &[DataExpression] {
+        &self.post_expressions
+    }
+
+    pub fn push_post_expression(&mut self, expression: DataExpression) {
+        self.post_expressions.push(expression);
     }
 }
 

--- a/rust/experimental/query_engine/expressions/src/transform_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/transform_expressions.rs
@@ -161,7 +161,7 @@ impl MapKeyListExpression {
         &self.target
     }
 
-    pub fn get_keys(&self) -> &Vec<ScalarExpression> {
+    pub fn get_keys(&self) -> &[ScalarExpression] {
         &self.keys
     }
 }
@@ -248,7 +248,7 @@ impl MapSelectionExpression {
         &self.target
     }
 
-    pub fn get_selectors(&self) -> &Vec<MapSelector> {
+    pub fn get_selectors(&self) -> &[MapSelector] {
         &self.selectors
     }
 

--- a/rust/experimental/query_engine/expressions/src/value_accessor.rs
+++ b/rust/experimental/query_engine/expressions/src/value_accessor.rs
@@ -36,7 +36,7 @@ impl ValueAccessor {
         !self.selectors.is_empty()
     }
 
-    pub fn get_selectors(&self) -> &Vec<ScalarExpression> {
+    pub fn get_selectors(&self) -> &[ScalarExpression] {
         &self.selectors
     }
 

--- a/rust/experimental/query_engine/kql-parser/src/aggregate_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/aggregate_expressions.rs
@@ -9,7 +9,7 @@ use crate::{Rule, scalar_expression::parse_scalar_expression};
 
 pub(crate) fn parse_aggregate_assignment_expression(
     aggregate_assignment_expression_rule: Pair<Rule>,
-    state: &ParserState,
+    state: &dyn ParserScope,
 ) -> Result<(Box<str>, AggregationExpression), ParserError> {
     let mut aggregate_assignment_rules = aggregate_assignment_expression_rule.into_inner();
 
@@ -24,7 +24,7 @@ pub(crate) fn parse_aggregate_assignment_expression(
 
 fn parse_aggregate_expression(
     aggregate_expression_rule: Pair<Rule>,
-    state: &ParserState,
+    state: &dyn ParserScope,
 ) -> Result<AggregationExpression, ParserError> {
     let query_location = to_query_location(&aggregate_expression_rule);
 

--- a/rust/experimental/query_engine/kql-parser/src/logical_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/logical_expressions.rs
@@ -9,7 +9,7 @@ use crate::{Rule, scalar_expression::parse_scalar_expression};
 
 pub(crate) fn parse_comparison_expression(
     comparison_expression_rule: Pair<Rule>,
-    state: &ParserState,
+    state: &dyn ParserScope,
 ) -> Result<LogicalExpression, ParserError> {
     let query_location = to_query_location(&comparison_expression_rule);
 
@@ -190,7 +190,7 @@ pub(crate) fn parse_comparison_expression(
 
 pub(crate) fn parse_logical_expression(
     logical_expression_rule: Pair<Rule>,
-    state: &ParserState,
+    state: &dyn ParserScope,
 ) -> Result<LogicalExpression, ParserError> {
     let query_location = to_query_location(&logical_expression_rule);
 

--- a/rust/experimental/query_engine/kql-parser/src/scalar_conditional_function_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_conditional_function_expressions.rs
@@ -11,7 +11,7 @@ use crate::{
 
 pub(crate) fn parse_conditional_expression(
     conditional_expression_rule: Pair<Rule>,
-    state: &ParserState,
+    state: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&conditional_expression_rule);
 
@@ -35,7 +35,7 @@ pub(crate) fn parse_conditional_expression(
 
 pub(crate) fn parse_case_expression(
     case_expression_rule: Pair<Rule>,
-    state: &ParserState,
+    state: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&case_expression_rule);
 
@@ -90,7 +90,7 @@ pub(crate) fn parse_case_expression(
 
 pub(crate) fn parse_coalesce_expression(
     coalesce_expression_rule: Pair<Rule>,
-    state: &ParserState,
+    state: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&coalesce_expression_rule);
 

--- a/rust/experimental/query_engine/kql-parser/src/scalar_conversion_function_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_conversion_function_expressions.rs
@@ -9,7 +9,7 @@ use crate::{Rule, scalar_expression::parse_scalar_expression};
 
 pub(crate) fn parse_tostring_expression(
     tostring_rule: Pair<Rule>,
-    state: &ParserState,
+    state: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&tostring_rule);
     let mut inner = tostring_rule.into_inner();
@@ -26,7 +26,7 @@ pub(crate) fn parse_tostring_expression(
 
 pub(crate) fn parse_toint_expression(
     toint_rule: Pair<Rule>,
-    state: &ParserState,
+    state: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&toint_rule);
     let mut inner = toint_rule.into_inner();
@@ -43,7 +43,7 @@ pub(crate) fn parse_toint_expression(
 
 pub(crate) fn parse_tobool_expression(
     tobool_rule: Pair<Rule>,
-    state: &ParserState,
+    state: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&tobool_rule);
     let mut inner = tobool_rule.into_inner();
@@ -58,7 +58,7 @@ pub(crate) fn parse_tobool_expression(
 
 pub(crate) fn parse_tofloat_expression(
     tofloat_rule: Pair<Rule>,
-    state: &ParserState,
+    state: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&tofloat_rule);
     let mut inner = tofloat_rule.into_inner();
@@ -73,7 +73,7 @@ pub(crate) fn parse_tofloat_expression(
 
 pub(crate) fn parse_tolong_expression(
     tolong_rule: Pair<Rule>,
-    state: &ParserState,
+    state: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&tolong_rule);
     let mut inner = tolong_rule.into_inner();
@@ -88,7 +88,7 @@ pub(crate) fn parse_tolong_expression(
 
 pub(crate) fn parse_toreal_expression(
     toreal_rule: Pair<Rule>,
-    state: &ParserState,
+    state: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&toreal_rule);
     let mut inner = toreal_rule.into_inner();
@@ -103,7 +103,7 @@ pub(crate) fn parse_toreal_expression(
 
 pub(crate) fn parse_todouble_expression(
     todouble_rule: Pair<Rule>,
-    state: &ParserState,
+    state: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&todouble_rule);
     let mut inner = todouble_rule.into_inner();
@@ -118,7 +118,7 @@ pub(crate) fn parse_todouble_expression(
 
 pub(crate) fn parse_todatetime_expression(
     todatetime_rule: Pair<Rule>,
-    state: &ParserState,
+    state: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&todatetime_rule);
     let mut inner = todatetime_rule.into_inner();
@@ -136,7 +136,7 @@ pub(crate) fn parse_todatetime_expression(
 
 pub(crate) fn parse_totimespan_expression(
     totimespan_rule: Pair<Rule>,
-    state: &ParserState,
+    state: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&totimespan_rule);
     let mut inner = totimespan_rule.into_inner();

--- a/rust/experimental/query_engine/kql-parser/src/scalar_expression.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_expression.rs
@@ -14,7 +14,7 @@ use crate::{
 
 pub(crate) fn parse_scalar_expression(
     scalar_expression_rule: Pair<Rule>,
-    state: &ParserState,
+    state: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let scalar_rule = scalar_expression_rule.into_inner().next().unwrap();
 

--- a/rust/experimental/query_engine/kql-parser/src/scalar_mathematical_function_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_mathematical_function_expressions.rs
@@ -9,7 +9,7 @@ use crate::{Rule, scalar_expression::parse_scalar_expression};
 
 pub(crate) fn parse_negate_expression(
     negate_expression_rule: Pair<Rule>,
-    state: &ParserState,
+    state: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&negate_expression_rule);
     let mut inner = negate_expression_rule.into_inner();
@@ -26,7 +26,7 @@ pub(crate) fn parse_negate_expression(
 
 pub(crate) fn parse_bin_expression(
     bin_expression_rule: Pair<Rule>,
-    state: &ParserState,
+    state: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&bin_expression_rule);
 
@@ -42,7 +42,7 @@ pub(crate) fn parse_bin_expression(
 
 pub(crate) fn parse_arithmetic_expression(
     arithmetic_expr_rule: Pair<Rule>,
-    state: &ParserState,
+    state: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&arithmetic_expr_rule);
     let mut inner_rules = arithmetic_expr_rule.into_inner();
@@ -78,7 +78,7 @@ pub(crate) fn parse_arithmetic_expression(
 
 fn parse_arithmetic_factor(
     factor_rule: Pair<Rule>,
-    state: &ParserState,
+    state: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&factor_rule);
     let mut inner_rules = factor_rule.into_inner();

--- a/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
@@ -249,7 +249,7 @@ pub(crate) fn parse_real_expression(
 ///   `unknown` -> `Source(MapKey("attributes"), MapKey("unknown"))`
 pub(crate) fn parse_accessor_expression(
     accessor_expression_rule: Pair<Rule>,
-    state: &ParserState,
+    state: &dyn ParserScope,
     allow_root_scalar: bool,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&accessor_expression_rule);
@@ -557,7 +557,7 @@ pub(crate) fn parse_accessor_expression(
     }
 }
 
-fn get_value_type(state: &ParserState, value_accessor: &ValueAccessor) -> Option<ValueType> {
+fn get_value_type(state: &dyn ParserScope, value_accessor: &ValueAccessor) -> Option<ValueType> {
     let selectors = value_accessor.get_selectors();
     let mut value_type = None;
     if selectors.is_empty() {
@@ -1307,7 +1307,7 @@ mod tests {
 
     #[test]
     fn test_parse_accessor_expression_implicit_source_and_default_map() {
-        let run_test = |query: &str, expected: &Vec<ScalarExpression>| {
+        let run_test = |query: &str, expected: &[ScalarExpression]| {
             let mut result = KqlPestParser::parse(Rule::accessor_expression, query).unwrap();
 
             let expression = parse_accessor_expression(

--- a/rust/experimental/query_engine/kql-parser/src/scalar_string_function_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_string_function_expressions.rs
@@ -9,7 +9,7 @@ use crate::{Rule, scalar_expression::parse_scalar_expression};
 
 pub(crate) fn parse_strlen_expression(
     strlen_expression_rule: Pair<Rule>,
-    state: &ParserState,
+    state: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&strlen_expression_rule);
 
@@ -41,7 +41,7 @@ pub(crate) fn parse_strlen_expression(
 
 pub(crate) fn parse_replace_string_expression(
     replace_string_expression_rule: Pair<Rule>,
-    state: &ParserState,
+    state: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&replace_string_expression_rule);
 
@@ -59,7 +59,7 @@ pub(crate) fn parse_replace_string_expression(
 
     fn parse_and_validate_string_rule(
         rule: Pair<Rule>,
-        state: &ParserState,
+        state: &dyn ParserScope,
     ) -> Result<ScalarExpression, ParserError> {
         let location = to_query_location(&rule);
 
@@ -85,7 +85,7 @@ pub(crate) fn parse_replace_string_expression(
 
 pub(crate) fn parse_substring_expression(
     substring_expression_rule: Pair<Rule>,
-    state: &ParserState,
+    state: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&substring_expression_rule);
 
@@ -143,7 +143,7 @@ pub(crate) fn parse_substring_expression(
 
 pub(crate) fn parse_parse_json_expression(
     parse_json_expression_rule: Pair<Rule>,
-    state: &ParserState,
+    state: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&parse_json_expression_rule);
 

--- a/rust/experimental/query_engine/kql-parser/src/scalar_temporal_function_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_temporal_function_expressions.rs
@@ -9,7 +9,7 @@ use crate::{Rule, scalar_expression::parse_scalar_expression};
 
 pub(crate) fn parse_now_expression(
     now_expression_rule: Pair<Rule>,
-    state: &ParserState,
+    state: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&now_expression_rule);
 

--- a/rust/experimental/query_engine/kql-parser/src/shared_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/shared_expressions.rs
@@ -12,7 +12,7 @@ use crate::{
 
 pub(crate) fn parse_assignment_expression(
     assignment_expression_rule: Pair<Rule>,
-    state: &ParserState,
+    state: &dyn ParserScope,
 ) -> Result<TransformExpression, ParserError> {
     let query_location = to_query_location(&assignment_expression_rule);
 
@@ -75,7 +75,7 @@ pub(crate) fn parse_assignment_expression(
 
 pub(crate) fn parse_let_expression(
     let_expression_rule: Pair<Rule>,
-    state: &ParserState,
+    state: &dyn ParserScope,
 ) -> Result<TransformExpression, ParserError> {
     let query_location = to_query_location(&let_expression_rule);
 

--- a/rust/experimental/query_engine/parser-abstractions/src/parser_state.rs
+++ b/rust/experimental/query_engine/parser-abstractions/src/parser_state.rs
@@ -10,6 +10,7 @@ use crate::{ParserError, ParserMapSchema, ParserOptions};
 pub struct ParserState {
     source_map_schema: Option<ParserMapSchema>,
     attached_data_names: HashSet<Box<str>>,
+    global_variable_names: HashSet<Box<str>>,
     variable_names: HashSet<Box<str>>,
     constants: HashMap<Box<str>, (usize, ValueType)>,
     pipeline_builder: PipelineExpressionBuilder,
@@ -24,54 +25,16 @@ impl ParserState {
         Self {
             source_map_schema: options.source_map_schema,
             attached_data_names: options.attached_data_names,
+            global_variable_names: HashSet::new(),
             variable_names: HashSet::new(),
             constants: HashMap::new(),
             pipeline_builder: PipelineExpressionBuilder::new(query),
         }
     }
 
-    pub fn get_query(&self) -> &str {
-        self.get_pipeline().get_query()
-    }
-
-    pub fn get_query_slice(&self, query_location: &QueryLocation) -> &str {
-        self.get_pipeline().get_query_slice(query_location)
-    }
-
-    pub fn get_pipeline(&self) -> &PipelineExpression {
-        self.pipeline_builder.as_ref()
-    }
-
-    pub fn get_source_schema(&self) -> Option<&ParserMapSchema> {
-        self.source_map_schema.as_ref()
-    }
-
-    pub fn is_well_defined_identifier(&self, name: &str) -> bool {
-        name == "source"
-            || self.is_attached_data_defined(name)
-            || self.is_variable_defined(name)
-            || self.get_constant(name).is_some()
-    }
-
-    pub fn is_attached_data_defined(&self, name: &str) -> bool {
-        self.attached_data_names.contains(name)
-    }
-
-    pub fn is_variable_defined(&self, name: &str) -> bool {
-        self.variable_names.contains(name)
-    }
-
-    pub fn get_constant(&self, name: &str) -> Option<(usize, ValueType)> {
-        self.constants.get(name).cloned()
-    }
-
-    pub fn push_variable_name(&mut self, name: &str) {
-        self.variable_names.insert(name.into());
-    }
-
     pub fn push_global_variable(&mut self, name: &str, value: ScalarExpression) {
         self.pipeline_builder.push_global_variable(name, value);
-        self.variable_names.insert(name.into());
+        self.global_variable_names.insert(name.into());
     }
 
     pub fn push_constant(&mut self, name: &str, value: StaticScalarExpression) {
@@ -91,4 +54,127 @@ impl ParserState {
             .build()
             .map_err(|e| e.iter().map(ParserError::from).collect())
     }
+}
+
+impl ParserScope for ParserState {
+    fn get_pipeline(&self) -> &PipelineExpression {
+        self.pipeline_builder.as_ref()
+    }
+
+    fn get_source_schema(&self) -> Option<&ParserMapSchema> {
+        self.source_map_schema.as_ref()
+    }
+
+    fn is_well_defined_identifier(&self, name: &str) -> bool {
+        name == "source"
+            || self.is_attached_data_defined(name)
+            || self.is_variable_defined(name)
+            || self.get_constant(name).is_some()
+    }
+
+    fn is_attached_data_defined(&self, name: &str) -> bool {
+        self.attached_data_names.contains(name)
+    }
+
+    fn is_variable_defined(&self, name: &str) -> bool {
+        self.variable_names.contains(name) || self.global_variable_names.contains(name)
+    }
+
+    fn get_constant(&self, name: &str) -> Option<(usize, ValueType)> {
+        self.constants.get(name).cloned()
+    }
+
+    fn push_variable_name(&mut self, name: &str) {
+        self.variable_names.insert(name.into());
+    }
+
+    fn create_scope<'a>(&'a self, options: ParserOptions) -> ParserStateScope<'a> {
+        ParserStateScope {
+            pipeline_builder: &self.pipeline_builder,
+            source_map_schema: options.source_map_schema,
+            attached_data_names: options.attached_data_names,
+            global_variable_names: &self.global_variable_names,
+            variable_names: HashSet::new(),
+            constants: &self.constants,
+        }
+    }
+}
+
+pub struct ParserStateScope<'a> {
+    pipeline_builder: &'a PipelineExpressionBuilder,
+    source_map_schema: Option<ParserMapSchema>,
+    attached_data_names: HashSet<Box<str>>,
+    global_variable_names: &'a HashSet<Box<str>>,
+    variable_names: HashSet<Box<str>>,
+    constants: &'a HashMap<Box<str>, (usize, ValueType)>,
+}
+
+impl ParserScope for ParserStateScope<'_> {
+    fn get_pipeline(&self) -> &PipelineExpression {
+        self.pipeline_builder.as_ref()
+    }
+
+    fn get_source_schema(&self) -> Option<&ParserMapSchema> {
+        self.source_map_schema.as_ref()
+    }
+
+    fn is_well_defined_identifier(&self, name: &str) -> bool {
+        name == "source"
+            || self.is_attached_data_defined(name)
+            || self.is_variable_defined(name)
+            || self.get_constant(name).is_some()
+    }
+
+    fn is_attached_data_defined(&self, name: &str) -> bool {
+        self.attached_data_names.contains(name)
+    }
+
+    fn is_variable_defined(&self, name: &str) -> bool {
+        self.variable_names.contains(name) || self.global_variable_names.contains(name)
+    }
+
+    fn get_constant(&self, name: &str) -> Option<(usize, ValueType)> {
+        self.constants.get(name).cloned()
+    }
+
+    fn push_variable_name(&mut self, name: &str) {
+        self.variable_names.insert(name.into());
+    }
+
+    fn create_scope<'a>(&'a self, options: ParserOptions) -> ParserStateScope<'a> {
+        ParserStateScope {
+            pipeline_builder: self.pipeline_builder,
+            source_map_schema: options.source_map_schema,
+            attached_data_names: options.attached_data_names,
+            global_variable_names: self.global_variable_names,
+            variable_names: HashSet::new(),
+            constants: self.constants,
+        }
+    }
+}
+
+pub trait ParserScope {
+    fn get_pipeline(&self) -> &PipelineExpression;
+
+    fn get_query(&self) -> &str {
+        self.get_pipeline().get_query()
+    }
+
+    fn get_query_slice(&self, query_location: &QueryLocation) -> &str {
+        self.get_pipeline().get_query_slice(query_location)
+    }
+
+    fn get_source_schema(&self) -> Option<&ParserMapSchema>;
+
+    fn is_well_defined_identifier(&self, name: &str) -> bool;
+
+    fn is_attached_data_defined(&self, name: &str) -> bool;
+
+    fn is_variable_defined(&self, name: &str) -> bool;
+
+    fn get_constant(&self, name: &str) -> Option<(usize, ValueType)>;
+
+    fn push_variable_name(&mut self, name: &str);
+
+    fn create_scope<'a>(&'a self, options: ParserOptions) -> ParserStateScope<'a>;
 }


### PR DESCRIPTION
## Changes

* Adds support for running expressions over the summary records once they are generated