### PR TITLE
nit: improve enginemetrics script to ignore zero values

### DIFF
--- a/rust/otap-dataflow/scripts/engine-metrics.py
+++ b/rust/otap-dataflow/scripts/engine-metrics.py
@@ -80,7 +80,9 @@ def fmt(v, unit="", instrument=""):
         return "-"
     if is_mmsc(v):
         c = v["count"]
-        avg = v["sum"] / c if c else 0
+        if c == 0:
+            return "n=0"
+        avg = v["sum"] / c
         return (
             f"min={v['min']:.1f} max={v['max']:.1f} "
             f"avg={avg:.1f} n={_fmt_num(c)}"


### PR DESCRIPTION
Simple display improvement from the script.

before (false)

```txt
auth.success.latency: min=179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368.0 max=-179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368.0 avg=0.0 n=0
```

after

```txt
auth.success.latency: n=0
```