### PR TITLE
[query-engine] Summary schema validation support in KQL parser

### DIFF
--- a/rust/experimental/query_engine/kql-parser/src/aggregate_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/aggregate_expressions.rs
@@ -14,12 +14,20 @@ pub(crate) fn parse_aggregate_assignment_expression(
     let mut aggregate_assignment_rules = aggregate_assignment_expression_rule.into_inner();
 
     let destination_rule = aggregate_assignment_rules.next().unwrap();
-    let destination_rule_str = destination_rule.as_str();
+    let destination_rule_location = to_query_location(&destination_rule);
+
+    let identifier = destination_rule.as_str().trim();
+
+    crate::tabular_expressions::validate_summary_identifier(
+        scope,
+        destination_rule_location,
+        identifier,
+    )?;
 
     let aggregation_expression =
         parse_aggregate_expression(aggregate_assignment_rules.next().unwrap(), scope)?;
 
-    Ok((destination_rule_str.into(), aggregation_expression))
+    Ok((identifier.into(), aggregation_expression))
 }
 
 fn parse_aggregate_expression(

--- a/rust/experimental/query_engine/parser-abstractions/src/parser.rs
+++ b/rust/experimental/query_engine/parser-abstractions/src/parser.rs
@@ -20,6 +20,7 @@ pub trait Parser {
 
 pub struct ParserOptions {
     pub(crate) source_map_schema: Option<ParserMapSchema>,
+    pub(crate) summary_map_schema: Option<ParserMapSchema>,
     pub(crate) attached_data_names: HashSet<Box<str>>,
 }
 
@@ -27,12 +28,19 @@ impl ParserOptions {
     pub fn new() -> ParserOptions {
         Self {
             source_map_schema: None,
+            summary_map_schema: None,
             attached_data_names: HashSet::new(),
         }
     }
 
     pub fn with_source_map_schema(mut self, source_map_schema: ParserMapSchema) -> ParserOptions {
         self.source_map_schema = Some(source_map_schema);
+
+        self
+    }
+
+    pub fn with_summary_map_schema(mut self, summary_map_schema: ParserMapSchema) -> ParserOptions {
+        self.summary_map_schema = Some(summary_map_schema);
 
         self
     }
@@ -52,6 +60,7 @@ impl Default for ParserOptions {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct ParserMapSchema {
     keys: HashMap<Box<str>, ParserMapKeySchema>,
     default_map_key: Option<Box<str>>,
@@ -191,6 +200,7 @@ impl Default for ParserMapSchema {
     }
 }
 
+#[derive(Debug, Clone)]
 pub enum ParserMapKeySchema {
     Any,
     Array,
@@ -201,6 +211,7 @@ pub enum ParserMapKeySchema {
     Map(Option<ParserMapSchema>),
     Regex,
     String,
+    TimeSpan,
 }
 
 impl ParserMapKeySchema {
@@ -215,6 +226,27 @@ impl ParserMapKeySchema {
             ParserMapKeySchema::Map(_) => Some(ValueType::Map),
             ParserMapKeySchema::Regex => Some(ValueType::Regex),
             ParserMapKeySchema::String => Some(ValueType::String),
+            ParserMapKeySchema::TimeSpan => Some(ValueType::TimeSpan),
+        }
+    }
+}
+
+impl TryFrom<&str> for ParserMapKeySchema {
+    type Error = ();
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "Any" => Ok(ParserMapKeySchema::Any),
+            "Array" => Ok(ParserMapKeySchema::Array),
+            "Boolean" => Ok(ParserMapKeySchema::Boolean),
+            "DateTime" => Ok(ParserMapKeySchema::DateTime),
+            "Double" => Ok(ParserMapKeySchema::Double),
+            "Integer" => Ok(ParserMapKeySchema::Integer),
+            "Map" => Ok(ParserMapKeySchema::Map(None)),
+            "Regex" => Ok(ParserMapKeySchema::Regex),
+            "String" => Ok(ParserMapKeySchema::String),
+            "TimeSpan" => Ok(ParserMapKeySchema::TimeSpan),
+            _ => Err(()),
         }
     }
 }

--- a/rust/experimental/query_engine/parser-abstractions/src/parser_state.rs
+++ b/rust/experimental/query_engine/parser-abstractions/src/parser_state.rs
@@ -9,6 +9,7 @@ use crate::{ParserError, ParserMapSchema, ParserOptions};
 
 pub struct ParserState {
     source_map_schema: Option<ParserMapSchema>,
+    summary_map_schema: Option<ParserMapSchema>,
     attached_data_names: HashSet<Box<str>>,
     global_variable_names: HashSet<Box<str>>,
     variable_names: HashSet<Box<str>>,
@@ -24,6 +25,7 @@ impl ParserState {
     pub fn new_with_options(query: &str, options: ParserOptions) -> ParserState {
         Self {
             source_map_schema: options.source_map_schema,
+            summary_map_schema: options.summary_map_schema,
             attached_data_names: options.attached_data_names,
             global_variable_names: HashSet::new(),
             variable_names: HashSet::new(),
@@ -65,6 +67,10 @@ impl ParserScope for ParserState {
         self.source_map_schema.as_ref()
     }
 
+    fn get_summary_schema(&self) -> Option<&ParserMapSchema> {
+        self.summary_map_schema.as_ref()
+    }
+
     fn is_well_defined_identifier(&self, name: &str) -> bool {
         name == "source"
             || self.is_attached_data_defined(name)
@@ -92,6 +98,7 @@ impl ParserScope for ParserState {
         ParserStateScope {
             pipeline_builder: &self.pipeline_builder,
             source_map_schema: options.source_map_schema,
+            summary_map_schema: options.summary_map_schema,
             attached_data_names: options.attached_data_names,
             global_variable_names: &self.global_variable_names,
             variable_names: HashSet::new(),
@@ -103,6 +110,7 @@ impl ParserScope for ParserState {
 pub struct ParserStateScope<'a> {
     pipeline_builder: &'a PipelineExpressionBuilder,
     source_map_schema: Option<ParserMapSchema>,
+    summary_map_schema: Option<ParserMapSchema>,
     attached_data_names: HashSet<Box<str>>,
     global_variable_names: &'a HashSet<Box<str>>,
     variable_names: HashSet<Box<str>>,
@@ -116,6 +124,10 @@ impl ParserScope for ParserStateScope<'_> {
 
     fn get_source_schema(&self) -> Option<&ParserMapSchema> {
         self.source_map_schema.as_ref()
+    }
+
+    fn get_summary_schema(&self) -> Option<&ParserMapSchema> {
+        self.summary_map_schema.as_ref()
     }
 
     fn is_well_defined_identifier(&self, name: &str) -> bool {
@@ -145,6 +157,7 @@ impl ParserScope for ParserStateScope<'_> {
         ParserStateScope {
             pipeline_builder: self.pipeline_builder,
             source_map_schema: options.source_map_schema,
+            summary_map_schema: options.summary_map_schema,
             attached_data_names: options.attached_data_names,
             global_variable_names: self.global_variable_names,
             variable_names: HashSet::new(),
@@ -165,6 +178,8 @@ pub trait ParserScope {
     }
 
     fn get_source_schema(&self) -> Option<&ParserMapSchema>;
+
+    fn get_summary_schema(&self) -> Option<&ParserMapSchema>;
 
     fn is_well_defined_identifier(&self, name: &str) -> bool;
 


### PR DESCRIPTION
## Changes

* Support validation of summary schema in KQL parser