### PR TITLE
[otap-df-otap] Fix signal type input in OTAP Exporter

### DIFF
--- a/rust/otap-dataflow/crates/otap/src/otap_exporter.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_exporter.rs
@@ -350,7 +350,7 @@ async fn stream_arrow_batches<T: StreamingArrowService>(
                         shutdown = handle_res_stream(
                             res.into_inner(),
                             pdata_metrics_tx.clone(),
-                            SignalType::Logs,
+                            signal_type,
                             shutdown_rx.clone()
                         ).await;
                     }


### PR DESCRIPTION
## Changes
- Use the argument `signal_type` instead of hardcoded `SignalType::Logs`