### PR TITLE
Fix CI for Ubuntu 24 runner: Docker Buildx + Python setup

### DIFF
--- a/.github/workflows/pipeline-perf-test-continuous.yml
+++ b/.github/workflows/pipeline-perf-test-continuous.yml
@@ -71,7 +71,7 @@ jobs:
           git submodule init
           git submodule update
           cd rust/otap-dataflow
-          docker build --build-context otel-arrow=../../ -f Dockerfile -t df_engine .
+          docker buildx build --load --build-context otel-arrow=../../ -f Dockerfile -t df_engine .
           cd ../..
 
       - name: Install dependencies

--- a/.github/workflows/pipeline-perf-test-nightly.yml
+++ b/.github/workflows/pipeline-perf-test-nightly.yml
@@ -72,7 +72,7 @@ jobs:
           git submodule init
           git submodule update
           cd rust/otap-dataflow
-          docker build --build-context otel-arrow=../../ -f Dockerfile -t df_engine .
+          docker buildx build --load --build-context otel-arrow=../../ -f Dockerfile -t df_engine .
           cd ../..
 
       - name: Build otelarrowcol

--- a/rust/otap-dataflow/Dockerfile
+++ b/rust/otap-dataflow/Dockerfile
@@ -6,7 +6,7 @@
 # In order to include these in the build context, and to avoid conflicting
 # with the arrow enabled go collector build files in the repo root, the image
 # must be built with additional --build-context flags as follows:
-# docker build --build-context otel-arrow=../../ -f Dockerfile -t df_engine .
+# docker buildx build --load --build-context otel-arrow=../../ -f Dockerfile -t df_engine .
 FROM --platform=$BUILDPLATFORM docker.io/rust:1.94@sha256:0e6da0c8f06f25e9591f21c0f741cd4ff1086e271c3330f29f6e4e95869c7843 AS dataflow-build
 WORKDIR /build/rust/dataflow
 ARG BUILDPLATFORM
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y protobuf-compiler
 
 # The build process relies on these libraries outside of the current context.
 # Build command from the otap-dataflow directory:
-# docker build --build-context otel-arrow=../../ -f Dockerfile -t df_engine .
+# docker buildx build --load --build-context otel-arrow=../../ -f Dockerfile -t df_engine .
 COPY --from=otel-arrow /proto/opentelemetry/proto /build/proto/opentelemetry/proto
 COPY --from=otel-arrow /proto/opentelemetry-proto /build/proto/opentelemetry-proto
 COPY --from=otel-arrow /rust/experimental /build/rust/experimental


### PR DESCRIPTION
The self-hosted perf test runner changed from Oracle Linux 8 to Ubuntu 24. This broke the CI in two ways:

1. **Docker:** The runner lacks the `buildx` component, which is needed for `--build-context` and `FROM --platform` in the Dockerfile. Fixed by adding `docker/setup-buildx-action` and using `docker buildx build --load`.

2. **Python:** The OL8-specific Python install step was skipped (condition `id == 'ol'` fails on Ubuntu), and Ubuntu 24 doesn't provide a `python` command by default. Fixed by replacing the OL8 block with `actions/setup-python`.

This also cleans up ~184 lines of now-unnecessary OL8-specific code (detect_os step, dnf installs, python shim, disk-cleanup).