### PR TITLE
perf: increase syslog TCP load generator target rate

### DIFF
--- a/tools/pipeline_perf_test/load_generator/loadgen.py
+++ b/tools/pipeline_perf_test/load_generator/loadgen.py
@@ -132,7 +132,7 @@ class LoadGenConfig(BaseModel):
     batch_size: int = Field(5000, gt=0, description="Number of logs per batch")
     threads: int = Field(4, gt=0, description="Number of worker threads to run")
     target_rate: Optional[int] = Field(
-        None, gt=0, description="Optional target messages per second"
+        None, ge=0, description="Optional target messages per second (0 = no limit)"
     )
     tcp_connection_per_thread: bool = Field(
         True, description="Use a dedicated TCP connection per-thread"

--- a/tools/pipeline_perf_test/test_suites/integration/nightly/syslog-docker.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/nightly/syslog-docker.yaml
@@ -79,6 +79,8 @@ tests:
         exporter: otap
         # Non CEF message of approximately the same size as CEF message
         syslog_message: 'NOT-CEF:0|Security|threatmanager|1.0|100|worm stopped|10|src=192.168.1.10 dst=10.0.0.25 spt=443 dpt=8080 proto=TCP act=blocked cs1Label=MalwareType cs1=Worm cs2Label=DetectionMethod cs2=Heuristic cs3Label=Severity cs3=High requestMethod=POST'
+        syslog_rate: 0
+        syslog_threads: 8
         observation_interval: 60
   - name: SYSLOG-3164-ATTR-OTLP
     from_template:
@@ -90,6 +92,8 @@ tests:
         exporter: otlp
         # Non CEF message of approximately the same size as CEF message
         syslog_message: 'NOT-CEF:0|Security|threatmanager|1.0|100|worm stopped|10|src=192.168.1.10 dst=10.0.0.25 spt=443 dpt=8080 proto=TCP act=blocked cs1Label=MalwareType cs1=Worm cs2Label=DetectionMethod cs2=Heuristic cs3Label=Severity cs3=High requestMethod=POST'
+        syslog_rate: 0
+        syslog_threads: 8
         observation_interval: 60
   - name: SYSLOG-3164-CEF-ATTR-OTLP
     from_template:
@@ -100,6 +104,8 @@ tests:
         backend_receiver_type: otlp
         exporter: otlp
         syslog_message: 'CEF:0|Security|threatmanager|1.0|100|worm stopped|10|src=192.168.1.10 dst=10.0.0.25 spt=443 dpt=8080 proto=TCP act=blocked cs1Label=MalwareType cs1=Worm cs2Label=DetectionMethod cs2=Heuristic cs3Label=Severity cs3=High requestMethod=POST'
+        syslog_rate: 0
+        syslog_threads: 8
         observation_interval: 60
   - name: SYSLOG-3164-CEF-ATTR-OTAP
     from_template:
@@ -110,4 +116,6 @@ tests:
         backend_receiver_type: otap
         exporter: otap
         syslog_message: 'CEF:0|Security|threatmanager|1.0|100|worm stopped|10|src=192.168.1.10 dst=10.0.0.25 spt=443 dpt=8080 proto=TCP act=blocked cs1Label=MalwareType cs1=Worm cs2Label=DetectionMethod cs2=Heuristic cs3Label=Severity cs3=High requestMethod=POST'
+        syslog_rate: 0
+        syslog_threads: 8
         observation_interval: 60

--- a/tools/pipeline_perf_test/test_suites/integration/nightly/syslog-tcp-docker.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/nightly/syslog-tcp-docker.yaml
@@ -80,7 +80,7 @@ tests:
         syslog_transport: tcp
         # Non CEF message of approximately the same size as CEF message
         syslog_message: 'NOT-CEF:0|Security|threatmanager|1.0|100|worm stopped|10|src=192.168.1.10 dst=10.0.0.25 spt=443 dpt=8080 proto=TCP act=blocked cs1Label=MalwareType cs1=Worm cs2Label=DetectionMethod cs2=Heuristic cs3Label=Severity cs3=High requestMethod=POST'
-        syslog_rate: 999999999
+        syslog_rate: 0
         observation_interval: 60
   - name: SYSLOG-TCP-3164-ATTR-OTLP
     from_template:
@@ -93,7 +93,7 @@ tests:
         syslog_transport: tcp
         # Non CEF message of approximately the same size as CEF message
         syslog_message: 'NOT-CEF:0|Security|threatmanager|1.0|100|worm stopped|10|src=192.168.1.10 dst=10.0.0.25 spt=443 dpt=8080 proto=TCP act=blocked cs1Label=MalwareType cs1=Worm cs2Label=DetectionMethod cs2=Heuristic cs3Label=Severity cs3=High requestMethod=POST'
-        syslog_rate: 999999999
+        syslog_rate: 0
         observation_interval: 60
   - name: SYSLOG-TCP-3164-CEF-ATTR-OTLP
     from_template:
@@ -105,7 +105,7 @@ tests:
         exporter: otlp
         syslog_transport: tcp
         syslog_message: 'CEF:0|Security|threatmanager|1.0|100|worm stopped|10|src=192.168.1.10 dst=10.0.0.25 spt=443 dpt=8080 proto=TCP act=blocked cs1Label=MalwareType cs1=Worm cs2Label=DetectionMethod cs2=Heuristic cs3Label=Severity cs3=High requestMethod=POST'
-        syslog_rate: 999999999
+        syslog_rate: 0
         observation_interval: 60
   - name: SYSLOG-TCP-3164-CEF-ATTR-OTAP
     from_template:
@@ -117,5 +117,5 @@ tests:
         exporter: otap
         syslog_transport: tcp
         syslog_message: 'CEF:0|Security|threatmanager|1.0|100|worm stopped|10|src=192.168.1.10 dst=10.0.0.25 spt=443 dpt=8080 proto=TCP act=blocked cs1Label=MalwareType cs1=Worm cs2Label=DetectionMethod cs2=Heuristic cs3Label=Severity cs3=High requestMethod=POST'
-        syslog_rate: 999999999
+        syslog_rate: 0
         observation_interval: 60


### PR DESCRIPTION
## Summary

Remove the 5K logs/sec rate cap on the syslog load generator tests (both TCP and UDP) so they can actually stress-test the df-engine.

## Changes

1. **`loadgen.py`**: Changed `target_rate` Pydantic field from `gt=0` to `ge=0` so that `0` is accepted. When `target_rate` is 0 (falsy), the existing worker code skips all timer/sleep logic entirely, running at max throughput.

2. **`syslog-tcp-docker.yaml`**: Added `syslog_rate: 0` to all 4 test template variables. (The template's `update_component_strategy` step was overriding the component-level config with a hardcoded default of 5000.)

3. **`syslog-docker.yaml`** (UDP): Added `syslog_rate: 0` and `syslog_threads: 8` to all 4 test template variables. UDP needs multiple threads because each message is a separate `sendto()` syscall, limiting a single Python thread to ~9K logs/sec.

## Results (1-core df-engine, 0% drops)

### TCP (1 thread, no rate limit)
| Test | Before | After | Speedup |
|---|---|---|---|
| ATTR-OTLP | 5,418 | **197,321** | 36x |
| CEF-ATTR-OTLP | 5,420 | **93,609** | 17x |
| ATTR-OTAP | 5,420 | **90,130** | 17x |
| CEF-ATTR-OTAP | 5,420 | **80,434** | 15x |

### UDP (8 threads, no rate limit)
| Test | Before | After | Speedup |
|---|---|---|---|
| ATTR-OTLP | 5,418 | **57,127** | 11x |
| CEF-ATTR-OTLP | 5,420 | **56,819** | 10x |
| ATTR-OTAP | 5,420 | **55,397** | 10x |
| CEF-ATTR-OTAP | 5,420 | **55,153** | 10x |

All tests now saturate the 1-core df-engine with 0% log drops (except CEF-ATTR-OTAP UDP at 0.4%).