### PR TITLE
[query-engine] Remove ImmutableValueExpression

### DIFF
--- a/rust/experimental/query_engine/engine-recordset/src/engine.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/engine.rs
@@ -622,12 +622,10 @@ mod tests {
         pipeline_builder.push_expression(DataExpression::Transform(TransformExpression::Set(
             SetTransformExpression::new(
                 QueryLocation::new_fake(),
-                ImmutableValueExpression::Scalar(ScalarExpression::Variable(
-                    VariableScalarExpression::new(
-                        QueryLocation::new_fake(),
-                        StringScalarExpression::new(QueryLocation::new_fake(), "gvar1"),
-                        ValueAccessor::new(),
-                    ),
+                ScalarExpression::Variable(VariableScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    StringScalarExpression::new(QueryLocation::new_fake(), "gvar1"),
+                    ValueAccessor::new(),
                 )),
                 MutableValueExpression::Source(SourceScalarExpression::new(
                     QueryLocation::new_fake(),
@@ -780,11 +778,9 @@ mod tests {
             ),
             DataExpression::Transform(TransformExpression::Set(SetTransformExpression::new(
                 QueryLocation::new_fake(),
-                ImmutableValueExpression::Scalar(ScalarExpression::Static(
-                    StaticScalarExpression::Null(NullScalarExpression::new(
-                        QueryLocation::new_fake(),
-                    )),
-                )),
+                ScalarExpression::Static(StaticScalarExpression::Null(NullScalarExpression::new(
+                    QueryLocation::new_fake(),
+                ))),
                 MutableValueExpression::Source(SourceScalarExpression::new(
                     QueryLocation::new_fake(),
                     ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(

--- a/rust/experimental/query_engine/engine-recordset/src/transform/transform_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/transform/transform_expressions.rs
@@ -10,12 +10,9 @@ use std::{
 use data_engine_expressions::*;
 
 use crate::{
-    execution_context::*,
-    resolved_value_mut::*,
-    scalars::*,
+    execution_context::*, resolved_value_mut::*, scalars::*,
     transform::reduce_map_transform_expression::execute_map_reduce_transform_expression,
-    value_expressions::{execute_immutable_value_expression, execute_mutable_value_expression},
-    *,
+    value_expressions::execute_mutable_value_expression, *,
 };
 
 pub fn execute_transform_expression<'a, TRecord: Record>(
@@ -24,7 +21,7 @@ pub fn execute_transform_expression<'a, TRecord: Record>(
 ) -> Result<(), ExpressionError> {
     match transform_expression {
         TransformExpression::Set(s) => {
-            let mut source = execute_immutable_value_expression(execution_context, s.get_source())?;
+            let mut source = execute_scalar_expression(execution_context, s.get_source())?;
 
             let mutable_value_expression = s.get_destination();
 
@@ -437,12 +434,10 @@ mod tests {
         // Test updating a key on source
         let result = run_test(TransformExpression::Set(SetTransformExpression::new(
             QueryLocation::new_fake(),
-            ImmutableValueExpression::Scalar(ScalarExpression::Static(
-                StaticScalarExpression::String(StringScalarExpression::new(
-                    QueryLocation::new_fake(),
-                    "hello world",
-                )),
-            )),
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "hello world",
+            ))),
             MutableValueExpression::Source(SourceScalarExpression::new(
                 QueryLocation::new_fake(),
                 ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
@@ -462,16 +457,14 @@ mod tests {
         // Test updating a key on source using data read from the source
         let result = run_test(TransformExpression::Set(SetTransformExpression::new(
             QueryLocation::new_fake(),
-            ImmutableValueExpression::Scalar(ScalarExpression::Source(
-                SourceScalarExpression::new(
-                    QueryLocation::new_fake(),
-                    ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
-                        StaticScalarExpression::String(StringScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            "key3",
-                        )),
-                    )]),
-                ),
+            ScalarExpression::Source(SourceScalarExpression::new(
+                QueryLocation::new_fake(),
+                ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                    StaticScalarExpression::String(StringScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        "key3",
+                    )),
+                )]),
             )),
             MutableValueExpression::Source(SourceScalarExpression::new(
                 QueryLocation::new_fake(),
@@ -497,12 +490,10 @@ mod tests {
         // Test adding a key
         let result = run_test(TransformExpression::Set(SetTransformExpression::new(
             QueryLocation::new_fake(),
-            ImmutableValueExpression::Scalar(ScalarExpression::Static(
-                StaticScalarExpression::String(StringScalarExpression::new(
-                    QueryLocation::new_fake(),
-                    "hello world",
-                )),
-            )),
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "hello world",
+            ))),
             MutableValueExpression::Source(SourceScalarExpression::new(
                 QueryLocation::new_fake(),
                 ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
@@ -522,12 +513,10 @@ mod tests {
         // Test updating an index
         let result = run_test(TransformExpression::Set(SetTransformExpression::new(
             QueryLocation::new_fake(),
-            ImmutableValueExpression::Scalar(ScalarExpression::Static(
-                StaticScalarExpression::String(StringScalarExpression::new(
-                    QueryLocation::new_fake(),
-                    "hello world",
-                )),
-            )),
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "hello world",
+            ))),
             MutableValueExpression::Source(SourceScalarExpression::new(
                 QueryLocation::new_fake(),
                 ValueAccessor::new_with_selectors(vec![
@@ -553,12 +542,10 @@ mod tests {
         // Test updating an index using negative lookup
         let result = run_test(TransformExpression::Set(SetTransformExpression::new(
             QueryLocation::new_fake(),
-            ImmutableValueExpression::Scalar(ScalarExpression::Static(
-                StaticScalarExpression::String(StringScalarExpression::new(
-                    QueryLocation::new_fake(),
-                    "hello world",
-                )),
-            )),
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "hello world",
+            ))),
             MutableValueExpression::Source(SourceScalarExpression::new(
                 QueryLocation::new_fake(),
                 ValueAccessor::new_with_selectors(vec![
@@ -645,11 +632,8 @@ mod tests {
         run_test(
             TransformExpression::Set(SetTransformExpression::new(
                 QueryLocation::new_fake(),
-                ImmutableValueExpression::Scalar(ScalarExpression::Static(
-                    StaticScalarExpression::String(StringScalarExpression::new(
-                        QueryLocation::new_fake(),
-                        "hello world!",
-                    )),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "hello world!"),
                 )),
                 MutableValueExpression::Variable(VariableScalarExpression::new(
                     QueryLocation::new_fake(),
@@ -670,12 +654,10 @@ mod tests {
         run_test(
             TransformExpression::Set(SetTransformExpression::new(
                 QueryLocation::new_fake(),
-                ImmutableValueExpression::Scalar(ScalarExpression::Variable(
-                    VariableScalarExpression::new(
-                        QueryLocation::new_fake(),
-                        StringScalarExpression::new(QueryLocation::new_fake(), "var2"),
-                        ValueAccessor::new(),
-                    ),
+                ScalarExpression::Variable(VariableScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    StringScalarExpression::new(QueryLocation::new_fake(), "var2"),
+                    ValueAccessor::new(),
                 )),
                 MutableValueExpression::Variable(VariableScalarExpression::new(
                     QueryLocation::new_fake(),
@@ -696,11 +678,8 @@ mod tests {
         run_test(
             TransformExpression::Set(SetTransformExpression::new(
                 QueryLocation::new_fake(),
-                ImmutableValueExpression::Scalar(ScalarExpression::Static(
-                    StaticScalarExpression::String(StringScalarExpression::new(
-                        QueryLocation::new_fake(),
-                        "goodbye world",
-                    )),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "goodbye world"),
                 )),
                 MutableValueExpression::Variable(VariableScalarExpression::new(
                     QueryLocation::new_fake(),
@@ -721,11 +700,8 @@ mod tests {
         run_test(
             TransformExpression::Set(SetTransformExpression::new(
                 QueryLocation::new_fake(),
-                ImmutableValueExpression::Scalar(ScalarExpression::Static(
-                    StaticScalarExpression::String(StringScalarExpression::new(
-                        QueryLocation::new_fake(),
-                        "goodbye world",
-                    )),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "goodbye world"),
                 )),
                 MutableValueExpression::Variable(VariableScalarExpression::new(
                     QueryLocation::new_fake(),
@@ -755,11 +731,8 @@ mod tests {
         run_test(
             TransformExpression::Set(SetTransformExpression::new(
                 QueryLocation::new_fake(),
-                ImmutableValueExpression::Scalar(ScalarExpression::Static(
-                    StaticScalarExpression::String(StringScalarExpression::new(
-                        QueryLocation::new_fake(),
-                        "goodbye world",
-                    )),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "goodbye world"),
                 )),
                 MutableValueExpression::Variable(VariableScalarExpression::new(
                     QueryLocation::new_fake(),
@@ -790,11 +763,8 @@ mod tests {
         run_test(
             TransformExpression::Set(SetTransformExpression::new(
                 QueryLocation::new_fake(),
-                ImmutableValueExpression::Scalar(ScalarExpression::Static(
-                    StaticScalarExpression::String(StringScalarExpression::new(
-                        QueryLocation::new_fake(),
-                        "goodbye world",
-                    )),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "goodbye world"),
                 )),
                 MutableValueExpression::Variable(VariableScalarExpression::new(
                     QueryLocation::new_fake(),

--- a/rust/experimental/query_engine/engine-recordset/src/value_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/value_expressions.rs
@@ -7,29 +7,6 @@ use data_engine_expressions::*;
 
 use crate::{execution_context::*, resolved_value_mut::*, scalars::*, *};
 
-pub fn execute_immutable_value_expression<'a, 'b, 'c, TRecord: Record>(
-    execution_context: &'b ExecutionContext<'a, '_, '_, TRecord>,
-    immutable_value_expression: &'a ImmutableValueExpression,
-) -> Result<ResolvedValue<'c>, ExpressionError>
-where
-    'a: 'c,
-    'b: 'c,
-{
-    match immutable_value_expression {
-        ImmutableValueExpression::Scalar(scalar_expression) => {
-            let value = execute_scalar_expression(execution_context, scalar_expression)?;
-
-            execution_context.add_diagnostic_if_enabled(
-                RecordSetEngineDiagnosticLevel::Verbose,
-                immutable_value_expression,
-                || format!("Evaluated as: '{value}'"),
-            );
-
-            Ok(value)
-        }
-    }
-}
-
 pub fn execute_mutable_value_expression<'a, 'b, 'c, TRecord: Record>(
     execution_context: &'b ExecutionContext<'a, '_, '_, TRecord>,
     mutable_value_expression: &'a MutableValueExpression,
@@ -422,31 +399,6 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
-
-    #[test]
-    fn test_execute_immutable_value_expression() {
-        let run_test = |immutable_value_expression, expected_value: Value| {
-            let mut test = TestExecutionContext::new();
-
-            let execution_context = test.create_execution_context();
-
-            let value =
-                execute_immutable_value_expression(&execution_context, &immutable_value_expression)
-                    .unwrap();
-
-            assert_eq!(expected_value, value.to_value());
-        };
-
-        run_test(
-            ImmutableValueExpression::Scalar(ScalarExpression::Static(
-                StaticScalarExpression::String(StringScalarExpression::new(
-                    QueryLocation::new_fake(),
-                    "hello world",
-                )),
-            )),
-            Value::String(&StringValueStorage::new("hello world".into())),
-        );
-    }
 
     #[test]
     fn test_execute_source_mutable_value_expression() {

--- a/rust/experimental/query_engine/expressions/src/transform_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/transform_expressions.rs
@@ -44,14 +44,14 @@ impl Expression for TransformExpression {
 #[derive(Debug, Clone, PartialEq)]
 pub struct SetTransformExpression {
     query_location: QueryLocation,
-    source: ImmutableValueExpression,
+    source: ScalarExpression,
     destination: MutableValueExpression,
 }
 
 impl SetTransformExpression {
     pub fn new(
         query_location: QueryLocation,
-        source: ImmutableValueExpression,
+        source: ScalarExpression,
         destination: MutableValueExpression,
     ) -> SetTransformExpression {
         Self {
@@ -61,7 +61,7 @@ impl SetTransformExpression {
         }
     }
 
-    pub fn get_source(&self) -> &ImmutableValueExpression {
+    pub fn get_source(&self) -> &ScalarExpression {
         &self.source
     }
 

--- a/rust/experimental/query_engine/expressions/src/value_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/value_expressions.rs
@@ -1,9 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    Expression, QueryLocation, ScalarExpression, SourceScalarExpression, VariableScalarExpression,
-};
+use crate::{Expression, QueryLocation, SourceScalarExpression, VariableScalarExpression};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum MutableValueExpression {
@@ -32,26 +30,6 @@ impl Expression for MutableValueExpression {
         match self {
             MutableValueExpression::Source(_) => "MutableValueExpression(Source)",
             MutableValueExpression::Variable(_) => "MutableValueExpression(Variable)",
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum ImmutableValueExpression {
-    /// Scalar value.
-    Scalar(ScalarExpression),
-}
-
-impl Expression for ImmutableValueExpression {
-    fn get_query_location(&self) -> &QueryLocation {
-        match self {
-            ImmutableValueExpression::Scalar(s) => s.get_query_location(),
-        }
-    }
-
-    fn get_name(&self) -> &'static str {
-        match self {
-            ImmutableValueExpression::Scalar(_) => "ImmutableValueExpression(Scalar)",
         }
     }
 }

--- a/rust/experimental/query_engine/kql-parser/src/shared_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/shared_expressions.rs
@@ -13,14 +13,7 @@ use crate::{
 pub(crate) fn parse_source_assignment_expression(
     assignment_expression_rule: Pair<Rule>,
     scope: &dyn ParserScope,
-) -> Result<
-    (
-        QueryLocation,
-        ImmutableValueExpression,
-        SourceScalarExpression,
-    ),
-    ParserError,
-> {
+) -> Result<(QueryLocation, ScalarExpression, SourceScalarExpression), ParserError> {
     let query_location = to_query_location(&assignment_expression_rule);
 
     let mut assignment_rules = assignment_expression_rule.into_inner();
@@ -72,11 +65,7 @@ pub(crate) fn parse_source_assignment_expression(
         _ => panic!("Unexpected rule in assignment_expression: {source_rule}"),
     };
 
-    Ok((
-        query_location,
-        ImmutableValueExpression::Scalar(scalar),
-        destination,
-    ))
+    Ok((query_location, scalar, destination))
 }
 
 pub(crate) fn parse_let_expression(
@@ -104,7 +93,7 @@ pub(crate) fn parse_let_expression(
 
     Ok(TransformExpression::Set(SetTransformExpression::new(
         query_location,
-        ImmutableValueExpression::Scalar(scalar),
+        scalar,
         MutableValueExpression::Variable(VariableScalarExpression::new(
             identifier.get_query_location().clone(),
             identifier,
@@ -170,11 +159,8 @@ mod tests {
             "new_attribute = 1",
             TransformExpression::Set(SetTransformExpression::new(
                 QueryLocation::new_fake(),
-                ImmutableValueExpression::Scalar(ScalarExpression::Static(
-                    StaticScalarExpression::Integer(IntegerScalarExpression::new(
-                        QueryLocation::new_fake(),
-                        1,
-                    )),
+                ScalarExpression::Static(StaticScalarExpression::Integer(
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
                 )),
                 MutableValueExpression::Source(SourceScalarExpression::new(
                     QueryLocation::new_fake(),
@@ -192,11 +178,8 @@ mod tests {
             "variable = 'hello world'",
             TransformExpression::Set(SetTransformExpression::new(
                 QueryLocation::new_fake(),
-                ImmutableValueExpression::Scalar(ScalarExpression::Static(
-                    StaticScalarExpression::String(StringScalarExpression::new(
-                        QueryLocation::new_fake(),
-                        "hello world",
-                    )),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "hello world"),
                 )),
                 MutableValueExpression::Source(SourceScalarExpression::new(
                     QueryLocation::new_fake(),
@@ -262,11 +245,8 @@ mod tests {
             "let var1 = 1;",
             TransformExpression::Set(SetTransformExpression::new(
                 QueryLocation::new_fake(),
-                ImmutableValueExpression::Scalar(ScalarExpression::Static(
-                    StaticScalarExpression::Integer(IntegerScalarExpression::new(
-                        QueryLocation::new_fake(),
-                        1,
-                    )),
+                ScalarExpression::Static(StaticScalarExpression::Integer(
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
                 )),
                 MutableValueExpression::Variable(VariableScalarExpression::new(
                     QueryLocation::new_fake(),

--- a/rust/experimental/query_engine/kql-parser/src/tabular_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/tabular_expressions.rs
@@ -935,11 +935,8 @@ mod tests {
             "extend new_attribute1 = 1",
             vec![TransformExpression::Set(SetTransformExpression::new(
                 QueryLocation::new_fake(),
-                ImmutableValueExpression::Scalar(ScalarExpression::Static(
-                    StaticScalarExpression::Integer(IntegerScalarExpression::new(
-                        QueryLocation::new_fake(),
-                        1,
-                    )),
+                ScalarExpression::Static(StaticScalarExpression::Integer(
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
                 )),
                 MutableValueExpression::Source(SourceScalarExpression::new(
                     QueryLocation::new_fake(),
@@ -961,12 +958,12 @@ mod tests {
             "extend const_str = const_str",
             vec![TransformExpression::Set(SetTransformExpression::new(
                 QueryLocation::new_fake(),
-                ImmutableValueExpression::Scalar(ScalarExpression::Constant(
-                    ConstantScalarExpression::Reference(ReferenceConstantScalarExpression::new(
+                ScalarExpression::Constant(ConstantScalarExpression::Reference(
+                    ReferenceConstantScalarExpression::new(
                         QueryLocation::new_fake(),
                         ValueType::String,
                         0,
-                    )),
+                    ),
                 )),
                 MutableValueExpression::Source(SourceScalarExpression::new(
                     QueryLocation::new_fake(),
@@ -985,11 +982,8 @@ mod tests {
             vec![
                 TransformExpression::Set(SetTransformExpression::new(
                     QueryLocation::new_fake(),
-                    ImmutableValueExpression::Scalar(ScalarExpression::Static(
-                        StaticScalarExpression::Integer(IntegerScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            1,
-                        )),
+                    ScalarExpression::Static(StaticScalarExpression::Integer(
+                        IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
                     )),
                     MutableValueExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -1003,11 +997,8 @@ mod tests {
                 )),
                 TransformExpression::Set(SetTransformExpression::new(
                     QueryLocation::new_fake(),
-                    ImmutableValueExpression::Scalar(ScalarExpression::Static(
-                        StaticScalarExpression::Integer(IntegerScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            2,
-                        )),
+                    ScalarExpression::Static(StaticScalarExpression::Integer(
+                        IntegerScalarExpression::new(QueryLocation::new_fake(), 2),
                     )),
                     MutableValueExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -1026,11 +1017,8 @@ mod tests {
             "extend body.nested[0] = 1",
             vec![TransformExpression::Set(SetTransformExpression::new(
                 QueryLocation::new_fake(),
-                ImmutableValueExpression::Scalar(ScalarExpression::Static(
-                    StaticScalarExpression::Integer(IntegerScalarExpression::new(
-                        QueryLocation::new_fake(),
-                        1,
-                    )),
+                ScalarExpression::Static(StaticScalarExpression::Integer(
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
                 )),
                 MutableValueExpression::Source(SourceScalarExpression::new(
                     QueryLocation::new_fake(),
@@ -1055,12 +1043,10 @@ mod tests {
             "extend variable = variable",
             vec![TransformExpression::Set(SetTransformExpression::new(
                 QueryLocation::new_fake(),
-                ImmutableValueExpression::Scalar(ScalarExpression::Variable(
-                    VariableScalarExpression::new(
-                        QueryLocation::new_fake(),
-                        StringScalarExpression::new(QueryLocation::new_fake(), "variable"),
-                        ValueAccessor::new(),
-                    ),
+                ScalarExpression::Variable(VariableScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    StringScalarExpression::new(QueryLocation::new_fake(), "variable"),
+                    ValueAccessor::new(),
                 )),
                 MutableValueExpression::Source(SourceScalarExpression::new(
                     QueryLocation::new_fake(),
@@ -1218,12 +1204,10 @@ mod tests {
             vec![
                 TransformExpression::Set(SetTransformExpression::new(
                     QueryLocation::new_fake(),
-                    ImmutableValueExpression::Scalar(ScalarExpression::Variable(
-                        VariableScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            StringScalarExpression::new(QueryLocation::new_fake(), "variable"),
-                            ValueAccessor::new(),
-                        ),
+                    ScalarExpression::Variable(VariableScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        StringScalarExpression::new(QueryLocation::new_fake(), "variable"),
+                        ValueAccessor::new(),
                     )),
                     MutableValueExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -1267,12 +1251,10 @@ mod tests {
             vec![
                 TransformExpression::Set(SetTransformExpression::new(
                     QueryLocation::new_fake(),
-                    ImmutableValueExpression::Scalar(ScalarExpression::Variable(
-                        VariableScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            StringScalarExpression::new(QueryLocation::new_fake(), "variable"),
-                            ValueAccessor::new(),
-                        ),
+                    ScalarExpression::Variable(VariableScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        StringScalarExpression::new(QueryLocation::new_fake(), "variable"),
+                        ValueAccessor::new(),
                     )),
                     MutableValueExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -1318,13 +1300,11 @@ mod tests {
             vec![
                 TransformExpression::Set(SetTransformExpression::new(
                     QueryLocation::new_fake(),
-                    ImmutableValueExpression::Scalar(ScalarExpression::Constant(
-                        ConstantScalarExpression::Reference(
-                            ReferenceConstantScalarExpression::new(
-                                QueryLocation::new_fake(),
-                                ValueType::String,
-                                0,
-                            ),
+                    ScalarExpression::Constant(ConstantScalarExpression::Reference(
+                        ReferenceConstantScalarExpression::new(
+                            QueryLocation::new_fake(),
+                            ValueType::String,
+                            0,
                         ),
                     )),
                     MutableValueExpression::Source(SourceScalarExpression::new(
@@ -1367,12 +1347,10 @@ mod tests {
             vec![
                 TransformExpression::Set(SetTransformExpression::new(
                     QueryLocation::new_fake(),
-                    ImmutableValueExpression::Scalar(ScalarExpression::Variable(
-                        VariableScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            StringScalarExpression::new(QueryLocation::new_fake(), "variable"),
-                            ValueAccessor::new(),
-                        ),
+                    ScalarExpression::Variable(VariableScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        StringScalarExpression::new(QueryLocation::new_fake(), "variable"),
+                        ValueAccessor::new(),
                     )),
                     MutableValueExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -1391,21 +1369,16 @@ mod tests {
                 )),
                 TransformExpression::Set(SetTransformExpression::new(
                     QueryLocation::new_fake(),
-                    ImmutableValueExpression::Scalar(ScalarExpression::Attached(
-                        AttachedScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            StringScalarExpression::new(QueryLocation::new_fake(), "resource"),
-                            ValueAccessor::new_with_selectors(vec![ScalarExpression::Variable(
-                                VariableScalarExpression::new(
-                                    QueryLocation::new_fake(),
-                                    StringScalarExpression::new(
-                                        QueryLocation::new_fake(),
-                                        "variable",
-                                    ),
-                                    ValueAccessor::new(),
-                                ),
-                            )]),
-                        ),
+                    ScalarExpression::Attached(AttachedScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        StringScalarExpression::new(QueryLocation::new_fake(), "resource"),
+                        ValueAccessor::new_with_selectors(vec![ScalarExpression::Variable(
+                            VariableScalarExpression::new(
+                                QueryLocation::new_fake(),
+                                StringScalarExpression::new(QueryLocation::new_fake(), "variable"),
+                                ValueAccessor::new(),
+                            ),
+                        )]),
                     )),
                     MutableValueExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -1499,11 +1472,8 @@ mod tests {
             vec![
                 TransformExpression::Set(SetTransformExpression::new(
                     QueryLocation::new_fake(),
-                    ImmutableValueExpression::Scalar(ScalarExpression::Static(
-                        StaticScalarExpression::String(StringScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            "hello world",
-                        )),
+                    ScalarExpression::Static(StaticScalarExpression::String(
+                        StringScalarExpression::new(QueryLocation::new_fake(), "hello world"),
                     )),
                     MutableValueExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -2468,11 +2438,8 @@ mod tests {
             .with_post_expressions(vec![DataExpression::Transform(
                 TransformExpression::Set(SetTransformExpression::new(
                     QueryLocation::new_fake(),
-                    ImmutableValueExpression::Scalar(ScalarExpression::Static(
-                        StaticScalarExpression::Integer(IntegerScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            1,
-                        )),
+                    ScalarExpression::Static(StaticScalarExpression::Integer(
+                        IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
                     )),
                     MutableValueExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -2657,11 +2624,8 @@ mod tests {
                 ),
                 DataExpression::Transform(TransformExpression::Set(SetTransformExpression::new(
                     QueryLocation::new_fake(),
-                    ImmutableValueExpression::Scalar(ScalarExpression::Static(
-                        StaticScalarExpression::Integer(IntegerScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            1,
-                        )),
+                    ScalarExpression::Static(StaticScalarExpression::Integer(
+                        IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
                     )),
                     MutableValueExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -2746,11 +2710,8 @@ mod tests {
             vec![DataExpression::Transform(TransformExpression::Set(
                 SetTransformExpression::new(
                     QueryLocation::new_fake(),
-                    ImmutableValueExpression::Scalar(ScalarExpression::Static(
-                        StaticScalarExpression::Integer(IntegerScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            1,
-                        )),
+                    ScalarExpression::Static(StaticScalarExpression::Integer(
+                        IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
                     )),
                     MutableValueExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -2787,11 +2748,8 @@ mod tests {
             vec![
                 DataExpression::Transform(TransformExpression::Set(SetTransformExpression::new(
                     QueryLocation::new_fake(),
-                    ImmutableValueExpression::Scalar(ScalarExpression::Static(
-                        StaticScalarExpression::Integer(IntegerScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            1,
-                        )),
+                    ScalarExpression::Static(StaticScalarExpression::Integer(
+                        IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
                     )),
                     MutableValueExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),


### PR DESCRIPTION
## Changes

* Removes `ImmutableValueExpression` in favor of just using `ScalarExpression` directly

## Details

I thought there might be other source of data but the way things worked out `ImmutableValueExpression` is really just some extra ceremony wrapping `ScalarExpression`.