### PR TITLE
Add engine-level cpu_utilization metric

### DIFF
--- a/rust/otap-dataflow/crates/engine/src/engine_metrics.rs
+++ b/rust/otap-dataflow/crates/engine/src/engine_metrics.rs
@@ -104,11 +104,10 @@ impl EngineMetricsMonitor {
         let now_cpu = ProcessTime::now();
         let wall_delta = now_wall.duration_since(self.wall_start);
         let cpu_delta = now_cpu.duration_since(self.cpu_start);
-        let wall_micros = wall_delta.as_micros();
-        if wall_micros > 0 {
-            let utilization = (cpu_delta.as_micros() as f64
-                / (wall_micros as f64 * self.num_cores as f64))
-                .clamp(0.0, 1.0);
+        let wall_secs = wall_delta.as_secs_f64();
+        if wall_secs > 0.0 {
+            let utilization =
+                (cpu_delta.as_secs_f64() / (wall_secs * self.num_cores as f64)).clamp(0.0, 1.0);
             self.metrics.cpu_utilization.set(utilization);
         } else {
             self.metrics.cpu_utilization.set(0.0);


### PR DESCRIPTION
Continuing from https://github.com/open-telemetry/otel-arrow/pull/2153

Adds process-wide CPU utilization to the engine.metrics set, aligned with the OTel semantic convention [process.cpu.utilization](https://github.com/open-telemetry/semantic-conventions/blob/b1e15d5fa4e4dc627374022d546959810e549043/docs/system/process-metrics.md#metric-processcpuutilization). Reported as a 0–1 ratio **normalized** across **all system cores** (not just the cores Engine is configured to use)

Emits utilization directly (rather than a cumulative cpu_time counter like Go Collector's process_cpu_seconds_total) so users can read the metric as-is without PromQL rate() or similar query-time derivation — not every deployment has that capability.

Uses cpu_time::ProcessTime (already a dependency) for cross-platform process CPU time.

(Extremely useful for one to tell if we are utilizing the full CPU. Current metrics might show 100% utilization of the cores it is using, but without this metric, we can't tell what percentage of entire machine is taken up)