### PR TITLE
[query-engine] RecordSet engine diagnostic level adjustments 2

### DIFF
--- a/rust/experimental/query_engine/engine-recordset/src/logical_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/logical_expressions.rs
@@ -9,9 +9,22 @@ pub fn execute_logical_expression<'a, TRecord: Record>(
     execution_context: &ExecutionContext<'a, '_, TRecord>,
     logical_expression: &'a LogicalExpression,
 ) -> Result<bool, ExpressionError> {
+    execute_logical_expression_with_options(
+        execution_context,
+        logical_expression,
+        SelectionOptions::new(),
+    )
+}
+
+pub fn execute_logical_expression_with_options<'a, TRecord: Record>(
+    execution_context: &ExecutionContext<'a, '_, TRecord>,
+    logical_expression: &'a LogicalExpression,
+    selection_options: SelectionOptions,
+) -> Result<bool, ExpressionError> {
     let value = match logical_expression {
         LogicalExpression::Scalar(s) => {
-            let value = execute_scalar_expression(execution_context, s)?;
+            let value =
+                execute_scalar_expression_with_options(execution_context, s, selection_options)?;
 
             if let Some(b) = value.to_value().convert_to_bool() {
                 b
@@ -26,9 +39,17 @@ pub fn execute_logical_expression<'a, TRecord: Record>(
             }
         }
         LogicalExpression::EqualTo(e) => {
-            let left = execute_scalar_expression(execution_context, e.get_left())?;
+            let left = execute_scalar_expression_with_options(
+                execution_context,
+                e.get_left(),
+                selection_options.clone(),
+            )?;
 
-            let right = execute_scalar_expression(execution_context, e.get_right())?;
+            let right = execute_scalar_expression_with_options(
+                execution_context,
+                e.get_right(),
+                selection_options,
+            )?;
 
             Value::are_values_equal(
                 e.get_query_location(),
@@ -38,16 +59,32 @@ pub fn execute_logical_expression<'a, TRecord: Record>(
             )?
         }
         LogicalExpression::GreaterThan(g) => {
-            let left = execute_scalar_expression(execution_context, g.get_left())?;
+            let left = execute_scalar_expression_with_options(
+                execution_context,
+                g.get_left(),
+                selection_options.clone(),
+            )?;
 
-            let right = execute_scalar_expression(execution_context, g.get_right())?;
+            let right = execute_scalar_expression_with_options(
+                execution_context,
+                g.get_right(),
+                selection_options,
+            )?;
 
             Value::compare_values(g.get_query_location(), &left.to_value(), &right.to_value())? > 0
         }
         LogicalExpression::GreaterThanOrEqualTo(g) => {
-            let left = execute_scalar_expression(execution_context, g.get_left())?;
+            let left = execute_scalar_expression_with_options(
+                execution_context,
+                g.get_left(),
+                selection_options.clone(),
+            )?;
 
-            let right = execute_scalar_expression(execution_context, g.get_right())?;
+            let right = execute_scalar_expression_with_options(
+                execution_context,
+                g.get_right(),
+                selection_options,
+            )?;
 
             Value::compare_values(g.get_query_location(), &left.to_value(), &right.to_value())? >= 0
         }
@@ -67,8 +104,16 @@ pub fn execute_logical_expression<'a, TRecord: Record>(
             }
         }
         LogicalExpression::Contains(c) => {
-            let haystack = execute_scalar_expression(execution_context, c.get_haystack())?;
-            let needle = execute_scalar_expression(execution_context, c.get_needle())?;
+            let haystack = execute_scalar_expression_with_options(
+                execution_context,
+                c.get_haystack(),
+                selection_options.clone(),
+            )?;
+            let needle = execute_scalar_expression_with_options(
+                execution_context,
+                c.get_needle(),
+                selection_options,
+            )?;
 
             Value::contains(
                 c.get_query_location(),
@@ -78,8 +123,16 @@ pub fn execute_logical_expression<'a, TRecord: Record>(
             )?
         }
         LogicalExpression::Matches(m) => {
-            let haystack = execute_scalar_expression(execution_context, m.get_haystack())?;
-            let pattern = execute_scalar_expression(execution_context, m.get_pattern())?;
+            let haystack = execute_scalar_expression_with_options(
+                execution_context,
+                m.get_haystack(),
+                selection_options.clone(),
+            )?;
+            let pattern = execute_scalar_expression_with_options(
+                execution_context,
+                m.get_pattern(),
+                selection_options,
+            )?;
 
             Value::matches(
                 m.get_query_location(),

--- a/rust/experimental/query_engine/engine-recordset/src/scalars/scalar_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/scalars/scalar_expressions.rs
@@ -7,7 +7,7 @@ use data_engine_expressions::*;
 
 use crate::{
     execution_context::*,
-    logical_expressions::execute_logical_expression,
+    logical_expressions::{execute_logical_expression, execute_logical_expression_with_options},
     scalars::{
         execute_collection_scalar_expression, execute_convert_scalar_expression,
         execute_math_scalar_expression, execute_parse_scalar_expression,
@@ -26,6 +26,7 @@ static VALUE_TYPE_NAMES: LazyLock<Vec<StringValueStorage>> = LazyLock::new(|| {
     items
 });
 
+#[derive(Clone)]
 pub struct SelectionOptions {
     selector_not_found_diagnostic_level: RecordSetEngineDiagnosticLevel,
 }
@@ -198,7 +199,13 @@ where
 
             // Evaluate conditions in order and return first matching result
             for (condition, expression) in expressions_with_conditions {
-                if execute_logical_expression(execution_context, condition)? {
+                if execute_logical_expression_with_options(
+                    execution_context,
+                    condition,
+                    SelectionOptions::new().with_selector_not_found_diagnostic_level(
+                        RecordSetEngineDiagnosticLevel::Info,
+                    ),
+                )? {
                     result = Some(execute_scalar_expression(execution_context, expression)?);
                     break;
                 }


### PR DESCRIPTION
Similar to #2032

# Changes

* Lowers some spammy `case` diagnostics from "Warn" to "Info" in RecordSet engine

# Details

@drewrelmas has been doing some integration testing and noticed these "warnings" showing up which are more or less normal\expected.

* When using `case(thing1=='some_value', value, default_thing)` we don't really need to "warn" if "thing1" couldn't be found because `case` is probably being used to account for that in the first place.