### PR TITLE
fix: use microsoft namespace for Geneva exporter URN

### DIFF
--- a/rust/otap-dataflow/crates/otap/src/experimental/geneva_exporter/README.md
+++ b/rust/otap-dataflow/crates/otap/src/experimental/geneva_exporter/README.md
@@ -21,7 +21,7 @@ cargo build --release --features geneva-exporter
 ./target/release/df_engine --help
 ```
 
-You should see `urn:otel:geneva:exporter` in the Exporters list.
+You should see `urn:microsoft:geneva:exporter` in the Exporters list.
 
 ## Usage
 

--- a/rust/otap-dataflow/crates/otap/src/experimental/geneva_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/otap/src/experimental/geneva_exporter/mod.rs
@@ -15,7 +15,7 @@
 //! ```yaml
 //! nodes:
 //!   - id: geneva-exporter
-//!     urn: "urn:otel:geneva:exporter"
+//!     urn: "urn:microsoft:geneva:exporter"
 //!     config:
 //!       endpoint: "https://geneva.microsoft.com"
 //!       environment: "production"
@@ -67,7 +67,7 @@ use crate::metrics::ExporterPDataMetrics;
 use crate::pdata::OtapPdata;
 
 /// The URN for the Geneva exporter
-pub const GENEVA_EXPORTER_URN: &str = "urn:otel:geneva:exporter";
+pub const GENEVA_EXPORTER_URN: &str = "urn:microsoft:geneva:exporter";
 
 /// Configuration for the Geneva Exporter
 #[derive(Debug, Deserialize, Clone)]
@@ -883,7 +883,7 @@ mod tests {
 
     #[test]
     fn test_urn_constant() {
-        assert_eq!(GENEVA_EXPORTER_URN, "urn:otel:geneva:exporter");
+        assert_eq!(GENEVA_EXPORTER_URN, "urn:microsoft:geneva:exporter");
     }
 
     // TODO: Add integration tests when we can mock GenevaClient:

--- a/rust/otap-dataflow/crates/otap/src/experimental/geneva_exporter/otlp-geneva.yaml
+++ b/rust/otap-dataflow/crates/otap/src/experimental/geneva_exporter/otlp-geneva.yaml
@@ -49,7 +49,7 @@ groups:
 
           # Geneva exporter configuration
           geneva-exporter:
-            type: "urn:otel:geneva:exporter"
+            type: "urn:microsoft:geneva:exporter"
             config:
               # ============================================================
               # REQUIRED FIELDS - Replace with your Geneva deployment values


### PR DESCRIPTION
The Geneva exporter URN was incorrectly using the `otel` namespace (`urn:otel:geneva:exporter`), but Geneva is a Microsoft product - not an OpenTelemetry-provided component.

Updated to `urn:microsoft:geneva:exporter` to follow the existing Microsoft namespace conventions:
   - `urn:microsoft_azure:*` - for Azure-specific products (e.g., `urn:microsoft_azure:monitor:exporter`)
   - `urn:microsoft:*` - for non-Azure Microsoft products (e.g., `urn:microsoft:recordset_kql:processor`)
