### PR TITLE
Update repo codecov to allow for fluctuation

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -3,7 +3,7 @@ coverage:
     project: # Overall repo coverage
       default:
         target: auto # Increase
-        threshold: 0.5% # Allow small fluctuation
+        threshold: 0.1% # Allow small fluctuation
 
 comment:
   layout: "header, diff, flags, components"


### PR DESCRIPTION
Currently the codecov status check tends to transiently mark builds red due to very small fluctuation in coverage percentages.

The best examples of this are in non-code PRs like updating github workflow hash versions or release version updates:

- https://app.codecov.io/gh/open-telemetry/otel-arrow/pull/1131/indirect-changes
- https://app.codecov.io/gh/open-telemetry/otel-arrow/pull/1202/indirect-changes
- https://app.codecov.io/gh/open-telemetry/otel-arrow/pull/1192/indirect-changes

It seems there may be some flakiness based on fake data generation - it is shown under 'indirect changes' for these PRs:

<img width="3218" height="569" alt="image" src="https://github.com/user-attachments/assets/8e25ba75-df2c-4387-9b89-de3f5aa9258c" />

This change:

- allows `0.1%` fluctuation in overall repo coverage to avoid the small +- percentage. 
- fixes a small misconfiguration in the `component_management` section (`ignore` isn't a valid key there for path scoping)