### PR TITLE
Add support for KQL not()

### DIFF
--- a/rust/experimental/query_engine/kql-parser/src/kql.pest
+++ b/rust/experimental/query_engine/kql-parser/src/kql.pest
@@ -255,10 +255,8 @@ scalar_list_expression = {
     "(" ~ scalar_expression ~ ("," ~ scalar_expression)* ~ ")"
 }
 
-not_expression = { "not" ~ "(" ~ scalar_expression ~ ")" }
 logical_expression = {
     scalar_expression
-    not_expression
 }
 
 assignment_expression = { accessor_expression ~ "=" ~ scalar_expression }

--- a/rust/experimental/query_engine/kql-parser/src/kql.pest
+++ b/rust/experimental/query_engine/kql-parser/src/kql.pest
@@ -212,6 +212,11 @@ temporal_expressions = {
     now_expression
 }
 
+not_expression = { "not" ~ "(" ~ logical_expression ~ ")" }
+logical_function_expressions = {
+    not_expression
+}
+
 /* Note: Order is imporant here. Once Pest has matched something it won't go
 backwards. For example if integer_literal is defined before time_expression "1h"
 would be parsed as integer_literal(1) and the remaining "h" would be fed into
@@ -224,6 +229,7 @@ scalar_unary_expression = {
     | array_expressions
     | math_expressions
     | temporal_expressions
+    | logical_function_expressions
     | parse_expressions
     | accessor_expression
     | "(" ~ scalar_expression ~ ")"

--- a/rust/experimental/query_engine/kql-parser/src/kql.pest
+++ b/rust/experimental/query_engine/kql-parser/src/kql.pest
@@ -212,6 +212,7 @@ temporal_unary_expressions = {
     now_expression
 }
 
+not_expression = { "not" ~ "(" ~ logical_expression ~ ")" }
 logical_unary_expressions = {
     not_expression
 }

--- a/rust/experimental/query_engine/kql-parser/src/kql.pest
+++ b/rust/experimental/query_engine/kql-parser/src/kql.pest
@@ -127,9 +127,9 @@ regex_expression = { "regex(" ~ string_literal ~ ("," ~ string_literal)? ~ ")" }
 dynamic_array_expression = { "[" ~ (dynamic_inner_expression ~ ("," ~ dynamic_inner_expression)*)? ~ "]" }
 dynamic_map_item_expression = { string_literal ~ ":" ~ dynamic_inner_expression }
 dynamic_map_expression = { "{" ~ (dynamic_map_item_expression ~ ("," ~ dynamic_map_item_expression)*)? ~ "}" }
-dynamic_inner_expression = _{ dynamic_array_expression|dynamic_map_expression|type_expressions }
+dynamic_inner_expression = _{ dynamic_array_expression|dynamic_map_expression|type_unary_expressions }
 dynamic_expression = { "dynamic" ~ "(" ~ dynamic_inner_expression ~ ")" }
-type_expressions = {
+type_unary_expressions = {
     null_literal
     | real_expression
     | datetime_expression
@@ -146,7 +146,7 @@ type_expressions = {
 conditional_expression = { ("iff"|"iif") ~ "(" ~ logical_expression ~ "," ~ scalar_expression ~ "," ~ scalar_expression ~ ")" }
 case_expression = { "case" ~ "(" ~ logical_expression ~ "," ~ scalar_expression ~ ("," ~ logical_expression ~ "," ~ scalar_expression)* ~ "," ~ scalar_expression ~ ")" }
 coalesce_expression = { "coalesce" ~ "(" ~ scalar_expression ~ "," ~ scalar_expression ~ ("," ~ scalar_expression)* ~ ")" }
-conditional_expressions = {
+conditional_unary_expressions = {
     conditional_expression
     | case_expression
     | coalesce_expression
@@ -161,7 +161,7 @@ toreal_expression = { "toreal" ~ "(" ~ scalar_expression ~ ")" }
 todouble_expression = { "todouble" ~ "(" ~ scalar_expression ~ ")" }
 todatetime_expression = { "todatetime" ~ "(" ~ scalar_expression ~ ")" }
 totimespan_expression = { "totimespan" ~ "(" ~ scalar_expression ~ ")" }
-conversion_expressions = {
+conversion_unary_expressions = {
     tostring_expression
     | toint_expression
     | tobool_expression
@@ -179,7 +179,7 @@ substring_expression = { "substring" ~ "(" ~ scalar_expression ~ "," ~ scalar_ex
 strcat_expression = { "strcat" ~ scalar_list_expression }
 strcat_delim_expression = { "strcat_delim" ~ "(" ~ scalar_expression ~ "," ~ scalar_expression ~ ("," ~ scalar_expression)* ~ ")" }
 extract_expression = { "extract" ~ "(" ~ scalar_expression ~ "," ~ scalar_expression ~ "," ~ scalar_expression ~ ")" }
-string_expressions = {
+string_unary_expressions = {
     strlen_expression
     | replace_string_expression
     | substring_expression
@@ -190,30 +190,29 @@ string_expressions = {
 
 parse_json_expression = { "parse_json" ~ "(" ~ scalar_expression ~ ")" }
 parse_regex_expression = { "parse_regex" ~ "(" ~ scalar_expression ~ ("," ~ scalar_expression)? ~ ")" }
-parse_expressions = {
+parse_unary_expressions = {
     parse_json_expression
     | parse_regex_expression
 }
 
 array_concat_expression = { "array_concat" ~ scalar_list_expression }
-array_expressions = {
+array_unary_expressions = {
     array_concat_expression
 }
 
 negate_expression = { "-" ~ scalar_unary_expression }
 bin_expression = { "bin" ~ "(" ~ scalar_expression ~ "," ~ scalar_expression ~ ")" }
-math_expressions = {
+math_unary_expressions = {
     negate_expression
     | bin_expression
 }
 
 now_expression = { "now" ~ "(" ~ scalar_expression? ~ ")" }
-temporal_expressions = {
+temporal_unary_expressions = {
     now_expression
 }
 
-not_expression = { "not" ~ "(" ~ logical_expression ~ ")" }
-logical_function_expressions = {
+logical_unary_expressions = {
     not_expression
 }
 
@@ -222,15 +221,15 @@ backwards. For example if integer_literal is defined before time_expression "1h"
 would be parsed as integer_literal(1) and the remaining "h" would be fed into
 the next rule. */
 scalar_unary_expression = {
-    type_expressions
-    | conditional_expressions
-    | conversion_expressions
-    | string_expressions
-    | array_expressions
-    | math_expressions
-    | temporal_expressions
-    | logical_function_expressions
-    | parse_expressions
+    type_unary_expressions
+    | conditional_unary_expressions
+    | conversion_unary_expressions
+    | string_unary_expressions
+    | array_unary_expressions
+    | math_unary_expressions
+    | temporal_unary_expressions
+    | logical_unary_expressions
+    | parse_unary_expressions
     | accessor_expression
     | "(" ~ scalar_expression ~ ")"
 }
@@ -255,8 +254,10 @@ scalar_list_expression = {
     "(" ~ scalar_expression ~ ("," ~ scalar_expression)* ~ ")"
 }
 
+not_expression = { "not" ~ "(" ~ scalar_expression ~ ")" }
 logical_expression = {
     scalar_expression
+    not_expression
 }
 
 assignment_expression = { accessor_expression ~ "=" ~ scalar_expression }

--- a/rust/experimental/query_engine/kql-parser/src/lib.rs
+++ b/rust/experimental/query_engine/kql-parser/src/lib.rs
@@ -10,6 +10,7 @@ pub(crate) mod scalar_array_function_expressions;
 pub(crate) mod scalar_conditional_function_expressions;
 pub(crate) mod scalar_conversion_function_expressions;
 pub(crate) mod scalar_expression;
+pub(crate) mod scalar_logical_function_expressions;
 pub(crate) mod scalar_mathematical_function_expressions;
 pub(crate) mod scalar_parse_function_expressions;
 pub(crate) mod scalar_primitive_expressions;

--- a/rust/experimental/query_engine/kql-parser/src/scalar_array_function_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_array_function_expressions.rs
@@ -7,15 +7,15 @@ use pest::iterators::Pair;
 
 use crate::{Rule, scalar_expression::parse_scalar_expression};
 
-pub(crate) fn parse_array_expressions(
-    array_expressions_rule: Pair<Rule>,
+pub(crate) fn parse_array_unary_expressions(
+    array_unary_expressions_rule: Pair<Rule>,
     scope: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
-    let rule = array_expressions_rule.into_inner().next().unwrap();
+    let rule = array_unary_expressions_rule.into_inner().next().unwrap();
 
     match rule.as_rule() {
         Rule::array_concat_expression => parse_array_concat_expression(rule, scope),
-        _ => panic!("Unexpected rule in array_expressions: {rule}"),
+        _ => panic!("Unexpected rule in array_unary_expressions: {rule}"),
     }
 }
 

--- a/rust/experimental/query_engine/kql-parser/src/scalar_conditional_function_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_conditional_function_expressions.rs
@@ -9,17 +9,20 @@ use crate::{
     Rule, logical_expressions::parse_logical_expression, scalar_expression::parse_scalar_expression,
 };
 
-pub(crate) fn parse_conditional_expressions(
-    conditional_expressions_rule: Pair<Rule>,
+pub(crate) fn parse_conditional_unary_expressions(
+    conditional_unary_expressions_rule: Pair<Rule>,
     scope: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
-    let rule = conditional_expressions_rule.into_inner().next().unwrap();
+    let rule = conditional_unary_expressions_rule
+        .into_inner()
+        .next()
+        .unwrap();
 
     match rule.as_rule() {
         Rule::conditional_expression => parse_conditional_expression(rule, scope),
         Rule::case_expression => parse_case_expression(rule, scope),
         Rule::coalesce_expression => parse_coalesce_expression(rule, scope),
-        _ => panic!("Unexpected rule in conditional_expressions: {rule}"),
+        _ => panic!("Unexpected rule in conditional_unary_expressions: {rule}"),
     }
 }
 

--- a/rust/experimental/query_engine/kql-parser/src/scalar_conversion_function_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_conversion_function_expressions.rs
@@ -7,11 +7,14 @@ use pest::iterators::Pair;
 
 use crate::{Rule, scalar_expression::parse_scalar_expression};
 
-pub(crate) fn parse_conversion_expressions(
-    conversion_expressions_rule: Pair<Rule>,
+pub(crate) fn parse_conversion_unary_expressions(
+    conversion_unary_expressions_rule: Pair<Rule>,
     scope: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
-    let rule = conversion_expressions_rule.into_inner().next().unwrap();
+    let rule = conversion_unary_expressions_rule
+        .into_inner()
+        .next()
+        .unwrap();
 
     match rule.as_rule() {
         Rule::tostring_expression => parse_tostring_expression(rule, scope),
@@ -23,7 +26,7 @@ pub(crate) fn parse_conversion_expressions(
         Rule::todouble_expression => parse_todouble_expression(rule, scope),
         Rule::todatetime_expression => parse_todatetime_expression(rule, scope),
         Rule::totimespan_expression => parse_totimespan_expression(rule, scope),
-        _ => panic!("Unexpected rule in conversion_expressions: {rule}"),
+        _ => panic!("Unexpected rule in conversion_unary_expressions: {rule}"),
     }
 }
 

--- a/rust/experimental/query_engine/kql-parser/src/scalar_expression.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_expression.rs
@@ -10,9 +10,9 @@ use pest::{iterators::Pair, pratt_parser::*};
 use crate::{
     Rule, logical_expressions::to_logical_expression, scalar_array_function_expressions::*,
     scalar_conditional_function_expressions::*, scalar_conversion_function_expressions::*,
-    scalar_mathematical_function_expressions::*, scalar_parse_function_expressions::*,
-    scalar_primitive_expressions::*, scalar_string_function_expressions::*,
-    scalar_temporal_function_expressions::*,
+    scalar_logical_function_expressions::*, scalar_mathematical_function_expressions::*,
+    scalar_parse_function_expressions::*, scalar_primitive_expressions::*,
+    scalar_string_function_expressions::*, scalar_temporal_function_expressions::*,
 };
 
 static PRATT_PARSER: LazyLock<PrattParser<Rule>> = LazyLock::new(|| {
@@ -293,6 +293,7 @@ pub(crate) fn parse_scalar_unary_expression(
         Rule::array_expressions => parse_array_expressions(rule, scope)?,
         Rule::math_expressions => parse_math_expressions(rule, scope)?,
         Rule::temporal_expressions => parse_temporal_expressions(rule, scope)?,
+        Rule::logical_function_expressions => parse_logical_function_expressions(rule, scope)?,
         Rule::accessor_expression => {
             // Note: When used as a scalar expression it is valid for an
             // accessor to fold into a static at the root so

--- a/rust/experimental/query_engine/kql-parser/src/scalar_expression.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_expression.rs
@@ -10,7 +10,7 @@ use pest::{iterators::Pair, pratt_parser::*};
 use crate::{
     Rule, logical_expressions::to_logical_expression, scalar_array_function_expressions::*,
     scalar_conditional_function_expressions::*, scalar_conversion_function_expressions::*,
-    scalar_logical_unary_expressions::*, scalar_mathematical_function_expressions::*,
+    scalar_logical_function_expressions::*, scalar_mathematical_function_expressions::*,
     scalar_parse_function_expressions::*, scalar_primitive_expressions::*,
     scalar_string_function_expressions::*, scalar_temporal_function_expressions::*,
 };

--- a/rust/experimental/query_engine/kql-parser/src/scalar_expression.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_expression.rs
@@ -10,7 +10,7 @@ use pest::{iterators::Pair, pratt_parser::*};
 use crate::{
     Rule, logical_expressions::to_logical_expression, scalar_array_function_expressions::*,
     scalar_conditional_function_expressions::*, scalar_conversion_function_expressions::*,
-    scalar_logical_function_expressions::*, scalar_mathematical_function_expressions::*,
+    scalar_logical_unary_expressions::*, scalar_mathematical_function_expressions::*,
     scalar_parse_function_expressions::*, scalar_primitive_expressions::*,
     scalar_string_function_expressions::*, scalar_temporal_function_expressions::*,
 };
@@ -285,15 +285,17 @@ pub(crate) fn parse_scalar_unary_expression(
     let rule = scalar_unary_expression_rule.into_inner().next().unwrap();
 
     Ok(match rule.as_rule() {
-        Rule::type_expressions => ScalarExpression::Static(parse_type_expressions(rule)?),
-        Rule::conditional_expressions => parse_conditional_expressions(rule, scope)?,
-        Rule::conversion_expressions => parse_conversion_expressions(rule, scope)?,
-        Rule::string_expressions => parse_string_expressions(rule, scope)?,
-        Rule::parse_expressions => parse_parse_expressions(rule, scope)?,
-        Rule::array_expressions => parse_array_expressions(rule, scope)?,
-        Rule::math_expressions => parse_math_expressions(rule, scope)?,
-        Rule::temporal_expressions => parse_temporal_expressions(rule, scope)?,
-        Rule::logical_function_expressions => parse_logical_function_expressions(rule, scope)?,
+        Rule::type_unary_expressions => {
+            ScalarExpression::Static(parse_type_unary_expressions(rule)?)
+        }
+        Rule::conditional_unary_expressions => parse_conditional_unary_expressions(rule, scope)?,
+        Rule::conversion_unary_expressions => parse_conversion_unary_expressions(rule, scope)?,
+        Rule::string_unary_expressions => parse_string_unary_expressions(rule, scope)?,
+        Rule::parse_unary_expressions => parse_parse_unary_expressions(rule, scope)?,
+        Rule::array_unary_expressions => parse_array_unary_expressions(rule, scope)?,
+        Rule::math_unary_expressions => parse_math_unary_expressions(rule, scope)?,
+        Rule::temporal_unary_expressions => parse_temporal_unary_expressions(rule, scope)?,
+        Rule::logical_unary_expressions => parse_logical_unary_expressions(rule, scope)?,
         Rule::accessor_expression => {
             // Note: When used as a scalar expression it is valid for an
             // accessor to fold into a static at the root so

--- a/rust/experimental/query_engine/kql-parser/src/scalar_logical_function_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_logical_function_expressions.rs
@@ -1,0 +1,115 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use data_engine_expressions::*;
+use data_engine_parser_abstractions::*;
+use pest::iterators::Pair;
+
+use crate::{Rule, logical_expressions::parse_logical_expression};
+
+pub(crate) fn parse_logical_function_expressions(
+    logical_function_expressions_rule: Pair<Rule>,
+    scope: &dyn ParserScope,
+) -> Result<ScalarExpression, ParserError> {
+    let rule = logical_function_expressions_rule
+        .into_inner()
+        .next()
+        .unwrap();
+
+    match rule.as_rule() {
+        Rule::not_expression => parse_not_expression(rule, scope),
+        _ => panic!("Unexpected rule in logical_function_expressions: {rule}"),
+    }
+}
+
+fn parse_not_expression(
+    not_expression_rule: Pair<Rule>,
+    scope: &dyn ParserScope,
+) -> Result<ScalarExpression, ParserError> {
+    let query_location = to_query_location(&not_expression_rule);
+
+    let mut not_rules = not_expression_rule.into_inner();
+    let logical_expr_rule = not_rules.next().unwrap();
+
+    let inner_logical = parse_logical_expression(logical_expr_rule, scope)?;
+
+    Ok(ScalarExpression::Logical(
+        LogicalExpression::Not(NotLogicalExpression::new(query_location, inner_logical)).into(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::KqlPestParser;
+    use pest::Parser;
+
+    #[test]
+    fn test_pest_parse_not_expression_rule() {
+        pest_test_helpers::test_pest_rule::<KqlPestParser, Rule>(
+            Rule::not_expression,
+            &[
+                "not(true)",
+                "not(false)",
+                "not(1 == 1)",
+                "not(field contains 'value')",
+                "not(x > 5 and y < 10)",
+            ],
+            &[
+                "not()",     // missing argument
+                "not(1, 2)", // too many arguments
+                "not true",  // missing parentheses
+            ],
+        );
+    }
+
+    #[test]
+    fn test_parse_not_expression() {
+        let run_test = |input: &str, expected: LogicalExpression| {
+            println!("Testing: {input}");
+
+            let state = ParserState::new_with_options(
+                input,
+                ParserOptions::new().with_attached_data_names(&["resource"]),
+            );
+
+            let mut result = KqlPestParser::parse(Rule::not_expression, input).unwrap();
+
+            let result = parse_not_expression(result.next().unwrap(), &state).unwrap();
+
+            let expected_scalar = ScalarExpression::Logical(expected.into());
+
+            assert_eq!(result, expected_scalar);
+        };
+
+        run_test(
+            "not(true)",
+            LogicalExpression::Not(NotLogicalExpression::new(
+                QueryLocation::new_fake(),
+                LogicalExpression::Scalar(ScalarExpression::Static(
+                    StaticScalarExpression::Boolean(BooleanScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        true,
+                    )),
+                )),
+            )),
+        );
+
+        run_test(
+            "not(1 == 2)",
+            LogicalExpression::Not(NotLogicalExpression::new(
+                QueryLocation::new_fake(),
+                LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                    QueryLocation::new_fake(),
+                    ScalarExpression::Static(StaticScalarExpression::Integer(
+                        IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+                    )),
+                    ScalarExpression::Static(StaticScalarExpression::Integer(
+                        IntegerScalarExpression::new(QueryLocation::new_fake(), 2),
+                    )),
+                    false,
+                )),
+            )),
+        );
+    }
+}

--- a/rust/experimental/query_engine/kql-parser/src/scalar_logical_function_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_logical_function_expressions.rs
@@ -7,18 +7,15 @@ use pest::iterators::Pair;
 
 use crate::{Rule, logical_expressions::parse_logical_expression};
 
-pub(crate) fn parse_logical_function_expressions(
-    logical_function_expressions_rule: Pair<Rule>,
+pub(crate) fn parse_logical_unary_expressions(
+    logical_unary_expressions_rule: Pair<Rule>,
     scope: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
-    let rule = logical_function_expressions_rule
-        .into_inner()
-        .next()
-        .unwrap();
+    let rule = logical_unary_expressions_rule.into_inner().next().unwrap();
 
     match rule.as_rule() {
         Rule::not_expression => parse_not_expression(rule, scope),
-        _ => panic!("Unexpected rule in logical_function_expressions: {rule}"),
+        _ => panic!("Unexpected rule in logical_unary_expressions: {rule}"),
     }
 }
 

--- a/rust/experimental/query_engine/kql-parser/src/scalar_mathematical_function_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_mathematical_function_expressions.rs
@@ -7,16 +7,16 @@ use pest::iterators::Pair;
 
 use crate::{Rule, scalar_expression::*};
 
-pub(crate) fn parse_math_expressions(
-    math_expressions_rule: Pair<Rule>,
+pub(crate) fn parse_math_unary_expressions(
+    math_unary_expressions_rule: Pair<Rule>,
     scope: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
-    let rule = math_expressions_rule.into_inner().next().unwrap();
+    let rule = math_unary_expressions_rule.into_inner().next().unwrap();
 
     match rule.as_rule() {
         Rule::negate_expression => parse_negate_expression(rule, scope),
         Rule::bin_expression => parse_bin_expression(rule, scope),
-        _ => panic!("Unexpected rule in math_expressions: {rule}"),
+        _ => panic!("Unexpected rule in math_unary_expressions: {rule}"),
     }
 }
 

--- a/rust/experimental/query_engine/kql-parser/src/scalar_parse_function_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_parse_function_expressions.rs
@@ -7,16 +7,16 @@ use pest::iterators::Pair;
 
 use crate::{Rule, scalar_expression::parse_scalar_expression};
 
-pub(crate) fn parse_parse_expressions(
-    parse_expressions_rule: Pair<Rule>,
+pub(crate) fn parse_parse_unary_expressions(
+    parse_unary_expressions_rule: Pair<Rule>,
     scope: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
-    let rule = parse_expressions_rule.into_inner().next().unwrap();
+    let rule = parse_unary_expressions_rule.into_inner().next().unwrap();
 
     match rule.as_rule() {
         Rule::parse_json_expression => parse_parse_json_expression(rule, scope),
         Rule::parse_regex_expression => parse_parse_regex_expression(rule, scope),
-        _ => panic!("Unexpected rule in parse_expressions: {rule}"),
+        _ => panic!("Unexpected rule in parse_unary_expressions: {rule}"),
     }
 }
 

--- a/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
@@ -10,10 +10,10 @@ use pest::iterators::Pair;
 
 use crate::{Rule, scalar_expression::parse_scalar_expression};
 
-pub(crate) fn parse_type_expressions(
-    type_expressions_rule: Pair<Rule>,
+pub(crate) fn parse_type_unary_expressions(
+    type_unary_expressions_rule: Pair<Rule>,
 ) -> Result<StaticScalarExpression, ParserError> {
-    let rule = type_expressions_rule.into_inner().next().unwrap();
+    let rule = type_unary_expressions_rule.into_inner().next().unwrap();
 
     Ok(match rule.as_rule() {
         Rule::null_literal => parse_standard_null_literal(rule),
@@ -26,7 +26,7 @@ pub(crate) fn parse_type_expressions(
         Rule::double_literal => parse_standard_double_literal(rule, None)?,
         Rule::integer_literal => parse_standard_integer_literal(rule)?,
         Rule::string_literal => parse_string_literal(rule),
-        _ => panic!("Unexpected rule in type_expressions: {rule}"),
+        _ => panic!("Unexpected rule in type_unary_expressions: {rule}"),
     })
 }
 
@@ -264,7 +264,9 @@ fn parse_dynamic_expression(
         let query_location = to_query_location(&dynamic_inner_expression_rule);
 
         match dynamic_inner_expression_rule.as_rule() {
-            Rule::type_expressions => Ok(parse_type_expressions(dynamic_inner_expression_rule)?),
+            Rule::type_unary_expressions => {
+                Ok(parse_type_unary_expressions(dynamic_inner_expression_rule)?)
+            }
             Rule::dynamic_array_expression => {
                 let mut values = Vec::new();
 
@@ -1429,7 +1431,7 @@ mod tests {
                 (Rule::minus_token, "-"),
                 (Rule::scalar_expression, "'name'"),
                 (Rule::scalar_unary_expression, "'name'"),
-                (Rule::type_expressions, "'name'"),
+                (Rule::type_unary_expressions, "'name'"),
                 (Rule::string_literal, "'name'"),
             ],
         );

--- a/rust/experimental/query_engine/kql-parser/src/scalar_string_function_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_string_function_expressions.rs
@@ -7,11 +7,11 @@ use pest::iterators::Pair;
 
 use crate::{Rule, scalar_expression::parse_scalar_expression};
 
-pub(crate) fn parse_string_expressions(
-    string_expressions_rule: Pair<Rule>,
+pub(crate) fn parse_string_unary_expressions(
+    string_unary_expressions_rule: Pair<Rule>,
     scope: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
-    let rule = string_expressions_rule.into_inner().next().unwrap();
+    let rule = string_unary_expressions_rule.into_inner().next().unwrap();
 
     match rule.as_rule() {
         Rule::strlen_expression => parse_strlen_expression(rule, scope),
@@ -20,7 +20,7 @@ pub(crate) fn parse_string_expressions(
         Rule::strcat_expression => parse_strcat_expression(rule, scope),
         Rule::strcat_delim_expression => parse_strcat_delim_expression(rule, scope),
         Rule::extract_expression => parse_extract_expression(rule, scope),
-        _ => panic!("Unexpected rule in string_expressions_rule: {rule}"),
+        _ => panic!("Unexpected rule in string_unary_expressions_rule: {rule}"),
     }
 }
 

--- a/rust/experimental/query_engine/kql-parser/src/scalar_temporal_function_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_temporal_function_expressions.rs
@@ -7,15 +7,15 @@ use pest::iterators::Pair;
 
 use crate::{Rule, scalar_expression::parse_scalar_expression};
 
-pub(crate) fn parse_temporal_expressions(
-    temporal_expressions_rule: Pair<Rule>,
+pub(crate) fn parse_temporal_unary_expressions(
+    temporal_unary_expressions_rule: Pair<Rule>,
     scope: &dyn ParserScope,
 ) -> Result<ScalarExpression, ParserError> {
-    let rule = temporal_expressions_rule.into_inner().next().unwrap();
+    let rule = temporal_unary_expressions_rule.into_inner().next().unwrap();
 
     match rule.as_rule() {
         Rule::now_expression => parse_now_expression(rule, scope),
-        _ => panic!("Unexpected rule in temporal_expressions: {rule}"),
+        _ => panic!("Unexpected rule in temporal_unary_expressions: {rule}"),
     }
 }
 


### PR DESCRIPTION
Noticed we have the `LogicalExpression` support for `not()` (used in conjunction with `where`) but never added this standalone in the KQL grammar