### PR TITLE
Configuration validation errors should prevent startup

### DIFF
--- a/rust/otap-dataflow/crates/controller/src/lib.rs
+++ b/rust/otap-dataflow/crates/controller/src/lib.rs
@@ -208,6 +208,13 @@ impl<PData: 'static + Clone + Send + Sync + std::fmt::Debug> Controller<PData> {
             }
         }
 
+        // Check if any threads failed and return the first error
+        for result in results {
+            if let Err(e) = result {
+                return Err(e);
+            }
+        }
+
         // ToDo Add CTRL-C handler to initiate graceful shutdown of pipelines and admin server.
 
         // In this project phase (alpha), we park the main thread indefinitely. This is useful for

--- a/rust/otap-dataflow/crates/otap/Cargo.toml
+++ b/rust/otap-dataflow/crates/otap/Cargo.toml
@@ -38,6 +38,7 @@ tonic-middleware = { workspace = true }
 tonic-prost = { workspace = true }
 prost = { workspace = true }
 
+otap-df-controller = { path = "../controller" }
 otap-df-engine = { path = "../engine" }
 otap-df-engine-macros = { path = "../engine-macros" }
 otap-df-channel = { path = "../channel" }

--- a/rust/otap-dataflow/crates/otap/configs/test-invalid-config.yaml
+++ b/rust/otap-dataflow/crates/otap/configs/test-invalid-config.yaml
@@ -1,0 +1,29 @@
+settings:
+  default_pipeline_ctrl_msg_channel_size: 100
+  default_node_ctrl_msg_channel_size: 100
+  default_pdata_channel_size: 100
+
+nodes:
+  fake_generator:
+    kind: receiver
+    plugin_urn: "urn:otel:otap:fake_data_generator:receiver"
+    out_ports:
+      out_port:
+        destinations:
+          - retry_processor
+        dispatch_strategy: round_robin
+
+  retry_processor:
+    kind: processor
+    plugin_urn: "urn:otap:processor:retry_processor"
+    out_ports:
+      out_port:
+        destinations:
+          - noop_exporter
+        dispatch_strategy: round_robin
+    config: {}  # Missing required fields like max_retries
+
+  noop_exporter:
+    kind: exporter
+    plugin_urn: "urn:otel:noop:exporter"
+    config:


### PR DESCRIPTION
It looks like there was a regression causing configuration validation logic not to fail or print at startup.

I think this is the desired behavior.
