### PR TITLE
[PerfTest] temporarily remove arrow payload compression in benchmark suites

### DIFF
--- a/tools/pipeline_perf_test/test_suites/integration/templates/configs/engine/otap-attr-otap.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/templates/configs/engine/otap-attr-otap.yaml
@@ -38,3 +38,5 @@ nodes:
     config:
       grpc_endpoint: "http://{{backend_hostname}}:1235"
       compression_method: zstd
+      arrow:
+        payload_compression: none

--- a/tools/pipeline_perf_test/test_suites/integration/templates/configs/engine/otlp-attr-otap.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/templates/configs/engine/otlp-attr-otap.yaml
@@ -37,3 +37,5 @@ nodes:
     config:
       grpc_endpoint: "http://{{backend_hostname}}:1235"
       compression_method: zstd
+      arrow:
+        payload_compression: none

--- a/tools/pipeline_perf_test/test_suites/integration/templates/configs/engine/syslog-attr-otap.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/templates/configs/engine/syslog-attr-otap.yaml
@@ -35,3 +35,5 @@ nodes:
     config:
       grpc_endpoint: "http://{{backend_hostname}}:1235"
       compression_method: zstd
+      arrow:
+        payload_compression: none

--- a/tools/pipeline_perf_test/test_suites/integration/templates/configs/loadgen/config.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/integration/templates/configs/loadgen/config.yaml.j2
@@ -44,3 +44,7 @@ nodes:
       {% else %}
       error: "Unknown loadgen_exporter_type: {{ exporter_type }}"
       {% endif %}
+      {% if loadgen_exporter_type == "otap" %}
+      arrow:
+        payload_compression: none
+      {% endif %}


### PR DESCRIPTION
Until the Arrow-rs patch mentioned in https://github.com/open-telemetry/otel-arrow/issues/1129 is merged and in-use here, we need to disable the payload compression in the perf test benchmarks.