### PR TITLE
Use temp_dir() in tests as an OS-agnostic path

### DIFF
--- a/rust/otap-dataflow/crates/otap/src/object_store.rs
+++ b/rust/otap-dataflow/crates/otap/src/object_store.rs
@@ -211,16 +211,18 @@ mod test {
 
     #[test]
     fn test_get_testdelayed_file_storage() {
+        let tmp = std::env::temp_dir().display().to_string();
         let storage = StorageType::File {
-            base_uri: "testdelayed:///tmp".to_string(),
+            base_uri: format!("testdelayed://{tmp}").to_string(),
         };
         assert!(from_storage_type(&storage).is_ok());
     }
 
     #[test]
     fn test_get_file_storage() {
+        let tmp = std::env::temp_dir().display().to_string();
         let storage = StorageType::File {
-            base_uri: "/tmp".to_string(),
+            base_uri: tmp,
         };
         assert!(from_storage_type(&storage).is_ok());
     }


### PR DESCRIPTION
Tests are failing on Windows because `LocalFileSystem` requires an existing path, but `/tmp` does not exist there.

See: https://github.com/open-telemetry/otel-arrow/pull/1517