### PR TITLE
[query-engine] Constant folding tweaks

### DIFF
--- a/rust/experimental/query_engine/expressions/src/logical_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/logical_expressions.rs
@@ -56,6 +56,17 @@ impl LogicalExpression {
             LogicalExpression::Contains(c) => c.try_resolve_static(scope),
             LogicalExpression::Matches(m) => m.try_resolve_static(scope),
         }? {
+            match s {
+                ResolvedStaticScalarExpression::FoldEligibleReference(r)
+                | ResolvedStaticScalarExpression::Reference(r) => {
+                    if let Value::Boolean(b) = r.to_value() {
+                        // Note: We don't fold a static which is already a valid bool.
+                        return Ok(Some(b.get_value()));
+                    }
+                }
+                _ => {}
+            }
+
             let value = s.to_value();
 
             if let Some(b) = value.convert_to_bool() {

--- a/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
@@ -144,7 +144,7 @@ impl ScalarExpression {
         unreachable!()
     }
 
-    pub(crate) fn try_resolve_static_inner<'a>(
+    fn try_resolve_static_inner<'a>(
         &'a mut self,
         scope: &PipelineResolutionScope<'a>,
     ) -> Result<Option<ResolvedStaticScalarExpression<'a>>, ExpressionError> {
@@ -161,7 +161,11 @@ impl ScalarExpression {
                 v.accessor.try_fold(scope)?;
                 Ok(None)
             }
-            ScalarExpression::Static(_) => unreachable!(),
+            ScalarExpression::Static(_) => {
+                // Note: Static resolution should be handled before the call to
+                // try_resolve_static_inner.
+                unreachable!()
+            }
             ScalarExpression::Constant(c) => Ok(Some(c.resolve_static(scope))),
             ScalarExpression::Collection(c) => c.try_resolve_static(scope),
             ScalarExpression::Logical(l) => match l.try_resolve_static(scope)? {

--- a/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
@@ -17,7 +17,7 @@ pub enum ScalarExpression {
     Attached(AttachedScalarExpression),
 
     /// A constant static value defined in a collection on [`PipelineExpression`].
-    Constant(ConstantScalarExpression),
+    Constant(ReferenceConstantScalarExpression),
 
     /// Returns one of many inner scalar expressions based on multiple logical conditions.
     Case(CaseScalarExpression),
@@ -102,6 +102,14 @@ impl ScalarExpression {
         &'a mut self,
         scope: &PipelineResolutionScope<'a>,
     ) -> Result<Option<ResolvedStaticScalarExpression<'a>>, ExpressionError> {
+        if let ScalarExpression::Static(s) = self {
+            return Ok(Some(if s.foldable() {
+                ResolvedStaticScalarExpression::FoldEligibleReference(s)
+            } else {
+                ResolvedStaticScalarExpression::Reference(s)
+            }));
+        }
+
         let computed = {
             // Note: The unsafe re-borrow here is to work around false positives
             // in the current iteration of the rust borrow checker:
@@ -117,16 +125,20 @@ impl ScalarExpression {
             match scalar.try_resolve_static_inner(scope)? {
                 None => return Ok(None),
                 Some(ResolvedStaticScalarExpression::Computed(c)) => c,
+                Some(ResolvedStaticScalarExpression::FoldEligibleReference(r)) => r.clone(),
                 Some(r) => return Ok(Some(r)),
             }
         };
 
+        // Note: We replace the scalar with the computed value so that the
+        // result gets folded into the expression tree.
         *self = ScalarExpression::Static(computed);
 
         if let ScalarExpression::Static(s) = self {
-            return Ok(Some(ResolvedStaticScalarExpression::FoldEligibleReference(
-                s,
-            )));
+            return Ok(Some(match s.foldable() {
+                true => ResolvedStaticScalarExpression::FoldEligibleReference(s),
+                false => ResolvedStaticScalarExpression::Reference(s),
+            }));
         }
 
         unreachable!()
@@ -149,15 +161,7 @@ impl ScalarExpression {
                 v.accessor.try_fold(scope)?;
                 Ok(None)
             }
-            ScalarExpression::Static(s) => {
-                if s.foldable() {
-                    Ok(Some(ResolvedStaticScalarExpression::FoldEligibleReference(
-                        s,
-                    )))
-                } else {
-                    Ok(Some(ResolvedStaticScalarExpression::Reference(s)))
-                }
-            }
+            ScalarExpression::Static(_) => unreachable!(),
             ScalarExpression::Constant(c) => Ok(Some(c.resolve_static(scope))),
             ScalarExpression::Collection(c) => c.try_resolve_static(scope),
             ScalarExpression::Logical(l) => match l.try_resolve_static(scope)? {
@@ -217,7 +221,7 @@ impl Expression for ScalarExpression {
             ScalarExpression::Coalesce(_) => "ScalarExpression(Coalesce)",
             ScalarExpression::Conditional(_) => "ScalarExpression(Conditional)",
             ScalarExpression::Case(_) => "ScalarExpression(Case)",
-            ScalarExpression::Constant(c) => c.get_name(),
+            ScalarExpression::Constant(_) => "ScalarExpression(Constant)",
             ScalarExpression::Convert(c) => c.get_name(),
             ScalarExpression::Length(_) => "ScalarExpression(Length)",
             ScalarExpression::Slice(_) => "ScalarExpression(Slice)",
@@ -357,96 +361,6 @@ impl Expression for VariableScalarExpression {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum ConstantScalarExpression {
-    /// A constant which is retrieved via a lookup to the collection maintained
-    /// on [`PipelineExpression`].
-    Reference(ReferenceConstantScalarExpression),
-
-    /// A constant which has been copied from the collection maintained on
-    /// [`PipelineExpression`] into a local expression.
-    Copy(CopyConstantScalarExpression),
-}
-
-impl ConstantScalarExpression {
-    pub(crate) fn get_value_type(&self) -> ValueType {
-        match self {
-            ConstantScalarExpression::Reference(r) => r.get_value_type(),
-            ConstantScalarExpression::Copy(c) => c.get_value().get_value_type(),
-        }
-    }
-
-    pub fn to_value<'a, 'b, 'c>(&'a self, pipeline: &'b PipelineExpression) -> Value<'c>
-    where
-        'a: 'c,
-        'b: 'c,
-    {
-        match self {
-            ConstantScalarExpression::Reference(r) => {
-                let constant_id = r.get_constant_id();
-
-                pipeline
-                    .get_constant(constant_id)
-                    .unwrap_or_else(|| {
-                        panic!("Constant for id '{constant_id}' was not found on pipeline")
-                    })
-                    .to_value()
-            }
-            ConstantScalarExpression::Copy(c) => c.value.to_value(),
-        }
-    }
-
-    pub(crate) fn resolve_static<'a>(
-        &'a mut self,
-        scope: &PipelineResolutionScope<'a>,
-    ) -> ResolvedStaticScalarExpression<'a> {
-        match self {
-            ConstantScalarExpression::Reference(r) => {
-                let constant_id = r.get_constant_id();
-
-                let value = scope.get_constant(constant_id).unwrap_or_else(|| {
-                    panic!("Constant for id '{constant_id}' was not found on pipeline")
-                });
-
-                match value.foldable() {
-                    true => {
-                        // Note: If we get a folded static we convert the
-                        // constant expression to a copy instead of a reference.
-                        // The effect this has is for small constants a copy is
-                        // made in the tree to bypass a lookup at runtime.
-                        *self = ConstantScalarExpression::Copy(CopyConstantScalarExpression::new(
-                            self.get_query_location().clone(),
-                            constant_id,
-                            value.clone(),
-                        ));
-                        ResolvedStaticScalarExpression::FoldEligibleReference(value)
-                    }
-                    false => ResolvedStaticScalarExpression::Reference(value),
-                }
-            }
-            ConstantScalarExpression::Copy(c) => {
-                ResolvedStaticScalarExpression::FoldEligibleReference(&c.value)
-            }
-        }
-    }
-}
-
-impl Expression for ConstantScalarExpression {
-    fn get_query_location(&self) -> &QueryLocation {
-        match self {
-            ConstantScalarExpression::Reference(r) => r.get_query_location(),
-            ConstantScalarExpression::Copy(c) => c.get_query_location(),
-        }
-    }
-
-    fn get_name(&self) -> &'static str {
-        match self {
-            ConstantScalarExpression::Reference(_) => "ConstantScalar(Reference)",
-            ConstantScalarExpression::Copy(_) => "ConstantScalar(Copy)",
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
 pub struct ReferenceConstantScalarExpression {
     query_location: QueryLocation,
     value_type: ValueType,
@@ -473,6 +387,34 @@ impl ReferenceConstantScalarExpression {
     pub fn get_constant_id(&self) -> usize {
         self.constant_id
     }
+
+    pub(crate) fn resolve_static<'a>(
+        &'a mut self,
+        scope: &PipelineResolutionScope<'a>,
+    ) -> ResolvedStaticScalarExpression<'a> {
+        let constant_id = self.get_constant_id();
+
+        let value = scope
+            .get_constant(constant_id)
+            .unwrap_or_else(|| panic!("Constant for id '{constant_id}' was not found on pipeline"));
+
+        match value.foldable() {
+            true => {
+                // Note: If we get a folded static we convert the
+                // constant expression to a copy instead of a reference.
+                // The effect this has is for small constants a copy is
+                // made in the tree to bypass a lookup at runtime.
+                ResolvedStaticScalarExpression::Computed(StaticScalarExpression::Constant(
+                    CopyConstantScalarExpression::new(
+                        self.get_query_location().clone(),
+                        constant_id,
+                        value.clone(),
+                    ),
+                ))
+            }
+            false => ResolvedStaticScalarExpression::Reference(value),
+        }
+    }
 }
 
 impl Expression for ReferenceConstantScalarExpression {
@@ -482,45 +424,6 @@ impl Expression for ReferenceConstantScalarExpression {
 
     fn get_name(&self) -> &'static str {
         "ReferenceConstantScalarExpression"
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct CopyConstantScalarExpression {
-    query_location: QueryLocation,
-    constant_id: usize,
-    value: StaticScalarExpression,
-}
-
-impl CopyConstantScalarExpression {
-    pub fn new(
-        query_location: QueryLocation,
-        constant_id: usize,
-        value: StaticScalarExpression,
-    ) -> CopyConstantScalarExpression {
-        Self {
-            query_location,
-            constant_id,
-            value,
-        }
-    }
-
-    pub fn get_constant_id(&self) -> usize {
-        self.constant_id
-    }
-
-    pub fn get_value(&self) -> &StaticScalarExpression {
-        &self.value
-    }
-}
-
-impl Expression for CopyConstantScalarExpression {
-    fn get_query_location(&self) -> &QueryLocation {
-        &self.query_location
-    }
-
-    fn get_name(&self) -> &'static str {
-        "CopyConstantScalarExpression"
     }
 }
 
@@ -1159,28 +1062,12 @@ mod tests {
         );
 
         run_test_success(
-            ScalarExpression::Constant(ConstantScalarExpression::Reference(
-                ReferenceConstantScalarExpression::new(
-                    QueryLocation::new_fake(),
-                    ValueType::String,
-                    0,
-                ),
+            ScalarExpression::Constant(ReferenceConstantScalarExpression::new(
+                QueryLocation::new_fake(),
+                ValueType::String,
+                0,
             )),
             Some(ValueType::String),
-        );
-
-        run_test_success(
-            ScalarExpression::Constant(ConstantScalarExpression::Copy(
-                CopyConstantScalarExpression::new(
-                    QueryLocation::new_fake(),
-                    0,
-                    StaticScalarExpression::Integer(IntegerScalarExpression::new(
-                        QueryLocation::new_fake(),
-                        1,
-                    )),
-                ),
-            )),
-            Some(ValueType::Integer),
         );
     }
 
@@ -1412,6 +1299,10 @@ mod tests {
                 pipeline.push_constant(StaticScalarExpression::String(
                     StringScalarExpression::new(QueryLocation::new_fake(), "hello world"),
                 ));
+                pipeline.push_constant(StaticScalarExpression::Array(ArrayScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    vec![],
+                )));
 
                 let actual = expression
                     .try_resolve_static(&pipeline.get_resolution_scope())
@@ -1492,22 +1383,14 @@ mod tests {
             )),
         );
 
+        // Note: Reference to constant string gets folded into a static in this test.
         run_test_success(
-            ScalarExpression::Constant(ConstantScalarExpression::Reference(
-                ReferenceConstantScalarExpression::new(
-                    QueryLocation::new_fake(),
-                    ValueType::String,
-                    0,
-                ),
-            )),
-            Some(StaticScalarExpression::String(StringScalarExpression::new(
+            ScalarExpression::Constant(ReferenceConstantScalarExpression::new(
                 QueryLocation::new_fake(),
-                "hello world",
-            ))),
-        );
-
-        run_test_success(
-            ScalarExpression::Constant(ConstantScalarExpression::Copy(
+                ValueType::String,
+                0,
+            )),
+            Some(StaticScalarExpression::Constant(
                 CopyConstantScalarExpression::new(
                     QueryLocation::new_fake(),
                     0,
@@ -1517,9 +1400,18 @@ mod tests {
                     )),
                 ),
             )),
-            Some(StaticScalarExpression::String(StringScalarExpression::new(
+        );
+
+        // Note: Reference to constant array does not get folded into a static in this test.
+        run_test_success(
+            ScalarExpression::Constant(ReferenceConstantScalarExpression::new(
                 QueryLocation::new_fake(),
-                "hello world",
+                ValueType::String,
+                1,
+            )),
+            Some(StaticScalarExpression::Array(ArrayScalarExpression::new(
+                QueryLocation::new_fake(),
+                vec![],
             ))),
         );
     }

--- a/rust/experimental/query_engine/expressions/src/scalars/statics/resolved_static_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/statics/resolved_static_scalar_expression.rs
@@ -5,22 +5,27 @@ use crate::*;
 
 #[derive(Debug)]
 pub enum ResolvedStaticScalarExpression<'a> {
-    Reference(&'a StaticScalarExpression),
+    /// A value computed by an expression.
     Computed(StaticScalarExpression),
+
+    /// A reference to a static or a constant which cannot be folded.
+    Reference(&'a StaticScalarExpression),
+
+    /// A reference to a static which may be folded.
     FoldEligibleReference(&'a StaticScalarExpression),
 }
 
 impl ResolvedStaticScalarExpression<'_> {
     pub fn try_fold(self) -> Option<StaticScalarExpression> {
         match self {
+            ResolvedStaticScalarExpression::Computed(c) => Some(c),
             ResolvedStaticScalarExpression::Reference(_) => {
                 // Note: Don't copy referenced statics because if they were
                 // foldable they would already have switched to values. For
                 // example the reference could be to a large constant array.
                 None
             }
-            ResolvedStaticScalarExpression::Computed(s) => Some(s),
-            ResolvedStaticScalarExpression::FoldEligibleReference(s) => Some(s.clone()),
+            ResolvedStaticScalarExpression::FoldEligibleReference(r) => Some(r.clone()),
         }
     }
 }
@@ -28,9 +33,9 @@ impl ResolvedStaticScalarExpression<'_> {
 impl AsStaticValue for ResolvedStaticScalarExpression<'_> {
     fn to_static_value(&self) -> StaticValue<'_> {
         match self {
-            ResolvedStaticScalarExpression::Reference(s) => s.to_static_value(),
-            ResolvedStaticScalarExpression::Computed(s) => s.to_static_value(),
-            ResolvedStaticScalarExpression::FoldEligibleReference(s) => s.to_static_value(),
+            ResolvedStaticScalarExpression::Computed(c) => c.to_static_value(),
+            ResolvedStaticScalarExpression::Reference(r) => r.to_static_value(),
+            ResolvedStaticScalarExpression::FoldEligibleReference(r) => r.to_static_value(),
         }
     }
 }
@@ -38,9 +43,9 @@ impl AsStaticValue for ResolvedStaticScalarExpression<'_> {
 impl AsRef<StaticScalarExpression> for ResolvedStaticScalarExpression<'_> {
     fn as_ref(&self) -> &StaticScalarExpression {
         match self {
-            ResolvedStaticScalarExpression::Reference(s) => s,
-            ResolvedStaticScalarExpression::Computed(s) => s,
-            ResolvedStaticScalarExpression::FoldEligibleReference(s) => s,
+            ResolvedStaticScalarExpression::Computed(c) => c,
+            ResolvedStaticScalarExpression::Reference(r) => r,
+            ResolvedStaticScalarExpression::FoldEligibleReference(r) => r,
         }
     }
 }

--- a/rust/experimental/query_engine/expressions/src/scalars/statics/static_scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/statics/static_scalar_expressions.rs
@@ -238,6 +238,11 @@ impl CopyConstantScalarExpression {
         constant_id: usize,
         value: StaticScalarExpression,
     ) -> CopyConstantScalarExpression {
+        // Note: It doesn't make sense for a constant to point to another
+        // constant so we validate this but if it does happen for some reason it
+        // shouldn't cause any problems.
+        debug_assert!(!matches!(value, StaticScalarExpression::Constant(_)));
+
         Self {
             query_location,
             constant_id,

--- a/rust/experimental/query_engine/expressions/src/scalars/statics/static_scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/statics/static_scalar_expressions.rs
@@ -16,6 +16,9 @@ pub enum StaticScalarExpression {
     /// Resolve a static bool value provided directly in a query.
     Boolean(BooleanScalarExpression),
 
+    /// Resolve a static value provided by a constant directly in a query.
+    Constant(CopyConstantScalarExpression),
+
     /// Resolve a static DateTime value provided directly in a query.
     DateTime(DateTimeScalarExpression),
 
@@ -49,6 +52,7 @@ impl StaticScalarExpression {
         match self {
             StaticScalarExpression::Array(_) => false,
             StaticScalarExpression::Boolean(_) => true,
+            StaticScalarExpression::Constant(_) => true,
             StaticScalarExpression::DateTime(_) => true,
             StaticScalarExpression::Double(_) => true,
             StaticScalarExpression::Integer(_) => true,
@@ -143,6 +147,7 @@ impl Expression for StaticScalarExpression {
         match self {
             StaticScalarExpression::Array(a) => a.get_query_location(),
             StaticScalarExpression::Boolean(b) => b.get_query_location(),
+            StaticScalarExpression::Constant(c) => c.get_query_location(),
             StaticScalarExpression::DateTime(d) => d.get_query_location(),
             StaticScalarExpression::Double(d) => d.get_query_location(),
             StaticScalarExpression::Integer(i) => i.get_query_location(),
@@ -158,6 +163,7 @@ impl Expression for StaticScalarExpression {
         match self {
             StaticScalarExpression::Array(_) => "StaticScalar(Array)",
             StaticScalarExpression::Boolean(_) => "StaticScalar(Boolean)",
+            StaticScalarExpression::Constant(_) => "StaticScalar(Constant)",
             StaticScalarExpression::DateTime(_) => "StaticScalar(DateTime)",
             StaticScalarExpression::Double(_) => "StaticScalar(Double)",
             StaticScalarExpression::Integer(_) => "StaticScalar(Integer)",
@@ -175,6 +181,7 @@ impl AsStaticValue for StaticScalarExpression {
         match self {
             StaticScalarExpression::Array(a) => StaticValue::Array(a),
             StaticScalarExpression::Boolean(b) => StaticValue::Boolean(b),
+            StaticScalarExpression::Constant(c) => c.get_value().to_static_value(),
             StaticScalarExpression::DateTime(d) => StaticValue::DateTime(d),
             StaticScalarExpression::Double(d) => StaticValue::Double(d),
             StaticScalarExpression::Integer(i) => StaticValue::Integer(i),
@@ -215,6 +222,45 @@ impl Expression for BooleanScalarExpression {
 impl BooleanValue for BooleanScalarExpression {
     fn get_value(&self) -> bool {
         self.value
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CopyConstantScalarExpression {
+    query_location: QueryLocation,
+    constant_id: usize,
+    value: Box<StaticScalarExpression>,
+}
+
+impl CopyConstantScalarExpression {
+    pub fn new(
+        query_location: QueryLocation,
+        constant_id: usize,
+        value: StaticScalarExpression,
+    ) -> CopyConstantScalarExpression {
+        Self {
+            query_location,
+            constant_id,
+            value: value.into(),
+        }
+    }
+
+    pub fn get_constant_id(&self) -> usize {
+        self.constant_id
+    }
+
+    pub fn get_value(&self) -> &StaticScalarExpression {
+        &self.value
+    }
+}
+
+impl Expression for CopyConstantScalarExpression {
+    fn get_query_location(&self) -> &QueryLocation {
+        &self.query_location
+    }
+
+    fn get_name(&self) -> &'static str {
+        "CopyConstantScalarExpression"
     }
 }
 

--- a/rust/experimental/query_engine/expressions/src/value_accessor.rs
+++ b/rust/experimental/query_engine/expressions/src/value_accessor.rs
@@ -60,13 +60,8 @@ impl ValueAccessor {
         &mut self,
         scope: &PipelineResolutionScope,
     ) -> Result<(), ExpressionError> {
-        let selectors = &mut self.selectors;
-        for selector in selectors {
-            if let Some(ResolvedStaticScalarExpression::Computed(s)) =
-                selector.try_resolve_static(scope)?
-            {
-                *selector = ScalarExpression::Static(s.clone());
-            }
+        for selector in &mut self.selectors {
+            selector.try_resolve_static(scope)?;
         }
         Ok(())
     }

--- a/rust/experimental/query_engine/kql-parser/src/logical_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/logical_expressions.rs
@@ -556,12 +556,10 @@ mod tests {
                         )),
                     )]),
                 )),
-                ScalarExpression::Constant(ConstantScalarExpression::Reference(
-                    ReferenceConstantScalarExpression::new(
-                        QueryLocation::new_fake(),
-                        ValueType::Regex,
-                        0,
-                    ),
+                ScalarExpression::Constant(ReferenceConstantScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    ValueType::Regex,
+                    0,
                 )),
             )),
         );

--- a/rust/experimental/query_engine/kql-parser/src/query_expression.rs
+++ b/rust/experimental/query_engine/kql-parser/src/query_expression.rs
@@ -167,6 +167,35 @@ mod tests {
                 .unwrap(),
         );
 
+        run_test_success(
+            "let a = 1; let b = a; let c = b;",
+            PipelineExpressionBuilder::new("let a = 1; let b = a; let c = b;")
+                .with_constants(vec![
+                    StaticScalarExpression::Integer(IntegerScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        1,
+                    )),
+                    StaticScalarExpression::Constant(CopyConstantScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        0,
+                        StaticScalarExpression::Integer(IntegerScalarExpression::new(
+                            QueryLocation::new_fake(),
+                            1,
+                        )),
+                    )),
+                    StaticScalarExpression::Constant(CopyConstantScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        1,
+                        StaticScalarExpression::Integer(IntegerScalarExpression::new(
+                            QueryLocation::new_fake(),
+                            1,
+                        )),
+                    )),
+                ])
+                .build()
+                .unwrap(),
+        );
+
         // Note: The let statement becomes an unreferenced folded constant so
         // the whole expression essentially becomes a no-op.
         run_test_success(

--- a/rust/experimental/query_engine/kql-parser/src/query_expression.rs
+++ b/rust/experimental/query_engine/kql-parser/src/query_expression.rs
@@ -239,12 +239,10 @@ mod tests {
             .with_expressions(vec![
                 DataExpression::Transform(TransformExpression::Set(SetTransformExpression::new(
                     QueryLocation::new_fake(),
-                    ScalarExpression::Constant(ConstantScalarExpression::Reference(
-                        ReferenceConstantScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            ValueType::Integer,
-                            0,
-                        ),
+                    ScalarExpression::Constant(ReferenceConstantScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        ValueType::Integer,
+                        0,
                     )),
                     MutableValueExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -270,12 +268,10 @@ mod tests {
                                     "attributes",
                                 ),
                             )),
-                            ScalarExpression::Constant(ConstantScalarExpression::Reference(
-                                ReferenceConstantScalarExpression::new(
-                                    QueryLocation::new_fake(),
-                                    ValueType::String,
-                                    1,
-                                ),
+                            ScalarExpression::Constant(ReferenceConstantScalarExpression::new(
+                                QueryLocation::new_fake(),
+                                ValueType::String,
+                                1,
                             )),
                         ]),
                     )),

--- a/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
@@ -436,11 +436,7 @@ pub(crate) fn parse_accessor_expression(
                 }
 
                 return Ok(ScalarExpression::Constant(
-                    ConstantScalarExpression::Reference(ReferenceConstantScalarExpression::new(
-                        query_location,
-                        value_type,
-                        constant_id,
-                    )),
+                    ReferenceConstantScalarExpression::new(query_location, value_type, constant_id),
                 ));
             }
         }
@@ -1604,23 +1600,19 @@ mod tests {
 
         run_test_success(
             "const_str",
-            ScalarExpression::Constant(ConstantScalarExpression::Reference(
-                ReferenceConstantScalarExpression::new(
-                    QueryLocation::new_fake(),
-                    ValueType::String,
-                    3,
-                ),
+            ScalarExpression::Constant(ReferenceConstantScalarExpression::new(
+                QueryLocation::new_fake(),
+                ValueType::String,
+                3,
             )),
         );
 
         run_test_success(
             "const_int",
-            ScalarExpression::Constant(ConstantScalarExpression::Reference(
-                ReferenceConstantScalarExpression::new(
-                    QueryLocation::new_fake(),
-                    ValueType::Integer,
-                    0,
-                ),
+            ScalarExpression::Constant(ReferenceConstantScalarExpression::new(
+                QueryLocation::new_fake(),
+                ValueType::Integer,
+                0,
             )),
         );
 
@@ -1631,19 +1623,15 @@ mod tests {
             ScalarExpression::Source(SourceScalarExpression::new(
                 QueryLocation::new_fake(),
                 ValueAccessor::new_with_selectors(vec![
-                    ScalarExpression::Constant(ConstantScalarExpression::Reference(
-                        ReferenceConstantScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            ValueType::String,
-                            3,
-                        ),
+                    ScalarExpression::Constant(ReferenceConstantScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        ValueType::String,
+                        3,
                     )),
-                    ScalarExpression::Constant(ConstantScalarExpression::Reference(
-                        ReferenceConstantScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            ValueType::Integer,
-                            0,
-                        ),
+                    ScalarExpression::Constant(ReferenceConstantScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        ValueType::Integer,
+                        0,
                     )),
                 ]),
             )),
@@ -1658,15 +1646,19 @@ mod tests {
                     ConditionalScalarExpression::new(
                         QueryLocation::new_fake(),
                         LogicalExpression::Scalar(ScalarExpression::Static(
-                            StaticScalarExpression::Boolean(BooleanScalarExpression::new(
+                            StaticScalarExpression::Constant(CopyConstantScalarExpression::new(
                                 QueryLocation::new_fake(),
-                                false,
+                                2,
+                                StaticScalarExpression::Boolean(BooleanScalarExpression::new(
+                                    QueryLocation::new_fake(),
+                                    false,
+                                )),
                             )),
                         )),
                         ScalarExpression::Static(StaticScalarExpression::String(
                             StringScalarExpression::new(QueryLocation::new_fake(), "a"),
                         )),
-                        ScalarExpression::Constant(ConstantScalarExpression::Copy(
+                        ScalarExpression::Static(StaticScalarExpression::Constant(
                             CopyConstantScalarExpression::new(
                                 QueryLocation::new_fake(),
                                 3,
@@ -1748,12 +1740,10 @@ mod tests {
                     ScalarExpression::Static(StaticScalarExpression::String(
                         StringScalarExpression::new(QueryLocation::new_fake(), "const_str"),
                     )),
-                    ScalarExpression::Constant(ConstantScalarExpression::Reference(
-                        ReferenceConstantScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            ValueType::String,
-                            0,
-                        ),
+                    ScalarExpression::Constant(ReferenceConstantScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        ValueType::String,
+                        0,
                     )),
                 ]),
             )),

--- a/rust/experimental/query_engine/kql-parser/src/tabular_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/tabular_expressions.rs
@@ -958,12 +958,10 @@ mod tests {
             "extend const_str = const_str",
             vec![TransformExpression::Set(SetTransformExpression::new(
                 QueryLocation::new_fake(),
-                ScalarExpression::Constant(ConstantScalarExpression::Reference(
-                    ReferenceConstantScalarExpression::new(
-                        QueryLocation::new_fake(),
-                        ValueType::String,
-                        0,
-                    ),
+                ScalarExpression::Constant(ReferenceConstantScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    ValueType::String,
+                    0,
                 )),
                 MutableValueExpression::Source(SourceScalarExpression::new(
                     QueryLocation::new_fake(),
@@ -1300,12 +1298,10 @@ mod tests {
             vec![
                 TransformExpression::Set(SetTransformExpression::new(
                     QueryLocation::new_fake(),
-                    ScalarExpression::Constant(ConstantScalarExpression::Reference(
-                        ReferenceConstantScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            ValueType::String,
-                            0,
-                        ),
+                    ScalarExpression::Constant(ReferenceConstantScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        ValueType::String,
+                        0,
                     )),
                     MutableValueExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -2494,7 +2490,7 @@ mod tests {
                                     "Attributes",
                                 ),
                             )),
-                            ScalarExpression::Constant(ConstantScalarExpression::Copy(
+                            ScalarExpression::Static(StaticScalarExpression::Constant(
                                 CopyConstantScalarExpression::new(
                                     QueryLocation::new_fake(),
                                     0,

--- a/rust/experimental/query_engine/parser-abstractions/src/parser_state.rs
+++ b/rust/experimental/query_engine/parser-abstractions/src/parser_state.rs
@@ -193,8 +193,7 @@ pub trait ParserScope {
     ) -> Option<&'a StaticScalarExpression> {
         match scalar {
             ScalarExpression::Static(v) => Some(v),
-            ScalarExpression::Constant(ConstantScalarExpression::Copy(v)) => Some(v.get_value()),
-            ScalarExpression::Constant(ConstantScalarExpression::Reference(v)) => Some(
+            ScalarExpression::Constant(v) => Some(
                 self.get_pipeline()
                     .get_constant(v.get_constant_id())
                     .expect("Constant not found"),


### PR DESCRIPTION
## Changes

* Moves folded/copied constant under `StaticScalarExpression`

## Details

Working towards automatically replacing expressions which are statically known with constant values. The way constants were defined previously we could have static values under `ScalarExpression:Static` or under `ScalarExpression::Constant(ConstantScalarExpression::Copy)`. For that to work resolution logic needs to handle\understand the special constant location everywhere which was proving to be very complex to build and likely difficult to maintain. To avoid all that complexity completely what this PR does is move folded/copied constants under the static tree so they are handled as any other static value.