### PR TITLE
fix: remove orphan record.Schema() call in NewLogsMessage

### DIFF
--- a/go/pkg/record_message/arrow_record.go
+++ b/go/pkg/record_message/arrow_record.go
@@ -47,7 +47,6 @@ func NewMetricsMessage(schemaID string, record arrow.Record) *RecordMessage {
 // NewLogsMessage creates a reference to a new RecordMessage from a given Arrow Record representing a collection of
 // logs.
 func NewLogsMessage(schemaID string, record arrow.Record) *RecordMessage {
-	record.Schema()
 	return &RecordMessage{
 		schemaID:    schemaID,
 		payloadType: v1.ArrowPayloadType_LOGS,


### PR DESCRIPTION
I'm playing with otel arrow and noticed this orphaned `record.Schema()` call in NewLogsMessage. This PR removes the call.