### PR TITLE
PerfTest machine - check NUMA status

### DIFF
--- a/.github/workflows/pipeline-perf-test-continuous.yml
+++ b/.github/workflows/pipeline-perf-test-continuous.yml
@@ -18,6 +18,15 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: System topology (NUMA, CPU, memory)
+        run: |
+          echo "### System Topology" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          lscpu | grep -E "Model name|Socket|Core|Thread|NUMA|CPU\(s\)" | tee -a $GITHUB_STEP_SUMMARY
+          echo "" | tee -a $GITHUB_STEP_SUMMARY
+          numactl --hardware 2>/dev/null | tee -a $GITHUB_STEP_SUMMARY || echo "numactl not available"
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
       - id: detect_os
         name: Detect OS (self-hosted)
         shell: bash


### PR DESCRIPTION
Just a simple CI step to find more about the perf test machine from CNCF. Primarily to find out if they have NUMA and we can leverage it to test if engine's NUMA awareness is tested/proved. If not, we need to request different machine(s).