### PR TITLE
[query-engine] Add support for parsing KQL dynamic expressions

### DIFF
--- a/rust/experimental/query_engine/kql-parser/src/kql.pest
+++ b/rust/experimental/query_engine/kql-parser/src/kql.pest
@@ -124,12 +124,18 @@ time_expression = {
     | "timespan(" ~ (double_literal|integer_literal) ~ time_units_literal? ~ ")"
 }
 regex_expression = { "regex(" ~ string_literal ~ ("," ~ string_literal)? ~ ")" }
-type_expressions = _{
+dynamic_array_expression = { "[" ~ (dynamic_inner_expression ~ ("," ~ dynamic_inner_expression)*)? ~ "]" }
+dynamic_map_item_expression = { string_literal ~ ":" ~ dynamic_inner_expression }
+dynamic_map_expression = { "{" ~ (dynamic_map_item_expression ~ ("," ~ dynamic_map_item_expression)*)? ~ "}" }
+dynamic_inner_expression = _{ dynamic_array_expression|dynamic_map_expression|type_expression }
+dynamic_expression = { "dynamic" ~ "(" ~ dynamic_inner_expression ~ ")" }
+type_expression = {
     null_literal
     | real_expression
     | datetime_expression
     | time_expression
     | regex_expression
+    | dynamic_expression
     | true_literal
     | false_literal
     | double_literal
@@ -218,7 +224,7 @@ backwards. For example if integer_literal is defined before time_expression "1h"
 would be parsed as integer_literal(1) and the remaining "h" would be fed into
 the next rule. */
 scalar_expression = {
-    type_expressions
+    type_expression
     | conditional_expressions
     | conversion_expressions
     | string_expressions

--- a/rust/experimental/query_engine/kql-parser/src/scalar_expression.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_expression.rs
@@ -20,13 +20,7 @@ pub(crate) fn parse_scalar_expression(
     let scalar_rule = scalar_expression_rule.into_inner().next().unwrap();
 
     let scalar = match scalar_rule.as_rule() {
-        Rule::null_literal => ScalarExpression::Static(parse_standard_null_literal(scalar_rule)),
-        Rule::real_expression => ScalarExpression::Static(parse_real_expression(scalar_rule)?),
-        Rule::datetime_expression => {
-            ScalarExpression::Static(parse_datetime_expression(scalar_rule)?)
-        }
-        Rule::time_expression => ScalarExpression::Static(parse_timespan_expression(scalar_rule)?),
-        Rule::regex_expression => ScalarExpression::Static(parse_regex_expression(scalar_rule)?),
+        Rule::type_expression => ScalarExpression::Static(parse_type_expression(scalar_rule)?),
         Rule::conditional_expression => parse_conditional_expression(scalar_rule, scope)?,
         Rule::case_expression => parse_case_expression(scalar_rule, scope)?,
         Rule::coalesce_expression => parse_coalesce_expression(scalar_rule, scope)?,
@@ -48,16 +42,6 @@ pub(crate) fn parse_scalar_expression(
         Rule::strcat_delim_expression => parse_strcat_delim_expression(scalar_rule, scope)?,
         Rule::extract_expression => parse_extract_expression(scalar_rule, scope)?,
         Rule::array_concat_expression => parse_array_concat_expression(scalar_rule, scope)?,
-        Rule::true_literal | Rule::false_literal => {
-            ScalarExpression::Static(parse_standard_bool_literal(scalar_rule))
-        }
-        Rule::double_literal => {
-            ScalarExpression::Static(parse_standard_double_literal(scalar_rule, None)?)
-        }
-        Rule::integer_literal => {
-            ScalarExpression::Static(parse_standard_integer_literal(scalar_rule)?)
-        }
-        Rule::string_literal => ScalarExpression::Static(parse_string_literal(scalar_rule)),
         Rule::negate_expression => parse_negate_expression(scalar_rule, scope)?,
         Rule::bin_expression => parse_bin_expression(scalar_rule, scope)?,
         Rule::now_expression => parse_now_expression(scalar_rule, scope)?,

--- a/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
@@ -1,12 +1,36 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
+
 use chrono::TimeDelta;
 use data_engine_expressions::*;
 use data_engine_parser_abstractions::*;
 use pest::iterators::Pair;
 
 use crate::{Rule, scalar_expression::parse_scalar_expression};
+
+pub(crate) fn parse_type_expression(
+    type_expression_rule: Pair<Rule>,
+) -> Result<StaticScalarExpression, ParserError> {
+    let type_expression_rule = type_expression_rule.into_inner().next().unwrap();
+
+    Ok(match type_expression_rule.as_rule() {
+        Rule::null_literal => parse_standard_null_literal(type_expression_rule),
+        Rule::real_expression => parse_real_expression(type_expression_rule)?,
+        Rule::datetime_expression => parse_datetime_expression(type_expression_rule)?,
+        Rule::time_expression => parse_timespan_expression(type_expression_rule)?,
+        Rule::regex_expression => parse_regex_expression(type_expression_rule)?,
+        Rule::dynamic_expression => parse_dynamic_expression(type_expression_rule)?,
+        Rule::true_literal | Rule::false_literal => {
+            parse_standard_bool_literal(type_expression_rule)
+        }
+        Rule::double_literal => parse_standard_double_literal(type_expression_rule, None)?,
+        Rule::integer_literal => parse_standard_integer_literal(type_expression_rule)?,
+        Rule::string_literal => parse_string_literal(type_expression_rule),
+        _ => panic!("Unexpected rule in type_expression_rule: {type_expression_rule}"),
+    })
+}
 
 /// The goal of this code is to unescape string literal values as they come in
 /// when parsed from pest:
@@ -229,6 +253,64 @@ pub(crate) fn parse_regex_expression(
         query_location,
         regex,
     )))
+}
+
+pub(crate) fn parse_dynamic_expression(
+    dynamic_expression_rule: Pair<Rule>,
+) -> Result<StaticScalarExpression, ParserError> {
+    return parse_dynamic_inner_expression(dynamic_expression_rule.into_inner().next().unwrap());
+
+    fn parse_dynamic_inner_expression(
+        dynamic_inner_expression_rule: Pair<Rule>,
+    ) -> Result<StaticScalarExpression, ParserError> {
+        let query_location = to_query_location(&dynamic_inner_expression_rule);
+
+        match dynamic_inner_expression_rule.as_rule() {
+            Rule::type_expression => Ok(parse_type_expression(dynamic_inner_expression_rule)?),
+            Rule::dynamic_array_expression => {
+                let mut values = Vec::new();
+
+                for array_rule in dynamic_inner_expression_rule.into_inner() {
+                    values.push(parse_dynamic_inner_expression(array_rule)?);
+                }
+
+                Ok(StaticScalarExpression::Array(ArrayScalarExpression::new(
+                    query_location,
+                    values,
+                )))
+            }
+            Rule::dynamic_map_expression => {
+                let mut values = HashMap::new();
+
+                for dynamic_map_item_expression in dynamic_inner_expression_rule.into_inner() {
+                    let mut dynamic_map_item_expression_rules =
+                        dynamic_map_item_expression.into_inner();
+
+                    let key = parse_standard_string_literal(
+                        dynamic_map_item_expression_rules.next().unwrap(),
+                    );
+
+                    let value = parse_dynamic_inner_expression(
+                        dynamic_map_item_expression_rules.next().unwrap(),
+                    )?;
+
+                    if let StaticScalarExpression::String(s) = key {
+                        values.insert(s.get_value().into(), value);
+                    } else {
+                        panic!(
+                            "Unexpected rule in dynamic_map_item_expression: {dynamic_map_item_expression_rules}"
+                        );
+                    }
+                }
+
+                Ok(StaticScalarExpression::Map(MapScalarExpression::new(
+                    query_location,
+                    values,
+                )))
+            }
+            _ => panic!("Unexpected rule in dynamic_expression: {dynamic_inner_expression_rule}"),
+        }
+    }
 }
 
 pub(crate) fn parse_real_expression(
@@ -1102,6 +1184,112 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_dynamic_expression() {
+        let run_test = |input: &str, expected: StaticScalarExpression| {
+            let mut result = KqlPestParser::parse(Rule::dynamic_expression, input).unwrap();
+
+            let actual = parse_dynamic_expression(result.next().unwrap()).unwrap();
+
+            assert_eq!(expected, actual);
+        };
+
+        run_test(
+            "dynamic(1)",
+            StaticScalarExpression::Integer(IntegerScalarExpression::new(
+                QueryLocation::new_fake(),
+                1,
+            )),
+        );
+
+        run_test(
+            "dynamic(real(1))",
+            StaticScalarExpression::Double(DoubleScalarExpression::new(
+                QueryLocation::new_fake(),
+                1.0,
+            )),
+        );
+
+        run_test(
+            "dynamic('hello world')",
+            StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "hello world",
+            )),
+        );
+
+        run_test(
+            "dynamic([])",
+            StaticScalarExpression::Array(ArrayScalarExpression::new(
+                QueryLocation::new_fake(),
+                vec![],
+            )),
+        );
+
+        run_test(
+            "dynamic([1, [18], dynamic({})])",
+            StaticScalarExpression::Array(ArrayScalarExpression::new(
+                QueryLocation::new_fake(),
+                vec![
+                    StaticScalarExpression::Integer(IntegerScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        1,
+                    )),
+                    StaticScalarExpression::Array(ArrayScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        vec![StaticScalarExpression::Integer(
+                            IntegerScalarExpression::new(QueryLocation::new_fake(), 18),
+                        )],
+                    )),
+                    StaticScalarExpression::Map(MapScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        HashMap::new(),
+                    )),
+                ],
+            )),
+        );
+
+        run_test(
+            "dynamic({})",
+            StaticScalarExpression::Map(MapScalarExpression::new(
+                QueryLocation::new_fake(),
+                HashMap::new(),
+            )),
+        );
+
+        run_test(
+            "dynamic({'key1':1, 'key2':[1], 'key3':{}})",
+            StaticScalarExpression::Map(MapScalarExpression::new(
+                QueryLocation::new_fake(),
+                HashMap::from([
+                    (
+                        "key1".into(),
+                        StaticScalarExpression::Integer(IntegerScalarExpression::new(
+                            QueryLocation::new_fake(),
+                            1,
+                        )),
+                    ),
+                    (
+                        "key2".into(),
+                        StaticScalarExpression::Array(ArrayScalarExpression::new(
+                            QueryLocation::new_fake(),
+                            vec![StaticScalarExpression::Integer(
+                                IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+                            )],
+                        )),
+                    ),
+                    (
+                        "key3".into(),
+                        StaticScalarExpression::Map(MapScalarExpression::new(
+                            QueryLocation::new_fake(),
+                            HashMap::new(),
+                        )),
+                    ),
+                ]),
+            )),
+        );
+    }
+
+    #[test]
     fn test_pest_parse_real_expression_rule() {
         pest_test_helpers::test_pest_rule::<KqlPestParser, Rule>(
             Rule::real_expression,
@@ -1227,6 +1415,7 @@ mod tests {
                 (Rule::identifier_literal, "abc"),
                 (Rule::minus_token, "-"),
                 (Rule::scalar_expression, "'name'"),
+                (Rule::type_expression, "'name'"),
                 (Rule::string_literal, "'name'"),
             ],
         );


### PR DESCRIPTION
## Changes

* Adds support in the KQL parser for the `dynamic` expression