### PR TITLE
Update Makefile builder command to replace in build.yaml and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ WORKDIR /otel-arrow
 COPY . .
 ENV CGO_ENABLED=0
 
-# Note the version MUST MATCH otelarrowcol-build.yaml
+# Note the version should match the builder version referenced in the Makefile.
+# The version is overridden when running `make builder`.
 RUN go install go.opentelemetry.io/collector/cmd/builder@v0.142.0
 
 # This command generates main.go, go.mod but does not update deps.

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ doc:
 
 
 
-# Install opentelemetry-collector builder at a specific version which should always match component references in collector/otelarrowcol-build.yaml
-# This command attempts to update this version in both otelarrowcol-build.yaml and Dockerfile
+# Install opentelemetry-collector builder at a specific version which should (almost always) match component references in collector/otelarrowcol-build.yaml
+# In addition to installing the builder, this command attempts to synchronize this version in both otelarrowcol-build.yaml and Dockerfile
 # In the event that Collector and Collector-Contrib references need to be different versions, manual edits may be required after running this command
 BUILDER_VERSION = v0.142.0
 BUILDER = builder

--- a/collector/otelarrowcol-build.yaml
+++ b/collector/otelarrowcol-build.yaml
@@ -25,6 +25,8 @@ dist:
   # Users: This can be customized for integration into your CI/CD system.
   output_path: collector/cmd/otelarrowcol
 
+# Note that all component versions should (almost always) match the builder version referenced in the Makefile.
+# The version is overridden when running `make builder`.
 exporters:
   # This is the core OpenTelemetry Protocol with Apache Arrow exporter
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter v0.142.0


### PR DESCRIPTION
Following up on https://github.com/open-telemetry/otel-arrow/pull/1682#discussion_r2640864598

In 99% of cases, the same version should be used for:
* Builder
* Collector/Collector-Contrib references in `otelarrowcol-build.yaml`
* Main `Dockerfile`

This addition to `builder` command would be invoked every time `genotelarrowcol` is invoked but could be brittle if more references are added elsewhere in the repo.

#1482 is probably the correct long-term approach to stop building our own collector in this repo.