### PR TITLE
Add license header

### DIFF
--- a/rust/otap-dataflow/crates/otap/tests/smoke_fake_batch_issue_1310.rs
+++ b/rust/otap-dataflow/crates/otap/tests/smoke_fake_batch_issue_1310.rs
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 #![allow(missing_docs)]
 //! Integration smoke test for fake-batch-perf-issue-1310.
 


### PR DESCRIPTION
Part of #1333 

## Changes
- Add license header to `smoke_fake_batch_issue_1310.rs` to fix this: https://github.com/open-telemetry/otel-arrow/actions/runs/18701333499/job/53330573847?pr=1309