### PR TITLE
Add tonic middleware to handle go exporter's grpc-encoding zstdarrow header value

### DIFF
--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -85,6 +85,7 @@ tonic = { version = "0.14", default-features = false, features = [
     "gzip",
     "deflate",
 ] }
+tonic-middleware = "0.4.0"
 tonic-prost = "0.14"
 prost = "0.14"
 

--- a/rust/otap-dataflow/crates/otap/Cargo.toml
+++ b/rust/otap-dataflow/crates/otap/Cargo.toml
@@ -34,6 +34,7 @@ uuid.workspace = true
 weaver_forge.workspace = true
 weaver_common.workspace = true
 tonic = { workspace = true }
+tonic-middleware = { workspace = true }
 tonic-prost = { workspace = true }
 prost = { workspace = true }
 

--- a/rust/otap-dataflow/crates/otap/src/otap_grpc.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_grpc.rs
@@ -28,6 +28,7 @@ use tonic::{Request, Response, Status};
 
 use crate::pdata::OtapPdata;
 
+pub mod middleware;
 pub mod otlp;
 
 /// struct that implements the ArrowLogsService trait

--- a/rust/otap-dataflow/crates/otap/src/otap_grpc/middleware.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_grpc/middleware.rs
@@ -1,0 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Middlewares for gRPC server
+
+pub mod zstd_header;

--- a/rust/otap-dataflow/crates/otap/src/otap_grpc/middleware/zstd_header.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_grpc/middleware/zstd_header.rs
@@ -1,0 +1,44 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Middlewares for adapting gRPC encoding request header
+
+use async_trait::async_trait;
+use http::{Request, Response};
+use tonic::body::Body;
+use tonic_middleware::{Middleware, ServiceBound};
+
+const ENCODING_HEADER: &str = "grpc-encoding";
+
+/// Tonic middleware implementation that will replace the `grpc-encoding` header that the golang
+/// exporter produces (which has the format zstdarrow[0-9]) with the value that tonic expects, 
+/// which is just "zstd"
+#[derive(Clone, Default)]
+pub struct ZstdRequestHeaderAdapter {}
+
+#[async_trait]
+impl<S> Middleware<S> for ZstdRequestHeaderAdapter
+where
+    S: ServiceBound,
+    S::Future: Send,
+{
+    async fn call(
+        &self,
+        mut req: Request<Body>,
+        mut service: S,
+    ) -> Result<Response<Body>, S::Error> {
+        let headers = req.headers_mut();
+        if let Some(header_val) = headers.get(ENCODING_HEADER) {
+            let header_bytes = header_val.as_bytes();
+            if header_bytes.starts_with(b"zstdarrow") {
+                _ = headers.insert(
+                    ENCODING_HEADER,
+                    "zstd".parse().expect("can parse to header value"),
+                );
+            }
+        }
+
+        let result = service.call(req).await?;
+        Ok(result)
+    }
+}

--- a/rust/otap-dataflow/crates/otap/src/otap_grpc/middleware/zstd_header.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_grpc/middleware/zstd_header.rs
@@ -11,7 +11,7 @@ use tonic_middleware::{Middleware, ServiceBound};
 const ENCODING_HEADER: &str = "grpc-encoding";
 
 /// Tonic middleware implementation that will replace the `grpc-encoding` header that the golang
-/// exporter produces (which has the format zstdarrow[0-9]) with the value that tonic expects, 
+/// exporter produces (which has the format zstdarrow[0-9]) with the value that tonic expects,
 /// which is just "zstd"
 #[derive(Clone, Default)]
 pub struct ZstdRequestHeaderAdapter {}

--- a/rust/otap-dataflow/crates/otap/src/otap_grpc/middleware/zstd_header.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_grpc/middleware/zstd_header.rs
@@ -4,11 +4,12 @@
 //! Middlewares for adapting gRPC encoding request header
 
 use async_trait::async_trait;
-use http::{Request, Response};
+use http::{HeaderName, HeaderValue, Request, Response};
 use tonic::body::Body;
 use tonic_middleware::{Middleware, ServiceBound};
 
-const ENCODING_HEADER: &str = "grpc-encoding";
+static ENCODING_HEADER: HeaderName = HeaderName::from_static("grpc-encoding");
+static ZSTD_HEADER_VALUE: HeaderValue = HeaderValue::from_static("zstd");
 
 /// Tonic middleware implementation that will replace the `grpc-encoding` header that the golang
 /// exporter produces (which has the format zstdarrow[0-9]) with the value that tonic expects,
@@ -28,13 +29,10 @@ where
         mut service: S,
     ) -> Result<Response<Body>, S::Error> {
         let headers = req.headers_mut();
-        if let Some(header_val) = headers.get(ENCODING_HEADER) {
+        if let Some(header_val) = headers.get(&ENCODING_HEADER) {
             let header_bytes = header_val.as_bytes();
             if header_bytes.starts_with(b"zstdarrow") {
-                _ = headers.insert(
-                    ENCODING_HEADER,
-                    "zstd".parse().expect("can parse to header value"),
-                );
+                _ = headers.insert(&ENCODING_HEADER, ZSTD_HEADER_VALUE.clone());
             }
         }
 

--- a/rust/otap-dataflow/crates/otap/src/otap_receiver.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_receiver.rs
@@ -11,6 +11,7 @@
 
 use crate::OTAP_RECEIVER_FACTORIES;
 use crate::compression::CompressionMethod;
+use crate::otap_grpc::middleware::zstd_header::ZstdRequestHeaderAdapter;
 use crate::otap_grpc::{ArrowLogsServiceImpl, ArrowMetricsServiceImpl, ArrowTracesServiceImpl};
 use crate::pdata::OtapPdata;
 use async_trait::async_trait;
@@ -35,6 +36,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use tonic::codegen::tokio_stream::wrappers::TcpListenerStream;
 use tonic::transport::Server;
+use tonic_middleware::MiddlewareLayer;
 
 const OTAP_RECEIVER_URN: &str = "urn:otel:otap:receiver";
 
@@ -145,6 +147,7 @@ impl shared::Receiver<OtapPdata> for OTAPReceiver {
         }
 
         let server = Server::builder()
+            .layer(MiddlewareLayer::new(ZstdRequestHeaderAdapter::default()))
             .add_service(logs_service_server)
             .add_service(metrics_service_server)
             .add_service(trace_service_server);


### PR DESCRIPTION
closes: #1068 