### PR TITLE
Add batch_uncompressed_size metric to Azure Monitor exporter

### DIFF
--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs
@@ -207,6 +207,10 @@ impl AzureMonitorExporter {
             None => return Ok(()), // No pending batch - nothing to do
         };
 
+        self.metrics
+            .borrow_mut()
+            .add_batch_uncompressed_size(pending_batch.uncompressed_size as f64);
+
         let client = self.client_pool.take();
         if let Some(completed_export) = self
             .in_flight_exports

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/gzip_batcher.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/gzip_batcher.rs
@@ -72,6 +72,8 @@ pub struct GzipResult {
     pub row_count: u64,
     /// Number of gzip sync flushes performed while building this batch.
     pub flush_count: usize,
+    /// Total uncompressed size of the JSON payload in bytes (including structural bytes).
+    pub uncompressed_size: usize,
 }
 
 impl GzipBatcher {
@@ -197,6 +199,7 @@ impl GzipBatcher {
 
         let row_count = self.row_count;
         let flush_count = self.flush_count;
+        let uncompressed_size = self.total_uncompressed_size + 1; // +1 for ']'
 
         // Reset state
         self.remaining_size = TARGET_COMPRESSED_LIMIT;
@@ -210,6 +213,7 @@ impl GzipBatcher {
             compressed_data: Bytes::from(compressed_data),
             row_count,
             flush_count,
+            uncompressed_size,
         });
 
         Ok(FinalizeResult::Ok)

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/metrics.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/metrics.rs
@@ -73,6 +73,10 @@ pub struct AzureMonitorExporterMetrics {
     /// Recorded once per batch; HTTP retries do not produce additional observations.
     #[metric(unit = "By")]
     pub batch_size: Mmsc,
+    /// Uncompressed batch size in bytes (min/max/sum/count).
+    /// Recorded once per batch, before compression.
+    #[metric(unit = "By")]
+    pub batch_uncompressed_size: Mmsc,
     /// Current number of in-flight export requests.
     #[metric(unit = "{export}")]
     pub in_flight_exports: Gauge<u64>,
@@ -202,6 +206,13 @@ impl AzureMonitorExporterMetricsTracker {
         self.metrics.batch_size.get()
     }
 
+    /// Get the uncompressed batch size snapshot (min/max/sum/count) in bytes.
+    #[inline]
+    #[must_use]
+    pub fn batch_uncompressed_size(&self) -> MmscSnapshot {
+        self.metrics.batch_uncompressed_size.get()
+    }
+
     /// Get the current in-flight exports gauge value.
     #[inline]
     #[must_use]
@@ -288,10 +299,16 @@ impl AzureMonitorExporterMetricsTracker {
         self.metrics.auth_failures.inc();
     }
 
-    /// Record a batch size observation in bytes.
+    /// Record a compressed batch size observation in bytes.
     #[inline]
     pub fn add_batch_size(&mut self, size_bytes: f64) {
         self.metrics.batch_size.record(size_bytes);
+    }
+
+    /// Record an uncompressed batch size observation in bytes.
+    #[inline]
+    pub fn add_batch_uncompressed_size(&mut self, size_bytes: f64) {
+        self.metrics.batch_uncompressed_size.record(size_bytes);
     }
 
     /// Set the current number of in-flight exports.

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/telemetry.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/telemetry.md
@@ -24,6 +24,7 @@ by the crate and log events emitted via `otel_*` log macros.
 | `azure_monitor_exporter.metrics.auth_failures` | Number of failed authentication attempts. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/auth.rs` |
 | `azure_monitor_exporter.metrics.auth_success_latency` | Authentication success latency in milliseconds (min/max/sum/count). | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/auth.rs` |
 | `azure_monitor_exporter.metrics.batch_size` | Compressed batch size in bytes (min/max/sum/count). | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs` |
+| `azure_monitor_exporter.metrics.batch_uncompressed_size` | Uncompressed batch size in bytes (min/max/sum/count). | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
 | `azure_monitor_exporter.metrics.in_flight_exports` | Current number of in-flight export requests. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
 | `azure_monitor_exporter.metrics.batch_to_msg_count` | Current number of batch-to-message mappings. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
 | `azure_monitor_exporter.metrics.msg_to_batch_count` | Current number of message-to-batch mappings. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |


### PR DESCRIPTION
Adds an Mmsc metric that tracks the uncompressed (pre-gzip) size of each batch sent to Azure Monitor, complementing the existing `batch_size` metric which tracks compressed size. Together, these enable computing compression ratios (`sum(batch_size) / sum(batch_uncompressed_size)`).

**Changes:**
- **gzip_batcher.rs**: Add `uncompressed_size` field to `GzipResult`, computed from the batcher's existing `total_uncompressed_size` tracking (+1 for the closing `]`).
- **metrics.rs**: Add `batch_uncompressed_size: Mmsc` metric and `add_batch_uncompressed_size()` helper.
- **exporter.rs**: Record the metric in `queue_pending_batch()`, once per batch.
- **telemetry.md**: Add metric entry.