### PR TITLE
fix: race condition in quiver's WAL writer cursor validation

### DIFF
--- a/rust/otap-dataflow/crates/quiver/src/wal/writer.rs
+++ b/rust/otap-dataflow/crates/quiver/src/wal/writer.rs
@@ -661,7 +661,7 @@ impl WalWriter {
     /// Call this after downstream has confirmed durability (e.g., segment flush).
     pub(crate) async fn persist_cursor(&mut self, cursor: &WalConsumerCursor) -> WalResult<()> {
         self.coordinator
-            .persist_cursor(&mut self.active_file, cursor)
+            .persist_cursor(&self.active_file, cursor)
             .await
     }
 
@@ -1418,7 +1418,7 @@ impl WalCoordinator {
 
     async fn persist_cursor(
         &mut self,
-        active_file: &mut ActiveWalFile,
+        active_file: &ActiveWalFile,
         cursor: &WalConsumerCursor,
     ) -> WalResult<()> {
         self.validate_cursor(active_file, cursor)?;


### PR DESCRIPTION
# Change Summary

Fix a race condition in the WAL cursor validation where `tokio::fs::File::metadata()` can return a stale file length after `write_all()`, causing spurious `InvalidConsumerCursor("safe offset beyond wal tail")` errors during ingestion.

Tokio's `File::poll_write()` returns `Ready` before the blocking-pool write task completes the OS `write()` syscall. `metadata()` bypasses the File's state machine and can observe the pre-write length. The fix replaces the `metadata().await?.len()` call with the in-memory tracked `active_file.len()`, which is updated synchronously after each write.

Since `validate_cursor()` no longer performs I/O, it is changed from `async fn` to `fn`, and the `&mut ActiveWalFile` parameters on `validate_cursor` and `ensure_entry_boundary` are relaxed to `&ActiveWalFile`.

## What issue does this PR close?

* Closes #2487

## How are these changes tested?

- The existing `startup_deletes_expired_segments_without_loading` test exercises the affected code path. It was what originally surfaced the bug in CI.

## Are there any user-facing changes?

No. This fixes an internal race condition that could cause transient ingest failures under high throughput or blocking-pool contention. Behavior is otherwise unchanged.
