### PR TITLE
fix otlp exporter test flake

### DIFF
--- a/rust/otap-dataflow/crates/otap/src/otlp_exporter.rs
+++ b/rust/otap-dataflow/crates/otap/src/otlp_exporter.rs
@@ -466,6 +466,16 @@ mod tests {
         // doesn't exit early if it can't make the initial connection, and also that the grpc
         // client will reconnect in the event of a server shutdown
 
+        for i in 0..10 {
+            println!("ATTEMPT {i}");
+            do_flakey_test_internal();
+            println!("ATTEMPT {i} finished");
+        }
+        // fail the job so we can rerun it.
+        assert_eq!(1, 2);
+    }
+
+    fn do_flakey_test_internal() {
         let grpc_addr = "127.0.0.1";
         let grpc_port = portpicker::pick_unused_port().expect("No free ports");
         let grpc_endpoint = format!("http://{grpc_addr}:{grpc_port}");
@@ -693,8 +703,5 @@ mod tests {
         tokio_rt
             .block_on(server_handle)
             .expect("server shutdown success");
-
-        // fail the job so we can rerun it.
-        assert_eq!(1, 2);
     }
 }

--- a/rust/otap-dataflow/crates/otap/src/otlp_exporter.rs
+++ b/rust/otap-dataflow/crates/otap/src/otlp_exporter.rs
@@ -510,6 +510,8 @@ mod tests {
             tokio::sync::mpsc::channel(1);
         let (req_sender, req_receiver) = tokio::sync::mpsc::channel(32);
 
+        println!("here we go");
+
         async fn start_exporter(
             exporter: ExporterWrapper<OtapPdata>,
             pipeline_ctrl_msg_tx: PipelineCtrlMsgSender<OtapPdata>,
@@ -551,6 +553,7 @@ mod tests {
                 .await
                 .unwrap();
             let metrics = metrics_rx.recv_async().await.unwrap();
+            println!("got metrics");
             let logs_failed_count = metrics.get_metrics()[5]; // logs failed
             assert_eq!(logs_failed_count, 1);
 
@@ -690,5 +693,8 @@ mod tests {
         tokio_rt
             .block_on(server_handle)
             .expect("server shutdown success");
+
+        // fail the job so we can rerun it.
+        assert_eq!(1, 2);
     }
 }

--- a/rust/otap-dataflow/crates/otap/src/otlp_exporter.rs
+++ b/rust/otap-dataflow/crates/otap/src/otlp_exporter.rs
@@ -461,16 +461,6 @@ mod tests {
 
     #[test]
     fn test_receiver_not_ready_on_start_and_reconnect() {
-                for i in 0..50 {
-            println!("ATTEMPT {i}");
-            do_flakey_test_internal();
-            println!("ATTEMPT {i} finished");
-        }
-        // fail the job so we can rerun it.
-        assert_eq!(1, 2);
-    }
-
-    fn do_flakey_test_internal() {
         // the purpose of this test is to that the exporter behaves as expected in the face of
         // server that may start and stop asynchronously of the exporter. it ensures the exporter
         // doesn't exit early if it can't make the initial connection, and also that the grpc
@@ -689,6 +679,8 @@ mod tests {
                 )
             )
         });
+
+        // assert no error
         exporter_result.unwrap();
         test_drive_result.unwrap();
 

--- a/rust/otap-dataflow/crates/otap/src/otlp_exporter.rs
+++ b/rust/otap-dataflow/crates/otap/src/otlp_exporter.rs
@@ -667,8 +667,9 @@ mod tests {
             .await;
         });
 
-        let (exporter_result, test_drive_result) = tokio_rt.block_on(async move {
+        let (r1, r2) = tokio_rt.block_on(async move {
             tokio::join!(
+            // tokio::try_join!(
                 start_exporter(exporter, pipeline_ctrl_msg_tx),
                 drive_test(
                     server_startup_sender,
@@ -682,10 +683,9 @@ mod tests {
                 )
             )
         });
-
-        // assert no error
-        exporter_result.unwrap();
-        test_drive_result.unwrap();
+        //.unwrap();
+        r1.unwrap();
+        r2.unwrap();
 
         tokio_rt
             .block_on(server_handle)


### PR DESCRIPTION
Closes: https://github.com/open-telemetry/otel-arrow/issues/1231

Try to fix test failure observed here: 
https://github.com/open-telemetry/otel-arrow/actions/runs/18234929441/job/51926734884

The issue here was that, when we were asserting that the "logs_failed" metric was incremented after we send a request which could not be serviced, we'd send the pdata, then send the `CollectTelemetry` pdata message, then wait to receive telemetry on the metrics reporter channel. The problem with this is that the channel that gets fed into the exporter biases control messages, so in some cases the exporter would see the `CollectTelemetry` message first. When this happens, there could be no telemetry to report, which means nothing would be sent on the pdata reporter channel and the test would deadlock.

Because the test driver can't reliably control the order in which the exporter sees these messages two messages in the failure case, we change the test to just check at the of the pdata sequence and ensure we saw the correct number of exported & failed messages. This is reliable because before checking this, we send a pdata message that should succeed and we can wait on the `req_receiver` ensure the client saw and send this message before we send the `CollectTelemetry` message.

I ran the test in a loop 50x on this commit https://github.com/open-telemetry/otel-arrow/pull/1230/commits/72e30d114daaa71e4918e53a486448cf3e1e426a to ensure it passes reliably.