### PR TITLE
Remove unused transform_failures metric

### DIFF
--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/metrics.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/metrics.rs
@@ -90,9 +90,6 @@ pub struct AzureMonitorExporterMetrics {
     /// Number of successful heartbeat sends.
     #[metric(unit = "{heartbeat}")]
     pub heartbeats: Counter<u64>,
-    /// Number of log records that failed to serialize during transformation.
-    #[metric(unit = "{record}")]
-    pub transform_failures: Counter<u64>,
 }
 
 /// Full metrics tracker for the Azure Monitor exporter.
@@ -336,12 +333,6 @@ impl AzureMonitorExporterMetricsTracker {
     #[inline]
     pub fn add_heartbeat(&mut self) {
         self.metrics.heartbeats.inc();
-    }
-
-    /// Increment the transform failures counter.
-    #[inline]
-    pub fn add_transform_failures(&mut self, count: u64) {
-        self.metrics.transform_failures.add(count);
     }
 
     /// Record an HTTP response status code.

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/telemetry.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/telemetry.md
@@ -30,7 +30,6 @@ by the crate and log events emitted via `otel_*` log macros.
 | `azure_monitor_exporter.metrics.msg_to_data_count` | Current number of message-to-data mappings. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
 | `azure_monitor_exporter.metrics.log_entries_too_large` | Number of log entries rejected for exceeding batch size limit. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
 | `azure_monitor_exporter.metrics.heartbeats` | Number of heartbeat sends attempted/successful. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
-| `azure_monitor_exporter.metrics.transform_failures` | Number of log records that failed JSON serialization during transform. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/transformer.rs` |
 
 ## Logs
 


### PR DESCRIPTION
The `transform_failures` counter and its `add_transform_failures()` helper were declared but never called from any production code. The transformer is infallible (`convert_to_log_analytics` returns `Vec<Bytes>`, not `Result`), so there is no code path that could increment this counter.

This PR removes:
- The `transform_failures: Counter<u64>` field from `AzureMonitorExporterMetrics`
- The `add_transform_failures()` mutation helper
- The corresponding entry in `telemetry.md`