### PR TITLE
Properly specify matchFileNames for Docker digest updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -17,6 +17,8 @@
     // this reference implementation has been removed from our build pipelines
     "rust/beaubourg/**"
   ],
+  // NOTE: Rule ordering matters here
+  // Later rules will override earlier rules
   "packageRules": [
     {
       // reduces the number of Renovate PRs


### PR DESCRIPTION
Renovate improperly grouped together a few different types of update in #1492. It performed a 'digest' update in 3 places together:
* Github workflow files
* `go.mod` file
* `Dockerfile`s

This seems to have happened because of Renovate precedence ordering, the fact that Github workflow versions look like image hashes, and `golang.org/x/exp` not having proper release tag, defaulting to commit hash.

By locking down the `digest` rule to only `Dockerfile`, these should be properly split in future.