### PR TITLE
OTLP receiver: new Settings with support for wait_for_result

### DIFF
--- a/rust/otap-dataflow/crates/otap/src/otap_grpc/otlp/server.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_grpc/otlp/server.rs
@@ -411,11 +411,10 @@ impl tower_service::Service<Request<Body>> for MetricsServiceServer {
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn call(&mut self, req: Request<Body>) -> Self::Future {
-        let common = self.common.clone();
         match req.uri().path() {
             super::METRICS_SERVICE_EXPORT_PATH => {
                 let common = self.common.clone();
-                let mut grpc = new_grpc(SignalType::Logs, common.settings);
+                let mut grpc = new_grpc(SignalType::Metrics, common.settings);
                 let service = OtapBatchService::new(common.effect_handler, common.state);
                 Box::pin(async move { Ok(grpc.unary(service, req).await) })
             }
@@ -455,11 +454,10 @@ impl tower_service::Service<Request<Body>> for TraceServiceServer {
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn call(&mut self, req: Request<Body>) -> Self::Future {
-        let common = self.common.clone();
         match req.uri().path() {
             super::TRACE_SERVICE_EXPORT_PATH => {
                 let common = self.common.clone();
-                let mut grpc = new_grpc(SignalType::Logs, common.settings);
+                let mut grpc = new_grpc(SignalType::Traces, common.settings);
                 let service = OtapBatchService::new(common.effect_handler, common.state);
                 Box::pin(async move { Ok(grpc.unary(service, req).await) })
             }

--- a/rust/otap-dataflow/crates/otap/src/otlp_receiver.rs
+++ b/rust/otap-dataflow/crates/otap/src/otlp_receiver.rs
@@ -601,7 +601,7 @@ mod tests {
     }
 
     #[test]
-    fn test_otlp_receiver() {
+    fn test_otlp_receiver_ack() {
         let test_runtime = TestRuntime::new();
 
         let grpc_addr = "127.0.0.1";


### PR DESCRIPTION
Introduces `wait_for_result` in the OTLP receiver.

Fixes #1311 

As I begun to understand this code, I could see ways to shorten it while adding new configuration support.

The new struct `Settings` follows collector practice where there is a widely-used non-configuration object used to pass startup conditions, this follows that convention.

Comments added: it was not clear at first why we construct Grpc<.> and OtapBatchService<.> in each request.