### PR TITLE
chore(deps): Adjust remaining instances of pipCommand not being pinned by hash

### DIFF
--- a/.github/workflows/pipeline-perf-on-label.yaml
+++ b/.github/workflows/pipeline-perf-on-label.yaml
@@ -108,7 +108,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --user --upgrade pip
           python -m pip install --user --require-hashes -r tools/pipeline_perf_test/orchestrator/requirements.lock.txt
           python -m pip install --user --require-hashes -r tools/pipeline_perf_test/load_generator/requirements.lock.txt
 
@@ -145,7 +144,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --user --upgrade pip
           python -m pip install --user --require-hashes -r tools/pipeline_perf_test/orchestrator/requirements.lock.txt
           python -m pip install --user --require-hashes -r tools/pipeline_perf_test/load_generator/requirements.lock.txt
 

--- a/.github/workflows/pipeline-perf-test-continuous.yml
+++ b/.github/workflows/pipeline-perf-test-continuous.yml
@@ -76,7 +76,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --user --upgrade pip
           python -m pip install --user --require-hashes -r tools/pipeline_perf_test/orchestrator/requirements.lock.txt
           python -m pip install --user --require-hashes -r tools/pipeline_perf_test/load_generator/requirements.lock.txt
 

--- a/.github/workflows/pipeline-perf-test-manual-pr.yaml
+++ b/.github/workflows/pipeline-perf-test-manual-pr.yaml
@@ -99,7 +99,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --user --upgrade pip
           python -m pip install --user --require-hashes -r tools/pipeline_perf_test/orchestrator/requirements.lock.txt
           python -m pip install --user --require-hashes -r tools/pipeline_perf_test/load_generator/requirements.lock.txt
 

--- a/.github/workflows/pipeline-perf-test-nightly.yml
+++ b/.github/workflows/pipeline-perf-test-nightly.yml
@@ -81,7 +81,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --user --upgrade pip
           python -m pip install --user --require-hashes -r tools/pipeline_perf_test/orchestrator/requirements.lock.txt
           python -m pip install --user --require-hashes -r tools/pipeline_perf_test/load_generator/requirements.lock.txt
 

--- a/tools/pipeline_perf_test/load_generator/Dockerfile
+++ b/tools/pipeline_perf_test/load_generator/Dockerfile
@@ -3,8 +3,8 @@ FROM python:3.14-slim@sha256:6a27522252aef8432841f224d9baaa6e9fce07b07584154fa0b
 WORKDIR /app
 
 # Install dependencies
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+COPY requirements.lock.txt .
+RUN python -m pip install --no-cache-dir --require-hashes -r requirements.lock.txt
 
 # Copy the load generator code
 COPY *.py ./


### PR DESCRIPTION
# Change Summary

Follow-up to #2241 

## What issue does this PR close?

Security warnings from GitHub

## How are these changes tested?

n/a

## Are there any user-facing changes?

n/a
