### PR TITLE
Upgrade arrow to improve zstd payload compression performance in OTAP Exporter

### DIFF
--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -47,9 +47,9 @@ otap-df-otap = { path = "crates/otap" }
 
 ahash = "0.8.11"
 arrayvec = "0.7.6"
-arrow = "56.1" # TODO upgrade to 57 after perf test
-arrow-ipc = { version = "56.1", features=["zstd"] }
-arrow-schema = { version = "56.1" }
+arrow = "57.0"
+arrow-ipc = { version = "57.0", features=["zstd"] }
+arrow-schema = { version = "57.0" }
 async-stream = "0.3.6"
 async-trait = "0.1.88"
 async-unsync = "0.3.0"
@@ -83,7 +83,7 @@ once_cell = "1.20.2"
 opentelemetry-proto = { version = "0.31", default-features = false} #TODO - use it from submodule instead of crate(?)
 parking_lot = "0.12.4"
 paste = "1"
-parquet = { version = "56.1", default-features = false, features = ["arrow", "async", "object_store"]}
+parquet = { version = "57.0", default-features = false, features = ["arrow", "async", "object_store"]}
 portpicker = "0.1.1"
 pretty_assertions = "1.4.1"
 proc-macro2 = "1.0"


### PR DESCRIPTION
Closes #1129 

arrow-rs 57.0 has an improvement for the performance of zstd IPC compression https://github.com/apache/arrow-rs/pull/8405