### PR TITLE
OPL Parser: support `extend`/`set` operator call

### DIFF
--- a/rust/otap-dataflow/crates/opl/src/opl.pest
+++ b/rust/otap-dataflow/crates/opl/src/opl.pest
@@ -6,42 +6,42 @@ ident = @{ ("_" | ASCII_ALPHA) ~ ("_" | ASCII_ALPHANUMERIC)* }
 
 double_quote_string_char = _{
     !("\"" | "\\") ~ ANY
-    | "\\" ~ ("\"" | "\\" | "n" | "r" | "t")
-    | "\\" ~ ("u" ~ ASCII_HEX_DIGIT{4})
+  | "\\" ~ ("\"" | "\\" | "n" | "r" | "t")
+  | "\\" ~ ("u" ~ ASCII_HEX_DIGIT{4})
 }
 single_quote_string_char = _{
     !("'" | "\\") ~ ANY
-    | "\\" ~ ("'" | "\\" | "n" | "r" | "t")
-    | "\\" ~ ("u" ~ ASCII_HEX_DIGIT{4})
+  | "\\" ~ ("'" | "\\" | "n" | "r" | "t")
+  | "\\" ~ ("u" ~ ASCII_HEX_DIGIT{4})
 }
 
 string_literal = {
     ("\"" ~ double_quote_string_char* ~ "\"")
-    | ("'" ~ single_quote_string_char* ~ "'")
+  | ("'" ~ single_quote_string_char* ~ "'")
 }
 
 identifier_expression = {
     ident
 }
 
-bool_true_token = @{ "true" }
+bool_true_token  = @{ "true" }
 bool_false_token = @{ "false" }
-null_token = @{ "null" }
+null_token       = @{ "null" }
 
 primitive_expression = {
     string_literal
-    | bool_true_token
-    | bool_false_token
-    | null_token
-    | identifier_expression
-    | "(" ~ expression ~ ")"
+  | bool_true_token
+  | bool_false_token
+  | null_token
+  | identifier_expression
+  | "(" ~ expression ~ ")"
 }
 
 index_expression = {
     // TODO: the way this grammar is defined doesn't yet handle
     // - nested indexing (e.g. a["x"]["y"])
     // - computing index from some complex expression (e.g. a[i + 1])
-    //
+    // 
     // This should probably be defined as  `member_expression ~ "[" ~ expression ~ "]"
     // but that makes the grammar left recursive so it would need which makes parsing a
     // bit more complicated, so we can change the implementation when this is needed.
@@ -54,41 +54,42 @@ attribute_selection_expression = {
 
 member_expression = {
     index_expression
-    | primitive_expression
-    | attribute_selection_expression
-    // TODO function calls
+  | primitive_expression
+  | attribute_selection_expression // TODO function calls
 }
 
 integer_literal = @{
     ("0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*)
 }
 
-exponent_literal = { ^"e" ~ ("+" | "-")? ~ integer_literal }
-float_literal = @{
+exponent_literal =  { ^"e" ~ ("+" | "-")? ~ integer_literal }
+float_literal    = @{
     (integer_literal ~ "." ~ integer_literal ~ exponent_literal?)
-    | (integer_literal ~ exponent_literal)
+  | (integer_literal ~ exponent_literal)
 }
 
 number_literal = {
-    float_literal | integer_literal
+    float_literal
+  | integer_literal
 }
 
 negate_token = @{ "-" }
-not_token = @{ "not" }
+not_token    = @{ "not" }
 
 unary_expression = {
     number_literal
-    | negate_token ~ number_literal
-    // TODO negative unary
-    // | "-" ~ unary_expression
-    | not_token ~ unary_expression
-    | member_expression
+  | negate_token ~ number_literal // TODO negative unary
+  // | "-" ~ unary_expression
+
+  | not_token ~ unary_expression
+  | member_expression
 }
 
 additive_op_add = @{ "+" }
 additive_op_sub = @{ "-" }
-additive_op = _{
-    additive_op_add | additive_op_sub
+additive_op     = _{
+    additive_op_add
+  | additive_op_sub
 }
 
 additive_expression = {
@@ -98,18 +99,21 @@ additive_expression = {
 multiplicative_op_mul = @{ "*" }
 multiplicative_op_div = @{ "/" }
 multiplicative_op_mod = @{ "%" }
-multiplicative_op = _{
-    multiplicative_op_mul | multiplicative_op_div | multiplicative_op_mod
+multiplicative_op     = _{
+    multiplicative_op_mul
+  | multiplicative_op_div
+  | multiplicative_op_mod
 }
 
 multiplicative_expression = {
     unary_expression ~ (multiplicative_op ~ unary_expression)*
 }
 
-rel_op_eq = @{ "==" }
-rel_op_neq = @{ "!="}
-rel_op = _{
-    rel_op_eq | rel_op_neq
+rel_op_eq  = @{ "==" }
+rel_op_neq = @{ "!=" }
+rel_op     = _{
+    rel_op_eq
+  | rel_op_neq
 }
 
 rel_expression = {
@@ -130,8 +134,19 @@ expression = {
     or_expression
 }
 
+assignment_expression = {
+    (attribute_selection_expression | index_expression | identifier_expression) ~ "=" ~ expression
+}
+
 source = {
-    "logs" | "metrics" | "traces" | "signals"
+    "logs"
+  | "metrics"
+  | "traces"
+  | "signals"
+}
+
+set_operator_call = {
+    ("set" | "extend") ~ assignment_expression
 }
 
 where_operator_call = {
@@ -139,7 +154,8 @@ where_operator_call = {
 }
 
 operator_call = {
-    where_operator_call
+    set_operator_call
+  | where_operator_call
 }
 
 pipeline_stage = {

--- a/rust/otap-dataflow/crates/opl/src/parser.rs
+++ b/rust/otap-dataflow/crates/opl/src/parser.rs
@@ -11,6 +11,7 @@ use data_engine_parser_abstractions::{
     Parser, ParserError, ParserOptions, ParserResult, ParserState, to_query_location,
 };
 
+mod assignment;
 mod expression;
 mod operator;
 mod pipeline;

--- a/rust/otap-dataflow/crates/opl/src/parser/assignment.rs
+++ b/rust/otap-dataflow/crates/opl/src/parser/assignment.rs
@@ -1,0 +1,193 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use data_engine_expressions::{
+    MutableValueExpression, ScalarExpression, SetTransformExpression, SourceScalarExpression,
+    StaticScalarExpression, StringScalarExpression, ValueAccessor,
+};
+use data_engine_parser_abstractions::{ParserError, to_query_location};
+use pest::iterators::Pair;
+
+use crate::parser::expression::{
+    parse_attribute_selection_expression, parse_expression, parse_index_expression,
+};
+use crate::parser::{Rule, invalid_child_rule_error};
+
+pub(crate) fn parse_assignment_expression(
+    rule: Pair<'_, Rule>,
+) -> Result<SetTransformExpression, ParserError> {
+    let query_location = to_query_location(&rule);
+    let mut inner_rules = rule.into_inner();
+    if inner_rules.len() != 2 {
+        return Err(ParserError::SyntaxError(
+            query_location,
+            format!("Expected exactly two rules. Found {}", inner_rules.len()),
+        ));
+    }
+
+    // safety: we've checked just above that there are two rules
+    let left = inner_rules.next().expect("two rules");
+    let right = inner_rules.next().expect("two rules");
+
+    let left_query_location = to_query_location(&left);
+    let destination = match left.as_rule() {
+        Rule::identifier_expression => MutableValueExpression::Source(SourceScalarExpression::new(
+            left_query_location.clone(),
+            ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                StaticScalarExpression::String(StringScalarExpression::new(
+                    left_query_location,
+                    left.as_str(),
+                )),
+            )]),
+        )),
+        Rule::index_expression => match parse_index_expression(left)?.into() {
+            ScalarExpression::Source(source_expr) => MutableValueExpression::Source(source_expr),
+            other => {
+                return Err(ParserError::SyntaxError(
+                    left_query_location,
+                    format!(
+                        "Expected source scalar for index_expression rule, found {:?}",
+                        other
+                    ),
+                ));
+            }
+        },
+        Rule::attribute_selection_expression => match parse_attribute_selection_expression(left)?
+            .into()
+        {
+            ScalarExpression::Source(source_expr) => MutableValueExpression::Source(source_expr),
+            other => {
+                return Err(ParserError::SyntaxError(
+                    left_query_location,
+                    format!(
+                        "Expected source scalar for attribute_selection_expression rule, found {:?}",
+                        other
+                    ),
+                ));
+            }
+        },
+        invalid_rule => {
+            return Err(invalid_child_rule_error(
+                left_query_location,
+                Rule::assignment_expression,
+                invalid_rule,
+            ));
+        }
+    };
+
+    let right_query_location = to_query_location(&right);
+    let source = match right.as_rule() {
+        Rule::expression => parse_expression(right)?.into(),
+        invalid_rule => {
+            return Err(invalid_child_rule_error(
+                right_query_location,
+                Rule::assignment_expression,
+                invalid_rule,
+            ));
+        }
+    };
+
+    Ok(SetTransformExpression::new(
+        query_location,
+        source,
+        destination,
+    ))
+}
+
+#[cfg(test)]
+mod test {
+    use data_engine_expressions::{
+        IntegerScalarExpression, QueryLocation, ScalarExpression, StaticScalarExpression,
+        StringScalarExpression,
+    };
+    use pest::Parser;
+
+    use super::*;
+    use crate::parser::pest::OplPestParser;
+
+    #[test]
+    fn test_simple_assignment() {
+        let input = "a = 1";
+        let mut rules = OplPestParser::parse(Rule::assignment_expression, input).unwrap();
+        assert_eq!(rules.len(), 1);
+        let rule = rules.next().unwrap();
+        let result = parse_assignment_expression(rule).unwrap();
+
+        let expected = SetTransformExpression::new(
+            QueryLocation::new_fake(),
+            ScalarExpression::Static(StaticScalarExpression::Integer(
+                IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+            )),
+            MutableValueExpression::Source(SourceScalarExpression::new(
+                QueryLocation::new_fake(),
+                ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                    StaticScalarExpression::String(StringScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        "a",
+                    )),
+                )]),
+            )),
+        );
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_attribute_assignment() {
+        let input = "attributes[\"x\"] = 1";
+        let mut rules = OplPestParser::parse(Rule::assignment_expression, input).unwrap();
+        assert_eq!(rules.len(), 1);
+        let rule = rules.next().unwrap();
+        let result = parse_assignment_expression(rule).unwrap();
+
+        let expected = SetTransformExpression::new(
+            QueryLocation::new_fake(),
+            ScalarExpression::Static(StaticScalarExpression::Integer(
+                IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+            )),
+            MutableValueExpression::Source(SourceScalarExpression::new(
+                QueryLocation::new_fake(),
+                ValueAccessor::new_with_selectors(vec![
+                    ScalarExpression::Static(StaticScalarExpression::String(
+                        StringScalarExpression::new(QueryLocation::new_fake(), "attributes"),
+                    )),
+                    ScalarExpression::Static(StaticScalarExpression::String(
+                        StringScalarExpression::new(QueryLocation::new_fake(), "x"),
+                    )),
+                ]),
+            )),
+        );
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_nested_field_assignment() {
+        let input = "instrumentation_scope.name = \"sdk\"";
+        let mut rules = OplPestParser::parse(Rule::assignment_expression, input).unwrap();
+        assert_eq!(rules.len(), 1);
+        let rule = rules.next().unwrap();
+        let result = parse_assignment_expression(rule).unwrap();
+
+        let expected = SetTransformExpression::new(
+            QueryLocation::new_fake(),
+            ScalarExpression::Static(StaticScalarExpression::String(StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "sdk",
+            ))),
+            MutableValueExpression::Source(SourceScalarExpression::new(
+                QueryLocation::new_fake(),
+                ValueAccessor::new_with_selectors(vec![
+                    ScalarExpression::Static(StaticScalarExpression::String(
+                        StringScalarExpression::new(
+                            QueryLocation::new_fake(),
+                            "instrumentation_scope",
+                        ),
+                    )),
+                    ScalarExpression::Static(StaticScalarExpression::String(
+                        StringScalarExpression::new(QueryLocation::new_fake(), "name"),
+                    )),
+                ]),
+            )),
+        );
+        assert_eq!(result, expected);
+    }
+}


### PR DESCRIPTION
closes: #1761 

Adds parser support for the `extend` operator to the OPL Parser.

Example syntax:
```kql
extend severity_text = "ERROR"
extend attributes["x"] = "y"
extend instrumentation_scope.name = "sdk"
```

`set` is a keyword that can be used as an alias for `extend`. The thinking is, this is a bit easier to understand for users w/out a kql background or users who might be more familiar with the [`set` function from OTTL transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor#basic-config)