### PR TITLE
[query-engine] Static resolution improvements

### DIFF
--- a/rust/experimental/query_engine/engine-recordset/src/scalars/parse_scalar_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/scalars/parse_scalar_expressions.rs
@@ -29,7 +29,7 @@ where
                     return Err(ExpressionError::ParseError(
                         p.get_query_location().clone(),
                         format!(
-                            "Input of '{:?}' type could not be pased as JSON",
+                            "Input of '{:?}' type could not be parsed as JSON",
                             value.get_value_type()
                         ),
                     ));

--- a/rust/experimental/query_engine/engine-recordset/src/scalars/scalar_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/scalars/scalar_expressions.rs
@@ -319,7 +319,7 @@ where
 
             let range_start_inclusive = match s.get_range_start_inclusive() {
                 Some(start) => SliceScalarExpression::validate_resolved_range_value(
-                    s.get_query_location(),
+                    start.get_query_location(),
                     "start",
                     execute_scalar_expression(execution_context, start)?.to_value(),
                 )?,
@@ -327,7 +327,7 @@ where
             };
             let range_end_exclusive = match s.get_range_end_exclusive() {
                 Some(end) => Some(SliceScalarExpression::validate_resolved_range_value(
-                    s.get_query_location(),
+                    end.get_query_location(),
                     "end",
                     execute_scalar_expression(execution_context, end)?.to_value(),
                 )?),

--- a/rust/experimental/query_engine/engine-recordset/src/scalars/scalar_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/scalars/scalar_expressions.rs
@@ -318,14 +318,16 @@ where
             let inner_value = execute_scalar_expression(execution_context, s.get_source())?;
 
             let range_start_inclusive = match s.get_range_start_inclusive() {
-                Some(start) => s.validate_resolved_range_value(
+                Some(start) => SliceScalarExpression::validate_resolved_range_value(
+                    s.get_query_location(),
                     "start",
                     execute_scalar_expression(execution_context, start)?.to_value(),
                 )?,
                 None => 0,
             };
             let range_end_exclusive = match s.get_range_end_exclusive() {
-                Some(end) => Some(s.validate_resolved_range_value(
+                Some(end) => Some(SliceScalarExpression::validate_resolved_range_value(
+                    s.get_query_location(),
                     "end",
                     execute_scalar_expression(execution_context, end)?.to_value(),
                 )?),
@@ -334,7 +336,8 @@ where
 
             let v = match inner_value.try_resolve_string() {
                 Ok(string_value) => {
-                    let range_end_exclusive = s.validate_slice_range(
+                    let range_end_exclusive = SliceScalarExpression::validate_slice_range(
+                        s.get_query_location(),
                         "String",
                         string_value.get_value().chars().count(),
                         range_start_inclusive,
@@ -349,7 +352,8 @@ where
                 }
                 Err(v) => match v.try_resolve_array() {
                     Ok(array_value) => {
-                        let range_end_exclusive = s.validate_slice_range(
+                        let range_end_exclusive = SliceScalarExpression::validate_slice_range(
+                            s.get_query_location(),
                             "Array",
                             array_value.len(),
                             range_start_inclusive,

--- a/rust/experimental/query_engine/engine-recordset/src/summary/summary_data_expression.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/summary/summary_data_expression.rs
@@ -161,7 +161,7 @@ mod tests {
                     OwnedValue::String(StringValueStorage::new("value3".into())),
                 );
 
-            let pipeline = PipelineExpressionBuilder::new(" ")
+            let pipeline = PipelineExpressionBuilder::new("")
                 .with_expressions(vec![DataExpression::Summary(summary_data_expression)])
                 .build()
                 .unwrap();
@@ -376,7 +376,7 @@ mod tests {
                 OwnedValue::Integer(IntegerValueStorage::new(18)),
             );
 
-            let pipeline = PipelineExpressionBuilder::new(" ")
+            let pipeline = PipelineExpressionBuilder::new("")
                 .with_expressions(vec![DataExpression::Summary(summary_data_expression)])
                 .build()
                 .unwrap();

--- a/rust/experimental/query_engine/expressions/src/logical_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/logical_expressions.rs
@@ -169,7 +169,7 @@ impl ChainLogicalExpression {
                 }
             }
 
-            Ok(Some(ResolvedStaticScalarExpression::Value(
+            Ok(Some(ResolvedStaticScalarExpression::Computed(
                 StaticScalarExpression::Boolean(BooleanScalarExpression::new(
                     self.query_location.clone(),
                     result,
@@ -248,7 +248,7 @@ impl EqualToLogicalExpression {
                     self.case_insensitive,
                 )?;
 
-                Ok(Some(ResolvedStaticScalarExpression::Value(
+                Ok(Some(ResolvedStaticScalarExpression::Computed(
                     StaticScalarExpression::Boolean(BooleanScalarExpression::new(
                         self.query_location.clone(),
                         b,
@@ -309,7 +309,7 @@ impl GreaterThanLogicalExpression {
             (Some(l), Some(r)) => {
                 let r = Value::compare_values(&self.query_location, &l.to_value(), &r.to_value())?;
 
-                Ok(Some(ResolvedStaticScalarExpression::Value(
+                Ok(Some(ResolvedStaticScalarExpression::Computed(
                     StaticScalarExpression::Boolean(BooleanScalarExpression::new(
                         self.query_location.clone(),
                         r > 0,
@@ -370,7 +370,7 @@ impl GreaterThanOrEqualToLogicalExpression {
             (Some(l), Some(r)) => {
                 let r = Value::compare_values(&self.query_location, &l.to_value(), &r.to_value())?;
 
-                Ok(Some(ResolvedStaticScalarExpression::Value(
+                Ok(Some(ResolvedStaticScalarExpression::Computed(
                     StaticScalarExpression::Boolean(BooleanScalarExpression::new(
                         self.query_location.clone(),
                         r >= 0,
@@ -418,7 +418,7 @@ impl NotLogicalExpression {
         scope: &PipelineResolutionScope,
     ) -> Result<Option<ResolvedStaticScalarExpression<'_>>, ExpressionError> {
         if let Some(v) = self.inner_expression.try_resolve_static(scope)? {
-            Ok(Some(ResolvedStaticScalarExpression::Value(
+            Ok(Some(ResolvedStaticScalarExpression::Computed(
                 StaticScalarExpression::Boolean(BooleanScalarExpression::new(
                     self.query_location.clone(),
                     !v,
@@ -493,7 +493,7 @@ impl ContainsLogicalExpression {
                     self.case_insensitive,
                 )?;
 
-                Ok(Some(ResolvedStaticScalarExpression::Value(
+                Ok(Some(ResolvedStaticScalarExpression::Computed(
                     StaticScalarExpression::Boolean(BooleanScalarExpression::new(
                         query_location.clone(),
                         r,
@@ -556,7 +556,7 @@ impl MatchesLogicalExpression {
             (Some(h), Some(n)) => {
                 let r = Value::matches(query_location, &h.to_value(), &n.to_value())?;
 
-                Ok(Some(ResolvedStaticScalarExpression::Value(
+                Ok(Some(ResolvedStaticScalarExpression::Computed(
                     StaticScalarExpression::Boolean(BooleanScalarExpression::new(
                         query_location.clone(),
                         r,

--- a/rust/experimental/query_engine/expressions/src/logical_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/logical_expressions.rs
@@ -495,7 +495,7 @@ impl ContainsLogicalExpression {
 
                 Ok(Some(ResolvedStaticScalarExpression::Value(
                     StaticScalarExpression::Boolean(BooleanScalarExpression::new(
-                        self.query_location.clone(),
+                        query_location.clone(),
                         r,
                     )),
                 )))
@@ -558,7 +558,7 @@ impl MatchesLogicalExpression {
 
                 Ok(Some(ResolvedStaticScalarExpression::Value(
                     StaticScalarExpression::Boolean(BooleanScalarExpression::new(
-                        self.query_location.clone(),
+                        query_location.clone(),
                         r,
                     )),
                 )))

--- a/rust/experimental/query_engine/expressions/src/logical_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/logical_expressions.rs
@@ -40,23 +40,36 @@ pub enum LogicalExpression {
 }
 
 impl LogicalExpression {
-    pub(crate) fn try_resolve_static<'a, 'b, 'c>(
-        &'a self,
-        pipeline: &'b PipelineExpression,
-    ) -> Result<Option<ResolvedStaticScalarExpression<'c>>, ExpressionError>
-    where
-        'a: 'c,
-        'b: 'c,
-    {
-        match self {
-            LogicalExpression::Scalar(s) => s.try_resolve_static(pipeline),
-            LogicalExpression::EqualTo(e) => e.try_resolve_static(pipeline),
-            LogicalExpression::GreaterThan(g) => g.try_resolve_static(pipeline),
-            LogicalExpression::GreaterThanOrEqualTo(g) => g.try_resolve_static(pipeline),
-            LogicalExpression::Not(n) => n.try_resolve_static(pipeline),
-            LogicalExpression::Chain(c) => c.try_resolve_static(pipeline),
-            LogicalExpression::Contains(c) => c.try_resolve_static(pipeline),
-            LogicalExpression::Matches(m) => m.try_resolve_static(pipeline),
+    pub(crate) fn try_resolve_static(
+        &mut self,
+        scope: &PipelineResolutionScope,
+    ) -> Result<Option<bool>, ExpressionError> {
+        if let Some(s) = match self {
+            LogicalExpression::Scalar(s) => s.try_resolve_static(scope),
+            LogicalExpression::EqualTo(e) => e.try_resolve_static(scope),
+            LogicalExpression::GreaterThan(g) => g.try_resolve_static(scope),
+            LogicalExpression::GreaterThanOrEqualTo(g) => g.try_resolve_static(scope),
+            LogicalExpression::Not(n) => n.try_resolve_static(scope),
+            LogicalExpression::Chain(c) => c.try_resolve_static(scope),
+            LogicalExpression::Contains(c) => c.try_resolve_static(scope),
+            LogicalExpression::Matches(m) => m.try_resolve_static(scope),
+        }? {
+            let value = s.to_value();
+
+            if let Some(b) = value.convert_to_bool() {
+                Ok(Some(b))
+            } else {
+                let t = value.get_value_type();
+                Err(ExpressionError::TypeMismatch(
+                    self.get_query_location().clone(),
+                    format!(
+                        "Value of '{:?}' type returned by logical expression could not be converted to bool",
+                        t
+                    ),
+                ))
+            }
+        } else {
+            Ok(None)
         }
     }
 }
@@ -122,18 +135,14 @@ impl ChainLogicalExpression {
         (&self.first_expression, &self.chain_expressions)
     }
 
-    pub(crate) fn try_resolve_static<'a, 'b, 'c>(
-        &'a self,
-        pipeline: &'b PipelineExpression,
-    ) -> Result<Option<ResolvedStaticScalarExpression<'c>>, ExpressionError>
-    where
-        'a: 'c,
-        'b: 'c,
-    {
-        if let Some(b) = try_resolve_logical_static(&self.first_expression, pipeline)? {
+    pub(crate) fn try_resolve_static(
+        &mut self,
+        scope: &PipelineResolutionScope,
+    ) -> Result<Option<ResolvedStaticScalarExpression<'_>>, ExpressionError> {
+        if let Some(b) = self.first_expression.try_resolve_static(scope)? {
             let mut result = b;
 
-            for c in &self.chain_expressions {
+            for c in &mut self.chain_expressions {
                 match c {
                     ChainedLogicalExpression::Or(or) => {
                         if result {
@@ -141,7 +150,7 @@ impl ChainLogicalExpression {
                             break;
                         }
 
-                        match try_resolve_logical_static(or, pipeline)? {
+                        match or.try_resolve_static(scope)? {
                             Some(b) => result = b,
                             None => return Ok(None),
                         }
@@ -152,7 +161,7 @@ impl ChainLogicalExpression {
                             break;
                         }
 
-                        match try_resolve_logical_static(and, pipeline)? {
+                        match and.try_resolve_static(scope)? {
                             Some(b) => result = b,
                             None => return Ok(None),
                         }
@@ -223,16 +232,12 @@ impl EqualToLogicalExpression {
         &self.right
     }
 
-    pub(crate) fn try_resolve_static<'a, 'b, 'c>(
-        &'a self,
-        pipeline: &'b PipelineExpression,
-    ) -> Result<Option<ResolvedStaticScalarExpression<'c>>, ExpressionError>
-    where
-        'a: 'c,
-        'b: 'c,
-    {
-        let left = self.get_left().try_resolve_static(pipeline)?;
-        let right = self.get_right().try_resolve_static(pipeline)?;
+    pub(crate) fn try_resolve_static(
+        &mut self,
+        scope: &PipelineResolutionScope,
+    ) -> Result<Option<ResolvedStaticScalarExpression<'_>>, ExpressionError> {
+        let left = self.left.try_resolve_static(scope)?;
+        let right = self.right.try_resolve_static(scope)?;
 
         match (left, right) {
             (Some(l), Some(r)) => {
@@ -293,16 +298,12 @@ impl GreaterThanLogicalExpression {
         &self.right
     }
 
-    pub(crate) fn try_resolve_static<'a, 'b, 'c>(
-        &'a self,
-        pipeline: &'b PipelineExpression,
-    ) -> Result<Option<ResolvedStaticScalarExpression<'c>>, ExpressionError>
-    where
-        'a: 'c,
-        'b: 'c,
-    {
-        let left = self.get_left().try_resolve_static(pipeline)?;
-        let right = self.get_right().try_resolve_static(pipeline)?;
+    pub(crate) fn try_resolve_static(
+        &mut self,
+        scope: &PipelineResolutionScope,
+    ) -> Result<Option<ResolvedStaticScalarExpression<'_>>, ExpressionError> {
+        let left = self.left.try_resolve_static(scope)?;
+        let right = self.right.try_resolve_static(scope)?;
 
         match (left, right) {
             (Some(l), Some(r)) => {
@@ -358,16 +359,12 @@ impl GreaterThanOrEqualToLogicalExpression {
         &self.right
     }
 
-    pub(crate) fn try_resolve_static<'a, 'b, 'c>(
-        &'a self,
-        pipeline: &'b PipelineExpression,
-    ) -> Result<Option<ResolvedStaticScalarExpression<'c>>, ExpressionError>
-    where
-        'a: 'c,
-        'b: 'c,
-    {
-        let left = self.get_left().try_resolve_static(pipeline)?;
-        let right = self.get_right().try_resolve_static(pipeline)?;
+    pub(crate) fn try_resolve_static(
+        &mut self,
+        scope: &PipelineResolutionScope,
+    ) -> Result<Option<ResolvedStaticScalarExpression<'_>>, ExpressionError> {
+        let left = self.left.try_resolve_static(scope)?;
+        let right = self.right.try_resolve_static(scope)?;
 
         match (left, right) {
             (Some(l), Some(r)) => {
@@ -416,15 +413,11 @@ impl NotLogicalExpression {
         &self.inner_expression
     }
 
-    pub(crate) fn try_resolve_static<'a, 'b, 'c>(
-        &'a self,
-        pipeline: &'b PipelineExpression,
-    ) -> Result<Option<ResolvedStaticScalarExpression<'c>>, ExpressionError>
-    where
-        'a: 'c,
-        'b: 'c,
-    {
-        if let Some(v) = try_resolve_logical_static(self.get_inner_expression(), pipeline)? {
+    pub(crate) fn try_resolve_static(
+        &mut self,
+        scope: &PipelineResolutionScope,
+    ) -> Result<Option<ResolvedStaticScalarExpression<'_>>, ExpressionError> {
+        if let Some(v) = self.inner_expression.try_resolve_static(scope)? {
             Ok(Some(ResolvedStaticScalarExpression::Value(
                 StaticScalarExpression::Boolean(BooleanScalarExpression::new(
                     self.query_location.clone(),
@@ -482,21 +475,19 @@ impl ContainsLogicalExpression {
         &self.needle
     }
 
-    pub(crate) fn try_resolve_static<'a, 'b, 'c>(
-        &'a self,
-        pipeline: &'b PipelineExpression,
-    ) -> Result<Option<ResolvedStaticScalarExpression<'c>>, ExpressionError>
-    where
-        'a: 'c,
-        'b: 'c,
-    {
-        let haystack = self.get_haystack().try_resolve_static(pipeline)?;
-        let needle = self.get_needle().try_resolve_static(pipeline)?;
+    pub(crate) fn try_resolve_static(
+        &mut self,
+        scope: &PipelineResolutionScope,
+    ) -> Result<Option<ResolvedStaticScalarExpression<'_>>, ExpressionError> {
+        let query_location = &self.query_location;
+
+        let haystack = self.haystack.try_resolve_static(scope)?;
+        let needle = self.needle.try_resolve_static(scope)?;
 
         match (haystack, needle) {
             (Some(h), Some(n)) => {
                 let r = Value::contains(
-                    self.get_query_location(),
+                    query_location,
                     &h.to_value(),
                     &n.to_value(),
                     self.case_insensitive,
@@ -552,20 +543,18 @@ impl MatchesLogicalExpression {
         &self.pattern
     }
 
-    pub(crate) fn try_resolve_static<'a, 'b, 'c>(
-        &'a self,
-        pipeline: &'b PipelineExpression,
-    ) -> Result<Option<ResolvedStaticScalarExpression<'c>>, ExpressionError>
-    where
-        'a: 'c,
-        'b: 'c,
-    {
-        let haystack = self.get_haystack().try_resolve_static(pipeline)?;
-        let pattern = self.get_pattern().try_resolve_static(pipeline)?;
+    pub(crate) fn try_resolve_static(
+        &mut self,
+        scope: &PipelineResolutionScope,
+    ) -> Result<Option<ResolvedStaticScalarExpression<'_>>, ExpressionError> {
+        let query_location = &self.query_location;
+
+        let haystack = self.haystack.try_resolve_static(scope)?;
+        let pattern = self.pattern.try_resolve_static(scope)?;
 
         match (haystack, pattern) {
             (Some(h), Some(n)) => {
-                let r = Value::matches(self.get_query_location(), &h.to_value(), &n.to_value())?;
+                let r = Value::matches(query_location, &h.to_value(), &n.to_value())?;
 
                 Ok(Some(ResolvedStaticScalarExpression::Value(
                     StaticScalarExpression::Boolean(BooleanScalarExpression::new(
@@ -589,29 +578,6 @@ impl Expression for MatchesLogicalExpression {
     }
 }
 
-fn try_resolve_logical_static(
-    logical_expression: &LogicalExpression,
-    pipeline: &PipelineExpression,
-) -> Result<Option<bool>, ExpressionError> {
-    if let Some(s) = logical_expression.try_resolve_static(pipeline)? {
-        let value = s.to_value();
-
-        if let Some(b) = value.convert_to_bool() {
-            Ok(Some(b))
-        } else {
-            Err(ExpressionError::TypeMismatch(
-                logical_expression.get_query_location().clone(),
-                format!(
-                    "Value of '{:?}' type returned by logical expression could not be converted to bool",
-                    value.get_value_type()
-                ),
-            ))
-        }
-    } else {
-        Ok(None)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use regex::Regex;
@@ -620,23 +586,14 @@ mod tests {
 
     #[test]
     fn test_equal_to_try_resolve_static() {
-        let run_test = |input: LogicalExpression, expected: Option<bool>| {
-            let pipeline = Default::default();
+        let run_test = |mut input: LogicalExpression, expected: Option<bool>| {
+            let pipeline: PipelineExpression = Default::default();
 
-            let r = input.try_resolve_static(&pipeline).unwrap();
+            let r = input
+                .try_resolve_static(&pipeline.get_resolution_scope())
+                .unwrap();
 
-            assert_eq!(
-                expected
-                    .map(
-                        |v| StaticScalarExpression::Boolean(BooleanScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            v
-                        ))
-                    )
-                    .as_ref()
-                    .map(|v| v.to_value()),
-                r.as_ref().map(|v| v.to_value())
-            )
+            assert_eq!(expected, r)
         };
 
         run_test(
@@ -684,23 +641,14 @@ mod tests {
 
     #[test]
     fn test_greater_than_try_resolve_static() {
-        let run_test = |input: LogicalExpression, expected: Option<bool>| {
-            let pipeline = Default::default();
+        let run_test = |mut input: LogicalExpression, expected: Option<bool>| {
+            let pipeline: PipelineExpression = Default::default();
 
-            let r = input.try_resolve_static(&pipeline).unwrap();
+            let r = input
+                .try_resolve_static(&pipeline.get_resolution_scope())
+                .unwrap();
 
-            assert_eq!(
-                expected
-                    .map(
-                        |v| StaticScalarExpression::Boolean(BooleanScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            v
-                        ))
-                    )
-                    .as_ref()
-                    .map(|v| v.to_value()),
-                r.as_ref().map(|v| v.to_value())
-            )
+            assert_eq!(expected, r)
         };
 
         run_test(
@@ -758,23 +706,14 @@ mod tests {
 
     #[test]
     fn test_greater_than_or_equal_to_try_resolve_static() {
-        let run_test = |input: LogicalExpression, expected: Option<bool>| {
-            let pipeline = Default::default();
+        let run_test = |mut input: LogicalExpression, expected: Option<bool>| {
+            let pipeline: PipelineExpression = Default::default();
 
-            let r = input.try_resolve_static(&pipeline).unwrap();
+            let r = input
+                .try_resolve_static(&pipeline.get_resolution_scope())
+                .unwrap();
 
-            assert_eq!(
-                expected
-                    .map(
-                        |v| StaticScalarExpression::Boolean(BooleanScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            v
-                        ))
-                    )
-                    .as_ref()
-                    .map(|v| v.to_value()),
-                r.as_ref().map(|v| v.to_value())
-            )
+            assert_eq!(expected, r)
         };
 
         run_test(
@@ -832,23 +771,14 @@ mod tests {
 
     #[test]
     fn test_not_try_resolve_static() {
-        let run_test = |input: LogicalExpression, expected: Option<bool>| {
-            let pipeline = Default::default();
+        let run_test = |mut input: LogicalExpression, expected: Option<bool>| {
+            let pipeline: PipelineExpression = Default::default();
 
-            let r = input.try_resolve_static(&pipeline).unwrap();
+            let r = input
+                .try_resolve_static(&pipeline.get_resolution_scope())
+                .unwrap();
 
-            assert_eq!(
-                expected
-                    .map(
-                        |v| StaticScalarExpression::Boolean(BooleanScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            v
-                        ))
-                    )
-                    .as_ref()
-                    .map(|v| v.to_value()),
-                r.as_ref().map(|v| v.to_value())
-            )
+            assert_eq!(expected, r)
         };
 
         run_test(
@@ -879,23 +809,14 @@ mod tests {
 
     #[test]
     fn test_chain_try_resolve_static() {
-        let run_test = |input: LogicalExpression, expected: Option<bool>| {
-            let pipeline = Default::default();
+        let run_test = |mut input: LogicalExpression, expected: Option<bool>| {
+            let pipeline: PipelineExpression = Default::default();
 
-            let r = input.try_resolve_static(&pipeline).unwrap();
+            let r = input
+                .try_resolve_static(&pipeline.get_resolution_scope())
+                .unwrap();
 
-            assert_eq!(
-                expected
-                    .map(
-                        |v| StaticScalarExpression::Boolean(BooleanScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            v
-                        ))
-                    )
-                    .as_ref()
-                    .map(|v| v.to_value()),
-                r.as_ref().map(|v| v.to_value())
-            )
+            assert_eq!(expected, r)
         };
 
         run_test(
@@ -986,23 +907,14 @@ mod tests {
 
     #[test]
     fn test_contains_try_resolve_static() {
-        let run_test = |input: LogicalExpression, expected: Option<bool>| {
-            let pipeline = Default::default();
+        let run_test = |mut input: LogicalExpression, expected: Option<bool>| {
+            let pipeline: PipelineExpression = Default::default();
 
-            let r = input.try_resolve_static(&pipeline).unwrap();
+            let r = input
+                .try_resolve_static(&pipeline.get_resolution_scope())
+                .unwrap();
 
-            assert_eq!(
-                expected
-                    .map(
-                        |v| StaticScalarExpression::Boolean(BooleanScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            v
-                        ))
-                    )
-                    .as_ref()
-                    .map(|v| v.to_value()),
-                r.as_ref().map(|v| v.to_value())
-            )
+            assert_eq!(expected, r)
         };
 
         run_test(
@@ -1036,29 +948,22 @@ mod tests {
 
     #[test]
     fn test_matches_try_resolve_static() {
-        let run_test_success = |input: LogicalExpression, expected: Option<bool>| {
-            let pipeline = Default::default();
+        let run_test_success = |mut input: LogicalExpression, expected: Option<bool>| {
+            let pipeline: PipelineExpression = Default::default();
 
-            let r = input.try_resolve_static(&pipeline).unwrap();
+            let r = input
+                .try_resolve_static(&pipeline.get_resolution_scope())
+                .unwrap();
 
-            assert_eq!(
-                expected
-                    .map(
-                        |v| StaticScalarExpression::Boolean(BooleanScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            v
-                        ))
-                    )
-                    .as_ref()
-                    .map(|v| v.to_value()),
-                r.as_ref().map(|v| v.to_value())
-            )
+            assert_eq!(expected, r)
         };
 
-        let run_test_failure = |input: LogicalExpression| {
-            let pipeline = Default::default();
+        let run_test_failure = |mut input: LogicalExpression| {
+            let pipeline: PipelineExpression = Default::default();
 
-            let e = input.try_resolve_static(&pipeline).unwrap_err();
+            let e = input
+                .try_resolve_static(&pipeline.get_resolution_scope())
+                .unwrap_err();
 
             assert!(matches!(e, ExpressionError::ParseError(_, _)));
         };

--- a/rust/experimental/query_engine/expressions/src/pipeline_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/pipeline_expression.rs
@@ -80,7 +80,7 @@ impl PipelineExpression {
 
 impl Default for PipelineExpression {
     fn default() -> Self {
-        PipelineExpression::new(" ")
+        PipelineExpression::new("")
     }
 }
 

--- a/rust/experimental/query_engine/expressions/src/pipeline_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/pipeline_expression.rs
@@ -66,6 +66,12 @@ impl PipelineExpression {
         &self.initializations
     }
 
+    pub fn get_resolution_scope(&self) -> PipelineResolutionScope<'_> {
+        PipelineResolutionScope {
+            constants: &self.constants,
+        }
+    }
+
     pub(crate) fn optimize(&mut self) -> Result<(), Vec<ExpressionError>> {
         // todo: Implement constant folding and other optimizations
         Ok(())
@@ -74,7 +80,7 @@ impl PipelineExpression {
 
 impl Default for PipelineExpression {
     fn default() -> Self {
-        PipelineExpression::new("")
+        PipelineExpression::new(" ")
     }
 }
 
@@ -85,6 +91,16 @@ impl Expression for PipelineExpression {
 
     fn get_name(&self) -> &'static str {
         "PipelineExpression"
+    }
+}
+
+pub struct PipelineResolutionScope<'a> {
+    constants: &'a Vec<StaticScalarExpression>,
+}
+
+impl<'a> PipelineResolutionScope<'a> {
+    pub fn get_constant(&self, constant_id: usize) -> Option<&'a StaticScalarExpression> {
+        self.constants.get(constant_id)
     }
 }
 

--- a/rust/experimental/query_engine/expressions/src/scalars/convert_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/convert_scalar_expression.rs
@@ -93,14 +93,14 @@ impl ConvertScalarExpression {
             ConvertScalarExpression::Boolean(c) => {
                 if let Some(v) = c.inner_expression.try_resolve_static(scope)? {
                     if let Some(b) = v.to_value().convert_to_bool() {
-                        Ok(Some(ResolvedStaticScalarExpression::Value(
+                        Ok(Some(ResolvedStaticScalarExpression::Computed(
                             StaticScalarExpression::Boolean(BooleanScalarExpression::new(
                                 c.query_location.clone(),
                                 b,
                             )),
                         )))
                     } else {
-                        Ok(Some(ResolvedStaticScalarExpression::Value(
+                        Ok(Some(ResolvedStaticScalarExpression::Computed(
                             StaticScalarExpression::Null(NullScalarExpression::new(
                                 c.query_location.clone(),
                             )),
@@ -113,14 +113,14 @@ impl ConvertScalarExpression {
             ConvertScalarExpression::DateTime(c) => {
                 if let Some(v) = c.inner_expression.try_resolve_static(scope)? {
                     if let Some(d) = v.to_value().convert_to_datetime() {
-                        Ok(Some(ResolvedStaticScalarExpression::Value(
+                        Ok(Some(ResolvedStaticScalarExpression::Computed(
                             StaticScalarExpression::DateTime(DateTimeScalarExpression::new(
                                 c.query_location.clone(),
                                 d,
                             )),
                         )))
                     } else {
-                        Ok(Some(ResolvedStaticScalarExpression::Value(
+                        Ok(Some(ResolvedStaticScalarExpression::Computed(
                             StaticScalarExpression::Null(NullScalarExpression::new(
                                 c.query_location.clone(),
                             )),
@@ -133,14 +133,14 @@ impl ConvertScalarExpression {
             ConvertScalarExpression::Double(c) => {
                 if let Some(v) = c.inner_expression.try_resolve_static(scope)? {
                     if let Some(d) = v.to_value().convert_to_double() {
-                        Ok(Some(ResolvedStaticScalarExpression::Value(
+                        Ok(Some(ResolvedStaticScalarExpression::Computed(
                             StaticScalarExpression::Double(DoubleScalarExpression::new(
                                 c.query_location.clone(),
                                 d,
                             )),
                         )))
                     } else {
-                        Ok(Some(ResolvedStaticScalarExpression::Value(
+                        Ok(Some(ResolvedStaticScalarExpression::Computed(
                             StaticScalarExpression::Null(NullScalarExpression::new(
                                 c.query_location.clone(),
                             )),
@@ -153,14 +153,14 @@ impl ConvertScalarExpression {
             ConvertScalarExpression::Integer(c) => {
                 if let Some(v) = c.inner_expression.try_resolve_static(scope)? {
                     if let Some(i) = v.to_value().convert_to_integer() {
-                        Ok(Some(ResolvedStaticScalarExpression::Value(
+                        Ok(Some(ResolvedStaticScalarExpression::Computed(
                             StaticScalarExpression::Integer(IntegerScalarExpression::new(
                                 c.query_location.clone(),
                                 i,
                             )),
                         )))
                     } else {
-                        Ok(Some(ResolvedStaticScalarExpression::Value(
+                        Ok(Some(ResolvedStaticScalarExpression::Computed(
                             StaticScalarExpression::Null(NullScalarExpression::new(
                                 c.query_location.clone(),
                             )),
@@ -174,7 +174,7 @@ impl ConvertScalarExpression {
                 if let Some(v) = c.inner_expression.try_resolve_static(scope)? {
                     let v = v.to_value();
                     if let Value::Null = v {
-                        Ok(Some(ResolvedStaticScalarExpression::Value(
+                        Ok(Some(ResolvedStaticScalarExpression::Computed(
                             StaticScalarExpression::String(StringScalarExpression::new(
                                 c.query_location.clone(),
                                 "",
@@ -187,7 +187,7 @@ impl ConvertScalarExpression {
                             value = Some(StringScalarExpression::new(c.query_location.clone(), s));
                         });
 
-                        Ok(Some(ResolvedStaticScalarExpression::Value(
+                        Ok(Some(ResolvedStaticScalarExpression::Computed(
                             StaticScalarExpression::String(
                                 value.expect("Inner value did not return a string"),
                             ),
@@ -200,14 +200,14 @@ impl ConvertScalarExpression {
             ConvertScalarExpression::TimeSpan(t) => {
                 if let Some(v) = t.inner_expression.try_resolve_static(scope)? {
                     if let Some(ts) = v.to_value().convert_to_timespan() {
-                        Ok(Some(ResolvedStaticScalarExpression::Value(
+                        Ok(Some(ResolvedStaticScalarExpression::Computed(
                             StaticScalarExpression::TimeSpan(TimeSpanScalarExpression::new(
                                 t.query_location.clone(),
                                 ts,
                             )),
                         )))
                     } else {
-                        Ok(Some(ResolvedStaticScalarExpression::Value(
+                        Ok(Some(ResolvedStaticScalarExpression::Computed(
                             StaticScalarExpression::Null(NullScalarExpression::new(
                                 t.query_location.clone(),
                             )),

--- a/rust/experimental/query_engine/expressions/src/scalars/math_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/math_scalar_expression.rs
@@ -237,7 +237,7 @@ impl MathScalarExpression {
                     v,
                 )))
             } else {
-                Ok(Some(ResolvedStaticScalarExpression::Value(
+                Ok(Some(ResolvedStaticScalarExpression::Computed(
                     StaticScalarExpression::Null(NullScalarExpression::new(
                         unary_expression.query_location.clone(),
                     )),
@@ -271,7 +271,7 @@ impl MathScalarExpression {
                         v,
                     )))
                 } else {
-                    Ok(Some(ResolvedStaticScalarExpression::Value(
+                    Ok(Some(ResolvedStaticScalarExpression::Computed(
                         StaticScalarExpression::Null(NullScalarExpression::new(
                             binary_expression.query_location.clone(),
                         )),
@@ -288,22 +288,22 @@ impl MathScalarExpression {
     ) -> ResolvedStaticScalarExpression<'a> {
         match value {
             NumericValue::Integer(i) => {
-                ResolvedStaticScalarExpression::Value(StaticScalarExpression::Integer(
+                ResolvedStaticScalarExpression::Computed(StaticScalarExpression::Integer(
                     IntegerScalarExpression::new(query_location.clone(), i),
                 ))
             }
             NumericValue::DateTime(d) => {
-                ResolvedStaticScalarExpression::Value(StaticScalarExpression::DateTime(
+                ResolvedStaticScalarExpression::Computed(StaticScalarExpression::DateTime(
                     DateTimeScalarExpression::new(query_location.clone(), d),
                 ))
             }
             NumericValue::Double(d) => {
-                ResolvedStaticScalarExpression::Value(StaticScalarExpression::Double(
+                ResolvedStaticScalarExpression::Computed(StaticScalarExpression::Double(
                     DoubleScalarExpression::new(query_location.clone(), d),
                 ))
             }
             NumericValue::TimeSpan(t) => {
-                ResolvedStaticScalarExpression::Value(StaticScalarExpression::TimeSpan(
+                ResolvedStaticScalarExpression::Computed(StaticScalarExpression::TimeSpan(
                     TimeSpanScalarExpression::new(query_location.clone(), t),
                 ))
             }

--- a/rust/experimental/query_engine/expressions/src/scalars/parse_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/parse_scalar_expression.rs
@@ -86,7 +86,7 @@ impl ParseJsonScalarExpression {
     ) -> Result<Option<ResolvedStaticScalarExpression<'_>>, ExpressionError> {
         let query_location = self.inner_expression.get_query_location().clone();
 
-        match &mut self.inner_expression.try_resolve_static(scope)? {
+        match self.inner_expression.try_resolve_static(scope)? {
             Some(v) => Ok(Some(ResolvedStaticScalarExpression::Computed(
                 if let Value::String(s) = v.to_value() {
                     StaticScalarExpression::from_json(query_location, s.get_value())?

--- a/rust/experimental/query_engine/expressions/src/scalars/parse_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/parse_scalar_expression.rs
@@ -84,19 +84,17 @@ impl ParseJsonScalarExpression {
         &mut self,
         scope: &PipelineResolutionScope,
     ) -> Result<Option<ResolvedStaticScalarExpression<'_>>, ExpressionError> {
-        let query_location = &self.query_location;
+        let query_location = self.inner_expression.get_query_location().clone();
 
         match &mut self.inner_expression.try_resolve_static(scope)? {
             Some(v) => Ok(Some(ResolvedStaticScalarExpression::Value(
                 if let Value::String(s) = v.to_value() {
-                    StaticScalarExpression::from_json(self.query_location.clone(), s.get_value())?
+                    StaticScalarExpression::from_json(query_location, s.get_value())?
                 } else {
+                    let t = v.get_value_type();
                     return Err(ExpressionError::ParseError(
-                        query_location.clone(),
-                        format!(
-                            "Input of '{:?}' type could not be pased as JSON",
-                            v.get_value_type()
-                        ),
+                        query_location,
+                        format!("Input of '{:?}' type could not be pased as JSON", t),
                     ));
                 },
             ))),

--- a/rust/experimental/query_engine/expressions/src/scalars/parse_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/parse_scalar_expression.rs
@@ -87,7 +87,7 @@ impl ParseJsonScalarExpression {
         let query_location = self.inner_expression.get_query_location().clone();
 
         match &mut self.inner_expression.try_resolve_static(scope)? {
-            Some(v) => Ok(Some(ResolvedStaticScalarExpression::Value(
+            Some(v) => Ok(Some(ResolvedStaticScalarExpression::Computed(
                 if let Value::String(s) = v.to_value() {
                     StaticScalarExpression::from_json(query_location, s.get_value())?
                 } else {
@@ -177,7 +177,7 @@ impl ParseRegexScalarExpression {
             }
         };
 
-        Ok(Some(ResolvedStaticScalarExpression::Value(
+        Ok(Some(ResolvedStaticScalarExpression::Computed(
             StaticScalarExpression::Regex(RegexScalarExpression::new(
                 self.query_location.clone(),
                 regex,

--- a/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
@@ -74,8 +74,8 @@ pub enum ScalarExpression {
 
 impl ScalarExpression {
     pub fn try_resolve_value_type(
-        &self,
-        pipeline: &PipelineExpression,
+        &mut self,
+        scope: &PipelineResolutionScope,
     ) -> Result<Option<ValueType>, ExpressionError> {
         match self {
             ScalarExpression::Source(s) => Ok(s.get_value_type()),
@@ -85,45 +85,49 @@ impl ScalarExpression {
             ScalarExpression::Constant(c) => Ok(Some(c.get_value_type())),
             ScalarExpression::List(_) => Ok(Some(ValueType::Array)),
             ScalarExpression::Logical(_) => Ok(Some(ValueType::Boolean)),
-            ScalarExpression::Coalesce(c) => c.try_resolve_value_type(pipeline),
-            ScalarExpression::Conditional(c) => c.try_resolve_value_type(pipeline),
-            ScalarExpression::Case(c) => c.try_resolve_value_type(pipeline),
-            ScalarExpression::Convert(c) => c.try_resolve_value_type(pipeline),
-            ScalarExpression::Length(l) => l.try_resolve_value_type(pipeline),
-            ScalarExpression::Slice(s) => s.try_resolve_value_type(pipeline),
-            ScalarExpression::Parse(p) => p.try_resolve_value_type(pipeline),
-            ScalarExpression::Temporal(t) => t.try_resolve_value_type(pipeline),
-            ScalarExpression::Text(r) => r.try_resolve_value_type(pipeline),
-            ScalarExpression::Math(m) => m.try_resolve_value_type(pipeline),
+            ScalarExpression::Coalesce(c) => c.try_resolve_value_type(scope),
+            ScalarExpression::Conditional(c) => c.try_resolve_value_type(scope),
+            ScalarExpression::Case(c) => c.try_resolve_value_type(scope),
+            ScalarExpression::Convert(c) => c.try_resolve_value_type(scope),
+            ScalarExpression::Length(l) => l.try_resolve_value_type(scope),
+            ScalarExpression::Slice(s) => s.try_resolve_value_type(scope),
+            ScalarExpression::Parse(p) => p.try_resolve_value_type(scope),
+            ScalarExpression::Temporal(t) => t.try_resolve_value_type(scope),
+            ScalarExpression::Text(r) => r.try_resolve_value_type(scope),
+            ScalarExpression::Math(m) => m.try_resolve_value_type(scope),
         }
     }
 
-    pub fn try_resolve_static<'a, 'b, 'c>(
-        &'a self,
-        pipeline: &'b PipelineExpression,
-    ) -> Result<Option<ResolvedStaticScalarExpression<'c>>, ExpressionError>
-    where
-        'a: 'c,
-        'b: 'c,
-    {
+    pub fn try_resolve_static<'a>(
+        &'a mut self,
+        scope: &PipelineResolutionScope<'a>,
+    ) -> Result<Option<ResolvedStaticScalarExpression<'a>>, ExpressionError> {
         match self {
             ScalarExpression::Source(_) => Ok(None),
             ScalarExpression::Attached(_) => Ok(None),
             ScalarExpression::Variable(_) => Ok(None),
             ScalarExpression::Static(s) => Ok(Some(ResolvedStaticScalarExpression::Reference(s))),
-            ScalarExpression::Constant(c) => Ok(Some(c.resolve_static(pipeline))),
-            ScalarExpression::List(l) => l.try_resolve_static(pipeline),
-            ScalarExpression::Logical(l) => l.try_resolve_static(pipeline),
-            ScalarExpression::Coalesce(c) => c.try_resolve_static(pipeline),
-            ScalarExpression::Conditional(c) => c.try_resolve_static(pipeline),
-            ScalarExpression::Case(c) => c.try_resolve_static(pipeline),
-            ScalarExpression::Convert(c) => c.try_resolve_static(pipeline),
-            ScalarExpression::Length(l) => l.try_resolve_static(pipeline),
-            ScalarExpression::Slice(s) => s.try_resolve_static(pipeline),
-            ScalarExpression::Parse(p) => p.try_resolve_static(pipeline),
-            ScalarExpression::Temporal(t) => t.try_resolve_static(pipeline),
-            ScalarExpression::Text(r) => r.try_resolve_static(pipeline),
-            ScalarExpression::Math(m) => m.try_resolve_static(pipeline),
+            ScalarExpression::Constant(c) => Ok(Some(c.resolve_static(scope))),
+            ScalarExpression::List(l) => l.try_resolve_static(scope),
+            ScalarExpression::Logical(l) => match l.try_resolve_static(scope)? {
+                Some(v) => Ok(Some(ResolvedStaticScalarExpression::Value(
+                    StaticScalarExpression::Boolean(BooleanScalarExpression::new(
+                        l.get_query_location().clone(),
+                        v,
+                    )),
+                ))),
+                None => Ok(None),
+            },
+            ScalarExpression::Coalesce(c) => c.try_resolve_static(scope),
+            ScalarExpression::Conditional(c) => c.try_resolve_static(scope),
+            ScalarExpression::Case(c) => c.try_resolve_static(scope),
+            ScalarExpression::Convert(c) => c.try_resolve_static(scope),
+            ScalarExpression::Length(l) => l.try_resolve_static(scope),
+            ScalarExpression::Slice(s) => s.try_resolve_static(scope),
+            ScalarExpression::Parse(p) => p.try_resolve_static(scope),
+            ScalarExpression::Temporal(t) => t.try_resolve_static(scope),
+            ScalarExpression::Text(r) => r.try_resolve_static(scope),
+            ScalarExpression::Math(m) => m.try_resolve_static(scope),
         }
     }
 }
@@ -340,20 +344,16 @@ impl ConstantScalarExpression {
         }
     }
 
-    pub(crate) fn resolve_static<'a, 'b, 'c>(
-        &'a self,
-        pipeline: &'b PipelineExpression,
-    ) -> ResolvedStaticScalarExpression<'c>
-    where
-        'a: 'c,
-        'b: 'c,
-    {
+    pub(crate) fn resolve_static<'a>(
+        &'a mut self,
+        scope: &PipelineResolutionScope<'a>,
+    ) -> ResolvedStaticScalarExpression<'a> {
         match self {
             ConstantScalarExpression::Reference(r) => {
                 let constant_id = r.get_constant_id();
 
                 ResolvedStaticScalarExpression::Reference(
-                    pipeline.get_constant(constant_id).unwrap_or_else(|| {
+                    scope.get_constant(constant_id).unwrap_or_else(|| {
                         panic!("Constant for id '{constant_id}' was not found on pipeline")
                     }),
                 )
@@ -481,11 +481,11 @@ impl CoalesceScalarExpression {
     }
 
     pub(crate) fn try_resolve_value_type(
-        &self,
-        pipeline: &PipelineExpression,
+        &mut self,
+        scope: &PipelineResolutionScope,
     ) -> Result<Option<ValueType>, ExpressionError> {
-        for expression in &self.expressions {
-            match expression.try_resolve_value_type(pipeline)? {
+        for expression in &mut self.expressions {
+            match expression.try_resolve_value_type(scope)? {
                 Some(r) => {
                     if r != ValueType::Null {
                         return Ok(Some(r));
@@ -498,16 +498,12 @@ impl CoalesceScalarExpression {
         Ok(Some(ValueType::Null))
     }
 
-    pub(crate) fn try_resolve_static<'a, 'b, 'c>(
-        &'a self,
-        pipeline: &'b PipelineExpression,
-    ) -> Result<Option<ResolvedStaticScalarExpression<'c>>, ExpressionError>
-    where
-        'a: 'c,
-        'b: 'c,
-    {
-        for expression in &self.expressions {
-            match expression.try_resolve_static(pipeline)? {
+    pub(crate) fn try_resolve_static<'a>(
+        &'a mut self,
+        scope: &PipelineResolutionScope<'a>,
+    ) -> Result<Option<ResolvedStaticScalarExpression<'a>>, ExpressionError> {
+        for expression in &mut self.expressions {
+            match expression.try_resolve_static(scope)? {
                 Some(r) => {
                     if r.get_value_type() != ValueType::Null {
                         return Ok(Some(r));
@@ -569,15 +565,15 @@ impl ConditionalScalarExpression {
     }
 
     pub(crate) fn try_resolve_value_type(
-        &self,
-        pipeline: &PipelineExpression,
+        &mut self,
+        scope: &PipelineResolutionScope,
     ) -> Result<Option<ValueType>, ExpressionError> {
-        if let Some(s) = self.try_resolve_static(pipeline)? {
+        if let Some(s) = self.try_resolve_static(scope)? {
             return Ok(Some(s.get_value_type()));
         }
 
-        let true_e = self.true_expression.try_resolve_static(pipeline)?;
-        let false_e = self.false_expression.try_resolve_static(pipeline)?;
+        let true_e = self.true_expression.try_resolve_static(scope)?;
+        let false_e = self.false_expression.try_resolve_static(scope)?;
 
         if true_e.is_some() && false_e.is_some() {
             if let (Some(true_expr), Some(false_expr)) = (true_e, false_e) {
@@ -593,41 +589,14 @@ impl ConditionalScalarExpression {
         Ok(None)
     }
 
-    pub(crate) fn try_resolve_static<'a, 'b, 'c>(
-        &'a self,
-        pipeline: &'b PipelineExpression,
-    ) -> Result<Option<ResolvedStaticScalarExpression<'c>>, ExpressionError>
-    where
-        'a: 'c,
-        'b: 'c,
-    {
-        let condition = self.condition.try_resolve_static(pipeline)?;
-
-        if condition.is_none() {
-            return Ok(None);
-        }
-
-        match condition.unwrap().to_value() {
-            Value::Boolean(b) => {
-                if b.get_value() {
-                    let true_e = self.true_expression.try_resolve_static(pipeline)?;
-
-                    if true_e.is_none() {
-                        return Ok(None);
-                    }
-
-                    return Ok(Some(true_e.unwrap()));
-                }
-
-                let false_e = self.false_expression.try_resolve_static(pipeline)?;
-
-                if false_e.is_none() {
-                    return Ok(None);
-                }
-
-                Ok(Some(false_e.unwrap()))
-            }
-            _ => panic!("LogicalExpression did not return a bool value"),
+    pub(crate) fn try_resolve_static<'a>(
+        &'a mut self,
+        scope: &PipelineResolutionScope<'a>,
+    ) -> Result<Option<ResolvedStaticScalarExpression<'a>>, ExpressionError> {
+        match self.condition.try_resolve_static(scope)? {
+            None => Ok(None),
+            Some(true) => self.true_expression.try_resolve_static(scope),
+            Some(false) => self.false_expression.try_resolve_static(scope),
         }
     }
 }
@@ -671,18 +640,18 @@ impl CaseScalarExpression {
     }
 
     pub(crate) fn try_resolve_value_type(
-        &self,
-        pipeline: &PipelineExpression,
+        &mut self,
+        scope: &PipelineResolutionScope,
     ) -> Result<Option<ValueType>, ExpressionError> {
-        if let Some(s) = self.try_resolve_static(pipeline)? {
+        if let Some(s) = self.try_resolve_static(scope)? {
             return Ok(Some(s.get_value_type()));
         }
 
         // Check if all expressions (including else) have the same static type
         let mut resolved_type: Option<ValueType> = None;
 
-        for (_, expr) in &self.expressions_with_conditions {
-            if let Some(expr_static) = expr.try_resolve_static(pipeline)? {
+        for (_, expr) in &mut self.expressions_with_conditions {
+            if let Some(expr_static) = expr.try_resolve_static(scope)? {
                 let expr_type = expr_static.get_value_type();
                 if let Some(existing_type) = &resolved_type {
                     if *existing_type != expr_type {
@@ -696,7 +665,7 @@ impl CaseScalarExpression {
             }
         }
 
-        if let Some(else_static) = self.else_expression.try_resolve_static(pipeline)? {
+        if let Some(else_static) = self.else_expression.try_resolve_static(scope)? {
             let else_type = else_static.get_value_type();
             if let Some(existing_type) = &resolved_type {
                 if *existing_type == else_type {
@@ -710,44 +679,25 @@ impl CaseScalarExpression {
         Ok(None)
     }
 
-    pub(crate) fn try_resolve_static<'a, 'b, 'c>(
-        &'a self,
-        pipeline: &'b PipelineExpression,
-    ) -> Result<Option<ResolvedStaticScalarExpression<'c>>, ExpressionError>
-    where
-        'a: 'c,
-        'b: 'c,
-    {
+    pub(crate) fn try_resolve_static<'a>(
+        &'a mut self,
+        scope: &PipelineResolutionScope<'a>,
+    ) -> Result<Option<ResolvedStaticScalarExpression<'a>>, ExpressionError> {
         // Check each condition in order
-        for (condition, expression) in &self.expressions_with_conditions {
-            let condition_result = condition.try_resolve_static(pipeline)?;
-
-            if condition_result.is_none() {
-                return Ok(None);
-            }
-
-            match condition_result.unwrap().to_value() {
-                Value::Boolean(b) => {
-                    if b.get_value() {
+        for (condition, expression) in &mut self.expressions_with_conditions {
+            match condition.try_resolve_static(scope)? {
+                None => return Ok(None),
+                Some(b) => {
+                    if b {
                         // This condition is true, return its expression
-                        let expr_result = expression.try_resolve_static(pipeline)?;
-                        if expr_result.is_none() {
-                            return Ok(None);
-                        }
-                        return Ok(Some(expr_result.unwrap()));
+                        return expression.try_resolve_static(scope);
                     }
-                    // This condition is false, continue to next condition
                 }
-                _ => panic!("LogicalExpression did not return a bool value"),
             }
         }
 
         // No condition was true, return else expression
-        let else_result = self.else_expression.try_resolve_static(pipeline)?;
-        if else_result.is_none() {
-            return Ok(None);
-        }
-        Ok(Some(else_result.unwrap()))
+        self.else_expression.try_resolve_static(scope)
     }
 }
 
@@ -783,13 +733,10 @@ impl LengthScalarExpression {
     }
 
     pub(crate) fn try_resolve_value_type(
-        &self,
-        pipeline: &PipelineExpression,
+        &mut self,
+        scope: &PipelineResolutionScope,
     ) -> Result<Option<ValueType>, ExpressionError> {
-        if let Some(v) = self
-            .get_inner_expression()
-            .try_resolve_value_type(pipeline)?
-        {
+        if let Some(v) = self.inner_expression.try_resolve_value_type(scope)? {
             Ok(Some(match v {
                 ValueType::String | ValueType::Array | ValueType::Map => ValueType::Integer,
                 _ => ValueType::Null,
@@ -799,15 +746,11 @@ impl LengthScalarExpression {
         }
     }
 
-    pub(crate) fn try_resolve_static<'a, 'b, 'c>(
-        &'a self,
-        pipeline: &'b PipelineExpression,
-    ) -> Result<Option<ResolvedStaticScalarExpression<'c>>, ExpressionError>
-    where
-        'a: 'c,
-        'b: 'c,
-    {
-        if let Some(v) = self.get_inner_expression().try_resolve_static(pipeline)? {
+    pub(crate) fn try_resolve_static(
+        &mut self,
+        scope: &PipelineResolutionScope,
+    ) -> Result<Option<ResolvedStaticScalarExpression<'_>>, ExpressionError> {
+        if let Some(v) = self.inner_expression.try_resolve_static(scope)? {
             Ok(Some(ResolvedStaticScalarExpression::Value(
                 match v.to_value() {
                     Value::String(s) => {
@@ -865,18 +808,14 @@ impl ListScalarExpression {
         &self.value_expressions
     }
 
-    pub(crate) fn try_resolve_static<'a, 'b, 'c>(
-        &'a self,
-        pipeline: &'b PipelineExpression,
-    ) -> Result<Option<ResolvedStaticScalarExpression<'c>>, ExpressionError>
-    where
-        'a: 'c,
-        'b: 'c,
-    {
+    pub(crate) fn try_resolve_static(
+        &mut self,
+        scope: &PipelineResolutionScope,
+    ) -> Result<Option<ResolvedStaticScalarExpression<'_>>, ExpressionError> {
         let mut values = Vec::new();
 
-        for v in self.get_value_expressions() {
-            match v.try_resolve_static(pipeline)? {
+        for v in &mut self.value_expressions {
+            match v.try_resolve_static(scope)? {
                 Some(ResolvedStaticScalarExpression::Reference(v)) => {
                     values.push(v.clone());
                 }
@@ -942,14 +881,14 @@ impl SliceScalarExpression {
     }
 
     pub(crate) fn try_resolve_value_type(
-        &self,
-        pipeline: &PipelineExpression,
+        &mut self,
+        scope: &PipelineResolutionScope,
     ) -> Result<Option<ValueType>, ExpressionError> {
-        if let Some(s) = self.try_resolve_static(pipeline)? {
+        if let Some(s) = self.try_resolve_static(scope)? {
             return Ok(Some(s.get_value_type()));
         }
 
-        if let Some(t) = self.get_source().try_resolve_value_type(pipeline)? {
+        if let Some(t) = self.source.try_resolve_value_type(scope)? {
             match t {
                 ValueType::Array => Ok(Some(ValueType::Array)),
                 ValueType::String => Ok(Some(ValueType::String)),
@@ -960,34 +899,39 @@ impl SliceScalarExpression {
         }
     }
 
-    pub(crate) fn try_resolve_static<'a, 'b, 'c>(
-        &'a self,
-        pipeline: &'b PipelineExpression,
-    ) -> Result<Option<ResolvedStaticScalarExpression<'c>>, ExpressionError>
-    where
-        'a: 'c,
-        'b: 'c,
-    {
-        let range_start_inclusive = match self.get_range_start_inclusive() {
-            Some(s) => match s.try_resolve_static(pipeline)? {
-                Some(v) => self.validate_resolved_range_value("start", v.to_value())?,
+    pub(crate) fn try_resolve_static(
+        &mut self,
+        scope: &PipelineResolutionScope,
+    ) -> Result<Option<ResolvedStaticScalarExpression<'_>>, ExpressionError> {
+        let query_location = &self.query_location;
+
+        let range_start_inclusive = match &mut self.range_start_inclusive {
+            Some(s) => match s.try_resolve_static(scope)? {
+                Some(v) => {
+                    Self::validate_resolved_range_value(query_location, "start", v.to_value())?
+                }
                 None => return Ok(None),
             },
             None => 0,
         };
 
-        let range_end_exclusive = match self.get_range_end_exclusive() {
-            Some(s) => match s.try_resolve_static(pipeline)? {
-                Some(v) => Some(self.validate_resolved_range_value("end", v.to_value())?),
+        let range_end_exclusive = match &mut self.range_end_exclusive {
+            Some(s) => match s.try_resolve_static(scope)? {
+                Some(v) => Some(Self::validate_resolved_range_value(
+                    query_location,
+                    "end",
+                    v.to_value(),
+                )?),
                 None => return Ok(None),
             },
             None => None,
         };
 
-        match self.get_source().try_resolve_static(pipeline)? {
+        match self.source.try_resolve_static(scope)? {
             Some(s) => match s.to_value() {
                 Value::Array(a) => {
-                    self.validate_slice_range(
+                    Self::validate_slice_range(
+                        query_location,
                         "Array",
                         a.len(),
                         range_start_inclusive,
@@ -1001,7 +945,8 @@ impl SliceScalarExpression {
                     Ok(None)
                 }
                 Value::String(s) => {
-                    let range_end_exclusive = self.validate_slice_range(
+                    let range_end_exclusive = Self::validate_slice_range(
+                        query_location,
                         "String",
                         s.get_value().chars().count(),
                         range_start_inclusive,
@@ -1038,7 +983,7 @@ impl SliceScalarExpression {
     }
 
     pub fn validate_resolved_range_value(
-        &self,
+        query_location: &QueryLocation,
         name: &str,
         value: Value,
     ) -> Result<usize, ExpressionError> {
@@ -1046,21 +991,21 @@ impl SliceScalarExpression {
             let v = i.get_value();
             if v < 0 {
                 return Err(ExpressionError::ValidationFailure(
-                    self.get_query_location().clone(),
+                    query_location.clone(),
                     format!("Range {name} for a slice expression cannot be a negative value"),
                 ));
             }
             Ok(v as usize)
         } else {
             Err(ExpressionError::TypeMismatch(
-                self.get_query_location().clone(),
+                query_location.clone(),
                 format!("Range {name} for a slice expression should be an integer type"),
             ))
         }
     }
 
     pub fn validate_slice_range(
-        &self,
+        query_location: &QueryLocation,
         name: &str,
         target_length: usize,
         range_start_inclusive: usize,
@@ -1070,7 +1015,7 @@ impl SliceScalarExpression {
 
         if range_start_inclusive > end {
             return Err(ExpressionError::ValidationFailure(
-                self.query_location.clone(),
+                query_location.clone(),
                 format!(
                     "{name} slice index starts at '{range_start_inclusive}' but ends at '{end}'"
                 ),
@@ -1078,7 +1023,7 @@ impl SliceScalarExpression {
         }
         if end > target_length {
             return Err(ExpressionError::ValidationFailure(
-                self.query_location.clone(),
+                query_location.clone(),
                 format!(
                     "{name} slice index ends at '{end}' which is beyond the length of '{target_length}'"
                 ),
@@ -1122,9 +1067,11 @@ mod tests {
 
     #[test]
     pub fn try_resolve_value_type() {
-        let run_test_success = |expression: ScalarExpression, expected: Option<ValueType>| {
+        let run_test_success = |mut expression: ScalarExpression, expected: Option<ValueType>| {
+            let pipeline: PipelineExpression = Default::default();
+
             let actual = expression
-                .try_resolve_value_type(&Default::default())
+                .try_resolve_value_type(&pipeline.get_resolution_scope())
                 .unwrap();
 
             assert_eq!(expected, actual)
@@ -1229,14 +1176,18 @@ mod tests {
 
     #[test]
     pub fn test_coalesce_try_resolve_value_type() {
-        let run_test = |expression: CoalesceScalarExpression, expected: Option<Value>| {
-            let pipeline = Default::default();
+        let run_test = |mut expression: CoalesceScalarExpression, expected: Option<Value>| {
+            let pipeline: PipelineExpression = Default::default();
 
-            let actual_type = expression.try_resolve_value_type(&pipeline).unwrap();
+            let actual_type = expression
+                .try_resolve_value_type(&pipeline.get_resolution_scope())
+                .unwrap();
 
             assert_eq!(expected.as_ref().map(|v| v.get_value_type()), actual_type);
 
-            let actual_static = expression.try_resolve_static(&pipeline).unwrap();
+            let actual_static = expression
+                .try_resolve_static(&pipeline.get_resolution_scope())
+                .unwrap();
 
             assert_eq!(expected, actual_static.as_ref().map(|v| v.to_value()));
         };
@@ -1316,10 +1267,12 @@ mod tests {
 
     #[test]
     pub fn test_conditional_try_resolve_value_type() {
-        let run_test_success = |expression: ConditionalScalarExpression,
+        let run_test_success = |mut expression: ConditionalScalarExpression,
                                 expected: Option<ValueType>| {
+            let pipeline: PipelineExpression = Default::default();
+
             let actual = expression
-                .try_resolve_value_type(&Default::default())
+                .try_resolve_value_type(&pipeline.get_resolution_scope())
                 .unwrap();
 
             assert_eq!(expected, actual)
@@ -1443,14 +1396,16 @@ mod tests {
     #[test]
     pub fn test_try_resolve_static() {
         let run_test_success =
-            |expression: ScalarExpression, expected: Option<StaticScalarExpression>| {
+            |mut expression: ScalarExpression, expected: Option<StaticScalarExpression>| {
                 let mut pipeline: PipelineExpression = Default::default();
 
                 pipeline.push_constant(StaticScalarExpression::String(
                     StringScalarExpression::new(QueryLocation::new_fake(), "hello world"),
                 ));
 
-                let actual = expression.try_resolve_static(&pipeline).unwrap();
+                let actual = expression
+                    .try_resolve_static(&pipeline.get_resolution_scope())
+                    .unwrap();
 
                 assert_eq!(expected, actual.map(|v| v.as_ref().clone()))
             };
@@ -1589,11 +1544,12 @@ mod tests {
     #[test]
     pub fn test_conditional_try_resolve_static() {
         let run_test_success =
-            |expression: ConditionalScalarExpression, expected: Option<StaticScalarExpression>| {
-                let pipeline = Default::default();
+            |mut expression: ConditionalScalarExpression,
+             expected: Option<StaticScalarExpression>| {
+                let pipeline: PipelineExpression = Default::default();
 
                 let actual = expression
-                    .try_resolve_static(&pipeline)
+                    .try_resolve_static(&pipeline.get_resolution_scope())
                     .unwrap()
                     .map(|v| v.as_ref().clone());
 
@@ -1704,14 +1660,18 @@ mod tests {
     pub fn test_length_scalar_expression_try_resolve() {
         fn run_test(input: Vec<(ScalarExpression, Option<ValueType>, Option<Value>)>) {
             for (inner, expected_type, expected_value) in input {
-                let e = LengthScalarExpression::new(QueryLocation::new_fake(), inner);
+                let mut e = LengthScalarExpression::new(QueryLocation::new_fake(), inner);
 
-                let pipeline = Default::default();
+                let pipeline: PipelineExpression = Default::default();
 
-                let actual_type = e.try_resolve_value_type(&pipeline).unwrap();
+                let actual_type = e
+                    .try_resolve_value_type(&pipeline.get_resolution_scope())
+                    .unwrap();
                 assert_eq!(expected_type, actual_type);
 
-                let actual_value = e.try_resolve_static(&pipeline).unwrap();
+                let actual_value = e
+                    .try_resolve_static(&pipeline.get_resolution_scope())
+                    .unwrap();
                 assert_eq!(expected_value, actual_value.as_ref().map(|v| v.to_value()));
             }
         }
@@ -1800,13 +1760,17 @@ mod tests {
 
     #[test]
     pub fn test_slice_scalar_expression_try_resolve() {
-        fn run_test_failure(input: SliceScalarExpression, expected: ExpressionError) {
-            let pipeline = Default::default();
+        fn run_test_failure(mut input: SliceScalarExpression, expected: ExpressionError) {
+            let pipeline: PipelineExpression = Default::default();
 
-            let actual_type = input.try_resolve_value_type(&pipeline).unwrap_err();
+            let actual_type = input
+                .try_resolve_value_type(&pipeline.get_resolution_scope())
+                .unwrap_err();
             validate_error(&expected, actual_type);
 
-            let actual_value = input.try_resolve_static(&pipeline).unwrap_err();
+            let actual_value = input
+                .try_resolve_static(&pipeline.get_resolution_scope())
+                .unwrap_err();
             validate_error(&expected, actual_value);
 
             fn validate_error(expected: &ExpressionError, actual: ExpressionError) {
@@ -1898,30 +1862,38 @@ mod tests {
     #[test]
     pub fn test_string_slice_scalar_expression_try_resolve() {
         fn run_test_success(
-            input: SliceScalarExpression,
+            mut input: SliceScalarExpression,
             expected_value_type: Option<ValueType>,
             expected_value: Option<Value>,
         ) {
-            let pipeline = Default::default();
+            let pipeline: PipelineExpression = Default::default();
 
-            let actual_type = input.try_resolve_value_type(&pipeline).unwrap();
+            let actual_type = input
+                .try_resolve_value_type(&pipeline.get_resolution_scope())
+                .unwrap();
             assert_eq!(expected_value_type, actual_type);
 
-            let actual_value = input.try_resolve_static(&pipeline).unwrap();
+            let actual_value = input
+                .try_resolve_static(&pipeline.get_resolution_scope())
+                .unwrap();
             assert_eq!(expected_value, actual_value.as_ref().map(|v| v.to_value()));
         }
 
-        fn run_test_failure(input: SliceScalarExpression, expected_msg: &str) {
-            let pipeline = Default::default();
+        fn run_test_failure(mut input: SliceScalarExpression, expected_msg: &str) {
+            let pipeline: PipelineExpression = Default::default();
 
-            let actual_type = input.try_resolve_value_type(&pipeline).unwrap_err();
+            let actual_type = input
+                .try_resolve_value_type(&pipeline.get_resolution_scope())
+                .unwrap_err();
             if let ExpressionError::ValidationFailure(_, a) = actual_type {
                 assert_eq!(expected_msg, a);
             } else {
                 panic!("Unexpected ExpressionError")
             }
 
-            let actual_value = input.try_resolve_static(&pipeline).unwrap_err();
+            let actual_value = input
+                .try_resolve_static(&pipeline.get_resolution_scope())
+                .unwrap_err();
             if let ExpressionError::ValidationFailure(_, a) = actual_value {
                 assert_eq!(expected_msg, a);
             } else {
@@ -2081,30 +2053,38 @@ mod tests {
     #[test]
     pub fn test_array_slice_scalar_expression_try_resolve() {
         fn run_test_success(
-            input: SliceScalarExpression,
+            mut input: SliceScalarExpression,
             expected_value_type: Option<ValueType>,
             expected_value: Option<Value>,
         ) {
-            let pipeline = Default::default();
+            let pipeline: PipelineExpression = Default::default();
 
-            let actual_type = input.try_resolve_value_type(&pipeline).unwrap();
+            let actual_type = input
+                .try_resolve_value_type(&pipeline.get_resolution_scope())
+                .unwrap();
             assert_eq!(expected_value_type, actual_type);
 
-            let actual_value = input.try_resolve_static(&pipeline).unwrap();
+            let actual_value = input
+                .try_resolve_static(&pipeline.get_resolution_scope())
+                .unwrap();
             assert_eq!(expected_value, actual_value.as_ref().map(|v| v.to_value()));
         }
 
-        fn run_test_failure(input: SliceScalarExpression, expected_msg: &str) {
-            let pipeline = Default::default();
+        fn run_test_failure(mut input: SliceScalarExpression, expected_msg: &str) {
+            let pipeline: PipelineExpression = Default::default();
 
-            let actual_type = input.try_resolve_value_type(&pipeline).unwrap_err();
+            let actual_type = input
+                .try_resolve_value_type(&pipeline.get_resolution_scope())
+                .unwrap_err();
             if let ExpressionError::ValidationFailure(_, a) = actual_type {
                 assert_eq!(expected_msg, a);
             } else {
                 panic!("Unexpected ExpressionError")
             }
 
-            let actual_value = input.try_resolve_static(&pipeline).unwrap_err();
+            let actual_value = input
+                .try_resolve_static(&pipeline.get_resolution_scope())
+                .unwrap_err();
             if let ExpressionError::ValidationFailure(_, a) = actual_value {
                 assert_eq!(expected_msg, a);
             } else {

--- a/rust/experimental/query_engine/expressions/src/scalars/statics/static_scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/statics/static_scalar_expressions.rs
@@ -42,6 +42,35 @@ pub enum StaticScalarExpression {
 }
 
 impl StaticScalarExpression {
+    pub(crate) fn try_fold(&self) -> Option<StaticScalarExpression> {
+        // Note: The goal here is to diferentiate which statics can be
+        // folded/copied in the expression tree and which ones should always be
+        // referenced.
+        match self {
+            StaticScalarExpression::Array(_) => None,
+            StaticScalarExpression::Boolean(b) => Some(StaticScalarExpression::Boolean(b.clone())),
+            StaticScalarExpression::DateTime(d) => {
+                Some(StaticScalarExpression::DateTime(d.clone()))
+            }
+            StaticScalarExpression::Double(d) => Some(StaticScalarExpression::Double(d.clone())),
+            StaticScalarExpression::Integer(i) => Some(StaticScalarExpression::Integer(i.clone())),
+            StaticScalarExpression::Map(_) => None,
+            StaticScalarExpression::Null(n) => Some(StaticScalarExpression::Null(n.clone())),
+            StaticScalarExpression::Regex(_) => None,
+            StaticScalarExpression::String(s) => {
+                let value = &s.value;
+                if value.len() < 32 {
+                    Some(StaticScalarExpression::String(s.clone()))
+                } else {
+                    None
+                }
+            }
+            StaticScalarExpression::TimeSpan(t) => {
+                Some(StaticScalarExpression::TimeSpan(t.clone()))
+            }
+        }
+    }
+
     pub fn from_json(
         query_location: QueryLocation,
         input: &str,

--- a/rust/experimental/query_engine/expressions/src/scalars/statics/static_scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/statics/static_scalar_expressions.rs
@@ -59,7 +59,7 @@ impl StaticScalarExpression {
             StaticScalarExpression::Regex(_) => None,
             StaticScalarExpression::String(s) => {
                 let value = &s.value;
-                if value.len() < 32 {
+                if value.len() <= 32 {
                     Some(StaticScalarExpression::String(s.clone()))
                 } else {
                     None

--- a/rust/experimental/query_engine/expressions/src/scalars/temporal_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/temporal_scalar_expression.rs
@@ -11,22 +11,18 @@ pub enum TemporalScalarExpression {
 
 impl TemporalScalarExpression {
     pub(crate) fn try_resolve_value_type(
-        &self,
-        _pipeline: &PipelineExpression,
+        &mut self,
+        _scope: &PipelineResolutionScope,
     ) -> Result<Option<ValueType>, ExpressionError> {
         match self {
             TemporalScalarExpression::Now(_) => Ok(Some(ValueType::DateTime)),
         }
     }
 
-    pub(crate) fn try_resolve_static<'a, 'b, 'c>(
-        &'a self,
-        _pipeline: &'b PipelineExpression,
-    ) -> Result<Option<ResolvedStaticScalarExpression<'c>>, ExpressionError>
-    where
-        'a: 'c,
-        'b: 'c,
-    {
+    pub(crate) fn try_resolve_static(
+        &mut self,
+        _scope: &PipelineResolutionScope,
+    ) -> Result<Option<ResolvedStaticScalarExpression<'_>>, ExpressionError> {
         match self {
             TemporalScalarExpression::Now(_) => Ok(None),
         }

--- a/rust/experimental/query_engine/expressions/src/scalars/text_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/text_scalar_expression.rs
@@ -129,14 +129,14 @@ impl ReplaceTextScalarExpression {
                 &replacement_value,
                 self.case_insensitive,
             ) {
-                Ok(Some(ResolvedStaticScalarExpression::Value(
+                Ok(Some(ResolvedStaticScalarExpression::Computed(
                     StaticScalarExpression::String(StringScalarExpression::new(
                         self.query_location.clone(),
                         &result,
                     )),
                 )))
             } else {
-                Ok(Some(ResolvedStaticScalarExpression::Value(
+                Ok(Some(ResolvedStaticScalarExpression::Computed(
                     StaticScalarExpression::Null(NullScalarExpression::new(
                         self.query_location.clone(),
                     )),

--- a/rust/experimental/query_engine/expressions/src/value_accessor.rs
+++ b/rust/experimental/query_engine/expressions/src/value_accessor.rs
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::ScalarExpression;
+use crate::*;
 
 /// Contains the rules used to resolve data from a target
 ///
@@ -54,6 +54,21 @@ impl ValueAccessor {
         }
 
         Some(self.selectors.remove(index))
+    }
+
+    pub(crate) fn try_fold(
+        &mut self,
+        scope: &PipelineResolutionScope,
+    ) -> Result<(), ExpressionError> {
+        let selectors = &mut self.selectors;
+        for selector in selectors {
+            if let Some(ResolvedStaticScalarExpression::Computed(s)) =
+                selector.try_resolve_static(scope)?
+            {
+                *selector = ScalarExpression::Static(s);
+            }
+        }
+        Ok(())
     }
 }
 

--- a/rust/experimental/query_engine/kql-parser/src/logical_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/logical_expressions.rs
@@ -203,12 +203,13 @@ pub(crate) fn parse_logical_expression(
                     Ok(parse_comparison_expression(logical_expression_rule, state)?)
                 }
                 Rule::scalar_expression => {
-                    let scalar = parse_scalar_expression(logical_expression_rule, state)?;
+                    let mut scalar = parse_scalar_expression(logical_expression_rule, state)?;
 
                     if let ScalarExpression::Logical(l) = scalar {
                         Ok(*l)
                     } else {
-                        let value_type_result = scalar.try_resolve_value_type(state.get_pipeline());
+                        let value_type_result = scalar
+                            .try_resolve_value_type(&state.get_pipeline().get_resolution_scope());
                         if let Err(e) = value_type_result {
                             return Err(ParserError::from(&e));
                         }

--- a/rust/experimental/query_engine/kql-parser/src/query_expression.rs
+++ b/rust/experimental/query_engine/kql-parser/src/query_expression.rs
@@ -67,20 +67,22 @@ pub(crate) fn parse_query(
                         if let MutableValueExpression::Variable(v) = s.get_destination() {
                             let name = v.get_name().get_value();
 
-                            match s.get_source() {
-                                ImmutableValueExpression::Scalar(scalar) => {
+                            match s.get_source().clone() {
+                                ImmutableValueExpression::Scalar(mut scalar) => {
                                     if let ScalarExpression::Static(s) = scalar {
-                                        state.push_constant(name, s.clone())
+                                        state.push_constant(name, s)
                                     } else {
-                                        match scalar.try_resolve_static(state.get_pipeline()) {
+                                        match scalar.try_resolve_static(
+                                            &state.get_pipeline().get_resolution_scope(),
+                                        ) {
                                             Ok(Some(ResolvedStaticScalarExpression::Value(s))) => {
-                                                state.push_constant(name, s.clone())
+                                                state.push_constant(name, s)
                                             }
                                             Ok(None)
                                             | Ok(Some(
                                                 ResolvedStaticScalarExpression::Reference(_),
                                             )) => {
-                                                state.push_global_variable(name, scalar.clone());
+                                                state.push_global_variable(name, scalar);
                                             }
                                             Err(e) => errors.push((&e).into()),
                                         }

--- a/rust/experimental/query_engine/kql-parser/src/query_expression.rs
+++ b/rust/experimental/query_engine/kql-parser/src/query_expression.rs
@@ -75,9 +75,12 @@ pub(crate) fn parse_query(
                                         match scalar.try_resolve_static(
                                             &state.get_pipeline().get_resolution_scope(),
                                         ) {
-                                            Ok(Some(ResolvedStaticScalarExpression::Value(s))) => {
-                                                state.push_constant(name, s)
-                                            }
+                                            Ok(Some(ResolvedStaticScalarExpression::Computed(
+                                                s,
+                                            ))) => state.push_constant(name, s),
+                                            Ok(Some(
+                                                ResolvedStaticScalarExpression::FoldedConstant(s),
+                                            )) => state.push_constant(name, s.clone()),
                                             Ok(None)
                                             | Ok(Some(
                                                 ResolvedStaticScalarExpression::Reference(_),

--- a/rust/experimental/query_engine/kql-parser/src/scalar_mathematical_function_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_mathematical_function_expressions.rs
@@ -515,12 +515,13 @@ mod tests {
 
             let state = ParserState::new(input);
             let mut result = KqlPestParser::parse(Rule::scalar_expression, input).unwrap();
-            let expression = parse_scalar_expression(result.next().unwrap(), &state).unwrap();
+            let mut expression = parse_scalar_expression(result.next().unwrap(), &state).unwrap();
 
-            // Create a dummy pipeline for static resolution
-            let pipeline = PipelineExpression::default();
+            let pipeline: PipelineExpression = Default::default();
 
-            if let Ok(Some(resolved)) = expression.try_resolve_static(&pipeline) {
+            if let Ok(Some(resolved)) =
+                expression.try_resolve_static(&pipeline.get_resolution_scope())
+            {
                 match resolved.to_value() {
                     Value::Integer(i) => Some(i.get_value()),
                     _ => None,
@@ -557,11 +558,13 @@ mod tests {
 
             let state = ParserState::new(input);
             let mut result = KqlPestParser::parse(Rule::scalar_expression, input).unwrap();
-            let expression = parse_scalar_expression(result.next().unwrap(), &state).unwrap();
+            let mut expression = parse_scalar_expression(result.next().unwrap(), &state).unwrap();
 
-            let pipeline = PipelineExpression::default();
+            let pipeline: PipelineExpression = Default::default();
 
-            if let Ok(Some(resolved)) = expression.try_resolve_static(&pipeline) {
+            if let Ok(Some(resolved)) =
+                expression.try_resolve_static(&pipeline.get_resolution_scope())
+            {
                 match resolved.to_value() {
                     Value::Double(d) => Some(d.get_value()),
                     _ => None,

--- a/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
@@ -1662,22 +1662,26 @@ mod tests {
                     ConditionalScalarExpression::new(
                         QueryLocation::new_fake(),
                         LogicalExpression::Scalar(ScalarExpression::Constant(
-                            ConstantScalarExpression::Reference(
-                                ReferenceConstantScalarExpression::new(
+                            ConstantScalarExpression::Copy(CopyConstantScalarExpression::new(
+                                QueryLocation::new_fake(),
+                                2,
+                                StaticScalarExpression::Boolean(BooleanScalarExpression::new(
                                     QueryLocation::new_fake(),
-                                    ValueType::Boolean,
-                                    2,
-                                ),
-                            ),
+                                    false,
+                                )),
+                            )),
                         )),
                         ScalarExpression::Static(StaticScalarExpression::String(
                             StringScalarExpression::new(QueryLocation::new_fake(), "a"),
                         )),
-                        ScalarExpression::Constant(ConstantScalarExpression::Reference(
-                            ReferenceConstantScalarExpression::new(
+                        ScalarExpression::Constant(ConstantScalarExpression::Copy(
+                            CopyConstantScalarExpression::new(
                                 QueryLocation::new_fake(),
-                                ValueType::String,
                                 3,
+                                StaticScalarExpression::String(StringScalarExpression::new(
+                                    QueryLocation::new_fake(),
+                                    "hello world",
+                                )),
                             ),
                         )),
                     ),

--- a/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
@@ -337,9 +337,10 @@ pub(crate) fn parse_accessor_expression(
                 true
             }
             Rule::scalar_expression => {
-                let scalar = parse_scalar_expression(pair, state)?;
+                let mut scalar = parse_scalar_expression(pair, state)?;
 
-                let value_type_result = scalar.try_resolve_value_type(state.get_pipeline());
+                let value_type_result =
+                    scalar.try_resolve_value_type(&state.get_pipeline().get_resolution_scope());
                 if let Err(e) = value_type_result {
                     return Err(ParserError::from(&e));
                 }

--- a/rust/experimental/query_engine/kql-parser/src/scalar_string_function_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_string_function_expressions.rs
@@ -17,10 +17,10 @@ pub(crate) fn parse_strlen_expression(
 
     let inner_expression_rule = strlen_rules.next().unwrap();
     let inner_expression_rule_location = to_query_location(&inner_expression_rule);
-    let inner_expression = parse_scalar_expression(inner_expression_rule, state)?;
+    let mut inner_expression = parse_scalar_expression(inner_expression_rule, state)?;
 
     let inner_expression_value_type_result = inner_expression
-        .try_resolve_value_type(state.get_pipeline())
+        .try_resolve_value_type(&state.get_pipeline().get_resolution_scope())
         .map_err(|e| ParserError::from(&e))?;
 
     if let Some(v) = inner_expression_value_type_result
@@ -63,10 +63,10 @@ pub(crate) fn parse_replace_string_expression(
     ) -> Result<ScalarExpression, ParserError> {
         let location = to_query_location(&rule);
 
-        let scalar = parse_scalar_expression(rule, state)?;
+        let mut scalar = parse_scalar_expression(rule, state)?;
 
         let scalar_value_type_result = scalar
-            .try_resolve_value_type(state.get_pipeline())
+            .try_resolve_value_type(&state.get_pipeline().get_resolution_scope())
             .map_err(|e| ParserError::from(&e))?;
 
         if let Some(v) = scalar_value_type_result
@@ -94,10 +94,10 @@ pub(crate) fn parse_substring_expression(
 
     let starting_index_rule = substring_rules.next().unwrap();
     let starting_index_rule_location = to_query_location(&starting_index_rule);
-    let starting_index_scalar = parse_scalar_expression(starting_index_rule, state)?;
+    let mut starting_index_scalar = parse_scalar_expression(starting_index_rule, state)?;
 
     let starting_index_value_type_result = starting_index_scalar
-        .try_resolve_value_type(state.get_pipeline())
+        .try_resolve_value_type(&state.get_pipeline().get_resolution_scope())
         .map_err(|e| ParserError::from(&e))?;
 
     if let Some(v) = starting_index_value_type_result
@@ -112,10 +112,10 @@ pub(crate) fn parse_substring_expression(
 
     let length_scalar = if let Some(length_rule) = substring_rules.next() {
         let length_scalar_rule_location = to_query_location(&length_rule);
-        let length_scalar = parse_scalar_expression(length_rule, state)?;
+        let mut length_scalar = parse_scalar_expression(length_rule, state)?;
 
         let length_scalar_value_type_result = length_scalar
-            .try_resolve_value_type(state.get_pipeline())
+            .try_resolve_value_type(&state.get_pipeline().get_resolution_scope())
             .map_err(|e| ParserError::from(&e))?;
 
         if let Some(v) = length_scalar_value_type_result
@@ -151,10 +151,10 @@ pub(crate) fn parse_parse_json_expression(
 
     let inner_rule = parse_json_rules.next().unwrap();
     let inner_rule_location = to_query_location(&inner_rule);
-    let inner_scalar = parse_scalar_expression(inner_rule, state)?;
+    let mut inner_scalar = parse_scalar_expression(inner_rule, state)?;
 
     if let Some(v) = inner_scalar
-        .try_resolve_value_type(state.get_pipeline())
+        .try_resolve_value_type(&state.get_pipeline().get_resolution_scope())
         .map_err(|e| ParserError::from(&e))?
         && v != ValueType::String
     {
@@ -165,7 +165,7 @@ pub(crate) fn parse_parse_json_expression(
         });
     }
 
-    let parse_json_scalar = ScalarExpression::Parse(ParseScalarExpression::Json(
+    let mut parse_json_scalar = ScalarExpression::Parse(ParseScalarExpression::Json(
         ParseJsonScalarExpression::new(query_location, inner_scalar),
     ));
 
@@ -174,7 +174,7 @@ pub(crate) fn parse_parse_json_expression(
     // tree gets constant folding which should automatically call into
     // try_resolve_static.
     parse_json_scalar
-        .try_resolve_static(state.get_pipeline())
+        .try_resolve_static(&state.get_pipeline().get_resolution_scope())
         .map_err(|e| ParserError::from(&e))?;
 
     Ok(parse_json_scalar)

--- a/rust/experimental/query_engine/parser-abstractions/src/parser_state.rs
+++ b/rust/experimental/query_engine/parser-abstractions/src/parser_state.rs
@@ -177,4 +177,20 @@ pub trait ParserScope {
     fn push_variable_name(&mut self, name: &str);
 
     fn create_scope<'a>(&'a self, options: ParserOptions) -> ParserStateScope<'a>;
+
+    fn scalar_as_static<'a>(
+        &'a self,
+        scalar: &'a ScalarExpression,
+    ) -> Option<&'a StaticScalarExpression> {
+        match scalar {
+            ScalarExpression::Static(v) => Some(v),
+            ScalarExpression::Constant(ConstantScalarExpression::Copy(v)) => Some(v.get_value()),
+            ScalarExpression::Constant(ConstantScalarExpression::Reference(v)) => Some(
+                self.get_pipeline()
+                    .get_constant(v.get_constant_id())
+                    .expect("Constant not found"),
+            ),
+            _ => None,
+        }
+    }
 }


### PR DESCRIPTION
## Changes

* Simplify the signature for static resolution methods (less lifetimes)
* Implement some static folding when static resolution is manually invoked by parsers