### PR TITLE
PipelinePerfTest - remove running with debug flags

### DIFF
--- a/.github/workflows/pipeline-perf-on-label.yaml
+++ b/.github/workflows/pipeline-perf-on-label.yaml
@@ -115,7 +115,7 @@ jobs:
       - name: Run pipeline performance test suite
         run: |
           cd tools/pipeline_perf_test
-          python orchestrator/run_orchestrator.py --debug --config test_suites/integration/continuous/100klrps-docker.yaml
+          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/100klrps-docker.yaml
 
   # Run on ubuntu-latest for basic validation when no label is present
   pipeline-perf-test-basic:
@@ -152,5 +152,5 @@ jobs:
       - name: Run pipeline performance test suite
         run: |
           cd tools/pipeline_perf_test
-          python orchestrator/run_orchestrator.py --debug --config test_suites/integration/continuous/100klrps-docker.yaml
+          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/100klrps-docker.yaml
 

--- a/.github/workflows/pipeline-perf-test-continuous.yml
+++ b/.github/workflows/pipeline-perf-test-continuous.yml
@@ -83,12 +83,12 @@ jobs:
         - name: Run pipeline performance test log suite
           run: |
             cd tools/pipeline_perf_test
-            python orchestrator/run_orchestrator.py --debug --config test_suites/integration/continuous/100klrps-docker.yaml
+            python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/100klrps-docker.yaml
 
         - name: Run pipeline performance test log suite - Saturation
           run: |
             cd tools/pipeline_perf_test
-            python orchestrator/run_orchestrator.py --debug --config test_suites/integration/continuous/saturation-docker.yaml
+            python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/saturation-docker.yaml
 
         - name: Upload benchmark results for processing
           uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/pipeline-perf-test-manual-pr.yaml
+++ b/.github/workflows/pipeline-perf-test-manual-pr.yaml
@@ -106,7 +106,7 @@ jobs:
       - name: Run pipeline performance test suite
         run: |
           cd tools/pipeline_perf_test
-          python orchestrator/run_orchestrator.py --debug --config "${{ inputs.suite_config }}"
+          python orchestrator/run_orchestrator.py --config "${{ inputs.suite_config }}"
 
       - name: Set PR status based on result
         if: always()

--- a/.github/workflows/pipeline-perf-test-nightly.yml
+++ b/.github/workflows/pipeline-perf-test-nightly.yml
@@ -87,22 +87,22 @@ jobs:
         - name: Run syslog performance test log suite
           run: |
             cd tools/pipeline_perf_test
-            python orchestrator/run_orchestrator.py --debug --config test_suites/integration/nightly/syslog-docker.yaml
+            python orchestrator/run_orchestrator.py --config test_suites/integration/nightly/syslog-docker.yaml
 
         - name: Run backpressure performance test log suite
           run: |
             cd tools/pipeline_perf_test
-            python orchestrator/run_orchestrator.py --debug --config test_suites/integration/nightly/backpressure-docker.yaml
+            python orchestrator/run_orchestrator.py --config test_suites/integration/nightly/backpressure-docker.yaml
 
         - name: Run filter performance test log suite
           run: |
             cd tools/pipeline_perf_test
-            python orchestrator/run_orchestrator.py --debug --config test_suites/integration/nightly/filter-docker.yaml
+            python orchestrator/run_orchestrator.py --config test_suites/integration/nightly/filter-docker.yaml
 
         - name: Run filter performance test otelcol log suite
           run: |
             cd tools/pipeline_perf_test
-            python orchestrator/run_orchestrator.py --debug --config test_suites/integration/nightly/otelcol-docker.yaml
+            python orchestrator/run_orchestrator.py --config test_suites/integration/nightly/otelcol-docker.yaml
 
         - name: Upload syslog results for processing
           uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2


### PR DESCRIPTION
https://github.com/open-telemetry/otel-arrow/pull/1656 added ability to show logs from the containers. The "--debug" flag is also doing it, which feels quite noisy. This PR removes the "--debug" flag from all perf tests.