### PR TITLE
Fix PipelineCtrlMsgManager deadlock when node control channel is full

### DIFF
--- a/rust/otap-dataflow/crates/engine/src/pipeline_ctrl.rs
+++ b/rust/otap-dataflow/crates/engine/src/pipeline_ctrl.rs
@@ -275,9 +275,27 @@ impl<PData> PipelineCtrlMsgManager<PData> {
         let mut is_draining = false;
         let mut draining_deadline: Option<Instant> = None;
 
+        // Single reusable timer for retrying buffered sends. Created once,
+        // reset only when `pending_sends` transitions from empty to non-empty.
+        // This avoids allocating a new Sleep future on every loop iteration
+        // (the standard tokio::select! pinned-sleep pattern).
+        let retry_delay = tokio::time::sleep(Duration::from_millis(5));
+        tokio::pin!(retry_delay);
+        let mut retry_armed = false;
+
         loop {
             // Drain any buffered sends before processing new messages.
             self.drain_pending_sends();
+
+            // Arm the retry timer when pending sends appear; disarm when drained.
+            if !self.pending_sends.is_empty() && !retry_armed {
+                retry_delay
+                    .as_mut()
+                    .reset(tokio::time::Instant::now() + Duration::from_millis(5));
+                retry_armed = true;
+            } else if self.pending_sends.is_empty() {
+                retry_armed = false;
+            }
 
             // Check if we've exceeded the draining deadline
             if let Some(deadline) = draining_deadline {
@@ -482,8 +500,10 @@ impl<PData> PipelineCtrlMsgManager<PData> {
                 // Placed last so incoming messages and timers are always
                 // prioritized — incoming acks may be exactly what unblocks
                 // the congested node.
-                _ = tokio::time::sleep(Duration::from_millis(5)),
-                    if !self.pending_sends.is_empty() => {
+                // Uses a pinned/reused sleep to avoid allocating a new timer
+                // future on every loop iteration.
+                _ = &mut retry_delay, if retry_armed => {
+                    retry_armed = false;
                     // drain_pending_sends() runs at loop top; just wake up.
                     continue;
                 }


### PR DESCRIPTION
# Change Summary

This is almost the same as @cijothomas's #2152 but with changes around draining logic and reusing the `VecDeque` instance.

Change `send()` from blocking-async to non-blocking with buffered retry:

- **`try_send()` + `VecDeque` buffer**: When a node's control channel is full, the message is pushed into a `pending_sends: VecDeque<(usize, NodeControlMsg<PData>)>` instead of blocking.
- **`drain_pending_sends()`**: At the top of each event loop iteration, buffered messages are retried. Messages that still can't be delivered are re-queued at the back of the deque.
- **Retry wakeup via `select!`**: A 5ms sleep branch in `tokio::select!` wakes the loop when there are pending sends, placed *last* (after the message recv and timer branches) so incoming messages — especially acks that could unblock congested nodes — are always prioritized.
- **Observability**: A warning is logged when the pending sends buffer reaches a threshold (100), helping operators diagnose sustained backpressure.

The manager is now fully non-blocking on the outbound path (manager -> nodes), eliminating the circular-wait possibility.

### Note on the unbounded `VecDeque`

The `pending_sends` buffer is unbounded, but this is acceptable in practice. The buffer only grows when a node's control channel is persistently full — each event loop iteration can add at most one message to the buffer. Under normal operation the buffer stays empty; it only accumulates messages during transient backpressure spikes and drains as soon as the congested node catches up. If a node is permanently stuck (never draining its control channel), the buffer will grow indefinitely, but this indicates a fundamental problem with that node — the warning logged at 100 entries surfaces this to operators so they can investigate.

## What issue does this PR close?

* Closes #2157 

## How are these changes tested?

A test (`test_circular_wait_between_node_and_manager`) reproduces the exact production scenario:
- Pipeline ctrl channel capacity 3, Node A control channel capacity 1, Node B capacity 10
- An active Node A task sends `DeliverAck` in a loop (simulating the exporter batch-ack pattern)
- Asserts that Node B receives its ack within 500ms — without the fix, this times out due to the circular wait

## Are there any user-facing changes?

No