### PR TITLE
Correct labeler behavior to match desired label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,7 +4,7 @@ rust:
 go:
 - changed-files:
   - any-glob-to-any-file: 'go/**/*'
-ci/cd:
+ci-repo:
 - changed-files:
   - any-glob-to-any-file: '.github/**/*'
 query-engine:


### PR DESCRIPTION
Noticed that many issues associated with CI / repo housekeeping were assigned under [`ci-repo` label](https://github.com/open-telemetry/otel-arrow/issues?q=state%3Aopen%20label%3Aci-repo). This snaps labeler assignment to follow that.

Will be deprecating the labels `ci/cd` and `housekeeping` in favor of this one.