### PR TITLE
fix: Field to batch index mapping in otap batch unify

### DIFF
--- a/rust/otap-dataflow/crates/pdata/src/otap/groups.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/groups.rs
@@ -1390,10 +1390,8 @@ fn unify<const N: usize>(batches: &mut [[Option<RecordBatch>; N]]) -> Result<()>
 
     for payload_type_index in 0..N {
         schemas.clear(); // We're going to reuse this allocation across loop iterations
-        schemas.extend(
-            select_all(batches, payload_type_index)
-                .map(|batch| batch.and_then(|b| Some(b.schema()))),
-        );
+        schemas
+            .extend(select_all(batches, payload_type_index).map(|batch| batch.map(|b| b.schema())));
 
         field_name_to_batch_indices.clear();
 
@@ -1448,10 +1446,8 @@ fn unify<const N: usize>(batches: &mut [[Option<RecordBatch>; N]]) -> Result<()>
 
         // repopulate the list of schemas in case any dictionary datatypes were changed
         schemas.clear();
-        schemas.extend(
-            select_all(batches, payload_type_index)
-                .map(|batch| batch.and_then(|b| Some(b.schema()))),
-        );
+        schemas
+            .extend(select_all(batches, payload_type_index).map(|batch| batch.map(|b| b.schema())));
 
         // Let's find missing optional columns; note that this must happen after we deal with the
         // dict columns since we rely on the assumption that all fields with the same name will have


### PR DESCRIPTION
# Change Summary

Part of the otap batch `unify` logic tracks which otap batches have which fields. The implementation extracts the schemas for some payload type from each batch and assumes that the index in the schemas list is equivalent to the index in the `batches` slice. 

However, `select` filters out missing payload types from each batch, so if some batches are missing a payload then the index is not the same.

The fix is to maintain the 1:1 mapping of schema index to batch index by not filtering out missing batches.

## What issue does this PR close?

Related to #1334, but there are still more issues listed there.

## How are these changes tested?

Uncommenting the complex metrics tests. The tests now make it farther and some scenarios see more success, but there are still at least two more known issues.

## Are there any user-facing changes?

No.