### PR TITLE
Minor improvement to OTLP exporter internal logs/events

### DIFF
--- a/rust/otap-dataflow/crates/admin/src/pipeline_group.rs
+++ b/rust/otap-dataflow/crates/admin/src/pipeline_group.rs
@@ -8,6 +8,16 @@
 //!   - Query parameters:
 //!     - `wait` (bool, default: false) - if true, block until all pipelines have stopped
 //!     - `timeout_secs` (u64, default: 60) - maximum seconds to wait when `wait=true`
+//!
+//!   Example (fire-and-forget):
+//!   ```sh
+//!   curl -X POST http://localhost:8080/pipeline-groups/shutdown
+//!   ```
+//!   Example (wait for graceful shutdown with 30s timeout):
+//!   ```sh
+//!   curl -X POST "http://localhost:8080/pipeline-groups/shutdown?wait=true&timeout_secs=30"
+//!   ```
+//!
 //!   - 200 OK if `wait=true` and all pipelines stopped successfully
 //!   - 202 Accepted if the stop request was accepted and is being processed (async operation)
 //!   - 400 Bad Request if the pipeline is already stopped (ToDo)

--- a/rust/otap-dataflow/crates/otap/src/otap_receiver.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_receiver.rs
@@ -319,6 +319,7 @@ impl shared::Receiver<OtapPdata> for OTAPReceiver {
                 loop {
                     match ctrl_msg_recv.recv().await {
                         Ok(NodeControlMsg::Shutdown { deadline, .. }) => {
+                            otap_df_telemetry::otel_info!("otap.receiver.shutdown");
                             let snapshot = self.metrics.snapshot();
                             _ = telemetry_cancel_handle.cancel().await;
                             return Ok(TerminalState::new(deadline, [snapshot]));

--- a/rust/otap-dataflow/crates/otap/src/otlp_exporter.rs
+++ b/rust/otap-dataflow/crates/otap/src/otlp_exporter.rs
@@ -224,6 +224,7 @@ impl Exporter<OtapPdata> for OTLPExporter {
 
             match msg {
                 Message::Control(NodeControlMsg::Shutdown { deadline, .. }) => {
+                    otel_info!("otlp.exporter.shutdown");
                     debug_assert!(
                         pending_msg.is_none(),
                         "pending message should have been drained before shutdown"

--- a/rust/otap-dataflow/crates/otap/src/otlp_receiver.rs
+++ b/rust/otap-dataflow/crates/otap/src/otlp_receiver.rs
@@ -383,6 +383,7 @@ impl OTLPReceiver {
     ) -> Result<Option<TerminalState>, Error> {
         match msg {
             NodeControlMsg::Shutdown { deadline, .. } => {
+                otap_df_telemetry::otel_info!("otlp.receiver.shutdown");
                 let snapshot = self.metrics.lock().snapshot();
                 if let Some(handle) = telemetry_cancel_handle.take() {
                     _ = handle.cancel().await;


### PR DESCRIPTION
# Change Summary
Applied suggestion from https://github.com/open-telemetry/otel-arrow/pull/1987


## Are there any user-facing changes?

Yes, less expensive logs, without losing information!
