### PR TITLE
chore: bump rand from 0.9.2 to v0.10.0

### DIFF
--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -128,7 +128,7 @@ prometheus = "0.14.0"
 prost = "0.14"
 prost-types = "0.14"
 quote = "1.0"
-rand = "0.9.2"
+rand = "0.10.0"
 rcgen = "0.14"
 roaring = "0.11.2"
 rustls = { version = "0.23.22", default-features = false, features = ["ring", "std", "tls12"] }

--- a/rust/otap-dataflow/crates/otap/src/experimental/azure_monitor_exporter/client.rs
+++ b/rust/otap-dataflow/crates/otap/src/experimental/azure_monitor_exporter/client.rs
@@ -3,7 +3,7 @@
 
 use bytes::Bytes;
 
-use rand::{Rng, SeedableRng, rngs::SmallRng};
+use rand::{RngExt, SeedableRng, rngs::SmallRng};
 use reqwest::{
     Client,
     header::{AUTHORIZATION, CONTENT_ENCODING, CONTENT_TYPE, HeaderValue},

--- a/rust/otap-dataflow/crates/otap/src/experimental/azure_monitor_exporter/gzip_batcher.rs
+++ b/rust/otap-dataflow/crates/otap/src/experimental/azure_monitor_exporter/gzip_batcher.rs
@@ -181,7 +181,7 @@ impl GzipBatcher {
 mod tests {
     use super::*;
     use flate2::read::GzDecoder;
-    use rand::Rng;
+    use rand::RngExt;
     use std::io::Read;
 
     // ==================== Test Helpers ====================

--- a/rust/otap-dataflow/crates/otap/src/fake_data_generator/fake_data.rs
+++ b/rust/otap-dataflow/crates/otap/src/fake_data_generator/fake_data.rs
@@ -6,7 +6,7 @@
 //!
 
 use otap_df_pdata::{SpanID, TraceID};
-use rand::Rng;
+use rand::RngExt;
 
 use std::time::{SystemTime, UNIX_EPOCH};
 

--- a/rust/otap-dataflow/crates/pdata/src/decode/decoder.rs
+++ b/rust/otap-dataflow/crates/pdata/src/decode/decoder.rs
@@ -209,7 +209,7 @@ mod tests {
         UInt16Array, UInt32Array, UInt64Array,
     };
     use arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
-    use rand::Rng;
+    use rand::RngExt;
     use rand::distr::{Alphanumeric, SampleString};
     use std::io::Cursor;
     use std::sync::Arc;

--- a/rust/otap-dataflow/crates/pdata/src/otap/transform/concatenate.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/transform/concatenate.rs
@@ -795,7 +795,7 @@ mod schema_tests {
     use super::*;
     use crate::record_batch;
     use arrow::array::{Array, DictionaryArray, PrimitiveArray, UInt8Array, UInt16Array};
-    use rand::Rng;
+    use rand::RngExt;
     use std::sync::Arc;
 
     #[test]

--- a/rust/otap-dataflow/crates/quiver-e2e/src/bundle.rs
+++ b/rust/otap-dataflow/crates/quiver-e2e/src/bundle.rs
@@ -15,7 +15,7 @@ use arrow_schema::{DataType, Field, Schema};
 use quiver::record_bundle::{
     BundleDescriptor, PayloadRef, RecordBundle, SchemaFingerprint, SlotDescriptor, SlotId,
 };
-use rand::Rng;
+use rand::RngExt;
 
 /// Configuration for test bundle generation.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
 ### Description:

  Updates rand dependency from 0.9.2 to 0.10.0.

  The main breaking change affecting this codebase is the trait rename `Rng` -> `RngExt` as indicated in [migration guide](https://rust-random.github.io/book/update-0.10.html):

``
Users of rand will often need to import rand::RngExt may need to migrate from R: RngCore to R: Rng (noting that where R: Rng was previously used
   it may be preferable to keep R: Rng even though the direct replacement would be R: RngExt; the two bounds are equivalent for R: Sized).
``

Note - this supersede #1997 which is failing for these breaking changes in newer version.
