### PR TITLE
Small parquet exporter fixes and add example config

### DIFF
--- a/rust/otap-dataflow/configs/fake-parquet.yaml
+++ b/rust/otap-dataflow/configs/fake-parquet.yaml
@@ -9,21 +9,21 @@ nodes:
     out_ports:
       out_port:
         destinations:
-          - exporter
+        - exporter
         dispatch_strategy: round_robin
     config:
       traffic_config:
-        # max_signal_count: 1000
         max_batch_size: 1000
         signals_per_second: 30
         log_weight: 100
       registry_path: https://github.com/open-telemetry/semantic-conventions.git[model]
   exporter:
     kind: exporter
-    plugin_urn: "urn:otel:otap:perf:exporter"
+    plugin_urn: "urn:otel:otap:parquet:exporter"
     config:
-      frequency: 1000
-      cpu_usage: false
-      mem_usage: false
-      disk_usage: false
-      io_usage: false
+      base_uri: /tmp
+      partitioning_strategies:
+      - schema_metadata: ["_part_id"]
+      writer_options:
+        flush_when_older_than: 10s
+

--- a/rust/otap-dataflow/configs/fake-perf.yaml
+++ b/rust/otap-dataflow/configs/fake-perf.yaml
@@ -13,9 +13,9 @@ nodes:
         dispatch_strategy: round_robin
     config:
       traffic_config:
-        # max_signal_count: 1000
+        max_signal_count: 1000
         max_batch_size: 1000
-        signals_per_second: 30
+        signals_per_second: 1000
         log_weight: 100
       registry_path: https://github.com/open-telemetry/semantic-conventions.git[model]
   exporter:

--- a/rust/otap-dataflow/crates/otap/src/parquet_exporter.rs
+++ b/rust/otap-dataflow/crates/otap/src/parquet_exporter.rs
@@ -1080,7 +1080,7 @@ mod test {
     }
 
     #[test]
-    fn test_handles_null_ids_correctly() {
+    fn test_handles_null_ids() {
         let test_runtime = TestRuntime::<OtapPdata>::new();
         let temp_dir = tempfile::tempdir().unwrap();
         let base_dir: String = temp_dir.path().to_str().unwrap().into();

--- a/rust/otap-dataflow/crates/otap/src/parquet_exporter/config.rs
+++ b/rust/otap-dataflow/crates/otap/src/parquet_exporter/config.rs
@@ -40,6 +40,7 @@ pub struct WriterOptions {
     ///
     /// Note that files may actually be buffered for slightly longer than this value. For more
     /// details see [`Self::flush_age_check_interval`]
+    #[serde(default)]
     #[serde(with = "humantime_serde")]
     pub flush_when_older_than: Option<Duration>,
 }

--- a/rust/otap-dataflow/crates/otap/src/parquet_exporter/idgen.rs
+++ b/rust/otap-dataflow/crates/otap/src/parquet_exporter/idgen.rs
@@ -198,7 +198,7 @@ impl PartitionSequenceIdGenerator {
             .enumerate()
             .map(|(i, field)| {
                 if i == id_column_index {
-                    Arc::new(Field::new(column_name, DataType::UInt32, false))
+                    Arc::new(Field::new(column_name, DataType::UInt32, true))
                 } else {
                     field.clone()
                 }


### PR DESCRIPTION
Fixes a few small issues with parquet exporter:
- fix `flush_when_older_than` missing value not being deserialized as `None` by serde
- fix bug generating unique IDs for ID columns with null values

Also adds a configuration example for generating parquet data.