### PR TITLE
remove unused convert_case dependency

### DIFF
--- a/rust/otap-dataflow/crates/pdata/src/otlp/macros/Cargo.toml
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/macros/Cargo.toml
@@ -15,5 +15,4 @@ proc-macro = true
 syn = { version = "2.0", features = ["full", "extra-traits"] }
 quote = "1.0"
 proc-macro2 = "1.0"
-convert_case = "0.8.0"
 otap-df-pdata-otlp-model = { workspace = true }


### PR DESCRIPTION
supersedes https://github.com/open-telemetry/otel-arrow/pull/1753

This dependency is no longer used since we cleaned up the derive macro in https://github.com/open-telemetry/otel-arrow/pull/1384/files