### PR TITLE
Reduce WARN volume on azure_monitor_exporter Heartbeat failure

### DIFF
--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/heartbeat.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/heartbeat.rs
@@ -7,7 +7,6 @@ use super::client::AZURE_MONITOR_SOURCE_RESOURCEID_HEADER;
 use super::config::{ApiConfig, HeartbeatOverrides};
 use super::error::Error;
 use chrono::Utc;
-use otap_df_telemetry::otel_warn;
 use reqwest::{
     Client,
     header::{AUTHORIZATION, CONTENT_TYPE, HeaderValue},
@@ -222,12 +221,6 @@ impl Heartbeat {
 
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
-
-        otel_warn!(
-            "azure_monitor_exporter.heartbeat.error",
-            status = status.as_u16(),
-            message = %body
-        );
 
         match status.as_u16() {
             401 => Err(Error::unauthorized(body)),


### PR DESCRIPTION
# Change Summary

On heartbeat failure (simulated in this case by providing an invalid dcr identifier), internal telemetry produces two almost identical WARN logs:

Produced by inner `Heartbeat.send()`:
> 2026-04-10T15:58:58.087Z  WARN  otap-df-contrib-nodes::azure_monitor_exporter.heartbeat.error: {"error":{"code":"NotFound","message":"Data collection rule with immutable Id 'dcr-badid' not found."}} [status=404] entity/node.attrs: node.id=exporter node.urn=urn:microsoft:exporter:azure_monitor node.type=exporter pipeline.id=main pipeline.group.id=example-azuremonitorpipeline core.id=0 numa.node.id=0 process.instance.id=AGOXQHRN2NZSBC2J3VHVEMWHMU host.id=CPC-drewr-ZFPSN container.id=

Produced by outer continuous loop:
> 2026-04-10T15:58:58.087Z  WARN  otap-df-contrib-nodes::azure_monitor_exporter.heartbeat.send_failed: [error=UnexpectedStatus { status: 404, body: "{\"error\":{\"code\":\"NotFound\",\"message\":\"Data collection rule with immutable Id 'dcr-badid' not found.\"}}" }] entity/node.attrs: node.id=exporter node.urn=urn:microsoft:exporter:azure_monitor node.type=exporter pipeline.id=main pipeline.group.id=example-azuremonitorpipeline core.id=0 numa.node.id=0 process.instance.id=AGOXQHRN2NZSBC2J3VHVEMWHMU host.id=CPC-drewr-ZFPSN container.id=

Since the caller of `Heartbeat.send()` already logs the error with the same details:

https://github.com/open-telemetry/otel-arrow/blob/b5f0814099566c119a29aa8465a137e04adbeeb4/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs#L585-L588

The inner WARN only doubles telemetry volume for the same information.

https://github.com/open-telemetry/otel-arrow/blob/b5f0814099566c119a29aa8465a137e04adbeeb4/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/heartbeat.rs#L226-L230

## What issue does this PR close?

N/A

## How are these changes tested?

Debug run of df_engine

## Are there any user-facing changes?

Yes, less telemetry on Heartbeat failure scenarios