### PR TITLE
[query-engine] Improve validation in KQL accessor expressions when source is referenced directly

### DIFF
--- a/rust/experimental/query_engine/kql-parser/src/tabular_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/tabular_expressions.rs
@@ -1778,7 +1778,7 @@ mod tests {
 
         run_test_failure(
             "project source[0]",
-            "The 'source[0]' accessor expression should refer to a map key on the source when used in a project expression",
+            "Cannot index into a map using a 'Integer' value",
         );
 
         run_test_failure(
@@ -2127,7 +2127,7 @@ mod tests {
 
         run_test_failure(
             "project-keep source[0]",
-            "The 'source[0]' accessor expression should refer to a map key on the source when used in a project-keep expression",
+            "Cannot index into a map using a 'Integer' value",
         );
 
         run_test_failure(
@@ -2534,7 +2534,7 @@ mod tests {
 
         run_test_failure(
             "project-away source[0]",
-            "The 'source[0]' accessor expression should refer to a map key on the source when used in a project-away expression",
+            "Cannot index into a map using a 'Integer' value",
         );
 
         run_test_failure(


### PR DESCRIPTION
## Changes

* Improve the schema validation in KQL accessor expressions when `source` is referenced directly

## Details

We have schema validation in the KQL parser. When schema is defined we'll use it to resolve types and detect invalid usage when possible.

Currently we only do schema validation when `source` is referenced implicitly. For example `extend c = SomeField`. What this PR does is extend that validation to also run when `source` is referenced explicitly for example `extend c = source.SomeField`.