### PR TITLE
ci: add help wanted auto-comment workflow

### DIFF
--- a/.github/workflows/project_management_comment.yml
+++ b/.github/workflows/project_management_comment.yml
@@ -1,0 +1,27 @@
+name: Add comment
+on:
+  issues:
+    types:
+      - labeled
+permissions:
+  contents: read
+
+jobs:
+  add-comment:
+    if: github.event.label.name == 'help wanted'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
+        with:
+          egress-policy: audit
+
+      - name: Add comment
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            This issue is available for anyone to work on. Feel free to leave a comment if you'd like to be assigned. **Make sure to reference this issue in your pull request.**
+            :sparkles: Thank you for your contribution! :sparkles:


### PR DESCRIPTION
Adds a GitHub Actions workflow that
automatically posts a welcoming comment when the `help wanted` label is applied to an issue.

### What it does

- Posts a comment inviting contributors to pick up the issue and request assignment
- Reminds them to reference the issue in their PR

### Why

A consistent, automated welcome message that:

- **Signals availability** - Makes it immediately visible to contributors browsing issues or receiving notifications that this one is open for contribution, without requiring them to looking into labels.
- **Sets expectations** - The "reference this issue in your PR" instruction ensures PRs are linked, so the issue auto-closes on merge and maintains traceability.
- **Reduces maintainer toil** - No one has to manually comment each time `help wanted` is applied.