### PR TITLE
Add AuthError source in azure_monitor_exporter

### DIFF
--- a/rust/otap-dataflow/crates/otap/src/experimental/azure_monitor_exporter/error.rs
+++ b/rust/otap-dataflow/crates/otap/src/experimental/azure_monitor_exporter/error.rs
@@ -22,7 +22,7 @@ pub enum Error {
 
     // ==================== Authentication Errors ====================
     /// Authentication/authorization error.
-    #[error("Auth error ({kind}){}", .source.as_ref().map(|e| format!(": {}", e)).unwrap_or_default())]
+    #[error("Auth error ({kind}){}", source.as_ref().map(|e| format!(": {}", e)).unwrap_or_default())]
     Auth {
         /// The kind of authentication error.
         kind: AuthErrorKind,
@@ -349,7 +349,10 @@ mod tests {
             "token expired",
         );
         let error = Error::token_acquisition(azure_error);
-        assert_eq!(error.to_string(), "Auth error (token acquisition): token expired");
+        assert_eq!(
+            error.to_string(),
+            "Auth error (token acquisition): token expired"
+        );
         assert!(error.source().is_some());
     }
 


### PR DESCRIPTION
# Change Summary

Troubleshooting some transient Auth errors using `azure_monitor_exporter` component. We should expose the error coming from `azure_core` crate.

## What issue does this PR close?

n/a

## How are these changes tested?

Unit tests

## Are there any user-facing changes?

No
