### PR TITLE
[PerfTest] add workflow to manually trigger perf-tests for a given pr

### DIFF
--- a/.github/workflows/pipeline-perf-test-manual-pr.yaml
+++ b/.github/workflows/pipeline-perf-test-manual-pr.yaml
@@ -1,0 +1,86 @@
+# Manual version of the pipeline perf test that can be triggered for a given PR.
+name: Pipeline Performance Tests - Manual PR
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to run performance tests against"
+        required: true
+        type: number
+      suite_config:
+        description: "Path to benchmark suite config (relative to repo)"
+        required: true
+        type: string
+        default: tools/pipeline_perf_test/test_suites/integration/continuous/100klrps-docker.yaml
+
+# Cancel in-progress runs for the same PR if a new manual run is started
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  pipeline-perf-test:
+    runs-on: oracle-bare-metal-64cpu-512gb-x86-64
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
+      # Check out the PR's merge commit so tests run against how it would integrate with the base branch.
+      # This works for PRs from the same repo or forks.
+      - name: Checkout PR merge ref
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: refs/pull/${{ inputs.pr_number }}/merge
+          fetch-depth: 0
+          persist-credentials: true
+
+      - id: detect_os
+        name: Detect OS (self-hosted)
+        shell: bash
+        run: |
+          . /etc/os-release
+          echo "id=$ID" >> "$GITHUB_OUTPUT"
+          echo "version_id=$VERSION_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Install/prepare Python 3.11 on Oracle Linux 8 (self-hosted only)
+        if: ${{ runner.os == 'Linux' && steps.detect_os.outputs.id == 'ol' && startsWith(steps.detect_os.outputs.version_id, '8') }}
+        shell: bash
+        run: |
+          set -euxo pipefail
+          sudo dnf -y install oracle-epel-release-el8 || true
+          sudo dnf -y config-manager --set-enabled ol8_codeready_builder || true
+          sudo dnf -y makecache
+          sudo dnf -y install python3.11 python3.11-devel || true
+          if ! /usr/bin/python3.11 -m pip --version >/dev/null 2>&1; then
+            /usr/bin/python3.11 -m ensurepip --upgrade || true
+          fi
+          /usr/bin/python3.11 -m pip install --upgrade pip setuptools wheel || true
+          mkdir -p "$HOME/.local/bin"
+          ln -sf /usr/bin/python3.11 "$HOME/.local/bin/python"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          python --version
+          python -m pip --version
+
+      - name: Build dataflow_engine
+        run: |
+          git submodule init
+          git submodule update
+          cd rust/otap-dataflow
+          docker build --build-context otel-arrow=../../ -f Dockerfile -t df_engine .
+          cd ../..
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --user --upgrade pip
+          pip install --user -r tools/pipeline_perf_test/orchestrator/requirements.txt
+          pip install --user -r tools/pipeline_perf_test/load_generator/requirements.txt
+
+      - name: Run pipeline performance test suite
+        run: |
+          cd tools/pipeline_perf_test
+          python orchestrator/run_orchestrator.py --debug --config "${{ inputs.suite_config }}"


### PR DESCRIPTION
This workflow will allow folks with the correct permissions to run a text-output-only version of the benchmark suite on the same bare metal runner used on commits to main / nightly. This is needed to evaluate performance of some PRs prior to merge.