### PR TITLE
Minor refactoring

### DIFF
--- a/rust/otap-dataflow/crates/pdata-views/src/views/metrics.rs
+++ b/rust/otap-dataflow/crates/pdata-views/src/views/metrics.rs
@@ -477,7 +477,7 @@ impl DataPointFlags {
 
     /// Return the raw flags value.
     #[must_use]
-    pub fn into_inner(self) -> u32 {
+    pub const fn into_inner(self) -> u32 {
         self.0
     }
 }

--- a/rust/otap-dataflow/crates/telemetry/src/instrument.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/instrument.rs
@@ -44,7 +44,7 @@ impl<T: Copy + Default> Counter<T> {
 
     /// Returns the current value of the counter.
     #[inline]
-    pub fn get(&self) -> T {
+    pub const fn get(&self) -> T {
         self.0
     }
 }
@@ -132,7 +132,7 @@ where
 
     /// Returns the current value of the counter.
     #[inline]
-    pub fn get(&self) -> T {
+    pub const fn get(&self) -> T {
         self.0
     }
 
@@ -250,7 +250,7 @@ where
 
     /// Returns the current value of the gauge.
     #[inline]
-    pub fn get(&self) -> T {
+    pub const fn get(&self) -> T {
         self.0
     }
 }

--- a/rust/otel-arrow-rust/src/otap.rs
+++ b/rust/otel-arrow-rust/src/otap.rs
@@ -102,7 +102,7 @@ impl OtapArrowRecords {
     }
 
     #[must_use]
-    fn tag(&self) -> OtapArrowRecordTag {
+    const fn tag(&self) -> OtapArrowRecordTag {
         match self {
             Self::Logs(_) => OtapArrowRecordTag::Logs,
             Self::Metrics(_) => OtapArrowRecordTag::Metrics,
@@ -795,7 +795,7 @@ impl OtapBatchStore for Traces {
 
 /// Return the child payload types for the given payload type
 #[must_use]
-pub fn child_payload_types(payload_type: ArrowPayloadType) -> &'static [ArrowPayloadType] {
+pub const fn child_payload_types(payload_type: ArrowPayloadType) -> &'static [ArrowPayloadType] {
     match payload_type {
         ArrowPayloadType::Logs => &[
             ArrowPayloadType::ResourceAttrs,
@@ -811,7 +811,7 @@ pub fn child_payload_types(payload_type: ArrowPayloadType) -> &'static [ArrowPay
         ],
         ArrowPayloadType::SpanEvents => &[ArrowPayloadType::SpanEventAttrs],
         ArrowPayloadType::SpanLinks => &[ArrowPayloadType::SpanLinkAttrs],
-        ArrowPayloadType::UnivariateMetrics => &[
+        ArrowPayloadType::UnivariateMetrics | ArrowPayloadType::MultivariateMetrics => &[
             ArrowPayloadType::ResourceAttrs,
             ArrowPayloadType::ScopeAttrs,
             ArrowPayloadType::LogAttrs,
@@ -838,9 +838,6 @@ pub fn child_payload_types(payload_type: ArrowPayloadType) -> &'static [ArrowPay
 
         ArrowPayloadType::ExpHistogramDpExemplars => {
             &[ArrowPayloadType::ExpHistogramDpExemplarAttrs]
-        }
-        ArrowPayloadType::MultivariateMetrics => {
-            child_payload_types(ArrowPayloadType::UnivariateMetrics)
         }
         _ => &[],
     }

--- a/rust/otel-arrow-rust/src/otap/groups.rs
+++ b/rust/otel-arrow-rust/src/otap/groups.rs
@@ -171,7 +171,7 @@ impl RecordsGroup {
 
     /// Is the container empty?
     #[must_use]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         match self {
             Self::Logs(logs) => logs.is_empty(),
             Self::Metrics(metrics) => metrics.is_empty(),
@@ -181,7 +181,7 @@ impl RecordsGroup {
 
     /// Find the number of OtapArrowRecords we've got.
     #[must_use]
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         match self {
             Self::Logs(logs) => logs.len(),
             Self::Metrics(metrics) => metrics.len(),

--- a/rust/otel-arrow-rust/src/pdata/otlp/mod.rs
+++ b/rust/otel-arrow-rust/src/pdata/otlp/mod.rs
@@ -159,7 +159,7 @@ impl PrecomputedSizes {
 
     /// Get the current length for tracking child positions
     #[must_use]
-    pub fn position(&self) -> usize {
+    pub const fn position(&self) -> usize {
         self.sizes.len()
     }
 


### PR DESCRIPTION
## Changes
- Mark methods `const` where applicable
- Simplify the handling of `ArrowPayloadType::MultivariateMetrics` logic within the `match` statement to avoid recursive calling of the method `child_payload_types`