### PR TITLE
[PerfTest] - remove less relevant metrics from benchmark results

### DIFF
--- a/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_logs.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_logs.yaml
@@ -258,33 +258,10 @@ queries:
   - name: Create Final Github Actions Format table
     sql: |
       CREATE TABLE gh_actions_benchmark AS
-          SELECT 'dropped_logs_total' AS name, 'count' AS unit, CAST(logs_lost AS FLOAT) AS value,
-                metadata_row."test.suite" || '/' || metadata_row."test.name" || ' - Dropped Log Count' AS extra
-          FROM log_loss
-          CROSS JOIN metadata_row
-
-          UNION ALL
-
           SELECT 'dropped_logs_percentage' AS name, '%' AS unit, CAST(logs_lost_pct AS FLOAT) * 100 AS value,
                 metadata_row."test.suite" || '/' || metadata_row."test.name" || ' - Dropped Logs %' AS extra
           FROM log_loss
           CROSS JOIN metadata_row
-
-          UNION ALL
-
-          SELECT 'cpu_percentage_avg' AS name, '%' AS unit, avg_value * 100 AS value,
-                metadata_row."test.suite" || '/' || metadata_row."test.name" || ' - CPU Percentage' AS extra
-          FROM component_resource_metrics
-          CROSS JOIN metadata_row
-          WHERE component_name IN ('go-collector', 'df-engine') AND metric_name IN ('container.cpu.usage', 'process.cpu.usage')
-
-          UNION ALL
-
-          SELECT 'cpu_percentage_max' AS name, '%' AS unit, max_value * 100 AS value,
-                metadata_row."test.suite" || '/' || metadata_row."test.name" || ' - CPU Percentage' AS extra
-          FROM component_resource_metrics
-          CROSS JOIN metadata_row
-          WHERE component_name IN ('go-collector', 'df-engine') AND metric_name IN ('container.cpu.usage', 'process.cpu.usage')
 
           UNION ALL
 
@@ -321,22 +298,6 @@ queries:
           FROM component_resource_metrics
           CROSS JOIN metadata_row
           WHERE component_name IN ('go-collector', 'df-engine') AND metric_name IN ('container.memory.usage', 'process.memory.usage')
-
-          UNION ALL
-
-          SELECT 'logs_produced_total' AS name, 'count' AS unit, total_increase AS value,
-                metadata_row."test.suite" || '/' || metadata_row."test.name" || ' - Log Counts' AS extra
-          FROM aggregate_send_receive_rates
-          CROSS JOIN metadata_row
-          WHERE metric_name = 'logs_produced'
-
-          UNION ALL
-
-          SELECT 'logs_received_total' AS name, 'count' AS unit, total_increase AS value,
-                metadata_row."test.suite" || '/' || metadata_row."test.name" || ' - Log Counts' AS extra
-          FROM aggregate_send_receive_rates
-          CROSS JOIN metadata_row
-          WHERE metric_name = 'logs'
 
           UNION ALL
 


### PR DESCRIPTION
Removing few metrics that I think are not very relevant.
1. Cpu usage - we have Cpu usage that is normalized (0-100 always) as alternative.
2. Total count of logs (produced/lost/received) - we have Log/sec and test duration. And lost percentage.

The metrics are still collected, just not stored and rendered in the benchmarks in pages like https://open-telemetry.github.io/otel-arrow/benchmarks/continuous-saturation/ 
If needed, they can still be found in the console output.