### PR TITLE
[otap-dataflow] allow optional exclude/include in the filter processor

### DIFF
--- a/rust/otap-dataflow/crates/otap/src/filter_processor.rs
+++ b/rust/otap-dataflow/crates/otap/src/filter_processor.rs
@@ -166,6 +166,218 @@ mod tests {
     use std::pin::Pin;
     use std::sync::Arc;
 
+    // build logs data for testing version 1
+    fn build_logs_1() -> LogsData {
+        LogsData::new(vec![
+            // ResourceLogs for prod/checkout-service
+            ResourceLogs::new(
+                Resource::build()
+                    .attributes(vec![
+                        KeyValue::new("version", AnyValue::new_string("2.0")),
+                        KeyValue::new("service.name", AnyValue::new_string("checkout-service")),
+                        KeyValue::new("service.version", AnyValue::new_string("1.4.3")),
+                        KeyValue::new("service.instance.number", AnyValue::new_int(42)),
+                        KeyValue::new("deployment.environment", AnyValue::new_string("prod")),
+                        KeyValue::new("cloud.region", AnyValue::new_string("us-central1")),
+                        KeyValue::new("host.cpu_cores", AnyValue::new_int(8)),
+                        KeyValue::new("host.uptime_sec", AnyValue::new_int(86_400)),
+                        KeyValue::new("sampling.rate", AnyValue::new_double(0.25)),
+                        KeyValue::new("debug.enabled", AnyValue::new_bool(false)),
+                        KeyValue::new("process.pid", AnyValue::new_int(12345)),
+                        KeyValue::new("team", AnyValue::new_string("payments")),
+                        KeyValue::new("telemetry.sdk.language", AnyValue::new_string("rust")),
+                    ])
+                    .finish(),
+                vec![ScopeLogs::new(
+                    InstrumentationScope::build()
+                        .name("library")
+                        .version("scopev1")
+                        .finish(),
+                    vec![
+                        LogRecord::build()
+                            .time_unix_nano(2_200_000_000u64)
+                            .severity_number(SeverityNumber::Warn)
+                            .body(AnyValue::new_string("event"))
+                            .attributes(vec![
+                                KeyValue::new("component", AnyValue::new_string("rest")),
+                                KeyValue::new("http.method", AnyValue::new_string("POST")),
+                                KeyValue::new("http.route", AnyValue::new_string("/api/checkout")),
+                                KeyValue::new("http.status_code", AnyValue::new_int(200)),
+                                KeyValue::new("retryable", AnyValue::new_bool(false)),
+                                KeyValue::new("backoff_ms", AnyValue::new_int(0)),
+                                KeyValue::new("throttle_factor", AnyValue::new_double(0.0)),
+                            ])
+                            .severity_text("WARN")
+                            .body(AnyValue::new_string("checkout started"))
+                            .finish(),
+                        LogRecord::build()
+                            .time_unix_nano(2_300_000_000u64)
+                            .severity_number(SeverityNumber::Error)
+                            .body(AnyValue::new_string("event"))
+                            .attributes(vec![
+                                KeyValue::new("exception.type", AnyValue::new_string("io::Error")),
+                                KeyValue::new(
+                                    "exception.message",
+                                    AnyValue::new_string("connection reset by peer"),
+                                ),
+                                KeyValue::new(
+                                    "exception.stacktrace",
+                                    AnyValue::new_string("...stack..."),
+                                ),
+                                KeyValue::new(
+                                    "peer.address",
+                                    AnyValue::new_string("10.42.0.7:5432"),
+                                ),
+                                KeyValue::new("peer.port", AnyValue::new_int(5432)),
+                                KeyValue::new("peer.tls", AnyValue::new_bool(true)),
+                                KeyValue::new("bytes_sent", AnyValue::new_int(0)),
+                                KeyValue::new("jitter", AnyValue::new_double(0.003)),
+                            ])
+                            .severity_text("ERROR")
+                            .body(AnyValue::new_string("failed to write to socket"))
+                            .finish(),
+                        LogRecord::build()
+                            .time_unix_nano(2_600_000_000u64)
+                            .severity_number(SeverityNumber::Warn)
+                            .body(AnyValue::new_string("event"))
+                            .attributes(vec![
+                                KeyValue::new("component", AnyValue::new_string("db")),
+                                KeyValue::new(
+                                    "query",
+                                    AnyValue::new_string(
+                                        "UPDATE inventory SET count = count - 1 WHERE sku='ABC123'",
+                                    ),
+                                ),
+                                KeyValue::new("rows_affected", AnyValue::new_int(1)),
+                                KeyValue::new("success", AnyValue::new_bool(true)),
+                            ])
+                            .severity_text("WARN")
+                            .body(AnyValue::new_string("inventory updated"))
+                            .finish(),
+                    ],
+                )],
+            ),
+            ResourceLogs::new(
+                Resource::build()
+                    .attributes(vec![
+                        KeyValue::new("version", AnyValue::new_string("2.0")),
+                        KeyValue::new("service.name", AnyValue::new_string("inventory-service")),
+                        KeyValue::new("service.version", AnyValue::new_string("0.9.1")),
+                        KeyValue::new("service.instance.number", AnyValue::new_int(7)),
+                        KeyValue::new("deployment.environment", AnyValue::new_string("staging")),
+                        KeyValue::new("cloud.region", AnyValue::new_string("us-central1")),
+                        KeyValue::new("host.cpu_cores", AnyValue::new_int(4)),
+                        KeyValue::new("host.uptime_sec", AnyValue::new_int(12_345)),
+                        KeyValue::new("sampling.rate", AnyValue::new_double(0.10)),
+                        KeyValue::new("debug.enabled", AnyValue::new_bool(true)),
+                        KeyValue::new("process.pid", AnyValue::new_int(22222)),
+                        KeyValue::new("team", AnyValue::new_string("inventory")),
+                    ])
+                    .finish(),
+                vec![ScopeLogs::new(
+                    InstrumentationScope::build()
+                        .name("library")
+                        .version("scopev2")
+                        .finish(),
+                    vec![
+                        LogRecord::build()
+                            .time_unix_nano(3_000_000_000u64)
+                            .severity_number(SeverityNumber::Warn)
+                            .body(AnyValue::new_string("event"))
+                            .attributes(vec![
+                                KeyValue::new("component", AnyValue::new_string("rest")),
+                                KeyValue::new(
+                                    "http.route",
+                                    AnyValue::new_string("/api/internal/cache_warm"),
+                                ),
+                                KeyValue::new("http.status_code", AnyValue::new_int(200)),
+                                KeyValue::new("success", AnyValue::new_bool(true)),
+                            ])
+                            .severity_text("WARN")
+                            .body(AnyValue::new_string("warmup complete"))
+                            .finish(),
+                        LogRecord::build()
+                            .time_unix_nano(3_100_000_000u64)
+                            .severity_number(SeverityNumber::Info)
+                            .body(AnyValue::new_string("event"))
+                            .attributes(vec![
+                                KeyValue::new("event.domain", AnyValue::new_string("ops")),
+                                KeyValue::new("message", AnyValue::new_string("heartbeat")),
+                                KeyValue::new("uptime_sec", AnyValue::new_int(100)),
+                            ])
+                            .severity_text("INFO")
+                            .body(AnyValue::new_string("heartbeat"))
+                            .finish(),
+                    ],
+                )],
+            ),
+        ])
+    }
+
+    // build logs data for testing version 2
+    fn build_logs_2() -> LogsData {
+        LogsData::new(vec![ResourceLogs::new(
+            Resource::build()
+                .attributes(vec![
+                    KeyValue::new("version", AnyValue::new_string("2.0")),
+                    KeyValue::new(
+                        "service.name",
+                        AnyValue::new_string("payments-checkout-service"),
+                    ),
+                    KeyValue::new("service.version", AnyValue::new_string("1.4.3")),
+                    KeyValue::new("service.instance.number", AnyValue::new_int(42)),
+                    // Use "production" to exercise regex ^prod(uction)?$
+                    KeyValue::new("deployment.environment", AnyValue::new_string("production")),
+                    KeyValue::new("cloud.region", AnyValue::new_string("us-central1")),
+                    KeyValue::new("host.cpu_cores", AnyValue::new_int(8)),
+                    KeyValue::new("host.uptime_sec", AnyValue::new_int(86_400)),
+                    KeyValue::new("sampling.rate", AnyValue::new_double(0.25)),
+                    KeyValue::new("debug.enabled", AnyValue::new_bool(false)),
+                    KeyValue::new("process.pid", AnyValue::new_int(12345)),
+                    KeyValue::new("team", AnyValue::new_string("payments")),
+                    KeyValue::new("telemetry.sdk.language", AnyValue::new_string("rust")),
+                ])
+                .finish(),
+            vec![ScopeLogs::new(
+                InstrumentationScope::build()
+                    .name("library")
+                    .version("scopev1")
+                    .finish(),
+                vec![
+                    // Log A: WARN with string body; attributes include int/float/bool
+                    LogRecord::build()
+                        .time_unix_nano(2_200_000_000u64)
+                        .severity_number(SeverityNumber::Warn)
+                        .body(AnyValue::new_string("event"))
+                        .attributes(vec![
+                            KeyValue::new("component", AnyValue::new_string("rest")),
+                            KeyValue::new("http.status_code", AnyValue::new_int(200)),
+                            KeyValue::new("feature_flag", AnyValue::new_bool(true)),
+                            KeyValue::new("load", AnyValue::new_double(0.73)),
+                            KeyValue::new("items_count", AnyValue::new_int(2)),
+                        ])
+                        .severity_text("WARN")
+                        .body(AnyValue::new_string("ok checkout #1"))
+                        .finish(),
+                    // Log B: ERROR with numeric (double) body; attributes include int/float/bool
+                    LogRecord::build()
+                        .time_unix_nano(2_300_000_000u64)
+                        .severity_number(SeverityNumber::Error)
+                        .body(AnyValue::new_string("event"))
+                        .attributes(vec![
+                            KeyValue::new("component", AnyValue::new_string("svc")),
+                            KeyValue::new("retryable", AnyValue::new_bool(false)),
+                            KeyValue::new("attempt", AnyValue::new_int(3)),
+                            KeyValue::new("error_rate", AnyValue::new_double(0.02)),
+                        ])
+                        .severity_text("ERROR")
+                        .body(AnyValue::new_double(12.5))
+                        .finish(),
+                ],
+            )],
+        )])
+    }
+
     /// Validation closure that checks the outputted data
     fn validation_procedure() -> impl FnOnce(ValidateContext) -> Pin<Box<dyn Future<Output = ()>>> {
         |mut _ctx| Box::pin(async move {})
@@ -177,145 +389,7 @@ mod tests {
         move |mut ctx| {
             Box::pin(async move {
                 // send log message
-                let logs_data = LogsData::new(vec![
-    // ResourceLogs for prod/checkout-service
-    ResourceLogs::new(
-        Resource::build()
-            .attributes(vec![
-                KeyValue::new("version", AnyValue::new_string("2.0")),
-                KeyValue::new("service.name", AnyValue::new_string("checkout-service")),
-                KeyValue::new("service.version", AnyValue::new_string("1.4.3")),
-                KeyValue::new("service.instance.number", AnyValue::new_int(42)),
-                KeyValue::new("deployment.environment", AnyValue::new_string("prod")),
-                KeyValue::new("cloud.region", AnyValue::new_string("us-central1")),
-                KeyValue::new("host.cpu_cores", AnyValue::new_int(8)),
-                KeyValue::new("host.uptime_sec", AnyValue::new_int(86_400)),
-                KeyValue::new("sampling.rate", AnyValue::new_double(0.25)),
-                KeyValue::new("debug.enabled", AnyValue::new_bool(false)),
-                KeyValue::new("process.pid", AnyValue::new_int(12345)),
-                KeyValue::new("team", AnyValue::new_string("payments")),
-                KeyValue::new("telemetry.sdk.language", AnyValue::new_string("rust")),
-            ])
-            .finish(),
-        vec![
-            ScopeLogs::new(
-                InstrumentationScope::build()
-                    .name("library")
-                    .version("scopev1")
-                    .finish(),
-                vec![
-                    // WARN: passes include; will be removed by exclude via severity_texts/body
-                    LogRecord::build()
-                        .time_unix_nano(2_200_000_000u64)
-                        .severity_number(SeverityNumber::Warn)
-                        .body(AnyValue::new_string("event"))
-                        .attributes(vec![
-                    KeyValue::new("component", AnyValue::new_string("rest")),
-                    KeyValue::new("http.method", AnyValue::new_string("POST")),
-                    KeyValue::new("http.route", AnyValue::new_string("/api/checkout")),
-                    KeyValue::new("http.status_code", AnyValue::new_int(200)),
-                    KeyValue::new("retryable", AnyValue::new_bool(false)),
-                    KeyValue::new("backoff_ms", AnyValue::new_int(0)),
-                            KeyValue::new("throttle_factor", AnyValue::new_double(0.0)),
-                        ])
-                        .severity_text("WARN")
-                        .body(AnyValue::new_string("checkout started"))
-                        .finish(),
-
-                    // ERROR: passes include; not removed by exclude
-                    LogRecord::build()
-                        .time_unix_nano(2_300_000_000u64)
-                        .severity_number(SeverityNumber::Error)
-                        .body(AnyValue::new_string("event"))
-                .attributes(vec![
-                    KeyValue::new("exception.type", AnyValue::new_string("io::Error")),
-                    KeyValue::new("exception.message", AnyValue::new_string("connection reset by peer")),
-                    KeyValue::new("exception.stacktrace", AnyValue::new_string("...stack...")),
-                    KeyValue::new("peer.address", AnyValue::new_string("10.42.0.7:5432")),
-                    KeyValue::new("peer.port", AnyValue::new_int(5432)),
-                    KeyValue::new("peer.tls", AnyValue::new_bool(true)),
-                    KeyValue::new("bytes_sent", AnyValue::new_int(0)),
-                            KeyValue::new("jitter", AnyValue::new_double(0.003)),
-                        ])
-                        .severity_text("ERROR")
-                        .body(AnyValue::new_string("failed to write to socket"))
-                        .finish(),
-
-                    // WARN: component=db; fails exclude (component=db)
-                    LogRecord::build()
-                        .time_unix_nano(2_600_000_000u64)
-                        .severity_number(SeverityNumber::Warn)
-                        .body(AnyValue::new_string("event"))
-                .attributes(vec![
-                    KeyValue::new("component", AnyValue::new_string("db")),
-                    KeyValue::new("query", AnyValue::new_string("UPDATE inventory SET count = count - 1 WHERE sku='ABC123'")),
-                    KeyValue::new("rows_affected", AnyValue::new_int(1)),
-                            KeyValue::new("success", AnyValue::new_bool(true)),
-                        ])
-                        .severity_text("WARN")
-                        .body(AnyValue::new_string("inventory updated"))
-                        .finish(),
-                ],
-            ),
-        ],
-    ),
-
-    // ResourceLogs for staging/inventory-service (excluded by both filters)
-    ResourceLogs::new(
-        Resource::build()
-            .attributes(vec![
-        KeyValue::new("version", AnyValue::new_string("2.0")),
-        KeyValue::new("service.name", AnyValue::new_string("inventory-service")),
-        KeyValue::new("service.version", AnyValue::new_string("0.9.1")),
-        KeyValue::new("service.instance.number", AnyValue::new_int(7)),
-        KeyValue::new("deployment.environment", AnyValue::new_string("staging")),
-        KeyValue::new("cloud.region", AnyValue::new_string("us-central1")),
-        KeyValue::new("host.cpu_cores", AnyValue::new_int(4)),
-        KeyValue::new("host.uptime_sec", AnyValue::new_int(12_345)),
-        KeyValue::new("sampling.rate", AnyValue::new_double(0.10)),
-        KeyValue::new("debug.enabled", AnyValue::new_bool(true)),
-        KeyValue::new("process.pid", AnyValue::new_int(22222)),
-                KeyValue::new("team", AnyValue::new_string("inventory")),
-            ])
-            .finish(),
-        vec![
-            ScopeLogs::new(
-                InstrumentationScope::build()
-                    .name("library")
-                    .version("scopev2")
-                    .finish(),
-                vec![
-                    LogRecord::build()
-                        .time_unix_nano(3_000_000_000u64)
-                        .severity_number(SeverityNumber::Warn)
-                        .body(AnyValue::new_string("event"))
-                .attributes(vec![
-                    KeyValue::new("component", AnyValue::new_string("rest")),
-                    KeyValue::new("http.route", AnyValue::new_string("/api/internal/cache_warm")),
-                    KeyValue::new("http.status_code", AnyValue::new_int(200)),
-                            KeyValue::new("success", AnyValue::new_bool(true)),
-                        ])
-                        .severity_text("WARN")
-                        .body(AnyValue::new_string("warmup complete"))
-                        .finish(),
-
-                    LogRecord::build()
-                        .time_unix_nano(3_100_000_000u64)
-                        .severity_number(SeverityNumber::Info)
-                        .body(AnyValue::new_string("event"))
-                .attributes(vec![
-                    KeyValue::new("event.domain", AnyValue::new_string("ops")),
-                    KeyValue::new("message", AnyValue::new_string("heartbeat")),
-                            KeyValue::new("uptime_sec", AnyValue::new_int(100)),
-                        ])
-                        .severity_text("INFO")
-                        .body(AnyValue::new_string("heartbeat"))
-                        .finish(),
-                ],
-            ),
-        ],
-    ),
-]);
+                let logs_data = build_logs_1();
 
                 //convert logsdata to otappdata
                 let mut bytes = vec![];
@@ -484,69 +558,7 @@ mod tests {
         move |mut ctx| {
             Box::pin(async move {
                 // send log message
-                let logs_data = LogsData::new(vec![ResourceLogs::new(
-                    Resource::build()
-                        .attributes(vec![
-                            KeyValue::new("version", AnyValue::new_string("2.0")),
-                            KeyValue::new(
-                                "service.name",
-                                AnyValue::new_string("payments-checkout-service"),
-                            ),
-                            KeyValue::new("service.version", AnyValue::new_string("1.4.3")),
-                            KeyValue::new("service.instance.number", AnyValue::new_int(42)),
-                            // Use "production" to exercise regex ^prod(uction)?$
-                            KeyValue::new(
-                                "deployment.environment",
-                                AnyValue::new_string("production"),
-                            ),
-                            KeyValue::new("cloud.region", AnyValue::new_string("us-central1")),
-                            KeyValue::new("host.cpu_cores", AnyValue::new_int(8)),
-                            KeyValue::new("host.uptime_sec", AnyValue::new_int(86_400)),
-                            KeyValue::new("sampling.rate", AnyValue::new_double(0.25)),
-                            KeyValue::new("debug.enabled", AnyValue::new_bool(false)),
-                            KeyValue::new("process.pid", AnyValue::new_int(12345)),
-                            KeyValue::new("team", AnyValue::new_string("payments")),
-                            KeyValue::new("telemetry.sdk.language", AnyValue::new_string("rust")),
-                        ])
-                        .finish(),
-                    vec![ScopeLogs::new(
-                        InstrumentationScope::build()
-                            .name("library")
-                            .version("scopev1")
-                            .finish(),
-                        vec![
-                            // Log A: WARN with string body; attributes include int/float/bool
-                            LogRecord::build()
-                                .time_unix_nano(2_200_000_000u64)
-                                .severity_number(SeverityNumber::Warn)
-                                .body(AnyValue::new_string("event"))
-                                .attributes(vec![
-                                    KeyValue::new("component", AnyValue::new_string("rest")),
-                                    KeyValue::new("http.status_code", AnyValue::new_int(200)),
-                                    KeyValue::new("feature_flag", AnyValue::new_bool(true)),
-                                    KeyValue::new("load", AnyValue::new_double(0.73)),
-                                    KeyValue::new("items_count", AnyValue::new_int(2)),
-                                ])
-                                .severity_text("WARN")
-                                .body(AnyValue::new_string("ok checkout #1"))
-                                .finish(),
-                            // Log B: ERROR with numeric (double) body; attributes include int/float/bool
-                            LogRecord::build()
-                                .time_unix_nano(2_300_000_000u64)
-                                .severity_number(SeverityNumber::Error)
-                                .body(AnyValue::new_string("event"))
-                                .attributes(vec![
-                                    KeyValue::new("component", AnyValue::new_string("svc")),
-                                    KeyValue::new("retryable", AnyValue::new_bool(false)),
-                                    KeyValue::new("attempt", AnyValue::new_int(3)),
-                                    KeyValue::new("error_rate", AnyValue::new_double(0.02)),
-                                ])
-                                .severity_text("ERROR")
-                                .body(AnyValue::new_double(12.5))
-                                .finish(),
-                        ],
-                    )],
-                )]);
+                let logs_data = build_logs_2();
 
                 //convert logsdata to otappdata
                 let mut bytes = vec![];
@@ -693,6 +705,340 @@ mod tests {
         test_runtime
             .set_processor(processor)
             .run_test(scenario_regex())
+            .validate(validation_procedure());
+    }
+
+    /// Test closure that simulates a typical processor scenario.
+    fn scenario_strict_include_only()
+    -> impl FnOnce(TestContext<OtapPdata>) -> Pin<Box<dyn Future<Output = ()>>> {
+        move |mut ctx| {
+            Box::pin(async move {
+                // send log message
+                let logs_data = build_logs_1();
+
+                //convert logsdata to otappdata
+                let mut bytes = vec![];
+                logs_data
+                    .encode(&mut bytes)
+                    .expect("failed to encode log data into bytes");
+                let otlp_logs_bytes =
+                    OtapPdata::new_default(OtlpProtoBytes::ExportLogsRequest(bytes).into());
+                ctx.process(Message::PData(otlp_logs_bytes))
+                    .await
+                    .expect("failed to process");
+                let msgs = ctx.drain_pdata().await;
+                assert_eq!(msgs.len(), 1);
+                let received_logs_data = &msgs[0];
+                let (_, payload) = received_logs_data.clone().into_parts();
+                let otlp_bytes: OtlpProtoBytes = payload
+                    .try_into()
+                    .expect("failed to convert to OtlpProtoBytes");
+                let received_logs_data = match otlp_bytes {
+                    OtlpProtoBytes::ExportLogsRequest(bytes) => LogsData::decode(bytes.as_slice())
+                        .expect("failed to decode logs into logsdata"),
+                    _ => panic!("expected logs type"),
+                };
+
+                let expected_logs_data = LogsData::new(vec![
+                    // ResourceLogs for prod/checkout-service
+                    ResourceLogs::new(
+                        Resource::build()
+                            .attributes(vec![
+                                KeyValue::new("version", AnyValue::new_string("2.0")),
+                                KeyValue::new(
+                                    "service.name",
+                                    AnyValue::new_string("checkout-service"),
+                                ),
+                                KeyValue::new("service.version", AnyValue::new_string("1.4.3")),
+                                KeyValue::new("service.instance.number", AnyValue::new_int(42)),
+                                KeyValue::new(
+                                    "deployment.environment",
+                                    AnyValue::new_string("prod"),
+                                ),
+                                KeyValue::new("cloud.region", AnyValue::new_string("us-central1")),
+                                KeyValue::new("host.cpu_cores", AnyValue::new_int(8)),
+                                KeyValue::new("host.uptime_sec", AnyValue::new_int(86_400)),
+                                KeyValue::new("sampling.rate", AnyValue::new_double(0.25)),
+                                KeyValue::new("debug.enabled", AnyValue::new_bool(false)),
+                                KeyValue::new("process.pid", AnyValue::new_int(12345)),
+                                KeyValue::new("team", AnyValue::new_string("payments")),
+                                KeyValue::new(
+                                    "telemetry.sdk.language",
+                                    AnyValue::new_string("rust"),
+                                ),
+                            ])
+                            .finish(),
+                        vec![ScopeLogs::new(
+                            InstrumentationScope::build()
+                                .name("library")
+                                .version("scopev1")
+                                .finish(),
+                            vec![
+                                // ERROR: passes include; not removed by exclude
+                                LogRecord::build()
+                                    .time_unix_nano(2_300_000_000u64)
+                                    .severity_number(SeverityNumber::Error)
+                                    .body(AnyValue::new_string("event"))
+                                    .attributes(vec![
+                                        KeyValue::new(
+                                            "exception.type",
+                                            AnyValue::new_string("io::Error"),
+                                        ),
+                                        KeyValue::new(
+                                            "exception.message",
+                                            AnyValue::new_string("connection reset by peer"),
+                                        ),
+                                        KeyValue::new(
+                                            "exception.stacktrace",
+                                            AnyValue::new_string("...stack..."),
+                                        ),
+                                        KeyValue::new(
+                                            "peer.address",
+                                            AnyValue::new_string("10.42.0.7:5432"),
+                                        ),
+                                        KeyValue::new("peer.port", AnyValue::new_int(5432)),
+                                        KeyValue::new("peer.tls", AnyValue::new_bool(true)),
+                                        KeyValue::new("bytes_sent", AnyValue::new_int(0)),
+                                        KeyValue::new("jitter", AnyValue::new_double(0.003)),
+                                    ])
+                                    .severity_text("ERROR")
+                                    .body(AnyValue::new_string("failed to write to socket"))
+                                    .finish(),
+                            ],
+                        )],
+                    ),
+                ]);
+                assert_eq!(received_logs_data, expected_logs_data);
+            })
+        }
+    }
+
+    #[test]
+    fn test_filter_processor_logs_strict_include_only() {
+        let test_runtime = TestRuntime::new();
+
+        let include_props = LogMatchProperties::new(
+            MatchType::Strict,
+            vec![
+                KeyValueFilter::new(
+                    "deployment.environment".to_string(),
+                    AnyValueFilter::String("prod".to_string()),
+                ),
+                KeyValueFilter::new(
+                    "service.instance.number".to_string(),
+                    AnyValueFilter::Int(42),
+                ),
+                KeyValueFilter::new("sampling.rate".to_string(), AnyValueFilter::Double(0.25)),
+                KeyValueFilter::new("debug.enabled".to_string(), AnyValueFilter::Boolean(false)),
+            ],
+            vec![
+                KeyValueFilter::new("peer.port".to_string(), AnyValueFilter::Int(5432)),
+                KeyValueFilter::new("jitter".to_string(), AnyValueFilter::Double(0.003)),
+            ],
+            vec!["WARN".to_string(), "ERROR".to_string()], // test severity_texts
+            Some(LogSeverityNumberMatchProperties::new(13, true)), // WARN and above
+            vec![
+                AnyValueFilter::String("checkout started".to_string()),
+                AnyValueFilter::String("failed to write to socket".to_string()),
+            ], // test bodies
+        );
+
+        let log_filter = LogFilter::new(
+            Some(include_props),
+            None,
+            Vec::new(), // log_record ignored
+        );
+
+        let config = Config::new(log_filter);
+        let user_config = Arc::new(NodeUserConfig::new_processor_config(FILTER_PROCESSOR_URN));
+        let metrics_registry_handle = MetricsRegistryHandle::new();
+        let controller_ctx = ControllerContext::new(metrics_registry_handle);
+        let pipeline_ctx =
+            controller_ctx.pipeline_context_with("grp".into(), "pipeline".into(), 0, 0);
+        let processor = ProcessorWrapper::local(
+            FilterProcessor::new(config, pipeline_ctx),
+            test_node(test_runtime.config().name.clone()),
+            user_config,
+            test_runtime.config(),
+        );
+
+        test_runtime
+            .set_processor(processor)
+            .run_test(scenario_strict_include_only())
+            .validate(validation_procedure());
+    }
+
+    /// Test closure that simulates a typical processor scenario.
+    fn scenario_strict_exclude_only()
+    -> impl FnOnce(TestContext<OtapPdata>) -> Pin<Box<dyn Future<Output = ()>>> {
+        move |mut ctx| {
+            Box::pin(async move {
+                // send log message
+                let logs_data = build_logs_1();
+
+                //convert logsdata to otappdata
+                let mut bytes = vec![];
+                logs_data
+                    .encode(&mut bytes)
+                    .expect("failed to encode log data into bytes");
+                let otlp_logs_bytes =
+                    OtapPdata::new_default(OtlpProtoBytes::ExportLogsRequest(bytes).into());
+                ctx.process(Message::PData(otlp_logs_bytes))
+                    .await
+                    .expect("failed to process");
+                let msgs = ctx.drain_pdata().await;
+                assert_eq!(msgs.len(), 1);
+                let received_logs_data = &msgs[0];
+                let (_, payload) = received_logs_data.clone().into_parts();
+                let otlp_bytes: OtlpProtoBytes = payload
+                    .try_into()
+                    .expect("failed to convert to OtlpProtoBytes");
+                let received_logs_data = match otlp_bytes {
+                    OtlpProtoBytes::ExportLogsRequest(bytes) => LogsData::decode(bytes.as_slice())
+                        .expect("failed to decode logs into logsdata"),
+                    _ => panic!("expected logs type"),
+                };
+
+                let expected_logs_data = LogsData::new(vec![
+                    // ResourceLogs for prod/checkout-service
+                    ResourceLogs::new(
+                        Resource::build()
+                            .attributes(vec![
+                                KeyValue::new("version", AnyValue::new_string("2.0")),
+                                KeyValue::new(
+                                    "service.name",
+                                    AnyValue::new_string("checkout-service"),
+                                ),
+                                KeyValue::new("service.version", AnyValue::new_string("1.4.3")),
+                                KeyValue::new("service.instance.number", AnyValue::new_int(42)),
+                                KeyValue::new(
+                                    "deployment.environment",
+                                    AnyValue::new_string("prod"),
+                                ),
+                                KeyValue::new("cloud.region", AnyValue::new_string("us-central1")),
+                                KeyValue::new("host.cpu_cores", AnyValue::new_int(8)),
+                                KeyValue::new("host.uptime_sec", AnyValue::new_int(86_400)),
+                                KeyValue::new("sampling.rate", AnyValue::new_double(0.25)),
+                                KeyValue::new("debug.enabled", AnyValue::new_bool(false)),
+                                KeyValue::new("process.pid", AnyValue::new_int(12345)),
+                                KeyValue::new("team", AnyValue::new_string("payments")),
+                                KeyValue::new(
+                                    "telemetry.sdk.language",
+                                    AnyValue::new_string("rust"),
+                                ),
+                            ])
+                            .finish(),
+                        vec![ScopeLogs::new(
+                            InstrumentationScope::build()
+                                .name("library")
+                                .version("scopev1")
+                                .finish(),
+                            vec![
+                                LogRecord::build()
+                                    .time_unix_nano(2_200_000_000u64)
+                                    .severity_number(SeverityNumber::Warn)
+                                    .body(AnyValue::new_string("event"))
+                                    .attributes(vec![
+                                        KeyValue::new("component", AnyValue::new_string("rest")),
+                                        KeyValue::new("http.method", AnyValue::new_string("POST")),
+                                        KeyValue::new(
+                                            "http.route",
+                                            AnyValue::new_string("/api/checkout"),
+                                        ),
+                                        KeyValue::new("http.status_code", AnyValue::new_int(200)),
+                                        KeyValue::new("retryable", AnyValue::new_bool(false)),
+                                        KeyValue::new("backoff_ms", AnyValue::new_int(0)),
+                                        KeyValue::new("throttle_factor", AnyValue::new_double(0.0)),
+                                    ])
+                                    .severity_text("WARN")
+                                    .body(AnyValue::new_string("checkout started"))
+                                    .finish(),
+                                LogRecord::build()
+                                    .time_unix_nano(2_300_000_000u64)
+                                    .severity_number(SeverityNumber::Error)
+                                    .body(AnyValue::new_string("event"))
+                                    .attributes(vec![
+                                        KeyValue::new(
+                                            "exception.type",
+                                            AnyValue::new_string("io::Error"),
+                                        ),
+                                        KeyValue::new(
+                                            "exception.message",
+                                            AnyValue::new_string("connection reset by peer"),
+                                        ),
+                                        KeyValue::new(
+                                            "exception.stacktrace",
+                                            AnyValue::new_string("...stack..."),
+                                        ),
+                                        KeyValue::new(
+                                            "peer.address",
+                                            AnyValue::new_string("10.42.0.7:5432"),
+                                        ),
+                                        KeyValue::new("peer.port", AnyValue::new_int(5432)),
+                                        KeyValue::new("peer.tls", AnyValue::new_bool(true)),
+                                        KeyValue::new("bytes_sent", AnyValue::new_int(0)),
+                                        KeyValue::new("jitter", AnyValue::new_double(0.003)),
+                                    ])
+                                    .severity_text("ERROR")
+                                    .body(AnyValue::new_string("failed to write to socket"))
+                                    .finish(),
+                            ],
+                        )],
+                    ),
+                ]);
+                assert_eq!(received_logs_data, expected_logs_data);
+            })
+        }
+    }
+
+    #[test]
+    fn test_filter_processor_logs_strict_exclude_only() {
+        let test_runtime = TestRuntime::new();
+
+        let exclude_props = LogMatchProperties::new(
+            MatchType::Strict,
+            vec![KeyValueFilter::new(
+                "deployment.environment".to_string(),
+                AnyValueFilter::String("staging".to_string()),
+            )],
+            vec![
+                KeyValueFilter::new(
+                    "component".to_string(),
+                    AnyValueFilter::String("db".to_string()),
+                ),
+                KeyValueFilter::new("retryable".to_string(), AnyValueFilter::Boolean(true)),
+            ],
+            vec!["INFO".to_string()],
+            None,
+            vec![
+                AnyValueFilter::String("inventory updated".to_string()), // exclude by body
+                AnyValueFilter::String("warmup complete".to_string()),
+                AnyValueFilter::String("heartbeat".to_string()),
+            ],
+        );
+
+        let log_filter = LogFilter::new(
+            None,
+            Some(exclude_props),
+            Vec::new(), // log_record ignored
+        );
+
+        let config = Config::new(log_filter);
+        let user_config = Arc::new(NodeUserConfig::new_processor_config(FILTER_PROCESSOR_URN));
+        let metrics_registry_handle = MetricsRegistryHandle::new();
+        let controller_ctx = ControllerContext::new(metrics_registry_handle);
+        let pipeline_ctx =
+            controller_ctx.pipeline_context_with("grp".into(), "pipeline".into(), 0, 0);
+        let processor = ProcessorWrapper::local(
+            FilterProcessor::new(config, pipeline_ctx),
+            test_node(test_runtime.config().name.clone()),
+            user_config,
+            test_runtime.config(),
+        );
+
+        test_runtime
+            .set_processor(processor)
+            .run_test(scenario_strict_exclude_only())
             .validate(validation_procedure());
     }
 }

--- a/rust/otap-dataflow/crates/pdata/src/otap/filter/logs.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/filter/logs.rs
@@ -9,7 +9,6 @@ use crate::arrays::{
     get_required_array, get_required_array_from_struct_array,
     get_required_array_from_struct_array_from_record_batch, get_required_struct_array,
 };
-use crate::encode::record::logs;
 use crate::otap::OtapArrowRecords;
 use crate::otap::error::{Error, Result};
 use crate::otap::filter::{
@@ -22,7 +21,6 @@ use arrow::array::{
     Array, BooleanArray, Float64Array, Int32Array, Int64Array, StringArray, UInt16Array,
 };
 use arrow::buffer::BooleanBuffer;
-use nix::libc::option;
 use serde::Deserialize;
 use std::collections::HashMap;
 


### PR DESCRIPTION
Changed the include and exclude fields to be optional so that both don't have to be defined at the same time.

fixes issue described in https://github.com/open-telemetry/otel-arrow/issues/1352