### PR TITLE
Implement no-op for update_rusage_metrics on unsupported platforms

### DIFF
--- a/rust/otap-dataflow/crates/engine/src/pipeline_metrics.rs
+++ b/rust/otap-dataflow/crates/engine/src/pipeline_metrics.rs
@@ -754,7 +754,11 @@ impl PipelineMetricsMonitor {
     }
 
     #[cfg(not(any(target_os = "linux", target_os = "freebsd", target_os = "openbsd")))]
-    fn update_rusage_metrics(&mut self) {}
+    fn update_rusage_metrics(&mut self) {
+        // Field exists but rusage metrics are not supported on this platform.
+        // Silence unused field warning by reading here and setting to _.
+        let _ = self.rusage_thread_supported;
+    }
 }
 
 impl Drop for PipelineMetricsMonitor {


### PR DESCRIPTION
# Change Summary

Implement no-op for update_rusage_metrics on unsupported platforms to fix the `error: field rusage_thread_supported is never read` build warning on macos, Windows, etc...

## What issue does this PR close?
* Closes #1858

## How are these changes tested?
Verified that build warning is fixed on macos

## Are there any user-facing changes?
No
