### PR TITLE
fix the parquet shutdown test flakiness again

### DIFF
--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -65,6 +65,7 @@ linkme = "0.3.33"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["full"] }
+url = "2.5.7"
 weaver_forge = { git = "https://github.com/open-telemetry/weaver.git", tag = "v0.17.0" }
 weaver_common = { git = "https://github.com/open-telemetry/weaver.git", tag = "v0.17.0"}
 

--- a/rust/otap-dataflow/crates/otap/Cargo.toml
+++ b/rust/otap-dataflow/crates/otap/Cargo.toml
@@ -62,3 +62,4 @@ weaver_common.workspace = true
 [dev-dependencies]
 portpicker = "0.1.1"
 tempfile.workspace = true
+url.workspace = true

--- a/rust/otap-dataflow/crates/otap/src/parquet_exporter/object_store.rs
+++ b/rust/otap-dataflow/crates/otap/src/parquet_exporter/object_store.rs
@@ -2,15 +2,144 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use object_store::ObjectStore;
 use object_store::local::LocalFileSystem;
+
+#[cfg(test)]
+use url::Url;
 
 pub(crate) fn from_uri(uri: &str) -> Result<Arc<dyn ObjectStore>, object_store::Error> {
     // TODO eventually we should support choosing the correct object_store implementation
     // from the URL. E.g. s3://my-bucket/path/ would signify using the S3 implementation instead
     // related issue: https://github.com/open-telemetry/otel-arrow/issues/501
 
+    #[cfg(test)]
+    {
+        if uri.starts_with("testdelayed://") {
+            return test::delayed_test_object_store(uri)
+        }
+    }
+
     let object_store = LocalFileSystem::new_with_prefix(uri)?;
     Ok(Arc::new(object_store))
 }
+
+#[cfg(test)]
+mod test {
+    use std::fmt::Display;
+
+    use super::*;
+    
+    use futures::stream::BoxStream;
+    use object_store::{GetOptions, MultipartUpload, ListResult, ObjectMeta, 
+        PutOptions, PutResult, GetResult,
+        PutMultipartOpts, PutPayload, Result};
+    use object_store::path::Path;
+    use tokio::time::sleep;
+
+    /// Creates an instance of object store that will have it's writes delayed by some amount.
+    /// The amount to delay should be in the querystring parameters of the uri
+    pub(super) fn delayed_test_object_store(uri: &str) -> Result<Arc<dyn ObjectStore>, object_store::Error> {
+        let url = Url::parse(uri).map_err(|e| object_store::Error::Generic {
+            store: "test_delayed",
+            source: Box::new(e),
+        })?;
+
+        let path = url.path().to_string();
+
+        let delay = url
+            .query_pairs()
+            .find(|(k, _)| k == "delay")
+            .map(|(_, v)| {
+                let s = v.as_ref();
+                humantime_serde::re::humantime::parse_duration(s).unwrap_or(Duration::from_millis(0))
+            })
+            .unwrap_or(Duration::from_millis(0));
+
+
+        let fs_store = LocalFileSystem::new_with_prefix(path)?;
+        Ok(Arc::new(DelayedObjectStore::new(fs_store, delay)))
+    }
+
+    /// An implementation of object store that does a little delay before it writes data. This can
+    /// be used for testing various write timeout scenarios
+    #[derive(Debug)]
+    pub struct DelayedObjectStore<S> {
+        inner: Arc<S>,
+        delay: Duration,
+    }
+
+    impl<S> DelayedObjectStore<S> {
+        pub fn new(inner: S, delay: Duration) -> Self {
+            Self { inner: Arc::new(inner), delay }
+        }
+    }
+
+    impl<S> Display for DelayedObjectStore<S> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            // Show inner type name + delay
+            write!(
+                f,
+                "DelayedObjectStore(inner={}, delay={:?})",
+                std::any::type_name::<S>(),
+                self.delay
+            )
+        }
+    }
+
+
+    #[async_trait::async_trait]
+    impl<S> ObjectStore for DelayedObjectStore<S>
+    where
+        S: ObjectStore + Send + Sync + 'static,
+    {
+        async fn put_opts(
+            &self,
+            location: &Path,
+            payload: PutPayload,
+            opts: PutOptions,
+        ) -> Result<PutResult>{
+            sleep(self.delay).await;
+            self.inner.put_opts(location, payload, opts).await
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            location: &Path,
+            opts: PutMultipartOpts,
+        ) -> Result<Box<dyn MultipartUpload>>{
+            self.inner.put_multipart_opts(location, opts).await
+        }
+
+        async fn get_opts(
+            &self,
+            location: &Path,
+            opts: GetOptions,
+        ) -> Result<GetResult> {
+            self.inner.get_opts(location, opts).await
+        }
+
+        async fn list_with_delimiter(&self, prefix: Option<&Path>) -> Result<ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+
+        async fn delete(&self, location: &Path) -> Result<()> {
+            self.inner.delete(location).await
+        }
+
+        fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, Result<ObjectMeta>> {
+            self.inner.list(prefix)
+        }
+
+        async fn copy(&self, from: &Path, to: &Path) -> Result<()> {
+            self.inner.copy(from, to).await
+        }
+
+        async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
+            self.inner.copy_if_not_exists(from, to).await
+        }
+    }
+}
+


### PR DESCRIPTION
Hopefully this will finally fix the parquet shutdown test being flakey 🤞 

Instead of buffering up enough rows and _hoping_ that when we send the shutdown signal that the writer won't have enough time to flush them, we use an implementation of object store that forces there to be a delay before we write to the filesystem. That way when we call shutdown, the parquet should call flush_all on the writer manager, which will close the parquet file writers, which will hit this delay when they try to write the parquet footer, which will _hopefully_ cause a timeout and reliably this test will pass..