### PR TITLE
CI flakiness - fix some tests

### DIFF
--- a/rust/otap-dataflow/crates/otap/src/syslog_cef_receiver.rs
+++ b/rust/otap-dataflow/crates/otap/src/syslog_cef_receiver.rs
@@ -1653,9 +1653,7 @@ mod telemetry_tests {
             let receiver = SyslogCefReceiver::with_pipeline(
                 pipeline,
                 Config {
-                    protocol: Protocol::Udp(UdpConfig {
-                        listening_addr,
-                    }),
+                    protocol: Protocol::Udp(UdpConfig { listening_addr }),
                     batch: Some(BatchConfig {
                         flush_timeout_ms: None,
                         max_size: NonZeroU16::new(1),


### PR DESCRIPTION
Fix flaky udp_telemetry_refused_when_downstream_closed test by setting max_batch_size=1 to flush immediately instead of relying on a timing-dependent interval tick.