### PR TITLE
task(temporal_reaggregation_processor): Pull otap id state out to its own construct and remove passthrough batch state from the processor

### DIFF
--- a/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/mod.rs
@@ -147,6 +147,52 @@ pub fn create_temporal_reaggregation_processor(
     ))
 }
 
+/// A grouping of counters used to track the current otap id for each table.
+/// This is split out from [`IdentityState`] because the passthrough batch doesn't
+/// have a need for all of the hashmaps used to aggregate, but both batches need
+/// to track these ids.
+struct OtapIdState {
+    resource: u16,
+    scope: u16,
+    metric: u16,
+    ndp: u32,
+    hdp: u32,
+    ehdp: u32,
+    sdp: u32,
+    exemplar: u32,
+    hdp_exemplar: u32,
+    ehdp_exemplar: u32,
+}
+impl OtapIdState {
+    fn new() -> Self {
+        Self {
+            resource: 0,
+            scope: 0,
+            metric: 0,
+            ndp: 0,
+            hdp: 0,
+            ehdp: 0,
+            sdp: 0,
+            exemplar: 0,
+            hdp_exemplar: 0,
+            ehdp_exemplar: 0,
+        }
+    }
+
+    fn clear(&mut self) {
+        self.resource = 0;
+        self.scope = 0;
+        self.metric = 0;
+        self.ndp = 0;
+        self.hdp = 0;
+        self.ehdp = 0;
+        self.sdp = 0;
+        self.exemplar = 0;
+        self.hdp_exemplar = 0;
+        self.ehdp_exemplar = 0;
+    }
+}
+
 /// State for the current in-progress batch. This is all the stuff that has to
 /// be cleared between batches
 struct IdentityState {
@@ -154,17 +200,7 @@ struct IdentityState {
     scopes: HashMap<ScopeId<'static>, u16>,
     metrics: HashMap<MetricId<'static>, u16>,
     streams: HashMap<StreamId<'static>, StreamMeta>,
-
-    next_id_resource: u16,
-    next_id_scope: u16,
-    next_id_metric: u16,
-    next_id_ndp: u32,
-    next_id_hdp: u32,
-    next_id_ehdp: u32,
-    next_id_sdp: u32,
-    next_id_ndp_exemplar: u32,
-    next_id_hdp_exemplar: u32,
-    next_id_ehdp_exemplar: u32,
+    next: OtapIdState,
 }
 
 impl IdentityState {
@@ -174,17 +210,7 @@ impl IdentityState {
             scopes: HashMap::new(),
             metrics: HashMap::new(),
             streams: HashMap::new(),
-
-            next_id_resource: 0,
-            next_id_scope: 0,
-            next_id_metric: 0,
-            next_id_ndp: 0,
-            next_id_hdp: 0,
-            next_id_ehdp: 0,
-            next_id_sdp: 0,
-            next_id_ndp_exemplar: 0,
-            next_id_hdp_exemplar: 0,
-            next_id_ehdp_exemplar: 0,
+            next: OtapIdState::new(),
         }
     }
 
@@ -193,16 +219,7 @@ impl IdentityState {
         self.scopes.clear();
         self.metrics.clear();
         self.streams.clear();
-        self.next_id_resource = 0;
-        self.next_id_scope = 0;
-        self.next_id_metric = 0;
-        self.next_id_ndp = 0;
-        self.next_id_hdp = 0;
-        self.next_id_ehdp = 0;
-        self.next_id_sdp = 0;
-        self.next_id_ndp_exemplar = 0;
-        self.next_id_hdp_exemplar = 0;
-        self.next_id_ehdp_exemplar = 0;
+        self.next.clear();
     }
 }
 
@@ -213,12 +230,18 @@ impl IdentityState {
 /// stream. On each timer tick it flushes the accumulated state as an
 /// [`OtapArrowRecords`] batch.
 pub struct TemporalReaggregationProcessor {
+    /// Processor metrics
     metrics: MetricSet<TemporalReaggregationMetrics>,
+
+    /// The collection period for aggregating metrics before emitting a batch
     collection_period: Duration,
+
     /// Maximum number of unique streams allowed in a single aggregating batch.
     max_stream_cardinality: u16,
+
     /// Whether the periodic flush timer has been started.
     timer_started: bool,
+
     // Reusable byte buffer for computing attribute hashes.
     hash_buf: HashBuffer,
 
@@ -226,16 +249,12 @@ pub struct TemporalReaggregationProcessor {
     /// integer Ids. It is outside the scope of [Self::builder] to figure out
     /// what ids to assign, so we do that here. Like the builder, this is reset
     /// on every flush trigger.
-    id_state: IdentityState,
+    identities: IdentityState,
 
     /// The in progress aggregated metrics builder. All the data which can be
     /// aggregated for each inbound batch is accumulated here until a flush
     /// trigger is hit and the builder is reset.
     builder: MetricSignalBuilder,
-
-    /// Reusable state for the passthrough batch. Cleared before each use in
-    /// passthrough output.
-    passthrough_state: IdentityState,
 
     /// Contexts for all of the inbound batches that have not been fully
     /// acked or nacked
@@ -343,9 +362,8 @@ impl TemporalReaggregationProcessor {
             max_stream_cardinality: config.max_stream_cardinality.get(),
             timer_started: false,
             hash_buf: HashBuffer::new(),
-            id_state: IdentityState::new(),
+            identities: IdentityState::new(),
             builder: MetricSignalBuilder::new(),
-            passthrough_state: IdentityState::new(),
             inbound_batches: SlotState::new(config.inbound_request_limit.get()),
             pending_flush: Vec::new(),
             outbound_batches: SlotState::new(config.outbound_request_limit.get()),
@@ -768,7 +786,7 @@ impl TemporalReaggregationProcessor {
         &mut self,
         view: &V,
     ) -> Result<AggregationResult, AggregationError> {
-        self.passthrough_state.clear();
+        let mut next_pt_id = OtapIdState::new();
         let mut pt_builder = MetricSignalBuilder::new();
 
         for resource_metrics in view.resources() {
@@ -838,7 +856,7 @@ impl TemporalReaggregationProcessor {
                         let res_otap_id = match pt_resource_id {
                             Some(x) => x,
                             None => {
-                                let id = next_id_16(&mut self.passthrough_state.next_id_resource)?;
+                                let id = next_id_16(&mut next_pt_id.resource)?;
                                 if let Some(ref resource) = resource {
                                     pt_builder.append_resource(id, resource);
                                 }
@@ -850,7 +868,7 @@ impl TemporalReaggregationProcessor {
                         let scp_otap_id = match pt_scope_id {
                             Some(x) => x,
                             None => {
-                                let id = next_id_16(&mut self.passthrough_state.next_id_scope)?;
+                                let id = next_id_16(&mut next_pt_id.scope)?;
                                 if let Some(ref scope) = scope {
                                     pt_builder.append_scope(id, scope);
                                 }
@@ -859,8 +877,7 @@ impl TemporalReaggregationProcessor {
                             }
                         };
 
-                        let otap_metric_id =
-                            next_id_16(&mut self.passthrough_state.next_id_metric)?;
+                        let otap_metric_id = next_id_16(&mut next_pt_id.metric)?;
                         let (data_type, aggregation_temporality, is_monotonic) =
                             identity::metric_type_info_of(&data);
                         pt_builder.append_metric(
@@ -877,13 +894,18 @@ impl TemporalReaggregationProcessor {
                             scope_schema_url,
                         );
 
-                        self.append_passthrough_datapoints(&mut pt_builder, &data, otap_metric_id)?;
+                        self.append_passthrough_datapoints(
+                            &mut pt_builder,
+                            &mut next_pt_id,
+                            &data,
+                            otap_metric_id,
+                        )?;
                     }
                 }
             }
         }
 
-        if self.passthrough_state.next_id_metric == 0 {
+        if next_pt_id.metric == 0 {
             return Ok(AggregationResult::AllAggregated);
         }
 
@@ -895,14 +917,14 @@ impl TemporalReaggregationProcessor {
         resource_id: ResourceId,
         view: Option<&R>,
     ) -> Result<u16, AggregationError> {
-        match self.id_state.resources.entry_ref(&resource_id) {
+        match self.identities.resources.entry_ref(&resource_id) {
             Occupied(o) => Ok(*o.get()),
             Vacant(v) => {
-                let id = self.id_state.next_id_resource;
+                let id = self.identities.next.resource;
                 if id == u16::MAX {
                     return Err(AggregationError::IdOverflow);
                 }
-                self.id_state.next_id_resource += 1;
+                self.identities.next.resource += 1;
                 if let Some(view) = view {
                     self.builder.append_resource(id, view);
                 }
@@ -918,14 +940,14 @@ impl TemporalReaggregationProcessor {
         view: Option<&S>,
     ) -> Result<u16, AggregationError> {
         let lookup = ScopeIdRef(&scope_id.clone());
-        match self.id_state.scopes.entry_ref(&lookup) {
+        match self.identities.scopes.entry_ref(&lookup) {
             Occupied(o) => Ok(*o.get()),
             Vacant(v) => {
-                let id = self.id_state.next_id_scope;
+                let id = self.identities.next.scope;
                 if id == u16::MAX {
                     return Err(AggregationError::IdOverflow);
                 }
-                self.id_state.next_id_scope += 1;
+                self.identities.next.scope += 1;
                 if let Some(view) = view {
                     self.builder.append_scope(id, view);
                 }
@@ -947,14 +969,14 @@ impl TemporalReaggregationProcessor {
         scope_schema_url: &[u8],
     ) -> Result<u16, AggregationError> {
         let lookup = MetricIdRef(&metric_id.clone());
-        match self.id_state.metrics.entry_ref(&lookup) {
+        match self.identities.metrics.entry_ref(&lookup) {
             Occupied(o) => Ok(*o.get()),
             Vacant(v) => {
-                let id = self.id_state.next_id_metric;
+                let id = self.identities.next.metric;
                 if id == u16::MAX {
                     return Err(AggregationError::IdOverflow);
                 }
-                self.id_state.next_id_metric += 1;
+                self.identities.next.metric += 1;
                 self.builder.append_metric(
                     id,
                     view,
@@ -1039,9 +1061,9 @@ impl TemporalReaggregationProcessor {
         otap_metric_id: u16,
     ) -> Result<(), AggregationError> {
         let time = dp.time_unix_nano();
-        let streams_len = self.id_state.streams.len();
+        let streams_len = self.identities.streams.len();
         let lookup = StreamIdRef(&stream_id.clone());
-        match self.id_state.streams.entry_ref(&lookup) {
+        match self.identities.streams.entry_ref(&lookup) {
             Occupied(mut o) => {
                 let s = o.get_mut();
                 if time > s.time_unix_nano {
@@ -1054,11 +1076,11 @@ impl TemporalReaggregationProcessor {
                 if streams_len >= self.max_stream_cardinality as usize {
                     return Err(AggregationError::StreamCardinalityExceeded);
                 }
-                let dp_id = self.id_state.next_id_ndp;
+                let dp_id = self.identities.next.ndp;
                 if dp_id == u32::MAX {
                     return Err(AggregationError::IdOverflow);
                 }
-                self.id_state.next_id_ndp += 1;
+                self.identities.next.ndp += 1;
                 let row_index = self.builder.append_number_dp(dp_id, otap_metric_id, dp);
                 _ = v.insert_with_key(
                     stream_id.into_owned(),
@@ -1079,9 +1101,9 @@ impl TemporalReaggregationProcessor {
         otap_metric_id: u16,
     ) -> Result<(), AggregationError> {
         let time = dp.time_unix_nano();
-        let streams_len = self.id_state.streams.len();
+        let streams_len = self.identities.streams.len();
         let lookup = StreamIdRef(&stream_id.clone());
-        match self.id_state.streams.entry_ref(&lookup) {
+        match self.identities.streams.entry_ref(&lookup) {
             Occupied(mut o) => {
                 let s = o.get_mut();
                 if time > s.time_unix_nano {
@@ -1094,11 +1116,11 @@ impl TemporalReaggregationProcessor {
                 if streams_len >= self.max_stream_cardinality as usize {
                     return Err(AggregationError::StreamCardinalityExceeded);
                 }
-                let dp_id = self.id_state.next_id_hdp;
+                let dp_id = self.identities.next.hdp;
                 if dp_id == u32::MAX {
                     return Err(AggregationError::IdOverflow);
                 }
-                self.id_state.next_id_hdp += 1;
+                self.identities.next.hdp += 1;
                 let row_index = self.builder.append_histogram_dp(dp_id, otap_metric_id, dp);
                 _ = v.insert_with_key(
                     stream_id.into_owned(),
@@ -1119,9 +1141,9 @@ impl TemporalReaggregationProcessor {
         otap_metric_id: u16,
     ) -> Result<(), AggregationError> {
         let time = dp.time_unix_nano();
-        let streams_len = self.id_state.streams.len();
+        let streams_len = self.identities.streams.len();
         let lookup = StreamIdRef(&stream_id.clone());
-        match self.id_state.streams.entry_ref(&lookup) {
+        match self.identities.streams.entry_ref(&lookup) {
             Occupied(mut o) => {
                 let s = o.get_mut();
                 if time > s.time_unix_nano {
@@ -1134,11 +1156,11 @@ impl TemporalReaggregationProcessor {
                 if streams_len >= self.max_stream_cardinality as usize {
                     return Err(AggregationError::StreamCardinalityExceeded);
                 }
-                let dp_id = self.id_state.next_id_ehdp;
+                let dp_id = self.identities.next.ehdp;
                 if dp_id == u32::MAX {
                     return Err(AggregationError::IdOverflow);
                 }
-                self.id_state.next_id_ehdp += 1;
+                self.identities.next.ehdp += 1;
                 let row_index = self
                     .builder
                     .append_exp_histogram_dp(dp_id, otap_metric_id, dp);
@@ -1161,9 +1183,9 @@ impl TemporalReaggregationProcessor {
         otap_metric_id: u16,
     ) -> Result<(), AggregationError> {
         let time = dp.time_unix_nano();
-        let streams_len = self.id_state.streams.len();
+        let streams_len = self.identities.streams.len();
         let lookup = StreamIdRef(&stream_id.clone());
-        match self.id_state.streams.entry_ref(&lookup) {
+        match self.identities.streams.entry_ref(&lookup) {
             Occupied(mut o) => {
                 let s = o.get_mut();
                 if time > s.time_unix_nano {
@@ -1176,11 +1198,11 @@ impl TemporalReaggregationProcessor {
                 if streams_len >= self.max_stream_cardinality as usize {
                     return Err(AggregationError::StreamCardinalityExceeded);
                 }
-                let dp_id = self.id_state.next_id_sdp;
+                let dp_id = self.identities.next.sdp;
                 if dp_id == u32::MAX {
                     return Err(AggregationError::IdOverflow);
                 }
-                self.id_state.next_id_sdp += 1;
+                self.identities.next.sdp += 1;
                 let row_index = self.builder.append_summary_dp(dp_id, otap_metric_id, dp);
                 _ = v.insert_with_key(
                     stream_id.into_owned(),
@@ -1199,6 +1221,7 @@ impl TemporalReaggregationProcessor {
     fn append_passthrough_datapoints<'a, D: DataView<'a>>(
         &mut self,
         pt_builder: &mut MetricSignalBuilder,
+        ids: &mut OtapIdState,
         data: &D,
         otap_metric_id: u16,
     ) -> Result<(), AggregationError> {
@@ -1206,38 +1229,30 @@ impl TemporalReaggregationProcessor {
             DataType::Gauge => {
                 if let Some(gauge) = data.as_gauge() {
                     for dp in gauge.data_points() {
-                        let dp_id = next_id_32(&mut self.passthrough_state.next_id_ndp)?;
+                        let dp_id = next_id_32(&mut ids.ndp)?;
                         let _ = pt_builder.append_number_dp(dp_id, otap_metric_id, &dp);
-                        pt_builder.append_number_dp_exemplars(
-                            dp_id,
-                            &dp,
-                            &mut self.passthrough_state.next_id_ndp_exemplar,
-                        )?;
+                        pt_builder.append_number_dp_exemplars(dp_id, &dp, &mut ids.exemplar)?;
                     }
                 }
             }
             DataType::Sum => {
                 if let Some(sum) = data.as_sum() {
                     for dp in sum.data_points() {
-                        let dp_id = next_id_32(&mut self.passthrough_state.next_id_ndp)?;
+                        let dp_id = next_id_32(&mut ids.ndp)?;
                         let _ = pt_builder.append_number_dp(dp_id, otap_metric_id, &dp);
-                        pt_builder.append_number_dp_exemplars(
-                            dp_id,
-                            &dp,
-                            &mut self.passthrough_state.next_id_ndp_exemplar,
-                        )?;
+                        pt_builder.append_number_dp_exemplars(dp_id, &dp, &mut ids.exemplar)?;
                     }
                 }
             }
             DataType::Histogram => {
                 if let Some(hist) = data.as_histogram() {
                     for dp in hist.data_points() {
-                        let dp_id = next_id_32(&mut self.passthrough_state.next_id_hdp)?;
+                        let dp_id = next_id_32(&mut ids.hdp)?;
                         let _ = pt_builder.append_histogram_dp(dp_id, otap_metric_id, &dp);
                         pt_builder.append_histogram_dp_exemplars(
                             dp_id,
                             &dp,
-                            &mut self.passthrough_state.next_id_hdp_exemplar,
+                            &mut ids.hdp_exemplar,
                         )?;
                     }
                 }
@@ -1245,12 +1260,12 @@ impl TemporalReaggregationProcessor {
             DataType::ExponentialHistogram => {
                 if let Some(exp) = data.as_exponential_histogram() {
                     for dp in exp.data_points() {
-                        let dp_id = next_id_32(&mut self.passthrough_state.next_id_ehdp)?;
+                        let dp_id = next_id_32(&mut ids.ehdp)?;
                         let _ = pt_builder.append_exp_histogram_dp(dp_id, otap_metric_id, &dp);
                         pt_builder.append_exp_histogram_dp_exemplars(
                             dp_id,
                             &dp,
-                            &mut self.passthrough_state.next_id_ehdp_exemplar,
+                            &mut ids.ehdp_exemplar,
                         )?;
                     }
                 }
@@ -1258,7 +1273,7 @@ impl TemporalReaggregationProcessor {
             DataType::Summary => {
                 if let Some(summary) = data.as_summary() {
                     for dp in summary.data_points() {
-                        let dp_id = next_id_32(&mut self.passthrough_state.next_id_sdp)?;
+                        let dp_id = next_id_32(&mut ids.sdp)?;
                         let _ = pt_builder.append_summary_dp(dp_id, otap_metric_id, &dp);
                     }
                 }
@@ -1268,7 +1283,7 @@ impl TemporalReaggregationProcessor {
     }
 
     fn clear_state(&mut self) {
-        self.id_state.clear();
+        self.identities.clear();
         self.builder.clear();
     }
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/mod.rs
@@ -151,6 +151,7 @@ pub fn create_temporal_reaggregation_processor(
 /// This is split out from [`IdentityState`] because the passthrough batch doesn't
 /// have a need for all of the hashmaps used to aggregate, but both batches need
 /// to track these ids.
+#[derive(Default)]
 struct OtapIdState {
     resource: u16,
     scope: u16,
@@ -163,25 +164,10 @@ struct OtapIdState {
     hdp_exemplar: u32,
     ehdp_exemplar: u32,
 }
-impl OtapIdState {
-    fn new() -> Self {
-        Self {
-            resource: 0,
-            scope: 0,
-            metric: 0,
-            ndp: 0,
-            hdp: 0,
-            ehdp: 0,
-            sdp: 0,
-            ndp_exemplar: 0,
-            hdp_exemplar: 0,
-            ehdp_exemplar: 0,
-        }
-    }
-}
 
 /// State for the current in-progress batch. This is all the stuff that has to
 /// be cleared between batches
+#[derive(Default)]
 struct IdentityState {
     resources: HashMap<ResourceId, u16>,
     scopes: HashMap<ScopeId<'static>, u16>,
@@ -192,13 +178,7 @@ struct IdentityState {
 
 impl IdentityState {
     fn new() -> Self {
-        Self {
-            resources: HashMap::new(),
-            scopes: HashMap::new(),
-            metrics: HashMap::new(),
-            streams: HashMap::new(),
-            next: OtapIdState::new(),
-        }
+        Self::default()
     }
 
     fn clear(&mut self) {
@@ -206,7 +186,7 @@ impl IdentityState {
         self.scopes.clear();
         self.metrics.clear();
         self.streams.clear();
-        self.next = OtapIdState::new();
+        self.next = OtapIdState::default();
     }
 }
 
@@ -773,7 +753,7 @@ impl TemporalReaggregationProcessor {
         &mut self,
         view: &V,
     ) -> Result<AggregationResult, AggregationError> {
-        let mut next_pt_id = OtapIdState::new();
+        let mut next_pt_id = OtapIdState::default();
         let mut pt_builder = MetricSignalBuilder::new();
 
         for resource_metrics in view.resources() {

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/mod.rs
@@ -159,7 +159,7 @@ struct OtapIdState {
     hdp: u32,
     ehdp: u32,
     sdp: u32,
-    exemplar: u32,
+    ndp_exemplar: u32,
     hdp_exemplar: u32,
     ehdp_exemplar: u32,
 }
@@ -173,23 +173,10 @@ impl OtapIdState {
             hdp: 0,
             ehdp: 0,
             sdp: 0,
-            exemplar: 0,
+            ndp_exemplar: 0,
             hdp_exemplar: 0,
             ehdp_exemplar: 0,
         }
-    }
-
-    fn clear(&mut self) {
-        self.resource = 0;
-        self.scope = 0;
-        self.metric = 0;
-        self.ndp = 0;
-        self.hdp = 0;
-        self.ehdp = 0;
-        self.sdp = 0;
-        self.exemplar = 0;
-        self.hdp_exemplar = 0;
-        self.ehdp_exemplar = 0;
     }
 }
 
@@ -219,7 +206,7 @@ impl IdentityState {
         self.scopes.clear();
         self.metrics.clear();
         self.streams.clear();
-        self.next.clear();
+        self.next = OtapIdState::new();
     }
 }
 
@@ -1231,7 +1218,7 @@ impl TemporalReaggregationProcessor {
                     for dp in gauge.data_points() {
                         let dp_id = next_id_32(&mut ids.ndp)?;
                         let _ = pt_builder.append_number_dp(dp_id, otap_metric_id, &dp);
-                        pt_builder.append_number_dp_exemplars(dp_id, &dp, &mut ids.exemplar)?;
+                        pt_builder.append_number_dp_exemplars(dp_id, &dp, &mut ids.ndp_exemplar)?;
                     }
                 }
             }
@@ -1240,7 +1227,7 @@ impl TemporalReaggregationProcessor {
                     for dp in sum.data_points() {
                         let dp_id = next_id_32(&mut ids.ndp)?;
                         let _ = pt_builder.append_number_dp(dp_id, otap_metric_id, &dp);
-                        pt_builder.append_number_dp_exemplars(dp_id, &dp, &mut ids.exemplar)?;
+                        pt_builder.append_number_dp_exemplars(dp_id, &dp, &mut ids.ndp_exemplar)?;
                     }
                 }
             }


### PR DESCRIPTION
# Change Summary

This is just a bit of cleanup to the temporal_reaggregation_processor to pull the minimum common state for building passthrough and aggregated batches out to its own type. I also:
- Removed the passthrough batch state since from the processor itself since the lifetime of that state is only per call to `process_view`.
- Delegate some boilerplate to a derived `Default::default` implementation

## What issue does this PR close?

* Part of #2422 

## How are these changes tested?

Unit.

## Are there any user-facing changes?

No.