### PR TITLE
[query-engine] Fix up DateTime attributes in OTLP bridge when schema is present

### DIFF
--- a/rust/experimental/query_engine/parser-abstractions/src/parser.rs
+++ b/rust/experimental/query_engine/parser-abstractions/src/parser.rs
@@ -18,6 +18,7 @@ pub trait Parser {
     ) -> Result<PipelineExpression, Vec<ParserError>>;
 }
 
+#[derive(Clone)]
 pub struct ParserOptions {
     pub(crate) source_map_schema: Option<ParserMapSchema>,
     pub(crate) summary_map_schema: Option<ParserMapSchema>,
@@ -51,6 +52,14 @@ impl ParserOptions {
         }
 
         self
+    }
+
+    pub fn get_source_map_schema(&self) -> Option<&ParserMapSchema> {
+        self.source_map_schema.as_ref()
+    }
+
+    pub fn get_summary_map_schema(&self) -> Option<&ParserMapSchema> {
+        self.summary_map_schema.as_ref()
     }
 }
 


### PR DESCRIPTION
## Changes

* In OTLP bridge if schema says an attribute key should be a DateTime but it is found to be a String attempt an automatic conversion

## Details

@drewrelmas has found users to be making multiple calls into the recordset engine while processing the same batch of records. In the first call a DateTime is created. In a later call that DateTime is used in a `summary` (eg: `bin(TimeGenerated, 10m)`). The problem is, the bridge input and output is OTLP where "extended" things like DateTimes become Strings. This is a stopgap while we look at better solutions.