### PR TITLE
 feat: Remove experimental-tls feature flag and make TLS always available 

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -376,6 +376,9 @@ jobs:
       - name: cargo check benchmarks --no-default-features
         run: cargo check -p benchmarks --benches --no-default-features
         working-directory: ./rust/${{ matrix.folder }}
+      - name: cargo test otap integration targets --no-run
+        run: cargo test -p otap-df-otap --tests --no-run
+        working-directory: ./rust/${{ matrix.folder }}
 
   # Required matrix combinations for test_and_coverage: otap-dataflow on ubuntu and windows
   test_and_coverage_required:

--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -251,9 +251,6 @@ unchecked-arithmetic = []
 # Dev/test tooling (fake data generator).
 dev-tools = ["otap-df-core-nodes/dev-tools"]
 
-# Experimental features
-experimental-tls = ["otap-df-otap/experimental-tls", "otap-df-core-nodes/experimental-tls"]
-
 # Cryptographic provider selection (mutually exclusive).
 # Exactly one must be enabled when using TLS or any rustls-backed dependency (e.g. reqwest).
 crypto-ring = ["otap-df-otap/crypto-ring"]

--- a/rust/otap-dataflow/configs/test-mtls.yaml
+++ b/rust/otap-dataflow/configs/test-mtls.yaml
@@ -9,7 +9,7 @@ groups:
         #
         # How to test:
         # 1. Generate certificates: ./scripts/generate-test-certs.sh
-        # 2. Start the collector: cargo run --features experimental-tls -- --config configs/test-mtls.yaml
+        # 2. Start the collector: cargo run -- --config configs/test-mtls.yaml
         # 3. Send test data to the receiver on https://127.0.0.1:4317 with client cert
 
         policies:

--- a/rust/otap-dataflow/crates/core-nodes/Cargo.toml
+++ b/rust/otap-dataflow/crates/core-nodes/Cargo.toml
@@ -66,7 +66,6 @@ weaver_resolver = { workspace = true, optional = true }
 weaver_semconv = { workspace = true, optional = true }
 
 [features]
-experimental-tls = ["otap-df-otap/experimental-tls"]
 dev-tools = ["dep:weaver_common", "dep:weaver_forge", "dep:weaver_resolved_schema", "dep:weaver_resolver", "dep:weaver_semconv"]
 bench = []
 

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs
@@ -135,47 +135,44 @@ impl OtlpHttpExporter {
             })?;
         }
 
-        #[cfg(feature = "experimental-tls")]
-        {
-            if let Some(tls) = &config.http.tls {
-                // server_name not currently supported
-                if let Some(_server_name) = &tls.server_name {
-                    return Err(ConfigError::InvalidUserConfig {
-                        error: "TLS configuration error: server_name_override is not supported by \
-                        the current Rust OTLP HTTP client implementation (reqwest/rustls) remove \
-                        server_name_override."
-                            .into(),
-                    });
-                }
+        if let Some(tls) = &config.http.tls {
+            // server_name not currently supported
+            if let Some(_server_name) = &tls.server_name {
+                return Err(ConfigError::InvalidUserConfig {
+                    error: "TLS configuration error: server_name_override is not supported by \
+                    the current Rust OTLP HTTP client implementation (reqwest/rustls) remove \
+                    server_name_override."
+                        .into(),
+                });
+            }
 
-                if let Some(true) = tls.insecure {
-                    // Keeping with the same behaviour in the golang collector: if this is
-                    // configured, but the endpoints are start with https, we still send the
-                    // request using https. Just warn about the ignored config mismatch.
-                    let wants_https = config.endpoint.starts_with("https://")
-                        || config
-                            .logs_endpoint
-                            .as_ref()
-                            .map(|e| e.starts_with("https://"))
-                            .unwrap_or(false)
-                        || config
-                            .metrics_endpoint
-                            .as_ref()
-                            .map(|e| e.starts_with("https://"))
-                            .unwrap_or(false)
-                        || config
-                            .traces_endpoint
-                            .as_ref()
-                            .map(|e| e.starts_with("https://"))
-                            .unwrap_or(false);
-                    if wants_https {
-                        otel_warn!(
-                            "otlp.exporter.http.validate_insecure_flag",
-                            message = "config setting http.tls.insecure = true is ignored. \
-                                requests will still be sent with TLS to endpoints configured \
-                                with scheme https"
-                        )
-                    }
+            if let Some(true) = tls.insecure {
+                // Keeping with the same behaviour in the golang collector: if this is
+                // configured, but the endpoints are start with https, we still send the
+                // request using https. Just warn about the ignored config mismatch.
+                let wants_https = config.endpoint.starts_with("https://")
+                    || config
+                        .logs_endpoint
+                        .as_ref()
+                        .map(|e| e.starts_with("https://"))
+                        .unwrap_or(false)
+                    || config
+                        .metrics_endpoint
+                        .as_ref()
+                        .map(|e| e.starts_with("https://"))
+                        .unwrap_or(false)
+                    || config
+                        .traces_endpoint
+                        .as_ref()
+                        .map(|e| e.starts_with("https://"))
+                        .unwrap_or(false);
+                if wants_https {
+                    otel_warn!(
+                        "otlp.exporter.http.validate_insecure_flag",
+                        message = "config setting http.tls.insecure = true is ignored. \
+                            requests will still be sent with TLS to endpoints configured \
+                            with scheme https"
+                    )
                 }
             }
         }
@@ -754,7 +751,6 @@ mod test {
     use tokio_util::sync::CancellationToken;
     use tokio_util::task::TaskTracker;
 
-    #[cfg(feature = "experimental-tls")]
     use {
         otap_df_config::tls::{TlsClientConfig, TlsConfig, TlsServerConfig},
         otap_test_tls_certs::{ExtendedKeyUsage, generate_ca},
@@ -928,7 +924,6 @@ mod test {
     /// run test HTTP server serving OTLP HTTP API. Internally, this uses the OTLP HTTP server that
     /// is used in OTLP Receiver. This returns a cancellation token (to shutdown the server when
     /// the test is finished), and a receiver that will emit any pdata that the server produces.
-    #[cfg(feature = "experimental-tls")]
     fn run_tls_server(
         tokio_rt: &Runtime,
         pipeline_ctx: &PipelineContext,
@@ -2033,7 +2028,6 @@ mod test {
             })
     }
 
-    #[cfg(feature = "experimental-tls")]
     fn run_tls_success_test(
         client_tls_config: TlsClientConfig,
         server_tls_config: TlsServerConfig,
@@ -2128,7 +2122,6 @@ mod test {
             })
     }
 
-    #[cfg(feature = "experimental-tls")]
     fn run_tls_failure_test(
         client_tls_config: TlsClientConfig,
         server_tls_config: TlsServerConfig,
@@ -2219,7 +2212,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "experimental-tls")]
     fn test_from_config_validates_server_name_override_set() {
         let invalid_config = serde_json::json!({
             "endpoint": "https://localhost",
@@ -2253,7 +2245,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "experimental-tls")]
     fn test_tls_server_only_ca_pem_from_str() {
         otap_df_otap::crypto::ensure_crypto_provider();
 
@@ -2301,7 +2292,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "experimental-tls")]
     fn test_tls_server_only_ca_pem_from_file() {
         otap_df_otap::crypto::ensure_crypto_provider();
 
@@ -2350,7 +2340,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "experimental-tls")]
     fn test_tls_server_insecure_skip_verify_true() {
         otap_df_otap::crypto::ensure_crypto_provider();
 
@@ -2399,7 +2388,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "experimental-tls")]
     fn test_tls_server_failure_no_ca_configured() {
         otap_df_otap::crypto::ensure_crypto_provider();
 
@@ -2450,7 +2438,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "experimental-tls")]
     fn test_tls_server_failure_invalid_ca_configured() {
         otap_df_otap::crypto::ensure_crypto_provider();
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
@@ -2501,7 +2488,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "experimental-tls")]
     fn test_tls_server_failure_server_name_mismatch() {
         otap_df_otap::crypto::ensure_crypto_provider();
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
@@ -2550,7 +2536,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "experimental-tls")]
     fn test_tls_mtls_success_cert_pem() {
         otap_df_otap::crypto::ensure_crypto_provider();
 
@@ -2603,7 +2588,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "experimental-tls")]
     fn test_tls_mtls_success_cert_file() {
         otap_df_otap::crypto::ensure_crypto_provider();
 
@@ -2657,7 +2641,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "experimental-tls")]
     fn test_tls_mtls_failure_wrong_client_cert() {
         otap_df_otap::crypto::ensure_crypto_provider();
 
@@ -2719,7 +2702,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "experimental-tls")]
     fn test_start_returns_error_if_mtls_cert_without_key() {
         otap_df_otap::crypto::ensure_crypto_provider();
 
@@ -2775,7 +2757,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "experimental-tls")]
     fn test_start_returns_error_if_mtls_key_without_cert() {
         otap_df_otap::crypto::ensure_crypto_provider();
 

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/otap_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/otap_receiver/mod.rs
@@ -9,7 +9,6 @@
 //! ToDo: Implement proper deadline function for Shutdown ctrl msg
 //!
 
-#[cfg(feature = "experimental-tls")]
 use otap_df_config::tls::TlsServerConfig;
 use otap_df_otap::OTAP_RECEIVER_FACTORIES;
 use otap_df_otap::compression::CompressionMethod;
@@ -20,7 +19,6 @@ use otap_df_otap::otap_grpc::{
     ArrowLogsServiceImpl, ArrowMetricsServiceImpl, ArrowTracesServiceImpl, Settings,
 };
 use otap_df_otap::pdata::OtapPdata;
-#[cfg(feature = "experimental-tls")]
 use otap_df_otap::tls_utils::{build_tls_acceptor, create_tls_stream};
 
 use async_trait::async_trait;
@@ -95,7 +93,6 @@ pub struct Config {
     pub timeout: Option<Duration>,
 
     /// TLS configuration
-    #[cfg(feature = "experimental-tls")]
     pub tls: Option<TlsServerConfig>,
 }
 
@@ -364,7 +361,6 @@ impl shared::Receiver<OtapPdata> for OTAPReceiver {
             server_builder = server_builder.timeout(timeout);
         }
 
-        #[cfg(feature = "experimental-tls")]
         let maybe_tls_acceptor =
             build_tls_acceptor(self.config.tls.as_ref())
                 .await
@@ -375,7 +371,6 @@ impl shared::Receiver<OtapPdata> for OTAPReceiver {
                     source_detail: format_error_sources(&e),
                 })?;
 
-        #[cfg(feature = "experimental-tls")]
         let handshake_timeout = self.config.tls.as_ref().and_then(|t| t.handshake_timeout);
 
         let server = server_builder
@@ -399,7 +394,6 @@ impl shared::Receiver<OtapPdata> for OTAPReceiver {
         let server_task = {
             let grpc_shutdown = grpc_shutdown.clone();
             async {
-                #[cfg(feature = "experimental-tls")]
                 match maybe_tls_acceptor {
                     Some(tls_acceptor) => {
                         let tls_stream =
@@ -417,14 +411,6 @@ impl shared::Receiver<OtapPdata> for OTAPReceiver {
                             })
                             .await
                     }
-                }
-                #[cfg(not(feature = "experimental-tls"))]
-                {
-                    server
-                        .serve_with_incoming_shutdown(listener_stream, async move {
-                            grpc_shutdown.cancelled().await;
-                        })
-                        .await
                 }
             }
         };

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/otlp_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/otlp_receiver/mod.rs
@@ -22,7 +22,6 @@ use otap_df_otap::otap_grpc::otlp::server_new::{
     LogsServiceServer, MetricsServiceServer, OtlpServerSettings, TraceServiceServer,
 };
 use otap_df_otap::pdata::OtapPdata;
-#[cfg(feature = "experimental-tls")]
 use otap_df_otap::tls_utils::{build_tls_acceptor, create_tls_stream};
 
 use async_trait::async_trait;
@@ -571,7 +570,6 @@ impl shared::Receiver<OtapPdata> for OTLPReceiver {
                 .add_service(metrics_server.expect("gRPC enabled but metrics_server is None"))
                 .add_service(traces_server.expect("gRPC enabled but traces_server is None"));
 
-            #[cfg(feature = "experimental-tls")]
             let maybe_tls_acceptor =
                 build_tls_acceptor(grpc_config.tls.as_ref())
                     .await
@@ -582,33 +580,21 @@ impl shared::Receiver<OtapPdata> for OTLPReceiver {
                         source_detail: format_error_sources(&e),
                     })?;
 
-            #[cfg(feature = "experimental-tls")]
             let handshake_timeout = grpc_config.tls.as_ref().and_then(|t| t.handshake_timeout);
 
             let task: GrpcServerTask = {
                 let grpc_shutdown = grpc_shutdown.clone();
-                #[cfg(feature = "experimental-tls")]
-                {
-                    match maybe_tls_acceptor {
-                        Some(tls_acceptor) => {
-                            let tls_stream =
-                                create_tls_stream(incoming, tls_acceptor, handshake_timeout);
-                            Box::pin(server.serve_with_incoming_shutdown(tls_stream, async move {
-                                grpc_shutdown.cancelled().await;
-                            }))
-                        }
-                        None => {
-                            Box::pin(server.serve_with_incoming_shutdown(incoming, async move {
-                                grpc_shutdown.cancelled().await;
-                            }))
-                        }
+                match maybe_tls_acceptor {
+                    Some(tls_acceptor) => {
+                        let tls_stream =
+                            create_tls_stream(incoming, tls_acceptor, handshake_timeout);
+                        Box::pin(server.serve_with_incoming_shutdown(tls_stream, async move {
+                            grpc_shutdown.cancelled().await;
+                        }))
                     }
-                }
-                #[cfg(not(feature = "experimental-tls"))]
-                {
-                    Box::pin(server.serve_with_incoming_shutdown(incoming, async move {
+                    None => Box::pin(server.serve_with_incoming_shutdown(incoming, async move {
                         grpc_shutdown.cancelled().await;
-                    }))
+                    })),
                 }
             };
 

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/syslog_cef_receiver/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/syslog_cef_receiver/README.md
@@ -1,5 +1,7 @@
 # Syslog and CEF Receiver
 
+<!-- markdownlint-disable MD013 -->
+
 **URN:** `urn:otel:receiver:syslog_cef`
 
 A high-performance receiver for ingesting syslog messages (RFC 3164 and RFC 5424)
@@ -27,7 +29,7 @@ receivers:
       tcp:
         listening_addr: "0.0.0.0:514"
 
-        # Optional: TLS configuration (requires "experimental-tls" feature)
+        # Optional: TLS configuration
         tls:
           cert_file: "/path/to/server.crt"
           key_file: "/path/to/server.key"
@@ -90,7 +92,7 @@ receivers:
 
 ### TCP with TLS (RFC 5425)
 
-When the `experimental-tls` feature is enabled, the receiver supports
+The receiver supports
 Syslog over TLS:
 
 - Encrypted transport for sensitive log data
@@ -439,4 +441,4 @@ pipelines:
 
 | Feature | Description |
 | ------- | ----------- |
-| `experimental-tls` | Enables TLS support for secure TCP connections |
+| Built-in TLS support | Enables TLS support for secure TCP connections |

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs
@@ -33,11 +33,8 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncReadExt, BufReader};
 
-#[cfg(feature = "experimental-tls")]
 use otap_df_config::tls::TlsServerConfig;
-#[cfg(feature = "experimental-tls")]
 use otap_df_otap::tls_utils::{accept_tls_connection, build_tls_acceptor};
-#[cfg(feature = "experimental-tls")]
 use otap_df_telemetry::otel_debug;
 
 /// Arrow records encoder for syslog messages
@@ -79,7 +76,6 @@ struct TcpConfig {
     /// TLS configuration for secure TCP connections (Syslog over TLS, RFC 5425).
     ///
     /// When configured, TCP connections will require TLS.
-    #[cfg(feature = "experimental-tls")]
     tls: Option<TlsServerConfig>,
 }
 
@@ -143,7 +139,6 @@ impl Config {
         Self {
             protocol: Protocol::Tcp(TcpConfig {
                 listening_addr,
-                #[cfg(feature = "experimental-tls")]
                 tls: None,
             }),
             batch: None,
@@ -332,7 +327,6 @@ impl local::Receiver<OtapPdata> for SyslogCefReceiver {
                 let listener = effect_handler.tcp_listener(tcp_config.listening_addr)?;
 
                 // Build TLS acceptor if TLS is configured
-                #[cfg(feature = "experimental-tls")]
                 let maybe_tls_acceptor = build_tls_acceptor(tcp_config.tls.as_ref())
                     .await
                     .map_err(|e| Error::ReceiverError {
@@ -343,13 +337,11 @@ impl local::Receiver<OtapPdata> for SyslogCefReceiver {
                     })?;
 
                 // Extract handshake timeout from TLS config (if present)
-                #[cfg(feature = "experimental-tls")]
                 let maybe_handshake_timeout = tcp_config
                     .tls
                     .as_ref()
                     .and_then(|tls| tls.handshake_timeout);
 
-                #[cfg(feature = "experimental-tls")]
                 if maybe_tls_acceptor.is_some() {
                     otel_info!(
                         "syslog_cef_receiver.tls_enabled",
@@ -447,9 +439,7 @@ impl local::Receiver<OtapPdata> for SyslogCefReceiver {
                                     let admission_state = self.admission_state.clone();
 
                                     // Clone TLS acceptor for the spawned task
-                                    #[cfg(feature = "experimental-tls")]
                                     let tls_acceptor = maybe_tls_acceptor.clone();
-                                    #[cfg(feature = "experimental-tls")]
                                     let tls_handshake_timeout = maybe_handshake_timeout;
 
                                     // Clone shutdown flag for the spawned task
@@ -470,7 +460,6 @@ impl local::Receiver<OtapPdata> for SyslogCefReceiver {
                                         task_active_count.set(task_active_count.get() + 1);
 
                                         // Perform TLS handshake if configured, creating a unified reader type
-                                        #[cfg(feature = "experimental-tls")]
                                         let mut reader: Box<dyn AsyncBufRead + Unpin> = if let Some(acceptor) = tls_acceptor {
                                             // Use configured timeout or fall back to 10 seconds (the serde default)
                                             let timeout = tls_handshake_timeout
@@ -500,9 +489,6 @@ impl local::Receiver<OtapPdata> for SyslogCefReceiver {
                                         } else {
                                             Box::new(BufReader::new(socket))
                                         };
-
-                                        #[cfg(not(feature = "experimental-tls"))]
-                                        let mut reader = BufReader::new(socket);
 
                                         // Suppress unused variable warning when TLS is disabled
                                         let _ = peer_addr;
@@ -1023,7 +1009,6 @@ pub struct SyslogCefReceiverMetrics {
     pub tcp_connections_active: UpDownCounter<u64>,
 
     /// Number of TLS handshake failures
-    #[cfg(feature = "experimental-tls")]
     #[metric(unit = "{error}")]
     pub tls_handshake_failures: Counter<u64>,
 
@@ -1915,7 +1900,6 @@ mod config_tests {
         );
     }
 
-    #[cfg(feature = "experimental-tls")]
     #[test]
     fn valid_tcp_with_tls() {
         let json = serde_json::json!({
@@ -1936,7 +1920,6 @@ mod config_tests {
         );
     }
 
-    #[cfg(feature = "experimental-tls")]
     #[test]
     fn valid_tcp_with_tls_and_client_ca() {
         let json = serde_json::json!({
@@ -1958,7 +1941,6 @@ mod config_tests {
         );
     }
 
-    #[cfg(feature = "experimental-tls")]
     #[test]
     fn valid_tcp_with_tls_handshake_timeout() {
         let json = serde_json::json!({
@@ -1980,7 +1962,6 @@ mod config_tests {
         );
     }
 
-    #[cfg(feature = "experimental-tls")]
     #[test]
     fn udp_with_tls_rejected() {
         let json = serde_json::json!({

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/syslog_cef_receiver/telemetry.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/syslog_cef_receiver/telemetry.md
@@ -1,5 +1,7 @@
 # Syslog CEF Receiver Telemetry
 
+<!-- markdownlint-disable MD013 -->
+
 This document lists telemetry emitted directly by the
 `syslog_cef_receiver` component. It includes metric instruments registered
 by the component and log events emitted via `otel_*` log macros.
@@ -16,16 +18,16 @@ Metrics are registered under the metric set name `syslog_cef.receiver.metrics`.
 | `syslog_cef.receiver.metrics.received_logs_truncated` | Counter | `{item}` | Number of log records whose raw message exceeded the maximum message size and were truncated before parsing. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
 | `syslog_cef.receiver.metrics.received_logs_forward_failed` | Counter | `{item}` | Number of log records refused by downstream (backpressure/unavailable). | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
 | `syslog_cef.receiver.metrics.tcp_connections_active` | UpDownCounter | `{conn}` | Number of currently active TCP connections. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
-| `syslog_cef.receiver.metrics.tls_handshake_failures` | Counter | `{error}` | Number of TLS handshake failures. Only available with the `experimental-tls` feature. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
+| `syslog_cef.receiver.metrics.tls_handshake_failures` | Counter | `{error}` | Number of TLS handshake failures. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
 
 ## Logs
 
 | Event name | Level | Description | Produced in file |
 | --- | --- | --- | --- |
 | `syslog_cef_receiver.start` | `info` | Receiver startup with protocol (TCP or UDP) and listening address. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
-| `syslog_cef_receiver.tls_enabled` | `info` | TLS has been enabled for the TCP receiver. Only emitted with the `experimental-tls` feature. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
-| `syslog_cef_receiver.tls.handshake.success` | `debug` | TLS handshake completed successfully for an incoming connection. Only emitted with the `experimental-tls` feature. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
-| `syslog_cef_receiver.tls.handshake.failed` | `warn` | TLS handshake failed; the connection is closed. Only emitted with the `experimental-tls` feature. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
+| `syslog_cef_receiver.tls_enabled` | `info` | TLS has been enabled for the TCP receiver. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
+| `syslog_cef_receiver.tls.handshake.success` | `debug` | TLS handshake completed successfully for an incoming connection. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
+| `syslog_cef_receiver.tls.handshake.failed` | `warn` | TLS handshake failed; the connection is closed. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
 | `syslog_cef_receiver.drain_ingress.timeout` | `warn` | Ingress drain timeout expired with connection tasks still active during shutdown. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
 | `syslog_cef_receiver.arrow_records.build_failed` | `warn` | Failed to build Arrow records from a parsed batch; the batch is dropped. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
 

--- a/rust/otap-dataflow/crates/otap/Cargo.toml
+++ b/rust/otap-dataflow/crates/otap/Cargo.toml
@@ -77,12 +77,12 @@ url = { workspace = true }
 # Azure feature dependencies (for object_store)
 azure_identity = { workspace = true, optional = true }
 azure_core = { workspace = true, optional = true,  features = ["reqwest"] }
-rustls-native-certs = { workspace = true, optional = true }
-arc-swap = { workspace = true, optional = true }
-rustls = { workspace = true, optional = true }
-rustls-pki-types = { workspace = true, optional = true }
-tokio-rustls = { workspace = true, optional = true }
-notify = { workspace = true, optional = true }
+rustls-native-certs.workspace = true
+arc-swap.workspace = true
+rustls.workspace = true
+rustls-pki-types.workspace = true
+tokio-rustls.workspace = true
+notify.workspace = true
 rustls-openssl = { workspace = true, optional = true }
 
 # Quiver persistence engine (durable buffer processor)
@@ -91,11 +91,10 @@ blake3.workspace = true
 byte-unit.workspace = true
 
 [features]
-test-utils = ["dep:rustls", "rustls/ring", "otap-df-pdata/testing"]
-experimental-tls = ["dep:rustls", "dep:rustls-pki-types", "dep:tokio-rustls", "dep:rustls-native-certs", "dep:arc-swap", "dep:notify", "tonic/tls-native-roots"]
-crypto-ring = ["dep:rustls", "rustls/ring", "tokio-rustls?/ring"]
-crypto-aws-lc = ["dep:rustls", "rustls/aws_lc_rs", "tokio-rustls?/aws-lc-rs"]
-crypto-openssl = ["dep:rustls", "dep:rustls-openssl", "tonic/tls-native-roots"]
+test-utils = ["rustls/ring", "otap-df-pdata/testing"]
+crypto-ring = ["rustls/ring", "tokio-rustls/ring"]
+crypto-aws-lc = ["rustls/aws_lc_rs", "tokio-rustls/aws-lc-rs"]
+crypto-openssl = ["dep:rustls-openssl", "tonic/tls-native-roots"]
 azure = ["object_store/azure", "object_store/cloud", "dep:azure_identity", "dep:azure_core"]
 aws = ["object_store/aws", "object_store/cloud"]
 

--- a/rust/otap-dataflow/crates/otap/src/crypto.rs
+++ b/rust/otap-dataflow/crates/otap/src/crypto.rs
@@ -77,7 +77,6 @@ pub fn install_crypto_provider() -> Result<(), String> {
 ///
 /// Uses [`std::sync::Once`] so it is safe to call from every test — the actual
 /// installation happens at most once per process.
-#[cfg(any(test, feature = "test-utils"))]
 pub fn ensure_crypto_provider() {
     use std::sync::Once;
     static INIT: Once = Once::new();

--- a/rust/otap-dataflow/crates/otap/src/crypto.rs
+++ b/rust/otap-dataflow/crates/otap/src/crypto.rs
@@ -19,6 +19,12 @@
 /// This function must be called **once**, early in `main()`, before any TLS
 /// connections are established (including via `reqwest`, `tonic`, etc.).
 ///
+/// TLS support is always compiled in, but a crypto provider is only required
+/// when the process actually uses TLS/HTTPS paths. Plaintext-only pipelines can
+/// run without a `crypto-*` feature. Any HTTPS exporter, TLS receiver, or
+/// HTTPS proxy configuration requires one of: `crypto-ring`,
+/// `crypto-aws-lc`, or `crypto-openssl`.
+///
 /// # Errors
 ///
 /// Returns `Err` if a provider was already installed (non-fatal in most cases).

--- a/rust/otap-dataflow/crates/otap/src/lib.rs
+++ b/rust/otap-dataflow/crates/otap/src/lib.rs
@@ -63,7 +63,6 @@ pub mod crypto;
 pub mod transport_headers;
 
 /// TLS utilities
-#[cfg(feature = "experimental-tls")]
 pub mod tls_utils;
 
 /// Factory for OTAP-based pipeline

--- a/rust/otap-dataflow/crates/otap/src/otap_grpc/client_settings.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_grpc/client_settings.rs
@@ -5,12 +5,9 @@
 
 use crate::compression::CompressionMethod;
 use crate::otap_grpc::proxy::ProxyConfig;
-
-#[cfg(feature = "experimental-tls")]
 use crate::tls_utils;
 use hyper_util::rt::TokioIo;
 use otap_df_config::byte_units;
-#[cfg(feature = "experimental-tls")]
 use otap_df_config::tls::TlsClientConfig;
 use serde::Deserialize;
 use std::io;
@@ -95,8 +92,6 @@ pub struct GrpcClientSettings {
     pub timeout: Option<Duration>,
 
     /// Client-side TLS/mTLS configuration.
-    /// Requires the `experimental-tls` feature to be enabled.
-    #[cfg(feature = "experimental-tls")]
     #[serde(default)]
     pub tls: Option<TlsClientConfig>,
 
@@ -125,10 +120,6 @@ pub enum GrpcEndpointError {
     /// IO error while reading certificates/keys for TLS.
     #[error("tls configuration error: {0}")]
     Io(#[from] io::Error),
-
-    /// TLS support is not compiled in.
-    #[error("TLS support is disabled; enable the `experimental-tls` feature")]
-    TlsFeatureDisabled,
 
     /// Proxy configuration or connection error.
     #[error("proxy error: {0}")]
@@ -200,27 +191,13 @@ impl GrpcClientSettings {
     pub async fn build_endpoint_with_tls(&self) -> Result<Endpoint, GrpcEndpointError> {
         let endpoint = self.build_endpoint()?;
 
-        #[cfg(feature = "experimental-tls")]
-        {
-            // Decision to enable TLS is handled by load_client_tls_config (Secure by Default)
-            let tls =
-                tls_utils::load_client_tls_config(self.tls.as_ref(), &self.grpc_endpoint).await?;
+        // Decision to enable TLS is handled by load_client_tls_config (secure by default).
+        let tls = tls_utils::load_client_tls_config(self.tls.as_ref(), &self.grpc_endpoint).await?;
 
-            if let Some(tls_config) = tls {
-                Ok(endpoint.tls_config(tls_config)?)
-            } else {
-                Ok(endpoint)
-            }
-        }
-
-        #[cfg(not(feature = "experimental-tls"))]
-        {
-            let wants_tls = is_https_endpoint(&self.grpc_endpoint);
-            if wants_tls {
-                Err(GrpcEndpointError::TlsFeatureDisabled)
-            } else {
-                Ok(endpoint)
-            }
+        if let Some(tls_config) = tls {
+            Ok(endpoint.tls_config(tls_config)?)
+        } else {
+            Ok(endpoint)
         }
     }
 
@@ -360,7 +337,6 @@ impl Default for GrpcClientSettings {
             http2_keepalive_timeout: default_http2_keepalive_timeout(),
             keep_alive_while_idle: default_keep_alive_while_idle(),
             timeout: None,
-            #[cfg(feature = "experimental-tls")]
             tls: None,
             buffer_size: None,
             proxy: None,
@@ -382,11 +358,6 @@ pub(crate) const fn default_tcp_nodelay() -> bool {
 
 pub(crate) const fn default_tcp_keepalive() -> Option<Duration> {
     Some(Duration::from_secs(45))
-}
-
-#[cfg(not(feature = "experimental-tls"))]
-fn is_https_endpoint(endpoint: &str) -> bool {
-    endpoint.trim_start().starts_with("https://")
 }
 
 const fn default_initial_stream_window_size() -> Option<u32> {
@@ -417,14 +388,9 @@ const fn default_keep_alive_while_idle() -> bool {
 #[allow(missing_docs)]
 mod tests {
     use super::*;
-
-    #[cfg(feature = "experimental-tls")]
+    use otap_df_config::tls::{TlsClientConfig, TlsConfig};
     use tempfile::NamedTempFile;
 
-    #[cfg(feature = "experimental-tls")]
-    use otap_df_config::tls::{TlsClientConfig, TlsConfig};
-
-    #[cfg(feature = "experimental-tls")]
     #[test]
     fn defaults_match_previous_client_tuning() {
         let settings: GrpcClientSettings =
@@ -467,7 +433,6 @@ mod tests {
         assert_eq!(settings.effective_concurrency_limit(), 1);
     }
 
-    #[cfg(feature = "experimental-tls")]
     #[tokio::test]
     async fn build_endpoint_with_tls_allows_plain_http_when_tls_unset() {
         crate::crypto::ensure_crypto_provider();
@@ -477,7 +442,6 @@ mod tests {
         let _ = endpoint;
     }
 
-    #[cfg(feature = "experimental-tls")]
     #[tokio::test]
     async fn build_endpoint_with_tls_accepts_https_without_explicit_tls_block() {
         crate::crypto::ensure_crypto_provider();
@@ -490,7 +454,6 @@ mod tests {
         let _ = endpoint;
     }
 
-    #[cfg(feature = "experimental-tls")]
     #[tokio::test]
     async fn client_tls_defaults_are_scheme_driven_when_tls_block_absent() {
         crate::crypto::ensure_crypto_provider();
@@ -506,7 +469,6 @@ mod tests {
         assert!(https.is_some());
     }
 
-    #[cfg(feature = "experimental-tls")]
     #[tokio::test]
     async fn build_endpoint_with_tls_insecure_does_not_rewrite_scheme() {
         crate::crypto::ensure_crypto_provider();
@@ -523,7 +485,6 @@ mod tests {
         assert_eq!(endpoint.uri().scheme_str(), Some("https"));
     }
 
-    #[cfg(feature = "experimental-tls")]
     #[tokio::test]
     async fn client_tls_insecure_true_without_custom_ca_returns_no_explicit_tls_config() {
         crate::crypto::ensure_crypto_provider();
@@ -538,7 +499,6 @@ mod tests {
         assert!(tls.is_none());
     }
 
-    #[cfg(feature = "experimental-tls")]
     #[tokio::test]
     async fn client_tls_insecure_true_with_custom_ca_still_builds_tls_config() {
         crate::crypto::ensure_crypto_provider();
@@ -557,7 +517,6 @@ mod tests {
         assert!(tls.is_some());
     }
 
-    #[cfg(feature = "experimental-tls")]
     #[tokio::test]
     async fn client_tls_insecure_skip_verify_true_fails_fast() {
         crate::crypto::ensure_crypto_provider();
@@ -575,7 +534,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "experimental-tls")]
     #[tokio::test]
     async fn build_endpoint_with_tls_allows_http_when_tls_is_configured() {
         crate::crypto::ensure_crypto_provider();
@@ -599,7 +557,6 @@ mod tests {
         let _ = endpoint;
     }
 
-    #[cfg(feature = "experimental-tls")]
     #[tokio::test]
     async fn build_endpoint_with_tls_rejects_partial_mtls_cert_without_key() {
         crate::crypto::ensure_crypto_provider();
@@ -622,7 +579,6 @@ mod tests {
         assert!(err.to_string().contains("certificate") || err.to_string().contains("mTLS"));
     }
 
-    #[cfg(feature = "experimental-tls")]
     #[tokio::test]
     async fn build_endpoint_with_tls_rejects_partial_mtls_key_without_cert() {
         crate::crypto::ensure_crypto_provider();
@@ -645,7 +601,6 @@ mod tests {
         assert!(err.to_string().contains("certificate") || err.to_string().contains("mTLS"));
     }
 
-    #[cfg(feature = "experimental-tls")]
     #[tokio::test]
     #[cfg_attr(
         any(target_os = "windows", target_os = "macos"),
@@ -670,7 +625,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "experimental-tls")]
     #[tokio::test]
     async fn build_endpoint_with_tls_enforces_tls_file_size_limit() {
         crate::crypto::ensure_crypto_provider();
@@ -697,7 +651,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "experimental-tls")]
     #[tokio::test]
     async fn build_endpoint_with_tls_errors_when_no_trust_anchors() {
         crate::crypto::ensure_crypto_provider();
@@ -719,7 +672,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "experimental-tls")]
     #[tokio::test]
     async fn build_endpoint_with_tls_enforces_cert_file_size_limit() {
         crate::crypto::ensure_crypto_provider();
@@ -753,7 +705,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "experimental-tls")]
     #[tokio::test]
     async fn build_endpoint_with_tls_fails_with_empty_ca_pem() {
         crate::crypto::ensure_crypto_provider();
@@ -793,7 +744,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "experimental-tls")]
     #[tokio::test]
     async fn build_endpoint_with_tls_accepts_server_name_override() {
         crate::crypto::ensure_crypto_provider();
@@ -814,7 +764,6 @@ mod tests {
         let _ = endpoint;
     }
 
-    #[cfg(feature = "experimental-tls")]
     #[tokio::test]
     async fn build_endpoint_with_tls_enables_tls_by_default_on_http() {
         crate::crypto::ensure_crypto_provider();
@@ -831,7 +780,6 @@ mod tests {
         let _ = endpoint;
     }
 
-    #[cfg(feature = "experimental-tls")]
     #[tokio::test]
     async fn build_endpoint_with_tls_disables_tls_when_insecure_true() {
         crate::crypto::ensure_crypto_provider();
@@ -847,26 +795,6 @@ mod tests {
         let endpoint = settings.build_endpoint_with_tls().await.unwrap();
         // Verification: endpoint shouldn't have TLS config?
         // We can't verify that easily, but we know it returned successfully.
-        let _ = endpoint;
-    }
-
-    #[cfg(not(feature = "experimental-tls"))]
-    #[test]
-    fn build_endpoint_with_tls_rejects_https_when_feature_disabled() {
-        let settings: GrpcClientSettings =
-            serde_json::from_str(r#"{ "grpc_endpoint": "https://localhost:4317" }"#).unwrap();
-
-        let err = futures::executor::block_on(settings.build_endpoint_with_tls()).unwrap_err();
-        assert!(matches!(err, GrpcEndpointError::TlsFeatureDisabled));
-    }
-
-    #[cfg(not(feature = "experimental-tls"))]
-    #[test]
-    fn build_endpoint_with_tls_allows_http_when_feature_disabled() {
-        let settings: GrpcClientSettings =
-            serde_json::from_str(r#"{ "grpc_endpoint": "http://localhost:4317" }"#).unwrap();
-
-        let endpoint = futures::executor::block_on(settings.build_endpoint_with_tls()).unwrap();
         let _ = endpoint;
     }
 

--- a/rust/otap-dataflow/crates/otap/src/otap_grpc/proxy.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_grpc/proxy.rs
@@ -15,41 +15,32 @@
 //! The implementation uses HTTP CONNECT method to establish tunnels through proxies.
 //! It supports both:
 //! - `http://proxy:port` (plaintext to proxy)
-//! - `https://proxy:port` (TLS to proxy, requires `experimental-tls`)
+//! - `https://proxy:port` (TLS to proxy)
 
 use crate::socket_options;
 use base64::Engine;
 use base64::prelude::*;
 use http::Uri;
 use ipnet::IpNet;
-#[cfg(feature = "experimental-tls")]
 use otap_df_config::tls::TlsClientConfig;
 use otap_df_telemetry::{otel_debug, otel_warn};
-#[cfg(feature = "experimental-tls")]
 use rustls::RootCertStore;
-#[cfg(feature = "experimental-tls")]
 use rustls_native_certs::load_native_certs;
-#[cfg(feature = "experimental-tls")]
 use rustls_pki_types::pem::PemObject;
-#[cfg(feature = "experimental-tls")]
 use rustls_pki_types::{CertificateDer, ServerName};
 use serde::Deserialize;
 use std::borrow::Cow;
 use std::env;
 use std::io;
 use std::net::IpAddr;
-#[cfg(feature = "experimental-tls")]
 use std::path::Path;
 use std::time::Duration;
 use thiserror::Error;
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
-#[cfg(feature = "experimental-tls")]
 use tokio::sync::OnceCell;
-#[cfg(feature = "experimental-tls")]
 use tokio_rustls::TlsConnector;
 
-#[cfg(feature = "experimental-tls")]
 use crate::tls_utils::read_file_with_limit_async;
 
 /// A URL-like string that should be treated as sensitive.
@@ -158,7 +149,6 @@ pub enum ProxyError {
     InvalidUri(String),
 
     /// TLS handshake or setup failure while connecting to an HTTPS proxy.
-    #[cfg(feature = "experimental-tls")]
     #[error("failed to establish TLS connection to proxy: {0}")]
     ProxyTlsHandshake(String),
 }
@@ -195,8 +185,6 @@ pub struct ProxyConfig {
     /// TLS/mTLS settings for HTTPS proxy connections (`https://proxy-host:port`).
     ///
     /// This setting is ignored for `http://` proxy URLs.
-    /// Requires the `experimental-tls` feature.
-    #[cfg(feature = "experimental-tls")]
     #[serde(default)]
     pub tls: Option<TlsClientConfig>,
 }
@@ -225,7 +213,6 @@ impl ProxyConfig {
                 .or_else(|_| env::var("no_proxy"))
                 .ok()
                 .filter(|s| !s.is_empty()),
-            #[cfg(feature = "experimental-tls")]
             tls: None,
         }
     }
@@ -240,7 +227,6 @@ impl ProxyConfig {
             https_proxy: self.https_proxy.or(env_config.https_proxy),
             all_proxy: self.all_proxy.or(env_config.all_proxy),
             no_proxy: self.no_proxy.or(env_config.no_proxy),
-            #[cfg(feature = "experimental-tls")]
             tls: self.tls,
         }
     }
@@ -253,7 +239,6 @@ impl std::fmt::Display for ProxyConfig {
         let _ = dbg.field("https_proxy", &self.https_proxy);
         let _ = dbg.field("all_proxy", &self.all_proxy);
         let _ = dbg.field("no_proxy", &self.no_proxy);
-        #[cfg(feature = "experimental-tls")]
         let _ = dbg.field("tls", &self.tls.as_ref().map(|_| "[configured]"));
         dbg.finish()
     }
@@ -448,7 +433,6 @@ impl ProxyConfig {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ProxyScheme {
     Http,
-    #[cfg(feature = "experimental-tls")]
     Https,
 }
 
@@ -472,18 +456,7 @@ fn parse_proxy_url(proxy_url: &str) -> Result<ParsedProxyUrl, ProxyError> {
 
     let scheme = match uri.scheme_str().unwrap_or("http") {
         "http" => ProxyScheme::Http,
-        "https" => {
-            #[cfg(feature = "experimental-tls")]
-            {
-                ProxyScheme::Https
-            }
-            #[cfg(not(feature = "experimental-tls"))]
-            {
-                return Err(ProxyError::InvalidProxyUrl(format!(
-                    "https:// proxy URLs require the `experimental-tls` feature (proxy URL: {proxy_url_redacted})"
-                )));
-            }
-        }
+        "https" => ProxyScheme::Https,
         other => {
             return Err(ProxyError::InvalidProxyUrl(format!(
                 "unsupported proxy URL scheme `{other}` ({proxy_url_redacted})"
@@ -500,7 +473,6 @@ fn parse_proxy_url(proxy_url: &str) -> Result<ParsedProxyUrl, ProxyError> {
 
     let port = uri.port_u16().unwrap_or(match scheme {
         ProxyScheme::Http => 3128,
-        #[cfg(feature = "experimental-tls")]
         ProxyScheme::Https => 443,
     });
 
@@ -525,7 +497,6 @@ fn parse_proxy_url(proxy_url: &str) -> Result<ParsedProxyUrl, ProxyError> {
     })
 }
 
-#[cfg(feature = "experimental-tls")]
 fn tls_server_name_for_proxy(
     proxy_host: &str,
     tls: Option<&TlsClientConfig>,
@@ -545,7 +516,6 @@ fn tls_server_name_for_proxy(
     })
 }
 
-#[cfg(feature = "experimental-tls")]
 async fn read_proxy_tls_file(path: &Path, field: &str) -> Result<Vec<u8>, ProxyError> {
     read_file_with_limit_async(path).await.map_err(|e| {
         ProxyError::InvalidProxyUrl(format!(
@@ -555,7 +525,6 @@ async fn read_proxy_tls_file(path: &Path, field: &str) -> Result<Vec<u8>, ProxyE
     })
 }
 
-#[cfg(feature = "experimental-tls")]
 async fn load_proxy_system_root_certs() -> Result<Vec<CertificateDer<'static>>, ProxyError> {
     // Cache system roots for the process lifetime to avoid repeated blocking OS/keychain reads.
     static SYSTEM_ROOTS: OnceCell<Vec<CertificateDer<'static>>> = OnceCell::const_new();
@@ -581,7 +550,6 @@ async fn load_proxy_system_root_certs() -> Result<Vec<CertificateDer<'static>>, 
     Ok(roots.clone())
 }
 
-#[cfg(feature = "experimental-tls")]
 async fn build_proxy_tls_connector(
     proxy_host: &str,
     tls: Option<&TlsClientConfig>,
@@ -980,7 +948,6 @@ pub(crate) async fn connect_tcp_stream_with_proxy_config(
             ProxyScheme::Http => {
                 http_connect_tunnel_on_stream(stream, host, port, proxy_auth.as_deref()).await?
             }
-            #[cfg(feature = "experimental-tls")]
             ProxyScheme::Https => {
                 let (connector, server_name) =
                     build_proxy_tls_connector(proxy_host.as_str(), proxy_config.tls.as_ref())
@@ -1038,7 +1005,6 @@ mod tests {
         result
     }
 
-    #[cfg(feature = "experimental-tls")]
     async fn start_tls_proxy_for_handshake_failure()
     -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
         use otap_test_tls_certs::{ExtendedKeyUsage, generate_ca};
@@ -1232,7 +1198,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "experimental-tls")]
     #[test]
     fn test_parse_proxy_url_accepts_https() {
         let parsed = parse_proxy_url("https://secure-proxy.example.com:8443").unwrap();
@@ -1242,7 +1207,6 @@ mod tests {
         assert_eq!(parsed.scheme, ProxyScheme::Https);
     }
 
-    #[cfg(feature = "experimental-tls")]
     #[test]
     fn test_parse_proxy_url_https_default_port() {
         let parsed = parse_proxy_url("https://secure-proxy.example.com").unwrap();
@@ -1250,13 +1214,6 @@ mod tests {
         assert_eq!(parsed.port, 443);
         assert!(parsed.auth_header.is_none());
         assert_eq!(parsed.scheme, ProxyScheme::Https);
-    }
-
-    #[cfg(not(feature = "experimental-tls"))]
-    #[test]
-    fn test_parse_proxy_url_rejects_https_without_tls_feature() {
-        let err = parse_proxy_url("https://secure-proxy.example.com").unwrap_err();
-        assert!(err.to_string().contains("experimental-tls"));
     }
 
     #[test]
@@ -1271,7 +1228,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "experimental-tls")]
     #[tokio::test]
     async fn test_build_proxy_tls_connector_rejects_insecure() {
         let tls = TlsClientConfig {
@@ -1288,7 +1244,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "experimental-tls")]
     #[tokio::test]
     async fn test_build_proxy_tls_connector_rejects_insecure_skip_verify() {
         let tls = TlsClientConfig {
@@ -1305,7 +1260,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "experimental-tls")]
     #[tokio::test]
     async fn test_build_proxy_tls_connector_rejects_empty_trust_store() {
         let tls = TlsClientConfig {
@@ -1322,7 +1276,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "experimental-tls")]
     #[tokio::test]
     async fn test_build_proxy_tls_connector_reports_ca_file_read_error_as_config_error() {
         use std::path::PathBuf;
@@ -1347,7 +1300,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "experimental-tls")]
     #[tokio::test]
     async fn test_build_proxy_tls_connector_rejects_partial_mtls_config() {
         use otap_df_config::tls::TlsConfig;
@@ -1375,7 +1327,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "experimental-tls")]
     #[test]
     fn test_tls_server_name_for_proxy_rejects_invalid_name() {
         let tls = TlsClientConfig {
@@ -1389,7 +1340,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "experimental-tls")]
     #[tokio::test]
     async fn test_connect_tcp_stream_with_proxy_config_maps_tls_handshake_error() {
         use otap_df_config::tls::TlsConfig;

--- a/rust/otap-dataflow/crates/otap/src/otap_grpc/server_settings.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_grpc/server_settings.rs
@@ -6,7 +6,6 @@
 use crate::compression::{self, CompressionMethod};
 use crate::otap_grpc::otlp::server_new::OtlpServerSettings;
 use otap_df_config::byte_units;
-#[cfg(feature = "experimental-tls")]
 use otap_df_config::tls::TlsServerConfig;
 use serde::Deserialize;
 use std::net::SocketAddr;
@@ -179,7 +178,6 @@ pub struct GrpcServerSettings {
     /// Optional TLS configuration for the gRPC server.
     ///
     /// When configured, the server will use TLS/mTLS for secure connections.
-    #[cfg(feature = "experimental-tls")]
     #[serde(default)]
     pub tls: Option<TlsServerConfig>,
 }
@@ -335,7 +333,6 @@ impl Default for GrpcServerSettings {
             max_concurrent_streams: None,
             wait_for_result: default_wait_for_result(),
             timeout: None,
-            #[cfg(feature = "experimental-tls")]
             tls: None,
         }
     }

--- a/rust/otap-dataflow/crates/otap/src/otlp_http.rs
+++ b/rust/otap-dataflow/crates/otap/src/otlp_http.rs
@@ -48,9 +48,7 @@ use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 use zstd::stream::read::Decoder as ZstdDecoder;
 
-#[cfg(feature = "experimental-tls")]
 use crate::tls_utils::build_tls_acceptor;
-#[cfg(feature = "experimental-tls")]
 use otap_df_config::tls::TlsServerConfig;
 
 pub mod client_settings;
@@ -124,9 +122,6 @@ pub struct HttpServerSettings {
     pub accept_compressed_requests: bool,
 
     /// Optional TLS configuration.
-    ///
-    /// This is only available when the `experimental-tls` feature is enabled.
-    #[cfg(feature = "experimental-tls")]
     #[serde(default)]
     pub tls: Option<TlsServerConfig>,
 }
@@ -144,7 +139,6 @@ impl Default for HttpServerSettings {
             wait_for_result: default_wait_for_result(),
             timeout: default_http_timeout(),
             accept_compressed_requests: default_accept_compressed_requests(),
-            #[cfg(feature = "experimental-tls")]
             tls: None,
         }
     }
@@ -842,7 +836,6 @@ pub async fn serve(
 
     let tracker = TaskTracker::new();
 
-    #[cfg(feature = "experimental-tls")]
     let maybe_tls_acceptor = build_tls_acceptor(settings.tls.as_ref()).await?;
 
     loop {
@@ -884,36 +877,34 @@ pub async fn serve(
                     local_semaphore: local_semaphore.clone(),
                 };
 
-                #[cfg(feature = "experimental-tls")]
-                {
-                    if let Some(acceptor) = maybe_tls_acceptor.clone() {
-                        let shutdown = shutdown.clone();
-                        drop(tracker.spawn(async move {
-                            let tls_stream = match acceptor.accept(stream).await {
-                                Ok(s) => s,
-                                Err(_) => return,
-                            };
-                            let io = TokioIo::new(tls_stream);
-                            let executor = hyper_util::rt::TokioExecutor::new();
-                            let conn = hyper_util::server::conn::auto::Builder::new(executor);
-                            let conn = conn.serve_connection(io, service_fn(move |req| handler.clone().handle(req)));
+                if let Some(acceptor) = maybe_tls_acceptor.clone() {
+                    let shutdown = shutdown.clone();
+                    drop(tracker.spawn(async move {
+                        let tls_stream = match acceptor.accept(stream).await {
+                            Ok(s) => s,
+                            Err(_) => return,
+                        };
+                        let io = TokioIo::new(tls_stream);
+                        let executor = hyper_util::rt::TokioExecutor::new();
+                        let conn = hyper_util::server::conn::auto::Builder::new(executor);
+                        let conn =
+                            conn.serve_connection(io, service_fn(move |req| handler.clone().handle(req)));
 
-                            let mut conn = std::pin::pin!(conn);
+                        let mut conn = std::pin::pin!(conn);
 
-                            tokio::select! {
-                                res = &mut conn => {
-                                    if let Err(err) = res {
-                                        otap_df_telemetry::otel_debug!("otlp_http_receiver.connection_error", error = err.to_string());
-                                    }
-                                },
-                                _ = shutdown.cancelled() => {
-                                    conn.as_mut().graceful_shutdown();
-                                    let _ = conn.await;
+                        tokio::select! {
+                            res = &mut conn => {
+                                if let Err(err) = res {
+                                    otap_df_telemetry::otel_debug!("otlp_http_receiver.connection_error", error = err.to_string());
                                 }
+                            },
+                            _ = shutdown.cancelled() => {
+                                conn.as_mut().graceful_shutdown();
+                                let _ = conn.await;
                             }
-                        }));
-                        continue;
-                    }
+                        }
+                    }));
+                    continue;
                 }
 
                 let shutdown = shutdown.clone();

--- a/rust/otap-dataflow/crates/otap/src/otlp_http/client_settings.rs
+++ b/rust/otap-dataflow/crates/otap/src/otlp_http/client_settings.rs
@@ -8,8 +8,6 @@ use serde::Deserialize;
 use std::io;
 use std::time::Duration;
 use tower::limit::ConcurrencyLimitLayer;
-
-#[cfg(feature = "experimental-tls")]
 use {
     crate::tls_utils::read_file_with_limit_async, otap_df_config::tls::TlsClientConfig,
     otap_df_telemetry::otel_error, reqwest::Certificate, reqwest::Identity,
@@ -51,8 +49,6 @@ pub struct HttpClientSettings {
     pub timeout: Option<Duration>,
 
     /// Client-side TLS/mTLS configuration.
-    /// Requires the `experimental-tls` feature to be enabled.
-    #[cfg(feature = "experimental-tls")]
     #[serde(default)]
     pub tls: Option<TlsClientConfig>,
 }
@@ -86,7 +82,6 @@ impl HttpClientSettings {
             client_builder = client_builder.timeout(timeout)
         }
 
-        #[cfg(feature = "experimental-tls")]
         if let Some(tls) = &self.tls {
             let mut certs = vec![];
 
@@ -215,7 +210,6 @@ impl Default for HttpClientSettings {
             tcp_keepalive: default_tcp_keepalive(),
             tcp_keepalive_interval: None,
             timeout: None,
-            #[cfg(feature = "experimental-tls")]
             tls: None,
         }
     }

--- a/rust/otap-dataflow/crates/otap/src/tls_utils.rs
+++ b/rust/otap-dataflow/crates/otap/src/tls_utils.rs
@@ -5,6 +5,7 @@ use arc_swap::ArcSwap;
 use base64::prelude::*;
 use futures::{Stream, StreamExt};
 use notify::{Event, RecursiveMode, Watcher};
+use otap_df_config::tls::TlsClientConfig;
 use otap_df_config::tls::TlsServerConfig;
 use otap_df_telemetry::{otel_debug, otel_error, otel_info, otel_warn};
 use rustls::RootCertStore;
@@ -25,16 +26,9 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, SystemTime};
-use tonic::transport::{Identity, ServerTlsConfig};
-
-#[cfg(feature = "experimental-tls")]
 use tokio::sync::OnceCell;
-
-#[cfg(feature = "experimental-tls")]
-use otap_df_config::tls::TlsClientConfig;
-
-#[cfg(feature = "experimental-tls")]
 use tonic::transport::{Certificate, ClientTlsConfig};
+use tonic::transport::{Identity, ServerTlsConfig};
 
 /// Maximum allowed size for TLS certificate and key files (4MB).
 /// This limit is chosen to be generous enough for typical certificate chains (which are usually < 10KB)
@@ -173,7 +167,6 @@ pub async fn load_server_tls_config(
 ///   with tonic's transport layer)
 ///
 /// Consider implementing certificate hot reload if this becomes an operational requirement.
-#[cfg(feature = "experimental-tls")]
 pub(crate) async fn load_client_tls_config(
     config: Option<&TlsClientConfig>,
     endpoint_uri: &str,
@@ -325,7 +318,6 @@ pub(crate) async fn load_client_tls_config(
     Ok(Some(tls))
 }
 
-#[cfg(feature = "experimental-tls")]
 async fn add_system_trust_anchors_if_enabled(
     tls: ClientTlsConfig,
     include_system: bool,

--- a/rust/otap-dataflow/crates/otap/tests/mtls_tests.rs
+++ b/rust/otap-dataflow/crates/otap/tests/mtls_tests.rs
@@ -3,8 +3,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#![cfg(feature = "experimental-tls")]
-
 use otap_df_config::tls::{TlsConfig, TlsServerConfig};
 use otap_df_otap::tls_utils::build_reloadable_server_config;
 use otap_df_telemetry::{otel_debug, otel_info};

--- a/rust/otap-dataflow/crates/otap/tests/otlp_exporter_proxy_tls.rs
+++ b/rust/otap-dataflow/crates/otap/tests/otlp_exporter_proxy_tls.rs
@@ -3,7 +3,6 @@
 
 //! Integration tests validating exporter-side proxy + TLS behavior for the OTLP exporter.
 
-#![cfg(feature = "experimental-tls")]
 #![allow(missing_docs)]
 
 use bytes::Bytes;

--- a/rust/otap-dataflow/crates/otap/tests/otlp_exporter_tls.rs
+++ b/rust/otap-dataflow/crates/otap/tests/otlp_exporter_tls.rs
@@ -3,7 +3,6 @@
 
 //! Integration test validating exporter-side TLS/mTLS for the OTLP exporter.
 
-#![cfg(feature = "experimental-tls")]
 #![allow(missing_docs)]
 
 use otap_df_config::tls::{TlsClientConfig, TlsConfig};

--- a/rust/otap-dataflow/crates/otap/tests/tls_limits.rs
+++ b/rust/otap-dataflow/crates/otap/tests/tls_limits.rs
@@ -3,7 +3,6 @@
 
 #![allow(missing_docs)]
 
-#[cfg(feature = "experimental-tls")]
 mod tests {
     use otap_df_config::tls::{TlsConfig, TlsServerConfig};
     use otap_df_otap::tls_utils::load_server_tls_config;

--- a/rust/otap-dataflow/crates/otap/tests/tls_reload.rs
+++ b/rust/otap-dataflow/crates/otap/tests/tls_reload.rs
@@ -4,7 +4,6 @@
 #![allow(missing_docs)]
 #![allow(unused_results)]
 
-#[cfg(feature = "experimental-tls")]
 mod tests {
     use otap_df_config::tls::{TlsConfig, TlsServerConfig};
     use otap_df_otap::tls_utils::build_reloadable_server_config;

--- a/rust/otap-dataflow/crates/otap/tests/tls_stream.rs
+++ b/rust/otap-dataflow/crates/otap/tests/tls_stream.rs
@@ -3,7 +3,6 @@
 
 #![allow(missing_docs)]
 
-#[cfg(feature = "experimental-tls")]
 mod tests {
     use futures::StreamExt;
     use otap_df_otap::tls_utils::create_tls_stream;

--- a/rust/otap-dataflow/crates/validation/Cargo.toml
+++ b/rust/otap-dataflow/crates/validation/Cargo.toml
@@ -39,7 +39,6 @@ otap-df-controller = { workspace = true }
 prost = { workspace = true }
 
 [features]
-experimental-tls = ["otap-df-otap/experimental-tls", "otap-df-core-nodes/experimental-tls"]
 crypto-ring = ["otap-df-otap/crypto-ring"]
 crypto-aws-lc = ["otap-df-otap/crypto-aws-lc"]
 crypto-openssl = ["otap-df-otap/crypto-openssl"]

--- a/rust/otap-dataflow/crates/validation/README.md
+++ b/rust/otap-dataflow/crates/validation/README.md
@@ -1,5 +1,7 @@
 # Validation Framework
 
+<!-- markdownlint-disable MD013 -->
+
 End-to-end harness for standing up a **system-under-validation (SUV)**
 pipeline, driving OTLP/OTAP traffic into it, capturing the output, and
 asserting invariants.
@@ -178,7 +180,7 @@ e.g. `receiver`, `exporter`.
   - default: 2-2
 - `with_tls(TlsConfig)` - enable TLS on the generator's exporter
   - optional; see [TLS / mTLS](#tls--mtls) for details
-  - requires the `experimental-tls` feature flag
+  - uses the built-in TLS support
 - `to_container(ContainerConnection)` - use a custom exporter that sends to a
   test container instead of directly to the SUV pipeline receiver
   - mutually exclusive with `otlp_grpc()` / `otap_grpc()`
@@ -189,7 +191,7 @@ the keys under `nodes:` in your pipeline YAML.
 
 ### TLS / mTLS
 
-> Requires the `experimental-tls` feature flag.
+> Uses the built-in TLS support.
 
 TLS support is configured on the **Generator** side. The generator's exporter
 connects to a TLS-enabled receiver in the SUV pipeline. Use `${VAR}` placeholders

--- a/rust/otap-dataflow/crates/validation/src/lib.rs
+++ b/rust/otap-dataflow/crates/validation/src/lib.rs
@@ -205,7 +205,6 @@ mod tests {
 
 #[cfg(test)]
 #[cfg(validation_tests)]
-#[cfg(feature = "experimental-tls")]
 mod tls_tests {
     use crate::pipeline::Pipeline;
     use crate::scenario::Scenario;

--- a/rust/otap-dataflow/crates/validation/src/traffic.rs
+++ b/rust/otap-dataflow/crates/validation/src/traffic.rs
@@ -117,8 +117,6 @@ pub enum MessageType {
 ///
 /// Construct via [`TlsConfig::tls_only`] or [`TlsConfig::mtls`].
 ///
-/// **Note:** Requires the `experimental-tls` feature to be enabled on `otap-df-otap`,
-/// otherwise the rendered pipeline config will fail to deserialize.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct TlsConfig {
     pub(crate) ca_cert_path: PathBuf,

--- a/rust/otap-dataflow/docs/otlp-receiver.md
+++ b/rust/otap-dataflow/docs/otlp-receiver.md
@@ -1,5 +1,7 @@
 # OTLP Receiver
 
+<!-- markdownlint-disable MD013 -->
+
 The OTLP Receiver ingests telemetry data via the OpenTelemetry Protocol (OTLP)
 and forwards it into the OTAP dataflow pipeline. It supports both gRPC (HTTP/2)
 and HTTP/1.1 protocols with unified concurrency control.
@@ -343,8 +345,10 @@ nodes:
           # --- Concurrency limits ---
           # 0 = auto-tune to downstream channel capacity
           max_concurrent_requests: 0
-          max_concurrent_streams: null  # HTTP/2 streams per connection (null = auto)
-          transport_concurrency_limit: null  # Per-connection limit (null = auto)
+          # HTTP/2 streams per connection (null = auto)
+          max_concurrent_streams: null
+          # Per-connection limit (null = auto)
+          transport_concurrency_limit: null
           load_shed: true               # Fast reject when overloaded
 
           # --- Compression ---
@@ -506,7 +510,7 @@ match downstream channel capacity.
 
 ## TLS Support
 
-TLS is available via the `experimental-tls` feature flag. Each protocol has its
+TLS is available by default. Each protocol has its
 own independent TLS configuration:
 
 ```yaml
@@ -548,7 +552,8 @@ ACK/NACK routed back through the pipeline result path before responding to the
 client:
 
 ```text
-Client -> Receiver -> Pipeline -> [Downstream nodes] -> Ack/Nack unwind -> Receiver -> Client
+Client -> Receiver -> Pipeline -> [Downstream nodes]
+       -> Ack/Nack unwind -> Receiver -> Client
 ```
 
 This provides delivery confirmation but does NOT guarantee end-to-end delivery

--- a/rust/otap-dataflow/docs/proxy-support.md
+++ b/rust/otap-dataflow/docs/proxy-support.md
@@ -1,5 +1,7 @@
 # HTTP Proxy Support for OTLP/OTAP Exporters
 
+<!-- markdownlint-disable MD013 -->
+
 ## Overview
 
 This document describes the HTTP CONNECT proxy tunneling implementation for OTLP
@@ -54,7 +56,7 @@ If the proxy URL is `https://...`, the exporter first establishes TLS to the
 proxy, then sends CONNECT over that TLS channel:
 
 > Note: `https://` proxy transport requires building with the
-> `experimental-tls` feature.
+> built-in TLS support.
 
 ```text
 +-----------+                                          +-----------+
@@ -136,7 +138,7 @@ export NO_PROXY=localhost,127.0.0.1,*.internal,192.168.0.0/16
 `HTTPS_PROXY` (and `proxy.https_proxy` in YAML) may be either:
 
 - `http://...` for plaintext exporter-to-proxy transport
-- `https://...` for TLS exporter-to-proxy transport (requires `experimental-tls`)
+- `https://...` for TLS exporter-to-proxy transport
 
 **Note**: Variable names are case-insensitive. Both `HTTP_PROXY` and
 `http_proxy` are recognized.
@@ -145,11 +147,8 @@ export NO_PROXY=localhost,127.0.0.1,*.internal,192.168.0.0/16
 
 Explicit proxy configuration in YAML overrides environment variables:
 
-`proxy.tls` and `https://` proxy URLs require building with the
-`experimental-tls` feature.
-`proxy.tls` is only used for `https://` proxy URLs; with `http://` proxy URLs it
-is ignored. In non-`experimental-tls` builds, `proxy.tls` is an unknown field
-and configuration deserialization fails (due to `deny_unknown_fields`).
+`proxy.tls` is only used with `https://` proxy URLs.
+With `http://` proxy URLs, `proxy.tls` is ignored.
 
 ```yaml
 grpc_client:

--- a/rust/otap-dataflow/scripts/validate-configs.sh
+++ b/rust/otap-dataflow/scripts/validate-configs.sh
@@ -26,7 +26,7 @@ else
     # Note: --all-features cannot be used because jemalloc and mimalloc are
     # mutually exclusive (compile_error! in non-test builds).
     cargo build \
-        --features azure,aws,experimental-tls,contrib-exporters,contrib-processors,recordset-kql-processor,azure-monitor-exporter,geneva-exporter,condense-attributes-processor,resource-validator-processor \
+        --features azure,aws,contrib-exporters,contrib-processors,recordset-kql-processor,azure-monitor-exporter,geneva-exporter,condense-attributes-processor,resource-validator-processor \
         --manifest-path "$PROJECT_DIR/Cargo.toml"
     BINARY="$PROJECT_DIR/target/debug/df_engine"
 fi

--- a/rust/otap-dataflow/src/main.rs
+++ b/rust/otap-dataflow/src/main.rs
@@ -52,19 +52,6 @@ compile_error!(
 // When all features are enabled (e.g. --all-features), crypto.rs uses a
 // priority order (ring > aws-lc > openssl) so the binary still works.
 #[cfg(all(
-    not(any(
-        feature = "crypto-ring",
-        feature = "crypto-aws-lc",
-        feature = "crypto-openssl"
-    )),
-    not(any(test, doc)),
-    not(clippy)
-))]
-compile_error!(
-    "One crypto provider feature must be enabled. \
-     Enable exactly one of: crypto-ring, crypto-aws-lc, crypto-openssl."
-);
-#[cfg(all(
     feature = "crypto-ring",
     feature = "crypto-aws-lc",
     not(any(test, doc)),

--- a/rust/otap-dataflow/src/main.rs
+++ b/rust/otap-dataflow/src/main.rs
@@ -52,6 +52,19 @@ compile_error!(
 // When all features are enabled (e.g. --all-features), crypto.rs uses a
 // priority order (ring > aws-lc > openssl) so the binary still works.
 #[cfg(all(
+    not(any(
+        feature = "crypto-ring",
+        feature = "crypto-aws-lc",
+        feature = "crypto-openssl"
+    )),
+    not(any(test, doc)),
+    not(clippy)
+))]
+compile_error!(
+    "One crypto provider feature must be enabled. \
+     Enable exactly one of: crypto-ring, crypto-aws-lc, crypto-openssl."
+);
+#[cfg(all(
     feature = "crypto-ring",
     feature = "crypto-aws-lc",
     not(any(test, doc)),


### PR DESCRIPTION
 ### Summary                                 
                                          
  Remove the `experimental-tls` feature gate and make TLS support available by
  default across OTAP Dataflow.                                                                                                                                                           
   
  ### What changed                                                                                                                                                                        
                  
  - Removed the `experimental-tls` feature wiring from the workspace and all                                                                                                              
    affected crates
  - Made the core TLS dependencies in `otap-df-otap` unconditional
  - Removed feature-gated TLS fallback paths and the obsolete
    `TlsFeatureDisabled` error variant    
  - Made existing TLS tests compile and run by default
  - Updated configs, scripts, and docs to stop referring to `experimental-tls`                                                                                                            
  - Added a binary-level compile-time guard in `df_engine` so normal builds must
    enable exactly one crypto provider:                                                                                                                                                   
    - `crypto-ring`
    - `crypto-aws-lc`                                                                                                                                                                     
    - `crypto-openssl`                        
                                                                                                                                                                                          
  ### Notes       
                                                                                                                                                                                          
  - This change does not alter the existing `crypto-*` feature flags; it only
    removes the compile-time gate around TLS availability.                                                                                                                                
  - `tonic/tls-native-roots` was intentionally not made unconditional. Native
    trust anchors are loaded directly via `rustls_native_certs` in the TLS helper
    paths, so this is not an omission.