### PR TITLE
[PerfTest] - add new hooks for df_engine as a loadgen/backend

### DIFF
--- a/tools/pipeline_perf_test/orchestrator/docs/plugins/README.md
+++ b/tools/pipeline_perf_test/orchestrator/docs/plugins/README.md
@@ -33,6 +33,7 @@ This directory contains auto-generated documentation for all plugin registries.
 | Type | Plugin Name | Module | Class | Config Class | Description |
 |------|-------------|--------|-------|--------------|-------------|
 | `pipeline_perf_loadgen` | `pipeline_perf_loadgen` | `lib.impl.strategies.execution.pipeline_perf_loadgen` | `PipelinePerfLoadgenExecution` | `PipelinePerfLoadgenConfig` | Execution strategy implementation for controlling the pipeline performance load generator |
+| `df_perf_wrapper` | `df_perf_wrapper` | `lib.impl.strategies.execution.df_perf_wrapper` | `DFPerfWrapperExecution` | `DFPerfWrapperConfig` | Execution strategy implementation for controlling the dataflow engine with perf exporter |
 
 ## Plugin Summary: `hook_strategies`
 
@@ -47,6 +48,10 @@ This directory contains auto-generated documentation for all plugin registries.
 | `raise_exception` | `raise_exception` | `lib.impl.strategies.hooks.raise_exception` | `RaiseExceptionHook` | `RaiseExceptionConfig` | Hook strategy that raises an exception |
 | `record_event` | `record_event` | `lib.impl.strategies.hooks.record_event` | `RecordEventHook` | `RecordEventConfig` | Hook strategy that records an event to the context's current span |
 | `run_command` | `run_command` | `lib.impl.strategies.hooks.run_command` | `RunCommandHook` | `RunCommandConfig` | Hook strategy that runs a specified shell command |
+| `send_http_request` | `send_http_request` | `lib.impl.strategies.hooks.send_http_request` | `SendHttpRequestHook` | `SendHttpRequestConfig` | Hook strategy that sends an HTTP request to a configured endpoint |
+| `ready_check_http` | `ready_check_http` | `lib.impl.strategies.hooks.ready_check_http` | `ReadyCheckHttpHook` | `ReadyCheckHttpConfig` | Hook strategy that performs a readiness check against an HTTP(S) endpoint |
+| `render_template` | `render_template` | `lib.impl.strategies.hooks.render_template` | `RenderTemplateHook` | `RenderTemplateConfig` | Hook strategy that renders a Jinja2 template using provided variables |
+| `ensure_process` | `ensure_process` | `lib.impl.strategies.hooks.process.ensure_process` | `EnsureProcess` | `EnsureProcessConfig` | Hook strategy to ensure component specified is running and hasn't crashed after start |
 
 ## Plugin Summary: `step_actions`
 
@@ -56,6 +61,7 @@ This directory contains auto-generated documentation for all plugin registries.
 | `multi_component_action` | `multi_component_action` | `lib.impl.actions.multi_component_action` | `MultiComponentAction` | `MultiComponentActionConfig` | Step action that executes a specified lifecycle phase on one or more components |
 | `wait` | `wait` | `lib.impl.actions.wait_action` | `WaitAction` | `WaitActionConfig` | Step action that introduces a delay during test execution |
 | `update_component_strategy` | `update_component_strategy` | `lib.impl.actions.update_component_strategy` | `UpdateComponentStrategyAction` | `UpdateComponentStrategyConfig` | Step action that applies updates to a strategy configuration of a managed component |
+| `no_op` | `no_op` | `lib.impl.actions.no_op_action` | `NoOpAction` | `NoOpActionConfig` | Abstract base class representing a test step action |
 
 ## Plugin Summary: `report_formatters`
 

--- a/tools/pipeline_perf_test/orchestrator/docs/plugins/README.md
+++ b/tools/pipeline_perf_test/orchestrator/docs/plugins/README.md
@@ -60,7 +60,7 @@ This directory contains auto-generated documentation for all plugin registries.
 | `multi_component_action` | `multi_component_action` | `lib.impl.actions.multi_component_action` | `MultiComponentAction` | `MultiComponentActionConfig` | Step action that executes a specified lifecycle phase on one or more components |
 | `wait` | `wait` | `lib.impl.actions.wait_action` | `WaitAction` | `WaitActionConfig` | Step action that introduces a delay during test execution |
 | `update_component_strategy` | `update_component_strategy` | `lib.impl.actions.update_component_strategy` | `UpdateComponentStrategyAction` | `UpdateComponentStrategyConfig` | Step action that applies updates to a strategy configuration of a managed component |
-| `no_op` | `no_op` | `lib.impl.actions.no_op_action` | `NoOpAction` | `NoOpActionConfig` | Abstract base class representing a test step action |
+| `no_op` | `no_op` | `lib.impl.actions.no_op_action` | `NoOpAction` | `NoOpActionConfig` | Step action that does nothing when execute is called |
 
 ## Plugin Summary: `report_formatters`
 

--- a/tools/pipeline_perf_test/orchestrator/docs/plugins/README.md
+++ b/tools/pipeline_perf_test/orchestrator/docs/plugins/README.md
@@ -33,7 +33,6 @@ This directory contains auto-generated documentation for all plugin registries.
 | Type | Plugin Name | Module | Class | Config Class | Description |
 |------|-------------|--------|-------|--------------|-------------|
 | `pipeline_perf_loadgen` | `pipeline_perf_loadgen` | `lib.impl.strategies.execution.pipeline_perf_loadgen` | `PipelinePerfLoadgenExecution` | `PipelinePerfLoadgenConfig` | Execution strategy implementation for controlling the pipeline performance load generator |
-| `df_perf_wrapper` | `df_perf_wrapper` | `lib.impl.strategies.execution.df_perf_wrapper` | `DFPerfWrapperExecution` | `DFPerfWrapperConfig` | Execution strategy implementation for controlling the dataflow engine with perf exporter |
 
 ## Plugin Summary: `hook_strategies`
 

--- a/tools/pipeline_perf_test/orchestrator/docs/plugins/deployment_strategies.md
+++ b/tools/pipeline_perf_test/orchestrator/docs/plugins/deployment_strategies.md
@@ -75,6 +75,10 @@ components:
 
 - StepContext
 
+**Installs Default Hooks:**
+
+- EnsureProcess
+
 **Description:**
 
 ```python

--- a/tools/pipeline_perf_test/orchestrator/docs/plugins/execution_strategies.md
+++ b/tools/pipeline_perf_test/orchestrator/docs/plugins/execution_strategies.md
@@ -5,6 +5,7 @@
 | Type Name | Module | Class | Config Class | Description Summary |
 |-----------|--------|-------|--------------|----------------------|
 | `pipeline_perf_loadgen` | `lib.impl.strategies.execution.pipeline_perf_loadgen` | `PipelinePerfLoadgenExecution` | `PipelinePerfLoadgenConfig` | Execution strategy implementation for controlling the pipeline performance load generator |
+| `df_perf_wrapper` | `lib.impl.strategies.execution.df_perf_wrapper` | `DFPerfWrapperExecution` | `DFPerfWrapperConfig` | Execution strategy implementation for controlling the dataflow engine with perf exporter |
 
 ---
 
@@ -49,8 +50,55 @@ components:
       pipeline_perf_loadgen:
         endpoint:  "http://localhost:5001/"
         threads: 1
+        target_rate: 10000
+        tcp_connection_per_thread: false
         body_size: 25
         num_attributes: 2
         attribute_value_size: 15
         batch_size: 10000
+        load_type: otlp
+```
+
+## `df_perf_wrapper`
+
+**Class**: `lib.impl.strategies.execution.df_perf_wrapper.DFPerfWrapperExecution`
+
+**Config Class**: `lib.impl.strategies.execution.df_perf_wrapper.DFPerfWrapperConfig`
+
+**Supported Contexts:**
+
+- StepContext
+
+**Description:**
+
+```python
+"""
+Execution strategy implementation for controlling the dataflow engine with perf exporter.
+
+This strategy starts and stops the engine by issuing HTTP POST requests
+to designated 'start' and 'stop' endpoints.
+
+Attributes:
+    type (ClassVar[Literal["df_perf_wrapper"]]): Identifier for this strategy.
+    config (DFPerfWrapperConfig): Configuration instance with load parameters.
+    default_hooks (dict): Placeholder for lifecycle hooks (empty by default).
+    start_endpoint (str): Fully qualified URL for starting the load generator.
+    stop_endpoint (str): Fully qualified URL for stopping the load generator.
+
+Methods:
+    start(component, ctx): Sends a POST request to start load generation with configured parameters.
+    stop(component, ctx): Sends a POST request to stop load generation.
+"""
+```
+
+**Example YAML:**
+
+```yaml
+components:
+  load-generator:
+    execution:
+      df_perf_wrapper:
+        endpoint:  "http://localhost:5001/"
+        num_cores: 1
+        pipeline: /home/dataflow/config/my_config.yaml
 ```

--- a/tools/pipeline_perf_test/orchestrator/docs/plugins/execution_strategies.md
+++ b/tools/pipeline_perf_test/orchestrator/docs/plugins/execution_strategies.md
@@ -5,7 +5,6 @@
 | Type Name | Module | Class | Config Class | Description Summary |
 |-----------|--------|-------|--------------|----------------------|
 | `pipeline_perf_loadgen` | `lib.impl.strategies.execution.pipeline_perf_loadgen` | `PipelinePerfLoadgenExecution` | `PipelinePerfLoadgenConfig` | Execution strategy implementation for controlling the pipeline performance load generator |
-| `df_perf_wrapper` | `lib.impl.strategies.execution.df_perf_wrapper` | `DFPerfWrapperExecution` | `DFPerfWrapperConfig` | Execution strategy implementation for controlling the dataflow engine with perf exporter |
 
 ---
 
@@ -57,48 +56,4 @@ components:
         attribute_value_size: 15
         batch_size: 10000
         load_type: otlp
-```
-
-## `df_perf_wrapper`
-
-**Class**: `lib.impl.strategies.execution.df_perf_wrapper.DFPerfWrapperExecution`
-
-**Config Class**: `lib.impl.strategies.execution.df_perf_wrapper.DFPerfWrapperConfig`
-
-**Supported Contexts:**
-
-- StepContext
-
-**Description:**
-
-```python
-"""
-Execution strategy implementation for controlling the dataflow engine with perf exporter.
-
-This strategy starts and stops the engine by issuing HTTP POST requests
-to designated 'start' and 'stop' endpoints.
-
-Attributes:
-    type (ClassVar[Literal["df_perf_wrapper"]]): Identifier for this strategy.
-    config (DFPerfWrapperConfig): Configuration instance with load parameters.
-    default_hooks (dict): Placeholder for lifecycle hooks (empty by default).
-    start_endpoint (str): Fully qualified URL for starting the load generator.
-    stop_endpoint (str): Fully qualified URL for stopping the load generator.
-
-Methods:
-    start(component, ctx): Sends a POST request to start load generation with configured parameters.
-    stop(component, ctx): Sends a POST request to stop load generation.
-"""
-```
-
-**Example YAML:**
-
-```yaml
-components:
-  load-generator:
-    execution:
-      df_perf_wrapper:
-        endpoint:  "http://localhost:5001/"
-        num_cores: 1
-        pipeline: /home/dataflow/config/my_config.yaml
 ```

--- a/tools/pipeline_perf_test/orchestrator/docs/plugins/step_actions.md
+++ b/tools/pipeline_perf_test/orchestrator/docs/plugins/step_actions.md
@@ -8,7 +8,7 @@
 | `multi_component_action` | `lib.impl.actions.multi_component_action` | `MultiComponentAction` | `MultiComponentActionConfig` | Step action that executes a specified lifecycle phase on one or more components |
 | `wait` | `lib.impl.actions.wait_action` | `WaitAction` | `WaitActionConfig` | Step action that introduces a delay during test execution |
 | `update_component_strategy` | `lib.impl.actions.update_component_strategy` | `UpdateComponentStrategyAction` | `UpdateComponentStrategyConfig` | Step action that applies updates to a strategy configuration of a managed component |
-| `no_op` | `lib.impl.actions.no_op_action` | `NoOpAction` | `NoOpActionConfig` | Abstract base class representing a test step action |
+| `no_op` | `lib.impl.actions.no_op_action` | `NoOpAction` | `NoOpActionConfig` | Step action that does nothing when execute is called |
 
 ---
 
@@ -180,14 +180,7 @@ tests:
 
 ```python
 """
-Abstract base class representing a test step action.
-
-This class defines the interface for all test step actions that can be
-performed in a testing framework. Each action must be initialized with
-a configuration object and must implement an execution method that takes
-the current test step context.
-
-Subclasses are required to implement the __init__ and execute methods.
+Step action that does nothing when execute is called.
 """
 ```
 

--- a/tools/pipeline_perf_test/orchestrator/docs/plugins/step_actions.md
+++ b/tools/pipeline_perf_test/orchestrator/docs/plugins/step_actions.md
@@ -8,6 +8,7 @@
 | `multi_component_action` | `lib.impl.actions.multi_component_action` | `MultiComponentAction` | `MultiComponentActionConfig` | Step action that executes a specified lifecycle phase on one or more components |
 | `wait` | `lib.impl.actions.wait_action` | `WaitAction` | `WaitActionConfig` | Step action that introduces a delay during test execution |
 | `update_component_strategy` | `lib.impl.actions.update_component_strategy` | `UpdateComponentStrategyAction` | `UpdateComponentStrategyConfig` | Step action that applies updates to a strategy configuration of a managed component |
+| `no_op` | `lib.impl.actions.no_op_action` | `NoOpAction` | `NoOpActionConfig` | Abstract base class representing a test step action |
 
 ---
 
@@ -163,4 +164,40 @@ tests:
               docker:
                 volumes:
                   - ./configs/test_batch_sizes/component_configs/collector-config-batch-10k.yaml:/etc/otel/collector-config.yaml:ro
+```
+
+## `no_op`
+
+**Class**: `lib.impl.actions.no_op_action.NoOpAction`
+
+**Config Class**: `lib.impl.actions.no_op_action.NoOpActionConfig`
+
+**Supported Contexts:**
+
+- StepContext
+
+**Description:**
+
+```python
+"""
+Abstract base class representing a test step action.
+
+This class defines the interface for all test step actions that can be
+performed in a testing framework. Each action must be initialized with
+a configuration object and must implement an execution method that takes
+the current test step context.
+
+Subclasses are required to implement the __init__ and execute methods.
+"""
+```
+
+**Example YAML:**
+
+```yaml
+tests:
+  - name: Test Placeholder Step
+    steps:
+      - name: Do Nothing Step
+        action:
+          no_op: {}
 ```

--- a/tools/pipeline_perf_test/orchestrator/docs/reports/sql_report.md
+++ b/tools/pipeline_perf_test/orchestrator/docs/reports/sql_report.md
@@ -1,0 +1,80 @@
+# Report Plugin: sql_report
+
+**Class**: `lib.impl.strategies.hooks.reporting.sql_report.SQLReportHook`
+
+**Config Class**: `lib.impl.strategies.hooks.reporting.sql_report.SQLReportConfig`
+
+**Supported Contexts:**
+
+- FrameworkElementHookContext
+
+**Description:**
+
+```python
+"""
+Base class for reporting hooks that generate and persist structured reports.
+
+This abstract strategy defines a consistent workflow for generating reports from
+execution context data and sending them through any configured report pipelines.
+
+Subclasses must implement `_execute(ctx) -> Report`, which defines the logic for
+generating the report based on the context.
+
+Lifecycle:
+    1. `_execute` is called to produce a `Report` object.
+    2. All configured pipelines from the hook config are executed on the report.
+    3. The report is saved to the suite's `ReportRuntime` under its name.
+
+Attributes:
+    config (StandardReportingHookStrategyConfig): Configuration object containing metadata
+        and any registered pipelines.
+    pipelines (List[ReportingPipeline]): Pipelines that process or export the report after creation.
+
+Methods:
+    _execute(ctx: BaseContext) -> Report:
+        Abstract method that must be implemented by subclasses to define report generation logic.
+
+    execute(ctx: BaseContext):
+        Executes the full report generation lifecycle, including pipeline execution and persistence.
+
+Raises:
+    NotImplementedError: If `_execute` is not implemented in a subclass.
+"""
+```
+
+**Example YAML:**
+
+```yaml
+hooks:
+  run:
+    post:
+      - sql_report:
+          name: PerfReprort - OTLP
+          report_config:
+            load_tables:
+                foo_table:
+                    path:
+                    format:
+            queries:
+            - name: "aggregate_metrics"
+                sql: |
+            result_tables:
+                - foo
+                - bar
+            write_tables:
+                foo_table:
+                    path:
+                    format:
+          # OR report_config_file: ./report_configs/whatever.yaml
+          output:
+            - format:
+                template: {}
+              destination:
+                console: {}
+```
+
+## Supported Aggregations
+
+*None.*
+
+## Sample Outputs

--- a/tools/pipeline_perf_test/orchestrator/lib/impl/actions/__init__.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/impl/actions/__init__.py
@@ -2,3 +2,4 @@ from . import component_action
 from . import multi_component_action
 from . import wait_action
 from . import update_component_strategy
+from . import no_op_action

--- a/tools/pipeline_perf_test/orchestrator/lib/impl/actions/no_op_action.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/impl/actions/no_op_action.py
@@ -8,11 +8,19 @@ ACTION_NAME = "no_op"
 
 @step_action_registry.register_config(ACTION_NAME)
 class NoOpActionConfig(StepActionConfig):
+    """
+    Configuration class for the No Op action.
+    """
+
     pass
 
 
 @step_action_registry.register_class(ACTION_NAME)
 class NoOpAction(StepAction):
+    """
+    Step action that does nothing when execute is called.
+    """
+
     PLUGIN_META = PluginMeta(
         supported_contexts=[StepContext.__name__],
         installs_hooks=[],

--- a/tools/pipeline_perf_test/orchestrator/lib/impl/actions/no_op_action.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/impl/actions/no_op_action.py
@@ -1,0 +1,33 @@
+from ...core.context import StepContext
+from ...core.framework.step import StepActionConfig, StepAction
+from ...runner.registry import step_action_registry, PluginMeta
+
+
+ACTION_NAME = "no_op"
+
+
+@step_action_registry.register_config(ACTION_NAME)
+class NoOpActionConfig(StepActionConfig):
+    pass
+
+
+@step_action_registry.register_class(ACTION_NAME)
+class NoOpAction(StepAction):
+    PLUGIN_META = PluginMeta(
+        supported_contexts=[StepContext.__name__],
+        installs_hooks=[],
+        yaml_example="""
+tests:
+  - name: Test Placeholder Step
+    steps:
+      - name: Do Nothing Step
+        action:
+          no_op: {}
+""",
+    )
+
+    def __init__(self, config: NoOpActionConfig):
+        self.config = config
+
+    def execute(self, _ctx: StepContext):
+        pass

--- a/tools/pipeline_perf_test/orchestrator/lib/impl/strategies/common/process.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/impl/strategies/common/process.py
@@ -1,4 +1,3 @@
-
 import subprocess
 from typing import ClassVar, Literal, Optional, Union
 

--- a/tools/pipeline_perf_test/orchestrator/lib/impl/strategies/deployment/process.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/impl/strategies/deployment/process.py
@@ -24,6 +24,7 @@ components:
         command: python -m ./load_generator/loadgen.py --serve
         environment: {}
 """
+
 import os
 import shlex
 import subprocess
@@ -99,9 +100,7 @@ components:
         """Initialize the strategy and specify default hooks to register."""
         self.config = config
         self.default_component_hooks = {
-            HookableComponentPhase.POST_DEPLOY: [
-                EnsureProcess(EnsureProcessConfig())
-            ]
+            HookableComponentPhase.POST_DEPLOY: [EnsureProcess(EnsureProcessConfig())]
         }
         self.stop_event = None
 

--- a/tools/pipeline_perf_test/orchestrator/lib/impl/strategies/hooks/__init__.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/impl/strategies/hooks/__init__.py
@@ -5,3 +5,6 @@ from .reporting import *
 from .raise_exception import RaiseExceptionConfig, RaiseExceptionHook
 from .record_event import RecordEventConfig, RecordEventHook
 from .run_command import RunCommandConfig, RunCommandHook
+from .send_http_request import SendHttpRequestConfig, SendHttpRequestHook
+from .ready_check_http import ReadyCheckHttpConfig, ReadyCheckHttpHook
+from .render_template import RenderTemplateConfig, RenderTemplateHook

--- a/tools/pipeline_perf_test/orchestrator/lib/impl/strategies/hooks/docker/network.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/impl/strategies/hooks/docker/network.py
@@ -236,7 +236,7 @@ components:
             ctx.status = ExecutionStatus.FAILURE
             ctx.error = f"Docker network '{network_name}' not found."
         except APIError as e:
-            if "active endpoints" in e.strerror:
+            if not e.strerror or "active endpoints" in e.strerror:
                 ctx.status = ExecutionStatus.SKIPPED
                 return
             logger.error(f"Error removing Docker network: {e}")

--- a/tools/pipeline_perf_test/orchestrator/lib/impl/strategies/hooks/ready_check_http.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/impl/strategies/hooks/ready_check_http.py
@@ -1,0 +1,168 @@
+import time
+from typing import Optional, Union
+
+import requests
+
+from ....core.context.base import BaseContext
+from ....core.context import ComponentHookContext, FrameworkElementHookContext
+from ....runner.registry import hook_registry, PluginMeta
+
+from .send_http_request import SendHttpRequestConfig, SendHttpRequestHook
+
+
+HOOK_NAME = "ready_check_http"
+
+
+@hook_registry.register_config(HOOK_NAME)
+class ReadyCheckHttpConfig(SendHttpRequestConfig):
+    """
+    Configuration class for the 'ready_check_http' hook.
+
+    Extends SendHttpRequestConfig to support readiness polling behavior.
+    This configuration allows repeated HTTP requests to a target endpoint
+    until specific success criteria are met, or a retry limit is reached.
+
+    Attributes:
+        max_retries (int, optional): The maximum number of attempts to check readiness.
+            Default is 10.
+        retry_interval (float, optional): Delay in seconds between each retry attempt.
+            Default is 1.0.
+        expected_status (int, optional): Optional expected HTTP status code.
+            If set, the response must return this status to be considered ready.
+        expected_json_field (str, optional): A top-level JSON field name to check in the response body.
+        expected_json_value (str|int|bool|float, optional): The value expected for the JSON field.
+            Both `expected_json_field` and `expected_json_value` must be set to enable this check.
+        expected_text_substring (str, optional): A plain text substring that must be present
+            in the response body for the check to pass.
+
+    Notes:
+        If multiple conditions are set (e.g., status code and body checks),
+        all must pass for the readiness check to succeed.
+    """
+
+    max_retries: Optional[int] = 10
+    retry_interval: Optional[float] = 1.0
+    expected_status: Optional[int] = None
+    # Optional body checks
+    expected_json_field: Optional[str] = None
+    expected_json_value: Optional[Union[str, int, bool, float]] = None
+    expected_text_substring: Optional[str] = None
+
+
+@hook_registry.register_class(HOOK_NAME)
+class ReadyCheckHttpHook(SendHttpRequestHook):
+    """
+    Hook strategy that performs a readiness check against an HTTP(S) endpoint.
+
+    This hook repeatedly sends an HTTP request to a target endpoint to verify its availability.
+    The readiness check passes if all configured conditions are met, such as:
+    - Expected HTTP status code
+    - Presence of a specific field/value in the JSON body
+    - Presence of a text substring in the response body
+
+    It is useful for polling service health endpoints before executing test steps or deployments.
+
+    Configuration is inherited from SendHttpRequestConfig and extended in ReadyCheckHttpConfig.
+    """
+
+    PLUGIN_META = PluginMeta(
+        supported_contexts=[
+            FrameworkElementHookContext.__name__,
+            ComponentHookContext.__name__,
+        ],
+        installs_hooks=[],
+        yaml_example="""
+tests:
+  - name: Wait for service readiness
+    steps:
+      - name: Ensure API is ready
+        hooks:
+          run:
+            pre:
+              - ready_check_http:
+                  url: https://api.example.com/health
+                  method: GET
+                  payload: {}
+                  headers: {}
+                  expected_status: 200
+                  expected_json_field: status
+                  expected_json_value: ready
+                  max_retries: 5
+                  retry_interval: 2
+""",
+    )
+
+    def execute(self, ctx: BaseContext):
+        """
+        Send the health check HTTP requests using the requests module.
+
+        Args:
+            ctx (BaseContext): The execution context, providing utilities like logging.
+
+        Raises:
+            RuntimeError: If requests fail in excess of max retries.
+        """
+
+        logger = ctx.get_logger(__name__)
+        logger.debug("Starting ready check HTTP hook...")
+
+        for attempt in range(1, self.config.max_retries + 1):
+            try:
+                response = requests.request(
+                    method=self.config.method.upper(),
+                    url=self.config.url,
+                    headers=self.config.headers,
+                    json=self.config.payload,
+                    timeout=self.config.timeout,
+                )
+
+                logger.debug(
+                    f"Attempt {attempt}: Received status {response.status_code}"
+                )
+
+                # --- Check expected status ---
+                if self.config.expected_status is not None:
+                    if response.status_code != self.config.expected_status:
+                        logger.debug(
+                            f"Expected status {self.config.expected_status}, "
+                            f"but got {response.status_code}"
+                        )
+                        continue
+
+                # --- Check JSON field & value ---
+                if (
+                    self.config.expected_json_field
+                    and self.config.expected_json_value is not None
+                ):
+                    try:
+                        json_data = response.json()
+                        actual_value = json_data.get(self.config.expected_json_field)
+                        if actual_value != self.config.expected_json_value:
+                            logger.debug(
+                                f"JSON field '{self.config.expected_json_field}' "
+                                f"was '{actual_value}', expected '{self.config.expected_json_value}'"
+                            )
+                            continue
+                    except Exception as e:
+                        logger.debug(f"Failed to parse JSON or match field: {e}")
+                        continue
+
+                # --- Check text substring ---
+                if self.config.expected_text_substring:
+                    if self.config.expected_text_substring not in response.text:
+                        logger.debug(
+                            f"Text '{self.config.expected_text_substring}' not found in response body"
+                        )
+                        continue
+
+                # If no expected conditions were set, pass on success status or assume success
+                logger.info(f"Ready check passed on attempt {attempt}")
+                return
+
+            except requests.RequestException as e:
+                logger.debug(f"Attempt {attempt} failed with exception: {e}")
+
+            if attempt < self.config.max_retries:
+                time.sleep(self.config.retry_interval)
+
+        raise RuntimeError("Ready check failed: conditions not satisfied in time.")

--- a/tools/pipeline_perf_test/orchestrator/lib/impl/strategies/hooks/render_template.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/impl/strategies/hooks/render_template.py
@@ -1,0 +1,128 @@
+"""
+Hook strategy module for rendering Jinja2 templates.
+
+This module defines the `render_template` hook, which renders a Jinja2 template
+from a specified source file to a destination file using provided variables.
+
+Classes:
+    - RenderTemplateConfig: Configuration schema for the template rendering.
+    - RenderTemplateHook: Hook strategy that performs the Jinja2 template rendering.
+
+Use case:
+    Useful for generating config files, scripts, or data files during the test
+    lifecycle using dynamic data and templates.
+"""
+
+from ....core.strategies.hook_strategy import HookStrategy, HookStrategyConfig
+from ....core.context.base import BaseContext
+from ....core.context import ComponentHookContext, FrameworkElementHookContext
+from ....runner.registry import hook_registry, PluginMeta
+from typing import Dict
+from jinja2 import Environment, FileSystemLoader, TemplateError
+import os
+
+HOOK_NAME = "render_template"
+
+
+@hook_registry.register_config(HOOK_NAME)
+class RenderTemplateConfig(HookStrategyConfig):
+    """
+    Configuration class for the 'render_template' hook.
+
+    Attributes:
+        template_path (str): Path to the Jinja2 template file.
+        output_path (str): Path where the rendered file should be written.
+        variables (Dict[str, Any]): Key-value pairs to use in rendering the template.
+    """
+
+    template_path: str
+    output_path: str
+    variables: Dict[str, str]
+
+
+@hook_registry.register_class(HOOK_NAME)
+class RenderTemplateHook(HookStrategy):
+    """
+    Hook strategy that renders a Jinja2 template using provided variables.
+
+    This class is responsible for loading the template file, rendering it with
+    the given variables, and saving the result to the output file.
+    """
+
+    PLUGIN_META = PluginMeta(
+        supported_contexts=[
+            FrameworkElementHookContext.__name__,
+            ComponentHookContext.__name__,
+        ],
+        installs_hooks=[],
+        yaml_example="""
+tests:
+  - name: Test Config Generator
+    steps:
+      - name: Setup with Template
+        action:
+          noop: {}
+        hooks:
+          run:
+            pre:
+              - render_template:
+                  template_path: templates/config.j2
+                  output_path: /tmp/generated_config.yaml
+                  variables:
+                    env: staging
+                    retries: "5"
+""",
+    )
+
+    def __init__(self, config: RenderTemplateConfig):
+        """
+        Initialize the hook with its configuration.
+
+        Args:
+            config (RenderTemplateConfig): Configuration object with template path,
+                                           output path, and variable dictionary.
+        """
+        self.config = config
+
+    def execute(self, ctx: BaseContext):
+        """
+        Render the template and write it to the output path.
+
+        Args:
+            ctx (BaseContext): Execution context providing utilities like logging.
+
+        Raises:
+            FileNotFoundError: If the template file does not exist.
+            TemplateError: If rendering fails due to template syntax or logic.
+        """
+        logger = ctx.get_logger(__name__)
+
+        template_path = self.config.template_path
+        output_path = self.config.output_path
+        variables = self.config.variables
+
+        template_dir = os.path.dirname(template_path)
+        template_file = os.path.basename(template_path)
+
+        logger.debug(f"Loading template: {template_file} from {template_dir}")
+        logger.debug(f"Rendering with variables: {variables}")
+        logger.debug(f"Output will be written to: {output_path}")
+
+        try:
+            env = Environment(loader=FileSystemLoader(template_dir))
+            template = env.get_template(template_file)
+            rendered = template.render(variables)
+
+            os.makedirs(os.path.dirname(output_path), exist_ok=True)
+
+            with open(output_path, "w") as f:
+                f.write(rendered)
+
+            logger.info(f"Rendered template saved to {output_path}")
+
+        except FileNotFoundError as e:
+            logger.error(f"Template file not found: {e}")
+            raise
+        except TemplateError as e:
+            logger.error(f"Template rendering failed: {e}")
+            raise

--- a/tools/pipeline_perf_test/orchestrator/lib/impl/strategies/hooks/send_http_request.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/impl/strategies/hooks/send_http_request.py
@@ -1,0 +1,132 @@
+"""
+Hook strategy module for sending HTTP(S) requests.
+
+This module defines the `send_http_request` hook, which enables HTTP requests
+to be triggered during a test's lifecycle. It can be used to notify external
+systems, trigger APIs, or integrate with web services at specific hook phases.
+
+Classes:
+    - SendHttpRequestConfig: Configuration schema specifying HTTP method, URL, headers, and payload.
+    - SendHttpRequestHook: Hook strategy that sends the configured HTTP request when invoked.
+
+Use case:
+    Useful for sending notifications, logging to external systems, or triggering RESTful actions
+    as part of a test or deployment pipeline.
+
+Warnings:
+    This hook performs external network operations. Ensure that endpoint URLs and request
+    content are trusted and secure, particularly in public or production environments.
+"""
+
+from typing import Optional
+
+import requests
+
+from ....core.strategies.hook_strategy import HookStrategy, HookStrategyConfig
+from ....core.context.base import BaseContext
+from ....core.context import ComponentHookContext, FrameworkElementHookContext
+from ....runner.registry import hook_registry, PluginMeta
+
+
+HOOK_NAME = "send_http_request"
+
+
+@hook_registry.register_config(HOOK_NAME)
+class SendHttpRequestConfig(HookStrategyConfig):
+    """
+    Configuration class for the 'send_http_request' hook.
+
+    Attributes:
+        url (str): The full URL to send the HTTP request to.
+        method (str): HTTP method (GET, POST, PUT, DELETE, etc.).
+        headers (dict, optional): Optional headers to include in the request.
+        payload (dict, optional): Optional JSON payload for methods like POST or PUT.
+        timeout (int, optional): Request timeout in seconds (default: 10).
+        raise_for_status (bool, optional): Raise an exception if status is not ok (default: true).
+    """
+
+    url: str
+    method: Optional[str]
+    headers: Optional[dict] = None
+    payload: Optional[dict] = None
+    timeout: Optional[int] = 10
+    raise_for_status: Optional[bool] = True
+
+
+@hook_registry.register_class(HOOK_NAME)
+class SendHttpRequestHook(HookStrategy):
+    """
+    Hook strategy that sends an HTTP request to a configured endpoint.
+
+    This class performs an HTTP operation using the provided configuration when invoked.
+    """
+
+    PLUGIN_META = PluginMeta(
+        supported_contexts=[
+            FrameworkElementHookContext.__name__,
+            ComponentHookContext.__name__,
+        ],
+        installs_hooks=[],
+        yaml_example="""
+tests:
+  - name: Notify external system
+    steps:
+      - name: Post to webhook before step
+        action:
+          wait:
+            delay_seconds: 5
+        hooks:
+          run:
+            pre:
+              - send_http_request:
+                  url: https://example.com/webhook
+                  method: POST
+                  headers:
+                    Content-Type: application/json
+                    Authorization: Bearer abc123
+                  payload:
+                    event: start
+                    step: initialize
+""",
+    )
+
+    def __init__(self, config: SendHttpRequestConfig):
+        """
+        Initialize the hook with its configuration.
+
+        Args:
+            config (SendHttpRequestConfig): HTTP request configuration.
+        """
+        self.config = config
+
+    def execute(self, ctx: BaseContext):
+        """
+        Send the HTTP request using the requests module.
+
+        Args:
+            ctx (BaseContext): The execution context, providing utilities like logging.
+
+        Raises:
+            requests.RequestException: If the HTTP request fails.
+        """
+
+        logger = ctx.get_logger(__name__)
+        logger.debug(
+            f"Preparing HTTP {self.config.method} request to {self.config.url}"
+        )
+
+        try:
+            response = requests.request(
+                method=self.config.method.upper(),
+                url=self.config.url,
+                headers=self.config.headers,
+                json=self.config.payload,
+                timeout=self.config.timeout,
+            )
+            logger.debug(f"HTTP response {response.text}")
+            if self.config.raise_for_status:
+                response.raise_for_status()
+            logger.debug(f"HTTP request complete: {response.status_code}")
+        except requests.RequestException as e:
+            logger.error(f"HTTP request failed: {e}")
+            raise

--- a/tools/pipeline_perf_test/orchestrator/tests/impl/actions/test_component_action.py
+++ b/tools/pipeline_perf_test/orchestrator/tests/impl/actions/test_component_action.py
@@ -1,0 +1,91 @@
+import pytest
+import types
+from unittest.mock import MagicMock
+
+from lib.core.component import Component, ComponentPhase
+from lib.core.context import StepContext
+from lib.core.framework.step import StepAction
+from lib.impl.actions.component_action import (
+    ComponentAction,
+    ComponentActionConfig,
+    ACTION_NAME,
+)
+from lib.runner.registry import step_action_registry
+
+
+def test_component_action_is_registered():
+    # Confirm action and config are registered
+    assert ACTION_NAME in step_action_registry.element
+    assert ACTION_NAME in step_action_registry.config
+
+    assert step_action_registry.element[ACTION_NAME] is ComponentAction
+    assert step_action_registry.config[ACTION_NAME] is ComponentActionConfig
+
+
+def test_component_action_instantiation():
+    config = ComponentActionConfig(target="load-generator", phase=ComponentPhase.START)
+    action = ComponentAction(config)
+    assert isinstance(action, StepAction)
+    assert action.config.target == "load-generator"
+    assert action.config.phase == ComponentPhase.START
+
+
+def test_component_action_execute_calls_phase_method():
+    # Dummy method with tracking
+    def dummy_start(self, ctx):
+        dummy_start.called = True
+        dummy_start.called_with = ctx
+
+    dummy_start.called = False
+    dummy_start.called_with = None
+
+    # Component with real method (not a mock)
+    mock_component = MagicMock(spec=Component)
+    mock_component.start = types.MethodType(dummy_start, mock_component)
+
+    # Context
+    mock_ctx = MagicMock(spec=StepContext)
+    mock_ctx.get_component_by_name.return_value = mock_component
+
+    config = ComponentActionConfig(target="load-generator", phase=ComponentPhase.START)
+    action = ComponentAction(config)
+
+    action.execute(mock_ctx)
+
+    # Assertions
+    assert dummy_start.called is True
+    assert dummy_start.called_with == mock_ctx
+    mock_ctx.set_step_component.assert_called_once_with(mock_component)
+
+
+def test_component_action_raises_if_component_missing_method():
+    mock_component = MagicMock(spec=Component)
+    # Explicitly ensure it doesn't have a 'stop' attribute
+    if hasattr(mock_component, "stop"):
+        delattr(mock_component, "stop")
+
+    mock_ctx = MagicMock(spec=StepContext)
+    mock_ctx.get_component_by_name.return_value = mock_component
+
+    config = ComponentActionConfig(target="foo", phase=ComponentPhase.STOP)
+    action = ComponentAction(config)
+
+    with pytest.raises(ValueError, match="does not have action stop"):
+        action.execute(mock_ctx)
+
+
+def test_component_action_raises_if_component_invalid():
+    # Component is not of type Component
+    mock_ctx = MagicMock(spec=StepContext)
+    mock_ctx.get_component_by_name.return_value = object()  # Invalid type
+
+    config = ComponentActionConfig(target="foo", phase=ComponentPhase.START)
+    action = ComponentAction(config)
+
+    with pytest.raises(AssertionError, match="Expected Component not found"):
+        action.execute(mock_ctx)
+
+
+def test_component_action_plugin_meta():
+    assert ComponentAction.PLUGIN_META.yaml_example
+    assert StepContext.__name__ in ComponentAction.PLUGIN_META.supported_contexts

--- a/tools/pipeline_perf_test/orchestrator/tests/impl/actions/test_multi_component_action.py
+++ b/tools/pipeline_perf_test/orchestrator/tests/impl/actions/test_multi_component_action.py
@@ -1,0 +1,126 @@
+import types
+import pytest
+from unittest.mock import MagicMock
+
+from lib.core.component import Component, ComponentPhase
+from lib.core.context import StepContext
+from lib.core.framework.step import StepAction
+from lib.impl.actions.multi_component_action import (
+    ACTION_NAME,
+    MultiComponentAction,
+    MultiComponentActionConfig,
+)
+from lib.runner.registry import step_action_registry
+
+
+def test_multi_component_action_is_registered():
+    assert ACTION_NAME in step_action_registry.element
+    assert ACTION_NAME in step_action_registry.config
+    assert step_action_registry.element[ACTION_NAME] is MultiComponentAction
+    assert step_action_registry.config[ACTION_NAME] is MultiComponentActionConfig
+
+
+def test_multi_component_action_instantiation():
+    config = MultiComponentActionConfig(phase=ComponentPhase.START, targets=["comp1"])
+    action = MultiComponentAction(config)
+    assert isinstance(action, StepAction)
+    assert action.config.targets == ["comp1"]
+    assert action.config.phase == ComponentPhase.START
+
+
+def test_execute_with_specified_targets_calls_correct_methods():
+    # Dummy lifecycle method with tracking
+    def start(self, ctx):
+        start.called[self.name] = ctx
+
+    start.called = {}
+
+    comp1 = MagicMock(spec=Component)
+    comp1.name = "comp1"
+    comp1.start = types.MethodType(start, comp1)
+
+    comp2 = MagicMock(spec=Component)
+    comp2.name = "comp2"
+    comp2.start = types.MethodType(start, comp2)
+
+    # Context returns these components by name
+    mock_ctx = MagicMock(spec=StepContext)
+    mock_ctx.get_component_by_name.side_effect = lambda name: {
+        "comp1": comp1,
+        "comp2": comp2,
+    }[name]
+
+    config = MultiComponentActionConfig(
+        phase=ComponentPhase.START, targets=["comp1", "comp2"]
+    )
+    action = MultiComponentAction(config)
+
+    action.execute(mock_ctx)
+
+    assert start.called["comp1"] == mock_ctx
+    assert start.called["comp2"] == mock_ctx
+
+    mock_ctx.set_step_component.assert_any_call(comp1)
+    mock_ctx.set_step_component.assert_any_call(comp2)
+
+
+def test_execute_with_all_components_calls_correct_methods():
+    # Dummy method
+    def start(self, ctx):
+        start.called[self.name] = ctx
+
+    start.called = {}
+
+    comp1 = MagicMock(spec=Component)
+    comp1.name = "comp1"
+    comp1.start = types.MethodType(start, comp1)
+
+    comp2 = MagicMock(spec=Component)
+    comp2.name = "comp2"
+    comp2.start = types.MethodType(start, comp2)
+
+    # Context provides all components
+    mock_ctx = MagicMock(spec=StepContext)
+    mock_ctx.get_components.return_value = {"comp1": comp1, "comp2": comp2}
+
+    config = MultiComponentActionConfig(phase=ComponentPhase.START, targets=None)
+    action = MultiComponentAction(config)
+    action.execute(mock_ctx)
+
+    assert start.called["comp1"] == mock_ctx
+    assert start.called["comp2"] == mock_ctx
+
+
+def test_execute_raises_if_component_missing_method():
+    comp = MagicMock(spec=Component)
+    comp.name = "comp1"
+    # Ensure 'stop' is not defined
+    if hasattr(comp, "stop"):
+        delattr(comp, "stop")
+
+    mock_ctx = MagicMock(spec=StepContext)
+    mock_ctx.get_component_by_name.return_value = comp
+
+    config = MultiComponentActionConfig(phase=ComponentPhase.STOP, targets=["comp1"])
+    action = MultiComponentAction(config)
+
+    with pytest.raises(ValueError, match="does not have action stop"):
+        action.execute(mock_ctx)
+
+
+def test_execute_raises_if_target_not_a_component():
+    mock_ctx = MagicMock(spec=StepContext)
+    mock_ctx.get_component_by_name.return_value = object()  # Not a Component
+
+    config = MultiComponentActionConfig(
+        phase=ComponentPhase.START, targets=["bad-comp"]
+    )
+    action = MultiComponentAction(config)
+
+    with pytest.raises(AssertionError, match="Expected Component not found"):
+        action.execute(mock_ctx)
+
+
+def test_multi_component_action_plugin_meta():
+    assert MultiComponentAction.PLUGIN_META.yaml_example
+    assert StepContext.__name__ in MultiComponentAction.PLUGIN_META.supported_contexts

--- a/tools/pipeline_perf_test/orchestrator/tests/impl/actions/test_noop_action.py
+++ b/tools/pipeline_perf_test/orchestrator/tests/impl/actions/test_noop_action.py
@@ -1,0 +1,39 @@
+import pytest
+from unittest.mock import MagicMock
+
+from lib.core.context import StepContext
+from lib.core.framework.step import StepAction
+from lib.impl.actions.no_op_action import NoOpAction, NoOpActionConfig, ACTION_NAME
+from lib.runner.registry import step_action_registry
+
+
+def test_noop_action_is_registered():
+    # Ensure the NoOpAction and its config are registered correctly
+    assert ACTION_NAME in step_action_registry.element
+    assert ACTION_NAME in step_action_registry.config
+
+    assert step_action_registry.element[ACTION_NAME] is NoOpAction
+    assert step_action_registry.config[ACTION_NAME] is NoOpActionConfig
+
+
+def test_noop_action_instantiation():
+    # Ensure NoOpAction can be instantiated without error
+    config = NoOpActionConfig()
+    action = NoOpAction(config)
+    assert isinstance(action, StepAction)
+    assert action.config == config
+
+
+def test_noop_action_execute_does_nothing():
+    # Execute the action and assert no exceptions or side effects
+    config = NoOpActionConfig()
+    action = NoOpAction(config)
+
+    mock_ctx = MagicMock(spec=StepContext)
+    action.execute(mock_ctx)  # Should not raise or return anything
+
+
+def test_noop_action_plugin_meta():
+    # Validate the metadata structure is intact
+    assert NoOpAction.PLUGIN_META.yaml_example
+    assert StepContext.__name__ in NoOpAction.PLUGIN_META.supported_contexts

--- a/tools/pipeline_perf_test/orchestrator/tests/impl/actions/test_update_component_strategy.py
+++ b/tools/pipeline_perf_test/orchestrator/tests/impl/actions/test_update_component_strategy.py
@@ -1,0 +1,157 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from pydantic import BaseModel
+
+from lib.core.context import StepContext
+from lib.core.framework.step import StepAction
+from lib.impl.actions.update_component_strategy import (
+    UpdateComponentStrategyAction,
+    UpdateComponentStrategyConfig,
+    update_model,
+    ACTION_NAME,
+)
+from lib.runner.registry import step_action_registry
+from lib.impl.component.managed_component import ManagedComponent
+from lib.runner.wrappers import ConfigurableWrapper
+
+
+def test_update_component_strategy_is_registered():
+    # Ensure action and config are registered
+    assert ACTION_NAME in step_action_registry.element
+    assert ACTION_NAME in step_action_registry.config
+
+    assert step_action_registry.element[ACTION_NAME] is UpdateComponentStrategyAction
+    assert step_action_registry.config[ACTION_NAME] is UpdateComponentStrategyConfig
+
+
+def test_update_component_strategy_instantiation():
+    config = UpdateComponentStrategyConfig(
+        target="my-component", deployment={"docker": {"image": "my/image"}}
+    )
+    action = UpdateComponentStrategyAction(config)
+    assert isinstance(action, StepAction)
+    assert action.config.target == "my-component"
+
+
+def make_mock_wrapper(config_dict):
+    config = MagicMock()
+    config.model_copy.return_value = config  # simulate Pydantic's copy/update
+    wrapper = MagicMock(spec=ConfigurableWrapper)
+    wrapper.config = config
+    wrapper.model_copy.return_value = wrapper
+    wrapper.element_type = list(config_dict.keys())[0]
+    return wrapper
+
+
+@patch("lib.impl.actions.update_component_strategy.CompositeMonitoringStrategy")
+def test_update_component_strategy_execute_success(mock_monitoring_strategy):
+    # Create mock component with strategy wrappers
+    mock_component = MagicMock(spec=ManagedComponent)
+    mock_config = MagicMock()
+
+    deployment_wrapper = make_mock_wrapper({"docker": {"image": "new"}})
+    monitoring_wrapper = make_mock_wrapper({"composite": {"enabled": True}})
+    execution_wrapper = make_mock_wrapper({"shell": {"cmd": "run"}})
+    configuration_wrapper = make_mock_wrapper({"config": {"opt": "val"}})
+
+    mock_config.deployment = deployment_wrapper
+    mock_config.monitoring = monitoring_wrapper
+    mock_config.execution = execution_wrapper
+    mock_config.configuration = configuration_wrapper
+
+    mock_component.component_config = mock_config
+    mock_component.replace_strategy.return_value = True
+
+    # Mock context
+    mock_ctx = MagicMock(spec=StepContext)
+    mock_ctx.get_component_by_name.return_value = mock_component
+
+    config = UpdateComponentStrategyConfig(
+        target="otel-collector",
+        deployment={"docker": {"image": "new"}},
+        monitoring={"composite": {"enabled": True}},
+        execution={"shell": {"cmd": "run"}},
+        configuration={"config": {"opt": "val"}},
+    )
+
+    action = UpdateComponentStrategyAction(config)
+    action.execute(mock_ctx)
+
+    # Assert replace_strategy was called multiple times
+    assert mock_component.replace_strategy.call_count >= 1
+    mock_ctx.set_step_component.assert_called_once_with(mock_component)
+
+
+def test_update_component_strategy_raises_on_invalid_component():
+    mock_ctx = MagicMock(spec=StepContext)
+    mock_ctx.get_component_by_name.return_value = None  # Simulate missing component
+
+    config = UpdateComponentStrategyConfig(target="missing")
+    action = UpdateComponentStrategyAction(config)
+
+    with pytest.raises(AssertionError):
+        action.execute(mock_ctx)
+
+
+def test_update_component_strategy_raises_on_no_strategy_updated():
+    # Setup mock component
+    mock_component = MagicMock(spec=ManagedComponent)
+    mock_config = MagicMock()
+
+    deployment_wrapper = make_mock_wrapper({"docker": {"image": "fake"}})
+    mock_config.deployment = deployment_wrapper
+
+    mock_component.component_config = mock_config
+    mock_component.replace_strategy.return_value = False  # Simulate failure
+
+    mock_ctx = MagicMock(spec=StepContext)
+    mock_ctx.get_component_by_name.return_value = mock_component
+
+    config = UpdateComponentStrategyConfig(
+        target="otel-collector", deployment={"docker": {"image": "fake"}}
+    )
+
+    action = UpdateComponentStrategyAction(config)
+
+    with pytest.raises(RuntimeError, match="Failed to update component"):
+        action.execute(mock_ctx)
+
+
+def test_update_model_merges_config():
+    # Step 1: Mock inner config (Pydantic model)
+    mock_inner_config = MagicMock(spec=BaseModel)
+    mock_inner_config.model_copy.return_value = "updated_inner_config"
+
+    # Step 2: Mock ConfigurableWrapper with element_type and config
+    mock_wrapper = MagicMock(spec=ConfigurableWrapper)
+    mock_wrapper.config = mock_inner_config
+    mock_wrapper.element_type = "dummy"
+    mock_wrapper.model_copy.return_value = "updated_wrapper"
+
+    # Step 3: Mock the overall model holding the wrapper
+    model = MagicMock()
+    model.model_copy.return_value = "updated_model"
+    setattr(model, "dummy", mock_wrapper)
+
+    # Step 4: Construct update dict
+    update_dict = {"dummy": {"dummy": {"x": 42}}}
+
+    result = update_model(model, update_dict)
+
+    # Verify correct calls
+    mock_inner_config.model_copy.assert_called_once_with(update={"x": 42})
+    mock_wrapper.model_copy.assert_called_once_with(
+        update={"config": "updated_inner_config"}
+    )
+    model.model_copy.assert_called_once_with(update={"dummy": "updated_wrapper"})
+
+    assert result == "updated_model"
+
+
+def test_update_component_strategy_plugin_meta():
+    assert UpdateComponentStrategyAction.PLUGIN_META.yaml_example
+    assert (
+        StepContext.__name__
+        in UpdateComponentStrategyAction.PLUGIN_META.supported_contexts
+    )

--- a/tools/pipeline_perf_test/orchestrator/tests/impl/actions/test_wait_action.py
+++ b/tools/pipeline_perf_test/orchestrator/tests/impl/actions/test_wait_action.py
@@ -1,0 +1,42 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from lib.core.context import StepContext
+from lib.core.framework.step import StepAction
+from lib.impl.actions.wait_action import WaitAction, WaitActionConfig, ACTION_NAME
+from lib.runner.registry import step_action_registry
+
+
+def test_wait_action_is_registered():
+    # Ensure the WaitAction and its config are registered correctly
+    assert ACTION_NAME in step_action_registry.element
+    assert ACTION_NAME in step_action_registry.config
+
+    assert step_action_registry.element[ACTION_NAME] is WaitAction
+    assert step_action_registry.config[ACTION_NAME] is WaitActionConfig
+
+
+def test_wait_action_instantiation():
+    # Ensure WaitAction can be instantiated with a config
+    config = WaitActionConfig(delay_seconds=1.5)
+    action = WaitAction(config)
+    assert isinstance(action, StepAction)
+    assert action.config.delay_seconds == 1.5
+
+
+@patch("lib.impl.actions.wait_action.time.sleep", autospec=True)
+def test_wait_action_execute_calls_sleep(mock_sleep):
+    # Ensure that time.sleep is called with the correct delay
+    config = WaitActionConfig(delay_seconds=2.0)
+    action = WaitAction(config)
+
+    mock_ctx = MagicMock(spec=StepContext)
+    action.execute(mock_ctx)
+
+    mock_sleep.assert_called_once_with(2.0)
+
+
+def test_wait_action_plugin_meta():
+    # Validate the metadata structure is intact
+    assert WaitAction.PLUGIN_META.yaml_example
+    assert StepContext.__name__ in WaitAction.PLUGIN_META.supported_contexts

--- a/tools/pipeline_perf_test/orchestrator/tests/impl/strategies/hooks/test_ready_check_http.py
+++ b/tools/pipeline_perf_test/orchestrator/tests/impl/strategies/hooks/test_ready_check_http.py
@@ -1,0 +1,151 @@
+import pytest
+from unittest.mock import Mock, patch
+
+from lib.impl.strategies.hooks.ready_check_http import (
+    ReadyCheckHttpHook,
+    ReadyCheckHttpConfig,
+)
+
+from lib.core.context.base import BaseContext
+
+
+class DummyContext(BaseContext):
+    def get_logger(self, name=None):
+        import logging
+
+        logging.basicConfig(level=logging.DEBUG)
+        return logging.getLogger(name or __name__)
+
+
+@pytest.fixture
+def base_config():
+    return {"url": "https://example.com/health", "method": "GET", "timeout": 1}
+
+
+@patch("lib.impl.strategies.hooks.ready_check_http.requests.request")
+def test_success_on_first_try(mock_request, base_config):
+    mock_response = Mock(status_code=200, text="OK")
+    mock_request.return_value = mock_response
+
+    config = ReadyCheckHttpConfig(expected_status=200, **base_config)
+    hook = ReadyCheckHttpHook(config)
+
+    hook.execute(DummyContext())
+    mock_request.assert_called_once()
+
+
+@patch("lib.impl.strategies.hooks.ready_check_http.requests.request")
+def test_eventual_success_after_retries(mock_request, base_config):
+    fail_response = Mock(status_code=503, text="Unavailable")
+    success_response = Mock(status_code=200, text="OK")
+    mock_request.side_effect = [fail_response, fail_response, success_response]
+
+    config = ReadyCheckHttpConfig(
+        expected_status=200, max_retries=5, retry_interval=0.01, **base_config
+    )
+    hook = ReadyCheckHttpHook(config)
+
+    hook.execute(DummyContext())
+    assert mock_request.call_count == 3
+
+
+@patch("lib.impl.strategies.hooks.ready_check_http.requests.request")
+def test_failure_after_max_retries(mock_request, base_config):
+    mock_request.return_value = Mock(status_code=503)
+
+    config = ReadyCheckHttpConfig(
+        expected_status=200, max_retries=3, retry_interval=0.01, **base_config
+    )
+    hook = ReadyCheckHttpHook(config)
+
+    with pytest.raises(RuntimeError, match="Ready check failed"):
+        hook.execute(DummyContext())
+
+    assert mock_request.call_count == 3
+
+
+@patch("lib.impl.strategies.hooks.ready_check_http.requests.request")
+def test_json_field_value_match_success(mock_request, base_config):
+    mock_response = Mock(status_code=200)
+    mock_response.json.return_value = {"status": "ready"}
+    mock_request.return_value = mock_response
+
+    config = ReadyCheckHttpConfig(
+        expected_status=200,
+        expected_json_field="status",
+        expected_json_value="ready",
+        **base_config
+    )
+    hook = ReadyCheckHttpHook(config)
+    hook.execute(DummyContext())
+
+
+@patch("lib.impl.strategies.hooks.ready_check_http.requests.request")
+def test_json_field_value_mismatch(mock_request, base_config):
+    mock_response = Mock(status_code=200)
+    mock_response.json.return_value = {"status": "starting"}
+    mock_request.return_value = mock_response
+
+    config = ReadyCheckHttpConfig(
+        expected_status=200,
+        expected_json_field="status",
+        expected_json_value="ready",
+        max_retries=2,
+        retry_interval=0.01,
+        **base_config
+    )
+    hook = ReadyCheckHttpHook(config)
+    with pytest.raises(RuntimeError):
+        hook.execute(DummyContext())
+
+
+@patch("lib.impl.strategies.hooks.ready_check_http.requests.request")
+def test_text_substring_match(mock_request, base_config):
+    mock_response = Mock(status_code=200, text="Service is ready")
+    mock_response.json.return_value = {}
+    mock_request.return_value = mock_response
+
+    config = ReadyCheckHttpConfig(
+        expected_status=200, expected_text_substring="ready", **base_config
+    )
+    hook = ReadyCheckHttpHook(config)
+    hook.execute(DummyContext())
+
+
+@patch("lib.impl.strategies.hooks.ready_check_http.requests.request")
+def test_invalid_json_does_not_crash(mock_request, base_config):
+    mock_response = Mock(status_code=200, text="Not JSON")
+    mock_response.json.side_effect = ValueError("Invalid JSON")
+    mock_request.return_value = mock_response
+
+    config = ReadyCheckHttpConfig(
+        expected_status=200,
+        expected_json_field="status",
+        expected_json_value="ready",
+        max_retries=2,
+        retry_interval=0.01,
+        **base_config
+    )
+    hook = ReadyCheckHttpHook(config)
+    with pytest.raises(RuntimeError):
+        hook.execute(DummyContext())
+
+
+@patch("lib.impl.strategies.hooks.ready_check_http.requests.request")
+def test_all_conditions_must_pass(mock_request, base_config):
+    mock_response = Mock(status_code=200, text="Healthy")
+    mock_response.json.return_value = {"status": "not-ready"}
+    mock_request.return_value = mock_response
+
+    config = ReadyCheckHttpConfig(
+        expected_status=200,
+        expected_json_field="status",
+        expected_json_value="ready",
+        expected_text_substring="Healthy",
+        max_retries=2,
+        retry_interval=0.01,
+        **base_config
+    )
+    hook = ReadyCheckHttpHook(config)
+    with pytest.raises(RuntimeError):
+        hook.execute(DummyContext())

--- a/tools/pipeline_perf_test/orchestrator/tests/impl/strategies/hooks/test_render_template.py
+++ b/tools/pipeline_perf_test/orchestrator/tests/impl/strategies/hooks/test_render_template.py
@@ -1,0 +1,94 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from jinja2 import TemplateError, exceptions
+
+from lib.impl.strategies.hooks.render_template import (
+    RenderTemplateHook,
+    RenderTemplateConfig,
+)
+
+
+def test_render_template_hook_successful_render(tmp_path):
+    # Setup paths
+    template_content = "Hello, {{ name }}!"
+    template_path = tmp_path / "template.j2"
+    output_path = tmp_path / "output.txt"
+
+    # Create a template file
+    template_path.write_text(template_content)
+
+    # Config with variables
+    config = RenderTemplateConfig(
+        template_path=str(template_path),
+        output_path=str(output_path),
+        variables={"name": "World"},
+    )
+    hook = RenderTemplateHook(config=config)
+
+    # Mock context
+    mock_ctx = MagicMock()
+    mock_logger = MagicMock()
+    mock_ctx.get_logger.return_value = mock_logger
+
+    # Execute
+    hook.execute(mock_ctx)
+
+    # Assert file written with rendered content
+    assert output_path.read_text() == "Hello, World!"
+
+    # Logger checks
+    mock_logger.debug.assert_any_call(
+        f"Loading template: {template_path.name} from {template_path.parent}"
+    )
+    mock_logger.debug.assert_any_call(f"Rendering with variables: {config.variables}")
+    mock_logger.info.assert_called_once_with(
+        f"Rendered template saved to {str(output_path)}"
+    )
+
+
+def test_render_template_hook_template_not_found():
+    # Config pointing to a nonexistent template file
+    config = RenderTemplateConfig(
+        template_path="/nonexistent/template.j2",
+        output_path="/tmp/output.txt",
+        variables={"foo": "bar"},
+    )
+    hook = RenderTemplateHook(config=config)
+
+    # Mock context
+    mock_ctx = MagicMock()
+    mock_logger = MagicMock()
+    mock_ctx.get_logger.return_value = mock_logger
+
+    with pytest.raises(exceptions.TemplateNotFound):
+        hook.execute(mock_ctx)
+
+    mock_logger.error.assert_called()
+
+
+@patch("jinja2.Environment.get_template")
+def test_render_template_hook_rendering_error(mock_get_template):
+    # Setup: simulate Jinja2 template rendering error
+    mock_template = MagicMock()
+    mock_template.render.side_effect = TemplateError("Rendering failed")
+    mock_get_template.return_value = mock_template
+
+    config = RenderTemplateConfig(
+        template_path="/fake/path/template.j2",
+        output_path="/fake/output.txt",
+        variables={"foo": "bar"},
+    )
+    hook = RenderTemplateHook(config=config)
+
+    mock_ctx = MagicMock()
+    mock_logger = MagicMock()
+    mock_ctx.get_logger.return_value = mock_logger
+
+    with pytest.raises(TemplateError, match="Rendering failed"):
+        hook.execute(mock_ctx)
+
+    mock_logger.error.assert_called()
+    assert any(
+        "Template rendering failed" in call[0][0]
+        for call in mock_logger.error.call_args_list
+    )

--- a/tools/pipeline_perf_test/orchestrator/tests/impl/strategies/hooks/test_send_http_request.py
+++ b/tools/pipeline_perf_test/orchestrator/tests/impl/strategies/hooks/test_send_http_request.py
@@ -1,0 +1,109 @@
+import pytest
+from unittest.mock import patch, Mock
+
+from lib.impl.strategies.hooks.send_http_request import (
+    SendHttpRequestHook,
+    SendHttpRequestConfig,
+)
+from lib.core.context.base import BaseContext
+
+
+class DummyContext(BaseContext):
+    def get_logger(self, name=None):
+        import logging
+
+        logging.basicConfig(level=logging.DEBUG)
+        return logging.getLogger(name or __name__)
+
+
+@pytest.fixture
+def base_config():
+    return {
+        "url": "https://example.com/notify",
+        "method": "POST",
+        "headers": {"Content-Type": "application/json"},
+        "payload": {"event": "start"},
+        "timeout": 5,
+        "raise_for_status": True,
+    }
+
+
+@patch("lib.impl.strategies.hooks.send_http_request.requests.request")
+def test_successful_request(mock_request, base_config):
+    mock_response = Mock(status_code=200, text="Success")
+    mock_request.return_value = mock_response
+
+    config = SendHttpRequestConfig(**base_config)
+    hook = SendHttpRequestHook(config)
+
+    hook.execute(DummyContext())
+    mock_request.assert_called_once_with(
+        method="POST",
+        url="https://example.com/notify",
+        headers={"Content-Type": "application/json"},
+        json={"event": "start"},
+        timeout=5,
+    )
+
+
+@patch("lib.impl.strategies.hooks.send_http_request.requests.request")
+def test_request_without_headers_or_payload(mock_request):
+    mock_response = Mock(status_code=204, text="")
+    mock_request.return_value = mock_response
+
+    config = SendHttpRequestConfig(
+        url="https://example.com/ping",
+        method="GET",
+        timeout=3,
+    )
+    hook = SendHttpRequestHook(config)
+
+    hook.execute(DummyContext())
+
+    mock_request.assert_called_once_with(
+        method="GET",
+        url="https://example.com/ping",
+        headers=None,
+        json=None,
+        timeout=3,
+    )
+
+
+@patch("lib.impl.strategies.hooks.send_http_request.requests.request")
+def test_raises_on_http_error(mock_request, base_config):
+    mock_response = Mock(status_code=500, text="Internal Server Error")
+    mock_response.raise_for_status.side_effect = Exception("500 Server Error")
+    mock_request.return_value = mock_response
+
+    config = SendHttpRequestConfig(**base_config)
+    hook = SendHttpRequestHook(config)
+
+    with pytest.raises(Exception, match="500 Server Error"):
+        hook.execute(DummyContext())
+
+
+@patch("lib.impl.strategies.hooks.send_http_request.requests.request")
+def test_does_not_raise_when_turned_off(mock_request, base_config):
+    mock_response = Mock(status_code=500, text="Internal Server Error")
+    mock_response.raise_for_status.side_effect = Exception("Should not raise")
+    mock_request.return_value = mock_response
+
+    base_config["raise_for_status"] = False
+    config = SendHttpRequestConfig(**base_config)
+    hook = SendHttpRequestHook(config)
+
+    # Should NOT raise
+    hook.execute(DummyContext())
+
+
+@patch("lib.impl.strategies.hooks.send_http_request.requests.request")
+def test_network_error(mock_request, base_config):
+    from requests.exceptions import Timeout
+
+    mock_request.side_effect = Timeout("Request timed out")
+
+    config = SendHttpRequestConfig(**base_config)
+    hook = SendHttpRequestHook(config)
+
+    with pytest.raises(Timeout, match="timed out"):
+        hook.execute(DummyContext())


### PR DESCRIPTION
This PR adds new hook strategies to the framework in support of using the dataflow engine as a load-generator and backend receiver, and other test suite development QOL fixes:

| Type | Plugin Name | Module | Class | Config Class | Description |
|------|-------------|--------|-------|--------------|-------------|
| `send_http_request` | `send_http_request` | `lib.impl.strategies.hooks.send_http_request` | `SendHttpRequestHook` | `SendHttpRequestConfig` | Hook strategy that sends an HTTP request to a configured endpoint |
| `ready_check_http` | `ready_check_http` | `lib.impl.strategies.hooks.ready_check_http` | `ReadyCheckHttpHook` | `ReadyCheckHttpConfig` | Hook strategy that performs a readiness check against an HTTP(S) endpoint |
| `render_template` | `render_template` | `lib.impl.strategies.hooks.render_template` | `RenderTemplateHook` | `RenderTemplateConfig` | Hook strategy that renders a Jinja2 template using provided variables |
| `ensure_process` | `ensure_process` | `lib.impl.strategies.hooks.process.ensure_process` | `EnsureProcess` | `EnsureProcessConfig` | Hook strategy to ensure component specified is running and hasn't crashed after start |
| `no_op` | `no_op` | `lib.impl.actions.no_op_action` | `NoOpAction` | `NoOpActionConfig` | Abstract base class representing a test step action |

