### PR TITLE
[otap-df-engine] Fix timer drift

### DIFF
--- a/rust/otap-dataflow/crates/engine/src/pipeline_ctrl.rs
+++ b/rust/otap-dataflow/crates/engine/src/pipeline_ctrl.rs
@@ -103,9 +103,6 @@ impl PipelineCtrlMsgManager {
                         if when > now {
                             tokio::time::sleep_until(when).await;
                         }
-                    } else {
-                        // No timers scheduled, wait indefinitely.
-                        futures::future::pending::<()>().await;
                     }
                 }, if next_expiry.is_some() => {
                     if let Some(Reverse((when, node_id))) = self.timers.pop() {
@@ -120,7 +117,7 @@ impl PipelineCtrlMsgManager {
                                 }
 
                                 // Schedule next recurrence
-                                let next_when = Instant::now() + timer_state.duration;
+                                let next_when = when + timer_state.duration;
                                 self.timers.push(Reverse((next_when, node_id)));
                                 timer_state.scheduled_time = next_when;
                             } else if timer_state.is_canceled {


### PR DESCRIPTION
## Changes

- Fix timer drift 

```diff
// Current implementation - causes drift
- let next_when = Instant::now() + duration;

// Better approach - maintains consistent intervals
+ let next_when = when + duration;
```

Problem:

```rust
// Say we want a 100ms recurring timer:
// Timer 1: Schedule for T+100ms
// Timer 1 fires at: T+102ms (2ms late due to system load)
// Timer 2: Schedule for (T+102ms) + 100ms = T+202ms  ← Should be T+200ms!
// Timer 2 fires at: T+205ms (3ms late)  
// Timer 3: Schedule for (T+205ms) + 100ms = T+305ms  ← Should be T+300ms!
//
// After 10 iterations, we could be 50ms+ off schedule!

// With the fix: let next_when = when + duration;
// Timer 1: Schedule for T+100ms
// Timer 1 fires at: T+102ms (2ms late, but we don't care)
// Timer 2: Schedule for (T+100ms) + 100ms = T+200ms  ← Correct!
// Timer 2 fires at: T+203ms (3ms late, but schedule stays correct)
// Timer 3: Schedule for (T+200ms) + 100ms = T+300ms  ← Still correct!
//
// The actual firing time can vary, but the schedule stays consistent
```
