### PR TITLE
collect terminal metrics snapshot in exporter TestRuntime

### DIFF
--- a/rust/otap-dataflow/crates/engine/src/testing/exporter.rs
+++ b/rust/otap-dataflow/crates/engine/src/testing/exporter.rs
@@ -264,8 +264,8 @@ impl<PData: Clone + Debug + 'static> TestRuntime<PData> {
                 .map(|terminal_state| {
                     for snapshot in terminal_state.into_metrics() {
                         let _ = metrics_reporter_terminal.try_report_snapshot(snapshot);
-                        metrics_collector.clone().collect_once();
                     }
+                    metrics_collector.collect_pending(); // Collect after sending all the
                 })
         });
         TestPhase {

--- a/rust/otap-dataflow/crates/telemetry/src/collector.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/collector.rs
@@ -43,10 +43,10 @@ impl InternalCollector {
         )
     }
 
-    /// Performs a single collection of metrics from the reporting channel and,
-    /// if there are any buffered messages, aggregates them into the `registry`.
-    pub fn collect_once(self: Arc<Self>) {
-        if let Ok(metrics) = self.metrics_receiver.try_recv() {
+    /// Drains all pending metrics from the reporting channel and aggregates
+    /// them into the `registry`.
+    pub fn collect_pending(&self) {
+        while let Ok(metrics) = self.metrics_receiver.try_recv() {
             self.registry
                 .accumulate_metric_set_snapshot(metrics.key, &metrics.metrics);
         }


### PR DESCRIPTION
# Change Summary

<!--
Replace with a brief summary of the change in this PR
-->

Collects the telemetry returned by the component in the exporter `TestRuntime`.

A new function is added to manually invoke the telemetry loop one time on `InternalCollector`. This is called if the exporter returned a terminal state with some metrics snapshots.

## What issue does this PR close?

<!--
We highly recommend correlation of every PR to an issue
-->

* Closes https://github.com/open-telemetry/otel-arrow/issues/2081

## How are these changes tested?

I tested these manually in a unit test I had on a feature branch:
https://github.com/open-telemetry/otel-arrow/commit/2722031d02d56477fd09ad05d78a543417172a21

More test coverage will be added later on: I plan to use this in a followup to PR https://github.com/open-telemetry/otel-arrow/pull/2070 to add a comprehensive suite of unit tests to the metrics reported by the OTLP HTTP exporter

## Are there any user-facing changes?

 <!-- If yes, provide further info below -->
 
 No
