### PR TITLE
Columnar Query Engine/OPL Parser support for `TextScalarExpression::Capture`

### DIFF
--- a/rust/otap-dataflow/crates/opl/src/parser/expression.rs
+++ b/rust/otap-dataflow/crates/opl/src/parser/expression.rs
@@ -5,14 +5,15 @@ use std::sync::LazyLock;
 
 use data_engine_expressions::{
     AndLogicalExpression, BinaryMathematicalScalarExpression, BooleanScalarExpression,
-    CollectionScalarExpression, CombineScalarExpression, ContainsLogicalExpression,
-    DoubleScalarExpression, DoubleValue, EqualToLogicalExpression, Expression,
-    GreaterThanLogicalExpression, GreaterThanOrEqualToLogicalExpression, IntegerScalarExpression,
-    IntegerValue, InvokeFunctionArgument, InvokeFunctionScalarExpression, JoinTextScalarExpression,
-    ListScalarExpression, LogicalExpression, MatchesLogicalExpression, MathScalarExpression,
-    NotLogicalExpression, NullScalarExpression, OrLogicalExpression, QueryLocation,
-    ReplaceTextScalarExpression, ScalarExpression, SliceScalarExpression, SourceScalarExpression,
-    StaticScalarExpression, StringScalarExpression, TextScalarExpression, ValueAccessor,
+    CaptureTextScalarExpression, CollectionScalarExpression, CombineScalarExpression,
+    ContainsLogicalExpression, DoubleScalarExpression, DoubleValue, EqualToLogicalExpression,
+    Expression, GreaterThanLogicalExpression, GreaterThanOrEqualToLogicalExpression,
+    IntegerScalarExpression, IntegerValue, InvokeFunctionArgument, InvokeFunctionScalarExpression,
+    JoinTextScalarExpression, ListScalarExpression, LogicalExpression, MatchesLogicalExpression,
+    MathScalarExpression, NotLogicalExpression, NullScalarExpression, OrLogicalExpression,
+    QueryLocation, ReplaceTextScalarExpression, ScalarExpression, SliceScalarExpression,
+    SourceScalarExpression, StaticScalarExpression, StringScalarExpression, TextScalarExpression,
+    ValueAccessor,
 };
 use data_engine_parser_abstractions::{
     ParserError, parse_standard_double_literal, parse_standard_integer_literal,
@@ -800,6 +801,25 @@ fn parse_function_call(
             ))
             .into())
         }
+        "regexp_capture" => {
+            if args.len() != 3 {
+                return Err(ParserError::SyntaxError(
+                    query_location,
+                    format!(
+                        "Function '{fn_name}' expects 3 arguments, got {}",
+                        args.len()
+                    ),
+                ));
+            }
+
+            let source = args.remove(0);
+            let pattern = args.remove(0);
+            let capture_group = args.remove(0);
+            Ok(ScalarExpression::Text(TextScalarExpression::Capture(
+                CaptureTextScalarExpression::new(query_location, source, pattern, capture_group),
+            ))
+            .into())
+        }
         "replace" => {
             if args.len() != 3 {
                 return Err(ParserError::SyntaxError(
@@ -889,15 +909,15 @@ mod test {
 
     use data_engine_expressions::{
         AndLogicalExpression, BinaryMathematicalScalarExpression, BooleanScalarExpression,
-        CollectionScalarExpression, CombineScalarExpression, ContainsLogicalExpression,
-        DateTimeScalarExpression, DoubleScalarExpression, EqualToLogicalExpression,
-        GreaterThanLogicalExpression, GreaterThanOrEqualToLogicalExpression,
-        IntegerScalarExpression, JoinTextScalarExpression, ListScalarExpression, LogicalExpression,
-        MatchesLogicalExpression, MathScalarExpression, NotLogicalExpression, NullScalarExpression,
-        OrLogicalExpression, PipelineFunction, PipelineFunctionParameter,
-        PipelineFunctionParameterType, QueryLocation, ReplaceTextScalarExpression,
-        ScalarExpression, SourceScalarExpression, StaticScalarExpression, StringScalarExpression,
-        TextScalarExpression, ValueAccessor,
+        CaptureTextScalarExpression, CollectionScalarExpression, CombineScalarExpression,
+        ContainsLogicalExpression, DateTimeScalarExpression, DoubleScalarExpression,
+        EqualToLogicalExpression, GreaterThanLogicalExpression,
+        GreaterThanOrEqualToLogicalExpression, IntegerScalarExpression, JoinTextScalarExpression,
+        ListScalarExpression, LogicalExpression, MatchesLogicalExpression, MathScalarExpression,
+        NotLogicalExpression, NullScalarExpression, OrLogicalExpression, PipelineFunction,
+        PipelineFunctionParameter, PipelineFunctionParameterType, QueryLocation,
+        ReplaceTextScalarExpression, ScalarExpression, SourceScalarExpression,
+        StaticScalarExpression, StringScalarExpression, TextScalarExpression, ValueAccessor,
     };
     use data_engine_parser_abstractions::{ParserError, ParserFunction, ParserState};
     use pest::Parser;
@@ -2066,7 +2086,7 @@ mod test {
     }
 
     #[test]
-    fn test_parse_replace_with_delimiter_function_call() {
+    fn test_parse_replace_function_call() {
         let input = "replace(severity_text, \"N\", \"M\")";
         let mut rules = OplPestParser::parse(Rule::member_expression, input).unwrap();
         assert_eq!(rules.len(), 1);
@@ -2101,6 +2121,41 @@ mod test {
         assert_eq!(result, expected);
     }
 
+    #[test]
+    fn test_parse_regexp_capture_function_call() {
+        let input = "regexp_capture(severity_text, \".*(.).*\", 1)";
+        let mut rules = OplPestParser::parse(Rule::member_expression, input).unwrap();
+        assert_eq!(rules.len(), 1);
+
+        let result: ScalarExpression =
+            parse_member_expression(rules.next().unwrap(), default_pipeline_builder().as_ref())
+                .unwrap()
+                .into();
+
+        let expected = ScalarExpression::Text(TextScalarExpression::Capture(
+            CaptureTextScalarExpression::new(
+                QueryLocation::new_fake(),
+                ScalarExpression::Source(SourceScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                        StaticScalarExpression::String(StringScalarExpression::new(
+                            QueryLocation::new_fake(),
+                            "severity_text",
+                        )),
+                    )]),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), ".*(.).*"),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::Integer(
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+                )),
+            ),
+        ));
+
+        assert_eq!(result, expected);
+    }
+
     fn parse_known_func_with_args(
         fn_name: &str,
         args: &[&str],
@@ -2121,6 +2176,22 @@ mod test {
             vec!["one", "two", "three", "four"],
         ] {
             let err = parse_known_func_with_args("replace", &args).unwrap_err();
+            assert_eq!(
+                err.to_string(),
+                format!("Function 'replace' expects 3 arguments, got {}", args.len())
+            )
+        }
+    }
+
+    #[test]
+    fn parse_regexp_capture_function_call_with_wrong_arity() {
+        for args in [
+            vec![],
+            vec!["one"],
+            vec!["one", "two"],
+            vec!["one", "two", "three", "four"],
+        ] {
+            let err = parse_known_func_with_args("regexp_capture", &args).unwrap_err();
             assert_eq!(
                 err.to_string(),
                 format!("Function 'replace' expects 3 arguments, got {}", args.len())

--- a/rust/otap-dataflow/crates/opl/src/parser/expression.rs
+++ b/rust/otap-dataflow/crates/opl/src/parser/expression.rs
@@ -875,8 +875,12 @@ fn parse_function_call(
                 )
             })?;
 
-            let expected_num_args = function_def.get_parameter_names().len();
-            if args.len() != expected_num_args {
+            // TODO - this is kind of a sketchy way to get the number of required parameters.
+            // In the future, we may want to consider adding a bit more information in the
+            // function signature.
+            let expected_num_args =
+                function_def.get_parameter_names().len() - function_def.get_default_values().len();
+            if args.len() < expected_num_args {
                 return Err(ParserError::SyntaxError(
                     query_location,
                     format!(

--- a/rust/otap-dataflow/crates/opl/src/parser/expression.rs
+++ b/rust/otap-dataflow/crates/opl/src/parser/expression.rs
@@ -2194,7 +2194,10 @@ mod test {
             let err = parse_known_func_with_args("regexp_capture", &args).unwrap_err();
             assert_eq!(
                 err.to_string(),
-                format!("Function 'replace' expects 3 arguments, got {}", args.len())
+                format!(
+                    "Function 'regexp_capture' expects 3 arguments, got {}",
+                    args.len()
+                )
             )
         }
     }

--- a/rust/otap-dataflow/crates/query-engine/Cargo.toml
+++ b/rust/otap-dataflow/crates/query-engine/Cargo.toml
@@ -17,6 +17,7 @@ datafusion = { workspace = true, features = [
 ] }
 futures-core = { workspace = true }
 memchr = { workspace = true }
+paste = { workspace = true }
 parking_lot = { workspace = true }
 roaring = { workspace = true }
 smallvec = { workspace = true }

--- a/rust/otap-dataflow/crates/query-engine/Cargo.toml
+++ b/rust/otap-dataflow/crates/query-engine/Cargo.toml
@@ -19,7 +19,6 @@ futures-core = { workspace = true }
 memchr = { workspace = true }
 paste = { workspace = true }
 parking_lot = { workspace = true }
-roaring = { workspace = true }
 smallvec = { workspace = true }
 thiserror = { workspace = true }
 data_engine_expressions = { workspace = true }

--- a/rust/otap-dataflow/crates/query-engine/src/consts.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/consts.rs
@@ -7,4 +7,5 @@ pub(crate) const SCOPE_FIELD_NAME: &str = "instrumentation_scope";
 pub(crate) const VALUE_FIELD_NAME: &str = "value";
 
 pub(crate) const ENCODE_FUNC_NAME: &str = "encode";
+pub(crate) const REGEXP_SUBSTR_FUNC_NAME: &str = "regexp_substr";
 pub(crate) const SHA256_FUNC_NAME: &str = "sha256";

--- a/rust/otap-dataflow/crates/query-engine/src/parser.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/parser.rs
@@ -5,8 +5,8 @@
 //! query-engine
 
 use data_engine_expressions::{
-    NullScalarExpression, PipelineFunctionParameter, PipelineFunctionParameterType, QueryLocation,
-    ScalarExpression, StaticScalarExpression,
+    IntegerScalarExpression, NullScalarExpression, PipelineFunctionParameter,
+    PipelineFunctionParameterType, QueryLocation, ScalarExpression, StaticScalarExpression,
 };
 use data_engine_parser_abstractions::ParserOptions;
 
@@ -23,11 +23,75 @@ pub fn default_parser_options() -> ParserOptions {
         // number of arguments is currently validated by the parser, but the rest of the parameter
         // definitions are left as placeholders. Additional parameter validation happens at query
         // planning time.
+        //
+        // Note that for functions that take optional parameters, we are currently explicitly
+        // filling in the default values, because our expression tree doesn't have the concept of
+        // optional parameters (signatures with different arities), even though the underlying
+        // function might support this. Eventually we may clean this up with modifications to the
+        // expression tree.
+        //
         .with_external_function(SHA256_FUNC_NAME, param_placeholders(1), None)
         .with_external_function(ENCODE_FUNC_NAME, param_placeholders(2), None)
         .with_external_function(
             REGEXP_SUBSTR_FUNC_NAME,
-            param_placeholders_some_optional(2, 4),
+            vec![
+                (
+                    "",
+                    PipelineFunctionParameter::new(
+                        QueryLocation::new_fake(),
+                        PipelineFunctionParameterType::Scalar(None),
+                    ),
+                    None,
+                ),
+                (
+                    "",
+                    PipelineFunctionParameter::new(
+                        QueryLocation::new_fake(),
+                        PipelineFunctionParameterType::Scalar(None),
+                    ),
+                    None,
+                ),
+                (
+                    "start",
+                    PipelineFunctionParameter::new(
+                        QueryLocation::new_fake(),
+                        PipelineFunctionParameterType::Scalar(None),
+                    ),
+                    Some(ScalarExpression::Static(StaticScalarExpression::Integer(
+                        IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+                    ))),
+                ),
+                (
+                    "occurrence",
+                    PipelineFunctionParameter::new(
+                        QueryLocation::new_fake(),
+                        PipelineFunctionParameterType::Scalar(None),
+                    ),
+                    Some(ScalarExpression::Static(StaticScalarExpression::Integer(
+                        IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+                    ))),
+                ),
+                (
+                    "flags",
+                    PipelineFunctionParameter::new(
+                        QueryLocation::new_fake(),
+                        PipelineFunctionParameterType::Scalar(None),
+                    ),
+                    Some(ScalarExpression::Static(StaticScalarExpression::Null(
+                        NullScalarExpression::new(QueryLocation::new_fake()),
+                    ))),
+                ),
+                (
+                    "group",
+                    PipelineFunctionParameter::new(
+                        QueryLocation::new_fake(),
+                        PipelineFunctionParameterType::Scalar(None),
+                    ),
+                    Some(ScalarExpression::Static(StaticScalarExpression::Integer(
+                        IntegerScalarExpression::new(QueryLocation::new_fake(), 0),
+                    ))),
+                ),
+            ],
             None,
         )
 }
@@ -52,49 +116,4 @@ fn param_placeholders(
     }
 
     params
-}
-
-fn param_placeholders_with_default_value(
-    num_params: usize,
-) -> Vec<(
-    &'static str,
-    PipelineFunctionParameter,
-    Option<ScalarExpression>,
-)> {
-    // TODO in the future we will have try to have a better mechanism for specifying
-    // the function signature. For now, just define as many unique parameter names as
-    // needed. This helper function is only used internally, and gets called during tests
-    // so we know this won't panic at runtime.
-    static PARAM_NAMES: &[&'static str] = &["1", "2", "3", "4", "5"];
-    let mut params = Vec::with_capacity(num_params);
-
-    for i in 0..num_params {
-        params.push((
-            PARAM_NAMES[i],
-            PipelineFunctionParameter::new(
-                QueryLocation::new_fake(),
-                PipelineFunctionParameterType::Scalar(None),
-            ),
-            Some(ScalarExpression::Static(StaticScalarExpression::Null(
-                NullScalarExpression::new(QueryLocation::new_fake()),
-            ))),
-        ))
-    }
-
-    params
-}
-
-fn param_placeholders_some_optional(
-    required: usize,
-    optional: usize,
-) -> Vec<(
-    &'static str,
-    PipelineFunctionParameter,
-    Option<ScalarExpression>,
-)> {
-    let mut required = param_placeholders(required);
-    let mut optional = param_placeholders_with_default_value(optional);
-    required.append(&mut optional);
-
-    required
 }

--- a/rust/otap-dataflow/crates/query-engine/src/parser.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/parser.rs
@@ -5,11 +5,12 @@
 //! query-engine
 
 use data_engine_expressions::{
-    PipelineFunctionParameter, PipelineFunctionParameterType, QueryLocation, ScalarExpression,
+    NullScalarExpression, PipelineFunctionParameter, PipelineFunctionParameterType, QueryLocation,
+    ScalarExpression, StaticScalarExpression,
 };
 use data_engine_parser_abstractions::ParserOptions;
 
-use crate::consts::{ENCODE_FUNC_NAME, SHA256_FUNC_NAME};
+use crate::consts::{ENCODE_FUNC_NAME, REGEXP_SUBSTR_FUNC_NAME, SHA256_FUNC_NAME};
 
 /// Create parser options that can be used when parsing an expression that will be executed with
 /// this query engine
@@ -24,6 +25,11 @@ pub fn default_parser_options() -> ParserOptions {
         // planning time.
         .with_external_function(SHA256_FUNC_NAME, param_placeholders(1), None)
         .with_external_function(ENCODE_FUNC_NAME, param_placeholders(2), None)
+        .with_external_function(
+            REGEXP_SUBSTR_FUNC_NAME,
+            param_placeholders_some_optional(2, 4),
+            None,
+        )
 }
 
 fn param_placeholders(
@@ -46,4 +52,49 @@ fn param_placeholders(
     }
 
     params
+}
+
+fn param_placeholders_with_default_value(
+    num_params: usize,
+) -> Vec<(
+    &'static str,
+    PipelineFunctionParameter,
+    Option<ScalarExpression>,
+)> {
+    // TODO in the future we will have try to have a better mechanism for specifying
+    // the function signature. For now, just define as many unique parameter names as
+    // needed. This helper function is only used internally, and gets called during tests
+    // so we know this won't panic at runtime.
+    static PARAM_NAMES: &[&'static str] = &["1", "2", "3", "4", "5"];
+    let mut params = Vec::with_capacity(num_params);
+
+    for i in 0..num_params {
+        params.push((
+            PARAM_NAMES[i],
+            PipelineFunctionParameter::new(
+                QueryLocation::new_fake(),
+                PipelineFunctionParameterType::Scalar(None),
+            ),
+            Some(ScalarExpression::Static(StaticScalarExpression::Null(
+                NullScalarExpression::new(QueryLocation::new_fake()),
+            ))),
+        ))
+    }
+
+    params
+}
+
+fn param_placeholders_some_optional(
+    required: usize,
+    optional: usize,
+) -> Vec<(
+    &'static str,
+    PipelineFunctionParameter,
+    Option<ScalarExpression>,
+)> {
+    let mut required = param_placeholders(required);
+    let mut optional = param_placeholders_with_default_value(optional);
+    required.append(&mut optional);
+
+    required
 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
@@ -4473,7 +4473,7 @@ mod test {
     async fn test_update_attr_to_regexp_capture_with_non_scalar_args_kql_parser() {
         test_update_attr_to_regexp_capture_with_non_scalar_args::<KqlParser>(
             "extract",
-            &["severity_text", "event_name", "severity_number"],
+            &["severity_text", "severity_number", "event_name"],
         )
         .await
     }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
@@ -4477,4 +4477,38 @@ mod test {
         )
         .await
     }
+
+    #[tokio::test]
+    async fn test_update_attr_to_regexp_substring_func_call_with_scalars() {
+        let logs_data = to_logs_data(vec![
+            LogRecord::build()
+                .attributes(vec![KeyValue::new(
+                    "attr",
+                    AnyValue::new_string("hello world"),
+                )])
+                .finish(),
+        ]);
+
+        let query =
+            r#"logs | extend attributes["s1"] = regexp_substr(attributes["attr"], "hell.")"#;
+        let pipeline_expr = OplParser::parse_with_options(&query, default_parser_options())
+            .unwrap()
+            .pipeline;
+        let mut pipeline = Pipeline::new(pipeline_expr);
+
+        let input = otlp_to_otap(&OtlpProtoMessage::Logs(logs_data));
+
+        let result = pipeline.execute(input).await.unwrap();
+        let OtlpProtoMessage::Logs(result_logs_data) = otap_to_otlp(&result) else {
+            panic!("invalid signal type");
+        };
+        let log_0 = &result_logs_data.resource_logs[0].scope_logs[0].log_records[0];
+        assert_eq!(
+            log_0.attributes,
+            vec![
+                KeyValue::new("attr", AnyValue::new_string("hello world")),
+                KeyValue::new("s1", AnyValue::new_string("hello")),
+            ]
+        );
+    }
 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
@@ -4408,4 +4408,73 @@ mod test {
         )
         .await
     }
+
+    async fn test_update_attr_to_regexp_capture_with_non_scalar_args<P: Parser>(
+        fn_name: &str,
+        args: &[&str],
+    ) {
+        // clearly this isn't a well formed batch of logs, but the test here is just to ensure
+        // that some non-scalar args can be passed into the function call
+        let logs_data = to_logs_data(vec![
+            LogRecord::build()
+                .event_name("hello world")
+                .severity_text("(.).*")
+                .severity_number(1)
+                .finish(),
+            LogRecord::build()
+                .event_name("hello world")
+                .severity_text(".(.)(..).*")
+                .severity_number(2)
+                .finish(),
+        ]);
+
+        let query = format!(
+            r#"logs | extend event_name = {fn_name}({})"#,
+            args.join(", ")
+        );
+        let pipeline_expr = P::parse_with_options(&query, default_parser_options())
+            .unwrap()
+            .pipeline;
+        let mut pipeline = Pipeline::new(pipeline_expr);
+
+        let input = otlp_to_otap(&OtlpProtoMessage::Logs(logs_data));
+
+        let result = pipeline.execute(input).await.unwrap();
+        let OtlpProtoMessage::Logs(result_logs_data) = otap_to_otlp(&result) else {
+            panic!("invalid signal type");
+        };
+        assert_eq!(
+            &result_logs_data.resource_logs[0].scope_logs[0].log_records,
+            &[
+                LogRecord::build()
+                    .event_name("h")
+                    .severity_text("(.).*")
+                    .severity_number(1)
+                    .finish(),
+                LogRecord::build()
+                    .event_name("ll")
+                    .severity_text(".(.)(..).*")
+                    .severity_number(2)
+                    .finish(),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_attr_to_regexp_capture_with_non_scalar_args_opl_parser() {
+        test_update_attr_to_regexp_capture_with_non_scalar_args::<OplParser>(
+            "regexp_capture",
+            &["event_name", "severity_text", "severity_number"],
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_update_attr_to_regexp_capture_with_non_scalar_args_kql_parser() {
+        test_update_attr_to_regexp_capture_with_non_scalar_args::<KqlParser>(
+            "extract",
+            &["severity_text", "event_name", "severity_number"],
+        )
+        .await
+    }
 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
@@ -4478,8 +4478,7 @@ mod test {
         .await
     }
 
-    #[tokio::test]
-    async fn test_update_attr_to_regexp_substring_func_call_with_scalars() {
+    async fn test_update_attr_to_regexp_substring_func_call_with_scalars<P: Parser>() {
         let logs_data = to_logs_data(vec![
             LogRecord::build()
                 .attributes(vec![KeyValue::new(
@@ -4491,7 +4490,7 @@ mod test {
 
         let query =
             r#"logs | extend attributes["s1"] = regexp_substr(attributes["attr"], "hell.")"#;
-        let pipeline_expr = OplParser::parse_with_options(&query, default_parser_options())
+        let pipeline_expr = P::parse_with_options(query, default_parser_options())
             .unwrap()
             .pipeline;
         let mut pipeline = Pipeline::new(pipeline_expr);
@@ -4510,5 +4509,15 @@ mod test {
                 KeyValue::new("s1", AnyValue::new_string("hello")),
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn test_update_attr_to_regexp_substring_func_call_with_scalars_opl_parser() {
+        test_update_attr_to_regexp_substring_func_call_with_scalars::<OplParser>().await
+    }
+
+    #[tokio::test]
+    async fn test_update_attr_to_regexp_substring_func_call_with_scalars_kq_parser() {
+        test_update_attr_to_regexp_substring_func_call_with_scalars::<KqlParser>().await
     }
 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
@@ -4352,4 +4352,60 @@ mod test {
     async fn test_update_attr_to_replace_with_non_scalar_args_kql_parser() {
         test_update_attr_to_replace_with_non_scalar_args::<KqlParser>("replace_string").await
     }
+
+    async fn test_update_attr_to_regexp_capture_with_scalars<P: Parser>(
+        fn_name: &str,
+        args: &[&str],
+    ) {
+        let logs_data = to_logs_data(vec![
+            LogRecord::build()
+                .attributes(vec![KeyValue::new(
+                    "attr",
+                    AnyValue::new_string("hello world"),
+                )])
+                .finish(),
+        ]);
+
+        let query = format!(
+            r#"logs | extend attributes["s1"] = {fn_name}({})"#,
+            args.join(", ")
+        );
+        let pipeline_expr = P::parse_with_options(&query, default_parser_options())
+            .unwrap()
+            .pipeline;
+        let mut pipeline = Pipeline::new(pipeline_expr);
+
+        let input = otlp_to_otap(&OtlpProtoMessage::Logs(logs_data));
+
+        let result = pipeline.execute(input).await.unwrap();
+        let OtlpProtoMessage::Logs(result_logs_data) = otap_to_otlp(&result) else {
+            panic!("invalid signal type");
+        };
+        let log_0 = &result_logs_data.resource_logs[0].scope_logs[0].log_records[0];
+        assert_eq!(
+            log_0.attributes,
+            vec![
+                KeyValue::new("attr", AnyValue::new_string("hello world")),
+                KeyValue::new("s1", AnyValue::new_string("world")),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_attr_to_regexp_capture_with_scalars_opl_parser() {
+        test_update_attr_to_regexp_capture_with_scalars::<OplParser>(
+            "regexp_capture",
+            &["attributes[\"attr\"]", "\".*hello (.*)$\"", "1"],
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_update_attr_to_regexp_capture_with_scalars_kql_parser() {
+        test_update_attr_to_regexp_capture_with_scalars::<KqlParser>(
+            "extract",
+            &["\".*hello (.*)$\"", "1", "attributes[\"attr\"]"],
+        )
+        .await
+    }
 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
@@ -4409,6 +4409,70 @@ mod test {
         .await
     }
 
+    async fn test_update_attr_to_regexp_capture_with_named_group<P: Parser>(
+        fn_name: &str,
+        args: &[&str],
+    ) {
+        let logs_data = to_logs_data(vec![
+            LogRecord::build()
+                .attributes(vec![KeyValue::new(
+                    "attr",
+                    AnyValue::new_string("hello world"),
+                )])
+                .finish(),
+        ]);
+
+        let query = format!(
+            r#"logs | extend attributes["s1"] = {fn_name}({})"#,
+            args.join(", ")
+        );
+        let pipeline_expr = P::parse_with_options(&query, default_parser_options())
+            .unwrap()
+            .pipeline;
+        let mut pipeline = Pipeline::new(pipeline_expr);
+
+        let input = otlp_to_otap(&OtlpProtoMessage::Logs(logs_data));
+
+        let result = pipeline.execute(input).await.unwrap();
+        let OtlpProtoMessage::Logs(result_logs_data) = otap_to_otlp(&result) else {
+            panic!("invalid signal type");
+        };
+        let log_0 = &result_logs_data.resource_logs[0].scope_logs[0].log_records[0];
+        assert_eq!(
+            log_0.attributes,
+            vec![
+                KeyValue::new("attr", AnyValue::new_string("hello world")),
+                KeyValue::new("s1", AnyValue::new_string("hello")),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_attr_to_regexp_capture_with_named_group_parser() {
+        test_update_attr_to_regexp_capture_with_named_group::<OplParser>(
+            "regexp_capture",
+            &[
+                "attributes[\"attr\"]",
+                "\".*(?P<greeting>.....+) \"",
+                "\"greeting\"",
+            ],
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_update_attr_to_regexp_capture_with_named_group_kql_parser() {
+        test_update_attr_to_regexp_capture_with_named_group::<KqlParser>(
+            "extract",
+            &[
+                "\".*(?P<greeting>.....+) \"",
+                "\"greeting\"",
+                "attributes[\"attr\"]",
+            ],
+        )
+        .await
+    }
+
     async fn test_update_attr_to_regexp_capture_with_non_scalar_args<P: Parser>(
         fn_name: &str,
         args: &[&str],

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
@@ -50,11 +50,12 @@ use arrow::compute::filter_record_batch;
 use arrow::compute::kernels::cmp::eq;
 use arrow::datatypes::{DataType, Field, Schema};
 use data_engine_expressions::{
-    BinaryMathematicalScalarExpression, BooleanValue, CollectionScalarExpression,
-    CombineScalarExpression, DoubleValue, Expression, IntegerValue, InvokeFunctionArgument,
-    InvokeFunctionScalarExpression, JoinTextScalarExpression, MathScalarExpression,
-    PipelineFunction, PipelineFunctionImplementation, ReplaceTextScalarExpression,
-    ScalarExpression, StaticScalarExpression, StringValue, TextScalarExpression,
+    BinaryMathematicalScalarExpression, BooleanValue, CaptureTextScalarExpression,
+    CollectionScalarExpression, CombineScalarExpression, DoubleValue, Expression, IntegerValue,
+    InvokeFunctionArgument, InvokeFunctionScalarExpression, JoinTextScalarExpression,
+    MathScalarExpression, PipelineFunction, PipelineFunctionImplementation,
+    ReplaceTextScalarExpression, ScalarExpression, StaticScalarExpression, StringScalarExpression,
+    StringValue, TextScalarExpression,
 };
 use datafusion::common::DFSchema;
 use datafusion::functions::core::expr_ext::FieldAccessor;
@@ -83,7 +84,7 @@ use crate::pipeline::expr::join::join;
 use crate::pipeline::expr::types::{
     ExprLogicalType, coerce_arithmetic, nested_struct_field_type, root_field_type,
 };
-use crate::pipeline::functions::substring;
+use crate::pipeline::functions::{regexp_capture, substring};
 use crate::pipeline::planner::{AttributesIdentifier, ColumnAccessor};
 use crate::pipeline::project::{Projection, ProjectionOptions};
 
@@ -689,6 +690,46 @@ impl ExprLogicalPlanner {
         }
     }
 
+    fn plan_regex_capture_text_expr(
+        &self,
+        capture_text_expr: &CaptureTextScalarExpression,
+        functions: &[PipelineFunction],
+    ) -> Result<ScopedLogicalExpr> {
+        let capture_scalar_expr = match capture_text_expr.get_pattern() {
+            ScalarExpression::Static(StaticScalarExpression::Regex(regexp_expr)) => {
+                // the datafusion UDF for this expects a string, so if the arg is a scalar regex
+                // convert it into a string so it will be planed as a scalar string literal
+                Cow::Owned(ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(
+                        regexp_expr.get_query_location().clone(),
+                        regexp_expr.get_value().as_str(),
+                    ),
+                )))
+            }
+            other => Cow::Borrowed(other),
+        };
+
+        let (df_udf_args, source_scope, requires_dict_downcast) = self.plan_function_args(
+            [
+                capture_text_expr.get_haystack(),
+                &capture_scalar_expr,
+                capture_text_expr.get_capture_group(),
+            ]
+            .into_iter(),
+            functions,
+        )?;
+
+        Ok(ScopedLogicalExpr {
+            logical_expr: Expr::ScalarFunction(ScalarFunction::new_udf(
+                regexp_capture(),
+                df_udf_args,
+            )),
+            expr_type: ExprLogicalType::String,
+            source: source_scope,
+            requires_dict_downcast,
+        })
+    }
+
     fn plan_replace_text_expr(
         &self,
         replace_text_expr: &ReplaceTextScalarExpression,
@@ -727,9 +768,9 @@ impl ExprLogicalPlanner {
             TextScalarExpression::Replace(replace_text_expr) => {
                 self.plan_replace_text_expr(replace_text_expr, functions)
             }
-            other_expr => Err(Error::NotYetSupportedError {
-                message: format!("text expression not yet supported {other_expr:?}"),
-            }),
+            TextScalarExpression::Capture(capture_text_expr) => {
+                self.plan_regex_capture_text_expr(capture_text_expr, functions)
+            }
         }
     }
 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
@@ -84,7 +84,7 @@ use crate::pipeline::expr::join::join;
 use crate::pipeline::expr::types::{
     ExprLogicalType, coerce_arithmetic, nested_struct_field_type, root_field_type,
 };
-use crate::pipeline::functions::{regexp_capture, substring};
+use crate::pipeline::functions::{regexp_substr, substring};
 use crate::pipeline::planner::{AttributesIdentifier, ColumnAccessor};
 use crate::pipeline::project::{Projection, ProjectionOptions};
 
@@ -709,7 +709,7 @@ impl ExprLogicalPlanner {
             other => Cow::Borrowed(other),
         };
 
-        let (df_udf_args, source_scope, requires_dict_downcast) = self.plan_function_args(
+        let (mut df_udf_args, source_scope, requires_dict_downcast) = self.plan_function_args(
             [
                 capture_text_expr.get_haystack(),
                 &capture_scalar_expr,
@@ -721,8 +721,15 @@ impl ExprLogicalPlanner {
 
         Ok(ScopedLogicalExpr {
             logical_expr: Expr::ScalarFunction(ScalarFunction::new_udf(
-                regexp_capture(),
-                df_udf_args,
+                regexp_substr(),
+                vec![
+                    df_udf_args.remove(0), // source
+                    df_udf_args.remove(0), // pattern
+                    lit(1),                // start
+                    lit(1),                // occurrence
+                    Expr::default(),       // flags = literal Null
+                    df_udf_args.remove(0), // group
+                ],
             )),
             expr_type: ExprLogicalType::String,
             source: source_scope,

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
@@ -290,6 +290,9 @@ impl ExprLogicalPlanner {
                     StaticScalarExpression::String(string_expr) => {
                         (lit(string_expr.get_value()), ExprLogicalType::String)
                     }
+                    StaticScalarExpression::Null(_) => {
+                        (Expr::default(), ExprLogicalType::AnyValue) // default is lit(null)
+                    }
                     _ => {
                         return Err(Error::NotYetSupportedError {
                             message: format!(

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
@@ -66,7 +66,6 @@ use datafusion::logical_expr::expr::ScalarFunction;
 use datafusion::logical_expr::{
     BinaryExpr, ColumnarValue, Expr, Operator, ScalarUDF, cast, col, lit,
 };
-use datafusion::logical_expr_common::signature::Arity;
 use datafusion::physical_expr::{PhysicalExprRef, create_physical_expr};
 use datafusion::prelude::SessionContext;
 use datafusion::scalar::ScalarValue;
@@ -78,13 +77,13 @@ use otap_df_pdata::otlp::attributes::AttributeValueType;
 use otap_df_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
 use otap_df_pdata::schema::consts;
 
-use crate::consts::{ENCODE_FUNC_NAME, SHA256_FUNC_NAME};
+use crate::consts::{ENCODE_FUNC_NAME, REGEXP_SUBSTR_FUNC_NAME, SHA256_FUNC_NAME};
 use crate::error::{Error, Result};
 use crate::pipeline::expr::join::join;
 use crate::pipeline::expr::types::{
     ExprLogicalType, coerce_arithmetic, nested_struct_field_type, root_field_type,
 };
-use crate::pipeline::functions::{regexp_substr, substring};
+use crate::pipeline::functions::{arity_range, regexp_substr, substring};
 use crate::pipeline::planner::{AttributesIdentifier, ColumnAccessor};
 use crate::pipeline::project::{Projection, ProjectionOptions};
 
@@ -538,11 +537,16 @@ impl ExprLogicalPlanner {
         // check that we've been passed the correct number of arguments.
         //
         // TODO: in future we could also do some additional checking here on the types
-        if let Arity::Fixed(num_params) = df_udf.scalar_udf.signature().type_signature.arity() {
-            if num_args != num_params {
+        if let Some(arity_range) = arity_range(&df_udf.scalar_udf.signature().type_signature) {
+            if !arity_range.contains(&num_args) {
                 return Err(Error::InvalidPipelineError {
                     cause: format!(
-                        "function '{func_name}' expects {num_params} arguments. Received {num_args}"
+                        "function '{func_name}' expects {} arguments. Received {num_args}",
+                        if arity_range.len() > 1 {
+                            format!("{}-{}", arity_range.start, arity_range.end - 1)
+                        } else {
+                            format!("{}", arity_range.start)
+                        }
                     ),
                     query_location: Some(invoke_function_expression.get_query_location().clone()),
                 });
@@ -813,6 +817,9 @@ impl DataFusionFunctionDef {
         // upstream in datafusion_functions)
         Some(match func_name {
             ENCODE_FUNC_NAME => Self::new(encode(), ExprLogicalType::String, false, None),
+            REGEXP_SUBSTR_FUNC_NAME => {
+                Self::new(regexp_substr(), ExprLogicalType::String, false, None)
+            }
             SHA256_FUNC_NAME => Self::new(sha256(), ExprLogicalType::Binary, true, None),
             _ => return None,
         })

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/functions.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/functions.rs
@@ -10,12 +10,12 @@ use datafusion::functions::{export_functions, make_udf_function};
 use datafusion::logical_expr as datafusion_expr;
 
 mod contains;
-mod regexp_capture;
+mod regexp_substr;
 mod substring;
 
 make_udf_function!(contains::ExtendedContainsFunc, contains);
 make_udf_function!(substring::SubstringFunc, substring);
-make_udf_function!(regexp_capture::RegexpCaptureFunc, regexp_capture);
+make_udf_function!(regexp_substr::RegexpSubstrFunc, regexp_substr);
 
 /// helper functions to create logical plan expressions that invoke UDFs
 pub mod expr_fn {

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/functions.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/functions.rs
@@ -10,10 +10,12 @@ use datafusion::functions::{export_functions, make_udf_function};
 use datafusion::logical_expr as datafusion_expr;
 
 mod contains;
+mod regexp_capture;
 mod substring;
 
 make_udf_function!(contains::ExtendedContainsFunc, contains);
 make_udf_function!(substring::SubstringFunc, substring);
+make_udf_function!(regexp_capture::RegexpCaptureFunc, regexp_capture);
 
 /// helper functions to create logical plan expressions that invoke UDFs
 pub mod expr_fn {

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/functions.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/functions.rs
@@ -3,11 +3,14 @@
 
 //! Contains function definitions such as datafusion UDFs
 
+use std::ops::Range;
+
 use datafusion::functions::{export_functions, make_udf_function};
 
 // Note: this is imported like this because the make_udf_function macro uses
 // `datafusion_expr` internally to reference this crate
-use datafusion::logical_expr as datafusion_expr;
+use datafusion::logical_expr::{self as datafusion_expr, TypeSignature};
+use datafusion::logical_expr_common::signature::Arity;
 
 mod contains;
 mod regexp_substr;
@@ -26,4 +29,50 @@ pub mod expr_fn {
         "Return true if `search_string` is found within `string`.",
         string search_string
     ));
+}
+
+/// Get the range of number of args the function signature will accept.
+///
+/// This is useful in cases where the function has [`TypeSignature::OneOf`] with many variants
+/// and we want to check during planning that at least one of the internals has the correct
+/// number of args for some signature. In these cases, we don't rely in [`Signature::arity`]
+/// because it returns the max arity.
+pub(crate) fn arity_range(signature: &TypeSignature) -> Option<Range<usize>> {
+    match signature {
+        TypeSignature::OneOf(variants) => {
+            let mut min = usize::MAX;
+            let mut max = 0;
+            for variant in variants {
+                match variant.arity() {
+                    Arity::Fixed(n) => {
+                        if n < min {
+                            min = n;
+                        }
+                        if n > max {
+                            max = n
+                        }
+                    }
+                    Arity::Variable => {
+                        // func can take any number of args
+                        return None;
+                    }
+                }
+            }
+
+            Some(Range {
+                start: min,
+                end: max + 1,
+            })
+        }
+        _ => {
+            if let Arity::Fixed(n) = signature.arity() {
+                Some(Range {
+                    start: n,
+                    end: n + 1,
+                })
+            } else {
+                None
+            }
+        }
+    }
 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_capture.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_capture.rs
@@ -286,7 +286,6 @@ where
                 let regex_arr_str = regex_arr.as_string::<i32>();
                 regex_capture_with_regex_iter(values, regex_arr_str.iter(), groups)
             }
-            // TODO need tests for this
             DataType::Dictionary(k, v) => {
                 if !matches!(v.as_ref(), &DataType::Utf8) {
                     return exec_err!(
@@ -559,8 +558,8 @@ mod test {
         UInt8Array, UInt16Array, UInt32Array, UInt64Array,
     };
     use arrow::datatypes::{
-        ArrowDictionaryKeyType, Field, Int8Type, Int16Type, Int32Type, Int64Type, Schema,
-        UInt8Type, UInt16Type, UInt64Type,
+        ArrowDictionaryKeyType, ArrowNativeType, Field, Int8Type, Int16Type, Int32Type, Int64Type,
+        Schema, UInt8Type, UInt16Type, UInt32Type, UInt64Type,
     };
     use datafusion::common::DFSchema;
     use datafusion::logical_expr::ColumnarValue;
@@ -593,7 +592,8 @@ mod test {
             vec![col("test_col"), lit("hello (.*)"), lit(1u16)],
         ));
 
-        let input_col = StringArray::from_iter_values(["hello world", "hello otap", "arrow"]);
+        let input_col =
+            StringArray::from_iter_values(["hello world", "otap", "hello otap", "arrow"]);
 
         let input = RecordBatch::try_new(
             Arc::new(Schema::new(vec![Field::new(
@@ -615,8 +615,12 @@ mod test {
 
         let result = physical_expr.evaluate(&input).unwrap();
 
-        let expected: ArrayRef =
-            Arc::new(StringArray::from_iter([Some("world"), Some("otap"), None]));
+        let expected: ArrayRef = Arc::new(StringArray::from_iter([
+            Some("world"),
+            None,
+            Some("otap"),
+            None,
+        ]));
         match result {
             ColumnarValue::Array(arr) => {
                 assert_eq!(&arr, &expected)
@@ -627,8 +631,9 @@ mod test {
         }
     }
 
-    #[tokio::test]
-    async fn test_dict_utf8_arr_values_scalar_pattern_scalar_group() {
+    async fn test_dict_utf8_arr_values_scalar_pattern_scalar_group_generic<
+        K: ArrowDictionaryKeyType,
+    >() {
         let session_context = Pipeline::create_session_context();
 
         let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
@@ -637,7 +642,9 @@ mod test {
         ));
 
         let input_col = DictionaryArray::new(
-            UInt8Array::from_iter_values(vec![0, 0, 1]),
+            PrimitiveArray::<K>::from_iter_values(
+                [0usize, 0, 1].map(|i| K::Native::from_usize(i).unwrap()),
+            ),
             Arc::new(StringArray::from_iter_values(["hello world", "arrow"])),
         );
 
@@ -662,7 +669,71 @@ mod test {
         let result = physical_expr.evaluate(&input).unwrap();
 
         let expected: ArrayRef = Arc::new(DictionaryArray::new(
-            UInt8Array::from_iter([Some(0), Some(0), None]),
+            PrimitiveArray::<K>::from_iter(
+                [Some(0usize), Some(0), None].map(|i| i.map(|i| K::Native::from_usize(i).unwrap())),
+            ),
+            Arc::new(StringArray::from_iter_values(["world", ""])),
+        ));
+        match result {
+            ColumnarValue::Array(arr) => {
+                assert_eq!(&arr, &expected)
+            }
+            s => {
+                panic!("invalid ColumnarValue variant ColumnarValue::Scalar({s:?})")
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_dict_utf8_arr_values_scalar_pattern_scalar_group() {
+        test_dict_utf8_arr_values_scalar_pattern_scalar_group_generic::<Int8Type>().await;
+        test_dict_utf8_arr_values_scalar_pattern_scalar_group_generic::<Int16Type>().await;
+        test_dict_utf8_arr_values_scalar_pattern_scalar_group_generic::<Int32Type>().await;
+        test_dict_utf8_arr_values_scalar_pattern_scalar_group_generic::<Int64Type>().await;
+        test_dict_utf8_arr_values_scalar_pattern_scalar_group_generic::<UInt8Type>().await;
+        test_dict_utf8_arr_values_scalar_pattern_scalar_group_generic::<UInt16Type>().await;
+        test_dict_utf8_arr_values_scalar_pattern_scalar_group_generic::<UInt32Type>().await;
+        test_dict_utf8_arr_values_scalar_pattern_scalar_group_generic::<UInt64Type>().await;
+    }
+
+    #[tokio::test]
+    async fn test_dict_utf8_arr_values_with_nulls_scalar_pattern_scalar_group() {
+        // test to ensure we preserve the original nulls when reconciling the
+        // nulls from dict values that didn't match the passed scalar regex
+        let session_context = Pipeline::create_session_context();
+
+        let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
+            regexp_capture(),
+            vec![col("test_col"), lit("hello (.*)"), lit(1u16)],
+        ));
+
+        let input_col = DictionaryArray::new(
+            UInt8Array::from_iter([Some(0), Some(1), None]),
+            Arc::new(StringArray::from_iter_values(["hello world", "arrow"])),
+        );
+
+        let input = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "test_col",
+                input_col.data_type().clone(),
+                true,
+            )])),
+            vec![Arc::new(input_col)],
+        )
+        .unwrap();
+
+        let df_schema =
+            DFSchema::from_unqualified_fields(input.schema().fields.clone(), Default::default())
+                .unwrap();
+
+        let physical_expr =
+            create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
+                .unwrap();
+
+        let result = physical_expr.evaluate(&input).unwrap();
+
+        let expected: ArrayRef = Arc::new(DictionaryArray::new(
+            UInt8Array::from_iter([Some(0), None, None]),
             Arc::new(StringArray::from_iter_values(["world", ""])),
         ));
         match result {
@@ -761,6 +832,69 @@ mod test {
                 panic!("invalid ColumnarValue variant ColumnarValue::Scalar({s:?})")
             }
         }
+    }
+
+    async fn test_utf8_arr_dict_utf8_arr_pattern_scalar_group_generic<K: ArrowDictionaryKeyType>() {
+        let session_context = Pipeline::create_session_context();
+
+        let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
+            regexp_capture(),
+            vec![col("test_col"), col("regexp_col"), lit(1u16)],
+        ));
+
+        let input_col = StringArray::from_iter_values(["hello world", "hello otap", "arrow"]);
+        let regex_col = DictionaryArray::new(
+            PrimitiveArray::<K>::from_iter_values(
+                [0usize, 1usize, 2usize].map(|i| K::Native::from_usize(i).unwrap()),
+            ),
+            Arc::new(StringArray::from_iter_values([
+                ".(.).*",
+                "..(..).*",
+                "(arr)(ow)",
+            ])),
+        );
+
+        let input = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("test_col", input_col.data_type().clone(), true),
+                Field::new("regexp_col", regex_col.data_type().clone(), true),
+            ])),
+            vec![Arc::new(input_col), Arc::new(regex_col)],
+        )
+        .unwrap();
+
+        let df_schema =
+            DFSchema::from_unqualified_fields(input.schema().fields.clone(), Default::default())
+                .unwrap();
+
+        let physical_expr =
+            create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
+                .unwrap();
+
+        let result = physical_expr.evaluate(&input).unwrap();
+
+        let expected: ArrayRef =
+            Arc::new(StringArray::from_iter([Some("e"), Some("ll"), Some("arr")]));
+        match result {
+            ColumnarValue::Array(arr) => {
+                assert_eq!(&arr, &expected)
+            }
+            s => {
+                panic!("invalid ColumnarValue variant ColumnarValue::Scalar({s:?})")
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_utf8_arr_dict_utf8_arr_pattern_scalar_group() {
+        test_utf8_arr_dict_utf8_arr_pattern_scalar_group_generic::<Int8Type>().await;
+        test_utf8_arr_dict_utf8_arr_pattern_scalar_group_generic::<Int16Type>().await;
+        test_utf8_arr_dict_utf8_arr_pattern_scalar_group_generic::<Int32Type>().await;
+        test_utf8_arr_dict_utf8_arr_pattern_scalar_group_generic::<Int64Type>().await;
+        test_utf8_arr_dict_utf8_arr_pattern_scalar_group_generic::<UInt8Type>().await;
+        test_utf8_arr_dict_utf8_arr_pattern_scalar_group_generic::<UInt16Type>().await;
+        test_utf8_arr_dict_utf8_arr_pattern_scalar_group_generic::<UInt32Type>().await;
+        test_utf8_arr_dict_utf8_arr_pattern_scalar_group_generic::<UInt64Type>().await;
     }
 
     #[tokio::test]
@@ -903,6 +1037,53 @@ mod test {
         let inputs: Vec<ArrayRef> = vec![
             Arc::new(LargeStringArray::from_iter_values([".*(.).*"])),
             Arc::new(StringViewArray::from_iter_values([".*(.).*"])),
+        ];
+
+        let session_context = Pipeline::create_session_context();
+        let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
+            regexp_capture(),
+            vec![col("test_col"), col("regex_col"), lit(0u16)],
+        ));
+
+        for regex_col in inputs {
+            let input_col = StringArray::from_iter_values(["hello"]);
+            let input = RecordBatch::try_new(
+                Arc::new(Schema::new(vec![
+                    Field::new("test_col", input_col.data_type().clone(), true),
+                    Field::new("regex_col", regex_col.data_type().clone(), true),
+                ])),
+                vec![Arc::new(input_col.clone()), Arc::new(regex_col.clone())],
+            )
+            .unwrap();
+
+            let df_schema = DFSchema::from_unqualified_fields(
+                input.schema().fields.clone(),
+                Default::default(),
+            )
+            .unwrap();
+
+            let physical_expr =
+                create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
+                    .unwrap();
+
+            let error = physical_expr.evaluate(&input).unwrap_err();
+            assert!(
+                error
+                    .to_string()
+                    .contains("Unsupported data type for regexes array"),
+                "unexpected error: `{}`",
+                error
+            )
+        }
+    }
+
+    #[tokio::test]
+    async fn test_invalid_but_coercible_dict_regex_input_arrays_are_rejected() {
+        let inputs: Vec<ArrayRef> = vec![
+            Arc::new(DictionaryArray::new(
+                UInt8Array::from_iter_values([0]),
+                Arc::new(LargeStringArray::from_iter_values([".*(.).*"])),
+            )),
             Arc::new(DictionaryArray::new(
                 UInt8Array::from_iter_values([0]),
                 Arc::new(StringViewArray::from_iter_values([".*(.).*"])),
@@ -940,7 +1121,7 @@ mod test {
             assert!(
                 error
                     .to_string()
-                    .contains("Unsupported data type for regexes array"),
+                    .contains("Unsupported dictionary values type for regexes array"),
                 "unexpected error: `{}`",
                 error
             )

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_capture.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_capture.rs
@@ -95,10 +95,10 @@ impl ScalarUDFImpl for RegexpCaptureFunc {
 
     fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
         // datafusion won't call this since we implement return_field_from_args
-        return Err(DataFusionError::Internal(format!(
+        Err(DataFusionError::Internal(format!(
             "return_type should not be called on {}",
             FUNC_NAME
-        )));
+        )))
     }
 
     fn return_field_from_args(&self, args: ReturnFieldArgs<'_>) -> Result<FieldRef> {
@@ -216,7 +216,7 @@ fn invoke_for_dict_source<K: ArrowDictionaryKeyType>(
             // convert them to matched patterns
             let dict_vals_str = dict_vals.as_string::<i32>();
             let new_vals = regex_capture(dict_vals_str.iter(), regexes, groups)?;
-            replace_dict_values(&dict_arr, new_vals)
+            replace_dict_values(dict_arr, new_vals)
         }
         _ => {
             let typed_str_dict = dict_arr
@@ -529,7 +529,7 @@ where
         match (value, regex, group) {
             (Some(value), Some(regex), Some(group)) => {
                 let regex = compile_and_cache_regex(regex, None, &mut regex_cache)?;
-                if let Some(capture) = regex.captures(value).map(|c| c.get(group)).flatten() {
+                if let Some(capture) = regex.captures(value).and_then(|c| c.get(group)) {
                     if null_run > 0 {
                         result_builder.append_nulls(null_run);
                     }
@@ -1134,7 +1134,7 @@ mod test {
     async fn test_coercing_scalar_integer_types() {
         let session_context = Pipeline::create_session_context();
 
-        for group_expr in vec![
+        for group_expr in [
             lit(1u8),
             lit(1u16),
             lit(1u32),
@@ -1295,7 +1295,7 @@ mod test {
     async fn test_coercing_negative_signed_scalar_integer_types() {
         let session_context = Pipeline::create_session_context();
 
-        for group_expr in vec![lit(-1i8), lit(-1i16), lit(-1i32), lit(-1i64)] {
+        for group_expr in [lit(-1i8), lit(-1i16), lit(-1i32), lit(-1i64)] {
             let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
                 regexp_capture(),
                 vec![col("test_col"), lit("hello (.*)"), group_expr],

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_capture.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_capture.rs
@@ -10,20 +10,18 @@ use arrow::array::{
 };
 use arrow::buffer::{BooleanBuffer, NullBuffer};
 use arrow::datatypes::{
-    ArrowDictionaryKeyType, ArrowNativeType, DataType, Int8Type, Int16Type, Int32Type, Int64Type,
-    UInt8Type, UInt16Type,
+    ArrowDictionaryKeyType, ArrowNativeType, DataType, Field, FieldRef, Int8Type, Int16Type,
+    Int32Type, Int64Type, UInt8Type, UInt16Type, UInt32Type, UInt64Type,
 };
-use arrow::util::bit_iterator::BitIndexIterator;
 use arrow::util::bit_util;
 use datafusion::common::types::{NativeType, logical_int64, logical_string, logical_uint16};
 use datafusion::error::Result;
 use datafusion::functions::regex::compile_regex;
 use datafusion::logical_expr::{
-    Coercion, ColumnarValue, Documentation, ScalarFunctionArgs, ScalarUDFImpl, Signature,
-    TypeSignature, TypeSignatureClass, Volatility,
+    Coercion, ColumnarValue, Documentation, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDFImpl,
+    Signature, TypeSignature, TypeSignatureClass, Volatility,
 };
 use datafusion::scalar::ScalarValue;
-use otap_df_pdata::proto::opentelemetry::metrics::v1::metric::Data;
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct RegexpCaptureFunc {
@@ -83,11 +81,21 @@ impl ScalarUDFImpl for RegexpCaptureFunc {
     // TODO - not supposed to call this .... there's another one where we can figure out the
     // return type from the args
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
-        if arg_types.is_empty() {
-            todo!("TODO")
-        }
+        // TODO - return an error because this shouldn't be called
+        todo!()
+    }
 
-        Ok(arg_types[0].clone())
+    fn return_field_from_args(&self, args: ReturnFieldArgs) -> Result<FieldRef> {
+        // TODO len check on args & scalar arguments
+        // TODO comment on why this is like this
+        let return_type =
+            if args.scalar_arguments[1].is_some() && args.scalar_arguments[2].is_some() {
+                args.arg_fields[0].data_type().clone()
+            } else {
+                DataType::Utf8
+            };
+
+        Ok(Arc::new(Field::new(self.name(), return_type, true)))
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
@@ -105,7 +113,10 @@ impl ScalarUDFImpl for RegexpCaptureFunc {
         let str_arr = str_arr.to_array(len)?;
 
         let result = match str_arr.data_type() {
-            DataType::Utf8 => regex_capture(&str_arr.as_string::<i32>(), regexes, groups),
+            DataType::Utf8 => {
+                let str_arr = str_arr.as_string::<i32>();
+                regex_capture(str_arr.iter(), regexes, groups)
+            }
             DataType::Dictionary(k, v) => {
                 if !matches!(v.as_ref(), &DataType::Utf8) {
                     todo!("invalid type")
@@ -117,11 +128,24 @@ impl ScalarUDFImpl for RegexpCaptureFunc {
                         // fast path, can just match the regexes against the dicts values and
                         // convert them to matched patterns
                         let dict_vals_str = dict_vals.as_string::<i32>();
-                        let new_vals = regex_capture(&dict_vals_str, regexes, groups)?;
+                        let new_vals = regex_capture(dict_vals_str.iter(), regexes, groups)?;
                         replace_dict_values(&str_arr, k.as_ref(), new_vals)
                     }
                     _ => {
-                        todo!()
+                        match k.as_ref() {
+                            DataType::UInt8 => {
+                                let dict_arr = as_dictionary_array::<UInt8Type>(&str_arr);
+
+                                // safety: we've checked the value type is utf8 the
+                                let strs = dict_arr
+                                    .downcast_dict::<StringArray>()
+                                    .expect("dict vals are strings");
+                                regex_capture(strs.into_iter(), regexes, groups)
+                            }
+                            _ => {
+                                todo!()
+                            }
+                        }
                     }
                 }
             }
@@ -143,8 +167,8 @@ fn get_dict_values(dict_arr: &ArrayRef, dict_key_type: &DataType) -> Result<Arra
     let dict_vals = match dict_key_type {
         DataType::UInt8 => as_dictionary_array::<UInt8Type>(&dict_arr).values(),
         DataType::UInt16 => as_dictionary_array::<UInt16Type>(&dict_arr).values(),
-        DataType::UInt32 => as_dictionary_array::<UInt16Type>(&dict_arr).values(),
-        DataType::UInt64 => as_dictionary_array::<UInt16Type>(&dict_arr).values(),
+        DataType::UInt32 => as_dictionary_array::<UInt32Type>(&dict_arr).values(),
+        DataType::UInt64 => as_dictionary_array::<UInt64Type>(&dict_arr).values(),
         DataType::Int8 => as_dictionary_array::<Int8Type>(&dict_arr).values(),
         DataType::Int16 => as_dictionary_array::<Int16Type>(&dict_arr).values(),
         DataType::Int32 => as_dictionary_array::<Int32Type>(&dict_arr).values(),
@@ -165,13 +189,27 @@ fn replace_dict_values(
         DataType::UInt8 => {
             replace_dict_values_generic(as_dictionary_array::<UInt8Type>(&dict_arr), new_values)
         }
-        // DataType::UInt16 => as_dictionary_array::<UInt16Type>(&dict_arr).values(),
-        // DataType::UInt32 => as_dictionary_array::<UInt16Type>(&dict_arr).values(),
-        // DataType::UInt64 => as_dictionary_array::<UInt16Type>(&dict_arr).values(),
-        // DataType::Int8 => as_dictionary_array::<Int8Type>(&dict_arr).values(),
-        // DataType::Int16 => as_dictionary_array::<Int16Type>(&dict_arr).values(),
-        // DataType::Int32 => as_dictionary_array::<Int32Type>(&dict_arr).values(),
-        // DataType::Int64 => as_dictionary_array::<Int64Type>(&dict_arr).values(),
+        DataType::UInt16 => {
+            replace_dict_values_generic(as_dictionary_array::<UInt16Type>(&dict_arr), new_values)
+        }
+        DataType::UInt32 => {
+            replace_dict_values_generic(as_dictionary_array::<UInt32Type>(&dict_arr), new_values)
+        }
+        DataType::UInt64 => {
+            replace_dict_values_generic(as_dictionary_array::<UInt64Type>(&dict_arr), new_values)
+        }
+        DataType::Int8 => {
+            replace_dict_values_generic(as_dictionary_array::<Int8Type>(&dict_arr), new_values)
+        }
+        DataType::Int16 => {
+            replace_dict_values_generic(as_dictionary_array::<Int16Type>(&dict_arr), new_values)
+        }
+        DataType::Int32 => {
+            replace_dict_values_generic(as_dictionary_array::<Int32Type>(&dict_arr), new_values)
+        }
+        DataType::Int64 => {
+            replace_dict_values_generic(as_dictionary_array::<Int64Type>(&dict_arr), new_values)
+        }
         _ => {
             todo!()
         }
@@ -218,13 +256,13 @@ fn replace_dict_values_generic<K: ArrowDictionaryKeyType>(
     }
 }
 
-fn regex_capture<'a, S>(
-    values: &S,
+fn regex_capture<'a, I>(
+    values: I,
     regexes: &ColumnarValue,
     groups: &ColumnarValue,
 ) -> Result<ArrayRef>
 where
-    S: StringArrayType<'a>,
+    I: Iterator<Item = Option<&'a str>>,
 {
     match regexes {
         ColumnarValue::Array(regex_arr) => match regex_arr.data_type() {
@@ -246,14 +284,14 @@ where
     }
 }
 
-fn regex_capture_with_regex_iter<'a, 'b, S, I>(
-    values: &S,
-    regexes: I,
+fn regex_capture_with_regex_iter<'a, 'b, I1, I2>(
+    values: I1,
+    regexes: I2,
     groups: &ColumnarValue,
 ) -> Result<ArrayRef>
 where
-    S: StringArrayType<'a>,
-    I: Iterator<Item = Option<&'b str>>,
+    I1: Iterator<Item = Option<&'a str>>,
+    I2: Iterator<Item = Option<&'b str>>,
 {
     match groups {
         ColumnarValue::Array(arr) => {
@@ -271,20 +309,20 @@ where
     }
 }
 
-fn regex_capture_with_group_iter<'a, 'b, S, I1, I2>(
-    values: &S,
-    regexes: I1,
-    groups: I2,
+fn regex_capture_with_group_iter<'a, 'b, I1, I2, I3>(
+    values: I1,
+    regexes: I2,
+    groups: I3,
 ) -> Result<ArrayRef>
 where
-    S: StringArrayType<'a>,
-    I1: Iterator<Item = Option<&'b str>>,
-    I2: Iterator<Item = Option<usize>>,
+    I1: Iterator<Item = Option<&'a str>>,
+    I2: Iterator<Item = Option<&'b str>>,
+    I3: Iterator<Item = Option<usize>>,
 {
     let mut result_builder = StringBuilder::new();
     let mut null_run = 0;
 
-    for ((value, regex), group) in values.iter().zip(regexes).zip(groups) {
+    for ((value, regex), group) in values.zip(regexes).zip(groups) {
         match (value, regex, group) {
             (Some(value), Some(regex), Some(group)) => {
                 let regex = compile_regex(regex, None)?;
@@ -330,7 +368,7 @@ mod test {
     // - uncoercable data types
 
     #[tokio::test]
-    async fn test_utf8_arr_scalar_pattern_scalar_group() {
+    async fn test_utf8_arr_values_scalar_pattern_scalar_group() {
         let session_context = Pipeline::create_session_context();
 
         let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
@@ -373,7 +411,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_dict_utf8_arr_scalar_pattern_scalar_group() {
+    async fn test_dict_utf8_arr_values_scalar_pattern_scalar_group() {
         let session_context = Pipeline::create_session_context();
 
         let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
@@ -410,6 +448,51 @@ mod test {
             UInt8Array::from_iter([Some(0), Some(0), None]),
             Arc::new(StringArray::from_iter_values(["world", ""])),
         ));
+        match result {
+            ColumnarValue::Array(arr) => {
+                assert_eq!(&arr, &expected)
+            }
+            s => {
+                panic!("invalid ColumnarValue variant ColumnarValue::Scalar({s:?})")
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_dict_utf8_arr_values_dict_utf8_arr_pattern_scalar_group() {
+        let session_context = Pipeline::create_session_context();
+
+        let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
+            regexp_capture(),
+            vec![col("test_col"), col("regexp_col"), lit(1u16)],
+        ));
+
+        let input_col = DictionaryArray::new(
+            UInt8Array::from_iter_values(vec![0, 0, 1]),
+            Arc::new(StringArray::from_iter_values(["hello world", "arrow"])),
+        );
+        let regex_col = StringArray::from_iter_values([".(.).*", "..(..).*", "(arr)(ow)"]);
+
+        let input = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("test_col", input_col.data_type().clone(), true),
+                Field::new("regexp_col", regex_col.data_type().clone(), true),
+            ])),
+            vec![Arc::new(input_col), Arc::new(regex_col)],
+        )
+        .unwrap();
+
+        let df_schema =
+            DFSchema::from_unqualified_fields(input.schema().fields.clone(), Default::default())
+                .unwrap();
+
+        let physical_expr =
+            create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
+                .unwrap();
+
+        let result = physical_expr.evaluate(&input).unwrap();
+
+        let expected: ArrayRef = Arc::new(StringArray::from_iter_values(["e", "ll", "arr"]));
         match result {
             ColumnarValue::Array(arr) => {
                 assert_eq!(&arr, &expected)

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_capture.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_capture.rs
@@ -35,15 +35,15 @@ const FUNC_NAME: &str = "regexp_capture";
 /// return `"world"`. It returns `None` if the regex does not match the source, or if the
 /// capture group is not in the regex.
 ///
-/// Capture group 0 represents the full regex. For example if passed
-/// `regexp_capture("hello world", ".*hello (.*).*", 1)`, this would return "hello world".
+/// Capture group 0 represents the full source text that matched. For example if passed
+/// `regexp_capture("hello world", ".*hello (.*).*", 0)`, this would return "hello world".
 ///
-/// If capture group < 0, this always returns null.
+/// If capture group < 0, this returns null.
 ///
-/// # Type information:
+/// # Return Type:
 ///
 /// If the source is a dictionary, this will try to keep the return type as a dictionary array.
-/// However, if different regexs/capture groups are passed for each row of input, we can't
+/// However, if non-scalar regexs/capture groups are passed for each row of input, we can't
 /// guarantee the dictionary won't overflow. For this reason, if the regex/capture group args
 /// are not scalars, the return type will be the native string array.
 ///
@@ -75,6 +75,8 @@ impl RegexpCaptureFunc {
                 "pattern".to_string(),
                 "capture_group".to_string(),
             ])
+            // safety: these parameter names are valid because they match the arity of the
+            // signature and there are no duplicates, so it is safe to expect here
             .expect("valid parameter names"),
         }
     }
@@ -94,7 +96,7 @@ impl ScalarUDFImpl for RegexpCaptureFunc {
     }
 
     fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
-        // datafusion won't call this since we implement return_field_from_args
+        // won't be called this since we implement return_field_from_args
         Err(DataFusionError::Internal(format!(
             "return_type should not be called on {}",
             FUNC_NAME
@@ -108,6 +110,8 @@ impl ScalarUDFImpl for RegexpCaptureFunc {
                 FUNC_NAME
             );
         }
+
+        // see note in type documentation for reasoning about the return type
         let return_type =
             if args.scalar_arguments[1].is_some() && args.scalar_arguments[2].is_some() {
                 args.arg_fields[0].data_type().clone()

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_capture.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_capture.rs
@@ -5,8 +5,8 @@ use std::any::Any;
 use std::sync::Arc;
 
 use arrow::array::{
-    Array, ArrayRef, AsArray, DictionaryArray, PrimitiveArray, StringArray, StringArrayType,
-    StringBuilder, as_dictionary_array, make_array,
+    Array, ArrayRef, ArrowPrimitiveType, AsArray, DictionaryArray, PrimitiveArray, StringArray,
+    StringArrayType, StringBuilder, as_dictionary_array, make_array,
 };
 use arrow::buffer::{BooleanBuffer, NullBuffer};
 use arrow::datatypes::{
@@ -14,7 +14,10 @@ use arrow::datatypes::{
     Int32Type, Int64Type, UInt8Type, UInt16Type, UInt32Type, UInt64Type,
 };
 use arrow::util::bit_util;
-use datafusion::common::types::{NativeType, logical_int64, logical_string, logical_uint16};
+use datafusion::common::exec_err;
+use datafusion::common::types::{
+    LogicalUnionFields, NativeType, logical_int64, logical_string, logical_uint16,
+};
 use datafusion::error::Result;
 use datafusion::functions::regex::compile_regex;
 use datafusion::logical_expr::{
@@ -23,6 +26,27 @@ use datafusion::logical_expr::{
 };
 use datafusion::scalar::ScalarValue;
 
+const FUNC_NAME: &str = "regexp_capture";
+
+/// This scalar UDF implementation takes three arguments: source (string), regex (string) and
+/// capture group (int) and returns the portion of the text from the source that is matched by
+/// the capture group.
+///
+/// For example, if passed: `regexp_capture("hello world", ".*hello (.*).*", 1)`, it would
+/// return `"world"`. It returns `None` if the regex does not match the source, or if the
+/// capture group is not in the regex.
+///
+/// Capture group 0 represents the full regex. For example if passed
+/// `regexp_capture("hello world", ".*hello (.*).*", 1)`, this would return "hello world".
+///
+/// # Type information:
+///
+/// If the source is a dictionary, this will try to keep the return type as a dictionary array.
+/// However, if different regexs/capture groups are passed for each row of input, we can't
+/// guarantee the dictionary won't overflow. For this reason, if the regex/capture group args
+/// are not scalars, the return type will be the native string array.
+///
+///
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct RegexpCaptureFunc {
     signature: Signature,
@@ -39,19 +63,9 @@ impl RegexpCaptureFunc {
         Self {
             signature: Signature::one_of(
                 vec![TypeSignature::Coercible(vec![
-                    Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
-                    // TODO - if we don't end up supporting something dynamic on the other side
-                    // then we should maybe just make this 2nd arg a straight up str?
-                    Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
-                    Coercion::new_implicit(
-                        // TODO - should we allow that there are more than u16::Max capture groups?
-                        TypeSignatureClass::Native(logical_uint16()),
-                        vec![
-                            // TODO are there others
-                            TypeSignatureClass::Native(logical_int64()),
-                        ],
-                        NativeType::UInt16,
-                    ),
+                    Coercion::new_exact(TypeSignatureClass::Native(Arc::new(NativeType::String))),
+                    Coercion::new_exact(TypeSignatureClass::Native(Arc::new(NativeType::String))),
+                    Coercion::new_exact(TypeSignatureClass::Integer),
                 ])],
                 Volatility::Immutable,
             )
@@ -71,7 +85,7 @@ impl ScalarUDFImpl for RegexpCaptureFunc {
     }
 
     fn name(&self) -> &str {
-        "regexp_capture"
+        FUNC_NAME
     }
 
     fn signature(&self) -> &Signature {
@@ -103,54 +117,62 @@ impl ScalarUDFImpl for RegexpCaptureFunc {
             todo!("return error")
         }
 
-        let str_arr = &args.args[0];
+        let sources = &args.args[0];
         let regexes = &args.args[1];
         let groups = &args.args[2];
-        let len = match str_arr {
+        let len = match sources {
             ColumnarValue::Array(arr) => arr.len(),
-            ColumnarValue::Scalar(scalar) => 1,
+            ColumnarValue::Scalar(_) => 1,
         };
-        let str_arr = str_arr.to_array(len)?;
+        let source_arr = sources.to_array(len)?;
 
-        let result = match str_arr.data_type() {
+        let result = match source_arr.data_type() {
             DataType::Utf8 => {
-                let str_arr = str_arr.as_string::<i32>();
+                let str_arr = source_arr.as_string::<i32>();
                 regex_capture(str_arr.iter(), regexes, groups)
             }
             DataType::Dictionary(k, v) => {
                 if !matches!(v.as_ref(), &DataType::Utf8) {
-                    todo!("invalid type")
+                    return exec_err!(
+                        "Unsupported data type {:?} for function `{}`",
+                        source_arr.data_type(),
+                        self.name()
+                    );
                 }
 
-                let dict_vals = get_dict_values(&str_arr, k.as_ref())?;
-                match (regexes, groups) {
-                    (ColumnarValue::Scalar(_), ColumnarValue::Scalar(_)) => {
-                        // fast path, can just match the regexes against the dicts values and
-                        // convert them to matched patterns
-                        let dict_vals_str = dict_vals.as_string::<i32>();
-                        let new_vals = regex_capture(dict_vals_str.iter(), regexes, groups)?;
-                        replace_dict_values(&str_arr, k.as_ref(), new_vals)
+                match k.as_ref() {
+                    DataType::Int8 => {
+                        invoke_for_dict_source::<Int8Type>(&source_arr, regexes, groups)
                     }
-                    _ => {
-                        match k.as_ref() {
-                            DataType::UInt8 => {
-                                let dict_arr = as_dictionary_array::<UInt8Type>(&str_arr);
-
-                                // safety: we've checked the value type is utf8 the
-                                let strs = dict_arr
-                                    .downcast_dict::<StringArray>()
-                                    .expect("dict vals are strings");
-                                regex_capture(strs.into_iter(), regexes, groups)
-                            }
-                            _ => {
-                                todo!()
-                            }
-                        }
+                    DataType::Int16 => {
+                        invoke_for_dict_source::<Int16Type>(&source_arr, regexes, groups)
                     }
+                    DataType::Int32 => {
+                        invoke_for_dict_source::<Int32Type>(&source_arr, regexes, groups)
+                    }
+                    DataType::Int64 => {
+                        invoke_for_dict_source::<Int64Type>(&source_arr, regexes, groups)
+                    }
+                    DataType::UInt8 => {
+                        invoke_for_dict_source::<UInt8Type>(&source_arr, regexes, groups)
+                    }
+                    DataType::UInt16 => {
+                        invoke_for_dict_source::<UInt16Type>(&source_arr, regexes, groups)
+                    }
+                    DataType::UInt32 => {
+                        invoke_for_dict_source::<UInt32Type>(&source_arr, regexes, groups)
+                    }
+                    DataType::UInt64 => {
+                        invoke_for_dict_source::<UInt64Type>(&source_arr, regexes, groups)
+                    }
+                    other => exec_err!("Invalid dictionary key {other:?}"),
                 }
             }
-            _ => {
-                todo!()
+            other => {
+                exec_err!(
+                    "Unsupported data type {other:?} for function `{}`",
+                    self.name()
+                )
             }
         }?;
 
@@ -163,60 +185,37 @@ impl ScalarUDFImpl for RegexpCaptureFunc {
     }
 }
 
-fn get_dict_values(dict_arr: &ArrayRef, dict_key_type: &DataType) -> Result<ArrayRef> {
-    let dict_vals = match dict_key_type {
-        DataType::UInt8 => as_dictionary_array::<UInt8Type>(&dict_arr).values(),
-        DataType::UInt16 => as_dictionary_array::<UInt16Type>(&dict_arr).values(),
-        DataType::UInt32 => as_dictionary_array::<UInt32Type>(&dict_arr).values(),
-        DataType::UInt64 => as_dictionary_array::<UInt64Type>(&dict_arr).values(),
-        DataType::Int8 => as_dictionary_array::<Int8Type>(&dict_arr).values(),
-        DataType::Int16 => as_dictionary_array::<Int16Type>(&dict_arr).values(),
-        DataType::Int32 => as_dictionary_array::<Int32Type>(&dict_arr).values(),
-        DataType::Int64 => as_dictionary_array::<Int64Type>(&dict_arr).values(),
-        _ => {
-            todo!()
-        }
-    };
-    Ok(Arc::clone(dict_vals))
-}
-
-fn replace_dict_values(
-    dict_arr: &ArrayRef,
-    dict_key_type: &DataType,
-    new_values: ArrayRef,
+fn invoke_for_dict_source<K: ArrowDictionaryKeyType>(
+    source_arr: &ArrayRef,
+    regexes: &ColumnarValue,
+    groups: &ColumnarValue,
 ) -> Result<ArrayRef> {
-    match dict_key_type {
-        DataType::UInt8 => {
-            replace_dict_values_generic(as_dictionary_array::<UInt8Type>(&dict_arr), new_values)
-        }
-        DataType::UInt16 => {
-            replace_dict_values_generic(as_dictionary_array::<UInt16Type>(&dict_arr), new_values)
-        }
-        DataType::UInt32 => {
-            replace_dict_values_generic(as_dictionary_array::<UInt32Type>(&dict_arr), new_values)
-        }
-        DataType::UInt64 => {
-            replace_dict_values_generic(as_dictionary_array::<UInt64Type>(&dict_arr), new_values)
-        }
-        DataType::Int8 => {
-            replace_dict_values_generic(as_dictionary_array::<Int8Type>(&dict_arr), new_values)
-        }
-        DataType::Int16 => {
-            replace_dict_values_generic(as_dictionary_array::<Int16Type>(&dict_arr), new_values)
-        }
-        DataType::Int32 => {
-            replace_dict_values_generic(as_dictionary_array::<Int32Type>(&dict_arr), new_values)
-        }
-        DataType::Int64 => {
-            replace_dict_values_generic(as_dictionary_array::<Int64Type>(&dict_arr), new_values)
+    let dict_arr = source_arr.as_dictionary::<K>();
+    let dict_vals = dict_arr.values();
+    match (regexes, groups) {
+        (ColumnarValue::Scalar(_), ColumnarValue::Scalar(_)) => {
+            // fast path, can just match the regexes against the dicts values and
+            // convert them to matched patterns
+            let dict_vals_str = dict_vals.as_string::<i32>();
+            let new_vals = regex_capture(dict_vals_str.iter(), regexes, groups)?;
+            replace_dict_values(&dict_arr, new_vals)
         }
         _ => {
-            todo!()
+            let sources_iter = dict_arr
+                .downcast_dict::<StringArray>()
+                .expect("dict vals are strings");
+            regex_capture(sources_iter.into_iter(), regexes, groups)
         }
     }
 }
 
-fn replace_dict_values_generic<K: ArrowDictionaryKeyType>(
+/// This is called after we've matched the scalar regex on the dictionary values.
+///
+/// It replaces the values array in the dictionary with the result which contains portions of
+/// the dict values (which were used as input) that matched the regex capture group. For dict
+/// values that didn't match, this handles swapping the nulls from the dict values null buffer
+/// to the keys null buffer.
+fn replace_dict_values<K: ArrowDictionaryKeyType>(
     dict_arr: &DictionaryArray<K>,
     new_values: ArrayRef,
 ) -> Result<ArrayRef> {
@@ -270,8 +269,11 @@ where
                 let regex_arr_str = regex_arr.as_string::<i32>();
                 regex_capture_with_regex_iter(values, regex_arr_str.iter(), groups)
             }
-            _ => {
-                todo!()
+            other => {
+                exec_err!(
+                    "Unsupported data type for regexes array {other:?} in function `{}`",
+                    FUNC_NAME
+                )
             }
         },
         ColumnarValue::Scalar(regex_scalar) => {
@@ -294,19 +296,64 @@ where
     I2: Iterator<Item = Option<&'b str>>,
 {
     match groups {
-        ColumnarValue::Array(arr) => {
-            todo!()
-        }
+        ColumnarValue::Array(arr) => match arr.data_type() {
+            DataType::Int8 => {
+                regex_capture_with_group_primitive_arr::<_, _, Int8Type>(values, regexes, arr)
+            }
+            DataType::Int16 => {
+                regex_capture_with_group_primitive_arr::<_, _, Int16Type>(values, regexes, arr)
+            }
+            DataType::Int32 => {
+                regex_capture_with_group_primitive_arr::<_, _, Int32Type>(values, regexes, arr)
+            }
+            DataType::Int64 => {
+                regex_capture_with_group_primitive_arr::<_, _, Int64Type>(values, regexes, arr)
+            }
+            DataType::UInt8 => {
+                regex_capture_with_group_primitive_arr::<_, _, UInt8Type>(values, regexes, arr)
+            }
+            DataType::UInt16 => {
+                regex_capture_with_group_primitive_arr::<_, _, UInt16Type>(values, regexes, arr)
+            }
+            DataType::UInt32 => {
+                regex_capture_with_group_primitive_arr::<_, _, UInt32Type>(values, regexes, arr)
+            }
+            DataType::UInt64 => {
+                regex_capture_with_group_primitive_arr::<_, _, UInt64Type>(values, regexes, arr)
+            }
+            _ => {
+                todo!()
+            }
+        },
         ColumnarValue::Scalar(scalar) => {
-            // TODO maybe like check if it's negative (at least to know what happens)
-            let u64_scalar = scalar.cast_to(&DataType::UInt64)?;
-            let ScalarValue::UInt64(group) = u64_scalar else {
-                unreachable!("we've casted this to UInt64")
+            let unsigned_scalar = scalar.cast_to(&DataType::UInt32)?;
+            let ScalarValue::UInt32(group) = unsigned_scalar else {
+                unreachable!("we've casted this to UInt32")
             };
             let group = group.map(|i| i as usize);
             regex_capture_with_group_iter(values, regexes, std::iter::repeat(group))
         }
     }
+}
+
+fn regex_capture_with_group_primitive_arr<'a, 'b, I1, I2, T: ArrowPrimitiveType>(
+    values: I1,
+    regexes: I2,
+    groups: &ArrayRef,
+) -> Result<ArrayRef>
+where
+    I1: Iterator<Item = Option<&'a str>>,
+    I2: Iterator<Item = Option<&'b str>>,
+{
+    let zero = T::Native::default();
+    regex_capture_with_group_iter(
+        values,
+        regexes,
+        groups
+            .as_primitive::<T>()
+            .iter()
+            .map(|i| i.and_then(|i| (i >= zero).then_some(i.as_usize()))),
+    )
 }
 
 fn regex_capture_with_group_iter<'a, 'b, I1, I2, I3>(
@@ -351,7 +398,11 @@ where
 
 #[cfg(test)]
 mod test {
-    use arrow::array::{Array, ArrayRef, DictionaryArray, RecordBatch, StringArray, UInt8Array};
+    use arrow::array::{
+        Array, ArrayRef, BinaryArray, DictionaryArray, Int8Array, Int16Array, Int32Array,
+        Int64Array, LargeStringArray, RecordBatch, StringArray, StringViewArray, UInt8Array,
+        UInt16Array, UInt32Array, UInt64Array,
+    };
     use arrow::datatypes::{Field, Schema};
     use datafusion::common::DFSchema;
     use datafusion::logical_expr::ColumnarValue;
@@ -543,6 +594,393 @@ mod test {
             s => {
                 panic!("invalid ColumnarValue variant ColumnarValue::Scalar({s:?})")
             }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_capture_group_not_in_regex() {
+        let session_context = Pipeline::create_session_context();
+
+        let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
+            regexp_capture(),
+            vec![col("test_col"), lit("hello (.*)"), lit(2u16)],
+        ));
+
+        let input_col = StringArray::from_iter_values(["hello world", "hello otap", "arrow"]);
+
+        let input = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "test_col",
+                input_col.data_type().clone(),
+                true,
+            )])),
+            vec![Arc::new(input_col)],
+        )
+        .unwrap();
+
+        let df_schema =
+            DFSchema::from_unqualified_fields(input.schema().fields.clone(), Default::default())
+                .unwrap();
+
+        let physical_expr =
+            create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
+                .unwrap();
+
+        let result = physical_expr.evaluate(&input).unwrap();
+
+        let expected: ArrayRef = Arc::new(StringArray::new_null(3));
+        match result {
+            ColumnarValue::Array(arr) => {
+                assert_eq!(&arr, &expected)
+            }
+            s => {
+                panic!("invalid ColumnarValue variant ColumnarValue::Scalar({s:?})")
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_zero_capture_group_matches_full_text() {
+        let session_context = Pipeline::create_session_context();
+
+        let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
+            regexp_capture(),
+            vec![col("test_col"), lit("hello (.*)"), lit(0u16)],
+        ));
+
+        let input_col = StringArray::from_iter_values(["hello world", "hello otap", "arrow"]);
+
+        let input = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "test_col",
+                input_col.data_type().clone(),
+                true,
+            )])),
+            vec![Arc::new(input_col.clone())],
+        )
+        .unwrap();
+
+        let df_schema =
+            DFSchema::from_unqualified_fields(input.schema().fields.clone(), Default::default())
+                .unwrap();
+
+        let physical_expr =
+            create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
+                .unwrap();
+
+        let result = physical_expr.evaluate(&input).unwrap();
+
+        let expected: ArrayRef = Arc::new(StringArray::from_iter([
+            Some("hello world"),
+            Some("hello otap"),
+            None,
+        ]));
+        match result {
+            ColumnarValue::Array(arr) => {
+                assert_eq!(&arr, &expected)
+            }
+            s => {
+                panic!("invalid ColumnarValue variant ColumnarValue::Scalar({s:?})")
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_invalid_but_coercible_source_input_types_are_rejected() {
+        let inputs: Vec<ArrayRef> = vec![
+            Arc::new(LargeStringArray::from_iter_values(["hello world"])),
+            Arc::new(StringViewArray::from_iter_values(["hello world"])),
+            Arc::new(DictionaryArray::new(
+                UInt8Array::from_iter_values([0]),
+                Arc::new(StringViewArray::from_iter_values(["hello world"])),
+            )),
+        ];
+
+        let session_context = Pipeline::create_session_context();
+        let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
+            regexp_capture(),
+            vec![col("test_col"), lit("hello (.*)"), lit(0u16)],
+        ));
+
+        for input_col in inputs {
+            let input = RecordBatch::try_new(
+                Arc::new(Schema::new(vec![Field::new(
+                    "test_col",
+                    input_col.data_type().clone(),
+                    true,
+                )])),
+                vec![Arc::new(input_col.clone())],
+            )
+            .unwrap();
+
+            let df_schema = DFSchema::from_unqualified_fields(
+                input.schema().fields.clone(),
+                Default::default(),
+            )
+            .unwrap();
+
+            let physical_expr =
+                create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
+                    .unwrap();
+
+            let error = physical_expr.evaluate(&input).unwrap_err();
+            assert!(
+                error.to_string().contains("Unsupported data type"),
+                "unexpected error: `{}`",
+                error
+            )
+        }
+    }
+
+    #[tokio::test]
+    async fn test_invalid_but_coercible_regex_input_arrays_are_rejected() {
+        let inputs: Vec<ArrayRef> = vec![
+            Arc::new(LargeStringArray::from_iter_values([".*(.).*"])),
+            Arc::new(StringViewArray::from_iter_values([".*(.).*"])),
+            Arc::new(DictionaryArray::new(
+                UInt8Array::from_iter_values([0]),
+                Arc::new(StringViewArray::from_iter_values([".*(.).*"])),
+            )),
+        ];
+
+        let session_context = Pipeline::create_session_context();
+        let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
+            regexp_capture(),
+            vec![col("test_col"), col("regex_col"), lit(0u16)],
+        ));
+
+        for regex_col in inputs {
+            let input_col = StringArray::from_iter_values(["hello"]);
+            let input = RecordBatch::try_new(
+                Arc::new(Schema::new(vec![
+                    Field::new("test_col", input_col.data_type().clone(), true),
+                    Field::new("regex_col", regex_col.data_type().clone(), true),
+                ])),
+                vec![Arc::new(input_col.clone()), Arc::new(regex_col.clone())],
+            )
+            .unwrap();
+
+            let df_schema = DFSchema::from_unqualified_fields(
+                input.schema().fields.clone(),
+                Default::default(),
+            )
+            .unwrap();
+
+            let physical_expr =
+                create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
+                    .unwrap();
+
+            let error = physical_expr.evaluate(&input).unwrap_err();
+            assert!(
+                error
+                    .to_string()
+                    .contains("Unsupported data type for regexes array"),
+                "unexpected error: `{}`",
+                error
+            )
+        }
+    }
+
+    #[tokio::test]
+    async fn test_coercing_scalar_integer_types() {
+        let session_context = Pipeline::create_session_context();
+
+        for group_expr in vec![
+            lit(1u8),
+            lit(1u16),
+            lit(1u32),
+            lit(1u64),
+            lit(1i8),
+            lit(1i16),
+            lit(1i32),
+            lit(1i64),
+        ] {
+            let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
+                regexp_capture(),
+                vec![col("test_col"), lit("hello (.*)"), group_expr],
+            ));
+
+            let input_col = StringArray::from_iter_values(["hello world", "hello otap", "arrow"]);
+
+            let input = RecordBatch::try_new(
+                Arc::new(Schema::new(vec![Field::new(
+                    "test_col",
+                    input_col.data_type().clone(),
+                    true,
+                )])),
+                vec![Arc::new(input_col)],
+            )
+            .unwrap();
+
+            let df_schema = DFSchema::from_unqualified_fields(
+                input.schema().fields.clone(),
+                Default::default(),
+            )
+            .unwrap();
+
+            let physical_expr =
+                create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
+                    .unwrap();
+
+            let result = physical_expr.evaluate(&input).unwrap();
+
+            let expected: ArrayRef =
+                Arc::new(StringArray::from_iter([Some("world"), Some("otap"), None]));
+            match result {
+                ColumnarValue::Array(arr) => {
+                    assert_eq!(&arr, &expected)
+                }
+                s => {
+                    panic!("invalid ColumnarValue variant ColumnarValue::Scalar({s:?})")
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_coercing_scalar_array_types() {
+        let session_context = Pipeline::create_session_context();
+        let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
+            regexp_capture(),
+            vec![col("test_col"), lit("hello (.*)"), col("group_col")],
+        ));
+
+        let group_cols: Vec<ArrayRef> = vec![
+            Arc::new(UInt8Array::from_iter_values([1, 1, 1])),
+            Arc::new(UInt16Array::from_iter_values([1, 1, 1])),
+            Arc::new(UInt32Array::from_iter_values([1, 1, 1])),
+            Arc::new(UInt64Array::from_iter_values([1, 1, 1])),
+            Arc::new(Int8Array::from_iter_values([1, 1, 1])),
+            Arc::new(Int16Array::from_iter_values([1, 1, 1])),
+            Arc::new(Int32Array::from_iter_values([1, 1, 1])),
+            Arc::new(Int64Array::from_iter_values([1, 1, 1])),
+        ];
+
+        for group_col in group_cols {
+            let input_col = StringArray::from_iter_values(["hello world", "hello otap", "arrow"]);
+            let input = RecordBatch::try_new(
+                Arc::new(Schema::new(vec![
+                    Field::new("test_col", input_col.data_type().clone(), true),
+                    Field::new("group_col", group_col.data_type().clone(), true),
+                ])),
+                vec![Arc::new(input_col), Arc::new(group_col)],
+            )
+            .unwrap();
+
+            let df_schema = DFSchema::from_unqualified_fields(
+                input.schema().fields.clone(),
+                Default::default(),
+            )
+            .unwrap();
+
+            let physical_expr =
+                create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
+                    .unwrap();
+
+            let result = physical_expr.evaluate(&input).unwrap();
+
+            let expected: ArrayRef =
+                Arc::new(StringArray::from_iter([Some("world"), Some("otap"), None]));
+            match result {
+                ColumnarValue::Array(arr) => {
+                    assert_eq!(&arr, &expected)
+                }
+                s => {
+                    panic!("invalid ColumnarValue variant ColumnarValue::Scalar({s:?})")
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_coercing_scalar_array_types_with_negative_vals() {
+        let session_context = Pipeline::create_session_context();
+        let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
+            regexp_capture(),
+            vec![col("test_col"), lit("hello (.*)"), col("group_col")],
+        ));
+
+        let group_cols: Vec<ArrayRef> = vec![
+            Arc::new(Int8Array::from_iter_values([-1])),
+            Arc::new(Int16Array::from_iter_values([-1])),
+            Arc::new(Int32Array::from_iter_values([-1])),
+            Arc::new(Int64Array::from_iter_values([-1])),
+        ];
+
+        for group_col in group_cols {
+            let input_col = StringArray::from_iter_values(["hello world"]);
+            let input = RecordBatch::try_new(
+                Arc::new(Schema::new(vec![
+                    Field::new("test_col", input_col.data_type().clone(), true),
+                    Field::new("group_col", group_col.data_type().clone(), true),
+                ])),
+                vec![Arc::new(input_col), Arc::new(group_col)],
+            )
+            .unwrap();
+
+            let df_schema = DFSchema::from_unqualified_fields(
+                input.schema().fields.clone(),
+                Default::default(),
+            )
+            .unwrap();
+
+            let physical_expr =
+                create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
+                    .unwrap();
+
+            let result = physical_expr.evaluate(&input).unwrap();
+
+            let expected: ArrayRef = Arc::new(StringArray::new_null(1));
+            match result {
+                ColumnarValue::Array(arr) => {
+                    assert_eq!(&arr, &expected)
+                }
+                s => {
+                    panic!("invalid ColumnarValue variant ColumnarValue::Scalar({s:?})")
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_coercing_negative_signed_scalar_integer_types() {
+        let session_context = Pipeline::create_session_context();
+
+        for group_expr in vec![lit(-1i8), lit(-1i16), lit(-1i32), lit(-1i64)] {
+            let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
+                regexp_capture(),
+                vec![col("test_col"), lit("hello (.*)"), group_expr],
+            ));
+
+            let input_col = StringArray::from_iter_values(["hello world", "hello otap", "arrow"]);
+
+            let input = RecordBatch::try_new(
+                Arc::new(Schema::new(vec![Field::new(
+                    "test_col",
+                    input_col.data_type().clone(),
+                    true,
+                )])),
+                vec![Arc::new(input_col)],
+            )
+            .unwrap();
+
+            let df_schema = DFSchema::from_unqualified_fields(
+                input.schema().fields.clone(),
+                Default::default(),
+            )
+            .unwrap();
+
+            let physical_expr =
+                create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
+                    .unwrap();
+
+            let error = physical_expr.evaluate(&input).unwrap_err();
+            assert!(
+                error
+                    .to_string()
+                    .contains("Can't cast value -1 to type UInt"),
+                "unexpected error message {error}"
+            );
         }
     }
 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_capture.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_capture.rs
@@ -218,10 +218,10 @@ fn invoke_for_dict_source<K: ArrowDictionaryKeyType>(
             replace_dict_values(&dict_arr, new_vals)
         }
         _ => {
-            let sources_iter = dict_arr
+            let typed_str_dict = dict_arr
                 .downcast_dict::<StringArray>()
                 .expect("dict vals are strings");
-            regex_capture(sources_iter.into_iter(), regexes, groups)
+            regex_capture(typed_str_dict.into_iter(), regexes, groups)
         }
     }
 }
@@ -286,6 +286,49 @@ where
                 let regex_arr_str = regex_arr.as_string::<i32>();
                 regex_capture_with_regex_iter(values, regex_arr_str.iter(), groups)
             }
+            // TODO need tests for this
+            DataType::Dictionary(k, v) => {
+                if !matches!(v.as_ref(), &DataType::Utf8) {
+                    return exec_err!(
+                        "Unsupported dictionary values type for regexes array {:?} in function `{}`",
+                        k.as_ref(),
+                        FUNC_NAME
+                    );
+                }
+
+                match k.as_ref() {
+                    DataType::Int8 => {
+                        invoke_for_dict_regex::<_, Int8Type>(values, regex_arr, groups)
+                    }
+                    DataType::Int16 => {
+                        invoke_for_dict_regex::<_, Int16Type>(values, regex_arr, groups)
+                    }
+                    DataType::Int32 => {
+                        invoke_for_dict_regex::<_, Int32Type>(values, regex_arr, groups)
+                    }
+                    DataType::Int64 => {
+                        invoke_for_dict_regex::<_, Int64Type>(values, regex_arr, groups)
+                    }
+                    DataType::UInt8 => {
+                        invoke_for_dict_regex::<_, UInt8Type>(values, regex_arr, groups)
+                    }
+                    DataType::UInt16 => {
+                        invoke_for_dict_regex::<_, UInt16Type>(values, regex_arr, groups)
+                    }
+                    DataType::UInt32 => {
+                        invoke_for_dict_regex::<_, UInt32Type>(values, regex_arr, groups)
+                    }
+                    DataType::UInt64 => {
+                        invoke_for_dict_regex::<_, UInt64Type>(values, regex_arr, groups)
+                    }
+                    other => {
+                        exec_err!(
+                            "Unsupported dictionary key type for regexes array {other:?} in function `{}`",
+                            FUNC_NAME
+                        )
+                    }
+                }
+            }
             other => {
                 exec_err!(
                     "Unsupported data type for regexes array {other:?} in function `{}`",
@@ -301,6 +344,24 @@ where
             regex_capture_with_regex_iter(values, std::iter::repeat(str_regex.as_deref()), groups)
         }
     }
+}
+
+/// Invoke the UDF for the case that the regex is a dictionary encoded array.
+///
+/// This expects that the type has already been verified to be `DataType::<K, Utf8>`
+fn invoke_for_dict_regex<'a, I, K: ArrowDictionaryKeyType>(
+    values: I,
+    regex_dict_arr: &ArrayRef,
+    groups: &ColumnarValue,
+) -> Result<ArrayRef>
+where
+    I: Iterator<Item = Option<&'a str>>,
+{
+    let dict_arr = regex_dict_arr.as_dictionary::<K>();
+    let typed_regex_dict = dict_arr
+        .downcast_dict::<StringArray>()
+        .expect("dict values are strings");
+    regex_capture_with_regex_iter(values, typed_regex_dict.into_iter(), groups)
 }
 
 macro_rules! dispatch_dict_groups {

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_capture.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_capture.rs
@@ -185,8 +185,16 @@ impl ScalarUDFImpl for RegexpCaptureFunc {
             }
         }?;
 
-        // TODO - maybe coerce back to scalar ..
-        Ok(ColumnarValue::Array(result))
+        let all_scalar = matches!(sources, ColumnarValue::Scalar(_))
+            && matches!(regexes, ColumnarValue::Scalar(_))
+            && matches!(groups, ColumnarValue::Scalar(_));
+
+        if all_scalar {
+            let scalar = ScalarValue::try_from_array(&result, 0)?;
+            Ok(ColumnarValue::Scalar(scalar))
+        } else {
+            Ok(ColumnarValue::Array(result))
+        }
     }
 
     fn documentation(&self) -> Option<&Documentation> {
@@ -485,18 +493,19 @@ where
 #[cfg(test)]
 mod test {
     use arrow::array::{
-        Array, ArrayRef, ArrowPrimitiveType, BinaryArray, DictionaryArray, Int8Array, Int16Array,
-        Int32Array, Int64Array, LargeStringArray, PrimitiveArray, RecordBatch, StringArray,
-        StringViewArray, UInt8Array, UInt16Array, UInt32Array, UInt64Array,
+        Array, ArrayRef, ArrowPrimitiveType, DictionaryArray, Int8Array, Int16Array, Int32Array,
+        Int64Array, LargeStringArray, PrimitiveArray, RecordBatch, StringArray, StringViewArray,
+        UInt8Array, UInt16Array, UInt32Array, UInt64Array,
     };
     use arrow::datatypes::{
         ArrowDictionaryKeyType, Field, Int8Type, Int16Type, Int32Type, Int64Type, Schema,
-        UInt8Type, UInt16Type, UInt32Type, UInt64Type,
+        UInt8Type, UInt16Type, UInt64Type,
     };
     use datafusion::common::DFSchema;
     use datafusion::logical_expr::ColumnarValue;
     use datafusion::logical_expr::{Expr, col, expr::ScalarFunction, lit};
     use datafusion::physical_expr::create_physical_expr;
+    use datafusion::scalar::ScalarValue;
     use std::sync::Arc;
 
     use crate::pipeline::Pipeline;
@@ -1239,6 +1248,46 @@ mod test {
             s => {
                 panic!("invalid ColumnarValue variant ColumnarValue::Scalar({s:?})")
             }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_all_scalar_args_returns_scalar() {
+        let session_context = Pipeline::create_session_context();
+
+        // matching case
+        let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
+            regexp_capture(),
+            vec![lit("hello world"), lit("hello (.*)"), lit(1u16)],
+        ));
+
+        let input = RecordBatch::new_empty(Arc::new(Schema::empty()));
+        let df_schema = DFSchema::empty();
+
+        let physical_expr =
+            create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
+                .unwrap();
+
+        let result = physical_expr.evaluate(&input).unwrap();
+        match result {
+            ColumnarValue::Scalar(ScalarValue::Utf8(Some(s))) => assert_eq!(s, "world"),
+            other => panic!("expected Scalar(Utf8(Some(\"world\"))), got {other:?}"),
+        }
+
+        // non-matching case
+        let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
+            regexp_capture(),
+            vec![lit("arrow"), lit("hello (.*)"), lit(1u16)],
+        ));
+
+        let physical_expr =
+            create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
+                .unwrap();
+
+        let result = physical_expr.evaluate(&input).unwrap();
+        match result {
+            ColumnarValue::Scalar(ScalarValue::Utf8(None)) => {}
+            other => panic!("expected Scalar(Utf8(None)), got {other:?}"),
         }
     }
 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_capture.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_capture.rs
@@ -4,8 +4,17 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use arrow::array::{ArrayRef, AsArray, StringArrayType, StringBuilder};
-use arrow::datatypes::DataType;
+use arrow::array::{
+    Array, ArrayRef, AsArray, DictionaryArray, PrimitiveArray, StringArray, StringArrayType,
+    StringBuilder, as_dictionary_array, make_array,
+};
+use arrow::buffer::{BooleanBuffer, NullBuffer};
+use arrow::datatypes::{
+    ArrowDictionaryKeyType, ArrowNativeType, DataType, Int8Type, Int16Type, Int32Type, Int64Type,
+    UInt8Type, UInt16Type,
+};
+use arrow::util::bit_iterator::BitIndexIterator;
+use arrow::util::bit_util;
 use datafusion::common::types::{NativeType, logical_int64, logical_string, logical_uint16};
 use datafusion::error::Result;
 use datafusion::functions::regex::compile_regex;
@@ -14,6 +23,7 @@ use datafusion::logical_expr::{
     TypeSignature, TypeSignatureClass, Volatility,
 };
 use datafusion::scalar::ScalarValue;
+use otap_df_pdata::proto::opentelemetry::metrics::v1::metric::Data;
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct RegexpCaptureFunc {
@@ -70,6 +80,8 @@ impl ScalarUDFImpl for RegexpCaptureFunc {
         &self.signature
     }
 
+    // TODO - not supposed to call this .... there's another one where we can figure out the
+    // return type from the args
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         if arg_types.is_empty() {
             todo!("TODO")
@@ -94,6 +106,25 @@ impl ScalarUDFImpl for RegexpCaptureFunc {
 
         let result = match str_arr.data_type() {
             DataType::Utf8 => regex_capture(&str_arr.as_string::<i32>(), regexes, groups),
+            DataType::Dictionary(k, v) => {
+                if !matches!(v.as_ref(), &DataType::Utf8) {
+                    todo!("invalid type")
+                }
+
+                let dict_vals = get_dict_values(&str_arr, k.as_ref())?;
+                match (regexes, groups) {
+                    (ColumnarValue::Scalar(_), ColumnarValue::Scalar(_)) => {
+                        // fast path, can just match the regexes against the dicts values and
+                        // convert them to matched patterns
+                        let dict_vals_str = dict_vals.as_string::<i32>();
+                        let new_vals = regex_capture(&dict_vals_str, regexes, groups)?;
+                        replace_dict_values(&str_arr, k.as_ref(), new_vals)
+                    }
+                    _ => {
+                        todo!()
+                    }
+                }
+            }
             _ => {
                 todo!()
             }
@@ -105,6 +136,85 @@ impl ScalarUDFImpl for RegexpCaptureFunc {
 
     fn documentation(&self) -> Option<&Documentation> {
         None
+    }
+}
+
+fn get_dict_values(dict_arr: &ArrayRef, dict_key_type: &DataType) -> Result<ArrayRef> {
+    let dict_vals = match dict_key_type {
+        DataType::UInt8 => as_dictionary_array::<UInt8Type>(&dict_arr).values(),
+        DataType::UInt16 => as_dictionary_array::<UInt16Type>(&dict_arr).values(),
+        DataType::UInt32 => as_dictionary_array::<UInt16Type>(&dict_arr).values(),
+        DataType::UInt64 => as_dictionary_array::<UInt16Type>(&dict_arr).values(),
+        DataType::Int8 => as_dictionary_array::<Int8Type>(&dict_arr).values(),
+        DataType::Int16 => as_dictionary_array::<Int16Type>(&dict_arr).values(),
+        DataType::Int32 => as_dictionary_array::<Int32Type>(&dict_arr).values(),
+        DataType::Int64 => as_dictionary_array::<Int64Type>(&dict_arr).values(),
+        _ => {
+            todo!()
+        }
+    };
+    Ok(Arc::clone(dict_vals))
+}
+
+fn replace_dict_values(
+    dict_arr: &ArrayRef,
+    dict_key_type: &DataType,
+    new_values: ArrayRef,
+) -> Result<ArrayRef> {
+    match dict_key_type {
+        DataType::UInt8 => {
+            replace_dict_values_generic(as_dictionary_array::<UInt8Type>(&dict_arr), new_values)
+        }
+        // DataType::UInt16 => as_dictionary_array::<UInt16Type>(&dict_arr).values(),
+        // DataType::UInt32 => as_dictionary_array::<UInt16Type>(&dict_arr).values(),
+        // DataType::UInt64 => as_dictionary_array::<UInt16Type>(&dict_arr).values(),
+        // DataType::Int8 => as_dictionary_array::<Int8Type>(&dict_arr).values(),
+        // DataType::Int16 => as_dictionary_array::<Int16Type>(&dict_arr).values(),
+        // DataType::Int32 => as_dictionary_array::<Int32Type>(&dict_arr).values(),
+        // DataType::Int64 => as_dictionary_array::<Int64Type>(&dict_arr).values(),
+        _ => {
+            todo!()
+        }
+    }
+}
+
+fn replace_dict_values_generic<K: ArrowDictionaryKeyType>(
+    dict_arr: &DictionaryArray<K>,
+    new_values: ArrayRef,
+) -> Result<ArrayRef> {
+    match new_values.nulls() {
+        Some(val_nulls) => {
+            let mut new_nulls = match dict_arr.keys().nulls() {
+                Some(key_nulls) => key_nulls.buffer().to_vec(),
+                None => vec![0xFF; bit_util::ceil(dict_arr.len(), 8)],
+            };
+
+            let dict_keys = dict_arr.keys();
+            for i in 0..dict_arr.len() {
+                let key = dict_keys.values()[i].as_usize();
+                if val_nulls.is_null(key) {
+                    bit_util::unset_bit(&mut new_nulls, i);
+                }
+            }
+
+            let new_data = new_values.to_data().into_builder().nulls(None).build()?;
+
+            Ok(Arc::new(DictionaryArray::new(
+                PrimitiveArray::<K>::new(
+                    dict_arr.keys().values().clone(),
+                    Some(NullBuffer::new(BooleanBuffer::new(
+                        new_nulls.into(),
+                        0,
+                        dict_arr.len(),
+                    ))),
+                ),
+                make_array(new_data),
+            )))
+        }
+        None => Ok(Arc::new(DictionaryArray::new(
+            dict_arr.keys().clone(),
+            new_values,
+        ))),
     }
 }
 
@@ -203,7 +313,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use arrow::array::{Array, ArrayRef, RecordBatch, StringArray};
+    use arrow::array::{Array, ArrayRef, DictionaryArray, RecordBatch, StringArray, UInt8Array};
     use arrow::datatypes::{Field, Schema};
     use datafusion::common::DFSchema;
     use datafusion::logical_expr::ColumnarValue;
@@ -252,6 +362,54 @@ mod test {
 
         let expected: ArrayRef =
             Arc::new(StringArray::from_iter([Some("world"), Some("otap"), None]));
+        match result {
+            ColumnarValue::Array(arr) => {
+                assert_eq!(&arr, &expected)
+            }
+            s => {
+                panic!("invalid ColumnarValue variant ColumnarValue::Scalar({s:?})")
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_dict_utf8_arr_scalar_pattern_scalar_group() {
+        let session_context = Pipeline::create_session_context();
+
+        let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
+            regexp_capture(),
+            vec![col("test_col"), lit("hello (.*)"), lit(1u16)],
+        ));
+
+        let input_col = DictionaryArray::new(
+            UInt8Array::from_iter_values(vec![0, 0, 1]),
+            Arc::new(StringArray::from_iter_values(["hello world", "arrow"])),
+        );
+
+        let input = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "test_col",
+                input_col.data_type().clone(),
+                true,
+            )])),
+            vec![Arc::new(input_col)],
+        )
+        .unwrap();
+
+        let df_schema =
+            DFSchema::from_unqualified_fields(input.schema().fields.clone(), Default::default())
+                .unwrap();
+
+        let physical_expr =
+            create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
+                .unwrap();
+
+        let result = physical_expr.evaluate(&input).unwrap();
+
+        let expected: ArrayRef = Arc::new(DictionaryArray::new(
+            UInt8Array::from_iter([Some(0), Some(0), None]),
+            Arc::new(StringArray::from_iter_values(["world", ""])),
+        ));
         match result {
             ColumnarValue::Array(arr) => {
                 assert_eq!(&arr, &expected)

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_capture.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_capture.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use arrow::array::{
     Array, ArrayRef, ArrowPrimitiveType, AsArray, DictionaryArray, PrimitiveArray, StringArray,
-    StringArrayType, StringBuilder, as_dictionary_array, make_array,
+    StringBuilder, make_array,
 };
 use arrow::buffer::{BooleanBuffer, NullBuffer};
 use arrow::datatypes::{
@@ -15,10 +15,8 @@ use arrow::datatypes::{
 };
 use arrow::util::bit_util;
 use datafusion::common::exec_err;
-use datafusion::common::types::{
-    LogicalUnionFields, NativeType, logical_int64, logical_string, logical_uint16,
-};
-use datafusion::error::Result;
+use datafusion::common::types::NativeType;
+use datafusion::error::{DataFusionError, Result};
 use datafusion::functions::regex::compile_regex;
 use datafusion::logical_expr::{
     Coercion, ColumnarValue, Documentation, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDFImpl,
@@ -38,6 +36,8 @@ const FUNC_NAME: &str = "regexp_capture";
 ///
 /// Capture group 0 represents the full regex. For example if passed
 /// `regexp_capture("hello world", ".*hello (.*).*", 1)`, this would return "hello world".
+///
+/// If capture group < 0, this always returns null.
 ///
 /// # Type information:
 ///
@@ -92,16 +92,21 @@ impl ScalarUDFImpl for RegexpCaptureFunc {
         &self.signature
     }
 
-    // TODO - not supposed to call this .... there's another one where we can figure out the
-    // return type from the args
-    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
-        // TODO - return an error because this shouldn't be called
-        todo!()
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        // datafusion won't call this since we implement return_field_from_args
+        return Err(DataFusionError::Internal(format!(
+            "return_type should not be called on {}",
+            FUNC_NAME
+        )));
     }
 
-    fn return_field_from_args(&self, args: ReturnFieldArgs) -> Result<FieldRef> {
-        // TODO len check on args & scalar arguments
-        // TODO comment on why this is like this
+    fn return_field_from_args(&self, args: ReturnFieldArgs<'_>) -> Result<FieldRef> {
+        if args.arg_fields.len() != 3 || args.scalar_arguments.len() != 3 {
+            return exec_err!(
+                "{} `return_field_from_args` called with invalid number of args. expected 3",
+                FUNC_NAME
+            );
+        }
         let return_type =
             if args.scalar_arguments[1].is_some() && args.scalar_arguments[2].is_some() {
                 args.arg_fields[0].data_type().clone()
@@ -114,7 +119,11 @@ impl ScalarUDFImpl for RegexpCaptureFunc {
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         if args.args.len() != 3 {
-            todo!("return error")
+            return exec_err!(
+                "{} `return_field_from_args` called with invalid number of args. expected 3. got {}",
+                FUNC_NAME,
+                args.args.len()
+            );
         }
 
         let sources = &args.args[0];
@@ -286,6 +295,68 @@ where
     }
 }
 
+macro_rules! dispatch_dict_groups {
+    ($values:expr, $regexes:expr, $groups:expr, $key_dt:expr, $val_dt:expr) => {
+        paste::paste! {
+            match $key_dt {
+                DataType::Int8 => dispatch_dict_groups!(@val $values, $regexes, $groups, Int8Type, $val_dt),
+                DataType::Int16 => dispatch_dict_groups!(@val $values, $regexes, $groups, Int16Type, $val_dt),
+                DataType::Int32 => dispatch_dict_groups!(@val $values, $regexes, $groups, Int32Type, $val_dt),
+                DataType::Int64 => dispatch_dict_groups!(@val $values, $regexes, $groups, Int64Type, $val_dt),
+                DataType::UInt8 => dispatch_dict_groups!(@val $values, $regexes, $groups, UInt8Type, $val_dt),
+                DataType::UInt16 => dispatch_dict_groups!(@val $values, $regexes, $groups, UInt16Type, $val_dt),
+                DataType::UInt32 => dispatch_dict_groups!(@val $values, $regexes, $groups, UInt32Type, $val_dt),
+                DataType::UInt64 => dispatch_dict_groups!(@val $values, $regexes, $groups, UInt64Type, $val_dt),
+                other => exec_err!("Unsupported dictionary key type for groups: {other:?}"),
+            }
+        }
+    };
+    (@val $values:expr, $regexes:expr, $groups:expr, $ktyp:ty, $val_dt:expr) => {
+        match $val_dt {
+            DataType::Int8 => regex_capture_with_group_dict_arr::<_, _, $ktyp, Int8Type>($values, $regexes, $groups),
+            DataType::Int16 => regex_capture_with_group_dict_arr::<_, _, $ktyp, Int16Type>($values, $regexes, $groups),
+            DataType::Int32 => regex_capture_with_group_dict_arr::<_, _, $ktyp, Int32Type>($values, $regexes, $groups),
+            DataType::Int64 => regex_capture_with_group_dict_arr::<_, _, $ktyp, Int64Type>($values, $regexes, $groups),
+            DataType::UInt8 => regex_capture_with_group_dict_arr::<_, _, $ktyp, UInt8Type>($values, $regexes, $groups),
+            DataType::UInt16 => regex_capture_with_group_dict_arr::<_, _, $ktyp, UInt16Type>($values, $regexes, $groups),
+            DataType::UInt32 => regex_capture_with_group_dict_arr::<_, _, $ktyp, UInt32Type>($values, $regexes, $groups),
+            DataType::UInt64 => regex_capture_with_group_dict_arr::<_, _, $ktyp, UInt64Type>($values, $regexes, $groups),
+            other => exec_err!("Unsupported dictionary value type for groups: {other:?}"),
+        }
+    };
+}
+
+fn regex_capture_with_group_dict_arr<'a, 'b, I1, I2, K, V>(
+    values: I1,
+    regexes: I2,
+    groups: &ArrayRef,
+) -> Result<ArrayRef>
+where
+    I1: Iterator<Item = Option<&'a str>>,
+    I2: Iterator<Item = Option<&'b str>>,
+    K: ArrowDictionaryKeyType,
+    V: ArrowPrimitiveType,
+{
+    let dict = groups.as_dictionary::<K>();
+    let dict_values = dict.values().as_primitive::<V>();
+    let zero = V::Native::default();
+    regex_capture_with_group_iter(
+        values,
+        regexes,
+        dict.keys().iter().map(|key| {
+            key.and_then(|k| {
+                let idx = k.as_usize();
+                if dict_values.is_null(idx) {
+                    None
+                } else {
+                    let v = dict_values.value(idx);
+                    (v >= zero).then_some(v.as_usize())
+                }
+            })
+        }),
+    )
+}
+
 fn regex_capture_with_regex_iter<'a, 'b, I1, I2>(
     values: I1,
     regexes: I2,
@@ -321,16 +392,31 @@ where
             DataType::UInt64 => {
                 regex_capture_with_group_primitive_arr::<_, _, UInt64Type>(values, regexes, arr)
             }
-            _ => {
-                todo!()
+            DataType::Dictionary(k, v) => {
+                dispatch_dict_groups!(values, regexes, arr, k.as_ref(), v.as_ref())
+            }
+            other => {
+                exec_err!(
+                    "Unsupported data type for groups array {other:?} in function `{}`",
+                    FUNC_NAME
+                )
             }
         },
         ColumnarValue::Scalar(scalar) => {
-            let unsigned_scalar = scalar.cast_to(&DataType::UInt32)?;
-            let ScalarValue::UInt32(group) = unsigned_scalar else {
-                unreachable!("we've casted this to UInt32")
+            let group = match scalar.cast_to(&DataType::UInt64) {
+                Ok(unsigned_scalar) => {
+                    let ScalarValue::UInt64(group) = unsigned_scalar else {
+                        unreachable!("we've casted this to UInt64")
+                    };
+                    group.map(|i| i as usize)
+                }
+
+                // if we couldn't cast, it means we had a negative integer scalar
+                // so always treat the group as null, meaning the result for all
+                // the rows will be null.
+                _ => None,
             };
-            let group = group.map(|i| i as usize);
+
             regex_capture_with_group_iter(values, regexes, std::iter::repeat(group))
         }
     }
@@ -399,11 +485,14 @@ where
 #[cfg(test)]
 mod test {
     use arrow::array::{
-        Array, ArrayRef, BinaryArray, DictionaryArray, Int8Array, Int16Array, Int32Array,
-        Int64Array, LargeStringArray, RecordBatch, StringArray, StringViewArray, UInt8Array,
-        UInt16Array, UInt32Array, UInt64Array,
+        Array, ArrayRef, ArrowPrimitiveType, BinaryArray, DictionaryArray, Int8Array, Int16Array,
+        Int32Array, Int64Array, LargeStringArray, PrimitiveArray, RecordBatch, StringArray,
+        StringViewArray, UInt8Array, UInt16Array, UInt32Array, UInt64Array,
     };
-    use arrow::datatypes::{Field, Schema};
+    use arrow::datatypes::{
+        ArrowDictionaryKeyType, Field, Int8Type, Int16Type, Int32Type, Int64Type, Schema,
+        UInt8Type, UInt16Type, UInt32Type, UInt64Type,
+    };
     use datafusion::common::DFSchema;
     use datafusion::logical_expr::ColumnarValue;
     use datafusion::logical_expr::{Expr, col, expr::ScalarFunction, lit};
@@ -413,10 +502,17 @@ mod test {
     use crate::pipeline::Pipeline;
     use crate::pipeline::functions::regexp_capture;
 
-    // TODO test cases:
-    // - negative group
-    // - zero group
-    // - uncoercable data types
+    fn make_dict_array<K: ArrowDictionaryKeyType, V: ArrowPrimitiveType>(
+        keys: &[K::Native],
+        values: &[V::Native],
+    ) -> ArrayRef {
+        Arc::new(DictionaryArray::new(
+            PrimitiveArray::<K>::from_iter_values(keys.iter().copied()),
+            Arc::new(PrimitiveArray::<V>::from_iter_values(
+                values.iter().copied(),
+            )),
+        ))
+    }
 
     #[tokio::test]
     async fn test_utf8_arr_values_scalar_pattern_scalar_group() {
@@ -974,13 +1070,175 @@ mod test {
                 create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
                     .unwrap();
 
-            let error = physical_expr.evaluate(&input).unwrap_err();
-            assert!(
-                error
-                    .to_string()
-                    .contains("Can't cast value -1 to type UInt"),
-                "unexpected error message {error}"
-            );
+            let result = physical_expr.evaluate(&input).unwrap();
+            let expected: ArrayRef = Arc::new(StringArray::new_null(3));
+            match result {
+                ColumnarValue::Array(arr) => {
+                    assert_eq!(&arr, &expected)
+                }
+                s => {
+                    panic!("invalid ColumnarValue variant ColumnarValue::Scalar({s:?})")
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_dict_encoded_group_arrays() {
+        let session_context = Pipeline::create_session_context();
+        let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
+            regexp_capture(),
+            vec![col("test_col"), lit("hello (.*)"), col("group_col")],
+        ));
+
+        // Each dict array maps all 3 rows to a single value of 1.
+        // Tests a sample of key/value type combinations.
+        let group_cols: Vec<ArrayRef> = vec![
+            make_dict_array::<UInt8Type, Int32Type>(&[0, 0, 0], &[1]),
+            make_dict_array::<Int16Type, UInt64Type>(&[0, 0, 0], &[1]),
+            make_dict_array::<Int32Type, Int8Type>(&[0, 0, 0], &[1]),
+            make_dict_array::<UInt64Type, UInt16Type>(&[0, 0, 0], &[1]),
+            make_dict_array::<Int8Type, Int64Type>(&[0, 0, 0], &[1]),
+        ];
+
+        for group_col in group_cols {
+            let input_col = StringArray::from_iter_values(["hello world", "hello otap", "arrow"]);
+            let input = RecordBatch::try_new(
+                Arc::new(Schema::new(vec![
+                    Field::new("test_col", input_col.data_type().clone(), true),
+                    Field::new("group_col", group_col.data_type().clone(), true),
+                ])),
+                vec![Arc::new(input_col), Arc::new(group_col.clone())],
+            )
+            .unwrap();
+
+            let df_schema = DFSchema::from_unqualified_fields(
+                input.schema().fields.clone(),
+                Default::default(),
+            )
+            .unwrap();
+
+            let physical_expr =
+                create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
+                    .unwrap();
+
+            let result = physical_expr.evaluate(&input).unwrap();
+
+            let expected: ArrayRef =
+                Arc::new(StringArray::from_iter([Some("world"), Some("otap"), None]));
+            match result {
+                ColumnarValue::Array(arr) => {
+                    assert_eq!(
+                        &arr,
+                        &expected,
+                        "failed for group_col type {:?}",
+                        group_col.data_type()
+                    )
+                }
+                s => {
+                    panic!("invalid ColumnarValue variant ColumnarValue::Scalar({s:?})")
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_dict_encoded_group_arrays_with_negative_vals() {
+        let session_context = Pipeline::create_session_context();
+        let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
+            regexp_capture(),
+            vec![col("test_col"), lit("hello (.*)"), col("group_col")],
+        ));
+
+        let group_cols: Vec<ArrayRef> = vec![
+            make_dict_array::<UInt8Type, Int8Type>(&[0], &[-1]),
+            make_dict_array::<UInt8Type, Int16Type>(&[0], &[-1]),
+            make_dict_array::<UInt8Type, Int32Type>(&[0], &[-1]),
+            make_dict_array::<UInt8Type, Int64Type>(&[0], &[-1]),
+        ];
+
+        for group_col in group_cols {
+            let input_col = StringArray::from_iter_values(["hello world"]);
+            let input = RecordBatch::try_new(
+                Arc::new(Schema::new(vec![
+                    Field::new("test_col", input_col.data_type().clone(), true),
+                    Field::new("group_col", group_col.data_type().clone(), true),
+                ])),
+                vec![Arc::new(input_col), Arc::new(group_col.clone())],
+            )
+            .unwrap();
+
+            let df_schema = DFSchema::from_unqualified_fields(
+                input.schema().fields.clone(),
+                Default::default(),
+            )
+            .unwrap();
+
+            let physical_expr =
+                create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
+                    .unwrap();
+
+            let result = physical_expr.evaluate(&input).unwrap();
+
+            let expected: ArrayRef = Arc::new(StringArray::new_null(1));
+            match result {
+                ColumnarValue::Array(arr) => {
+                    assert_eq!(
+                        &arr,
+                        &expected,
+                        "failed for group_col type {:?}",
+                        group_col.data_type()
+                    )
+                }
+                s => {
+                    panic!("invalid ColumnarValue variant ColumnarValue::Scalar({s:?})")
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_dict_encoded_group_arrays_with_null_keys() {
+        let session_context = Pipeline::create_session_context();
+        let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
+            regexp_capture(),
+            vec![col("test_col"), lit("hello (.*)"), col("group_col")],
+        ));
+
+        // Key index 0 -> value 1, but second row has a null key
+        let group_col: ArrayRef = Arc::new(DictionaryArray::new(
+            PrimitiveArray::<UInt8Type>::from_iter([Some(0), None, Some(0)]),
+            Arc::new(PrimitiveArray::<Int32Type>::from_iter_values([1])),
+        ));
+
+        let input_col = StringArray::from_iter_values(["hello world", "hello otap", "arrow"]);
+        let input = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("test_col", input_col.data_type().clone(), true),
+                Field::new("group_col", group_col.data_type().clone(), true),
+            ])),
+            vec![Arc::new(input_col), Arc::new(group_col)],
+        )
+        .unwrap();
+
+        let df_schema =
+            DFSchema::from_unqualified_fields(input.schema().fields.clone(), Default::default())
+                .unwrap();
+
+        let physical_expr =
+            create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
+                .unwrap();
+
+        let result = physical_expr.evaluate(&input).unwrap();
+
+        let expected: ArrayRef = Arc::new(StringArray::from_iter([Some("world"), None, None]));
+        match result {
+            ColumnarValue::Array(arr) => {
+                assert_eq!(&arr, &expected)
+            }
+            s => {
+                panic!("invalid ColumnarValue variant ColumnarValue::Scalar({s:?})")
+            }
         }
     }
 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_capture.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_capture.rs
@@ -1,0 +1,307 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::any::Any;
+use std::sync::Arc;
+
+use arrow::array::{ArrayRef, AsArray, StringArrayType, StringBuilder};
+use arrow::datatypes::DataType;
+use datafusion::common::types::{NativeType, logical_int64, logical_string, logical_uint16};
+use datafusion::error::Result;
+use datafusion::functions::regex::compile_regex;
+use datafusion::logical_expr::{
+    Coercion, ColumnarValue, Documentation, ScalarFunctionArgs, ScalarUDFImpl, Signature,
+    TypeSignature, TypeSignatureClass, Volatility,
+};
+use datafusion::scalar::ScalarValue;
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct RegexpCaptureFunc {
+    signature: Signature,
+}
+
+impl Default for RegexpCaptureFunc {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RegexpCaptureFunc {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::one_of(
+                vec![TypeSignature::Coercible(vec![
+                    Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                    // TODO - if we don't end up supporting something dynamic on the other side
+                    // then we should maybe just make this 2nd arg a straight up str?
+                    Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                    Coercion::new_implicit(
+                        // TODO - should we allow that there are more than u16::Max capture groups?
+                        TypeSignatureClass::Native(logical_uint16()),
+                        vec![
+                            // TODO are there others
+                            TypeSignatureClass::Native(logical_int64()),
+                        ],
+                        NativeType::UInt16,
+                    ),
+                ])],
+                Volatility::Immutable,
+            )
+            .with_parameter_names(vec![
+                "str".to_string(),
+                "pattern".to_string(),
+                "capture_group".to_string(),
+            ])
+            .expect("valid parameter names"),
+        }
+    }
+}
+
+impl ScalarUDFImpl for RegexpCaptureFunc {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "regexp_capture"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        if arg_types.is_empty() {
+            todo!("TODO")
+        }
+
+        Ok(arg_types[0].clone())
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        if args.args.len() != 3 {
+            todo!("return error")
+        }
+
+        let str_arr = &args.args[0];
+        let regexes = &args.args[1];
+        let groups = &args.args[2];
+        let len = match str_arr {
+            ColumnarValue::Array(arr) => arr.len(),
+            ColumnarValue::Scalar(scalar) => 1,
+        };
+        let str_arr = str_arr.to_array(len)?;
+
+        let result = match str_arr.data_type() {
+            DataType::Utf8 => regex_capture(&str_arr.as_string::<i32>(), regexes, groups),
+            _ => {
+                todo!()
+            }
+        }?;
+
+        // TODO - maybe coerce back to scalar ..
+        Ok(ColumnarValue::Array(result))
+    }
+
+    fn documentation(&self) -> Option<&Documentation> {
+        None
+    }
+}
+
+fn regex_capture<'a, S>(
+    values: &S,
+    regexes: &ColumnarValue,
+    groups: &ColumnarValue,
+) -> Result<ArrayRef>
+where
+    S: StringArrayType<'a>,
+{
+    match regexes {
+        ColumnarValue::Array(regex_arr) => match regex_arr.data_type() {
+            DataType::Utf8 => {
+                let regex_arr_str = regex_arr.as_string::<i32>();
+                regex_capture_with_regex_iter(values, regex_arr_str.iter(), groups)
+            }
+            _ => {
+                todo!()
+            }
+        },
+        ColumnarValue::Scalar(regex_scalar) => {
+            let regex_scalar_str = regex_scalar.cast_to(&DataType::Utf8)?;
+            let ScalarValue::Utf8(str_regex) = regex_scalar_str else {
+                unreachable!("we've casted this to Utf8")
+            };
+            regex_capture_with_regex_iter(values, std::iter::repeat(str_regex.as_deref()), groups)
+        }
+    }
+}
+
+fn regex_capture_with_regex_iter<'a, 'b, S, I>(
+    values: &S,
+    regexes: I,
+    groups: &ColumnarValue,
+) -> Result<ArrayRef>
+where
+    S: StringArrayType<'a>,
+    I: Iterator<Item = Option<&'b str>>,
+{
+    match groups {
+        ColumnarValue::Array(arr) => {
+            todo!()
+        }
+        ColumnarValue::Scalar(scalar) => {
+            // TODO maybe like check if it's negative (at least to know what happens)
+            let u64_scalar = scalar.cast_to(&DataType::UInt64)?;
+            let ScalarValue::UInt64(group) = u64_scalar else {
+                unreachable!("we've casted this to UInt64")
+            };
+            let group = group.map(|i| i as usize);
+            regex_capture_with_group_iter(values, regexes, std::iter::repeat(group))
+        }
+    }
+}
+
+fn regex_capture_with_group_iter<'a, 'b, S, I1, I2>(
+    values: &S,
+    regexes: I1,
+    groups: I2,
+) -> Result<ArrayRef>
+where
+    S: StringArrayType<'a>,
+    I1: Iterator<Item = Option<&'b str>>,
+    I2: Iterator<Item = Option<usize>>,
+{
+    let mut result_builder = StringBuilder::new();
+    let mut null_run = 0;
+
+    for ((value, regex), group) in values.iter().zip(regexes).zip(groups) {
+        match (value, regex, group) {
+            (Some(value), Some(regex), Some(group)) => {
+                let regex = compile_regex(regex, None)?;
+                if let Some(capture) = regex.captures(value).map(|c| c.get(group)).flatten() {
+                    if null_run > 0 {
+                        result_builder.append_nulls(null_run);
+                    }
+
+                    result_builder.append_value(&value[capture.start()..capture.end()]);
+                    null_run = 0;
+                } else {
+                    null_run += 1
+                }
+            }
+            _ => {
+                null_run += 1;
+            }
+        }
+    }
+    if null_run > 0 {
+        result_builder.append_nulls(null_run);
+    }
+
+    Ok(Arc::new(result_builder.finish()))
+}
+
+#[cfg(test)]
+mod test {
+    use arrow::array::{Array, ArrayRef, RecordBatch, StringArray};
+    use arrow::datatypes::{Field, Schema};
+    use datafusion::common::DFSchema;
+    use datafusion::logical_expr::ColumnarValue;
+    use datafusion::logical_expr::{Expr, col, expr::ScalarFunction, lit};
+    use datafusion::physical_expr::create_physical_expr;
+    use std::sync::Arc;
+
+    use crate::pipeline::Pipeline;
+    use crate::pipeline::functions::regexp_capture;
+
+    // TODO test cases:
+    // - negative group
+    // - zero group
+    // - uncoercable data types
+
+    #[tokio::test]
+    async fn test_utf8_arr_scalar_pattern_scalar_group() {
+        let session_context = Pipeline::create_session_context();
+
+        let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
+            regexp_capture(),
+            vec![col("test_col"), lit("hello (.*)"), lit(1u16)],
+        ));
+
+        let input_col = StringArray::from_iter_values(["hello world", "hello otap", "arrow"]);
+
+        let input = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "test_col",
+                input_col.data_type().clone(),
+                true,
+            )])),
+            vec![Arc::new(input_col)],
+        )
+        .unwrap();
+
+        let df_schema =
+            DFSchema::from_unqualified_fields(input.schema().fields.clone(), Default::default())
+                .unwrap();
+
+        let physical_expr =
+            create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
+                .unwrap();
+
+        let result = physical_expr.evaluate(&input).unwrap();
+
+        let expected: ArrayRef =
+            Arc::new(StringArray::from_iter([Some("world"), Some("otap"), None]));
+        match result {
+            ColumnarValue::Array(arr) => {
+                assert_eq!(&arr, &expected)
+            }
+            s => {
+                panic!("invalid ColumnarValue variant ColumnarValue::Scalar({s:?})")
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_utf8_arr_utf8_arr_pattern_scalar_group() {
+        let session_context = Pipeline::create_session_context();
+
+        let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
+            regexp_capture(),
+            vec![col("test_col"), col("regexp_col"), lit(1u16)],
+        ));
+
+        let input_col = StringArray::from_iter_values(["hello world", "hello otap", "arrow"]);
+        let regex_col = StringArray::from_iter_values([".(.).*", "..(..).*", "(arr)(ow)"]);
+
+        let input = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("test_col", input_col.data_type().clone(), true),
+                Field::new("regexp_col", regex_col.data_type().clone(), true),
+            ])),
+            vec![Arc::new(input_col), Arc::new(regex_col)],
+        )
+        .unwrap();
+
+        let df_schema =
+            DFSchema::from_unqualified_fields(input.schema().fields.clone(), Default::default())
+                .unwrap();
+
+        let physical_expr =
+            create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
+                .unwrap();
+
+        let result = physical_expr.evaluate(&input).unwrap();
+
+        let expected: ArrayRef =
+            Arc::new(StringArray::from_iter([Some("e"), Some("ll"), Some("arr")]));
+        match result {
+            ColumnarValue::Array(arr) => {
+                assert_eq!(&arr, &expected)
+            }
+            s => {
+                panic!("invalid ColumnarValue variant ColumnarValue::Scalar({s:?})")
+            }
+        }
+    }
+}

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_capture.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_capture.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::any::Any;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow::array::{
@@ -17,7 +18,7 @@ use arrow::util::bit_util;
 use datafusion::common::exec_err;
 use datafusion::common::types::NativeType;
 use datafusion::error::{DataFusionError, Result};
-use datafusion::functions::regex::compile_regex;
+use datafusion::functions::regex::compile_and_cache_regex;
 use datafusion::logical_expr::{
     Coercion, ColumnarValue, Documentation, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDFImpl,
     Signature, TypeSignature, TypeSignatureClass, Volatility,
@@ -520,13 +521,14 @@ where
     I2: Iterator<Item = Option<&'b str>>,
     I3: Iterator<Item = Option<usize>>,
 {
+    let mut regex_cache = HashMap::new();
     let mut result_builder = StringBuilder::new();
     let mut null_run = 0;
 
     for ((value, regex), group) in values.zip(regexes).zip(groups) {
         match (value, regex, group) {
             (Some(value), Some(regex), Some(group)) => {
-                let regex = compile_regex(regex, None)?;
+                let regex = compile_and_cache_regex(regex, None, &mut regex_cache)?;
                 if let Some(capture) = regex.captures(value).map(|c| c.get(group)).flatten() {
                     if null_run > 0 {
                         result_builder.append_nulls(null_run);

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_substr.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_substr.rs
@@ -6,8 +6,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow::array::{
-    Array, ArrayRef, ArrowPrimitiveType, AsArray, DictionaryArray, PrimitiveArray, StringArray,
-    StringBuilder, make_array,
+    Array, ArrayRef, AsArray, DictionaryArray, PrimitiveArray, StringArray, StringBuilder,
+    make_array,
 };
 use arrow::buffer::{BooleanBuffer, NullBuffer};
 use arrow::datatypes::{
@@ -25,64 +25,85 @@ use datafusion::logical_expr::{
 };
 use datafusion::scalar::ScalarValue;
 
-const FUNC_NAME: &str = "regexp_capture";
+const FUNC_NAME: &str = "regexp_substr";
 
-/// This scalar UDF implementation takes three arguments: source (string), regex (string) and
-/// capture group (int) and returns the portion of the text from the source that is matched by
-/// the capture group.
+/// This scalar UDF implements the SQL Server `REGEXP_SUBSTR` function signature:
 ///
-/// For example, if passed: `regexp_capture("hello world", ".*hello (.*).*", 1)`, it would
-/// return `"world"`. It returns `None` if the regex does not match the source, or if the
-/// capture group is not in the regex.
+/// ```text
+/// regexp_substr(string_expression, pattern [, start [, occurrence [, flags [, group]]]])
+/// ```
 ///
-/// Capture group 0 represents the full source text that matched. For example if passed
-/// `regexp_capture("hello world", ".*hello (.*).*", 0)`, this would return "hello world".
+/// It returns the portion of `string_expression` that matches the `pattern` (or a capture
+/// group within it). Returns `NULL` if no match is found.
 ///
-/// If capture group < 0, this returns null.
+/// # Parameters
 ///
-/// # Return Type:
+/// - `string_expression` (string): The source text to search.
+/// - `pattern` (string): The regular expression pattern.
+/// - `start` (integer, optional, default `1`): 1-based character position to begin searching.
+///   Must be >= 1. If greater than the string length, returns NULL.
+/// - `occurrence` (integer, optional, default `1`): Which occurrence of the pattern to return.
+///   Must be >= 1.
+/// - `flags` (string, optional): Regex modifier flags passed to the regex engine. Supported:
+///   `i` (case-insensitive), `m` (multi-line), `s` (dot-all), `c` (case-sensitive, default).
+/// - `group` (integer, optional, default `0`): Which capture group to return. `0` returns the
+///   full match. If the group is not present in the pattern, returns NULL. Negative → NULL.
 ///
-/// If the source is a dictionary, this will try to keep the return type as a dictionary array.
-/// However, if non-scalar regexs/capture groups are passed for each row of input, we can't
-/// guarantee the dictionary won't overflow. For this reason, if the regex/capture group args
-/// are not scalars, the return type will be the native string array.
+/// # Return Type
 ///
-///
+/// If the source is a dictionary and all other arguments are scalars (or absent), the return
+/// type preserves the dictionary encoding. Otherwise the return type is `Utf8`.
 #[derive(Debug, PartialEq, Eq, Hash)]
-pub struct RegexpCaptureFunc {
+pub struct RegexpSubstrFunc {
     signature: Signature,
 }
 
-impl Default for RegexpCaptureFunc {
+impl Default for RegexpSubstrFunc {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl RegexpCaptureFunc {
+/// Build a `Coercible` type signature for a given arity (2..=6).
+///
+/// Parameter types in order:
+///   0: String  (source)
+///   1: String  (pattern)
+///   2: Integer (start)
+///   3: Integer (occurrence)
+///   4: String  (flags)
+///   5: Integer (group)
+fn coercible_for_arity(n: usize) -> TypeSignature {
+    let all_types: [Coercion; 6] = [
+        Coercion::new_exact(TypeSignatureClass::Native(Arc::new(NativeType::String))),
+        Coercion::new_exact(TypeSignatureClass::Native(Arc::new(NativeType::String))),
+        Coercion::new_exact(TypeSignatureClass::Integer),
+        Coercion::new_exact(TypeSignatureClass::Integer),
+        Coercion::new_exact(TypeSignatureClass::Native(Arc::new(NativeType::String))),
+        Coercion::new_exact(TypeSignatureClass::Integer),
+    ];
+    TypeSignature::Coercible(all_types.into_iter().take(n).collect())
+}
+
+/// All parameter names (truncated to match the arity at construction).
+const PARAM_NAMES: &[&str] = &["str", "pattern", "start", "occurrence", "flags", "group"];
+
+impl RegexpSubstrFunc {
     pub fn new() -> Self {
         Self {
             signature: Signature::one_of(
-                vec![TypeSignature::Coercible(vec![
-                    Coercion::new_exact(TypeSignatureClass::Native(Arc::new(NativeType::String))),
-                    Coercion::new_exact(TypeSignatureClass::Native(Arc::new(NativeType::String))),
-                    Coercion::new_exact(TypeSignatureClass::Integer),
-                ])],
+                (2..=6).map(coercible_for_arity).collect(),
                 Volatility::Immutable,
             )
-            .with_parameter_names(vec![
-                "str".to_string(),
-                "pattern".to_string(),
-                "capture_group".to_string(),
-            ])
-            // safety: these parameter names are valid because they match the arity of the
+            .with_parameter_names(PARAM_NAMES.iter().map(|s| s.to_string()).collect())
+            // safety: these parameter names are valid because they cover the max arity of the
             // signature and there are no duplicates, so it is safe to expect here
             .expect("valid parameter names"),
         }
     }
 }
 
-impl ScalarUDFImpl for RegexpCaptureFunc {
+impl ScalarUDFImpl for RegexpSubstrFunc {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -104,36 +125,60 @@ impl ScalarUDFImpl for RegexpCaptureFunc {
     }
 
     fn return_field_from_args(&self, args: ReturnFieldArgs<'_>) -> Result<FieldRef> {
-        if args.arg_fields.len() != 3 || args.scalar_arguments.len() != 3 {
+        let n = args.arg_fields.len();
+        if !(2..=6).contains(&n) || args.scalar_arguments.len() != n {
             return exec_err!(
-                "{} `return_field_from_args` called with invalid number of args. expected 3",
+                "{} `return_field_from_args` called with invalid number of args. expected 2-6",
                 FUNC_NAME
             );
         }
 
-        // see note in type documentation for reasoning about the return type
-        let return_type =
-            if args.scalar_arguments[1].is_some() && args.scalar_arguments[2].is_some() {
-                args.arg_fields[0].data_type().clone()
-            } else {
-                DataType::Utf8
-            };
+        // Preserve the source data type (e.g. dictionary encoding) only when every
+        // non-source argument is a scalar. If any is a non-scalar array we fall back
+        // to Utf8.
+        let all_extra_scalar = args.scalar_arguments[1..].iter().all(|s| s.is_some());
+        let return_type = if all_extra_scalar {
+            args.arg_fields[0].data_type().clone()
+        } else {
+            DataType::Utf8
+        };
 
         Ok(Arc::new(Field::new(self.name(), return_type, true)))
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
-        if args.args.len() != 3 {
+        let n = args.args.len();
+        if !(2..=6).contains(&n) {
             return exec_err!(
-                "{} `return_field_from_args` called with invalid number of args. expected 3. got {}",
+                "{} called with invalid number of args. expected 2-6. got {}",
                 FUNC_NAME,
-                args.args.len()
+                n
             );
         }
 
         let sources = &args.args[0];
-        let regexes = &args.args[1];
-        let groups = &args.args[2];
+        let patterns = &args.args[1];
+        let starts = if n >= 3 {
+            args.args[2].clone()
+        } else {
+            ColumnarValue::Scalar(ScalarValue::Int64(Some(1)))
+        };
+        let occurrences = if n >= 4 {
+            args.args[3].clone()
+        } else {
+            ColumnarValue::Scalar(ScalarValue::Int64(Some(1)))
+        };
+        let flags = if n >= 5 {
+            args.args[4].clone()
+        } else {
+            ColumnarValue::Scalar(ScalarValue::Utf8(None))
+        };
+        let groups = if n >= 6 {
+            args.args[5].clone()
+        } else {
+            ColumnarValue::Scalar(ScalarValue::Int64(Some(0)))
+        };
+
         let len = match sources {
             ColumnarValue::Array(arr) => arr.len(),
             ColumnarValue::Scalar(_) => 1,
@@ -143,7 +188,14 @@ impl ScalarUDFImpl for RegexpCaptureFunc {
         let result = match source_arr.data_type() {
             DataType::Utf8 => {
                 let str_arr = source_arr.as_string::<i32>();
-                regex_capture(str_arr.iter(), regexes, groups)
+                regex_substr(
+                    str_arr.iter(),
+                    patterns,
+                    &starts,
+                    &occurrences,
+                    &flags,
+                    &groups,
+                )
             }
             DataType::Dictionary(k, v) => {
                 if !matches!(v.as_ref(), &DataType::Utf8) {
@@ -155,30 +207,70 @@ impl ScalarUDFImpl for RegexpCaptureFunc {
                 }
 
                 match k.as_ref() {
-                    DataType::Int8 => {
-                        invoke_for_dict_source::<Int8Type>(&source_arr, regexes, groups)
-                    }
-                    DataType::Int16 => {
-                        invoke_for_dict_source::<Int16Type>(&source_arr, regexes, groups)
-                    }
-                    DataType::Int32 => {
-                        invoke_for_dict_source::<Int32Type>(&source_arr, regexes, groups)
-                    }
-                    DataType::Int64 => {
-                        invoke_for_dict_source::<Int64Type>(&source_arr, regexes, groups)
-                    }
-                    DataType::UInt8 => {
-                        invoke_for_dict_source::<UInt8Type>(&source_arr, regexes, groups)
-                    }
-                    DataType::UInt16 => {
-                        invoke_for_dict_source::<UInt16Type>(&source_arr, regexes, groups)
-                    }
-                    DataType::UInt32 => {
-                        invoke_for_dict_source::<UInt32Type>(&source_arr, regexes, groups)
-                    }
-                    DataType::UInt64 => {
-                        invoke_for_dict_source::<UInt64Type>(&source_arr, regexes, groups)
-                    }
+                    DataType::Int8 => invoke_for_dict_source::<Int8Type>(
+                        &source_arr,
+                        patterns,
+                        &starts,
+                        &occurrences,
+                        &flags,
+                        &groups,
+                    ),
+                    DataType::Int16 => invoke_for_dict_source::<Int16Type>(
+                        &source_arr,
+                        patterns,
+                        &starts,
+                        &occurrences,
+                        &flags,
+                        &groups,
+                    ),
+                    DataType::Int32 => invoke_for_dict_source::<Int32Type>(
+                        &source_arr,
+                        patterns,
+                        &starts,
+                        &occurrences,
+                        &flags,
+                        &groups,
+                    ),
+                    DataType::Int64 => invoke_for_dict_source::<Int64Type>(
+                        &source_arr,
+                        patterns,
+                        &starts,
+                        &occurrences,
+                        &flags,
+                        &groups,
+                    ),
+                    DataType::UInt8 => invoke_for_dict_source::<UInt8Type>(
+                        &source_arr,
+                        patterns,
+                        &starts,
+                        &occurrences,
+                        &flags,
+                        &groups,
+                    ),
+                    DataType::UInt16 => invoke_for_dict_source::<UInt16Type>(
+                        &source_arr,
+                        patterns,
+                        &starts,
+                        &occurrences,
+                        &flags,
+                        &groups,
+                    ),
+                    DataType::UInt32 => invoke_for_dict_source::<UInt32Type>(
+                        &source_arr,
+                        patterns,
+                        &starts,
+                        &occurrences,
+                        &flags,
+                        &groups,
+                    ),
+                    DataType::UInt64 => invoke_for_dict_source::<UInt64Type>(
+                        &source_arr,
+                        patterns,
+                        &starts,
+                        &occurrences,
+                        &flags,
+                        &groups,
+                    ),
                     other => exec_err!("Invalid dictionary key {other:?}"),
                 }
             }
@@ -190,9 +282,10 @@ impl ScalarUDFImpl for RegexpCaptureFunc {
             }
         }?;
 
-        let all_scalar = matches!(sources, ColumnarValue::Scalar(_))
-            && matches!(regexes, ColumnarValue::Scalar(_))
-            && matches!(groups, ColumnarValue::Scalar(_));
+        let all_scalar = args
+            .args
+            .iter()
+            .all(|a| matches!(a, ColumnarValue::Scalar(_)));
 
         if all_scalar {
             let scalar = ScalarValue::try_from_array(&result, 0)?;
@@ -209,25 +302,46 @@ impl ScalarUDFImpl for RegexpCaptureFunc {
 
 fn invoke_for_dict_source<K: ArrowDictionaryKeyType>(
     source_arr: &ArrayRef,
-    regexes: &ColumnarValue,
+    patterns: &ColumnarValue,
+    starts: &ColumnarValue,
+    occurrences: &ColumnarValue,
+    flags: &ColumnarValue,
     groups: &ColumnarValue,
 ) -> Result<ArrayRef> {
     let dict_arr = source_arr.as_dictionary::<K>();
     let dict_vals = dict_arr.values();
-    match (regexes, groups) {
-        (ColumnarValue::Scalar(_), ColumnarValue::Scalar(_)) => {
-            // fast path, can just match the regexes against the dicts values and
-            // convert them to matched patterns
-            let dict_vals_str = dict_vals.as_string::<i32>();
-            let new_vals = regex_capture(dict_vals_str.iter(), regexes, groups)?;
-            replace_dict_values(dict_arr, new_vals)
-        }
-        _ => {
-            let typed_str_dict = dict_arr
-                .downcast_dict::<StringArray>()
-                .expect("dict vals are strings");
-            regex_capture(typed_str_dict.into_iter(), regexes, groups)
-        }
+
+    let all_extra_scalar = matches!(patterns, ColumnarValue::Scalar(_))
+        && matches!(starts, ColumnarValue::Scalar(_))
+        && matches!(occurrences, ColumnarValue::Scalar(_))
+        && matches!(flags, ColumnarValue::Scalar(_))
+        && matches!(groups, ColumnarValue::Scalar(_));
+
+    if all_extra_scalar {
+        // Fast path: match against dictionary values only, then remap keys.
+        let dict_vals_str = dict_vals.as_string::<i32>();
+        let new_vals = regex_substr(
+            dict_vals_str.iter(),
+            patterns,
+            starts,
+            occurrences,
+            flags,
+            groups,
+        )?;
+        replace_dict_values(dict_arr, new_vals)
+    } else {
+        // Slow path: expand dictionary to per-row strings.
+        let typed_str_dict = dict_arr
+            .downcast_dict::<StringArray>()
+            .expect("dict vals are strings");
+        regex_substr(
+            typed_str_dict.into_iter(),
+            patterns,
+            starts,
+            occurrences,
+            flags,
+            groups,
+        )
     }
 }
 
@@ -277,204 +391,244 @@ fn replace_dict_values<K: ArrowDictionaryKeyType>(
     }
 }
 
-fn regex_capture<'a, I>(
+fn regex_substr<'a, I>(
     values: I,
-    regexes: &ColumnarValue,
+    patterns: &ColumnarValue,
+    starts: &ColumnarValue,
+    occurrences: &ColumnarValue,
+    flags: &ColumnarValue,
     groups: &ColumnarValue,
 ) -> Result<ArrayRef>
 where
     I: Iterator<Item = Option<&'a str>>,
 {
-    match regexes {
-        ColumnarValue::Array(regex_arr) => match regex_arr.data_type() {
-            DataType::Utf8 => {
-                let regex_arr_str = regex_arr.as_string::<i32>();
-                regex_capture_with_regex_iter(values, regex_arr_str.iter(), groups)
-            }
-            DataType::Dictionary(k, v) => {
-                if !matches!(v.as_ref(), &DataType::Utf8) {
-                    return exec_err!(
-                        "Unsupported dictionary values type for regexes array {:?} in function `{}`",
-                        k.as_ref(),
-                        FUNC_NAME
-                    );
-                }
-
-                match k.as_ref() {
-                    DataType::Int8 => {
-                        invoke_for_dict_regex::<_, Int8Type>(values, regex_arr, groups)
-                    }
-                    DataType::Int16 => {
-                        invoke_for_dict_regex::<_, Int16Type>(values, regex_arr, groups)
-                    }
-                    DataType::Int32 => {
-                        invoke_for_dict_regex::<_, Int32Type>(values, regex_arr, groups)
-                    }
-                    DataType::Int64 => {
-                        invoke_for_dict_regex::<_, Int64Type>(values, regex_arr, groups)
-                    }
-                    DataType::UInt8 => {
-                        invoke_for_dict_regex::<_, UInt8Type>(values, regex_arr, groups)
-                    }
-                    DataType::UInt16 => {
-                        invoke_for_dict_regex::<_, UInt16Type>(values, regex_arr, groups)
-                    }
-                    DataType::UInt32 => {
-                        invoke_for_dict_regex::<_, UInt32Type>(values, regex_arr, groups)
-                    }
-                    DataType::UInt64 => {
-                        invoke_for_dict_regex::<_, UInt64Type>(values, regex_arr, groups)
-                    }
-                    other => {
-                        exec_err!(
-                            "Unsupported dictionary key type for regexes array {other:?} in function `{}`",
-                            FUNC_NAME
-                        )
-                    }
-                }
-            }
-            other => {
-                exec_err!(
-                    "Unsupported data type for regexes array {other:?} in function `{}`",
-                    FUNC_NAME
-                )
-            }
-        },
+    match patterns {
+        ColumnarValue::Array(pattern_arr) => {
+            let casted = cast_str_array_to_utf8(pattern_arr)?;
+            let str_arr = casted.as_string::<i32>();
+            regex_substr_with_pattern_iter(
+                values,
+                str_arr.iter(),
+                starts,
+                occurrences,
+                flags,
+                groups,
+            )
+        }
         ColumnarValue::Scalar(regex_scalar) => {
             let regex_scalar_str = regex_scalar.cast_to(&DataType::Utf8)?;
             let ScalarValue::Utf8(str_regex) = regex_scalar_str else {
                 unreachable!("we've casted this to Utf8")
             };
-            regex_capture_with_regex_iter(values, std::iter::repeat(str_regex.as_deref()), groups)
+            regex_substr_with_pattern_iter(
+                values,
+                std::iter::repeat(str_regex.as_deref()),
+                starts,
+                occurrences,
+                flags,
+                groups,
+            )
         }
     }
 }
 
-/// Invoke the UDF for the case that the regex is a dictionary encoded array.
-///
-/// This expects that the type has already been verified to be `DataType::<K, Utf8>`
-fn invoke_for_dict_regex<'a, I, K: ArrowDictionaryKeyType>(
-    values: I,
-    regex_dict_arr: &ArrayRef,
-    groups: &ColumnarValue,
-) -> Result<ArrayRef>
-where
-    I: Iterator<Item = Option<&'a str>>,
-{
-    let dict_arr = regex_dict_arr.as_dictionary::<K>();
-    let typed_regex_dict = dict_arr
-        .downcast_dict::<StringArray>()
-        .expect("dict values are strings");
-    regex_capture_with_regex_iter(values, typed_regex_dict.into_iter(), groups)
-}
+// ---------------------------------------------------------------------------
+// Resolve the flags ColumnarValue into an iterator
+// ---------------------------------------------------------------------------
 
-macro_rules! dispatch_dict_groups {
-    ($values:expr, $regexes:expr, $groups:expr, $key_dt:expr, $val_dt:expr) => {
-        paste::paste! {
-            match $key_dt {
-                DataType::Int8 => dispatch_dict_groups!(@val $values, $regexes, $groups, Int8Type, $val_dt),
-                DataType::Int16 => dispatch_dict_groups!(@val $values, $regexes, $groups, Int16Type, $val_dt),
-                DataType::Int32 => dispatch_dict_groups!(@val $values, $regexes, $groups, Int32Type, $val_dt),
-                DataType::Int64 => dispatch_dict_groups!(@val $values, $regexes, $groups, Int64Type, $val_dt),
-                DataType::UInt8 => dispatch_dict_groups!(@val $values, $regexes, $groups, UInt8Type, $val_dt),
-                DataType::UInt16 => dispatch_dict_groups!(@val $values, $regexes, $groups, UInt16Type, $val_dt),
-                DataType::UInt32 => dispatch_dict_groups!(@val $values, $regexes, $groups, UInt32Type, $val_dt),
-                DataType::UInt64 => dispatch_dict_groups!(@val $values, $regexes, $groups, UInt64Type, $val_dt),
-                other => exec_err!("Unsupported dictionary key type for groups: {other:?}"),
-            }
-        }
-    };
-    (@val $values:expr, $regexes:expr, $groups:expr, $ktyp:ty, $val_dt:expr) => {
-        match $val_dt {
-            DataType::Int8 => regex_capture_with_group_dict_arr::<_, _, $ktyp, Int8Type>($values, $regexes, $groups),
-            DataType::Int16 => regex_capture_with_group_dict_arr::<_, _, $ktyp, Int16Type>($values, $regexes, $groups),
-            DataType::Int32 => regex_capture_with_group_dict_arr::<_, _, $ktyp, Int32Type>($values, $regexes, $groups),
-            DataType::Int64 => regex_capture_with_group_dict_arr::<_, _, $ktyp, Int64Type>($values, $regexes, $groups),
-            DataType::UInt8 => regex_capture_with_group_dict_arr::<_, _, $ktyp, UInt8Type>($values, $regexes, $groups),
-            DataType::UInt16 => regex_capture_with_group_dict_arr::<_, _, $ktyp, UInt16Type>($values, $regexes, $groups),
-            DataType::UInt32 => regex_capture_with_group_dict_arr::<_, _, $ktyp, UInt32Type>($values, $regexes, $groups),
-            DataType::UInt64 => regex_capture_with_group_dict_arr::<_, _, $ktyp, UInt64Type>($values, $regexes, $groups),
-            other => exec_err!("Unsupported dictionary value type for groups: {other:?}"),
-        }
-    };
-}
-
-fn regex_capture_with_group_dict_arr<'a, 'b, I1, I2, K, V>(
+fn regex_substr_with_pattern_iter<'a, 'b, I1, I2>(
     values: I1,
-    regexes: I2,
-    groups: &ArrayRef,
+    patterns: I2,
+    starts: &ColumnarValue,
+    occurrences: &ColumnarValue,
+    flags: &ColumnarValue,
+    groups: &ColumnarValue,
 ) -> Result<ArrayRef>
 where
     I1: Iterator<Item = Option<&'a str>>,
     I2: Iterator<Item = Option<&'b str>>,
-    K: ArrowDictionaryKeyType,
-    V: ArrowPrimitiveType,
 {
-    let dict = groups.as_dictionary::<K>();
-    let dict_values = dict.values().as_primitive::<V>();
-    let zero = V::Native::default();
-    regex_capture_with_group_iter(
-        values,
-        regexes,
-        dict.keys().iter().map(|key| {
-            key.and_then(|k| {
-                let idx = k.as_usize();
-                if dict_values.is_null(idx) {
-                    None
-                } else {
-                    let v = dict_values.value(idx);
-                    (v >= zero).then_some(v.as_usize())
+    match flags {
+        ColumnarValue::Array(flags_arr) => {
+            let casted = cast_str_array_to_utf8(flags_arr)?;
+            let str_arr = casted.as_string::<i32>();
+            regex_substr_with_flags_iter(
+                values,
+                patterns,
+                str_arr.iter(),
+                starts,
+                occurrences,
+                groups,
+            )
+        }
+        ColumnarValue::Scalar(flags_scalar) => {
+            let flags_opt = match flags_scalar {
+                ScalarValue::Utf8(s) => s.clone(),
+                ScalarValue::Null => None,
+                other => {
+                    let casted = other.cast_to(&DataType::Utf8)?;
+                    let ScalarValue::Utf8(s) = casted else {
+                        unreachable!("we've casted this to Utf8")
+                    };
+                    s
                 }
-            })
-        }),
-    )
+            };
+            regex_substr_with_flags_iter(
+                values,
+                patterns,
+                std::iter::repeat(flags_opt.as_deref()),
+                starts,
+                occurrences,
+                groups,
+            )
+        }
+    }
 }
 
-fn regex_capture_with_regex_iter<'a, 'b, I1, I2>(
+// ---------------------------------------------------------------------------
+// Resolve the `start` ColumnarValue into an iterator
+// ---------------------------------------------------------------------------
+
+/// Cast any integer array (including dictionary-encoded) to `Int64Array`.
+///
+/// This avoids the combinatorial monomorphization explosion that would result
+/// from dispatching on every possible (key, value) type pair for dictionary
+/// integer arrays.
+fn cast_int_array_to_int64(arr: &ArrayRef) -> Result<ArrayRef> {
+    arrow::compute::cast(arr, &DataType::Int64)
+        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
+}
+
+/// Cast any string array (including dictionary-encoded) to `StringArray` (Utf8).
+fn cast_str_array_to_utf8(arr: &ArrayRef) -> Result<ArrayRef> {
+    arrow::compute::cast(arr, &DataType::Utf8)
+        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
+}
+
+fn regex_substr_with_flags_iter<'a, 'b, 'c, I1, I2, I3>(
     values: I1,
-    regexes: I2,
+    patterns: I2,
+    flags: I3,
+    starts: &ColumnarValue,
+    occurrences: &ColumnarValue,
     groups: &ColumnarValue,
 ) -> Result<ArrayRef>
 where
     I1: Iterator<Item = Option<&'a str>>,
     I2: Iterator<Item = Option<&'b str>>,
+    I3: Iterator<Item = Option<&'c str>>,
+{
+    match starts {
+        ColumnarValue::Array(arr) => {
+            let casted = cast_int_array_to_int64(arr)?;
+            let int_arr = casted.as_primitive::<Int64Type>();
+            regex_substr_with_start_iter(
+                values,
+                patterns,
+                flags,
+                int_arr
+                    .iter()
+                    .map(|i| i.and_then(|i| (i >= 1).then_some(i as usize))),
+                occurrences,
+                groups,
+            )
+        }
+        ColumnarValue::Scalar(scalar) => {
+            let start_val = columnar_int_scalar_to_usize(scalar)?;
+            regex_substr_with_start_iter(
+                values,
+                patterns,
+                flags,
+                std::iter::repeat(start_val),
+                occurrences,
+                groups,
+            )
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Resolve the `occurrence` ColumnarValue into an iterator
+// ---------------------------------------------------------------------------
+
+fn regex_substr_with_start_iter<'a, 'b, 'c, I1, I2, I3, I4>(
+    values: I1,
+    patterns: I2,
+    flags: I3,
+    starts: I4,
+    occurrences: &ColumnarValue,
+    groups: &ColumnarValue,
+) -> Result<ArrayRef>
+where
+    I1: Iterator<Item = Option<&'a str>>,
+    I2: Iterator<Item = Option<&'b str>>,
+    I3: Iterator<Item = Option<&'c str>>,
+    I4: Iterator<Item = Option<usize>>,
+{
+    match occurrences {
+        ColumnarValue::Array(arr) => {
+            let casted = cast_int_array_to_int64(arr)?;
+            let int_arr = casted.as_primitive::<Int64Type>();
+            regex_substr_with_occ_iter(
+                values,
+                patterns,
+                flags,
+                starts,
+                int_arr
+                    .iter()
+                    .map(|i| i.and_then(|i| (i >= 1).then_some(i as usize))),
+                groups,
+            )
+        }
+        ColumnarValue::Scalar(scalar) => {
+            let occ_val = columnar_int_scalar_to_usize(scalar)?;
+            regex_substr_with_occ_iter(
+                values,
+                patterns,
+                flags,
+                starts,
+                std::iter::repeat(occ_val),
+                groups,
+            )
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Resolve the `group` ColumnarValue into an iterator
+// ---------------------------------------------------------------------------
+
+fn regex_substr_with_occ_iter<'a, 'b, 'c, I1, I2, I3, I4, I5>(
+    values: I1,
+    patterns: I2,
+    flags: I3,
+    starts: I4,
+    occurrences: I5,
+    groups: &ColumnarValue,
+) -> Result<ArrayRef>
+where
+    I1: Iterator<Item = Option<&'a str>>,
+    I2: Iterator<Item = Option<&'b str>>,
+    I3: Iterator<Item = Option<&'c str>>,
+    I4: Iterator<Item = Option<usize>>,
+    I5: Iterator<Item = Option<usize>>,
 {
     match groups {
-        ColumnarValue::Array(arr) => match arr.data_type() {
-            DataType::Int8 => {
-                regex_capture_with_group_primitive_arr::<_, _, Int8Type>(values, regexes, arr)
-            }
-            DataType::Int16 => {
-                regex_capture_with_group_primitive_arr::<_, _, Int16Type>(values, regexes, arr)
-            }
-            DataType::Int32 => {
-                regex_capture_with_group_primitive_arr::<_, _, Int32Type>(values, regexes, arr)
-            }
-            DataType::Int64 => {
-                regex_capture_with_group_primitive_arr::<_, _, Int64Type>(values, regexes, arr)
-            }
-            DataType::UInt8 => {
-                regex_capture_with_group_primitive_arr::<_, _, UInt8Type>(values, regexes, arr)
-            }
-            DataType::UInt16 => {
-                regex_capture_with_group_primitive_arr::<_, _, UInt16Type>(values, regexes, arr)
-            }
-            DataType::UInt32 => {
-                regex_capture_with_group_primitive_arr::<_, _, UInt32Type>(values, regexes, arr)
-            }
-            DataType::UInt64 => {
-                regex_capture_with_group_primitive_arr::<_, _, UInt64Type>(values, regexes, arr)
-            }
-            DataType::Dictionary(k, v) => {
-                dispatch_dict_groups!(values, regexes, arr, k.as_ref(), v.as_ref())
-            }
-            other => {
-                exec_err!(
-                    "Unsupported data type for groups array {other:?} in function `{}`",
-                    FUNC_NAME
-                )
-            }
-        },
+        ColumnarValue::Array(arr) => {
+            let casted = cast_int_array_to_int64(arr)?;
+            let int_arr = casted.as_primitive::<Int64Type>();
+            println!("{:?}", int_arr);
+            regex_substr_core(
+                values,
+                patterns,
+                flags,
+                starts,
+                occurrences,
+                int_arr
+                    .iter()
+                    .map(|i| i.and_then(|i| (i >= 0).then_some(i as usize))),
+            )
+        }
         ColumnarValue::Scalar(scalar) => {
             let group = match scalar.cast_to(&DataType::UInt64) {
                 Ok(unsigned_scalar) => {
@@ -483,65 +637,119 @@ where
                     };
                     group.map(|i| i as usize)
                 }
-
                 // if we couldn't cast, it means we had a negative integer scalar
                 // so always treat the group as null, meaning the result for all
                 // the rows will be null.
                 _ => None,
             };
 
-            regex_capture_with_group_iter(values, regexes, std::iter::repeat(group))
+            regex_substr_core(
+                values,
+                patterns,
+                flags,
+                starts,
+                occurrences,
+                std::iter::repeat(group),
+            )
         }
     }
 }
 
-fn regex_capture_with_group_primitive_arr<'a, 'b, I1, I2, T: ArrowPrimitiveType>(
-    values: I1,
-    regexes: I2,
-    groups: &ArrayRef,
-) -> Result<ArrayRef>
-where
-    I1: Iterator<Item = Option<&'a str>>,
-    I2: Iterator<Item = Option<&'b str>>,
-{
-    let zero = T::Native::default();
-    regex_capture_with_group_iter(
-        values,
-        regexes,
-        groups
-            .as_primitive::<T>()
-            .iter()
-            .map(|i| i.and_then(|i| (i >= zero).then_some(i.as_usize()))),
-    )
+// ---------------------------------------------------------------------------
+// Helpers & core matching logic
+// ---------------------------------------------------------------------------
+
+/// Convert a scalar integer ColumnarValue to `Option<usize>`.
+///
+/// Returns `Some(n)` for a positive integer, `None` for null or values that
+/// cannot be represented as a non-negative usize (e.g. negative integers).
+fn columnar_int_scalar_to_usize(scalar: &ScalarValue) -> Result<Option<usize>> {
+    match scalar.cast_to(&DataType::UInt64) {
+        Ok(unsigned_scalar) => {
+            let ScalarValue::UInt64(val) = unsigned_scalar else {
+                unreachable!("we've casted this to UInt64")
+            };
+            Ok(val.map(|i| i as usize))
+        }
+        // negative integer → treat as null
+        _ => Ok(None),
+    }
 }
 
-fn regex_capture_with_group_iter<'a, 'b, I1, I2, I3>(
+/// The innermost matching function. All six parameter iterators have been fully
+/// resolved by this point.
+///
+/// For each row this function:
+/// 1. Applies the `start` offset (1-based character position) to the source.
+/// 2. Compiles the regex with the given flags.
+/// 3. Finds the `occurrence`-th match (1-based).
+/// 4. Extracts the specified capture `group`.
+fn regex_substr_core<'a, 'b, 'c, I1, I2, I3, I4, I5, I6>(
     values: I1,
-    regexes: I2,
-    groups: I3,
+    patterns: I2,
+    flags: I3,
+    starts: I4,
+    occurrences: I5,
+    groups: I6,
 ) -> Result<ArrayRef>
 where
     I1: Iterator<Item = Option<&'a str>>,
     I2: Iterator<Item = Option<&'b str>>,
-    I3: Iterator<Item = Option<usize>>,
+    I3: Iterator<Item = Option<&'c str>>,
+    I4: Iterator<Item = Option<usize>>,
+    I5: Iterator<Item = Option<usize>>,
+    I6: Iterator<Item = Option<usize>>,
 {
     let mut regex_cache = HashMap::new();
     let mut result_builder = StringBuilder::new();
     let mut null_run = 0;
 
-    for ((value, regex), group) in values.zip(regexes).zip(groups) {
-        match (value, regex, group) {
-            (Some(value), Some(regex), Some(group)) => {
-                let regex = compile_and_cache_regex(regex, None, &mut regex_cache)?;
-                if let Some(capture) = regex.captures(value).and_then(|c| c.get(group)) {
-                    if null_run > 0 {
-                        result_builder.append_nulls(null_run);
-                    }
+    let iter = values
+        .zip(patterns)
+        .zip(flags)
+        .zip(starts)
+        .zip(occurrences)
+        .zip(groups);
 
-                    result_builder.append_value(&value[capture.start()..capture.end()]);
-                    null_run = 0;
+    for (((((value, pattern), flag), start), occurrence), group) in iter {
+        match (value, pattern, start, occurrence, group) {
+            (Some(value), Some(pattern), Some(start), Some(occurrence), Some(group)) => {
+                // Apply the start offset (1-based char position → byte offset).
+                let byte_offset = if start <= 1 {
+                    0
                 } else {
-                    null_run += 1
+                    match value.char_indices().nth(start - 1) {
+                        Some((byte_idx, _)) => byte_idx,
+                        // start is beyond the string length → null
+                        None => {
+                            null_run += 1;
+                            continue;
+                        }
+                    }
+                };
+                let search_str = &value[byte_offset..];
+
+                let regex = compile_and_cache_regex(pattern, flag, &mut regex_cache)?;
+
+                // Find the occurrence-th match (1-based).
+                let matched = if occurrence <= 1 {
+                    regex.captures(search_str)
+                } else {
+                    regex.captures_iter(search_str).nth(occurrence - 1)
+                };
+
+                if let Some(captures) = matched {
+                    if let Some(capture) = captures.get(group) {
+                        if null_run > 0 {
+                            result_builder.append_nulls(null_run);
+                        }
+                        result_builder.append_value(&search_str[capture.start()..capture.end()]);
+                        null_run = 0;
+                    } else {
+                        null_run += 1;
+                    }
+                } else {
+                    null_run += 1;
                 }
             }
             _ => {
@@ -575,7 +783,7 @@ mod test {
     use std::sync::Arc;
 
     use crate::pipeline::Pipeline;
-    use crate::pipeline::functions::regexp_capture;
+    use crate::pipeline::functions::regexp_substr;
 
     fn make_dict_array<K: ArrowDictionaryKeyType, V: ArrowPrimitiveType>(
         keys: &[K::Native],
@@ -589,13 +797,26 @@ mod test {
         ))
     }
 
+    /// Helper: build 6-arg form equivalent to old `regexp_capture(source, pattern, group)`.
+    /// Fills in start=1, occurrence=1, flags=NULL.
+    fn capture_args(source: Expr, pattern: Expr, group: Expr) -> Vec<Expr> {
+        vec![
+            source,
+            pattern,
+            lit(1i64),                    // start
+            lit(1i64),                    // occurrence
+            lit(ScalarValue::Utf8(None)), // flags
+            group,                        // group
+        ]
+    }
+
     #[tokio::test]
     async fn test_utf8_arr_values_scalar_pattern_scalar_group() {
         let session_context = Pipeline::create_session_context();
 
         let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
-            regexp_capture(),
-            vec![col("test_col"), lit("hello (.*)"), lit(1u16)],
+            regexp_substr(),
+            capture_args(col("test_col"), lit("hello (.*)"), lit(1u16)),
         ));
 
         let input_col =
@@ -643,8 +864,8 @@ mod test {
         let session_context = Pipeline::create_session_context();
 
         let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
-            regexp_capture(),
-            vec![col("test_col"), lit("hello (.*)"), lit(1u16)],
+            regexp_substr(),
+            capture_args(col("test_col"), lit("hello (.*)"), lit(1u16)),
         ));
 
         let input_col = DictionaryArray::new(
@@ -709,8 +930,8 @@ mod test {
         let session_context = Pipeline::create_session_context();
 
         let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
-            regexp_capture(),
-            vec![col("test_col"), lit("hello (.*)"), lit(1u16)],
+            regexp_substr(),
+            capture_args(col("test_col"), lit("hello (.*)"), lit(1u16)),
         ));
 
         let input_col = DictionaryArray::new(
@@ -757,8 +978,8 @@ mod test {
         let session_context = Pipeline::create_session_context();
 
         let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
-            regexp_capture(),
-            vec![col("test_col"), col("regexp_col"), lit(1u16)],
+            regexp_substr(),
+            capture_args(col("test_col"), col("regexp_col"), lit(1u16)),
         ));
 
         let input_col = DictionaryArray::new(
@@ -802,8 +1023,8 @@ mod test {
         let session_context = Pipeline::create_session_context();
 
         let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
-            regexp_capture(),
-            vec![col("test_col"), col("regexp_col"), lit(1u16)],
+            regexp_substr(),
+            capture_args(col("test_col"), col("regexp_col"), lit(1u16)),
         ));
 
         let input_col = StringArray::from_iter_values(["hello world", "hello otap", "arrow"]);
@@ -844,8 +1065,8 @@ mod test {
         let session_context = Pipeline::create_session_context();
 
         let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
-            regexp_capture(),
-            vec![col("test_col"), col("regexp_col"), lit(1u16)],
+            regexp_substr(),
+            capture_args(col("test_col"), col("regexp_col"), lit(1u16)),
         ));
 
         let input_col = StringArray::from_iter_values(["hello world", "hello otap", "arrow"]);
@@ -908,8 +1129,8 @@ mod test {
         let session_context = Pipeline::create_session_context();
 
         let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
-            regexp_capture(),
-            vec![col("test_col"), lit("hello (.*)"), lit(2u16)],
+            regexp_substr(),
+            capture_args(col("test_col"), lit("hello (.*)"), lit(2u16)),
         ));
 
         let input_col = StringArray::from_iter_values(["hello world", "hello otap", "arrow"]);
@@ -950,8 +1171,8 @@ mod test {
         let session_context = Pipeline::create_session_context();
 
         let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
-            regexp_capture(),
-            vec![col("test_col"), lit("hello (.*)"), lit(0u16)],
+            regexp_substr(),
+            capture_args(col("test_col"), lit("hello (.*)"), lit(0u16)),
         ));
 
         let input_col = StringArray::from_iter_values(["hello world", "hello otap", "arrow"]);
@@ -1004,8 +1225,8 @@ mod test {
 
         let session_context = Pipeline::create_session_context();
         let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
-            regexp_capture(),
-            vec![col("test_col"), lit("hello (.*)"), lit(0u16)],
+            regexp_substr(),
+            capture_args(col("test_col"), lit("hello (.*)"), lit(0u16)),
         ));
 
         for input_col in inputs {
@@ -1039,53 +1260,10 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_invalid_but_coercible_regex_input_arrays_are_rejected() {
+    async fn test_coercible_regex_input_arrays_are_cast_to_utf8() {
         let inputs: Vec<ArrayRef> = vec![
             Arc::new(LargeStringArray::from_iter_values([".*(.).*"])),
             Arc::new(StringViewArray::from_iter_values([".*(.).*"])),
-        ];
-
-        let session_context = Pipeline::create_session_context();
-        let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
-            regexp_capture(),
-            vec![col("test_col"), col("regex_col"), lit(0u16)],
-        ));
-
-        for regex_col in inputs {
-            let input_col = StringArray::from_iter_values(["hello"]);
-            let input = RecordBatch::try_new(
-                Arc::new(Schema::new(vec![
-                    Field::new("test_col", input_col.data_type().clone(), true),
-                    Field::new("regex_col", regex_col.data_type().clone(), true),
-                ])),
-                vec![Arc::new(input_col.clone()), Arc::new(regex_col.clone())],
-            )
-            .unwrap();
-
-            let df_schema = DFSchema::from_unqualified_fields(
-                input.schema().fields.clone(),
-                Default::default(),
-            )
-            .unwrap();
-
-            let physical_expr =
-                create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
-                    .unwrap();
-
-            let error = physical_expr.evaluate(&input).unwrap_err();
-            assert!(
-                error
-                    .to_string()
-                    .contains("Unsupported data type for regexes array"),
-                "unexpected error: `{}`",
-                error
-            )
-        }
-    }
-
-    #[tokio::test]
-    async fn test_invalid_but_coercible_dict_regex_input_arrays_are_rejected() {
-        let inputs: Vec<ArrayRef> = vec![
             Arc::new(DictionaryArray::new(
                 UInt8Array::from_iter_values([0]),
                 Arc::new(LargeStringArray::from_iter_values([".*(.).*"])),
@@ -1098,8 +1276,8 @@ mod test {
 
         let session_context = Pipeline::create_session_context();
         let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
-            regexp_capture(),
-            vec![col("test_col"), col("regex_col"), lit(0u16)],
+            regexp_substr(),
+            capture_args(col("test_col"), col("regex_col"), lit(0u16)),
         ));
 
         for regex_col in inputs {
@@ -1123,14 +1301,16 @@ mod test {
                 create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
                     .unwrap();
 
-            let error = physical_expr.evaluate(&input).unwrap_err();
-            assert!(
-                error
-                    .to_string()
-                    .contains("Unsupported dictionary values type for regexes array"),
-                "unexpected error: `{}`",
-                error
-            )
+            let result = physical_expr.evaluate(&input).unwrap();
+            let expected: ArrayRef = Arc::new(StringArray::from_iter_values(["hello"]));
+            match result {
+                ColumnarValue::Array(arr) => {
+                    assert_eq!(&arr, &expected)
+                }
+                s => {
+                    panic!("invalid ColumnarValue variant ColumnarValue::Scalar({s:?})")
+                }
+            }
         }
     }
 
@@ -1149,8 +1329,8 @@ mod test {
             lit(1i64),
         ] {
             let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
-                regexp_capture(),
-                vec![col("test_col"), lit("hello (.*)"), group_expr],
+                regexp_substr(),
+                capture_args(col("test_col"), lit("hello (.*)"), group_expr),
             ));
 
             let input_col = StringArray::from_iter_values(["hello world", "hello otap", "arrow"]);
@@ -1194,8 +1374,8 @@ mod test {
     async fn test_coercing_scalar_array_types() {
         let session_context = Pipeline::create_session_context();
         let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
-            regexp_capture(),
-            vec![col("test_col"), lit("hello (.*)"), col("group_col")],
+            regexp_substr(),
+            capture_args(col("test_col"), lit("hello (.*)"), col("group_col")),
         ));
 
         let group_cols: Vec<ArrayRef> = vec![
@@ -1249,8 +1429,8 @@ mod test {
     async fn test_coercing_scalar_array_types_with_negative_vals() {
         let session_context = Pipeline::create_session_context();
         let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
-            regexp_capture(),
-            vec![col("test_col"), lit("hello (.*)"), col("group_col")],
+            regexp_substr(),
+            capture_args(col("test_col"), lit("hello (.*)"), col("group_col")),
         ));
 
         let group_cols: Vec<ArrayRef> = vec![
@@ -1301,8 +1481,8 @@ mod test {
 
         for group_expr in [lit(-1i8), lit(-1i16), lit(-1i32), lit(-1i64)] {
             let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
-                regexp_capture(),
-                vec![col("test_col"), lit("hello (.*)"), group_expr],
+                regexp_substr(),
+                capture_args(col("test_col"), lit("hello (.*)"), group_expr),
             ));
 
             let input_col = StringArray::from_iter_values(["hello world", "hello otap", "arrow"]);
@@ -1344,8 +1524,8 @@ mod test {
     async fn test_dict_encoded_group_arrays() {
         let session_context = Pipeline::create_session_context();
         let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
-            regexp_capture(),
-            vec![col("test_col"), lit("hello (.*)"), col("group_col")],
+            regexp_substr(),
+            capture_args(col("test_col"), lit("hello (.*)"), col("group_col")),
         ));
 
         // Each dict array maps all 3 rows to a single value of 1.
@@ -1403,8 +1583,8 @@ mod test {
     async fn test_dict_encoded_group_arrays_with_negative_vals() {
         let session_context = Pipeline::create_session_context();
         let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
-            regexp_capture(),
-            vec![col("test_col"), lit("hello (.*)"), col("group_col")],
+            regexp_substr(),
+            capture_args(col("test_col"), lit("hello (.*)"), col("group_col")),
         ));
 
         let group_cols: Vec<ArrayRef> = vec![
@@ -1458,8 +1638,8 @@ mod test {
     async fn test_dict_encoded_group_arrays_with_null_keys() {
         let session_context = Pipeline::create_session_context();
         let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
-            regexp_capture(),
-            vec![col("test_col"), lit("hello (.*)"), col("group_col")],
+            regexp_substr(),
+            capture_args(col("test_col"), lit("hello (.*)"), col("group_col")),
         ));
 
         // Key index 0 -> value 1, but second row has a null key
@@ -1505,8 +1685,8 @@ mod test {
 
         // matching case
         let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
-            regexp_capture(),
-            vec![lit("hello world"), lit("hello (.*)"), lit(1u16)],
+            regexp_substr(),
+            capture_args(lit("hello world"), lit("hello (.*)"), lit(1u16)),
         ));
 
         let input = RecordBatch::new_empty(Arc::new(Schema::empty()));
@@ -1524,8 +1704,8 @@ mod test {
 
         // non-matching case
         let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
-            regexp_capture(),
-            vec![lit("arrow"), lit("hello (.*)"), lit(1u16)],
+            regexp_substr(),
+            capture_args(lit("arrow"), lit("hello (.*)"), lit(1u16)),
         ));
 
         let physical_expr =

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_substr.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_substr.rs
@@ -773,7 +773,7 @@ mod test {
     };
     use arrow::datatypes::{
         ArrowDictionaryKeyType, ArrowNativeType, Field, Int8Type, Int16Type, Int32Type, Int64Type,
-        Schema, UInt8Type, UInt16Type, UInt32Type, UInt64Type,
+        Schema, UInt8Type, UInt16Type, UInt64Type,
     };
     use datafusion::common::DFSchema;
     use datafusion::logical_expr::ColumnarValue;
@@ -797,8 +797,7 @@ mod test {
         ))
     }
 
-    /// Helper: build 6-arg form equivalent to old `regexp_capture(source, pattern, group)`.
-    /// Fills in start=1, occurrence=1, flags=NULL.
+    /// Helper for testing regexp capture group behaviour: build 6-arg form of args
     fn capture_args(source: Expr, pattern: Expr, group: Expr) -> Vec<Expr> {
         vec![
             source,
@@ -811,7 +810,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_utf8_arr_values_scalar_pattern_scalar_group() {
+    async fn test_capture_utf8_arr_values_scalar_pattern_scalar_group() {
         let session_context = Pipeline::create_session_context();
 
         let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
@@ -858,7 +857,7 @@ mod test {
         }
     }
 
-    async fn test_dict_utf8_arr_values_scalar_pattern_scalar_group_generic<
+    async fn test_capture_dict_utf8_arr_values_scalar_pattern_scalar_group_generic<
         K: ArrowDictionaryKeyType,
     >() {
         let session_context = Pipeline::create_session_context();
@@ -912,19 +911,13 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_dict_utf8_arr_values_scalar_pattern_scalar_group() {
-        test_dict_utf8_arr_values_scalar_pattern_scalar_group_generic::<Int8Type>().await;
-        test_dict_utf8_arr_values_scalar_pattern_scalar_group_generic::<Int16Type>().await;
-        test_dict_utf8_arr_values_scalar_pattern_scalar_group_generic::<Int32Type>().await;
-        test_dict_utf8_arr_values_scalar_pattern_scalar_group_generic::<Int64Type>().await;
-        test_dict_utf8_arr_values_scalar_pattern_scalar_group_generic::<UInt8Type>().await;
-        test_dict_utf8_arr_values_scalar_pattern_scalar_group_generic::<UInt16Type>().await;
-        test_dict_utf8_arr_values_scalar_pattern_scalar_group_generic::<UInt32Type>().await;
-        test_dict_utf8_arr_values_scalar_pattern_scalar_group_generic::<UInt64Type>().await;
+    async fn test_capture_dict_utf8_arr_values_scalar_pattern_scalar_group() {
+        test_capture_dict_utf8_arr_values_scalar_pattern_scalar_group_generic::<UInt8Type>().await;
+        test_capture_dict_utf8_arr_values_scalar_pattern_scalar_group_generic::<UInt16Type>().await;
     }
 
     #[tokio::test]
-    async fn test_dict_utf8_arr_values_with_nulls_scalar_pattern_scalar_group() {
+    async fn test_capture_dict_utf8_arr_values_with_nulls_scalar_pattern_scalar_group() {
         // test to ensure we preserve the original nulls when reconciling the
         // nulls from dict values that didn't match the passed scalar regex
         let session_context = Pipeline::create_session_context();
@@ -974,7 +967,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_dict_utf8_arr_values_dict_utf8_arr_pattern_scalar_group() {
+    async fn test_capture_dict_utf8_arr_values_dict_utf8_arr_pattern_scalar_group() {
         let session_context = Pipeline::create_session_context();
 
         let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
@@ -1019,7 +1012,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_utf8_arr_utf8_arr_pattern_scalar_group() {
+    async fn test_capture_utf8_arr_utf8_arr_pattern_scalar_group() {
         let session_context = Pipeline::create_session_context();
 
         let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
@@ -1061,7 +1054,9 @@ mod test {
         }
     }
 
-    async fn test_utf8_arr_dict_utf8_arr_pattern_scalar_group_generic<K: ArrowDictionaryKeyType>() {
+    async fn test_capture_utf8_arr_dict_utf8_arr_pattern_scalar_group_generic<
+        K: ArrowDictionaryKeyType,
+    >() {
         let session_context = Pipeline::create_session_context();
 
         let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
@@ -1113,19 +1108,13 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_utf8_arr_dict_utf8_arr_pattern_scalar_group() {
-        test_utf8_arr_dict_utf8_arr_pattern_scalar_group_generic::<Int8Type>().await;
-        test_utf8_arr_dict_utf8_arr_pattern_scalar_group_generic::<Int16Type>().await;
-        test_utf8_arr_dict_utf8_arr_pattern_scalar_group_generic::<Int32Type>().await;
-        test_utf8_arr_dict_utf8_arr_pattern_scalar_group_generic::<Int64Type>().await;
-        test_utf8_arr_dict_utf8_arr_pattern_scalar_group_generic::<UInt8Type>().await;
-        test_utf8_arr_dict_utf8_arr_pattern_scalar_group_generic::<UInt16Type>().await;
-        test_utf8_arr_dict_utf8_arr_pattern_scalar_group_generic::<UInt32Type>().await;
-        test_utf8_arr_dict_utf8_arr_pattern_scalar_group_generic::<UInt64Type>().await;
+    async fn test_capture_utf8_arr_dict_utf8_arr_pattern_scalar_group() {
+        test_capture_utf8_arr_dict_utf8_arr_pattern_scalar_group_generic::<UInt8Type>().await;
+        test_capture_utf8_arr_dict_utf8_arr_pattern_scalar_group_generic::<UInt16Type>().await;
     }
 
     #[tokio::test]
-    async fn test_capture_group_not_in_regex() {
+    async fn test_capture_capture_group_not_in_regex() {
         let session_context = Pipeline::create_session_context();
 
         let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
@@ -1167,7 +1156,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_zero_capture_group_matches_full_text() {
+    async fn test_capture_zero_capture_group_matches_full_text() {
         let session_context = Pipeline::create_session_context();
 
         let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
@@ -1213,7 +1202,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_invalid_but_coercible_source_input_types_are_rejected() {
+    async fn test_capture_invalid_but_coercible_source_input_types_are_rejected() {
         let inputs: Vec<ArrayRef> = vec![
             Arc::new(LargeStringArray::from_iter_values(["hello world"])),
             Arc::new(StringViewArray::from_iter_values(["hello world"])),
@@ -1260,7 +1249,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_coercible_regex_input_arrays_are_cast_to_utf8() {
+    async fn test_capture_coercible_regex_input_arrays_are_cast_to_utf8() {
         let inputs: Vec<ArrayRef> = vec![
             Arc::new(LargeStringArray::from_iter_values([".*(.).*"])),
             Arc::new(StringViewArray::from_iter_values([".*(.).*"])),
@@ -1315,7 +1304,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_coercing_scalar_integer_types() {
+    async fn test_capture_coercing_scalar_integer_types() {
         let session_context = Pipeline::create_session_context();
 
         for group_expr in [
@@ -1371,7 +1360,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_coercing_scalar_array_types() {
+    async fn test_capture_coercing_scalar_array_types() {
         let session_context = Pipeline::create_session_context();
         let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
             regexp_substr(),
@@ -1426,7 +1415,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_coercing_scalar_array_types_with_negative_vals() {
+    async fn test_capture_coercing_scalar_array_types_with_negative_vals() {
         let session_context = Pipeline::create_session_context();
         let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
             regexp_substr(),
@@ -1476,7 +1465,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_coercing_negative_signed_scalar_integer_types() {
+    async fn test_capture_coercing_negative_signed_scalar_integer_types() {
         let session_context = Pipeline::create_session_context();
 
         for group_expr in [lit(-1i8), lit(-1i16), lit(-1i32), lit(-1i64)] {
@@ -1521,7 +1510,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_dict_encoded_group_arrays() {
+    async fn test_capture_dict_encoded_group_arrays() {
         let session_context = Pipeline::create_session_context();
         let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
             regexp_substr(),
@@ -1580,7 +1569,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_dict_encoded_group_arrays_with_negative_vals() {
+    async fn test_capture_dict_encoded_group_arrays_with_negative_vals() {
         let session_context = Pipeline::create_session_context();
         let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
             regexp_substr(),
@@ -1635,7 +1624,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_dict_encoded_group_arrays_with_null_keys() {
+    async fn test_capture_dict_encoded_group_arrays_with_null_keys() {
         let session_context = Pipeline::create_session_context();
         let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
             regexp_substr(),
@@ -1680,7 +1669,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_all_scalar_args_returns_scalar() {
+    async fn test_capture_all_scalar_args_returns_scalar() {
         let session_context = Pipeline::create_session_context();
 
         // matching case
@@ -1716,6 +1705,342 @@ mod test {
         match result {
             ColumnarValue::Scalar(ScalarValue::Utf8(None)) => {}
             other => panic!("expected Scalar(Utf8(None)), got {other:?}"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests for new regexp_substr parameters: start, occurrence, flags
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_two_arg_form_returns_full_match() {
+        let session_context = Pipeline::create_session_context();
+
+        let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
+            regexp_substr(),
+            vec![col("test_col"), lit("hello \\w+")],
+        ));
+
+        let input_col =
+            StringArray::from_iter_values(["hello world", "otap", "hello otap", "arrow"]);
+        let input = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "test_col",
+                input_col.data_type().clone(),
+                true,
+            )])),
+            vec![Arc::new(input_col)],
+        )
+        .unwrap();
+
+        let df_schema =
+            DFSchema::from_unqualified_fields(input.schema().fields.clone(), Default::default())
+                .unwrap();
+        let physical_expr =
+            create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
+                .unwrap();
+
+        let result = physical_expr.evaluate(&input).unwrap();
+        let expected: ArrayRef = Arc::new(StringArray::from_iter([
+            Some("hello world"),
+            None,
+            Some("hello otap"),
+            None,
+        ]));
+        match result {
+            ColumnarValue::Array(arr) => assert_eq!(&arr, &expected),
+            s => panic!("expected Array, got {s:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_start_parameter() {
+        let session_context = Pipeline::create_session_context();
+
+        // regexp_substr("xxhello world", "hello (\\w+)", start=3) — skip first 2 chars
+        let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
+            regexp_substr(),
+            vec![col("test_col"), lit("hello (\\w+)"), lit(3i64)],
+        ));
+
+        let input_col =
+            StringArray::from_iter_values(["xxhello world", "hello world", "xxhello otap"]);
+        let input = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "test_col",
+                input_col.data_type().clone(),
+                true,
+            )])),
+            vec![Arc::new(input_col)],
+        )
+        .unwrap();
+
+        let df_schema =
+            DFSchema::from_unqualified_fields(input.schema().fields.clone(), Default::default())
+                .unwrap();
+        let physical_expr =
+            create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
+                .unwrap();
+
+        let result = physical_expr.evaluate(&input).unwrap();
+        // start=3 means search from char index 2 onward:
+        //   "xxhello world" -> search "hello world" -> full match "hello world"
+        //   "hello world"   -> search "llo world"   -> no match (pattern starts with "hello")
+        //   "xxhello otap"  -> search "hello otap"  -> full match "hello otap"
+        let expected: ArrayRef = Arc::new(StringArray::from_iter([
+            Some("hello world"),
+            None,
+            Some("hello otap"),
+        ]));
+        match result {
+            ColumnarValue::Array(arr) => assert_eq!(&arr, &expected),
+            s => panic!("expected Array, got {s:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_start_beyond_string_length_returns_null() {
+        let session_context = Pipeline::create_session_context();
+
+        let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
+            regexp_substr(),
+            vec![col("test_col"), lit("hello"), lit(100i64)],
+        ));
+
+        let input_col = StringArray::from_iter_values(["hello world"]);
+        let input = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "test_col",
+                input_col.data_type().clone(),
+                true,
+            )])),
+            vec![Arc::new(input_col)],
+        )
+        .unwrap();
+
+        let df_schema =
+            DFSchema::from_unqualified_fields(input.schema().fields.clone(), Default::default())
+                .unwrap();
+        let physical_expr =
+            create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
+                .unwrap();
+
+        let result = physical_expr.evaluate(&input).unwrap();
+        let expected: ArrayRef = Arc::new(StringArray::new_null(1));
+        match result {
+            ColumnarValue::Array(arr) => assert_eq!(&arr, &expected),
+            s => panic!("expected Array, got {s:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_occurrence_parameter() {
+        let session_context = Pipeline::create_session_context();
+
+        // Find the 2nd occurrence of a word
+        // regexp_substr(source, "\\w+", start=1, occurrence=2)
+        let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
+            regexp_substr(),
+            vec![col("test_col"), lit("\\w+"), lit(1i64), lit(2i64)],
+        ));
+
+        let input_col = StringArray::from_iter_values(["hello world", "one", "a b c"]);
+        let input = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "test_col",
+                input_col.data_type().clone(),
+                true,
+            )])),
+            vec![Arc::new(input_col)],
+        )
+        .unwrap();
+
+        let df_schema =
+            DFSchema::from_unqualified_fields(input.schema().fields.clone(), Default::default())
+                .unwrap();
+        let physical_expr =
+            create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
+                .unwrap();
+
+        let result = physical_expr.evaluate(&input).unwrap();
+        // "hello world" -> 2nd word match = "world"
+        // "one"         -> only 1 match, 2nd doesn't exist = null
+        // "a b c"       -> 2nd word match = "b"
+        let expected: ArrayRef =
+            Arc::new(StringArray::from_iter([Some("world"), None, Some("b")]));
+        match result {
+            ColumnarValue::Array(arr) => assert_eq!(&arr, &expected),
+            s => panic!("expected Array, got {s:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_occurrence_beyond_matches_returns_null() {
+        let session_context = Pipeline::create_session_context();
+
+        // occurrence=10 but there's only 1 match
+        let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
+            regexp_substr(),
+            vec![col("test_col"), lit("hello"), lit(1i64), lit(10i64)],
+        ));
+
+        let input_col = StringArray::from_iter_values(["hello world"]);
+        let input = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "test_col",
+                input_col.data_type().clone(),
+                true,
+            )])),
+            vec![Arc::new(input_col)],
+        )
+        .unwrap();
+
+        let df_schema =
+            DFSchema::from_unqualified_fields(input.schema().fields.clone(), Default::default())
+                .unwrap();
+        let physical_expr =
+            create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
+                .unwrap();
+
+        let result = physical_expr.evaluate(&input).unwrap();
+        let expected: ArrayRef = Arc::new(StringArray::new_null(1));
+        match result {
+            ColumnarValue::Array(arr) => assert_eq!(&arr, &expected),
+            s => panic!("expected Array, got {s:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_flags_case_insensitive() {
+        let session_context = Pipeline::create_session_context();
+
+        // regexp_substr(source, "HELLO", start=1, occurrence=1, flags="i")
+        let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
+            regexp_substr(),
+            vec![
+                col("test_col"),
+                lit("HELLO"),
+                lit(1i64),
+                lit(1i64),
+                lit("i"),
+            ],
+        ));
+
+        let input_col = StringArray::from_iter_values(["hello world", "HELLO WORLD", "no match"]);
+        let input = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "test_col",
+                input_col.data_type().clone(),
+                true,
+            )])),
+            vec![Arc::new(input_col)],
+        )
+        .unwrap();
+
+        let df_schema =
+            DFSchema::from_unqualified_fields(input.schema().fields.clone(), Default::default())
+                .unwrap();
+        let physical_expr =
+            create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
+                .unwrap();
+
+        let result = physical_expr.evaluate(&input).unwrap();
+        // Case-insensitive: "HELLO" matches "hello" and "HELLO", not "no match"
+        let expected: ArrayRef = Arc::new(StringArray::from_iter([
+            Some("hello"),
+            Some("HELLO"),
+            None,
+        ]));
+        match result {
+            ColumnarValue::Array(arr) => assert_eq!(&arr, &expected),
+            s => panic!("expected Array, got {s:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_start_and_occurrence_combined() {
+        let session_context = Pipeline::create_session_context();
+
+        // Start from position 6, find 2nd word
+        // regexp_substr(source, "\\w+", start=6, occurrence=2)
+        let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
+            regexp_substr(),
+            vec![col("test_col"), lit("\\w+"), lit(6i64), lit(2i64)],
+        ));
+
+        let input_col = StringArray::from_iter_values(["hello world foo bar"]);
+        let input = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "test_col",
+                input_col.data_type().clone(),
+                true,
+            )])),
+            vec![Arc::new(input_col)],
+        )
+        .unwrap();
+
+        let df_schema =
+            DFSchema::from_unqualified_fields(input.schema().fields.clone(), Default::default())
+                .unwrap();
+        let physical_expr =
+            create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
+                .unwrap();
+
+        let result = physical_expr.evaluate(&input).unwrap();
+        // start=6 -> search " world foo bar" (from char 5 onward)
+        // 1st word match in " world foo bar" = "world"
+        // 2nd word match = "foo"
+        let expected: ArrayRef = Arc::new(StringArray::from_iter([Some("foo")]));
+        match result {
+            ColumnarValue::Array(arr) => assert_eq!(&arr, &expected),
+            s => panic!("expected Array, got {s:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_all_six_args() {
+        let session_context = Pipeline::create_session_context();
+
+        // regexp_substr("xxHELLO world HELLO foo", "hello (\\w+)", 3, 2, "i", 1)
+        // start=3 -> search from char 2: "HELLO world HELLO foo"
+        // pattern with flag "i": case-insensitive "hello (\\w+)"
+        // occurrence=2 -> 2nd match: "HELLO foo"
+        // group=1 -> capture group 1: "foo"
+        let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
+            regexp_substr(),
+            vec![
+                col("test_col"),
+                lit("hello (\\w+)"),
+                lit(3i64),
+                lit(2i64),
+                lit("i"),
+                lit(1i64),
+            ],
+        ));
+
+        let input_col = StringArray::from_iter_values(["xxHELLO world HELLO foo"]);
+        let input = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "test_col",
+                input_col.data_type().clone(),
+                true,
+            )])),
+            vec![Arc::new(input_col)],
+        )
+        .unwrap();
+
+        let df_schema =
+            DFSchema::from_unqualified_fields(input.schema().fields.clone(), Default::default())
+                .unwrap();
+        let physical_expr =
+            create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
+                .unwrap();
+
+        let result = physical_expr.evaluate(&input).unwrap();
+        let expected: ArrayRef = Arc::new(StringArray::from_iter([Some("foo")]));
+        match result {
+            ColumnarValue::Array(arr) => assert_eq!(&arr, &expected),
+            s => panic!("expected Array, got {s:?}"),
         }
     }
 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_substr.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_substr.rs
@@ -88,17 +88,30 @@ fn coercible_for_arity(n: usize) -> TypeSignature {
 /// All parameter names (truncated to match the arity at construction).
 const PARAM_NAMES: &[&str] = &["str", "pattern", "start", "occurrence", "flags", "group"];
 
+/// Build a arity-6 variant where the group param (6th) is a string (named group).
+fn coercible_for_arity_6_named_group() -> TypeSignature {
+    TypeSignature::Coercible(vec![
+        Coercion::new_exact(TypeSignatureClass::Native(Arc::new(NativeType::String))),
+        Coercion::new_exact(TypeSignatureClass::Native(Arc::new(NativeType::String))),
+        Coercion::new_exact(TypeSignatureClass::Integer),
+        Coercion::new_exact(TypeSignatureClass::Integer),
+        Coercion::new_exact(TypeSignatureClass::Native(Arc::new(NativeType::String))),
+        Coercion::new_exact(TypeSignatureClass::Native(Arc::new(NativeType::String))),
+    ])
+}
+
 impl RegexpSubstrFunc {
     pub fn new() -> Self {
+        let mut variants: Vec<TypeSignature> = (2..=6).map(coercible_for_arity).collect();
+        // Add a second arity-6 variant where the group param is a string (named group).
+        variants.push(coercible_for_arity_6_named_group());
+
         Self {
-            signature: Signature::one_of(
-                (2..=6).map(coercible_for_arity).collect(),
-                Volatility::Immutable,
-            )
-            .with_parameter_names(PARAM_NAMES.iter().map(|s| s.to_string()).collect())
-            // safety: these parameter names are valid because they cover the max arity of the
-            // signature and there are no duplicates, so it is safe to expect here
-            .expect("valid parameter names"),
+            signature: Signature::one_of(variants, Volatility::Immutable)
+                .with_parameter_names(PARAM_NAMES.iter().map(|s| s.to_string()).collect())
+                // safety: these parameter names are valid because they cover the max arity
+                // of the signature and there are no duplicates, so it is safe to expect here
+                .expect("valid parameter names"),
         }
     }
 }
@@ -615,43 +628,64 @@ where
 {
     match groups {
         ColumnarValue::Array(arr) => {
-            let casted = cast_int_array_to_int64(arr)?;
-            let int_arr = casted.as_primitive::<Int64Type>();
-            println!("{:?}", int_arr);
-            regex_substr_core(
-                values,
-                patterns,
-                flags,
-                starts,
-                occurrences,
-                int_arr
-                    .iter()
-                    .map(|i| i.and_then(|i| (i >= 0).then_some(i as usize))),
-            )
+            if arr.data_type().is_integer()
+                || matches!(arr.data_type(), DataType::Dictionary(_, v) if v.is_integer())
+            {
+                // Integer group array — capture group by index
+                let casted = cast_int_array_to_int64(arr)?;
+                let int_arr = casted.as_primitive::<Int64Type>();
+                regex_substr_core(
+                    values,
+                    patterns,
+                    flags,
+                    starts,
+                    occurrences,
+                    int_arr.iter().map(|i| {
+                        i.and_then(|i| (i >= 0).then_some(CaptureGroupRef::Index(i as usize)))
+                    }),
+                )
+            } else {
+                // String group array — capture group by name
+                let casted = cast_str_array_to_utf8(arr)?;
+                let str_arr = casted.as_string::<i32>();
+                regex_substr_core(
+                    values,
+                    patterns,
+                    flags,
+                    starts,
+                    occurrences,
+                    str_arr.iter().map(|s| s.map(CaptureGroupRef::Name)),
+                )
+            }
         }
-        ColumnarValue::Scalar(scalar) => {
-            let group = match scalar.cast_to(&DataType::UInt64) {
-                Ok(unsigned_scalar) => {
-                    let ScalarValue::UInt64(group) = unsigned_scalar else {
-                        unreachable!("we've casted this to UInt64")
-                    };
-                    group.map(|i| i as usize)
-                }
-                // if we couldn't cast, it means we had a negative integer scalar
-                // so always treat the group as null, meaning the result for all
-                // the rows will be null.
-                _ => None,
-            };
+        ColumnarValue::Scalar(scalar) => match scalar {
+            // String scalar — capture group by name
+            ScalarValue::Utf8(name) => {
+                let group = name.as_deref().map(CaptureGroupRef::Name);
+                regex_substr_core(
+                    values, patterns, flags, starts, occurrences, std::iter::repeat(group),
+                )
+            }
+            // Integer scalar — capture group by index
+            _ => {
+                let group = match scalar.cast_to(&DataType::UInt64) {
+                    Ok(unsigned_scalar) => {
+                        let ScalarValue::UInt64(group) = unsigned_scalar else {
+                            unreachable!("we've casted this to UInt64")
+                        };
+                        group.map(|i| CaptureGroupRef::Index(i as usize))
+                    }
+                    // if we couldn't cast, it means we had a negative integer scalar
+                    // so always treat the group as null, meaning the result for all
+                    // the rows will be null.
+                    _ => None,
+                };
 
-            regex_substr_core(
-                values,
-                patterns,
-                flags,
-                starts,
-                occurrences,
-                std::iter::repeat(group),
-            )
-        }
+                regex_substr_core(
+                    values, patterns, flags, starts, occurrences, std::iter::repeat(group),
+                )
+            }
+        },
     }
 }
 
@@ -676,6 +710,13 @@ fn columnar_int_scalar_to_usize(scalar: &ScalarValue) -> Result<Option<usize>> {
     }
 }
 
+/// A reference to a capture group, either by numeric index or by name.
+#[derive(Clone, Copy)]
+enum CaptureGroupRef<'a> {
+    Index(usize),
+    Name(&'a str),
+}
+
 /// The innermost matching function. All six parameter iterators have been fully
 /// resolved by this point.
 ///
@@ -684,7 +725,7 @@ fn columnar_int_scalar_to_usize(scalar: &ScalarValue) -> Result<Option<usize>> {
 /// 2. Compiles the regex with the given flags.
 /// 3. Finds the `occurrence`-th match (1-based).
 /// 4. Extracts the specified capture `group`.
-fn regex_substr_core<'a, 'b, 'c, I1, I2, I3, I4, I5, I6>(
+fn regex_substr_core<'a, 'b, 'c, 'd, I1, I2, I3, I4, I5, I6>(
     values: I1,
     patterns: I2,
     flags: I3,
@@ -698,7 +739,7 @@ where
     I3: Iterator<Item = Option<&'c str>>,
     I4: Iterator<Item = Option<usize>>,
     I5: Iterator<Item = Option<usize>>,
-    I6: Iterator<Item = Option<usize>>,
+    I6: Iterator<Item = Option<CaptureGroupRef<'d>>>,
 {
     let mut regex_cache = HashMap::new();
     let mut result_builder = StringBuilder::new();
@@ -739,7 +780,11 @@ where
                 };
 
                 if let Some(captures) = matched {
-                    if let Some(capture) = captures.get(group) {
+                    let capture = match group {
+                        CaptureGroupRef::Index(i) => captures.get(i),
+                        CaptureGroupRef::Name(n) => captures.name(n),
+                    };
+                    if let Some(capture) = capture {
                         if null_run > 0 {
                             result_builder.append_nulls(null_run);
                         }
@@ -2041,6 +2086,175 @@ mod test {
         match result {
             ColumnarValue::Array(arr) => assert_eq!(&arr, &expected),
             s => panic!("expected Array, got {s:?}"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Named capture group tests
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_named_group_scalar() {
+        let session_context = Pipeline::create_session_context();
+
+        // regexp_substr(source, "hello (?P<rest>.*)", 1, 1, NULL, "rest")
+        let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
+            regexp_substr(),
+            vec![
+                col("test_col"),
+                lit("hello (?P<rest>.*)"),
+                lit(1i64),
+                lit(1i64),
+                lit(ScalarValue::Utf8(None)),
+                lit("rest"),
+            ],
+        ));
+
+        let input_col =
+            StringArray::from_iter_values(["hello world", "otap", "hello otap", "arrow"]);
+        let input = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "test_col",
+                input_col.data_type().clone(),
+                true,
+            )])),
+            vec![Arc::new(input_col)],
+        )
+        .unwrap();
+
+        let df_schema =
+            DFSchema::from_unqualified_fields(input.schema().fields.clone(), Default::default())
+                .unwrap();
+        let physical_expr =
+            create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
+                .unwrap();
+
+        let result = physical_expr.evaluate(&input).unwrap();
+        let expected: ArrayRef = Arc::new(StringArray::from_iter([
+            Some("world"),
+            None,
+            Some("otap"),
+            None,
+        ]));
+        match result {
+            ColumnarValue::Array(arr) => assert_eq!(&arr, &expected),
+            s => panic!("expected Array, got {s:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_named_group_not_in_regex_returns_null() {
+        let session_context = Pipeline::create_session_context();
+
+        let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
+            regexp_substr(),
+            vec![
+                col("test_col"),
+                lit("hello (.*)"),
+                lit(1i64),
+                lit(1i64),
+                lit(ScalarValue::Utf8(None)),
+                lit("nonexistent"),
+            ],
+        ));
+
+        let input_col = StringArray::from_iter_values(["hello world", "hello otap"]);
+        let input = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "test_col",
+                input_col.data_type().clone(),
+                true,
+            )])),
+            vec![Arc::new(input_col)],
+        )
+        .unwrap();
+
+        let df_schema =
+            DFSchema::from_unqualified_fields(input.schema().fields.clone(), Default::default())
+                .unwrap();
+        let physical_expr =
+            create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
+                .unwrap();
+
+        let result = physical_expr.evaluate(&input).unwrap();
+        let expected: ArrayRef = Arc::new(StringArray::new_null(2));
+        match result {
+            ColumnarValue::Array(arr) => assert_eq!(&arr, &expected),
+            s => panic!("expected Array, got {s:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_named_group_string_array() {
+        let session_context = Pipeline::create_session_context();
+
+        let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
+            regexp_substr(),
+            vec![
+                col("test_col"),
+                lit("(?P<first>\\w+) (?P<second>\\w+)"),
+                lit(1i64),
+                lit(1i64),
+                lit(ScalarValue::Utf8(None)),
+                col("group_col"),
+            ],
+        ));
+
+        let input_col = StringArray::from_iter_values(["hello world", "foo bar", "one two"]);
+        let group_col = StringArray::from_iter_values(["first", "second", "first"]);
+
+        let input = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("test_col", input_col.data_type().clone(), true),
+                Field::new("group_col", group_col.data_type().clone(), true),
+            ])),
+            vec![Arc::new(input_col), Arc::new(group_col)],
+        )
+        .unwrap();
+
+        let df_schema =
+            DFSchema::from_unqualified_fields(input.schema().fields.clone(), Default::default())
+                .unwrap();
+        let physical_expr =
+            create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
+                .unwrap();
+
+        let result = physical_expr.evaluate(&input).unwrap();
+        let expected: ArrayRef =
+            Arc::new(StringArray::from_iter_values(["hello", "bar", "one"]));
+        match result {
+            ColumnarValue::Array(arr) => assert_eq!(&arr, &expected),
+            s => panic!("expected Array, got {s:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_named_group_all_scalar() {
+        let session_context = Pipeline::create_session_context();
+
+        let plan = Expr::ScalarFunction(ScalarFunction::new_udf(
+            regexp_substr(),
+            vec![
+                lit("hello world"),
+                lit("hello (?P<rest>.*)"),
+                lit(1i64),
+                lit(1i64),
+                lit(ScalarValue::Utf8(None)),
+                lit("rest"),
+            ],
+        ));
+
+        let input = RecordBatch::new_empty(Arc::new(Schema::empty()));
+        let df_schema = DFSchema::empty();
+
+        let physical_expr =
+            create_physical_expr(&plan, &df_schema, session_context.state().execution_props())
+                .unwrap();
+
+        let result = physical_expr.evaluate(&input).unwrap();
+        match result {
+            ColumnarValue::Scalar(ScalarValue::Utf8(Some(s))) => assert_eq!(s, "world"),
+            other => panic!("expected Scalar(Utf8(Some(\"world\"))), got {other:?}"),
         }
     }
 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_substr.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_substr.rs
@@ -663,7 +663,12 @@ where
             ScalarValue::Utf8(name) => {
                 let group = name.as_deref().map(CaptureGroupRef::Name);
                 regex_substr_core(
-                    values, patterns, flags, starts, occurrences, std::iter::repeat(group),
+                    values,
+                    patterns,
+                    flags,
+                    starts,
+                    occurrences,
+                    std::iter::repeat(group),
                 )
             }
             // Integer scalar — capture group by index
@@ -682,7 +687,12 @@ where
                 };
 
                 regex_substr_core(
-                    values, patterns, flags, starts, occurrences, std::iter::repeat(group),
+                    values,
+                    patterns,
+                    flags,
+                    starts,
+                    occurrences,
+                    std::iter::repeat(group),
                 )
             }
         },
@@ -1911,8 +1921,7 @@ mod test {
         // "hello world" -> 2nd word match = "world"
         // "one"         -> only 1 match, 2nd doesn't exist = null
         // "a b c"       -> 2nd word match = "b"
-        let expected: ArrayRef =
-            Arc::new(StringArray::from_iter([Some("world"), None, Some("b")]));
+        let expected: ArrayRef = Arc::new(StringArray::from_iter([Some("world"), None, Some("b")]));
         match result {
             ColumnarValue::Array(arr) => assert_eq!(&arr, &expected),
             s => panic!("expected Array, got {s:?}"),
@@ -1991,11 +2000,8 @@ mod test {
 
         let result = physical_expr.evaluate(&input).unwrap();
         // Case-insensitive: "HELLO" matches "hello" and "HELLO", not "no match"
-        let expected: ArrayRef = Arc::new(StringArray::from_iter([
-            Some("hello"),
-            Some("HELLO"),
-            None,
-        ]));
+        let expected: ArrayRef =
+            Arc::new(StringArray::from_iter([Some("hello"), Some("HELLO"), None]));
         match result {
             ColumnarValue::Array(arr) => assert_eq!(&arr, &expected),
             s => panic!("expected Array, got {s:?}"),
@@ -2220,8 +2226,7 @@ mod test {
                 .unwrap();
 
         let result = physical_expr.evaluate(&input).unwrap();
-        let expected: ArrayRef =
-            Arc::new(StringArray::from_iter_values(["hello", "bar", "one"]));
+        let expected: ArrayRef = Arc::new(StringArray::from_iter_values(["hello", "bar", "one"]));
         match result {
             ColumnarValue::Array(arr) => assert_eq!(&arr, &expected),
             s => panic!("expected Array, got {s:?}"),


### PR DESCRIPTION
# Change Summary

<!--
Replace with a brief summary of the change in this PR
-->

Partially support `TextScalarExpression::Capture` in columnar query engine.
https://github.com/open-telemetry/otel-arrow/blob/b5f0814099566c119a29aa8465a137e04adbeeb4/rust/experimental/query_engine/expressions/src/scalars/text_scalar_expression.rs#L7-L11

This currently only supports identifying the capture group by number or name.

In KQL, the `extract` function gets parsed into this type:
```kql
logs | set severity_text = extract(".*severity=(.*).*", 1, event_name)
```

In OPL, I added a function called `regexp_capture` that has similar arguments:
```kql
logs | set severity_text = regexp_capture(event_name, ".*severity=(.*).*", 1)
```

Named capture groups are also supported:
```kql
logs | set attributes["x"] = regexp_capture(attributes["y"], ".*(?P<mygroup>.....+) ", "mygroup")
```

The order of the arguments are slightly different from KQL's `extract` function. This follows the convention used in datafusion's [regexp scalar functions](https://datafusion.apache.org/user-guide/sql/scalar_functions.html#regular-expression-functions) (which are based on various functions available in SQL) where the first argument is the string and second is the pattern.

Underneath the hood, this is implemented using a ScalarUDF called `regexp_substr`, that accepts the same signature found in many SQL dialetcs (such as https://docs.snowflake.com/en/sql-reference/functions/regexp_substr), with the additional capability that this can be called using a named group instead of a group number. This is probably overkill for just the capture group extraction case, but I was thinking it was best to do something flexible/standard and that we could probably try donating this to upstream datafusion eventually.

This function is also available to be called in OPL/KQL directly:
```kql
logs | extend attributes["s1"] = regexp_substr(attributes["attr"], "hell.")
```

The `regex_substr` function is optimized for the case all the arguments are scalars, except for the first argument which is the source string column. If any of the other arguments are not scalar, it casts the array into either a  string array or Int64 array. This keeps the imlementation straight forward, and having a ton of edge cases for dict handling.

There's currently some funny logic in the handling for the optional parameters that I'm not proud of. Datafusion functions support optional arguments (via multiple signatures), but our expression tree expects every function to have a well-defined number of parameters, and the defaults are actually supplied to the parser state. Currently KQL is using these  - if params are supplied in the query, it fills them in. OPL parser isn't doing this and just delegates to the function to figure it out internally. In the future, I'll probably try to fix up the expressions we use for function signature in our expression tree to add the concept of optional parameters. 

## What issue does this PR close?

<!--
We highly recommend correlation of every PR to an issue
-->

* Closes #2578

## How are these changes tested?

unit

## Are there any user-facing changes?

Yes - these functions are available for use in transform processor.

 <!-- If yes, provide further info below -->
