### PR TITLE
[query-engine] RecordSet engine diagnostic level adjustments

### DIFF
--- a/rust/experimental/query_engine/engine-recordset/src/execution_context.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/execution_context.rs
@@ -5,7 +5,7 @@ use std::{cell::*, collections::HashMap};
 
 use crate::{
     scalars::{
-        execute_argument_scalar_expression, execute_scalar_expression,
+        SelectionOptions, execute_argument_scalar_expression, execute_scalar_expression,
         execute_source_scalar_expression, execute_variable_scalar_expression,
     },
     value_expressions::{execute_mutable_value_expression, get_borrow_source},
@@ -254,11 +254,21 @@ where
                         a,
                     ),
                     MutableValueExpression::Source(s) => (
-                        execute_source_scalar_expression(self.parent_execution_context, m, s)?,
+                        execute_source_scalar_expression(
+                            self.parent_execution_context,
+                            m,
+                            s,
+                            &SelectionOptions::new(),
+                        )?,
                         s,
                     ),
                     MutableValueExpression::Variable(v) => (
-                        execute_variable_scalar_expression(self.parent_execution_context, m, v)?,
+                        execute_variable_scalar_expression(
+                            self.parent_execution_context,
+                            m,
+                            v,
+                            &SelectionOptions::new(),
+                        )?,
                         m,
                     ),
                 }

--- a/rust/experimental/query_engine/engine-recordset/src/transform/transform_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/transform/transform_expressions.rs
@@ -367,7 +367,7 @@ pub fn execute_transform_expression<'a, TRecord: Record>(
                                 match target_map.remove(k) {
                                     ValueMutRemoveResult::NotFound => {
                                         execution_context.add_diagnostic_if_enabled(
-                                            RecordSetEngineDiagnosticLevel::Warn,
+                                            RecordSetEngineDiagnosticLevel::Info,
                                             r,
                                             || format!("Map key {key} could not be found on target map"),
                                         );


### PR DESCRIPTION
# Changes

* Lowers some spammy diagnostics from "Warn" to "Info" in RecordSet engine

# Details

@drewrelmas has been doing some integration testing and noticed these "warnings" showing up for cases that didn't really need any attention:

* When using `coalesce(thing1, thing2)` we don't really need to "warn" if "thing1" couldn't be found.
* When using `project-away thing1, thing2` we don't really need to "warn" if "thing1" wasn't found (just a no-op in that case).