### PR TITLE
Ack/Nack support [WIP]

### DIFF
--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -88,6 +88,9 @@ tonic = { version = "0.14", default-features = false, features = [
 tonic-middleware = "0.4.0"
 tonic-prost = "0.14"
 prost = "0.14"
+bitflags = "2.9"
+bytemuck = "1.23"
+smallvec = "1.15"
 
 [features]
 default = []

--- a/rust/otap-dataflow/crates/channel/src/error.rs
+++ b/rust/otap-dataflow/crates/channel/src/error.rs
@@ -18,6 +18,16 @@ pub enum SendError<T> {
     Closed(T),
 }
 
+impl<T> SendError<T> {
+    /// Retrieves inner. TODO: why discard full vs closed?
+    pub fn inner(self) -> T {
+        match self {
+            Self::Full(t) => t,
+            Self::Closed(t) => t,
+        }
+    }
+}
+
 /// Errors that can occur when consuming messages from a channel.
 #[derive(thiserror::Error, Debug)]
 pub enum RecvError {

--- a/rust/otap-dataflow/crates/engine/Cargo.toml
+++ b/rust/otap-dataflow/crates/engine/Cargo.toml
@@ -31,6 +31,9 @@ linkme = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }
 flume = { workspace = true }
+bitflags = { workspace = true }
+bytemuck = { workspace = true }
+smallvec = { workspace = true }
 
 socket2 = { version = "0.6.0", features = ["all"] }
 

--- a/rust/otap-dataflow/crates/engine/src/control.rs
+++ b/rust/otap-dataflow/crates/engine/src/control.rs
@@ -135,6 +135,12 @@ pub enum NodeControlMsg<PData> {
         // For future usage
     },
 
+    /// Data after a delay.
+    DelayedData {
+        /// The data; may or may not have subscribe_to called
+        data: Box<PData>,
+    },
+
     /// Dedicated signal to ask a node to collect/flush its local telemetry metrics.
     ///
     /// This separates metrics collection from the generic TimerTick to allow

--- a/rust/otap-dataflow/crates/engine/src/control.rs
+++ b/rust/otap-dataflow/crates/engine/src/control.rs
@@ -37,7 +37,7 @@ impl From<CtxVal> for usize {
 }
 
 /// Standard context values
-pub type CtxData = SmallVec<[CtxVal; 2]>;
+pub type CallData = SmallVec<[CtxVal; 2]>;
 
 /// The ACK
 #[derive(Debug, Clone)]
@@ -46,21 +46,16 @@ pub struct AckMsg<PData> {
     pub accepted: Box<PData>,
 
     /// Subscriber information returned.
-    pub context: Option<CtxData>,
+    pub calldata: Option<CallData>,
 }
 
 impl<PData> AckMsg<PData> {
     /// Creates a new ACK
-    pub fn new(accepted: PData, context: CtxData) -> Self {
+    pub fn new(accepted: PData) -> Self {
         Self {
             accepted: Box::new(accepted),
-            context: Some(context),
+            calldata: None,
         }
-    }
-
-    /// Refer to the accepted PData.
-    pub fn accepted(&self) -> &PData {
-        &*self.accepted
     }
 }
 
@@ -74,36 +69,22 @@ pub struct NackMsg<PData> {
     pub permanent: bool,
 
     /// Subscriber information returned.
-    pub context: Option<CtxData>,
+    pub calldata: Option<CallData>,
 
     /// Refused pdata, presumed to have payload.
     pub refused: Box<PData>,
 }
 
 impl<PData> NackMsg<PData> {
-    // /// Create a new transient NACK (permanent: false)
-    // pub fn new_transient<T: Into<String>>(reason: T, refused: PData) -> Self {
-    //     Self {
-    //         reason: reason.into(),
-    //         permanent: false,
-    //         context,
-    //         refused: Box::new(refused),
-    //     }
-    // }
-
-    // /// Create a new permanent NACK
-    // pub fn new_permanent<T: Into<String>>(reason: T, refused: PData) -> Self {
-    //     Self {
-    //         reason: reason.into(),
-    //         permanent: true,
-    //         refused: Box::new(refused),
-    //     }
-    // }
-
-    //
-    //pub fn take_reply(self) -> (Self, {
-    //
-    //}
+    /// Create a new transient NACK (permanent: false)
+    pub fn new<T: Into<String>>(reason: T, refused: PData) -> Self {
+        Self {
+            reason: reason.into(),
+            permanent: false,
+            calldata: None,
+            refused: Box::new(refused),
+        }
+    }
 }
 
 /// Control messages sent by the pipeline engine to nodes to manage their behavior,

--- a/rust/otap-dataflow/crates/engine/src/control.rs
+++ b/rust/otap-dataflow/crates/engine/src/control.rs
@@ -43,14 +43,18 @@ pub type CtxData = SmallVec<[CtxVal; 2]>;
 #[derive(Debug, Clone)]
 pub struct AckMsg<PData> {
     /// Accepteded pdata, presumed context-only.
-    accepted: Box<PData>,
+    pub accepted: Box<PData>,
+
+    /// Subscriber information returned.
+    pub context: Option<CtxData>,
 }
 
 impl<PData> AckMsg<PData> {
     /// Creates a new ACK
-    pub fn new(accepted: PData) -> Self {
+    pub fn new(accepted: PData, context: CtxData) -> Self {
         Self {
             accepted: Box::new(accepted),
+            context: Some(context),
         }
     }
 

--- a/rust/otap-dataflow/crates/engine/src/effect_handler.rs
+++ b/rust/otap-dataflow/crates/engine/src/effect_handler.rs
@@ -251,7 +251,7 @@ impl<PData> EffectHandlerCore<PData> {
 #[async_trait(?Send)]
 pub trait ProducerEffectHandlerExtension<PData> {
     /// Subscribe to a set of interests.
-    async fn subscribe_to(&self, int: Interests, ctx: CallData, data: &mut PData);
+    fn subscribe_to(&self, int: Interests, ctx: CallData, data: &mut PData);
 }
 
 /// Effect handler extensions for consumers specific to data type.

--- a/rust/otap-dataflow/crates/engine/src/effect_handler.rs
+++ b/rust/otap-dataflow/crates/engine/src/effect_handler.rs
@@ -4,12 +4,12 @@
 //! Common foundation of all effect handlers.
 
 use crate::control::{CtxData, NackMsg, PipelineControlMsg, PipelineCtrlMsgSender};
-use crate::error::Error;
+use crate::error::{Error, TypedError};
 use crate::node::NodeId;
 use async_trait::async_trait;
 use otap_df_channel::error::SendError;
 use std::net::SocketAddr;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::net::{TcpListener, UdpSocket};
 
 bitflags::bitflags! {
@@ -213,8 +213,14 @@ impl<PData> EffectHandlerCore<PData> {
         })
     }
 
-    pub async fn notify_nack(&mut self, _nack: NackMsg<PData>) {
-        // @@@
+    pub async fn delay_message(
+        &self,
+        _data: Box<PData>,
+        _resume: Instant,
+    ) -> Result<(), TypedError<PData>> {
+        // @@@ TODO: Sending a delay request, will return to _this_
+        // component for sending.
+        Ok(())
     }
 }
 
@@ -223,6 +229,9 @@ impl<PData> EffectHandlerCore<PData> {
 pub trait EffectHandlerExtension<PData> {
     /// Subscribe to a set of interests.
     async fn subscribe_to(&self, int: Interests, ctx: CtxData, data: &mut PData);
+
+    /// @@@ TODO; this will send to the PipelineControl manager
+    async fn notify_nack(&self, _nack: NackMsg<PData>);
 }
 
 /// Handle to cancel a running timer.

--- a/rust/otap-dataflow/crates/engine/src/error.rs
+++ b/rust/otap-dataflow/crates/engine/src/error.rs
@@ -254,4 +254,11 @@ pub enum Error {
     /// Too many nodes are configured.
     #[error("Too many nodes defined")]
     TooManyNodes {},
+
+    /// Telemetry-related errors
+    #[error("Telemetry error: {error}")]
+    Telemetry {
+        /// Telemetry error.
+        error: otap_df_telemetry::error::Error,
+    },
 }

--- a/rust/otap-dataflow/crates/engine/src/exporter.rs
+++ b/rust/otap-dataflow/crates/engine/src/exporter.rs
@@ -246,7 +246,7 @@ impl<PData> NodeWithPDataReceiver<PData> for ExporterWrapper<PData> {
 
 #[cfg(test)]
 mod tests {
-    use crate::control::NodeControlMsg;
+    use crate::control::{AckMsg, NodeControlMsg};
     use crate::exporter::{Error, ExporterWrapper};
     use crate::local::exporter as local;
     use crate::local::message::LocalReceiver;
@@ -454,9 +454,11 @@ mod tests {
     async fn test_control_priority() {
         let (control_tx, pdata_tx, mut channel) = make_chan();
 
-        pdata_tx.send_async("pdata1".to_owned()).await.unwrap();
+        let req1 = "req1".to_owned(); // was already sent, awaiting ack
+        let req2 = "req2".to_owned(); // sending now
+        pdata_tx.send_async(req2).await.unwrap();
         control_tx
-            .send_async(NodeControlMsg::Ack { id: 1 })
+            .send_async(NodeControlMsg::Ack(AckMsg::new(req1.clone())))
             .await
             .unwrap();
 
@@ -464,12 +466,12 @@ mod tests {
         let msg = channel.recv().await.unwrap();
         assert!(matches!(
             msg,
-            Message::Control(NodeControlMsg::Ack { id: 1 })
+            Message::Control(NodeControlMsg::Ack(ref a)) if *a.accepted() == req1,
         ));
 
         // Then pdata message
         let msg = channel.recv().await.unwrap();
-        assert!(matches!(msg, Message::PData(ref s) if s == "pdata1"));
+        assert!(matches!(msg, Message::PData(ref s) if s == "req2"));
     }
 
     #[tokio::test]
@@ -628,7 +630,7 @@ mod tests {
         // following the shutdown.
         assert!(
             control_tx
-                .send_async(NodeControlMsg::Ack { id: 99 })
+                .send_async(NodeControlMsg::Ack(AckMsg::new("99".to_owned())))
                 .await
                 .is_err()
         );

--- a/rust/otap-dataflow/crates/engine/src/lib.rs
+++ b/rust/otap-dataflow/crates/engine/src/lib.rs
@@ -46,10 +46,12 @@ pub mod shared;
 pub mod testing;
 
 /// Data-specific extensions to the effect handler.
-pub use effect_handler::{EffectHandlerExtension, Interests};
+pub use effect_handler::{
+    ConsumerEffectHandlerExtension, Interests, ProducerEffectHandlerExtension,
+};
 
 /// Used in the effect handler extensions.
-pub use control::{AckMsg, CtxData, NackMsg};
+pub use control::{AckMsg, CallData, NackMsg};
 pub use node::NodeId;
 
 /// Trait for factory types that expose a name.

--- a/rust/otap-dataflow/crates/engine/src/lib.rs
+++ b/rust/otap-dataflow/crates/engine/src/lib.rs
@@ -49,7 +49,7 @@ pub mod testing;
 pub use effect_handler::{EffectHandlerExtension, Interests};
 
 /// Used in the effect handler extensions.
-pub use control::{CtxData, NackMsg};
+pub use control::{AckMsg, CtxData, NackMsg};
 pub use node::NodeId;
 
 /// Trait for factory types that expose a name.

--- a/rust/otap-dataflow/crates/engine/src/lib.rs
+++ b/rust/otap-dataflow/crates/engine/src/lib.rs
@@ -9,7 +9,7 @@ use crate::{
     exporter::ExporterWrapper,
     local::message::{LocalReceiver, LocalSender},
     message::{Receiver, Sender},
-    node::{Node, NodeDefs, NodeId, NodeName, NodeType},
+    node::{Node, NodeDefs, NodeName, NodeType},
     processor::ProcessorWrapper,
     receiver::ReceiverWrapper,
     runtime_pipeline::{PipeNode, RuntimePipeline},
@@ -44,6 +44,13 @@ pub mod pipeline_ctrl;
 pub mod runtime_pipeline;
 pub mod shared;
 pub mod testing;
+
+/// Data-specific extensions to the effect handler.
+pub use effect_handler::{EffectHandlerExtension, Interests};
+
+/// Used in the effect handler extensions.
+pub use control::{CtxData, NackMsg};
+pub use node::NodeId;
 
 /// Trait for factory types that expose a name.
 ///

--- a/rust/otap-dataflow/crates/engine/src/local/exporter.rs
+++ b/rust/otap-dataflow/crates/engine/src/local/exporter.rs
@@ -33,8 +33,9 @@
 //! To ensure scalability, the pipeline engine will start multiple instances of the same pipeline
 //! in parallel on different cores, each with its own exporter instance.
 
+use crate::control::{AckMsg, NackMsg};
 use crate::effect_handler::{EffectHandlerCore, TelemetryTimerCancelHandle, TimerCancelHandle};
-use crate::error::Error;
+use crate::error::{Error, TypedError};
 use crate::message::MessageChannel;
 use crate::node::NodeId;
 use async_trait::async_trait;
@@ -133,6 +134,22 @@ impl<PData> EffectHandler<PData> {
         duration: Duration,
     ) -> Result<TelemetryTimerCancelHandle<PData>, Error> {
         self.core.start_periodic_telemetry(duration).await
+    }
+
+    /// Send an Ack to a node of known-interest.
+    pub async fn route_ack<F>(&self, ack: AckMsg<PData>, cxf: F) -> Result<(), TypedError<PData>>
+    where
+        F: FnOnce(AckMsg<PData>) -> Option<(usize, AckMsg<PData>)>,
+    {
+        self.core.route_ack(ack, cxf).await
+    }
+
+    /// Send a Nack to a node of known-interest.
+    pub async fn route_nack<F>(&self, nack: NackMsg<PData>, cxf: F) -> Result<(), TypedError<PData>>
+    where
+        F: FnOnce(NackMsg<PData>) -> Option<(usize, NackMsg<PData>)>,
+    {
+        self.core.route_nack(nack, cxf).await
     }
 
     // More methods will be added in the future as needed.

--- a/rust/otap-dataflow/crates/engine/src/local/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/local/processor.rs
@@ -32,6 +32,7 @@
 //! To ensure scalability, the pipeline engine will start multiple instances of the same pipeline
 //! in parallel on different cores, each with its own processor instance.
 
+use crate::control::{AckMsg, NackMsg};
 use crate::effect_handler::{EffectHandlerCore, TimerCancelHandle};
 use crate::error::{Error, TypedError};
 use crate::local::message::LocalSender;
@@ -205,13 +206,31 @@ impl<PData> EffectHandler<PData> {
         self.core.start_periodic_timer(duration).await
     }
 
-    ///
+    /// Delay a message until a future time.
     pub async fn delay_message(
         &self,
         data: Box<PData>,
         resume: Instant,
     ) -> Result<(), TypedError<PData>> {
         self.core.delay_message(data, resume).await
+    }
+
+    /// Send an Ack to a node of known-interest.
+    pub async fn route_ack(
+        &self,
+        node_id: usize,
+        ack: AckMsg<PData>,
+    ) -> Result<(), TypedError<PData>> {
+        self.core.route_ack(node_id, ack).await
+    }
+
+    /// Send a Nack to a node of known-interest.
+    pub async fn route_nack(
+        &self,
+        node_id: usize,
+        nack: NackMsg<PData>,
+    ) -> Result<(), TypedError<PData>> {
+        self.core.route_nack(node_id, nack).await
     }
 
     // More methods will be added in the future as needed.

--- a/rust/otap-dataflow/crates/engine/src/local/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/local/processor.rs
@@ -32,6 +32,7 @@
 //! To ensure scalability, the pipeline engine will start multiple instances of the same pipeline
 //! in parallel on different cores, each with its own processor instance.
 
+use crate::control::NackMsg;
 use crate::effect_handler::{EffectHandlerCore, TimerCancelHandle};
 use crate::error::{Error, TypedError};
 use crate::local::message::LocalSender;
@@ -203,6 +204,11 @@ impl<PData> EffectHandler<PData> {
         duration: Duration,
     ) -> Result<TimerCancelHandle<PData>, Error> {
         self.core.start_periodic_timer(duration).await
+    }
+
+    /// Reply with a Nack.
+    pub async fn notify_nack(&mut self, nack: NackMsg<PData>) {
+        self.core.notify_nack(nack).await
     }
 
     // More methods will be added in the future as needed.

--- a/rust/otap-dataflow/crates/engine/src/local/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/local/processor.rs
@@ -32,7 +32,6 @@
 //! To ensure scalability, the pipeline engine will start multiple instances of the same pipeline
 //! in parallel on different cores, each with its own processor instance.
 
-use crate::control::NackMsg;
 use crate::effect_handler::{EffectHandlerCore, TimerCancelHandle};
 use crate::error::{Error, TypedError};
 use crate::local::message::LocalSender;
@@ -41,7 +40,7 @@ use crate::node::NodeId;
 use async_trait::async_trait;
 use otap_df_config::PortName;
 use std::collections::HashMap;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 /// A trait for processors in the pipeline (!Send definition).
 #[async_trait(?Send)]
@@ -206,9 +205,13 @@ impl<PData> EffectHandler<PData> {
         self.core.start_periodic_timer(duration).await
     }
 
-    /// Reply with a Nack.
-    pub async fn notify_nack(&mut self, nack: NackMsg<PData>) {
-        self.core.notify_nack(nack).await
+    ///
+    pub async fn delay_message(
+        &self,
+        data: Box<PData>,
+        resume: Instant,
+    ) -> Result<(), TypedError<PData>> {
+        self.core.delay_message(data, resume).await
     }
 
     // More methods will be added in the future as needed.

--- a/rust/otap-dataflow/crates/engine/src/local/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/local/processor.rs
@@ -216,21 +216,19 @@ impl<PData> EffectHandler<PData> {
     }
 
     /// Send an Ack to a node of known-interest.
-    pub async fn route_ack(
-        &self,
-        node_id: usize,
-        ack: AckMsg<PData>,
-    ) -> Result<(), TypedError<PData>> {
-        self.core.route_ack(node_id, ack).await
+    pub async fn route_ack<F>(&self, ack: AckMsg<PData>, cxf: F) -> Result<(), TypedError<PData>>
+    where
+        F: FnOnce(AckMsg<PData>) -> Option<(usize, AckMsg<PData>)>,
+    {
+        self.core.route_ack(ack, cxf).await
     }
 
     /// Send a Nack to a node of known-interest.
-    pub async fn route_nack(
-        &self,
-        node_id: usize,
-        nack: NackMsg<PData>,
-    ) -> Result<(), TypedError<PData>> {
-        self.core.route_nack(node_id, nack).await
+    pub async fn route_nack<F>(&self, nack: NackMsg<PData>, cxf: F) -> Result<(), TypedError<PData>>
+    where
+        F: FnOnce(NackMsg<PData>) -> Option<(usize, NackMsg<PData>)>,
+    {
+        self.core.route_nack(nack, cxf).await
     }
 
     // More methods will be added in the future as needed.

--- a/rust/otap-dataflow/crates/engine/src/message.rs
+++ b/rust/otap-dataflow/crates/engine/src/message.rs
@@ -3,7 +3,7 @@
 
 //! Message definitions for the pipeline engine.
 
-use crate::control::NodeControlMsg;
+use crate::control::{AckMsg, NackMsg, NodeControlMsg};
 use crate::local::message::{LocalReceiver, LocalSender};
 use crate::shared::message::{SharedReceiver, SharedSender};
 use otap_df_channel::error::{RecvError, SendError};
@@ -25,27 +25,23 @@ pub enum Message<PData> {
     Control(NodeControlMsg<PData>),
 }
 
-impl<Data> Message<Data> {
+impl<PData> Message<PData> {
     /// Create a data message with the given payload.
     #[must_use]
-    pub fn data_msg(data: Data) -> Self {
+    pub fn data_msg(data: PData) -> Self {
         Message::PData(data)
     }
 
-    /// Create a ACK control message with the given ID.
+    /// Create a ACK control message
     #[must_use]
-    pub fn ack_ctrl_msg(id: u64) -> Self {
-        Message::Control(NodeControlMsg::Ack { id })
+    pub fn ack_ctrl_msg(ack: AckMsg<PData>) -> Self {
+        Message::Control(NodeControlMsg::Ack(ack))
     }
 
-    /// Create a NACK control message with the given ID and reason.
+    /// Create a NACK control message.
     #[must_use]
-    pub fn nack_ctrl_msg(id: u64, reason: &str, pdata: Option<Data>) -> Self {
-        Message::Control(NodeControlMsg::Nack {
-            id,
-            pdata: pdata.map(Box::new),
-            reason: reason.to_owned(),
-        })
+    pub fn nack_ctrl_msg(nack: NackMsg<PData>) -> Self {
+        Message::Control(NodeControlMsg::Nack(nack))
     }
 
     /// Creates a config control message with the given configuration.

--- a/rust/otap-dataflow/crates/engine/src/node.rs
+++ b/rust/otap-dataflow/crates/engine/src/node.rs
@@ -43,7 +43,7 @@ pub trait Node<PData> {
 #[derive(Clone, Debug)]
 pub struct NodeId {
     /// A unique integer.
-    pub(crate) index: usize,
+    pub index: usize,
 
     /// A unique name as defined by otap_df_config.
     pub name: NodeName,

--- a/rust/otap-dataflow/crates/engine/src/testing/receiver.rs
+++ b/rust/otap-dataflow/crates/engine/src/testing/receiver.rs
@@ -8,7 +8,7 @@
 
 use crate::config::ReceiverConfig;
 use crate::control::{
-    Controllable, NodeControlMsg, PipelineCtrlMsgReceiver, pipeline_ctrl_msg_channel,
+    Controllable, NodeControlMsg, PipelineCtrlMsgReceiver, pipeline_ctrl_msg_channel, AckMsg, NackMsg,
 };
 use crate::error::Error;
 use crate::local::message::{LocalReceiver, LocalSender};
@@ -25,6 +25,49 @@ use std::time::Duration;
 use tokio::task::LocalSet;
 use tokio::time::sleep;
 
+/// Trait for preparing Ack/Nack messages with proper correlation data in tests.
+/// 
+/// This trait abstracts the correlation preparation logic that would normally be
+/// handled by ConsumerEffectHandlerExtension::notify_ack/notify_nack in production.
+/// Pipeline-specific implementations can provide the proper correlation handling
+/// while keeping the test harness generic.
+pub trait TestCorrelationHandler<PData> {
+    /// Prepare an AckMsg with proper correlation data for testing.
+    /// 
+    /// This simulates what ConsumerEffectHandlerExtension::notify_ack() does:
+    /// - Extracts correlation information from the context stack
+    /// - Sets appropriate calldata for routing back to the original requester
+    /// 
+    /// Returns None if no correlation subscriber is found (equivalent to next_ack returning None).
+    fn prepare_ack(&self, data: PData) -> Option<(usize, AckMsg<PData>)>;
+    
+    /// Prepare a NackMsg with proper correlation data for testing.
+    /// 
+    /// This simulates what ConsumerEffectHandlerExtension::notify_nack() does:
+    /// - Extracts correlation information from the context stack  
+    /// - Sets appropriate calldata for routing back to the original requester
+    /// 
+    /// Returns None if no correlation subscriber is found (equivalent to next_nack returning None).
+    fn prepare_nack(&self, data: PData, reason: String) -> Option<(usize, NackMsg<PData>)>;
+}
+
+/// Auto-acknowledgment behavior for test harness
+#[derive(Debug, Clone, PartialEq)]
+pub enum AutoAckBehavior {
+    /// Automatically send Ack for every received message
+    AlwaysAck,
+    /// Automatically send Nack for every received message  
+    AlwaysNack,
+    /// Do not send any automatic responses
+    Manual,
+}
+
+impl Default for AutoAckBehavior {
+    fn default() -> Self {
+        Self::AlwaysAck
+    }
+}
+
 /// Context used during the test phase of a test.
 pub struct TestContext<PData> {
     /// Sender for control messages
@@ -35,6 +78,9 @@ pub struct TestContext<PData> {
 pub struct NotSendValidateContext<PData> {
     pdata_receiver: Receiver<PData>,
     counters: CtrlMsgCounters,
+    control_sender: Sender<NodeControlMsg<PData>>,
+    auto_ack_behavior: AutoAckBehavior,
+    correlation_handler: Option<Box<dyn TestCorrelationHandler<PData>>>,
 }
 
 /// Context used during the validation phase of a test (Send context).
@@ -98,16 +144,116 @@ impl<PData> TestContext<PData> {
     }
 }
 
-impl<PData> NotSendValidateContext<PData> {
+impl<PData: Clone> NotSendValidateContext<PData> {
     /// Receives a pdata message produced by the receiver.
+    /// Automatically sends Ack/Nack response based on the configured behavior.
     pub async fn recv(&mut self) -> Result<PData, RecvError> {
-        self.pdata_receiver.recv().await
+        println!("[TEST DEBUG] Validation waiting for message...");
+        let data = self.pdata_receiver.recv().await?;
+        println!("[TEST DEBUG] Validation received message from receiver");
+        
+        // Send automatic Ack/Nack response based on configuration
+        match self.auto_ack_behavior {
+            AutoAckBehavior::AlwaysAck => {
+                use crate::control::{AckMsg, NodeControlMsg};
+                
+                // Create basic AckMsg - the receiver will need to handle correlation properly
+                let ack_msg = AckMsg::new(data.clone());
+                println!("[TEST DEBUG] Sending auto-Ack back to receiver (basic version)");
+                if let Err(e) = self.control_sender.send(NodeControlMsg::Ack(ack_msg)).await {
+                    eprintln!("[TEST ERROR] Failed to send automatic Ack in test: {}", e);
+                } else {
+                    println!("[TEST DEBUG] Auto-Ack sent successfully");
+                }
+                
+                // TODO: For proper correlation, we need to use Context::next_ack()
+                // This requires access to otap-specific types not available in engine crate
+            }
+            AutoAckBehavior::AlwaysNack => {
+                use crate::control::{NackMsg, NodeControlMsg};
+                
+                // Create basic NackMsg - the receiver will need to handle correlation properly  
+                let nack_msg = NackMsg::new("Test configured to Nack", data.clone());
+                println!("[TEST DEBUG] Sending auto-Nack back to receiver (basic version)");
+                if let Err(e) = self.control_sender.send(NodeControlMsg::Nack(nack_msg)).await {
+                    eprintln!("[TEST ERROR] Failed to send automatic Nack in test: {}", e);
+                } else {
+                    println!("[TEST DEBUG] Auto-Nack sent successfully");
+                }
+                
+                // TODO: For proper correlation, we need to use Context::next_nack()
+                // This requires access to otap-specific types not available in engine crate
+            }
+            AutoAckBehavior::Manual => {
+                println!("[TEST DEBUG] Manual mode - no automatic response");
+            }
+        }
+        
+        println!("[TEST DEBUG] Returning message to validation");
+        Ok(data)
     }
 
     /// Returns the control message counters.
     #[must_use]
     pub fn counters(&self) -> CtrlMsgCounters {
         self.counters.clone()
+    }
+
+    /// Set a correlation handler for proper Ack/Nack preparation in tests.
+    pub fn set_correlation_handler(&mut self, handler: Box<dyn TestCorrelationHandler<PData>>) {
+        self.correlation_handler = Some(handler);
+    }
+
+    /// Manually send a prepared Ack using the correlation handler if available.
+    pub async fn send_prepared_ack(&mut self, data: PData) -> Result<(), Error> {
+        if let Some(ref handler) = self.correlation_handler {
+            if let Some((_node_id, prepared_ack)) = handler.prepare_ack(data) {
+                println!("[TEST DEBUG] Sending manually prepared Ack with proper correlation");
+                self.control_sender
+                    .send(NodeControlMsg::Ack(prepared_ack))
+                    .await
+                    .map_err(|e| Error::PipelineControlMsgError {
+                        error: e.to_string(),
+                    })
+            } else {
+                Err(Error::PipelineControlMsgError {
+                    error: "Correlation handler returned None for Ack".to_string(),
+                })
+            }
+        } else {
+            Err(Error::PipelineControlMsgError {
+                error: "No correlation handler set".to_string(),
+            })
+        }
+    }
+
+    /// Manually send a prepared Nack using the correlation handler if available.
+    pub async fn send_prepared_nack(&mut self, data: PData, reason: String) -> Result<(), Error> {
+        if let Some(ref handler) = self.correlation_handler {
+            if let Some((_node_id, prepared_nack)) = handler.prepare_nack(data, reason) {
+                println!("[TEST DEBUG] Sending manually prepared Nack with proper correlation");
+                self.control_sender
+                    .send(NodeControlMsg::Nack(prepared_nack))
+                    .await
+                    .map_err(|e| Error::PipelineControlMsgError {
+                        error: e.to_string(),
+                    })
+            } else {
+                Err(Error::PipelineControlMsgError {
+                    error: "Correlation handler returned None for Nack".to_string(),
+                })
+            }
+        } else {
+            Err(Error::PipelineControlMsgError {
+                error: "No correlation handler set".to_string(),
+            })
+        }
+    }
+
+    /// Get access to the control sender for manual Ack/Nack sending
+    /// This is used by pipeline-specific test code that needs to handle correlation
+    pub fn control_sender(&self) -> &Sender<NodeControlMsg<PData>> {
+        &self.control_sender
     }
 }
 
@@ -168,6 +314,9 @@ pub struct ValidationPhase<PData> {
     counters: CtrlMsgCounters,
 
     pdata_receiver: Receiver<PData>,
+    
+    /// Control sender for sending Ack/Nack messages back to the receiver
+    control_sender: Sender<NodeControlMsg<PData>>,
 
     /// Join handle for the running the receiver task
     run_receiver_handle: tokio::task::JoinHandle<()>,
@@ -276,16 +425,18 @@ impl<PData: Debug + 'static> TestPhase<PData> {
         });
 
         let context = TestContext {
-            control_sender: self.control_sender,
+            control_sender: self.control_sender.clone(),
         };
         let run_test_handle = self.local_tasks.spawn_local(async move {
             f(context).await;
         });
+        
         ValidationPhase {
             rt: self.rt,
             local_tasks: self.local_tasks,
             counters: self.counters,
             pdata_receiver,
+            control_sender: self.control_sender,
             run_receiver_handle,
             run_test_handle,
             pipeline_ctrl_msg_receiver: pipeline_ctrl_msg_rx,
@@ -295,7 +446,7 @@ impl<PData: Debug + 'static> TestPhase<PData> {
 
 impl<PData> ValidationPhase<PData> {
     /// Runs all spawned tasks to completion and executes the provided future to validate test
-    /// expectations.
+    /// expectations concurrently with the test scenario.
     ///
     /// # Type Parameters
     ///
@@ -314,20 +465,26 @@ impl<PData> ValidationPhase<PData> {
         let context = NotSendValidateContext {
             pdata_receiver: self.pdata_receiver,
             counters: self.counters,
+            control_sender: self.control_sender.clone(),
+            auto_ack_behavior: AutoAckBehavior::Manual, // Disable auto-ack for proper correlation
+            correlation_handler: None, // Default to no correlation handler
         };
 
-        // First run all the spawned tasks to completion
-        self.rt.block_on(self.local_tasks);
-
-        self.rt
-            .block_on(self.run_receiver_handle)
-            .expect("Receiver task failed");
-
-        self.rt
-            .block_on(self.run_test_handle)
-            .expect("Test task failed");
-
-        // Then run the validation future with the test context
-        self.rt.block_on(future_fn(context))
+        // Use select! to run validation concurrently with the LocalSet tasks
+        self.rt.block_on(async move {
+            tokio::select! {
+                biased;
+                
+                // Run the validation future
+                validation_result = future_fn(context) => {
+                    validation_result
+                }
+                
+                // Run the local tasks (receiver and test scenario)
+                _ = self.local_tasks => {
+                    panic!("LocalSet completed before validation finished")
+                }
+            }
+        })
     }
 }

--- a/rust/otap-dataflow/crates/otap/Cargo.toml
+++ b/rust/otap-dataflow/crates/otap/Cargo.toml
@@ -37,7 +37,7 @@ tonic = { workspace = true }
 tonic-middleware = { workspace = true }
 tonic-prost = { workspace = true }
 prost = { workspace = true }
-
+smallvec = { workspace = true }
 otap-df-engine = { path = "../engine" }
 otap-df-engine-macros = { path = "../engine-macros" }
 otap-df-channel = { path = "../channel" }

--- a/rust/otap-dataflow/crates/otap/src/otap_batch_processor.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_batch_processor.rs
@@ -710,6 +710,9 @@ impl local::Processor<OtapPdata> for OtapBatchProcessor {
                         }
                         Ok(())
                     }
+                    otap_df_engine::control::NodeControlMsg::DelayedData { .. } => {
+                        unreachable!("not used")
+                    }
                     otap_df_engine::control::NodeControlMsg::Ack { .. }
                     | otap_df_engine::control::NodeControlMsg::Nack { .. } => Ok(()),
                 }

--- a/rust/otap-dataflow/crates/otap/src/otap_grpc/otlp/server.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_grpc/otlp/server.rs
@@ -7,11 +7,9 @@
 //! use these servers to receive telemetry data and deserialize it lazily only if some pipeline
 //! requires it
 
-use std::cmp::Reverse;
 use std::convert::Infallible;
 use std::sync::{Arc, Mutex};
 use std::task::Poll;
-use std::time::{Duration, Instant};
 
 use crate::pdata::{OtapPdata, OtlpProtoBytes};
 use crate::proto::opentelemetry::collector::logs::v1::ExportLogsServiceResponse;
@@ -22,12 +20,12 @@ use http::{Request, Response};
 use otap_df_config::experimental::SignalType;
 use otap_df_engine::control::CtxVal;
 use otap_df_engine::{
-    AckMsg, CallData, Interests, NackMsg, ProducerEffectHandlerExtension, shared::receiver::EffectHandler,
+    AckMsg, CallData, Interests, NackMsg, ProducerEffectHandlerExtension,
+    shared::receiver::EffectHandler,
 };
 use prost::Message;
 use prost::bytes::Buf;
 use smallvec::smallvec;
-use std::collections::BTreeSet;
 use tokio::sync::oneshot;
 use tonic::Status;
 use tonic::body::Body;
@@ -40,14 +38,12 @@ use tonic::server::{Grpc, NamedService, UnaryService};
 pub struct ServerConfig {
     /// Maximum number of slots
     max_slots: usize,
-    /// Default timeout for requests
-    default_timeout: Duration,
 }
 
 /// Data stored in each correlation slot
 struct SlotData {
     /// Channel to send response back to gRPC handler
-    channel: oneshot::Sender<Result<(), NackMsg<OtapPdata>>>,
+    channel: Option<oneshot::Sender<Result<(), NackMsg<OtapPdata>>>>,
 
     /// Coutner
     generation: SlotGeneration,
@@ -63,14 +59,13 @@ struct SlotGeneration(usize);
 
 /// The value placed in CallData
 #[derive(Clone, Copy, Debug)]
-struct SlotKey(SlotIndex, SlotGeneration);
+pub struct SlotKey(SlotIndex, SlotGeneration);
 
 // Default implementations for when slots are not in use
 impl Default for SlotData {
     fn default() -> Self {
-        let (tx, _rx) = oneshot::channel();
         Self {
-            channel: tx,
+            channel: None,
             generation: SlotGeneration(0),
         }
     }
@@ -86,7 +81,7 @@ impl SlotGeneration {
     fn as_usize(self) -> usize {
         self.0
     }
-    
+
     fn increment(self) -> Self {
         SlotGeneration(self.0.wrapping_add(1))
     }
@@ -96,11 +91,11 @@ impl SlotKey {
     fn new(index: SlotIndex, generation: SlotGeneration) -> Self {
         Self(index, generation)
     }
-    
+
     fn index(self) -> SlotIndex {
         self.0
     }
-    
+
     fn generation(self) -> SlotGeneration {
         self.1
     }
@@ -122,93 +117,69 @@ pub struct ServerState {
     /// this set.
     free_slots: Vec<SlotIndex>,
 
-    /// Set of active slots (i.e., those not in free_slots) ordered by
-    /// timeout.
-    timeouts: BTreeSet<(Reverse<Instant>, SlotIndex)>,
+    /// Server configuration.
+    config: ServerConfig,
 }
 
 /// Shared correlation state between gRPC handlers and effect handlers
-type SharedCorrelationState = Arc<Mutex<ServerState>>;
+pub type SharedCorrelationState = Arc<Mutex<ServerState>>;
 
 /// Route an Ack/Nack response back to the appropriate correlation slot
 pub fn route_response(
-    correlation_state: &SharedCorrelationState,
+    state: &SharedCorrelationState,
     calldata: Option<CallData>,
     result: Result<(), NackMsg<OtapPdata>>,
-) -> bool {
+) {
+    println!("[ROUTE DEBUG] route_response called");
     let calldata = match calldata {
-        Some(data) => data,
-        None => return false, // No correlation data available
+        Some(data) => {
+            println!("[ROUTE DEBUG] Calldata present: {:?}", data);
+            data
+        }
+        None => {
+            println!("[ROUTE DEBUG] No calldata - cannot route response");
+            return;
+        }
     };
-    
-    // Extract slot index and generation from CallData
-    if calldata.len() >= 2 {
-        let slot_index = SlotIndex(calldata[0].into());
-        let generation = SlotGeneration(calldata[1].into());
-        let slot_key = SlotKey::new(slot_index, generation);
-        
-        let mut state = correlation_state.lock().unwrap();
-        state.deliver_response(slot_key, result)
-    } else {
-        false // Invalid CallData format
-    }
+
+    let slot_index = SlotIndex(calldata[0].into());
+    let generation = SlotGeneration(calldata[1].into());
+    let slot_key = SlotKey::new(slot_index, generation);
+    println!("[ROUTE DEBUG] Routing to slot_key: index={}, generation={}", slot_index.0, generation.0);
+
+    let mut state = state.lock().unwrap();
+    println!("[ROUTE DEBUG] Acquired state lock, calling deliver_response");
+    state.deliver_response(slot_key, result);
+    println!("[ROUTE DEBUG] deliver_response completed");
 }
 
-/// Example integration: Route Ack message using Context::next_ack
-pub fn route_ack_response(
-    correlation_state: &SharedCorrelationState,
-    ack: AckMsg<OtapPdata>,
-) -> bool {
-    use crate::pdata::Context;
-    
-    if let Some((_node_id, ack_with_calldata)) = Context::next_ack(ack) {
-        route_response(correlation_state, ack_with_calldata.calldata, Ok(()))
-    } else {
-        false // No correlation subscriber found
-    }
+/// Route the ack
+pub fn route_ack_response(state: &SharedCorrelationState, ack: AckMsg<OtapPdata>) {
+    println!("[ROUTE DEBUG] route_ack_response called");
+    route_response(state, ack.calldata, Ok(()));
+    println!("[ROUTE DEBUG] route_ack_response completed");
 }
 
-/// Example integration: Route Nack message using Context::next_nack
-pub fn route_nack_response(
-    correlation_state: &SharedCorrelationState,
-    nack: NackMsg<OtapPdata>,
-) -> bool {
-    use crate::pdata::Context;
-    
-    if let Some((_node_id, nack_with_calldata)) = Context::next_nack(nack) {
-        let result = Err(nack_with_calldata.clone());
-        route_response(correlation_state, nack_with_calldata.calldata, result)
-    } else {
-        false // No correlation subscriber found
-    }
+/// Route a Nack response back to the appropriate correlation slot  
+pub fn route_nack_response(state: &SharedCorrelationState, mut nack: NackMsg<OtapPdata>) {
+    let calldata = nack.calldata.take();
+    route_response(state, calldata, Err(nack))
 }
 
 impl ServerConfig {
     /// Create default server configuration
     pub fn default() -> Self {
-        Self {
-            max_slots: 1000,
-            default_timeout: Duration::from_secs(30),
-        }
+        Self { max_slots: 1000 }
     }
 }
 
 impl ServerState {
     /// Create new correlation state with specified limits
-    fn new(config: &ServerConfig) -> Self {
+    fn new(config: ServerConfig) -> Self {
         Self {
             slots: Vec::with_capacity(config.max_slots.min(1024)),
             free_slots: Vec::new(),
-            timeouts: BTreeSet::new(),
-        }
-    }
-
-    /// Helper to remove timeout entry for a slot
-    fn remove_timeout_for_slot(&mut self, slot_index: SlotIndex) {
-        if let Some(entry) = self.timeouts.iter()
-            .find(|(_, idx)| *idx == slot_index)
-            .copied() {
-            let _ = self.timeouts.remove(&entry);
+            config,
         }
     }
 
@@ -216,114 +187,96 @@ impl ServerState {
     fn allocate_slot(
         &mut self,
         channel: oneshot::Sender<Result<(), NackMsg<OtapPdata>>>,
-        config: &ServerConfig,
     ) -> Option<SlotKey> {
-        // Helper to add timeout and create SlotKey
-        let add_timeout_and_create_key = |timeouts: &mut BTreeSet<_>, slot_index, generation| {
-            let timeout = Instant::now() + config.default_timeout;
-            let _ = timeouts.insert((Reverse(timeout), slot_index));
-            SlotKey::new(slot_index, generation)
-        };
-
-        // Try to reuse a free slot first
+        println!("[ALLOC DEBUG] allocate_slot called");
         if let Some(slot_index) = self.free_slots.pop() {
-            let idx = slot_index.as_usize();
-            if idx < self.slots.len() {
-                // Increment generation and update slot
-                let new_generation = self.slots[idx].generation.increment();
-                self.slots[idx] = SlotData {
-                    channel,
-                    generation: new_generation,
-                };
-                
-                return Some(add_timeout_and_create_key(&mut self.timeouts, slot_index, new_generation));
-            }
+            println!("[ALLOC DEBUG] Reusing free slot at index {}", slot_index.as_usize());
+            let unused_generation = self
+                .slots
+                .get_mut(slot_index.as_usize())
+                .map(|data| {
+                    println!("[ALLOC DEBUG] Current generation for slot {}: {}", slot_index.as_usize(), data.generation.0);
+                    data.channel = Some(channel);
+                    // generation is incremented when it is placed in free_slots.
+                    data.generation
+                })
+                .expect("some");
+
+            println!("[ALLOC DEBUG] ✅ Allocated existing slot: index={}, generation={}", slot_index.as_usize(), unused_generation.0);
+            return Some(SlotKey::new(slot_index, unused_generation));
         }
-        
+
+        println!("[ALLOC DEBUG] No free slots available, checking if can grow");
         // If no free slots and we can still grow
-        if self.slots.len() < config.max_slots {
+        if self.slots.len() < self.config.max_slots {
             let slot_index = SlotIndex(self.slots.len());
-            let generation = SlotGeneration(1); // First use of this slot
-            
+            let generation = SlotGeneration(1);
+
             self.slots.push(SlotData {
-                channel,
+                channel: Some(channel),
                 generation,
             });
-            
-            Some(add_timeout_and_create_key(&mut self.timeouts, slot_index, generation))
+
+            Some(SlotKey::new(slot_index, generation))
         } else {
             None // At capacity
         }
     }
 
-    /// Clean up expired slots, returning count of slots cleaned
-    fn cleanup_expired(&mut self, now: Instant) -> usize {
-        let mut cleaned = 0;
-        let mut expired_slots = Vec::new();
-        
-        // Collect expired slots
-        for &(Reverse(timeout), slot_index) in &self.timeouts {
-            if timeout <= now {
-                expired_slots.push(slot_index);
-            } else {
-                break; // BTreeSet is ordered, so no more expired entries
-            }
-        }
-        
-        // Process expired slots
-        for slot_index in expired_slots {
-            // Remove from timeouts
-            self.remove_timeout_for_slot(slot_index);
-            
-            let idx = slot_index.as_usize();
-            if idx < self.slots.len() {
-                // Send timeout error to the waiting gRPC handler
-                let default_slot = SlotData::default();
-                let old_slot = std::mem::replace(&mut self.slots[idx], default_slot);
-                
-                let _ = old_slot.channel.send(Err(NackMsg::new(
-                    "Request timeout",
-                    // We need to create a dummy OtapPdata for the error.
-                    // In a real timeout, we don't have the original data.
-                    OtapPdata::new_todo_context(
-                        OtlpProtoBytes::ExportLogsRequest(vec![]).into(),
-                    ),
-                )));
-                
-                // Add slot back to free list
-                self.free_slots.push(slot_index);
-                cleaned += 1;
-            }
-        }
-        
-        cleaned
-    }
-
     /// Deliver response to a specific slot
-    fn deliver_response(
+    pub(crate) fn deliver_response(
         &mut self,
         slot_key: SlotKey,
         result: Result<(), NackMsg<OtapPdata>>,
-    ) -> bool {
-        let slot_index = slot_key.index();
-        let expected_generation = slot_key.generation();
-        let idx = slot_index.as_usize();
+    ) {
+        println!("[DELIVER DEBUG] deliver_response called with slot_key: index={}, generation={}", 
+                slot_key.index().0, slot_key.generation().0);
         
-        if idx < self.slots.len() {
-            let current_generation = self.slots[idx].generation;
-            if current_generation == expected_generation {
-                // Remove from timeouts and mark slot as free
-                self.remove_timeout_for_slot(slot_index);
-                
-                let default_slot = SlotData::default();
-                let old_slot = std::mem::replace(&mut self.slots[idx], default_slot);
-                let _ = old_slot.channel.send(result);
-                
-                self.free_slots.push(slot_index);
-                return true;
-            }
+        let slot_index = slot_key.index();
+        println!("[DELIVER DEBUG] Looking up slot at index {}", slot_index.as_usize());
+
+        let data = self.slots.get_mut(slot_index.as_usize()).expect("some");
+        println!("[DELIVER DEBUG] Found slot data, generation check: slot.generation={}, key.generation={}", 
+                data.generation.0, slot_key.generation().0);
+        
+        if data.generation == slot_key.generation() {
+            println!("[DELIVER DEBUG] Generation matches! Attempting to send result...");
+            match data.channel.take().map(|sender| sender.send(result)) {
+                Some(Ok(_)) => {
+                    println!("[DELIVER DEBUG] ✅ Result sent successfully to channel!");
+                }
+                Some(Err(_)) => {
+                    println!("[DELIVER DEBUG] ❌ Failed to send result to channel (receiver dropped?)");
+                }
+                None => {
+                    println!("[DELIVER DEBUG] ❌ No channel available (already taken/canceled/timed out)");
+                }
+            };
+            data.generation = data.generation.increment();
+            self.free_slots.push(slot_index);
+            println!("[DELIVER DEBUG] Slot freed and generation incremented to {}", data.generation.0);
+        } else {
+            println!("[DELIVER DEBUG] ❌ Generation mismatch! Ignoring stale response.");
         }
-        false // Slot not found or generation mismatch
+    }
+
+    /// Free a slot when a gRPC request is cancelled
+    pub(crate) fn free_slot(&mut self, slot_key: SlotKey) {
+        println!("[FREE DEBUG] free_slot called for slot: index={}, generation={}", 
+                slot_key.index().0, slot_key.generation().0);
+        let slot_index = slot_key.index();
+
+        let data = self.slots.get_mut(slot_index.as_usize()).expect("some");
+        println!("[FREE DEBUG] Current slot generation: {}", data.generation.0);
+        
+        if data.generation == slot_key.generation() {
+            println!("[FREE DEBUG] ✅ Generation matches - freeing slot and incrementing generation");
+            data.generation = data.generation.increment();
+            println!("[FREE DEBUG] New generation after increment: {}", data.generation.0);
+            self.free_slots.push(slot_index);
+        } else {
+            println!("[FREE DEBUG] ❌ Generation mismatch - not freeing slot");
+        }
     }
 }
 
@@ -425,17 +378,14 @@ impl Decoder for OtapBatchDecoder {
 /// implementation of tonic service that handles the decoded request (the OtapBatch).
 struct OtapBatchService {
     effect_handler: EffectHandler<OtapPdata>,
-    correlation_state: SharedCorrelationState,
+    state: SharedCorrelationState,
 }
 
 impl OtapBatchService {
-    fn new(
-        effect_handler: EffectHandler<OtapPdata>,
-        correlation_state: SharedCorrelationState,
-    ) -> Self {
+    fn new(effect_handler: EffectHandler<OtapPdata>, state: SharedCorrelationState) -> Self {
         Self {
             effect_handler,
-            correlation_state,
+            state,
         }
     }
 }
@@ -447,25 +397,47 @@ impl UnaryService<OtapPdata> for OtapBatchService {
     fn call(&mut self, request: tonic::Request<OtapPdata>) -> Self::Future {
         let mut otap_batch = request.into_inner();
         let effect_handler = self.effect_handler.clone();
-        let correlation_state = self.correlation_state.clone();
+        let state = self.state.clone();
 
         Box::pin(async move {
-            // Create response channel
+            println!("[GRPC DEBUG] gRPC service call started");
             let (tx, rx) = oneshot::channel();
-            
-            // Create config for this request  
-            let config = ServerConfig::default();
+            println!("[GRPC DEBUG] Created oneshot channel for correlation");
 
-            // Allocate correlation slot
             let slot_key = {
-                let mut state = correlation_state.lock().unwrap();
-                match state.allocate_slot(tx, &config) {
-                    Some(key) => key,
+                let mut state = state.lock().unwrap();
+                println!("[GRPC DEBUG] Acquired state lock for slot allocation");
+                match state.allocate_slot(tx) {
+                    Some(key) => {
+                        println!("[GRPC DEBUG] ✅ Allocated slot: index={}, generation={}", key.index().0, key.generation().0);
+                        key
+                    }
                     None => {
-                        // At capacity, return resource exhausted
+                        println!("[GRPC DEBUG] ❌ Failed to allocate slot - too many concurrent requests");
                         return Err(Status::resource_exhausted("Too many concurrent requests"));
                     }
                 }
+            };
+
+            // Create guard to clean up slot if this future is cancelled/dropped
+            struct SlotGuard {
+                slot_key: SlotKey,
+                state: SharedCorrelationState,
+            }
+
+            impl Drop for SlotGuard {
+                fn drop(&mut self) {
+                    println!("[GRPC DEBUG] 🧹 SlotGuard dropping - gRPC call cancelled/completed: slot={}, gen={}", 
+                            self.slot_key.index().0, self.slot_key.generation().0);
+                    if let Ok(mut state) = self.state.lock() {
+                        state.free_slot(self.slot_key);
+                    }
+                }
+            }
+
+            let _guard = SlotGuard {
+                slot_key,
+                state: state.clone(),
             };
 
             // Create CallData with correlation information
@@ -484,14 +456,15 @@ impl UnaryService<OtapPdata> for OtapBatchService {
             // Send message to pipeline
             match effect_handler.send_message(otap_batch).await {
                 Ok(_) => {
+                    println!("[GRPC DEBUG] Message sent to pipeline, waiting for Ack/Nack response...");
                     // Wait for Ack/Nack response
                     match rx.await {
                         Ok(Ok(())) => {
-                            // Received Ack
+                            println!("[GRPC DEBUG] ✅ Received successful Ack response!");
                             Ok(tonic::Response::new(()))
                         }
                         Ok(Err(nack_msg)) => {
-                            // Received Nack, convert to gRPC error
+                            println!("[GRPC DEBUG] ❌ Received Nack response: {}", nack_msg.reason);
                             let status = if nack_msg.permanent {
                                 Status::invalid_argument(nack_msg.reason)
                             } else {
@@ -500,13 +473,13 @@ impl UnaryService<OtapPdata> for OtapBatchService {
                             Err(status)
                         }
                         Err(_) => {
-                            // Channel was closed (shouldn't happen in normal operation)
+                            println!("[GRPC DEBUG] ❌ Channel closed while waiting for response");
                             Err(Status::internal("Response channel closed unexpectedly"))
                         }
                     }
                 }
                 Err(e) => {
-                    // Failed to send to pipeline
+                    // Failed to send to pipeline - clean up slot via drop
                     Err(Status::internal(
                         format!("Failed to send to pipeline: {e}",),
                     ))
@@ -521,18 +494,15 @@ async fn handle_service_request(
     req: Request<Body>,
     signal: SignalType,
     effect_handler: EffectHandler<OtapPdata>,
-    correlation_state: SharedCorrelationState,
+    state: SharedCorrelationState,
     accept_compression_encodings: EnabledCompressionEncodings,
     send_compression_encodings: EnabledCompressionEncodings,
 ) -> Response<Body> {
     let codec = OtlpBytesCodec::new(signal);
     let mut grpc = Grpc::new(codec)
         .apply_compression_config(accept_compression_encodings, send_compression_encodings);
-    grpc.unary(
-        OtapBatchService::new(effect_handler, correlation_state),
-        req,
-    )
-    .await
+    grpc.unary(OtapBatchService::new(effect_handler, state), req)
+        .await
 }
 
 /// generate a response for a path the grpc server does not know about
@@ -554,7 +524,7 @@ fn unimplemented_resp() -> Response<Body> {
 #[derive(Clone)]
 pub struct LogsServiceServer {
     effect_handler: EffectHandler<OtapPdata>,
-    correlation_state: SharedCorrelationState,
+    state: SharedCorrelationState,
     accept_compression_encodings: EnabledCompressionEncodings,
     send_compression_encodings: EnabledCompressionEncodings,
 }
@@ -564,19 +534,19 @@ impl LogsServiceServer {
     #[must_use]
     pub fn new(effect_handler: EffectHandler<OtapPdata>) -> Self {
         let config = ServerConfig::default();
-        let correlation_state = Arc::new(Mutex::new(ServerState::new(&config)));
+        let state = Arc::new(Mutex::new(ServerState::new(config)));
 
         Self {
             effect_handler,
-            correlation_state,
+            state,
             accept_compression_encodings: Default::default(),
             send_compression_encodings: Default::default(),
         }
     }
-    
+
     /// Get correlation state for sharing with effect handlers
-    pub fn correlation_state(&self) -> SharedCorrelationState {
-        self.correlation_state.clone()
+    pub fn state(&self) -> SharedCorrelationState {
+        self.state.clone()
     }
 
     /// compress responses with the given encoding if the client supports it
@@ -603,7 +573,7 @@ impl tower_service::Service<Request<Body>> for LogsServiceServer {
         match req.uri().path() {
             super::LOGS_SERVICE_EXPORT_PATH => {
                 let effect_handler = self.effect_handler.clone();
-                let correlation_state = self.correlation_state.clone();
+                let state = self.state.clone();
                 let accept_compression_encodings = self.accept_compression_encodings;
                 let send_compression_encodings = self.send_compression_encodings;
                 Box::pin(async move {
@@ -611,7 +581,7 @@ impl tower_service::Service<Request<Body>> for LogsServiceServer {
                         req,
                         SignalType::Logs,
                         effect_handler,
-                        correlation_state,
+                        state,
                         accept_compression_encodings,
                         send_compression_encodings,
                     )
@@ -636,7 +606,7 @@ impl NamedService for LogsServiceServer {
 #[derive(Clone)]
 pub struct MetricsServiceServer {
     effect_handler: EffectHandler<OtapPdata>,
-    correlation_state: SharedCorrelationState,
+    state: SharedCorrelationState,
     accept_compression_encodings: EnabledCompressionEncodings,
     send_compression_encodings: EnabledCompressionEncodings,
 }
@@ -646,19 +616,19 @@ impl MetricsServiceServer {
     #[must_use]
     pub fn new(effect_handler: EffectHandler<OtapPdata>) -> Self {
         let config = ServerConfig::default();
-        let correlation_state = Arc::new(Mutex::new(ServerState::new(&config)));
+        let state = Arc::new(Mutex::new(ServerState::new(config)));
 
         Self {
             effect_handler,
-            correlation_state,
+            state,
             accept_compression_encodings: Default::default(),
             send_compression_encodings: Default::default(),
         }
     }
-    
+
     /// Get correlation state for sharing with effect handlers
-    pub fn correlation_state(&self) -> SharedCorrelationState {
-        self.correlation_state.clone()
+    pub fn state(&self) -> SharedCorrelationState {
+        self.state.clone()
     }
 
     /// compress responses with the given encoding if the client supports it
@@ -685,7 +655,7 @@ impl tower_service::Service<Request<Body>> for MetricsServiceServer {
         match req.uri().path() {
             super::METRICS_SERVICE_EXPORT_PATH => {
                 let effect_handler = self.effect_handler.clone();
-                let correlation_state = self.correlation_state.clone();
+                let state = self.state.clone();
                 let accept_compression_encodings = self.accept_compression_encodings;
                 let send_compression_encodings = self.send_compression_encodings;
                 Box::pin(async move {
@@ -693,7 +663,7 @@ impl tower_service::Service<Request<Body>> for MetricsServiceServer {
                         req,
                         SignalType::Metrics,
                         effect_handler,
-                        correlation_state,
+                        state,
                         accept_compression_encodings,
                         send_compression_encodings,
                     )
@@ -718,7 +688,7 @@ impl NamedService for MetricsServiceServer {
 #[derive(Clone)]
 pub struct TraceServiceServer {
     effect_handler: EffectHandler<OtapPdata>,
-    correlation_state: SharedCorrelationState,
+    state: SharedCorrelationState,
     accept_compression_encodings: EnabledCompressionEncodings,
     send_compression_encodings: EnabledCompressionEncodings,
 }
@@ -728,19 +698,19 @@ impl TraceServiceServer {
     #[must_use]
     pub fn new(effect_handler: EffectHandler<OtapPdata>) -> Self {
         let config = ServerConfig::default();
-        let correlation_state = Arc::new(Mutex::new(ServerState::new(&config)));
+        let state = Arc::new(Mutex::new(ServerState::new(config)));
 
         Self {
             effect_handler,
-            correlation_state,
+            state,
             accept_compression_encodings: Default::default(),
             send_compression_encodings: Default::default(),
         }
     }
-    
+
     /// Get correlation state for sharing with effect handlers
-    pub fn correlation_state(&self) -> SharedCorrelationState {
-        self.correlation_state.clone()
+    pub fn state(&self) -> SharedCorrelationState {
+        self.state.clone()
     }
 
     /// compress responses with the given encoding if the client supports it
@@ -767,7 +737,7 @@ impl tower_service::Service<Request<Body>> for TraceServiceServer {
         match req.uri().path() {
             super::TRACE_SERVICE_EXPORT_PATH => {
                 let effect_handler = self.effect_handler.clone();
-                let correlation_state = self.correlation_state.clone();
+                let state = self.state.clone();
                 let accept_compression_encodings = self.accept_compression_encodings;
                 let send_compression_encodings = self.send_compression_encodings;
                 Box::pin(async move {
@@ -775,7 +745,7 @@ impl tower_service::Service<Request<Body>> for TraceServiceServer {
                         req,
                         SignalType::Traces,
                         effect_handler,
-                        correlation_state,
+                        state,
                         accept_compression_encodings,
                         send_compression_encodings,
                     )

--- a/rust/otap-dataflow/crates/otap/src/otlp_grpc.rs
+++ b/rust/otap-dataflow/crates/otap/src/otlp_grpc.rs
@@ -3,11 +3,9 @@
 
 //! Expose the OTLP gRPC services.
 //!
-//! Provides a set of structs and enums that interact with the gRPC Server
-//!
-//! Implements the necessary service traits for OTLP data
-//!
-//! ToDo Modify OTLPData -> Optimize message transport
+//! This is not production code, used for validating testing and
+//! benchmarking of the standard gRPC OTLP service with the OTAP-based
+//! service.
 use crate::proto::opentelemetry::collector::{
     logs::v1::{
         ExportLogsServiceRequest, ExportLogsServiceResponse, logs_service_server::LogsService,
@@ -86,14 +84,13 @@ impl LogsService for LogsServiceImpl {
         &self,
         request: Request<ExportLogsServiceRequest>,
     ) -> Result<Response<ExportLogsServiceResponse>, Status> {
-        // TODO: HERE: How is the OTLPData converted to OtapPdata?
-        // This type does not implement subscribe_to, there's no
-        // context, extension not implemented.
+        // Note! we have to subscribe_to() with data used for Ack/Nack
+        // handling somewhere else.
         _ = self
             .effect_handler
             .send_message(OTLPData::Logs(request.into_inner()))
             .await;
-        // TODO: HERE: how do we wait for the Ack/Nack.
+        // Note! how do we wait for the Ack/Nack?
         Ok(Response::new(ExportLogsServiceResponse {
             partial_success: None,
         }))
@@ -106,7 +103,6 @@ impl MetricsService for MetricsServiceImpl {
         &self,
         request: Request<ExportMetricsServiceRequest>,
     ) -> Result<Response<ExportMetricsServiceResponse>, Status> {
-        // TODO: HERE: how do we subscribe, wait for the Ack/Nack.
         _ = self
             .effect_handler
             .send_message(OTLPData::Metrics(request.into_inner()))
@@ -123,7 +119,6 @@ impl TraceService for TraceServiceImpl {
         &self,
         request: Request<ExportTraceServiceRequest>,
     ) -> Result<Response<ExportTraceServiceResponse>, Status> {
-        // TODO: HERE: how do we subscribe, wait for the Ack/Nack.
         _ = self
             .effect_handler
             .send_message(OTLPData::Traces(request.into_inner()))
@@ -140,7 +135,6 @@ impl ProfilesService for ProfilesServiceImpl {
         &self,
         request: Request<ExportProfilesServiceRequest>,
     ) -> Result<Response<ExportProfilesServiceResponse>, Status> {
-        // TODO: HERE: how do we subscribe, wait for the Ack/Nack.
         _ = self
             .effect_handler
             .send_message(OTLPData::Profiles(request.into_inner()))

--- a/rust/otap-dataflow/crates/otap/src/otlp_grpc.rs
+++ b/rust/otap-dataflow/crates/otap/src/otlp_grpc.rs
@@ -86,10 +86,14 @@ impl LogsService for LogsServiceImpl {
         &self,
         request: Request<ExportLogsServiceRequest>,
     ) -> Result<Response<ExportLogsServiceResponse>, Status> {
+        // TODO: HERE: How is the OTLPData converted to OtapPdata?
+        // This type does not implement subscribe_to, there's no
+        // context, extension not implemented.
         _ = self
             .effect_handler
             .send_message(OTLPData::Logs(request.into_inner()))
             .await;
+        // TODO: HERE: how do we wait for the Ack/Nack.
         Ok(Response::new(ExportLogsServiceResponse {
             partial_success: None,
         }))
@@ -102,6 +106,7 @@ impl MetricsService for MetricsServiceImpl {
         &self,
         request: Request<ExportMetricsServiceRequest>,
     ) -> Result<Response<ExportMetricsServiceResponse>, Status> {
+        // TODO: HERE: how do we subscribe, wait for the Ack/Nack.
         _ = self
             .effect_handler
             .send_message(OTLPData::Metrics(request.into_inner()))
@@ -118,6 +123,7 @@ impl TraceService for TraceServiceImpl {
         &self,
         request: Request<ExportTraceServiceRequest>,
     ) -> Result<Response<ExportTraceServiceResponse>, Status> {
+        // TODO: HERE: how do we subscribe, wait for the Ack/Nack.
         _ = self
             .effect_handler
             .send_message(OTLPData::Traces(request.into_inner()))
@@ -134,6 +140,7 @@ impl ProfilesService for ProfilesServiceImpl {
         &self,
         request: Request<ExportProfilesServiceRequest>,
     ) -> Result<Response<ExportProfilesServiceResponse>, Status> {
+        // TODO: HERE: how do we subscribe, wait for the Ack/Nack.
         _ = self
             .effect_handler
             .send_message(OTLPData::Profiles(request.into_inner()))

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -114,7 +114,7 @@ impl Context {
     }
 
     /// Consume frames to locate the most recent subscriber with ACKS.
-    pub(crate) fn next_ack(mut ack: AckMsg<OtapPdata>) -> Option<(usize, AckMsg<OtapPdata>)> {
+    pub fn next_ack(mut ack: AckMsg<OtapPdata>) -> Option<(usize, AckMsg<OtapPdata>)> {
         ack.accepted
             .context
             .next_with_interest(Interests::ACKS)
@@ -125,7 +125,7 @@ impl Context {
     }
 
     /// Consume frames to locate the most recent subscriber with NACKS.
-    pub(crate) fn next_nack(mut nack: NackMsg<OtapPdata>) -> Option<(usize, NackMsg<OtapPdata>)> {
+    pub fn next_nack(mut nack: NackMsg<OtapPdata>) -> Option<(usize, NackMsg<OtapPdata>)> {
         nack.refused
             .context
             .next_with_interest(Interests::NACKS)

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -560,7 +560,7 @@ impl TryFrom<OtlpProtoBytes> for OtapArrowRecords {
 impl ProducerEffectHandlerExtension<OtapPdata>
     for otap_df_engine::local::processor::EffectHandler<OtapPdata>
 {
-    async fn subscribe_to(&self, int: Interests, ctx: CallData, data: &mut OtapPdata) {
+    fn subscribe_to(&self, int: Interests, ctx: CallData, data: &mut OtapPdata) {
         data.context
             .subscribe_to(int, ctx, self.processor_id().index)
     }
@@ -570,7 +570,7 @@ impl ProducerEffectHandlerExtension<OtapPdata>
 impl ProducerEffectHandlerExtension<OtapPdata>
     for otap_df_engine::local::receiver::EffectHandler<OtapPdata>
 {
-    async fn subscribe_to(&self, int: Interests, ctx: CallData, data: &mut OtapPdata) {
+    fn subscribe_to(&self, int: Interests, ctx: CallData, data: &mut OtapPdata) {
         data.context
             .subscribe_to(int, ctx, self.receiver_id().index)
     }
@@ -580,7 +580,7 @@ impl ProducerEffectHandlerExtension<OtapPdata>
 impl ProducerEffectHandlerExtension<OtapPdata>
     for otap_df_engine::shared::processor::EffectHandler<OtapPdata>
 {
-    async fn subscribe_to(&self, int: Interests, ctx: CallData, data: &mut OtapPdata) {
+    fn subscribe_to(&self, int: Interests, ctx: CallData, data: &mut OtapPdata) {
         data.context
             .subscribe_to(int, ctx, self.processor_id().index)
     }
@@ -590,7 +590,7 @@ impl ProducerEffectHandlerExtension<OtapPdata>
 impl ProducerEffectHandlerExtension<OtapPdata>
     for otap_df_engine::shared::receiver::EffectHandler<OtapPdata>
 {
-    async fn subscribe_to(&self, int: Interests, ctx: CallData, data: &mut OtapPdata) {
+    fn subscribe_to(&self, int: Interests, ctx: CallData, data: &mut OtapPdata) {
         data.context
             .subscribe_to(int, ctx, self.receiver_id().index)
     }

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -521,9 +521,10 @@ impl EffectHandlerExtension<OtapPdata>
             .subscribe_to(int, ctx, self.processor_id().index)
     }
 
-    // async fn reply_nack(&self, nack: NackMsg<OtapPdata>) {
-    //     // @@@
-    // }
+    /// Reply with a Nack.
+    async fn notify_nack(&mut self, nack: NackMsg<OtapPdata>) {
+        // @@@ pop from data.context.stack, set that in nack.context
+    }
 }
 
 #[cfg(test)]

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -554,6 +554,8 @@ impl TryFrom<OtlpProtoBytes> for OtapArrowRecords {
     }
 }
 
+/* -------- Effect handler extensions -------- */
+
 #[async_trait::async_trait(?Send)]
 impl ProducerEffectHandlerExtension<OtapPdata>
     for otap_df_engine::local::processor::EffectHandler<OtapPdata>
@@ -567,6 +569,26 @@ impl ProducerEffectHandlerExtension<OtapPdata>
 #[async_trait::async_trait(?Send)]
 impl ProducerEffectHandlerExtension<OtapPdata>
     for otap_df_engine::local::receiver::EffectHandler<OtapPdata>
+{
+    async fn subscribe_to(&self, int: Interests, ctx: CallData, data: &mut OtapPdata) {
+        data.context
+            .subscribe_to(int, ctx, self.receiver_id().index)
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl ProducerEffectHandlerExtension<OtapPdata>
+    for otap_df_engine::shared::processor::EffectHandler<OtapPdata>
+{
+    async fn subscribe_to(&self, int: Interests, ctx: CallData, data: &mut OtapPdata) {
+        data.context
+            .subscribe_to(int, ctx, self.processor_id().index)
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl ProducerEffectHandlerExtension<OtapPdata>
+    for otap_df_engine::shared::receiver::EffectHandler<OtapPdata>
 {
     async fn subscribe_to(&self, int: Interests, ctx: CallData, data: &mut OtapPdata) {
         data.context

--- a/rust/otap-dataflow/crates/otap/src/retry_processor.rs
+++ b/rust/otap-dataflow/crates/otap/src/retry_processor.rs
@@ -34,23 +34,6 @@
 //! - Maximum retry attempts
 //! - Initial and maximum retry delays
 //! - Backoff multiplier
-//! - Queue capacity limits
-//!
-//! ## Example
-//!
-//! ```rust
-//! use otap_df_otap::retry_processor::{RetryConfig, RetryProcessor};
-//!
-//! let config = RetryConfig {
-//!     max_retries: 3,
-//!     initial_retry_delay_ms: 1000,
-//!     max_retry_delay_ms: 30000,
-//!     backoff_multiplier: 2.0,
-//!     max_pending_messages: 10000,
-//!     cleanup_interval_secs: 60,
-//! };
-//! let processor = RetryProcessor::with_config(config);
-//! ```
 
 use crate::pdata::OtapPdata;
 
@@ -60,10 +43,10 @@ use otap_df_config::experimental::SignalType;
 use otap_df_config::{error::Error as ConfigError, node::NodeUserConfig};
 use otap_df_engine::context::PipelineContext;
 use otap_df_engine::{
-    ProcessorFactory,
+    EffectHandlerExtension, Interests, ProcessorFactory,
     config::ProcessorConfig,
-    control::NodeControlMsg,
-    error::Error,
+    control::{CtxData, NodeControlMsg},
+    error::{Error, TypedError},
     local::processor::{EffectHandler, Processor},
     message::Message,
     node::NodeId,
@@ -73,12 +56,8 @@ use otap_df_telemetry::instrument::Counter;
 use otap_df_telemetry::metrics::MetricSet;
 use otap_df_telemetry_macros::metric_set;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-
-/// Maximum age for failed messages before cleanup (5 minutes)
-const MAX_FAILED_MESSAGE_AGE_SECS: u64 = 300;
 
 /// URN for the RetryProcessor processor
 pub const RETRY_PROCESSOR_URN: &str = "urn:otap:processor:retry_processor";
@@ -246,10 +225,6 @@ pub struct RetryConfig {
     pub max_retry_delay_ms: u64,
     /// Multiplier applied to delay for exponential backoff
     pub backoff_multiplier: f64,
-    /// Maximum number of messages that can be pending retry
-    pub max_pending_messages: usize,
-    /// Interval in seconds for cleanup of expired messages
-    pub cleanup_interval_secs: u64,
 }
 
 impl Default for RetryConfig {
@@ -259,17 +234,8 @@ impl Default for RetryConfig {
             initial_retry_delay_ms: 1000,
             max_retry_delay_ms: 30000,
             backoff_multiplier: 2.0,
-            max_pending_messages: 10000,
-            cleanup_interval_secs: 60,
         }
     }
-}
-
-struct PendingMessage {
-    data: OtapPdata,
-    retry_count: usize,
-    next_retry_time: Instant,
-    last_error: String,
 }
 
 /// OTAP RetryProcessor
@@ -288,10 +254,8 @@ pub static RETRY_PROCESSOR_FACTORY: ProcessorFactory<OtapPdata> = ProcessorFacto
 /// Register SignalTypeRouter as an OTAP processor factory
 pub struct RetryProcessor {
     config: RetryConfig,
-    pending_messages: HashMap<u64, PendingMessage>,
-    next_message_id: u64,
-    last_cleanup_time: Instant,
-    /// Optional metrics handle (present when constructed with a PipelineContext)
+
+    /// Optional metrics handle
     metrics: Option<MetricSet<RetryProcessorMetrics>>,
 }
 
@@ -323,24 +287,43 @@ pub fn create_retry_processor(
     ))
 }
 
-impl RetryProcessor {
-    /// Creates a new RetryProcessor with default configuration
-    #[must_use]
-    pub fn new() -> Self {
-        Self::with_config(RetryConfig::default())
-    }
+// impl Default for RetryProcessor {
+//     fn default() -> Self {
+//         Self::new()
+//     }
+// }
 
-    /// Creates a new RetryProcessor with the specified configuration
-    #[must_use]
-    pub fn with_config(config: RetryConfig) -> Self {
+#[derive(Debug)]
+struct RetryState {
+    retries: usize, // register
+}
+
+impl RetryState {
+    fn new() -> Self {
+        Self { retries: 0 }
+    }
+}
+
+impl From<RetryState> for CtxData {
+    fn from(value: RetryState) -> Self {
+        smallvec::smallvec![value.retries.into()]
+    }
+}
+
+impl From<CtxData> for RetryState {
+    fn from(value: CtxData) -> Self {
         Self {
-            config,
-            pending_messages: HashMap::new(),
-            next_message_id: 1,
-            last_cleanup_time: Instant::now(),
-            metrics: None,
+            retries: value[0].into(),
         }
     }
+}
+
+impl RetryProcessor {
+    // /// Creates a new RetryProcessor with default configuration
+    // #[must_use]
+    // pub fn new() -> Self {
+    //     Self::with_config(RetryConfig::default())
+    // }
 
     /// Creates a new RetryProcessor with metrics registered via PipelineContext
     #[must_use]
@@ -348,145 +331,8 @@ impl RetryProcessor {
         let metrics = pipeline_ctx.register_metrics::<RetryProcessorMetrics>();
         Self {
             config,
-            pending_messages: HashMap::new(),
-            next_message_id: 1,
-            last_cleanup_time: Instant::now(),
             metrics: Some(metrics),
         }
-    }
-
-    fn acknowledge(&mut self, id: u64) -> bool {
-        if let Some(_removed) = self.pending_messages.remove(&id) {
-            log::debug!("Acknowledged and removed message with ID: {id}");
-            if let Some(m) = self.metrics.as_mut() {
-                m.msgs_acked.inc();
-            }
-            true
-        } else {
-            log::warn!("Attempted to acknowledge non-existent message with ID: {id}");
-            false
-        }
-    }
-
-    async fn handle_nack(
-        &mut self,
-        id: u64,
-        reason: String,
-        _pdata: Option<Box<OtapPdata>>,
-        _effect_handler: &mut EffectHandler<OtapPdata>,
-    ) -> Result<(), Error> {
-        if let Some(m) = self.metrics.as_mut() {
-            m.nacks_received.inc();
-        }
-        if let Some(mut pending) = self.pending_messages.remove(&id) {
-            pending.retry_count += 1;
-            pending.last_error = reason;
-
-            if pending.retry_count <= self.config.max_retries {
-                let delay_ms = (self.config.initial_retry_delay_ms as f64
-                    * self
-                        .config
-                        .backoff_multiplier
-                        .powi(pending.retry_count as i32 - 1))
-                .min(self.config.max_retry_delay_ms as f64) as u64;
-
-                pending.next_retry_time = Instant::now() + Duration::from_millis(delay_ms);
-                let retry_count = pending.retry_count;
-                let _previous = self.pending_messages.insert(id, pending);
-                if let Some(m) = self.metrics.as_mut() {
-                    m.retry_attempts.inc();
-                }
-                log::debug!("Scheduled message {id} for retry attempt {retry_count}");
-            } else {
-                log::error!(
-                    "Message {} exceeded max retries ({}), dropping. Last error: {}",
-                    id,
-                    self.config.max_retries,
-                    pending.last_error
-                );
-                if let Some(m) = self.metrics.as_mut() {
-                    m.msgs_dropped_exceeded_retries.inc();
-                }
-            }
-        } else {
-            log::warn!("Attempted to handle nack for non-existent message with ID: {id}");
-        }
-        Ok(())
-    }
-
-    async fn process_pending_retries(
-        &mut self,
-        effect_handler: &mut EffectHandler<OtapPdata>,
-    ) -> Result<(), Error> {
-        let now = Instant::now();
-        let mut ready_messages = Vec::new();
-
-        for (&id, pending) in &self.pending_messages {
-            if pending.next_retry_time <= now {
-                ready_messages.push((id, pending.data.clone()));
-            }
-        }
-
-        for (id, data) in ready_messages {
-            log::debug!("Retrying message with ID: {id}");
-            let signal = data.signal_type();
-            let items = data.num_items() as u64;
-            match effect_handler.send_message(data).await {
-                Ok(()) => {
-                    if let Some(m) = self.metrics.as_mut() {
-                        m.msgs_retried.inc();
-                        m.add_produced_success(signal, items);
-                    }
-                }
-                Err(e) => {
-                    if let Some(m) = self.metrics.as_mut() {
-                        m.add_produced_refused(signal, items);
-                    }
-                    return Err(e.into());
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    fn cleanup_expired_messages(&mut self) {
-        let now = Instant::now();
-        if now.duration_since(self.last_cleanup_time)
-            < Duration::from_secs(self.config.cleanup_interval_secs)
-        {
-            return;
-        }
-
-        // Clean up messages that have exceeded max retries and are old
-        let max_age = Duration::from_secs(MAX_FAILED_MESSAGE_AGE_SECS);
-        let expired_ids: Vec<u64> = self
-            .pending_messages
-            .iter()
-            .filter_map(|(&id, pending)| {
-                let age = now.duration_since(pending.next_retry_time);
-                if pending.retry_count > self.config.max_retries && age > max_age {
-                    Some(id)
-                } else {
-                    None
-                }
-            })
-            .collect();
-
-        let mut removed = 0u64;
-        for id in expired_ids {
-            if self.pending_messages.remove(&id).is_some() {
-                log::warn!("Removed expired message with ID: {id}");
-                removed += 1;
-            }
-        }
-        if removed > 0 {
-            if let Some(m) = self.metrics.as_mut() {
-                m.msgs_removed_expired.add(removed);
-            }
-        }
-
-        self.last_cleanup_time = now;
     }
 }
 
@@ -497,75 +343,110 @@ impl Processor<OtapPdata> for RetryProcessor {
         msg: Message<OtapPdata>,
         effect_handler: &mut EffectHandler<OtapPdata>,
     ) -> Result<(), Error> {
+        // TODO Can we add automatic metric for the unsubscribed Ack
+        // for metrics on the return path?
         match msg {
-            Message::PData(data) => {
-                // Clone only if we need to add to retry queue AND send downstream
-                let signal = data.signal_type();
-                let items = data.num_items() as u64;
-                // Check if queue is full first to avoid unnecessary clone
-                if self.pending_messages.len() >= self.config.max_pending_messages {
-                    let error_msg = format!(
-                        "Retry queue is full (capacity: {}), cannot add message",
-                        self.config.max_pending_messages
-                    );
-                    log::warn!("{error_msg}");
-                    if let Some(m) = self.metrics.as_mut() {
-                        m.msgs_dropped_queue_full.inc();
-                        m.add_consumed_failure(signal, items);
+            Message::PData(mut data) => {
+                effect_handler
+                    .subscribe_to(Interests::NACKS, RetryState::new().into(), &mut data)
+                    .await;
+                match effect_handler.send_message(data).await {
+                    Ok(()) => {
+                        // Request control flows downstream.
+                        Ok(())
                     }
-                    // Send NACK upstream to signal backpressure instead of forwarding message
-                    // For now, we'll just log and drop the message
-                    return Err(Error::ProcessorError {
-                        processor: effect_handler.processor_id(),
-                        error: error_msg,
-                    });
-                } else {
-                    // Queue has space, add message for retry and send downstream
-                    let id = self.next_message_id;
-                    self.next_message_id += 1;
-
-                    let pending = PendingMessage {
-                        data: data.clone(), // Only clone when we know we need to store AND send
-                        retry_count: 0,
-                        next_retry_time: Instant::now(),
-                        last_error: String::new(),
-                    };
-
-                    let _previous = self.pending_messages.insert(id, pending);
-                    if let Some(m) = self.metrics.as_mut() {
-                        m.msgs_enqueued.inc();
-                        m.add_consumed_success(signal, items);
-                    }
-                    log::debug!("Added message {id} to retry queue");
-
-                    match effect_handler.send_message(data).await {
-                        Ok(()) => {
-                            if let Some(m) = self.metrics.as_mut() {
-                                m.add_produced_success(signal, items);
-                            }
+                    Err(TypedError::ChannelSendError(sent)) => {
+                        // TODO: Note we remove full vs closed info here.
+                        let data = sent.inner();
+                        let signal = data.signal_type();
+                        let items = data.num_items();
+                        // TODO: Note that if we fail to send, we drop.
+                        // How would we delay or Nack when the outbound queue is full?
+                        if let Some(m) = self.metrics.as_mut() {
+                            m.add_produced_failure(signal, items as u64);
                         }
-                        Err(e) => {
-                            if let Some(m) = self.metrics.as_mut() {
-                                m.add_produced_refused(signal, items);
-                            }
-                            return Err(e.into());
-                        }
+                        // TODO: What do we return?
+                        Ok(())
                     }
+                    Err(e) => Err(e.into()),
                 }
-                Ok(())
             }
             Message::Control(control_msg) => match control_msg {
-                NodeControlMsg::Ack { id } => {
-                    let _ = self.acknowledge(id);
-                    Ok(())
-                }
-                NodeControlMsg::Nack { id, reason, pdata } => {
-                    self.handle_nack(id, reason, pdata, effect_handler).await
-                }
-                NodeControlMsg::TimerTick { .. } => {
-                    self.process_pending_retries(effect_handler).await?;
-                    self.cleanup_expired_messages();
-                    Ok(())
+                NodeControlMsg::Nack(mut nack) => {
+                    // If the error is permanent or too many retries.
+                    // If the payload is empty: the effect is also
+                    // permanent, as by intentionaly failing to return
+                    // the data.
+                    if nack.permanent {
+                        // Passthrough
+                        effect_handler.notify_nack(nack).await;
+                        return Ok(());
+                    } else if nack.context.is_none() || nack.refused.is_empty() {
+                        nack.reason = format!("retry internal error: {}", nack.reason);
+                        nack.permanent = true;
+                        effect_handler.notify_nack(nack).await;
+                        return Ok(());
+                    }
+
+                    let mut rstate: RetryState = nack.context.take().expect("some").into();
+
+                    if rstate.retries >= self.config.max_retries {
+                        nack.reason = format!("max retries reached: {}", nack.reason);
+                        effect_handler.notify_nack(nack).await;
+                        return Ok(());
+                    }
+
+                    // Retry attempt: increment counter and schedule delayed retry
+                    rstate.retries += 1;
+
+                    let now = Instant::now();
+                    let delay_ms = (self.config.initial_retry_delay_ms as f64
+                        * self
+                            .config
+                            .backoff_multiplier
+                            .powi(rstate.retries as i32 - 1))
+                    .min(self.config.max_retry_delay_ms as f64)
+                        as u64;
+
+                    // TODO: implement delay!
+                    let next_retry_time = now + Duration::from_millis(delay_ms);
+                    let _ = next_retry_time;
+
+                    // E.g., check deadline-before-retry
+                    // let deadline = nack.refused.deadline();
+                    // let expired = deadline
+                    //     .map(|dead| dead <= next_retry_time)
+                    //     .unwrap_or(false);
+                    // if expired {
+                    //     // Deadline expired: forward NACK upstream. Not permanent.
+                    //     nack.reason = format!("final retry: {}", nack.reason);
+                    //     effect_handler.notify_nack(nack).await?;
+                    //     return Ok(());
+                    // }
+
+                    // Updated RetryState back onto context for retry attempt
+                    let mut rereq = nack.refused;
+                    effect_handler
+                        .subscribe_to(Interests::NACKS, rstate.into(), &mut rereq)
+                        .await;
+
+                    match effect_handler.send_message(*rereq).await {
+                        Ok(()) => Ok(()),
+                        Err(TypedError::ChannelSendError(sent)) => {
+                            // TODO: Note we remove full vs closed info here.
+                            let data = sent.inner();
+                            let signal = data.signal_type();
+                            let items = data.num_items();
+
+                            // TODO: Note that if we fail to send, we drop.
+                            // Can we delay or Nack when the outbound queue is full?
+                            if let Some(m) = self.metrics.as_mut() {
+                                m.add_produced_failure(signal, items as u64);
+                            }
+                            Ok(())
+                        }
+                        Err(e) => Err(e.into()),
+                    }
                 }
                 NodeControlMsg::CollectTelemetry {
                     mut metrics_reporter,
@@ -581,809 +462,15 @@ impl Processor<OtapPdata> for RetryProcessor {
                     }
                     Ok(())
                 }
+                NodeControlMsg::Ack(_) | NodeControlMsg::TimerTick { .. } => {
+                    unreachable!("impossible");
+                }
                 NodeControlMsg::Shutdown { .. } => {
-                    let pending_ids: Vec<u64> = self.pending_messages.keys().cloned().collect();
-                    for id in pending_ids {
-                        if let Some(pending) = self.pending_messages.remove(&id) {
-                            let _ = effect_handler.send_message(pending.data).await;
-                        }
-                    }
+                    // @@@ TODO Stop retrying; should just work b/c
+                    // SendError<T> will tell you a permanent closed?
                     Ok(())
                 }
             },
         }
-    }
-}
-
-impl Default for RetryProcessor {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::fixtures::{SimpleDataGenOptions, create_simple_logs_arrow_record_batches};
-    use otap_df_channel::mpsc;
-    use otap_df_engine::config::ProcessorConfig;
-    use otap_df_engine::context::ControllerContext;
-    use otap_df_engine::local::message::LocalSender;
-    use otap_df_engine::testing::test_node;
-    use otap_df_telemetry::registry::MetricsRegistryHandle;
-    use otel_arrow_rust::Consumer;
-    use otel_arrow_rust::otap::{OtapArrowRecords, from_record_messages};
-    use serde_json::json;
-    use tokio::time::{Duration, sleep};
-
-    fn create_test_channel<T>(capacity: usize) -> (mpsc::Sender<T>, mpsc::Receiver<T>) {
-        mpsc::Channel::new(capacity)
-    }
-
-    fn create_test_processor() -> RetryProcessor {
-        let config = RetryConfig {
-            max_retries: 3,
-            initial_retry_delay_ms: 100,
-            max_retry_delay_ms: 1000,
-            backoff_multiplier: 2.0,
-            max_pending_messages: 10,
-            cleanup_interval_secs: 1,
-        };
-        RetryProcessor::with_config(config)
-    }
-
-    fn create_test_data(_id: u64) -> OtapPdata {
-        let mut consumer = Consumer::default();
-        let otap_data = consumer
-            .consume_bar(&mut create_simple_logs_arrow_record_batches(
-                SimpleDataGenOptions {
-                    num_rows: 1,
-                    ..Default::default()
-                },
-            ))
-            .unwrap();
-        OtapPdata::new_default(OtapArrowRecords::Logs(from_record_messages(otap_data)).into())
-    }
-
-    /// Test helper to compare two OtapPdata instances for equivalence.
-    fn requests_match(expected: &OtapPdata, actual: &OtapPdata) -> bool {
-        // ToDo: Implement full semantic equivalence checking similar to Go's assert.Equiv()
-        expected.num_items() == actual.num_items()
-    }
-
-    #[test]
-    fn test_factory_creation() {
-        let config = json!({
-            "max_retries": 5,
-            "initial_retry_delay_ms": 500,
-            "max_retry_delay_ms": 15000,
-            "backoff_multiplier": 1.5,
-            "max_pending_messages": 5000,
-            "cleanup_interval_secs": 30
-        });
-        let processor_config = ProcessorConfig::new("test_retry");
-
-        // Create a proper pipeline context for the test
-        let metrics_registry_handle = MetricsRegistryHandle::new();
-        let controller_ctx = ControllerContext::new(metrics_registry_handle);
-        let pipeline_ctx =
-            controller_ctx.pipeline_context_with("grp".into(), "pipeline".into(), 0, 0);
-        let mut node_config = NodeUserConfig::new_processor_config(RETRY_PROCESSOR_URN);
-        node_config.config = config;
-        let result = create_retry_processor(
-            pipeline_ctx,
-            test_node(processor_config.name.clone()),
-            Arc::new(node_config),
-            &processor_config,
-        );
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_process_pdata_message() {
-        let mut processor = create_test_processor();
-        let (sender, receiver) = create_test_channel(10);
-        let mut senders_map = HashMap::new();
-        let _ = senders_map.insert("out".into(), LocalSender::MpscSender(sender));
-        let mut effect_handler = EffectHandler::new(test_node("retry"), senders_map, None);
-
-        let test_data = create_test_data(1);
-        let message = Message::PData(test_data.clone());
-
-        processor
-            .process(message, &mut effect_handler)
-            .await
-            .unwrap();
-
-        // Should have one pending message
-        assert_eq!(processor.pending_messages.len(), 1);
-
-        // Should have sent message downstream
-        let received = receiver.recv().await.unwrap();
-        assert!(requests_match(&test_data, &received));
-    }
-
-    #[tokio::test]
-    async fn test_ack_removes_pending() {
-        let mut processor = create_test_processor();
-        let (sender, receiver) = create_test_channel(10);
-        let mut senders_map = HashMap::new();
-        let _ = senders_map.insert("out".into(), LocalSender::MpscSender(sender));
-        let mut effect_handler = EffectHandler::new(test_node("retry"), senders_map, None);
-
-        // Add a message
-        let test_data = create_test_data(1);
-        processor
-            .process(Message::PData(test_data.clone()), &mut effect_handler)
-            .await
-            .unwrap();
-        assert_eq!(processor.pending_messages.len(), 1);
-
-        // Consume the downstream message
-        let _ = receiver.recv().await.unwrap();
-
-        // ACK the message
-        processor
-            .process(
-                Message::Control(NodeControlMsg::Ack { id: 1 }),
-                &mut effect_handler,
-            )
-            .await
-            .unwrap();
-
-        // Should be removed from pending
-        assert_eq!(processor.pending_messages.len(), 0);
-    }
-
-    #[tokio::test]
-    async fn test_nack_schedules_retry() {
-        let mut processor = create_test_processor();
-        let (sender, receiver) = create_test_channel(10);
-        let mut senders_map = HashMap::new();
-        let _ = senders_map.insert("out".into(), LocalSender::MpscSender(sender));
-        let mut effect_handler = EffectHandler::new(test_node("retry"), senders_map, None);
-
-        // Add a message
-        let test_data = create_test_data(1);
-        processor
-            .process(Message::PData(test_data.clone()), &mut effect_handler)
-            .await
-            .unwrap();
-        let _ = receiver.recv().await.unwrap();
-
-        // NACK the message
-        processor
-            .process(
-                Message::Control(NodeControlMsg::Nack {
-                    id: 1,
-                    reason: "Test failure".to_string(),
-                    pdata: None,
-                }),
-                &mut effect_handler,
-            )
-            .await
-            .unwrap();
-
-        // Should still have one pending message with incremented retry count
-        assert_eq!(processor.pending_messages.len(), 1);
-        let pending = processor.pending_messages.get(&1).unwrap();
-        assert_eq!(pending.retry_count, 1);
-        assert_eq!(pending.last_error, "Test failure");
-    }
-
-    #[tokio::test]
-    async fn test_max_retries_exceeded() {
-        let mut processor = create_test_processor();
-        let (sender, receiver) = create_test_channel(10);
-        let mut senders_map = HashMap::new();
-        let _ = senders_map.insert("out".into(), LocalSender::MpscSender(sender));
-        let mut effect_handler = EffectHandler::new(test_node("retry"), senders_map, None);
-
-        // Add a message
-        let test_data = create_test_data(1);
-        processor
-            .process(Message::PData(test_data.clone()), &mut effect_handler)
-            .await
-            .unwrap();
-        let _ = receiver.recv().await.unwrap();
-
-        // NACK the message multiple times to exceed max retries
-        for i in 1..=4 {
-            processor
-                .process(
-                    Message::Control(NodeControlMsg::Nack {
-                        id: 1,
-                        reason: format!("Test failure {i}"),
-                        pdata: None,
-                    }),
-                    &mut effect_handler,
-                )
-                .await
-                .unwrap();
-        }
-
-        // Message should be dropped after exceeding max retries
-        assert_eq!(processor.pending_messages.len(), 0);
-    }
-
-    #[tokio::test]
-    async fn test_timer_tick_retries_ready_messages() {
-        let mut processor = create_test_processor();
-        let (sender, receiver) = create_test_channel(10);
-        let mut senders_map = HashMap::new();
-        let _ = senders_map.insert("out".into(), LocalSender::MpscSender(sender));
-        let mut effect_handler = EffectHandler::new(test_node("retry"), senders_map, None);
-
-        // Add a message and NACK it
-        let test_data = create_test_data(1);
-        processor
-            .process(Message::PData(test_data.clone()), &mut effect_handler)
-            .await
-            .unwrap();
-        let _ = receiver.recv().await.unwrap();
-
-        processor
-            .process(
-                Message::Control(NodeControlMsg::Nack {
-                    id: 1,
-                    reason: "Test failure".to_string(),
-                    pdata: None,
-                }),
-                &mut effect_handler,
-            )
-            .await
-            .unwrap();
-
-        // Wait for retry delay to pass
-        sleep(Duration::from_millis(150)).await;
-
-        // Process timer tick
-        processor
-            .process(
-                Message::Control(NodeControlMsg::TimerTick {}),
-                &mut effect_handler,
-            )
-            .await
-            .unwrap();
-
-        // Should have sent retry message
-        let retry_data = receiver.recv().await.unwrap();
-        assert!(requests_match(&test_data, &retry_data));
-    }
-
-    #[tokio::test]
-    async fn test_queue_full_returns_error() {
-        let config = RetryConfig {
-            max_pending_messages: 2, // Small queue for testing
-            ..Default::default()
-        };
-        let mut processor = RetryProcessor::with_config(config);
-        let (sender, receiver) = create_test_channel(10);
-        let mut senders_map = HashMap::new();
-        let _ = senders_map.insert("out".into(), LocalSender::MpscSender(sender));
-        let mut effect_handler = EffectHandler::new(test_node("retry"), senders_map, None);
-
-        // Fill the queue
-        for i in 1..=2 {
-            let test_data = create_test_data(i);
-            processor
-                .process(Message::PData(test_data), &mut effect_handler)
-                .await
-                .unwrap();
-            let _ = receiver.recv().await.unwrap();
-        }
-
-        // Try to add one more message - should fail
-        let test_data = create_test_data(3);
-        let result = processor
-            .process(Message::PData(test_data), &mut effect_handler)
-            .await;
-        assert!(result.is_err());
-
-        if let Err(Error::ProcessorError { error, .. }) = result {
-            assert!(error.contains("Retry queue is full"));
-        } else {
-            panic!("Expected ProcessorError");
-        }
-    }
-
-    #[tokio::test]
-    async fn test_exponential_backoff() {
-        let mut processor = create_test_processor();
-        let (sender, receiver) = create_test_channel(10);
-        let mut senders_map = HashMap::new();
-        let _ = senders_map.insert("out".into(), LocalSender::MpscSender(sender));
-        let mut effect_handler = EffectHandler::new(test_node("retry"), senders_map, None);
-
-        // Add a message
-        let test_data = create_test_data(1);
-        processor
-            .process(Message::PData(test_data), &mut effect_handler)
-            .await
-            .unwrap();
-        let _ = receiver.recv().await.unwrap();
-
-        // NACK it to get first retry count
-        processor
-            .process(
-                Message::Control(NodeControlMsg::Nack {
-                    id: 1,
-                    reason: "First failure".to_string(),
-                    pdata: None,
-                }),
-                &mut effect_handler,
-            )
-            .await
-            .unwrap();
-
-        let first_retry_count = processor.pending_messages.get(&1).unwrap().retry_count;
-        assert_eq!(first_retry_count, 1);
-
-        // NACK it again to get second retry count
-        processor
-            .process(
-                Message::Control(NodeControlMsg::Nack {
-                    id: 1,
-                    reason: "Second failure".to_string(),
-                    pdata: None,
-                }),
-                &mut effect_handler,
-            )
-            .await
-            .unwrap();
-
-        let second_retry_count = processor.pending_messages.get(&1).unwrap().retry_count;
-        assert_eq!(second_retry_count, 2);
-
-        // Verify exponential backoff by checking the retry counts increase
-        // This is more reliable than timing-based assertions
-        assert!(second_retry_count > first_retry_count);
-    }
-
-    #[tokio::test]
-    async fn test_shutdown_flushes_pending_messages() {
-        let mut processor = create_test_processor();
-        let (sender, receiver) = create_test_channel(10);
-        let mut senders_map = HashMap::new();
-        let _ = senders_map.insert("out".into(), LocalSender::MpscSender(sender));
-        let mut effect_handler = EffectHandler::new(test_node("retry"), senders_map, None);
-
-        // Add multiple messages and NACK them
-        for i in 1..=3 {
-            let test_data = create_test_data(i);
-            processor
-                .process(Message::PData(test_data), &mut effect_handler)
-                .await
-                .unwrap();
-            let _ = receiver.recv().await.unwrap();
-
-            processor
-                .process(
-                    Message::Control(NodeControlMsg::Nack {
-                        id: i,
-                        reason: "Test failure".to_string(),
-                        pdata: None,
-                    }),
-                    &mut effect_handler,
-                )
-                .await
-                .unwrap();
-        }
-
-        assert_eq!(processor.pending_messages.len(), 3);
-
-        // Shutdown should flush all pending messages
-        processor
-            .process(
-                Message::Control(NodeControlMsg::Shutdown {
-                    deadline: Duration::from_secs(5),
-                    reason: "Test shutdown".to_string(),
-                }),
-                &mut effect_handler,
-            )
-            .await
-            .unwrap();
-
-        // All pending messages should be cleared
-        assert_eq!(processor.pending_messages.len(), 0);
-
-        // Should have sent all pending messages downstream
-        for _ in 1..=3 {
-            let _ = receiver.recv().await.unwrap();
-        }
-    }
-
-    #[tokio::test]
-    async fn test_config_update() {
-        let mut processor = create_test_processor();
-        let (sender, _receiver) = create_test_channel(10);
-        let mut senders_map = HashMap::new();
-        let _ = senders_map.insert("out".into(), LocalSender::MpscSender(sender));
-        let mut effect_handler = EffectHandler::new(test_node("retry"), senders_map, None);
-
-        let new_config = RetryConfig {
-            max_retries: 5,
-            initial_retry_delay_ms: 200,
-            max_retry_delay_ms: 2000,
-            backoff_multiplier: 3.0,
-            max_pending_messages: 20,
-            cleanup_interval_secs: 2,
-        };
-
-        let config_json = serde_json::to_value(new_config.clone()).unwrap();
-        processor
-            .process(
-                Message::Control(NodeControlMsg::Config {
-                    config: config_json,
-                }),
-                &mut effect_handler,
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(processor.config.max_retries, new_config.max_retries);
-        assert_eq!(
-            processor.config.initial_retry_delay_ms,
-            new_config.initial_retry_delay_ms
-        );
-        assert_eq!(
-            processor.config.max_retry_delay_ms,
-            new_config.max_retry_delay_ms
-        );
-        assert_eq!(
-            processor.config.backoff_multiplier,
-            new_config.backoff_multiplier
-        );
-        assert_eq!(
-            processor.config.max_pending_messages,
-            new_config.max_pending_messages
-        );
-        assert_eq!(
-            processor.config.cleanup_interval_secs,
-            new_config.cleanup_interval_secs
-        );
-    }
-}
-
-#[cfg(test)]
-mod telemetry_tests {
-    use super::*;
-    use crate::fixtures::{SimpleDataGenOptions, create_simple_logs_arrow_record_batches};
-    use otap_df_engine::context::ControllerContext;
-    use otap_df_engine::control::NodeControlMsg;
-    use otap_df_engine::local::message::LocalSender;
-    use otap_df_engine::local::processor::EffectHandler as LocalEffectHandler;
-    use otap_df_engine::message::Message;
-    use otap_df_engine::testing::test_node;
-    use otap_df_telemetry::MetricsSystem;
-    use otel_arrow_rust::Consumer;
-    use otel_arrow_rust::otap::{OtapArrowRecords, from_record_messages};
-    use std::collections::HashMap;
-    use tokio::time::{Duration, sleep};
-
-    // Helper: create a minimal OtapPdata logs payload with 1 row
-    fn make_test_pdata() -> OtapPdata {
-        let mut consumer = Consumer::default();
-        let otap_data = consumer
-            .consume_bar(&mut create_simple_logs_arrow_record_batches(
-                SimpleDataGenOptions {
-                    num_rows: 1,
-                    ..Default::default()
-                },
-            ))
-            .unwrap();
-        OtapPdata::new_default(OtapArrowRecords::Logs(from_record_messages(otap_data)).into())
-    }
-
-    // Collects current metrics for the retry processor set into a map
-    fn collect_retry_metrics_map(
-        registry: &otap_df_telemetry::registry::MetricsRegistryHandle,
-    ) -> std::collections::HashMap<&'static str, u64> {
-        let mut out = std::collections::HashMap::new();
-        registry.visit_current_metrics(|desc, _attrs, iter| {
-            if desc.name == "retry.processor.metrics" {
-                for (field, value) in iter {
-                    let _ = out.insert(field.name, value);
-                }
-            }
-        });
-        out
-    }
-
-    #[tokio::test]
-    async fn test_metrics_collect_telemetry_reports_counters() {
-        // 1) Telemetry system and registry/reporter
-        let metrics_system = MetricsSystem::default();
-        let registry = metrics_system.registry();
-        let reporter = metrics_system.reporter();
-        // Start background collection loop
-        let _collector = tokio::spawn(metrics_system.run_collection_loop());
-
-        // 2) Pipeline context to register metrics under
-        let controller = ControllerContext::new(registry.clone());
-        let pipeline = controller.pipeline_context_with("grp".into(), "pipe".into(), 0, 0);
-
-        // 3) RetryProcessor with metrics registered via pipeline context
-        let cfg = RetryConfig {
-            max_retries: 2,
-            initial_retry_delay_ms: 50,
-            max_retry_delay_ms: 200,
-            backoff_multiplier: 2.0,
-            max_pending_messages: 10,
-            cleanup_interval_secs: 1,
-        };
-        let mut proc = RetryProcessor::with_pipeline_ctx(pipeline, cfg);
-
-        // 4) Local effect handler with a default 'out' port
-        let (tx_out, rx_out) = otap_df_channel::mpsc::Channel::new(4);
-        let mut senders = HashMap::new();
-        let _ = senders.insert("out".into(), LocalSender::MpscSender(tx_out));
-        let mut eh = LocalEffectHandler::new(test_node("retry_proc_telemetry"), senders, None);
-
-        // Enqueue a message (should inc msgs.enqueued) and send downstream
-        let pdata = make_test_pdata();
-        proc.process(Message::PData(pdata), &mut eh).await.unwrap();
-        let _ = rx_out.recv().await.expect("downstream message");
-
-        // NACK it (id=1) to schedule a retry (inc nacks.received, retry.attempts)
-        proc.process(
-            Message::Control(NodeControlMsg::Nack {
-                id: 1,
-                reason: "fail".into(),
-                pdata: None,
-            }),
-            &mut eh,
-        )
-        .await
-        .unwrap();
-
-        // Wait and tick to perform retry (inc msgs.retried)
-        sleep(Duration::from_millis(60)).await;
-        proc.process(Message::Control(NodeControlMsg::TimerTick {}), &mut eh)
-            .await
-            .unwrap();
-        let _ = rx_out.recv().await.expect("retry downstream message");
-
-        // ACK it (inc msgs.acked)
-        proc.process(Message::Control(NodeControlMsg::Ack { id: 1 }), &mut eh)
-            .await
-            .unwrap();
-
-        // Trigger telemetry snapshot (report + reset)
-        proc.process(
-            Message::Control(NodeControlMsg::CollectTelemetry {
-                metrics_reporter: reporter.clone(),
-            }),
-            &mut eh,
-        )
-        .await
-        .unwrap();
-
-        // Allow collector to pull the snapshot
-        sleep(Duration::from_millis(50)).await;
-
-        let map = collect_retry_metrics_map(&registry);
-        // Basic expectations: enqueued >=1, nacks >=1, retries >=1, retried >=1, acked >=1
-        let get = |key: &str| map.get(key).copied().unwrap_or(0);
-        assert!(
-            get("msgs.enqueued") >= 1,
-            "msgs.enqueued should be >= 1, got {}",
-            get("msgs.enqueued")
-        );
-        assert!(
-            get("nacks.received") >= 1,
-            "nacks.received should be >= 1, got {}",
-            get("nacks.received")
-        );
-        assert!(
-            get("retry.attempts") >= 1,
-            "retry.attempts should be >= 1, got {}",
-            get("retry.attempts")
-        );
-        assert!(
-            get("msgs.retried") >= 1,
-            "msgs.retried should be >= 1, got {}",
-            get("msgs.retried")
-        );
-        assert!(
-            get("msgs.acked") >= 1,
-            "msgs.acked should be >= 1, got {}",
-            get("msgs.acked")
-        );
-    }
-
-    #[tokio::test]
-    async fn test_metrics_queue_full_increments_drop_counter() {
-        // Telemetry system
-        let ms = MetricsSystem::default();
-        let registry = ms.registry();
-        let reporter = ms.reporter();
-        let _collector = tokio::spawn(ms.run_collection_loop());
-
-        // Pipeline + processor (capacity 1)
-        let controller = ControllerContext::new(registry.clone());
-        let pipeline = controller.pipeline_context_with("grp".into(), "pipe".into(), 0, 0);
-        let cfg = RetryConfig {
-            max_pending_messages: 1,
-            ..Default::default()
-        };
-        let mut proc = RetryProcessor::with_pipeline_ctx(pipeline, cfg);
-
-        // Effect handler with an 'out' port
-        let (tx_out, rx_out) = otap_df_channel::mpsc::Channel::new(2);
-        let mut senders = HashMap::new();
-        let _ = senders.insert("out".into(), LocalSender::MpscSender(tx_out));
-        let mut eh = LocalEffectHandler::new(test_node("retry_queue_full"), senders, None);
-
-        // 1st message enqueues fine
-        proc.process(Message::PData(make_test_pdata()), &mut eh)
-            .await
-            .unwrap();
-        let _ = rx_out.recv().await.expect("downstream first");
-
-        // 2nd message should hit queue full and return error
-        let res = proc
-            .process(Message::PData(make_test_pdata()), &mut eh)
-            .await;
-        assert!(res.is_err(), "expected queue full error");
-
-        // Report telemetry
-        proc.process(
-            Message::Control(NodeControlMsg::CollectTelemetry {
-                metrics_reporter: reporter.clone(),
-            }),
-            &mut eh,
-        )
-        .await
-        .unwrap();
-        sleep(Duration::from_millis(50)).await;
-
-        let map = collect_retry_metrics_map(&registry);
-        let get = |key: &str| map.get(key).copied().unwrap_or(0);
-        assert!(get("msgs.enqueued") >= 1, "expected at least one enqueued");
-        assert!(
-            get("msgs.dropped.queue.full") >= 1,
-            "expected queue full drop counter to be >= 1"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_metrics_exceeded_retries_dropped_increments_counter() {
-        // Telemetry system
-        let ms = MetricsSystem::default();
-        let registry = ms.registry();
-        let reporter = ms.reporter();
-        let _collector = tokio::spawn(ms.run_collection_loop());
-
-        // Pipeline + processor: allow only 1 retry
-        let controller = ControllerContext::new(registry.clone());
-        let pipeline = controller.pipeline_context_with("grp".into(), "pipe".into(), 0, 0);
-        let cfg = RetryConfig {
-            max_retries: 1,
-            initial_retry_delay_ms: 10,
-            max_retry_delay_ms: 10,
-            backoff_multiplier: 2.0,
-            max_pending_messages: 10,
-            cleanup_interval_secs: 1,
-        };
-        let mut proc = RetryProcessor::with_pipeline_ctx(pipeline, cfg);
-
-        // Effect handler
-        let (tx_out, rx_out) = otap_df_channel::mpsc::Channel::new(4);
-        let mut senders = HashMap::new();
-        let _ = senders.insert("out".into(), LocalSender::MpscSender(tx_out));
-        let mut eh = LocalEffectHandler::new(test_node("retry_exceeded"), senders, None);
-
-        // Enqueue and send downstream
-        proc.process(Message::PData(make_test_pdata()), &mut eh)
-            .await
-            .unwrap();
-        let _ = rx_out.recv().await.expect("downstream message");
-
-        // First NACK -> schedule retry (not dropped)
-        proc.process(
-            Message::Control(NodeControlMsg::Nack {
-                id: 1,
-                reason: "fail1".into(),
-                pdata: None,
-            }),
-            &mut eh,
-        )
-        .await
-        .unwrap();
-
-        // Second NACK -> exceed max and drop
-        proc.process(
-            Message::Control(NodeControlMsg::Nack {
-                id: 1,
-                reason: "fail2".into(),
-                pdata: None,
-            }),
-            &mut eh,
-        )
-        .await
-        .unwrap();
-
-        // Collect telemetry
-        proc.process(
-            Message::Control(NodeControlMsg::CollectTelemetry {
-                metrics_reporter: reporter.clone(),
-            }),
-            &mut eh,
-        )
-        .await
-        .unwrap();
-        sleep(Duration::from_millis(30)).await;
-
-        let map = collect_retry_metrics_map(&registry);
-        let get = |key: &str| map.get(key).copied().unwrap_or(0);
-        assert!(
-            get("msgs.dropped.exceeded.retries") >= 1,
-            "expected exceeded retries drop >= 1"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_metrics_cleanup_expired_increments_counter() {
-        use std::time::{Duration as StdDuration, Instant as StdInstant};
-        // Telemetry system
-        let ms = MetricsSystem::default();
-        let registry = ms.registry();
-        let reporter = ms.reporter();
-        let _collector = tokio::spawn(ms.run_collection_loop());
-
-        // Pipeline + processor
-        let controller = ControllerContext::new(registry.clone());
-        let pipeline = controller.pipeline_context_with("grp".into(), "pipe".into(), 0, 0);
-        let cfg = RetryConfig {
-            cleanup_interval_secs: 1,
-            max_retries: 0,
-            ..Default::default()
-        };
-        let mut proc = RetryProcessor::with_pipeline_ctx(pipeline, cfg);
-
-        // Insert a fabricated expired pending message (retry_count > max_retries and age > MAX_FAILED_MESSAGE_AGE_SECS)
-        let expired_id = 42u64;
-        let pending = PendingMessage {
-            data: make_test_pdata(),
-            retry_count: proc.config.max_retries + 1,
-            next_retry_time: StdInstant::now()
-                - StdDuration::from_secs(MAX_FAILED_MESSAGE_AGE_SECS + 5),
-            last_error: "expired".into(),
-        };
-        let _ = proc.pending_messages.insert(expired_id, pending);
-        // Ensure cleanup interval elapsed
-        proc.last_cleanup_time = StdInstant::now() - StdDuration::from_secs(2);
-
-        // Run cleanup
-        proc.cleanup_expired_messages();
-        assert!(
-            !proc.pending_messages.contains_key(&expired_id),
-            "expired message should be removed"
-        );
-
-        // Report telemetry -> should include msgs.removed.expired >= 1
-        // We need an effect handler but won't send data
-        let (tx_out, _rx_out) = otap_df_channel::mpsc::Channel::new(1);
-        let mut senders = HashMap::new();
-        let _ = senders.insert("out".into(), LocalSender::MpscSender(tx_out));
-        let mut eh = LocalEffectHandler::new(test_node("retry_cleanup"), senders, None);
-
-        proc.process(
-            Message::Control(NodeControlMsg::CollectTelemetry {
-                metrics_reporter: reporter.clone(),
-            }),
-            &mut eh,
-        )
-        .await
-        .unwrap();
-        sleep(Duration::from_millis(30)).await;
-
-        let map = collect_retry_metrics_map(&registry);
-        let get = |key: &str| map.get(key).copied().unwrap_or(0);
-        assert!(
-            get("msgs.removed.expired") >= 1,
-            "expected msgs.removed.expired >= 1"
-        );
     }
 }

--- a/rust/otap-dataflow/crates/otap/src/retry_processor.rs
+++ b/rust/otap-dataflow/crates/otap/src/retry_processor.rs
@@ -298,13 +298,11 @@ impl Processor<OtapPdata> for RetryProcessor {
         // for metrics on the return path?
         match msg {
             Message::PData(mut data) => {
-                effect_handler
-                    .subscribe_to(
-                        Interests::NACKS | Interests::ACKS,
-                        RetryState::new().into(),
-                        &mut data,
-                    )
-                    .await;
+                effect_handler.subscribe_to(
+                    Interests::NACKS | Interests::ACKS,
+                    RetryState::new().into(),
+                    &mut data,
+                );
                 match effect_handler.send_message(data).await {
                     Ok(()) => {
                         // Request control flows downstream.
@@ -382,9 +380,7 @@ impl Processor<OtapPdata> for RetryProcessor {
 
                     // Updated RetryState back onto context for retry attempt
                     let mut rereq = nack.refused;
-                    effect_handler
-                        .subscribe_to(Interests::NACKS, rstate.into(), &mut rereq)
-                        .await;
+                    effect_handler.subscribe_to(Interests::NACKS, rstate.into(), &mut rereq);
 
                     // Enter a delay, we'll continue in the
                     // DelayedData branch next.


### PR DESCRIPTION
Replaces #1114, #1083.

This PR demonstrates: 

- New AckMsg, NackMsg types
- Interests is a bitflags! of ACKS and NACKS
- CtxVal is [u8;8] with bytemuck::cast
- CallData is SmallVec of 2 CtxVal
- Context is a Vec<Frame>
- Frame is { Interests, CallData, NodeId }
- ProducerEffectHandlerExtension: subscribe_to for Interests w/ call data
- ConsumerEffectHandlerExtension: notify_nack and notify_ack invoke the delivery path
- DelayedData is a placeholder NodeControlMsg for data returning after a retry_processor attempt
- OTLP exporter proof-of-concept returns Ack and Nack: TODOs about cloning of data
- OTLP receiver has comments indicating needs like a way to block the RPC awaiting Ack/Nack
- EffectHandler wrappers for core delay_data(), route_ack(), and route_nack() methods

No testing.
Extraneous: renames OtapPayload::payload() to take_payload(), eases minor confusion. See how we "dump" data, and the TODOs it creates; we're losing information about num_items though we've retained signal type here.
