### PR TITLE
refactor(engine): extract IndexedMinHeap from node-local wakeup scheduler

### DIFF
--- a/rust/otap-dataflow/crates/engine/src/indexed_min_heap.rs
+++ b/rust/otap-dataflow/crates/engine/src/indexed_min_heap.rs
@@ -14,7 +14,7 @@ use std::hash::Hash;
 
 /// Outcome of an [`IndexedMinHeap::insert`] call.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum InsertOutcome {
+pub(crate) enum InsertOutcome {
     /// A new entry was added to the heap.
     Inserted,
     /// An existing entry's priority was replaced.
@@ -27,7 +27,7 @@ pub enum InsertOutcome {
 /// Entries are `(K, P)` pairs.  The heap is ordered by `P` where the
 /// *smallest* priority sits at the root.  Keys must be unique — inserting
 /// a key that already exists replaces its priority in place.
-pub struct IndexedMinHeap<K, P> {
+pub(crate) struct IndexedMinHeap<K, P> {
     entries: Vec<Entry<K, P>>,
     indices: HashMap<K, usize>,
 }

--- a/rust/otap-dataflow/crates/engine/src/indexed_min_heap.rs
+++ b/rust/otap-dataflow/crates/engine/src/indexed_min_heap.rs
@@ -95,7 +95,10 @@ where
             InsertOutcome::Replaced
         } else {
             let index = self.entries.len();
-            self.entries.push(Entry { key: key.clone(), priority });
+            self.entries.push(Entry {
+                key: key.clone(),
+                priority,
+            });
             assert!(
                 self.indices.insert(key, index).is_none(),
                 "new key should not already exist in index map"

--- a/rust/otap-dataflow/crates/engine/src/indexed_min_heap.rs
+++ b/rust/otap-dataflow/crates/engine/src/indexed_min_heap.rs
@@ -1,0 +1,481 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! A generic indexed binary min-heap with O(1) key lookup and O(log n)
+//! insert, remove, and in-place priority update.
+//!
+//! The heap stores `(K, P)` pairs where `K` is a unique key and `P` is a
+//! priority value.  A companion `HashMap<K, usize>` tracks each key's
+//! current position in the underlying `Vec`, enabling efficient keyed
+//! operations that a standard `BinaryHeap` cannot provide.
+
+use std::collections::HashMap;
+use std::hash::Hash;
+
+/// Outcome of an [`IndexedMinHeap::insert`] call.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum InsertOutcome {
+    /// A new entry was added to the heap.
+    Inserted,
+    /// An existing entry's priority was replaced.
+    Replaced,
+}
+
+/// A binary min-heap that supports O(1) key lookup and O(log n) keyed
+/// insertion, removal, and in-place priority updates.
+///
+/// Entries are `(K, P)` pairs.  The heap is ordered by `P` where the
+/// *smallest* priority sits at the root.  Keys must be unique — inserting
+/// a key that already exists replaces its priority in place.
+pub struct IndexedMinHeap<K, P> {
+    entries: Vec<Entry<K, P>>,
+    indices: HashMap<K, usize>,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Entry<K, P> {
+    key: K,
+    priority: P,
+}
+
+impl<K, P> IndexedMinHeap<K, P>
+where
+    K: Eq + Hash + Copy + std::fmt::Debug,
+    P: Ord,
+{
+    /// Creates an empty heap.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+            indices: HashMap::new(),
+        }
+    }
+
+    /// Returns the number of entries in the heap.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Returns `true` if the heap contains no entries.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Returns a reference to the `(key, priority)` pair with the smallest
+    /// priority, or `None` if the heap is empty.
+    #[must_use]
+    pub fn peek(&self) -> Option<(&K, &P)> {
+        self.entries.first().map(|e| (&e.key, &e.priority))
+    }
+
+    /// Returns `true` if the heap contains an entry for `key`.
+    pub fn contains_key(&self, key: &K) -> bool {
+        self.indices.contains_key(key)
+    }
+
+    /// Inserts `key` with the given `priority`.
+    ///
+    /// If `key` already exists its priority is replaced in place and the
+    /// heap property is restored.  Returns whether the key was newly inserted
+    /// or replaced.
+    pub fn insert(&mut self, key: K, priority: P) -> InsertOutcome {
+        if let Some(&index) = self.indices.get(&key) {
+            self.entries[index].priority = priority;
+            self.repair_at(index);
+            InsertOutcome::Replaced
+        } else {
+            let index = self.entries.len();
+            self.entries.push(Entry { key, priority });
+            assert!(
+                self.indices.insert(key, index).is_none(),
+                "new key should not already exist in index map"
+            );
+            self.sift_up(index);
+            InsertOutcome::Inserted
+        }
+    }
+
+    /// Removes the entry with the smallest priority and returns its
+    /// `(key, priority)` pair, or `None` if the heap is empty.
+    pub fn pop(&mut self) -> Option<(K, P)> {
+        if self.entries.is_empty() {
+            return None;
+        }
+        let root_key = self.entries[0].key;
+        let removed = self
+            .indices
+            .remove(&root_key)
+            .expect("root key should exist in index map");
+        debug_assert_eq!(removed, 0);
+        let entry = self.remove_at(0);
+        Some((entry.key, entry.priority))
+    }
+
+    /// Removes the entry for `key` and returns its `(key, priority)` pair,
+    /// or `None` if the key is not present.
+    pub fn remove(&mut self, key: &K) -> Option<(K, P)> {
+        let index = self.indices.remove(key)?;
+        let entry = self.remove_at(index);
+        debug_assert_eq!(&entry.key, key);
+        Some((entry.key, entry.priority))
+    }
+
+    /// Removes all entries from the heap.
+    pub fn clear(&mut self) {
+        self.entries.clear();
+        self.indices.clear();
+    }
+
+    // -- internal heap machinery ------------------------------------------
+
+    fn swap(&mut self, a: usize, b: usize) {
+        if a == b {
+            return;
+        }
+        self.entries.swap(a, b);
+        let key_a = self.entries[a].key;
+        let key_b = self.entries[b].key;
+        let _ = self
+            .indices
+            .insert(key_a, a)
+            .expect("swapped key a should exist in index map");
+        let _ = self
+            .indices
+            .insert(key_b, b)
+            .expect("swapped key b should exist in index map");
+    }
+
+    fn sift_up(&mut self, mut index: usize) {
+        while index > 0 {
+            let parent = (index - 1) / 2;
+            if self.entries[index].priority >= self.entries[parent].priority {
+                break;
+            }
+            self.swap(index, parent);
+            index = parent;
+        }
+    }
+
+    fn sift_down(&mut self, mut index: usize) {
+        let len = self.entries.len();
+        loop {
+            let left = index * 2 + 1;
+            if left >= len {
+                break;
+            }
+            let right = left + 1;
+            let mut smallest = left;
+            if right < len && self.entries[right].priority < self.entries[left].priority {
+                smallest = right;
+            }
+            if self.entries[smallest].priority >= self.entries[index].priority {
+                break;
+            }
+            self.swap(index, smallest);
+            index = smallest;
+        }
+    }
+
+    fn repair_at(&mut self, index: usize) {
+        if index > 0 {
+            let parent = (index - 1) / 2;
+            if self.entries[index].priority < self.entries[parent].priority {
+                self.sift_up(index);
+                return;
+            }
+        }
+        self.sift_down(index);
+    }
+
+    /// Removes the entry at `index`, restoring the heap property.
+    ///
+    /// The caller must have already removed the key from `self.indices`.
+    fn remove_at(&mut self, index: usize) -> Entry<K, P> {
+        let last = self
+            .entries
+            .len()
+            .checked_sub(1)
+            .expect("remove_at requires a non-empty heap");
+
+        if index == last {
+            return self.entries.pop().expect("last entry should exist");
+        }
+
+        self.entries.swap(index, last);
+        let removed = self.entries.pop().expect("removed entry should exist");
+
+        // Update the index of the entry that was moved into `index`.
+        let moved_key = self.entries[index].key;
+        let _ = self
+            .indices
+            .insert(moved_key, index)
+            .expect("moved key should exist in index map");
+        self.repair_at(index);
+        removed
+    }
+
+    /// Asserts that the heap invariant and the index map are consistent.
+    ///
+    /// This is intended for use in tests and debug builds.
+    #[cfg(debug_assertions)]
+    pub fn assert_consistent(&self) {
+        assert_eq!(self.entries.len(), self.indices.len());
+
+        for (i, entry) in self.entries.iter().enumerate() {
+            assert_eq!(
+                self.indices.get(&entry.key).copied(),
+                Some(i),
+                "heap index must match map entry"
+            );
+            if i > 0 {
+                let parent = (i - 1) / 2;
+                assert!(
+                    self.entries[i].priority >= self.entries[parent].priority,
+                    "heap child must not have smaller priority than parent"
+                );
+            }
+        }
+    }
+}
+
+impl<K, P> Default for IndexedMinHeap<K, P>
+where
+    K: Eq + Hash + Copy + std::fmt::Debug,
+    P: Ord,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_heap() {
+        let heap: IndexedMinHeap<u32, u32> = IndexedMinHeap::new();
+        assert!(heap.is_empty());
+        assert_eq!(heap.len(), 0);
+        assert_eq!(heap.peek(), None);
+    }
+
+    #[test]
+    fn insert_and_peek() {
+        let mut heap = IndexedMinHeap::new();
+        assert_eq!(heap.insert(1u32, 10u32), InsertOutcome::Inserted);
+        assert_eq!(heap.peek(), Some((&1, &10)));
+        assert_eq!(heap.len(), 1);
+        #[cfg(debug_assertions)]
+        heap.assert_consistent();
+    }
+
+    #[test]
+    fn insert_maintains_min_order() {
+        let mut heap = IndexedMinHeap::new();
+        let _ = heap.insert(1u32, 30u32);
+        let _ = heap.insert(2, 10);
+        let _ = heap.insert(3, 20);
+        #[cfg(debug_assertions)]
+        heap.assert_consistent();
+
+        assert_eq!(heap.peek(), Some((&2, &10)));
+    }
+
+    #[test]
+    fn pop_returns_entries_in_priority_order() {
+        let mut heap = IndexedMinHeap::new();
+        let _ = heap.insert(1u32, 30u32);
+        let _ = heap.insert(2, 10);
+        let _ = heap.insert(3, 20);
+
+        assert_eq!(heap.pop(), Some((2, 10)));
+        #[cfg(debug_assertions)]
+        heap.assert_consistent();
+        assert_eq!(heap.pop(), Some((3, 20)));
+        #[cfg(debug_assertions)]
+        heap.assert_consistent();
+        assert_eq!(heap.pop(), Some((1, 30)));
+        #[cfg(debug_assertions)]
+        heap.assert_consistent();
+        assert_eq!(heap.pop(), None);
+    }
+
+    #[test]
+    fn insert_replaces_existing_key() {
+        let mut heap = IndexedMinHeap::new();
+        let _ = heap.insert(1u32, 30u32);
+        let _ = heap.insert(2, 10);
+        assert_eq!(heap.insert(1, 5), InsertOutcome::Replaced);
+        #[cfg(debug_assertions)]
+        heap.assert_consistent();
+
+        // Key 1 now has priority 5, should be the new root.
+        assert_eq!(heap.peek(), Some((&1, &5)));
+        assert_eq!(heap.len(), 2);
+    }
+
+    #[test]
+    fn replace_priority_upward() {
+        let mut heap = IndexedMinHeap::new();
+        let _ = heap.insert(1u32, 10u32);
+        let _ = heap.insert(2, 20);
+        let _ = heap.insert(3, 30);
+
+        // Make key 3 the highest priority.
+        let _ = heap.insert(3, 1);
+        #[cfg(debug_assertions)]
+        heap.assert_consistent();
+        assert_eq!(heap.peek(), Some((&3, &1)));
+    }
+
+    #[test]
+    fn replace_priority_downward() {
+        let mut heap = IndexedMinHeap::new();
+        let _ = heap.insert(1u32, 10u32);
+        let _ = heap.insert(2, 20);
+        let _ = heap.insert(3, 30);
+
+        // Make key 1 the lowest priority.
+        let _ = heap.insert(1, 100);
+        #[cfg(debug_assertions)]
+        heap.assert_consistent();
+        assert_eq!(heap.peek(), Some((&2, &20)));
+    }
+
+    #[test]
+    fn remove_by_key() {
+        let mut heap = IndexedMinHeap::new();
+        let _ = heap.insert(1u32, 10u32);
+        let _ = heap.insert(2, 20);
+        let _ = heap.insert(3, 30);
+
+        assert_eq!(heap.remove(&2), Some((2, 20)));
+        #[cfg(debug_assertions)]
+        heap.assert_consistent();
+        assert_eq!(heap.len(), 2);
+        assert!(!heap.contains_key(&2));
+
+        // Remaining entries still ordered.
+        assert_eq!(heap.pop(), Some((1, 10)));
+        assert_eq!(heap.pop(), Some((3, 30)));
+    }
+
+    #[test]
+    fn remove_nonexistent_key_returns_none() {
+        let mut heap = IndexedMinHeap::new();
+        let _ = heap.insert(1u32, 10u32);
+        assert_eq!(heap.remove(&99), None);
+        assert_eq!(heap.len(), 1);
+    }
+
+    #[test]
+    fn remove_root() {
+        let mut heap = IndexedMinHeap::new();
+        let _ = heap.insert(1u32, 10u32);
+        let _ = heap.insert(2, 20);
+        let _ = heap.insert(3, 30);
+
+        assert_eq!(heap.remove(&1), Some((1, 10)));
+        #[cfg(debug_assertions)]
+        heap.assert_consistent();
+        assert_eq!(heap.peek(), Some((&2, &20)));
+    }
+
+    #[test]
+    fn remove_last_entry() {
+        let mut heap = IndexedMinHeap::new();
+        let _ = heap.insert(1u32, 10u32);
+        assert_eq!(heap.remove(&1), Some((1, 10)));
+        assert!(heap.is_empty());
+    }
+
+    #[test]
+    fn clear_empties_the_heap() {
+        let mut heap = IndexedMinHeap::new();
+        let _ = heap.insert(1u32, 10u32);
+        let _ = heap.insert(2, 20);
+        heap.clear();
+        assert!(heap.is_empty());
+        assert_eq!(heap.peek(), None);
+    }
+
+    #[test]
+    fn contains_key_works() {
+        let mut heap = IndexedMinHeap::new();
+        let _ = heap.insert(1u32, 10u32);
+        assert!(heap.contains_key(&1));
+        assert!(!heap.contains_key(&2));
+    }
+
+    #[test]
+    fn many_inserts_maintain_heap_order() {
+        let mut heap = IndexedMinHeap::new();
+        // Insert in reverse order.
+        for i in (0u32..100).rev() {
+            let _ = heap.insert(i, i);
+        }
+        #[cfg(debug_assertions)]
+        heap.assert_consistent();
+
+        for expected in 0u32..100 {
+            assert_eq!(heap.pop(), Some((expected, expected)));
+        }
+        assert!(heap.is_empty());
+    }
+
+    #[test]
+    fn equal_priorities_are_stable_by_insertion_order() {
+        // With equal priorities, the heap only guarantees they all come out,
+        // not a specific order among equals. Verify all are returned.
+        let mut heap = IndexedMinHeap::new();
+        let _ = heap.insert(1u32, 0u32);
+        let _ = heap.insert(2, 0);
+        let _ = heap.insert(3, 0);
+        #[cfg(debug_assertions)]
+        heap.assert_consistent();
+
+        let mut keys = Vec::new();
+        while let Some((k, _)) = heap.pop() {
+            keys.push(k);
+        }
+        keys.sort();
+        assert_eq!(keys, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn remove_middle_entry_preserves_heap() {
+        let mut heap = IndexedMinHeap::new();
+        for i in 0u32..10 {
+            let _ = heap.insert(i, i * 10);
+        }
+
+        // Remove entry in the middle of the heap.
+        assert_eq!(heap.remove(&5), Some((5, 50)));
+        #[cfg(debug_assertions)]
+        heap.assert_consistent();
+
+        let mut prev = 0u32;
+        while let Some((_, p)) = heap.pop() {
+            assert!(p >= prev);
+            prev = p;
+        }
+    }
+
+    #[test]
+    fn repeated_replace_same_key() {
+        let mut heap = IndexedMinHeap::new();
+        let _ = heap.insert(1u32, 100u32);
+        for p in (1u32..=50).rev() {
+            assert_eq!(heap.insert(1, p), InsertOutcome::Replaced);
+            #[cfg(debug_assertions)]
+            heap.assert_consistent();
+            assert_eq!(heap.len(), 1);
+            assert_eq!(heap.peek(), Some((&1, &p)));
+        }
+        assert_eq!(heap.pop(), Some((1, 1)));
+    }
+}

--- a/rust/otap-dataflow/crates/engine/src/indexed_min_heap.rs
+++ b/rust/otap-dataflow/crates/engine/src/indexed_min_heap.rs
@@ -27,12 +27,19 @@ pub(crate) enum InsertOutcome {
 /// Entries are `(K, P)` pairs.  The heap is ordered by `P` where the
 /// *smallest* priority sits at the root.  Keys must be unique — inserting
 /// a key that already exists replaces its priority in place.
+///
+/// # Key cloning
+///
+/// Keys are cloned during insert, swap, pop, and removal operations.
+/// Callers should prefer cheap-to-clone key types (e.g. integers).
+//  Using an expensive-to-clone key will add overhead proportional to
+//  tree depth on every heap operation.
 pub(crate) struct IndexedMinHeap<K, P> {
     entries: Vec<Entry<K, P>>,
     indices: HashMap<K, usize>,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 struct Entry<K, P> {
     key: K,
     priority: P,
@@ -40,7 +47,7 @@ struct Entry<K, P> {
 
 impl<K, P> IndexedMinHeap<K, P>
 where
-    K: Eq + Hash + Copy + std::fmt::Debug,
+    K: Eq + Hash + Clone + std::fmt::Debug,
     P: Ord,
 {
     /// Creates an empty heap.
@@ -88,7 +95,7 @@ where
             InsertOutcome::Replaced
         } else {
             let index = self.entries.len();
-            self.entries.push(Entry { key, priority });
+            self.entries.push(Entry { key: key.clone(), priority });
             assert!(
                 self.indices.insert(key, index).is_none(),
                 "new key should not already exist in index map"
@@ -104,7 +111,7 @@ where
         if self.entries.is_empty() {
             return None;
         }
-        let root_key = self.entries[0].key;
+        let root_key = self.entries[0].key.clone();
         let removed = self
             .indices
             .remove(&root_key)
@@ -136,8 +143,8 @@ where
             return;
         }
         self.entries.swap(a, b);
-        let key_a = self.entries[a].key;
-        let key_b = self.entries[b].key;
+        let key_a = self.entries[a].key.clone();
+        let key_b = self.entries[b].key.clone();
         let _ = self
             .indices
             .insert(key_a, a)
@@ -208,7 +215,7 @@ where
         let removed = self.entries.pop().expect("removed entry should exist");
 
         // Update the index of the entry that was moved into `index`.
-        let moved_key = self.entries[index].key;
+        let moved_key = self.entries[index].key.clone();
         let _ = self
             .indices
             .insert(moved_key, index)
@@ -243,7 +250,7 @@ where
 
 impl<K, P> Default for IndexedMinHeap<K, P>
 where
-    K: Eq + Hash + Copy + std::fmt::Debug,
+    K: Eq + Hash + Clone + std::fmt::Debug,
     P: Ord,
 {
     fn default() -> Self {

--- a/rust/otap-dataflow/crates/engine/src/lib.rs
+++ b/rust/otap-dataflow/crates/engine/src/lib.rs
@@ -69,6 +69,7 @@ mod control_plane_metrics;
 pub mod effect_handler;
 pub mod engine_metrics;
 pub mod entity_context;
+pub mod indexed_min_heap;
 pub mod local;
 pub mod memory_limiter;
 pub mod node;

--- a/rust/otap-dataflow/crates/engine/src/lib.rs
+++ b/rust/otap-dataflow/crates/engine/src/lib.rs
@@ -69,7 +69,7 @@ mod control_plane_metrics;
 pub mod effect_handler;
 pub mod engine_metrics;
 pub mod entity_context;
-pub mod indexed_min_heap;
+pub(crate) mod indexed_min_heap;
 pub mod local;
 pub mod memory_limiter;
 pub mod node;

--- a/rust/otap-dataflow/crates/engine/src/node_local_scheduler.rs
+++ b/rust/otap-dataflow/crates/engine/src/node_local_scheduler.rs
@@ -333,10 +333,7 @@ mod tests {
 
         assert!(scheduler.heap.contains_key(&WakeupSlot(3)));
         // Verify that slot 1 (earliest deadline) should still be at the root.
-        assert_eq!(
-            scheduler.heap.peek().map(|(k, _)| *k),
-            Some(WakeupSlot(1))
-        );
+        assert_eq!(scheduler.heap.peek().map(|(k, _)| *k), Some(WakeupSlot(1)));
 
         assert!(scheduler.cancel_wakeup(WakeupSlot(3)));
         assert_heap_bound(&scheduler);

--- a/rust/otap-dataflow/crates/engine/src/node_local_scheduler.rs
+++ b/rust/otap-dataflow/crates/engine/src/node_local_scheduler.rs
@@ -4,7 +4,7 @@
 //! Node-local wakeup scheduling for processor inboxes.
 
 use crate::control::{WakeupRevision, WakeupSlot};
-use std::collections::HashMap;
+use crate::indexed_min_heap::IndexedMinHeap;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use tokio::sync::Notify;
@@ -45,18 +45,32 @@ impl WakeupSetOutcome {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
-struct ScheduledWakeup {
-    slot: WakeupSlot,
+/// Priority key for the wakeup heap.  Ordered by wall-clock time first,
+/// then by revision to break ties deterministically.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct WakeupPriority {
     when: Instant,
     revision: WakeupRevision,
+}
+
+impl Ord for WakeupPriority {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.when
+            .cmp(&other.when)
+            .then_with(|| self.revision.cmp(&other.revision))
+    }
+}
+
+impl PartialOrd for WakeupPriority {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 struct NodeLocalScheduler {
     wakeup_capacity: usize,
     next_revision: WakeupRevision,
-    wakeups: Vec<ScheduledWakeup>,
-    wakeup_indices: HashMap<WakeupSlot, usize>,
+    heap: IndexedMinHeap<WakeupSlot, WakeupPriority>,
     shutting_down: bool,
 }
 
@@ -65,8 +79,7 @@ impl NodeLocalScheduler {
         Self {
             wakeup_capacity,
             next_revision: 0,
-            wakeups: Vec::new(),
-            wakeup_indices: HashMap::new(),
+            heap: IndexedMinHeap::new(),
             shutting_down: false,
         }
     }
@@ -75,97 +88,6 @@ impl NodeLocalScheduler {
         let next = self.next_revision;
         self.next_revision = self.next_revision.saturating_add(1);
         next
-    }
-
-    fn wakeup_precedes(left: &ScheduledWakeup, right: &ScheduledWakeup) -> bool {
-        left.when < right.when || (left.when == right.when && left.revision < right.revision)
-    }
-
-    fn swap_entries(&mut self, left: usize, right: usize) {
-        if left == right {
-            return;
-        }
-
-        self.wakeups.swap(left, right);
-
-        let left_slot = self.wakeups[left].slot;
-        let right_slot = self.wakeups[right].slot;
-        let _ = self
-            .wakeup_indices
-            .insert(left_slot, left)
-            .expect("left slot index should exist");
-        let _ = self
-            .wakeup_indices
-            .insert(right_slot, right)
-            .expect("right slot index should exist");
-    }
-
-    fn sift_up(&mut self, mut index: usize) {
-        while index > 0 {
-            let parent = (index - 1) / 2;
-            if !Self::wakeup_precedes(&self.wakeups[index], &self.wakeups[parent]) {
-                break;
-            }
-            self.swap_entries(index, parent);
-            index = parent;
-        }
-    }
-
-    fn sift_down(&mut self, mut index: usize) {
-        let len = self.wakeups.len();
-        loop {
-            let left = index * 2 + 1;
-            if left >= len {
-                break;
-            }
-
-            let right = left + 1;
-            let mut smallest = left;
-            if right < len && Self::wakeup_precedes(&self.wakeups[right], &self.wakeups[left]) {
-                smallest = right;
-            }
-
-            if !Self::wakeup_precedes(&self.wakeups[smallest], &self.wakeups[index]) {
-                break;
-            }
-
-            self.swap_entries(index, smallest);
-            index = smallest;
-        }
-    }
-
-    fn repair_heap_at(&mut self, index: usize) {
-        if index > 0 {
-            let parent = (index - 1) / 2;
-            if Self::wakeup_precedes(&self.wakeups[index], &self.wakeups[parent]) {
-                self.sift_up(index);
-                return;
-            }
-        }
-        self.sift_down(index);
-    }
-
-    fn remove_heap_entry(&mut self, index: usize) -> ScheduledWakeup {
-        let last = self
-            .wakeups
-            .len()
-            .checked_sub(1)
-            .expect("heap entry removal requires a non-empty heap");
-
-        if index == last {
-            return self.wakeups.pop().expect("last wakeup should exist");
-        }
-
-        self.wakeups.swap(index, last);
-        let removed = self.wakeups.pop().expect("removed wakeup should exist");
-
-        let moved_slot = self.wakeups[index].slot;
-        let _ = self
-            .wakeup_indices
-            .insert(moved_slot, index)
-            .expect("moved slot index should exist");
-        self.repair_heap_at(index);
-        removed
     }
 
     fn set_wakeup(
@@ -177,28 +99,18 @@ impl NodeLocalScheduler {
             return Err(WakeupError::ShuttingDown);
         }
 
-        if let Some(&index) = self.wakeup_indices.get(&slot) {
+        if self.heap.contains_key(&slot) {
             let revision = self.next_revision();
-            self.wakeups[index].when = when;
-            self.wakeups[index].revision = revision;
-            self.repair_heap_at(index);
+            let priority = WakeupPriority { when, revision };
+            let _ = self.heap.insert(slot, priority);
             Ok(WakeupSetOutcome::Replaced { revision })
         } else {
-            if self.wakeup_indices.len() >= self.wakeup_capacity {
+            if self.heap.len() >= self.wakeup_capacity {
                 return Err(WakeupError::Capacity);
             }
             let revision = self.next_revision();
-            let index = self.wakeups.len();
-            self.wakeups.push(ScheduledWakeup {
-                slot,
-                when,
-                revision,
-            });
-            assert!(
-                self.wakeup_indices.insert(slot, index).is_none(),
-                "new wakeup slot should not already exist"
-            );
-            self.sift_up(index);
+            let priority = WakeupPriority { when, revision };
+            let _ = self.heap.insert(slot, priority);
             Ok(WakeupSetOutcome::Inserted { revision })
         }
     }
@@ -207,60 +119,26 @@ impl NodeLocalScheduler {
         if self.shutting_down {
             return false;
         }
-
-        let Some(index) = self.wakeup_indices.remove(&slot) else {
-            return false;
-        };
-
-        let removed = self.remove_heap_entry(index);
-        debug_assert_eq!(removed.slot, slot);
-        true
-    }
-
-    #[cfg(debug_assertions)]
-    fn assert_consistent(&self) {
-        assert_eq!(self.wakeups.len(), self.wakeup_indices.len());
-
-        for (index, wakeup) in self.wakeups.iter().enumerate() {
-            assert_eq!(
-                self.wakeup_indices.get(&wakeup.slot).copied(),
-                Some(index),
-                "heap index must match map entry"
-            );
-
-            if index > 0 {
-                let parent = (index - 1) / 2;
-                assert!(
-                    !Self::wakeup_precedes(&self.wakeups[index], &self.wakeups[parent]),
-                    "heap child must not precede parent"
-                );
-            }
-        }
+        self.heap.remove(&slot).is_some()
     }
 
     fn next_expiry(&mut self) -> Option<Instant> {
         #[cfg(debug_assertions)]
-        self.assert_consistent();
-        self.wakeups.first().map(|wakeup| wakeup.when)
+        self.heap.assert_consistent();
+        self.heap.peek().map(|(_, priority)| priority.when)
     }
 
     fn pop_due(&mut self, now: Instant) -> Option<(WakeupSlot, Instant, WakeupRevision)> {
         #[cfg(debug_assertions)]
-        self.assert_consistent();
+        self.heap.assert_consistent();
 
-        let next_due = self.wakeups.first().map(|wakeup| wakeup.when)?;
+        let next_due = self.heap.peek().map(|(_, p)| p.when)?;
         if next_due > now {
             return None;
         }
 
-        let slot = self.wakeups.first().expect("due wakeup should exist").slot;
-        let removed_index = self
-            .wakeup_indices
-            .remove(&slot)
-            .expect("due wakeup slot index should exist");
-        debug_assert_eq!(removed_index, 0);
-        let wakeup = self.remove_heap_entry(0);
-        Some((wakeup.slot, wakeup.when, wakeup.revision))
+        let (slot, priority) = self.heap.pop().expect("due wakeup should exist");
+        Some((slot, priority.when, priority.revision))
     }
 
     fn begin_shutdown(&mut self) {
@@ -268,12 +146,11 @@ impl NodeLocalScheduler {
             return;
         }
         self.shutting_down = true;
-        self.wakeup_indices.clear();
-        self.wakeups.clear();
+        self.heap.clear();
     }
 
     fn is_drained(&self) -> bool {
-        self.wakeup_indices.is_empty()
+        self.heap.is_empty()
     }
 }
 
@@ -357,13 +234,8 @@ mod tests {
     use std::time::Duration;
 
     fn assert_heap_bound(scheduler: &NodeLocalScheduler) {
-        assert_eq!(
-            scheduler.wakeups.len(),
-            scheduler.wakeup_indices.len(),
-            "scheduler should keep exactly one heap entry per live slot"
-        );
         #[cfg(debug_assertions)]
-        scheduler.assert_consistent();
+        scheduler.heap.assert_consistent();
     }
 
     #[test]
@@ -400,7 +272,7 @@ mod tests {
             Ok(WakeupSetOutcome::Replaced { revision: 1 })
         );
         assert_heap_bound(&scheduler);
-        assert_eq!(scheduler.wakeups.len(), 1);
+        assert_eq!(scheduler.heap.len(), 1);
         assert_eq!(scheduler.next_expiry(), Some(sooner));
         assert_eq!(scheduler.pop_due(sooner), Some((WakeupSlot(3), sooner, 1)));
         assert_heap_bound(&scheduler);
@@ -459,15 +331,7 @@ mod tests {
             Ok(WakeupSetOutcome::Replaced { revision: 4 })
         );
 
-        let moved_index = scheduler
-            .wakeup_indices
-            .get(&WakeupSlot(3))
-            .copied()
-            .expect("rescheduled slot should still be tracked");
-        assert!(
-            moved_index > 0,
-            "rescheduled slot should be a non-root entry"
-        );
+        assert!(scheduler.heap.contains_key(&WakeupSlot(3)));
 
         assert!(scheduler.cancel_wakeup(WakeupSlot(3)));
         assert_heap_bound(&scheduler);
@@ -510,7 +374,7 @@ mod tests {
             let expected_revision: WakeupRevision = 32 - offset;
             assert_eq!(outcome.revision(), expected_revision);
             assert_heap_bound(&scheduler);
-            assert_eq!(scheduler.wakeups.len(), 1);
+            assert_eq!(scheduler.heap.len(), 1);
             assert_eq!(scheduler.next_expiry(), Some(when));
         }
 

--- a/rust/otap-dataflow/crates/engine/src/node_local_scheduler.rs
+++ b/rust/otap-dataflow/crates/engine/src/node_local_scheduler.rs
@@ -332,6 +332,11 @@ mod tests {
         );
 
         assert!(scheduler.heap.contains_key(&WakeupSlot(3)));
+        // Verify that slot 1 (earliest deadline) should still be at the root.
+        assert_eq!(
+            scheduler.heap.peek().map(|(k, _)| *k),
+            Some(WakeupSlot(1))
+        );
 
         assert!(scheduler.cancel_wakeup(WakeupSlot(3)));
         assert_heap_bound(&scheduler);


### PR DESCRIPTION
# Change Summary

Extracts the hand-rolled binary heap (Vec<ScheduledWakeup> + HashMap<WakeupSlot, usize>) from NodeLocalScheduler into a generic, reusable IndexedMinHeap<K, P> data structure with its own module and test suite.

## What issue does this PR close?

* Closes #2587 

## How are these changes tested?

cargo test -p otap-df-engine -- "indexed_min_heap|node_local_scheduler"

Existing unit tests in node_local_scheduler and new unit tests in indexed_min_heap.

## Are there any user-facing changes?

No. All changes are internal to otap-df-engine. No downstream crate or user-facing behavior changes.