### PR TITLE
Fix perf result uploading

### DIFF
--- a/.github/workflows/scripts/consolidate-benchmarks.sh
+++ b/.github/workflows/scripts/consolidate-benchmarks.sh
@@ -22,9 +22,5 @@ done
 # Combine all benchmark JSON files into a single output (find them recursively)
 find "${INPUT_DIR}" -name "*.json" -type f -exec cat {} \; | jq -s 'map(.[])' > "${OUTPUT_FILE}"
 
-# Trim commit messages to just the first line (PR title)
-jq 'map(.commit.message |= (split("\n")[0]))' "${OUTPUT_FILE}" > "${OUTPUT_FILE}.tmp"
-mv "${OUTPUT_FILE}.tmp" "${OUTPUT_FILE}"
-
 echo "Consolidated benchmark data:"
 cat "${OUTPUT_FILE}"


### PR DESCRIPTION
https://github.com/open-telemetry/otel-arrow/pull/1651 didn't work well, as the GH Action is adding the commit info late, and we don't have a way to interfere easily. Will check for some other option, but until then, this PR must be merged to get back broken perf uploading!