### PR TITLE
[query-engine] Rename state -> scope in KQL parser code

### DIFF
--- a/rust/experimental/query_engine/kql-parser/src/aggregate_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/aggregate_expressions.rs
@@ -9,7 +9,7 @@ use crate::{Rule, scalar_expression::parse_scalar_expression};
 
 pub(crate) fn parse_aggregate_assignment_expression(
     aggregate_assignment_expression_rule: Pair<Rule>,
-    state: &dyn ParserScope,
+    scope: &dyn ParserScope,
 ) -> Result<(Box<str>, AggregationExpression), ParserError> {
     let mut aggregate_assignment_rules = aggregate_assignment_expression_rule.into_inner();
 
@@ -17,14 +17,14 @@ pub(crate) fn parse_aggregate_assignment_expression(
     let destination_rule_str = destination_rule.as_str();
 
     let aggregation_expression =
-        parse_aggregate_expression(aggregate_assignment_rules.next().unwrap(), state)?;
+        parse_aggregate_expression(aggregate_assignment_rules.next().unwrap(), scope)?;
 
     Ok((destination_rule_str.into(), aggregation_expression))
 }
 
 fn parse_aggregate_expression(
     aggregate_expression_rule: Pair<Rule>,
-    state: &dyn ParserScope,
+    scope: &dyn ParserScope,
 ) -> Result<AggregationExpression, ParserError> {
     let query_location = to_query_location(&aggregate_expression_rule);
 
@@ -32,7 +32,7 @@ fn parse_aggregate_expression(
         Rule::average_aggregate_expression => AggregationExpression::new(
             query_location,
             AggregationFunction::Average,
-            Some(parse_scalar_expression(aggregate_expression_rule, state)?),
+            Some(parse_scalar_expression(aggregate_expression_rule, scope)?),
         ),
         Rule::count_aggregate_expression => {
             AggregationExpression::new(query_location, AggregationFunction::Count, None)
@@ -40,17 +40,17 @@ fn parse_aggregate_expression(
         Rule::maximum_aggregate_expression => AggregationExpression::new(
             query_location,
             AggregationFunction::Maximum,
-            Some(parse_scalar_expression(aggregate_expression_rule, state)?),
+            Some(parse_scalar_expression(aggregate_expression_rule, scope)?),
         ),
         Rule::minimum_aggregate_expression => AggregationExpression::new(
             query_location,
             AggregationFunction::Minimum,
-            Some(parse_scalar_expression(aggregate_expression_rule, state)?),
+            Some(parse_scalar_expression(aggregate_expression_rule, scope)?),
         ),
         Rule::sum_aggregate_expression => AggregationExpression::new(
             query_location,
             AggregationFunction::Sum,
-            Some(parse_scalar_expression(aggregate_expression_rule, state)?),
+            Some(parse_scalar_expression(aggregate_expression_rule, scope)?),
         ),
         _ => panic!("Unexpected rule in aggregate_expression: {aggregate_expression_rule}"),
     };

--- a/rust/experimental/query_engine/kql-parser/src/logical_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/logical_expressions.rs
@@ -9,7 +9,7 @@ use crate::{Rule, scalar_expression::parse_scalar_expression};
 
 pub(crate) fn parse_comparison_expression(
     comparison_expression_rule: Pair<Rule>,
-    state: &dyn ParserScope,
+    scope: &dyn ParserScope,
 ) -> Result<LogicalExpression, ParserError> {
     let query_location = to_query_location(&comparison_expression_rule);
 
@@ -18,7 +18,7 @@ pub(crate) fn parse_comparison_expression(
     let left_rule = comparison_rules.next().unwrap();
 
     let left = match left_rule.as_rule() {
-        Rule::scalar_expression => parse_scalar_expression(left_rule, state)?,
+        Rule::scalar_expression => parse_scalar_expression(left_rule, scope)?,
         _ => panic!("Unexpected rule in comparison_expression: {left_rule}"),
     };
 
@@ -34,11 +34,11 @@ pub(crate) fn parse_comparison_expression(
         | Rule::not_in_insensitive_token => {
             // For "in" operations, we expect parentheses and multiple values
             // The next_rule should be the first scalar_expression inside the parentheses
-            let mut values = vec![parse_scalar_expression(next_rule, state)?];
+            let mut values = vec![parse_scalar_expression(next_rule, scope)?];
 
             // Collect additional values if they exist
             for value_rule in comparison_rules {
-                values.push(parse_scalar_expression(value_rule, state)?);
+                values.push(parse_scalar_expression(value_rule, scope)?);
             }
 
             // For "in" operations, the semantics are flipped:
@@ -69,7 +69,7 @@ pub(crate) fn parse_comparison_expression(
         _ => {
             // Standard binary operations
             let right = match next_rule.as_rule() {
-                Rule::scalar_expression => parse_scalar_expression(next_rule, state)?,
+                Rule::scalar_expression => parse_scalar_expression(next_rule, scope)?,
                 _ => panic!("Unexpected rule in comparison_expression: {next_rule}"),
             };
 
@@ -191,7 +191,7 @@ pub(crate) fn parse_comparison_expression(
 
 pub(crate) fn parse_logical_expression(
     logical_expression_rule: Pair<Rule>,
-    state: &dyn ParserScope,
+    scope: &dyn ParserScope,
 ) -> Result<LogicalExpression, ParserError> {
     let query_location = to_query_location(&logical_expression_rule);
 
@@ -201,16 +201,16 @@ pub(crate) fn parse_logical_expression(
         |logical_expression_rule: Pair<Rule>| -> Result<LogicalExpression, ParserError> {
             match logical_expression_rule.as_rule() {
                 Rule::comparison_expression => {
-                    Ok(parse_comparison_expression(logical_expression_rule, state)?)
+                    Ok(parse_comparison_expression(logical_expression_rule, scope)?)
                 }
                 Rule::scalar_expression => {
-                    let mut scalar = parse_scalar_expression(logical_expression_rule, state)?;
+                    let mut scalar = parse_scalar_expression(logical_expression_rule, scope)?;
 
                     if let ScalarExpression::Logical(l) = scalar {
                         Ok(*l)
                     } else {
                         let value_type_result = scalar
-                            .try_resolve_value_type(&state.get_pipeline().get_resolution_scope());
+                            .try_resolve_value_type(&scope.get_pipeline().get_resolution_scope());
                         if let Err(e) = value_type_result {
                             return Err(ParserError::from(&e));
                         }

--- a/rust/experimental/query_engine/kql-parser/src/scalar_array_function_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_array_function_expressions.rs
@@ -9,7 +9,7 @@ use crate::{Rule, scalar_expression::parse_scalar_expression};
 
 pub(crate) fn parse_array_concat_expression(
     array_concat_expression_rule: Pair<Rule>,
-    state: &dyn ParserScope,
+    scope: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&array_concat_expression_rule);
 
@@ -18,9 +18,9 @@ pub(crate) fn parse_array_concat_expression(
     let mut values = Vec::new();
 
     for rule in array_concat_rules {
-        let mut scalar = parse_scalar_expression(rule, state)?;
+        let mut scalar = parse_scalar_expression(rule, scope)?;
 
-        if let Some(t) = state.try_resolve_value_type(&mut scalar)? {
+        if let Some(t) = scope.try_resolve_value_type(&mut scalar)? {
             if t != ValueType::Array {
                 return Err(ParserError::QueryLanguageDiagnostic {
                     location: scalar.get_query_location().clone(),

--- a/rust/experimental/query_engine/kql-parser/src/scalar_conditional_function_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_conditional_function_expressions.rs
@@ -11,7 +11,7 @@ use crate::{
 
 pub(crate) fn parse_conditional_expression(
     conditional_expression_rule: Pair<Rule>,
-    state: &dyn ParserScope,
+    scope: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&conditional_expression_rule);
 
@@ -26,16 +26,16 @@ pub(crate) fn parse_conditional_expression(
     Ok(ScalarExpression::Conditional(
         ConditionalScalarExpression::new(
             query_location,
-            parse_logical_expression(condition_logical, state)?,
-            parse_scalar_expression(true_scalar, state)?,
-            parse_scalar_expression(false_scalar, state)?,
+            parse_logical_expression(condition_logical, scope)?,
+            parse_scalar_expression(true_scalar, scope)?,
+            parse_scalar_expression(false_scalar, scope)?,
         ),
     ))
 }
 
 pub(crate) fn parse_case_expression(
     case_expression_rule: Pair<Rule>,
-    state: &dyn ParserScope,
+    scope: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&case_expression_rule);
 
@@ -60,13 +60,13 @@ pub(crate) fn parse_case_expression(
     let mut i = 0;
     while i < rules_vec.len() - 1 {
         // Parse condition
-        let condition = parse_logical_expression(rules_vec[i].clone(), state)?;
+        let condition = parse_logical_expression(rules_vec[i].clone(), scope)?;
         i += 1;
 
         // Parse corresponding expression
         if i < rules_vec.len() - 1 {
             // Not the last element (which is else)
-            let expression = parse_scalar_expression(rules_vec[i].clone(), state)?;
+            let expression = parse_scalar_expression(rules_vec[i].clone(), scope)?;
             expressions_with_conditions.push((condition, expression));
             i += 1;
         } else {
@@ -79,7 +79,7 @@ pub(crate) fn parse_case_expression(
     }
 
     // Parse the else expression (last element)
-    let else_expression = parse_scalar_expression(rules_vec[rules_vec.len() - 1].clone(), state)?;
+    let else_expression = parse_scalar_expression(rules_vec[rules_vec.len() - 1].clone(), scope)?;
 
     Ok(ScalarExpression::Case(CaseScalarExpression::new(
         query_location,
@@ -90,7 +90,7 @@ pub(crate) fn parse_case_expression(
 
 pub(crate) fn parse_coalesce_expression(
     coalesce_expression_rule: Pair<Rule>,
-    state: &dyn ParserScope,
+    scope: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&coalesce_expression_rule);
 
@@ -100,16 +100,16 @@ pub(crate) fn parse_coalesce_expression(
 
     expressions.push(parse_scalar_expression(
         coalesce_rules.next().unwrap(),
-        state,
+        scope,
     )?);
 
     expressions.push(parse_scalar_expression(
         coalesce_rules.next().unwrap(),
-        state,
+        scope,
     )?);
 
     for e in coalesce_rules {
-        expressions.push(parse_scalar_expression(e, state)?);
+        expressions.push(parse_scalar_expression(e, scope)?);
     }
 
     Ok(ScalarExpression::Coalesce(CoalesceScalarExpression::new(

--- a/rust/experimental/query_engine/kql-parser/src/scalar_conversion_function_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_conversion_function_expressions.rs
@@ -9,7 +9,7 @@ use crate::{Rule, scalar_expression::parse_scalar_expression};
 
 pub(crate) fn parse_tostring_expression(
     tostring_rule: Pair<Rule>,
-    state: &dyn ParserScope,
+    scope: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&tostring_rule);
     let mut inner = tostring_rule.into_inner();
@@ -18,7 +18,7 @@ pub(crate) fn parse_tostring_expression(
     let scalar_expr_rule = inner.next().unwrap();
 
     // Parse and wrap in conversion expression
-    let inner_expr = parse_scalar_expression(scalar_expr_rule, state)?;
+    let inner_expr = parse_scalar_expression(scalar_expr_rule, scope)?;
     Ok(ScalarExpression::Convert(ConvertScalarExpression::String(
         ConversionScalarExpression::new(query_location, inner_expr),
     )))
@@ -26,7 +26,7 @@ pub(crate) fn parse_tostring_expression(
 
 pub(crate) fn parse_toint_expression(
     toint_rule: Pair<Rule>,
-    state: &dyn ParserScope,
+    scope: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&toint_rule);
     let mut inner = toint_rule.into_inner();
@@ -35,7 +35,7 @@ pub(crate) fn parse_toint_expression(
     let scalar_expr_rule = inner.next().unwrap();
 
     // Parse and wrap in conversion expression
-    let inner_expr = parse_scalar_expression(scalar_expr_rule, state)?;
+    let inner_expr = parse_scalar_expression(scalar_expr_rule, scope)?;
     Ok(ScalarExpression::Convert(ConvertScalarExpression::Integer(
         ConversionScalarExpression::new(query_location, inner_expr),
     )))
@@ -43,14 +43,14 @@ pub(crate) fn parse_toint_expression(
 
 pub(crate) fn parse_tobool_expression(
     tobool_rule: Pair<Rule>,
-    state: &dyn ParserScope,
+    scope: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&tobool_rule);
     let mut inner = tobool_rule.into_inner();
 
     let scalar_expr_rule = inner.next().unwrap();
 
-    let inner_expr = parse_scalar_expression(scalar_expr_rule, state)?;
+    let inner_expr = parse_scalar_expression(scalar_expr_rule, scope)?;
     Ok(ScalarExpression::Convert(ConvertScalarExpression::Boolean(
         ConversionScalarExpression::new(query_location, inner_expr),
     )))
@@ -58,14 +58,14 @@ pub(crate) fn parse_tobool_expression(
 
 pub(crate) fn parse_tofloat_expression(
     tofloat_rule: Pair<Rule>,
-    state: &dyn ParserScope,
+    scope: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&tofloat_rule);
     let mut inner = tofloat_rule.into_inner();
 
     let scalar_expr_rule = inner.next().unwrap();
 
-    let inner_expr = parse_scalar_expression(scalar_expr_rule, state)?;
+    let inner_expr = parse_scalar_expression(scalar_expr_rule, scope)?;
     Ok(ScalarExpression::Convert(ConvertScalarExpression::Double(
         ConversionScalarExpression::new(query_location, inner_expr),
     )))
@@ -73,14 +73,14 @@ pub(crate) fn parse_tofloat_expression(
 
 pub(crate) fn parse_tolong_expression(
     tolong_rule: Pair<Rule>,
-    state: &dyn ParserScope,
+    scope: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&tolong_rule);
     let mut inner = tolong_rule.into_inner();
 
     let scalar_expr_rule = inner.next().unwrap();
 
-    let inner_expr = parse_scalar_expression(scalar_expr_rule, state)?;
+    let inner_expr = parse_scalar_expression(scalar_expr_rule, scope)?;
     Ok(ScalarExpression::Convert(ConvertScalarExpression::Integer(
         ConversionScalarExpression::new(query_location, inner_expr),
     )))
@@ -88,14 +88,14 @@ pub(crate) fn parse_tolong_expression(
 
 pub(crate) fn parse_toreal_expression(
     toreal_rule: Pair<Rule>,
-    state: &dyn ParserScope,
+    scope: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&toreal_rule);
     let mut inner = toreal_rule.into_inner();
 
     let scalar_expr_rule = inner.next().unwrap();
 
-    let inner_expr = parse_scalar_expression(scalar_expr_rule, state)?;
+    let inner_expr = parse_scalar_expression(scalar_expr_rule, scope)?;
     Ok(ScalarExpression::Convert(ConvertScalarExpression::Double(
         ConversionScalarExpression::new(query_location, inner_expr),
     )))
@@ -103,14 +103,14 @@ pub(crate) fn parse_toreal_expression(
 
 pub(crate) fn parse_todouble_expression(
     todouble_rule: Pair<Rule>,
-    state: &dyn ParserScope,
+    scope: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&todouble_rule);
     let mut inner = todouble_rule.into_inner();
 
     let scalar_expr_rule = inner.next().unwrap();
 
-    let inner_expr = parse_scalar_expression(scalar_expr_rule, state)?;
+    let inner_expr = parse_scalar_expression(scalar_expr_rule, scope)?;
     Ok(ScalarExpression::Convert(ConvertScalarExpression::Double(
         ConversionScalarExpression::new(query_location, inner_expr),
     )))
@@ -118,14 +118,14 @@ pub(crate) fn parse_todouble_expression(
 
 pub(crate) fn parse_todatetime_expression(
     todatetime_rule: Pair<Rule>,
-    state: &dyn ParserScope,
+    scope: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&todatetime_rule);
     let mut inner = todatetime_rule.into_inner();
 
     let scalar_expr_rule = inner.next().unwrap();
 
-    let inner_expr = parse_scalar_expression(scalar_expr_rule, state)?;
+    let inner_expr = parse_scalar_expression(scalar_expr_rule, scope)?;
     Ok(ScalarExpression::Convert(
         ConvertScalarExpression::DateTime(ConversionScalarExpression::new(
             query_location,
@@ -136,14 +136,14 @@ pub(crate) fn parse_todatetime_expression(
 
 pub(crate) fn parse_totimespan_expression(
     totimespan_rule: Pair<Rule>,
-    state: &dyn ParserScope,
+    scope: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&totimespan_rule);
     let mut inner = totimespan_rule.into_inner();
 
     let scalar_expr_rule = inner.next().unwrap();
 
-    let inner_expr = parse_scalar_expression(scalar_expr_rule, state)?;
+    let inner_expr = parse_scalar_expression(scalar_expr_rule, scope)?;
     Ok(ScalarExpression::Convert(
         ConvertScalarExpression::TimeSpan(ConversionScalarExpression::new(
             query_location,

--- a/rust/experimental/query_engine/kql-parser/src/scalar_expression.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_expression.rs
@@ -14,7 +14,7 @@ use crate::{
 
 pub(crate) fn parse_scalar_expression(
     scalar_expression_rule: Pair<Rule>,
-    state: &dyn ParserScope,
+    scope: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let scalar_rule = scalar_expression_rule.into_inner().next().unwrap();
 
@@ -25,25 +25,25 @@ pub(crate) fn parse_scalar_expression(
             ScalarExpression::Static(parse_datetime_expression(scalar_rule)?)
         }
         Rule::time_expression => ScalarExpression::Static(parse_timespan_expression(scalar_rule)?),
-        Rule::conditional_expression => parse_conditional_expression(scalar_rule, state)?,
-        Rule::case_expression => parse_case_expression(scalar_rule, state)?,
-        Rule::coalesce_expression => parse_coalesce_expression(scalar_rule, state)?,
-        Rule::tostring_expression => parse_tostring_expression(scalar_rule, state)?,
-        Rule::toint_expression => parse_toint_expression(scalar_rule, state)?,
-        Rule::tobool_expression => parse_tobool_expression(scalar_rule, state)?,
-        Rule::tofloat_expression => parse_tofloat_expression(scalar_rule, state)?,
-        Rule::tolong_expression => parse_tolong_expression(scalar_rule, state)?,
-        Rule::toreal_expression => parse_toreal_expression(scalar_rule, state)?,
-        Rule::todouble_expression => parse_todouble_expression(scalar_rule, state)?,
-        Rule::todatetime_expression => parse_todatetime_expression(scalar_rule, state)?,
-        Rule::totimespan_expression => parse_totimespan_expression(scalar_rule, state)?,
-        Rule::strlen_expression => parse_strlen_expression(scalar_rule, state)?,
-        Rule::replace_string_expression => parse_replace_string_expression(scalar_rule, state)?,
-        Rule::substring_expression => parse_substring_expression(scalar_rule, state)?,
-        Rule::parse_json_expression => parse_parse_json_expression(scalar_rule, state)?,
-        Rule::strcat_expression => parse_strcat_expression(scalar_rule, state)?,
-        Rule::strcat_delim_expression => parse_strcat_delim_expression(scalar_rule, state)?,
-        Rule::array_concat_expression => parse_array_concat_expression(scalar_rule, state)?,
+        Rule::conditional_expression => parse_conditional_expression(scalar_rule, scope)?,
+        Rule::case_expression => parse_case_expression(scalar_rule, scope)?,
+        Rule::coalesce_expression => parse_coalesce_expression(scalar_rule, scope)?,
+        Rule::tostring_expression => parse_tostring_expression(scalar_rule, scope)?,
+        Rule::toint_expression => parse_toint_expression(scalar_rule, scope)?,
+        Rule::tobool_expression => parse_tobool_expression(scalar_rule, scope)?,
+        Rule::tofloat_expression => parse_tofloat_expression(scalar_rule, scope)?,
+        Rule::tolong_expression => parse_tolong_expression(scalar_rule, scope)?,
+        Rule::toreal_expression => parse_toreal_expression(scalar_rule, scope)?,
+        Rule::todouble_expression => parse_todouble_expression(scalar_rule, scope)?,
+        Rule::todatetime_expression => parse_todatetime_expression(scalar_rule, scope)?,
+        Rule::totimespan_expression => parse_totimespan_expression(scalar_rule, scope)?,
+        Rule::strlen_expression => parse_strlen_expression(scalar_rule, scope)?,
+        Rule::replace_string_expression => parse_replace_string_expression(scalar_rule, scope)?,
+        Rule::substring_expression => parse_substring_expression(scalar_rule, scope)?,
+        Rule::parse_json_expression => parse_parse_json_expression(scalar_rule, scope)?,
+        Rule::strcat_expression => parse_strcat_expression(scalar_rule, scope)?,
+        Rule::strcat_delim_expression => parse_strcat_delim_expression(scalar_rule, scope)?,
+        Rule::array_concat_expression => parse_array_concat_expression(scalar_rule, scope)?,
         Rule::true_literal | Rule::false_literal => {
             ScalarExpression::Static(parse_standard_bool_literal(scalar_rule))
         }
@@ -54,9 +54,9 @@ pub(crate) fn parse_scalar_expression(
             ScalarExpression::Static(parse_standard_integer_literal(scalar_rule)?)
         }
         Rule::string_literal => ScalarExpression::Static(parse_string_literal(scalar_rule)),
-        Rule::negate_expression => parse_negate_expression(scalar_rule, state)?,
-        Rule::bin_expression => parse_bin_expression(scalar_rule, state)?,
-        Rule::now_expression => parse_now_expression(scalar_rule, state)?,
+        Rule::negate_expression => parse_negate_expression(scalar_rule, scope)?,
+        Rule::bin_expression => parse_bin_expression(scalar_rule, scope)?,
+        Rule::now_expression => parse_now_expression(scalar_rule, scope)?,
         Rule::accessor_expression => {
             // Note: When used as a scalar expression it is valid for an
             // accessor to fold into a static at the root so
@@ -64,11 +64,11 @@ pub(crate) fn parse_scalar_expression(
             // [scalar], [scalar]) evaluated as iff([logical],
             // accessor(some_constant1), accessor(some_constant2)) can safely
             // fold to iff([logical], String("constant1"), String("constant2")).
-            parse_accessor_expression(scalar_rule, state, true)?
+            parse_accessor_expression(scalar_rule, scope, true)?
         }
-        Rule::scalar_expression => parse_scalar_expression(scalar_rule, state)?,
+        Rule::scalar_expression => parse_scalar_expression(scalar_rule, scope)?,
         Rule::logical_expression => {
-            let l = parse_logical_expression(scalar_rule, state)?;
+            let l = parse_logical_expression(scalar_rule, scope)?;
 
             if let LogicalExpression::Scalar(s) = l {
                 s
@@ -76,7 +76,7 @@ pub(crate) fn parse_scalar_expression(
                 ScalarExpression::Logical(l.into())
             }
         }
-        Rule::arithmetic_expression => parse_arithmetic_expression(scalar_rule, state)?,
+        Rule::arithmetic_expression => parse_arithmetic_expression(scalar_rule, scope)?,
         _ => panic!("Unexpected rule in scalar_expression: {scalar_rule}"),
     };
 

--- a/rust/experimental/query_engine/kql-parser/src/scalar_temporal_function_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_temporal_function_expressions.rs
@@ -9,7 +9,7 @@ use crate::{Rule, scalar_expression::parse_scalar_expression};
 
 pub(crate) fn parse_now_expression(
     now_expression_rule: Pair<Rule>,
-    state: &dyn ParserScope,
+    scope: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
     let query_location = to_query_location(&now_expression_rule);
 
@@ -21,7 +21,7 @@ pub(crate) fn parse_now_expression(
         ))),
         Some(r) => match r.as_rule() {
             Rule::scalar_expression => {
-                let offset = parse_scalar_expression(r, state)?;
+                let offset = parse_scalar_expression(r, scope)?;
 
                 Ok(ScalarExpression::Math(MathScalarExpression::Add(
                     BinaryMathematicalScalarExpression::new(

--- a/rust/experimental/query_engine/kql-parser/src/tabular_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/tabular_expressions.rs
@@ -19,7 +19,7 @@ use crate::{
 
 pub(crate) fn parse_extend_expression(
     extend_expression_rule: Pair<Rule>,
-    state: &dyn ParserScope,
+    scope: &dyn ParserScope,
 ) -> Result<Vec<TransformExpression>, ParserError> {
     let extend_rules = extend_expression_rule.into_inner();
 
@@ -29,7 +29,7 @@ pub(crate) fn parse_extend_expression(
         match rule.as_rule() {
             Rule::assignment_expression => {
                 let (query_location, source, destination) =
-                    parse_source_assignment_expression(rule, state)?;
+                    parse_source_assignment_expression(rule, scope)?;
 
                 set_expressions.push(TransformExpression::Set(SetTransformExpression::new(
                     query_location,
@@ -46,7 +46,7 @@ pub(crate) fn parse_extend_expression(
 
 pub(crate) fn parse_project_expression(
     project_expression_rule: Pair<Rule>,
-    state: &dyn ParserScope,
+    scope: &dyn ParserScope,
 ) -> Result<Vec<TransformExpression>, ParserError> {
     let query_location = to_query_location(&project_expression_rule);
 
@@ -62,11 +62,11 @@ pub(crate) fn parse_project_expression(
         match rule.as_rule() {
             Rule::assignment_expression => {
                 let (query_location, source, destination) =
-                    parse_source_assignment_expression(rule, state)?;
+                    parse_source_assignment_expression(rule, scope)?;
 
                 process_map_selection_source_scalar_expression(
                     "project",
-                    state,
+                    scope,
                     &destination,
                     &mut reduction,
                 )?;
@@ -78,12 +78,12 @@ pub(crate) fn parse_project_expression(
                 )));
             }
             Rule::accessor_expression => {
-                let accessor_expression = parse_accessor_expression(rule, state, true)?;
+                let accessor_expression = parse_accessor_expression(rule, scope, true)?;
 
                 if let ScalarExpression::Source(s) = &accessor_expression {
                     process_map_selection_source_scalar_expression(
                         "project",
-                        state,
+                        scope,
                         s,
                         &mut reduction,
                     )?;
@@ -92,7 +92,7 @@ pub(crate) fn parse_project_expression(
                         rule_location.clone(),
                         format!(
                             "To be valid in a project expression '{}' should be an assignment expression or an accessor expression which refers to the source",
-                            state.get_query_slice(&rule_location).trim()
+                            scope.get_query_slice(&rule_location).trim()
                         ),
                     ));
                 }
@@ -103,7 +103,7 @@ pub(crate) fn parse_project_expression(
 
     push_map_transformation_expression(
         "project",
-        state,
+        scope,
         &mut expressions,
         &query_location,
         true,
@@ -115,7 +115,7 @@ pub(crate) fn parse_project_expression(
 
 pub(crate) fn parse_project_keep_expression(
     project_keep_expression_rule: Pair<Rule>,
-    state: &dyn ParserScope,
+    scope: &dyn ParserScope,
 ) -> Result<Vec<TransformExpression>, ParserError> {
     let query_location = to_query_location(&project_keep_expression_rule);
 
@@ -131,7 +131,7 @@ pub(crate) fn parse_project_keep_expression(
         match rule.as_rule() {
             Rule::identifier_or_pattern_literal => {
                 if let Some(identifier_or_pattern) =
-                    parse_identifier_or_pattern_literal(state, rule_location.clone(), rule)?
+                    parse_identifier_or_pattern_literal(scope, rule_location.clone(), rule)?
                 {
                     match identifier_or_pattern {
                         IdentifierOrPattern::Identifier(s) => reduction.keys.push(s),
@@ -147,18 +147,18 @@ pub(crate) fn parse_project_keep_expression(
                         rule_location.clone(),
                         format!(
                             "To be valid in a project-keep expression '{}' should be an accessor expression which refers to data on the source",
-                            state.get_query_slice(&rule_location).trim()
+                            scope.get_query_slice(&rule_location).trim()
                         ),
                     ));
                 }
             }
             Rule::accessor_expression => {
-                let accessor_expression = parse_accessor_expression(rule, state, true)?;
+                let accessor_expression = parse_accessor_expression(rule, scope, true)?;
 
                 if let ScalarExpression::Source(s) = &accessor_expression {
                     process_map_selection_source_scalar_expression(
                         "project-keep",
-                        state,
+                        scope,
                         s,
                         &mut reduction,
                     )?;
@@ -167,7 +167,7 @@ pub(crate) fn parse_project_keep_expression(
                         rule_location.clone(),
                         format!(
                             "To be valid in a project-keep expression '{}' should be an accessor expression which refers to the source",
-                            state.get_query_slice(&rule_location).trim()
+                            scope.get_query_slice(&rule_location).trim()
                         ),
                     ));
                 }
@@ -178,7 +178,7 @@ pub(crate) fn parse_project_keep_expression(
 
     push_map_transformation_expression(
         "project-keep",
-        state,
+        scope,
         &mut expressions,
         &query_location,
         true,
@@ -190,7 +190,7 @@ pub(crate) fn parse_project_keep_expression(
 
 pub(crate) fn parse_project_away_expression(
     project_away_expression_rule: Pair<Rule>,
-    state: &dyn ParserScope,
+    scope: &dyn ParserScope,
 ) -> Result<Vec<TransformExpression>, ParserError> {
     let query_location = to_query_location(&project_away_expression_rule);
 
@@ -206,7 +206,7 @@ pub(crate) fn parse_project_away_expression(
         match rule.as_rule() {
             Rule::identifier_or_pattern_literal => {
                 if let Some(identifier_or_pattern) =
-                    parse_identifier_or_pattern_literal(state, rule_location.clone(), rule)?
+                    parse_identifier_or_pattern_literal(scope, rule_location.clone(), rule)?
                 {
                     match identifier_or_pattern {
                         IdentifierOrPattern::Identifier(s) => reduction.keys.push(s),
@@ -222,18 +222,18 @@ pub(crate) fn parse_project_away_expression(
                         rule_location.clone(),
                         format!(
                             "To be valid in a project-away expression '{}' should be an accessor expression which refers to data on the source",
-                            state.get_query_slice(&rule_location).trim()
+                            scope.get_query_slice(&rule_location).trim()
                         ),
                     ));
                 }
             }
             Rule::accessor_expression => {
-                let accessor_expression = parse_accessor_expression(rule, state, true)?;
+                let accessor_expression = parse_accessor_expression(rule, scope, true)?;
 
                 if let ScalarExpression::Source(s) = &accessor_expression {
                     process_map_selection_source_scalar_expression(
                         "project-away",
-                        state,
+                        scope,
                         s,
                         &mut reduction,
                     )?;
@@ -242,7 +242,7 @@ pub(crate) fn parse_project_away_expression(
                         rule_location.clone(),
                         format!(
                             "To be valid in a project-away expression '{}' should be an accessor expression which refers to the source",
-                            state.get_query_slice(&rule_location).trim()
+                            scope.get_query_slice(&rule_location).trim()
                         ),
                     ));
                 }
@@ -253,7 +253,7 @@ pub(crate) fn parse_project_away_expression(
 
     push_map_transformation_expression(
         "project-away",
-        state,
+        scope,
         &mut expressions,
         &query_location,
         false,
@@ -265,14 +265,14 @@ pub(crate) fn parse_project_away_expression(
 
 pub(crate) fn parse_where_expression(
     where_expression_rule: Pair<Rule>,
-    state: &dyn ParserScope,
+    scope: &dyn ParserScope,
 ) -> Result<DataExpression, ParserError> {
     let query_location = to_query_location(&where_expression_rule);
 
     let where_rule = where_expression_rule.into_inner().next().unwrap();
 
     let predicate = match where_rule.as_rule() {
-        Rule::logical_expression => parse_logical_expression(where_rule, state)?,
+        Rule::logical_expression => parse_logical_expression(where_rule, scope)?,
         _ => panic!("Unexpected rule in where_expression: {where_rule}"),
     };
 
@@ -288,7 +288,7 @@ pub(crate) fn parse_where_expression(
 
 pub(crate) fn parse_summarize_expression(
     summarize_expression_rule: Pair<Rule>,
-    state: &dyn ParserScope,
+    scope: &dyn ParserScope,
 ) -> Result<DataExpression, ParserError> {
     let query_location = to_query_location(&summarize_expression_rule);
 
@@ -300,7 +300,7 @@ pub(crate) fn parse_summarize_expression(
         match summarize_rule.as_rule() {
             Rule::aggregate_assignment_expression => {
                 let (key, aggregate) =
-                    parse_aggregate_assignment_expression(summarize_rule, state)?;
+                    parse_aggregate_assignment_expression(summarize_rule, scope)?;
 
                 aggregation_expressions.insert(key, aggregate);
             }
@@ -312,20 +312,20 @@ pub(crate) fn parse_summarize_expression(
 
                 match group_by_first_rule.as_rule() {
                     Rule::identifier_literal => {
-                        let scalar = parse_scalar_expression(group_by.next().unwrap(), state)?;
+                        let scalar = parse_scalar_expression(group_by.next().unwrap(), scope)?;
 
                         group_by_expressions
                             .insert(group_by_first_rule.as_str().trim().into(), scalar);
                     }
                     Rule::accessor_expression => {
                         let mut accessor =
-                            parse_accessor_expression(group_by_first_rule, state, true)?;
+                            parse_accessor_expression(group_by_first_rule, scope, true)?;
 
                         // Note: The call here into try_resolve_static is to
                         // make sure all eligible selectors on the accessor are
                         // folded into static values.
                         accessor
-                            .try_resolve_static(&state.get_pipeline().get_resolution_scope())
+                            .try_resolve_static(&scope.get_pipeline().get_resolution_scope())
                             .map_err(|e| ParserError::from(&e))?;
 
                         match &accessor {
@@ -334,7 +334,7 @@ pub(crate) fn parse_summarize_expression(
                                     parse_group_by_accessor(
                                         &group_by_first_rule_location,
                                         s.get_value_accessor(),
-                                        state,
+                                        scope,
                                     )?,
                                     accessor,
                                 );
@@ -344,7 +344,7 @@ pub(crate) fn parse_summarize_expression(
                                     parse_group_by_accessor(
                                         &group_by_first_rule_location,
                                         a.get_value_accessor(),
-                                        state,
+                                        scope,
                                     )?,
                                     accessor,
                                 );
@@ -354,7 +354,7 @@ pub(crate) fn parse_summarize_expression(
                                     parse_group_by_accessor(
                                         &group_by_first_rule_location,
                                         v.get_value_accessor(),
-                                        state,
+                                        scope,
                                     )?,
                                     accessor,
                                 );
@@ -371,7 +371,7 @@ pub(crate) fn parse_summarize_expression(
                 }
             }
             _ => {
-                let scope = state.create_scope(ParserOptions::new());
+                let scope = scope.create_scope(ParserOptions::new());
 
                 for e in parse_tabular_expression_rule(summarize_rule, &scope)? {
                     post_expressions.push(e);
@@ -446,7 +446,7 @@ pub(crate) fn parse_summarize_expression(
 
 pub(crate) fn parse_tabular_expression(
     tabular_expression_rule: Pair<Rule>,
-    state: &dyn ParserScope,
+    scope: &dyn ParserScope,
 ) -> Result<Vec<DataExpression>, ParserError> {
     let mut rules = tabular_expression_rule.into_inner();
 
@@ -457,7 +457,7 @@ pub(crate) fn parse_tabular_expression(
     let mut expressions = Vec::new();
 
     for rule in rules {
-        for e in parse_tabular_expression_rule(rule, state)? {
+        for e in parse_tabular_expression_rule(rule, scope)? {
             expressions.push(e);
         }
     }
@@ -467,20 +467,20 @@ pub(crate) fn parse_tabular_expression(
 
 pub(crate) fn parse_tabular_expression_rule(
     tabular_expression_rule: Pair<Rule>,
-    state: &dyn ParserScope,
+    scope: &dyn ParserScope,
 ) -> Result<Vec<DataExpression>, ParserError> {
     let mut expressions = Vec::new();
 
     match tabular_expression_rule.as_rule() {
         Rule::extend_expression => {
-            let extend_expressions = parse_extend_expression(tabular_expression_rule, state)?;
+            let extend_expressions = parse_extend_expression(tabular_expression_rule, scope)?;
 
             for e in extend_expressions {
                 expressions.push(DataExpression::Transform(e));
             }
         }
         Rule::project_expression => {
-            let project_expressions = parse_project_expression(tabular_expression_rule, state)?;
+            let project_expressions = parse_project_expression(tabular_expression_rule, scope)?;
 
             for e in project_expressions {
                 expressions.push(DataExpression::Transform(e));
@@ -488,7 +488,7 @@ pub(crate) fn parse_tabular_expression_rule(
         }
         Rule::project_keep_expression => {
             let project_keep_expressions =
-                parse_project_keep_expression(tabular_expression_rule, state)?;
+                parse_project_keep_expression(tabular_expression_rule, scope)?;
 
             for e in project_keep_expressions {
                 expressions.push(DataExpression::Transform(e));
@@ -496,17 +496,17 @@ pub(crate) fn parse_tabular_expression_rule(
         }
         Rule::project_away_expression => {
             let project_away_expressions =
-                parse_project_away_expression(tabular_expression_rule, state)?;
+                parse_project_away_expression(tabular_expression_rule, scope)?;
 
             for e in project_away_expressions {
                 expressions.push(DataExpression::Transform(e));
             }
         }
         Rule::where_expression => {
-            expressions.push(parse_where_expression(tabular_expression_rule, state)?)
+            expressions.push(parse_where_expression(tabular_expression_rule, scope)?)
         }
         Rule::summarize_expression => {
-            expressions.push(parse_summarize_expression(tabular_expression_rule, state)?)
+            expressions.push(parse_summarize_expression(tabular_expression_rule, scope)?)
         }
         _ => panic!("Unexpected rule in tabular_expression: {tabular_expression_rule}"),
     }
@@ -541,7 +541,7 @@ enum IdentifierOrPattern {
 }
 
 fn parse_identifier_or_pattern_literal(
-    state: &dyn ParserScope,
+    scope: &dyn ParserScope,
     location: QueryLocation,
     identifier_or_pattern_literal: Pair<Rule>,
 ) -> Result<Option<IdentifierOrPattern>, ParserError> {
@@ -574,9 +574,9 @@ fn parse_identifier_or_pattern_literal(
         Ok(Some(IdentifierOrPattern::Pattern(
             RegexScalarExpression::new(location, regex.unwrap()),
         )))
-    } else if state.is_well_defined_identifier(&value) {
+    } else if scope.is_well_defined_identifier(&value) {
         Ok(None)
-    } else if let Some(schema) = state.get_source_schema() {
+    } else if let Some(schema) = scope.get_source_schema() {
         if schema.get_schema_for_key(&value).is_some() {
             Ok(Some(IdentifierOrPattern::Identifier(
                 StringScalarExpression::new(location, &value),
@@ -606,7 +606,7 @@ fn parse_identifier_or_pattern_literal(
 
 fn process_map_selection_source_scalar_expression(
     expression_name: &str,
-    state: &dyn ParserScope,
+    scope: &dyn ParserScope,
     source: &SourceScalarExpression,
     reduction: &mut MapReductionState,
 ) -> Result<(), ParserError> {
@@ -623,7 +623,7 @@ fn process_map_selection_source_scalar_expression(
             location.clone(),
             format!(
                 "The '{}' accessor expression should refer to a map key on the source when used in a {expression_name} expression",
-                state.get_query_slice(location).trim()
+                scope.get_query_slice(location).trim()
             ),
         ));
     }
@@ -631,14 +631,14 @@ fn process_map_selection_source_scalar_expression(
     let destination_selectors = destination_accessor.get_selectors();
 
     if destination_selectors.len() == 2 {
-        // Note: If state has source keys defined look for selectors targeting maps off the root.
+        // Note: If scope has source keys defined look for selectors targeting maps off the root.
         if let ScalarExpression::Static(StaticScalarExpression::String(root)) =
             destination_selectors.first().unwrap()
         {
             let root_key = root.get_value();
 
             if Some(Some(Some(ValueType::Map)))
-                == state
+                == scope
                     .get_source_schema()
                     .map(|v| v.get_schema_for_key(root_key).map(|v| v.get_value_type()))
             {
@@ -694,7 +694,7 @@ impl MapReductionState {
 
 fn push_map_transformation_expression(
     expression_name: &str,
-    state: &dyn ParserScope,
+    scope: &dyn ParserScope,
     expressions: &mut Vec<TransformExpression>,
     query_location: &QueryLocation,
     retain: bool,
@@ -792,7 +792,7 @@ fn push_map_transformation_expression(
         );
 
         if !reduction.patterns.is_empty() {
-            if let Some(schema) = state.get_source_schema() {
+            if let Some(schema) = scope.get_source_schema() {
                 let default_source_map = schema.get_default_map_key();
                 let mut default_source_map_matched_regex = false;
 
@@ -865,7 +865,7 @@ fn push_map_transformation_expression(
                     location.clone(),
                     format!(
                         "The '{}' accessor expression should refer to a map key on the source when used in a {expression_name} expression",
-                        state.get_query_slice(location).trim()
+                        scope.get_query_slice(location).trim()
                     ),
                 ));
             }


### PR DESCRIPTION
Following up on feedback from @drewrelmas 