### PR TITLE
[otap-df-enfine] Avoid allocation in info method

### DIFF
--- a/rust/otap-dataflow/crates/engine/src/effect_handler.rs
+++ b/rust/otap-dataflow/crates/engine/src/effect_handler.rs
@@ -50,9 +50,9 @@ impl EffectHandlerCore {
     pub(crate) async fn info(&self, message: &str) {
         use tokio::io::{AsyncWriteExt, stdout};
         let mut out = stdout();
-        let formatted_message = format!("{message}\n");
         // Ignore write errors as they're typically not recoverable for stdout
-        let _ = out.write_all(formatted_message.as_bytes()).await;
+        let _ = out.write_all(message.as_bytes()).await;
+        let _ = out.write_all(b"\n").await;
         let _ = out.flush().await;
     }
 


### PR DESCRIPTION
## Changes
- Avoid the string allocation by `format!` by directly writing the message and new line character to the buffer