### PR TITLE
fix: Fix flaky exit from validation tests using Go Collector

### DIFF
--- a/rust/otap-dataflow/crates/pdata/src/validation/collector.rs
+++ b/rust/otap-dataflow/crates/pdata/src/validation/collector.rs
@@ -105,12 +105,26 @@ impl CollectorProcess {
             desc: "wait",
         })?;
 
-        status
-            .success()
-            .then_some(())
-            .ok_or_else(|| Error::BadExitStatus {
-                code: status.code(),
-            })
+        // Accept either a clean exit or signal-based termination from
+        // our SIGTERM. On Unix, a process killed by a signal has
+        // code() == None and success() == false, which is expected
+        // after we send SIGTERM.
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::ExitStatusExt;
+            if status.success() || status.signal() == Some(nix::libc::SIGTERM) {
+                return Ok(());
+            }
+        }
+
+        #[cfg(not(unix))]
+        if status.success() {
+            return Ok(());
+        }
+
+        Err(Error::BadExitStatus {
+            code: status.code(),
+        })
     }
 
     /// Start a collector with the given configuration


### PR DESCRIPTION
# Change Summary

Attempt to resolve flaky test errors like https://github.com/open-telemetry/otel-arrow/actions/runs/24095193797/job/70291785363

> stderr ───
    [Collector stderr] 2026-04-07T17:44:05.061Z	info	otelconftelemetry/metrics.go:25	Internal metrics telemetry disabled	{"resource": {"service.instance.id": "7d185158-8cea-440f-a698-0cf50e1fc669", "service.name": "otelarrowcol", "service.version": "0.47.0"}}
    [Collector stderr] 2026-04-07T17:44:05.062Z	warn	builders/builders.go:40	"otlp" alias is deprecated; use "otlp_grpc" instead	{"resource": {"service.instance.id": "7d185158-8cea-440f-a698-0cf50e1fc669", "service.name": "otelarrowcol", "service.version": "0.47.0"}, "otelcol.component.id": "otlp", "otelcol.component.kind": "exporter", "otelcol.signal": "logs"}
    [Collector stderr] 2026-04-07T17:44:05.064Z	info	service@v0.149.0/service.go:241	Starting otelarrowcol...	{"resource": {"service.instance.id": "7d185158-8cea-440f-a698-0cf50e1fc669", "service.name": "otelarrowcol", "service.version": "0.47.0"}, "Version": "0.47.0", "NumCPU": 4}
    [Collector stderr] 2026-04-07T17:44:05.064Z	info	extensions/extensions.go:40	Starting extensions...	{"resource": {"service.instance.id": "7d185158-8cea-440f-a698-0cf50e1fc669", "service.name": "otelarrowcol", "service.version": "0.47.0"}}
    [Collector stderr] 2026-04-07T17:44:05.065Z	info	otlpreceiver@v0.149.0/otlp.go:120	Starting GRPC server	{"resource": {"service.instance.id": "7d185158-8cea-440f-a698-0cf50e1fc669", "service.name": "otelarrowcol", "service.version": "0.47.0"}, "otelcol.component.id": "otlp", "otelcol.component.kind": "receiver", "endpoint": "127.0.0.1:22746"}
    [Collector stderr] 2026-04-07T17:44:05.065Z	info	service@v0.149.0/service.go:264	Everything is ready. Begin running and processing data.	{"resource": {"service.instance.id": "7d185158-8cea-440f-a698-0cf50e1fc669", "service.name": "otelarrowcol", "service.version": "0.47.0"}}
    Sending SIGTERM to collector process 43870

> thread 'validation::otlp::tests::test_otlp_logs_single_request' (43869) panicked at crates/pdata/src/validation/scenarios.rs:34:13:
    Test failed: BadExitStatus { code: None }

The test doesn't fail for actual workload assertions, but simply unexpected process status code on exit. This should be an accepted condition.

## What issue does this PR close?

N/A

## How are these changes tested?

CI

## Are there any user-facing changes?

No