### PR TITLE
Bound Syslog/CEF message size to prevent unbounded memory growth

### DIFF
--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs
@@ -60,6 +60,12 @@ const DEFAULT_MAX_BATCH_SIZE: u16 = 100;
 /// 2048 bytes).
 const MAX_MESSAGE_SIZE: usize = 16 * 1024;
 
+/// Initial capacity for the per-connection TCP message buffer.
+///
+/// Most syslog messages are well under 4 KiB, so this avoids early
+/// reallocations. The buffer can grow up to [`MAX_MESSAGE_SIZE`] if needed.
+const INITIAL_MSG_BUFFER_CAPACITY: usize = 4096;
+
 /// Maximum time to wait for spawned TCP tasks to drain during shutdown.
 const MAX_TASK_DRAIN_WAIT: Duration = Duration::from_secs(1);
 
@@ -462,7 +468,7 @@ impl local::Receiver<OtapPdata> for SyslogCefReceiver {
                                         // Suppress unused variable warning when TLS is disabled
                                         let _ = peer_addr;
 
-                                        let mut line_bytes = Vec::with_capacity(4096);
+                                        let mut line_bytes = Vec::with_capacity(INITIAL_MSG_BUFFER_CAPACITY);
 
                                         let mut arrow_records_builder = ArrowRecordsBuilder::new();
 


### PR DESCRIPTION
# Change Summary

Introduces a 16 KiB per-message size limit (`MAX_MESSAGE_SIZE`) for the syslog CEF receiver to prevent unbounded memory growth from malicious or misbehaving clients.

### Before vs After

| Aspect | Before | After |
|---|---|---|
| TCP message size | Unbounded (memory exhaustion risk) | Capped at 16 KiB per message |
| UDP receive buffer | 1 KiB stack array (silent truncation) | 16 KiB heap `Vec` |
| Truncation visibility | None | `received_logs_truncated` metric |
| TCP line buffer allocation | `Vec::new()` (multiple early reallocs) | `Vec::with_capacity(4096)` |
| Oversized message handling | N/A | Parsed and forwarded as partial data |

### Problem

- **TCP**: `read_until(b'\n')` would keep appending bytes to a `Vec` until a newline appeared. A client sending data without newlines could exhaust memory.
- **UDP**: The receive buffer was a 1 KiB stack array, too small for most real-world syslog messages and silently truncating them with no visibility.

### Changes

- Add `read_line_bounded()` helper that wraps `AsyncReadExt::take()` + `AsyncBufReadExt::read_until()` to cap TCP reads at `MAX_MESSAGE_SIZE` (16 KiB) per message. Returns a `BoundedReadResult` enum (`Complete`, `Truncated`, or `Eof`) so callers can distinguish outcomes.
- Upgrade UDP receive buffer from 1 KiB stack array to 16 KiB heap `Vec`, matching the TCP limit.
- Add `received_logs_truncated` metric to track messages that exceeded the size limit. For TCP, truncation is detected precisely. For UDP, it uses a best-effort heuristic (datagram fills buffer).
- Pre-allocate TCP line buffer with `Vec::with_capacity(4096)` to avoid early reallocations for typical messages.
- Add doc comments explaining cancellation safety: `buf` may contain partial data from `select!` cancellation and must not be cleared between calls unless discarding the current message.

### Design decisions

- **Truncated messages are still forwarded**: Preserves partial data (syslog header, timestamp, severity) rather than dropping it. The tail of an oversized message is also processed as its own message.
- **Metric semantics**: `received_logs_total` counts each bounded read as a separate message. An oversized message that splits into head + tail counts as 2.

## What issue does this PR close?

Towards #1149 

## How are these changes tested?

- **TCP truncation integration test**: Sends an oversized message followed by a normal message, verifies all 3 records (truncated head, tail, normal) are received.
- **6 unit tests for `read_line_bounded`**: Empty reader, complete line, truncation, exact-limit edge case, EOF with partial data, and multi-call behavior after truncation.
- **Telemetry test updates**: Metric index adjustments to account for the new `received_logs_truncated` field.

## Are there any user-facing changes?

No
