### PR TITLE
Encode OTAP -> OTLP proto bytes directly for Slice/Map AnyValues

### DIFF
--- a/rust/otap-dataflow/crates/otap/src/encoder.rs
+++ b/rust/otap-dataflow/crates/otap/src/encoder.rs
@@ -964,8 +964,9 @@ mod test {
 
     use otap_df_pdata_views::otlp::bytes::logs::RawLogsData;
     use otap_df_pdata_views::otlp::bytes::traces::RawTraceData;
+    use otel_arrow_rust::otlp::ProtoBuffer;
     use otel_arrow_rust::otlp::attributes::AttributeValueType;
-    use otel_arrow_rust::otlp::attributes::cbor::decode_pcommon_val;
+    use otel_arrow_rust::otlp::attributes::cbor::proto_encode_cbor_bytes;
     use otel_arrow_rust::proto::opentelemetry::common::v1::{
         AnyValue, ArrayValue, InstrumentationScope, KeyValue, KeyValueList, any_value,
     };
@@ -3513,17 +3514,22 @@ mod test {
         assert!(otap_batch.get(ArrowPayloadType::LogAttrs).is_none());
 
         // check the serialized values are what is expected
-        let deserialized_array = decode_pcommon_val(&expected_serialized_array).unwrap();
+        let mut proto_buf = ProtoBuffer::new();
+        proto_encode_cbor_bytes(&expected_serialized_array, &mut proto_buf).unwrap();
+        let deserialized_array = AnyValue::decode(proto_buf.as_ref()).unwrap();
+
         assert_eq!(
-            deserialized_array,
+            deserialized_array.value,
             Some(any_value::Value::ArrayValue(ArrayValue {
                 values: vec![AnyValue::new_bool(true)]
             }))
         );
 
-        let deserialized_kvs = decode_pcommon_val(&expected_serialized_kvs).unwrap();
+        proto_buf.clear();
+        proto_encode_cbor_bytes(&expected_serialized_kvs, &mut proto_buf).unwrap();
+        let deserialized_kvs = AnyValue::decode(proto_buf.as_ref()).unwrap();
         assert_eq!(
-            deserialized_kvs,
+            deserialized_kvs.value,
             Some(any_value::Value::KvlistValue(KeyValueList {
                 values: vec![KeyValue::new("key1", AnyValue::new_bool(true))]
             }))
@@ -3749,17 +3755,21 @@ mod test {
         assert_eq!(logs_attrs, &expected_attrs);
 
         // check the serialized values are what is expected
-        let deserialized_array = decode_pcommon_val(&expected_serialized_array).unwrap();
+        let mut proto_buf = ProtoBuffer::new();
+        proto_encode_cbor_bytes(&expected_serialized_array, &mut proto_buf).unwrap();
+        let deserialized_array = AnyValue::decode(proto_buf.as_ref()).unwrap();
         assert_eq!(
-            deserialized_array,
+            deserialized_array.value,
             Some(any_value::Value::ArrayValue(ArrayValue {
                 values: vec![AnyValue::new_bool(true)]
             }))
         );
 
-        let deserialized_kvs = decode_pcommon_val(&expected_serialized_kvs).unwrap();
+        proto_buf.clear();
+        proto_encode_cbor_bytes(&expected_serialized_kvs, &mut proto_buf).unwrap();
+        let deserialized_kvs = AnyValue::decode(proto_buf.as_ref()).unwrap();
         assert_eq!(
-            deserialized_kvs,
+            deserialized_kvs.value,
             Some(any_value::Value::KvlistValue(KeyValueList {
                 values: vec![KeyValue::new("key1", AnyValue::new_bool(true))]
             }))

--- a/rust/otap-dataflow/crates/otap/src/encoder/cbor.rs
+++ b/rust/otap-dataflow/crates/otap/src/encoder/cbor.rs
@@ -145,13 +145,13 @@ mod test {
                 any_value::Value::BytesValue(vec![1, 2, 3]),
             ),
             (
-                AnyValue::new_array(vec![AnyValue::new_bool(false), AnyValue::new_int(-1)]),
+                AnyValue::new_array(vec![AnyValue::new_bool(false), AnyValue::new_int(1)]),
                 any_value::Value::ArrayValue(ArrayValue::new(vec![
                     AnyValue {
                         value: Some(any_value::Value::BoolValue(false)),
                     },
                     AnyValue {
-                        value: Some(any_value::Value::IntValue(-1)),
+                        value: Some(any_value::Value::IntValue(1)),
                     },
                 ])),
             ),

--- a/rust/otap-dataflow/crates/otap/src/encoder/cbor.rs
+++ b/rust/otap-dataflow/crates/otap/src/encoder/cbor.rs
@@ -118,12 +118,14 @@ mod test {
     use super::*;
     use otap_df_pdata_views::otlp::proto::common::{ObjAny, ObjKeyValue};
     use otap_df_pdata_views::otlp::proto::wrappers::Wraps;
+    use otel_arrow_rust::otlp::ProtoBuffer;
     use otel_arrow_rust::{
-        otlp::attributes::cbor::decode_pcommon_val,
+        otlp::attributes::cbor::proto_encode_cbor_bytes,
         proto::opentelemetry::common::v1::{
             AnyValue, ArrayValue, KeyValue, KeyValueList, any_value,
         },
     };
+    use prost::Message;
 
     #[test]
     fn test_round_trip_anyvals() {
@@ -182,9 +184,11 @@ mod test {
             serialize_any_values(vec![ObjAny::new(&source)].into_iter(), &mut serialized_val)
                 .unwrap();
 
-            let result = decode_pcommon_val(&serialized_val).unwrap();
+            let mut proto_buffer = ProtoBuffer::new();
+            proto_encode_cbor_bytes(&serialized_val, &mut proto_buffer).unwrap();
+            let result = AnyValue::decode(proto_buffer.as_ref()).unwrap();
             assert_eq!(
-                result,
+                result.value,
                 Some(any_value::Value::ArrayValue(ArrayValue::new(vec![
                     AnyValue {
                         value: Some(expected)
@@ -250,9 +254,11 @@ mod test {
             )
             .unwrap();
 
-            let result = decode_pcommon_val(&serialized_val).unwrap();
+            let mut proto_buffer = ProtoBuffer::new();
+            proto_encode_cbor_bytes(&serialized_val, &mut proto_buffer).unwrap();
+            let result = AnyValue::decode(proto_buffer.as_ref()).unwrap();
             assert_eq!(
-                result,
+                result.value,
                 Some(any_value::Value::KvlistValue(KeyValueList {
                     values: expected.clone()
                 }))

--- a/rust/otel-arrow-rust/src/otlp/attributes.rs
+++ b/rust/otel-arrow-rust/src/otlp/attributes.rs
@@ -9,6 +9,7 @@ use snafu::OptionExt;
 
 use crate::arrays::{MaybeDictArrayAccessor, NullableArrayAccessor, get_required_array};
 use crate::error::{self, Error, Result};
+use crate::otlp::attributes::cbor::proto_encode_cbor_bytes;
 use crate::otlp::common::{AnyValueArrays, ProtoBuffer};
 use crate::proto::consts::field_num::common::{
     ANY_VALUE_ARRAY_VALUE, ANY_VALUE_BOOL_VALUE, ANY_VALUE_BYTES_VALUE, ANY_VALUE_DOUBLE_VALUE,
@@ -146,23 +147,25 @@ pub(crate) fn encode_any_value(
             }
         }
 
-        // TODO for Map and Slice, we should be encoding directly from cbor to proto instead
-        // of going through the intermediate prost struct like we're currently doing below:
         AttributeValueType::Map => {
-            if let Some(any_val) = attr_arrays.value_at(index) {
-                if let Some(Value::KvlistValue(kv_list)) = any_val?.value {
-                    let mut bytes = vec![];
-                    kv_list.encode(&mut bytes).expect("buffer has capacity");
-                    result_buf.encode_bytes(ANY_VALUE_KVLIST_VALUE, bytes.as_ref());
+            if let Some(ser_bytes) = &attr_arrays.attr_ser {
+                if let Some(val) = ser_bytes.slice_at(index) {
+                    proto_encode_len_delimited_unknown_size!(
+                        ANY_VALUE_KVLIST_VALUE,
+                        proto_encode_cbor_bytes(val, result_buf)?,
+                        result_buf
+                    );
                 }
             }
         }
         AttributeValueType::Slice => {
-            if let Some(any_val) = attr_arrays.value_at(index) {
-                if let Some(Value::ArrayValue(list)) = any_val?.value {
-                    let mut bytes = vec![];
-                    list.encode(&mut bytes).expect("buffer has capacity");
-                    result_buf.encode_bytes(ANY_VALUE_ARRAY_VALUE, bytes.as_ref());
+            if let Some(ser_bytes) = &attr_arrays.attr_ser {
+                if let Some(val) = ser_bytes.slice_at(index) {
+                    proto_encode_len_delimited_unknown_size!(
+                        ANY_VALUE_KVLIST_VALUE,
+                        proto_encode_cbor_bytes(val, result_buf)?,
+                        result_buf
+                    );
                 }
             }
         }

--- a/rust/otel-arrow-rust/src/otlp/attributes.rs
+++ b/rust/otel-arrow-rust/src/otlp/attributes.rs
@@ -4,7 +4,6 @@
 use arrow::array::{ArrowPrimitiveType, PrimitiveArray, RecordBatch, StringArray};
 use arrow::datatypes::{UInt16Type, UInt32Type};
 use num_enum::TryFromPrimitive;
-use prost::Message;
 use snafu::OptionExt;
 
 use crate::arrays::{MaybeDictArrayAccessor, NullableArrayAccessor, get_required_array};
@@ -12,12 +11,10 @@ use crate::error::{self, Error, Result};
 use crate::otlp::attributes::cbor::proto_encode_cbor_bytes;
 use crate::otlp::common::{AnyValueArrays, ProtoBuffer};
 use crate::proto::consts::field_num::common::{
-    ANY_VALUE_ARRAY_VALUE, ANY_VALUE_BOOL_VALUE, ANY_VALUE_BYTES_VALUE, ANY_VALUE_DOUBLE_VALUE,
-    ANY_VALUE_INT_VALUE, ANY_VALUE_KVLIST_VALUE, ANY_VALUE_STRING_VALUE, KEY_VALUE_KEY,
-    KEY_VALUE_VALUE,
+    ANY_VALUE_BOOL_VALUE, ANY_VALUE_BYTES_VALUE, ANY_VALUE_DOUBLE_VALUE, ANY_VALUE_INT_VALUE,
+    ANY_VALUE_STRING_VALUE, KEY_VALUE_KEY, KEY_VALUE_VALUE,
 };
 use crate::proto::consts::wire_types;
-use crate::proto::opentelemetry::common::v1::any_value::Value;
 use crate::proto_encode_len_delimited_unknown_size;
 use crate::schema::consts;
 
@@ -146,26 +143,10 @@ pub(crate) fn encode_any_value(
                 }
             }
         }
-
-        AttributeValueType::Map => {
+        AttributeValueType::Map | AttributeValueType::Slice => {
             if let Some(ser_bytes) = &attr_arrays.attr_ser {
                 if let Some(val) = ser_bytes.slice_at(index) {
-                    proto_encode_len_delimited_unknown_size!(
-                        ANY_VALUE_KVLIST_VALUE,
-                        proto_encode_cbor_bytes(val, result_buf)?,
-                        result_buf
-                    );
-                }
-            }
-        }
-        AttributeValueType::Slice => {
-            if let Some(ser_bytes) = &attr_arrays.attr_ser {
-                if let Some(val) = ser_bytes.slice_at(index) {
-                    proto_encode_len_delimited_unknown_size!(
-                        ANY_VALUE_KVLIST_VALUE,
-                        proto_encode_cbor_bytes(val, result_buf)?,
-                        result_buf
-                    );
+                    proto_encode_cbor_bytes(val, result_buf)?;
                 }
             }
         }

--- a/rust/otel-arrow-rust/src/otlp/attributes/cbor.rs
+++ b/rust/otel-arrow-rust/src/otlp/attributes/cbor.rs
@@ -34,18 +34,17 @@ fn proto_encode_cbor_value(value: &ciborium::Value, result_buf: &mut ProtoBuffer
             result_buf.encode_varint(*bool_val as u64);
         }
         ciborium::Value::Bytes(bytes_val) => {
-            result_buf.encode_bytes(ANY_VALUE_BYTES_VALUE, &bytes_val);
+            result_buf.encode_bytes(ANY_VALUE_BYTES_VALUE, bytes_val);
         }
         ciborium::Value::Float(float_val) => {
             result_buf.encode_field_tag(ANY_VALUE_DOUBLE_VALUE, wire_types::FIXED64);
             result_buf.extend_from_slice(&float_val.to_le_bytes());
         }
         ciborium::Value::Text(str_val) => {
-            result_buf.encode_string(ANY_VALUE_STRING_VALUE, &str_val);
+            result_buf.encode_string(ANY_VALUE_STRING_VALUE, str_val);
         }
         ciborium::Value::Integer(int_val) => {
-            let int_val: u64 = int_val
-                .clone()
+            let int_val: u64 = (*int_val)
                 .try_into()
                 .context(error::InvalidSerializedIntAttributeValueSnafu)?;
             result_buf.encode_field_tag(ANY_VALUE_INT_VALUE, wire_types::VARINT);
@@ -61,7 +60,7 @@ fn proto_encode_cbor_value(value: &ciborium::Value, result_buf: &mut ProtoBuffer
         ciborium::Value::Map(kv_list_val) => {
             proto_encode_len_delimited_unknown_size!(
                 ANY_VALUE_KVLIST_VALUE,
-                proto_encode_cbor_kv_list(&kv_list_val, result_buf)?,
+                proto_encode_cbor_kv_list(kv_list_val, result_buf)?,
                 result_buf
             );
         }
@@ -113,7 +112,7 @@ fn proto_encode_cbor_kv(
 ) -> Result<()> {
     match key {
         ciborium::Value::Text(key_str) => {
-            result_buf.encode_string(KEY_VALUE_KEY, &key_str);
+            result_buf.encode_string(KEY_VALUE_KEY, key_str);
         }
         ciborium::Value::Null => {
             // empty key

--- a/rust/otel-arrow-rust/src/otlp/attributes/cbor.rs
+++ b/rust/otel-arrow-rust/src/otlp/attributes/cbor.rs
@@ -1,96 +1,136 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::error::{self, Error, Result};
-use crate::proto::opentelemetry::common::v1::any_value::Value;
-use crate::proto::opentelemetry::common::v1::{AnyValue, ArrayValue, KeyValue, KeyValueList};
+use crate::error::{self, Result};
+use crate::otlp::ProtoBuffer;
+use crate::proto::consts::field_num::common::{
+    ANY_VALUE_ARRAY_VALUE, ANY_VALUE_BOOL_VALUE, ANY_VALUE_BYTES_VALUE, ANY_VALUE_DOUBLE_VALUE,
+    ANY_VALUE_INT_VALUE, ANY_VALUE_KVLIST_VALUE, ANY_VALUE_STRING_VALUE, ARRAY_VALUE_VALUES,
+    KEY_VALUE_KEY, KEY_VALUE_LIST_VALUES, KEY_VALUE_VALUE,
+};
+use crate::proto::consts::wire_types;
+use crate::proto_encode_len_delimited_unknown_size;
 use snafu::ResultExt;
 
-/// Decode bytes from a serialized attribute into pcommon value.
+/// Decode bytes from a serialized attribute into protobuf bytes value.
 ///
 /// This should be used for values in the `ser` column of attributes and Log bodies.
-pub fn decode_pcommon_val(input: &[u8]) -> Result<Option<Value>> {
-    let decoded_val = ciborium::from_reader::<ciborium::Value, &[u8]>(input)
+pub fn proto_encode_cbor_bytes(input: &[u8], result_buf: &mut ProtoBuffer) -> Result<()> {
+    let value = ciborium::from_reader::<ciborium::Value, &[u8]>(input)
         .context(error::InvalidSerializedAttributeBytesSnafu)?;
 
-    MaybeValue::try_from(decoded_val).map(Into::into)
+    proto_encode_cbor_value(&value, result_buf)?;
+
+    Ok(())
 }
 
-/// `MaybeValue` is a thin wrapper around `Option<Value>`.
-///
-/// We use this so we to avoid violating the coherence rule when implementing TryFrom.
-struct MaybeValue(Option<Value>);
-
-impl From<MaybeValue> for Option<Value> {
-    fn from(value: MaybeValue) -> Self {
-        value.0
-    }
-}
-
-impl TryFrom<ciborium::Value> for MaybeValue {
-    type Error = Error;
-
-    fn try_from(value: ciborium::Value) -> Result<Self> {
-        let val = match value {
-            ciborium::Value::Null => None,
-            ciborium::Value::Text(string_val) => Some(Value::StringValue(string_val)),
-            ciborium::Value::Float(double_val) => Some(Value::DoubleValue(double_val)),
-            ciborium::Value::Bytes(bytes_val) => Some(Value::BytesValue(bytes_val)),
-            ciborium::Value::Bool(bool_val) => Some(Value::BoolValue(bool_val)),
-            ciborium::Value::Integer(int_val) => Some(Value::IntValue(
-                int_val
-                    .try_into()
-                    .context(error::InvalidSerializedIntAttributeValueSnafu)?,
-            )),
-            ciborium::Value::Array(array_vals) => Some(Value::try_from(array_vals)?),
-            ciborium::Value::Map(kv_vals) => Some(Value::try_from(kv_vals)?),
-            other => {
-                return error::UnsupportedSerializedAttributeValueSnafu { actual: other }.fail();
+fn proto_encode_cbor_value(value: &ciborium::Value, result_buf: &mut ProtoBuffer) -> Result<()> {
+    match value {
+        ciborium::Value::Null => {
+            // do nothing, it's an empty value
+        }
+        ciborium::Value::Bool(bool_val) => {
+            result_buf.encode_field_tag(ANY_VALUE_BOOL_VALUE, wire_types::VARINT);
+            result_buf.encode_varint(*bool_val as u64);
+        }
+        ciborium::Value::Bytes(bytes_val) => {
+            result_buf.encode_bytes(ANY_VALUE_BYTES_VALUE, &bytes_val);
+        }
+        ciborium::Value::Float(float_val) => {
+            result_buf.encode_field_tag(ANY_VALUE_DOUBLE_VALUE, wire_types::FIXED64);
+            result_buf.extend_from_slice(&float_val.to_le_bytes());
+        }
+        ciborium::Value::Text(str_val) => {
+            result_buf.encode_string(ANY_VALUE_STRING_VALUE, &str_val);
+        }
+        ciborium::Value::Integer(int_val) => {
+            let int_val: u64 = int_val
+                .clone()
+                .try_into()
+                .context(error::InvalidSerializedIntAttributeValueSnafu)?;
+            result_buf.encode_field_tag(ANY_VALUE_INT_VALUE, wire_types::VARINT);
+            result_buf.encode_varint(int_val);
+        }
+        ciborium::Value::Array(list_val) => {
+            proto_encode_len_delimited_unknown_size!(
+                ANY_VALUE_ARRAY_VALUE,
+                proto_encode_array_values(list_val, result_buf)?,
+                result_buf
+            );
+        }
+        ciborium::Value::Map(kv_list_val) => {
+            proto_encode_len_delimited_unknown_size!(
+                ANY_VALUE_KVLIST_VALUE,
+                proto_encode_cbor_kv_list(&kv_list_val, result_buf)?,
+                result_buf
+            );
+        }
+        other => {
+            return error::UnsupportedSerializedAttributeValueSnafu {
+                actual: other.clone(),
             }
-        };
-
-        Ok(Self(val))
+            .fail();
+        }
     }
+
+    Ok(())
 }
 
-/// Converts an array of cbor values into the ArrayValue variant of Value
-impl TryFrom<Vec<ciborium::Value>> for Value {
-    type Error = Error;
-
-    fn try_from(values: Vec<ciborium::Value>) -> std::result::Result<Self, Self::Error> {
-        let vals: Result<Vec<_>> = values
-            .into_iter()
-            .map(|element| match MaybeValue::try_from(element) {
-                Ok(val) => Ok(AnyValue { value: val.into() }),
-                Err(e) => Err(e),
-            })
-            .collect();
-
-        Ok(Value::ArrayValue(ArrayValue { values: vals? }))
+fn proto_encode_array_values(
+    list_val: &[ciborium::Value],
+    result_buf: &mut ProtoBuffer,
+) -> Result<()> {
+    for v in list_val {
+        proto_encode_len_delimited_unknown_size!(
+            ARRAY_VALUE_VALUES,
+            proto_encode_cbor_value(v, result_buf)?,
+            result_buf
+        );
     }
+
+    Ok(())
 }
 
-/// Converts the array of cbor kv pairs into the KvlistValue variant of Value
-impl TryFrom<Vec<(ciborium::Value, ciborium::Value)>> for Value {
-    type Error = Error;
-
-    fn try_from(
-        kv_values: Vec<(ciborium::Value, ciborium::Value)>,
-    ) -> std::result::Result<Self, Self::Error> {
-        let kvs: Result<Vec<_>> = kv_values
-            .into_iter()
-            .map(|(k, v)| {
-                if let ciborium::Value::Text(key) = k {
-                    match MaybeValue::try_from(v) {
-                        Ok(val) => Ok(KeyValue::new(key, AnyValue { value: val.into() })),
-                        Err(e) => Err(e),
-                    }
-                } else {
-                    error::InvalidSerializedMapKeyTypeSnafu { actual: k }.fail()
-                }
-            })
-            .collect();
-
-        Ok(Value::KvlistValue(KeyValueList::new(kvs?)))
+fn proto_encode_cbor_kv_list(
+    kv_list: &[(ciborium::Value, ciborium::Value)],
+    result_buf: &mut ProtoBuffer,
+) -> Result<()> {
+    for (k, v) in kv_list {
+        proto_encode_len_delimited_unknown_size!(
+            KEY_VALUE_LIST_VALUES,
+            proto_encode_cbor_kv(k, v, result_buf)?,
+            result_buf
+        );
     }
+
+    Ok(())
+}
+
+fn proto_encode_cbor_kv(
+    key: &ciborium::Value,
+    value: &ciborium::Value,
+    result_buf: &mut ProtoBuffer,
+) -> Result<()> {
+    match key {
+        ciborium::Value::Text(key_str) => {
+            result_buf.encode_string(KEY_VALUE_KEY, &key_str);
+        }
+        ciborium::Value::Null => {
+            // empty key
+        }
+        other => {
+            return error::InvalidSerializedMapKeyTypeSnafu {
+                actual: other.clone(),
+            }
+            .fail();
+        }
+    }
+
+    proto_encode_len_delimited_unknown_size!(
+        KEY_VALUE_VALUE,
+        proto_encode_cbor_value(value, result_buf)?,
+        result_buf
+    );
+
+    Ok(())
 }

--- a/rust/otel-arrow-rust/src/otlp/common.rs
+++ b/rust/otel-arrow-rust/src/otlp/common.rs
@@ -7,8 +7,7 @@ use crate::arrays::{
     get_required_array, get_u8_array,
 };
 use crate::error::{self, Error, Result};
-use crate::otlp::attributes::AttributeValueType;
-use crate::otlp::attributes::{Attribute16Arrays, cbor, encode_key_value};
+use crate::otlp::attributes::{Attribute16Arrays, encode_key_value};
 use crate::proto::consts::field_num::common::{
     INSTRUMENTATION_DROPPED_ATTRIBUTES_COUNT, INSTRUMENTATION_SCOPE_ATTRIBUTES,
     INSTRUMENTATION_SCOPE_NAME, INSTRUMENTATION_SCOPE_VERSION,
@@ -26,7 +25,7 @@ use arrow::array::{
 };
 use arrow::datatypes::{DataType, Field, Fields};
 use arrow::row::{Row, RowConverter, SortField};
-use snafu::{OptionExt, ResultExt};
+use snafu::OptionExt;
 use std::cmp::Ordering;
 use std::fmt;
 use std::fmt::Write;

--- a/rust/otel-arrow-rust/src/otlp/logs.rs
+++ b/rust/otel-arrow-rust/src/otlp/logs.rs
@@ -128,18 +128,6 @@ impl<'a> LogBodyArrays<'a> {
     }
 }
 
-impl NullableArrayAccessor for LogBodyArrays<'_> {
-    type Native = Result<AnyValue>;
-
-    fn value_at(&self, idx: usize) -> Option<Self::Native> {
-        if !self.is_valid(idx) {
-            return None;
-        }
-
-        self.anyval_arrays.value_at(idx)
-    }
-}
-
 impl<'a> TryFrom<&'a StructArray> for LogBodyArrays<'a> {
     type Error = Error;
 

--- a/rust/otel-arrow-rust/src/otlp/logs.rs
+++ b/rust/otel-arrow-rust/src/otlp/logs.rs
@@ -27,7 +27,6 @@ use crate::proto::consts::field_num::logs::{
 };
 use crate::proto::consts::wire_types;
 use crate::proto::opentelemetry::arrow::v1::ArrowPayloadType;
-use crate::proto::opentelemetry::common::v1::AnyValue;
 use crate::proto_encode_len_delimited_unknown_size;
 use crate::schema::consts;
 
@@ -502,7 +501,7 @@ mod test {
     use std::sync::Arc;
 
     use crate::proto::opentelemetry::arrow::v1::ArrowPayloadType;
-    use crate::proto::opentelemetry::common::v1::{InstrumentationScope, KeyValue};
+    use crate::proto::opentelemetry::common::v1::{AnyValue, InstrumentationScope, KeyValue};
     use crate::proto::opentelemetry::logs::v1::{LogRecord, ResourceLogs, ScopeLogs};
     use crate::proto::opentelemetry::resource::v1::Resource;
     use crate::schema::{FieldExt, consts};

--- a/rust/otel-arrow-rust/src/validation/scenarios.rs
+++ b/rust/otel-arrow-rust/src/validation/scenarios.rs
@@ -79,7 +79,7 @@ where
 
                         // Compare the received data with what was sent.
                         let expected_output_request = O::Request::from(expected_request);
-                        assert_eq!(expected_output_request, received_request);
+                        pretty_assertions::assert_eq!(expected_output_request, received_request);
 
                         Ok(())
                     }


### PR DESCRIPTION
closes: #1121 

Stop going to the intermediate prost struct when decoding Map / Slice AnyValues