### PR TITLE
Fix docker file for dataflow engine

### DIFF
--- a/rust/otap-dataflow/Dockerfile
+++ b/rust/otap-dataflow/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get install -y protobuf-compiler
 # docker build --build-context otel-arrow=../../ -f Dockerfile -t df_engine .
 COPY --from=otel-arrow /proto/opentelemetry/proto /build/proto/opentelemetry/proto
 COPY --from=otel-arrow /proto/opentelemetry-proto /build/proto/opentelemetry-proto
+COPY --from=otel-arrow /rust/experimental /build/rust/experimental
 
 COPY . /build/rust/dataflow/.
 


### PR DESCRIPTION
Fix Docker build by copying experimental directory needed for query-engine crate dependencies

Fixes https://github.com/open-telemetry/otel-arrow/actions/runs/20148927514/job/57836790390?pr=1602