### PR TITLE
[PerfTest] update continuous benchmark index page

### DIFF
--- a/docs/benchmarks/continuous/index.html
+++ b/docs/benchmarks/continuous/index.html
@@ -1,281 +1,464 @@
+
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes" />
-    <style>
-      html {
-        font-family: BlinkMacSystemFont,-apple-system,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Fira Sans","Droid Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
-        -webkit-font-smoothing: antialiased;
-        background-color: #fff;
-        font-size: 16px;
-      }
-      body {
-        color: #4a4a4a;
-        margin: 8px;
-        font-size: 1em;
-        font-weight: 400;
-      }
-      header {
-        margin-bottom: 8px;
-        display: flex;
-        flex-direction: column;
-      }
-      main {
-        width: 100%;
-        display: flex;
-        flex-direction: column;
-      }
-      a {
-        color: #3273dc;
-        cursor: pointer;
-        text-decoration: none;
-      }
-      a:hover {
-        color: #000;
-      }
-      button {
-        color: #fff;
-        background-color: #3298dc;
-        border-color: transparent;
-        cursor: pointer;
-        text-align: center;
-      }
-      button:hover {
-        background-color: #2793da;
-        flex: none;
-      }
-      .spacer {
-        flex: auto;
-      }
-      .small {
-        font-size: 0.75rem;
-      }
-      footer {
-        margin-top: 16px;
-        display: flex;
-        align-items: center;
-      }
-      .header-label {
-        margin-right: 4px;
-      }
-      .benchmark-set {
-        margin: 8px 0;
-        width: 100%;
-        display: flex;
-        flex-direction: column;
-      }
-      .benchmark-title {
-        font-size: 3rem;
-        font-weight: 600;
-        word-break: break-word;
-        text-align: center;
-      }
-      .benchmark-graphs {
-        display: flex;
-        flex-direction: row;
-        justify-content: space-around;
-        align-items: center;
-        flex-wrap: wrap;
-        width: 100%;
-      }
-      .benchmark-chart {
-        max-width: 1000px;
-      }
-    </style>
-    <title>Benchmarks</title>
-  </head>
 
-  <body>
-    <header id="header">
-      <div class="header-item">
-        <strong class="header-label">Last Update:</strong>
-        <span id="last-update"></span>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes" />
+  <style>
+    html {
+      font-family: BlinkMacSystemFont, -apple-system, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+      -webkit-font-smoothing: antialiased;
+      background-color: #fff;
+      font-size: 16px;
+    }
+
+    body {
+      margin: 0;
+      color: #4a4a4a;
+      font-size: 1em;
+      font-weight: 400;
+    }
+
+    header {
+      width: 100%;
+      display: flex;
+      flex-direction: row;
+      background-color: rgb(79, 98, 173);
+    }
+
+    main {
+      margin: 8px;
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+    }
+
+    a {
+      color: #3273dc;
+      cursor: pointer;
+      text-decoration: none;
+    }
+
+    a:hover {
+      color: #000;
+    }
+
+    button {
+      color: #fff;
+      background-color: #3298dc;
+      border-color: transparent;
+      cursor: pointer;
+      text-align: center;
+    }
+
+    button:hover {
+      background-color: #2793da;
+      flex: none;
+    }
+
+    .spacer {
+      flex: auto;
+    }
+
+    .small {
+      font-size: 0.75rem;
+    }
+
+    footer {
+      margin-top: 16px;
+      display: flex;
+      align-items: center;
+    }
+
+    .header-label {
+      margin-right: 4px;
+    }
+
+    .benchmark-set {
+      margin: 8px 0;
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .benchmark-title {
+      font-size: 3rem;
+      font-weight: 600;
+      word-break: break-word;
+      text-align: center;
+    }
+
+    .benchmark-graphs {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-around;
+      align-items: center;
+      flex-wrap: wrap;
+      width: 100%;
+    }
+
+    .benchmark-chart {
+      max-width: 1000px;
+    }
+
+    header nav {
+      width: 100%;
+      max-width: 1140px;
+      margin-left: auto;
+      margin-right: auto;
+      line-height: 24px;
+      min-height: 64px;
+      display: flex;
+      flex: 2;
+      align-items: center;
+    }
+
+    .logo svg {
+      height: 48px;
+      margin-left: 30px;
+    }
+
+    .header-item {
+      flex: 1;
+    }
+
+    div.container {
+      max-width: 1012px;
+      margin-right: auto;
+      margin-left: auto;
+    }
+
+
+    details summary {
+      font-size: 1.5em;
+      font-weight: bold;
+      cursor: pointer;
+      padding: 8px;
+      background-color: #f4f4f4;
+      border: 1px solid #ccc;
+      margin-top: 16px;
+    }
+
+    #toc ul {
+      padding-left: 20px;
+    }
+
+    #toc li {
+      margin-bottom: 4px;
+    }
+  </style>
+  <title>Dataflow Engine Benchmarks</title>
+</head>
+
+<body>
+  <header id="header">
+    <nav>
+      <div class="header-item logo">
+        <a href="https://opentelemetry.io">
+
+        </a>
       </div>
-      <div class="header-item">
-        <strong class="header-label">Repository:</strong>
-        <a id="repository-link" rel="noopener"></a>
-      </div>
-    </header>
+      <div class="header-item"><!-- links --></div>
+    </nav>
+  </header>
+
+
+  <div class="container">
+    <h2>Dataflow Engine Continuous Benchmarks</h2>
+    <div>
+      <strong>Last Update:</strong>
+      <span id="last-update"></span>
+    </div>
+    <div>
+      <strong>Repository:</strong>
+      <a id="repository-link" rel="noopener"></a>
+    </div>
+
+    <nav id="toc" style="margin-top: 16px;">
+      <h2>Table of Contents</h2>
+      <ul>
+        <li><a href="#summary-section">Aggregated Charts</a></li>
+        <li><a href="#detail-section">Scenario Charts</a></li>
+      </ul>
+    </nav>
     <main id="main"></main>
-    <footer>
-      <button id="dl-button">Download data as JSON</button>
-      <div class="spacer"></div>
-      <div class="small">Powered by <a rel="noopener" href="https://github.com/marketplace/actions/continuous-benchmark">github-action-benchmark</a></div>
-    </footer>
+  </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.2/dist/Chart.min.js"></script>
-    <script src="data.js"></script>
-    <script id="main-script">
-      'use strict';
-      (function() {
-        // Colors from https://github.com/github/linguist/blob/master/lib/linguist/languages.yml
-        const toolColors = {
-          cargo: '#dea584',
-          go: '#00add8',
-          benchmarkjs: '#f1e05a',
-          benchmarkluau: '#000080',
-          pytest: '#3572a5',
-          googlecpp: '#f34b7d',
-          catch2: '#f34b7d',
-          julia: '#a270ba',
-          jmh: '#b07219',
-          benchmarkdotnet: '#178600',
-          customBiggerIsBetter: '#38ff38',
-          customSmallerIsBetter: '#ff3838',
-          _: '#333333'
-        };
 
-        function init() {
-          function collectBenchesPerTestCase(entries) {
-            const map = new Map();
-            for (const entry of entries) {
-              const {commit, date, tool, benches} = entry;
-              for (const bench of benches) {
-                const result = { commit, date, tool, bench };
-                const arr = map.get(bench.name);
-                if (arr === undefined) {
-                  map.set(bench.name, [result]);
-                } else {
-                  arr.push(result);
-                }
-              }
-            }
-            return map;
+  <footer>
+    <button id="dl-button">Download data as JSON</button>
+    <div class="spacer"></div>
+    <div class="small">Powered by <a rel="noopener"
+        href="https://github.com/marketplace/actions/continuous-benchmark">github-action-benchmark</a></div>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.2/dist/Chart.min.js"></script>
+
+  <script src="data.js"></script>
+  
+  <script id="main-script">
+ 'use strict';
+(function () {
+  const COLORS = [
+    "#48aaf9", "#8a3ef2", "#78eeda", "#d78000", "#1248b3",
+    "#97dbfc", "#006174", "#00b6b6", "#854200", "#f3c8ad", "#410472",
+  ];
+
+  function init() {
+    function collectBenchesPerTestCase(entries) {
+      const byGroup = new Map();
+      const commitIds = [];
+      for (const entry of entries) {
+        const { commit, date, tool, benches } = entry;
+        const commitId = commit.id.slice(0, 7);
+        if (!commitIds.includes(commitId)) {
+          commitIds.push(commitId);
+        }
+        for (const bench of benches) {
+          const result = { commit, date, tool, bench };
+          let byName = byGroup.get(bench.extra);
+          if (byName === undefined) {
+            byName = new Map();
+            byGroup.set(bench.extra, byName);
           }
+          let byCommitId = byName.get(bench.name);
+          if (byCommitId === undefined) {
+            byCommitId = new Map();
+            byName.set(bench.name, byCommitId);
+          }
+          byCommitId.set(commitId, result);
+        }
+      }
+      return { commitIds, byGroup };
+    }
 
-          const data = window.BENCHMARK_DATA;
+    function collectAggregatedBenchmarks(entries) {
+      const grouped = new Map();
+      const commitIds = [];
 
-          // Render header
-          document.getElementById('last-update').textContent = new Date(data.lastUpdate).toString();
-          const repoLink = document.getElementById('repository-link');
-          repoLink.href = data.repoUrl;
-          repoLink.textContent = data.repoUrl;
+      for (const entry of entries) {
+        const { commit, date, tool, benches } = entry;
+        const commitId = commit.id.slice(0, 7);
+        if (!commitIds.includes(commitId)) {
+          commitIds.push(commitId);
+        }
 
-          // Render footer
-          document.getElementById('dl-button').onclick = () => {
-            const dataUrl = 'data:,' + JSON.stringify(data, null, 2);
-            const a = document.createElement('a');
-            a.href = dataUrl;
-            a.download = 'benchmark_data.json';
-            a.click();
+        for (const bench of benches) {
+          const extraParts = bench.extra.split('/');
+          if (extraParts.length !== 2) continue;
+
+          const prefix = extraParts[0].trim(); // e.g., CI 100kLRPS
+          const [testName, metricGroup] = extraParts[1].split(' - ').map(s => s.trim());
+
+          const header = `${prefix} - ${metricGroup}`; // section heading
+          const metricName = bench.name;
+
+          if (!grouped.has(header)) {
+            grouped.set(header, new Map());
+          }
+          const headerMap = grouped.get(header);
+
+          if (!headerMap.has(metricName)) {
+            headerMap.set(metricName, new Map());
+          }
+          const metricMap = headerMap.get(metricName);
+
+          if (!metricMap.has(testName)) {
+            metricMap.set(testName, new Map());
+          }
+          const testMap = metricMap.get(testName);
+
+          testMap.set(commitId, { commit, date, tool, bench });
+        }
+      }
+
+      return { commitIds, grouped };
+    }
+
+    const data = window.BENCHMARK_DATA;
+
+    // Header info
+    document.getElementById('last-update').textContent = new Date(data.lastUpdate).toString();
+    const repoLink = document.getElementById('repository-link');
+    repoLink.href = data.repoUrl;
+    repoLink.textContent = data.repoUrl;
+
+    // Footer button
+    document.getElementById('dl-button').onclick = () => {
+      const dataUrl = 'data:,' + JSON.stringify(data, null, 2);
+      const a = document.createElement('a');
+      a.href = dataUrl;
+      a.download = 'benchmark_data.json';
+      a.click();
+    };
+
+    // Prepare both datasets
+    return Object.keys(data.entries).map(name => {
+      const rawEntries = data.entries[name];
+      return {
+        name,
+        dataSet: collectBenchesPerTestCase(rawEntries),
+        aggregatedSet: collectAggregatedBenchmarks(rawEntries),
+      };
+    });
+  }
+
+  function renderAllChars(dataSets) {
+
+    function renderGraph(parent, name, commitIds, byName) {
+      const chartTitle = document.createElement('h3');
+      chartTitle.textContent = name;
+      parent.append(chartTitle);
+
+      const canvas = document.createElement('canvas');
+      canvas.className = 'benchmark-chart';
+      parent.appendChild(canvas);
+
+      const results = [];
+      for (const [seriesName, byCommitId] of byName.entries()) {
+        results.push({
+          name: seriesName,
+          dataset: commitIds.map(commitId => byCommitId.get(commitId) ?? null),
+        });
+      }
+
+      results.sort((a, b) => a.name.localeCompare(b.name));
+
+      const data = {
+        labels: commitIds,
+        datasets: results.map(({ name, dataset }, index) => {
+          const color = COLORS[index % COLORS.length];
+          return {
+            label: name,
+            data: dataset.map(d => d?.bench.value ?? null),
+            fill: false,
+            borderColor: color,
+            backgroundColor: color,
           };
+        }),
+      };
 
-          // Prepare data points for charts
-          return Object.keys(data.entries).map(name => ({
-            name,
-            dataSet: collectBenchesPerTestCase(data.entries[name]),
-          }));
+      const options = {
+        scales: {
+          xAxes: [{
+            scaleLabel: { display: true, labelString: 'commit' },
+          }],
+          yAxes: [{
+            scaleLabel: {
+              display: true,
+              labelString: results?.[0]?.dataset.find(d => d !== null)?.bench.unit ?? '',
+            },
+            ticks: { beginAtZero: true },
+          }]
+        },
+        tooltips: {
+          callbacks: {
+            afterTitle: items => {
+              const { datasetIndex, index } = items[0];
+              const data = results[datasetIndex].dataset[index];
+              if (!data) return '';
+              return '\n' + data.commit.message + '\n\n' + data.commit.timestamp + ' committed by @' + data.commit.author.username + '\n';
+            },
+            label: item => {
+              const { datasetIndex, index, value } = item;
+              const data = results[datasetIndex].dataset[index];
+              if (!data) return `${results[datasetIndex].name}: N/A`;
+              const { name, dataset } = results[datasetIndex];
+              const { range, unit } = data.bench;
+              let label = `${name}: ${value}`;
+              label += unit;
+              if (range) label += ` (${range})`;
+              return label;
+            },
+          },
+        },
+        legend: { display: true },
+      };
+
+      new Chart(canvas, { type: 'line', data, options });
+    }
+
+    function renderAggregatedCharts(aggregatedSet, main) {
+      const { commitIds, grouped } = aggregatedSet;
+
+      const setElem = document.createElement('div');
+      setElem.className = 'benchmark-set';
+      main.appendChild(setElem);
+
+      const graphsElem = document.createElement('div');
+      graphsElem.className = 'benchmark-graphs';
+      setElem.appendChild(graphsElem);
+
+      const sortedHeaders = [...grouped.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+      for (const [sectionName, metricMap] of sortedHeaders) {
+        const sectionHeader = document.createElement('h2');
+        sectionHeader.textContent = sectionName;
+        graphsElem.appendChild(sectionHeader);
+
+        const sortedMetrics = [...metricMap.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+        for (const [metricName, testMap] of sortedMetrics) {
+          renderGraph(graphsElem, metricName, commitIds, testMap);
         }
+      }
+    }
 
-        function renderAllChars(dataSets) {
+    function renderBenchSet(name, benchSet, main) {
+      const setElem = document.createElement('div');
+      setElem.className = 'benchmark-set';
+      main.appendChild(setElem);
 
-          function renderGraph(parent, name, dataset) {
-            const canvas = document.createElement('canvas');
-            canvas.className = 'benchmark-chart';
-            parent.appendChild(canvas);
+      const graphsElem = document.createElement('div');
+      graphsElem.className = 'benchmark-graphs';
+      setElem.appendChild(graphsElem);
 
-            const color = toolColors[dataset.length > 0 ? dataset[0].tool : '_'];
-            const data = {
-              labels: dataset.map(d => d.commit.id.slice(0, 7)),
-              datasets: [
-                {
-                  label: name,
-                  data: dataset.map(d => d.bench.value),
-                  borderColor: color,
-                  backgroundColor: color + '60', // Add alpha for #rrggbbaa
-                }
-              ],
-            };
-            const options = {
-              scales: {
-                xAxes: [
-                  {
-                    scaleLabel: {
-                      display: true,
-                      labelString: 'commit',
-                    },
-                  }
-                ],
-                yAxes: [
-                  {
-                    scaleLabel: {
-                      display: true,
-                      labelString: dataset.length > 0 ? dataset[0].bench.unit : '',
-                    },
-                    ticks: {
-                      beginAtZero: true,
-                    }
-                  }
-                ],
-              },
-              tooltips: {
-                callbacks: {
-                  afterTitle: items => {
-                    const {index} = items[0];
-                    const data = dataset[index];
-                    return '\n' + data.commit.message + '\n\n' + data.commit.timestamp + ' committed by @' + data.commit.committer.username + '\n';
-                  },
-                  label: item => {
-                    let label = item.value;
-                    const { range, unit } = dataset[item.index].bench;
-                    label += ' ' + unit;
-                    if (range) {
-                      label += ' (' + range + ')';
-                    }
-                    return label;
-                  },
-                  afterLabel: item => {
-                    const { extra } = dataset[item.index].bench;
-                    return extra ? '\n' + extra : '';
-                  }
-                }
-              },
-              onClick: (_mouseEvent, activeElems) => {
-                if (activeElems.length === 0) {
-                  return;
-                }
-                // XXX: Undocumented. How can we know the index?
-                const index = activeElems[0]._index;
-                const url = dataset[index].commit.url;
-                window.open(url, '_blank');
-              },
-            };
+      const { commitIds, byGroup } = benchSet;
+      const groups = [];
+      for (const [name, byName] of byGroup.entries()) {
+        groups.push({ name, byName });
+      }
+      groups.sort((a, b) => a.name.localeCompare(b.name));
 
-            new Chart(canvas, {
-              type: 'line',
-              data,
-              options,
-            });
-          }
+      for (const { name, byName } of groups) {
+        renderGraph(graphsElem, name, commitIds, byName);
+      }
+    }
 
-          function renderBenchSet(name, benchSet, main) {
-            const setElem = document.createElement('div');
-            setElem.className = 'benchmark-set';
-            main.appendChild(setElem);
+    const main = document.getElementById('main');
 
-            const nameElem = document.createElement('h1');
-            nameElem.className = 'benchmark-title';
-            nameElem.textContent = name;
-            setElem.appendChild(nameElem);
+    // Summary section (collapsible)
+    const summaryDetails = document.createElement('details');
+    summaryDetails.id = 'summary-section';
+    summaryDetails.open = true;
+    const summarySummary = document.createElement('summary');
+    summarySummary.textContent = 'Aggregated Charts';
+    summaryDetails.appendChild(summarySummary);
+    main.appendChild(summaryDetails);
 
-            const graphsElem = document.createElement('div');
-            graphsElem.className = 'benchmark-graphs';
-            setElem.appendChild(graphsElem);
+    // Add summary content
+    for (const { aggregatedSet } of dataSets) {
+      renderAggregatedCharts(aggregatedSet, summaryDetails);
+    }
 
-            for (const [benchName, benches] of benchSet.entries()) {
-              renderGraph(graphsElem, benchName, benches)
-            }
-          }
+    // Detail section (collapsible)
+    const detailDetails = document.createElement('details');
+    detailDetails.id = 'detail-section';
+    detailDetails.open = false;
+    const detailSummary = document.createElement('summary');
+    detailSummary.textContent = 'Scenario Charts';
+    detailDetails.appendChild(detailSummary);
+    main.appendChild(detailDetails);
 
-          const main = document.getElementById('main');
-          for (const {name, dataSet} of dataSets) {
-            renderBenchSet(name, dataSet, main);
-          }
-        }
+    // Add detail content
+    for (const { name, dataSet } of dataSets) {
+      renderBenchSet(name, dataSet, detailDetails);
+    }
+  }
 
-        renderAllChars(init()); // Start
-      })();
-    </script>
-  </body>
+  renderAllChars(init());
+})();
+
+  </script>
+</body>
+
 </html>


### PR DESCRIPTION
Note: This is for the "benchmarks" branch, not main.

This PR updates the index.html page at https://open-telemetry.github.io/otel-arrow/benchmarks/continuous/ to better support the 4-test suite (e.g. all 4 results for the same metric displayed in a single chart - more similar to the go collector output https://opentelemetry.io/docs/collector/benchmarks/).