### PR TITLE
test: improve handling of channel-send shutdown in durable_buffer_processor_tests

### DIFF
--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
@@ -1467,6 +1467,7 @@ impl DurableBuffer {
                         drop(handle);
                         ProcessBundleResult::Error(Error::ChannelSendError {
                             error: "downstream channel closed".to_string(),
+                            closed: true,
                         })
                     }
                     Err(otap_df_engine::error::TypedError::Error(e)) => {

--- a/rust/otap-dataflow/crates/engine/src/error.rs
+++ b/rust/otap-dataflow/crates/engine/src/error.rs
@@ -150,9 +150,13 @@ impl<T: Sized> From<TypedError<T>> for Error {
     /// This drops the SendError<T> field yielding an untyped error.
     fn from(value: TypedError<T>) -> Self {
         match value {
-            TypedError::ChannelSendError(e) => Error::ChannelSendError {
-                error: e.to_string(),
-            },
+            TypedError::ChannelSendError(e) => {
+                let closed = matches!(e, SendError::Closed(_));
+                Error::ChannelSendError {
+                    error: e.to_string(),
+                    closed,
+                }
+            }
             TypedError::RuntimeMsgError(e) => Error::RuntimeMsgError {
                 error: e.to_string(),
             },
@@ -181,8 +185,11 @@ pub enum Error {
     /// A wrapper for the channel errors.
     #[error("A data channel error occurred: {error}")]
     ChannelSendError {
-        /// The reason (e.g., channel full)
+        /// The reason (e.g., channel full or closed).
         error: String,
+        /// `true` when the channel was closed (receiver dropped), `false` when
+        /// the channel was merely full (backpressure).
+        closed: bool,
     },
 
     /// A wrapper for send errors on the runtime channels.

--- a/rust/otap-dataflow/crates/otap/tests/durable_buffer_processor_tests.rs
+++ b/rust/otap-dataflow/crates/otap/tests/durable_buffer_processor_tests.rs
@@ -638,11 +638,10 @@ where
 fn is_acceptable_shutdown_result(
     run_result: &Result<Vec<()>, otap_df_engine::error::Error>,
 ) -> bool {
-    match run_result {
-        Ok(_) => true,
-        Err(otap_df_engine::error::Error::ChannelSendError { error }) => error.contains("closed"),
-        Err(_) => false,
-    }
+    matches!(
+        run_result,
+        Ok(_) | Err(otap_df_engine::error::Error::ChannelSendError { closed: true, .. })
+    )
 }
 
 /// Wait for a condition to become true, with timeout.

--- a/rust/otap-dataflow/crates/otap/tests/durable_buffer_processor_tests.rs
+++ b/rust/otap-dataflow/crates/otap/tests/durable_buffer_processor_tests.rs
@@ -601,14 +601,10 @@ where
     };
 
     let _ = shutdown_handle.join();
-    // Accept either Ok or a "Channel is closed" error during shutdown.
-    // When an always-NACK exporter races with shutdown, the exporter may try to
-    // send a NACK after the control channel has closed. This is expected behavior
-    // for this test scenario (error_exporter + time-based shutdown).
-    let is_acceptable_shutdown = match &run_result {
-        Ok(_) => true,
-        Err(e) => e.to_string().contains("Channel is closed"),
-    };
+    // Accept either Ok or a channel-send shutdown race.
+    // When an always-NACK exporter races with shutdown, the pipeline can return
+    // a ChannelSendError depending on where closure is observed.
+    let is_acceptable_shutdown = is_acceptable_shutdown_result(&run_result);
     assert!(
         is_acceptable_shutdown,
         "pipeline failed to shut down cleanly: {:?}",
@@ -633,6 +629,17 @@ where
 // ─────────────────────────────────────────────────────────────────────────────
 // Test Helpers
 // ─────────────────────────────────────────────────────────────────────────────
+
+/// Return true when pipeline shutdown completed cleanly or hit an expected
+/// shutdown-time channel close race.
+fn is_acceptable_shutdown_result(
+    run_result: &Result<Vec<()>, otap_df_engine::error::Error>,
+) -> bool {
+    matches!(
+        run_result,
+        Ok(_) | Err(otap_df_engine::error::Error::ChannelSendError { .. })
+    )
+}
 
 /// Wait for a condition to become true, with timeout.
 ///
@@ -900,10 +907,7 @@ where
 
     let snapshot = shutdown_handle.join().expect("shutdown thread panicked");
 
-    let is_acceptable_shutdown = match &run_result {
-        Ok(_) => true,
-        Err(e) => e.to_string().contains("Channel is closed"),
-    };
+    let is_acceptable_shutdown = is_acceptable_shutdown_result(&run_result);
     assert!(
         is_acceptable_shutdown,
         "pipeline failed to shut down cleanly: {:?}",

--- a/rust/otap-dataflow/crates/otap/tests/durable_buffer_processor_tests.rs
+++ b/rust/otap-dataflow/crates/otap/tests/durable_buffer_processor_tests.rs
@@ -640,9 +640,7 @@ fn is_acceptable_shutdown_result(
 ) -> bool {
     match run_result {
         Ok(_) => true,
-        Err(otap_df_engine::error::Error::ChannelSendError { error }) => {
-            error.contains("closed")
-        }
+        Err(otap_df_engine::error::Error::ChannelSendError { error }) => error.contains("closed"),
         Err(_) => false,
     }
 }

--- a/rust/otap-dataflow/crates/otap/tests/durable_buffer_processor_tests.rs
+++ b/rust/otap-dataflow/crates/otap/tests/durable_buffer_processor_tests.rs
@@ -632,13 +632,19 @@ where
 
 /// Return true when pipeline shutdown completed cleanly or hit an expected
 /// shutdown-time channel close race.
+///
+/// Only the closed-channel case is accepted; other `ChannelSendError`
+/// reasons (e.g. "full") would indicate a real bug.
 fn is_acceptable_shutdown_result(
     run_result: &Result<Vec<()>, otap_df_engine::error::Error>,
 ) -> bool {
-    matches!(
-        run_result,
-        Ok(_) | Err(otap_df_engine::error::Error::ChannelSendError { .. })
-    )
+    match run_result {
+        Ok(_) => true,
+        Err(otap_df_engine::error::Error::ChannelSendError { error }) => {
+            error.contains("closed")
+        }
+        Err(_) => false,
+    }
 }
 
 /// Wait for a condition to become true, with timeout.


### PR DESCRIPTION
# Change Summary

Refactor how test code determines acceptable shutdown results in `durable_buffer_processor_tests.rs`. Don't rely on error message matching.

## What issue does this PR close?

n/a

## How are these changes tested?

Verified that the tests pass locally.

## Are there any user-facing changes?

No.
