### PR TITLE
Ignore flaky test from CI

### DIFF
--- a/rust/otap-dataflow/crates/validation/src/lib.rs
+++ b/rust/otap-dataflow/crates/validation/src/lib.rs
@@ -169,6 +169,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "flaky test, see https://github.com/open-telemetry/otel-arrow/issues/2227"]
     fn multiple_input_output() {
         Scenario::new()
             .pipeline(


### PR DESCRIPTION
Temporarily to get CI to be stable.

https://github.com/open-telemetry/otel-arrow/issues/2227 to track adding them back.