### PR TITLE
[query-engine] Implement fmt_with_indent for more expressions

### DIFF
--- a/rust/experimental/query_engine/expressions/src/pipeline_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/pipeline_expression.rs
@@ -151,8 +151,8 @@ impl std::fmt::Display for PipelineExpression {
                     write!(f, "    └── ")?;
                     e.fmt_with_indent(f, "        ")?;
                 } else {
-                    write!(f, "│   ├── ")?;
-                    e.fmt_with_indent(f, "│   │   ")?;
+                    write!(f, "    ├── ")?;
+                    e.fmt_with_indent(f, "    │   ")?;
                 }
             }
         }

--- a/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
@@ -630,15 +630,14 @@ impl Expression for CoalesceScalarExpression {
         if self.expressions.is_empty() {
             writeln!(f, "{indent}└── Expressions: []")?;
         } else {
-            writeln!(f, "{indent}└── Expressions:")?;
             let last_idx = self.expressions.len() - 1;
             for (i, e) in self.expressions.iter().enumerate() {
                 if i == last_idx {
-                    write!(f, "{indent}    └── ")?;
-                    e.fmt_with_indent(f, format!("{indent}        ").as_str())?;
+                    write!(f, "{indent}└── Expressions[{i}](Scalar): ")?;
+                    e.fmt_with_indent(f, format!("{indent}                            ").as_str())?;
                 } else {
-                    write!(f, "{indent}    ├── ")?;
-                    e.fmt_with_indent(f, format!("{indent}    │   ").as_str())?;
+                    write!(f, "{indent}├── Expressions[{i}](Scalar): ")?;
+                    e.fmt_with_indent(f, format!("{indent}│                           ").as_str())?;
                 }
             }
         }

--- a/rust/experimental/query_engine/expressions/src/scalars/statics/static_scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/statics/static_scalar_expressions.rs
@@ -193,7 +193,7 @@ impl Expression for StaticScalarExpression {
             StaticScalarExpression::Integer(i) => writeln!(f, "Integer: {}", i.get_value()),
             StaticScalarExpression::Map(m) => writeln!(f, "Map: {}", Value::Map(m)),
             StaticScalarExpression::Null(_) => writeln!(f, "Null"),
-            StaticScalarExpression::Regex(r) => writeln!(f, "Regex: {}", r.get_value()),
+            StaticScalarExpression::Regex(r) => writeln!(f, "Regex: {:?}", r.get_value().as_str()),
             StaticScalarExpression::String(s) => writeln!(f, "String: {:?}", s.get_value()),
             StaticScalarExpression::TimeSpan(t) => writeln!(f, "TimeSpan: {}", Value::TimeSpan(t)),
         }

--- a/rust/experimental/query_engine/expressions/src/value_accessor.rs
+++ b/rust/experimental/query_engine/expressions/src/value_accessor.rs
@@ -89,14 +89,19 @@ impl ValueAccessor {
         f: &mut std::fmt::Formatter<'_>,
         indent: &str,
     ) -> std::fmt::Result {
-        let last_idx = self.selectors.len() - 1;
-        for (i, e) in self.selectors.iter().enumerate() {
-            if i == last_idx {
-                write!(f, "{indent}└── ")?;
-                e.fmt_with_indent(f, format!("{indent}    ").as_str())?;
-            } else {
-                write!(f, "{indent}├── ")?;
-                e.fmt_with_indent(f, format!("{indent}│   ").as_str())?;
+        if self.selectors.is_empty() {
+            writeln!(f, "None")?;
+        } else {
+            writeln!(f)?;
+            let last_idx = self.selectors.len() - 1;
+            for (i, e) in self.selectors.iter().enumerate() {
+                if i == last_idx {
+                    write!(f, "{indent}└── ")?;
+                    e.fmt_with_indent(f, format!("{indent}    ").as_str())?;
+                } else {
+                    write!(f, "{indent}├── ")?;
+                    e.fmt_with_indent(f, format!("{indent}│   ").as_str())?;
+                }
             }
         }
         Ok(())

--- a/rust/experimental/query_engine/expressions/src/value_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/value_expressions.rs
@@ -44,4 +44,11 @@ impl Expression for MutableValueExpression {
             MutableValueExpression::Variable(_) => "MutableValueExpression(Variable)",
         }
     }
+
+    fn fmt_with_indent(&self, f: &mut std::fmt::Formatter<'_>, indent: &str) -> std::fmt::Result {
+        match self {
+            MutableValueExpression::Source(s) => s.fmt_with_indent(f, indent),
+            MutableValueExpression::Variable(v) => v.fmt_with_indent(f, indent),
+        }
+    }
 }


### PR DESCRIPTION
Relates to #1178

## Changes

* Implements `fmt_with_indent` for more expressions. Note: I had CoPilot do the initial work but I tweaked and cleaned everything up manually.

## Details

Examples:

```
Pipeline
├── Query: ""
├── Constants: []
├── Initializations: []
└── Expressions:
    └── Remove
        └── Target(Mutable): Variable
                             ├── Name: "var"
                             └── Accessor:
                                 └── String: "field"
```

```
Pipeline
├── Query: ""
├── Constants: []
├── Initializations: []
└── Expressions:
    └── RemoveMapKeys(Retain)
        ├── Target(Mutable): Source
        │                    └── Accessor:
        │                        └── String: "Attributes"
        ├── Keys[0](Scalar): Variable
        │                    ├── Name: "var1"
        │                    └── Accessor: None
        └── Keys[1](Scalar): Variable
                             ├── Name: "var2"
                             └── Accessor: None
```

```
Pipeline
├── Query: "\nsource\n | project-rename name = key1\n | project-rename name = key1, key1 = source.Attributes[name]\n | project-away key1['field'], name, *Time\n "
├── Constants: []
├── Initializations: []
└── Expressions:
    ├── Move
    │   ├── Source(Mutable): Source
    │   │                    └── Accessor:
    │   │                        ├── String: "Attributes"
    │   │                        └── String: "key1"
    │   └── Destination(Mutable): Source
    │                             └── Accessor:
    │                                 ├── String: "Attributes"
    │                                 └── String: "name"
    ├── RenameMapKeys
    │   ├── Target(Mutable): Source
    │   │                    └── Accessor: None
    │   ├── Keys[0]:
    │   │   ├── Source(Accessor):
    │   │   │   ├── String: "Attributes"
    │   │   │   └── String: "key1"
    │   │   └── Destination(Accessor):
    │   │       ├── String: "Attributes"
    │   │       └── String: "name"
    │   └── Keys[1]:
    │       ├── Source(Accessor):
    │       │   ├── String: "Attributes"
    │       │   └── Source
    │       │       └── Accessor:
    │       │           ├── String: "Attributes"
    │       │           └── String: "name"
    │       └── Destination(Accessor):
    │           ├── String: "Attributes"
    │           └── String: "key1"
    └── ReduceMap(Remove)
        ├── Target(Mutable): Source
        │                    └── Accessor: None
        ├── Selectors[0](KeyOrPattern): String: "ObservedTimestamp"
        ├── Selectors[1](KeyOrPattern): String: "Timestamp"
        ├── Selectors[2](Accessor):
        │   ├── String: "Attributes"
        │   ├── String: "key1"
        │   └── String: "field"
        ├── Selectors[3](Accessor):
        │   ├── String: "Attributes"
        │   └── Regex: "^.*Time"
        └── Selectors[4](Accessor):
            ├── String: "Attributes"
            └── String: "name"
```

```
Pipeline
├── Query: "\nsource\n | extend\n    c1 = coalesce(key1, name, 'n/a'),\n    c2 = case(name == int(null), name, key1 == int(null), 'b', key1),\n    l = strlen(name),\n    s1 = substring(name, 5),\n    s2 = substring(name, key1, key1)\n "
├── Constants: []
├── Initializations: []
└── Expressions:
    ├── Set
    │   ├── Source(Scalar): Coalesce
    │   │                   ├── Expressions[0](Scalar): Source
    │   │                   │                           └── Accessor:
    │   │                   │                               ├── String: "Attributes"
    │   │                   │                               └── String: "key1"
    │   │                   ├── Expressions[1](Scalar): Source
    │   │                   │                           └── Accessor:
    │   │                   │                               ├── String: "Attributes"
    │   │                   │                               └── String: "name"
    │   │                   └── Expressions[2](Scalar): String: "n/a"
    │   └── Destination(Mutable): Source
    │                             └── Accessor:
    │                                 ├── String: "Attributes"
    │                                 └── String: "c1"
    ├── Set
    │   ├── Source(Scalar): Case
    │   │                   ├── When[0]
    │   │                   │   ├── Condition(Logical): EqualTo
    │   │                   │   │                       ├── Left(Scalar): Source
    │   │                   │   │                       │                 └── Accessor:
    │   │                   │   │                       │                     ├── String: "Attributes"
    │   │                   │   │                       │                     └── String: "name"
    │   │                   │   │                       └── Right(Scalar): Null
    │   │                   │   └── Expression(Scalar): Source
    │   │                   │                           └── Accessor:
    │   │                   │                               ├── String: "Attributes"
    │   │                   │                               └── String: "name"
    │   │                   ├── When[1]
    │   │                   │   ├── Condition(Logical): EqualTo
    │   │                   │   │                       ├── Left(Scalar): Source
    │   │                   │   │                       │                 └── Accessor:
    │   │                   │   │                       │                     ├── String: "Attributes"
    │   │                   │   │                       │                     └── String: "key1"
    │   │                   │   │                       └── Right(Scalar): Null
    │   │                   │   └── Expression(Scalar): String: "b"
    │   │                   └── Else(Scalar): Source
    │   │                                     └── Accessor:
    │   │                                         ├── String: "Attributes"
    │   │                                         └── String: "key1"
    │   └── Destination(Mutable): Source
    │                             └── Accessor:
    │                                 ├── String: "Attributes"
    │                                 └── String: "c2"
    ├── Set
    │   ├── Source(Scalar): Length(Scalar): Source
    │   │                                   └── Accessor:
    │   │                                       ├── String: "Attributes"
    │   │                                       └── String: "name"
    │   └── Destination(Mutable): Source
    │                             └── Accessor:
    │                                 ├── String: "Attributes"
    │                                 └── String: "l"
    ├── Set
    │   ├── Source(Scalar): Slice
    │   │                   ├── Source(Scalar): Source
    │   │                   │                   └── Accessor:
    │   │                   │                       ├── String: "Attributes"
    │   │                   │                       └── String: "name"
    │   │                   ├── StartInclusive(Scalar): Integer: 5
    │   │                   └── EndExclusive: None
    │   └── Destination(Mutable): Source
    │                             └── Accessor:
    │                                 ├── String: "Attributes"
    │                                 └── String: "s1"
    └── Set
        ├── Source(Scalar): Slice
        │                   ├── Source(Scalar): Source
        │                   │                   └── Accessor:
        │                   │                       ├── String: "Attributes"
        │                   │                       └── String: "name"
        │                   ├── StartInclusive(Scalar): Source
        │                   │                           └── Accessor:
        │                   │                               ├── String: "Attributes"
        │                   │                               └── String: "key1"
        │                   └── EndExclusive(Scalar): Source
        │                                             └── Accessor:
        │                                                 ├── String: "Attributes"
        │                                                 └── String: "key1"
        └── Destination(Mutable): Source
                                  └── Accessor:
                                      ├── String: "Attributes"
                                      └── String: "s2"
```