### PR TITLE
[query-engine] Extend KQL parser schema into child maps

### DIFF
--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/bridge.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/bridge.rs
@@ -26,7 +26,7 @@ pub fn parse_kql_query_into_pipeline(query: &str) -> Result<PipelineExpression, 
                 .with_key_definition("SeverityNumber", ParserMapKeySchema::Integer)
                 .with_key_definition("SeverityText", ParserMapKeySchema::String)
                 .with_key_definition("Body", ParserMapKeySchema::Any)
-                .with_key_definition("Attributes", ParserMapKeySchema::Map)
+                .with_key_definition("Attributes", ParserMapKeySchema::Map(None))
                 .with_key_definition("TraceId", ParserMapKeySchema::Array)
                 .with_key_definition("SpanId", ParserMapKeySchema::Array)
                 .with_key_definition("TraceFlags", ParserMapKeySchema::Integer)

--- a/rust/experimental/query_engine/expressions/src/value_accessor.rs
+++ b/rust/experimental/query_engine/expressions/src/value_accessor.rs
@@ -40,6 +40,10 @@ impl ValueAccessor {
         &self.selectors
     }
 
+    pub fn get_selectors_mut(&mut self) -> &mut [ScalarExpression] {
+        &mut self.selectors
+    }
+
     pub fn insert_selector(&mut self, index: usize, selector: ScalarExpression) {
         self.selectors.insert(index, selector);
     }

--- a/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
@@ -557,8 +557,10 @@ pub(crate) fn parse_accessor_expression(
                         match key {
                             ParserMapKeySchema::Map(inner_schema) => {
                                 if let Some(schema) = inner_schema {
-                                    resolved_value_type =
-                                        schema.validate(value_accessor.get_selectors())?;
+                                    resolved_value_type = schema.try_resolve_value_type(
+                                        value_accessor.get_selectors_mut(),
+                                        &scope.get_pipeline().get_resolution_scope(),
+                                    )?;
                                 }
                             }
                             ParserMapKeySchema::Array | ParserMapKeySchema::Any => {
@@ -631,8 +633,10 @@ pub(crate) fn parse_accessor_expression(
                         }
 
                         if let Some(schema) = default_map_schema {
-                            resolved_value_type =
-                                schema.validate(value_accessor.get_selectors())?;
+                            resolved_value_type = schema.try_resolve_value_type(
+                                value_accessor.get_selectors_mut(),
+                                &scope.get_pipeline().get_resolution_scope(),
+                            )?;
                         }
 
                         value_accessor.insert_selector(

--- a/rust/experimental/query_engine/parser-abstractions/src/parser.rs
+++ b/rust/experimental/query_engine/parser-abstractions/src/parser.rs
@@ -78,7 +78,7 @@ impl ParserMapSchema {
         let definition = self
             .keys
             .entry(name.into())
-            .or_insert_with(|| ParserMapKeySchema::Map);
+            .or_insert_with(|| ParserMapKeySchema::Map(None));
         if definition.get_value_type() != Some(ValueType::Map) {
             panic!("Map key was already defined for '{name}' as something other than a map");
         }
@@ -94,8 +94,69 @@ impl ParserMapSchema {
         self.keys.get(name)
     }
 
-    pub fn get_default_map_key(&self) -> Option<&str> {
-        self.default_map_key.as_ref().map(|v| v.as_ref())
+    pub fn get_default_map(&self) -> Option<(&str, Option<&ParserMapSchema>)> {
+        if let Some(key) = &self.default_map_key
+            && let Some(ParserMapKeySchema::Map(inner_schema)) = self.get_schema_for_key(key)
+        {
+            Some((key.as_ref(), inner_schema.as_ref()))
+        } else {
+            None
+        }
+    }
+
+    pub fn validate(
+        &self,
+        selectors: &[ScalarExpression],
+    ) -> Result<Option<ValueType>, ParserError> {
+        if let Some(selector) = selectors.first() {
+            if let ScalarExpression::Static(StaticScalarExpression::String(string_selector)) =
+                selector
+            {
+                match self.get_schema_for_key(string_selector.get_value()) {
+                    Some(key) => {
+                        if selectors.len() > 1 {
+                            match key {
+                                ParserMapKeySchema::Map(inner_schema) => {
+                                    if let Some(schema) = inner_schema {
+                                        return schema.validate(&selectors[1..]);
+                                    }
+                                    return Ok(None);
+                                }
+                                ParserMapKeySchema::Array | ParserMapKeySchema::Any => {
+                                    // todo: Implement validation for arrays
+                                    return Ok(None);
+                                }
+                                _ => {
+                                    return Err(ParserError::SyntaxError(
+                                        selector.get_query_location().clone(),
+                                        format!(
+                                            "Cannot access into key '{}' which is defined as a '{}' type",
+                                            string_selector.get_value(),
+                                            key.get_value_type()
+                                                .map(|v| format!("{v:?}"))
+                                                .unwrap_or("Unknown".into())
+                                        ),
+                                    ));
+                                }
+                            }
+                        }
+
+                        return Ok(key.get_value_type());
+                    }
+                    None => {
+                        return Err(ParserError::SyntaxError(
+                            selector.get_query_location().clone(),
+                            format!(
+                                "The name '{}' does not refer to any known key on the target map",
+                                string_selector.get_value()
+                            ),
+                        ));
+                    }
+                }
+            }
+        }
+
+        Ok(Some(ValueType::Map))
     }
 }
 
@@ -112,7 +173,7 @@ pub enum ParserMapKeySchema {
     DateTime,
     Double,
     Integer,
-    Map,
+    Map(Option<ParserMapSchema>),
     Regex,
     String,
 }
@@ -126,7 +187,7 @@ impl ParserMapKeySchema {
             ParserMapKeySchema::DateTime => Some(ValueType::DateTime),
             ParserMapKeySchema::Double => Some(ValueType::Double),
             ParserMapKeySchema::Integer => Some(ValueType::Integer),
-            ParserMapKeySchema::Map => Some(ValueType::Map),
+            ParserMapKeySchema::Map(_) => Some(ValueType::Map),
             ParserMapKeySchema::Regex => Some(ValueType::Regex),
             ParserMapKeySchema::String => Some(ValueType::String),
         }


### PR DESCRIPTION
## Changes

* Extend schema support in KQL parser into child maps