### PR TITLE
[otap-df-otap] Update Syslog parser for improved RFC 3164 compliance

### DIFF
--- a/rust/otap-dataflow/crates/otap/src/syslog_cef_receiver/parser/mod.rs
+++ b/rust/otap-dataflow/crates/otap/src/syslog_cef_receiver/parser/mod.rs
@@ -55,6 +55,7 @@ pub(super) fn parse(input: &[u8]) -> Result<ParsedSyslogMessage<'_>, ParseError>
 }
 
 /// Parse priority from the beginning of a syslog message
+#[allow(clippy::manual_range_contains)]
 pub(super) fn parse_priority(input: &[u8]) -> Result<(Priority, &[u8]), ParseError> {
     if input.is_empty() || input[0] != b'<' {
         return Err(ParseError::InvalidPriority);
@@ -68,7 +69,7 @@ pub(super) fn parse_priority(input: &[u8]) -> Result<(Priority, &[u8]), ParseErr
     if end < 2 || end > 4 {
         return Err(ParseError::InvalidPriority);
     }
-    
+
     let priority_bytes = &input[1..end];
 
     // RFC 3164 Section 4.3.3: Check for leading zeros which make PRI "unidentifiable"

--- a/rust/otap-dataflow/crates/otap/src/syslog_cef_receiver/parser/mod.rs
+++ b/rust/otap-dataflow/crates/otap/src/syslog_cef_receiver/parser/mod.rs
@@ -64,14 +64,31 @@ pub(super) fn parse_priority(input: &[u8]) -> Result<(Priority, &[u8]), ParseErr
         .iter()
         .position(|&b| b == b'>')
         .ok_or(ParseError::InvalidPriority)?;
+
+    if end < 2 || end > 4 {
+        return Err(ParseError::InvalidPriority);
+    }
+    
     let priority_bytes = &input[1..end];
+
+    // RFC 3164 Section 4.3.3: Check for leading zeros which make PRI "unidentifiable"
+    // Example: <00> is invalid, <0> is valid
+    if priority_bytes.len() > 1 && priority_bytes[0] == b'0' {
+        return Err(ParseError::InvalidPriority);
+    }
+
     let priority_str = str::from_utf8(priority_bytes).map_err(|_| ParseError::InvalidUtf8)?;
     let priority_num: u8 = priority_str
         .parse()
         .map_err(|_| ParseError::InvalidPriority)?;
 
-    let facility = priority_num >> 3;
-    let severity = priority_num & 0x07;
+    // RFC 3164: Maximum valid priority is 191 (facility 23, severity 7)
+    if priority_num > 191 {
+        return Err(ParseError::InvalidPriority);
+    }
+
+    let facility = priority_num >> 3; // Upper 5 bits are facility. This is equivalent to priority_num / 8
+    let severity = priority_num & 0x07; // Lower 3 bits are severity. This is equivalent to priority_num % 8
 
     Ok((Priority { facility, severity }, &input[end + 1..]))
 }

--- a/rust/otap-dataflow/crates/otap/src/syslog_cef_receiver/parser/parsed_message.rs
+++ b/rust/otap-dataflow/crates/otap/src/syslog_cef_receiver/parser/parsed_message.rs
@@ -107,7 +107,8 @@ impl ParsedSyslogMessage<'_> {
             }
             ParsedSyslogMessage::Rfc3164(msg) => {
                 // Only return severity if it was actually present in the message
-                msg.priority.as_ref()
+                msg.priority
+                    .as_ref()
                     .map(|p| Self::to_otel_severity(p.severity))
             }
             ParsedSyslogMessage::Cef(_) => {

--- a/rust/otap-dataflow/crates/otap/src/syslog_cef_receiver/parser/rfc3164.rs
+++ b/rust/otap-dataflow/crates/otap/src/syslog_cef_receiver/parser/rfc3164.rs
@@ -154,6 +154,26 @@ mod tests {
     }
 
     #[test]
+    fn test_rfc3164_valid_priority_zero() {
+        // <0> is a valid priority (facility=0, severity=0)
+        let input = b"<0>Test message with priority zero";
+        let result = parse_rfc3164(input).unwrap();
+
+        // Priority should be parsed successfully
+        assert!(result.priority.is_some());
+        let priority = result.priority.unwrap();
+        assert_eq!(priority.facility, 0);
+        assert_eq!(priority.severity, 0);
+        assert_eq!(result.timestamp, None);
+        assert_eq!(result.hostname, None);
+        assert_eq!(result.tag, None);
+        assert_eq!(
+            result.content,
+            Some(b"Test message with priority zero".as_slice())
+        );
+    }
+
+    #[test]
     fn test_rfc3164_no_pri() {
         // RFC 3164 Section 4.3.3: Example 2 "Use the BFG!"
         let input = b"Use the BFG!";

--- a/rust/otap-dataflow/crates/otap/src/syslog_cef_receiver/parser/rfc3164.rs
+++ b/rust/otap-dataflow/crates/otap/src/syslog_cef_receiver/parser/rfc3164.rs
@@ -1,23 +1,47 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::syslog_cef_receiver::parser;
+
 /// RFC 3164 message structure
 #[derive(Debug, Clone, PartialEq)]
 pub struct Rfc3164Message<'a> {
-    pub(super) priority: crate::syslog_cef_receiver::parser::Priority,
+    pub(super) priority: Option<parser::Priority>,
     pub(super) timestamp: Option<&'a [u8]>,
     pub(super) hostname: Option<&'a [u8]>,
     pub(super) tag: Option<&'a [u8]>,
     pub(super) content: Option<&'a [u8]>,
-    pub(super) message: Option<&'a [u8]>,
     pub(super) input: &'a [u8],
 }
 
-/// Parse an RFC 3164 syslog message
+/// Parse an RFC 3164 syslog message from bytes, automatically detecting the format
+/// 
+/// This parser identifies and extracts fields from syslog messages but does not
+/// act as a relay. Messages without valid PRI headers are accepted and parsed
+/// for their content, but no default values are assigned. The calling code must
+/// decide how to handle missing fields.
+/// 
+/// # Behavior for RFC 3164 messages without PRI:
+/// - The message is parsed for any identifiable fields (timestamp, hostname, etc.)
+/// - No default priority is assigned
+/// - The entire message may be treated as content if no structure is found
 pub fn parse_rfc3164(
     input: &[u8],
-) -> Result<Rfc3164Message<'_>, crate::syslog_cef_receiver::parser::ParseError> {
-    let (priority, mut remaining) = crate::syslog_cef_receiver::parser::parse_priority(input)?;
+) -> Result<Rfc3164Message<'_>, parser::ParseError> {
+    // RFC 3164 Section 4.3: Check if we have a valid PRI
+    let (priority, mut remaining) = if input.starts_with(b"<") {
+        // Try to parse the PRI
+        match parser::parse_priority(input) {
+            Ok((pri, rest)) => (Some(pri), rest),
+            Err(_) => {
+                // Invalid PRI format, treat entire input as content
+                (None, input)
+            }
+        }
+    } else {
+        // No PRI at all (doesn't start with '<')
+        (None, input)
+    };
 
     // Parse timestamp (optional)
     let (timestamp, rest) = if remaining.len() >= 15 {
@@ -38,35 +62,35 @@ pub fn parse_rfc3164(
 
     remaining = rest;
 
-    // Parse hostname and tag
-    let (hostname, tag, content, message) =
+    // Parse hostname, tag, and content according to RFC 3164
+    let (hostname, tag, content) =
         if let Some(colon_pos) = remaining.iter().position(|&b| b == b':') {
             let before_colon = &remaining[..colon_pos];
             let after_colon = &remaining[colon_pos + 1..];
 
-            if let Some(space_pos) = before_colon.iter().rposition(|&b| b == b' ') {
-                // hostname tag: message
-                let hostname = Some(&before_colon[..space_pos]);
-                let tag = Some(&before_colon[space_pos + 1..]);
-                let message = if !after_colon.is_empty() && after_colon[0] == b' ' {
-                    Some(&after_colon[1..])
-                } else {
-                    Some(after_colon)
-                };
-                (hostname, tag, None, message)
+            // RFC 3164: Content is everything after "TAG: " (note the space)
+            // When there's a TAG, the text after tag: is the CONTENT
+            // When there's no TAG, the entire MSG part is the CONTENT
+            let content = if !after_colon.is_empty() && after_colon[0] == b' ' {
+                Some(&after_colon[1..])
             } else {
-                // tag: message (no hostname)
-                let tag = Some(before_colon);
-                let message = if !after_colon.is_empty() && after_colon[0] == b' ' {
-                    Some(&after_colon[1..])
-                } else {
-                    Some(after_colon)
-                };
-                (None, tag, None, message)
+                Some(after_colon)
+            };
+
+            if let Some(space_pos) = before_colon.iter().rposition(|&b| b == b' ') {
+                // Format: hostname TAG: CONTENT
+                (
+                    Some(&before_colon[..space_pos]),
+                    Some(&before_colon[space_pos + 1..]),
+                    content,
+                )
+            } else {
+                // Format: TAG: CONTENT (no hostname)
+                (None, Some(before_colon), content)
             }
         } else {
-            // No colon, treat as content
-            (None, None, Some(remaining), None)
+            // No colon found - entire remaining text is CONTENT (no TAG)
+            (None, None, Some(remaining))
         };
 
     Ok(Rfc3164Message {
@@ -75,7 +99,6 @@ pub fn parse_rfc3164(
         hostname,
         tag,
         content,
-        message,
         input,
     })
 }
@@ -89,14 +112,14 @@ mod tests {
         let input = b"<34>Oct 11 22:14:15 mymachine su: 'su root' failed for lonvick on /dev/pts/8";
         let result = parse_rfc3164(input).unwrap();
 
-        assert_eq!(result.priority.facility, 4);
-        assert_eq!(result.priority.severity, 2);
+        let priority = result.priority.unwrap();
+        assert_eq!(priority.facility, 4);
+        assert_eq!(priority.severity, 2);
         assert_eq!(result.timestamp, Some(b"Oct 11 22:14:15".as_slice()));
         assert_eq!(result.hostname, Some(b"mymachine".as_slice()));
         assert_eq!(result.tag, Some(b"su".as_slice()));
-        assert_eq!(result.content, None);
         assert_eq!(
-            result.message,
+            result.content,
             Some(b"'su root' failed for lonvick on /dev/pts/8".as_slice())
         );
     }
@@ -106,13 +129,13 @@ mod tests {
         let input = b"<34>hostname tag: message content";
         let result = parse_rfc3164(input).unwrap();
 
-        assert_eq!(result.priority.facility, 4);
-        assert_eq!(result.priority.severity, 2);
+        let priority = result.priority.unwrap();
+        assert_eq!(priority.facility, 4);
+        assert_eq!(priority.severity, 2);
         assert_eq!(result.timestamp, None);
         assert_eq!(result.hostname, Some(b"hostname".as_slice()));
         assert_eq!(result.tag, Some(b"tag".as_slice()));
-        assert_eq!(result.content, None);
-        assert_eq!(result.message, Some(b"message content".as_slice()));
+        assert_eq!(result.content, Some(b"message content".as_slice()));
     }
 
     #[test]
@@ -120,8 +143,9 @@ mod tests {
         let input = b"<34>This is just content without colon";
         let result = parse_rfc3164(input).unwrap();
 
-        assert_eq!(result.priority.facility, 4);
-        assert_eq!(result.priority.severity, 2);
+        let priority = result.priority.unwrap();
+        assert_eq!(priority.facility, 4);
+        assert_eq!(priority.severity, 2);
         assert_eq!(result.timestamp, None);
         assert_eq!(result.hostname, None);
         assert_eq!(result.tag, None);
@@ -129,6 +153,77 @@ mod tests {
             result.content,
             Some(b"This is just content without colon".as_slice())
         );
-        assert_eq!(result.message, None);
+    }
+
+    #[test]
+    fn test_rfc3164_no_pri() {
+        // RFC 3164 Section 4.3.3: Example 2 "Use the BFG!"
+        let input = b"Use the BFG!";
+        let result = parse_rfc3164(input).unwrap();
+
+        assert!(result.priority.is_none());
+        assert_eq!(result.timestamp, None);
+        assert_eq!(result.hostname, None);
+        assert_eq!(result.tag, None);
+        assert_eq!(result.content, Some(b"Use the BFG!".as_slice()));
+    }
+
+    #[test]
+    fn test_rfc3164_invalid_pri() {
+        // RFC 3164 Section 4.3.3: Unidentifiable PRI like "<00>"
+        let input = b"<00>Test message";
+        let result = parse_rfc3164(input).unwrap();
+
+        // Priority should be None and entire input treated as content
+        assert!(result.priority.is_none());
+        assert_eq!(result.timestamp, None);
+        assert_eq!(result.hostname, None);
+        assert_eq!(result.tag, None);
+        assert_eq!(result.content, Some(b"<00>Test message".as_slice()));
+
+        let input = b"<999Test message";
+        let result = parse_rfc3164(input).unwrap();
+
+        // Priority should be None and entire input treated as content
+        assert!(result.priority.is_none());
+        assert_eq!(result.timestamp, None);
+        assert_eq!(result.hostname, None);
+        assert_eq!(result.tag, None);
+        assert_eq!(result.content, Some(b"<999Test message".as_slice()));
+
+        let input = b"<abc> Test message";
+        let result = parse_rfc3164(input).unwrap();
+
+        // Priority should be None and entire input treated as content
+        assert!(result.priority.is_none());
+        assert_eq!(result.timestamp, None);
+        assert_eq!(result.hostname, None);
+        assert_eq!(result.tag, None);
+        assert_eq!(result.content, Some(b"<abc> Test message".as_slice()));
+
+        let input = b"<> Test message";
+        let result = parse_rfc3164(input).unwrap();
+
+        // Priority should be None and entire input treated as content
+        assert!(result.priority.is_none());
+        assert_eq!(result.timestamp, None);
+        assert_eq!(result.hostname, None);
+        assert_eq!(result.tag, None);
+        assert_eq!(result.content, Some(b"<> Test message".as_slice()));
+    }
+
+    #[test]
+    fn test_rfc3164_no_pri_with_timestamp_like_content() {
+        // Message that looks like it might have a timestamp but no PRI
+        let input = b"Oct 11 22:14:15 mymachine su: test message";
+        let result = parse_rfc3164(input).unwrap();
+
+        // Priority should be None
+        assert!(result.priority.is_none());
+        // The timestamp-looking part should be parsed as timestamp
+        assert_eq!(result.timestamp, Some(b"Oct 11 22:14:15".as_slice()));
+        assert_eq!(result.hostname, Some(b"mymachine".as_slice()));
+        assert_eq!(result.tag, Some(b"su".as_slice()));
+        assert_eq!(result.content, Some(b"test message".as_slice()));
     }
 }

--- a/rust/otap-dataflow/crates/otap/src/syslog_cef_receiver/parser/rfc3164.rs
+++ b/rust/otap-dataflow/crates/otap/src/syslog_cef_receiver/parser/rfc3164.rs
@@ -15,19 +15,17 @@ pub struct Rfc3164Message<'a> {
 }
 
 /// Parse an RFC 3164 syslog message from bytes, automatically detecting the format
-/// 
+///
 /// This parser identifies and extracts fields from syslog messages but does not
 /// act as a relay. Messages without valid PRI headers are accepted and parsed
 /// for their content, but no default values are assigned. The calling code must
 /// decide how to handle missing fields.
-/// 
+///
 /// # Behavior for RFC 3164 messages without PRI:
 /// - The message is parsed for any identifiable fields (timestamp, hostname, etc.)
 /// - No default priority is assigned
 /// - The entire message may be treated as content if no structure is found
-pub fn parse_rfc3164(
-    input: &[u8],
-) -> Result<Rfc3164Message<'_>, parser::ParseError> {
+pub fn parse_rfc3164(input: &[u8]) -> Result<Rfc3164Message<'_>, parser::ParseError> {
     // RFC 3164 Section 4.3: Check if we have a valid PRI
     let (priority, mut remaining) = if input.starts_with(b"<") {
         // Try to parse the PRI


### PR DESCRIPTION
## Changes
- Make priority optional for RFC 3164 messages to allow the parser to handle messages without PRI header correctly
- Removed the redundant field `message`