### PR TITLE
fix(deps): Fixes for latest Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -86,9 +86,14 @@
       ]
     },
     {
-      // prevent duplicate PRs from pip_requirements once pip-compile is enabled
+      // prevent duplicate PRs from pip_requirements once pip-compile is enabled;
+      // also disable on lock files so pip_requirements doesn't treat transitive
+      // deps (e.g. pydantic-core) as direct and raise independent update PRs
       "matchManagers": ["pip_requirements"],
-      "matchFileNames": ["tools/pipeline_perf_test/**/requirements.txt"],
+      "matchFileNames": [
+        "tools/pipeline_perf_test/**/requirements.txt",
+        "tools/pipeline_perf_test/**/requirements.lock.txt"
+      ],
       "enabled": false
     },
     {


### PR DESCRIPTION
# Change Summary

1. Renovate grouping isn't working quite correctly:
    * #2402
    * #2403
    * #2404
  
    Since these are coming as git refs and not from `crates.io`, I think we have to use the [cargo manager](https://docs.renovatebot.com/modules/manager/cargo/) instead of [crate dataSource](https://docs.renovatebot.com/modules/datasource/crate/).

2. pip_requirements manager is still trying to update indirect dependencies from `requirements.lock.txt` files:
    * #2401 

    Looking at [Renovate job logs](https://developer.mend.io/github/open-telemetry/otel-arrow) - the problem is that while the `pip_compile` correctly skips indirect deps, `pip_requirements` was still active on lock files.

## What issue does this PR close?

N/A

## How are these changes tested?

N/A

## Are there any user-facing changes?

No