### PR TITLE
[azuremonitorexporter] - Add config validation for duplicate column names

### DIFF
--- a/rust/otap-dataflow/crates/otap/src/experimental/azure_monitor_exporter/README.md
+++ b/rust/otap-dataflow/crates/otap/src/experimental/azure_monitor_exporter/README.md
@@ -91,6 +91,7 @@ To test using the provided configuration file:
 
 # In another terminal, send test data:
 
+# TODO: Why not show fake-receiver instead?
 # Option A: Using telemetrygen (recommended)
 telemetrygen logs --otlp-endpoint localhost:4317 --otlp-insecure --logs 10
 
@@ -134,13 +135,15 @@ resource_mapping:
 
 ### Scope Mapping
 
-Maps OpenTelemetry instrumentation scope to Azure fields:
+Maps OpenTelemetry instrumentation scope attributes to Azure fields:
 
 ```yaml
 scope_mapping:
   "otel.library.name": "LibraryName"
   "otel.library.version": "LibraryVersion"
 ```
+
+// TODO: Map Instrument Scope name,version,schema_url
 
 ### Log Record Mapping
 

--- a/rust/otap-dataflow/crates/otap/src/experimental/azure_monitor_exporter/transformer.rs
+++ b/rust/otap-dataflow/crates/otap/src/experimental/azure_monitor_exporter/transformer.rs
@@ -158,6 +158,7 @@ impl Transformer {
                 for log_record in scope_logs.log_records() {
                     record_map.clear();
 
+                    // TODO: Config is validated, revisit the below logic.
                     // normally config should be validated to avoid duplicate keys, but if that
                     // ever happens for any reason such as a bug, then the logic below ensures that
                     // the lowest level fields override the higher level ones.


### PR DESCRIPTION
AzureMonitor/LogAnalytics fields names must be unique. Given this is coming from config, we can easily validate it upfront.

Few other nits also.