### PR TITLE
fix: Temporarily disable the nightly otap-filter-otap Go collector scenario

### DIFF
--- a/tools/pipeline_perf_test/test_suites/integration/nightly/otelcol-docker.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/nightly/otelcol-docker.yaml
@@ -89,11 +89,15 @@ tests:
         collector_config_template: test_suites/integration/templates/configs/otelcol/otlp-filter-otap.yaml
         loadgen_exporter_type: otlp
         backend_receiver_type: otap
-  - name: OTAP-FILTER-OTAP (Go Collector)
-    from_template:
-      path: test_suites/integration/templates/test_steps/df-loadgen-steps-docker-otel.yaml
-      variables:
-        result_dir: "otelcol_filter"
-        collector_config_template: test_suites/integration/templates/configs/otelcol/otap-filter-otap.yaml
-        loadgen_exporter_type: otap
-        backend_receiver_type: otap
+
+  # Disabled because we need this fix to be released and to bump versions after:
+  #   https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/46879
+  #
+  # - name: OTAP-FILTER-OTAP (Go Collector)
+  #   from_template:
+  #     path: test_suites/integration/templates/test_steps/df-loadgen-steps-docker-otel.yaml
+  #     variables:
+  #       result_dir: "otelcol_filter"
+  #       collector_config_template: test_suites/integration/templates/configs/otelcol/otap-filter-otap.yaml
+  #       loadgen_exporter_type: otap
+  #       backend_receiver_type: otap


### PR DESCRIPTION
# Change Summary

This scenario has been blocking all the nightly benchmarks for a few weeks now and we can't fix it until this is released and we take a version bump: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/46879

It looks like it will be another couple of weeks for the next otel collector contrib release as the last one was just a few days ago. I'm proposing to disable the scenario for now to unblock everything else. 