### PR TITLE
azure monitor exporter: move batch size metrics to one place

### DIFF
--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs
@@ -193,8 +193,6 @@ impl LogsIngestionClient {
     /// * `Ok(Duration)` - Total time spent (including retries) if successful
     /// * `Err(String)` - Error message if all retries exhausted or non-retryable error
     pub async fn export(&mut self, body: Bytes) -> Result<Duration, Error> {
-        self.metrics.borrow_mut().add_batch_size(body.len() as f64);
-
         let mut attempt = 0u32;
         let mut rng = SmallRng::seed_from_u64(
             std::time::SystemTime::now()

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs
@@ -210,6 +210,9 @@ impl AzureMonitorExporter {
         self.metrics
             .borrow_mut()
             .add_batch_uncompressed_size(pending_batch.uncompressed_size as f64);
+        self.metrics
+            .borrow_mut()
+            .add_batch_size(pending_batch.compressed_data.len() as f64);
 
         let client = self.client_pool.take();
         if let Some(completed_export) = self


### PR DESCRIPTION
# Change Summary

move add_batch_size metric call to queue_export where uncompressed size is also recorded.

<!--
Replace with a brief summary of the change in this PR
-->

## What issue does this PR close?

<!--
We highly recommend correlation of every PR to an issue
-->

* Closes #NNN

## How are these changes tested?

## Are there any user-facing changes?

 <!-- If yes, provide further info below -->
