### PR TITLE
[query-engine] Adjust logging for conversion operations in RecordSet engine

### DIFF
--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/logs.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/logs.rs
@@ -35,7 +35,7 @@ impl RecordSet<LogRecord> for ExportLogsServiceRequest {
 
 impl Record for LogRecord {
     fn get_diagnostic_level(&self) -> Option<RecordSetEngineDiagnosticLevel> {
-        self.diagnostic_level.clone()
+        self.diagnostic_level
     }
 }
 

--- a/rust/experimental/query_engine/engine-recordset/src/engine.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/engine.rs
@@ -135,7 +135,7 @@ impl<'a, 'b, TRecord: Record + 'static> RecordSetEngineBatch<'a, 'b, TRecord> {
         }
 
         let execution_context = ExecutionContext::<TRecord>::new(
-            self.engine.diagnostic_level.clone(),
+            self.engine.diagnostic_level,
             &self.engine.external_function_implementations,
             self.pipeline,
             &self.global_variables,
@@ -201,7 +201,7 @@ impl<'a, 'b, TRecord: Record + 'static> RecordSetEngineBatch<'a, 'b, TRecord> {
             self.pipeline,
             self.diagnostics,
             process_summaries(
-                self.engine.diagnostic_level.clone(),
+                self.engine.diagnostic_level,
                 &self.engine.external_function_implementations,
                 &self.global_variables,
                 self.pipeline,
@@ -219,7 +219,7 @@ impl<'a, 'b, TRecord: Record + 'static> RecordSetEngineBatch<'a, 'b, TRecord> {
     ) -> RecordSetEngineResult<'a, TRecord> {
         let diagnostic_level = record
             .get_diagnostic_level()
-            .unwrap_or(self.engine.diagnostic_level.clone());
+            .unwrap_or(self.engine.diagnostic_level);
 
         let execution_context = ExecutionContext::new(
             diagnostic_level,
@@ -351,7 +351,7 @@ fn process_summaries<'a>(
             let summaries = Summaries::new(1);
 
             let execution_context = ExecutionContext::new(
-                diagnostic_level.clone(),
+                diagnostic_level,
                 external_function_implementations,
                 pipeline,
                 global_variables,
@@ -385,7 +385,7 @@ fn process_summaries<'a>(
             }
 
             let results = process_summaries(
-                diagnostic_level.clone(),
+                diagnostic_level,
                 external_function_implementations,
                 global_variables,
                 pipeline,

--- a/rust/experimental/query_engine/engine-recordset/src/engine_diagnostic.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/engine_diagnostic.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 
 use data_engine_expressions::Expression;
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum RecordSetEngineDiagnosticLevel {
     #[default]
     Verbose = 0,
@@ -80,7 +80,7 @@ impl<'a> RecordSetEngineDiagnostic<'a> {
     }
 
     pub fn get_diagnostic_level(&self) -> RecordSetEngineDiagnosticLevel {
-        self.diagnostic_level.clone()
+        self.diagnostic_level
     }
 
     pub fn get_expression(&self) -> &dyn Expression {

--- a/rust/experimental/query_engine/engine-recordset/src/execution_context.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/execution_context.rs
@@ -66,7 +66,7 @@ impl<'a, 'b, TRecord: Record + 'static> ExecutionContext<'a, 'b, TRecord> {
         arguments: Option<&'b dyn ExecutionContextArguments>,
     ) -> ExecutionContext<'a, 'b, MapValueStorage<OwnedValue>> {
         ExecutionContext::<MapValueStorage<OwnedValue>>::new(
-            self.diagnostic_level.clone(),
+            self.diagnostic_level,
             self.external_function_implementations,
             self.pipeline,
             self.get_variables().global_variables,

--- a/rust/experimental/query_engine/engine-recordset/src/scalars/convert_scalar_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/scalars/convert_scalar_expressions.rs
@@ -3,116 +3,93 @@
 
 use data_engine_expressions::*;
 
-use crate::{execution_context::*, scalars::execute_scalar_expression, *};
+use crate::{execution_context::*, scalars::*, *};
 
 pub fn execute_convert_scalar_expression<'a, 'b, 'c, TRecord: Record>(
     execution_context: &'b ExecutionContext<'a, '_, TRecord>,
     convert_scalar_expression: &'a ConvertScalarExpression,
+    selection_options: SelectionOptions,
 ) -> Result<ResolvedValue<'c>, ExpressionError>
 where
     'a: 'c,
     'b: 'c,
 {
-    let value = match convert_scalar_expression {
-        ConvertScalarExpression::Boolean(c) => {
-            let inner_value =
-                execute_scalar_expression(execution_context, c.get_inner_expression())?;
+    let (inner_expression, target_type) = unpack(convert_scalar_expression);
 
-            let value = inner_value.to_value();
+    let resolved_inner_value = execute_scalar_expression_with_options(
+        execution_context,
+        inner_expression,
+        selection_options,
+    )?;
 
-            if let Some(b) = value.convert_to_bool() {
+    let inner_value = resolved_inner_value.to_value();
+
+    let value = match target_type {
+        ValueType::Boolean => {
+            if let Some(b) = inner_value.convert_to_bool() {
                 ResolvedValue::Computed(OwnedValue::Boolean(BooleanValueStorage::new(b)))
             } else {
-                execution_context.add_diagnostic_if_enabled(
-                    RecordSetEngineDiagnosticLevel::Warn,
+                emit_conversion_failure_diagnostic(
+                    execution_context,
                     convert_scalar_expression,
-                    || {
-                        format!(
-                            "Input of '{:?}' type could not be converted into a bool",
-                            value.get_value_type()
-                        )
-                    },
+                    &inner_value,
+                    "bool",
                 );
 
                 ResolvedValue::Computed(OwnedValue::Null)
             }
         }
-        ConvertScalarExpression::DateTime(c) => {
-            let inner_value =
-                execute_scalar_expression(execution_context, c.get_inner_expression())?;
-
-            let value = inner_value.to_value();
-
-            if let Some(d) = value.convert_to_datetime() {
+        ValueType::DateTime => {
+            if let Some(d) = inner_value.convert_to_datetime() {
                 ResolvedValue::Computed(OwnedValue::DateTime(DateTimeValueStorage::new(d)))
             } else {
-                execution_context.add_diagnostic_if_enabled(
-                    RecordSetEngineDiagnosticLevel::Warn,
+                emit_conversion_failure_diagnostic(
+                    execution_context,
                     convert_scalar_expression,
-                    || {
-                        format!(
-                            "Input of '{:?}' type could not be converted into a DateTime",
-                            value.get_value_type()
-                        )
-                    },
+                    &inner_value,
+                    "DateTime",
                 );
+
                 ResolvedValue::Computed(OwnedValue::Null)
             }
         }
-        ConvertScalarExpression::Double(c) => {
-            let inner_value =
-                execute_scalar_expression(execution_context, c.get_inner_expression())?;
-
-            let value = inner_value.to_value();
-
-            if let Some(d) = value.convert_to_double() {
+        ValueType::Double => {
+            if let Some(d) = inner_value.convert_to_double() {
                 ResolvedValue::Computed(OwnedValue::Double(DoubleValueStorage::new(d)))
             } else {
-                execution_context.add_diagnostic_if_enabled(
-                    RecordSetEngineDiagnosticLevel::Warn,
+                emit_conversion_failure_diagnostic(
+                    execution_context,
                     convert_scalar_expression,
-                    || {
-                        format!(
-                            "Input of '{:?}' type could not be converted into a double",
-                            value.get_value_type()
-                        )
-                    },
+                    &inner_value,
+                    "double",
                 );
+
                 ResolvedValue::Computed(OwnedValue::Null)
             }
         }
-        ConvertScalarExpression::Integer(c) => {
-            let inner_value =
-                execute_scalar_expression(execution_context, c.get_inner_expression())?;
-
-            let value = inner_value.to_value();
-
-            if let Some(i) = value.convert_to_integer() {
+        ValueType::Integer => {
+            if let Some(i) = inner_value.convert_to_integer() {
                 ResolvedValue::Computed(OwnedValue::Integer(IntegerValueStorage::new(i)))
             } else {
-                execution_context.add_diagnostic_if_enabled(
-                    RecordSetEngineDiagnosticLevel::Warn,
+                emit_conversion_failure_diagnostic(
+                    execution_context,
                     convert_scalar_expression,
-                    || {
-                        format!(
-                            "Input of '{:?}' type could not be converted into an integer",
-                            value.get_value_type()
-                        )
-                    },
+                    &inner_value,
+                    "integer",
                 );
+
                 ResolvedValue::Computed(OwnedValue::Null)
             }
         }
-        ConvertScalarExpression::String(c) => {
-            let v = execute_scalar_expression(execution_context, c.get_inner_expression())?;
-            let value_type = v.get_value_type();
+        ValueType::String => {
+            let value_type = inner_value.get_value_type();
             if value_type == ValueType::String {
-                v
+                resolved_inner_value
             } else if value_type == ValueType::Null {
                 ResolvedValue::Computed(OwnedValue::String(StringValueStorage::new("".into())))
             } else {
                 let mut string_value = None;
-                v.to_value().convert_to_string(&mut |s| {
+                inner_value.convert_to_string(&mut |s| {
                     string_value = Some(StringValueStorage::new(s.into()))
                 });
                 ResolvedValue::Computed(OwnedValue::String(
@@ -120,28 +97,21 @@ where
                 ))
             }
         }
-        ConvertScalarExpression::TimeSpan(c) => {
-            let inner_value =
-                execute_scalar_expression(execution_context, c.get_inner_expression())?;
-
-            let value = inner_value.to_value();
-
-            if let Some(t) = value.convert_to_timespan() {
+        ValueType::TimeSpan => {
+            if let Some(t) = inner_value.convert_to_timespan() {
                 ResolvedValue::Computed(OwnedValue::TimeSpan(TimeSpanValueStorage::new(t)))
             } else {
-                execution_context.add_diagnostic_if_enabled(
-                    RecordSetEngineDiagnosticLevel::Warn,
+                emit_conversion_failure_diagnostic(
+                    execution_context,
                     convert_scalar_expression,
-                    || {
-                        format!(
-                            "Input of '{:?}' type could not be converted into a TimeSpan",
-                            value.get_value_type()
-                        )
-                    },
+                    &inner_value,
+                    "TimeSpan",
                 );
+
                 ResolvedValue::Computed(OwnedValue::Null)
             }
         }
+        _ => unreachable!("Unexpected ValueType conversion"),
     };
 
     execution_context.add_diagnostic_if_enabled(
@@ -151,6 +121,37 @@ where
     );
 
     Ok(value)
+}
+
+fn unpack(convert_scalar_expression: &ConvertScalarExpression) -> (&ScalarExpression, ValueType) {
+    match convert_scalar_expression {
+        ConvertScalarExpression::Boolean(c) => (c.get_inner_expression(), ValueType::Boolean),
+        ConvertScalarExpression::DateTime(c) => (c.get_inner_expression(), ValueType::DateTime),
+        ConvertScalarExpression::Double(c) => (c.get_inner_expression(), ValueType::Double),
+        ConvertScalarExpression::Integer(c) => (c.get_inner_expression(), ValueType::Integer),
+        ConvertScalarExpression::String(c) => (c.get_inner_expression(), ValueType::String),
+        ConvertScalarExpression::TimeSpan(c) => (c.get_inner_expression(), ValueType::TimeSpan),
+    }
+}
+
+fn emit_conversion_failure_diagnostic<'a, TRecord: Record>(
+    execution_context: &ExecutionContext<'a, '_, TRecord>,
+    convert_scalar_expression: &'a ConvertScalarExpression,
+    value: &Value<'_>,
+    type_name: &str,
+) {
+    if value.get_value_type() != ValueType::Null {
+        execution_context.add_diagnostic_if_enabled(
+            RecordSetEngineDiagnosticLevel::Warn,
+            convert_scalar_expression,
+            || {
+                format!(
+                    "Input of '{}' type could not be converted into a {type_name}",
+                    value.get_value_type()
+                )
+            },
+        );
+    }
 }
 
 #[cfg(test)]

--- a/rust/experimental/query_engine/engine-recordset/src/scalars/scalar_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/scalars/scalar_expressions.rs
@@ -220,7 +220,7 @@ where
             }
         }
         ScalarExpression::Convert(c) => {
-            return execute_convert_scalar_expression(execution_context, c);
+            return execute_convert_scalar_expression(execution_context, c, selection_options);
         }
         ScalarExpression::Length(l) => {
             let inner_value =
@@ -652,7 +652,7 @@ where
                             }
                             Ok(None) => {
                                 execution_context.add_diagnostic_if_enabled(
-                                    selection_options.selector_not_found_diagnostic_level.clone(),
+                                    selection_options.selector_not_found_diagnostic_level,
                                     expression,
                                     || format!("Could not find map key '{}' specified in accessor expression", map_key.get_value()),
                                 );
@@ -701,7 +701,7 @@ where
                                 }
                                 Ok(None) => {
                                     execution_context.add_diagnostic_if_enabled(
-                                        selection_options.selector_not_found_diagnostic_level.clone(),
+                                        selection_options.selector_not_found_diagnostic_level,
                                         expression,
                                         || format!("Could not find array index '{index}' specified in accessor expression"),
                                     );
@@ -778,7 +778,7 @@ fn select_from_value<'a, 'b, TRecord: Record>(
                             }
                             None => {
                                 execution_context.add_diagnostic_if_enabled(
-                                    selection_options.selector_not_found_diagnostic_level.clone(),
+                                    selection_options.selector_not_found_diagnostic_level,
                                     expression,
                                     || format!("Could not find map key '{}' specified in accessor expression", map_key.get_value()),
                                 );
@@ -819,7 +819,7 @@ fn select_from_value<'a, 'b, TRecord: Record>(
                                 }
                                 None => {
                                     execution_context.add_diagnostic_if_enabled(
-                                        selection_options.selector_not_found_diagnostic_level.clone(),
+                                        selection_options.selector_not_found_diagnostic_level,
                                         expression,
                                         || format!("Could not find array index '{index}' specified in accessor expression"),
                                     );


### PR DESCRIPTION
Relates to #2430

# Changes

* Pass along `SelectionOptions` to `execute_convert_scalar_expression`
* Tiddy:
  * Reduce code duplication in conversion code
  * Implement `Copy` for `RecordSetEngineDiagnosticLevel`

# Details

We pass along `SelectionOptions` so that `toint(Something)` will emit a warn if "Something" isn't found but `coalese(tonint(Something), null)` will emit an info. This follows the pattern we've established so far when some outer function is used to handle the "not found" case. The assumption being "not found" is expected\anticipated in these cases so a warning is not necessary\overkill.