### PR TITLE
Use otelbot app token for Tidy push

### DIFF
--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
+          persist-credentials: false
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version: "1.25.4"


### PR DESCRIPTION
Another attempt to get solution working for #1456.

It *almost* worked as expected in #1458 but I forgot an earlier lesson from [prepare-release](https://github.com/open-telemetry/otel-arrow/blob/382c61d4b35eaf8c4753b046d57aa7bc70d3b0e6/.github/workflows/prepare-release.yml#L133-L134) that we have to inject the special otelbot app token as an environment variable in the task that does the Git action. Otherwise, regular PR workflows are not triggered.

I've seen some evidence that we should opt out of persisting regular git creds from `checkout` in order for the `auth setup-git` to work. Would like to try this configuration.