### PR TITLE
[query-engine] Concat & Join expressions

### DIFF
--- a/rust/experimental/query_engine/engine-recordset/src/primitives/resolved_value.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/primitives/resolved_value.rs
@@ -31,6 +31,9 @@ pub enum ResolvedValue<'a> {
 
     /// A list of resolved values
     List(List<'a>),
+
+    /// A sequence of arrays
+    Sequence(Sequence<'a>),
 }
 
 impl<'a> ResolvedValue<'a> {
@@ -42,6 +45,9 @@ impl<'a> ResolvedValue<'a> {
             }
             ResolvedValue::List(l) => {
                 return l.copy_if_borrowed_from_target(target);
+            }
+            ResolvedValue::Sequence(s) => {
+                return s.copy_if_borrowed_from_target(target);
             }
             _ => None,
         };
@@ -102,6 +108,7 @@ impl<'a> ResolvedValue<'a> {
                 Slice::String(s) => Ok(ResolvedStringValue::Slice(s.into())),
             },
             ResolvedValue::List(_) => panic!(),
+            ResolvedValue::Sequence(_) => panic!(),
         }
     }
 
@@ -139,6 +146,7 @@ impl<'a> ResolvedValue<'a> {
             }
             ResolvedValue::Slice(_) => panic!(),
             ResolvedValue::List(_) => panic!(),
+            ResolvedValue::Sequence(_) => panic!(),
         }
     }
 
@@ -156,14 +164,18 @@ impl<'a> ResolvedValue<'a> {
                 }
             }
             ResolvedValue::Borrowed(s, b) => {
-                match Ref::filter_map(b, |v| {
+                match Ref::filter_map(Ref::clone(&b), |v| {
                     if let StaticValue::Array(s) = v.to_static_value() {
                         Some(s)
                     } else {
                         None
                     }
                 }) {
-                    Ok(v) => Ok(ResolvedArrayValue::Borrowed(s, v)),
+                    Ok(v) => Ok(ResolvedArrayValue::Borrowed(BorrowedArrayValue {
+                        source: s,
+                        orig: b,
+                        value: v,
+                    })),
                     Err(_) => panic!(),
                 }
             }
@@ -179,6 +191,7 @@ impl<'a> ResolvedValue<'a> {
                 Slice::String(_) => panic!(),
             },
             ResolvedValue::List(l) => Ok(ResolvedArrayValue::List(l)),
+            ResolvedValue::Sequence(s) => Ok(ResolvedArrayValue::Sequence(s)),
         }
     }
 }
@@ -194,6 +207,7 @@ impl From<ResolvedValue<'_>> for OwnedValue {
                 Slice::String(s) => Value::String(s).into(),
             },
             ResolvedValue::List(l) => Value::Array(&l).into(),
+            ResolvedValue::Sequence(s) => Value::Array(&s).into(),
         }
     }
 }
@@ -209,6 +223,7 @@ impl AsValue for ResolvedValue<'_> {
                 Slice::String(_) => ValueType::String,
             },
             ResolvedValue::List(_) => ValueType::Array,
+            ResolvedValue::Sequence(_) => ValueType::Array,
         }
     }
 
@@ -222,6 +237,7 @@ impl AsValue for ResolvedValue<'_> {
                 Slice::String(s) => Value::String(s),
             },
             ResolvedValue::List(l) => Value::Array(l),
+            ResolvedValue::Sequence(s) => Value::Array(s),
         }
     }
 }
@@ -423,6 +439,101 @@ impl StringValue for StringSlice<'_> {
 }
 
 #[derive(Debug)]
+pub struct Sequence<'a> {
+    values: Vec<ResolvedArrayValue<'a>>,
+}
+
+impl<'a> Sequence<'a> {
+    pub fn new(values: Vec<ResolvedArrayValue<'a>>) -> Sequence<'a> {
+        Self { values }
+    }
+
+    pub fn copy_if_borrowed_from_target(&mut self, target: &MutableValueExpression) -> bool {
+        let mut copied = false;
+
+        for value in &mut self.values {
+            if value.copy_if_borrowed_from_target(target) {
+                copied = true;
+            }
+        }
+
+        copied
+    }
+}
+
+impl ArrayValue for Sequence<'_> {
+    fn is_empty(&self) -> bool {
+        for v in &self.values {
+            if !v.is_empty() {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    fn len(&self) -> usize {
+        let mut len = 0;
+        for v in &self.values {
+            len += v.len();
+        }
+
+        len
+    }
+
+    fn get(&self, mut index: usize) -> Option<&(dyn AsValue)> {
+        for v in &self.values {
+            let end = v.len();
+            if index < end {
+                return v.get(index);
+            }
+            index -= end;
+        }
+
+        None
+    }
+
+    fn get_static(&self, _: usize) -> Result<Option<&(dyn AsStaticValue + 'static)>, String> {
+        Err("Sequence does not support static access".to_string())
+    }
+
+    fn get_item_range(
+        &self,
+        range: ArrayRange,
+        item_callback: &mut dyn IndexValueCallback,
+    ) -> bool {
+        let len = self.len();
+
+        let mut start = range.get_start_range_inclusize().unwrap_or(0);
+        let mut end = range.get_end_range_exclusive().unwrap_or(len);
+
+        if end > len {
+            panic!(
+                "range end index {} out of range for slice of length {}",
+                end, len
+            )
+        }
+
+        for v in &self.values {
+            let len = usize::min(end, v.len());
+            if len == 0 {
+                break;
+            }
+            if start < len {
+                let range = (start..len).into();
+                if !v.get_item_range(range, item_callback) {
+                    return false;
+                }
+            }
+            start += len;
+            end -= len;
+        }
+
+        true
+    }
+}
+
+#[derive(Debug)]
 pub enum ResolvedStringValue<'a> {
     /// A value resolved from the expression tree or an attached record
     Value(&'a dyn StringValue),
@@ -548,7 +659,7 @@ pub enum ResolvedArrayValue<'a> {
     Value(&'a dyn ArrayValue),
 
     /// A value borrowed from the record being modified by the engine
-    Borrowed(BorrowSource, Ref<'a, dyn ArrayValue + 'static>),
+    Borrowed(BorrowedArrayValue<'a>),
 
     /// A value computed by the engine as the result of a dynamic expression
     Computed(ArrayValueStorage<OwnedValue>),
@@ -558,17 +669,30 @@ pub enum ResolvedArrayValue<'a> {
 
     /// A list of resolved values
     List(List<'a>),
+
+    /// A sequence of arrays
+    Sequence(Sequence<'a>),
 }
 
-impl ResolvedArrayValue<'_> {
+#[derive(Debug)]
+pub struct BorrowedArrayValue<'a> {
+    source: BorrowSource,
+    orig: Ref<'a, dyn AsStaticValue + 'static>,
+    value: Ref<'a, dyn ArrayValue + 'static>,
+}
+
+impl<'a> ResolvedArrayValue<'a> {
     pub fn copy_if_borrowed_from_target(&mut self, target: &MutableValueExpression) -> bool {
         let v = match self {
-            ResolvedArrayValue::Borrowed(b, v) => Some((b, v)),
+            ResolvedArrayValue::Borrowed(b) => Some((&b.source, &b.value)),
             ResolvedArrayValue::Slice(s) => {
                 return s.inner_value.copy_if_borrowed_from_target(target);
             }
             ResolvedArrayValue::List(l) => {
                 return l.copy_if_borrowed_from_target(target);
+            }
+            ResolvedArrayValue::Sequence(s) => {
+                return s.copy_if_borrowed_from_target(target);
             }
             _ => None,
         };
@@ -592,13 +716,111 @@ impl ResolvedArrayValue<'_> {
         false
     }
 
+    pub fn take<FConvert, FTake, R>(
+        self,
+        range: ArrayRange,
+        convert: FConvert,
+        mut take: FTake,
+    ) -> Result<(), ExpressionError>
+    where
+        FConvert: Fn(usize, ResolvedValue<'a>) -> Result<R, ExpressionError>,
+        FTake: FnMut(R),
+    {
+        let start = range.get_start_range_inclusize().unwrap_or(0);
+
+        match self {
+            ResolvedArrayValue::Value(a) => {
+                let end = range.get_end_range_exclusive().unwrap_or(a.len());
+                for i in start..end {
+                    let v = (convert)(
+                        i,
+                        ResolvedValue::Value(
+                            a.get(i).expect("Array index was not found").to_value(),
+                        ),
+                    )?;
+                    (take)(v);
+                }
+                Ok(())
+            }
+            ResolvedArrayValue::Borrowed(b) => {
+                let a = &b.value;
+                let end = range.get_end_range_exclusive().unwrap_or(a.len());
+                for i in start..end {
+                    match Ref::filter_map(Ref::clone(a), |a| {
+                        a.get_static(i)
+                            .expect("Borrowed array does not implement get_static")
+                    }) {
+                        Ok(v) => {
+                            let v = (convert)(i, ResolvedValue::Borrowed(b.source.clone(), v))?;
+                            (take)(v);
+                        }
+                        Err(_) => panic!("Array index was not found"),
+                    }
+                }
+                Ok(())
+            }
+            ResolvedArrayValue::Computed(mut a) => {
+                let end = range.get_end_range_exclusive().unwrap_or(a.len());
+                for (i, v) in a.drain((start..end).into()).enumerate() {
+                    let v = (convert)(i, ResolvedValue::Computed(v))?;
+                    (take)(v);
+                }
+                Ok(())
+            }
+            ResolvedArrayValue::Slice(s) => {
+                let start = s.range_start_inclusive + start;
+                let end =
+                    s.range_start_inclusive + range.get_end_range_exclusive().unwrap_or(s.len());
+                s.inner_value.take((start..end).into(), convert, take)?;
+                Ok(())
+            }
+            ResolvedArrayValue::List(mut l) => {
+                let end = range.get_end_range_exclusive().unwrap_or(l.len());
+                for (i, v) in l.values.drain(start..end).enumerate() {
+                    (take)((convert)(i, v)?);
+                }
+                Ok(())
+            }
+            ResolvedArrayValue::Sequence(mut s) => {
+                let end = range.get_end_range_exclusive().unwrap_or(s.len());
+                for (i, v) in s.values.drain(start..end).enumerate() {
+                    let r = match v {
+                        ResolvedArrayValue::Value(a) => ResolvedValue::Value(Value::Array(a)),
+                        ResolvedArrayValue::Borrowed(b) => {
+                            ResolvedValue::Borrowed(b.source, b.orig)
+                        }
+                        ResolvedArrayValue::Computed(a) => {
+                            ResolvedValue::Computed(OwnedValue::Array(a))
+                        }
+                        ResolvedArrayValue::Slice(a) => ResolvedValue::Slice(Slice::Array(*a)),
+                        ResolvedArrayValue::List(l) => ResolvedValue::List(l),
+                        ResolvedArrayValue::Sequence(s) => ResolvedValue::Sequence(s),
+                    };
+
+                    (take)((convert)(i, r)?);
+                }
+                Ok(())
+            }
+        }
+    }
+
+    pub fn to_vec<F, R>(self, range: ArrayRange, convert: F) -> Result<Vec<R>, ExpressionError>
+    where
+        F: Fn(usize, ResolvedValue<'a>) -> Result<R, ExpressionError>,
+    {
+        let mut values = Vec::with_capacity(self.len());
+        self.take(range, convert, &mut |i| values.push(i))?;
+        Ok(values)
+    }
+
     fn get_array(&self) -> &dyn ArrayValue {
         match self {
             ResolvedArrayValue::Value(v) => *v,
-            ResolvedArrayValue::Borrowed(_, b) => &**b,
+            ResolvedArrayValue::Borrowed(b) => &*b.value,
             ResolvedArrayValue::Computed(c) => c,
             ResolvedArrayValue::Slice(s) => &**s,
             ResolvedArrayValue::List(l) => l,
+            ResolvedArrayValue::Sequence(s) => s,
         }
     }
 }
@@ -642,5 +864,126 @@ impl AsValue for ResolvedArrayValue<'_> {
 impl Display for ResolvedArrayValue<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.to_value().fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sequence_get_item_range() {
+        fn run_test(v: &Sequence, range: ArrayRange, expected: &[Value]) {
+            v.get_item_range(
+                range,
+                &mut IndexValueClosureCallback::new(|i, v| {
+                    assert_eq!(expected[i], v);
+                    true
+                }),
+            );
+        }
+
+        let sequence = Sequence::new(vec![
+            ResolvedArrayValue::Computed(ArrayValueStorage::new(vec![
+                OwnedValue::Integer(IntegerValueStorage::new(0)),
+                OwnedValue::Integer(IntegerValueStorage::new(1)),
+                OwnedValue::Integer(IntegerValueStorage::new(2)),
+            ])),
+            ResolvedArrayValue::Computed(ArrayValueStorage::new(vec![
+                OwnedValue::Integer(IntegerValueStorage::new(3)),
+                OwnedValue::Integer(IntegerValueStorage::new(4)),
+                OwnedValue::Integer(IntegerValueStorage::new(5)),
+            ])),
+        ]);
+
+        run_test(&sequence, (0..0).into(), &[]);
+        run_test(
+            &sequence,
+            (0..1).into(),
+            &[OwnedValue::Integer(IntegerValueStorage::new(0)).to_value()],
+        );
+        run_test(
+            &sequence,
+            (0..=2).into(),
+            &[
+                OwnedValue::Integer(IntegerValueStorage::new(0)).to_value(),
+                OwnedValue::Integer(IntegerValueStorage::new(1)).to_value(),
+                OwnedValue::Integer(IntegerValueStorage::new(2)).to_value(),
+            ],
+        );
+        run_test(
+            &sequence,
+            (1..=1).into(),
+            &[OwnedValue::Integer(IntegerValueStorage::new(1)).to_value()],
+        );
+        run_test(
+            &sequence,
+            (2..=3).into(),
+            &[
+                OwnedValue::Integer(IntegerValueStorage::new(2)).to_value(),
+                OwnedValue::Integer(IntegerValueStorage::new(3)).to_value(),
+            ],
+        );
+        run_test(
+            &sequence,
+            (2..).into(),
+            &[
+                OwnedValue::Integer(IntegerValueStorage::new(2)).to_value(),
+                OwnedValue::Integer(IntegerValueStorage::new(3)).to_value(),
+                OwnedValue::Integer(IntegerValueStorage::new(4)).to_value(),
+                OwnedValue::Integer(IntegerValueStorage::new(5)).to_value(),
+            ],
+        );
+        run_test(
+            &sequence,
+            (3..=5).into(),
+            &[
+                OwnedValue::Integer(IntegerValueStorage::new(3)).to_value(),
+                OwnedValue::Integer(IntegerValueStorage::new(4)).to_value(),
+                OwnedValue::Integer(IntegerValueStorage::new(5)).to_value(),
+            ],
+        );
+        run_test(
+            &sequence,
+            (..).into(),
+            &[
+                OwnedValue::Integer(IntegerValueStorage::new(0)).to_value(),
+                OwnedValue::Integer(IntegerValueStorage::new(1)).to_value(),
+                OwnedValue::Integer(IntegerValueStorage::new(2)).to_value(),
+                OwnedValue::Integer(IntegerValueStorage::new(3)).to_value(),
+                OwnedValue::Integer(IntegerValueStorage::new(4)).to_value(),
+                OwnedValue::Integer(IntegerValueStorage::new(5)).to_value(),
+            ],
+        );
+        run_test(&sequence, (10..).into(), &[]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_sequence_get_item_range_panic() {
+        fn run_test(v: &Sequence, range: ArrayRange, expected: &[Value]) {
+            v.get_item_range(
+                range,
+                &mut IndexValueClosureCallback::new(|i, v| {
+                    assert_eq!(expected[i], v);
+                    true
+                }),
+            );
+        }
+
+        let sequence = Sequence::new(vec![
+            ResolvedArrayValue::Computed(ArrayValueStorage::new(vec![
+                OwnedValue::Integer(IntegerValueStorage::new(0)),
+                OwnedValue::Integer(IntegerValueStorage::new(1)),
+                OwnedValue::Integer(IntegerValueStorage::new(2)),
+            ])),
+            ResolvedArrayValue::Computed(ArrayValueStorage::new(vec![
+                OwnedValue::Integer(IntegerValueStorage::new(3)),
+                OwnedValue::Integer(IntegerValueStorage::new(4)),
+                OwnedValue::Integer(IntegerValueStorage::new(5)),
+            ])),
+        ]);
+
+        run_test(&sequence, (..10).into(), &[]);
     }
 }

--- a/rust/experimental/query_engine/engine-recordset/src/primitives/value_storage.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/primitives/value_storage.rs
@@ -301,6 +301,12 @@ impl<T: EnumerableValueSource<T>> ArrayValueStorage<T> {
     pub fn get_values_mut(&mut self) -> &mut Vec<T> {
         &mut self.values
     }
+
+    pub fn drain(&mut self, range: ArrayRange) -> std::vec::Drain<'_, T> {
+        let start = range.get_start_range_inclusize().unwrap_or(0);
+        let end = range.get_end_range_exclusive().unwrap_or(self.values.len());
+        self.values.drain(start..end)
+    }
 }
 
 impl<T: EnumerableValueSource<T>> ArrayValue for ArrayValueStorage<T> {

--- a/rust/experimental/query_engine/engine-recordset/src/scalars/collection_scalar_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/scalars/collection_scalar_expressions.rs
@@ -1,0 +1,118 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use data_engine_expressions::*;
+
+use crate::{execution_context::*, scalars::execute_scalar_expression, *};
+
+pub fn execute_collection_scalar_expression<'a, 'b, 'c, TRecord: Record>(
+    execution_context: &'b ExecutionContext<'a, '_, '_, TRecord>,
+    collection_scalar_expression: &'a CollectionScalarExpression,
+) -> Result<ResolvedValue<'c>, ExpressionError>
+where
+    'a: 'c,
+    'b: 'c,
+{
+    match collection_scalar_expression {
+        CollectionScalarExpression::Concat(c) => {
+            match execute_scalar_expression(execution_context, c.get_values_expression())?
+                .try_resolve_array()
+            {
+                Ok(a) => {
+                    let values = a.to_vec((..).into(), |i, r| {
+                        match r.try_resolve_array() {
+                            Ok(v) => Ok(v),
+                            Err(v) => {
+                                Err(ExpressionError::TypeMismatch(
+                                    c.get_values_expression().get_query_location().clone(),
+                                    format!(
+                                        "Value of '{:?}' type returned by scalar expression at index '{i}' could not be converted to an array",
+                                        v.get_value_type()
+                                    ),
+                                ))
+                            }
+                        }
+                    })?;
+
+                    let r = ResolvedValue::Sequence(Sequence::new(values));
+
+                    execution_context.add_diagnostic_if_enabled(
+                        RecordSetEngineDiagnosticLevel::Verbose,
+                        collection_scalar_expression,
+                        || format!("Evaluated as: '{r}'"),
+                    );
+
+                    Ok(r)
+                }
+                Err(orig) => Err(ExpressionError::TypeMismatch(
+                    c.get_values_expression().get_query_location().clone(),
+                    format!(
+                        "Value of '{:?}' type returned by scalar expression was not an array",
+                        orig.get_value_type()
+                    ),
+                )),
+            }
+        }
+        CollectionScalarExpression::List(c) => {
+            let expressions = c.get_value_expressions();
+
+            let mut values = Vec::with_capacity(expressions.len());
+
+            for v in expressions {
+                values.push(execute_scalar_expression(execution_context, v)?);
+            }
+
+            let r = ResolvedValue::List(List::new(values));
+
+            execution_context.add_diagnostic_if_enabled(
+                RecordSetEngineDiagnosticLevel::Verbose,
+                collection_scalar_expression,
+                || format!("Evaluated as: '{r}'"),
+            );
+
+            Ok(r)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    pub fn text_execute_list_scalar_expression() {
+        fn run_test_success(input: Vec<ScalarExpression>, expected_value: Value) {
+            let expression = ScalarExpression::Collection(CollectionScalarExpression::List(
+                ListScalarExpression::new(QueryLocation::new_fake(), input),
+            ));
+
+            let mut test = TestExecutionContext::new();
+
+            let execution_context = test.create_execution_context();
+
+            let actual_value = execute_scalar_expression(&execution_context, &expression).unwrap();
+            assert_eq!(expected_value, actual_value.to_value());
+        }
+
+        run_test_success(
+            vec![],
+            OwnedValue::Array(ArrayValueStorage::new(vec![])).to_value(),
+        );
+
+        run_test_success(
+            vec![
+                ScalarExpression::Static(StaticScalarExpression::Integer(
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::Integer(
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 2),
+                )),
+            ],
+            OwnedValue::Array(ArrayValueStorage::new(vec![
+                OwnedValue::Integer(IntegerValueStorage::new(1)),
+                OwnedValue::Integer(IntegerValueStorage::new(2)),
+            ]))
+            .to_value(),
+        );
+    }
+}

--- a/rust/experimental/query_engine/engine-recordset/src/scalars/collection_scalar_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/scalars/collection_scalar_expressions.rs
@@ -80,7 +80,7 @@ mod tests {
     use super::*;
 
     #[test]
-    pub fn text_execute_list_scalar_expression() {
+    pub fn text_execute_list_collection_scalar_expression() {
         fn run_test_success(input: Vec<ScalarExpression>, expected_value: Value) {
             let expression = ScalarExpression::Collection(CollectionScalarExpression::List(
                 ListScalarExpression::new(QueryLocation::new_fake(), input),
@@ -113,6 +113,108 @@ mod tests {
                 OwnedValue::Integer(IntegerValueStorage::new(2)),
             ]))
             .to_value(),
+        );
+    }
+
+    #[test]
+    pub fn text_execute_concat_collection_scalar_expression() {
+        fn run_test_success(values: ScalarExpression, expected_value: &str) {
+            let expression = ScalarExpression::Collection(CollectionScalarExpression::Concat(
+                CombineScalarExpression::new(QueryLocation::new_fake(), values),
+            ));
+
+            let mut test = TestExecutionContext::new();
+
+            let execution_context = test.create_execution_context();
+
+            let actual_value = execute_scalar_expression(&execution_context, &expression).unwrap();
+            assert_eq!(expected_value, actual_value.to_value().to_string().as_str());
+        }
+
+        run_test_success(
+            ScalarExpression::Static(StaticScalarExpression::Array(ArrayScalarExpression::new(
+                QueryLocation::new_fake(),
+                vec![],
+            ))),
+            "[]",
+        );
+
+        run_test_success(
+            ScalarExpression::Static(StaticScalarExpression::Array(ArrayScalarExpression::new(
+                QueryLocation::new_fake(),
+                vec![
+                    StaticScalarExpression::Array(ArrayScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        vec![
+                            StaticScalarExpression::Integer(IntegerScalarExpression::new(
+                                QueryLocation::new_fake(),
+                                18,
+                            )),
+                            StaticScalarExpression::Integer(IntegerScalarExpression::new(
+                                QueryLocation::new_fake(),
+                                1,
+                            )),
+                        ],
+                    )),
+                    StaticScalarExpression::Array(ArrayScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        vec![],
+                    )),
+                    StaticScalarExpression::Array(ArrayScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        vec![StaticScalarExpression::Integer(
+                            IntegerScalarExpression::new(QueryLocation::new_fake(), 2),
+                        )],
+                    )),
+                ],
+            ))),
+            "[18,1,2]",
+        );
+
+        run_test_success(
+            ScalarExpression::Collection(CollectionScalarExpression::List(
+                ListScalarExpression::new(QueryLocation::new_fake(), vec![]),
+            )),
+            "[]",
+        );
+
+        run_test_success(
+            ScalarExpression::Collection(CollectionScalarExpression::List(
+                ListScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    vec![
+                        ScalarExpression::Static(StaticScalarExpression::Array(
+                            ArrayScalarExpression::new(
+                                QueryLocation::new_fake(),
+                                vec![
+                                    StaticScalarExpression::Integer(IntegerScalarExpression::new(
+                                        QueryLocation::new_fake(),
+                                        18,
+                                    )),
+                                    StaticScalarExpression::Integer(IntegerScalarExpression::new(
+                                        QueryLocation::new_fake(),
+                                        1,
+                                    )),
+                                ],
+                            ),
+                        )),
+                        ScalarExpression::Collection(CollectionScalarExpression::List(
+                            ListScalarExpression::new(
+                                QueryLocation::new_fake(),
+                                vec![
+                                    ScalarExpression::Static(StaticScalarExpression::Integer(
+                                        IntegerScalarExpression::new(QueryLocation::new_fake(), 2),
+                                    )),
+                                    ScalarExpression::Static(StaticScalarExpression::Integer(
+                                        IntegerScalarExpression::new(QueryLocation::new_fake(), 3),
+                                    )),
+                                ],
+                            ),
+                        )),
+                    ],
+                ),
+            )),
+            "[18,1,2,3]",
         );
     }
 }

--- a/rust/experimental/query_engine/engine-recordset/src/scalars/mod.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/scalars/mod.rs
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+pub(crate) mod collection_scalar_expressions;
 pub(crate) mod convert_scalar_expressions;
 pub(crate) mod math_scalar_expressions;
 pub(crate) mod parse_scalar_expressions;
@@ -8,6 +9,7 @@ pub(crate) mod scalar_expressions;
 pub(crate) mod temporal_scalar_expressions;
 pub(crate) mod text_scalar_expressions;
 
+pub use collection_scalar_expressions::*;
 pub use convert_scalar_expressions::*;
 pub use math_scalar_expressions::*;
 pub use parse_scalar_expressions::*;

--- a/rust/experimental/query_engine/engine-recordset/src/scalars/text_scalar_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/scalars/text_scalar_expressions.rs
@@ -14,6 +14,119 @@ where
     'b: 'c,
 {
     match text_scalar_expression {
+        TextScalarExpression::Concat(c) => {
+            match execute_scalar_expression(execution_context, c.get_values_expression())?
+                .try_resolve_array()
+            {
+                Ok(a) => {
+                    let mut s = String::new();
+
+                    a.take((..).into(), |_, r| Ok(r), &mut |r: ResolvedValue<'_>| {
+                        match r.to_value() {
+                            Value::String(v) => s.push_str(v.get_value()),
+                            v => {
+                                let mut result = None;
+                                v.convert_to_string(&mut |v| {
+                                    s.push_str(v);
+                                    result = Some(true)
+                                });
+                                result.expect(
+                                    "Encountered a Value which does not correctly implement convert_to_string",
+                                );
+                            }
+                        }
+                    })?;
+
+                    execution_context.add_diagnostic_if_enabled(
+                        RecordSetEngineDiagnosticLevel::Verbose,
+                        text_scalar_expression,
+                        || format!("Evaluated as: '{s}'"),
+                    );
+
+                    Ok(ResolvedValue::Computed(OwnedValue::String(
+                        StringValueStorage::new(s),
+                    )))
+                }
+                Err(v) => Err(ExpressionError::TypeMismatch(
+                    c.get_values_expression().get_query_location().clone(),
+                    format!(
+                        "Value of '{:?}' type returned by scalar expression was not an array",
+                        v.get_value_type()
+                    ),
+                )),
+            }
+        }
+        TextScalarExpression::Join(j) => {
+            let mut separator_as_string = String::new();
+            let separator_scalar =
+                execute_scalar_expression(execution_context, j.get_separator_expression())?;
+            let separator = match separator_scalar.to_value() {
+                Value::String(s) => s.get_value(),
+                v => {
+                    let mut result = None;
+                    v.convert_to_string(&mut |s| {
+                        separator_as_string.push_str(s);
+                        result = Some(true);
+                    });
+                    result.expect(
+                        "Encountered a Value which does not correctly implement convert_to_string",
+                    );
+                    separator_as_string.as_str()
+                }
+            };
+
+            match execute_scalar_expression(execution_context, j.get_values_expression())?
+                .try_resolve_array()
+            {
+                Ok(a) => {
+                    let mut s = String::new();
+                    let mut len = 0;
+
+                    a.take((..).into(), |_, r| Ok(r), &mut |r: ResolvedValue<'_>| {
+                        match r.to_value() {
+                            Value::String(v) => {
+                                len += 1;
+                                if len > 1 {
+                                    s.push_str(separator);
+                                }
+                                s.push_str(v.get_value())
+                            },
+                            v => {
+                                let mut result = None;
+                                v.convert_to_string(&mut |v| {
+                                    len += 1;
+                                    if len > 1 {
+                                        s.push_str(separator);
+                                    }
+                                    s.push_str(v);
+                                    result = Some(true)
+                                });
+                                result.expect(
+                                    "Encountered a Value which does not correctly implement convert_to_string",
+                                );
+                            }
+                        }
+                    })?;
+
+                    execution_context.add_diagnostic_if_enabled(
+                        RecordSetEngineDiagnosticLevel::Verbose,
+                        text_scalar_expression,
+                        || format!("Evaluated as: '{s}'"),
+                    );
+
+                    Ok(ResolvedValue::Computed(OwnedValue::String(
+                        StringValueStorage::new(s),
+                    )))
+                }
+                Err(v) => Err(ExpressionError::TypeMismatch(
+                    j.get_values_expression().get_query_location().clone(),
+                    format!(
+                        "Value of '{:?}' type returned by scalar expression was not an array",
+                        v.get_value_type()
+                    ),
+                )),
+            }
+        }
         TextScalarExpression::Replace(r) => {
             let haystack_value =
                 execute_scalar_expression(execution_context, r.get_haystack_expression())?;

--- a/rust/experimental/query_engine/engine-recordset/src/scalars/text_scalar_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/scalars/text_scalar_expressions.rs
@@ -475,4 +475,173 @@ mod tests {
             )),
         );
     }
+
+    #[test]
+    pub fn text_execute_concat_text_scalar_expression() {
+        fn run_test_success(values: ScalarExpression, expected_value: &str) {
+            let expression = ScalarExpression::Text(TextScalarExpression::Concat(
+                CombineScalarExpression::new(QueryLocation::new_fake(), values),
+            ));
+
+            let mut test = TestExecutionContext::new();
+
+            let execution_context = test.create_execution_context();
+
+            let actual_value = execute_scalar_expression(&execution_context, &expression).unwrap();
+            assert_eq!(expected_value, actual_value.to_value().to_string().as_str());
+        }
+
+        run_test_success(
+            ScalarExpression::Static(StaticScalarExpression::Array(ArrayScalarExpression::new(
+                QueryLocation::new_fake(),
+                vec![],
+            ))),
+            "",
+        );
+
+        run_test_success(
+            ScalarExpression::Static(StaticScalarExpression::Array(ArrayScalarExpression::new(
+                QueryLocation::new_fake(),
+                vec![
+                    StaticScalarExpression::Integer(IntegerScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        2,
+                    )),
+                    StaticScalarExpression::String(StringScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        "hello world",
+                    )),
+                ],
+            ))),
+            "2hello world",
+        );
+
+        run_test_success(
+            ScalarExpression::Collection(CollectionScalarExpression::List(
+                ListScalarExpression::new(QueryLocation::new_fake(), vec![]),
+            )),
+            "",
+        );
+
+        run_test_success(
+            ScalarExpression::Collection(CollectionScalarExpression::List(
+                ListScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    vec![
+                        ScalarExpression::Math(MathScalarExpression::Add(
+                            BinaryMathematicalScalarExpression::new(
+                                QueryLocation::new_fake(),
+                                ScalarExpression::Static(StaticScalarExpression::Integer(
+                                    IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+                                )),
+                                ScalarExpression::Static(StaticScalarExpression::Integer(
+                                    IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+                                )),
+                            ),
+                        )),
+                        ScalarExpression::Static(StaticScalarExpression::String(
+                            StringScalarExpression::new(QueryLocation::new_fake(), "hello world"),
+                        )),
+                    ],
+                ),
+            )),
+            "2hello world",
+        );
+    }
+
+    #[test]
+    pub fn text_execute_join_text_scalar_expression() {
+        fn run_test_success(
+            separator: ScalarExpression,
+            values: ScalarExpression,
+            expected_value: &str,
+        ) {
+            let expression = ScalarExpression::Text(TextScalarExpression::Join(
+                JoinTextScalarExpression::new(QueryLocation::new_fake(), separator, values),
+            ));
+
+            let mut test = TestExecutionContext::new();
+
+            let execution_context = test.create_execution_context();
+
+            let actual_value = execute_scalar_expression(&execution_context, &expression).unwrap();
+            assert_eq!(expected_value, actual_value.to_value().to_string().as_str());
+        }
+
+        run_test_success(
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "|",
+            ))),
+            ScalarExpression::Static(StaticScalarExpression::Array(ArrayScalarExpression::new(
+                QueryLocation::new_fake(),
+                vec![],
+            ))),
+            "",
+        );
+
+        run_test_success(
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "|",
+            ))),
+            ScalarExpression::Static(StaticScalarExpression::Array(ArrayScalarExpression::new(
+                QueryLocation::new_fake(),
+                vec![
+                    StaticScalarExpression::Integer(IntegerScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        2,
+                    )),
+                    StaticScalarExpression::String(StringScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        "hello world",
+                    )),
+                ],
+            ))),
+            "2|hello world",
+        );
+
+        run_test_success(
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "|",
+            ))),
+            ScalarExpression::Collection(CollectionScalarExpression::List(
+                ListScalarExpression::new(QueryLocation::new_fake(), vec![]),
+            )),
+            "",
+        );
+
+        run_test_success(
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                ", ",
+            ))),
+            ScalarExpression::Collection(CollectionScalarExpression::List(
+                ListScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    vec![
+                        ScalarExpression::Math(MathScalarExpression::Add(
+                            BinaryMathematicalScalarExpression::new(
+                                QueryLocation::new_fake(),
+                                ScalarExpression::Static(StaticScalarExpression::Integer(
+                                    IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+                                )),
+                                ScalarExpression::Static(StaticScalarExpression::Integer(
+                                    IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+                                )),
+                            ),
+                        )),
+                        ScalarExpression::Static(StaticScalarExpression::String(
+                            StringScalarExpression::new(QueryLocation::new_fake(), "hello"),
+                        )),
+                        ScalarExpression::Static(StaticScalarExpression::String(
+                            StringScalarExpression::new(QueryLocation::new_fake(), "world"),
+                        )),
+                    ],
+                ),
+            )),
+            "2, hello, world",
+        );
+    }
 }

--- a/rust/experimental/query_engine/expressions/src/primitives/array_value.rs
+++ b/rust/experimental/query_engine/expressions/src/primitives/array_value.rs
@@ -37,6 +37,22 @@ pub trait ArrayValue: Debug {
     }
 }
 
+impl AsStaticValue for dyn ArrayValue + 'static {
+    fn to_static_value(&self) -> StaticValue<'_> {
+        todo!()
+    }
+}
+
+impl AsValue for dyn ArrayValue {
+    fn get_value_type(&self) -> ValueType {
+        todo!()
+    }
+
+    fn to_value(&self) -> Value<'_> {
+        todo!()
+    }
+}
+
 #[derive(Debug)]
 pub struct ArrayRange {
     start_range_inclusize: Option<usize>,

--- a/rust/experimental/query_engine/expressions/src/scalars/collection_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/collection_scalar_expression.rs
@@ -1,0 +1,356 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::*;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum CollectionScalarExpression {
+    /// Returns an array containing all the elements provided in a sequence of arrays.
+    Concat(CombineScalarExpression),
+
+    /// Returns a sequence of inner scalar expressions as an array value.
+    List(ListScalarExpression),
+}
+
+impl CollectionScalarExpression {
+    pub(crate) fn try_resolve_value_type(
+        &mut self,
+        scope: &PipelineResolutionScope,
+    ) -> Result<Option<ValueType>, ExpressionError> {
+        match self {
+            CollectionScalarExpression::Concat(c) => c.try_resolve_array_value_type(scope),
+            CollectionScalarExpression::List(_) => Ok(Some(ValueType::Array)),
+        }
+    }
+
+    pub(crate) fn try_resolve_static(
+        &mut self,
+        scope: &PipelineResolutionScope,
+    ) -> Result<Option<ResolvedStaticScalarExpression<'_>>, ExpressionError> {
+        match self {
+            CollectionScalarExpression::Concat(_) => {
+                // Note: Arrays don't get folded so there isn't a static
+                // resolution path for concat, it is always a runtime thing.
+                Ok(None)
+            }
+            CollectionScalarExpression::List(c) => c.try_resolve_static(scope),
+        }
+    }
+}
+
+impl Expression for CollectionScalarExpression {
+    fn get_query_location(&self) -> &QueryLocation {
+        match self {
+            CollectionScalarExpression::Concat(c) => c.get_query_location(),
+            CollectionScalarExpression::List(c) => c.get_query_location(),
+        }
+    }
+
+    fn get_name(&self) -> &'static str {
+        match self {
+            CollectionScalarExpression::Concat(_) => "CollectionScalar(Concat)",
+            CollectionScalarExpression::List(_) => "CollectionScalar(List)",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CombineScalarExpression {
+    query_location: QueryLocation,
+    values_expression: Box<ScalarExpression>,
+}
+
+impl CombineScalarExpression {
+    pub fn new(
+        query_location: QueryLocation,
+        values_expression: ScalarExpression,
+    ) -> CombineScalarExpression {
+        Self {
+            query_location,
+            values_expression: values_expression.into(),
+        }
+    }
+
+    pub fn get_values_expression(&self) -> &ScalarExpression {
+        &self.values_expression
+    }
+
+    pub(crate) fn try_resolve_array_value_type(
+        &mut self,
+        scope: &PipelineResolutionScope,
+    ) -> Result<Option<ValueType>, ExpressionError> {
+        let values = &mut self.values_expression;
+
+        match values
+            .try_resolve_static(scope)?
+            .as_ref()
+            .map(|v| v.to_value())
+        {
+            Some(Value::Array(a)) => {
+                let completed = a.get_items(&mut IndexValueClosureCallback::new(|_, v| {
+                    v.get_value_type() == ValueType::Array
+                }));
+
+                if completed {
+                    Ok(Some(ValueType::Array))
+                } else {
+                    Ok(None)
+                }
+            }
+            Some(v) => {
+                let t = v.get_value_type();
+                Err(ExpressionError::TypeMismatch(
+                    values.get_query_location().clone(),
+                    format!(
+                        "Value of '{:?}' type returned by scalar expression was not an array",
+                        t
+                    ),
+                ))
+            }
+            None => Ok(None),
+        }
+    }
+
+    pub(crate) fn try_resolve_string_value_type(
+        &mut self,
+        scope: &PipelineResolutionScope,
+    ) -> Result<Option<ValueType>, ExpressionError> {
+        let values = &mut self.values_expression;
+
+        match values.try_resolve_value_type(scope)? {
+            Some(ValueType::Array) => Ok(Some(ValueType::String)),
+            Some(v) => Err(ExpressionError::TypeMismatch(
+                values.get_query_location().clone(),
+                format!(
+                    "Value of '{:?}' type returned by scalar expression was not an array",
+                    v
+                ),
+            )),
+            None => Ok(None),
+        }
+    }
+
+    pub(crate) fn try_resolve_string_static(
+        &mut self,
+        scope: &PipelineResolutionScope,
+    ) -> Result<Option<ResolvedStaticScalarExpression<'_>>, ExpressionError> {
+        let (mut values, len) = match self.values_expression.try_resolve_static(scope)? {
+            Some(ResolvedStaticScalarExpression::Value(StaticScalarExpression::Array(v))) => {
+                let value_expressions = v.get_values();
+
+                let mut len = 0;
+                let mut values = Vec::with_capacity(value_expressions.len());
+
+                for expression in value_expressions {
+                    let s = StringScalarExpression::new(
+                        expression.get_query_location().clone(),
+                        expression.to_value().to_string().as_str(),
+                    );
+
+                    len += s.get_value().len();
+
+                    values.push(s);
+                }
+
+                (values, len)
+            }
+            Some(ResolvedStaticScalarExpression::Reference(StaticScalarExpression::Array(v))) => {
+                let value_expressions = v.get_values();
+
+                let mut len = 0;
+                let mut values = Vec::with_capacity(value_expressions.len());
+
+                for expression in value_expressions {
+                    match expression.try_fold() {
+                        None => return Ok(None),
+                        Some(e) => {
+                            let s = StringScalarExpression::new(
+                                expression.get_query_location().clone(),
+                                e.to_value().to_string().as_str(),
+                            );
+
+                            len += s.get_value().len();
+
+                            values.push(s);
+                        }
+                    }
+                }
+
+                (values, len)
+            }
+            Some(v) => {
+                let t = v.get_value_type();
+                return Err(ExpressionError::TypeMismatch(
+                    self.values_expression.get_query_location().clone(),
+                    format!(
+                        "Value of '{:?}' type returned by scalar expression was not an array",
+                        t
+                    ),
+                ));
+            }
+            None => return Ok(None),
+        };
+
+        if values.len() == 1 {
+            Ok(Some(ResolvedStaticScalarExpression::Value(
+                StaticScalarExpression::String(values.drain(0..1).next().unwrap()),
+            )))
+        } else {
+            let mut s = String::with_capacity(len);
+
+            for v in values {
+                s.push_str(v.get_value());
+            }
+
+            Ok(Some(ResolvedStaticScalarExpression::Value(
+                StaticScalarExpression::String(StringScalarExpression::new(
+                    self.query_location.clone(),
+                    s.as_str(),
+                )),
+            )))
+        }
+    }
+}
+
+impl Expression for CombineScalarExpression {
+    fn get_query_location(&self) -> &QueryLocation {
+        &self.query_location
+    }
+
+    fn get_name(&self) -> &'static str {
+        "CombineScalarExpression"
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ListScalarExpression {
+    query_location: QueryLocation,
+    value_expressions: Vec<ScalarExpression>,
+}
+
+impl ListScalarExpression {
+    pub fn new(
+        query_location: QueryLocation,
+        value_expressions: Vec<ScalarExpression>,
+    ) -> ListScalarExpression {
+        Self {
+            query_location,
+            value_expressions,
+        }
+    }
+
+    pub fn get_value_expressions(&self) -> &[ScalarExpression] {
+        &self.value_expressions
+    }
+
+    pub(crate) fn try_resolve_static(
+        &mut self,
+        scope: &PipelineResolutionScope,
+    ) -> Result<Option<ResolvedStaticScalarExpression<'_>>, ExpressionError> {
+        let mut values = Vec::new();
+
+        for v in &mut self.value_expressions {
+            match v.try_resolve_static(scope)? {
+                Some(ResolvedStaticScalarExpression::Reference(_)) => {
+                    // Note: Don't copy referenced statics because if they were
+                    // foldable they would already have switched to values. For
+                    // example the reference could be to a large constant array.
+                    return Ok(None);
+                }
+                Some(ResolvedStaticScalarExpression::Value(v)) => {
+                    values.push(v);
+                }
+                None => return Ok(None),
+            }
+        }
+
+        Ok(Some(ResolvedStaticScalarExpression::Value(
+            StaticScalarExpression::Array(ArrayScalarExpression::new(
+                self.query_location.clone(),
+                values,
+            )),
+        )))
+    }
+}
+
+impl Expression for ListScalarExpression {
+    fn get_query_location(&self) -> &QueryLocation {
+        &self.query_location
+    }
+
+    fn get_name(&self) -> &'static str {
+        "ListScalarExpression"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_try_resolve_value_type() {
+        let run_test_success = |mut expression: ScalarExpression, expected: Option<ValueType>| {
+            let pipeline: PipelineExpression = Default::default();
+
+            let actual = expression
+                .try_resolve_value_type(&pipeline.get_resolution_scope())
+                .unwrap();
+
+            assert_eq!(expected, actual)
+        };
+
+        run_test_success(
+            ScalarExpression::Collection(CollectionScalarExpression::List(
+                ListScalarExpression::new(QueryLocation::new_fake(), vec![]),
+            )),
+            Some(ValueType::Array),
+        );
+    }
+
+    #[test]
+    fn test_try_resolve_static() {
+        let run_test_success =
+            |mut expression: ScalarExpression, expected: Option<StaticScalarExpression>| {
+                let mut pipeline: PipelineExpression = Default::default();
+
+                pipeline.push_constant(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "hello world"),
+                ));
+
+                let actual = expression
+                    .try_resolve_static(&pipeline.get_resolution_scope())
+                    .unwrap();
+
+                assert_eq!(expected, actual.map(|v| v.as_ref().clone()))
+            };
+
+        run_test_success(
+            ScalarExpression::Collection(CollectionScalarExpression::List(
+                ListScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    vec![
+                        ScalarExpression::Static(StaticScalarExpression::Integer(
+                            IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+                        )),
+                        ScalarExpression::Static(StaticScalarExpression::Integer(
+                            IntegerScalarExpression::new(QueryLocation::new_fake(), 2),
+                        )),
+                    ],
+                ),
+            )),
+            Some(StaticScalarExpression::Array(ArrayScalarExpression::new(
+                QueryLocation::new_fake(),
+                vec![
+                    StaticScalarExpression::Integer(IntegerScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        1,
+                    )),
+                    StaticScalarExpression::Integer(IntegerScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        2,
+                    )),
+                ],
+            ))),
+        );
+    }
+}

--- a/rust/experimental/query_engine/expressions/src/scalars/mod.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/mod.rs
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+pub(crate) mod collection_scalar_expression;
 pub(crate) mod convert_scalar_expression;
 pub(crate) mod math_scalar_expression;
 pub(crate) mod parse_scalar_expression;
@@ -9,6 +10,7 @@ pub(crate) mod statics;
 pub(crate) mod temporal_scalar_expression;
 pub(crate) mod text_scalar_expression;
 
+pub use collection_scalar_expression::*;
 pub use convert_scalar_expression::*;
 pub use math_scalar_expression::*;
 pub use parse_scalar_expression::*;

--- a/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
@@ -25,6 +25,9 @@ pub enum ScalarExpression {
     /// Returns the first non-null scalar expression in a list.
     Coalesce(CoalesceScalarExpression),
 
+    /// Contains scalar functions for performing collection operations.
+    Collection(CollectionScalarExpression),
+
     /// Returns one of two inner scalar expressions based on a logical condition.
     Conditional(ConditionalScalarExpression),
 
@@ -37,9 +40,6 @@ pub enum ScalarExpression {
     /// Returns the number of characters in an inner string value, the number of
     /// items in an inner array/map values, or null for invalid input.
     Length(LengthScalarExpression),
-
-    /// Returns a list of inner scalar expressions as an array value.
-    List(ListScalarExpression),
 
     /// Boolean value returned by the inner logical expression.
     Logical(Box<LogicalExpression>),
@@ -83,7 +83,7 @@ impl ScalarExpression {
             ScalarExpression::Variable(_) => Ok(None),
             ScalarExpression::Static(s) => Ok(Some(s.get_value_type())),
             ScalarExpression::Constant(c) => Ok(Some(c.get_value_type())),
-            ScalarExpression::List(_) => Ok(Some(ValueType::Array)),
+            ScalarExpression::Collection(c) => c.try_resolve_value_type(scope),
             ScalarExpression::Logical(_) => Ok(Some(ValueType::Boolean)),
             ScalarExpression::Coalesce(c) => c.try_resolve_value_type(scope),
             ScalarExpression::Conditional(c) => c.try_resolve_value_type(scope),
@@ -120,7 +120,7 @@ impl ScalarExpression {
                 None => Ok(Some(ResolvedStaticScalarExpression::Reference(s))),
             },
             ScalarExpression::Constant(c) => Ok(Some(c.resolve_static(scope))),
-            ScalarExpression::List(l) => l.try_resolve_static(scope),
+            ScalarExpression::Collection(c) => c.try_resolve_static(scope),
             ScalarExpression::Logical(l) => match l.try_resolve_static(scope)? {
                 Some(v) => Ok(Some(ResolvedStaticScalarExpression::Computed(
                     StaticScalarExpression::Boolean(BooleanScalarExpression::new(
@@ -152,7 +152,7 @@ impl Expression for ScalarExpression {
             ScalarExpression::Variable(v) => v.get_query_location(),
             ScalarExpression::Static(s) => s.get_query_location(),
             ScalarExpression::Constant(c) => c.get_query_location(),
-            ScalarExpression::List(l) => l.get_query_location(),
+            ScalarExpression::Collection(c) => c.get_query_location(),
             ScalarExpression::Logical(l) => l.get_query_location(),
             ScalarExpression::Coalesce(c) => c.get_query_location(),
             ScalarExpression::Conditional(c) => c.get_query_location(),
@@ -173,7 +173,7 @@ impl Expression for ScalarExpression {
             ScalarExpression::Attached(_) => "ScalarExpression(Attached)",
             ScalarExpression::Variable(_) => "ScalarExpression(Variable)",
             ScalarExpression::Static(s) => s.get_name(),
-            ScalarExpression::List(_) => "ScalarExpression(List)",
+            ScalarExpression::Collection(_) => "ScalarExpression(Collection)",
             ScalarExpression::Logical(_) => "ScalarExpression(Logical)",
             ScalarExpression::Coalesce(_) => "ScalarExpression(Coalesce)",
             ScalarExpression::Conditional(_) => "ScalarExpression(Conditional)",
@@ -814,61 +814,6 @@ impl Expression for LengthScalarExpression {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct ListScalarExpression {
-    query_location: QueryLocation,
-    value_expressions: Vec<ScalarExpression>,
-}
-
-impl ListScalarExpression {
-    pub fn new(
-        query_location: QueryLocation,
-        value_expressions: Vec<ScalarExpression>,
-    ) -> ListScalarExpression {
-        Self {
-            query_location,
-            value_expressions,
-        }
-    }
-
-    pub fn get_value_expressions(&self) -> &[ScalarExpression] {
-        &self.value_expressions
-    }
-
-    pub(crate) fn try_resolve_static(
-        &mut self,
-        scope: &PipelineResolutionScope,
-    ) -> Result<Option<ResolvedStaticScalarExpression<'_>>, ExpressionError> {
-        let mut values = Vec::new();
-
-        for v in &mut self.value_expressions {
-            match v.try_resolve_static(scope)?.and_then(|v| v.try_fold()) {
-                Some(v) => {
-                    values.push(v);
-                }
-                None => return Ok(None),
-            }
-        }
-
-        Ok(Some(ResolvedStaticScalarExpression::Computed(
-            StaticScalarExpression::Array(ArrayScalarExpression::new(
-                self.query_location.clone(),
-                values,
-            )),
-        )))
-    }
-}
-
-impl Expression for ListScalarExpression {
-    fn get_query_location(&self) -> &QueryLocation {
-        &self.query_location
-    }
-
-    fn get_name(&self) -> &'static str {
-        "ListScalarExpression"
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
 pub struct SliceScalarExpression {
     query_location: QueryLocation,
     source: Box<ScalarExpression>,
@@ -1139,11 +1084,6 @@ mod tests {
                 BooleanScalarExpression::new(QueryLocation::new_fake(), true),
             )),
             Some(ValueType::Boolean),
-        );
-
-        run_test_success(
-            ScalarExpression::List(ListScalarExpression::new(QueryLocation::new_fake(), vec![])),
-            Some(ValueType::Array),
         );
 
         run_test_success(
@@ -1474,33 +1414,6 @@ mod tests {
             Some(StaticScalarExpression::Boolean(
                 BooleanScalarExpression::new(QueryLocation::new_fake(), true),
             )),
-        );
-
-        run_test_success(
-            ScalarExpression::List(ListScalarExpression::new(
-                QueryLocation::new_fake(),
-                vec![
-                    ScalarExpression::Static(StaticScalarExpression::Integer(
-                        IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
-                    )),
-                    ScalarExpression::Static(StaticScalarExpression::Integer(
-                        IntegerScalarExpression::new(QueryLocation::new_fake(), 2),
-                    )),
-                ],
-            )),
-            Some(StaticScalarExpression::Array(ArrayScalarExpression::new(
-                QueryLocation::new_fake(),
-                vec![
-                    StaticScalarExpression::Integer(IntegerScalarExpression::new(
-                        QueryLocation::new_fake(),
-                        1,
-                    )),
-                    StaticScalarExpression::Integer(IntegerScalarExpression::new(
-                        QueryLocation::new_fake(),
-                        2,
-                    )),
-                ],
-            ))),
         );
 
         run_test_success(

--- a/rust/experimental/query_engine/expressions/src/scalars/statics/array_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/statics/array_scalar_expression.rs
@@ -6,18 +6,22 @@ use crate::*;
 #[derive(Debug, Clone, PartialEq)]
 pub struct ArrayScalarExpression {
     query_location: QueryLocation,
-    value: Vec<StaticScalarExpression>,
+    values: Vec<StaticScalarExpression>,
 }
 
 impl ArrayScalarExpression {
     pub fn new(
         query_location: QueryLocation,
-        value: Vec<StaticScalarExpression>,
+        values: Vec<StaticScalarExpression>,
     ) -> ArrayScalarExpression {
         Self {
             query_location,
-            value,
+            values,
         }
+    }
+
+    pub fn get_values(&self) -> &[StaticScalarExpression] {
+        &self.values
     }
 }
 
@@ -33,19 +37,19 @@ impl Expression for ArrayScalarExpression {
 
 impl ArrayValue for ArrayScalarExpression {
     fn is_empty(&self) -> bool {
-        self.value.is_empty()
+        self.values.is_empty()
     }
 
     fn len(&self) -> usize {
-        self.value.len()
+        self.values.len()
     }
 
     fn get(&self, index: usize) -> Option<&(dyn AsValue)> {
-        self.value.get(index).map(|v| v as &dyn AsValue)
+        self.values.get(index).map(|v| v as &dyn AsValue)
     }
 
     fn get_static(&self, index: usize) -> Result<Option<&(dyn AsStaticValue + 'static)>, String> {
-        Ok(self.value.get(index).map(|v| v as &dyn AsStaticValue))
+        Ok(self.values.get(index).map(|v| v as &dyn AsStaticValue))
     }
 
     fn get_item_range(
@@ -53,7 +57,7 @@ impl ArrayValue for ArrayScalarExpression {
         range: ArrayRange,
         item_callback: &mut dyn IndexValueCallback,
     ) -> bool {
-        for (index, value) in range.get_slice(&self.value).iter().enumerate() {
+        for (index, value) in range.get_slice(&self.values).iter().enumerate() {
             if !item_callback.next(index, value.to_value()) {
                 return false;
             }

--- a/rust/experimental/query_engine/expressions/src/scalars/statics/map_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/statics/map_scalar_expression.rs
@@ -8,7 +8,7 @@ use crate::*;
 #[derive(Debug, Clone, PartialEq)]
 pub struct MapScalarExpression {
     query_location: QueryLocation,
-    value: HashMap<Box<str>, StaticScalarExpression>,
+    values: HashMap<Box<str>, StaticScalarExpression>,
 }
 
 impl MapScalarExpression {
@@ -18,8 +18,12 @@ impl MapScalarExpression {
     ) -> MapScalarExpression {
         Self {
             query_location,
-            value,
+            values: value,
         }
+    }
+
+    pub fn get_values(&self) -> &HashMap<Box<str>, StaticScalarExpression> {
+        &self.values
     }
 }
 
@@ -35,23 +39,23 @@ impl Expression for MapScalarExpression {
 
 impl MapValue for MapScalarExpression {
     fn is_empty(&self) -> bool {
-        self.value.is_empty()
+        self.values.is_empty()
     }
 
     fn len(&self) -> usize {
-        self.value.len()
+        self.values.len()
     }
 
     fn contains_key(&self, key: &str) -> bool {
-        self.value.contains_key(key)
+        self.values.contains_key(key)
     }
 
     fn get(&self, key: &str) -> Option<&(dyn AsStaticValue + 'static)> {
-        self.value.get(key).map(|v| v as &dyn AsStaticValue)
+        self.values.get(key).map(|v| v as &dyn AsStaticValue)
     }
 
     fn get_items(&self, item_callback: &mut dyn KeyValueCallback) -> bool {
-        for (key, value) in &self.value {
+        for (key, value) in &self.values {
             if !item_callback.next(key, value.to_value()) {
                 return false;
             }

--- a/rust/experimental/query_engine/expressions/src/scalars/text_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/text_scalar_expression.rs
@@ -5,6 +5,13 @@ use crate::*;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum TextScalarExpression {
+    /// Returns a string combining all the provided strings in a sequence.
+    Concat(CombineScalarExpression),
+
+    /// Returns a string combining all the provided strings in a sequence with a
+    /// separater added between each element.
+    Join(JoinTextScalarExpression),
+
     /// Returns a string with all occurrences of a lookup value replaced with a
     /// replacement value or null for invalid input.
     Replace(ReplaceTextScalarExpression),
@@ -16,6 +23,8 @@ impl TextScalarExpression {
         scope: &PipelineResolutionScope,
     ) -> Result<Option<ValueType>, ExpressionError> {
         match self {
+            TextScalarExpression::Concat(c) => c.try_resolve_string_value_type(scope),
+            TextScalarExpression::Join(j) => j.try_resolve_value_type(scope),
             TextScalarExpression::Replace(r) => r.try_resolve_value_type(scope),
         }
     }
@@ -25,6 +34,8 @@ impl TextScalarExpression {
         scope: &PipelineResolutionScope,
     ) -> Result<Option<ResolvedStaticScalarExpression<'_>>, ExpressionError> {
         match self {
+            TextScalarExpression::Concat(c) => c.try_resolve_string_static(scope),
+            TextScalarExpression::Join(j) => j.try_resolve_static(scope),
             TextScalarExpression::Replace(r) => r.try_resolve_static(scope),
         }
     }
@@ -33,12 +44,16 @@ impl TextScalarExpression {
 impl Expression for TextScalarExpression {
     fn get_query_location(&self) -> &QueryLocation {
         match self {
+            TextScalarExpression::Concat(c) => c.get_query_location(),
+            TextScalarExpression::Join(j) => j.get_query_location(),
             TextScalarExpression::Replace(u) => u.get_query_location(),
         }
     }
 
     fn get_name(&self) -> &'static str {
         match self {
+            TextScalarExpression::Concat(_) => "TextScalar(Concat)",
+            TextScalarExpression::Join(_) => "TextScalar(Join)",
             TextScalarExpression::Replace(_) => "TextScalar(Replace)",
         }
     }
@@ -155,6 +170,155 @@ impl Expression for ReplaceTextScalarExpression {
 
     fn get_name(&self) -> &'static str {
         "ReplaceTextScalarExpression"
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct JoinTextScalarExpression {
+    query_location: QueryLocation,
+    separator_expression: Box<ScalarExpression>,
+    values_expression: Box<ScalarExpression>,
+}
+
+impl JoinTextScalarExpression {
+    pub fn get_separator_expression(&self) -> &ScalarExpression {
+        &self.separator_expression
+    }
+
+    pub fn get_values_expression(&self) -> &ScalarExpression {
+        &self.values_expression
+    }
+
+    pub(crate) fn try_resolve_value_type(
+        &mut self,
+        scope: &PipelineResolutionScope,
+    ) -> Result<Option<ValueType>, ExpressionError> {
+        let values = &mut self.values_expression;
+
+        match values.try_resolve_value_type(scope)? {
+            Some(ValueType::Array) => Ok(Some(ValueType::String)),
+            Some(v) => Err(ExpressionError::TypeMismatch(
+                values.get_query_location().clone(),
+                format!(
+                    "Value of '{:?}' type returned by scalar expression was not an array",
+                    v
+                ),
+            )),
+            None => Ok(None),
+        }
+    }
+
+    pub(crate) fn try_resolve_static(
+        &mut self,
+        scope: &PipelineResolutionScope,
+    ) -> Result<Option<ResolvedStaticScalarExpression<'_>>, ExpressionError> {
+        let separator = match self.separator_expression.try_resolve_static(scope)? {
+            None => return Ok(None),
+            Some(s) => {
+                let value = s.to_value().to_string();
+
+                StringScalarExpression::new(
+                    self.separator_expression.get_query_location().clone(),
+                    value.as_str(),
+                )
+            }
+        };
+
+        let (mut values, len) = match self.values_expression.try_resolve_static(scope)? {
+            Some(ResolvedStaticScalarExpression::Value(StaticScalarExpression::Array(v))) => {
+                let value_expressions = v.get_values();
+
+                let mut len = 0;
+                let mut values = Vec::with_capacity(value_expressions.len());
+
+                for expression in value_expressions {
+                    let s = StringScalarExpression::new(
+                        expression.get_query_location().clone(),
+                        expression.to_value().to_string().as_str(),
+                    );
+
+                    len += s.get_value().len();
+
+                    if values.len() == 1 {
+                        len += separator.get_value().len();
+                        values.push(separator.clone());
+                    }
+
+                    values.push(s);
+                }
+
+                (values, len)
+            }
+            Some(ResolvedStaticScalarExpression::Reference(StaticScalarExpression::Array(v))) => {
+                let value_expressions = v.get_values();
+
+                let mut len = 0;
+                let mut values = Vec::with_capacity(value_expressions.len());
+
+                for expression in value_expressions {
+                    match expression.try_fold() {
+                        None => return Ok(None),
+                        Some(e) => {
+                            let s = StringScalarExpression::new(
+                                expression.get_query_location().clone(),
+                                e.to_value().to_string().as_str(),
+                            );
+
+                            len += s.get_value().len();
+
+                            if values.len() == 1 {
+                                len += separator.get_value().len();
+                                values.push(separator.clone());
+                            }
+
+                            values.push(s);
+                        }
+                    }
+                }
+
+                (values, len)
+            }
+            Some(v) => {
+                let t = v.get_value_type();
+                return Err(ExpressionError::TypeMismatch(
+                    self.values_expression.get_query_location().clone(),
+                    format!(
+                        "Value of '{:?}' type returned by scalar expression was not an array",
+                        t
+                    ),
+                ));
+            }
+            None => return Ok(None),
+        };
+
+        if values.len() == 1 {
+            Ok(Some(ResolvedStaticScalarExpression::Value(
+                StaticScalarExpression::String(values.drain(0..1).next().unwrap()),
+            )))
+        } else {
+            let mut s = String::with_capacity(len);
+
+            for v in values {
+                s.push_str(v.get_value());
+            }
+
+            Ok(Some(ResolvedStaticScalarExpression::Value(
+                StaticScalarExpression::String(StringScalarExpression::new(
+                    self.query_location.clone(),
+                    s.as_str(),
+                )),
+            )))
+        }
+    }
+}
+
+impl Expression for JoinTextScalarExpression {
+    fn get_query_location(&self) -> &QueryLocation {
+        &self.query_location
+    }
+
+    fn get_name(&self) -> &'static str {
+        "JoinTextScalarExpression"
     }
 }
 

--- a/rust/experimental/query_engine/kql-parser/src/kql.pest
+++ b/rust/experimental/query_engine/kql-parser/src/kql.pest
@@ -156,11 +156,20 @@ strlen_expression = { "strlen" ~ "(" ~ scalar_expression ~ ")" }
 replace_string_expression = { "replace_string" ~ "(" ~ scalar_expression ~ "," ~ scalar_expression ~ "," ~ scalar_expression ~ ")" }
 substring_expression = { "substring" ~ "(" ~ scalar_expression ~ "," ~ scalar_expression ~ ("," ~ scalar_expression)? ~ ")" }
 parse_json_expression = { "parse_json" ~ "(" ~ scalar_expression ~ ")" }
+strcat_expression = { "strcat" ~ "(" ~ scalar_expression ~ ("," ~ scalar_expression)* ~ ")" }
+strcat_delim_expression = { "strcat_delim" ~ "(" ~ scalar_expression ~ "," ~ scalar_expression ~ ("," ~ scalar_expression)* ~ ")" }
 string_expressions = _{
     strlen_expression
     | replace_string_expression
     | substring_expression
     | parse_json_expression
+    | strcat_expression
+    | strcat_delim_expression
+}
+
+array_concat_expression = { "array_concat" ~ "(" ~ scalar_expression ~ ("," ~ scalar_expression)* ~ ")" }
+array_expressions = _{
+    array_concat_expression
 }
 
 negate_expression = { "-" ~ scalar_expression }
@@ -191,6 +200,7 @@ scalar_expression = {
     | conditional_expressions
     | conversion_expressions
     | string_expressions
+    | array_expressions
     | boolean_expression
     | double_literal
     | integer_literal

--- a/rust/experimental/query_engine/kql-parser/src/lib.rs
+++ b/rust/experimental/query_engine/kql-parser/src/lib.rs
@@ -6,6 +6,7 @@ pub(crate) mod date_utils;
 pub(crate) mod kql_parser;
 pub(crate) mod logical_expressions;
 pub(crate) mod query_expression;
+pub(crate) mod scalar_array_function_expressions;
 pub(crate) mod scalar_conditional_function_expressions;
 pub(crate) mod scalar_conversion_function_expressions;
 pub(crate) mod scalar_expression;

--- a/rust/experimental/query_engine/kql-parser/src/logical_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/logical_expressions.rs
@@ -44,8 +44,9 @@ pub(crate) fn parse_comparison_expression(
             // For "in" operations, the semantics are flipped:
             // [source] in ([value1], [value2]) means any of the values contains the source
             // So we create a list from the values and check if it contains the source
-            let list_expr =
-                ScalarExpression::List(ListScalarExpression::new(query_location.clone(), values));
+            let list_expr = ScalarExpression::Collection(CollectionScalarExpression::List(
+                ListScalarExpression::new(query_location.clone(), values),
+            ));
 
             let case_insensitive = matches!(
                 operation_rule.as_rule(),
@@ -806,18 +807,20 @@ mod tests {
             "variable in (var1, 'test2')",
             LogicalExpression::Contains(ContainsLogicalExpression::new(
                 QueryLocation::new_fake(),
-                ScalarExpression::List(ListScalarExpression::new(
-                    QueryLocation::new_fake(),
-                    vec![
-                        ScalarExpression::Variable(VariableScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            StringScalarExpression::new(QueryLocation::new_fake(), "var1"),
-                            ValueAccessor::new(),
-                        )),
-                        ScalarExpression::Static(StaticScalarExpression::String(
-                            StringScalarExpression::new(QueryLocation::new_fake(), "test2"),
-                        )),
-                    ],
+                ScalarExpression::Collection(CollectionScalarExpression::List(
+                    ListScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        vec![
+                            ScalarExpression::Variable(VariableScalarExpression::new(
+                                QueryLocation::new_fake(),
+                                StringScalarExpression::new(QueryLocation::new_fake(), "var1"),
+                                ValueAccessor::new(),
+                            )),
+                            ScalarExpression::Static(StaticScalarExpression::String(
+                                StringScalarExpression::new(QueryLocation::new_fake(), "test2"),
+                            )),
+                        ],
+                    ),
                 )),
                 ScalarExpression::Variable(VariableScalarExpression::new(
                     QueryLocation::new_fake(),
@@ -833,16 +836,18 @@ mod tests {
             "variable in~ ('test1', 'test2')",
             LogicalExpression::Contains(ContainsLogicalExpression::new(
                 QueryLocation::new_fake(),
-                ScalarExpression::List(ListScalarExpression::new(
-                    QueryLocation::new_fake(),
-                    vec![
-                        ScalarExpression::Static(StaticScalarExpression::String(
-                            StringScalarExpression::new(QueryLocation::new_fake(), "test1"),
-                        )),
-                        ScalarExpression::Static(StaticScalarExpression::String(
-                            StringScalarExpression::new(QueryLocation::new_fake(), "test2"),
-                        )),
-                    ],
+                ScalarExpression::Collection(CollectionScalarExpression::List(
+                    ListScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        vec![
+                            ScalarExpression::Static(StaticScalarExpression::String(
+                                StringScalarExpression::new(QueryLocation::new_fake(), "test1"),
+                            )),
+                            ScalarExpression::Static(StaticScalarExpression::String(
+                                StringScalarExpression::new(QueryLocation::new_fake(), "test2"),
+                            )),
+                        ],
+                    ),
                 )),
                 ScalarExpression::Variable(VariableScalarExpression::new(
                     QueryLocation::new_fake(),
@@ -860,16 +865,18 @@ mod tests {
                 QueryLocation::new_fake(),
                 LogicalExpression::Contains(ContainsLogicalExpression::new(
                     QueryLocation::new_fake(),
-                    ScalarExpression::List(ListScalarExpression::new(
-                        QueryLocation::new_fake(),
-                        vec![
-                            ScalarExpression::Static(StaticScalarExpression::String(
-                                StringScalarExpression::new(QueryLocation::new_fake(), "test1"),
-                            )),
-                            ScalarExpression::Static(StaticScalarExpression::String(
-                                StringScalarExpression::new(QueryLocation::new_fake(), "test2"),
-                            )),
-                        ],
+                    ScalarExpression::Collection(CollectionScalarExpression::List(
+                        ListScalarExpression::new(
+                            QueryLocation::new_fake(),
+                            vec![
+                                ScalarExpression::Static(StaticScalarExpression::String(
+                                    StringScalarExpression::new(QueryLocation::new_fake(), "test1"),
+                                )),
+                                ScalarExpression::Static(StaticScalarExpression::String(
+                                    StringScalarExpression::new(QueryLocation::new_fake(), "test2"),
+                                )),
+                            ],
+                        ),
                     )),
                     ScalarExpression::Variable(VariableScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -888,16 +895,18 @@ mod tests {
                 QueryLocation::new_fake(),
                 LogicalExpression::Contains(ContainsLogicalExpression::new(
                     QueryLocation::new_fake(),
-                    ScalarExpression::List(ListScalarExpression::new(
-                        QueryLocation::new_fake(),
-                        vec![
-                            ScalarExpression::Static(StaticScalarExpression::String(
-                                StringScalarExpression::new(QueryLocation::new_fake(), "test1"),
-                            )),
-                            ScalarExpression::Static(StaticScalarExpression::String(
-                                StringScalarExpression::new(QueryLocation::new_fake(), "test2"),
-                            )),
-                        ],
+                    ScalarExpression::Collection(CollectionScalarExpression::List(
+                        ListScalarExpression::new(
+                            QueryLocation::new_fake(),
+                            vec![
+                                ScalarExpression::Static(StaticScalarExpression::String(
+                                    StringScalarExpression::new(QueryLocation::new_fake(), "test1"),
+                                )),
+                                ScalarExpression::Static(StaticScalarExpression::String(
+                                    StringScalarExpression::new(QueryLocation::new_fake(), "test2"),
+                                )),
+                            ],
+                        ),
                     )),
                     ScalarExpression::Variable(VariableScalarExpression::new(
                         QueryLocation::new_fake(),

--- a/rust/experimental/query_engine/kql-parser/src/scalar_array_function_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_array_function_expressions.rs
@@ -1,0 +1,157 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use data_engine_expressions::*;
+use data_engine_parser_abstractions::*;
+use pest::iterators::Pair;
+
+use crate::{Rule, scalar_expression::parse_scalar_expression};
+
+pub(crate) fn parse_array_concat_expression(
+    array_concat_expression_rule: Pair<Rule>,
+    state: &dyn ParserScope,
+) -> Result<ScalarExpression, ParserError> {
+    let query_location = to_query_location(&array_concat_expression_rule);
+
+    let array_concat_rules = array_concat_expression_rule.into_inner();
+
+    let mut values = Vec::new();
+
+    for rule in array_concat_rules {
+        let mut scalar = parse_scalar_expression(rule, state)?;
+
+        if let Some(t) = state.try_resolve_value_type(&mut scalar)? {
+            if t != ValueType::Array {
+                return Err(ParserError::QueryLanguageDiagnostic {
+                    location: scalar.get_query_location().clone(),
+                    diagnostic_id: "KS234",
+                    message: "The expression value must be a dynamic array".into(),
+                });
+            }
+        }
+
+        values.push(scalar);
+    }
+
+    Ok(ScalarExpression::Collection(
+        CollectionScalarExpression::Concat(CombineScalarExpression::new(
+            query_location.clone(),
+            ScalarExpression::Collection(CollectionScalarExpression::List(
+                ListScalarExpression::new(query_location, values),
+            )),
+        )),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use pest::Parser;
+
+    use crate::KqlPestParser;
+
+    use super::*;
+
+    #[test]
+    fn test_parse_array_concat_expression() {
+        let run_test_success = |input: &str, expected: ScalarExpression| {
+            println!("Testing: {input}");
+
+            let state = ParserState::new(input);
+
+            let mut result = KqlPestParser::parse(Rule::scalar_expression, input).unwrap();
+
+            let expression = parse_scalar_expression(result.next().unwrap(), &state).unwrap();
+
+            assert_eq!(expected, expression);
+        };
+
+        let run_test_failure = |input: &str, expected_id: &str, expected_msg: &str| {
+            let state = ParserState::new(input);
+
+            let mut result = KqlPestParser::parse(Rule::logical_expression, input).unwrap();
+
+            let error = parse_scalar_expression(result.next().unwrap(), &state).unwrap_err();
+
+            if let ParserError::QueryLanguageDiagnostic {
+                location: _,
+                diagnostic_id: id,
+                message: msg,
+            } = error
+            {
+                assert_eq!(expected_id, id);
+                assert_eq!(expected_msg, msg);
+            } else {
+                panic!("Expected QueryLanguageDiagnostic");
+            }
+        };
+
+        run_test_success(
+            "array_concat(parse_json('[]'))",
+            ScalarExpression::Collection(CollectionScalarExpression::Concat(
+                CombineScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    ScalarExpression::Collection(CollectionScalarExpression::List(
+                        ListScalarExpression::new(
+                            QueryLocation::new_fake(),
+                            vec![ScalarExpression::Parse(ParseScalarExpression::Json(
+                                ParseJsonScalarExpression::new(
+                                    QueryLocation::new_fake(),
+                                    ScalarExpression::Static(StaticScalarExpression::String(
+                                        StringScalarExpression::new(
+                                            QueryLocation::new_fake(),
+                                            "[]",
+                                        ),
+                                    )),
+                                ),
+                            ))],
+                        ),
+                    )),
+                ),
+            )),
+        );
+
+        run_test_success(
+            "array_concat(parse_json('[]'), parse_json('[]'))",
+            ScalarExpression::Collection(CollectionScalarExpression::Concat(
+                CombineScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    ScalarExpression::Collection(CollectionScalarExpression::List(
+                        ListScalarExpression::new(
+                            QueryLocation::new_fake(),
+                            vec![
+                                ScalarExpression::Parse(ParseScalarExpression::Json(
+                                    ParseJsonScalarExpression::new(
+                                        QueryLocation::new_fake(),
+                                        ScalarExpression::Static(StaticScalarExpression::String(
+                                            StringScalarExpression::new(
+                                                QueryLocation::new_fake(),
+                                                "[]",
+                                            ),
+                                        )),
+                                    ),
+                                )),
+                                ScalarExpression::Parse(ParseScalarExpression::Json(
+                                    ParseJsonScalarExpression::new(
+                                        QueryLocation::new_fake(),
+                                        ScalarExpression::Static(StaticScalarExpression::String(
+                                            StringScalarExpression::new(
+                                                QueryLocation::new_fake(),
+                                                "[]",
+                                            ),
+                                        )),
+                                    ),
+                                )),
+                            ],
+                        ),
+                    )),
+                ),
+            )),
+        );
+
+        run_test_failure(
+            "array_concat(\"hello\")",
+            "KS234",
+            "The expression value must be a dynamic array",
+        );
+    }
+}

--- a/rust/experimental/query_engine/kql-parser/src/scalar_expression.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_expression.rs
@@ -6,7 +6,7 @@ use data_engine_parser_abstractions::*;
 use pest::iterators::Pair;
 
 use crate::{
-    Rule, logical_expressions::parse_logical_expression,
+    Rule, logical_expressions::parse_logical_expression, scalar_array_function_expressions::*,
     scalar_conditional_function_expressions::*, scalar_conversion_function_expressions::*,
     scalar_mathematical_function_expressions::*, scalar_primitive_expressions::*,
     scalar_string_function_expressions::*, scalar_temporal_function_expressions::*,
@@ -41,6 +41,9 @@ pub(crate) fn parse_scalar_expression(
         Rule::replace_string_expression => parse_replace_string_expression(scalar_rule, state)?,
         Rule::substring_expression => parse_substring_expression(scalar_rule, state)?,
         Rule::parse_json_expression => parse_parse_json_expression(scalar_rule, state)?,
+        Rule::strcat_expression => parse_strcat_expression(scalar_rule, state)?,
+        Rule::strcat_delim_expression => parse_strcat_delim_expression(scalar_rule, state)?,
+        Rule::array_concat_expression => parse_array_concat_expression(scalar_rule, state)?,
         Rule::true_literal | Rule::false_literal => {
             ScalarExpression::Static(parse_standard_bool_literal(scalar_rule))
         }

--- a/rust/experimental/query_engine/parser-abstractions/src/parser_state.rs
+++ b/rust/experimental/query_engine/parser-abstractions/src/parser_state.rs
@@ -178,6 +178,15 @@ pub trait ParserScope {
 
     fn create_scope<'a>(&'a self, options: ParserOptions) -> ParserStateScope<'a>;
 
+    fn try_resolve_value_type(
+        &self,
+        scalar: &mut ScalarExpression,
+    ) -> Result<Option<ValueType>, ParserError> {
+        scalar
+            .try_resolve_value_type(&self.get_pipeline().get_resolution_scope())
+            .map_err(|e| ParserError::from(&e))
+    }
+
     fn scalar_as_static<'a>(
         &'a self,
         scalar: &'a ScalarExpression,


### PR DESCRIPTION
## Changes

* Adds array concat, string concat, and string join expressions + recordset implementation
* Adds KQL support for `strcat`, `strcat_delim`, & `array_concat`