### PR TITLE
[WIP] Remove global delayed-data runtime plumbing

### DIFF
--- a/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
@@ -1305,40 +1305,15 @@ impl local::Processor<OtapPdata> for BatchProcessor {
                             }
                         };
 
-                        Ok(())
-                    }
-                    NodeControlMsg::DelayedData { data, when } => {
-                        let signal = data.signal_type();
-
-                        match self.format_for_signal_format(data.signal_format()) {
-                            Some(ActiveBatchProcessorFormatKind::Otap) => self
-                                .otap_format()
-                                .expect(
-                                    "otap batch state must exist when otap format kind is selected",
-                                )
-                                .for_signal(signal)
-                                .flush_signal_impl(effect, when, FlushReason::Timer)
-                                .await?,
-                            Some(ActiveBatchProcessorFormatKind::Otlp) => self
-                                .otlp_format()
-                                .expect(
-                                    "otlp batch state must exist when otlp format kind is selected",
-                                )
-                                .for_signal(signal)
-                                .flush_signal_impl(effect, when, FlushReason::Timer)
-                                .await?,
-                            None => return Err(Self::no_active_format_error()),
-                        };
-
-                        Ok(())
-                    }
-                    NodeControlMsg::Ack(ack) => self.handle_ack(effect, ack).await,
-                    NodeControlMsg::Nack(nack) => self.handle_nack(effect, nack).await,
-                    NodeControlMsg::DrainIngress { .. } => Ok(()),
-                    NodeControlMsg::TimerTick { .. } => unreachable!(),
-                    NodeControlMsg::MemoryPressureChanged { .. } => Ok(()),
+                    Ok(())
                 }
-            }
+                NodeControlMsg::ResumeData { .. } => Ok(()),
+                NodeControlMsg::Ack(ack) => self.handle_ack(effect, ack).await,
+                NodeControlMsg::Nack(nack) => self.handle_nack(effect, nack).await,
+                NodeControlMsg::DrainIngress { .. } => Ok(()),
+                NodeControlMsg::TimerTick { .. } => unreachable!(),
+                NodeControlMsg::MemoryPressureChanged { .. } => Ok(()),
+            },
             Message::PData(request) => self.process_signal_impl(effect, request).await,
         }
     }

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
@@ -1260,50 +1260,49 @@ impl local::Processor<OtapPdata> for BatchProcessor {
         effect: &mut local::EffectHandler<OtapPdata>,
     ) -> Result<(), EngineError> {
         match msg {
-            Message::Control(ctrl) => {
-                match ctrl {
-                    NodeControlMsg::Config { .. } => Ok(()),
-                    NodeControlMsg::Shutdown { .. } => {
-                        self.flush_shutdown(effect).await?;
-                        Ok(())
-                    }
-                    NodeControlMsg::CollectTelemetry {
-                        mut metrics_reporter,
-                    } => {
-                        effect
-                            .report_local_scheduler_metrics(&mut metrics_reporter)
-                            .map_err(|e| EngineError::InternalError {
-                                message: e.to_string(),
-                            })?;
-                        metrics_reporter.report(&mut self.metrics).map_err(|e| {
-                            EngineError::InternalError {
-                                message: e.to_string(),
-                            }
-                        })
-                    }
-                    NodeControlMsg::Wakeup { slot, when, .. } => {
-                        let Some((format, signal)) = signal_from_wakeup_slot(slot) else {
-                            return Ok(());
-                        };
+            Message::Control(ctrl) => match ctrl {
+                NodeControlMsg::Config { .. } => Ok(()),
+                NodeControlMsg::Shutdown { .. } => {
+                    self.flush_shutdown(effect).await?;
+                    Ok(())
+                }
+                NodeControlMsg::CollectTelemetry {
+                    mut metrics_reporter,
+                } => {
+                    effect
+                        .report_local_scheduler_metrics(&mut metrics_reporter)
+                        .map_err(|e| EngineError::InternalError {
+                            message: e.to_string(),
+                        })?;
+                    metrics_reporter.report(&mut self.metrics).map_err(|e| {
+                        EngineError::InternalError {
+                            message: e.to_string(),
+                        }
+                    })
+                }
+                NodeControlMsg::Wakeup { slot, when, .. } => {
+                    let Some((format, signal)) = signal_from_wakeup_slot(slot) else {
+                        return Ok(());
+                    };
 
-                        match format {
-                            SignalFormat::OtapRecords => {
-                                if let Some(mut otap_format) = self.otap_format() {
-                                    otap_format
-                                        .for_signal(signal)
-                                        .flush_signal_impl(effect, when, FlushReason::Timer)
-                                        .await?;
-                                }
+                    match format {
+                        SignalFormat::OtapRecords => {
+                            if let Some(mut otap_format) = self.otap_format() {
+                                otap_format
+                                    .for_signal(signal)
+                                    .flush_signal_impl(effect, when, FlushReason::Timer)
+                                    .await?;
                             }
-                            SignalFormat::OtlpBytes => {
-                                if let Some(mut otlp_format) = self.otlp_format() {
-                                    otlp_format
-                                        .for_signal(signal)
-                                        .flush_signal_impl(effect, when, FlushReason::Timer)
-                                        .await?;
-                                }
+                        }
+                        SignalFormat::OtlpBytes => {
+                            if let Some(mut otlp_format) = self.otlp_format() {
+                                otlp_format
+                                    .for_signal(signal)
+                                    .flush_signal_impl(effect, when, FlushReason::Timer)
+                                    .await?;
                             }
-                        };
+                        }
+                    };
 
                     Ok(())
                 }

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
@@ -1900,10 +1900,7 @@ impl otap_df_engine::local::processor::Processor<OtapPdata> for DurableBuffer {
                     self.handle_retry_wakeup(slot, revision, effect_handler)
                         .await
                 }
-                NodeControlMsg::DelayedData { .. } => {
-                    otel_warn!("durable_buffer.delayed_data.unexpected");
-                    Ok(())
-                }
+                NodeControlMsg::ResumeData { .. } => Ok(()),
             },
         }
     }

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/telemetry.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/telemetry.md
@@ -1,5 +1,7 @@
 # Durable Buffer Processor Telemetry
 
+<!-- markdownlint-disable MD013 -->
+
 This document lists telemetry emitted directly by the `durable_buffer_processor`
 module (`crates/otap/src/durable_buffer_processor/`).
 It includes metric instruments registered via `DurableBufferMetrics` and log
@@ -149,11 +151,8 @@ All events are emitted from `crates/otap/src/durable_buffer_processor/mod.rs`.
 | `durable_buffer.retry.backpressure` | `debug` | Retry halted due to downstream backpressure; bundle re-scheduled with `poll_interval` delay. |
 | `durable_buffer.retry.claim_failed` | `debug` | Could not re-claim bundle from Quiver for retry (bundle may have been resolved or segment dropped). |
 | `durable_buffer.retry.skipped` | `warn` | Just-claimed retry bundle was unexpectedly skipped (should not occur in normal operation). |
-| `durable_buffer.retry.schedule_failed` | `warn` | Failed to schedule a retry for a transiently NACKed bundle via `delay_data()`. |
+| `durable_buffer.retry.schedule_failed` | `warn` | Failed to schedule a retry wakeup for a transiently NACKed bundle. |
 | `durable_buffer.retry.reschedule_failed` | `warn` | Failed to re-schedule a deferred retry; bundle removed from `retry_scheduled` to allow poll to pick it up. |
-| `durable_buffer.retry.missing_calldata` | `warn` | `DelayedData` retry ticket has no source-route calldata; discarded. |
-| `durable_buffer.retry.invalid_calldata` | `warn` | `DelayedData` retry ticket calldata cannot be decoded as a retry ticket; discarded. |
-| `durable_buffer.delayed_data.unexpected` | `warn` | `DelayedData` message received that is not a recognized retry ticket; discarded. |
 
 ### Shutdown
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/log_sampling_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/log_sampling_processor/mod.rs
@@ -202,7 +202,7 @@ impl local::Processor<OtapPdata> for LogSamplingProcessor {
                 | NodeControlMsg::MemoryPressureChanged { .. }
                 | NodeControlMsg::DrainIngress { .. }
                 | NodeControlMsg::Wakeup { .. }
-                | NodeControlMsg::DelayedData { .. } => Ok(()),
+                | NodeControlMsg::ResumeData { .. } => Ok(()),
             },
         }
     }

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/retry_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/retry_processor/mod.rs
@@ -546,7 +546,7 @@ impl RetryProcessor {
 
         self.metrics.increment_retry_attempts(signal);
 
-        // Requeue the data onto this node, we'll continue in the DelayedData branch next.
+        // Requeue the data onto this node, we'll continue in the ResumeData branch next.
         match effect_handler.requeue_later(next_retry_time_i, rereq) {
             Ok(_) => Ok(()),
             Err(refused) => {
@@ -560,7 +560,7 @@ impl RetryProcessor {
         }
     }
 
-    async fn handle_delayed(
+    async fn handle_resumed(
         &mut self,
         _when: Instant,
         data: Box<OtapPdata>,
@@ -626,11 +626,11 @@ impl Processor<OtapPdata> for RetryProcessor {
             Message::Control(control_msg) => match control_msg {
                 NodeControlMsg::Ack(ack) => self.handle_ack(ack, effect_handler).await,
                 NodeControlMsg::Nack(nack) => self.handle_nack(nack, effect_handler).await,
-                NodeControlMsg::DelayedData { when, data } => {
+                NodeControlMsg::ResumeData { when, data } => {
                     if let Some(calldata) = data.source_route() {
                         let rstate: RetryState = calldata.calldata.try_into()?;
                         let _ = self
-                            .handle_delayed(when, data, effect_handler, rstate.num_items)
+                            .handle_resumed(when, data, effect_handler, rstate.num_items)
                             .await?;
                     }
                     Ok(())
@@ -1092,8 +1092,8 @@ mod test {
                             .take_due_local_control(when)
                             .expect("scheduled local control");
                         assert!(
-                            matches!(control, NodeControlMsg::DelayedData { .. }),
-                            "retry should requeue retained pdata as DelayedData"
+                            matches!(control, NodeControlMsg::ResumeData { .. }),
+                            "retry should requeue retained pdata as ResumeData"
                         );
                         ctx.process(Message::Control(control)).await.unwrap();
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/testing.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/testing.rs
@@ -234,7 +234,7 @@ pub(super) fn drain_upstream(
     ack_count: &mut usize,
     nack_count: &mut usize,
 ) {
-    // Drain runtime control (e.g. DelayData) -- just consume for now
+    // Drain runtime control -- just consume for now
     while runtime_ctrl_rx.try_recv().is_ok() {}
 
     // Drain pipeline completion (upstream ack/nack delivery)

--- a/rust/otap-dataflow/crates/engine/README.md
+++ b/rust/otap-dataflow/crates/engine/README.md
@@ -180,9 +180,9 @@ A realistic example looks like this:
 # admission while it waits for outstanding completions to reduce its inflight
 # count.
 # An exporter hits a temporary outage and emits a burst of DeliverNack.
-# The processor also needs to enqueue StartTimer / DelayData to retry work.
+# The processor also needs to enqueue timer or local-resume work to retry.
 #
-# If DeliverNack, StartTimer, DelayData, and Shutdown all share one bounded
+# If DeliverNack, timer work, local-resume work, and Shutdown all share one bounded
 # channel, the DeliverNack burst can fill it first.
 # Then:
 # - the exporter can block trying to publish more completion traffic
@@ -231,10 +231,10 @@ closed normal admission.
 The current message families are:
 
 - **Node control messages**: `Ack`, `Nack`, `Config`, `TimerTick`,
-  `CollectTelemetry`, `Wakeup`, `DelayedData`, `DrainIngress`, `Shutdown`
+  `CollectTelemetry`, `Wakeup`, `ResumeData`, `DrainIngress`, `Shutdown`
 - **Runtime control messages**: `StartTimer`, `CancelTimer`,
-  `StartTelemetryTimer`, `CancelTelemetryTimer`, `DelayData`,
-  `ReceiverDrained`, `Shutdown`
+  `StartTelemetryTimer`, `CancelTelemetryTimer`, `ReceiverDrained`,
+  `Shutdown`
 - **Pipeline completion messages**: `DeliverAck`, `DeliverNack`
 
 ## Runtime Message Dynamics
@@ -254,10 +254,10 @@ behavior:
    bounded-fair treatment.
 
 3. **Runtime-control flow**
-   Nodes send timer requests, delayed-data requests, `ReceiverDrained`, and
-   runtime `Shutdown` requests to the runtime-control channel. That channel is
-   consumed by `RuntimeCtrlMsgManager`, which handles orchestration and turns
-   due work back into node-control messages.
+   Nodes send timer requests, `ReceiverDrained`, and runtime `Shutdown`
+   requests to the runtime-control channel. That channel is consumed by
+   `RuntimeCtrlMsgManager`, which handles orchestration and turns due timer
+   work back into node-control messages.
 
 4. **Ack/Nack completion flow**
    Nodes that complete or reject work send `DeliverAck` and `DeliverNack` on
@@ -532,9 +532,10 @@ When graceful shutdown starts, the runtime control manager:
 
 1. Enters ingress-draining mode.
 2. Cancels recurring timers.
-3. Flushes queued delayed data back to the originating nodes as
-   `NodeControlMsg::DelayedData`.
-4. Sends `NodeControlMsg::DrainIngress` to every receiver.
+3. Sends `NodeControlMsg::DrainIngress` to every receiver.
+
+Processor-local delayed resumes stay inside each node's local scheduler and are
+not part of the shared runtime shutdown path.
 
 Each receiver is then responsible for stopping admission of new external work
 while keeping receiver-local drain state alive long enough to finish local

--- a/rust/otap-dataflow/crates/engine/src/control.rs
+++ b/rust/otap-dataflow/crates/engine/src/control.rs
@@ -300,12 +300,12 @@ pub enum NodeControlMsg<PData> {
         revision: WakeupRevision,
     },
 
-    /// Delayed data returning to the node which delayed it.
-    DelayedData {
-        /// When resumed
+    /// Processor-local delayed resume returning to the node that requeued it.
+    ResumeData {
+        /// Original scheduled resume instant.
         when: Instant,
 
-        /// The data.
+        /// The retained data payload.
         data: Box<PData>,
     },
 
@@ -337,7 +337,7 @@ pub enum NodeControlMsg<PData> {
 }
 
 /// Runtime-control messages sent by nodes to the pipeline runtime for
-/// orchestration, delayed-data handling, and shutdown.
+/// orchestration, timer scheduling, and shutdown.
 #[derive(Debug, Clone)]
 pub enum RuntimeControlMsg<PData> {
     /// Requests the pipeline engine to start a periodic timer for the specified node.
@@ -368,17 +368,6 @@ pub enum RuntimeControlMsg<PData> {
 
         /// Temporarily placed, see #1083. Placement is arbitrary.
         _temp: PhantomData<PData>,
-    },
-    /// Delay this data.
-    DelayData {
-        /// The delayer's node_id
-        node_id: usize,
-
-        /// When to resume
-        when: Instant,
-
-        /// The data
-        data: Box<PData>,
     },
     /// Indicates that a receiver has stopped admitting new ingress and
     /// completed any receiver-local drain work needed before downstream
@@ -747,7 +736,7 @@ where
 /// Control messages sent to extensions.
 ///
 /// This is a PData-free subset of [`NodeControlMsg`] — extensions never process
-/// pipeline data, so they have no `Ack`, `Nack`, or `DelayedData` variants.
+/// pipeline data, so they have no `Ack`, `Nack`, or `ResumeData` variants.
 #[derive(Debug, Clone)]
 pub enum ExtensionControlMsg {
     /// Notifies the extension of a configuration change.

--- a/rust/otap-dataflow/crates/engine/src/control_plane_metrics.rs
+++ b/rust/otap-dataflow/crates/engine/src/control_plane_metrics.rs
@@ -41,10 +41,10 @@ use std::time::Instant;
 /// Pipeline-scoped metrics for the shared runtime-control actor.
 ///
 /// This set describes shutdown/drain progress, pending control backlogs, and
-/// the state and throughput of the runtime-managed timer and delayed-data
-/// machinery. It is the primary metric set for understanding whether the
-/// pipeline runtime is still making progress under control-plane load and where
-/// graceful shutdown is spending time.
+/// the state and throughput of the runtime-managed timer machinery. It is the
+/// primary metric set for understanding whether the pipeline runtime is still
+/// making progress under control-plane load and where graceful shutdown is
+/// spending time.
 #[metric_set(name = "pipeline.runtime_control")]
 #[derive(Debug, Default, Clone)]
 pub(crate) struct RuntimeControlMetrics {
@@ -91,15 +91,6 @@ pub(crate) struct RuntimeControlMetrics {
     /// Level: `basic`.
     #[metric(name = "telemetry_timers.active", unit = "{timer}")]
     pub telemetry_timers_active: Gauge<u64>,
-    /// Number of delayed-data wakeups currently queued in the runtime manager.
-    ///
-    /// This is a key liveness signal for processors that depend on delayed
-    /// retries or one-shot wakeups: rising backlog means more admitted work is
-    /// waiting on the shared runtime control path.
-    ///
-    /// Level: `basic`.
-    #[metric(name = "delayed_data.queued", unit = "{message}")]
-    pub delayed_data_queued: Gauge<u64>,
     /// Count of `RuntimeControlMsg::Shutdown` requests accepted by this runtime.
     ///
     /// This marks the start of the runtime-managed drain sequence and is the
@@ -172,23 +163,6 @@ pub(crate) struct RuntimeControlMetrics {
     /// Level: `normal`.
     #[metric(name = "cancel_telemetry_timer.received", unit = "{message}")]
     pub cancel_telemetry_timer_received: Counter<u64>,
-    /// Count of `DelayData` requests received by the runtime manager.
-    ///
-    /// This measures how much work is being converted into deferred wakeups, a
-    /// common cause of control-plane load for retry and batching patterns.
-    ///
-    /// Level: `normal`.
-    #[metric(name = "delay_data.received", unit = "{message}")]
-    pub delay_data_received: Counter<u64>,
-    /// Count of delayed-data items returned immediately because drain is active.
-    ///
-    /// This is important for shutdown liveness: it shows the runtime is
-    /// flushing scheduled work back to origin nodes instead of leaving it
-    /// stranded behind future wakeup times.
-    ///
-    /// Level: `normal`.
-    #[metric(name = "delay_data.returned_during_drain", unit = "{message}")]
-    pub delay_data_returned_during_drain: Counter<u64>,
     /// Count of `TimerTick` control messages sent to nodes.
     ///
     /// This confirms that due timers are actually being delivered and helps
@@ -205,14 +179,6 @@ pub(crate) struct RuntimeControlMetrics {
     /// Level: `normal`.
     #[metric(name = "collect_telemetry.sent", unit = "{message}")]
     pub collect_telemetry_sent: Counter<u64>,
-    /// Count of delayed-data wakeups sent back to origin nodes.
-    ///
-    /// This is the completion-side counterpart to `delay_data.received` and is
-    /// a direct indicator that deferred work is resuming rather than stalling.
-    ///
-    /// Level: `normal`.
-    #[metric(name = "delayed_data.sent", unit = "{message}")]
-    pub delayed_data_sent: Counter<u64>,
     /// Distribution of time spent waiting for receivers to finish draining.
     ///
     /// This isolates the receiver-gated phase of shutdown and is useful for
@@ -377,7 +343,6 @@ pub(crate) struct RuntimeControlMetricsState {
     pending_sends_buffered: u64,
     timers_active: u64,
     telemetry_timers_active: u64,
-    delayed_data_queued: u64,
     shutdown_received: u64,
     drain_ingress_sent: u64,
     receiver_drained_received: u64,
@@ -387,11 +352,8 @@ pub(crate) struct RuntimeControlMetricsState {
     cancel_timer_received: u64,
     start_telemetry_timer_received: u64,
     cancel_telemetry_timer_received: u64,
-    delay_data_received: u64,
-    delay_data_returned_during_drain: u64,
     timer_tick_sent: u64,
     collect_telemetry_sent: u64,
-    delayed_data_sent: u64,
     drain_receiver_phase_duration_ns: Mmsc,
     drain_total_duration_ns: Mmsc,
     shutdown_started_at: Option<Instant>,
@@ -405,7 +367,6 @@ impl RuntimeControlMetricsState {
         level: MetricLevel,
         timers_active: usize,
         telemetry_timers_active: usize,
-        delayed_data_queued: usize,
     ) -> Self {
         Self {
             level,
@@ -417,7 +378,6 @@ impl RuntimeControlMetricsState {
             pending_sends_buffered: 0,
             timers_active: timers_active as u64,
             telemetry_timers_active: telemetry_timers_active as u64,
-            delayed_data_queued: delayed_data_queued as u64,
             shutdown_received: 0,
             drain_ingress_sent: 0,
             receiver_drained_received: 0,
@@ -427,11 +387,8 @@ impl RuntimeControlMetricsState {
             cancel_timer_received: 0,
             start_telemetry_timer_received: 0,
             cancel_telemetry_timer_received: 0,
-            delay_data_received: 0,
-            delay_data_returned_during_drain: 0,
             timer_tick_sent: 0,
             collect_telemetry_sent: 0,
-            delayed_data_sent: 0,
             drain_receiver_phase_duration_ns: Mmsc::default(),
             drain_total_duration_ns: Mmsc::default(),
             shutdown_started_at: None,
@@ -472,14 +429,6 @@ impl RuntimeControlMetricsState {
         }
         if self.telemetry_timers_active != telemetry_timers_active {
             self.telemetry_timers_active = telemetry_timers_active;
-            self.dirty = true;
-        }
-    }
-
-    pub(crate) fn set_delayed_data_queued(&mut self, queued: usize) {
-        let queued = queued as u64;
-        if self.delayed_data_queued != queued {
-            self.delayed_data_queued = queued;
             self.dirty = true;
         }
     }
@@ -582,31 +531,11 @@ impl RuntimeControlMetricsState {
         }
     }
 
-    pub(crate) fn record_delay_data_received(&mut self) {
-        if self.level >= MetricLevel::Normal {
-            self.delay_data_received += 1;
-            self.dirty = true;
-        }
-    }
-
-    pub(crate) fn record_delay_data_returned_during_drain(&mut self) {
-        if self.level >= MetricLevel::Normal {
-            self.delay_data_returned_during_drain += 1;
-            self.dirty = true;
-        }
-    }
-
-    pub(crate) fn record_due_events(
-        &mut self,
-        timer_ticks: usize,
-        collect_telemetry: usize,
-        delayed_data_sent: usize,
-    ) {
+    pub(crate) fn record_due_events(&mut self, timer_ticks: usize, collect_telemetry: usize) {
         if self.level >= MetricLevel::Normal {
             self.timer_tick_sent += timer_ticks as u64;
             self.collect_telemetry_sent += collect_telemetry as u64;
-            self.delayed_data_sent += delayed_data_sent as u64;
-            if timer_ticks > 0 || collect_telemetry > 0 || delayed_data_sent > 0 {
+            if timer_ticks > 0 || collect_telemetry > 0 {
                 self.dirty = true;
             }
         }
@@ -638,10 +567,6 @@ impl RuntimeControlMetricsState {
             .metrics
             .telemetry_timers_active
             .set(self.telemetry_timers_active);
-        registered
-            .metrics
-            .delayed_data_queued
-            .set(self.delayed_data_queued);
 
         if self.level >= MetricLevel::Normal {
             registered.metrics.shutdown_received = self.shutdown_received.into();
@@ -655,12 +580,8 @@ impl RuntimeControlMetricsState {
                 self.start_telemetry_timer_received.into();
             registered.metrics.cancel_telemetry_timer_received =
                 self.cancel_telemetry_timer_received.into();
-            registered.metrics.delay_data_received = self.delay_data_received.into();
-            registered.metrics.delay_data_returned_during_drain =
-                self.delay_data_returned_during_drain.into();
             registered.metrics.timer_tick_sent = self.timer_tick_sent.into();
             registered.metrics.collect_telemetry_sent = self.collect_telemetry_sent.into();
-            registered.metrics.delayed_data_sent = self.delayed_data_sent.into();
         } else {
             registered.metrics.shutdown_received = Counter::default();
             registered.metrics.drain_ingress_sent = Counter::default();
@@ -671,11 +592,8 @@ impl RuntimeControlMetricsState {
             registered.metrics.cancel_timer_received = Counter::default();
             registered.metrics.start_telemetry_timer_received = Counter::default();
             registered.metrics.cancel_telemetry_timer_received = Counter::default();
-            registered.metrics.delay_data_received = Counter::default();
-            registered.metrics.delay_data_returned_during_drain = Counter::default();
             registered.metrics.timer_tick_sent = Counter::default();
             registered.metrics.collect_telemetry_sent = Counter::default();
-            registered.metrics.delayed_data_sent = Counter::default();
         }
 
         if self.level >= MetricLevel::Detailed {
@@ -702,11 +620,8 @@ impl RuntimeControlMetricsState {
                     self.cancel_timer_received = 0;
                     self.start_telemetry_timer_received = 0;
                     self.cancel_telemetry_timer_received = 0;
-                    self.delay_data_received = 0;
-                    self.delay_data_returned_during_drain = 0;
                     self.timer_tick_sent = 0;
                     self.collect_telemetry_sent = 0;
-                    self.delayed_data_sent = 0;
                 }
                 if self.level >= MetricLevel::Detailed {
                     self.drain_receiver_phase_duration_ns = Mmsc::default();

--- a/rust/otap-dataflow/crates/engine/src/effect_handler.rs
+++ b/rust/otap-dataflow/crates/engine/src/effect_handler.rs
@@ -404,23 +404,6 @@ impl<PData> EffectHandlerCore<PData> {
         }
     }
 
-    /// Delay a message.
-    pub async fn delay_data(&self, when: Instant, data: Box<PData>) -> Result<(), PData> {
-        self.send_runtime_ctrl_msg(RuntimeControlMsg::DelayData {
-            node_id: self.node_id().index,
-            when,
-            data,
-        })
-        .await
-        .map(|_| ())
-        .map_err(|e| -> PData {
-            match e.inner() {
-                RuntimeControlMsg::DelayData { data, .. } => *data,
-                _ => unreachable!(),
-            }
-        })
-    }
-
     /// Requeue retained pdata onto this node later.
     pub fn requeue_later(&self, when: Instant, data: Box<PData>) -> Result<(), PData> {
         self.local_scheduler

--- a/rust/otap-dataflow/crates/engine/src/local/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/local/processor.rs
@@ -435,9 +435,20 @@ impl<PData> EffectHandler<PData> {
         self.core.start_periodic_telemetry(duration).await
     }
 
-    /// Delay data.
-    pub async fn delay_data(&self, when: Instant, data: Box<PData>) -> Result<(), PData> {
-        self.core.delay_data(when, data).await
+    /// Send an Ack to the runtime control manager for context unwinding.
+    pub async fn route_ack(&self, ack: AckMsg<PData>) -> Result<(), Error>
+    where
+        PData: crate::Unwindable,
+    {
+        self.core.route_ack(ack).await
+    }
+
+    /// Send a Nack to the runtime control manager for context unwinding.
+    pub async fn route_nack(&self, nack: NackMsg<PData>) -> Result<(), Error>
+    where
+        PData: crate::Unwindable,
+    {
+        self.core.route_nack(nack).await
     }
 
     /// Requeue retained pdata onto this node later.

--- a/rust/otap-dataflow/crates/engine/src/message.rs
+++ b/rust/otap-dataflow/crates/engine/src/message.rs
@@ -915,7 +915,7 @@ mod tests {
     /// Scenario: a processor-local delayed resume is scheduled for immediate
     /// delivery while the processor inbox is otherwise idle.
     /// Guarantees: the inbox surfaces the due retained payload as
-    /// `NodeControlMsg::DelayedData` with the original deadline and payload.
+    /// `NodeControlMsg::ResumeData` with the original deadline and payload.
     #[tokio::test]
     async fn processor_inbox_emits_due_delayed_resume_as_control_message() {
         let (_control_tx, _pdata_tx, scheduler, mut inbox) = local_processor_inbox(4);
@@ -930,7 +930,7 @@ mod tests {
             .expect("message should arrive");
         assert!(matches!(
             message,
-            Message::Control(NodeControlMsg::DelayedData { when: observed, data })
+            Message::Control(NodeControlMsg::ResumeData { when: observed, data })
                 if observed == when && *data == TestMsg::new("delayed")
         ));
     }
@@ -990,7 +990,7 @@ mod tests {
                     saw_pdata = true;
                     break;
                 }
-                Message::Control(NodeControlMsg::DelayedData { .. }) => {
+                Message::Control(NodeControlMsg::ResumeData { .. }) => {
                     delayed += 1;
                 }
                 other => panic!("unexpected message {other:?}"),
@@ -1165,7 +1165,7 @@ mod tests {
     /// Scenario: shutdown is latched while the processor-local scheduler still
     /// holds a future delayed resume.
     /// Guarantees: pending delayed resumes become immediately available as
-    /// `DelayedData` control traffic before the latched shutdown is delivered.
+    /// `ResumeData` control traffic before the latched shutdown is delivered.
     #[tokio::test]
     async fn processor_inbox_returns_pending_delayed_resumes_on_shutdown_latch() {
         let (control_tx, _pdata_tx, scheduler, mut inbox) = local_processor_inbox(4);
@@ -1202,7 +1202,7 @@ mod tests {
             .expect("delayed resume should return immediately during shutdown");
         assert!(matches!(
             resumed,
-            Message::Control(NodeControlMsg::DelayedData { when, data })
+            Message::Control(NodeControlMsg::ResumeData { when, data })
                 if when < original_when && *data == TestMsg::new("delayed")
         ));
 

--- a/rust/otap-dataflow/crates/engine/src/node_local_scheduler.rs
+++ b/rust/otap-dataflow/crates/engine/src/node_local_scheduler.rs
@@ -6,7 +6,7 @@
 //! This module implements two related but intentionally distinct mechanisms:
 //!
 //! - Delayed resume stores a retained `Box<PData>` until a deadline and then
-//!   surfaces that same payload as `NodeControlMsg::DelayedData`. Delayed
+//!   surfaces that same payload as `NodeControlMsg::ResumeData`. Delayed
 //!   resumes are append-only: there is no key, deduplication, or replacement.
 //!   Equal deadlines are emitted FIFO by scheduler sequence. Rejection is
 //!   payload-preserving so callers can turn failed scheduling into explicit
@@ -388,7 +388,7 @@ impl<PData> NodeLocalScheduler<PData> {
                 // Safety: take_resume is true only after peeking a due resume,
                 // and no delayed-resume mutation happens between peek and pop.
                 .expect("resume must exist");
-            return Some(NodeControlMsg::DelayedData {
+            return Some(NodeControlMsg::ResumeData {
                 when: resume.when,
                 data: resume.data,
             });
@@ -434,7 +434,7 @@ impl<PData> NodeLocalScheduler<PData> {
     }
 
     /// Latches shutdown and converts pending delayed resumes into immediate
-    /// `DelayedData` controls while dropping pending wakeups.
+    /// `ResumeData` controls while dropping pending wakeups.
     ///
     /// This preserves payload drain expectations for retry-like flows. Wakeups
     /// are intentionally not retained because they carry no payload.
@@ -445,7 +445,7 @@ impl<PData> NodeLocalScheduler<PData> {
         self.shutting_down = true;
 
         while let Some(resume) = self.delayed_resumes.pop() {
-            self.due_now.push_back(NodeControlMsg::DelayedData {
+            self.due_now.push_back(NodeControlMsg::ResumeData {
                 when: now,
                 data: resume.data,
             });
@@ -592,17 +592,17 @@ mod tests {
         scheduler.heap.assert_consistent();
     }
 
-    fn expect_delayed(
+    fn expect_resume(
         msg: Option<NodeControlMsg<i32>>,
         expected_when: Instant,
         expected_data: i32,
     ) {
         match msg {
-            Some(NodeControlMsg::DelayedData { when, data }) => {
+            Some(NodeControlMsg::ResumeData { when, data }) => {
                 assert_eq!(when, expected_when);
                 assert_eq!(*data, expected_data);
             }
-            _ => panic!("expected delayed data"),
+            _ => panic!("expected resume data"),
         }
     }
 
@@ -629,14 +629,14 @@ mod tests {
     /// Scenario: a retained payload is scheduled through the processor-local
     /// delayed-resume queue and then becomes due.
     /// Guarantees: the scheduler emits the original payload as
-    /// `NodeControlMsg::DelayedData` and clears the delayed-resume deadline.
+    /// `NodeControlMsg::ResumeData` and clears the delayed-resume deadline.
     #[test]
     fn requeue_later_emits_the_stored_payload() {
         let mut scheduler = NodeLocalScheduler::<i32>::new(2, 2);
         let when = Instant::now() + Duration::from_secs(1);
 
         assert_eq!(scheduler.requeue_later(when, Box::new(17)), Ok(()));
-        expect_delayed(scheduler.pop_due(when), when, 17);
+        expect_resume(scheduler.pop_due(when), when, 17);
         assert_eq!(scheduler.next_expiry(), None);
     }
 
@@ -658,10 +658,10 @@ mod tests {
         assert_eq!(scheduler.requeue_later(same_time_b, Box::new(2)), Ok(()));
         assert_eq!(scheduler.requeue_later(sooner, Box::new(0)), Ok(()));
 
-        expect_delayed(scheduler.pop_due(sooner), sooner, 0);
-        expect_delayed(scheduler.pop_due(same_time_a), same_time_a, 1);
-        expect_delayed(scheduler.pop_due(same_time_b), same_time_b, 2);
-        expect_delayed(scheduler.pop_due(later), later, 3);
+        expect_resume(scheduler.pop_due(sooner), sooner, 0);
+        expect_resume(scheduler.pop_due(same_time_a), same_time_a, 1);
+        expect_resume(scheduler.pop_due(same_time_b), same_time_b, 2);
+        expect_resume(scheduler.pop_due(later), later, 3);
     }
 
     /// Scenario: the delayed-resume heap has reached its configured capacity.
@@ -698,7 +698,7 @@ mod tests {
     /// Scenario: shutdown begins while future delayed resumes are still pending
     /// in the processor-local scheduler.
     /// Guarantees: pending delayed resumes are converted into immediate
-    /// `DelayedData` delivery using the shutdown-start timestamp.
+    /// `ResumeData` delivery using the shutdown-start timestamp.
     #[test]
     fn shutdown_makes_pending_delayed_resumes_due_immediately() {
         let mut scheduler = NodeLocalScheduler::new(4, 2);
@@ -713,8 +713,8 @@ mod tests {
 
         scheduler.begin_shutdown(now);
 
-        expect_delayed(scheduler.pop_due(now), now, 11);
-        expect_delayed(scheduler.pop_due(now), now, 12);
+        expect_resume(scheduler.pop_due(now), now, 11);
+        expect_resume(scheduler.pop_due(now), now, 12);
         assert!(scheduler.pop_due(now).is_none());
     }
 

--- a/rust/otap-dataflow/crates/engine/src/node_local_scheduler.rs
+++ b/rust/otap-dataflow/crates/engine/src/node_local_scheduler.rs
@@ -592,11 +592,7 @@ mod tests {
         scheduler.heap.assert_consistent();
     }
 
-    fn expect_resume(
-        msg: Option<NodeControlMsg<i32>>,
-        expected_when: Instant,
-        expected_data: i32,
-    ) {
+    fn expect_resume(msg: Option<NodeControlMsg<i32>>, expected_when: Instant, expected_data: i32) {
         match msg {
             Some(NodeControlMsg::ResumeData { when, data }) => {
                 assert_eq!(when, expected_when);

--- a/rust/otap-dataflow/crates/engine/src/pipeline_ctrl.rs
+++ b/rust/otap-dataflow/crates/engine/src/pipeline_ctrl.rs
@@ -4,12 +4,10 @@
 //! Runtime-control manager for handling timer-based operations.
 //!
 //! This module provides the `RuntimeCtrlMsgManager` which is responsible for managing
-//! timers for nodes in the pipeline. It handles scheduling, cancellation, and expiration
-//! of recurring timers, using a priority queue for efficient timer management.
+//! runtime timers, shutdown orchestration, and completion dispatch coordination.
 //!
 //! Note 1: This manager is designed for single-threaded async execution.
-//! Note 2: Other runtime-control messages can be added in the future, but currently only timers
-//! are supported.
+//! Note 2: Other runtime-control messages coordinate shutdown and completion flow.
 
 use crate::channel_metrics::{ConsumedMetrics, ProducedMetrics};
 use crate::clock;
@@ -49,39 +47,6 @@ const PENDING_SENDS_WARN_THRESHOLD: usize = 100;
 /// Maximum number of consecutive runtime-control messages handled before the
 /// manager forces one due expiry pass.
 const RUNTIME_CTRL_BURST: usize = 64;
-
-/// Represents delayed data with scheduling information.
-#[derive(Debug)]
-struct Delayed<PData> {
-    /// When to resume processing this data.
-    when: Instant,
-    /// Target node ID for the delayed data.
-    node_id: usize,
-    /// The delayed data payload.
-    data: Box<PData>,
-}
-
-/// For BinaryHeap ordering - earlier times have higher priority (min-heap behavior).
-impl<PData> Ord for Delayed<PData> {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        // Reverse ordering for min-heap (earlier times first)
-        other.when.cmp(&self.when)
-    }
-}
-
-impl<PData> PartialOrd for Delayed<PData> {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl<PData> PartialEq for Delayed<PData> {
-    fn eq(&self, other: &Self) -> bool {
-        self.when == other.when
-    }
-}
-
-impl<PData> Eq for Delayed<PData> {}
 
 /// Timer state for a node.
 struct TimerState {
@@ -254,8 +219,6 @@ pub struct RuntimeCtrlMsgManager<PData> {
     tick_timers: TimerSet,
     /// Repeating timers for telemetry collection (CollectTelemetry).
     telemetry_timers: TimerSet,
-    /// Delayed data in activation order.
-    delayed_data: BinaryHeap<Delayed<PData>>,
     /// Event reporter used to report major events influencing the pipeline's behavior.
     event_reporter: ObservedEventReporter,
     /// Global metrics reporter.
@@ -302,7 +265,6 @@ impl<PData> RuntimeCtrlMsgManager<PData> {
                 telemetry_policy.runtime_metrics,
                 0,
                 0,
-                0,
             ),
             pipeline_key,
             pipeline_context,
@@ -311,7 +273,6 @@ impl<PData> RuntimeCtrlMsgManager<PData> {
             control_senders,
             tick_timers: TimerSet::new(),
             telemetry_timers: TimerSet::new(),
-            delayed_data: BinaryHeap::new(),
             event_reporter,
             metrics_reporter,
             control_plane_metrics_flush_interval,
@@ -412,13 +373,12 @@ impl<PData> RuntimeCtrlMsgManager<PData> {
             } else {
                 let next_expiry = self.tick_timers.next_expiry();
                 let next_tel_expiry = self.telemetry_timers.next_expiry();
-                let next_delay_expiry = self.delayed_data.peek().map(|d| d.when);
-                opt_min(opt_min(next_expiry, next_tel_expiry), next_delay_expiry)
+                opt_min(next_expiry, next_tel_expiry)
             };
 
             // Runtime-control traffic can burst during shutdown or completion
             // churn. Force a due-event pass once the burst limit is reached so
-            // timer and delayed-data wakeups still make progress.
+            // timer and telemetry wakeups still make progress.
             if consecutive_runtime_ctrl >= RUNTIME_CTRL_BURST
                 && next_earliest.is_some_and(|when| when <= now)
             {
@@ -449,25 +409,15 @@ impl<PData> RuntimeCtrlMsgManager<PData> {
                             self.runtime_control_metrics
                                 .record_shutdown_received(now, pending_receivers.len());
                             // Receiver-first shutdown freezes timer-driven work
-                            // and flushes queued delayed data back to their
-                            // origin nodes before any downstream Shutdown is
-                            // sent. Receivers get DrainIngress first so they stop
-                            // admitting new work at the pipeline boundary.
+                            // before any downstream Shutdown is sent. Receivers
+                            // get DrainIngress first so they stop admitting new
+                            // work at the pipeline boundary.
                             self.tick_timers.cancel_all();
                             self.telemetry_timers.cancel_all();
                             self.runtime_control_metrics.set_timer_counts(
                                 self.tick_timers.timer_states.len(),
                                 self.telemetry_timers.timer_states.len(),
                             );
-                            let flushed = self.flush_delayed_data_now(now);
-                            self.runtime_control_metrics
-                                .set_delayed_data_queued(self.delayed_data.len());
-                            if flushed > 0 {
-                                for _ in 0..flushed {
-                                    self.runtime_control_metrics
-                                        .record_delay_data_returned_during_drain();
-                                }
-                            }
 
                             for node_id in pending_receivers.iter().copied() {
                                 self.send(
@@ -611,30 +561,6 @@ impl<PData> RuntimeCtrlMsgManager<PData> {
                                 );
                             }
                         }
-                        RuntimeControlMsg::DelayData { node_id, when, data } => {
-                            self.runtime_control_metrics.record_delay_data_received();
-                            if is_draining_ingress {
-                                // Once drain has started, newly requested delayed
-                                // data must not stay queued behind the shutdown
-                                // boundary. Return it immediately so the owning
-                                // node can resolve or discard it inside its
-                                // shutdown path.
-                                self.send(
-                                    node_id,
-                                    NodeControlMsg::DelayedData {
-                                        when: now,
-                                        data,
-                                    },
-                                );
-                                self.runtime_control_metrics
-                                    .record_delay_data_returned_during_drain();
-                            } else {
-                                let delayed = Delayed { node_id, when, data };
-                                self.delayed_data.push(delayed);
-                                self.runtime_control_metrics
-                                    .set_delayed_data_queued(self.delayed_data.len());
-                            }
-                        }
                     }
                 }
                 changed = self.memory_pressure_rx.changed(), if memory_pressure_updates_open => {
@@ -699,21 +625,6 @@ impl<PData> RuntimeCtrlMsgManager<PData> {
         Ok(())
     }
 
-    fn flush_delayed_data_now(&mut self, when: Instant) -> usize {
-        let mut flushed = 0;
-        while let Some(delayed) = self.delayed_data.pop() {
-            self.send(
-                delayed.node_id,
-                NodeControlMsg::DelayedData {
-                    when,
-                    data: delayed.data,
-                },
-            );
-            flushed += 1;
-        }
-        flushed
-    }
-
     fn handle_due_events(
         &mut self,
         now: Instant,
@@ -726,7 +637,6 @@ impl<PData> RuntimeCtrlMsgManager<PData> {
         let mut to_send: Vec<(usize, NodeControlMsg<PData>)> = Vec::new();
         let mut timer_tick_count = 0usize;
         let mut collect_telemetry_count = 0usize;
-        let mut delayed_data_count = 0usize;
 
         self.tick_timers.fire_due(now, |node_id| {
             to_send.push((*node_id, NodeControlMsg::TimerTick {}));
@@ -744,34 +654,12 @@ impl<PData> RuntimeCtrlMsgManager<PData> {
             collect_telemetry_count += 1;
         });
 
-        while self
-            .delayed_data
-            .peek()
-            .map(|d| d.when <= now)
-            .unwrap_or(false)
-        {
-            let delayed = self.delayed_data.pop().expect("ok");
-            to_send.push((
-                delayed.node_id,
-                NodeControlMsg::DelayedData {
-                    when: delayed.when,
-                    data: delayed.data,
-                },
-            ));
-            delayed_data_count += 1;
-        }
-
         self.runtime_control_metrics.set_timer_counts(
             self.tick_timers.timer_states.len(),
             self.telemetry_timers.timer_states.len(),
         );
         self.runtime_control_metrics
-            .set_delayed_data_queued(self.delayed_data.len());
-        self.runtime_control_metrics.record_due_events(
-            timer_tick_count,
-            collect_telemetry_count,
-            delayed_data_count,
-        );
+            .record_due_events(timer_tick_count, collect_telemetry_count);
 
         if let Some(pipeline_metrics_monitor) = pipeline_metrics_monitor.as_mut() {
             if self.telemetry.pipeline_metrics {
@@ -2112,108 +2000,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_delayed_data_heap_ordering() {
-        let now = Instant::now();
-        let mut delayed_heap = BinaryHeap::new();
-
-        let data1 = Box::new("data1".to_string());
-        let data2 = Box::new("data2".to_string());
-        let data3 = Box::new("data3".to_string());
-
-        let delayed1 = Delayed {
-            when: now + Duration::from_millis(300),
-            node_id: 1,
-            data: data1.clone(),
-        };
-        let delayed2 = Delayed {
-            when: now + Duration::from_millis(100),
-            node_id: 2,
-            data: data2.clone(),
-        };
-        let delayed3 = Delayed {
-            when: now + Duration::from_millis(200),
-            node_id: 3,
-            data: data3.clone(),
-        };
-
-        // Insert in non-chronological order to test heap behavior
-        delayed_heap.push(delayed1);
-        delayed_heap.push(delayed2);
-        delayed_heap.push(delayed3);
-
-        assert_eq!(delayed_heap.len(), 3,);
-
-        let first = delayed_heap.pop().expect("should exist");
-        assert_eq!(first.when, now + Duration::from_millis(100));
-        assert_eq!(first.node_id, 2,);
-        assert_eq!(*first.data, *data2);
-
-        let second = delayed_heap.pop().expect("should exist");
-        assert_eq!(second.when, now + Duration::from_millis(200));
-        assert_eq!(second.node_id, 3,);
-        assert_eq!(*second.data, *data3);
-
-        let third = delayed_heap.pop().expect("should exist");
-        assert_eq!(third.when, now + Duration::from_millis(300));
-        assert_eq!(third.node_id, 1,);
-        assert_eq!(*third.data, *data1);
-
-        assert!(delayed_heap.is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_delay_data_integration() {
-        let local = LocalSet::new();
-
-        local
-            .run_until(async {
-                let (manager, pipeline_tx, mut control_receivers, nodes, _pipeline_entity_guard) =
-                    setup_test_manager::<String>();
-
-                let node = nodes.first().expect("ok");
-                let delay_duration = Duration::from_millis(100);
-                let test_data = Box::new("test_delayed_data".to_string());
-                let delay_time = Instant::now() + delay_duration;
-
-                let manager_handle = tokio::task::spawn_local(async move { manager.run().await });
-
-                let delay_msg = RuntimeControlMsg::DelayData {
-                    node_id: node.index,
-                    when: delay_time,
-                    data: test_data.clone(),
-                };
-                pipeline_tx.send(delay_msg).await.unwrap();
-
-                // Wait for delayed data to be delivered
-                let mut receiver = control_receivers.remove(&node.index).unwrap();
-                let delayed_result = async { receiver.recv().await };
-
-                match delayed_result.await {
-                    Ok(NodeControlMsg::DelayedData { when, data }) => {
-                        assert_eq!(*data, *test_data);
-                        assert_eq!(when, delay_time);
-                    }
-                    Ok(other) => panic!("Expected DelayedData, got {other:?}"),
-                    Err(e) => panic!("Failed to receive message: {e:?}"),
-                }
-
-                pipeline_tx
-                    .send(RuntimeControlMsg::Shutdown {
-                        deadline: Instant::now() + Duration::from_secs(1),
-                        reason: "".to_owned(),
-                    })
-                    .await
-                    .unwrap();
-
-                // Drop the sender to let the manager exit draining mode
-                drop(pipeline_tx);
-
-                let _ = manager_handle.await;
-            })
-            .await;
-    }
-
     // A due timer tick must still reach its node while the runtime-control lane
     // is busy with unrelated requests. This guards against control traffic
     // starving timer expiry handling inside the manager loop.
@@ -2308,61 +2094,6 @@ mod tests {
                     .expect("CollectTelemetry should make progress under runtime control burst")
                     .expect("target control channel should stay open");
                 assert!(matches!(msg, NodeControlMsg::CollectTelemetry { .. }));
-
-                drop(pipeline_tx);
-                let shutdown_result = timeout(Duration::from_millis(200), manager_handle).await;
-                assert!(shutdown_result.is_ok(), "Manager should shutdown cleanly");
-            })
-            .await;
-    }
-
-    // DelayedData wakeups are another due event handled by the manager.
-    // This test ensures they are still dispatched promptly even when unrelated
-    // runtime-control requests keep arriving in a burst.
-    #[tokio::test]
-    async fn test_due_delayed_data_progress_under_runtime_ctrl_burst() {
-        let local = LocalSet::new();
-
-        local
-            .run_until(async {
-                let (
-                    mut manager,
-                    pipeline_tx,
-                    _control_senders,
-                    mut control_receivers,
-                    nodes,
-                    _pipeline_entity_guard,
-                ) = setup_test_manager_with_capacities::<String>(128, 10);
-
-                let noisy_node = nodes[0].clone();
-                let target = nodes[1].clone();
-                manager.delayed_data.push(Delayed {
-                    node_id: target.index,
-                    when: Instant::now(),
-                    data: Box::new("burst_delayed".to_owned()),
-                });
-
-                for _ in 0..96 {
-                    pipeline_tx
-                        .send(RuntimeControlMsg::StartTimer {
-                            node_id: noisy_node.index,
-                            duration: Duration::from_secs(60),
-                        })
-                        .await
-                        .unwrap();
-                }
-
-                let manager_handle = tokio::task::spawn_local(async move { manager.run().await });
-
-                let mut receiver = control_receivers.remove(&target.index).unwrap();
-                let msg = timeout(Duration::from_millis(500), receiver.recv())
-                    .await
-                    .expect("DelayedData should make progress under runtime control burst")
-                    .expect("target control channel should stay open");
-                assert!(matches!(
-                    msg,
-                    NodeControlMsg::DelayedData { ref data, .. } if **data == "burst_delayed"
-                ));
 
                 drop(pipeline_tx);
                 let shutdown_result = timeout(Duration::from_millis(200), manager_handle).await;
@@ -2868,132 +2599,6 @@ mod tests {
             .await;
     }
 
-    // DelayData submitted after draining begins represents retry work that
-    // should not stay hidden behind the delayed-data heap. The manager returns
-    // it to the origin node immediately so the node can decide what to do next.
-    #[tokio::test]
-    async fn test_new_delay_data_returned_immediately_during_draining() {
-        let local = LocalSet::new();
-
-        local
-            .run_until(async {
-                let (manager, pipeline_tx, mut control_receivers, nodes, _pipeline_entity_guard) =
-                    setup_test_manager::<String>();
-
-                let node = nodes.first().expect("ok");
-                let manager_handle = tokio::task::spawn_local(async move { manager.run().await });
-
-                pipeline_tx
-                    .send(RuntimeControlMsg::Shutdown {
-                        deadline: Instant::now() + Duration::from_secs(1),
-                        reason: "test shutdown".to_owned(),
-                    })
-                    .await
-                    .unwrap();
-
-                let mut receiver = control_receivers.remove(&node.index).unwrap();
-                let shutdown = timeout(Duration::from_millis(100), receiver.recv())
-                    .await
-                    .expect("processor should receive shutdown during draining")
-                    .expect("processor control channel should stay open");
-                assert!(matches!(shutdown, NodeControlMsg::Shutdown { .. }));
-
-                let original_when = Instant::now() + Duration::from_secs(30);
-                pipeline_tx
-                    .send(RuntimeControlMsg::DelayData {
-                        node_id: node.index,
-                        when: original_when,
-                        data: Box::new("drain_retry".to_owned()),
-                    })
-                    .await
-                    .unwrap();
-
-                let msg = timeout(Duration::from_millis(100), receiver.recv())
-                    .await
-                    .expect("DelayedData should be returned immediately during draining")
-                    .expect("processor control channel should stay open");
-
-                match msg {
-                    NodeControlMsg::DelayedData { when, data } => {
-                        assert_eq!(*data, "drain_retry");
-                        assert!(
-                            when < original_when,
-                            "DelayedData should be returned immediately, not at its original wake time"
-                        );
-                    }
-                    other => panic!("Expected DelayedData, got {other:?}"),
-                }
-
-                drop(pipeline_tx);
-                let shutdown_result = timeout(Duration::from_millis(100), manager_handle).await;
-                assert!(shutdown_result.is_ok(), "Manager should shutdown cleanly");
-            })
-            .await;
-    }
-
-    // Draining must also flush retry work that was already queued before
-    // shutdown. Once draining starts, delayed data is returned immediately
-    // rather than waiting for its original wake time.
-    #[tokio::test]
-    async fn test_queued_delayed_data_flushed_when_draining_begins() {
-        let local = LocalSet::new();
-
-        local
-            .run_until(async {
-                let (manager, pipeline_tx, mut control_receivers, nodes, _pipeline_entity_guard) =
-                    setup_test_manager::<String>();
-
-                let node = nodes.first().expect("ok");
-                let original_when = Instant::now() + Duration::from_secs(30);
-                pipeline_tx
-                    .send(RuntimeControlMsg::DelayData {
-                        node_id: node.index,
-                        when: original_when,
-                        data: Box::new("queued_retry".to_owned()),
-                    })
-                    .await
-                    .unwrap();
-
-                let manager_handle = tokio::task::spawn_local(async move { manager.run().await });
-                tokio::time::sleep(Duration::from_millis(10)).await;
-
-                pipeline_tx
-                    .send(RuntimeControlMsg::Shutdown {
-                        deadline: Instant::now() + Duration::from_secs(1),
-                        reason: "test shutdown".to_owned(),
-                    })
-                    .await
-                    .unwrap();
-
-                let mut receiver = control_receivers.remove(&node.index).unwrap();
-                let msg = timeout(Duration::from_millis(100), receiver.recv())
-                    .await
-                    .expect("Queued delayed data should flush when draining begins")
-                    .expect("processor control channel should stay open");
-                match msg {
-                    NodeControlMsg::DelayedData { when, data } => {
-                        assert_eq!(*data, "queued_retry");
-                        assert!(
-                            when < original_when,
-                            "Queued delayed data should be flushed immediately during shutdown"
-                        );
-                    }
-                    other => panic!("Expected DelayedData, got {other:?}"),
-                }
-
-                let shutdown = timeout(Duration::from_millis(100), receiver.recv())
-                    .await
-                    .expect("processor should receive shutdown after delayed-data flush")
-                    .expect("processor control channel should stay open");
-                assert!(matches!(shutdown, NodeControlMsg::Shutdown { .. }));
-
-                drop(pipeline_tx);
-                let shutdown_result = timeout(Duration::from_millis(100), manager_handle).await;
-                assert!(shutdown_result.is_ok(), "Manager should shutdown cleanly");
-            })
-            .await;
-    }
-
     /// A test PData type that carries a real frame stack, allowing the
     /// controller's `unwind_ack`/`unwind_nack` to pop frames and record metrics.
     #[derive(Debug, Clone)]
@@ -3272,21 +2877,17 @@ mod tests {
     const RUNTIME_PENDING_SENDS_BUFFERED: usize = 2;
     const RUNTIME_TIMERS_ACTIVE: usize = 3;
     const RUNTIME_TELEMETRY_TIMERS_ACTIVE: usize = 4;
-    const RUNTIME_DELAYED_DATA_QUEUED: usize = 5;
-    const RUNTIME_SHUTDOWN_RECEIVED: usize = 6;
-    const RUNTIME_DRAIN_INGRESS_SENT: usize = 7;
-    const RUNTIME_RECEIVER_DRAINED_RECEIVED: usize = 8;
-    const RUNTIME_DOWNSTREAM_SHUTDOWN_SENT: usize = 9;
-    const RUNTIME_SHUTDOWN_DEADLINE_FORCED: usize = 10;
-    const RUNTIME_START_TIMER_RECEIVED: usize = 11;
-    const RUNTIME_START_TELEMETRY_TIMER_RECEIVED: usize = 13;
-    const RUNTIME_DELAY_DATA_RECEIVED: usize = 15;
-    const RUNTIME_DELAY_DATA_RETURNED_DURING_DRAIN: usize = 16;
-    const RUNTIME_TIMER_TICK_SENT: usize = 17;
-    const RUNTIME_COLLECT_TELEMETRY_SENT: usize = 18;
-    const RUNTIME_DELAYED_DATA_SENT: usize = 19;
-    const RUNTIME_DRAIN_RECEIVER_PHASE_DURATION_NS: usize = 20;
-    const RUNTIME_DRAIN_TOTAL_DURATION_NS: usize = 21;
+    const RUNTIME_SHUTDOWN_RECEIVED: usize = 5;
+    const RUNTIME_DRAIN_INGRESS_SENT: usize = 6;
+    const RUNTIME_RECEIVER_DRAINED_RECEIVED: usize = 7;
+    const RUNTIME_DOWNSTREAM_SHUTDOWN_SENT: usize = 8;
+    const RUNTIME_SHUTDOWN_DEADLINE_FORCED: usize = 9;
+    const RUNTIME_START_TIMER_RECEIVED: usize = 10;
+    const RUNTIME_START_TELEMETRY_TIMER_RECEIVED: usize = 12;
+    const RUNTIME_TIMER_TICK_SENT: usize = 14;
+    const RUNTIME_COLLECT_TELEMETRY_SENT: usize = 15;
+    const RUNTIME_DRAIN_RECEIVER_PHASE_DURATION_NS: usize = 16;
+    const RUNTIME_DRAIN_TOTAL_DURATION_NS: usize = 17;
 
     const COMPLETION_PENDING_SENDS_BUFFERED: usize = 0;
     const COMPLETION_DELIVER_ACK_RECEIVED: usize = 1;
@@ -4284,7 +3885,6 @@ mod tests {
                         RUNTIME_PENDING_SENDS_BUFFERED,
                         RUNTIME_TIMERS_ACTIVE,
                         RUNTIME_TELEMETRY_TIMERS_ACTIVE,
-                        RUNTIME_DELAYED_DATA_QUEUED,
                     ],
                 )
                 .expect("runtime-control metrics should be exported");
@@ -4340,7 +3940,6 @@ mod tests {
                         RUNTIME_PENDING_SENDS_BUFFERED,
                         RUNTIME_TIMERS_ACTIVE,
                         RUNTIME_TELEMETRY_TIMERS_ACTIVE,
-                        RUNTIME_DELAYED_DATA_QUEUED,
                     ],
                 )
                 .expect("runtime-control metrics should export receiver-drained transition");
@@ -4441,7 +4040,6 @@ mod tests {
                         RUNTIME_PENDING_SENDS_BUFFERED,
                         RUNTIME_TIMERS_ACTIVE,
                         RUNTIME_TELEMETRY_TIMERS_ACTIVE,
-                        RUNTIME_DELAYED_DATA_QUEUED,
                     ],
                 )
                 .expect("runtime-control metrics should export forced-deadline snapshot");
@@ -4568,29 +4166,15 @@ mod tests {
                     })
                     .await
                     .unwrap();
-                pipeline_tx
-                    .send(RuntimeControlMsg::DelayData {
-                        node_id: processor.index,
-                        when: Instant::now() + Duration::from_millis(5),
-                        data: Box::new("retry".to_owned()),
-                    })
-                    .await
-                    .unwrap();
 
                 let mut processor_ctrl = control_receivers.remove(&processor.index).unwrap();
                 let mut timer_tick = false;
                 let mut collect_telemetry = false;
-                let mut delayed_data = false;
                 let deadline = tokio::time::Instant::now() + Duration::from_millis(250);
-                while !(timer_tick && collect_telemetry && delayed_data)
-                    && tokio::time::Instant::now() < deadline
-                {
+                while !(timer_tick && collect_telemetry) && tokio::time::Instant::now() < deadline {
                     match timeout(Duration::from_millis(100), processor_ctrl.recv()).await {
                         Ok(Ok(NodeControlMsg::TimerTick {})) => timer_tick = true,
                         Ok(Ok(NodeControlMsg::CollectTelemetry { .. })) => collect_telemetry = true,
-                        Ok(Ok(NodeControlMsg::DelayedData { data, .. })) => {
-                            delayed_data = *data == "retry"
-                        }
                         Ok(Ok(_)) => {}
                         Ok(Err(_)) | Err(_) => break,
                     }
@@ -4600,7 +4184,6 @@ mod tests {
                     collect_telemetry,
                     "due telemetry timer should reach the processor"
                 );
-                assert!(delayed_data, "due delayed data should be resumed");
 
                 drop(pipeline_tx);
                 let manager_result = timeout(Duration::from_millis(200), manager_handle).await;
@@ -4615,7 +4198,6 @@ mod tests {
                         RUNTIME_PENDING_SENDS_BUFFERED,
                         RUNTIME_TIMERS_ACTIVE,
                         RUNTIME_TELEMETRY_TIMERS_ACTIVE,
-                        RUNTIME_DELAYED_DATA_QUEUED,
                     ],
                 )
                 .expect("runtime-control metrics should export due-work counters");
@@ -4633,23 +4215,6 @@ mod tests {
                     1,
                     "start_telemetry_timer.received should count telemetry timer requests",
                 );
-                assert_u64(
-                    &due_metrics,
-                    RUNTIME_DELAY_DATA_RECEIVED,
-                    1,
-                    "delay_data.received should count delayed-data requests",
-                );
-                assert_u64(
-                    &due_metrics,
-                    RUNTIME_DELAYED_DATA_SENT,
-                    1,
-                    "delayed_data.sent should count due delayed-data dispatches",
-                );
-                // Recurring timers reschedule immediately after firing, so
-                // the 5ms timer may fire more than once before `drop(pipeline_tx)`
-                // closes the manager. Unlike delayed data (one-shot), these are
-                // inherently non-deterministic — we only require at least one
-                // dispatch was recorded.
                 assert_u64_gte(
                     &due_metrics,
                     RUNTIME_TIMER_TICK_SENT,
@@ -4661,99 +4226,6 @@ mod tests {
                     RUNTIME_COLLECT_TELEMETRY_SENT,
                     1,
                     "collect_telemetry.sent should count due telemetry dispatches",
-                );
-            })
-            .await;
-    }
-
-    // Once shutdown is latched, newly submitted DelayData requests should be
-    // returned immediately and counted separately from ordinary delayed-data
-    // scheduling.
-    #[tokio::test]
-    async fn test_runtime_control_metrics_track_delay_data_returned_during_drain() {
-        let local = LocalSet::new();
-
-        local
-            .run_until(async {
-                let RuntimeControlTelemetryHarness {
-                    manager,
-                    pipeline_tx,
-                    mut control_receivers,
-                    nodes,
-                    runtime_metrics_key,
-                    snapshot_rx,
-                    engine_rx: _engine_rx,
-                    ..
-                } = setup_runtime_control_telemetry_harness::<String>(
-                    vec![("processor", NodeType::Processor, 16)],
-                    MetricLevel::Normal,
-                );
-
-                let processor = nodes[0].clone();
-                let manager_handle = tokio::task::spawn_local(async move { manager.run().await });
-
-                pipeline_tx
-                    .send(RuntimeControlMsg::Shutdown {
-                        deadline: Instant::now() + Duration::from_secs(1),
-                        reason: "drain retry".to_owned(),
-                    })
-                    .await
-                    .unwrap();
-                pipeline_tx
-                    .send(RuntimeControlMsg::DelayData {
-                        node_id: processor.index,
-                        when: Instant::now() + Duration::from_secs(30),
-                        data: Box::new("retry".to_owned()),
-                    })
-                    .await
-                    .unwrap();
-
-                let mut processor_ctrl = control_receivers.remove(&processor.index).unwrap();
-                let first = timeout(Duration::from_millis(100), processor_ctrl.recv())
-                    .await
-                    .expect("processor should get first control message")
-                    .expect("processor control channel should stay open");
-                let second = timeout(Duration::from_millis(100), processor_ctrl.recv())
-                    .await
-                    .expect("processor should get delayed data during drain")
-                    .expect("processor control channel should stay open");
-                assert!(
-                    matches!(first, NodeControlMsg::Shutdown { .. })
-                        || matches!(second, NodeControlMsg::Shutdown { .. })
-                );
-                assert!(
-                    matches!(first, NodeControlMsg::DelayedData { .. })
-                        || matches!(second, NodeControlMsg::DelayedData { .. })
-                );
-
-                drop(pipeline_tx);
-                let manager_result = timeout(Duration::from_millis(200), manager_handle).await;
-                assert!(manager_result.is_ok(), "manager should stop cleanly");
-
-                let drain_metrics = collect_metric_set_snapshots(
-                    &snapshot_rx,
-                    runtime_metrics_key,
-                    &[
-                        RUNTIME_DRAIN_ACTIVE,
-                        RUNTIME_DRAIN_PENDING_RECEIVERS,
-                        RUNTIME_PENDING_SENDS_BUFFERED,
-                        RUNTIME_TIMERS_ACTIVE,
-                        RUNTIME_TELEMETRY_TIMERS_ACTIVE,
-                        RUNTIME_DELAYED_DATA_QUEUED,
-                    ],
-                )
-                .expect("runtime-control metrics should export drain-time delay-data counters");
-                assert_u64(
-                    &drain_metrics,
-                    RUNTIME_DELAY_DATA_RECEIVED,
-                    1,
-                    "delay_data.received should count the drain-time request",
-                );
-                assert_u64(
-                    &drain_metrics,
-                    RUNTIME_DELAY_DATA_RETURNED_DURING_DRAIN,
-                    1,
-                    "delay_data.returned_during_drain should count immediate drain returns",
                 );
             })
             .await;
@@ -4809,7 +4281,6 @@ mod tests {
                         RUNTIME_PENDING_SENDS_BUFFERED,
                         RUNTIME_TIMERS_ACTIVE,
                         RUNTIME_TELEMETRY_TIMERS_ACTIVE,
-                        RUNTIME_DELAYED_DATA_QUEUED,
                     ],
                 )
                 .expect("dirty runtime-control state should flush on the configured interval");
@@ -4837,7 +4308,6 @@ mod tests {
                             RUNTIME_PENDING_SENDS_BUFFERED,
                             RUNTIME_TIMERS_ACTIVE,
                             RUNTIME_TELEMETRY_TIMERS_ACTIVE,
-                            RUNTIME_DELAYED_DATA_QUEUED,
                         ],
                     )
                     .is_none(),
@@ -4904,7 +4374,6 @@ mod tests {
                         RUNTIME_PENDING_SENDS_BUFFERED,
                         RUNTIME_TIMERS_ACTIVE,
                         RUNTIME_TELEMETRY_TIMERS_ACTIVE,
-                        RUNTIME_DELAYED_DATA_QUEUED,
                     ],
                 )
                 .expect("shutdown latch should flush without waiting for the full interval");
@@ -5036,7 +4505,6 @@ mod tests {
                         RUNTIME_PENDING_SENDS_BUFFERED,
                         RUNTIME_TIMERS_ACTIVE,
                         RUNTIME_TELEMETRY_TIMERS_ACTIVE,
-                        RUNTIME_DELAYED_DATA_QUEUED,
                     ],
                 )
                 .expect("basic runtime-control metrics should be exported");
@@ -5129,7 +4597,6 @@ mod tests {
                         RUNTIME_PENDING_SENDS_BUFFERED,
                         RUNTIME_TIMERS_ACTIVE,
                         RUNTIME_TELEMETRY_TIMERS_ACTIVE,
-                        RUNTIME_DELAYED_DATA_QUEUED,
                     ],
                 )
                 .expect("normal runtime-control metrics should be exported");

--- a/rust/otap-dataflow/crates/engine/src/shared/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/shared/processor.rs
@@ -433,9 +433,20 @@ impl<PData> EffectHandler<PData> {
         self.core.start_periodic_telemetry(duration).await
     }
 
-    /// Delay data.
-    pub async fn delay_data(&self, when: Instant, data: Box<PData>) -> Result<(), PData> {
-        self.core.delay_data(when, data).await
+    /// Send an Ack to the runtime control manager for context unwinding.
+    pub async fn route_ack(&self, ack: AckMsg<PData>) -> Result<(), Error>
+    where
+        PData: crate::Unwindable,
+    {
+        self.core.route_ack(ack).await
+    }
+
+    /// Send a Nack to the runtime control manager for context unwinding.
+    pub async fn route_nack(&self, nack: NackMsg<PData>) -> Result<(), Error>
+    where
+        PData: crate::Unwindable,
+    {
+        self.core.route_nack(nack).await
     }
 
     /// Requeue retained pdata onto this node later.

--- a/rust/otap-dataflow/crates/engine/src/testing/dst/control_plane.rs
+++ b/rust/otap-dataflow/crates/engine/src/testing/dst/control_plane.rs
@@ -76,14 +76,6 @@ async fn run_control_plane_seed(seed: u64) {
             })
             .await
             .unwrap();
-        runtime_tx
-            .send(RuntimeControlMsg::DelayData {
-                node_id: processor_id.index,
-                when: clock.now() + Duration::from_millis(12),
-                data: Box::new(DstPData::new(9000)),
-            })
-            .await
-            .unwrap();
         yield_cycles(2).await;
         for _ in 0..(70 + rng.gen_range(6)) {
             runtime_tx
@@ -165,20 +157,12 @@ async fn run_control_plane_seed(seed: u64) {
             |msgs| {
                 msgs.iter()
                     .any(|msg| matches!(msg, NodeControlMsg::TimerTick {}))
-                    && msgs.iter().any(|msg| {
-                        matches!(
-                            msg,
-                            NodeControlMsg::DelayedData { data, .. } if data.id == 9000
-                        )
-                    })
                     && msgs.iter().any(|msg| matches!(msg, NodeControlMsg::Ack(_)))
                     && msgs
                         .iter()
                         .any(|msg| matches!(msg, NodeControlMsg::Nack(_)))
             },
-            &format!(
-                "seed={seed}: processor control receiver did not observe timer/delay/ack/nack"
-            ),
+            &format!("seed={seed}: processor control receiver did not observe timer/ack/nack"),
         )
         .await;
         assert!(
@@ -186,12 +170,6 @@ async fn run_control_plane_seed(seed: u64) {
                 .iter()
                 .any(|msg| matches!(msg, NodeControlMsg::TimerTick {})),
             "seed={seed}: due timer tick was starved under runtime-control burst"
-        );
-        assert!(
-            processor_msgs.iter().any(
-                |msg| matches!(msg, NodeControlMsg::DelayedData { data, .. } if data.id == 9000)
-            ),
-            "seed={seed}: delayed data did not resume under control pressure"
         );
 
         let ack_msg = processor_msgs.iter().find_map(|msg| match msg {
@@ -307,8 +285,8 @@ async fn run_control_plane_seed(seed: u64) {
     }));
 }
 
-// Exercise seeded control-plane mixes where runtime-control traffic, delayed
-// work, completion unwinding, and receiver-first shutdown all compete. The
+// Exercise seeded control-plane mixes where runtime-control traffic,
+// completion unwinding, and receiver-first shutdown all compete. The
 // assertion surface is liveness and ordering, not a single fixed trace.
 #[test]
 fn dst_runtime_control_plane_seeded() {

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -18,6 +18,7 @@ use std::num::NonZeroU64;
 use async_trait::async_trait;
 use otap_df_config::PortName;
 use otap_df_config::{SignalFormat, SignalType};
+use otap_df_engine::_private::AckNackRouting;
 use otap_df_engine::control::{AckMsg, CallData, Frame, NackMsg, RouteData, nanos_since_birth};
 use otap_df_engine::error::{Error, TypedError};
 use otap_df_engine::processor::{FlowMeasurementHook, StopwatchEffectHandler};
@@ -675,7 +676,6 @@ macro_rules! impl_consumer_ext {
         #[async_trait(?Send)]
         impl ConsumerEffectHandlerExtension<OtapPdata> for $handler {
             async fn notify_ack(&self, mut ack: AckMsg<OtapPdata>) -> Result<(), Error> {
-                use otap_df_engine::_private::AckNackRouting;
                 if ack.accepted.has_timing(Interests::ACKS) {
                     ack.unwind.return_time_ns = nanos_since_birth();
                 }
@@ -683,7 +683,6 @@ macro_rules! impl_consumer_ext {
             }
 
             async fn notify_nack(&self, mut nack: NackMsg<OtapPdata>) -> Result<(), Error> {
-                use otap_df_engine::_private::AckNackRouting;
                 if nack.refused.has_timing(Interests::NACKS) {
                     nack.unwind.return_time_ns = nanos_since_birth();
                 }

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -127,9 +127,8 @@ impl Context {
             .unwrap_or(false)
     }
 
-    /// Return the current source calldata. This is used with the
-    /// DelayedData message, in which a node delivers a message to
-    /// itself.
+    /// Return the current source calldata. This is used when a node resumes
+    /// retained data back to itself via the local scheduler.
     ///
     /// This is also useful in testing, it indicates the data that was
     /// sent by the source node.
@@ -560,9 +559,8 @@ impl OtapPdata {
     /// Return the source's calldata. Note that after a subscribe_to()
     /// has been called, the current node becomes the source.
     ///
-    /// Return the current source calldata. This is used with the
-    /// DelayedData message, in which a node delivers a message to
-    /// itself.
+    /// Return the current source calldata. This is used when a node resumes
+    /// retained data back to itself via the local scheduler.
     ///
     /// This is also useful in testing, it indicates the data that was
     /// sent by the source node.


### PR DESCRIPTION
**Not ready for review. https://github.com/open-telemetry/otel-arrow/pull/2471 must be merged first to reduce the scope of this PR**

# Change Summary

Remove the old runtime-managed delayed-data path now that node-local wakeups and node-local delayed resume are in place.

This PR deletes the remaining global delayed-data plumbing from the engine, including the runtime control path and the delayed-data-specific node control message flow. After the previous PRs:

- wakeup-style local scheduling is handled locally in `ProcessorInbox`
- retry-style delayed `pdata` resume is handled locally via `requeue_later(...)`

This is the cleanup step in the redesign tracked in #2465. It simplifies the runtime manager, reduces global contention, and makes shutdown behavior easier to reason about by removing delayed-data-specific special cases from the global control path.

## What issue does this PR close?

* Part of #2465

## How are these changes tested?

- Removed or updated engine tests that previously depended on the global
  delayed-data path
- Re-ran the existing coverage for:
  - local wakeups
  - local delayed resume
  - retry behavior
  - shutdown behavior
- Verified with:
    - `cargo xtask check`

## Are there any user-facing changes?

No user-facing changes.

This PR is an internal runtime cleanup only.