### PR TITLE
Script around Github markdown wrapping display differences for Release process

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -46,7 +46,12 @@ jobs:
 
       - name: Extract unreleased changelog content
         id: changelog
-        run: ./.github/workflows/scripts/extract-changelog.sh /tmp/changelog_content.txt
+        run: |
+          # Extract original content for CHANGELOG.md update (preserves formatting)
+          ./.github/workflows/scripts/extract-changelog.sh /tmp/changelog_content.txt
+          
+          # Extract normalized content for PR body (removes extra newlines)
+          ./.github/workflows/scripts/extract-changelog.sh /tmp/changelog_content_normalized.txt --normalize
 
       - name: Update collector build version
         run: |
@@ -76,7 +81,7 @@ jobs:
           git diff
           echo "--------------------------------"
           echo "Unreleased content:"
-          cat /tmp/changelog_content.txt
+          cat /tmp/changelog_content_normalized.txt
           echo "--------------------------------"
           echo "Git operations that would occur:"
           echo "  - Create branch: otelbot/release-v${{ inputs.version }}"
@@ -109,8 +114,8 @@ jobs:
           # not using secrets.GITHUB_TOKEN since pull requests from that token do not trigger workflows
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          # Read changelog content into a variable
-          CHANGELOG_CONTENT=$(cat /tmp/changelog_content.txt)
+          # Read normalized changelog content for PR body
+          CHANGELOG_CONTENT=$(cat /tmp/changelog_content_normalized.txt)
 
           # Create PR body content
           cat > /tmp/pr_body.md << EOF

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           # Extract original content for CHANGELOG.md update (preserves formatting)
           ./.github/workflows/scripts/extract-changelog.sh /tmp/changelog_content.txt
-          
+
           # Extract normalized content for PR body (removes extra newlines)
           ./.github/workflows/scripts/extract-changelog.sh /tmp/changelog_content_normalized.txt --normalize
 

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Extract changelog content for this release
         id: changelog
         run: |
-          .github/workflows/scripts/extract-changelog.sh "${{ inputs.version }}"
+          .github/workflows/scripts/extract-changelog.sh "${{ inputs.version }}" /tmp/release_content.txt --normalize
 
       - name: Dry run - Show planned changes
         if: inputs.dry_run

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -173,8 +173,8 @@ jobs:
           ## Go Modules
 
           This release includes the following Go modules:
-          - `github.com/open-telemetry/otel-arrow/go@v${{ inputs.version }}`
-          - `github.com/open-telemetry/otel-arrow/collector/cmd/otelarrowcol@v${{ inputs.version }}`
+          - github.com/open-telemetry/otel-arrow/go@v${{ inputs.version }}
+          - github.com/open-telemetry/otel-arrow/collector/cmd/otelarrowcol@v${{ inputs.version }}
           EOF
 
           # Create the GitHub release using GitHub CLI

--- a/.github/workflows/scripts/extract-changelog.sh
+++ b/.github/workflows/scripts/extract-changelog.sh
@@ -13,46 +13,50 @@ NC='\033[0m' # No Color
 
 # Function to show usage
 usage() {
-    echo "Usage: $0 [version] [output_file]"
+    echo "Usage: $0 [version] [output_file] [--normalize]"
     echo ""
     echo "Extract changelog content from CHANGELOG.md"
     echo ""
     echo "Arguments:"
     echo "  version       Version to extract (e.g., 0.40.0). If not provided, extracts 'Unreleased' content"
     echo "  output_file   Output file (default: /tmp/changelog_content.txt or /tmp/release_content.txt)"
+    echo "  --normalize   Normalize whitespace for PR body embedding (optional)"
     echo ""
     echo "Examples:"
     echo "  $0                           # Extract unreleased content"
     echo "  $0 /tmp/my_file.txt          # Extract unreleased content to custom file"
     echo "  $0 0.40.0                    # Extract content for version 0.40.0"
     echo "  $0 0.40.0 /tmp/my_file.txt   # Extract version content to custom file"
+    echo "  $0 /tmp/my_file.txt --normalize  # Extract and normalize unreleased content"
     exit 1
 }
 
-# Parse arguments - handle different calling patterns
 VERSION=""
 OUTPUT_FILE=""
+NORMALIZE=false
 
-if [ $# -eq 0 ]; then
-    # No arguments - extract unreleased content
-    OUTPUT_FILE="/tmp/changelog_content.txt"
-elif [ $# -eq 1 ]; then
-    # One argument - could be version or output file
-    if [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-        # It's a version
-        VERSION="$1"
+for arg in "$@"; do
+    case $arg in
+        --normalize)
+            NORMALIZE=true
+            ;;
+        *)
+            if [[ "$arg" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                VERSION="$arg"
+            else
+                OUTPUT_FILE="$arg"
+            fi
+            ;;
+    esac
+done
+
+# Set default output file if not specified
+if [ -z "$OUTPUT_FILE" ]; then
+    if [ -n "$VERSION" ]; then
         OUTPUT_FILE="/tmp/release_content.txt"
     else
-        # It's an output file for unreleased content
-        OUTPUT_FILE="$1"
+        OUTPUT_FILE="/tmp/changelog_content.txt"
     fi
-elif [ $# -eq 2 ]; then
-    # Two arguments - version and output file
-    VERSION="$1"
-    OUTPUT_FILE="$2"
-else
-    echo -e "${RED}Error: Too many arguments${NC}"
-    usage
 fi
 
 # Check if CHANGELOG.md exists
@@ -99,6 +103,73 @@ else
     echo -e "${GREEN}✓ Found release content for version ${VERSION}${NC}"
 fi
 
+# Normalize whitespace for PR/Release body embedding if requested
+if [ "$NORMALIZE" = true ]; then
+    echo -e "${YELLOW}Normalizing whitespace for PR/Release body...${NC}"
+
+    CONTENT=$(echo "$CONTENT" | awk '
+    function clean_and_print_item() {
+        if (current_item != "") {
+            # Clean up extra spaces in content (but preserve sub-bullet indentation)
+            if (current_item ~ /^  - /) {
+                # For sub-bullets, only clean spaces after the "  - " prefix
+                prefix = "  - "
+                content = substr(current_item, 5)
+                gsub(/  +/, " ", content)
+                current_item = prefix content
+            } else {
+                # For main items, clean all extra spaces
+                gsub(/  +/, " ", current_item)
+            }
+            print current_item
+        }
+    }
+    
+    BEGIN {
+        current_item = ""
+        in_list_item = 0
+    }
+    {
+        # Main list item or sub-bullet (starts with "- " or "  - ")
+        if ($0 ~ /^- / || $0 ~ /^  - /) {
+            # Print previous item if we have one
+            clean_and_print_item()
+            current_item = $0
+            in_list_item = 1
+        }
+        # Continuation line for main item (2 spaces, not sub-bullet)
+        else if ($0 ~ /^  / && !($0 ~ /^  - /) && in_list_item) {
+            # Remove leading spaces and append to current item
+            continuation = $0
+            sub(/^  /, "", continuation)
+            current_item = current_item " " continuation
+        }
+        # Continuation line for sub-bullet (4+ spaces)
+        else if ($0 ~ /^    / && in_list_item) {
+            # Remove leading spaces and append to current item
+            continuation = $0
+            sub(/^    /, "", continuation)
+            current_item = current_item " " continuation
+        }
+        # Non-list content or empty line
+        else {
+            # Print previous item if we have one
+            clean_and_print_item()
+            current_item = ""
+            in_list_item = 0
+            
+            # Print non-empty, non-list lines
+            if ($0 != "" && !($0 ~ /^- /)) {
+                print $0
+            }
+        }
+    }
+    END {
+        # Print final item if we have one
+        clean_and_print_item()
+    }')
+fi
+
 # Save to file
 echo "$CONTENT" > "$OUTPUT_FILE"
 
@@ -111,7 +182,15 @@ echo "----------------------------------------"
 
 echo ""
 if [ -z "$VERSION" ]; then
-    echo -e "${GREEN}✓ Successfully extracted unreleased changelog content${NC}"
+    if [ "$NORMALIZE" = true ]; then
+        echo -e "${GREEN}✓ Successfully extracted and normalized unreleased changelog content${NC}"
+    else
+        echo -e "${GREEN}✓ Successfully extracted unreleased changelog content${NC}"
+    fi
 else
-    echo -e "${GREEN}✓ Successfully extracted changelog content for version ${VERSION}${NC}"
+    if [ "$NORMALIZE" = true ]; then
+        echo -e "${GREEN}✓ Successfully extracted and normalized changelog content for version ${VERSION}${NC}"
+    else
+        echo -e "${GREEN}✓ Successfully extracted changelog content for version ${VERSION}${NC}"
+    fi
 fi


### PR DESCRIPTION
When using the `Prepare Release` and `Push Release` actions the extracted Changelog content displays incorrectly. The repo lint enforces line length in markdown files, leading to extra newlines in raw content:

```md
- Upgrade to v0.133.0 / v1.37.0 of collector dependencies.
  [#890](https://github.com/open-telemetry/otel-arrow/pull/890),
  [#1010](https://github.com/open-telemetry/otel-arrow/pull/1010)
  - Notable upgrade, this also bumps minimum Go version from `1.23.0` to `1.24`,
    see [collector
    #13627](https://github.com/open-telemetry/opentelemetry-collector/pull/13627)
    and [collector-contrib
    #41968](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/41968).
```

When viewing the [Changelog itself](https://github.com/open-telemetry/otel-arrow/blob/main/CHANGELOG.md) GitHub renders this in proper way. However, when we extract it to embed in a PR body (in `Prepare Release`) or in a Release object (in `Push Release`) the rendering is not the same:

<img width="1078" height="539" alt="image" src="https://github.com/user-attachments/assets/9eb14da1-4754-4a2c-962b-7bde9267bcba" />

The script now normalizes whitespace in the extracted content to display properly in the specific use cases we have:

<img width="2045" height="417" alt="image" src="https://github.com/user-attachments/assets/ca07579e-ca69-4ef3-8954-902a6f0c2852" />

Small improvement but saves 2 seconds of manual tweaking during each release 😄 
