### PR TITLE
AzMon - add count of network errors

### DIFF
--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs
@@ -229,7 +229,7 @@ impl LogsIngestionClient {
         let body_len = body.len();
         let start = Instant::now();
 
-        let response = self
+        let response = match self
             .http_client
             .post(&self.endpoint)
             .header(CONTENT_TYPE, "application/json")
@@ -238,7 +238,13 @@ impl LogsIngestionClient {
             .body(body)
             .send()
             .await
-            .map_err(Error::network)?;
+        {
+            Ok(resp) => resp,
+            Err(e) => {
+                self.metrics.borrow_mut().add_network_error();
+                return Err(Error::network(e));
+            }
+        };
 
         let status_code = response.status().as_u16();
         let elapsed = start.elapsed();

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/metrics.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/metrics.rs
@@ -61,6 +61,9 @@ pub struct AzureMonitorExporterMetrics {
     /// Number of HTTP 5xx (server error) responses.
     #[metric(unit = "{response}")]
     pub laclient_http_5xx: Counter<u64>,
+    /// Number of network errors (connect, timeout, etc.) before receiving an HTTP response.
+    #[metric(unit = "{error}")]
+    pub laclient_network_errors: Counter<u64>,
     /// Number of failed authentication attempts.
     pub auth_failures: Counter<u64>,
     /// Authentication success latency in milliseconds (min/max/sum/count).
@@ -317,6 +320,12 @@ impl AzureMonitorExporterMetricsTracker {
         self.metrics.msg_to_data_count.set(count);
     }
 
+    /// Increment the network error counter.
+    #[inline]
+    pub fn add_network_error(&mut self) {
+        self.metrics.laclient_network_errors.inc();
+    }
+
     /// Increment the log-entry-too-large counter.
     #[inline]
     pub fn add_log_entry_too_large(&mut self) {
@@ -464,6 +473,20 @@ mod tests {
         assert_eq!(stats.metrics().laclient_http_413.get(), 1);
         assert_eq!(stats.metrics().laclient_http_429.get(), 1);
         assert_eq!(stats.metrics().laclient_http_5xx.get(), 3);
+    }
+
+    #[test]
+    fn test_network_error_counter() {
+        let mut stats = new_test_tracker();
+
+        assert_eq!(stats.metrics().laclient_network_errors.get(), 0);
+
+        stats.add_network_error();
+        assert_eq!(stats.metrics().laclient_network_errors.get(), 1);
+
+        stats.add_network_error();
+        stats.add_network_error();
+        assert_eq!(stats.metrics().laclient_network_errors.get(), 3);
     }
 
     #[test]


### PR DESCRIPTION
Network errors (connect failures, timeouts) were **invisible** in the exporter's metrics dashboard — all HTTP status counters showed 0 even during total export failure. Added a laclient_network_errors counter that increments on each failed HTTP attempt before a response is received, making connectivity issues immediately diagnosable.

Tested by turning wifi off and running exporter. The new counters helps troubleshoot quickly