### PR TITLE
Use python 3.11 in perf run

### DIFF
--- a/.github/workflows/pipeline-perf-on-label.yaml
+++ b/.github/workflows/pipeline-perf-on-label.yaml
@@ -133,7 +133,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.14'
+          python-version: '3.11'
 
       - name: Build dataflow_engine
         run: |


### PR DESCRIPTION
Perf test run on GH runners were broken by https://github.com/open-telemetry/otel-arrow/pull/1709 as it bumped python version to 3.14. This PR reverts it back to 3.11
(Dedicated runners used 3.11 and has no change)