### PR TITLE
[query-engine] Fix strcat appending "null" bug

### DIFF
--- a/rust/experimental/query_engine/engine-recordset/src/scalars/text_scalar_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/scalars/text_scalar_expressions.rs
@@ -45,6 +45,9 @@ where
                     a.take((..).into(), |_, r| Ok(r), &mut |r: ResolvedValue<'_>| {
                         match r.to_value() {
                             Value::String(v) => s.push_str(v.get_value()),
+                            Value::Null => {
+                                // Note: Null becomes empty string
+                            },
                             v => {
                                 let mut result = None;
                                 v.convert_to_string(&mut |v| {


### PR DESCRIPTION
## Changes

* Fixes recordset engine so that when executing `strcat` it appends empty string for `null` instead of "null"