### PR TITLE
fix: improve reliability of test_durable_buffer_recovery_after_outage

### DIFF
--- a/rust/otap-dataflow/crates/otap/tests/durable_buffer_processor_tests.rs
+++ b/rust/otap-dataflow/crates/otap/tests/durable_buffer_processor_tests.rs
@@ -399,6 +399,9 @@ fn count_signals_in_segments(
                 .filter_map(|e| e.ok())
                 .filter(|e| e.path().extension().is_some_and(|ext| ext == "qseg"))
                 .map(|e| {
+                    // Errors are intentionally ignored here: this function polls for
+                    // segments that may be actively being written, so open failures
+                    // (incomplete header, locked file, etc.) are expected and transient.
                     SegmentReader::open(e.path())
                         .map(|reader| {
                             reader


### PR DESCRIPTION
# Change Summary

Improve the reliability of `test_durable_buffer_recovery_after_outage` so that it is not subject to minor timing differences across runs that may lead to test failure. Make test more precise by validating the exact number of signals persisted and received by the exporter.

## What issue does this PR close?

* Closes #1975

## How are these changes tested?

* Code inspection, manually running the test to attempt failure repro.

## Are there any user-facing changes?

No, this is change only affects test code.
