### PR TITLE
Add additional Rust-CI clippy/fmt for more OS values

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -140,7 +140,9 @@ jobs:
         - experimental/query_engine
         os:
         - ubuntu-latest
+        - ubuntu-24.04-arm
         - windows-latest
+        - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -217,7 +219,9 @@ jobs:
         - experimental/query_engine
         os:
         - ubuntu-latest
+        - ubuntu-24.04-arm
         - windows-latest
+        - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1


### PR DESCRIPTION
# Change Summary

Follow-up from 2026-02-05 SIG meeting

Requested to add `clippy` and `fmt` for the 4 OS targets already targeted in `test_and_coverage`

## What issue does this PR close?

n/a

## How are these changes tested?

CI runs

## Are there any user-facing changes?

No
