### PR TITLE
fix(query_engine): remove cross-workspace path dep that broke external git consumers

### DIFF
--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/Cargo.toml
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/Cargo.toml
@@ -24,8 +24,6 @@ criterion = { workspace = true }
 opentelemetry-proto = { workspace = true }
 prost = { workspace = true }
 
-otap-df-pdata = { path = "../../../otap-dataflow/crates/pdata", features = ["testing"] }
-
 [[bench]]
 name = "extend"
 harness = false

--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/benches/extend.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/benches/extend.rs
@@ -3,12 +3,71 @@
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use data_engine_recordset_otlp_bridge::*;
-use otap_df_pdata::testing::fixtures::logs_with_varying_attributes_and_properties;
+use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
+use opentelemetry_proto::tonic::common::v1::any_value::Value;
+use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue};
+use opentelemetry_proto::tonic::logs::v1::{LogRecord, ResourceLogs, ScopeLogs};
 use prost::Message;
 
+/// Generate a batch of synthetic log records with varying attributes and
+/// severity levels.  This is a self-contained replacement for the fixture that
+/// previously lived in `otap-df-pdata` so that the benchmark does not introduce
+/// a cross-workspace dependency.
 fn generate_logs_batch(batch_size: usize) -> Vec<u8> {
-    let logs_data = logs_with_varying_attributes_and_properties(batch_size);
-    logs_data.encode_to_vec()
+    let severity_levels: [(i32, &str); 4] = [
+        (1, "TRACE"), // SeverityNumber::Trace
+        (5, "DEBUG"), // SeverityNumber::Debug
+        (9, "INFO"),  // SeverityNumber::Info
+        (13, "WARN"), // SeverityNumber::Warn
+    ];
+
+    let log_records: Vec<LogRecord> = (0..batch_size)
+        .map(|i| {
+            let namespace = match i % 3 {
+                0 => "main",
+                1 => "otap_dataflow_engine",
+                _ => "arrow::array",
+            };
+
+            let attributes = vec![
+                KeyValue {
+                    key: "code.namespace".into(),
+                    value: Some(AnyValue {
+                        value: Some(Value::StringValue(namespace.into())),
+                    }),
+                },
+                KeyValue {
+                    key: "code.line.number".into(),
+                    value: Some(AnyValue {
+                        value: Some(Value::IntValue((i % 5) as i64)),
+                    }),
+                },
+            ];
+
+            let (severity_number, severity_text) = severity_levels[i % 4];
+
+            LogRecord {
+                time_unix_nano: i as u64,
+                severity_number,
+                severity_text: severity_text.into(),
+                event_name: format!("event {i}"),
+                attributes,
+                ..Default::default()
+            }
+        })
+        .collect();
+
+    let request = ExportLogsServiceRequest {
+        resource_logs: vec![ResourceLogs {
+            scope_logs: vec![ScopeLogs {
+                log_records,
+                ..Default::default()
+            }],
+            ..Default::default()
+        }],
+    };
+
+    request.encode_to_vec()
 }
 
 fn bench_log_pipeline(


### PR DESCRIPTION
## Summary

Fixes #2560

- Remove the `otap-df-pdata` dev-dependency from `engine-recordset-otlp-bridge` that created a circular cross-workspace reference between `query_engine` and `otap-dataflow`
- Inline the benchmark fixture using `opentelemetry-proto` types already available as dev-dependencies

## Root Cause

PR #2453 added `data_engine_recordset_otlp_bridge` as a workspace dependency in `otap-dataflow`, which meant `otap-dataflow` now referenced crates in the `query_engine` workspace. Meanwhile, `engine-recordset-otlp-bridge` (a `query_engine` member) had a dev-dependency pointing back into `otap-dataflow`:

```toml
# rust/experimental/query_engine/engine-recordset-otlp-bridge/Cargo.toml
[dev-dependencies]
otap-df-pdata = { path = "../../../otap-dataflow/crates/pdata", features = ["testing"] }
```

This bidirectional cross-workspace reference causes cargo's package discovery to fail when resolving any `otap-dataflow` crate as an external git dependency:

```
error: no matching package named `otap-df-pdata` found
location searched: Git repository .../otel-arrow.git?rev=...
```

## Fix

**`engine-recordset-otlp-bridge/Cargo.toml`** — Removed the `otap-df-pdata` dev-dependency.

**`engine-recordset-otlp-bridge/benches/extend.rs`** — Replaced the imported `logs_with_varying_attributes_and_properties` fixture with a self-contained `generate_logs_batch` function that builds equivalent `ExportLogsServiceRequest` protobuf bytes using `opentelemetry-proto` types (already a dev-dependency). The benchmark logic is otherwise unchanged.

## Validation

- `cargo check --workspace` in `query_engine` — passes
- `cargo bench -p data_engine_recordset_otlp_bridge --no-run` — benchmark compiles
- `cargo xtask check` in `otap-dataflow` — structure checks, fmt, clippy (0 warnings), all tests pass
- Tested as external git dep consumer from a downstream project — cargo resolves all `otap-df-*` packages successfully