### PR TITLE
feat(fake_data_generator): Add SUT saturation benchmark

### DIFF
--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/README.md
@@ -1,0 +1,53 @@
+# Fake Data Generator -- SUT Saturation Benchmarks
+
+## Purpose
+
+Verify that a **single fake-gen sender core can saturate a single
+`df_engine` (SUT) core** over OTLP gRPC, so that performance tests
+don't need multiple load-generator cores.
+
+```text
+  sender (1 core)           SUT (1 core)            backend (1 core)
+  fake-gen -> OTLP-export --> OTLP-recv -> OTLP-export --> OTLP-recv -> noop
+       :8080                     :8081                      :8082
+```
+
+## Configs (`bench/`)
+
+| File                        | Role        | Pipeline                          |
+|-----------------------------|-------------|-----------------------------------|
+| `sender-static-fresh.yaml`  | Load gen    | fake-gen(fresh) -> OTLP export    |
+| `sender-static-pregen.yaml` | Load gen    | fake-gen(pregen) -> OTLP export   |
+| `sut-otlp-forward.yaml`     | SUT         | OTLP recv -> OTLP export          |
+| `backend-noop.yaml`         | Backend     | OTLP recv -> noop                 |
+
+## Quick start
+
+```bash
+cd rust/otap-dataflow
+cargo build --release
+bash crates/core-nodes/src/receivers/fake_data_generator/bench/bench.sh
+```
+
+---
+
+## Results
+
+Apple M3 Pro (14 cores, 24 GB), 1 pipeline core per process, release
+build, logs only. Averaged over 4 runs.
+
+| Config              | Throughput       | Sender core | SUT core     |
+|---------------------|------------------|-------------|--------------|
+| static/fresh 1KB    | ~480 K logs/sec  | ~82 %       | **~97 %**    |
+| static/pregen 1KB   | ~500 K logs/sec  | ~66 %       | **~95 %**    |
+
+---
+
+## Conclusion
+
+**Use `static` + `pre_generated` + `log_body_size_bytes: 1024`.**
+
+This configuration saturates the SUT to ~95 % while consuming only
+~66 % of a single sender core. `pre_generated` uses ~16 % less sender
+CPU than `fresh` (~66 % vs ~82 %) at similar throughput, leaving more
+headroom. One load-gen core is sufficient!

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/bench/backend-noop.yaml
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/bench/backend-noop.yaml
@@ -1,0 +1,29 @@
+version: otel_dataflow/v1
+engine:
+  http_admin:
+    bind_address: "127.0.0.1:8082"
+groups:
+  default:
+    pipelines:
+      main:
+        policies:
+          channel_capacity:
+            control:
+              node: 100
+              pipeline: 100
+            pdata: 128
+
+        nodes:
+          receiver:
+            type: receiver:otlp
+            config:
+              protocols:
+                grpc:
+                  listening_addr: "127.0.0.1:4319"
+
+          exporter:
+            type: exporter:noop
+
+        connections:
+          - from: receiver
+            to: exporter

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/bench/bench.sh
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/bench/bench.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Fake Data Generator — SUT saturation benchmark.
+# Measures whether 1 sender core (fake-gen → OTLP export) can saturate
+# 1 SUT core (OTLP recv → OTLP export forwarding) over gRPC.
+#
+# Setup: 3 processes, 1 core each:
+#   sender(:8080) → SUT(:8081) → backend(:8082)
+#
+# Prerequisites:
+#   - Release build: cargo build --release
+#   - No other engine instances running on ports 8080–8082, 4317, 4319
+#
+# Usage (from rust/otap-dataflow/):
+#   bash crates/core-nodes/src/receivers/fake_data_generator/bench/bench.sh
+#
+# Each test runs for ~40s. Full suite takes ~3 minutes.
+
+set -eo pipefail
+BENCH_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$BENCH_DIR/../../../../.."  # rust/otap-dataflow/
+
+SETTLE=25
+SAMPLE=15
+
+cleanup() { pkill -f df_engine 2>/dev/null || true; sleep 2; }
+trap cleanup EXIT
+
+run_saturation() {
+  local label=$1 sender_config=$2
+
+  cargo run --release -- --config "$BENCH_DIR/backend-noop.yaml" --num-cores 1 >/dev/null 2>&1 &
+  local BACKEND=$!; sleep 2
+  cargo run --release -- --config "$BENCH_DIR/sut-otlp-forward.yaml" --num-cores 1 >/dev/null 2>&1 &
+  local SUT=$!; sleep 3
+  cargo run --release -- --config "$sender_config" --num-cores 1 >/dev/null 2>&1 &
+  local SENDER=$!; sleep $SETTLE
+
+  local sm=$(curl -s http://127.0.0.1:8080/metrics)
+  local em=$(curl -s http://127.0.0.1:8081/metrics)
+  local sender_cpu=$(echo "$sm" | awk '/^cpu_utilization\{set="pipeline/{print $2}')
+  local sut_cpu=$(echo "$em" | awk '/^cpu_utilization\{set="pipeline/{print $2}')
+  local logs1=$(echo "$sm" | awk '/^logs_produced\{/{print $2}')
+  sleep $SAMPLE
+  sm=$(curl -s http://127.0.0.1:8080/metrics)
+  local logs2=$(echo "$sm" | awk '/^logs_produced\{/{print $2}')
+  local rps=$(( (${logs2:-0} - ${logs1:-0}) / SAMPLE ))
+  local s_pct=$(echo "scale=1; ${sender_cpu:-0} * 100" | bc)
+  local e_pct=$(echo "scale=1; ${sut_cpu:-0} * 100" | bc)
+
+  printf "%-35s %10s %10s %10s\n" "$label" "$rps" "${s_pct}%" "${e_pct}%"
+  kill $SENDER $SUT $BACKEND 2>/dev/null || true; wait 2>/dev/null || true; sleep 3
+}
+
+echo ""
+echo "================================================================="
+echo " SUT saturation: sender → SUT(otlp-recv → otlp-export) → backend"
+echo " 1 core each, ${SETTLE}s settle, ${SAMPLE}s sample"
+echo "================================================================="
+printf "%-35s %10s %10s %10s\n" "Config" "Logs/sec" "Sender" "SUT"
+echo "-----------------------------------------------------------------"
+run_saturation "static/fresh 1KB"       "$BENCH_DIR/sender-static-fresh.yaml"
+run_saturation "static/pregen 1KB"      "$BENCH_DIR/sender-static-pregen.yaml"
+
+echo ""
+echo "Done."

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/bench/sender-static-fresh.yaml
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/bench/sender-static-fresh.yaml
@@ -1,0 +1,35 @@
+version: otel_dataflow/v1
+engine: {}
+groups:
+  default:
+    pipelines:
+      main:
+        policies:
+          channel_capacity:
+            control:
+              node: 100
+              pipeline: 100
+            pdata: 128
+
+        nodes:
+          receiver:
+            type: receiver:traffic_generator
+            config:
+              data_source: static
+              generation_strategy: fresh
+              traffic_config:
+                signals_per_second: null
+                max_batch_size: 50
+                metric_weight: 0
+                trace_weight: 0
+                log_weight: 1
+                log_body_size_bytes: 1024
+
+          exporter:
+            type: exporter:otlp_grpc
+            config:
+              grpc_endpoint: "http://127.0.0.1:4317"
+
+        connections:
+          - from: receiver
+            to: exporter

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/bench/sender-static-pregen.yaml
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/bench/sender-static-pregen.yaml
@@ -1,0 +1,35 @@
+version: otel_dataflow/v1
+engine: {}
+groups:
+  default:
+    pipelines:
+      main:
+        policies:
+          channel_capacity:
+            control:
+              node: 100
+              pipeline: 100
+            pdata: 128
+
+        nodes:
+          receiver:
+            type: receiver:traffic_generator
+            config:
+              data_source: static
+              generation_strategy: pre_generated
+              traffic_config:
+                signals_per_second: null
+                max_batch_size: 50
+                metric_weight: 0
+                trace_weight: 0
+                log_weight: 1
+                log_body_size_bytes: 1024
+
+          exporter:
+            type: exporter:otlp_grpc
+            config:
+              grpc_endpoint: "http://127.0.0.1:4317"
+
+        connections:
+          - from: receiver
+            to: exporter

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/bench/sut-otlp-forward.yaml
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/bench/sut-otlp-forward.yaml
@@ -1,0 +1,31 @@
+version: otel_dataflow/v1
+engine:
+  http_admin:
+    bind_address: "127.0.0.1:8081"
+groups:
+  default:
+    pipelines:
+      main:
+        policies:
+          channel_capacity:
+            control:
+              node: 100
+              pipeline: 100
+            pdata: 128
+
+        nodes:
+          receiver:
+            type: receiver:otlp
+            config:
+              protocols:
+                grpc:
+                  listening_addr: "127.0.0.1:4317"
+
+          exporter:
+            type: exporter:otlp_grpc
+            config:
+              grpc_endpoint: "http://127.0.0.1:4319"
+
+        connections:
+          - from: receiver
+            to: exporter


### PR DESCRIPTION
## Summary

Add a benchmark script and configs to measure whether the fake data generator can saturate a `df_engine` (SUT) over OTLP gRPC using a single core.

Part of #2540

## Setup

3 processes, 1 pipeline core each:

```
sender(fake-gen → OTLP) → SUT(OTLP recv → OTLP export) → backend(OTLP recv → noop)
     :8080                      :8081                           :8082
```

## Results (Apple M3 Pro)

| Config              | Throughput       | Sender core | SUT core     |
|---------------------|------------------|-------------|--------------|
| static/fresh 1KB    | ~480 K logs/sec  | ~82 %       | **~97 %**    |
| static/pregen 1KB   | ~500 K logs/sec  | ~66 %       | **~95 %**    |

**Conclusion:** `static` + `pre_generated` saturates the SUT to ~95% while using only ~66% of 1 sender core. No need for multi-core load generators.

## Files added

| File | Purpose |
|------|---------|
| `fake_data_generator/README.md` | Benchmark purpose, configs, results, conclusion |
| `fake_data_generator/bench/bench.sh` | Automated benchmark (~3 min) |
| `bench/sender-static-fresh.yaml` | Sender: fake-gen(fresh) → OTLP |
| `bench/sender-static-pregen.yaml` | Sender: fake-gen(pregen) → OTLP |
| `bench/sut-otlp-forward.yaml` | SUT: OTLP recv → OTLP export |
| `bench/backend-noop.yaml` | Backend: OTLP recv → noop |