### PR TITLE
[to benchmarks branch] Update charts tooltip to show just PR title

### DIFF
--- a/docs/benchmarks/binary-size/index.html
+++ b/docs/benchmarks/binary-size/index.html
@@ -214,7 +214,7 @@
                   afterTitle: items => {
                     const {index} = items[0];
                     const data = dataset[index];
-                    return '\n' + data.commit.message + '\n\n' + data.commit.timestamp + ' committed by @' + data.commit.committer.username + '\n';
+                    return '\n' + data.commit.message.split('\n')[0] + '\n\n' + data.commit.timestamp + ' committed by @' + data.commit.committer.username + '\n';
                   },
                   label: item => {
                     let label = item.value;

--- a/docs/benchmarks/continuous-saturation/index.html
+++ b/docs/benchmarks/continuous-saturation/index.html
@@ -367,7 +367,7 @@
               const { datasetIndex, index } = items[0];
               const data = results[datasetIndex].dataset[index];
               if (!data) return '';
-              return '\n' + data.commit.message + '\n\n' + data.commit.timestamp + ' committed by @' + data.commit.author.username + '\n';
+              return '\n' + data.commit.message.split('\n')[0] + '\n\n' + data.commit.timestamp + ' committed by @' + data.commit.author.username + '\n';
             },
             label: item => {
               const { datasetIndex, index, value } = item;

--- a/docs/benchmarks/continuous/index.html
+++ b/docs/benchmarks/continuous/index.html
@@ -367,7 +367,7 @@
               const { datasetIndex, index } = items[0];
               const data = results[datasetIndex].dataset[index];
               if (!data) return '';
-              return '\n' + data.commit.message + '\n\n' + data.commit.timestamp + ' committed by @' + data.commit.author.username + '\n';
+              return '\n' + data.commit.message.split('\n')[0] + '\n\n' + data.commit.timestamp + ' committed by @' + data.commit.author.username + '\n';
             },
             label: item => {
               const { datasetIndex, index, value } = item;

--- a/docs/benchmarks/nightly/backpressure/index.html
+++ b/docs/benchmarks/nightly/backpressure/index.html
@@ -399,7 +399,7 @@
               const { datasetIndex, index } = items[0];
               const data = results[datasetIndex].dataset[index];
               if (!data) return '';
-              return '\n' + data.commit.message + '\n\n' + data.commit.timestamp + ' committed by @' + data.commit.author.username + '\n';
+              return '\n' + data.commit.message.split('\n')[0] + '\n\n' + data.commit.timestamp + ' committed by @' + data.commit.author.username + '\n';
             },
             label: item => {
               const { datasetIndex, index, value } = item;

--- a/docs/benchmarks/nightly/filter/index.html
+++ b/docs/benchmarks/nightly/filter/index.html
@@ -399,7 +399,7 @@
               const { datasetIndex, index } = items[0];
               const data = results[datasetIndex].dataset[index];
               if (!data) return '';
-              return '\n' + data.commit.message + '\n\n' + data.commit.timestamp + ' committed by @' + data.commit.author.username + '\n';
+              return '\n' + data.commit.message.split('\n')[0] + '\n\n' + data.commit.timestamp + ' committed by @' + data.commit.author.username + '\n';
             },
             label: item => {
               const { datasetIndex, index, value } = item;

--- a/docs/benchmarks/nightly/syslog/index.html
+++ b/docs/benchmarks/nightly/syslog/index.html
@@ -411,7 +411,7 @@
               const { datasetIndex, index } = items[0];
               const data = results[datasetIndex].dataset[index];
               if (!data) return '';
-              return '\n' + data.commit.message + '\n\n' + data.commit.timestamp + ' committed by @' + data.commit.author.username + '\n';
+              return '\n' + data.commit.message.split('\n')[0] + '\n\n' + data.commit.timestamp + ' committed by @' + data.commit.author.username + '\n';
             },
             label: item => {
               const { datasetIndex, index, value } = item;

--- a/docs/benchmarks/pipeline-perf/index.html
+++ b/docs/benchmarks/pipeline-perf/index.html
@@ -214,7 +214,7 @@
                   afterTitle: items => {
                     const {index} = items[0];
                     const data = dataset[index];
-                    return '\n' + data.commit.message + '\n\n' + data.commit.timestamp + ' committed by @' + data.commit.committer.username + '\n';
+                    return '\n' + data.commit.message.split('\n')[0] + '\n\n' + data.commit.timestamp + ' committed by @' + data.commit.committer.username + '\n';
                   },
                   label: item => {
                     let label = item.value;


### PR DESCRIPTION
Finally found a better fix than https://github.com/open-telemetry/otel-arrow/pull/1651/changes

Screenshot with the fix below - now its possible to read the actual numbers!
<img width="764" height="235" alt="image" src="https://github.com/user-attachments/assets/67f23016-baf3-475c-be55-ea67275e637a" />

Without fix - impossible to read the actual value!

<img width="868" height="527" alt="image" src="https://github.com/user-attachments/assets/a0b8393b-55d1-4173-bb16-0e066883d394" />

