### PR TITLE
refactor: Use `.fields.find()` instead of `.index_of()` to look up field indices when batching

### DIFF
--- a/rust/otap-dataflow/crates/pdata/src/otap/groups.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/groups.rs
@@ -1045,7 +1045,7 @@ fn project_to_schema(schema: SchemaRef, rb: &RecordBatch) -> Result<RecordBatch>
     let projection: Vec<usize> = schema
         .fields()
         .iter()
-        .filter_map(|f| rb.schema().fields().find(f.name()).map(|(id, _)| id))
+        .filter_map(|f| rb.schema().fields().find(f.name()).map(|(idx, _)| idx))
         .collect();
 
     rb.project(&projection)


### PR DESCRIPTION
# Change Summary

Swap out the `index_of` API which creates and expensive string on the failure/missing case for `.fields.find()` API which just returns an option.


## What issue does this PR close?

Albert pointed this out to me here: https://github.com/open-telemetry/otel-arrow/pull/1922#discussion_r2744264230

## How are these changes tested?

## Are there any user-facing changes?

No.