### PR TITLE
retry auth forever if it fails instead of crashing the exporter

### DIFF
--- a/rust/otap-dataflow/crates/otap/src/experimental/azure_monitor_exporter/exporter.rs
+++ b/rust/otap-dataflow/crates/otap/src/experimental/azure_monitor_exporter/exporter.rs
@@ -336,10 +336,7 @@ impl AzureMonitorExporter {
             let delay_secs = (capped_delay_secs + jitter).max(1.0);
             let delay = tokio::time::Duration::from_secs_f64(delay_secs);
 
-            println!(
-                "[AzureMonitorExporter] Retrying in {:.1}s...",
-                delay_secs
-            );
+            println!("[AzureMonitorExporter] Retrying in {:.1}s...", delay_secs);
             tokio::time::sleep(delay).await;
         }
     }


### PR DESCRIPTION
- prevents auth failures from crashing the exporter, and should assist with self healing during, for example a potential outage.
- logging, metrics and thiserror changes are not part of this PR, it will be done in the future as improvements.