### PR TITLE
Make jemalloc optional in otap-df-engine on Linux

### DIFF
--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -32,6 +32,7 @@ path = "src/main.rs"
 [dependencies]
 otap-df-config.workspace = true
 otap-df-controller.workspace = true
+otap-df-engine.workspace = true
 otap-df-otap.workspace = true
 thiserror.workspace = true
 serde_json.workspace = true
@@ -48,6 +49,7 @@ otap-df-pdata-otlp-macros = { path = "./crates/pdata/src/otlp/macros"}
 otap-df-pdata-otlp-model = { path = "./crates/pdata/src/otlp/model"}
 otap-df-config = { path = "crates/config" }
 otap-df-controller = { path = "crates/controller" }
+otap-df-engine = { path = "crates/engine" }
 otap-df-otap = { path = "crates/otap" }
 otap-df-pdata = { path = "crates/pdata" }
 otap-df-telemetry = { path = "crates/telemetry" }
@@ -203,7 +205,7 @@ wiremock = "0.6.5"
 [features]
 # ToDo When jemalloc is enabled, we could use jemalloc_pprof to profile where memory is allocated. See https://crates.io/crates/jemalloc_pprof
 default = ["jemalloc"]
-jemalloc = ["dep:tikv-jemallocator"]
+jemalloc = ["dep:tikv-jemallocator", "otap-df-engine/jemalloc"]
 mimalloc = ["dep:mimalloc"]
 azure = ["otap-df-otap/azure"]
 unsafe-optimizations = ["unchecked-index", "unchecked-arithmetic"]

--- a/rust/otap-dataflow/crates/engine/Cargo.toml
+++ b/rust/otap-dataflow/crates/engine/Cargo.toml
@@ -14,7 +14,8 @@ workspace = true
 
 [features]
 testing = []
-jemalloc-testing = []
+jemalloc = ["dep:tikv-jemalloc-ctl"]
+jemalloc-testing = ["jemalloc"]
 test-utils = []
 
 [dependencies]
@@ -42,13 +43,12 @@ uuid = { workspace = true }
 once_cell = { workspace = true }
 data-encoding = { workspace = true }
 prost = { workspace = true }
-libmimalloc-sys = { workspace = true }
 byte-unit = { workspace = true }
 cpu-time = { workspace = true }
 nix = { workspace = true, features = ["resource"] }
 
 [target.'cfg(not(windows))'.dependencies]
-tikv-jemalloc-ctl = { workspace = true }
+tikv-jemalloc-ctl = { workspace = true, optional = true }
 
 [dev-dependencies]
 

--- a/rust/otap-dataflow/crates/engine/src/pipeline_metrics.rs
+++ b/rust/otap-dataflow/crates/engine/src/pipeline_metrics.rs
@@ -139,10 +139,8 @@ use otap_df_telemetry::registry::TelemetryRegistryHandle;
 use otap_df_telemetry_macros::metric_set;
 use std::time::Instant;
 
-#[cfg(not(windows))]
-use tikv_jemalloc_ctl::thread;
-#[cfg(not(windows))]
-use tikv_jemalloc_ctl::thread::ThreadLocal;
+#[cfg(all(not(windows), feature = "jemalloc"))]
+use tikv_jemalloc_ctl::{thread, thread::ThreadLocal};
 
 #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "openbsd"))]
 use nix::sys::resource::{UsageWho, getrusage};
@@ -394,16 +392,16 @@ pub struct TokioRuntimeMetrics {
 pub(crate) struct PipelineMetricsMonitor {
     start_time: Instant,
 
-    #[cfg(not(windows))]
+    #[cfg(all(not(windows), feature = "jemalloc"))]
     jemalloc_supported: bool,
 
-    #[cfg(not(windows))]
+    #[cfg(all(not(windows), feature = "jemalloc"))]
     allocated: Option<ThreadLocal<u64>>,
-    #[cfg(not(windows))]
+    #[cfg(all(not(windows), feature = "jemalloc"))]
     deallocated: Option<ThreadLocal<u64>>,
-    #[cfg(not(windows))]
+    #[cfg(all(not(windows), feature = "jemalloc"))]
     last_allocated: u64,
-    #[cfg(not(windows))]
+    #[cfg(all(not(windows), feature = "jemalloc"))]
     last_deallocated: u64,
 
     rusage_thread_supported: bool,
@@ -422,7 +420,7 @@ impl PipelineMetricsMonitor {
     pub(crate) fn new(pipeline_ctx: PipelineContext) -> Self {
         let now = Instant::now();
 
-        #[cfg(not(windows))]
+        #[cfg(all(not(windows), feature = "jemalloc"))]
         let (jemalloc_supported, allocated, deallocated, last_allocated, last_deallocated) = {
             // Try to initialize jemalloc thread-local stats. If the global allocator is not
             // jemalloc, these calls will fail and memory-related metrics will remain unchanged.
@@ -468,15 +466,15 @@ impl PipelineMetricsMonitor {
 
         Self {
             start_time: now,
-            #[cfg(not(windows))]
+            #[cfg(all(not(windows), feature = "jemalloc"))]
             jemalloc_supported,
-            #[cfg(not(windows))]
+            #[cfg(all(not(windows), feature = "jemalloc"))]
             allocated,
-            #[cfg(not(windows))]
+            #[cfg(all(not(windows), feature = "jemalloc"))]
             deallocated,
-            #[cfg(not(windows))]
+            #[cfg(all(not(windows), feature = "jemalloc"))]
             last_allocated,
-            #[cfg(not(windows))]
+            #[cfg(all(not(windows), feature = "jemalloc"))]
             last_deallocated,
             rusage_thread_supported,
             wall_start: now,
@@ -511,7 +509,7 @@ impl PipelineMetricsMonitor {
     /// signals and jemalloc-derived heap metrics.
     pub fn update_pipeline_metrics(&mut self) {
         // === Update thread memory allocation metrics (jemalloc only) ===
-        #[cfg(not(windows))]
+        #[cfg(all(not(windows), feature = "jemalloc"))]
         if self.jemalloc_supported {
             if let (Some(allocated), Some(deallocated)) =
                 (self.allocated.as_ref(), self.deallocated.as_ref())


### PR DESCRIPTION
# Change Summary

This tucks the jemalloc pipeline metrics behind a `jemalloc` feature in the engine crate.

## What issue does this PR close?

#1989

## How are these changes tested?

`cargo tree` with the feature on and off.

## Are there any user-facing changes?

No, the default feature still includes jemalloc.