### PR TITLE
[query-engine] Implement fmt_with_indent for summary expressions

### DIFF
--- a/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
@@ -557,7 +557,10 @@ impl Expression for ReferenceConstantScalarExpression {
     fn fmt_with_indent(&self, f: &mut std::fmt::Formatter<'_>, indent: &str) -> std::fmt::Result {
         writeln!(f, "Constant(Reference)")?;
         writeln!(f, "{indent}├── ValueType: {:?}", self.get_value_type())?;
-        writeln!(f, "{indent}└── Id: {}", self.get_constant_id())?;
+        writeln!(f, "{indent}├── Id: {}", self.get_constant_id())?;
+        write!(f, "{indent}└── Accessor: ")?;
+        self.accessor
+            .fmt_with_indent(f, format!("{indent}    ").as_str())?;
         Ok(())
     }
 }

--- a/rust/experimental/query_engine/expressions/src/summary/summary_data_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/summary/summary_data_expression.rs
@@ -82,6 +82,72 @@ impl Expression for SummaryDataExpression {
     fn get_name(&self) -> &'static str {
         "SummaryDataExpression"
     }
+
+    fn fmt_with_indent(&self, f: &mut std::fmt::Formatter<'_>, indent: &str) -> std::fmt::Result {
+        writeln!(f, "Summary")?;
+
+        if self.group_by_expressions.is_empty() {
+            writeln!(f, "{indent}├── GroupBys: None")?;
+        } else {
+            writeln!(f, "{indent}├── GroupBys: ")?;
+            let last_idx = self.group_by_expressions.len() - 1;
+            for (i, (name, g)) in self.group_by_expressions.iter().enumerate() {
+                if i == last_idx {
+                    write!(f, "{indent}│   └── {name} = ")?;
+                    g.fmt_with_indent(
+                        f,
+                        format!("{indent}│    {}   ", " ".repeat(name.len() + 3)).as_str(),
+                    )?;
+                } else {
+                    write!(f, "{indent}│   ├── {name} = ")?;
+                    g.fmt_with_indent(
+                        f,
+                        format!("{indent}│   │{}   ", " ".repeat(name.len() + 3)).as_str(),
+                    )?;
+                }
+            }
+        }
+
+        if self.aggregation_expressions.is_empty() {
+            writeln!(f, "{indent}├── Aggregations: None")?;
+        } else {
+            writeln!(f, "{indent}├── Aggregations: ")?;
+            let last_idx = self.aggregation_expressions.len() - 1;
+            for (i, (name, a)) in self.aggregation_expressions.iter().enumerate() {
+                if i == last_idx {
+                    write!(f, "{indent}│   └── {name} = ")?;
+                    a.fmt_with_indent(
+                        f,
+                        format!("{indent}│    {}   ", " ".repeat(name.len() + 3)).as_str(),
+                    )?;
+                } else {
+                    write!(f, "{indent}│   ├── {name} = ")?;
+                    a.fmt_with_indent(
+                        f,
+                        format!("{indent}│   │{}   ", " ".repeat(name.len() + 3)).as_str(),
+                    )?;
+                }
+            }
+        }
+
+        if self.post_expressions.is_empty() {
+            writeln!(f, "{indent}└── PostExpressions: None")?;
+        } else {
+            writeln!(f, "{indent}└── PostExpressions: ")?;
+            let last_idx = self.post_expressions.len() - 1;
+            for (i, e) in self.post_expressions.iter().enumerate() {
+                if i == last_idx {
+                    write!(f, "{indent}    └── ")?;
+                    e.fmt_with_indent(f, format!("{indent}        ").as_str())?;
+                } else {
+                    write!(f, "{indent}    ├── ")?;
+                    e.fmt_with_indent(f, format!("{indent}    │   ").as_str())?;
+                }
+            }
+        }
+
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -131,6 +197,17 @@ impl Expression for AggregationExpression {
 
     fn get_name(&self) -> &'static str {
         "AggregationExpression"
+    }
+
+    fn fmt_with_indent(&self, f: &mut std::fmt::Formatter<'_>, indent: &str) -> std::fmt::Result {
+        if let Some(value) = self.value_expression.as_ref() {
+            let header = format!("{:?}(Scalar): ", self.aggregation_function);
+            write!(f, "{header}")?;
+            value.fmt_with_indent(f, format!("{indent}{}", " ".repeat(header.len())).as_str())?;
+        } else {
+            writeln!(f, "{:?}", self.aggregation_function)?;
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Relates to #1178

## Details

Examples:

```
Pipeline
├── Query: "source\n | extend t = gettype(EventName) | summarize Count = count(), max(SeverityNumber) by Timestamp, EventName | extend t = gettype(Count)"
├── Constants:
│   └── 0 = Map: {"Array":"array","Boolean":"bool","DateTime":"datetime","Double":"real","Integer":"long","Map":"dictionary","Null":"null","Regex":"regex","String":"string","TimeSpan":"timespan"}
├── Initializations: []
└── Expressions:
    ├── Set
    │   ├── Source(Scalar): Constant(Reference)
    │   │                   ├── ValueType: Map
    │   │                   ├── Id: 0
    │   │                   └── Accessor:
    │   │                       └── GetType(Scalar): Source
    │   │                           └── Accessor:
    │   │                               └── String: "EventName"
    │   └── Destination(Mutable): Source
    │                             └── Accessor:
    │                                 ├── String: "Attributes"
    │                                 └── String: "t"
    └── Summary
        ├── GroupBys:
        │   ├── EventName = Source
        │   │               └── Accessor:
        │   │                   └── String: "EventName"
        │   └── Timestamp = Source
        │                   └── Accessor:
        │                       └── String: "Timestamp"
        ├── Aggregations:
        │   ├── Count = Count
        │   └── max_SeverityNumber = Maximum(Scalar): Source
        │                                             └── Accessor:
        │                                                 └── String: "SeverityNumber"
        └── PostExpressions:
            └── Set
                ├── Source(Scalar): Constant(Reference)
                │                   ├── ValueType: Map
                │                   ├── Id: 0
                │                   └── Accessor:
                │                       └── GetType(Scalar): Source
                │                           └── Accessor:
                │                               └── String: "Count"
                └── Destination(Mutable): Source
                                          └── Accessor:
                                              └── String: "t"
```