### PR TITLE
[otap-df-otap] Fix CEF version parsing

### DIFF
--- a/rust/otap-dataflow/crates/otap/src/syslog_cef_receiver/parser/cef.rs
+++ b/rust/otap-dataflow/crates/otap/src/syslog_cef_receiver/parser/cef.rs
@@ -271,7 +271,7 @@ mod tests {
         let result = parse_cef(input);
         assert!(result.is_err());
     }
-    
+
     #[test]
     fn test_cef_without_extensions() {
         let input = b"CEF:0|Security|threatmanager|1.0|100|worm successfully stopped|10|";


### PR DESCRIPTION
## Changes
- Fix CEF version parsing to comply with the CEF [spec](https://www.microfocus.com/documentation/arcsight/arcsight-smartconnectors-8.3/cef-implementation-standard/Content/CEF/Chapter%201%20What%20is%20CEF.htm).