### PR TITLE
Promote Albert Lockett to maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,13 +242,13 @@ you're more than welcome to participate!
 - [Drew Relmas](https://github.com/drewrelmas), Microsoft
 - [Joshua MacDonald](https://github.com/jmacd), Microsoft
 - [Laurent Qu&#xE9;rel](https://github.com/lquerel), F5
+- [Albert Lockett](https://github.com/albertlockett), F5
 
 For more information about the maintainer role, see the [community
 repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#maintainer).
 
 ### Approvers
 
-- [Albert Lockett](https://github.com/albertlockett), F5
 - [Lei Huang](https://github.com/v0y4g3r), Greptime
 
 For more information about the approver role, see the [community


### PR DESCRIPTION
Fixes #1284.
The Github team invite to arrow-maintainers has been processed.