### PR TITLE
[otap-dataflow] Config: enforce serde strictness and normalize option casing

### DIFF
--- a/rust/otap-dataflow/crates/config/src/engine.rs
+++ b/rust/otap-dataflow/crates/config/src/engine.rs
@@ -13,6 +13,7 @@ use std::collections::HashMap;
 /// Root configuration for the pipeline engine.
 /// Contains engine-level settings and all pipeline groups.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct EngineConfig {
     /// Settings that apply to the entire engine instance.
     pub settings: EngineSettings,
@@ -23,6 +24,7 @@ pub struct EngineConfig {
 
 /// Global settings for the engine.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct EngineSettings {
     /// Optional HTTP admin server configuration.
     pub http_admin: Option<HttpAdminSettings>,
@@ -33,6 +35,7 @@ pub struct EngineSettings {
 
 /// Configuration for the telemetry metrics system.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct TelemetrySettings {
     /// The size of the reporting channel.
     #[serde(default = "default_reporting_channel_size")]
@@ -44,6 +47,7 @@ pub struct TelemetrySettings {
 
 /// Configuration for the HTTP admin endpoints.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct HttpAdminSettings {
     /// The address to bind the HTTP server to (e.g., "127.0.0.1:8080").
     #[serde(default = "default_bind_address")]

--- a/rust/otap-dataflow/crates/config/src/pipeline.rs
+++ b/rust/otap-dataflow/crates/config/src/pipeline.rs
@@ -24,6 +24,7 @@ use std::sync::Arc;
 ///
 /// This configuration defines the pipeline’s nodes, the interconnections (hyper-edges), and pipeline-level settings.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct PipelineConfig {
     /// Type of the pipeline, which determines the type of PData it processes.
     ///
@@ -60,6 +61,7 @@ pub enum PipelineType {
 }
 /// A configuration for a pipeline.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct PipelineSettings {
     /// The default size of the node control message channels.
     /// These channels are used for sending control messages by the pipeline engine to nodes.

--- a/rust/otap-dataflow/crates/config/src/pipeline_group.rs
+++ b/rust/otap-dataflow/crates/config/src/pipeline_group.rs
@@ -13,6 +13,7 @@ use std::collections::HashMap;
 /// Configuration for a single pipeline group.
 /// Contains group-specific settings and all its pipelines.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct PipelineGroupConfig {
     /// All pipelines belonging to this pipeline group, keyed by pipeline ID.
     pub pipelines: HashMap<PipelineId, PipelineConfig>,
@@ -75,6 +76,7 @@ impl Default for PipelineGroupConfig {
 
 /// Pipeline group quota configuration.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(deny_unknown_fields)]
 pub struct Quota {
     /// CPU core allocation strategy for this pipeline group.
     #[serde(default)]

--- a/rust/otap-dataflow/crates/otap/src/compression.rs
+++ b/rust/otap-dataflow/crates/otap/src/compression.rs
@@ -10,15 +10,13 @@ use tonic::codec::CompressionEncoding;
 
 /// Enum to represent various compression methods
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum CompressionMethod {
     /// Fastest compression
-    #[serde(alias = "zstd")]
     Zstd,
     /// Most compatible compression method
-    #[serde(alias = "gzip")]
     Gzip,
     /// Used for legacy systems
-    #[serde(alias = "deflate")]
     Deflate,
 }
 
@@ -32,5 +30,26 @@ impl CompressionMethod {
             CompressionMethod::Zstd => CompressionEncoding::Zstd,
             CompressionMethod::Deflate => CompressionEncoding::Deflate,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compression_method_accepts_snake_case_only() {
+        // Valid canonical snake_case values
+        let zstd: CompressionMethod = serde_json::from_str("\"zstd\"").unwrap();
+        assert!(matches!(zstd, CompressionMethod::Zstd));
+        let gzip: CompressionMethod = serde_json::from_str("\"gzip\"").unwrap();
+        assert!(matches!(gzip, CompressionMethod::Gzip));
+        let deflate: CompressionMethod = serde_json::from_str("\"deflate\"").unwrap();
+        assert!(matches!(deflate, CompressionMethod::Deflate));
+
+        // Mixed/camel case should fail under strict snake_case
+        assert!(serde_json::from_str::<CompressionMethod>("\"Gzip\"").is_err());
+        assert!(serde_json::from_str::<CompressionMethod>("\"Zstd\"").is_err());
+        assert!(serde_json::from_str::<CompressionMethod>("\"Deflate\"").is_err());
     }
 }

--- a/rust/otap-dataflow/crates/otap/src/debug_processor/config.rs
+++ b/rust/otap-dataflow/crates/otap/src/debug_processor/config.rs
@@ -29,6 +29,7 @@ pub enum SignalActive {
 
 /// Defines the settings of the debug processor, controls the level of verbosity the processor outputs
 #[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     #[serde(default = "default_verbosity")]
     verbosity: Verbosity,

--- a/rust/otap-dataflow/crates/otap/src/fake_data_generator/config.rs
+++ b/rust/otap-dataflow/crates/otap/src/fake_data_generator/config.rs
@@ -28,6 +28,7 @@ pub enum OTLPSignal {
 }
 /// Configuration should take a scenario to play out
 #[derive(Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     // Configuration of the traffic to generate
     traffic_config: TrafficConfig,
@@ -37,6 +38,7 @@ pub struct Config {
 
 /// Configuration to describe the traffic being sent
 #[derive(Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct TrafficConfig {
     #[serde(default = "default_signals_per_second")]
     signals_per_second: Option<usize>,

--- a/rust/otap-dataflow/crates/otap/src/otap_exporter.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_exporter.rs
@@ -633,7 +633,7 @@ mod tests {
     fn test_from_config_success() {
         let json_config = json!({
             "grpc_endpoint": "http://localhost:4317",
-            "compression_method": "Gzip"
+            "compression_method": "gzip"
         });
 
         // Create a proper pipeline context for the test
@@ -658,7 +658,7 @@ mod tests {
     #[test]
     fn test_from_config_missing_required_field() {
         let json_config = json!({
-            "compression_method": "Gzip"
+            "compression_method": "gzip"
         });
 
         // Create a proper pipeline context for the test

--- a/rust/otap-dataflow/crates/otap/src/otap_exporter/config.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_exporter/config.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Deserializer};
 
 /// Configuration for the OTAP Exporter
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     /// The grpc endpoint to which OTAP service requests will be sent
     pub grpc_endpoint: String,
@@ -27,6 +28,7 @@ pub struct Config {
 
 /// Configuration for the arrow payloads produced by the [`OtapExporter`]
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ArrowConfig {
     /// Compression to use for IPC serialized payloads within the BatchArrowMessages
     ///
@@ -47,9 +49,9 @@ pub struct ArrowConfig {
 
 /// Compression options for arrow payloads
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ArrowPayloadCompression {
     /// Zstd compression
-    #[serde(alias = "zstd")]
     Zstd,
 }
 

--- a/rust/otap-dataflow/crates/otap/src/otap_receiver.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_receiver.rs
@@ -42,6 +42,7 @@ const OTAP_RECEIVER_URN: &str = "urn:otel:otap:receiver";
 
 /// Configuration for the OTAP Receiver
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     listening_addr: SocketAddr,
     compression_method: Option<CompressionMethod>,

--- a/rust/otap-dataflow/crates/otap/src/otlp_exporter.rs
+++ b/rust/otap-dataflow/crates/otap/src/otlp_exporter.rs
@@ -28,6 +28,7 @@ pub const OTLP_EXPORTER_URN: &str = "urn:otel:otlp:exporter";
 
 /// Configuration for the OTLP Exporter
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     /// The gRPC endpoint to connect to
     pub grpc_endpoint: String,

--- a/rust/otap-dataflow/crates/otap/src/otlp_receiver.rs
+++ b/rust/otap-dataflow/crates/otap/src/otlp_receiver.rs
@@ -32,6 +32,7 @@ pub const OTLP_RECEIVER_URN: &str = "urn::otel::otlp::receiver";
 
 /// Configuration for OTLP Receiver
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     listening_addr: SocketAddr,
     compression_method: Option<CompressionMethod>,

--- a/rust/otap-dataflow/crates/otap/src/perf_exporter/config.rs
+++ b/rust/otap-dataflow/crates/otap/src/perf_exporter/config.rs
@@ -8,6 +8,7 @@ use serde::Deserialize;
 
 /// Defines the settings of the perf exporter such as what to track
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     /// Time duration after which a perf trace is displayed (default = 1000ms).
     #[serde(default = "default_frequency")]

--- a/rust/otap-dataflow/crates/otap/src/syslog_cef_receiver.rs
+++ b/rust/otap-dataflow/crates/otap/src/syslog_cef_receiver.rs
@@ -33,6 +33,7 @@ const MAX_BATCH_SIZE: u16 = 100; // Maximum number of messages to build an Arrow
 
 /// Protocol type for the receiver
 #[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[allow(dead_code)]
 enum Protocol {
     /// TCP protocol
@@ -43,6 +44,7 @@ enum Protocol {
 
 /// config for a syslog cef receiver
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct Config {
     listening_addr: SocketAddr,
     /// The protocol to use for receiving messages

--- a/rust/otap-dataflow/crates/state/src/config.rs
+++ b/rust/otap-dataflow/crates/state/src/config.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 
 /// Configuration for the observed state store.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     /// The size of the reporting channel.
     pub reporting_channel_size: usize,

--- a/rust/otap-dataflow/crates/telemetry/src/config.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/config.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 
 /// Configuration for the telemetry metrics system.
 #[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     /// The size of the reporting channel.
     pub reporting_channel_size: usize,


### PR DESCRIPTION
- Add #[serde(deny_unknown_fields)] to user-facing config structs:
  - EngineConfig/EngineSettings/TelemetrySettings/HttpAdminSettings
  - PipelineConfig/PipelineSettings
  - PipelineGroupConfig/Quota
  - NodeUserConfig/HyperEdgeConfig
  - telemetry::Config, state::Config
  - otap: exporter/receiver/debug/fake_data/syslog_cef/perf configs
- Normalize enums to canonical snake_case where applicable:
  - otap::CompressionMethod
  - otap::otap_exporter::ArrowPayloadCompression
  - syslog_cef::Protocol
- Update existing tests to use canonical values (e.g., gzip), and add unit tests to assert unknown fields are rejected and only snake_case enum variants are accepted.

This implements PR 1 of #1099: strict parsing and canonical option casing.