### PR TITLE
[perf][otap-df-otap] Avoid redundant allocations for validating AttributeTransform config

### DIFF
--- a/rust/otel-arrow-rust/src/otap/transform.rs
+++ b/rust/otel-arrow-rust/src/otap/transform.rs
@@ -567,6 +567,7 @@ pub struct TransformStats {
 /// transformed batch and exact per-batch [`TransformStats`].
 ///
 /// Behavior and guarantees:
+/// - Expects the caller to validate the transform configuration by calling [`AttributesTransform::validate`].
 /// - Parity: the returned `RecordBatch` is the same result you would get from
 ///   [`transform_attributes`] for the same inputs.
 /// - Exact totals: `TransformStats` are computed during the transform with minimal overhead.
@@ -582,8 +583,6 @@ pub fn transform_attributes_with_stats(
     attrs_record_batch: &RecordBatch,
     transform: &AttributesTransform,
 ) -> Result<(RecordBatch, TransformStats)> {
-    transform.validate()?;
-
     let schema = attrs_record_batch.schema();
     let key_column_idx = schema.index_of(consts::ATTRIBUTE_KEY).map_err(|_| {
         error::ColumnNotFoundSnafu {


### PR DESCRIPTION
## Changes
- The transforms for `AttributesProcessor` are not changed after initialization
- Currently we are `AttributesTransform::validate()` in the hot-path. This method allocates a `BTreeSet` when called
- In this PR, I have updated the code to perform validation of `AttributesTransform` just one in the `new` method