### PR TITLE
Skip tls_reload_integration on Windows

### DIFF
--- a/rust/otap-dataflow/crates/otap/tests/tls_reload.rs
+++ b/rust/otap-dataflow/crates/otap/tests/tls_reload.rs
@@ -132,8 +132,8 @@ mod tests {
 
     #[tokio::test]
     #[cfg_attr(
-        target_os = "macos",
-        ignore = "Skipping on macOS due to flakiness. See https://github.com/open-telemetry/otel-arrow/issues/1614"
+        any(target_os = "windows", target_os = "macos"),
+        ignore = "Skipping on Windows and macOS due to flakiness. See https://github.com/open-telemetry/otel-arrow/issues/1614"
     )]
     async fn test_tls_reload_integration() {
         let _ = rustls::crypto::ring::default_provider().install_default();
@@ -210,8 +210,8 @@ mod tests {
         let stream = TcpStream::connect(local_addr).await.unwrap();
         let _ = connector1.connect(domain.clone(), stream).await; // May succeed or fail, doesn't matter
 
-        // Wait for async reload to complete
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        // Wait for async reload to complete - increased to reduce flakiness
+        tokio::time::sleep(Duration::from_secs(2)).await;
 
         // 6. Connect with Client trusting CA2 (Should Succeed)
         let mut root_store2 = rustls::RootCertStore::empty();


### PR DESCRIPTION
Failing on unrelated PR: https://github.com/open-telemetry/otel-arrow/actions/runs/20586507089/job/59123800890?pr=1697

Seems to be similar to other tests in this part of the code being unreliable on `macos` and `windows`. Already have issue #1614 tracking eventual fix.

For now, see if this gets CI back to stable.