### PR TITLE
[otel-arrow-rust] Minor optimization for batch_length method

### DIFF
--- a/rust/otel-arrow-rust/src/otap.rs
+++ b/rust/otel-arrow-rust/src/otap.rs
@@ -383,17 +383,18 @@ fn batch_length<const N: usize>(batches: &[Option<RecordBatch>; N]) -> usize {
     match N {
         Logs::COUNT => batches[POSITION_LOOKUP[ArrowPayloadType::Logs as usize]]
             .as_ref()
-            .map(|batch| batch.num_rows())
-            .unwrap_or(0),
+            .map_or(0, |batch| batch.num_rows()),
         Metrics::COUNT => DATA_POINTS_TYPES
             .iter()
-            .flat_map(|dpt| batches[POSITION_LOOKUP[*dpt as usize]].as_ref())
-            .map(|batch| batch.num_rows())
+            .map(|&dpt| {
+                batches[POSITION_LOOKUP[dpt as usize]]
+                    .as_ref()
+                    .map_or(0, |batch| batch.num_rows())
+            })
             .sum(),
         Traces::COUNT => batches[POSITION_LOOKUP[ArrowPayloadType::Spans as usize]]
             .as_ref()
-            .map(|batch| batch.num_rows())
-            .unwrap_or(0),
+            .map_or(0, |batch| batch.num_rows()),
         _ => {
             unreachable!()
         }


### PR DESCRIPTION
## Changes
- Minor optimization for Metrics by counting batch length in one pass instead of two
- Simplify the iterators for counting batch length for Logs and Traces