### PR TITLE
[query-engine] Regex capture support

### DIFF
--- a/rust/experimental/query_engine/engine-recordset/src/scalars/scalar_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/scalars/scalar_expressions.rs
@@ -312,7 +312,7 @@ where
                         range_end_exclusive,
                     )?;
 
-                    ResolvedValue::Slice(Slice::String(StringSlice::new(
+                    ResolvedValue::Slice(Slice::String(StringSlice::from_char_range(
                         string_value,
                         range_start_inclusive,
                         range_end_exclusive,

--- a/rust/experimental/query_engine/engine-recordset/src/scalars/text_scalar_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/scalars/text_scalar_expressions.rs
@@ -14,6 +14,35 @@ where
     'b: 'c,
 {
     match text_scalar_expression {
+        TextScalarExpression::Capture(c) => {
+            let v = match execute_scalar_expression(execution_context, c.get_haystack())?
+                .try_resolve_string()
+            {
+                Ok(s) => {
+                    match Value::capture(
+                        text_scalar_expression.get_query_location(),
+                        &s,
+                        &execute_scalar_expression(execution_context, c.get_pattern())?.to_value(),
+                        &execute_scalar_expression(execution_context, c.get_capture_group())?
+                            .to_value(),
+                    )? {
+                        Some(r) => ResolvedValue::Slice(Slice::String(
+                            StringSlice::from_byte_range(s, r.start, r.end),
+                        )),
+                        None => ResolvedValue::Computed(OwnedValue::Null),
+                    }
+                }
+                Err(_) => ResolvedValue::Computed(OwnedValue::Null),
+            };
+
+            execution_context.add_diagnostic_if_enabled(
+                RecordSetEngineDiagnosticLevel::Verbose,
+                text_scalar_expression,
+                || format!("Evaluated as: '{v}'"),
+            );
+
+            Ok(v)
+        }
         TextScalarExpression::Concat(c) => {
             match execute_scalar_expression(execution_context, c.get_values_expression())?
                 .try_resolve_array()
@@ -171,6 +200,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use regex::Regex;
+
     use super::*;
 
     #[test]
@@ -642,6 +673,137 @@ mod tests {
                 ),
             )),
             "2, hello, world",
+        );
+    }
+
+    #[test]
+    pub fn text_execute_capture_text_scalar_expression() {
+        fn run_test_success(capture: CaptureTextScalarExpression, expected_value: &str) {
+            let expression = ScalarExpression::Text(TextScalarExpression::Capture(capture));
+
+            let mut test = TestExecutionContext::new();
+
+            let execution_context = test.create_execution_context();
+
+            let actual_value = execute_scalar_expression(&execution_context, &expression).unwrap();
+            assert_eq!(expected_value, actual_value.to_value().to_string().as_str());
+        }
+
+        run_test_success(
+            CaptureTextScalarExpression::new(
+                QueryLocation::new_fake(),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "hello world"),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "(\\w*) world"),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::Integer(
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+                )),
+            ),
+            "hello",
+        );
+
+        // Note: The regex used here results in multiple captures but only the
+        // first one is returned.
+        run_test_success(
+            CaptureTextScalarExpression::new(
+                QueryLocation::new_fake(),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "hello world"),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "(\\w*)"),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::Integer(
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+                )),
+            ),
+            "hello",
+        );
+
+        run_test_success(
+            CaptureTextScalarExpression::new(
+                QueryLocation::new_fake(),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "hello world"),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::Regex(
+                    RegexScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        Regex::new("(?<name>\\w*) world").unwrap(),
+                    ),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "name"),
+                )),
+            ),
+            "hello",
+        );
+
+        run_test_success(
+            CaptureTextScalarExpression::new(
+                QueryLocation::new_fake(),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "hello invalid"),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "(\\w*) world"),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::Integer(
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+                )),
+            ),
+            "null",
+        );
+
+        run_test_success(
+            CaptureTextScalarExpression::new(
+                QueryLocation::new_fake(),
+                ScalarExpression::Static(StaticScalarExpression::Integer(
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 0),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "(\\w*) world"),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::Integer(
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+                )),
+            ),
+            "null",
+        );
+
+        run_test_success(
+            CaptureTextScalarExpression::new(
+                QueryLocation::new_fake(),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "hello world"),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "hello world"),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::Integer(
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+                )),
+            ),
+            "null",
+        );
+
+        run_test_success(
+            CaptureTextScalarExpression::new(
+                QueryLocation::new_fake(),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "hello world"),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "hello world"),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::Integer(
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 0),
+                )),
+            ),
+            "hello world",
         );
     }
 }

--- a/rust/experimental/query_engine/expressions/src/logical_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/logical_expressions.rs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use regex::Regex;
-
 use crate::*;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -570,68 +568,17 @@ impl MatchesLogicalExpression {
         let query_location = &self.query_location;
 
         let haystack = self.haystack.try_resolve_static(scope)?;
-        let pattern = self.pattern.try_resolve_static(scope)?;
+        let pattern =
+            ResolvedStaticScalarExpression::try_resolve_static_regex(&mut self.pattern, scope)?;
 
         match (haystack, pattern) {
-            (Some(h), Some(p)) => {
-                let is_match = match p.as_ref() {
-                    StaticScalarExpression::Regex(r) => {
-                        Value::matches(query_location, &h.to_value(), &Value::Regex(r))?
-                    }
-                    s => match Self::try_parse_regex(s)? {
-                        Some(r) => {
-                            let regex = StaticScalarExpression::Regex(r);
-                            let is_match =
-                                Value::matches(query_location, &h.to_value(), &regex.to_value())?;
-                            self.pattern = ScalarExpression::Static(regex);
-                            is_match
-                        }
-                        None => return Ok(None),
-                    },
-                };
-
-                Ok(Some(ResolvedStaticScalarExpression::Computed(
-                    StaticScalarExpression::Boolean(BooleanScalarExpression::new(
-                        query_location.clone(),
-                        is_match,
-                    )),
-                )))
-            }
-            (None, Some(p)) => {
-                if let Some(r) = Self::try_parse_regex(p.as_ref())? {
-                    self.pattern = ScalarExpression::Static(StaticScalarExpression::Regex(r));
-                }
-                Ok(None)
-            }
-            _ => Ok(None),
-        }
-    }
-
-    fn try_parse_regex(
-        value: &StaticScalarExpression,
-    ) -> Result<Option<RegexScalarExpression>, ExpressionError> {
-        if !value.foldable() {
-            return Ok(None);
-        }
-
-        let mut result = None;
-
-        value.to_value().convert_to_string(&mut |s| {
-            result = Some(Regex::new(s));
-        });
-
-        match result {
-            Some(Ok(r)) => Ok(Some(RegexScalarExpression::new(
-                value.get_query_location().clone(),
-                r,
+            (Some(h), Some(p)) => Ok(Some(ResolvedStaticScalarExpression::Computed(
+                StaticScalarExpression::Boolean(BooleanScalarExpression::new(
+                    query_location.clone(),
+                    Value::matches(query_location, &h.to_value(), &Value::Regex(p))?,
+                )),
             ))),
-            Some(Err(e)) => Err(ExpressionError::ParseError(
-                value.get_query_location().clone(),
-                format!("Failed to parse Regex from pattern: {e}"),
-            )),
-            None => {
-                panic!("Encountered a Value which does not correctly implement convert_to_string")
-            }
+            _ => Ok(None),
         }
     }
 }

--- a/rust/experimental/query_engine/kql-parser/src/kql.pest
+++ b/rust/experimental/query_engine/kql-parser/src/kql.pest
@@ -161,6 +161,7 @@ substring_expression = { "substring" ~ "(" ~ scalar_expression ~ "," ~ scalar_ex
 parse_json_expression = { "parse_json" ~ "(" ~ scalar_expression ~ ")" }
 strcat_expression = { "strcat" ~ "(" ~ scalar_expression ~ ("," ~ scalar_expression)* ~ ")" }
 strcat_delim_expression = { "strcat_delim" ~ "(" ~ scalar_expression ~ "," ~ scalar_expression ~ ("," ~ scalar_expression)* ~ ")" }
+extract_expression = { "extract" ~ "(" ~ scalar_expression ~ "," ~ scalar_expression ~ "," ~ scalar_expression ~ ")" }
 string_expressions = _{
     strlen_expression
     | replace_string_expression
@@ -168,6 +169,7 @@ string_expressions = _{
     | parse_json_expression
     | strcat_expression
     | strcat_delim_expression
+    | extract_expression
 }
 
 array_concat_expression = { "array_concat" ~ "(" ~ scalar_expression ~ ("," ~ scalar_expression)* ~ ")" }

--- a/rust/experimental/query_engine/kql-parser/src/scalar_expression.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_expression.rs
@@ -43,6 +43,7 @@ pub(crate) fn parse_scalar_expression(
         Rule::parse_json_expression => parse_parse_json_expression(scalar_rule, scope)?,
         Rule::strcat_expression => parse_strcat_expression(scalar_rule, scope)?,
         Rule::strcat_delim_expression => parse_strcat_delim_expression(scalar_rule, scope)?,
+        Rule::extract_expression => parse_extract_expression(scalar_rule, scope)?,
         Rule::array_concat_expression => parse_array_concat_expression(scalar_rule, scope)?,
         Rule::true_literal | Rule::false_literal => {
             ScalarExpression::Static(parse_standard_bool_literal(scalar_rule))

--- a/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
@@ -28,9 +28,7 @@ pub(crate) fn parse_string_literal(string_literal_rule: Pair<Rule>) -> StaticSca
         let mut current_char = c.unwrap();
         let mut skip_push = false;
 
-        if position == 1 || current_char == '\\' {
-            skip_push = true;
-        } else if last_char == '\\' {
+        if last_char == '\\' {
             match current_char {
                 '"' => current_char = '"',
                 '\'' => current_char = '\'',
@@ -40,9 +38,15 @@ pub(crate) fn parse_string_literal(string_literal_rule: Pair<Rule>) -> StaticSca
                 't' => current_char = '\t',
                 _ => panic!("Unexpected escape character"),
             }
+            last_char = '\0';
+        } else {
+            if position == 1 || current_char == '\\' {
+                skip_push = true;
+            }
+
+            last_char = current_char;
         }
 
-        last_char = current_char;
         position += 1;
 
         c = chars.next();
@@ -607,6 +611,7 @@ mod tests {
         run_test("'Hello world'", "Hello world");
         run_test("'Hello \" world'", "Hello \" world");
         run_test("'Hello \\' world'", "Hello ' world");
+        run_test("'(\\\\w*)'", "(\\w*)");
     }
 
     #[test]

--- a/rust/experimental/query_engine/kql-parser/src/scalar_string_function_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_string_function_expressions.rs
@@ -217,9 +217,66 @@ pub(crate) fn parse_strcat_delim_expression(
     )))
 }
 
+pub(crate) fn parse_extract_expression(
+    extract_expression_rule: Pair<Rule>,
+    scope: &dyn ParserScope,
+) -> Result<ScalarExpression, ParserError> {
+    let query_location = to_query_location(&extract_expression_rule);
+
+    let mut extract_rules = extract_expression_rule.into_inner();
+
+    let regex_rule = extract_rules.next().unwrap();
+    let regex_location = to_query_location(&regex_rule);
+    let mut regex = parse_scalar_expression(regex_rule, scope)?;
+    if let Some(v) = scope.try_resolve_value_type(&mut regex)?
+        && v != ValueType::Regex
+        && v != ValueType::String
+    {
+        return Err(ParserError::QueryLanguageDiagnostic {
+            location: regex_location,
+            diagnostic_id: "KS107",
+            message: "A value of type regex or string expected".into(),
+        });
+    }
+
+    let capture_rule = extract_rules.next().unwrap();
+    let capture_location = to_query_location(&capture_rule);
+    let mut capture_group = parse_scalar_expression(capture_rule, scope)?;
+
+    if let Some(v) = scope.try_resolve_value_type(&mut capture_group)?
+        && v != ValueType::Integer
+        && v != ValueType::String
+    {
+        return Err(ParserError::QueryLanguageDiagnostic {
+            location: capture_location,
+            diagnostic_id: "KS107",
+            message: "A value of type long or string expected".into(),
+        });
+    }
+
+    let source_rule = extract_rules.next().unwrap();
+    let source_location = to_query_location(&source_rule);
+    let mut source = parse_scalar_expression(source_rule, scope)?;
+
+    if let Some(v) = scope.try_resolve_value_type(&mut source)?
+        && v != ValueType::String
+    {
+        return Err(ParserError::QueryLanguageDiagnostic {
+            location: source_location,
+            diagnostic_id: "KS107",
+            message: "A value of type string expected".into(),
+        });
+    }
+
+    Ok(ScalarExpression::Text(TextScalarExpression::Capture(
+        CaptureTextScalarExpression::new(query_location, source, regex, capture_group),
+    )))
+}
+
 #[cfg(test)]
 mod tests {
     use pest::Parser;
+    use regex::Regex;
 
     use crate::KqlPestParser;
 
@@ -632,6 +689,119 @@ mod tests {
                     ),
                 )),
             ))),
+        );
+    }
+
+    #[test]
+    fn test_parse_extract_expression() {
+        let run_test_success = |input: &str, expected: ScalarExpression| {
+            println!("Testing: {input}");
+
+            let state = ParserState::new(input);
+
+            let mut result = KqlPestParser::parse(Rule::scalar_expression, input).unwrap();
+
+            let mut expression = parse_scalar_expression(result.next().unwrap(), &state).unwrap();
+
+            expression
+                .try_resolve_static(&state.get_pipeline().get_resolution_scope())
+                .unwrap();
+
+            assert_eq!(expected, expression);
+        };
+
+        let run_test_failure = |input: &str, expected_id: Option<&str>, expected_msg: &str| {
+            println!("Testing: {input}");
+
+            let state = ParserState::new(input);
+
+            let mut result = KqlPestParser::parse(Rule::scalar_expression, input).unwrap();
+
+            let error = match parse_scalar_expression(result.next().unwrap(), &state) {
+                Err(e) => e,
+                Ok(mut s) => s
+                    .try_resolve_static(&state.get_pipeline().get_resolution_scope())
+                    .map_err(|e| ParserError::from(&e))
+                    .unwrap_err(),
+            };
+
+            if let Some(eid) = expected_id {
+                if let ParserError::QueryLanguageDiagnostic {
+                    location: _,
+                    diagnostic_id: id,
+                    message: msg,
+                } = error
+                {
+                    assert_eq!(eid, id);
+                    assert_eq!(expected_msg, msg);
+                } else {
+                    panic!("Expected QueryLanguageDiagnostic");
+                }
+            } else if let ParserError::SyntaxError(_, msg) = error {
+                assert_eq!(expected_msg, msg);
+            } else {
+                panic!("Unexpected error");
+            }
+        };
+
+        // Note: This gets folded into a string.
+        run_test_success(
+            r#"extract('(\\w*)', 1, 'hello world')"#,
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "hello",
+            ))),
+        );
+
+        run_test_success(
+            r#"extract('(\\w*)', 1, SomeField)"#,
+            ScalarExpression::Text(TextScalarExpression::Capture(
+                CaptureTextScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    ScalarExpression::Source(SourceScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                            StaticScalarExpression::String(StringScalarExpression::new(
+                                QueryLocation::new_fake(),
+                                "SomeField",
+                            )),
+                        )]),
+                    )),
+                    ScalarExpression::Static(StaticScalarExpression::Regex(
+                        RegexScalarExpression::new(
+                            QueryLocation::new_fake(),
+                            Regex::new("(\\w*)").unwrap(),
+                        ),
+                    )),
+                    ScalarExpression::Static(StaticScalarExpression::Integer(
+                        IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+                    )),
+                ),
+            )),
+        );
+
+        run_test_failure(
+            r#"extract(timespan(1h), 1, 'hello world')"#,
+            Some("KS107"),
+            "A value of type regex or string expected",
+        );
+
+        run_test_failure(
+            r#"extract('hello world', timespan(1h), 'hello world')"#,
+            Some("KS107"),
+            "A value of type long or string expected",
+        );
+
+        run_test_failure(
+            r#"extract('hello world', 'name', timespan(1h))"#,
+            Some("KS107"),
+            "A value of type string expected",
+        );
+
+        run_test_failure(
+            r#"extract('(', 0, 'hello world')"#,
+            None,
+            "Failed to parse Regex from pattern: regex parse error:\n    (\n    ^\nerror: unclosed group",
         );
     }
 }


### PR DESCRIPTION
## Changes

* Adds expression and recordset engine implementation for simple regex capture (single group, first match)
* Adds KQL parsing for `extract` using the new expression