### PR TITLE
test: increase metrics reporter channel size to prevent overflow on slow CI systems

### DIFF
--- a/rust/otap-dataflow/crates/otap/tests/durable_buffer_processor_tests.rs
+++ b/rust/otap-dataflow/crates/otap/tests/durable_buffer_processor_tests.rs
@@ -483,8 +483,9 @@ where
         core_id: 0,
     };
     // Create a metrics reporter with our own receiver so we can inspect metrics.
-    // The channel is large enough to hold many telemetry collection cycles.
-    let (metrics_rx, metrics_reporter) = MetricsReporter::create_new_and_receiver(1000);
+    // Use a very large channel so it never overflows, even on extremely slow CI
+    // where many telemetry snapshots accumulate before the test drains them.
+    let (metrics_rx, metrics_reporter) = MetricsReporter::create_new_and_receiver(1_000_000);
     let event_reporter = observed_state_store.reporter(SendPolicy::default());
 
     let shutdown_handle = std::thread::spawn(move || {


### PR DESCRIPTION
# Change Summary

The test's `MetricsReporter` channel (capacity 1,000) could overflow on slow CI when many telemetry snapshots accumulated before the test drained them, causing the final snapshot (the one carrying `bundles_acked`) to be silently dropped by `try_send`.

Fixed by increasing the channel capacity to 1,000,000 so it never fills during a test run.

## What issue does this PR close?

* Closes #2259

## How are these changes tested?

Simulated (and reproduced) the failure locally and now understand root cause. Failure no longer repros (under simulated failure conditions) after this change.

## Are there any user-facing changes?

No
