### PR TITLE
extend test timeouts

### DIFF
--- a/rust/otap-dataflow/crates/validation/src/lib.rs
+++ b/rust/otap-dataflow/crates/validation/src/lib.rs
@@ -63,7 +63,6 @@ mod tests {
                     .control_streams(["traffic_gen"])
                     .core_range(2, 2),
             )
-            .expect_within(30)
             .run()
             .expect("validation scenario failed");
     }
@@ -91,7 +90,6 @@ mod tests {
                     .control_streams(["traffic_gen"])
                     .core_range(2, 2),
             )
-            .expect_within(30)
             .run()
             .expect("validation scenario failed");
     }
@@ -126,7 +124,6 @@ mod tests {
                     .validate(vec![deny, require])
                     .core_range(2, 2),
             )
-            .expect_within(30)
             .run()
             .expect("attribute processor validation failed");
     }
@@ -168,7 +165,6 @@ mod tests {
                     .control_streams(["traffic_gen"])
                     .core_range(2, 2),
             )
-            .expect_within(30)
             .run()
             .expect("filter processor validation failed");
     }
@@ -202,7 +198,6 @@ mod tests {
                     .validate(vec![ValidationInstructions::Equivalence])
                     .control_streams(["traffic_gen1", "traffic_gen2"]),
             )
-            .expect_within(30)
             .run()
             .expect("validation scenario failed");
     }
@@ -263,7 +258,6 @@ mod tls_tests {
                     .otlp_grpc("exporter")
                     .control_streams(["traffic_gen"]),
             )
-            .expect_within(30)
             .run()
             .expect("TLS validation scenario failed");
     }
@@ -327,7 +321,6 @@ mod tls_tests {
                     .otlp_grpc("exporter")
                     .control_streams(["traffic_gen"]),
             )
-            .expect_within(30)
             .run()
             .expect("mTLS validation scenario failed");
     }

--- a/rust/otap-dataflow/crates/validation/src/scenario.rs
+++ b/rust/otap-dataflow/crates/validation/src/scenario.rs
@@ -23,7 +23,7 @@ const DEFAULT_ADMIN_ADDR: &str = "127.0.0.1:8085";
 const DEFAULT_READY_MAX_ATTEMPTS: usize = 10;
 const DEFAULT_READY_BACKOFF: Duration = Duration::from_secs(3);
 const DEFAULT_METRICS_POLL: Duration = Duration::from_secs(2);
-const DEFAULT_SCENARIO_RUNTIME: Duration = Duration::from_secs(25);
+const DEFAULT_SCENARIO_RUNTIME: Duration = Duration::from_secs(60);
 
 /// Look up a container by label, validate that `internal_port` is set, and
 /// return the host port mapped to that internal port. If no mapping exists


### PR DESCRIPTION
# Change Summary

Raise validation test timeouts to 60s, from 25s and 30s. This seems to be better than disabling those tests on ARM and other platforms.