### PR TITLE
Fix cargo warning about 'profiles for the non root package will be ignored'

### DIFF
--- a/rust/otap-dataflow/crates/query-engine/Cargo.toml
+++ b/rust/otap-dataflow/crates/query-engine/Cargo.toml
@@ -34,13 +34,5 @@ otap-df-opl = { path = "../opl" }
 name = "filter"
 harness = false
 
-[profile.bench]
-opt-level = 3
-debug = false
-incremental = false
-lto = "fat"
-codegen-units = 1
-panic = "abort"
-
 [lints]
 workspace = true


### PR DESCRIPTION
# Change Summary

Fixes a cargo warning about 'profiles for the non root package will be ignored' from the `query-engine` crate.

## What issue does this PR close?
n/a

## How are these changes tested?
Validated that build warning is resolved

## Are there any user-facing changes?
No.
