### PR TITLE
[query-engine] Add support for friendly display of PipelineExpression

### DIFF
--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/tests/common/mod.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/tests/common/mod.rs
@@ -18,8 +18,7 @@ where
     println!("Request:");
     println!("{records:?}");
 
-    println!("Pipeline:");
-    println!("{pipeline:?}");
+    println!("{pipeline}");
 
     let mut batch = engine.begin_batch(pipeline).unwrap();
 

--- a/rust/experimental/query_engine/engine-recordset/src/engine.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/engine.rs
@@ -136,12 +136,31 @@ where
             None,
         );
 
+        if execution_context.is_diagnostic_level_enabled(RecordSetEngineDiagnosticLevel::Verbose) {
+            for (constant_id, constant) in self.pipeline.get_constants().iter().enumerate() {
+                execution_context.add_diagnostic(RecordSetEngineDiagnostic::new(
+                    RecordSetEngineDiagnosticLevel::Verbose,
+                    constant,
+                    format!("Constant defined with id '{constant_id}'"),
+                ));
+            }
+        }
+
         for init in initializations {
             match init {
-                PipelineInitialization::SetGlobalVariable { name, value } => {
-                    let value = execute_scalar_expression(&execution_context, value)?;
+                PipelineInitialization::SetGlobalVariable {
+                    name,
+                    value: scalar,
+                } => {
+                    let value = execute_scalar_expression(&execution_context, scalar)?;
 
                     self.global_variables.borrow_mut().set(name, value);
+
+                    execution_context.add_diagnostic_if_enabled(
+                        RecordSetEngineDiagnosticLevel::Verbose,
+                        scalar,
+                        || format!("Global variable defined with name '{name}'"),
+                    );
                 }
             }
         }
@@ -200,16 +219,6 @@ where
             attached_records,
             Some(record),
         );
-
-        if execution_context.is_diagnostic_level_enabled(RecordSetEngineDiagnosticLevel::Verbose) {
-            for (constant_id, constant) in self.pipeline.get_constants().iter().enumerate() {
-                execution_context.add_diagnostic(RecordSetEngineDiagnostic::new(
-                    RecordSetEngineDiagnosticLevel::Verbose,
-                    constant,
-                    format!("Constant defined with id '{constant_id}'"),
-                ));
-            }
-        }
 
         process_record(execution_context, self.pipeline.get_expressions())
     }

--- a/rust/experimental/query_engine/expressions/src/data_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/data_expressions.rs
@@ -44,6 +44,14 @@ impl Expression for DataExpression {
             DataExpression::Transform(_) => "DataExpression(Transform)",
         }
     }
+
+    fn fmt_with_indent(&self, f: &mut std::fmt::Formatter<'_>, indent: &str) -> std::fmt::Result {
+        match self {
+            DataExpression::Discard(d) => d.fmt_with_indent(f, indent),
+            DataExpression::Summary(s) => s.fmt_with_indent(f, indent),
+            DataExpression::Transform(t) => t.fmt_with_indent(f, indent),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -94,5 +102,18 @@ impl Expression for DiscardDataExpression {
 
     fn get_name(&self) -> &'static str {
         "DiscardDataExpression"
+    }
+
+    fn fmt_with_indent(&self, f: &mut std::fmt::Formatter<'_>, indent: &str) -> std::fmt::Result {
+        writeln!(f, "Discard")?;
+        match self.predicate.as_ref() {
+            None => writeln!(f, "{indent}└── Predicate: None")?,
+            Some(p) => {
+                writeln!(f, "{indent}└── Predicate:")?;
+                write!(f, "{indent}    └── ")?;
+                p.fmt_with_indent(f, format!("{indent}        ").as_str())?;
+            }
+        }
+        Ok(())
     }
 }

--- a/rust/experimental/query_engine/expressions/src/expression.rs
+++ b/rust/experimental/query_engine/expressions/src/expression.rs
@@ -12,6 +12,10 @@ pub trait Expression: Debug {
     fn get_query_location(&self) -> &QueryLocation;
 
     fn get_name(&self) -> &'static str;
+
+    fn fmt_with_indent(&self, f: &mut std::fmt::Formatter<'_>, _indent: &str) -> std::fmt::Result {
+        writeln!(f, "{self:?}")
+    }
 }
 
 #[derive(Debug, Clone, Eq)]

--- a/rust/experimental/query_engine/expressions/src/logical_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/logical_expressions.rs
@@ -93,6 +93,21 @@ impl LogicalExpression {
             Ok(None)
         }
     }
+
+    fn fmt_binary_with_indent(
+        f: &mut std::fmt::Formatter<'_>,
+        indent: &str,
+        name: &str,
+        left: &ScalarExpression,
+        right: &ScalarExpression,
+    ) -> std::fmt::Result {
+        writeln!(f, "{name}")?;
+        write!(f, "{indent}├── Left(Scalar): ")?;
+        left.fmt_with_indent(f, format!("{indent}│                 ").as_str())?;
+        write!(f, "{indent}└── Right(Scalar): ")?;
+        right.fmt_with_indent(f, format!("{indent}                   ").as_str())?;
+        Ok(())
+    }
 }
 
 impl Expression for LogicalExpression {
@@ -121,6 +136,26 @@ impl Expression for LogicalExpression {
             LogicalExpression::Or(_) => "LogicalExpression(Or)",
             LogicalExpression::Contains(_) => "LogicalExpression(Contains)",
             LogicalExpression::Matches(_) => "LogicalExpression(Matches)",
+        }
+    }
+
+    fn fmt_with_indent(&self, f: &mut std::fmt::Formatter<'_>, indent: &str) -> std::fmt::Result {
+        match self {
+            LogicalExpression::Scalar(s) => s.fmt_with_indent(f, indent),
+            LogicalExpression::EqualTo(e) => {
+                Self::fmt_binary_with_indent(f, indent, "EqualTo", &e.left, &e.right)
+            }
+            LogicalExpression::GreaterThan(g) => {
+                Self::fmt_binary_with_indent(f, indent, "GreaterThan", &g.left, &g.right)
+            }
+            LogicalExpression::GreaterThanOrEqualTo(g) => {
+                Self::fmt_binary_with_indent(f, indent, "GreaterThanOrEqualTo", &g.left, &g.right)
+            }
+            LogicalExpression::Not(n) => n.fmt_with_indent(f, indent),
+            LogicalExpression::And(a) => a.fmt_with_indent(f, indent),
+            LogicalExpression::Or(o) => o.fmt_with_indent(f, indent),
+            LogicalExpression::Contains(c) => c.fmt_with_indent(f, indent),
+            LogicalExpression::Matches(m) => m.fmt_with_indent(f, indent),
         }
     }
 }
@@ -189,6 +224,17 @@ impl Expression for AndLogicalExpression {
     fn get_name(&self) -> &'static str {
         "AndLogicalExpression"
     }
+
+    fn fmt_with_indent(&self, f: &mut std::fmt::Formatter<'_>, indent: &str) -> std::fmt::Result {
+        writeln!(f, "And")?;
+        write!(f, "{indent}├── Left(Logical): ")?;
+        self.left
+            .fmt_with_indent(f, format!("{indent}│                  ").as_str())?;
+        write!(f, "{indent}└── Right(Logical): ")?;
+        self.right
+            .fmt_with_indent(f, format!("{indent}                    ").as_str())?;
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -254,6 +300,17 @@ impl Expression for OrLogicalExpression {
 
     fn get_name(&self) -> &'static str {
         "OrLogicalExpression"
+    }
+
+    fn fmt_with_indent(&self, f: &mut std::fmt::Formatter<'_>, indent: &str) -> std::fmt::Result {
+        writeln!(f, "Or")?;
+        write!(f, "{indent}├── Left(Logical): ")?;
+        self.left
+            .fmt_with_indent(f, format!("{indent}│                  ").as_str())?;
+        write!(f, "{indent}└── Right(Logical): ")?;
+        self.right
+            .fmt_with_indent(f, format!("{indent}                    ").as_str())?;
+        Ok(())
     }
 }
 
@@ -498,6 +555,13 @@ impl Expression for NotLogicalExpression {
     fn get_name(&self) -> &'static str {
         "NotLogicalExpression"
     }
+
+    fn fmt_with_indent(&self, f: &mut std::fmt::Formatter<'_>, indent: &str) -> std::fmt::Result {
+        write!(f, "Not(Logical): ")?;
+        self.inner_expression
+            .fmt_with_indent(f, format!("{indent}              ").as_str())?;
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -573,6 +637,18 @@ impl Expression for ContainsLogicalExpression {
     fn get_name(&self) -> &'static str {
         "ContainsLogicalExpression"
     }
+
+    fn fmt_with_indent(&self, f: &mut std::fmt::Formatter<'_>, indent: &str) -> std::fmt::Result {
+        writeln!(f, "Contains")?;
+        write!(f, "{indent}├── Haystack(Scalar): ")?;
+        self.haystack
+            .fmt_with_indent(f, format!("{indent}│                     ").as_str())?;
+        write!(f, "{indent}├── Needle(Scalar): ")?;
+        self.needle
+            .fmt_with_indent(f, format!("{indent}│                   ").as_str())?;
+        writeln!(f, "{indent}└── CaseInsensitive: {}", self.case_insensitive)?;
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -632,6 +708,17 @@ impl Expression for MatchesLogicalExpression {
 
     fn get_name(&self) -> &'static str {
         "MatchesLogicalExpression"
+    }
+
+    fn fmt_with_indent(&self, f: &mut std::fmt::Formatter<'_>, indent: &str) -> std::fmt::Result {
+        writeln!(f, "Matches")?;
+        write!(f, "{indent}├── Haystack(Scalar): ")?;
+        self.haystack
+            .fmt_with_indent(f, format!("{indent}│                     ").as_str())?;
+        write!(f, "{indent}└── Pattern(Scalar): ")?;
+        self.pattern
+            .fmt_with_indent(f, format!("{indent}                     ").as_str())?;
+        Ok(())
     }
 }
 

--- a/rust/experimental/query_engine/expressions/src/pipeline_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/pipeline_expression.rs
@@ -103,6 +103,64 @@ impl Expression for PipelineExpression {
     }
 }
 
+impl std::fmt::Display for PipelineExpression {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Pipeline")?;
+
+        writeln!(f, "├── Query: {:?}", self.query)?;
+
+        if self.constants.is_empty() {
+            writeln!(f, "├── Constants: []")?;
+        } else {
+            writeln!(f, "├── Constants:")?;
+            let last_idx = self.constants.len() - 1;
+            for (i, c) in self.constants.iter().enumerate() {
+                if i == last_idx {
+                    write!(f, "│   └── {i} = ")?;
+                    c.fmt_with_indent(f, "│       ")?;
+                } else {
+                    write!(f, "│   ├── {i} = ")?;
+                    c.fmt_with_indent(f, "│   │   ")?;
+                }
+            }
+        }
+
+        if self.initializations.is_empty() {
+            writeln!(f, "├── Initializations: []")?;
+        } else {
+            writeln!(f, "├── Initializations:")?;
+            let last_idx = self.initializations.len() - 1;
+            for (i, e) in self.initializations.iter().enumerate() {
+                if i == last_idx {
+                    write!(f, "│   └── ")?;
+                    e.fmt_with_indent(f, "│       ")?;
+                } else {
+                    write!(f, "│   ├── ")?;
+                    e.fmt_with_indent(f, "│   │   ")?;
+                }
+            }
+        }
+
+        if self.expressions.is_empty() {
+            writeln!(f, "└── Expressions: []")?;
+        } else {
+            writeln!(f, "└── Expressions:")?;
+            let last_idx = self.expressions.len() - 1;
+            for (i, e) in self.expressions.iter().enumerate() {
+                if i == last_idx {
+                    write!(f, "    └── ")?;
+                    e.fmt_with_indent(f, "        ")?;
+                } else {
+                    write!(f, "│   ├── ")?;
+                    e.fmt_with_indent(f, "│   │   ")?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
 pub struct PipelineResolutionScope<'a> {
     constants: &'a Vec<StaticScalarExpression>,
 }
@@ -119,6 +177,25 @@ pub enum PipelineInitialization {
         name: String,
         value: ScalarExpression,
     },
+}
+
+impl PipelineInitialization {
+    pub(crate) fn fmt_with_indent(
+        &self,
+        f: &mut std::fmt::Formatter<'_>,
+        indent: &str,
+    ) -> std::fmt::Result {
+        match self {
+            PipelineInitialization::SetGlobalVariable { name, value } => {
+                writeln!(f, "SetGlobalVariable")?;
+                writeln!(f, "{indent}├── Name: {name:?}")?;
+                write!(f, "{indent}└── Value(Scalar): ")?;
+                value.fmt_with_indent(f, format!("{indent}                   ").as_str())?;
+            }
+        }
+
+        Ok(())
+    }
 }
 
 pub struct PipelineExpressionBuilder {

--- a/rust/experimental/query_engine/expressions/src/scalars/math_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/math_scalar_expression.rs
@@ -339,6 +339,20 @@ impl Expression for MathScalarExpression {
             MathScalarExpression::Subtract(_) => "MathScalar(Subtract)",
         }
     }
+
+    fn fmt_with_indent(&self, f: &mut std::fmt::Formatter<'_>, indent: &str) -> std::fmt::Result {
+        match self {
+            MathScalarExpression::Add(b) => b.fmt_with_indent(f, indent, "Add"),
+            MathScalarExpression::Bin(b) => b.fmt_with_indent(f, indent, "Bin"),
+            MathScalarExpression::Ceiling(u) => u.fmt_with_indent(f, indent, "Ceiling"),
+            MathScalarExpression::Divide(b) => b.fmt_with_indent(f, indent, "Divide"),
+            MathScalarExpression::Floor(u) => u.fmt_with_indent(f, indent, "Floor"),
+            MathScalarExpression::Modulus(b) => b.fmt_with_indent(f, indent, "Modulus"),
+            MathScalarExpression::Multiply(b) => b.fmt_with_indent(f, indent, "Multiply"),
+            MathScalarExpression::Negate(u) => u.fmt_with_indent(f, indent, "Negate"),
+            MathScalarExpression::Subtract(b) => b.fmt_with_indent(f, indent, "Subtract"),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -360,6 +374,20 @@ impl UnaryMathematicalScalarExpression {
 
     pub fn get_value_expression(&self) -> &ScalarExpression {
         &self.value_expression
+    }
+
+    pub(crate) fn fmt_with_indent(
+        &self,
+        f: &mut std::fmt::Formatter<'_>,
+        indent: &str,
+        name: &str,
+    ) -> std::fmt::Result {
+        write!(f, "{name}(Scalar): ")?;
+        self.value_expression.fmt_with_indent(
+            f,
+            format!("{indent}{}", " ".repeat(name.len() + 10)).as_str(),
+        )?;
+        Ok(())
     }
 }
 
@@ -399,6 +427,22 @@ impl BinaryMathematicalScalarExpression {
 
     pub fn get_right_expression(&self) -> &ScalarExpression {
         &self.right_expression
+    }
+
+    pub(crate) fn fmt_with_indent(
+        &self,
+        f: &mut std::fmt::Formatter<'_>,
+        indent: &str,
+        name: &str,
+    ) -> std::fmt::Result {
+        writeln!(f, "{name}")?;
+        write!(f, "{indent}├── Left(Scalar): ")?;
+        self.left_expression
+            .fmt_with_indent(f, format!("{indent}│                 ").as_str())?;
+        write!(f, "{indent}└── Right(Scalar): ")?;
+        self.right_expression
+            .fmt_with_indent(f, format!("{indent}                   ").as_str())?;
+        Ok(())
     }
 }
 

--- a/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
@@ -238,6 +238,28 @@ impl Expression for ScalarExpression {
             ScalarExpression::Math(m) => m.get_name(),
         }
     }
+
+    fn fmt_with_indent(&self, f: &mut std::fmt::Formatter<'_>, indent: &str) -> std::fmt::Result {
+        match self {
+            ScalarExpression::Attached(a) => a.fmt_with_indent(f, indent),
+            ScalarExpression::Constant(c) => c.fmt_with_indent(f, indent),
+            ScalarExpression::Case(c) => c.fmt_with_indent(f, indent),
+            ScalarExpression::Coalesce(c) => c.fmt_with_indent(f, indent),
+            ScalarExpression::Collection(c) => c.fmt_with_indent(f, indent),
+            ScalarExpression::Conditional(c) => c.fmt_with_indent(f, indent),
+            ScalarExpression::Convert(c) => c.fmt_with_indent(f, indent),
+            ScalarExpression::Temporal(t) => t.fmt_with_indent(f, indent),
+            ScalarExpression::Length(l) => l.fmt_with_indent(f, indent),
+            ScalarExpression::Logical(l) => l.fmt_with_indent(f, indent),
+            ScalarExpression::Math(m) => m.fmt_with_indent(f, indent),
+            ScalarExpression::Parse(p) => p.fmt_with_indent(f, indent),
+            ScalarExpression::Slice(s) => s.fmt_with_indent(f, indent),
+            ScalarExpression::Source(s) => s.fmt_with_indent(f, indent),
+            ScalarExpression::Static(s) => s.fmt_with_indent(f, indent),
+            ScalarExpression::Text(t) => t.fmt_with_indent(f, indent),
+            ScalarExpression::Variable(v) => v.fmt_with_indent(f, indent),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -294,6 +316,18 @@ impl Expression for SourceScalarExpression {
     fn get_name(&self) -> &'static str {
         "SourceScalarExpression"
     }
+
+    fn fmt_with_indent(&self, f: &mut std::fmt::Formatter<'_>, indent: &str) -> std::fmt::Result {
+        writeln!(f, "Source")?;
+        if !self.accessor.has_selectors() {
+            writeln!(f, "{indent}└── Accessor: None")?;
+        } else {
+            writeln!(f, "{indent}└── Accessor:")?;
+            self.accessor
+                .fmt_with_indent(f, format!("{indent}    ").as_str())?;
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -340,6 +374,19 @@ impl Expression for AttachedScalarExpression {
     fn get_name(&self) -> &'static str {
         "AttachedScalarExpression"
     }
+
+    fn fmt_with_indent(&self, f: &mut std::fmt::Formatter<'_>, indent: &str) -> std::fmt::Result {
+        writeln!(f, "Attached")?;
+        writeln!(f, "{indent}├── Name: {:?}", self.name.get_value())?;
+        if !self.accessor.has_selectors() {
+            writeln!(f, "{indent}└── Accessor: None")?;
+        } else {
+            writeln!(f, "{indent}└── Accessor:")?;
+            self.accessor
+                .fmt_with_indent(f, format!("{indent}    ").as_str())?;
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -385,6 +432,19 @@ impl Expression for VariableScalarExpression {
 
     fn get_name(&self) -> &'static str {
         "VariableScalarExpression"
+    }
+
+    fn fmt_with_indent(&self, f: &mut std::fmt::Formatter<'_>, indent: &str) -> std::fmt::Result {
+        writeln!(f, "Variable")?;
+        writeln!(f, "{indent}├── Name: {:?}", self.name.get_value())?;
+        if !self.accessor.has_selectors() {
+            writeln!(f, "{indent}└── Accessor: None")?;
+        } else {
+            writeln!(f, "{indent}└── Accessor:")?;
+            self.accessor
+                .fmt_with_indent(f, format!("{indent}    ").as_str())?;
+        }
+        Ok(())
     }
 }
 
@@ -492,6 +552,13 @@ impl Expression for ReferenceConstantScalarExpression {
 
     fn get_name(&self) -> &'static str {
         "ReferenceConstantScalarExpression"
+    }
+
+    fn fmt_with_indent(&self, f: &mut std::fmt::Formatter<'_>, indent: &str) -> std::fmt::Result {
+        writeln!(f, "Constant(Reference)")?;
+        writeln!(f, "{indent}├── ValueType: {:?}", self.get_value_type())?;
+        writeln!(f, "{indent}└── Id: {}", self.get_constant_id())?;
+        Ok(())
     }
 }
 
@@ -653,6 +720,23 @@ impl Expression for ConditionalScalarExpression {
 
     fn get_name(&self) -> &'static str {
         "ConditionalScalarExpression"
+    }
+
+    fn fmt_with_indent(&self, f: &mut std::fmt::Formatter<'_>, indent: &str) -> std::fmt::Result {
+        writeln!(f, "Conditional")?;
+        writeln!(f, "{indent}├── Condition:")?;
+        write!(f, "{indent}│   └── ")?;
+        self.condition
+            .fmt_with_indent(f, format!("{indent}│       ").as_str())?;
+        writeln!(f, "{indent}├── True:")?;
+        write!(f, "{indent}│   └── ")?;
+        self.true_expression
+            .fmt_with_indent(f, format!("{indent}│       ").as_str())?;
+        writeln!(f, "{indent}└── False:")?;
+        write!(f, "{indent}    └── ")?;
+        self.false_expression
+            .fmt_with_indent(f, format!("{indent}        ").as_str())?;
+        Ok(())
     }
 }
 

--- a/rust/experimental/query_engine/expressions/src/scalars/statics/static_scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/statics/static_scalar_expressions.rs
@@ -174,6 +174,30 @@ impl Expression for StaticScalarExpression {
             StaticScalarExpression::TimeSpan(_) => "StaticScalar(TimeSpan)",
         }
     }
+
+    fn fmt_with_indent(&self, f: &mut std::fmt::Formatter<'_>, indent: &str) -> std::fmt::Result {
+        match self {
+            StaticScalarExpression::Array(a) => {
+                writeln!(f, "Array: {}", Value::Array(a))
+            }
+            StaticScalarExpression::Boolean(b) => writeln!(f, "Bool: {}", b.get_value()),
+            StaticScalarExpression::Constant(c) => {
+                writeln!(f, "Constant(Copy)")?;
+                writeln!(f, "{indent}├── Id: {}", c.get_constant_id())?;
+                write!(f, "{indent}└── ")?;
+                c.get_value().fmt_with_indent(f, indent)?;
+                Ok(())
+            }
+            StaticScalarExpression::DateTime(d) => writeln!(f, "DateTime: {}", Value::DateTime(d)),
+            StaticScalarExpression::Double(d) => writeln!(f, "Double: {}", d.get_value()),
+            StaticScalarExpression::Integer(i) => writeln!(f, "Integer: {}", i.get_value()),
+            StaticScalarExpression::Map(m) => writeln!(f, "Map: {}", Value::Map(m)),
+            StaticScalarExpression::Null(_) => writeln!(f, "Null"),
+            StaticScalarExpression::Regex(r) => writeln!(f, "Regex: {}", r.get_value()),
+            StaticScalarExpression::String(s) => writeln!(f, "String: {:?}", s.get_value()),
+            StaticScalarExpression::TimeSpan(t) => writeln!(f, "TimeSpan: {}", Value::TimeSpan(t)),
+        }
+    }
 }
 
 impl AsStaticValue for StaticScalarExpression {

--- a/rust/experimental/query_engine/expressions/src/scalars/temporal_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/temporal_scalar_expression.rs
@@ -41,6 +41,12 @@ impl Expression for TemporalScalarExpression {
             TemporalScalarExpression::Now(_) => "TemporalScalar(Now)",
         }
     }
+
+    fn fmt_with_indent(&self, f: &mut std::fmt::Formatter<'_>, _indent: &str) -> std::fmt::Result {
+        match self {
+            TemporalScalarExpression::Now(_) => writeln!(f, "Now"),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/rust/experimental/query_engine/expressions/src/value_accessor.rs
+++ b/rust/experimental/query_engine/expressions/src/value_accessor.rs
@@ -84,6 +84,24 @@ impl ValueAccessor {
         Self::select_from_value(root, &mut s.drain(..))
     }
 
+    pub(crate) fn fmt_with_indent(
+        &self,
+        f: &mut std::fmt::Formatter<'_>,
+        indent: &str,
+    ) -> std::fmt::Result {
+        let last_idx = self.selectors.len() - 1;
+        for (i, e) in self.selectors.iter().enumerate() {
+            if i == last_idx {
+                write!(f, "{indent}└── ")?;
+                e.fmt_with_indent(f, format!("{indent}    ").as_str())?;
+            } else {
+                write!(f, "{indent}├── ")?;
+                e.fmt_with_indent(f, format!("{indent}│   ").as_str())?;
+            }
+        }
+        Ok(())
+    }
+
     fn select_from_value<'a>(
         root: &'a StaticScalarExpression,
         selectors: &mut std::vec::Drain<ScalarStaticResolutionResult<'a>>,


### PR DESCRIPTION
## Changes

* Adds foundation for "friendly" display of `PipelineExpression`s. Note: Not everything properly implements the contract yet. I'm hoping to use CoPilot to finish the rest as a follow-up.

## Details

* Based on @drewrelmas's [original work](https://github.com/open-telemetry/otel-arrow/blob/35d23213e095b1342d79231f17fc0f55db1a9e1e/rust/experimental/query_abstraction/intermediate_language/src/grammar_objects.rs#L13).
* I didn't do this before because these methods are kind of a pain to build/maintain. But I noticed others trying to [display](https://github.com/open-telemetry/otel-arrow/compare/main...albertlockett:otel-arrow:albert/kql-to-df-poc?expand=1#diff-ddf75d286c7bb7fb5915798bdc7bddc566061888daf658b9a057049af504e042R39) [things](https://github.com/gouslu/otel-arrow/blob/b635c907a1570bc80bb8178eea3881e87344b612/rust/experimental/query_engine/kql-parser/src/main.rs#L109) and figured it was time.

Example:

```
Pipeline
├── Query: "let c = 1d;\nlet s = \"hello world\";\nlet n = now();\nlet y = bin(n, c) - c;\nlet z = -now();\nsource\n | where (key1 matches regex key1 or key1 contains(key1) or int(null) == key1) and (iif(key1 != int(null), key1, name) == 1)\n "
├── Constants:
│   ├── 0 = TimeSpan: 1.00:00:00
│   └── 1 = String: "hello world"
├── Initializations:
│   ├── SetGlobalVariable
│   │   ├── Name: "n"
│   │   └── Value(Scalar): Now
│   ├── SetGlobalVariable
│   │   ├── Name: "y"
│   │   └── Value(Scalar): Subtract
│   │                      ├── Left(Scalar): Bin
│   │                      │                 ├── Left(Scalar): Variable
│   │                      │                 │                 ├── Name: "n"
│   │                      │                 │                 └── Accessor: None
│   │                      │                 └── Right(Scalar): Constant(Copy)
│   │                      │                                    ├── Id: 0
│   │                      │                                    └── TimeSpan: 1.00:00:00
│   │                      └── Right(Scalar): Constant(Copy)
│   │                                         ├── Id: 0
│   │                                         └── TimeSpan: 1.00:00:00
│   └── SetGlobalVariable
│       ├── Name: "z"
│       └── Value(Scalar): Negate(Scalar): Now
└── Expressions:
    └── Discard
        └── Predicate:
            └── Not(Logical): And
                              ├── Left(Logical): Or
                              │                  ├── Left(Logical): Or
                              │                  │                  ├── Left(Logical): Matches
                              │                  │                  │                  ├── Haystack(Scalar): Source
                              │                  │                  │                  │                     └── Accessor:
                              │                  │                  │                  │                         ├── String: "Attributes"
                              │                  │                  │                  │                         └── String: "key1"
                              │                  │                  │                  └── Pattern(Scalar): Source
                              │                  │                  │                                       └── Accessor:
                              │                  │                  │                                           ├── String: "Attributes"
                              │                  │                  │                                           └── String: "key1"
                              │                  │                  └── Right(Logical): Contains
                              │                  │                                      ├── Haystack(Scalar): Source
                              │                  │                                      │                     └── Accessor:
                              │                  │                                      │                         ├── String: "Attributes"
                              │                  │                                      │                         └── String: "key1"
                              │                  │                                      ├── Needle(Scalar): Source
                              │                  │                                      │                   └── Accessor:
                              │                  │                                      │                       ├── String: "Attributes"
                              │                  │                                      │                       └── String: "key1"
                              │                  │                                      └── CaseInsensitive: true
                              │                  └── Right(Logical): EqualTo
                              │                                      ├── Left(Scalar): Null
                              │                                      └── Right(Scalar): Source
                              │                                                         └── Accessor:
                              │                                                             ├── String: "Attributes"
                              │                                                             └── String: "key1"
                              └── Right(Logical): EqualTo
                                                  ├── Left(Scalar): Conditional
                                                  │                 ├── Condition(Logical): Not(Logical): EqualTo
                                                  │                 │                                     ├── Left(Scalar): Source
                                                  │                 │                                     │                 └── Accessor:
                                                  │                 │                                     │                     ├── String: "Attributes"
                                                  │                 │                                     │                     └── String: "key1"
                                                  │                 │                                     └── Right(Scalar): Null
                                                  │                 ├── True(Scalar): Source
                                                  │                 │                 └── Accessor:
                                                  │                 │                     ├── String: "Attributes"
                                                  │                 │                     └── String: "key1"
                                                  │                 └── False(Scalar): Source
                                                  │                                    └── Accessor:
                                                  │                                        ├── String: "Attributes"
                                                  │                                        └── String: "name"
                                                  └── Right(Scalar): Integer: 1                                                             └── Right(Scalar): Null
```