### PR TITLE
Fix manual perf test marker CI error

### DIFF
--- a/.github/workflows/pipeline-perf-verify-pr.yaml
+++ b/.github/workflows/pipeline-perf-verify-pr.yaml
@@ -5,7 +5,7 @@
 name: Require Manual Perf Tests (marker)
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 permissions:


### PR DESCRIPTION
Seeing test failures in the github action
[Require Manual Perf Tests (marker)](https://github.com/open-telemetry/otel-arrow/actions/workflows/pipeline-perf-verify-pr.yaml)

https://github.com/open-telemetry/otel-arrow/actions/runs/19105168788/job/54587203006

error: "Error: Unhandled error: HttpError: Resource not accessible by integration"

I think this happens because the `pull_request` event runs with a readonly access token if the PR comes from a fork
https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflows-in-forked-repositories

it's safe to use the `pull_request_target` event as long as we don't check out the code:
https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/