### PR TITLE
Update Approvers/Triagers list in main Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ you're more than welcome to participate!
 - [Laurent Qu&#xE9;rel](https://github.com/lquerel), F5
 
 For more information about the maintainer role, see the [community
-repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#triager).
+repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#maintainer).
 
 ### Approvers
 


### PR DESCRIPTION
# Change Summary

Part of https://github.com/open-telemetry/otel-arrow/issues/1863

Updates the Readme with some new membership information for repo Approvers and Triagers

## What issue does this PR close?

<!--
We highly recommend correlation of every PR to an issue
-->

n/a

## How are these changes tested?

n/a

## Are there any user-facing changes?

n/a
