### PR TITLE
fix handling of invalid trace and span IDs when encoding OTAP logs

### DIFF
--- a/rust/otap-dataflow/crates/pdata-views/src/otlp/bytes/logs.rs
+++ b/rust/otap-dataflow/crates/pdata-views/src/otlp/bytes/logs.rs
@@ -7,6 +7,8 @@
 use std::cell::Cell;
 use std::num::NonZeroUsize;
 
+use otel_arrow_rust::schema::{SpanId, TraceId};
+
 use crate::otlp::bytes::common::{KeyValueIter, RawAnyValue, RawInstrumentationScope, RawKeyValue};
 use crate::otlp::bytes::consts::field_num::logs::{
     LOG_RECORD_ATTRIBUTES, LOG_RECORD_BODY, LOG_RECORD_DROPPED_ATTRIBUTES_COUNT, LOG_RECORD_FLAGS,
@@ -456,8 +458,10 @@ impl LogRecordView for RawLogRecord<'_> {
     }
 
     #[inline]
-    fn span_id(&self) -> Option<&[u8]> {
-        self.bytes_parser.advance_to_find_field(LOG_RECORD_SPAN_ID)
+    fn span_id(&self) -> Option<&SpanId> {
+        self.bytes_parser
+            .advance_to_find_field(LOG_RECORD_SPAN_ID)
+            .and_then(|slice| slice.try_into().ok())
     }
 
     #[inline]
@@ -470,7 +474,9 @@ impl LogRecordView for RawLogRecord<'_> {
     }
 
     #[inline]
-    fn trace_id(&self) -> Option<&[u8]> {
-        self.bytes_parser.advance_to_find_field(LOG_RECORD_TRACE_ID)
+    fn trace_id(&self) -> Option<&TraceId> {
+        self.bytes_parser
+            .advance_to_find_field(LOG_RECORD_TRACE_ID)
+            .and_then(|slice| slice.try_into().ok())
     }
 }

--- a/rust/otap-dataflow/crates/pdata-views/src/otlp/proto/logs.rs
+++ b/rust/otap-dataflow/crates/pdata-views/src/otlp/proto/logs.rs
@@ -7,8 +7,11 @@
 use otel_arrow_rust::proto::opentelemetry::logs::v1::{
     LogRecord, LogsData, ResourceLogs, ScopeLogs,
 };
+use otel_arrow_rust::schema::{SpanId, TraceId};
 
-use crate::otlp::proto::common::{KeyValueIter, ObjAny, ObjInstrumentationScope, ObjKeyValue};
+use crate::otlp::proto::common::{
+    KeyValueIter, ObjAny, ObjInstrumentationScope, ObjKeyValue, parse_span_id, parse_trace_id,
+};
 use crate::otlp::proto::resource::ObjResource;
 use crate::otlp::proto::wrappers::{GenericIterator, GenericObj, Wraps};
 use crate::views::common::Str;
@@ -206,28 +209,12 @@ impl LogRecordView for ObjLogRecord<'_> {
     }
 
     #[inline]
-    fn trace_id(&self) -> Option<&[u8]> {
-        if is_valid_trace_id(&self.inner.trace_id) {
-            Some(self.inner.trace_id.as_slice())
-        } else {
-            None
-        }
+    fn trace_id(&self) -> Option<&TraceId> {
+        parse_trace_id(&self.inner.trace_id)
     }
 
     #[inline]
-    fn span_id(&self) -> Option<&[u8]> {
-        if is_valid_span_id(&self.inner.span_id) {
-            Some(self.inner.span_id.as_slice())
-        } else {
-            None
-        }
+    fn span_id(&self) -> Option<&SpanId> {
+        parse_span_id(&self.inner.span_id)
     }
-}
-
-fn is_valid_trace_id(buf: &[u8]) -> bool {
-    buf.len() == 16 && buf != [0; 16]
-}
-
-fn is_valid_span_id(buf: &[u8]) -> bool {
-    buf.len() == 8 && buf != [0; 8]
 }

--- a/rust/otap-dataflow/crates/pdata-views/src/views/logs.rs
+++ b/rust/otap-dataflow/crates/pdata-views/src/views/logs.rs
@@ -17,6 +17,7 @@ use crate::views::{
     common::{AnyValueView, AttributeView, InstrumentationScopeView, Str},
     resource::ResourceView,
 };
+use otel_arrow_rust::schema::{SpanId, TraceId};
 
 /// View for top level LogsData
 pub trait LogsDataView {
@@ -144,12 +145,12 @@ pub trait LogRecordView {
     /// Access the trace ID. Should return None if the underlying trace ID is missing, or if the
     /// backend representation of the trace ID is invalid. Invalid trace IDs include all-0s or a
     /// trace ID of incorrect length (length != 16)
-    fn trace_id(&self) -> Option<&[u8]>;
+    fn trace_id(&self) -> Option<&TraceId>;
 
     /// Access the span ID. Should return None if the underlying span ID is missing or if the
     /// backend representation of the span ID is invalid. Invalid span IDs include all-0s or a
     /// span ID or incorrect length (length != 8)
-    fn span_id(&self) -> Option<&[u8]>;
+    fn span_id(&self) -> Option<&SpanId>;
 
     // TODO event_name https://github.com/open-telemetry/otel-arrow/issues/422
 }

--- a/rust/otel-arrow-rust/src/encode/record/logs.rs
+++ b/rust/otel-arrow-rust/src/encode/record/logs.rs
@@ -21,7 +21,7 @@ use crate::{
         dictionary::DictionaryOptions,
     },
     otlp::attributes::store::AttributeValueType,
-    schema::{FieldExt, consts},
+    schema::{FieldExt, SpanId, TraceId, consts},
 };
 
 /// Record batch builder for logs
@@ -188,7 +188,7 @@ impl LogsRecordBatchBuilder {
     }
 
     /// append a value to the `trace_id` array
-    pub fn append_trace_id(&mut self, val: Option<&[u8]>) -> Result<(), ArrowError> {
+    pub fn append_trace_id(&mut self, val: Option<&TraceId>) -> Result<(), ArrowError> {
         if let Some(val) = val {
             self.trace_id.append_slice(val)
         } else {
@@ -198,7 +198,7 @@ impl LogsRecordBatchBuilder {
     }
 
     /// append a value to the `span_id` array
-    pub fn append_span_id(&mut self, val: Option<&[u8]>) -> Result<(), ArrowError> {
+    pub fn append_span_id(&mut self, val: Option<&SpanId>) -> Result<(), ArrowError> {
         if let Some(val) = val {
             self.span_id.append_slice(val)
         } else {


### PR DESCRIPTION
Fixes issue encoding OTAP when there are trace_ids and span_ids that are invalid length (e.g. from producers who send an empty slice to represent "null" for these fields).