### PR TITLE
Enable SO_REUSEPORT on OSes that support it.

### DIFF
--- a/rust/otap-dataflow/crates/engine/src/effect_handler.rs
+++ b/rust/otap-dataflow/crates/engine/src/effect_handler.rs
@@ -103,7 +103,13 @@ impl<PData> EffectHandlerCore<PData> {
         // IP and port. Incoming connections or packets are distributed between the sockets
         // (load balancing).
         // Goal: Load balancing incoming connections.
-        sock.set_reuse_port(true).map_err(into_engine_error)?;
+        #[cfg(any(
+            target_os = "linux",
+            target_os = "macos"
+        ))]
+        {
+            sock.set_reuse_port(true).map_err(into_engine_error)?;
+        }
         sock.set_nonblocking(true).map_err(into_engine_error)?;
         sock.bind(&addr.into()).map_err(into_engine_error)?;
         sock.listen(8192).map_err(into_engine_error)?;
@@ -149,7 +155,13 @@ impl<PData> EffectHandlerCore<PData> {
         // IP and port. Incoming packets are distributed between the sockets
         // (load balancing).
         // Goal: Load balancing incoming packets.
-        sock.set_reuse_port(true).map_err(into_engine_error)?;
+        #[cfg(any(
+            target_os = "linux",
+            target_os = "macos"
+        ))]
+        {
+            sock.set_reuse_port(true).map_err(into_engine_error)?;
+        }
         sock.set_nonblocking(true).map_err(into_engine_error)?;
         sock.bind(&addr.into()).map_err(into_engine_error)?;
 


### PR DESCRIPTION
Build fails on windows platforms as set_reuse_port() is not supported on windows platforms. With this change part of the code using set_reuse_port() will only be compiled on Linux & MacOs platforms.  