### PR TITLE
[query-engine] Add re-exports to bridge crate

### DIFF
--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/lib.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/lib.rs
@@ -17,5 +17,5 @@ pub use serializer::serializer_error::SerializerError;
 
 // Note: Re-export engine and parser to avoid users having to manually add
 // dependencies when using bridge API
-pub use data_engine_recordset::*;
 pub use data_engine_kql_parser::*;
+pub use data_engine_recordset::*;


### PR DESCRIPTION
## Changes

* Re-export engine & parser in bridge create

## Details

In order to use the public API in bridge you also have to depend on recordset engine and kql parser or parser_abstractions. Adding these re-exports just smooths that out as a convenience thing.