### PR TITLE
fix(geneva_exporter): per-signal metrics, accurate batch tracking, and per-upload latency

### DIFF
--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/mod.rs
@@ -402,7 +402,9 @@ impl GenevaExporter {
                             self.metrics.log_upload_success_duration.record(duration_ms);
                         }
                         SignalType::Traces => {
-                            self.metrics.trace_upload_success_duration.record(duration_ms);
+                            self.metrics
+                                .trace_upload_success_duration
+                                .record(duration_ms);
                         }
                         _ => {}
                     }
@@ -416,7 +418,9 @@ impl GenevaExporter {
                             self.metrics.log_upload_failed_duration.record(duration_ms);
                         }
                         SignalType::Traces => {
-                            self.metrics.trace_upload_failed_duration.record(duration_ms);
+                            self.metrics
+                                .trace_upload_failed_duration
+                                .record(duration_ms);
                         }
                         _ => {}
                     }


### PR DESCRIPTION
Addresses review comments from #2262  on the Geneva exporter's metrics instrumentation.
 
 ### Changes
 
 **1. Fix `try_for_each_concurrent` short-circuit (inflated failure counts)**
 
 Replaced `try_for_each_concurrent` with `buffer_unordered` + collect. All batches are now attempted regardless of individual failures. Successes and failures are counted accurately per-batch using `EncodedBatch::row_count`, rather than attributing all records to either success or failure.
 
 **2. Fix `upload_duration` recording aggregate wall-clock time**
 
 Upload latency is now recorded per individual batch upload, not once for the entire concurrent block. Each upload produces its own timing sample, giving accurate min/max/sum/count statistics.
 
 **3. Rename `unsupported_signals` to `metrics_payloads_dropped`**
 
 Metrics is the only unsupported signal type, so the generic name was misleading.
 
 **4. Split shared counters into per-signal metrics**
 
 All upload/failure/timing counters are now split into `log_*` and `trace_*` variants (e.g., `log_batches_uploaded`, `trace_upload_duration`). This lets operators identify which signal type is failing or experiencing latency. Signal-agnostic counters (`empty_payloads_skipped`, `conversion_errors`, `metrics_payloads_dropped`) remain shared.
 
 ### Known limitation (documented as TODO)
 
 When a payload is split into multiple Geneva batches and some fail, the entire payload is still NACKed and retried - potentially duplicating already-uploaded batches. Geneva assigns a fresh UUID per upload, so there is no  server-side dedup. The Azure Monitor exporter solves this with per-message batch tracking and deferred ACK/NACK; a similar approach should be adopted here in a follow-up.
 