### PR TITLE
Don't cancel perf runs for continous integration

### DIFF
--- a/.github/workflows/pipeline-perf-test-continuous.yml
+++ b/.github/workflows/pipeline-perf-test-continuous.yml
@@ -7,11 +7,6 @@ on:
         branches: [ main ]
     workflow_dispatch:
 
-# Cancel in-progress runs on new commits to same PR
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
     pipeline-perf-test:
         runs-on: oracle-bare-metal-64cpu-512gb-x86-64

--- a/.github/workflows/pipeline-perf-test-nightly.yml
+++ b/.github/workflows/pipeline-perf-test-nightly.yml
@@ -7,11 +7,6 @@ on:
       - cron: '0 10 * * *'  # runs every day at 10 AM UTC
     workflow_dispatch:
 
-# Cancel in-progress runs on new commits to same PR
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
     pipeline-perf-test:
         runs-on: oracle-bare-metal-64cpu-512gb-x86-64


### PR DESCRIPTION
Removes the `cancel-in-progress` concurrency configuration from both continuous and nightly pipeline performance test workflows. Each commit to main should get its own benchmark run to track performance across all commits, else its hard to pin point which commit broke/fixed perf.

(for the nightly run, this setting was irrelevant anyway as it is a scheduled run only)
