### PR TITLE
Use MB for binary size

### DIFF
--- a/.github/workflows/dataflow-engine-binary-size.yml
+++ b/.github/workflows/dataflow-engine-binary-size.yml
@@ -55,15 +55,16 @@ jobs:
         run: |
           SIZE=$(docker run --rm --entrypoint stat df_engine:${{ matrix.platform.name }} -c %s /home/dataflow/df_engine)
           SIZE_HR=$(numfmt --to=iec-i --suffix=B $SIZE)
-          echo "Binary size for ${{ matrix.platform.name }}: $SIZE_HR ($SIZE bytes)"
+          SIZE_MB=$(echo "scale=2; $SIZE / 1048576" | bc)
+          echo "Binary size for ${{ matrix.platform.name }}: $SIZE_HR ($SIZE_MB MB)"
 
           mkdir -p size-reports
           cat > size-reports/${{ matrix.platform.name }}.json << EOF
           [
             {
               "name": "${{ matrix.platform.name }}-binary-size",
-              "unit": "bytes",
-              "value": $SIZE
+              "unit": "MB",
+              "value": $SIZE_MB
             }
           ]
           EOF


### PR DESCRIPTION
https://open-telemetry.github.io/otel-arrow/benchmarks/binary-size/ is live now. It's tracked in bytes. I think its better to use MB for binary size.