### PR TITLE
Fix minor syntax warning in beaubourg engine (flagged by rust-analyzer in vscode)

### DIFF
--- a/rust/beaubourg/crates/engine/src/lib.rs
+++ b/rust/beaubourg/crates/engine/src/lib.rs
@@ -169,7 +169,7 @@ pub(crate) struct PipelineContext {
 /// Creates all the pipelines declared in the configuration file.
 pub(crate) async fn create_pipelines<Msg>(
     pipeline_context: PipelineContext,
-    observer: Option<Box<(dyn AsyncObserver + Send + Sync)>>,
+    observer: Option<Box<dyn AsyncObserver + Send + Sync>>,
     config: Config<Msg>,
     engine_controller: EngineController,
     singleton_manager: SingletonManager<Msg>,


### PR DESCRIPTION
# Change Summary

Fix a minor syntax warning about unused parens in beaubourg

## What issue does this PR close?

n/a

## How are these changes tested?

n/a

## Are there any user-facing changes?

No
