### PR TITLE
[query-engine] Fix bugs when performing assignment using defined names

### DIFF
--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/tests/otlp_kql_recordset.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/tests/otlp_kql_recordset.rs
@@ -306,7 +306,7 @@ fn test_summarize_with_pipeline() {
         ),
     );
 
-    let query = "let BatchTime = now(); source | summarize Count = count() by Body | where Count > 1 | extend processed_time = now(), batch_time = BatchTime";
+    let query = "let BatchTime = now(); source | summarize Count = count() by Body | where Count > 1 | extend ProcessedTime = now(), BatchTime = BatchTime";
 
     let pipeline = data_engine_recordset_otlp_bridge::parse_kql_query_into_pipeline(query).unwrap();
 
@@ -343,8 +343,8 @@ fn test_summarize_with_pipeline() {
         );
 
         match (
-            map.get("processed_time").map(|v| v.to_value()),
-            map.get("batch_time").map(|v| v.to_value()),
+            map.get("ProcessedTime").map(|v| v.to_value()),
+            map.get("BatchTime").map(|v| v.to_value()),
         ) {
             (Some(Value::DateTime(p)), Some(Value::DateTime(b))) => {
                 assert!(p.get_value() >= b.get_value());

--- a/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
@@ -404,13 +404,15 @@ pub(crate) fn parse_accessor_expression(
         Ok(ScalarExpression::Source(
             SourceScalarExpression::new_with_value_type(query_location, value_accessor, value_type),
         ))
-    } else if state.is_attached_data_defined(root_accessor_identity.get_value()) {
+    } else if allow_root_scalar
+        && state.is_attached_data_defined(root_accessor_identity.get_value())
+    {
         Ok(ScalarExpression::Attached(AttachedScalarExpression::new(
             query_location,
             root_accessor_identity,
             value_accessor,
         )))
-    } else if state.is_variable_defined(root_accessor_identity.get_value()) {
+    } else if allow_root_scalar && state.is_variable_defined(root_accessor_identity.get_value()) {
         Ok(ScalarExpression::Variable(VariableScalarExpression::new(
             query_location,
             root_accessor_identity,

--- a/rust/experimental/query_engine/kql-parser/src/shared_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/shared_expressions.rs
@@ -10,10 +10,17 @@ use crate::{
     scalar_primitive_expressions::parse_accessor_expression,
 };
 
-pub(crate) fn parse_assignment_expression(
+pub(crate) fn parse_source_assignment_expression(
     assignment_expression_rule: Pair<Rule>,
     state: &dyn ParserScope,
-) -> Result<TransformExpression, ParserError> {
+) -> Result<
+    (
+        QueryLocation,
+        ImmutableValueExpression,
+        SourceScalarExpression,
+    ),
+    ParserError,
+> {
     let query_location = to_query_location(&assignment_expression_rule);
 
     let mut assignment_rules = assignment_expression_rule.into_inner();
@@ -45,14 +52,13 @@ pub(crate) fn parse_assignment_expression(
                 ));
             }
 
-            MutableValueExpression::Source(s)
+            s
         }
-        ScalarExpression::Variable(v) => MutableValueExpression::Variable(v),
         _ => {
             return Err(ParserError::SyntaxError(
                 destination_rule_location,
                 format!(
-                    "'{}' destination accessor must refer to source or a variable to be used in an assignment expression",
+                    "'{}' destination accessor must refer to source to be used in an assignment expression",
                     destination_rule_str.trim()
                 ),
             ));
@@ -66,11 +72,11 @@ pub(crate) fn parse_assignment_expression(
         _ => panic!("Unexpected rule in assignment_expression: {source_rule}"),
     };
 
-    Ok(TransformExpression::Set(SetTransformExpression::new(
+    Ok((
         query_location,
         ImmutableValueExpression::Scalar(scalar),
         destination,
-    )))
+    ))
 }
 
 pub(crate) fn parse_let_expression(
@@ -116,7 +122,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_parse_assignment_expression() {
+    fn test_parse_source_assignment_expression() {
         let run_test_success = |input: &str, expected: TransformExpression| {
             let mut state = ParserState::new_with_options(
                 input,
@@ -127,9 +133,17 @@ mod tests {
 
             let mut result = KqlPestParser::parse(Rule::assignment_expression, input).unwrap();
 
-            let expression = parse_assignment_expression(result.next().unwrap(), &state).unwrap();
+            let (query_location, source, destination) =
+                parse_source_assignment_expression(result.next().unwrap(), &state).unwrap();
 
-            assert_eq!(expected, expression);
+            assert_eq!(
+                expected,
+                TransformExpression::Set(SetTransformExpression::new(
+                    query_location,
+                    source,
+                    MutableValueExpression::Source(destination)
+                ))
+            );
         };
 
         let run_test_failure = |input: &str, expected: &str| {
@@ -142,7 +156,8 @@ mod tests {
 
             let mut result = KqlPestParser::parse(Rule::assignment_expression, input).unwrap();
 
-            let error = parse_assignment_expression(result.next().unwrap(), &state).unwrap_err();
+            let error =
+                parse_source_assignment_expression(result.next().unwrap(), &state).unwrap_err();
 
             if let ParserError::SyntaxError(_, msg) = error {
                 assert_eq!(expected, msg);
@@ -183,10 +198,14 @@ mod tests {
                         "hello world",
                     )),
                 )),
-                MutableValueExpression::Variable(VariableScalarExpression::new(
+                MutableValueExpression::Source(SourceScalarExpression::new(
                     QueryLocation::new_fake(),
-                    StringScalarExpression::new(QueryLocation::new_fake(), "variable"),
-                    ValueAccessor::new(),
+                    ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                        StaticScalarExpression::String(StringScalarExpression::new(
+                            QueryLocation::new_fake(),
+                            "variable",
+                        )),
+                    )]),
                 )),
             )),
         );
@@ -194,11 +213,6 @@ mod tests {
         run_test_failure(
             "source = 1",
             "Cannot write directly to 'source' in an assignment expression use an accessor expression referencing a path on source instead",
-        );
-
-        run_test_failure(
-            "resource.attributes['new_attribute'] = 1",
-            "'resource.attributes['new_attribute']' destination accessor must refer to source or a variable to be used in an assignment expression",
         );
     }
 


### PR DESCRIPTION
Relates to #995

## Changes

* Fixes bugs when performing assignment in `project` & `extend` statements when the target name matches a variable or attached data