### PR TITLE
add filter to nightly html page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,11 @@ coverage.html
 
 # Python
 __pycache__/
+.tox/
+.venv
+.mypy_cache
+.pytest_cache
+*.egg-info
 
 # Benchmarks output
 /output/
@@ -57,3 +62,5 @@ __pycache__/
 # Collector test binary
 collector/cmd/otelarrowcol/otelarrowcol
 tools/pipeline_perf_test/load_generator/loadgen-manifest.yaml.tmp
+
+venv

--- a/docs/benchmarks/nightly/index.html
+++ b/docs/benchmarks/nightly/index.html
@@ -139,6 +139,12 @@
       </a>
       — Evaluations focusing on flow control and load management.
     </li>
+    <li>
+      <a href="https://open-telemetry.github.io/otel-arrow/benchmarks/nightly/filter/" target="_blank" rel="noopener">
+        Filter Benchmarks
+      </a>
+      — Evaluations focused on filter processor measurements.
+    </li>
   </ul>
 </section>
 


### PR DESCRIPTION
**Note: This for for the benchmarks branch, not *main***

To add filter results to https://open-telemetry.github.io/otel-arrow/benchmarks/nightly/