### PR TITLE
test: Use OPL parser in supported columnar query engine filter tests

### DIFF
--- a/rust/otap-dataflow/crates/query-engine/Cargo.toml
+++ b/rust/otap-dataflow/crates/query-engine/Cargo.toml
@@ -23,10 +23,12 @@ otap-df-pdata = { path = "../pdata" }
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }
 data_engine_kql_parser = { workspace = true }
+data_engine_parser_abstractions = { workspace = true }
 pretty_assertions = { workspace = true }
 prost = { workspace = true }
 tokio = { workspace = true }
 
+otap-df-opl = { path = "../opl" }
 
 [[bench]]
 name = "filter"

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline.rs
@@ -261,7 +261,7 @@ mod test {
 
     use data_engine_expressions::PipelineExpression;
 
-    use data_engine_kql_parser::{KqlParser, Parser};
+    use data_engine_parser_abstractions::Parser;
     use datafusion::catalog::streaming::StreamingTable;
     use datafusion::logical_expr::{col, lit};
     use otap_df_pdata::proto::OtlpProtoMessage;
@@ -296,8 +296,8 @@ mod test {
         MetricsData::decode(otlp_bytes.as_bytes()).unwrap()
     }
 
-    pub async fn exec_logs_pipeline(kql_expr: &str, logs_data: LogsData) -> LogsData {
-        let parser_result = KqlParser::parse(kql_expr).unwrap();
+    pub async fn exec_logs_pipeline<P: Parser>(kql_expr: &str, logs_data: LogsData) -> LogsData {
+        let parser_result = P::parse(kql_expr).unwrap();
         exec_logs_pipeline_expr(parser_result.pipeline, logs_data).await
     }
 

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/attributes.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/attributes.rs
@@ -127,7 +127,7 @@ mod test {
 
     #[tokio::test]
     async fn test_rename_single_attributes() {
-        let result = exec_logs_pipeline(
+        let result = exec_logs_pipeline::<KqlParser>(
             "logs | project-rename attributes[\"y\"] = attributes[\"x\"]",
             generate_logs_test_data(),
         )
@@ -145,7 +145,7 @@ mod test {
         );
 
         // test renaming resource attributes:
-        let result = exec_logs_pipeline(
+        let result = exec_logs_pipeline::<KqlParser>(
             "logs | project-rename resource.attributes[\"yr1\"] = resource.attributes[\"xr1\"]",
             generate_logs_test_data(),
         )
@@ -163,7 +163,7 @@ mod test {
         );
 
         // test renaming scope attributes:
-        let result = exec_logs_pipeline(
+        let result = exec_logs_pipeline::<KqlParser>(
             "logs | project-rename instrumentation_scope.attributes[\"ys1\"] = instrumentation_scope.attributes[\"xs1\"]",
             generate_logs_test_data(),
         )
@@ -184,7 +184,7 @@ mod test {
     #[tokio::test]
     async fn test_rename_multiple_attributes() {
         // test renaming multiple attributes from same batch
-        let result = exec_logs_pipeline(
+        let result = exec_logs_pipeline::<KqlParser>(
             "logs | 
                 project-rename 
                     attributes[\"y\"] = attributes[\"x\"], 
@@ -206,7 +206,7 @@ mod test {
         );
 
         // test renaming multiple attributes from many batches
-        let result = exec_logs_pipeline(
+        let result = exec_logs_pipeline::<KqlParser>(
             "logs | 
                 project-rename 
                     attributes[\"y\"] = attributes[\"x\"], 
@@ -256,7 +256,7 @@ mod test {
     #[tokio::test]
     async fn test_rename_when_no_attrs_batch_present() {
         let input = vec![LogRecord::build().event_name("test").finish()];
-        let result = exec_logs_pipeline(
+        let result = exec_logs_pipeline::<KqlParser>(
             "logs | 
                 project-rename 
                     attributes[\"y\"] = attributes[\"x\"], 
@@ -290,7 +290,7 @@ mod test {
 
     #[tokio::test]
     async fn test_delete_attributes() {
-        let result = exec_logs_pipeline(
+        let result = exec_logs_pipeline::<KqlParser>(
             "logs | project-away attributes[\"x\"]",
             generate_logs_test_data(),
         )
@@ -306,7 +306,7 @@ mod test {
         );
 
         // test moving multiple attributes simultaneously from different payloads
-        let result = exec_logs_pipeline(
+        let result = exec_logs_pipeline::<KqlParser>(
             "logs | 
                 project-away 
                     attributes[\"x\"], 
@@ -352,7 +352,7 @@ mod test {
             )],
         )]);
 
-        let result = exec_logs_pipeline(
+        let result = exec_logs_pipeline::<KqlParser>(
             "logs | 
                 project-away attributes[\"y\"],
                 resource.attributes[\"xr1\"], 


### PR DESCRIPTION
Closes #1757 

In https://github.com/open-telemetry/otel-arrow/pull/1752 we added a parser for OPL with some basic support for filtering expressions. 

This PR adds the OPL parser as a dev-dependency to the columnar query engine crate, and makes some of the tests generic over the parser implementation. This is a somewhat low impact way to get additional test coverage on the output of the parser and specifically trying to ensure that what the parser outputs is what the query engine expects.

Not all tests are refactored to be generic over the parser, as the nascent OPL parser does not yet support many types of syntax, including regex match, string contains, struct member access, or any kind of assignment expressions. All these will be added in future PRs and test will be updated accordingly.