### PR TITLE
Add AckMsg, NackMsg

### DIFF
--- a/rust/otap-dataflow/crates/engine/src/exporter.rs
+++ b/rust/otap-dataflow/crates/engine/src/exporter.rs
@@ -243,7 +243,7 @@ impl<PData> NodeWithPDataReceiver<PData> for ExporterWrapper<PData> {
 
 #[cfg(test)]
 mod tests {
-    use crate::control::NodeControlMsg;
+    use crate::control::{AckMsg, NodeControlMsg};
     use crate::exporter::{Error, ExporterWrapper};
     use crate::local::exporter as local;
     use crate::local::message::LocalReceiver;
@@ -452,17 +452,12 @@ mod tests {
         let (control_tx, pdata_tx, mut channel) = make_chan();
 
         pdata_tx.send_async("pdata1".to_owned()).await.unwrap();
-        control_tx
-            .send_async(NodeControlMsg::Ack { id: 1 })
-            .await
-            .unwrap();
+        let ack = NodeControlMsg::Ack(AckMsg::new(1, None));
+        control_tx.send_async(ack).await.unwrap();
 
         // Control message should be received first due to bias
         let msg = channel.recv().await.unwrap();
-        assert!(matches!(
-            msg,
-            Message::Control(NodeControlMsg::Ack { id: 1 })
-        ));
+        assert!(matches!(msg, Message::Control(NodeControlMsg::Ack(_))));
 
         // Then pdata message
         let msg = channel.recv().await.unwrap();
@@ -625,7 +620,7 @@ mod tests {
         // following the shutdown.
         assert!(
             control_tx
-                .send_async(NodeControlMsg::Ack { id: 99 })
+                .send_async(NodeControlMsg::Ack(AckMsg::new(99, None)))
                 .await
                 .is_err()
         );

--- a/rust/otap-dataflow/crates/engine/src/message.rs
+++ b/rust/otap-dataflow/crates/engine/src/message.rs
@@ -3,7 +3,7 @@
 
 //! Message definitions for the pipeline engine.
 
-use crate::control::NodeControlMsg;
+use crate::control::{AckMsg, NackMsg, NodeControlMsg};
 use crate::local::message::{LocalReceiver, LocalSender};
 use crate::shared::message::{SharedReceiver, SharedSender};
 use otap_df_channel::error::{RecvError, SendError};
@@ -34,18 +34,14 @@ impl<Data> Message<Data> {
 
     /// Create a ACK control message with the given ID.
     #[must_use]
-    pub fn ack_ctrl_msg(id: u64) -> Self {
-        Message::Control(NodeControlMsg::Ack { id })
+    pub fn ack_ctrl_msg(ack: AckMsg<Data>) -> Self {
+        Message::Control(NodeControlMsg::Ack(ack))
     }
 
     /// Create a NACK control message with the given ID and reason.
     #[must_use]
-    pub fn nack_ctrl_msg(id: u64, reason: &str, pdata: Option<Data>) -> Self {
-        Message::Control(NodeControlMsg::Nack {
-            id,
-            pdata: pdata.map(Box::new),
-            reason: reason.to_owned(),
-        })
+    pub fn nack_ctrl_msg(nack: NackMsg<Data>) -> Self {
+        Message::Control(NodeControlMsg::Nack(nack))
     }
 
     /// Creates a config control message with the given configuration.


### PR DESCRIPTION
Part of #977 
Taken from #1041.

The addition of AckMsg and NackMsg makes it easier for components to construct replies in various signal/success/failure cases, vs having to unpack the fields and re-assemble them in match statements.