### PR TITLE
[perf test] fix nightly benchmark configs for otlp rx compression settings update

### DIFF
--- a/tools/pipeline_perf_test/test_suites/integration/templates/configs/engine/backpressure/otlp-attr-otap.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/templates/configs/engine/backpressure/otlp-attr-otap.yaml
@@ -14,7 +14,7 @@ nodes:
         dispatch_strategy: round_robin
     config:
       listening_addr: "0.0.0.0:4317"
-      compression_method: gzip
+      request_compression: gzip
       wait_for_result: true
 
   attr:

--- a/tools/pipeline_perf_test/test_suites/integration/templates/configs/engine/backpressure/otlp-attr-otlp.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/templates/configs/engine/backpressure/otlp-attr-otlp.yaml
@@ -14,7 +14,7 @@ nodes:
         dispatch_strategy: round_robin
     config:
       listening_addr: "0.0.0.0:4317"
-      compression_method: gzip
+      request_compression: gzip
       wait_for_result: true
 
   attr:

--- a/tools/pipeline_perf_test/test_suites/integration/templates/configs/engine/filter/otlp-filter-otap.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/templates/configs/engine/filter/otlp-filter-otap.yaml
@@ -14,7 +14,7 @@ nodes:
         dispatch_strategy: round_robin
     config:
       listening_addr: "0.0.0.0:4317"
-      compression_method: gzip
+      request_compression: gzip
 
   filter:
     kind: processor

--- a/tools/pipeline_perf_test/test_suites/integration/templates/configs/engine/filter/otlp-filter-otlp.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/templates/configs/engine/filter/otlp-filter-otlp.yaml
@@ -14,7 +14,7 @@ nodes:
         dispatch_strategy: round_robin
     config:
       listening_addr: "0.0.0.0:4317"
-      compression_method: gzip
+      request_compression: gzip
 
   filter:
     kind: processor


### PR DESCRIPTION
This updates some configs that got missed on the nightly benchmark tests related to #1480. Fix compression setting field name.