### PR TITLE
chore: Run otelbot make genotelarrowcol for Dependabot PRs

### DIFF
--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -13,7 +13,8 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'renovate[bot]' && github.event.pull_request.head.repo.fork == false }}
+    # This workflow is used to ensure Renovate and Dependabot PRs to Go code are 'tidy' and are reflected in the generated code produced by makefile command
+    if: ${{ contains(fromJson('["renovate[bot]", "dependabot[bot]"]'), github.actor) && github.event.pull_request.head.repo.fork == false }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
# Change Summary

Related to #2373

When Go code changes, we need otelbot to run `make genotelarrowcol` command again to ensure changes are reflected in generated code. We already do this today on Renovate PRs.

