### PR TITLE
fix: cap batch size at u16::MAX for logs & traces with u16 IDs

### DIFF
--- a/rust/otap-dataflow/crates/pdata/src/error.rs
+++ b/rust/otap-dataflow/crates/pdata/src/error.rs
@@ -171,6 +171,13 @@ pub enum Error {
     #[error("Mixed signals")]
     MixedSignals,
 
+    #[error(
+        "Batch size too large for u16 IDs: requested {}, maximum allowed {}",
+        requested,
+        max_allowed
+    )]
+    BatchSizeTooLarge { requested: u64, max_allowed: u64 },
+
     #[error("Encoding error: {}", error)]
     Encoding {
         #[from]


### PR DESCRIPTION
Fixes #1947

## Problem

The `split_non_metric_batches` function didn't check ID column types before splitting batches. This caused potential overflow when:
- IDs are stored as `u16` (max: 65,535)
- `max_items` is configured higher than 65,535
- Result: batches exceed what u16 can represent → overflow/corruption

## Solution

Added global ID type detection and capped batch sizes appropriately:

1. **Global ID Type Check**: `requires_u16_cap()` scans all batches to detect u16 IDs
2. **Safe Arithmetic**: All calculations use u64 to prevent truncation on 32-bit platforms
3. **Zero Prevention**: Explicit checks ensure no zero-sized ranges
4. **Clean Code**: Removed iterator chains for clarity

## Changes

- Added `requires_u16_cap()` helper function
- Rewrote `split_non_metric_batches()` with u64-safe arithmetic
- Removed unused imports (`once`, `repeat`)

## Testing

✅ All 302 tests pass  
✅ Clippy clean (no warnings)  
✅ Code formatted

## Safety Properties

- ✅ No overflow
- ✅ No zero-sized ranges
- ✅ Deterministic behavior
- ✅ Cross-platform safe
- ✅ Backward compatible
- ✅ Matches metrics logic