### PR TITLE
columnar query engine support filtering by datetimes and additional int types

### DIFF
--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
@@ -42,7 +42,7 @@ use crate::pipeline::PipelineStage;
 use crate::pipeline::functions::expr_fn::contains;
 use crate::pipeline::planner::{
     AttributesIdentifier, BinaryArg, ColumnAccessor, try_attrs_value_filter_from_literal,
-    try_static_scalar_to_literal,
+    try_static_scalar_to_attr_literal, try_static_scalar_to_literal_for_column,
 };
 
 pub mod optimize;
@@ -232,10 +232,12 @@ impl FilterPlan {
                 ColumnAccessor::ColumnName(left_col_name) => match right_arg {
                     BinaryArg::Literal(right_lit) => {
                         // left = column & right = literal
+                        let right_expr =
+                            try_static_scalar_to_literal_for_column(&left_col_name, &right_lit)?;
                         Ok(FilterPlan::from(Expr::BinaryExpr(BinaryExpr::new(
                             Box::new(col(left_col_name)),
                             binary_op,
-                            Box::new(try_static_scalar_to_literal(&right_lit)?),
+                            Box::new(right_expr),
                         ))))
                     }
                     BinaryArg::Null => {
@@ -249,10 +251,14 @@ impl FilterPlan {
                 ColumnAccessor::StructCol(left_struct_name, left_struct_field) => match right_arg {
                     BinaryArg::Literal(right_lit) => {
                         // left = struct col & right = literal
+                        let right_expr = try_static_scalar_to_literal_for_column(
+                            &left_struct_field,
+                            &right_lit,
+                        )?;
                         Ok(FilterPlan::from(Expr::BinaryExpr(BinaryExpr::new(
                             Box::new(col(left_struct_name).field(left_struct_field)),
                             binary_op,
-                            Box::new(try_static_scalar_to_literal(&right_lit)?),
+                            Box::new(right_expr),
                         ))))
                     }
                     BinaryArg::Null => {
@@ -300,16 +306,22 @@ impl FilterPlan {
                 BinaryArg::Column(right_column) => match right_column {
                     ColumnAccessor::ColumnName(right_col_name) => {
                         // left = literal & right = column
+                        let left_expr =
+                            try_static_scalar_to_literal_for_column(&right_col_name, &left_lit)?;
                         Ok(FilterPlan::from(Expr::BinaryExpr(BinaryExpr::new(
-                            Box::new(try_static_scalar_to_literal(&left_lit)?),
+                            Box::new(left_expr),
                             binary_op,
                             Box::new(col(right_col_name)),
                         ))))
                     }
                     ColumnAccessor::StructCol(right_struct_name, right_struct_field) => {
                         // left = literal & right = struct col
+                        let left_expr = try_static_scalar_to_literal_for_column(
+                            &right_struct_field,
+                            &left_lit,
+                        )?;
                         Ok(FilterPlan::from(Expr::BinaryExpr(BinaryExpr::new(
-                            Box::new(try_static_scalar_to_literal(&left_lit)?),
+                            Box::new(left_expr),
                             binary_op,
                             Box::new(col(right_struct_name).field(right_struct_field)),
                         ))))
@@ -457,15 +469,16 @@ impl TryFrom<&ContainsLogicalExpression> for FilterPlan {
         match left_arg {
             BinaryArg::Column(left_column) => {
                 let (left_expr, attrs) = Self::contains_column_arg(left_column);
-                let right_expr =
-                    match right_arg {
-                        BinaryArg::Literal(right_lit) => try_static_scalar_to_literal(&right_lit)?,
-                        _ => return Err(Error::NotYetSupportedError {
+                let right_expr = match right_arg {
+                    BinaryArg::Literal(right_lit) => try_static_scalar_to_attr_literal(&right_lit)?,
+                    _ => {
+                        return Err(Error::NotYetSupportedError {
                             message:
                                 "text contains predicate comparing column left to non literal right"
                                     .into(),
-                        }),
-                    };
+                        });
+                    }
+                };
 
                 let contains_expr = contains(left_expr, right_expr);
                 Ok(match attrs {
@@ -481,7 +494,7 @@ impl TryFrom<&ContainsLogicalExpression> for FilterPlan {
                 })
             }
             BinaryArg::Literal(left_lit) => {
-                let left_expr = try_static_scalar_to_literal(&left_lit)?;
+                let left_expr = try_static_scalar_to_attr_literal(&left_lit)?;
                 let (right_expr, attrs) = match right_arg {
                     BinaryArg::Column(right_column) => Self::contains_column_arg(right_column),
                     _ => {
@@ -1795,37 +1808,88 @@ mod test {
 
     #[tokio::test]
     async fn test_simple_filter() {
-        let otap_batch = to_otap_logs(vec![
+        let ns_per_second: u64 = 1000 * 1000 * 1000;
+        let log_records = vec![
             LogRecord::build()
                 .severity_text("TRACE")
+                .severity_number(1)
+                .time_unix_nano(ns_per_second)
                 .event_name("1")
                 .finish(),
             LogRecord::build()
                 .severity_text("INFO")
+                .severity_number(9)
                 .event_name("2")
+                .time_unix_nano(2 * ns_per_second)
                 .finish(),
             LogRecord::build()
                 .severity_text("ERROR")
+                .severity_number(17)
+                .time_unix_nano(3 * ns_per_second)
                 .event_name("3")
                 .finish(),
-        ]);
+        ];
 
-        let parser_result = KqlParser::parse("logs | where severity_text == \"ERROR\"").unwrap();
-        let mut pipeline = Pipeline::new(parser_result.pipeline);
-        let result = pipeline.execute(otap_batch.clone()).await.unwrap();
-        let expected = to_otap_logs(vec![
-            LogRecord::build()
-                .severity_text("ERROR")
-                .event_name("3")
-                .finish(),
-        ]);
-        assert_eq!(result, expected);
+        let result = exec_logs_pipeline(
+            "logs | where severity_text == \"ERROR\"",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[log_records[2].clone()]
+        );
 
         // test same filter where the literal is on the left and column name on the right
-        let parser_result = KqlParser::parse("logs | where \"ERROR\" == severity_text").unwrap();
-        let mut pipeline = Pipeline::new(parser_result.pipeline);
-        let result = pipeline.execute(otap_batch.clone()).await.unwrap();
-        assert_eq!(result, expected);
+        let result = exec_logs_pipeline(
+            "logs | where \"ERROR\" == severity_text",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[log_records[2].clone()]
+        );
+
+        // test filtering by some other field types (u32, int32, timestamp)
+        let result = exec_logs_pipeline(
+            "logs | where severity_number == 17",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[log_records[2].clone()]
+        );
+        let result = exec_logs_pipeline(
+            "logs | where severity_number == 17",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[log_records[2].clone()]
+        );
+
+        let result = exec_logs_pipeline(
+            "logs | where time_unix_nano > datetime(1970-01-01 00:00:01.1)",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[log_records[1].clone(), log_records[2].clone()]
+        );
+
+        let result = exec_logs_pipeline(
+            "logs | where datetime(1970-01-01 00:00:01.1) > time_unix_nano",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[log_records[0].clone()]
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
part of #1508 

Adds support for filtering by integer types other than int64 and support for filtering by timestamp to the columnar query engine.

Before this change, every int field we encountered we assumed was int64, which worked when filtering by attribute values. However, there are a handful of fields in the OTel/OTAP data model that are not of this type so now we must check if we're applying a filter to one of these fields and, if so, create a literal for the binary expression with the correct integer type.

This PR also adds support for datetime literal - for example:
```kql
logs | where time_unix_nano > datetime(1970-01-01 00:00:01.1)
```