### PR TITLE
fix: premature pipeline control channel closure during shutdown

### DIFF
--- a/rust/otap-dataflow/crates/engine/src/pipeline_ctrl.rs
+++ b/rust/otap-dataflow/crates/engine/src/pipeline_ctrl.rs
@@ -25,9 +25,9 @@ use std::collections::{BinaryHeap, HashMap};
 use std::time::{Duration, Instant};
 
 /// Maximum time buffer between the end of draining and the shutdown deadline.
-/// The actual buffer is the minimum of this value and 10% of the time until deadline,
-/// ensuring we use at least 90% of available time for draining while capping the
-/// post-draining buffer at 1 second.
+/// The actual buffer is the minimum of this value and 10% of the time until deadline.
+/// This is a best-effort attempt to ensure that `PipelineCtrlMsgManager` exits before
+/// the caller's timeout fires, avoiding a race where both expire simultaneously.
 const MAX_DRAINING_BUFFER_DURATION: Duration = Duration::from_secs(1);
 
 /// Represents delayed data with scheduling information.


### PR DESCRIPTION
# Change Summary

Fixes an issue where the PipelineCtrlMsgManager breaks immediately after receiving a Shutdown message, which drops the pipeline control channel before nodes have finished their cleanup sequence. This causes nodes that try to send control messages (e.g., CancelTimer, CancelTelemetryTimer) during shutdown to fail with channel closed errors.

## What issue does this PR close?

* Closes #1915 

## How are these changes tested?

Added 5 additional tests to validate the shutdown handling in `PipelineCtrlMsgManager`.

## Are there any user-facing changes?

No