### PR TITLE
[query-engine] Refactor try_resolve_value_type calls in KQL parser to use new helper method

### DIFF
--- a/rust/experimental/query_engine/kql-parser/src/logical_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/logical_expressions.rs
@@ -209,12 +209,7 @@ pub(crate) fn parse_logical_expression(
                     if let ScalarExpression::Logical(l) = scalar {
                         Ok(*l)
                     } else {
-                        let value_type_result = scalar
-                            .try_resolve_value_type(&scope.get_pipeline().get_resolution_scope());
-                        if let Err(e) = value_type_result {
-                            return Err(ParserError::from(&e));
-                        }
-                        if let Some(t) = value_type_result.unwrap()
+                        if let Some(t) = scope.try_resolve_value_type(&mut scalar)?
                             && t != ValueType::Boolean
                         {
                             return Err(ParserError::QueryLanguageDiagnostic {

--- a/rust/experimental/query_engine/kql-parser/src/scalar_array_function_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_array_function_expressions.rs
@@ -20,14 +20,14 @@ pub(crate) fn parse_array_concat_expression(
     for rule in array_concat_rules {
         let mut scalar = parse_scalar_expression(rule, scope)?;
 
-        if let Some(t) = scope.try_resolve_value_type(&mut scalar)? {
-            if t != ValueType::Array {
-                return Err(ParserError::QueryLanguageDiagnostic {
-                    location: scalar.get_query_location().clone(),
-                    diagnostic_id: "KS234",
-                    message: "The expression value must be a dynamic array".into(),
-                });
-            }
+        if let Some(t) = scope.try_resolve_value_type(&mut scalar)?
+            && t != ValueType::Array
+        {
+            return Err(ParserError::QueryLanguageDiagnostic {
+                location: scalar.get_query_location().clone(),
+                diagnostic_id: "KS234",
+                message: "The expression value must be a dynamic array".into(),
+            });
         }
 
         values.push(scalar);

--- a/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
@@ -339,13 +339,7 @@ pub(crate) fn parse_accessor_expression(
             Rule::scalar_expression => {
                 let mut scalar = parse_scalar_expression(pair, scope)?;
 
-                let value_type_result =
-                    scalar.try_resolve_value_type(&scope.get_pipeline().get_resolution_scope());
-                if let Err(e) = value_type_result {
-                    return Err(ParserError::from(&e));
-                }
-
-                let value_type = value_type_result.unwrap();
+                let value_type = scope.try_resolve_value_type(&mut scalar)?;
 
                 if negate_location.is_some() {
                     if let Some(t) = value_type

--- a/rust/experimental/query_engine/kql-parser/src/scalar_string_function_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_string_function_expressions.rs
@@ -19,11 +19,7 @@ pub(crate) fn parse_strlen_expression(
     let inner_expression_rule_location = to_query_location(&inner_expression_rule);
     let mut inner_expression = parse_scalar_expression(inner_expression_rule, scope)?;
 
-    let inner_expression_value_type_result = inner_expression
-        .try_resolve_value_type(&scope.get_pipeline().get_resolution_scope())
-        .map_err(|e| ParserError::from(&e))?;
-
-    if let Some(v) = inner_expression_value_type_result
+    if let Some(v) = scope.try_resolve_value_type(&mut inner_expression)?
         && v != ValueType::String
     {
         return Err(ParserError::QueryLanguageDiagnostic {
@@ -65,11 +61,7 @@ pub(crate) fn parse_replace_string_expression(
 
         let mut scalar = parse_scalar_expression(rule, scope)?;
 
-        let scalar_value_type_result = scalar
-            .try_resolve_value_type(&scope.get_pipeline().get_resolution_scope())
-            .map_err(|e| ParserError::from(&e))?;
-
-        if let Some(v) = scalar_value_type_result
+        if let Some(v) = scope.try_resolve_value_type(&mut scalar)?
             && v != ValueType::String
         {
             return Err(ParserError::QueryLanguageDiagnostic {
@@ -96,11 +88,7 @@ pub(crate) fn parse_substring_expression(
     let starting_index_rule_location = to_query_location(&starting_index_rule);
     let mut starting_index_scalar = parse_scalar_expression(starting_index_rule, scope)?;
 
-    let starting_index_value_type_result = starting_index_scalar
-        .try_resolve_value_type(&scope.get_pipeline().get_resolution_scope())
-        .map_err(|e| ParserError::from(&e))?;
-
-    if let Some(v) = starting_index_value_type_result
+    if let Some(v) = scope.try_resolve_value_type(&mut starting_index_scalar)?
         && v != ValueType::Integer
     {
         return Err(ParserError::QueryLanguageDiagnostic {
@@ -114,11 +102,7 @@ pub(crate) fn parse_substring_expression(
         let length_scalar_rule_location = to_query_location(&length_rule);
         let mut length_scalar = parse_scalar_expression(length_rule, scope)?;
 
-        let length_scalar_value_type_result = length_scalar
-            .try_resolve_value_type(&scope.get_pipeline().get_resolution_scope())
-            .map_err(|e| ParserError::from(&e))?;
-
-        if let Some(v) = length_scalar_value_type_result
+        if let Some(v) = scope.try_resolve_value_type(&mut length_scalar)?
             && v != ValueType::Integer
         {
             return Err(ParserError::QueryLanguageDiagnostic {
@@ -153,9 +137,7 @@ pub(crate) fn parse_parse_json_expression(
     let inner_rule_location = to_query_location(&inner_rule);
     let mut inner_scalar = parse_scalar_expression(inner_rule, scope)?;
 
-    if let Some(v) = inner_scalar
-        .try_resolve_value_type(&scope.get_pipeline().get_resolution_scope())
-        .map_err(|e| ParserError::from(&e))?
+    if let Some(v) = scope.try_resolve_value_type(&mut inner_scalar)?
         && v != ValueType::String
     {
         return Err(ParserError::QueryLanguageDiagnostic {


### PR DESCRIPTION
nt