### PR TITLE
chore: fix the GFM NOTE format

### DIFF
--- a/rust/otap-dataflow/README.md
+++ b/rust/otap-dataflow/README.md
@@ -15,12 +15,12 @@ to produce an OpenTelemetry pipeline support, for use as an embedded
 software component, providing a framework for collecting OpenTelemetry
 data.
 
-> [!NOTE] These Rust libraries are the main deliverable of Phase 2 of
-> the OTel-Arrow project, as defined in the [project
-> phases](../../docs/project-phases.md).  The `df_engine` main
-> program built through `cargo` in [`src/main.rs`](./src/main.rs) is
-> provided as a means to test and validate OTAP pipelines built using
-> the dataflow engine.
+> [!NOTE]
+> These Rust libraries are the main deliverable of Phase 2 of the OTel-Arrow
+> project, as defined in the [project phases](../../docs/project-phases.md).
+> The `df_engine` main program built through `cargo` in
+> [`src/main.rs`](./src/main.rs) is provided as a means to test and validate
+> OTAP pipelines built using the dataflow engine.
 
 ## Architecture
 


### PR DESCRIPTION
# Change Summary

The [current doc](https://github.com/open-telemetry/otel-arrow/tree/main/rust/otap-dataflow#overview) looks like:

<img width="1352" height="289" alt="image" src="https://github.com/user-attachments/assets/64064433-012d-4373-9212-ee5f8312bcab" />

This PR will change it to:

<img width="1387" height="338" alt="image" src="https://github.com/user-attachments/assets/e182b0dd-0f04-426b-93c2-659360e7e682" />