### PR TITLE
fix: Batches may differ by field order after unification

### DIFF
--- a/rust/otap-dataflow/crates/pdata/src/otap/groups.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/groups.rs
@@ -1006,7 +1006,7 @@ fn generic_schemaless_concatenate<const N: usize>(
         if select(batches, i).next().is_some() {
             let schema = Arc::new(
                 // Note: The schemas of all the record batches should only differ
-                // by orer at this point. Schema::try_merge is just going to pick
+                // by order at this point. Schema::try_merge is just going to pick
                 // a canonical order for the fields, which we will project
                 // every record batch to.
                 //


### PR DESCRIPTION
# Change Summary

Note this is a band-aid to avoid larger changes, but it does solve a bunch of panics.

- Project batches to the merged schema before coalescing (reorder the fields to be the same)

## What issue does this PR close?

Related to: https://github.com/open-telemetry/otel-arrow/issues/1334.

## How are these changes tested?

New unit tests for the coalescing.

## Are there any user-facing changes?

No.