### PR TITLE
Remove duplicated documentation for OTAP pdata & document pdata module

### DIFF
--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -1,6 +1,18 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+//! This module manages how telemetry pipeline data (pdata) flows through pipeline
+//! components (receivers, processors, exporters) and how components receive
+//! acknowledgments (Ack) and negative acknowledgments (Nack) about this pdata.
+//!
+//! This includes:
+//! - Context: a stack of pipeline component subscriptions
+//! - Interests: allows components to declare whether they subscribe to Ack/Nack
+//!
+//! Components can subscribe to receive notifications when their pdata is accepted (Ack) or
+//! encountered issues (Nack) downstream, optionally preserving the payload for retry or logging.
+//! This functionality is exposed through various traits implemented by effect handlers.
+
 use async_trait::async_trait;
 use otap_df_config::SignalType;
 use otap_df_engine::error::Error;


### PR DESCRIPTION
Looks like somehow in our refactoring of otel_arrow_rust / otap pdata we duplicated the documentation for the pdata module. The documentation this PR removes is also in [pdata.rs](https://github.com/open-telemetry/otel-arrow/blob/430a4835157fdbe9cbf98b75970ff971476a39af/rust/otap-dataflow/crates/otap/src/pdata.rs#L4) and we probably don't need it in both places and adds documentation for the pdata module

Part of #1422.
