### PR TITLE
fix: correct label casing in issue templates to match existing repo labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: Report a bug in OTel-Arrow
 type: Bug
-labels: ["Bug"]
+labels: ["bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Suggest a new feature or enhancement for OTel-Arrow
 type: Feature
-labels: ["Feature"]
+labels: ["enhancement"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
# Change Summary

The `bug_report.yaml` and `feature_request.yaml` issue templates had labels
that didn't match any existing repository labels, so they were silently ignored
when issues were filed. This PR corrects them.

## What issue does this PR close?

<!--
We highly recommend correlation of every PR to an issue
-->

* Closes #2263

## How are these changes tested?

## Are there any user-facing changes?

 <!-- If yes, provide further info below -->
