### PR TITLE
Migrate to new bare metal runner (Ubuntu 24)

### DIFF
--- a/.github/workflows/pipeline-perf-on-label.yaml
+++ b/.github/workflows/pipeline-perf-on-label.yaml
@@ -41,7 +41,7 @@ jobs:
   pipeline-perf-test-dedicated:
     needs: label-check
     if: needs.label-check.outputs.has_label == 'true'
-    runs-on: oracle-bare-metal-64cpu-512gb-x86-64
+    runs-on: oracle-bare-metal-64cpu-1024gb-x86-64-ubuntu-24
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0

--- a/.github/workflows/pipeline-perf-test-continuous.yml
+++ b/.github/workflows/pipeline-perf-test-continuous.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   pipeline-perf-test:
-    runs-on: oracle-bare-metal-64cpu-512gb-x86-64
+    runs-on: oracle-bare-metal-64cpu-1024gb-x86-64-ubuntu-24
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0

--- a/.github/workflows/pipeline-perf-test-manual-pr.yaml
+++ b/.github/workflows/pipeline-perf-test-manual-pr.yaml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   pipeline-perf-test:
-    runs-on: oracle-bare-metal-64cpu-512gb-x86-64
+    runs-on: oracle-bare-metal-64cpu-1024gb-x86-64-ubuntu-24
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0

--- a/.github/workflows/pipeline-perf-test-nightly.yml
+++ b/.github/workflows/pipeline-perf-test-nightly.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   pipeline-perf-test:
-    runs-on: oracle-bare-metal-64cpu-512gb-x86-64
+    runs-on: oracle-bare-metal-64cpu-1024gb-x86-64-ubuntu-24
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0


### PR DESCRIPTION
Old runner:

- name: `oracle-bare-metal-64cpu-512gb-x86-64`
- 512gb memory
- Oracle Linux 8

New runner:

-  name: `oracle-bare-metal-64cpu-1024gb-x86-64-ubuntu-24`
- 1024gb memory
-  Ubuntu 24

I realize this could have some impact on benchmark baselines, so please post on https://github.com/open-telemetry/community/issues/3333 once you have migrated and are comfortable with the old one being removed.
