### PR TITLE
remove transport optimized ID encoding in filter processor

### DIFF
--- a/rust/otap-dataflow/crates/otap/src/filter_processor.rs
+++ b/rust/otap-dataflow/crates/otap/src/filter_processor.rs
@@ -113,7 +113,8 @@ impl local::Processor<OtapPdata> for FilterProcessor {
                 // convert to arrow records
                 let (context, payload) = pdata.into_parts();
 
-                let arrow_records: OtapArrowRecords = payload.try_into()?;
+                let mut arrow_records: OtapArrowRecords = payload.try_into()?;
+                arrow_records.decode_transport_optimized_ids()?;
 
                 let filtered_arrow_records: OtapArrowRecords = match signal {
                     SignalType::Metrics => {


### PR DESCRIPTION
I'm pretty sure this is why we're seeing the OTAP -> Filter benchmark dropping the logs.

We were assuming the IDs were plain encoded in the filter processor, but if they have the transport optimized encoding (e.g., if they were received by OTAP receiver), they'd have the delta encoding which would really mess things up when we try to join the attributes to the logs.