### PR TITLE
[PipelinePerf] setup verification of manual workflow runs for PRs

### DIFF
--- a/.github/workflows/pipeline-perf-test-manual-pr.yaml
+++ b/.github/workflows/pipeline-perf-test-manual-pr.yaml
@@ -1,7 +1,11 @@
 # Manual version of the pipeline perf test that can be triggered for a given PR.
+# This workflow writes to / expects to find a placeholder status on the PR ref since we aren't
+# able to directly insert a state into it from 'outside' of that context.
 name: Pipeline Performance Tests - Manual PR
 permissions:
   contents: read
+  pull-requests: read
+  statuses: write
 
 on:
   workflow_dispatch:
@@ -84,3 +88,35 @@ jobs:
         run: |
           cd tools/pipeline_perf_test
           python orchestrator/run_orchestrator.py --debug --config "${{ inputs.suite_config }}"
+
+      - name: Set PR status based on result
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Read PR number from workflow inputs
+            const prNumber = context.payload.inputs.pr_number;
+
+            // Get PR info
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+
+            const sha = pr.head.sha;
+
+            // Map job result to status state
+            const state = '{{ job.status }}' === 'success' ? 'success' : 'failure';
+
+            // Set commit status on PR
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha,
+              state,
+              context: 'perf-tests',
+              description: state === 'success'
+                ? 'Manual pipeline performance tests ran'
+                : 'Manual pipeline performance tests failed'
+            });

--- a/.github/workflows/pipeline-perf-verify-pr.yaml
+++ b/.github/workflows/pipeline-perf-verify-pr.yaml
@@ -1,0 +1,33 @@
+# This action inserts a placeholder status for a future manual perf-test to
+# write to on pull request events. It's required because the context of a manual
+# workflow run can't directly be tied to a PR. Instead we insert a pending status
+# here and then update it to success/fail in the manual workflow.
+name: Require Manual Perf Tests (marker)
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: write
+
+jobs:
+  mark-pending:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set pending status requiring manual perf tests
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = context.payload.pull_request.head.sha;
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: sha,
+              state: 'pending',
+              context: 'perf-tests',
+              description: 'Manual pipeline performance tests have not been run yet',
+              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/workflows/pipeline-perf-test-manual-pr.yaml`
+            });


### PR DESCRIPTION
These changes allow automated verification of a manually triggered perf test workflow for a given PR number. Because of how github actions work for this weird case, it's a 2 step thing:

- The new workflow file below (pipeline-perf-verify-pr.yaml) inserts a placeholder status into PRs on create/update that will remain "pending" indefinitely.
- The original manual workflow now updates that placeholder status with the result of it's own run (for the specified PR number).

So the flow is:
- New PR created, new job inserts the pending status result
- Maintainer triggers the manual run with target PR number
- Manual job runs and sets the previously pending result to pass/fail

New commits will clear the result back to pending.