### PR TITLE
Reduce initial HashMap capacity in AzureMonitorExporterState to lower…

### DIFF
--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/state.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/state.rs
@@ -19,12 +19,12 @@ pub struct AzureMonitorExporterState {
 }
 
 impl AzureMonitorExporterState {
-    /// Create state with preallocated capacity for high throughput.
+    /// Create state with a small initial capacity that grows on demand.
     pub fn new() -> Self {
         Self {
-            batch_to_msg: HashMap::with_capacity(262144),
-            msg_to_batch: HashMap::with_capacity(262144),
-            msg_to_data: HashMap::with_capacity(262144),
+            batch_to_msg: HashMap::with_capacity(256),
+            msg_to_batch: HashMap::with_capacity(256),
+            msg_to_data: HashMap::with_capacity(256),
         }
     }
 


### PR DESCRIPTION
The three HashMaps in AzureMonitorExporterState were pre-allocated with a capacity of 262,144 entries each. Because hashbrown stores key-value pairs inline (~792 bytes/slot for (Context, OtapPayload)), this reserved ~470 MiB **per exporter instance** even when the maps were empty. With multiple exporters per core, idle memory consumption alone reached several GiB.

This change lowers the initial capacity to 256. The maps grow geometrically on demand, so after a brief warmup (~10 doublings) they settle at whatever size the workload actually requires. Steady-state throughput is unaffected — only the cold/idle memory footprint changes, dropping from ~470 MiB to ~200 KiB per instance.

Related to https://github.com/open-telemetry/otel-arrow/pull/2165/changes, but should be reviewed independently.