### PR TITLE
Add CI check for macos (arm) and linux(arm)

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -30,6 +30,7 @@ jobs:
           - experimental/query_engine
         os:
           - ubuntu-latest
+          - ubuntu-24.04-arm
           - windows-latest
           - macos-latest
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Fix https://github.com/open-telemetry/otel-arrow/issues/1578