### PR TITLE
[query-engine] KQL matches regex & more constant folding

### DIFF
--- a/rust/experimental/query_engine/expressions/src/scalars/collection_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/collection_scalar_expression.rs
@@ -155,7 +155,7 @@ impl CombineScalarExpression {
                 (values, len)
             }
             Some(ResolvedStaticScalarExpression::Reference(StaticScalarExpression::Array(v)))
-            | Some(ResolvedStaticScalarExpression::FoldedConstant(
+            | Some(ResolvedStaticScalarExpression::FoldEligibleReference(
                 StaticScalarExpression::Array(v),
             )) => {
                 let value_expressions = v.get_values();

--- a/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
@@ -395,13 +395,10 @@ impl ConstantScalarExpression {
         }
     }
 
-    pub(crate) fn resolve_static<'a, 'b, 'c>(
+    pub(crate) fn resolve_static<'a>(
         &'a mut self,
-        scope: &PipelineResolutionScope<'b>,
-    ) -> ResolvedStaticScalarExpression<'c>
-    where
-        'a: 'c,
-        'b: 'c,
+        scope: &PipelineResolutionScope<'a>,
+    ) -> ResolvedStaticScalarExpression<'a>
     {
         match self {
             ConstantScalarExpression::Reference(r) => {

--- a/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
@@ -398,8 +398,7 @@ impl ConstantScalarExpression {
     pub(crate) fn resolve_static<'a>(
         &'a mut self,
         scope: &PipelineResolutionScope<'a>,
-    ) -> ResolvedStaticScalarExpression<'a>
-    {
+    ) -> ResolvedStaticScalarExpression<'a> {
         match self {
             ConstantScalarExpression::Reference(r) => {
                 let constant_id = r.get_constant_id();

--- a/rust/experimental/query_engine/expressions/src/scalars/statics/resolved_static_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/statics/resolved_static_scalar_expression.rs
@@ -7,7 +7,7 @@ use crate::*;
 pub enum ResolvedStaticScalarExpression<'a> {
     Reference(&'a StaticScalarExpression),
     Computed(StaticScalarExpression),
-    FoldedConstant(&'a StaticScalarExpression),
+    FoldEligibleReference(&'a StaticScalarExpression),
 }
 
 impl ResolvedStaticScalarExpression<'_> {
@@ -20,7 +20,7 @@ impl ResolvedStaticScalarExpression<'_> {
                 None
             }
             ResolvedStaticScalarExpression::Computed(s) => Some(s),
-            ResolvedStaticScalarExpression::FoldedConstant(s) => Some(s.clone()),
+            ResolvedStaticScalarExpression::FoldEligibleReference(s) => Some(s.clone()),
         }
     }
 }
@@ -30,18 +30,17 @@ impl AsStaticValue for ResolvedStaticScalarExpression<'_> {
         match self {
             ResolvedStaticScalarExpression::Reference(s) => s.to_static_value(),
             ResolvedStaticScalarExpression::Computed(s) => s.to_static_value(),
-            ResolvedStaticScalarExpression::FoldedConstant(s) => s.to_static_value(),
+            ResolvedStaticScalarExpression::FoldEligibleReference(s) => s.to_static_value(),
         }
     }
 }
 
-#[cfg(test)]
 impl AsRef<StaticScalarExpression> for ResolvedStaticScalarExpression<'_> {
     fn as_ref(&self) -> &StaticScalarExpression {
         match self {
             ResolvedStaticScalarExpression::Reference(s) => s,
             ResolvedStaticScalarExpression::Computed(s) => s,
-            ResolvedStaticScalarExpression::FoldedConstant(s) => s,
+            ResolvedStaticScalarExpression::FoldEligibleReference(s) => s,
         }
     }
 }

--- a/rust/experimental/query_engine/expressions/src/scalars/statics/static_scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/statics/static_scalar_expressions.rs
@@ -42,32 +42,28 @@ pub enum StaticScalarExpression {
 }
 
 impl StaticScalarExpression {
-    pub(crate) fn try_fold(&self) -> Option<StaticScalarExpression> {
+    pub(crate) fn foldable(&self) -> bool {
         // Note: The goal here is to diferentiate which statics can be
         // folded/copied in the expression tree and which ones should always be
         // referenced.
         match self {
-            StaticScalarExpression::Array(_) => None,
-            StaticScalarExpression::Boolean(b) => Some(StaticScalarExpression::Boolean(b.clone())),
-            StaticScalarExpression::DateTime(d) => {
-                Some(StaticScalarExpression::DateTime(d.clone()))
-            }
-            StaticScalarExpression::Double(d) => Some(StaticScalarExpression::Double(d.clone())),
-            StaticScalarExpression::Integer(i) => Some(StaticScalarExpression::Integer(i.clone())),
-            StaticScalarExpression::Map(_) => None,
-            StaticScalarExpression::Null(n) => Some(StaticScalarExpression::Null(n.clone())),
-            StaticScalarExpression::Regex(_) => None,
-            StaticScalarExpression::String(s) => {
-                let value = &s.value;
-                if value.len() <= 32 {
-                    Some(StaticScalarExpression::String(s.clone()))
-                } else {
-                    None
-                }
-            }
-            StaticScalarExpression::TimeSpan(t) => {
-                Some(StaticScalarExpression::TimeSpan(t.clone()))
-            }
+            StaticScalarExpression::Array(_) => false,
+            StaticScalarExpression::Boolean(_) => true,
+            StaticScalarExpression::DateTime(_) => true,
+            StaticScalarExpression::Double(_) => true,
+            StaticScalarExpression::Integer(_) => true,
+            StaticScalarExpression::Map(_) => false,
+            StaticScalarExpression::Null(_) => true,
+            StaticScalarExpression::Regex(_) => false,
+            StaticScalarExpression::String(s) => s.value.len() <= 32,
+            StaticScalarExpression::TimeSpan(_) => true,
+        }
+    }
+
+    pub(crate) fn try_fold(&self) -> Option<StaticScalarExpression> {
+        match self.foldable() {
+            true => Some(self.clone()),
+            false => None,
         }
     }
 

--- a/rust/experimental/query_engine/expressions/src/scalars/text_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/text_scalar_expression.rs
@@ -270,7 +270,7 @@ impl JoinTextScalarExpression {
                 (values, len)
             }
             Some(ResolvedStaticScalarExpression::Reference(StaticScalarExpression::Array(v)))
-            | Some(ResolvedStaticScalarExpression::FoldedConstant(
+            | Some(ResolvedStaticScalarExpression::FoldEligibleReference(
                 StaticScalarExpression::Array(v),
             )) => {
                 let value_expressions = v.get_values();

--- a/rust/experimental/query_engine/expressions/src/value_accessor.rs
+++ b/rust/experimental/query_engine/expressions/src/value_accessor.rs
@@ -65,7 +65,7 @@ impl ValueAccessor {
             if let Some(ResolvedStaticScalarExpression::Computed(s)) =
                 selector.try_resolve_static(scope)?
             {
-                *selector = ScalarExpression::Static(s);
+                *selector = ScalarExpression::Static(s.clone());
             }
         }
         Ok(())

--- a/rust/experimental/query_engine/kql-parser/src/kql.pest
+++ b/rust/experimental/query_engine/kql-parser/src/kql.pest
@@ -31,7 +31,7 @@ less_than_or_equal_to_token = @{ "<=" }
 and_token = @{ "and" }
 or_token = @{ "or" }
 
-// Misc Tokens
+// Comparison Tokens
 contains_token = @{ "contains" }
 contains_cs_token = @{ "contains_cs" }
 has_token = @{ "has" }
@@ -44,6 +44,9 @@ not_has_token = @{ "!has" }
 not_has_cs_token = @{ "!has_cs" }
 not_in_token = @{ "!in" }
 not_in_insensitive_token = @{ "!in~" }
+matches_regex_token = @{ "matches regex" }
+
+// Misc Tokens
 statement_end_token = { &";" }
 
 // Literals
@@ -214,7 +217,7 @@ scalar_expression = {
 }
 
 comparison_expression = {
-    scalar_expression ~ (not_contains_cs_token|not_contains_token|not_has_cs_token|not_has_token|contains_cs_token|contains_token|has_cs_token|has_token|equals_token|equals_insensitive_token|not_equals_token|not_equals_insensitive_token|greater_than_token|greater_than_or_equal_to_token|less_than_token|less_than_or_equal_to_token) ~ scalar_expression
+    scalar_expression ~ (not_contains_cs_token|not_contains_token|not_has_cs_token|not_has_token|contains_cs_token|contains_token|has_cs_token|has_token|equals_token|equals_insensitive_token|not_equals_token|not_equals_insensitive_token|greater_than_token|greater_than_or_equal_to_token|less_than_token|less_than_or_equal_to_token|matches_regex_token) ~ scalar_expression
     | scalar_expression ~ (not_in_insensitive_token|not_in_token|in_insensitive_token|in_token) ~ "(" ~ scalar_expression ~ ("," ~ scalar_expression)* ~ ")"
 }
 logical_expressions = _{ comparison_expression|scalar_expression }

--- a/rust/experimental/query_engine/kql-parser/src/query_expression.rs
+++ b/rust/experimental/query_engine/kql-parser/src/query_expression.rs
@@ -79,7 +79,7 @@ pub(crate) fn parse_query(
                                                 s,
                                             ))) => state.push_constant(name, s),
                                             Ok(Some(
-                                                ResolvedStaticScalarExpression::FoldedConstant(s),
+                                                ResolvedStaticScalarExpression::FoldEligibleReference(s),
                                             )) => state.push_constant(name, s.clone()),
                                             Ok(None)
                                             | Ok(Some(

--- a/rust/experimental/query_engine/kql-parser/src/scalar_array_function_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_array_function_expressions.rs
@@ -85,6 +85,7 @@ mod tests {
             }
         };
 
+        // Note: Inner json expression gets folded into a static array.
         run_test_success(
             "array_concat(parse_json('[]'))",
             ScalarExpression::Collection(CollectionScalarExpression::Concat(
@@ -93,16 +94,8 @@ mod tests {
                     ScalarExpression::Collection(CollectionScalarExpression::List(
                         ListScalarExpression::new(
                             QueryLocation::new_fake(),
-                            vec![ScalarExpression::Parse(ParseScalarExpression::Json(
-                                ParseJsonScalarExpression::new(
-                                    QueryLocation::new_fake(),
-                                    ScalarExpression::Static(StaticScalarExpression::String(
-                                        StringScalarExpression::new(
-                                            QueryLocation::new_fake(),
-                                            "[]",
-                                        ),
-                                    )),
-                                ),
+                            vec![ScalarExpression::Static(StaticScalarExpression::Array(
+                                ArrayScalarExpression::new(QueryLocation::new_fake(), vec![]),
                             ))],
                         ),
                     )),
@@ -110,6 +103,7 @@ mod tests {
             )),
         );
 
+        // Note: Inner json expressions get folded into a static arrays.
         run_test_success(
             "array_concat(parse_json('[]'), parse_json('[]'))",
             ScalarExpression::Collection(CollectionScalarExpression::Concat(
@@ -119,27 +113,11 @@ mod tests {
                         ListScalarExpression::new(
                             QueryLocation::new_fake(),
                             vec![
-                                ScalarExpression::Parse(ParseScalarExpression::Json(
-                                    ParseJsonScalarExpression::new(
-                                        QueryLocation::new_fake(),
-                                        ScalarExpression::Static(StaticScalarExpression::String(
-                                            StringScalarExpression::new(
-                                                QueryLocation::new_fake(),
-                                                "[]",
-                                            ),
-                                        )),
-                                    ),
+                                ScalarExpression::Static(StaticScalarExpression::Array(
+                                    ArrayScalarExpression::new(QueryLocation::new_fake(), vec![]),
                                 )),
-                                ScalarExpression::Parse(ParseScalarExpression::Json(
-                                    ParseJsonScalarExpression::new(
-                                        QueryLocation::new_fake(),
-                                        ScalarExpression::Static(StaticScalarExpression::String(
-                                            StringScalarExpression::new(
-                                                QueryLocation::new_fake(),
-                                                "[]",
-                                            ),
-                                        )),
-                                    ),
+                                ScalarExpression::Static(StaticScalarExpression::Array(
+                                    ArrayScalarExpression::new(QueryLocation::new_fake(), vec![]),
                                 )),
                             ],
                         ),

--- a/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
@@ -1657,14 +1657,10 @@ mod tests {
                 ValueAccessor::new_with_selectors(vec![ScalarExpression::Conditional(
                     ConditionalScalarExpression::new(
                         QueryLocation::new_fake(),
-                        LogicalExpression::Scalar(ScalarExpression::Constant(
-                            ConstantScalarExpression::Copy(CopyConstantScalarExpression::new(
+                        LogicalExpression::Scalar(ScalarExpression::Static(
+                            StaticScalarExpression::Boolean(BooleanScalarExpression::new(
                                 QueryLocation::new_fake(),
-                                2,
-                                StaticScalarExpression::Boolean(BooleanScalarExpression::new(
-                                    QueryLocation::new_fake(),
-                                    false,
-                                )),
+                                false,
                             )),
                         )),
                         ScalarExpression::Static(StaticScalarExpression::String(

--- a/rust/experimental/query_engine/kql-parser/src/scalar_string_function_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_string_function_expressions.rs
@@ -489,12 +489,29 @@ mod tests {
             }
         };
 
+        // Note: This whole expression is folded into a static array.
         run_test_success(
-            "parse_json('\"hello\"')",
+            "parse_json('[]')",
+            ScalarExpression::Static(StaticScalarExpression::Array(ArrayScalarExpression::new(
+                QueryLocation::new_fake(),
+                vec![],
+            ))),
+        );
+
+        run_test_success(
+            "parse_json(source.Attributes['json'])",
             ScalarExpression::Parse(ParseScalarExpression::Json(ParseJsonScalarExpression::new(
                 QueryLocation::new_fake(),
-                ScalarExpression::Static(StaticScalarExpression::String(
-                    StringScalarExpression::new(QueryLocation::new_fake(), "\"hello\""),
+                ScalarExpression::Source(SourceScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    ValueAccessor::new_with_selectors(vec![
+                        ScalarExpression::Static(StaticScalarExpression::String(
+                            StringScalarExpression::new(QueryLocation::new_fake(), "Attributes"),
+                        )),
+                        ScalarExpression::Static(StaticScalarExpression::String(
+                            StringScalarExpression::new(QueryLocation::new_fake(), "json"),
+                        )),
+                    ]),
                 )),
             ))),
         );


### PR DESCRIPTION
## Changes

* Adds support for KQL `matches regex` expression
* Builds on top of #1007 such that all computed values are folded into statics when `try_resolve_static` is invoked