### PR TITLE
[query-engine] Improve formatting of diagnostics when displayed

### DIFF
--- a/rust/experimental/query_engine/engine-recordset/src/engine.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/engine.rs
@@ -3,7 +3,7 @@
 
 use std::{
     cell::RefCell,
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fmt::{Debug, Display, Write},
     marker::PhantomData,
 };
@@ -479,26 +479,46 @@ fn format_diagnostics(
             r.cmp(&l)
         });
 
-        let mut line = String::new();
-        line.push_str(query_line);
+        let mut diagnostics = Vec::with_capacity(messages.len());
+        let mut columns = HashSet::new();
+
         for message in messages {
-            line.push('\n');
+            let mut diagnostic = String::new();
+
             let (_, column) = message
                 .get_expression()
                 .get_query_location()
                 .get_line_and_column_numbers();
 
-            line.push_str(&" ".repeat(column + 7));
-            line.push('[');
-            line.push_str(message.get_diagnostic_level().get_name());
-            line.push_str("] ");
-            line.push_str(message.get_expression().get_name());
-            line.push_str(": ");
-            line.push_str(message.get_message());
+            diagnostic.push_str(&" ".repeat(column + 7));
+            diagnostic.push_str("| [");
+            diagnostic.push_str(message.get_diagnostic_level().get_name());
+            diagnostic.push_str("] ");
+            diagnostic.push_str(message.get_expression().get_name());
+            diagnostic.push_str(": ");
+            diagnostic.push_str(message.get_message());
+
+            diagnostics.push((column, diagnostic));
+
+            columns.insert(column);
         }
+
+        let mut line = String::new();
+        line.push_str(query_line);
+        for (diagnostic_column, mut diagnostic) in diagnostics {
+            line.push('\n');
+            for column in &columns {
+                if diagnostic_column > *column {
+                    diagnostic.replace_range(column + 7..column + 8, "|");
+                }
+            }
+            line.push_str(&diagnostic);
+        }
+
         if line_number > 1 {
             f.write_char('\n')?;
         }
+
         write!(f, "ln {line_number:>3}: {line}")?;
         line_number += 1;
     }


### PR DESCRIPTION
## Changes

* Attempting to improve the readability of recordset engine diagnostics when displayed with the query

## Details

### Before

```
ln   1: source | where (key1 == int(null) or key1 != int(null) or key1 == int(null)) and (name == int(null))
                                                                                                  [Verbose] StaticScalar(Null): Evaluated as: 'null'
                                                                                               [Verbose] LogicalExpression(EqualTo): Evaluated as: 'true'
                                                                                          [Verbose] StaticScalar(String): Evaluated as: 'Attributes'
                                                                                          [Verbose] StaticScalar(String): Resolved '{"key1":null,"name":null}' value for key 'Attributes' specified in accessor expression
                                                                                          [Verbose] StaticScalar(String): Evaluated as: 'name'
                                                                                          [Verbose] StaticScalar(String): Resolved 'null' value for key 'name' specified in accessor expression
                                                                                          [Verbose] ScalarExpression(Source): Evaluated as: 'null'
                                                                                     [Verbose] LogicalExpression(And): Evaluated as: 'true'
                                                               [Verbose] LogicalExpression(Or): Evaluated as: 'true'
                                          [Verbose] LogicalExpression(Or): Evaluated as: 'true'
                                [Verbose] StaticScalar(Null): Evaluated as: 'null'
                             [Verbose] LogicalExpression(EqualTo): Evaluated as: 'true'
                        [Verbose] StaticScalar(String): Evaluated as: 'Attributes'
                        [Verbose] StaticScalar(String): Resolved '{"key1":null,"name":null}' value for key 'Attributes' specified in accessor expression
                        [Verbose] StaticScalar(String): Evaluated as: 'key1'
                        [Verbose] StaticScalar(String): Resolved 'null' value for key 'key1' specified in accessor expression
                        [Verbose] ScalarExpression(Source): Evaluated as: 'null'
                 [Verbose] LogicalExpression(Not): Evaluated as: 'false'
                 [Verbose] DiscardDataExpression: Record included
```

### After

```
ln   1: source | where (key1 == int(null) or key1 != int(null) or key1 == int(null)) and (name == int(null))
                 |      |    |  |         |                    |                     |    |    |  | [Verbose] StaticScalar(Null): Evaluated as: 'null'
                 |      |    |  |         |                    |                     |    |    | [Verbose] LogicalExpression(EqualTo): Evaluated as: 'true'
                 |      |    |  |         |                    |                     |    | [Verbose] StaticScalar(String): Evaluated as: 'Attributes'
                 |      |    |  |         |                    |                     |    | [Verbose] StaticScalar(String): Resolved '{"key1":null,"name":null}' value for key 'Attributes' specified in accessor expression
                 |      |    |  |         |                    |                     |    | [Verbose] StaticScalar(String): Evaluated as: 'name'
                 |      |    |  |         |                    |                     |    | [Verbose] StaticScalar(String): Resolved 'null' value for key 'name' specified in accessor expression
                 |      |    |  |         |                    |                     |    | [Verbose] ScalarExpression(Source): Evaluated as: 'null'
                 |      |    |  |         |                    |                     | [Verbose] LogicalExpression(And): Evaluated as: 'true'
                 |      |    |  |         |                    | [Verbose] LogicalExpression(Or): Evaluated as: 'true'
                 |      |    |  |         | [Verbose] LogicalExpression(Or): Evaluated as: 'true'
                 |      |    |  | [Verbose] StaticScalar(Null): Evaluated as: 'null'
                 |      |    | [Verbose] LogicalExpression(EqualTo): Evaluated as: 'true'
                 |      | [Verbose] StaticScalar(String): Evaluated as: 'Attributes'
                 |      | [Verbose] StaticScalar(String): Resolved '{"key1":null,"name":null}' value for key 'Attributes' specified in accessor expression
                 |      | [Verbose] StaticScalar(String): Evaluated as: 'key1'
                 |      | [Verbose] StaticScalar(String): Resolved 'null' value for key 'key1' specified in accessor expression
                 |      | [Verbose] ScalarExpression(Source): Evaluated as: 'null'
                 | [Verbose] LogicalExpression(Not): Evaluated as: 'false'
                 | [Verbose] DiscardDataExpression: Record included
```