### PR TITLE
[otap-dataflow] BatchProcessor internal telemetry

### DIFF
--- a/rust/otap-dataflow/crates/otap/src/encoder.rs
+++ b/rust/otap-dataflow/crates/otap/src/encoder.rs
@@ -3728,6 +3728,42 @@ mod test {
         _test_attributes_all_field_types_generic(RawLogsData::new(&logs_data_bytes));
     }
 
+    #[test]
+    fn test_encode_logs_batch_length_counts_rows() {
+        use otel_arrow_rust::otap::OtapArrowRecords;
+        use otel_arrow_rust::proto::opentelemetry::common::v1::{
+            AnyValue, InstrumentationScope, KeyValue,
+        };
+        use otel_arrow_rust::proto::opentelemetry::logs::v1::{
+            LogRecord, LogsData, ResourceLogs, ScopeLogs, SeverityNumber,
+        };
+        use otel_arrow_rust::proto::opentelemetry::resource::v1::Resource;
+
+        // Build logs with at least one attribute per record so log ids are set
+        let logs: Vec<LogRecord> = (0..3)
+            .map(|i| {
+                LogRecord::build(i as u64, SeverityNumber::Info, format!("log{i}"))
+                    .attributes(vec![KeyValue::new("k", AnyValue::new_string("v"))])
+                    .finish()
+            })
+            .collect();
+
+        let logs_data = LogsData::new(vec![
+            ResourceLogs::build(Resource::default())
+                .scope_logs(vec![
+                    ScopeLogs::build(InstrumentationScope::new("lib"))
+                        .log_records(logs)
+                        .finish(),
+                ])
+                .finish(),
+        ]);
+
+        let rec = encode_logs_otap_batch(&logs_data).expect("encode logs");
+        assert!(matches!(rec, OtapArrowRecords::Logs(_)));
+        let n = rec.batch_length();
+        assert!(n >= 3, "expected at least 3 log rows, got {n}");
+    }
+
     fn _generate_traces_data_all_fields() -> TracesData {
         let a_trace_id: TraceId = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
         let a_span_id: SpanId = [17, 18, 19, 20, 21, 22, 23, 24];

--- a/rust/otap-dataflow/crates/otap/src/otap_batch_processor/metrics.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_batch_processor/metrics.rs
@@ -1,0 +1,87 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Metrics for the OTAP batch processor.
+
+use otap_df_telemetry::instrument::Counter;
+use otap_df_telemetry_macros::metric_set;
+
+/// Minimal, essential metrics for the OTAP batch processor, plus observability for
+/// dirty-flag behavior and timer flush decisions.
+#[metric_set(name = "otap.processor.batch")]
+#[derive(Debug, Default, Clone)]
+pub struct OtapBatchProcessorMetrics {
+    /// Total rows received for logs signals
+    #[metric(unit = "{row}")]
+    pub received_rows_logs: Counter<u64>,
+    /// Total rows received for metrics signals
+    #[metric(unit = "{row}")]
+    pub received_rows_metrics: Counter<u64>,
+    /// Total rows received for traces signals
+    #[metric(unit = "{row}")]
+    pub received_rows_traces: Counter<u64>,
+
+    /// Number of flushes triggered by size threshold (all signals)
+    #[metric(unit = "{flush}")]
+    pub flushes_size: Counter<u64>,
+    /// Number of flushes triggered by timer (all signals)
+    #[metric(unit = "{flush}")]
+    pub flushes_timer: Counter<u64>,
+    /// Number of flushes triggered by shutdown (all signals)
+    #[metric(unit = "{flush}")]
+    pub flushes_shutdown: Counter<u64>,
+
+    /// Number of messages dropped due to conversion failures
+    #[metric(unit = "{msg}")]
+    pub dropped_conversion: Counter<u64>,
+    /// Number of batching errors encountered
+    #[metric(unit = "{error}")]
+    pub batching_errors: Counter<u64>,
+    /// Number of empty records dropped
+    #[metric(unit = "{msg}")]
+    pub dropped_empty_records: Counter<u64>,
+
+    /// Number of split requests issued to upstream batching
+    #[metric(unit = "{event}")]
+    pub split_requests: Counter<u64>,
+
+    /// Dirty flag set events for logs
+    #[metric(unit = "{event}")]
+    pub dirty_set_logs: Counter<u64>,
+    /// Dirty flag set events for metrics
+    #[metric(unit = "{event}")]
+    pub dirty_set_metrics: Counter<u64>,
+    /// Dirty flag set events for traces
+    #[metric(unit = "{event}")]
+    pub dirty_set_traces: Counter<u64>,
+
+    /// Dirty flag cleared events for logs
+    #[metric(unit = "{event}")]
+    pub dirty_cleared_logs: Counter<u64>,
+    /// Dirty flag cleared events for metrics
+    #[metric(unit = "{event}")]
+    pub dirty_cleared_metrics: Counter<u64>,
+    /// Dirty flag cleared events for traces
+    #[metric(unit = "{event}")]
+    pub dirty_cleared_traces: Counter<u64>,
+
+    /// Timer-triggered flushes that were performed for logs
+    #[metric(unit = "{flush}")]
+    pub timer_flush_performed_logs: Counter<u64>,
+    /// Timer-triggered flushes that were performed for metrics
+    #[metric(unit = "{flush}")]
+    pub timer_flush_performed_metrics: Counter<u64>,
+    /// Timer-triggered flushes that were performed for traces
+    #[metric(unit = "{flush}")]
+    pub timer_flush_performed_traces: Counter<u64>,
+
+    /// Timer-triggered flushes that were skipped for logs (not dirty)
+    #[metric(unit = "{flush}")]
+    pub timer_flush_skipped_logs: Counter<u64>,
+    /// Timer-triggered flushes that were skipped for metrics (not dirty)
+    #[metric(unit = "{flush}")]
+    pub timer_flush_skipped_metrics: Counter<u64>,
+    /// Timer-triggered flushes that were skipped for traces (not dirty)
+    #[metric(unit = "{flush}")]
+    pub timer_flush_skipped_traces: Counter<u64>,
+}


### PR DESCRIPTION
Adds internal telemetry to the batch processor to observe volumes and flush decisions without changing behavior.

Key changes
•  Metrics: define OtapBatchProcessorMetrics (moved to crates/otap/src/otap_batch_processor/metrics.rs); update imports. Processor import path unchanged.
•  Wiring: add optional metrics field and from_config_with_metrics; register and inject MetricSet in the factory.
•  Instrumentation: received_rows_{logs,metrics,traces}; flushes_{size,timer,shutdown}; split_requests; dropped_{conversion,empty_records}; batching_errors; dirty_set/cleared per signal; timer_flush{performed,skipped} per signal.
•  Tests: internal telemetry collection test; small encoder test.

Notes
•  No functional changes to batching or flush logic; telemetry-only.