### PR TITLE
[otap-df-otap] Add support for escape characters in CEF parser

### DIFF
--- a/rust/otap-dataflow/crates/otap/src/syslog_cef_receiver/parser/cef.rs
+++ b/rust/otap-dataflow/crates/otap/src/syslog_cef_receiver/parser/cef.rs
@@ -17,9 +17,71 @@ pub struct CefMessage<'a> {
 
 impl CefMessage<'_> {
     /// Parse and iterate over the extensions as key-value pairs
-    pub(crate) fn parse_extensions(&self) -> CefExtensionsIter<'_> {
+    pub(super) fn parse_extensions(&self) -> CefExtensionsIter<'_> {
         CefExtensionsIter::new(self.extensions)
     }
+}
+
+/// Zero-allocation helper to check if a slice needs unescaping
+#[inline]
+fn needs_unescaping(data: &[u8]) -> bool {
+    let len = data.len();
+    if len < 2 { 
+        return false; 
+    }
+    
+    // Use unchecked indexing since we know i+1 is valid
+    for i in 0..len - 1 {
+        if data[i] == b'\\' {
+            match data[i + 1] {
+                b'\\' | b'=' | b'n' | b'r' => return true,
+                _ => {}
+            }
+        }
+    }
+    false
+}
+
+/// Zero-allocation in-place unescaping for CEF extension values
+/// Returns the new length after unescaping
+#[inline]
+const fn unescape_inplace(data: &mut [u8]) -> usize {
+    let mut write_pos = 0;
+    let mut read_pos = 0;
+    
+    while read_pos < data.len() {
+        if read_pos + 1 < data.len() && data[read_pos] == b'\\' {
+            match data[read_pos + 1] {
+                b'\\' => {
+                    data[write_pos] = b'\\';
+                    read_pos += 2;
+                }
+                b'=' => {
+                    data[write_pos] = b'=';
+                    read_pos += 2;
+                }
+                b'n' => {
+                    data[write_pos] = b'\n';
+                    read_pos += 2;
+                }
+                b'r' => {
+                    data[write_pos] = b'\r';
+                    read_pos += 2;
+                }
+                _ => {
+                    // Not a recognized escape sequence, keep both characters
+                    data[write_pos] = data[read_pos];
+                    read_pos += 1;
+                }
+            }
+        } else {
+            data[write_pos] = data[read_pos];
+            read_pos += 1;
+        }
+        write_pos += 1;
+    }
+    
+    write_pos
 }
 
 /// Parse a CEF message
@@ -31,26 +93,44 @@ pub fn parse_cef(input: &[u8]) -> Result<CefMessage<'_>, super::ParseError> {
     let content = &input[4..];
 
     // Find up to 8 pipe-separated parts (7 required + 1 optional extensions)
+    // Handle escaped pipes in header fields
     let mut parts: [Option<&[u8]>; 8] = [None; 8];
     let mut parts_count = 0;
     let mut start = 0;
     let mut pipe_count = 0;
+    let mut i = 0;
 
-    for (i, &byte) in content.iter().enumerate() {
-        if byte == b'|' {
-            parts[parts_count] = Some(&content[start..i]);
-            parts_count += 1;
-            start = i + 1;
-            pipe_count += 1;
-            if pipe_count == 7 {
-                // After 7 pipes, the rest is extensions
-                if start < content.len() {
-                    parts[parts_count] = Some(&content[start..]);
-                    parts_count += 1;
+    while i < content.len() {
+        if content[i] == b'|' {
+            // Check if this pipe is escaped (preceded by unescaped backslash)
+            let mut escaped = false;
+            if i > 0 {
+                let mut backslash_count = 0;
+                let mut j = i;
+                while j > 0 && content[j - 1] == b'\\' {
+                    backslash_count += 1;
+                    j -= 1;
                 }
-                break;
+                // If odd number of backslashes, the pipe is escaped
+                escaped = backslash_count % 2 == 1;
+            }
+            
+            if !escaped {
+                parts[parts_count] = Some(&content[start..i]);
+                parts_count += 1;
+                start = i + 1;
+                pipe_count += 1;
+                if pipe_count == 7 {
+                    // After 7 pipes, the rest is extensions
+                    if start < content.len() {
+                        parts[parts_count] = Some(&content[start..]);
+                        parts_count += 1;
+                    }
+                    break;
+                }
             }
         }
+        i += 1;
     }
 
     // Add the last part if we didn't reach 7 pipes
@@ -106,21 +186,23 @@ pub fn parse_cef(input: &[u8]) -> Result<CefMessage<'_>, super::ParseError> {
 }
 
 /// Iterator for CEF extensions that parses on-demand
-pub(crate) struct CefExtensionsIter<'a> {
+pub(super) struct CefExtensionsIter<'a> {
     data: &'a [u8],
     pos: usize,
+    // Scratch buffer for unescaping - reused across iterations
+    scratch_buffer: Vec<u8>,
 }
 
 impl<'a> CefExtensionsIter<'a> {
     fn new(data: &'a [u8]) -> Self {
-        Self { data, pos: 0 }
+        Self { 
+            data, 
+            pos: 0,
+            scratch_buffer: Vec::new(), // TODO: This would allocate if the extensions provided in the input have to be unescaped. Could we avoid this allocation?
+        }
     }
-}
 
-impl<'a> Iterator for CefExtensionsIter<'a> {
-    type Item = (&'a [u8], &'a [u8]);
-
-    fn next(&mut self) -> Option<Self::Item> {
+    pub(super) fn next_extension(&mut self) -> Option<(&[u8], &[u8])> {
         if self.pos >= self.data.len() {
             return None;
         }
@@ -212,14 +294,35 @@ impl<'a> Iterator for CefExtensionsIter<'a> {
         }
 
         let key = &self.data[key_start..key_end];
-        let value = &self.data[value_start..self.pos];
+        let raw_value = &self.data[value_start..self.pos];
 
         // Move position to start of next key
         while self.pos < self.data.len() && self.data[self.pos] == b' ' {
             self.pos += 1;
         }
 
+        // Handle unescaping efficiently
+        let value = if needs_unescaping(raw_value) {
+            // Reuse scratch buffer to avoid allocations
+            self.scratch_buffer.clear();
+            self.scratch_buffer.extend_from_slice(raw_value);
+            let new_len = unescape_inplace(&mut self.scratch_buffer);
+            self.scratch_buffer.truncate(new_len);
+            &self.scratch_buffer[..]
+        } else {
+            raw_value
+        };
+
         Some((key, value))
+    }
+
+    /// Collect all extensions into a Vec, allocating only when necessary
+    fn collect_all(mut self) -> Vec<(Vec<u8>, Vec<u8>)> {
+        let mut result = Vec::new();
+        while let Some((key, value)) = self.next_extension() {
+            result.push((key.to_vec(), value.to_vec()));
+        }
+        result
     }
 }
 
@@ -240,11 +343,11 @@ mod tests {
         assert_eq!(result.name, b"worm successfully stopped".as_slice());
         assert_eq!(result.severity, b"10".as_slice());
 
-        let extensions: Vec<_> = result.parse_extensions().collect();
+        let extensions = result.parse_extensions().collect_all();
         assert_eq!(extensions.len(), 3);
-        assert_eq!(extensions[0], (b"src".as_slice(), b"10.0.0.1".as_slice()));
-        assert_eq!(extensions[1], (b"dst".as_slice(), b"2.1.2.2".as_slice()));
-        assert_eq!(extensions[2], (b"spt".as_slice(), b"1232".as_slice()));
+        assert_eq!((extensions[0].0.as_slice(), extensions[0].1.as_slice()), (b"src".as_slice(), b"10.0.0.1".as_slice()));
+        assert_eq!((extensions[1].0.as_slice(), extensions[1].1.as_slice()), (b"dst".as_slice(), b"2.1.2.2".as_slice()));
+        assert_eq!((extensions[2].0.as_slice(), extensions[2].1.as_slice()), (b"spt".as_slice(), b"1232".as_slice()));
     }
 
     #[test]
@@ -260,7 +363,7 @@ mod tests {
         assert_eq!(result.name, b"worm successfully stopped".as_slice());
         assert_eq!(result.severity, b"10".as_slice());
 
-        let extensions: Vec<_> = result.parse_extensions().collect();
+        let extensions = result.parse_extensions().collect_all();
         assert_eq!(extensions.len(), 0);
     }
 
@@ -269,16 +372,16 @@ mod tests {
         let input = b"CEF:0|V|P|1.0|100|name|10|msg=This is a message with spaces src=10.0.0.1";
         let result = parse_cef(input).unwrap();
 
-        let extensions: Vec<_> = result.parse_extensions().collect();
+        let extensions = result.parse_extensions().collect_all();
         assert_eq!(extensions.len(), 2);
         assert_eq!(
-            extensions[0],
+            (extensions[0].0.as_slice(), extensions[0].1.as_slice()),
             (
                 b"msg".as_slice(),
                 b"This is a message with spaces".as_slice()
             )
         );
-        assert_eq!(extensions[1], (b"src".as_slice(), b"10.0.0.1".as_slice()));
+        assert_eq!((extensions[1].0.as_slice(), extensions[1].1.as_slice()), (b"src".as_slice(), b"10.0.0.1".as_slice()));
     }
 
     #[test]
@@ -286,10 +389,10 @@ mod tests {
         let input = b"CEF:0|V|P|1.0|100|name|10|equation=a=b+c src=10.0.0.1";
         let result = parse_cef(input).unwrap();
 
-        let extensions: Vec<_> = result.parse_extensions().collect();
+        let extensions = result.parse_extensions().collect_all();
         assert_eq!(extensions.len(), 2);
-        assert_eq!(extensions[0], (b"equation".as_slice(), b"a=b+c".as_slice()));
-        assert_eq!(extensions[1], (b"src".as_slice(), b"10.0.0.1".as_slice()));
+        assert_eq!((extensions[0].0.as_slice(), extensions[0].1.as_slice()), (b"equation".as_slice(), b"a=b+c".as_slice()));
+        assert_eq!((extensions[1].0.as_slice(), extensions[1].1.as_slice()), (b"src".as_slice(), b"10.0.0.1".as_slice()));
     }
 
     #[test]
@@ -297,10 +400,10 @@ mod tests {
         let input = b"CEF:0|V|P|1.0|100|name|10|empty= src=10.0.0.1";
         let result = parse_cef(input).unwrap();
 
-        let extensions: Vec<_> = result.parse_extensions().collect();
+        let extensions = result.parse_extensions().collect_all();
         assert_eq!(extensions.len(), 2);
-        assert_eq!(extensions[0], (b"empty".as_slice(), b"".as_slice()));
-        assert_eq!(extensions[1], (b"src".as_slice(), b"10.0.0.1".as_slice()));
+        assert_eq!((extensions[0].0.as_slice(), extensions[0].1.as_slice()), (b"empty".as_slice(), b"".as_slice()));
+        assert_eq!((extensions[1].0.as_slice(), extensions[1].1.as_slice()), (b"src".as_slice(), b"10.0.0.1".as_slice()));
     }
 
     #[test]
@@ -308,13 +411,10 @@ mod tests {
         let input = b"CEF:0|V|P|1.0|100|name|10|value=has trailing spaces   next=value";
         let result = parse_cef(input).unwrap();
 
-        let extensions: Vec<_> = result.parse_extensions().collect();
+        let extensions = result.parse_extensions().collect_all();
         assert_eq!(extensions.len(), 2);
-        assert_eq!(
-            extensions[0],
-            (b"value".as_slice(), b"has trailing spaces".as_slice())
-        );
-        assert_eq!(extensions[1], (b"next".as_slice(), b"value".as_slice()));
+        assert_eq!((extensions[0].0.as_slice(), extensions[0].1.as_slice()), (b"value".as_slice(), b"has trailing spaces".as_slice()));
+        assert_eq!((extensions[1].0.as_slice(), extensions[1].1.as_slice()), (b"next".as_slice(), b"value".as_slice()));
     }
 
     #[test]
@@ -322,13 +422,35 @@ mod tests {
         let input = b"CEF:0|V|P|1.0|100|name|10|msg=escaped\\=equals src=10.0.0.1";
         let result = parse_cef(input).unwrap();
 
-        let extensions: Vec<_> = result.parse_extensions().collect();
+        let extensions = result.parse_extensions().collect_all();
         assert_eq!(extensions.len(), 2);
-        // Note: The escaped sequence is preserved in the raw bytes
-        assert_eq!(
-            extensions[0],
-            (b"msg".as_slice(), b"escaped\\=equals".as_slice())
-        );
-        assert_eq!(extensions[1], (b"src".as_slice(), b"10.0.0.1".as_slice()));
+        // Now properly unescaped
+        assert_eq!((extensions[0].0.as_slice(), extensions[0].1.as_slice()), (b"msg".as_slice(), b"escaped=equals".as_slice()));
+        assert_eq!((extensions[1].0.as_slice(), extensions[1].1.as_slice()), (b"src".as_slice(), b"10.0.0.1".as_slice()));
+    }
+
+    #[test]
+    fn test_header_pipe_escaping() {
+        let input = b"CEF:0|Security|threatmanager|1.0|100|detected a \\| in message|10|src=10.0.0.1";
+        let result = parse_cef(input).unwrap();
+        
+        assert_eq!(result.version, 0);
+        assert_eq!(result.device_vendor, b"Security".as_slice());
+        assert_eq!(result.device_product, b"threatmanager".as_slice());
+        assert_eq!(result.name, b"detected a \\| in message".as_slice()); // Raw bytes preserved
+        assert_eq!(result.severity, b"10".as_slice());
+    }
+
+    #[test] 
+    fn test_extension_unescaping_comprehensive() {
+        let input = b"CEF:0|V|P|1.0|100|name|10|msg=Line1\\nLine2 path=C:\\\\temp equals=a\\=b";
+        let result = parse_cef(input).unwrap();
+
+        let extensions = result.parse_extensions().collect_all();
+        assert_eq!(extensions.len(), 3);
+        
+        assert_eq!((extensions[0].0.as_slice(), extensions[0].1.as_slice()), (b"msg".as_slice(), b"Line1\nLine2".as_slice()));
+        assert_eq!((extensions[1].0.as_slice(), extensions[1].1.as_slice()), (b"path".as_slice(), b"C:\\temp".as_slice()));
+        assert_eq!((extensions[2].0.as_slice(), extensions[2].1.as_slice()), (b"equals".as_slice(), b"a=b".as_slice()));
     }
 }

--- a/rust/otap-dataflow/crates/otap/src/syslog_cef_receiver/parser/parsed_message.rs
+++ b/rust/otap-dataflow/crates/otap/src/syslog_cef_receiver/parser/parsed_message.rs
@@ -253,7 +253,7 @@ impl ParsedSyslogMessage<'_> {
                 log_attributes_arrow_records
                     .append_str(std::str::from_utf8(msg.severity).unwrap_or_default());
 
-                for (key, value) in msg.parse_extensions() {
+                while let Some((key, value)) = msg.parse_extensions().next_extension() {
                     log_attributes_arrow_records
                         .append_key(std::str::from_utf8(key).unwrap_or_default());
                     log_attributes_arrow_records


### PR DESCRIPTION
## Changes
- Add support for escape characters in CEF parser to comply with the spec: https://www.microfocus.com/documentation/arcsight/arcsight-smartconnectors-8.3/cef-implementation-standard/Content/CEF/Chapter%201%20What%20is%20CEF.htm