### PR TITLE
[query-engine] Implement fmt_with_indent for collection and conversion expressions

### DIFF
--- a/rust/experimental/query_engine/expressions/src/scalars/collection_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/collection_scalar_expression.rs
@@ -52,6 +52,13 @@ impl Expression for CollectionScalarExpression {
             CollectionScalarExpression::List(_) => "CollectionScalar(List)",
         }
     }
+
+    fn fmt_with_indent(&self, f: &mut std::fmt::Formatter<'_>, indent: &str) -> std::fmt::Result {
+        match self {
+            CollectionScalarExpression::Concat(c) => c.fmt_with_indent(f, indent),
+            CollectionScalarExpression::List(c) => c.fmt_with_indent(f, indent),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -206,6 +213,13 @@ impl Expression for CombineScalarExpression {
     fn get_name(&self) -> &'static str {
         "CombineScalarExpression"
     }
+
+    fn fmt_with_indent(&self, f: &mut std::fmt::Formatter<'_>, indent: &str) -> std::fmt::Result {
+        write!(f, "Concat(Scalar): ")?;
+        self.values_expression
+            .fmt_with_indent(f, format!("{indent}                ").as_str())?;
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -266,6 +280,33 @@ impl Expression for ListScalarExpression {
 
     fn get_name(&self) -> &'static str {
         "ListScalarExpression"
+    }
+
+    fn fmt_with_indent(&self, f: &mut std::fmt::Formatter<'_>, indent: &str) -> std::fmt::Result {
+        writeln!(f, "List")?;
+        let values = &self.value_expressions;
+        if values.is_empty() {
+            writeln!(f, "{indent}└── Values: []")?;
+        } else {
+            for (i, v) in values.iter().enumerate() {
+                let last = i + 1 == values.len();
+                let header = format!("Values[{i}](Scalar): ");
+                if last {
+                    write!(f, "{indent}└── {header}")?;
+                    v.fmt_with_indent(
+                        f,
+                        format!("{indent}    {}", " ".repeat(header.len())).as_str(),
+                    )?;
+                } else {
+                    write!(f, "{indent}├── {header}")?;
+                    v.fmt_with_indent(
+                        f,
+                        format!("{indent}│   {}", " ".repeat(header.len())).as_str(),
+                    )?;
+                }
+            }
+        }
+        Ok(())
     }
 }
 

--- a/rust/experimental/query_engine/expressions/src/scalars/convert_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/convert_scalar_expression.rs
@@ -243,6 +243,39 @@ impl Expression for ConvertScalarExpression {
             ConvertScalarExpression::TimeSpan(_) => "ConvertScalar(TimeSpan)",
         }
     }
+
+    fn fmt_with_indent(&self, f: &mut std::fmt::Formatter<'_>, indent: &str) -> std::fmt::Result {
+        let fmt_unary = |f: &mut std::fmt::Formatter<'_>,
+                         indent: &str,
+                         name: &str,
+                         inner: &ScalarExpression|
+         -> std::fmt::Result {
+            let header = format!("To{name}(Scalar): ");
+            write!(f, "{header}")?;
+            inner.fmt_with_indent(f, format!("{indent}{}", " ".repeat(header.len())).as_str())
+        };
+
+        match self {
+            ConvertScalarExpression::Boolean(c) => {
+                fmt_unary(f, indent, "Boolean", c.get_inner_expression())
+            }
+            ConvertScalarExpression::DateTime(c) => {
+                fmt_unary(f, indent, "DateTime", c.get_inner_expression())
+            }
+            ConvertScalarExpression::Double(c) => {
+                fmt_unary(f, indent, "Double", c.get_inner_expression())
+            }
+            ConvertScalarExpression::Integer(c) => {
+                fmt_unary(f, indent, "Integer", c.get_inner_expression())
+            }
+            ConvertScalarExpression::String(c) => {
+                fmt_unary(f, indent, "String", c.get_inner_expression())
+            }
+            ConvertScalarExpression::TimeSpan(c) => {
+                fmt_unary(f, indent, "TimeSpan", c.get_inner_expression())
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]


### PR DESCRIPTION
Relates to #1178

## Details

Example:

```
Pipeline
├── Query: "\nsource\n | extend\n    c1 = array_concat(parse_json('[]')),\n    c2 = array_concat(name, key1),\n    c3 = toint(key1)\n "
├── Constants: []
├── Initializations: []
└── Expressions:
    ├── Set
    │   ├── Source(Scalar): Concat(Scalar): List
    │   │                                   └── Values[0](Scalar): Array: []
    │   └── Destination(Mutable): Source
    │                             └── Accessor:
    │                                 ├── String: "Attributes"
    │                                 └── String: "c1"
    ├── Set
    │   ├── Source(Scalar): Concat(Scalar): List
    │   │                                   ├── Values[0](Scalar): Source
    │   │                                   │                      └── Accessor:
    │   │                                   │                          ├── String: "Attributes"
    │   │                                   │                          └── String: "name"
    │   │                                   └── Values[1](Scalar): Source
    │   │                                                          └── Accessor:
    │   │                                                              ├── String: "Attributes"
    │   │                                                              └── String: "key1"
    │   └── Destination(Mutable): Source
    │                             └── Accessor:
    │                                 ├── String: "Attributes"
    │                                 └── String: "c2"
    └── Set
        ├── Source(Scalar): ToInteger(Scalar): Source
        │                                      └── Accessor:
        │                                          ├── String: "Attributes"
        │                                          └── String: "key1"
        └── Destination(Mutable): Source
                                  └── Accessor:
                                      ├── String: "Attributes"
                                      └── String: "c3"
```