### PR TITLE
AzureMonitorExporter - lower severity to WARN

### DIFF
--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs
@@ -190,7 +190,7 @@ impl AzureMonitorExporter {
             m.add_failed_batch();
         }
 
-        otel_error!("azure_monitor_exporter.export.failed", batch_id = batch_id, error = %error);
+        otel_warn!("azure_monitor_exporter.export.failed", batch_id = batch_id, error = %error);
 
         for (_, context, payload) in failed_messages {
             effect_handler


### PR DESCRIPTION
# Change Summary

Downgrade from ERR to WARN for export failure.

Closes #2348 

## How are these changes tested?

## Are there any user-facing changes?

Yes lower severity for internal logs.
