### PR TITLE
[query-engine] Allow accessor expressions in KQL group by expressions

### DIFF
--- a/rust/experimental/query_engine/kql-parser/src/kql.pest
+++ b/rust/experimental/query_engine/kql-parser/src/kql.pest
@@ -247,7 +247,8 @@ aggregate_assignment_expression = {
 }
 
 group_by_expression = {
-    identifier_literal ~ ("=" ~ scalar_expression)?
+    identifier_literal ~ "=" ~ scalar_expression
+    | accessor_expression
 }
 
 summarize_expression = {

--- a/rust/experimental/query_engine/kql-parser/src/tabular_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/tabular_expressions.rs
@@ -307,24 +307,59 @@ pub(crate) fn parse_summarize_expression(
             Rule::group_by_expression => {
                 let mut group_by = summarize_rule.into_inner();
 
-                let identifier_rule = group_by.next().unwrap();
-                let identifier = identifier_rule.as_str();
+                let group_by_first_rule = group_by.next().unwrap();
+                let group_by_first_rule_location = to_query_location(&group_by_first_rule);
 
-                let scalar = if let Some(scalar_rule) = group_by.next() {
-                    parse_scalar_expression(scalar_rule, state)?
-                } else {
-                    ScalarExpression::Source(SourceScalarExpression::new(
-                        to_query_location(&identifier_rule),
-                        ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
-                            StaticScalarExpression::String(StringScalarExpression::new(
-                                to_query_location(&identifier_rule),
-                                identifier,
-                            )),
-                        )]),
-                    ))
-                };
+                match group_by_first_rule.as_rule() {
+                    Rule::identifier_literal => {
+                        let scalar = parse_scalar_expression(group_by.next().unwrap(), state)?;
 
-                group_by_expressions.insert(identifier.into(), scalar);
+                        group_by_expressions
+                            .insert(group_by_first_rule.as_str().trim().into(), scalar);
+                    }
+                    Rule::accessor_expression => {
+                        let accessor = parse_accessor_expression(group_by_first_rule, state, true)?;
+                        match &accessor {
+                            ScalarExpression::Source(s) => {
+                                group_by_expressions.insert(
+                                    parse_group_by_accessor(
+                                        &group_by_first_rule_location,
+                                        s.get_value_accessor(),
+                                        state,
+                                    )?,
+                                    accessor,
+                                );
+                            }
+                            ScalarExpression::Attached(a) => {
+                                group_by_expressions.insert(
+                                    parse_group_by_accessor(
+                                        &group_by_first_rule_location,
+                                        a.get_value_accessor(),
+                                        state,
+                                    )?,
+                                    accessor,
+                                );
+                            }
+                            ScalarExpression::Variable(v) => {
+                                group_by_expressions.insert(
+                                    parse_group_by_accessor(
+                                        &group_by_first_rule_location,
+                                        v.get_value_accessor(),
+                                        state,
+                                    )?,
+                                    accessor,
+                                );
+                            }
+                            _ => {
+                                return Err(ParserError::SyntaxError(
+                                    group_by_first_rule_location,
+                                    "Could not determine the source and/or name for summary group-by expression. Try using assignment syntax instead (Name = [expression]).".into(),
+                                ));
+                            }
+                        }
+                    }
+                    _ => panic!("Unexpected rule in group_by_expression: {group_by_first_rule}"),
+                }
             }
             _ => {
                 let scope = state.create_scope(ParserOptions::new());
@@ -337,10 +372,10 @@ pub(crate) fn parse_summarize_expression(
     }
 
     if group_by_expressions.is_empty() && aggregation_expressions.is_empty() {
-        Err(ParserError::SyntaxError(
+        return Err(ParserError::SyntaxError(
             query_location,
             "Invalid summarize operator: missing both aggregates and group-by expressions".into(),
-        ))
+        ));
     } else {
         let mut summary = SummaryDataExpression::new(
             query_location,
@@ -354,7 +389,44 @@ pub(crate) fn parse_summarize_expression(
             }
         }
 
-        Ok(DataExpression::Summary(summary))
+        return Ok(DataExpression::Summary(summary));
+    }
+
+    fn parse_group_by_accessor(
+        query_location: &QueryLocation,
+        value_accessor: &ValueAccessor,
+        scope: &dyn ParserScope,
+    ) -> Result<Box<str>, ParserError> {
+        let selectors = value_accessor.get_selectors();
+        if selectors.is_empty() {
+            Err(ParserError::SyntaxError(
+                query_location.clone(),
+                "Cannot refer to a root map directly in a group-by expression".into(),
+            ))
+        } else {
+            let last = selectors.last().unwrap();
+            match last.try_resolve_static(scope.get_pipeline()).map_err(|e| ParserError::from(&e))? {
+                Some(v) => {
+                    match v.to_value() {
+                        Value::String(s) => {
+                            Ok(s.get_value().into())
+                        }
+                        _ => {
+                            Err(ParserError::SyntaxError(
+                                last.get_query_location().clone(),
+                                "Could not determine the name for summary group-by expression. Try using assignment syntax instead (Name = [expression]).".into(),
+                            ))
+                        }
+                    }
+                }
+                _ => {
+                    Err(ParserError::SyntaxError(
+                        last.get_query_location().clone(),
+                        "Could not determine the name for summary group-by expression. Try using assignment syntax instead (Name = [expression]).".into(),
+                    ))
+                }
+            }
+        }
     }
 }
 
@@ -2201,7 +2273,26 @@ mod tests {
     #[test]
     pub fn test_parse_summarize_expression() {
         let run_test_success = |input: &str, expected: SummaryDataExpression| {
-            let state = ParserState::new(input);
+            let mut state = ParserState::new_with_options(
+                input,
+                ParserOptions::new()
+                    .with_source_map_schema(
+                        ParserMapSchema::new()
+                            .with_key_definition("a", ParserMapKeySchema::Any)
+                            .with_key_definition("c", ParserMapKeySchema::Any)
+                            .with_key_definition("Attributes", ParserMapKeySchema::Map)
+                            .set_default_map_key("Attributes"),
+                    )
+                    .with_attached_data_names(&["resource"]),
+            );
+
+            state.push_constant(
+                "const",
+                StaticScalarExpression::String(StringScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    "const_str",
+                )),
+            );
 
             let mut result = KqlPestParser::parse(Rule::summarize_expression, input).unwrap();
 
@@ -2211,7 +2302,26 @@ mod tests {
         };
 
         let run_test_failure = |input: &str, expected: &str| {
-            let state = ParserState::new(input);
+            let mut state = ParserState::new_with_options(
+                input,
+                ParserOptions::new()
+                    .with_source_map_schema(
+                        ParserMapSchema::new()
+                            .with_key_definition("a", ParserMapKeySchema::Any)
+                            .with_key_definition("c", ParserMapKeySchema::Any)
+                            .with_key_definition("Attributes", ParserMapKeySchema::Map)
+                            .set_default_map_key("Attributes"),
+                    )
+                    .with_attached_data_names(&["resource"]),
+            );
+
+            state.push_constant(
+                "const",
+                StaticScalarExpression::String(StringScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    "const_str",
+                )),
+            );
 
             let mut result = KqlPestParser::parse(Rule::summarize_expression, input).unwrap();
 
@@ -2363,9 +2473,140 @@ mod tests {
             )]),
         );
 
+        run_test_success(
+            "summarize by Level",
+            SummaryDataExpression::new(
+                QueryLocation::new_fake(),
+                HashMap::from([(
+                    "Level".into(),
+                    ScalarExpression::Source(SourceScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        ValueAccessor::new_with_selectors(vec![
+                            ScalarExpression::Static(StaticScalarExpression::String(
+                                StringScalarExpression::new(
+                                    QueryLocation::new_fake(),
+                                    "Attributes",
+                                ),
+                            )),
+                            ScalarExpression::Static(StaticScalarExpression::String(
+                                StringScalarExpression::new(QueryLocation::new_fake(), "Level"),
+                            )),
+                        ]),
+                    )),
+                )]),
+                HashMap::new(),
+            ),
+        );
+
+        run_test_success(
+            "summarize by Attributes[const]",
+            SummaryDataExpression::new(
+                QueryLocation::new_fake(),
+                HashMap::from([(
+                    "const_str".into(),
+                    ScalarExpression::Source(SourceScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        ValueAccessor::new_with_selectors(vec![
+                            ScalarExpression::Static(StaticScalarExpression::String(
+                                StringScalarExpression::new(
+                                    QueryLocation::new_fake(),
+                                    "Attributes",
+                                ),
+                            )),
+                            ScalarExpression::Constant(ConstantScalarExpression::Reference(
+                                ReferenceConstantScalarExpression::new(
+                                    QueryLocation::new_fake(),
+                                    ValueType::String,
+                                    0,
+                                ),
+                            )),
+                        ]),
+                    )),
+                )]),
+                HashMap::new(),
+            ),
+        );
+
+        run_test_success(
+            "summarize by Attributes['something']['else']",
+            SummaryDataExpression::new(
+                QueryLocation::new_fake(),
+                HashMap::from([(
+                    "else".into(),
+                    ScalarExpression::Source(SourceScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        ValueAccessor::new_with_selectors(vec![
+                            ScalarExpression::Static(StaticScalarExpression::String(
+                                StringScalarExpression::new(
+                                    QueryLocation::new_fake(),
+                                    "Attributes",
+                                ),
+                            )),
+                            ScalarExpression::Static(StaticScalarExpression::String(
+                                StringScalarExpression::new(QueryLocation::new_fake(), "something"),
+                            )),
+                            ScalarExpression::Static(StaticScalarExpression::String(
+                                StringScalarExpression::new(QueryLocation::new_fake(), "else"),
+                            )),
+                        ]),
+                    )),
+                )]),
+                HashMap::new(),
+            ),
+        );
+
+        run_test_success(
+            "summarize by resource.Attributes['service.name']",
+            SummaryDataExpression::new(
+                QueryLocation::new_fake(),
+                HashMap::from([(
+                    "service.name".into(),
+                    ScalarExpression::Attached(AttachedScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        StringScalarExpression::new(QueryLocation::new_fake(), "resource"),
+                        ValueAccessor::new_with_selectors(vec![
+                            ScalarExpression::Static(StaticScalarExpression::String(
+                                StringScalarExpression::new(
+                                    QueryLocation::new_fake(),
+                                    "Attributes",
+                                ),
+                            )),
+                            ScalarExpression::Static(StaticScalarExpression::String(
+                                StringScalarExpression::new(
+                                    QueryLocation::new_fake(),
+                                    "service.name",
+                                ),
+                            )),
+                        ]),
+                    )),
+                )]),
+                HashMap::new(),
+            ),
+        );
+
         run_test_failure(
             "summarize | extend v = 1",
             "Invalid summarize operator: missing both aggregates and group-by expressions",
+        );
+
+        run_test_failure(
+            "summarize by resource",
+            "Cannot refer to a root map directly in a group-by expression",
+        );
+
+        run_test_failure(
+            "summarize by Attributes[tostring(now())]",
+            "Could not determine the name for summary group-by expression. Try using assignment syntax instead (Name = [expression]).",
+        );
+
+        run_test_failure(
+            "summarize by Attributes['array'][0]",
+            "Could not determine the name for summary group-by expression. Try using assignment syntax instead (Name = [expression]).",
+        );
+
+        run_test_failure(
+            "summarize by const",
+            "Could not determine the source and/or name for summary group-by expression. Try using assignment syntax instead (Name = [expression]).",
         );
     }
 


### PR DESCRIPTION
## Changes

* Improve the user experience when using KQL `summarize` by allowing accessor expressions in group-by clauses with auto resolution of names