### PR TITLE
[otap-df-otap] Syslog CEF Receiver minor refactoring

### DIFF
--- a/rust/otap-dataflow/crates/otap/src/syslog_cef_receiver.rs
+++ b/rust/otap-dataflow/crates/otap/src/syslog_cef_receiver.rs
@@ -61,7 +61,7 @@ enum Protocol {
     Udp,
 }
 
-/// config for a syslog cef receiver
+/// Config for a syslog cef receiver
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct Config {
@@ -142,7 +142,7 @@ pub static SYSLOG_CEF_RECEIVER: ReceiverFactory<OtapPdata> = ReceiverFactory {
 #[async_trait(?Send)]
 impl local::Receiver<OtapPdata> for SyslogCefReceiver {
     async fn start(
-        mut self: Box<Self>,
+        self: Box<Self>,
         mut ctrl_chan: local::ControlChannel<OtapPdata>,
         effect_handler: local::EffectHandler<OtapPdata>,
     ) -> Result<TerminalState, Error> {
@@ -524,7 +524,7 @@ impl local::Receiver<OtapPdata> for SyslogCefReceiver {
                                         // Do not propagate downstream send errors; keep running
                                         // so that telemetry can still be collected (tests expect refused
                                         // to be counted and reported). We already incremented
-                                        // `received_logs_refused` above.
+                                        // `received_logs_forward_failed` above.
                                         if res.is_err() {
                                             // swallow error
                                         }

--- a/rust/otap-dataflow/crates/otap/src/syslog_cef_receiver/arrow_records_encoder.rs
+++ b/rust/otap-dataflow/crates/otap/src/syslog_cef_receiver/arrow_records_encoder.rs
@@ -63,7 +63,7 @@ impl ArrowRecordsBuilder {
         if syslog_message.is_fully_parsed() {
             self.logs.body.append_null();
         } else {
-            self.logs.body.append_str(syslog_message.input().as_bytes());
+            self.logs.body.append_str(syslog_message.input());
         }
 
         let attributes_added = syslog_message.add_attributes_to_arrow(&mut self.log_attrs);

--- a/rust/otap-dataflow/crates/otap/src/syslog_cef_receiver/parser/parsed_message.rs
+++ b/rust/otap-dataflow/crates/otap/src/syslog_cef_receiver/parser/parsed_message.rs
@@ -6,7 +6,6 @@ use crate::syslog_cef_receiver::parser::{
 };
 use chrono::{DateTime, Datelike, Local, NaiveDateTime, TimeZone, Utc};
 use otap_df_pdata::encode::record::attributes::StrKeysAttributesRecordBatchBuilder;
-use std::borrow::Cow;
 
 // Common attribute key constants for both RFC5424 and RFC3164 messages
 const SYSLOG_FACILITY: &str = "syslog.facility";
@@ -78,13 +77,13 @@ impl ParsedSyslogMessage<'_> {
     }
 
     /// Returns the original input received by the receiver
-    pub(crate) fn input(&self) -> Cow<'_, str> {
+    pub(crate) fn input(&self) -> &[u8] {
         match self {
-            ParsedSyslogMessage::Rfc5424(msg) => String::from_utf8_lossy(msg.input),
-            ParsedSyslogMessage::Rfc3164(msg) => String::from_utf8_lossy(msg.input),
-            ParsedSyslogMessage::Cef(msg) => String::from_utf8_lossy(msg.input),
-            ParsedSyslogMessage::CefWithRfc3164(msg, _) => String::from_utf8_lossy(msg.input),
-            ParsedSyslogMessage::CefWithRfc5424(msg, _) => String::from_utf8_lossy(msg.input),
+            ParsedSyslogMessage::Rfc5424(msg) => msg.input,
+            ParsedSyslogMessage::Rfc3164(msg) => msg.input,
+            ParsedSyslogMessage::Cef(msg) => msg.input,
+            ParsedSyslogMessage::CefWithRfc3164(msg, _) => msg.input,
+            ParsedSyslogMessage::CefWithRfc5424(msg, _) => msg.input,
         }
     }
 
@@ -481,10 +480,10 @@ mod tests {
         let input = b"<34>1 2003-10-11T22:14:15.003Z host app - - - Test message";
         let result = parse(input).unwrap();
 
-        let input_str = result.input();
+        let input_bytes = result.input();
         assert_eq!(
-            input_str,
-            "<34>1 2003-10-11T22:14:15.003Z host app - - - Test message"
+            input_bytes,
+            b"<34>1 2003-10-11T22:14:15.003Z host app - - - Test message"
         );
     }
 


### PR DESCRIPTION
# Change Summary
- Avoid unnecessary conversion of bytes to `&str` for `input()` method
- Minor edits
