### PR TITLE
[query-engine] Simply lifetimes on RecordSetEngine ExecutionContext struct

### DIFF
--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/tests/common/mod.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/tests/common/mod.rs
@@ -4,14 +4,12 @@
 use data_engine_expressions::*;
 use data_engine_recordset::*;
 
-pub(crate) fn process_records<'a, 'b, 'c, TRecords, TRecord>(
+pub(crate) fn process_records<'a, TRecords, TRecord>(
     pipeline: &'a PipelineExpression,
-    engine: &'b RecordSetEngine,
+    engine: &RecordSetEngine,
     records: &mut TRecords,
-) -> RecordSetEngineResults<'a, 'c, TRecord>
+) -> RecordSetEngineResults<'a, TRecord>
 where
-    'a: 'c,
-    'b: 'c,
     TRecords: RecordSet<TRecord>,
     TRecord: Record + 'static,
 {

--- a/rust/experimental/query_engine/engine-recordset/src/logical_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/logical_expressions.rs
@@ -6,7 +6,7 @@ use data_engine_expressions::*;
 use crate::{execution_context::*, scalars::*, *};
 
 pub fn execute_logical_expression<'a, TRecord: Record>(
-    execution_context: &ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &ExecutionContext<'a, '_, TRecord>,
     logical_expression: &'a LogicalExpression,
 ) -> Result<bool, ExpressionError> {
     let value = match logical_expression {

--- a/rust/experimental/query_engine/engine-recordset/src/scalars/collection_scalar_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/scalars/collection_scalar_expressions.rs
@@ -6,7 +6,7 @@ use data_engine_expressions::*;
 use crate::{execution_context::*, scalars::execute_scalar_expression, *};
 
 pub fn execute_collection_scalar_expression<'a, 'b, 'c, TRecord: Record>(
-    execution_context: &'b ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &'b ExecutionContext<'a, '_, TRecord>,
     collection_scalar_expression: &'a CollectionScalarExpression,
 ) -> Result<ResolvedValue<'c>, ExpressionError>
 where

--- a/rust/experimental/query_engine/engine-recordset/src/scalars/convert_scalar_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/scalars/convert_scalar_expressions.rs
@@ -6,7 +6,7 @@ use data_engine_expressions::*;
 use crate::{execution_context::*, scalars::execute_scalar_expression, *};
 
 pub fn execute_convert_scalar_expression<'a, 'b, 'c, TRecord: Record>(
-    execution_context: &'b ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &'b ExecutionContext<'a, '_, TRecord>,
     convert_scalar_expression: &'a ConvertScalarExpression,
 ) -> Result<ResolvedValue<'c>, ExpressionError>
 where

--- a/rust/experimental/query_engine/engine-recordset/src/scalars/math_scalar_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/scalars/math_scalar_expressions.rs
@@ -6,7 +6,7 @@ use data_engine_expressions::*;
 use crate::{execution_context::*, scalars::execute_scalar_expression, *};
 
 pub fn execute_math_scalar_expression<'a, 'b, 'c, TRecord: Record>(
-    execution_context: &'b ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &'b ExecutionContext<'a, '_, TRecord>,
     math_scalar_expression: &'a MathScalarExpression,
 ) -> Result<ResolvedValue<'c>, ExpressionError>
 where
@@ -49,7 +49,7 @@ where
 }
 
 fn execute_unary_operation<'a, 'b, TRecord: Record, F>(
-    execution_context: &ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &ExecutionContext<'a, '_, TRecord>,
     unary_expression: &'a UnaryMathematicalScalarExpression,
     op: F,
 ) -> Result<ResolvedValue<'b>, ExpressionError>
@@ -66,7 +66,7 @@ where
 }
 
 fn execute_binary_operation<'a, 'b, TRecord: Record, F>(
-    execution_context: &ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &ExecutionContext<'a, '_, TRecord>,
     binary_expression: &'a BinaryMathematicalScalarExpression,
     op: F,
 ) -> Result<ResolvedValue<'b>, ExpressionError>

--- a/rust/experimental/query_engine/engine-recordset/src/scalars/parse_scalar_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/scalars/parse_scalar_expressions.rs
@@ -6,7 +6,7 @@ use data_engine_expressions::*;
 use crate::{execution_context::*, scalars::execute_scalar_expression, *};
 
 pub fn execute_parse_scalar_expression<'a, 'b, 'c, TRecord: Record>(
-    execution_context: &'b ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &'b ExecutionContext<'a, '_, TRecord>,
     parse_scalar_expression: &'a ParseScalarExpression,
 ) -> Result<ResolvedValue<'c>, ExpressionError>
 where

--- a/rust/experimental/query_engine/engine-recordset/src/scalars/scalar_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/scalars/scalar_expressions.rs
@@ -26,7 +26,7 @@ static VALUE_TYPE_NAMES: LazyLock<Vec<StringValueStorage>> = LazyLock::new(|| {
 });
 
 pub fn execute_scalar_expression<'a, 'b, 'c, TRecord: Record>(
-    execution_context: &'b ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &'b ExecutionContext<'a, '_, TRecord>,
     scalar_expression: &'a ScalarExpression,
 ) -> Result<ResolvedValue<'c>, ExpressionError>
 where
@@ -472,7 +472,7 @@ where
 }
 
 fn select_from_borrowed_value<'a, 'b, 'c, TRecord: Record>(
-    execution_context: &'b ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &'b ExecutionContext<'a, '_, TRecord>,
     borrow_source: BorrowSource,
     borrow: Ref<'b, dyn AsStaticValue + 'static>,
     expression: &'a ScalarExpression,
@@ -600,7 +600,7 @@ where
 }
 
 fn select_from_value<'a, 'b, TRecord: Record>(
-    execution_context: &'b ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &'b ExecutionContext<'a, '_, TRecord>,
     root: Value<'b>,
     expression: &'a ScalarExpression,
     selectors: &mut Iter<'a, ScalarExpression>,

--- a/rust/experimental/query_engine/engine-recordset/src/scalars/temporal_scalar_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/scalars/temporal_scalar_expressions.rs
@@ -8,7 +8,7 @@ use chrono::Utc;
 use crate::{execution_context::*, *};
 
 pub fn execute_temporal_scalar_expression<'a, 'b, 'c, TRecord: Record>(
-    execution_context: &'b ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &'b ExecutionContext<'a, '_, TRecord>,
     temporal_scalar_expression: &'a TemporalScalarExpression,
 ) -> Result<ResolvedValue<'c>, ExpressionError>
 where

--- a/rust/experimental/query_engine/engine-recordset/src/scalars/text_scalar_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/scalars/text_scalar_expressions.rs
@@ -6,7 +6,7 @@ use data_engine_expressions::*;
 use crate::{execution_context::*, scalars::execute_scalar_expression, *};
 
 pub fn execute_text_scalar_expression<'a, 'b, 'c, TRecord: Record>(
-    execution_context: &'b ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &'b ExecutionContext<'a, '_, TRecord>,
     text_scalar_expression: &'a TextScalarExpression,
 ) -> Result<ResolvedValue<'c>, ExpressionError>
 where

--- a/rust/experimental/query_engine/engine-recordset/src/summary/summaries.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/summary/summaries.rs
@@ -24,7 +24,7 @@ impl<'a> Summaries<'a> {
 
     pub fn create_or_update_summary<T: Record>(
         &self,
-        execution_context: &ExecutionContext<'a, '_, '_, T>,
+        execution_context: &ExecutionContext<'a, '_, T>,
         summary_data_expression: &'a SummaryDataExpression,
         mut group_by_values: Vec<(Box<str>, ResolvedValue)>,
         mut aggregation_values: HashMap<Box<str>, SummaryAggregationUpdate>,
@@ -98,7 +98,7 @@ impl<'a> Summary<'a> {
 
     pub(crate) fn update<T: Record>(
         &mut self,
-        execution_context: &ExecutionContext<'a, '_, '_, T>,
+        execution_context: &ExecutionContext<'a, '_, T>,
         aggregation_values: HashMap<Box<str>, SummaryAggregationUpdate>,
     ) {
         for (key, aggregation) in aggregation_values {

--- a/rust/experimental/query_engine/engine-recordset/src/summary/summary_data_expression.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/summary/summary_data_expression.rs
@@ -7,7 +7,7 @@ use crate::{execution_context::*, scalars::*, *};
 use data_engine_expressions::*;
 
 pub fn execute_summary_data_expression<'a, TRecord: Record>(
-    execution_context: &ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &ExecutionContext<'a, '_, TRecord>,
     summary_data_expression: &'a SummaryDataExpression,
 ) -> Result<(), ExpressionError> {
     let group_by_expressions = summary_data_expression.get_group_by_expressions();

--- a/rust/experimental/query_engine/engine-recordset/src/transform/reduce_map_transform_expression.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/transform/reduce_map_transform_expression.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 pub fn execute_map_reduce_transform_expression<'a, TRecord: Record>(
-    execution_context: &ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &ExecutionContext<'a, '_, TRecord>,
     reduce_map_transform_expression: &'a ReduceMapTransformExpression,
 ) -> Result<(), ExpressionError> {
     match reduce_map_transform_expression {
@@ -287,7 +287,7 @@ impl PartialEq for MapReductionKey<'_> {
 impl Eq for MapReductionKey<'_> {}
 
 fn resolve_map_reduction<'a, 'b, 'c, TRecord: Record>(
-    execution_context: &'b ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &'b ExecutionContext<'a, '_, TRecord>,
     target: &'a MutableValueExpression,
     map_selection: &'a MapSelectionExpression,
 ) -> Result<MapReduction<'c>, ExpressionError>
@@ -345,7 +345,7 @@ where
 }
 
 fn process_map_reduction_accessor<'a, 'b, 'c, TRecord: Record>(
-    execution_context: &'b ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &'b ExecutionContext<'a, '_, TRecord>,
     target: &'a MutableValueExpression,
     mut selectors: Iter<'a, ScalarExpression>,
     current_reduction: &mut MapReduction<'c>,
@@ -405,7 +405,7 @@ where
 }
 
 fn remove_from_map<'a, TRecord: Record + 'static>(
-    execution_context: &ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &ExecutionContext<'a, '_, TRecord>,
     expression: &'a dyn Expression,
     map: &mut dyn MapValueMut,
     reduction: &MapReduction<'_>,
@@ -472,7 +472,7 @@ fn remove_from_map<'a, TRecord: Record + 'static>(
 }
 
 fn remove_from_array<'a, TRecord: Record + 'static>(
-    execution_context: &ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &ExecutionContext<'a, '_, TRecord>,
     expression: &'a dyn Expression,
     array: &mut dyn ArrayValueMut,
     reduction: &MapReduction<'_>,
@@ -551,7 +551,7 @@ fn remove_from_array<'a, TRecord: Record + 'static>(
 }
 
 fn keep_in_map<'a, TRecord: Record + 'static>(
-    execution_context: &ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &ExecutionContext<'a, '_, TRecord>,
     expression: &'a dyn Expression,
     map: &mut dyn MapValueMut,
     reduction: &MapReduction<'_>,
@@ -605,7 +605,7 @@ fn keep_in_map<'a, TRecord: Record + 'static>(
 }
 
 fn keep_in_array<'a, TRecord: Record + 'static>(
-    execution_context: &ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &ExecutionContext<'a, '_, TRecord>,
     expression: &'a dyn Expression,
     array: &mut dyn ArrayValueMut,
     reduction: &MapReduction<'_>,

--- a/rust/experimental/query_engine/engine-recordset/src/transform/rename_map_keys_transform_expression.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/transform/rename_map_keys_transform_expression.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 pub fn execute_rename_map_keys_transform_expression<'a, TRecord: Record>(
-    execution_context: &ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &ExecutionContext<'a, '_, TRecord>,
     rename_map_keys_transform_expression: &'a RenameMapKeysTransformExpression,
 ) -> Result<(), ExpressionError> {
     let target = rename_map_keys_transform_expression.get_target();
@@ -69,7 +69,7 @@ pub fn execute_rename_map_keys_transform_expression<'a, TRecord: Record>(
 }
 
 fn resolve_map_keys<'a, 'b, 'c, TRecord: Record>(
-    execution_context: &'b ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &'b ExecutionContext<'a, '_, TRecord>,
     target: &'a MutableValueExpression,
     map_keys: &'a [MapKeyRenameSelector],
 ) -> Result<(MapRename<'c>, MapRename<'c>), ExpressionError>
@@ -102,7 +102,7 @@ where
 }
 
 fn process_map_key_accessor<'a, 'b, 'c, TRecord: Record>(
-    execution_context: &'b ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &'b ExecutionContext<'a, '_, TRecord>,
     target: &'a MutableValueExpression,
     mut selectors: Iter<'a, ScalarExpression>,
     current_reduction: &mut MapRename<'c>,
@@ -161,7 +161,7 @@ where
 }
 
 fn remove<'a, TRecord: Record>(
-    execution_context: &ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &ExecutionContext<'a, '_, TRecord>,
     expression: &'a dyn Expression,
     values: &mut HashMap<usize, OwnedValue>,
     root: StaticValueMut,
@@ -294,7 +294,7 @@ fn remove<'a, TRecord: Record>(
 }
 
 fn set<'a, TRecord: Record>(
-    execution_context: &ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &ExecutionContext<'a, '_, TRecord>,
     expression: &'a dyn Expression,
     values: &mut HashMap<usize, OwnedValue>,
     root: StaticValueMut,

--- a/rust/experimental/query_engine/engine-recordset/src/transform/transform_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/transform/transform_expressions.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 
 pub fn execute_transform_expression<'a, TRecord: Record>(
-    execution_context: &ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &ExecutionContext<'a, '_, TRecord>,
     transform_expression: &'a TransformExpression,
 ) -> Result<(), ExpressionError> {
     match transform_expression {
@@ -485,7 +485,7 @@ impl Display for MapKeys<'_> {
 }
 
 fn resolve_map_keys<'a, 'b, 'c, TRecord: Record>(
-    execution_context: &'b ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &'b ExecutionContext<'a, '_, TRecord>,
     target: &'a MutableValueExpression,
     key_list: &'a MapKeyListExpression,
 ) -> Result<MapKeys<'c>, ExpressionError>

--- a/rust/experimental/query_engine/engine-recordset/src/value_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/value_expressions.rs
@@ -8,7 +8,7 @@ use data_engine_expressions::*;
 use crate::{execution_context::*, resolved_value_mut::*, scalars::*, *};
 
 pub fn execute_mutable_value_expression<'a, 'b, 'c, TRecord: Record>(
-    execution_context: &'b ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &'b ExecutionContext<'a, '_, TRecord>,
     mutable_value_expression: &'a MutableValueExpression,
 ) -> Result<Option<ResolvedValueMut<'b, 'c>>, ExpressionError>
 where
@@ -119,7 +119,7 @@ where
 }
 
 fn capture_selector_values_for_mutable_write<'a, 'b, 'c, TRecord: Record>(
-    execution_context: &'b ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &'b ExecutionContext<'a, '_, TRecord>,
     mutable_value_expression: &'a MutableValueExpression,
     selectors: &'a [ScalarExpression],
 ) -> Result<Vec<(&'a ScalarExpression, ResolvedValue<'c>)>, ExpressionError>
@@ -146,7 +146,7 @@ where
 }
 
 fn log_mutable_value_expression_evaluated<'a, TRecord: Record>(
-    execution_context: &ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &ExecutionContext<'a, '_, TRecord>,
     mutable_value_expression: &'a MutableValueExpression,
     value: &Option<ResolvedValueMut<'_, '_>>,
 ) {
@@ -173,7 +173,7 @@ fn log_mutable_value_expression_evaluated<'a, TRecord: Record>(
 }
 
 fn select_from_borrowed_root_map<'a, 'b, 'c, TRecord: Record>(
-    execution_context: &'b ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &'b ExecutionContext<'a, '_, TRecord>,
     root_expression: &'a dyn Expression,
     root: RefMut<'b, dyn MapValueMut + 'static>,
     mut selectors: Drain<(&'a ScalarExpression, ResolvedValue<'c>)>,
@@ -198,7 +198,7 @@ where
 }
 
 fn select_from_map_value_mut<'a, 'b, 'c, TRecord: Record>(
-    execution_context: &'b ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &'b ExecutionContext<'a, '_, TRecord>,
     expression: &'a dyn Expression,
     current_borrow: RefMut<'b, dyn MapValueMut + 'static>,
     current_selector: (&'a ScalarExpression, ResolvedValue<'c>),
@@ -264,7 +264,7 @@ where
 }
 
 fn select_from_array_value_mut<'a, 'b, 'c, TRecord: Record>(
-    execution_context: &'b ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &'b ExecutionContext<'a, '_, TRecord>,
     expression: &'a dyn Expression,
     current_borrow: RefMut<'b, dyn ArrayValueMut + 'static>,
     current_selector: (&'a ScalarExpression, ResolvedValue<'c>),
@@ -340,7 +340,7 @@ where
 }
 
 fn select_from_as_value_mut<'a, 'b, 'c, TRecord: Record>(
-    execution_context: &'b ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &'b ExecutionContext<'a, '_, TRecord>,
     expression: &'a dyn Expression,
     current_borrow: RefMut<'b, dyn AsStaticValueMut + 'static>,
     current_selector: (&'a ScalarExpression, ResolvedValue<'c>),
@@ -397,7 +397,7 @@ where
 }
 
 fn validate_array_index<'a, TRecord: Record>(
-    execution_context: &ExecutionContext<'a, '_, '_, TRecord>,
+    execution_context: &ExecutionContext<'a, '_, TRecord>,
     expression: &'a ScalarExpression,
     mut index: i64,
     array: &dyn ArrayValueMut,

--- a/rust/experimental/query_engine/expressions/src/primitives/array_value.rs
+++ b/rust/experimental/query_engine/expressions/src/primitives/array_value.rs
@@ -37,22 +37,6 @@ pub trait ArrayValue: Debug {
     }
 }
 
-impl AsStaticValue for dyn ArrayValue + 'static {
-    fn to_static_value(&self) -> StaticValue<'_> {
-        todo!()
-    }
-}
-
-impl AsValue for dyn ArrayValue {
-    fn get_value_type(&self) -> ValueType {
-        todo!()
-    }
-
-    fn to_value(&self) -> Value<'_> {
-        todo!()
-    }
-}
-
 #[derive(Debug)]
 pub struct ArrayRange {
     start_range_inclusize: Option<usize>,


### PR DESCRIPTION
## Changes

* Removes `'c` lifetime from `ExecutionContext` struct

## Details

`ExecutionContext` has `'a` lifetime for tracking the `PipelineExpression` and `'c` lifetime for tracking diagnostics associated with expressions in that pipeline. Really `'a` and `'c` are the same lifetime so what this PR does is just remove `'c` in favor of `'a`. Net gain is just simpler code.