### PR TITLE
[perf] Avoid allocations in transform plan creation hot-path

### DIFF
--- a/rust/otap-dataflow/crates/otap/src/attributes_processor.rs
+++ b/rust/otap-dataflow/crates/otap/src/attributes_processor.rs
@@ -47,7 +47,9 @@ use otap_df_engine::processor::ProcessorWrapper;
 use otap_df_telemetry::metrics::MetricSet;
 use otel_arrow_rust::otap::{
     OtapArrowRecords,
-    transform::{AttributesTransform, transform_attributes_with_stats},
+    transform::{
+        AttributesTransform, DeleteTransform, RenameTransform, transform_attributes_with_stats,
+    },
 };
 use otel_arrow_rust::proto::opentelemetry::arrow::v1::ArrowPayloadType;
 use serde::{Deserialize, Serialize};
@@ -166,12 +168,12 @@ impl AttributesProcessor {
             rename: if renames.is_empty() {
                 None
             } else {
-                Some(renames)
+                Some(RenameTransform::new(renames))
             },
             delete: if deletes.is_empty() {
                 None
             } else {
-                Some(deletes)
+                Some(DeleteTransform::new(deletes))
             },
         };
 

--- a/rust/otel-arrow-rust/benches/attribute_transform.rs
+++ b/rust/otel-arrow-rust/benches/attribute_transform.rs
@@ -10,7 +10,9 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::hint::black_box;
 use std::sync::Arc;
 
-use otel_arrow_rust::otap::transform::{transform_attributes, AttributesTransform, DeleteTransform, RenameTransform};
+use otel_arrow_rust::otap::transform::{
+    AttributesTransform, DeleteTransform, RenameTransform, transform_attributes,
+};
 use otel_arrow_rust::schema::consts;
 
 fn generate_native_keys_attr_batch(
@@ -116,7 +118,9 @@ fn bench_transform_attributes(c: &mut Criterion) {
                                     "attr24".into(),
                                     "attr_24".into(),
                                 )]))),
-                                delete: Some(DeleteTransform::new(BTreeSet::from_iter(["attr15".into()]))),
+                                delete: Some(DeleteTransform::new(BTreeSet::from_iter([
+                                    "attr15".into()
+                                ]))),
                             },
                         )
                         .expect("expect no errors");
@@ -137,7 +141,9 @@ fn bench_transform_attributes(c: &mut Criterion) {
                             input,
                             &AttributesTransform {
                                 rename: None,
-                                delete: Some(DeleteTransform::new(BTreeSet::from_iter(["attr15".into()]))),
+                                delete: Some(DeleteTransform::new(BTreeSet::from_iter([
+                                    "attr15".into()
+                                ]))),
                             },
                         )
                         .expect("expect no errors");
@@ -194,7 +200,9 @@ fn bench_transform_attributes(c: &mut Criterion) {
                             input,
                             &AttributesTransform {
                                 rename: None,
-                                delete: Some(DeleteTransform::new(BTreeSet::from_iter(["attr9".into()]))),
+                                delete: Some(DeleteTransform::new(BTreeSet::from_iter([
+                                    "attr9".into()
+                                ]))),
                             },
                         )
                         .expect("expect no errors");
@@ -218,7 +226,9 @@ fn bench_transform_attributes(c: &mut Criterion) {
                                     "attr3".into(),
                                     "attr_3".into(),
                                 )]))),
-                                delete: Some(DeleteTransform::new(BTreeSet::from_iter(["attr9".into()])))
+                                delete: Some(DeleteTransform::new(BTreeSet::from_iter([
+                                    "attr9".into()
+                                ]))),
                             },
                         )
                         .expect("expect no errors");
@@ -270,7 +280,9 @@ fn bench_transform_attributes(c: &mut Criterion) {
                             input,
                             &AttributesTransform {
                                 rename: None,
-                                delete: Some(DeleteTransform::new(BTreeSet::from_iter(["attr9".into()]))),
+                                delete: Some(DeleteTransform::new(BTreeSet::from_iter([
+                                    "attr9".into()
+                                ]))),
                             },
                         )
                         .expect("expect no errors");
@@ -295,7 +307,9 @@ fn bench_transform_attributes(c: &mut Criterion) {
                                     "attr3".into(),
                                     "attr_3".into(),
                                 )]))),
-                                delete: Some(DeleteTransform::new(BTreeSet::from_iter(["attr9".into()])))
+                                delete: Some(DeleteTransform::new(BTreeSet::from_iter([
+                                    "attr9".into()
+                                ]))),
                             },
                         )
                         .expect("expect no errors");

--- a/rust/otel-arrow-rust/benches/attribute_transform.rs
+++ b/rust/otel-arrow-rust/benches/attribute_transform.rs
@@ -10,7 +10,9 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::hint::black_box;
 use std::sync::Arc;
 
-use otel_arrow_rust::otap::transform::{transform_attributes, AttributesTransform, DeleteTransform, RenameTransform};
+use otel_arrow_rust::otap::transform::{
+    AttributesTransform, DeleteTransform, RenameTransform, transform_attributes,
+};
 use otel_arrow_rust::schema::consts;
 
 fn generate_native_keys_attr_batch(
@@ -63,32 +65,44 @@ fn generate_dict_keys_attribute_batch(
 fn bench_transform_attributes(c: &mut Criterion) {
     // Pre-create AttributesTransform instances to avoid measuring their creation cost
     let single_replace_no_delete = AttributesTransform {
-        rename: Some(RenameTransform::new(BTreeMap::from_iter([("attr24".into(), "attr_24".into())]))),
+        rename: Some(RenameTransform::new(BTreeMap::from_iter([(
+            "attr24".into(),
+            "attr_24".into(),
+        )]))),
         delete: None,
     };
-    
+
     let single_replace_single_delete = AttributesTransform {
-        rename: Some(RenameTransform::new(BTreeMap::from_iter([("attr24".into(), "attr_24".into())]))),
+        rename: Some(RenameTransform::new(BTreeMap::from_iter([(
+            "attr24".into(),
+            "attr_24".into(),
+        )]))),
         delete: Some(DeleteTransform::new(BTreeSet::from_iter(["attr15".into()]))),
     };
-    
+
     let no_replace_single_delete = AttributesTransform {
         rename: None,
         delete: Some(DeleteTransform::new(BTreeSet::from_iter(["attr15".into()]))),
     };
-    
+
     let attr3_replace_no_delete = AttributesTransform {
-        rename: Some(RenameTransform::new(BTreeMap::from_iter([("attr3".into(), "attr_3".into())]))),
+        rename: Some(RenameTransform::new(BTreeMap::from_iter([(
+            "attr3".into(),
+            "attr_3".into(),
+        )]))),
         delete: None,
     };
-    
+
     let no_replace_attr9_delete = AttributesTransform {
         rename: None,
         delete: Some(DeleteTransform::new(BTreeSet::from_iter(["attr9".into()]))),
     };
-    
+
     let attr3_replace_attr9_delete = AttributesTransform {
-        rename: Some(RenameTransform::new(BTreeMap::from_iter([("attr3".into(), "attr_3".into())]))),
+        rename: Some(RenameTransform::new(BTreeMap::from_iter([(
+            "attr3".into(),
+            "attr_3".into(),
+        )]))),
         delete: Some(DeleteTransform::new(BTreeSet::from_iter(["attr9".into()]))),
     };
 
@@ -115,11 +129,8 @@ fn bench_transform_attributes(c: &mut Criterion) {
                 b.iter_batched(
                     || input,
                     |input| {
-                        transform_attributes(
-                            black_box(input),
-                            &single_replace_no_delete,
-                        )
-                        .expect("expect no errors")
+                        transform_attributes(black_box(input), &single_replace_no_delete)
+                            .expect("expect no errors")
                     },
                     BatchSize::SmallInput,
                 )
@@ -133,11 +144,8 @@ fn bench_transform_attributes(c: &mut Criterion) {
                 b.iter_batched(
                     || input,
                     |input| {
-                        transform_attributes(
-                            black_box(input),
-                            &single_replace_single_delete,
-                        )
-                        .expect("expect no errors")
+                        transform_attributes(black_box(input), &single_replace_single_delete)
+                            .expect("expect no errors")
                     },
                     BatchSize::SmallInput,
                 )
@@ -150,11 +158,8 @@ fn bench_transform_attributes(c: &mut Criterion) {
                 b.iter_batched(
                     || input,
                     |input| {
-                        transform_attributes(
-                            black_box(input),
-                            &no_replace_single_delete,
-                        )
-                        .expect("expect no errors")
+                        transform_attributes(black_box(input), &no_replace_single_delete)
+                            .expect("expect no errors")
                     },
                     BatchSize::SmallInput,
                 )
@@ -179,11 +184,8 @@ fn bench_transform_attributes(c: &mut Criterion) {
                 b.iter_batched(
                     || input,
                     |input| {
-                        transform_attributes(
-                            black_box(input),
-                            &attr3_replace_no_delete,
-                        )
-                        .expect("expect no errors")
+                        transform_attributes(black_box(input), &attr3_replace_no_delete)
+                            .expect("expect no errors")
                     },
                     BatchSize::SmallInput,
                 )
@@ -196,11 +198,8 @@ fn bench_transform_attributes(c: &mut Criterion) {
                 b.iter_batched(
                     || input,
                     |input| {
-                        transform_attributes(
-                            black_box(input),
-                            &no_replace_attr9_delete,
-                        )
-                        .expect("expect no errors")
+                        transform_attributes(black_box(input), &no_replace_attr9_delete)
+                            .expect("expect no errors")
                     },
                     BatchSize::SmallInput,
                 )
@@ -213,11 +212,8 @@ fn bench_transform_attributes(c: &mut Criterion) {
                 b.iter_batched(
                     || input,
                     |input| {
-                        transform_attributes(
-                            black_box(input),
-                            &attr3_replace_attr9_delete,
-                        )
-                        .expect("expect no errors")
+                        transform_attributes(black_box(input), &attr3_replace_attr9_delete)
+                            .expect("expect no errors")
                     },
                     BatchSize::SmallInput,
                 )
@@ -236,11 +232,8 @@ fn bench_transform_attributes(c: &mut Criterion) {
                 b.iter_batched(
                     || input,
                     |input| {
-                        transform_attributes(
-                            black_box(input),
-                            &attr3_replace_no_delete,
-                        )
-                        .expect("expect no errors")
+                        transform_attributes(black_box(input), &attr3_replace_no_delete)
+                            .expect("expect no errors")
                     },
                     BatchSize::SmallInput,
                 )
@@ -254,11 +247,8 @@ fn bench_transform_attributes(c: &mut Criterion) {
                 b.iter_batched(
                     || input,
                     |input| {
-                        transform_attributes(
-                            black_box(input),
-                            &no_replace_attr9_delete,
-                        )
-                        .expect("expect no errors")
+                        transform_attributes(black_box(input), &no_replace_attr9_delete)
+                            .expect("expect no errors")
                     },
                     BatchSize::SmallInput,
                 )
@@ -272,11 +262,8 @@ fn bench_transform_attributes(c: &mut Criterion) {
                 b.iter_batched(
                     || input,
                     |input| {
-                        transform_attributes(
-                            black_box(input),
-                            &attr3_replace_attr9_delete,
-                        )
-                        .expect("expect no errors")
+                        transform_attributes(black_box(input), &attr3_replace_attr9_delete)
+                            .expect("expect no errors")
                     },
                     BatchSize::SmallInput,
                 )

--- a/rust/otel-arrow-rust/benches/attribute_transform.rs
+++ b/rust/otel-arrow-rust/benches/attribute_transform.rs
@@ -10,9 +10,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::hint::black_box;
 use std::sync::Arc;
 
-use otel_arrow_rust::otap::transform::{
-    AttributesTransform, DeleteTransform, RenameTransform, transform_attributes,
-};
+use otel_arrow_rust::otap::transform::{transform_attributes, AttributesTransform, DeleteTransform, RenameTransform};
 use otel_arrow_rust::schema::consts;
 
 fn generate_native_keys_attr_batch(
@@ -63,11 +61,42 @@ fn generate_dict_keys_attribute_batch(
 }
 
 fn bench_transform_attributes(c: &mut Criterion) {
+    // Pre-create AttributesTransform instances to avoid measuring their creation cost
+    let single_replace_no_delete = AttributesTransform {
+        rename: Some(RenameTransform::new(BTreeMap::from_iter([("attr24".into(), "attr_24".into())]))),
+        delete: None,
+    };
+    
+    let single_replace_single_delete = AttributesTransform {
+        rename: Some(RenameTransform::new(BTreeMap::from_iter([("attr24".into(), "attr_24".into())]))),
+        delete: Some(DeleteTransform::new(BTreeSet::from_iter(["attr15".into()]))),
+    };
+    
+    let no_replace_single_delete = AttributesTransform {
+        rename: None,
+        delete: Some(DeleteTransform::new(BTreeSet::from_iter(["attr15".into()]))),
+    };
+    
+    let attr3_replace_no_delete = AttributesTransform {
+        rename: Some(RenameTransform::new(BTreeMap::from_iter([("attr3".into(), "attr_3".into())]))),
+        delete: None,
+    };
+    
+    let no_replace_attr9_delete = AttributesTransform {
+        rename: None,
+        delete: Some(DeleteTransform::new(BTreeSet::from_iter(["attr9".into()]))),
+    };
+    
+    let attr3_replace_attr9_delete = AttributesTransform {
+        rename: Some(RenameTransform::new(BTreeMap::from_iter([("attr3".into(), "attr_3".into())]))),
+        delete: Some(DeleteTransform::new(BTreeSet::from_iter(["attr9".into()]))),
+    };
+
     let mut group = c.benchmark_group("transform_attributes_dict_keys");
     for (num_keys, num_rows) in [
         (32, 128),   // 32 keys, 128 rows, 4 rows/key
         (32, 1536),  // 32 keys, 1536 rows, 48 rows/key
-        (32, 8192),  // 2 keys, 8192 rows, 256 rows/key
+        (32, 8192),  // 32 keys, 8192 rows, 256 rows/key
         (128, 128),  // 128 keys, 128 rows, 1 rows/key
         (128, 1536), // 128 keys, 1536 rows, 12 rows/key
         (128, 8192), // 128 keys, 8192 rows, 64 rows/key
@@ -82,22 +111,15 @@ fn bench_transform_attributes(c: &mut Criterion) {
         let _ = group.bench_with_input(
             BenchmarkId::new("single_replace_no_deletes", &benchmark_id_param),
             &dict_transform_input,
-            |b, input| {
+            |b: &mut criterion::Bencher<'_>, input| {
                 b.iter_batched(
                     || input,
                     |input| {
-                        let result = transform_attributes(
-                            input,
-                            &AttributesTransform {
-                                rename: Some(RenameTransform::new(BTreeMap::from_iter([(
-                                    "attr24".into(),
-                                    "attr_24".into(),
-                                )]))),
-                                delete: None,
-                            },
+                        transform_attributes(
+                            black_box(input),
+                            &single_replace_no_delete,
                         )
-                        .expect("expect no errors");
-                        _ = black_box(result)
+                        .expect("expect no errors")
                     },
                     BatchSize::SmallInput,
                 )
@@ -111,20 +133,11 @@ fn bench_transform_attributes(c: &mut Criterion) {
                 b.iter_batched(
                     || input,
                     |input| {
-                        let result = transform_attributes(
-                            input,
-                            &AttributesTransform {
-                                rename: Some(RenameTransform::new(BTreeMap::from_iter([(
-                                    "attr24".into(),
-                                    "attr_24".into(),
-                                )]))),
-                                delete: Some(DeleteTransform::new(BTreeSet::from_iter([
-                                    "attr15".into()
-                                ]))),
-                            },
+                        transform_attributes(
+                            black_box(input),
+                            &single_replace_single_delete,
                         )
-                        .expect("expect no errors");
-                        _ = black_box(result)
+                        .expect("expect no errors")
                     },
                     BatchSize::SmallInput,
                 )
@@ -137,17 +150,11 @@ fn bench_transform_attributes(c: &mut Criterion) {
                 b.iter_batched(
                     || input,
                     |input| {
-                        let result = transform_attributes(
-                            input,
-                            &AttributesTransform {
-                                rename: None,
-                                delete: Some(DeleteTransform::new(BTreeSet::from_iter([
-                                    "attr15".into()
-                                ]))),
-                            },
+                        transform_attributes(
+                            black_box(input),
+                            &no_replace_single_delete,
                         )
-                        .expect("expect no errors");
-                        _ = black_box(result)
+                        .expect("expect no errors")
                     },
                     BatchSize::SmallInput,
                 )
@@ -172,18 +179,11 @@ fn bench_transform_attributes(c: &mut Criterion) {
                 b.iter_batched(
                     || input,
                     |input| {
-                        let result = transform_attributes(
-                            input,
-                            &AttributesTransform {
-                                rename: Some(RenameTransform::new(BTreeMap::from_iter([(
-                                    "attr3".into(),
-                                    "attr_3".into(),
-                                )]))),
-                                delete: None,
-                            },
+                        transform_attributes(
+                            black_box(input),
+                            &attr3_replace_no_delete,
                         )
-                        .expect("expect no errors");
-                        _ = black_box(result)
+                        .expect("expect no errors")
                     },
                     BatchSize::SmallInput,
                 )
@@ -196,17 +196,11 @@ fn bench_transform_attributes(c: &mut Criterion) {
                 b.iter_batched(
                     || input,
                     |input| {
-                        let result = transform_attributes(
-                            input,
-                            &AttributesTransform {
-                                rename: None,
-                                delete: Some(DeleteTransform::new(BTreeSet::from_iter([
-                                    "attr9".into()
-                                ]))),
-                            },
+                        transform_attributes(
+                            black_box(input),
+                            &no_replace_attr9_delete,
                         )
-                        .expect("expect no errors");
-                        _ = black_box(result)
+                        .expect("expect no errors")
                     },
                     BatchSize::SmallInput,
                 )
@@ -219,20 +213,11 @@ fn bench_transform_attributes(c: &mut Criterion) {
                 b.iter_batched(
                     || input,
                     |input| {
-                        let result = transform_attributes(
-                            input,
-                            &AttributesTransform {
-                                rename: Some(RenameTransform::new(BTreeMap::from_iter([(
-                                    "attr3".into(),
-                                    "attr_3".into(),
-                                )]))),
-                                delete: Some(DeleteTransform::new(BTreeSet::from_iter([
-                                    "attr9".into()
-                                ]))),
-                            },
+                        transform_attributes(
+                            black_box(input),
+                            &attr3_replace_attr9_delete,
                         )
-                        .expect("expect no errors");
-                        _ = black_box(result)
+                        .expect("expect no errors")
                     },
                     BatchSize::SmallInput,
                 )
@@ -251,18 +236,11 @@ fn bench_transform_attributes(c: &mut Criterion) {
                 b.iter_batched(
                     || input,
                     |input| {
-                        let result = transform_attributes(
-                            input,
-                            &AttributesTransform {
-                                rename: Some(RenameTransform::new(BTreeMap::from_iter([(
-                                    "attr3".into(),
-                                    "attr_3".into(),
-                                )]))),
-                                delete: None,
-                            },
+                        transform_attributes(
+                            black_box(input),
+                            &attr3_replace_no_delete,
                         )
-                        .expect("expect no errors");
-                        _ = black_box(result)
+                        .expect("expect no errors")
                     },
                     BatchSize::SmallInput,
                 )
@@ -276,17 +254,11 @@ fn bench_transform_attributes(c: &mut Criterion) {
                 b.iter_batched(
                     || input,
                     |input| {
-                        let result = transform_attributes(
-                            input,
-                            &AttributesTransform {
-                                rename: None,
-                                delete: Some(DeleteTransform::new(BTreeSet::from_iter([
-                                    "attr9".into()
-                                ]))),
-                            },
+                        transform_attributes(
+                            black_box(input),
+                            &no_replace_attr9_delete,
                         )
-                        .expect("expect no errors");
-                        _ = black_box(result)
+                        .expect("expect no errors")
                     },
                     BatchSize::SmallInput,
                 )
@@ -300,20 +272,11 @@ fn bench_transform_attributes(c: &mut Criterion) {
                 b.iter_batched(
                     || input,
                     |input| {
-                        let result = transform_attributes(
-                            input,
-                            &AttributesTransform {
-                                rename: Some(RenameTransform::new(BTreeMap::from_iter([(
-                                    "attr3".into(),
-                                    "attr_3".into(),
-                                )]))),
-                                delete: Some(DeleteTransform::new(BTreeSet::from_iter([
-                                    "attr9".into()
-                                ]))),
-                            },
+                        transform_attributes(
+                            black_box(input),
+                            &attr3_replace_attr9_delete,
                         )
-                        .expect("expect no errors");
-                        _ = black_box(result)
+                        .expect("expect no errors")
                     },
                     BatchSize::SmallInput,
                 )

--- a/rust/otel-arrow-rust/benches/attribute_transform.rs
+++ b/rust/otel-arrow-rust/benches/attribute_transform.rs
@@ -10,7 +10,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::hint::black_box;
 use std::sync::Arc;
 
-use otel_arrow_rust::otap::transform::{AttributesTransform, transform_attributes};
+use otel_arrow_rust::otap::transform::{transform_attributes, AttributesTransform, DeleteTransform, RenameTransform};
 use otel_arrow_rust::schema::consts;
 
 fn generate_native_keys_attr_batch(
@@ -87,10 +87,10 @@ fn bench_transform_attributes(c: &mut Criterion) {
                         let result = transform_attributes(
                             input,
                             &AttributesTransform {
-                                rename: Some(BTreeMap::from_iter([(
+                                rename: Some(RenameTransform::new(BTreeMap::from_iter([(
                                     "attr24".into(),
                                     "attr_24".into(),
-                                )])),
+                                )]))),
                                 delete: None,
                             },
                         )
@@ -112,11 +112,11 @@ fn bench_transform_attributes(c: &mut Criterion) {
                         let result = transform_attributes(
                             input,
                             &AttributesTransform {
-                                rename: Some(BTreeMap::from_iter([(
+                                rename: Some(RenameTransform::new(BTreeMap::from_iter([(
                                     "attr24".into(),
                                     "attr_24".into(),
-                                )])),
-                                delete: Some(BTreeSet::from_iter(["attr15".into()])),
+                                )]))),
+                                delete: Some(DeleteTransform::new(BTreeSet::from_iter(["attr15".into()]))),
                             },
                         )
                         .expect("expect no errors");
@@ -137,7 +137,7 @@ fn bench_transform_attributes(c: &mut Criterion) {
                             input,
                             &AttributesTransform {
                                 rename: None,
-                                delete: Some(BTreeSet::from_iter(["attr15".into()])),
+                                delete: Some(DeleteTransform::new(BTreeSet::from_iter(["attr15".into()]))),
                             },
                         )
                         .expect("expect no errors");
@@ -169,10 +169,10 @@ fn bench_transform_attributes(c: &mut Criterion) {
                         let result = transform_attributes(
                             input,
                             &AttributesTransform {
-                                rename: Some(BTreeMap::from_iter([(
+                                rename: Some(RenameTransform::new(BTreeMap::from_iter([(
                                     "attr3".into(),
                                     "attr_3".into(),
-                                )])),
+                                )]))),
                                 delete: None,
                             },
                         )
@@ -194,7 +194,7 @@ fn bench_transform_attributes(c: &mut Criterion) {
                             input,
                             &AttributesTransform {
                                 rename: None,
-                                delete: Some(BTreeSet::from_iter(["attr9".into()])),
+                                delete: Some(DeleteTransform::new(BTreeSet::from_iter(["attr9".into()]))),
                             },
                         )
                         .expect("expect no errors");
@@ -214,11 +214,11 @@ fn bench_transform_attributes(c: &mut Criterion) {
                         let result = transform_attributes(
                             input,
                             &AttributesTransform {
-                                rename: Some(BTreeMap::from_iter([(
+                                rename: Some(RenameTransform::new(BTreeMap::from_iter([(
                                     "attr3".into(),
                                     "attr_3".into(),
-                                )])),
-                                delete: Some(BTreeSet::from_iter(["attr9".into()])),
+                                )]))),
+                                delete: Some(DeleteTransform::new(BTreeSet::from_iter(["attr9".into()])))
                             },
                         )
                         .expect("expect no errors");
@@ -244,10 +244,10 @@ fn bench_transform_attributes(c: &mut Criterion) {
                         let result = transform_attributes(
                             input,
                             &AttributesTransform {
-                                rename: Some(BTreeMap::from_iter([(
+                                rename: Some(RenameTransform::new(BTreeMap::from_iter([(
                                     "attr3".into(),
                                     "attr_3".into(),
-                                )])),
+                                )]))),
                                 delete: None,
                             },
                         )
@@ -270,7 +270,7 @@ fn bench_transform_attributes(c: &mut Criterion) {
                             input,
                             &AttributesTransform {
                                 rename: None,
-                                delete: Some(BTreeSet::from_iter(["attr9".into()])),
+                                delete: Some(DeleteTransform::new(BTreeSet::from_iter(["attr9".into()]))),
                             },
                         )
                         .expect("expect no errors");
@@ -291,11 +291,11 @@ fn bench_transform_attributes(c: &mut Criterion) {
                         let result = transform_attributes(
                             input,
                             &AttributesTransform {
-                                rename: Some(BTreeMap::from_iter([(
+                                rename: Some(RenameTransform::new(BTreeMap::from_iter([(
                                     "attr3".into(),
                                     "attr_3".into(),
-                                )])),
-                                delete: Some(BTreeSet::from_iter(["attr9".into()])),
+                                )]))),
+                                delete: Some(DeleteTransform::new(BTreeSet::from_iter(["attr9".into()])))
                             },
                         )
                         .expect("expect no errors");

--- a/rust/otel-arrow-rust/src/otap/transform.rs
+++ b/rust/otel-arrow-rust/src/otap/transform.rs
@@ -2476,8 +2476,13 @@ mod test {
             (
                 // most basic transform
                 AttributesTransform {
-                    rename: Some(RenameTransform::new(BTreeMap::from_iter(vec![("b".into(), "B".into())]))),
-                    delete: Some(DeleteTransform::new(BTreeSet::from_iter(vec![("d".into())]))),
+                    rename: Some(RenameTransform::new(BTreeMap::from_iter(vec![(
+                        "b".into(),
+                        "B".into(),
+                    )]))),
+                    delete: Some(DeleteTransform::new(BTreeSet::from_iter(vec![
+                        ("d".into()),
+                    ]))),
                 },
                 (vec!["a", "b", "c", "d", "e"], vec!["1", "1", "3", "4", "5"]),
                 (vec!["a", "B", "c", "e"], vec!["1", "1", "3", "5"]),
@@ -2485,7 +2490,10 @@ mod test {
             (
                 // test replacements at array boundaries
                 AttributesTransform {
-                    rename: Some(RenameTransform::new(BTreeMap::from_iter(vec![("a".into(), "A".into())]))),
+                    rename: Some(RenameTransform::new(BTreeMap::from_iter(vec![(
+                        "a".into(),
+                        "A".into(),
+                    )]))),
                     delete: None,
                 },
                 (vec!["a", "b", "a", "d", "a"], vec!["1", "1", "3", "4", "5"]),
@@ -2494,7 +2502,10 @@ mod test {
             (
                 // test replacements where replacements longer than target
                 AttributesTransform {
-                    rename: Some(RenameTransform::new(BTreeMap::from_iter(vec![("a".into(), "AAA".into())]))),
+                    rename: Some(RenameTransform::new(BTreeMap::from_iter(vec![(
+                        "a".into(),
+                        "AAA".into(),
+                    )]))),
                     delete: None,
                 },
                 (vec!["a", "b", "a", "d", "a"], vec!["1", "1", "3", "4", "5"]),
@@ -2506,7 +2517,10 @@ mod test {
             (
                 // test replacements where replacements shorter than target
                 AttributesTransform {
-                    rename: Some(RenameTransform::new(BTreeMap::from_iter(vec![("aaa".into(), "a".into())]))),
+                    rename: Some(RenameTransform::new(BTreeMap::from_iter(vec![(
+                        "aaa".into(),
+                        "a".into(),
+                    )]))),
                     delete: None,
                 },
                 (
@@ -2518,7 +2532,10 @@ mod test {
             (
                 // test replacing single contiguous block of keys
                 AttributesTransform {
-                    rename: Some(RenameTransform::new(BTreeMap::from_iter(vec![("a".into(), "AA".into())]))),
+                    rename: Some(RenameTransform::new(BTreeMap::from_iter(vec![(
+                        "a".into(),
+                        "AA".into(),
+                    )]))),
                     delete: None,
                 },
                 (
@@ -2570,7 +2587,7 @@ mod test {
                 // test deletion at array boundaries without replaces
                 AttributesTransform {
                     rename: None,
-                    delete: Some(DeleteTransform::new(BTreeSet::from_iter(vec!["a".into()])))
+                    delete: Some(DeleteTransform::new(BTreeSet::from_iter(vec!["a".into()]))),
                 },
                 (vec!["a", "b", "a", "d", "a"], vec!["1", "1", "3", "4", "5"]),
                 (vec!["b", "d"], vec!["1", "4"]),
@@ -2579,7 +2596,7 @@ mod test {
                 // test delete contiguous segment
                 AttributesTransform {
                     rename: None,
-                    delete: Some(DeleteTransform::new(BTreeSet::from_iter(vec!["a".into()])))
+                    delete: Some(DeleteTransform::new(BTreeSet::from_iter(vec!["a".into()]))),
                 },
                 (
                     vec!["a", "a", "a", "b", "a", "a", "b", "b", "a", "a"],
@@ -2591,7 +2608,10 @@ mod test {
                 // test multiple deletes
                 AttributesTransform {
                     rename: None,
-                    delete: Some(DeleteTransform::new(BTreeSet::from_iter(vec!["a".into(), "b".into()])))
+                    delete: Some(DeleteTransform::new(BTreeSet::from_iter(vec![
+                        "a".into(),
+                        "b".into(),
+                    ]))),
                 },
                 (
                     vec!["a", "a", "a", "b", "a", "a", "b", "c", "a", "a"],
@@ -2602,8 +2622,11 @@ mod test {
             (
                 // test adjacent replacement and delete
                 AttributesTransform {
-                    rename: Some(RenameTransform::new(BTreeMap::from_iter(vec![("a".into(), "AAA".into())]))),
-                    delete: Some(DeleteTransform::new(BTreeSet::from_iter(vec!["b".into()])))
+                    rename: Some(RenameTransform::new(BTreeMap::from_iter(vec![(
+                        "a".into(),
+                        "AAA".into(),
+                    )]))),
+                    delete: Some(DeleteTransform::new(BTreeSet::from_iter(vec!["b".into()]))),
                 },
                 (vec!["_", "a", "a", "b", "c"], vec!["1", "2", "3", "4", "5"]),
                 (vec!["_", "AAA", "AAA", "c"], vec!["1", "2", "3", "5"]),
@@ -2612,7 +2635,7 @@ mod test {
                 // test we handle an empty rename
                 AttributesTransform {
                     rename: Some(RenameTransform::new(BTreeMap::from_iter(vec![]))),
-                    delete: Some(DeleteTransform::new(BTreeSet::from_iter(vec!["b".into()])))
+                    delete: Some(DeleteTransform::new(BTreeSet::from_iter(vec!["b".into()]))),
                 },
                 (vec!["a", "a", "b", "c"], vec!["1", "2", "3", "4"]),
                 (vec!["a", "a", "c"], vec!["1", "2", "4"]),
@@ -2620,7 +2643,10 @@ mod test {
             (
                 // test we handle an empty delete
                 AttributesTransform {
-                    rename: Some(RenameTransform::new(BTreeMap::from_iter(vec![("a".into(), "AAAA".into())]))),
+                    rename: Some(RenameTransform::new(BTreeMap::from_iter(vec![(
+                        "a".into(),
+                        "AAAA".into(),
+                    )]))),
                     delete: Some(DeleteTransform::new(BTreeSet::from_iter(vec![]))),
                 },
                 (vec!["a", "a", "b", "c"], vec!["1", "2", "3", "4"]),
@@ -2789,7 +2815,10 @@ mod test {
             let result = transform_attributes(
                 &record_batch,
                 &AttributesTransform {
-                    rename: Some(RenameTransform::new(BTreeMap::from_iter(vec![("k2".into(), "K2".into())]))),
+                    rename: Some(RenameTransform::new(BTreeMap::from_iter(vec![(
+                        "k2".into(),
+                        "K2".into(),
+                    )]))),
                     delete: Some(DeleteTransform::new(BTreeSet::from_iter(vec!["k3".into()]))),
                 },
             )
@@ -2943,8 +2972,14 @@ mod test {
         let result = transform_attributes(
             &input,
             &AttributesTransform {
-                rename: Some(RenameTransform::new(BTreeMap::from_iter(vec![("b".into(), "B".into())]))),
-                delete: Some(DeleteTransform::new(BTreeSet::from_iter(vec!["c".into(), "e".into()]))),
+                rename: Some(RenameTransform::new(BTreeMap::from_iter(vec![(
+                    "b".into(),
+                    "B".into(),
+                )]))),
+                delete: Some(DeleteTransform::new(BTreeSet::from_iter(vec![
+                    "c".into(),
+                    "e".into(),
+                ]))),
             },
         )
         .unwrap();
@@ -2973,8 +3008,11 @@ mod test {
             (
                 // basic dict transform
                 AttributesTransform {
-                    rename: Some(RenameTransform::new(BTreeMap::from_iter([("a".into(), "AA".into())]))),
-                    delete: Some(DeleteTransform::new(BTreeSet::from_iter(["b".into()])))
+                    rename: Some(RenameTransform::new(BTreeMap::from_iter([(
+                        "a".into(),
+                        "AA".into(),
+                    )]))),
+                    delete: Some(DeleteTransform::new(BTreeSet::from_iter(["b".into()]))),
                 },
                 (
                     // keys column - dict keys
@@ -3011,8 +3049,11 @@ mod test {
             (
                 // test with some nulls
                 AttributesTransform {
-                    rename: Some(RenameTransform::new(BTreeMap::from_iter([("a".into(), "AA".into())]))),
-                    delete: Some(DeleteTransform::new(BTreeSet::from_iter(["b".into()])))
+                    rename: Some(RenameTransform::new(BTreeMap::from_iter([(
+                        "a".into(),
+                        "AA".into(),
+                    )]))),
+                    delete: Some(DeleteTransform::new(BTreeSet::from_iter(["b".into()]))),
                 },
                 (
                     vec![
@@ -3075,7 +3116,10 @@ mod test {
                 // test if there's nulls in the dict keys. This would be unusual
                 // but technically it's possible
                 AttributesTransform {
-                    rename: Some(RenameTransform::new(BTreeMap::from_iter([("a".into(), "AA".into())]))),
+                    rename: Some(RenameTransform::new(BTreeMap::from_iter([(
+                        "a".into(),
+                        "AA".into(),
+                    )]))),
                     delete: Some(DeleteTransform::new(BTreeSet::from_iter(["b".into()]))),
                 },
                 (
@@ -3171,8 +3215,11 @@ mod test {
         let result = transform_attributes(
             &input,
             &AttributesTransform {
-                rename: Some(RenameTransform::new(BTreeMap::from_iter([("c".into(), "CCCCC".into())]))),
-                delete: Some(DeleteTransform::new(BTreeSet::from_iter(["b".into()])))
+                rename: Some(RenameTransform::new(BTreeMap::from_iter([(
+                    "c".into(),
+                    "CCCCC".into(),
+                )]))),
+                delete: Some(DeleteTransform::new(BTreeSet::from_iter(["b".into()]))),
             },
         )
         .unwrap();
@@ -3267,7 +3314,7 @@ mod test {
             &input,
             &AttributesTransform {
                 rename: None,
-                delete: Some(DeleteTransform::new(BTreeSet::from_iter(["b".into()])))
+                delete: Some(DeleteTransform::new(BTreeSet::from_iter(["b".into()]))),
             },
         )
         .unwrap();
@@ -3344,7 +3391,7 @@ mod test {
             &input,
             &AttributesTransform {
                 rename: None,
-                delete: Some(DeleteTransform::new(BTreeSet::from_iter(["b".into()])))
+                delete: Some(DeleteTransform::new(BTreeSet::from_iter(["b".into()]))),
             },
         )
         .unwrap();
@@ -3404,7 +3451,10 @@ mod test {
         let result = transform_attributes(
             &input,
             &AttributesTransform {
-                rename: Some(RenameTransform::new(BTreeMap::from_iter([("b".into(), "BBB".into())]))),
+                rename: Some(RenameTransform::new(BTreeMap::from_iter([(
+                    "b".into(),
+                    "BBB".into(),
+                )]))),
                 delete: Some(DeleteTransform::new(BTreeSet::from_iter(["e".into()]))),
             },
         )
@@ -3469,7 +3519,10 @@ mod test {
         let result = transform_attributes(
             &input,
             &AttributesTransform {
-                rename: Some(RenameTransform::new(BTreeMap::from_iter([("b".into(), "BBB".into())]))),
+                rename: Some(RenameTransform::new(BTreeMap::from_iter([(
+                    "b".into(),
+                    "BBB".into(),
+                )]))),
                 delete: Some(DeleteTransform::new(BTreeSet::from_iter(["e".into()]))),
             },
         )
@@ -3482,7 +3535,10 @@ mod test {
     fn test_invalid_attributes_transforms() {
         let test_cases = vec![
             AttributesTransform {
-                rename: Some(RenameTransform::new(BTreeMap::from_iter([("b".into(), "b".into())]))),
+                rename: Some(RenameTransform::new(BTreeMap::from_iter([(
+                    "b".into(),
+                    "b".into(),
+                )]))),
                 delete: None,
             },
             AttributesTransform {
@@ -3493,11 +3549,17 @@ mod test {
                 delete: None,
             },
             AttributesTransform {
-                rename: Some(RenameTransform::new(BTreeMap::from_iter([("b".into(), "a".into())]))),
+                rename: Some(RenameTransform::new(BTreeMap::from_iter([(
+                    "b".into(),
+                    "a".into(),
+                )]))),
                 delete: Some(DeleteTransform::new(BTreeSet::from_iter(vec!["b".into()]))),
             },
             AttributesTransform {
-                rename: Some(RenameTransform::new(BTreeMap::from_iter([("b".into(), "a".into())]))),
+                rename: Some(RenameTransform::new(BTreeMap::from_iter([(
+                    "b".into(),
+                    "a".into(),
+                )]))),
                 delete: Some(DeleteTransform::new(BTreeSet::from_iter(vec!["a".into()]))),
             },
         ];
@@ -3538,7 +3600,9 @@ mod test {
                 String::from("a"),
                 String::from("A"),
             )]))),
-            delete: Some(DeleteTransform::new(BTreeSet::from_iter([String::from("d")]))),
+            delete: Some(DeleteTransform::new(BTreeSet::from_iter([String::from(
+                "d",
+            )]))),
         };
 
         let (with_stats, stats) = transform_attributes_with_stats(&input, &tx).unwrap();
@@ -3578,7 +3642,9 @@ mod test {
                 String::from("a"),
                 String::from("A"),
             )]))),
-            delete: Some(DeleteTransform::new(BTreeSet::from_iter([String::from("d")]))),
+            delete: Some(DeleteTransform::new(BTreeSet::from_iter([String::from(
+                "d",
+            )]))),
         };
 
         let (with_stats, stats) = transform_attributes_with_stats(&input, &tx).unwrap();


### PR DESCRIPTION
## Changes
- Reference the precomputed bytes representation of the transforms instead of collecting them into `vec`s repeatedly
- Updated the transform benchmarks to use `black_box` around the input and to make the measurement more targeted