### PR TITLE
Relax metric assert on runtime_control_metrics

### DIFF
--- a/rust/otap-dataflow/crates/engine/src/pipeline_ctrl.rs
+++ b/rust/otap-dataflow/crates/engine/src/pipeline_ctrl.rs
@@ -3211,6 +3211,13 @@ mod tests {
         }
     }
 
+    fn assert_u64_gte(values: &[MetricValue], index: usize, min: u64, msg: &str) {
+        match values[index] {
+            MetricValue::U64(v) => assert!(v >= min, "{msg}: expected >= {min}, got {v}"),
+            other => panic!("{msg}: expected U64, got {other:?}"),
+        }
+    }
+
     /// Extract Mmsc from a MetricValue, returning the snapshot for further assertions.
     fn assert_mmsc(
         values: &[MetricValue],
@@ -4435,6 +4442,8 @@ mod tests {
                     ],
                 )
                 .expect("runtime-control metrics should export due-work counters");
+                // Inbound request counters are deterministic: the test sends
+                // exactly one of each message type.
                 assert_u64(
                     &due_metrics,
                     RUNTIME_START_TIMER_RECEIVED,
@@ -4455,21 +4464,26 @@ mod tests {
                 );
                 assert_u64(
                     &due_metrics,
+                    RUNTIME_DELAYED_DATA_SENT,
+                    1,
+                    "delayed_data.sent should count due delayed-data dispatches",
+                );
+                // Recurring timers reschedule immediately after firing, so
+                // the 5ms timer may fire more than once before `drop(pipeline_tx)`
+                // closes the manager. Unlike delayed data (one-shot), these are
+                // inherently non-deterministic — we only require at least one
+                // dispatch was recorded.
+                assert_u64_gte(
+                    &due_metrics,
                     RUNTIME_TIMER_TICK_SENT,
                     1,
                     "timer_tick.sent should count due timer dispatches",
                 );
-                assert_u64(
+                assert_u64_gte(
                     &due_metrics,
                     RUNTIME_COLLECT_TELEMETRY_SENT,
                     1,
                     "collect_telemetry.sent should count due telemetry dispatches",
-                );
-                assert_u64(
-                    &due_metrics,
-                    RUNTIME_DELAYED_DATA_SENT,
-                    1,
-                    "delayed_data.sent should count due delayed-data dispatches",
                 );
             })
             .await;


### PR DESCRIPTION
# Change Summary

This test has seen a few transient failures (commonly on Windows runs):
* https://github.com/open-telemetry/otel-arrow/actions/runs/23760385085/job/69237797347?pr=2461
* https://github.com/open-telemetry/otel-arrow/actions/runs/23809319658/job/69391753138?pr=2473

```
        FAIL [   0.033s] (1118/3015) otap-df-engine pipeline_ctrl::tests::test_runtime_control_metrics_track_due_work_dispatch
  stdout ───

    running 1 test
    test pipeline_ctrl::tests::test_runtime_control_metrics_track_due_work_dispatch ... FAILED

    failures:

    failures:
        pipeline_ctrl::tests::test_runtime_control_metrics_track_due_work_dispatch

    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 191 filtered out; finished in 0.02s
    
  stderr ───

    thread 'pipeline_ctrl::tests::test_runtime_control_metrics_track_due_work_dispatch' (10136) panicked at crates\engine\src\pipeline_ctrl.rs:3209:36:
    assertion `left == right` failed: timer_tick.sent should count due timer dispatches
      left: 2
     right: 1
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

The actual value is `2` instead of `1`.

From the context I can see, relaxing these assertions shouldn't compromise the validity of the test.

## What issue does this PR close?

Attempts to resolve one of the flaky tests mentioned in #2464

## How are these changes tested?

Unit tests

## Are there any user-facing changes?

No