### PR TITLE
Fix topic shutdown and mixed publish semantics

### DIFF
--- a/rust/otap-dataflow/crates/controller/src/lib.rs
+++ b/rust/otap-dataflow/crates/controller/src/lib.rs
@@ -3228,13 +3228,13 @@ groups:
         assert_eq!(
             topic
                 .try_publish(Arc::new(()))
-                .expect("publish should still reach broadcast"),
+                .expect("publish should report backpressure once balanced is full"),
             otap_df_engine::topic::PublishOutcome::DroppedOnFull
         );
         assert_eq!(
             topic
                 .try_publish(Arc::new(()))
-                .expect("publish should still reach broadcast"),
+                .expect("publish should keep reporting backpressure while balanced is full"),
             otap_df_engine::topic::PublishOutcome::DroppedOnFull
         );
         assert_eq!(
@@ -3263,6 +3263,6 @@ groups:
                 }
             }
         }
-        assert_eq!(broadcast_messages, 3);
+        assert_eq!(broadcast_messages, 1);
     }
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/topic_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/topic_exporter/mod.rs
@@ -31,7 +31,8 @@ use otap_df_telemetry::{otel_info, otel_warn};
 use otap_df_telemetry_macros::metric_set;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
+use std::future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
@@ -95,6 +96,34 @@ pub struct TopicExporter {
     metrics: MetricSet<TopicExporterMetrics>,
 }
 
+/// One upstream pdata message waiting for topic admission under `queue_on_full: block`.
+struct PendingPublish {
+    data: OtapPdata,
+    published: Arc<OtapPdata>,
+    should_track_end_to_end: bool,
+}
+
+impl PendingPublish {
+    /// Build the retained publish attempt state for one upstream pdata message.
+    fn new(data: OtapPdata, should_track_end_to_end: bool) -> Self {
+        Self {
+            published: Arc::new(data.clone_without_context()),
+            data,
+            should_track_end_to_end,
+        }
+    }
+}
+
+/// Result of one non-blocking attempt to admit a pending publish.
+enum PendingPublishProgress {
+    Published,
+    Pending,
+}
+
+/// Retry cadence while a topic publish remains blocked after an immediate
+/// fast-path admission attempt already failed.
+const PENDING_PUBLISH_RETRY_DELAY: Duration = Duration::from_millis(1);
+
 /// Declares the topic exporter as a local exporter factory.
 #[allow(unsafe_code)]
 #[distributed_slice(OTAP_EXPORTER_FACTORIES)]
@@ -152,6 +181,185 @@ impl TopicExporter {
             error: format!("Failed to parse topic exporter config: {e}"),
         })
     }
+
+    /// Resolve one pending publish without awaiting inside the topic runtime.
+    async fn try_progress_pending_publish(
+        pending_publish: &PendingPublish,
+        topic: &TopicHandle<OtapPdata>,
+        tracked_publisher: Option<&otap_df_engine::topic::TrackedTopicPublisher<OtapPdata>>,
+        effect_handler: &EffectHandler<OtapPdata>,
+        metrics: &mut MetricSet<TopicExporterMetrics>,
+        pending_messages: &mut HashMap<u64, OtapPdata>,
+        pending_outcomes: &mut FuturesUnordered<
+            Pin<Box<dyn Future<Output = (u64, TrackedPublishOutcome)> + Send>>,
+        >,
+    ) -> Result<PendingPublishProgress, Error> {
+        if pending_publish.should_track_end_to_end {
+            let tracked_publisher = tracked_publisher
+                .expect("tracked publisher should exist when ack propagation is auto");
+            match tracked_publisher.try_publish(pending_publish.published.clone())? {
+                TrackedTryPublishOutcome::Published(receipt) => {
+                    let message_id = receipt.message_id();
+                    metrics.published_messages.add(1);
+                    _ = pending_messages.insert(message_id, pending_publish.data.clone());
+                    pending_outcomes.push(Box::pin(async move {
+                        (message_id, receipt.wait_for_outcome().await)
+                    }));
+                    Ok(PendingPublishProgress::Published)
+                }
+                TrackedTryPublishOutcome::DroppedOnFull
+                | TrackedTryPublishOutcome::MaxInFlightReached => {
+                    Ok(PendingPublishProgress::Pending)
+                }
+            }
+        } else {
+            match topic.try_publish(pending_publish.published.clone())? {
+                PublishOutcome::Published => {
+                    metrics.published_messages.add(1);
+                    effect_handler
+                        .notify_ack(AckMsg::new(pending_publish.data.clone()))
+                        .await?;
+                    Ok(PendingPublishProgress::Published)
+                }
+                PublishOutcome::DroppedOnFull => Ok(PendingPublishProgress::Pending),
+            }
+        }
+    }
+
+    /// Fail all publish work still owned by the exporter during shutdown.
+    async fn flush_shutdown_pending(
+        effect_handler: &EffectHandler<OtapPdata>,
+        metrics: &mut MetricSet<TopicExporterMetrics>,
+        pending_publish: Option<PendingPublish>,
+        pending_messages: &mut HashMap<u64, OtapPdata>,
+    ) -> Result<(), Error> {
+        if let Some(pending_publish) = pending_publish {
+            metrics.shutdown_nacks.add(1);
+            effect_handler
+                .notify_nack(NackMsg::new(
+                    "topic exporter shutdown before topic admission",
+                    pending_publish.data,
+                ))
+                .await?;
+        }
+        for (_, data) in pending_messages.drain() {
+            metrics.shutdown_nacks.add(1);
+            effect_handler
+                .notify_nack(NackMsg::new(
+                    "topic exporter shutdown before downstream ack",
+                    data,
+                ))
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// Handle one incoming pdata message, using the immediate fast path when
+    /// topic admission is currently available and returning a retained pending
+    /// publish only when `queue_on_full: block` has to wait.
+    async fn handle_pdata_message(
+        data: OtapPdata,
+        queue_on_full: &TopicQueueOnFullPolicy,
+        ack_propagation_mode: TopicAckPropagationMode,
+        topic: &TopicHandle<OtapPdata>,
+        tracked_publisher: Option<&otap_df_engine::topic::TrackedTopicPublisher<OtapPdata>>,
+        effect_handler: &EffectHandler<OtapPdata>,
+        metrics: &mut MetricSet<TopicExporterMetrics>,
+        pending_messages: &mut HashMap<u64, OtapPdata>,
+        pending_outcomes: &mut FuturesUnordered<
+            Pin<Box<dyn Future<Output = (u64, TrackedPublishOutcome)> + Send>>,
+        >,
+    ) -> Result<Option<PendingPublish>, Error> {
+        let should_track_end_to_end = ack_propagation_mode == TopicAckPropagationMode::Auto
+            && data.has_ack_or_nack_interests();
+
+        match queue_on_full {
+            TopicQueueOnFullPolicy::Block => {
+                let pending_publish = PendingPublish::new(data, should_track_end_to_end);
+                match Self::try_progress_pending_publish(
+                    &pending_publish,
+                    topic,
+                    tracked_publisher,
+                    effect_handler,
+                    metrics,
+                    pending_messages,
+                    pending_outcomes,
+                )
+                .await?
+                {
+                    PendingPublishProgress::Published => Ok(None),
+                    PendingPublishProgress::Pending => Ok(Some(pending_publish)),
+                }
+            }
+            TopicQueueOnFullPolicy::DropNewest => {
+                let published = Arc::new(data.clone_without_context());
+                if should_track_end_to_end {
+                    let tracked_publisher = tracked_publisher
+                        .expect("tracked publisher should exist when ack propagation is auto");
+                    match tracked_publisher.try_publish(published)? {
+                        TrackedTryPublishOutcome::Published(receipt) => {
+                            let message_id = receipt.message_id();
+                            metrics.published_messages.add(1);
+                            _ = pending_messages.insert(message_id, data);
+                            pending_outcomes.push(Box::pin(async move {
+                                (message_id, receipt.wait_for_outcome().await)
+                            }));
+                        }
+                        TrackedTryPublishOutcome::DroppedOnFull => {
+                            metrics.dropped_messages_on_full.add(1);
+                            let exporter_id = effect_handler.exporter_id();
+                            otel_warn!(
+                                "topic_exporter.drop_newest",
+                                node = exporter_id.name.as_ref(),
+                                topic = topic.name().as_ref(),
+                                message = "Dropping message because topic queue is full"
+                            );
+                            effect_handler
+                                .notify_nack(NackMsg::new("topic queue full: dropped newest", data))
+                                .await?;
+                        }
+                        TrackedTryPublishOutcome::MaxInFlightReached => {
+                            metrics.dropped_messages_on_outcome_capacity.add(1);
+                            let exporter_id = effect_handler.exporter_id();
+                            otel_warn!(
+                                "topic_exporter.outcome_capacity_full",
+                                node = exporter_id.name.as_ref(),
+                                topic = topic.name().as_ref(),
+                                message = "Dropping message because tracked publish outcome capacity is exhausted"
+                            );
+                            effect_handler
+                                .notify_nack(NackMsg::new(
+                                    "topic publish outcome capacity exhausted",
+                                    data,
+                                ))
+                                .await?;
+                        }
+                    }
+                } else {
+                    match topic.try_publish(published)? {
+                        PublishOutcome::Published => {
+                            metrics.published_messages.add(1);
+                            effect_handler.notify_ack(AckMsg::new(data)).await?;
+                        }
+                        PublishOutcome::DroppedOnFull => {
+                            metrics.dropped_messages_on_full.add(1);
+                            let exporter_id = effect_handler.exporter_id();
+                            otel_warn!(
+                                "topic_exporter.drop_newest",
+                                node = exporter_id.name.as_ref(),
+                                topic = topic.name().as_ref(),
+                                message = "Dropping message because topic queue is full"
+                            );
+                            effect_handler
+                                .notify_nack(NackMsg::new("topic queue full: dropped newest", data))
+                                .await?;
+                        }
+                    }
+                }
+                Ok(None)
+            }
+        }
+    }
 }
 
 #[async_trait(?Send)]
@@ -172,6 +380,8 @@ impl Exporter<OtapPdata> for TopicExporter {
         let mut pending_outcomes: FuturesUnordered<
             Pin<Box<dyn Future<Output = (u64, TrackedPublishOutcome)> + Send>>,
         > = FuturesUnordered::new();
+        let mut pending_publish: Option<PendingPublish> = None;
+        let mut buffered_messages: VecDeque<Message<OtapPdata>> = VecDeque::new();
         let tracked_publisher = (ack_propagation_mode == TopicAckPropagationMode::Auto)
             .then(|| topic.tracked_publisher());
 
@@ -190,6 +400,76 @@ impl Exporter<OtapPdata> for TopicExporter {
 
         let run_result: Result<(), Error> = async {
             loop {
+                if let Some(pending) = pending_publish.as_ref() {
+                    match Self::try_progress_pending_publish(
+                        pending,
+                        &topic,
+                        tracked_publisher.as_ref(),
+                        &effect_handler,
+                        &mut metrics,
+                        &mut pending_messages,
+                        &mut pending_outcomes,
+                    )
+                    .await?
+                    {
+                        PendingPublishProgress::Published => {
+                            pending_publish = None;
+                            tokio::task::consume_budget().await;
+                            continue;
+                        }
+                        PendingPublishProgress::Pending => {}
+                    }
+                }
+
+                if pending_publish.is_none() {
+                    if let Some(msg) = buffered_messages.pop_front() {
+                        match msg {
+                            Message::Control(NodeControlMsg::CollectTelemetry {
+                                mut metrics_reporter,
+                            }) => {
+                                metrics.tracked_in_flight.set(pending_messages.len() as u64);
+                                _ = metrics_reporter.report(&mut metrics);
+                            }
+                            Message::Control(NodeControlMsg::Shutdown { .. }) => {
+                                Self::flush_shutdown_pending(
+                                    &effect_handler,
+                                    &mut metrics,
+                                    pending_publish.take(),
+                                    &mut pending_messages,
+                                )
+                                .await?;
+                                break;
+                            }
+                            Message::PData(data) => {
+                                pending_publish = Self::handle_pdata_message(
+                                    data,
+                                    &queue_on_full,
+                                    ack_propagation_mode,
+                                    &topic,
+                                    tracked_publisher.as_ref(),
+                                    &effect_handler,
+                                    &mut metrics,
+                                    &mut pending_messages,
+                                    &mut pending_outcomes,
+                                )
+                                .await?;
+                                tokio::task::consume_budget().await;
+                            }
+                            _ => {}
+                        }
+                        continue;
+                    }
+                }
+
+                let should_retry_pending_publish = pending_publish.is_some();
+                let mut retry_pending_publish = std::pin::pin!(async {
+                    if should_retry_pending_publish {
+                        tokio::time::sleep(PENDING_PUBLISH_RETRY_DELAY).await;
+                    } else {
+                        future::pending::<()>().await;
+                    }
+                });
+
                 tokio::select! {
                     biased;
 
@@ -238,116 +518,38 @@ impl Exporter<OtapPdata> for TopicExporter {
                             _ = metrics_reporter.report(&mut metrics);
                         }
                         Message::Control(NodeControlMsg::Shutdown { .. }) => {
-                            if !pending_messages.is_empty() {
-                                for (_, data) in pending_messages.drain() {
-                                    metrics.shutdown_nacks.add(1);
-                                    effect_handler
-                                        .notify_nack(NackMsg::new(
-                                            "topic exporter shutdown before downstream ack",
-                                            data,
-                                        ))
-                                        .await?;
-                                }
-                            }
+                            Self::flush_shutdown_pending(
+                                &effect_handler,
+                                &mut metrics,
+                                pending_publish.take(),
+                                &mut pending_messages,
+                            )
+                            .await?;
                             break;
                         }
                         Message::PData(data) => {
-                            // Topic hop is a transport boundary: do not propagate in-process
-                            // Ack/Nack routing state (node ids/call data) across pipelines.
-                            let published = Arc::new(data.clone_without_context());
-                            let should_track_end_to_end = ack_propagation_mode == TopicAckPropagationMode::Auto
-                                && data.has_ack_or_nack_interests();
-
-                            if should_track_end_to_end {
-                                let tracked_publisher = tracked_publisher
-                                    .as_ref()
-                                    .expect("tracked publisher should exist when ack propagation is auto");
-                                match queue_on_full {
-                                    TopicQueueOnFullPolicy::Block => {
-                                        let receipt = tracked_publisher.publish(published).await?;
-                                        let message_id = receipt.message_id();
-                                        metrics.published_messages.add(1);
-                                        _ = pending_messages.insert(message_id, data);
-                                        pending_outcomes.push(Box::pin(async move {
-                                            (message_id, receipt.wait_for_outcome().await)
-                                        }));
-                                    }
-                                    TopicQueueOnFullPolicy::DropNewest => match tracked_publisher.try_publish(published)? {
-                                        TrackedTryPublishOutcome::Published(receipt) => {
-                                            let message_id = receipt.message_id();
-                                            metrics.published_messages.add(1);
-                                            _ = pending_messages.insert(message_id, data);
-                                            pending_outcomes.push(Box::pin(async move {
-                                                (message_id, receipt.wait_for_outcome().await)
-                                            }));
-                                        }
-                                        TrackedTryPublishOutcome::DroppedOnFull => {
-                                            metrics.dropped_messages_on_full.add(1);
-                                            otel_warn!(
-                                                "topic_exporter.drop_newest",
-                                                node = exporter_id.name.as_ref(),
-                                                topic = topic.name().as_ref(),
-                                                message = "Dropping message because topic queue is full"
-                                            );
-                                            effect_handler
-                                                .notify_nack(NackMsg::new(
-                                                    "topic queue full: dropped newest",
-                                                    data,
-                                                ))
-                                                .await?;
-                                        }
-                                        TrackedTryPublishOutcome::MaxInFlightReached => {
-                                            metrics.dropped_messages_on_outcome_capacity.add(1);
-                                            otel_warn!(
-                                                "topic_exporter.outcome_capacity_full",
-                                                node = exporter_id.name.as_ref(),
-                                                topic = topic.name().as_ref(),
-                                                message = "Dropping message because tracked publish outcome capacity is exhausted"
-                                            );
-                                            effect_handler
-                                                .notify_nack(NackMsg::new(
-                                                    "topic publish outcome capacity exhausted",
-                                                    data,
-                                                ))
-                                                .await?;
-                                        }
-                                    },
-                                }
+                            if pending_publish.is_some() || !buffered_messages.is_empty() {
+                                buffered_messages.push_back(Message::PData(data));
                             } else {
-                                let publish_result = match queue_on_full {
-                                    TopicQueueOnFullPolicy::Block => {
-                                        topic.publish(published).await?;
-                                        Ok(PublishOutcome::Published)
-                                    }
-                                    TopicQueueOnFullPolicy::DropNewest => topic.try_publish(published),
-                                };
-
-                                match publish_result? {
-                                    PublishOutcome::Published => {
-                                        metrics.published_messages.add(1);
-                                        effect_handler.notify_ack(AckMsg::new(data)).await?;
-                                    }
-                                    PublishOutcome::DroppedOnFull => {
-                                        metrics.dropped_messages_on_full.add(1);
-                                        otel_warn!(
-                                            "topic_exporter.drop_newest",
-                                            node = exporter_id.name.as_ref(),
-                                            topic = topic.name().as_ref(),
-                                            message = "Dropping message because topic queue is full"
-                                        );
-                                        effect_handler
-                                            .notify_nack(NackMsg::new(
-                                                "topic queue full: dropped newest",
-                                                data,
-                                            ))
-                                            .await?;
-                                    }
-                                }
+                                pending_publish = Self::handle_pdata_message(
+                                    data,
+                                    &queue_on_full,
+                                    ack_propagation_mode,
+                                    &topic,
+                                    tracked_publisher.as_ref(),
+                                    &effect_handler,
+                                    &mut metrics,
+                                    &mut pending_messages,
+                                    &mut pending_outcomes,
+                                )
+                                .await?;
+                                tokio::task::consume_budget().await;
                             }
-                            tokio::task::consume_budget().await;
                         }
                         _ => {}
-                    }
+                    },
+
+                    _ = &mut retry_pending_publish => {}
                 }
             }
             Ok(())
@@ -381,7 +583,7 @@ mod tests {
         TopicBroker, TopicOptions, TopicSet,
     };
     use otap_df_otap::pdata::OtapPdata;
-    use otap_df_otap::testing::{TestCallData, create_test_pdata, next_ack};
+    use otap_df_otap::testing::{TestCallData, create_test_pdata, next_ack, next_nack};
     use otap_df_telemetry::reporter::MetricsReporter;
     use serde_json::json;
     use std::sync::Arc;
@@ -554,6 +756,323 @@ mod tests {
                 .await
                 .expect("exporter shutdown should be sent");
             let exporter_result = exporter_task.await.expect("exporter task should join");
+            assert!(exporter_result.is_ok(), "exporter should stop cleanly");
+        }));
+    }
+
+    /// Scenario: shutdown reaches a topic exporter while one untracked publish
+    /// is still waiting for queue space under `queue_on_full: block`.
+    /// Guarantees: the exporter stops retrying that publish, nacks the blocked
+    /// upstream pdata, and exits promptly.
+    #[test]
+    fn shutdown_interrupts_blocked_untracked_publish_with_block_policy() {
+        let (rt, local_tasks) = setup_test_runtime();
+        rt.block_on(local_tasks.run_until(async move {
+            let broker = TopicBroker::<OtapPdata>::new();
+            let topic_name =
+                otap_df_config::TopicName::parse("ingress").expect("topic name should parse");
+            let handle = broker
+                .create_in_memory_topic(
+                    topic_name.clone(),
+                    TopicOptions::Mixed {
+                        balanced_capacity: 1,
+                        broadcast_capacity: 1,
+                        on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                    },
+                )
+                .expect("topic should be created");
+
+            let topic_set = TopicSet::new("exporter-set");
+            _ = topic_set.insert(
+                topic_name.clone(),
+                PipelineTopicBinding::from(handle.clone()),
+            );
+
+            let mut exporter_ctx = create_test_pipeline_context();
+            exporter_ctx.set_topic_set(topic_set);
+
+            let exporter_node = test_node("topic_exporter");
+            let mut exporter_user_cfg = NodeUserConfig::new_exporter_config(TOPIC_EXPORTER_URN);
+            exporter_user_cfg.config = json!({
+                "topic": "ingress",
+                "queue_on_full": "block"
+            });
+
+            let mut exporter = (TOPIC_EXPORTER.create)(
+                exporter_ctx,
+                exporter_node.clone(),
+                Arc::new(exporter_user_cfg),
+                &ExporterConfig::new("topic_exporter"),
+            )
+            .expect("topic exporter should be created");
+
+            let (exporter_input_tx, exporter_input_rx) = create_not_send_channel::<OtapPdata>(8);
+            exporter
+                .set_pdata_receiver(
+                    exporter_node.clone(),
+                    PDataReceiver::Local(LocalReceiver::mpsc(exporter_input_rx)),
+                )
+                .expect("exporter input channel should be wired");
+
+            let exporter_ctrl = exporter.control_sender();
+            let (runtime_ctrl_tx, _runtime_ctrl_rx) = runtime_ctrl_msg_channel::<OtapPdata>(32);
+            let (pipeline_completion_tx, mut pipeline_completion_rx) =
+                pipeline_completion_msg_channel::<OtapPdata>(32);
+            let (_metrics_rx, metrics_reporter) = MetricsReporter::create_new_and_receiver(64);
+            let exporter_task = tokio::task::spawn_local(async move {
+                exporter
+                    .start(
+                        runtime_ctrl_tx,
+                        pipeline_completion_tx,
+                        metrics_reporter,
+                        Interests::empty(),
+                    )
+                    .await
+            });
+
+            let _subscriber = handle
+                .subscribe(
+                    SubscriptionMode::Balanced {
+                        group: "workers".into(),
+                    },
+                    SubscriberOptions::default(),
+                )
+                .expect("topic subscriber should be created");
+
+            let first_call_data = TestCallData::new_with(1, 1);
+            exporter_input_tx
+                .send(create_test_pdata().test_subscribe_to(
+                    Interests::ACKS | Interests::NACKS,
+                    first_call_data.clone().into(),
+                    1001,
+                ))
+                .expect("failed to send first pdata to topic exporter");
+
+            let first_completion = tokio::time::timeout(Duration::from_secs(2), async {
+                loop {
+                    if let PipelineCompletionMsg::DeliverAck { ack } = pipeline_completion_rx
+                        .recv()
+                        .await
+                        .expect("pipeline-completion channel closed unexpectedly")
+                    {
+                        break ack;
+                    }
+                }
+            })
+            .await
+            .expect("timed out waiting for first ack");
+            let (node_id, ack) = next_ack(first_completion).expect("ack should be routable");
+            assert_eq!(node_id, 1001);
+            let got: TestCallData = ack
+                .unwind
+                .route
+                .calldata
+                .try_into()
+                .expect("ack calldata should parse");
+            assert_eq!(got, first_call_data);
+
+            let second_call_data = TestCallData::new_with(2, 2);
+            exporter_input_tx
+                .send(create_test_pdata().test_subscribe_to(
+                    Interests::ACKS | Interests::NACKS,
+                    second_call_data.clone().into(),
+                    1002,
+                ))
+                .expect("failed to send second pdata to topic exporter");
+
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            exporter_ctrl
+                .send(NodeControlMsg::Shutdown {
+                    deadline: Instant::now() + Duration::from_secs(1),
+                    reason: "test shutdown".to_owned(),
+                })
+                .await
+                .expect("exporter shutdown should be sent");
+
+            let second_completion = tokio::time::timeout(Duration::from_secs(2), async {
+                loop {
+                    if let PipelineCompletionMsg::DeliverNack { nack } = pipeline_completion_rx
+                        .recv()
+                        .await
+                        .expect("pipeline-completion channel closed unexpectedly")
+                    {
+                        break nack;
+                    }
+                }
+            })
+            .await
+            .expect("timed out waiting for second nack");
+            let (node_id, nack) = next_nack(second_completion).expect("nack should be routable");
+            assert_eq!(node_id, 1002);
+            let got: TestCallData = nack
+                .unwind
+                .route
+                .calldata
+                .try_into()
+                .expect("nack calldata should parse");
+            assert_eq!(got, second_call_data);
+            assert!(
+                nack.reason
+                    .contains("topic exporter shutdown before topic admission")
+            );
+
+            let exporter_result = tokio::time::timeout(Duration::from_secs(2), exporter_task)
+                .await
+                .expect("exporter should exit promptly after shutdown")
+                .expect("exporter task should join");
+            assert!(exporter_result.is_ok(), "exporter should stop cleanly");
+        }));
+    }
+
+    /// Scenario: shutdown reaches a topic exporter while one tracked publish is
+    /// already pending downstream outcome and another tracked publish is still
+    /// waiting for queue space under `queue_on_full: block`.
+    /// Guarantees: shutdown nacks both the in-hand blocked publish and the
+    /// already-admitted tracked publish, then exits promptly.
+    #[test]
+    fn shutdown_interrupts_blocked_tracked_publish_with_block_policy() {
+        let (rt, local_tasks) = setup_test_runtime();
+        rt.block_on(local_tasks.run_until(async move {
+            let broker = TopicBroker::<OtapPdata>::new();
+            let topic_name =
+                otap_df_config::TopicName::parse("ingress").expect("topic name should parse");
+            let base_handle = broker
+                .create_in_memory_topic(
+                    topic_name.clone(),
+                    TopicOptions::Mixed {
+                        balanced_capacity: 1,
+                        broadcast_capacity: 1,
+                        on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                    },
+                )
+                .expect("topic should be created");
+            let exporter_handle = PipelineTopicBinding::from(base_handle.clone())
+                .with_default_ack_propagation_mode(TopicAckPropagationMode::Auto);
+
+            let topic_set = TopicSet::new("exporter-set");
+            _ = topic_set.insert(topic_name.clone(), exporter_handle);
+
+            let mut exporter_ctx = create_test_pipeline_context();
+            exporter_ctx.set_topic_set(topic_set);
+
+            let exporter_node = test_node("topic_exporter");
+            let mut exporter_user_cfg = NodeUserConfig::new_exporter_config(TOPIC_EXPORTER_URN);
+            exporter_user_cfg.config = json!({
+                "topic": "ingress",
+                "queue_on_full": "block"
+            });
+
+            let mut exporter = (TOPIC_EXPORTER.create)(
+                exporter_ctx,
+                exporter_node.clone(),
+                Arc::new(exporter_user_cfg),
+                &ExporterConfig::new("topic_exporter"),
+            )
+            .expect("topic exporter should be created");
+
+            let (exporter_input_tx, exporter_input_rx) = create_not_send_channel::<OtapPdata>(8);
+            exporter
+                .set_pdata_receiver(
+                    exporter_node.clone(),
+                    PDataReceiver::Local(LocalReceiver::mpsc(exporter_input_rx)),
+                )
+                .expect("exporter input channel should be wired");
+
+            let exporter_ctrl = exporter.control_sender();
+            let (runtime_ctrl_tx, _runtime_ctrl_rx) = runtime_ctrl_msg_channel::<OtapPdata>(32);
+            let (pipeline_completion_tx, mut pipeline_completion_rx) =
+                pipeline_completion_msg_channel::<OtapPdata>(32);
+            let (_metrics_rx, metrics_reporter) = MetricsReporter::create_new_and_receiver(64);
+            let exporter_task = tokio::task::spawn_local(async move {
+                exporter
+                    .start(
+                        runtime_ctrl_tx,
+                        pipeline_completion_tx,
+                        metrics_reporter,
+                        Interests::empty(),
+                    )
+                    .await
+            });
+
+            let _subscriber = base_handle
+                .subscribe(
+                    SubscriptionMode::Balanced {
+                        group: "workers".into(),
+                    },
+                    SubscriberOptions::default(),
+                )
+                .expect("topic subscriber should be created");
+
+            let first_call_data = TestCallData::new_with(11, 1);
+            exporter_input_tx
+                .send(create_test_pdata().test_subscribe_to(
+                    Interests::ACKS | Interests::NACKS,
+                    first_call_data.clone().into(),
+                    2001,
+                ))
+                .expect("failed to send first pdata to topic exporter");
+
+            tokio::time::sleep(Duration::from_millis(100)).await;
+
+            let second_call_data = TestCallData::new_with(22, 2);
+            exporter_input_tx
+                .send(create_test_pdata().test_subscribe_to(
+                    Interests::ACKS | Interests::NACKS,
+                    second_call_data.clone().into(),
+                    2002,
+                ))
+                .expect("failed to send second pdata to topic exporter");
+
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            exporter_ctrl
+                .send(NodeControlMsg::Shutdown {
+                    deadline: Instant::now() + Duration::from_secs(1),
+                    reason: "test shutdown".to_owned(),
+                })
+                .await
+                .expect("exporter shutdown should be sent");
+
+            let mut seen_nodes = Vec::new();
+            let mut reasons = Vec::new();
+            for _ in 0..2 {
+                let completion = tokio::time::timeout(Duration::from_secs(2), async {
+                    loop {
+                        if let PipelineCompletionMsg::DeliverNack { nack } = pipeline_completion_rx
+                            .recv()
+                            .await
+                            .expect("pipeline-completion channel closed unexpectedly")
+                        {
+                            break nack;
+                        }
+                    }
+                })
+                .await
+                .expect("timed out waiting for shutdown nacks");
+                let (node_id, nack) = next_nack(completion).expect("nack should be routable");
+                let got: TestCallData = nack
+                    .unwind
+                    .route
+                    .calldata
+                    .try_into()
+                    .expect("nack calldata should parse");
+                seen_nodes.push((node_id, got));
+                reasons.push(nack.reason);
+            }
+            assert!(seen_nodes.contains(&(2001, first_call_data)));
+            assert!(seen_nodes.contains(&(2002, second_call_data)));
+            assert!(
+                reasons
+                    .iter()
+                    .any(|reason| reason.contains("topic exporter shutdown before downstream ack"))
+            );
+            assert!(reasons
+                .iter()
+                .any(|reason| reason.contains("topic exporter shutdown before topic admission")));
+
+            let exporter_result = tokio::time::timeout(Duration::from_secs(2), exporter_task)
+                .await
+                .expect("exporter should exit promptly after shutdown")
+                .expect("exporter task should join");
             assert!(exporter_result.is_ok(), "exporter should stop cleanly");
         }));
     }

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/topic_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/topic_exporter/mod.rs
@@ -20,7 +20,8 @@ use otap_df_engine::message::{ExporterInbox, Message};
 use otap_df_engine::node::NodeId;
 use otap_df_engine::terminal_state::TerminalState;
 use otap_df_engine::topic::{
-    PublishOutcome, TopicHandle, TrackedPublishOutcome, TrackedTryPublishOutcome,
+    PublishOutcome, TopicHandle, TrackedPublishOutcome, TrackedPublishReceipt,
+    TrackedTryPublishOutcome,
 };
 use otap_df_engine::{ConsumerEffectHandlerExtension, ExporterFactory};
 use otap_df_otap::OTAP_EXPORTER_FACTORIES;
@@ -31,8 +32,8 @@ use otap_df_telemetry::{otel_info, otel_warn};
 use otap_df_telemetry_macros::metric_set;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::{HashMap, VecDeque};
-use std::future;
+use std::collections::HashMap;
+use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
@@ -96,33 +97,18 @@ pub struct TopicExporter {
     metrics: MetricSet<TopicExporterMetrics>,
 }
 
-/// One upstream pdata message waiting for topic admission under `queue_on_full: block`.
-struct PendingPublish {
+/// One upstream pdata message currently blocked in the topic runtime under
+/// `queue_on_full: block`.
+struct BlockedPublish {
     data: OtapPdata,
-    published: Arc<OtapPdata>,
-    should_track_end_to_end: bool,
+    future: Pin<Box<dyn Future<Output = Result<BlockedPublishCompletion, Error>>>>,
 }
 
-impl PendingPublish {
-    /// Build the retained publish attempt state for one upstream pdata message.
-    fn new(data: OtapPdata, should_track_end_to_end: bool) -> Self {
-        Self {
-            published: Arc::new(data.clone_without_context()),
-            data,
-            should_track_end_to_end,
-        }
-    }
+/// Completion of one blocked publish after the topic runtime has admitted it.
+enum BlockedPublishCompletion {
+    Untracked,
+    Tracked(TrackedPublishReceipt),
 }
-
-/// Result of one non-blocking attempt to admit a pending publish.
-enum PendingPublishProgress {
-    Published,
-    Pending,
-}
-
-/// Retry cadence while a topic publish remains blocked after an immediate
-/// fast-path admission attempt already failed.
-const PENDING_PUBLISH_RETRY_DELAY: Duration = Duration::from_millis(1);
 
 /// Declares the topic exporter as a local exporter factory.
 #[allow(unsafe_code)]
@@ -182,63 +168,38 @@ impl TopicExporter {
         })
     }
 
-    /// Resolve one pending publish without awaiting inside the topic runtime.
-    async fn try_progress_pending_publish(
-        pending_publish: &PendingPublish,
-        topic: &TopicHandle<OtapPdata>,
-        tracked_publisher: Option<&otap_df_engine::topic::TrackedTopicPublisher<OtapPdata>>,
-        effect_handler: &EffectHandler<OtapPdata>,
+    /// Convert one admitted tracked publish receipt into the exporter-owned
+    /// pending outcome bookkeeping.
+    fn record_tracked_publish(
+        receipt: TrackedPublishReceipt,
+        data: OtapPdata,
         metrics: &mut MetricSet<TopicExporterMetrics>,
         pending_messages: &mut HashMap<u64, OtapPdata>,
         pending_outcomes: &mut FuturesUnordered<
             Pin<Box<dyn Future<Output = (u64, TrackedPublishOutcome)> + Send>>,
         >,
-    ) -> Result<PendingPublishProgress, Error> {
-        if pending_publish.should_track_end_to_end {
-            let tracked_publisher = tracked_publisher
-                .expect("tracked publisher should exist when ack propagation is auto");
-            match tracked_publisher.try_publish(pending_publish.published.clone())? {
-                TrackedTryPublishOutcome::Published(receipt) => {
-                    let message_id = receipt.message_id();
-                    metrics.published_messages.add(1);
-                    _ = pending_messages.insert(message_id, pending_publish.data.clone());
-                    pending_outcomes.push(Box::pin(async move {
-                        (message_id, receipt.wait_for_outcome().await)
-                    }));
-                    Ok(PendingPublishProgress::Published)
-                }
-                TrackedTryPublishOutcome::DroppedOnFull
-                | TrackedTryPublishOutcome::MaxInFlightReached => {
-                    Ok(PendingPublishProgress::Pending)
-                }
-            }
-        } else {
-            match topic.try_publish(pending_publish.published.clone())? {
-                PublishOutcome::Published => {
-                    metrics.published_messages.add(1);
-                    effect_handler
-                        .notify_ack(AckMsg::new(pending_publish.data.clone()))
-                        .await?;
-                    Ok(PendingPublishProgress::Published)
-                }
-                PublishOutcome::DroppedOnFull => Ok(PendingPublishProgress::Pending),
-            }
-        }
+    ) {
+        let message_id = receipt.message_id();
+        metrics.published_messages.add(1);
+        _ = pending_messages.insert(message_id, data);
+        pending_outcomes.push(Box::pin(async move {
+            (message_id, receipt.wait_for_outcome().await)
+        }));
     }
 
     /// Fail all publish work still owned by the exporter during shutdown.
     async fn flush_shutdown_pending(
         effect_handler: &EffectHandler<OtapPdata>,
         metrics: &mut MetricSet<TopicExporterMetrics>,
-        pending_publish: Option<PendingPublish>,
+        blocked_publish: Option<BlockedPublish>,
         pending_messages: &mut HashMap<u64, OtapPdata>,
     ) -> Result<(), Error> {
-        if let Some(pending_publish) = pending_publish {
+        if let Some(blocked_publish) = blocked_publish {
             metrics.shutdown_nacks.add(1);
             effect_handler
                 .notify_nack(NackMsg::new(
                     "topic exporter shutdown before topic admission",
-                    pending_publish.data,
+                    blocked_publish.data,
                 ))
                 .await?;
         }
@@ -254,9 +215,35 @@ impl TopicExporter {
         Ok(())
     }
 
-    /// Handle one incoming pdata message, using the immediate fast path when
-    /// topic admission is currently available and returning a retained pending
-    /// publish only when `queue_on_full: block` has to wait.
+    /// Start one topic-owned blocked publish future after the immediate fast
+    /// path has already reported backpressure.
+    fn start_blocked_publish(
+        data: OtapPdata,
+        tracked_publisher: Option<&otap_df_engine::topic::TrackedTopicPublisher<OtapPdata>>,
+        topic: &TopicHandle<OtapPdata>,
+    ) -> BlockedPublish {
+        let published = Arc::new(data.clone_without_context());
+        let future: Pin<Box<dyn Future<Output = Result<BlockedPublishCompletion, Error>>>> =
+            if let Some(tracked_publisher) = tracked_publisher.cloned() {
+                Box::pin(async move {
+                    tracked_publisher
+                        .publish(published)
+                        .await
+                        .map(BlockedPublishCompletion::Tracked)
+                })
+            } else {
+                let topic = topic.clone();
+                Box::pin(async move {
+                    topic.publish(published).await?;
+                    Ok(BlockedPublishCompletion::Untracked)
+                })
+            };
+        BlockedPublish { data, future }
+    }
+
+    /// Handle one incoming pdata message, using an immediate non-blocking fast
+    /// path and retaining a single blocked publish only when block mode must
+    /// wait inside the topic runtime.
     async fn handle_pdata_message(
         data: OtapPdata,
         queue_on_full: &TopicQueueOnFullPolicy,
@@ -269,26 +256,43 @@ impl TopicExporter {
         pending_outcomes: &mut FuturesUnordered<
             Pin<Box<dyn Future<Output = (u64, TrackedPublishOutcome)> + Send>>,
         >,
-    ) -> Result<Option<PendingPublish>, Error> {
+    ) -> Result<Option<BlockedPublish>, Error> {
         let should_track_end_to_end = ack_propagation_mode == TopicAckPropagationMode::Auto
             && data.has_ack_or_nack_interests();
 
         match queue_on_full {
             TopicQueueOnFullPolicy::Block => {
-                let pending_publish = PendingPublish::new(data, should_track_end_to_end);
-                match Self::try_progress_pending_publish(
-                    &pending_publish,
-                    topic,
-                    tracked_publisher,
-                    effect_handler,
-                    metrics,
-                    pending_messages,
-                    pending_outcomes,
-                )
-                .await?
-                {
-                    PendingPublishProgress::Published => Ok(None),
-                    PendingPublishProgress::Pending => Ok(Some(pending_publish)),
+                let published = Arc::new(data.clone_without_context());
+                if should_track_end_to_end {
+                    let tracked_publisher = tracked_publisher
+                        .expect("tracked publisher should exist when ack propagation is auto");
+                    match tracked_publisher.try_publish(published)? {
+                        TrackedTryPublishOutcome::Published(receipt) => {
+                            Self::record_tracked_publish(
+                                receipt,
+                                data,
+                                metrics,
+                                pending_messages,
+                                pending_outcomes,
+                            );
+                            Ok(None)
+                        }
+                        TrackedTryPublishOutcome::DroppedOnFull
+                        | TrackedTryPublishOutcome::MaxInFlightReached => Ok(Some(
+                            Self::start_blocked_publish(data, Some(tracked_publisher), topic),
+                        )),
+                    }
+                } else {
+                    match topic.try_publish(published)? {
+                        PublishOutcome::Published => {
+                            metrics.published_messages.add(1);
+                            effect_handler.notify_ack(AckMsg::new(data)).await?;
+                            Ok(None)
+                        }
+                        PublishOutcome::DroppedOnFull => {
+                            Ok(Some(Self::start_blocked_publish(data, None, topic)))
+                        }
+                    }
                 }
             }
             TopicQueueOnFullPolicy::DropNewest => {
@@ -298,12 +302,13 @@ impl TopicExporter {
                         .expect("tracked publisher should exist when ack propagation is auto");
                     match tracked_publisher.try_publish(published)? {
                         TrackedTryPublishOutcome::Published(receipt) => {
-                            let message_id = receipt.message_id();
-                            metrics.published_messages.add(1);
-                            _ = pending_messages.insert(message_id, data);
-                            pending_outcomes.push(Box::pin(async move {
-                                (message_id, receipt.wait_for_outcome().await)
-                            }));
+                            Self::record_tracked_publish(
+                                receipt,
+                                data,
+                                metrics,
+                                pending_messages,
+                                pending_outcomes,
+                            );
                         }
                         TrackedTryPublishOutcome::DroppedOnFull => {
                             metrics.dropped_messages_on_full.add(1);
@@ -380,8 +385,7 @@ impl Exporter<OtapPdata> for TopicExporter {
         let mut pending_outcomes: FuturesUnordered<
             Pin<Box<dyn Future<Output = (u64, TrackedPublishOutcome)> + Send>>,
         > = FuturesUnordered::new();
-        let mut pending_publish: Option<PendingPublish> = None;
-        let mut buffered_messages: VecDeque<Message<OtapPdata>> = VecDeque::new();
+        let mut blocked_publish: Option<BlockedPublish> = None;
         let tracked_publisher = (ack_propagation_mode == TopicAckPropagationMode::Auto)
             .then(|| topic.tracked_publisher());
 
@@ -400,30 +404,46 @@ impl Exporter<OtapPdata> for TopicExporter {
 
         let run_result: Result<(), Error> = async {
             loop {
-                if let Some(pending) = pending_publish.as_ref() {
-                    match Self::try_progress_pending_publish(
-                        pending,
-                        &topic,
-                        tracked_publisher.as_ref(),
-                        &effect_handler,
-                        &mut metrics,
-                        &mut pending_messages,
-                        &mut pending_outcomes,
-                    )
-                    .await?
-                    {
-                        PendingPublishProgress::Published => {
-                            pending_publish = None;
-                            tokio::task::consume_budget().await;
-                            continue;
-                        }
-                        PendingPublishProgress::Pending => {}
-                    }
-                }
+                if let Some(blocked) = blocked_publish.as_mut() {
+                    tokio::select! {
+                        biased;
 
-                if pending_publish.is_none() {
-                    if let Some(msg) = buffered_messages.pop_front() {
-                        match msg {
+                        maybe_outcome = pending_outcomes.next(), if !pending_outcomes.is_empty() => {
+                            if let Some((message_id, outcome)) = maybe_outcome {
+                                if let Some(data) = pending_messages.remove(&message_id) {
+                                    match outcome {
+                                        TrackedPublishOutcome::Ack => {
+                                            metrics.end_to_end_acks.add(1);
+                                            effect_handler.notify_ack(AckMsg::new(data)).await?;
+                                        }
+                                        TrackedPublishOutcome::Nack { reason } => {
+                                            metrics.end_to_end_nacks.add(1);
+                                            effect_handler
+                                                .notify_nack(NackMsg::new(reason.as_ref(), data))
+                                                .await?;
+                                        }
+                                        TrackedPublishOutcome::TimedOut => {
+                                            metrics.outcome_timeouts.add(1);
+                                            metrics.end_to_end_nacks.add(1);
+                                            effect_handler
+                                                .notify_nack(NackMsg::new(
+                                                    "topic publish outcome timed out",
+                                                    data,
+                                                ))
+                                                .await?;
+                                        }
+                                        TrackedPublishOutcome::TopicClosed => {
+                                            metrics.end_to_end_nacks.add(1);
+                                            effect_handler
+                                                .notify_nack(NackMsg::new("topic closed", data))
+                                                .await?;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        msg = msg_chan.recv_when(false) => match msg? {
                             Message::Control(NodeControlMsg::CollectTelemetry {
                                 mut metrics_reporter,
                             }) => {
@@ -434,14 +454,107 @@ impl Exporter<OtapPdata> for TopicExporter {
                                 Self::flush_shutdown_pending(
                                     &effect_handler,
                                     &mut metrics,
-                                    pending_publish.take(),
+                                    blocked_publish.take(),
+                                    &mut pending_messages,
+                                )
+                                .await?;
+                                break;
+                            }
+                            Message::Control(_) => {}
+                            Message::PData(data) => {
+                                // Exporter inboxes force-drain buffered pdata during shutdown
+                                // even when normal exporter admission is closed. While one
+                                // publish is already blocked inside the topic runtime, any
+                                // additional pdata surfaced this way must be rejected promptly
+                                // rather than treated as unreachable.
+                                metrics.shutdown_nacks.add(1);
+                                effect_handler
+                                    .notify_nack(NackMsg::new(
+                                        "topic exporter shutdown before topic admission",
+                                        data,
+                                    ))
+                                    .await?;
+                            }
+                        },
+
+                        result = blocked.future.as_mut() => {
+                            let blocked = blocked_publish.take().expect("blocked publish should exist");
+                            match result? {
+                                BlockedPublishCompletion::Untracked => {
+                                    metrics.published_messages.add(1);
+                                    effect_handler.notify_ack(AckMsg::new(blocked.data)).await?;
+                                }
+                                BlockedPublishCompletion::Tracked(receipt) => {
+                                    Self::record_tracked_publish(
+                                        receipt,
+                                        blocked.data,
+                                        &mut metrics,
+                                        &mut pending_messages,
+                                        &mut pending_outcomes,
+                                    );
+                                }
+                            }
+                            tokio::task::consume_budget().await;
+                        }
+                    }
+                } else {
+                    tokio::select! {
+                        biased;
+
+                        maybe_outcome = pending_outcomes.next(), if !pending_outcomes.is_empty() => {
+                            if let Some((message_id, outcome)) = maybe_outcome {
+                                if let Some(data) = pending_messages.remove(&message_id) {
+                                    match outcome {
+                                        TrackedPublishOutcome::Ack => {
+                                            metrics.end_to_end_acks.add(1);
+                                            effect_handler.notify_ack(AckMsg::new(data)).await?;
+                                        }
+                                        TrackedPublishOutcome::Nack { reason } => {
+                                            metrics.end_to_end_nacks.add(1);
+                                            effect_handler
+                                                .notify_nack(NackMsg::new(reason.as_ref(), data))
+                                                .await?;
+                                        }
+                                        TrackedPublishOutcome::TimedOut => {
+                                            metrics.outcome_timeouts.add(1);
+                                            metrics.end_to_end_nacks.add(1);
+                                            effect_handler
+                                                .notify_nack(NackMsg::new(
+                                                    "topic publish outcome timed out",
+                                                    data,
+                                                ))
+                                                .await?;
+                                        }
+                                        TrackedPublishOutcome::TopicClosed => {
+                                            metrics.end_to_end_nacks.add(1);
+                                            effect_handler
+                                                .notify_nack(NackMsg::new("topic closed", data))
+                                                .await?;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        msg = msg_chan.recv() => match msg? {
+                            Message::Control(NodeControlMsg::CollectTelemetry {
+                                mut metrics_reporter,
+                            }) => {
+                                metrics.tracked_in_flight.set(pending_messages.len() as u64);
+                                _ = metrics_reporter.report(&mut metrics);
+                            }
+                            Message::Control(NodeControlMsg::Shutdown { .. }) => {
+                                Self::flush_shutdown_pending(
+                                    &effect_handler,
+                                    &mut metrics,
+                                    blocked_publish.take(),
                                     &mut pending_messages,
                                 )
                                 .await?;
                                 break;
                             }
                             Message::PData(data) => {
-                                pending_publish = Self::handle_pdata_message(
+                                blocked_publish = Self::handle_pdata_message(
                                     data,
                                     &queue_on_full,
                                     ack_propagation_mode,
@@ -455,101 +568,9 @@ impl Exporter<OtapPdata> for TopicExporter {
                                 .await?;
                                 tokio::task::consume_budget().await;
                             }
-                            _ => {}
-                        }
-                        continue;
-                    }
-                }
-
-                let should_retry_pending_publish = pending_publish.is_some();
-                let mut retry_pending_publish = std::pin::pin!(async {
-                    if should_retry_pending_publish {
-                        tokio::time::sleep(PENDING_PUBLISH_RETRY_DELAY).await;
-                    } else {
-                        future::pending::<()>().await;
-                    }
-                });
-
-                tokio::select! {
-                    biased;
-
-                    maybe_outcome = pending_outcomes.next(), if !pending_outcomes.is_empty() => {
-                        if let Some((message_id, outcome)) = maybe_outcome {
-                            if let Some(data) = pending_messages.remove(&message_id) {
-                                // Future: record tracked publish outcome latency here once
-                                // histogram instruments are available.
-                                match outcome {
-                                    TrackedPublishOutcome::Ack => {
-                                        metrics.end_to_end_acks.add(1);
-                                        effect_handler.notify_ack(AckMsg::new(data)).await?;
-                                    }
-                                    TrackedPublishOutcome::Nack { reason } => {
-                                        metrics.end_to_end_nacks.add(1);
-                                        effect_handler
-                                            .notify_nack(NackMsg::new(reason.as_ref(), data))
-                                            .await?;
-                                    }
-                                    TrackedPublishOutcome::TimedOut => {
-                                        metrics.outcome_timeouts.add(1);
-                                        metrics.end_to_end_nacks.add(1);
-                                        effect_handler
-                                            .notify_nack(NackMsg::new(
-                                                "topic publish outcome timed out",
-                                                data,
-                                            ))
-                                            .await?;
-                                    }
-                                    TrackedPublishOutcome::TopicClosed => {
-                                        metrics.end_to_end_nacks.add(1);
-                                        effect_handler
-                                            .notify_nack(NackMsg::new("topic closed", data))
-                                            .await?;
-                                    }
-                                }
-                            }
+                            Message::Control(_) => {}
                         }
                     }
-
-                    msg = msg_chan.recv() => match msg? {
-                        Message::Control(NodeControlMsg::CollectTelemetry {
-                            mut metrics_reporter,
-                        }) => {
-                            metrics.tracked_in_flight.set(pending_messages.len() as u64);
-                            _ = metrics_reporter.report(&mut metrics);
-                        }
-                        Message::Control(NodeControlMsg::Shutdown { .. }) => {
-                            Self::flush_shutdown_pending(
-                                &effect_handler,
-                                &mut metrics,
-                                pending_publish.take(),
-                                &mut pending_messages,
-                            )
-                            .await?;
-                            break;
-                        }
-                        Message::PData(data) => {
-                            if pending_publish.is_some() || !buffered_messages.is_empty() {
-                                buffered_messages.push_back(Message::PData(data));
-                            } else {
-                                pending_publish = Self::handle_pdata_message(
-                                    data,
-                                    &queue_on_full,
-                                    ack_propagation_mode,
-                                    &topic,
-                                    tracked_publisher.as_ref(),
-                                    &effect_handler,
-                                    &mut metrics,
-                                    &mut pending_messages,
-                                    &mut pending_outcomes,
-                                )
-                                .await?;
-                                tokio::task::consume_budget().await;
-                            }
-                        }
-                        _ => {}
-                    },
-
-                    _ = &mut retry_pending_publish => {}
                 }
             }
             Ok(())
@@ -915,6 +936,185 @@ mod tests {
                 nack.reason
                     .contains("topic exporter shutdown before topic admission")
             );
+
+            let exporter_result = tokio::time::timeout(Duration::from_secs(2), exporter_task)
+                .await
+                .expect("exporter should exit promptly after shutdown")
+                .expect("exporter task should join");
+            assert!(exporter_result.is_ok(), "exporter should stop cleanly");
+        }));
+    }
+
+    /// Scenario: shutdown reaches a topic exporter while one untracked publish
+    /// is blocked in the topic runtime and a second buffered pdata is force-
+    /// drained from the exporter inbox during shutdown.
+    /// Guarantees: both non-admitted pdata messages are nacked instead of
+    /// panicking the exporter loop, and the exporter exits cleanly.
+    #[test]
+    fn shutdown_nacks_force_drained_buffered_pdata_while_blocked_publish_is_in_flight() {
+        let (rt, local_tasks) = setup_test_runtime();
+        rt.block_on(local_tasks.run_until(async move {
+            let broker = TopicBroker::<OtapPdata>::new();
+            let topic_name =
+                otap_df_config::TopicName::parse("ingress").expect("topic name should parse");
+            let handle = broker
+                .create_in_memory_topic(
+                    topic_name.clone(),
+                    TopicOptions::Mixed {
+                        balanced_capacity: 1,
+                        broadcast_capacity: 1,
+                        on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                    },
+                )
+                .expect("topic should be created");
+
+            let topic_set = TopicSet::new("exporter-set");
+            _ = topic_set.insert(
+                topic_name.clone(),
+                PipelineTopicBinding::from(handle.clone()),
+            );
+
+            let mut exporter_ctx = create_test_pipeline_context();
+            exporter_ctx.set_topic_set(topic_set);
+
+            let exporter_node = test_node("topic_exporter");
+            let mut exporter_user_cfg = NodeUserConfig::new_exporter_config(TOPIC_EXPORTER_URN);
+            exporter_user_cfg.config = json!({
+                "topic": "ingress",
+                "queue_on_full": "block"
+            });
+
+            let mut exporter = (TOPIC_EXPORTER.create)(
+                exporter_ctx,
+                exporter_node.clone(),
+                Arc::new(exporter_user_cfg),
+                &ExporterConfig::new("topic_exporter"),
+            )
+            .expect("topic exporter should be created");
+
+            let (exporter_input_tx, exporter_input_rx) = create_not_send_channel::<OtapPdata>(8);
+            exporter
+                .set_pdata_receiver(
+                    exporter_node.clone(),
+                    PDataReceiver::Local(LocalReceiver::mpsc(exporter_input_rx)),
+                )
+                .expect("exporter input channel should be wired");
+
+            let exporter_ctrl = exporter.control_sender();
+            let (runtime_ctrl_tx, _runtime_ctrl_rx) = runtime_ctrl_msg_channel::<OtapPdata>(32);
+            let (pipeline_completion_tx, mut pipeline_completion_rx) =
+                pipeline_completion_msg_channel::<OtapPdata>(32);
+            let (_metrics_rx, metrics_reporter) = MetricsReporter::create_new_and_receiver(64);
+            let exporter_task = tokio::task::spawn_local(async move {
+                exporter
+                    .start(
+                        runtime_ctrl_tx,
+                        pipeline_completion_tx,
+                        metrics_reporter,
+                        Interests::empty(),
+                    )
+                    .await
+            });
+
+            let _subscriber = handle
+                .subscribe(
+                    SubscriptionMode::Balanced {
+                        group: "workers".into(),
+                    },
+                    SubscriberOptions::default(),
+                )
+                .expect("topic subscriber should be created");
+
+            let first_call_data = TestCallData::new_with(1, 1);
+            exporter_input_tx
+                .send(create_test_pdata().test_subscribe_to(
+                    Interests::ACKS | Interests::NACKS,
+                    first_call_data.clone().into(),
+                    3001,
+                ))
+                .expect("failed to send first pdata to topic exporter");
+
+            let first_completion = tokio::time::timeout(Duration::from_secs(2), async {
+                loop {
+                    if let PipelineCompletionMsg::DeliverAck { ack } = pipeline_completion_rx
+                        .recv()
+                        .await
+                        .expect("pipeline-completion channel closed unexpectedly")
+                    {
+                        break ack;
+                    }
+                }
+            })
+            .await
+            .expect("timed out waiting for first ack");
+            let (node_id, ack) = next_ack(first_completion).expect("ack should be routable");
+            assert_eq!(node_id, 3001);
+            let got: TestCallData = ack
+                .unwind
+                .route
+                .calldata
+                .try_into()
+                .expect("ack calldata should parse");
+            assert_eq!(got, first_call_data);
+
+            let second_call_data = TestCallData::new_with(2, 2);
+            exporter_input_tx
+                .send(create_test_pdata().test_subscribe_to(
+                    Interests::ACKS | Interests::NACKS,
+                    second_call_data.clone().into(),
+                    3002,
+                ))
+                .expect("failed to send second pdata to topic exporter");
+
+            let third_call_data = TestCallData::new_with(3, 3);
+            exporter_input_tx
+                .send(create_test_pdata().test_subscribe_to(
+                    Interests::ACKS | Interests::NACKS,
+                    third_call_data.clone().into(),
+                    3003,
+                ))
+                .expect("failed to send third pdata to topic exporter");
+
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            exporter_ctrl
+                .send(NodeControlMsg::Shutdown {
+                    deadline: Instant::now() + Duration::from_secs(1),
+                    reason: "test shutdown".to_owned(),
+                })
+                .await
+                .expect("exporter shutdown should be sent");
+
+            let mut seen = std::collections::HashMap::new();
+            while seen.len() < 2 {
+                let nack = tokio::time::timeout(Duration::from_secs(2), async {
+                    loop {
+                        if let PipelineCompletionMsg::DeliverNack { nack } = pipeline_completion_rx
+                            .recv()
+                            .await
+                            .expect("pipeline-completion channel closed unexpectedly")
+                        {
+                            break nack;
+                        }
+                    }
+                })
+                .await
+                .expect("timed out waiting for shutdown nacks");
+                let (node_id, nack) = next_nack(nack).expect("nack should be routable");
+                let got: TestCallData = nack
+                    .unwind
+                    .route
+                    .calldata
+                    .try_into()
+                    .expect("nack calldata should parse");
+                _ = seen.insert(node_id, got);
+                assert!(
+                    nack.reason
+                        .contains("topic exporter shutdown before topic admission")
+                );
+            }
+
+            assert_eq!(seen.get(&3002), Some(&second_call_data));
+            assert_eq!(seen.get(&3003), Some(&third_call_data));
 
             let exporter_result = tokio::time::timeout(Duration::from_secs(2), exporter_task)
                 .await

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/topic_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/topic_receiver/mod.rs
@@ -5,6 +5,7 @@
 
 use async_trait::async_trait;
 use linkme::distributed_slice;
+use otap_df_channel::error::SendError;
 use otap_df_config::TopicName;
 use otap_df_config::error::Error as ConfigError;
 use otap_df_config::node::NodeUserConfig;
@@ -33,6 +34,8 @@ use otap_df_telemetry_macros::metric_set;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use smallvec::smallvec;
+use std::collections::HashSet;
+use std::future;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -129,6 +132,18 @@ pub struct TopicReceiver {
     broadcast_on_lag: Option<TopicBroadcastOnLagPolicy>,
     metrics: MetricSet<TopicReceiverMetrics>,
 }
+
+/// Message received from the topic runtime but not yet admitted to the
+/// downstream pipeline.
+struct PendingForward {
+    pdata: OtapPdata,
+    tracked_message_id: Option<u64>,
+    send_started_at: Instant,
+}
+
+/// Retry cadence while a downstream channel remains full after an immediate
+/// fast-path forward attempt already failed.
+const PENDING_FORWARD_RETRY_DELAY: Duration = Duration::from_millis(1);
 
 /// Declares the topic receiver as a local receiver factory.
 #[allow(unsafe_code)]
@@ -233,14 +248,158 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
             ack_propagation = format!("{ack_propagation_mode:?}"),
             message = "Topic receiver started"
         );
-        let telemetry_cancel_handle = effect_handler
-            .start_periodic_telemetry(Duration::from_secs(1))
-            .await?;
+        let mut telemetry_cancel_handle = Some(
+            effect_handler
+                .start_periodic_telemetry(Duration::from_secs(1))
+                .await?,
+        );
+        let mut draining_deadline: Option<Instant> = None;
         let mut draining_reason: Option<String> = None;
-        let mut drained_notified = false;
+        let mut pending_tracked_message_ids = HashSet::new();
+        let mut pending_forward: Option<PendingForward> = None;
 
-        let run_result: Result<(), Error> = async {
+        let run_result: Result<TerminalState, Error> = async {
             loop {
+                if let Some(deadline) = draining_deadline {
+                    if let Some(pending) = pending_forward.take() {
+                        if let Some(reason) = draining_reason.as_deref() {
+                            if let Some(message_id) = pending.tracked_message_id {
+                                match subscription.nack(message_id, reason) {
+                                    Ok(()) => metrics.bridged_downstream_nacks.add(1),
+                                    Err(Error::MessageNotTracked) => {
+                                        metrics.bridge_invalid_or_untracked_id.add(1);
+                                    }
+                                    Err(e) => {
+                                        metrics.bridge_runtime_failures.add(1);
+                                        otel_warn!(
+                                            "topic_receiver.drain_ingress_pending_forward_nack_failed",
+                                            node = receiver_id.name.as_ref(),
+                                            topic = config.topic.as_ref(),
+                                            error = e.to_string(),
+                                            message = "Failed to nack an unsent tracked topic message while aborting ingress drain"
+                                        );
+                                    }
+                                }
+                            }
+                            otel_warn!(
+                                "topic_receiver.drain_ingress_drop_pending_forward",
+                                node = receiver_id.name.as_ref(),
+                                topic = config.topic.as_ref(),
+                                tracked = pending.tracked_message_id.is_some(),
+                                blocked_ms = pending.send_started_at.elapsed().as_millis() as u64,
+                                message = "Topic receiver dropped an unsent topic message while entering ingress drain"
+                            );
+                        }
+                    }
+
+                    if pending_tracked_message_ids.is_empty() {
+                        if let Some(handle) = telemetry_cancel_handle.take() {
+                            _ = handle.cancel().await;
+                        }
+                        effect_handler.notify_receiver_drained().await?;
+                        return Ok(TerminalState::new(deadline, [metrics.snapshot()]));
+                    }
+
+                    if Instant::now() >= deadline {
+                        if let Some(reason) = draining_reason.as_deref() {
+                            otel_warn!(
+                                "topic_receiver.drain_ingress.timeout",
+                                node = receiver_id.name.as_ref(),
+                                topic = config.topic.as_ref(),
+                                pending_tracked = pending_tracked_message_ids.len() as u64,
+                                message = "Topic receiver reached the ingress drain deadline with tracked topic outcomes still pending"
+                            );
+                            for message_id in pending_tracked_message_ids.drain() {
+                                match subscription.nack(message_id, reason) {
+                                    Ok(()) => metrics.bridged_downstream_nacks.add(1),
+                                    Err(Error::MessageNotTracked) => {
+                                        metrics.bridge_invalid_or_untracked_id.add(1);
+                                    }
+                                    Err(e) => {
+                                        metrics.bridge_runtime_failures.add(1);
+                                        otel_warn!(
+                                            "topic_receiver.drain_ingress_force_nack_failed",
+                                            node = receiver_id.name.as_ref(),
+                                            topic = config.topic.as_ref(),
+                                            error = e.to_string(),
+                                            message = "Failed to resolve a tracked topic message while forcing topic receiver drain"
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                        if let Some(handle) = telemetry_cancel_handle.take() {
+                            _ = handle.cancel().await;
+                        }
+                        effect_handler.notify_receiver_drained().await?;
+                        return Ok(TerminalState::new(deadline, [metrics.snapshot()]));
+                    }
+                }
+
+                if let Some(pending) = pending_forward.take() {
+                    match effect_handler.try_send_message_with_source_node(pending.pdata) {
+                        Ok(()) => {
+                            if let Some(message_id) = pending.tracked_message_id {
+                                _ = pending_tracked_message_ids.insert(message_id);
+                            }
+                            metrics.forwarded_messages.add(1);
+                            let blocked_for = pending.send_started_at.elapsed();
+                            if blocked_for.as_millis() >= 500 {
+                                metrics.downstream_backpressure_events.add(1);
+                                metrics
+                                    .downstream_blocked_ms
+                                    .add(blocked_for.as_millis() as u64);
+                                otel_warn!(
+                                    "topic_receiver.downstream_backpressure",
+                                    node = receiver_id.name.as_ref(),
+                                    topic = config.topic.as_ref(),
+                                    blocked_ms = blocked_for.as_millis() as u64,
+                                    message = "Topic receiver blocked while forwarding to downstream pipeline channel"
+                                );
+                            }
+                            tokio::task::consume_budget().await;
+                            continue;
+                        }
+                        Err(otap_df_engine::error::TypedError::ChannelSendError(
+                            SendError::Full(pdata),
+                        )) => {
+                            pending_forward = Some(PendingForward {
+                                pdata,
+                                tracked_message_id: pending.tracked_message_id,
+                                send_started_at: pending.send_started_at,
+                            });
+                        }
+                        Err(e) => {
+                            metrics.forward_failures.add(1);
+                            otel_warn!(
+                                "topic_receiver.forward_failed",
+                                node = receiver_id.name.as_ref(),
+                                topic = config.topic.as_ref(),
+                                error = e.to_string(),
+                                message = "Topic receiver failed forwarding to downstream channel"
+                            );
+                            return Err(Error::from(e));
+                        }
+                    }
+                }
+
+                let current_draining_deadline = draining_deadline;
+                let mut drain_sleep = std::pin::pin!(async move {
+                    if let Some(deadline) = current_draining_deadline {
+                        tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)).await;
+                    } else {
+                        future::pending::<()>().await;
+                    }
+                });
+                let should_retry_pending_send = pending_forward.is_some();
+                let mut retry_pending_send = std::pin::pin!(async {
+                    if should_retry_pending_send {
+                        tokio::time::sleep(PENDING_FORWARD_RETRY_DELAY).await;
+                    } else {
+                        future::pending::<()>().await;
+                    }
+                });
+
                 tokio::select! {
                     biased;
 
@@ -259,6 +418,7 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                                 } else if let Some(message_id) =
                                     Self::decode_topic_message_id(&ack.unwind.route.calldata)
                                 {
+                                    let _ = pending_tracked_message_ids.remove(&message_id);
                                     match subscription.ack(message_id) {
                                         Ok(()) => metrics.bridged_downstream_acks.add(1),
                                         Err(Error::MessageNotTracked) => {
@@ -292,16 +452,15 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                                     );
                                 }
                             }
-                            Ok(NodeControlMsg::DrainIngress { reason, .. }) => {
-                                if !drained_notified {
-                                    // TopicReceiver does not hold a separate wait_for_result
-                                    // backlog like OTLP/OTAP receivers. Once ingress is marked as
-                                    // draining, the runtime can consider the receiver drained
-                                    // immediately; later topic deliveries are rejected/nacked
-                                    // below instead of being admitted into the pipeline.
+                            Ok(NodeControlMsg::DrainIngress { deadline, reason }) => {
+                                if draining_deadline.is_none() {
+                                    // Receiver-first shutdown stops polling the topic
+                                    // subscription immediately. If Ack/Nack propagation is
+                                    // enabled, keep the receiver alive only long enough to bridge
+                                    // terminal outcomes for tracked messages that were already
+                                    // forwarded downstream.
+                                    draining_deadline = Some(deadline);
                                     draining_reason = Some(reason);
-                                    effect_handler.notify_receiver_drained().await?;
-                                    drained_notified = true;
                                 }
                             }
                             Ok(NodeControlMsg::Nack(nack)) => {
@@ -312,6 +471,7 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                                 } else if let Some(message_id) =
                                     Self::decode_topic_message_id(&nack.unwind.route.calldata)
                                 {
+                                    let _ = pending_tracked_message_ids.remove(&message_id);
                                     match subscription.nack(message_id, nack.reason.as_str()) {
                                         Ok(()) => metrics.bridged_downstream_nacks.add(1),
                                         Err(Error::MessageNotTracked) => {
@@ -345,47 +505,28 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                                     );
                                 }
                             }
-                            Ok(NodeControlMsg::Shutdown { .. }) => break,
+                            Ok(NodeControlMsg::Shutdown { deadline, .. }) => {
+                                if let Some(handle) = telemetry_cancel_handle.take() {
+                                    _ = handle.cancel().await;
+                                }
+                                return Ok(TerminalState::new(deadline, [metrics.snapshot()]));
+                            }
                             Ok(_) => {}
                             Err(e) => return Err(Error::ChannelRecvError(e)),
                         }
                     }
 
-                    recv = subscription.recv() => {
+                    recv = subscription.recv(), if draining_deadline.is_none() && pending_forward.is_none() => {
                         match recv {
                             Ok(RecvItem::Message(env)) => {
-                                if let Some(reason) = draining_reason.as_deref() {
-                                    // DrainIngress was already acknowledged to the runtime, so any
-                                    // message delivered after that point must be bounced at the
-                                    // topic boundary rather than forwarded into the pipeline.
-                                    if ack_propagation_mode == TopicAckPropagationMode::Auto
-                                        && env.tracked
-                                    {
-                                        match subscription.nack(env.id, reason) {
-                                            Ok(()) => metrics.bridged_downstream_nacks.add(1),
-                                            Err(Error::MessageNotTracked) => {
-                                                metrics.bridge_invalid_or_untracked_id.add(1);
-                                            }
-                                            Err(e) => {
-                                                metrics.bridge_runtime_failures.add(1);
-                                                otel_warn!(
-                                                    "topic_receiver.drain_ingress_reject_failed",
-                                                    node = receiver_id.name.as_ref(),
-                                                    topic = config.topic.as_ref(),
-                                                    error = e.to_string(),
-                                                    message = "Failed to reject topic message while receiver was draining ingress"
-                                                );
-                                            }
-                                        }
-                                    }
-                                    tokio::task::consume_budget().await;
-                                    continue;
-                                }
-
                                 // Topic hop is a transport boundary: reset in-process
                                 // Ack/Nack routing context before forwarding.
                                 // Use source-tag-aware send so fan-in wiring can attribute source node.
                                 let mut pdata = env.payload.clone_without_context();
+                                let tracked_message_id =
+                                    (ack_propagation_mode == TopicAckPropagationMode::Auto
+                                        && env.tracked)
+                                        .then_some(env.id);
                                 if ack_propagation_mode == TopicAckPropagationMode::Auto
                                     && env.tracked
                                 {
@@ -397,33 +538,35 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                                     );
                                 }
                                 let send_started_at = Instant::now();
-                                if let Err(e) = effect_handler.send_message_with_source_node(pdata).await {
-                                    metrics.forward_failures.add(1);
-                                    otel_warn!(
-                                        "topic_receiver.forward_failed",
-                                        node = receiver_id.name.as_ref(),
-                                        topic = config.topic.as_ref(),
-                                        error = e.to_string(),
-                                        message = "Topic receiver failed forwarding to downstream channel"
-                                    );
-                                    return Err(Error::from(e));
+                                match effect_handler.try_send_message_with_source_node(pdata) {
+                                    Ok(()) => {
+                                        if let Some(message_id) = tracked_message_id {
+                                            _ = pending_tracked_message_ids.insert(message_id);
+                                        }
+                                        metrics.forwarded_messages.add(1);
+                                        tokio::task::consume_budget().await;
+                                    }
+                                    Err(otap_df_engine::error::TypedError::ChannelSendError(
+                                        SendError::Full(pdata),
+                                    )) => {
+                                        pending_forward = Some(PendingForward {
+                                            pdata,
+                                            tracked_message_id,
+                                            send_started_at,
+                                        });
+                                    }
+                                    Err(e) => {
+                                        metrics.forward_failures.add(1);
+                                        otel_warn!(
+                                            "topic_receiver.forward_failed",
+                                            node = receiver_id.name.as_ref(),
+                                            topic = config.topic.as_ref(),
+                                            error = e.to_string(),
+                                            message = "Topic receiver failed forwarding to downstream channel"
+                                        );
+                                        return Err(Error::from(e));
+                                    }
                                 }
-                                metrics.forwarded_messages.add(1);
-                                let blocked_for = send_started_at.elapsed();
-                                if blocked_for.as_millis() >= 500 {
-                                    metrics.downstream_backpressure_events.add(1);
-                                    metrics
-                                        .downstream_blocked_ms
-                                        .add(blocked_for.as_millis() as u64);
-                                    otel_warn!(
-                                        "topic_receiver.downstream_backpressure",
-                                        node = receiver_id.name.as_ref(),
-                                        topic = config.topic.as_ref(),
-                                        blocked_ms = blocked_for.as_millis() as u64,
-                                        message = "Topic receiver blocked while forwarding to downstream pipeline channel"
-                                    );
-                                }
-                                tokio::task::consume_budget().await;
                             }
                             Ok(RecvItem::Lagged { missed }) => {
                                 metrics.lagged_notifications.add(1);
@@ -450,15 +593,20 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                             Err(e) => return Err(e),
                         }
                     }
+
+                    _ = &mut retry_pending_send => {}
+
+                    _ = &mut drain_sleep => {}
                 }
             }
-            Ok(())
+            Ok(TerminalState::default())
         }
         .await;
 
-        _ = telemetry_cancel_handle.cancel().await;
-        run_result?;
-        Ok(TerminalState::default())
+        if let Some(handle) = telemetry_cancel_handle.take() {
+            _ = handle.cancel().await;
+        }
+        run_result
     }
 }
 
@@ -727,6 +875,321 @@ mod tests {
                 receiver_result.is_ok(),
                 "receiver should stop cleanly after lag disconnect"
             );
+        }));
+    }
+
+    /// Scenario: receiver-first shutdown drains a topic receiver whose default
+    /// Ack/Nack propagation is disabled.
+    /// Guarantees: `DrainIngress` stops subscription polling and the receiver
+    /// exits promptly without waiting for downstream terminal outcomes.
+    #[test]
+    fn drain_ingress_exits_promptly_when_ack_propagation_is_disabled() {
+        let (rt, local_tasks) = setup_test_runtime();
+        rt.block_on(local_tasks.run_until(async move {
+            let broker = TopicBroker::<OtapPdata>::new();
+            let topic_name =
+                otap_df_config::TopicName::parse("ingress").expect("topic name should parse");
+            let handle = broker
+                .create_in_memory_topic(
+                    topic_name.clone(),
+                    TopicOptions::Mixed {
+                        balanced_capacity: 16,
+                        broadcast_capacity: 16,
+                        on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                    },
+                )
+                .expect("topic should be created");
+
+            let receiver_set = TopicSet::new("receiver-set");
+            _ = receiver_set.insert(
+                topic_name.clone(),
+                PipelineTopicBinding::from(handle.clone()),
+            );
+
+            let mut receiver_ctx = create_test_pipeline_context();
+            receiver_ctx.set_topic_set(receiver_set);
+
+            let receiver_node = test_node("topic_receiver");
+            let mut receiver_user_cfg = NodeUserConfig::new_receiver_config(TOPIC_RECEIVER_URN);
+            receiver_user_cfg.config = json!({
+                "topic": "ingress",
+                "subscription": {
+                    "mode": "balanced",
+                    "group": "sut-workers"
+                }
+            });
+
+            let mut receiver = (TOPIC_RECEIVER.create)(
+                receiver_ctx,
+                receiver_node.clone(),
+                Arc::new(receiver_user_cfg),
+                &ReceiverConfig::new("topic_receiver"),
+            )
+            .expect("topic receiver should be created");
+
+            let (receiver_output_tx, _receiver_output_rx) = create_not_send_channel::<OtapPdata>(8);
+            receiver
+                .set_pdata_sender(
+                    receiver_node.clone(),
+                    "".into(),
+                    PDataSender::Local(LocalSender::mpsc(receiver_output_tx)),
+                )
+                .expect("receiver output channel should be wired");
+
+            let receiver_ctrl = receiver.control_sender();
+            let (runtime_ctrl_tx, _runtime_ctrl_rx) = runtime_ctrl_msg_channel::<OtapPdata>(32);
+            let (pipeline_completion_tx, _pipeline_completion_rx) =
+                pipeline_completion_msg_channel::<OtapPdata>(32);
+            let (_metrics_rx, metrics_reporter) = MetricsReporter::create_new_and_receiver(64);
+            let receiver_task = tokio::task::spawn_local(async move {
+                receiver
+                    .start(
+                        runtime_ctrl_tx,
+                        pipeline_completion_tx,
+                        metrics_reporter,
+                        otap_df_engine::Interests::empty(),
+                    )
+                    .await
+            });
+
+            receiver_ctrl
+                .send(NodeControlMsg::DrainIngress {
+                    deadline: Instant::now() + Duration::from_secs(1),
+                    reason: "test drain".to_owned(),
+                })
+                .await
+                .expect("receiver drain should be sent");
+
+            let terminal_state = tokio::time::timeout(Duration::from_secs(2), receiver_task)
+                .await
+                .expect("receiver should exit promptly after drain ingress")
+                .expect("receiver task should join")
+                .expect("receiver should stop cleanly");
+            assert!(
+                terminal_state.deadline() > Instant::now(),
+                "receiver should return the drain deadline terminal state"
+            );
+        }));
+    }
+
+    /// Scenario: receiver-first shutdown hits a topic receiver after it has
+    /// already forwarded a tracked message with Ack/Nack propagation enabled.
+    /// Guarantees: the receiver stops polling new topic deliveries, stays alive
+    /// until the downstream terminal outcome is bridged, then exits promptly.
+    #[test]
+    fn drain_ingress_waits_for_forwarded_tracked_message_then_exits() {
+        let (rt, local_tasks) = setup_test_runtime();
+        rt.block_on(local_tasks.run_until(async move {
+            let broker = TopicBroker::<OtapPdata>::new();
+            let topic_name =
+                otap_df_config::TopicName::parse("ingress").expect("topic name should parse");
+            let base_handle = broker
+                .create_in_memory_topic(
+                    topic_name.clone(),
+                    TopicOptions::Mixed {
+                        balanced_capacity: 16,
+                        broadcast_capacity: 16,
+                        on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                    },
+                )
+                .expect("topic should be created");
+            let receiver_handle = PipelineTopicBinding::from(base_handle.clone())
+                .with_default_ack_propagation_mode(TopicAckPropagationMode::Auto);
+
+            let receiver_set = TopicSet::new("receiver-set");
+            _ = receiver_set.insert(topic_name.clone(), receiver_handle);
+
+            let mut receiver_ctx = create_test_pipeline_context();
+            receiver_ctx.set_topic_set(receiver_set);
+
+            let receiver_node = test_node("topic_receiver");
+            let mut receiver_user_cfg = NodeUserConfig::new_receiver_config(TOPIC_RECEIVER_URN);
+            receiver_user_cfg.config = json!({
+                "topic": "ingress",
+                "subscription": {
+                    "mode": "balanced",
+                    "group": "sut-workers"
+                }
+            });
+
+            let mut receiver = (TOPIC_RECEIVER.create)(
+                receiver_ctx,
+                receiver_node.clone(),
+                Arc::new(receiver_user_cfg),
+                &ReceiverConfig::new("topic_receiver"),
+            )
+            .expect("topic receiver should be created");
+
+            let (receiver_output_tx, receiver_output_rx) = create_not_send_channel::<OtapPdata>(8);
+            receiver
+                .set_pdata_sender(
+                    receiver_node.clone(),
+                    "".into(),
+                    PDataSender::Local(LocalSender::mpsc(receiver_output_tx)),
+                )
+                .expect("receiver output channel should be wired");
+
+            let receiver_ctrl = receiver.control_sender();
+            let (runtime_ctrl_tx, _runtime_ctrl_rx) = runtime_ctrl_msg_channel::<OtapPdata>(32);
+            let (pipeline_completion_tx, _pipeline_completion_rx) =
+                pipeline_completion_msg_channel::<OtapPdata>(32);
+            let (_metrics_rx, metrics_reporter) = MetricsReporter::create_new_and_receiver(64);
+            let receiver_task = tokio::task::spawn_local(async move {
+                receiver
+                    .start(
+                        runtime_ctrl_tx,
+                        pipeline_completion_tx,
+                        metrics_reporter,
+                        otap_df_engine::Interests::empty(),
+                    )
+                    .await
+            });
+
+            let publisher = base_handle.tracked_publisher();
+            let receipt = publisher
+                .publish(Arc::new(create_test_pdata()))
+                .await
+                .expect("publish should succeed");
+
+            let forwarded = tokio::time::timeout(Duration::from_secs(2), receiver_output_rx.recv())
+                .await
+                .expect("timed out waiting for receiver output")
+                .expect("receiver output channel should stay open");
+
+            receiver_ctrl
+                .send(NodeControlMsg::DrainIngress {
+                    deadline: Instant::now() + Duration::from_secs(2),
+                    reason: "test drain".to_owned(),
+                })
+                .await
+                .expect("receiver drain should be sent");
+
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            assert!(
+                !receiver_task.is_finished(),
+                "receiver should wait for the already-forwarded tracked message outcome"
+            );
+
+            let (_node_id, ack_for_receiver) = next_ack(AckMsg::new(forwarded))
+                .expect("receiver should attach ack calldata for topic bridge");
+            receiver_ctrl
+                .send(NodeControlMsg::Ack(ack_for_receiver))
+                .await
+                .expect("failed to send ack control to topic receiver");
+
+            let outcome = tokio::time::timeout(Duration::from_secs(2), receipt.wait_for_outcome())
+                .await
+                .expect("timed out waiting for tracked topic outcome");
+            assert_eq!(outcome, TrackedPublishOutcome::Ack);
+
+            let receiver_result = tokio::time::timeout(Duration::from_secs(2), receiver_task)
+                .await
+                .expect("receiver should exit once the tracked outcome is bridged")
+                .expect("receiver task should join");
+            assert!(receiver_result.is_ok(), "receiver should stop cleanly");
+        }));
+    }
+
+    /// Scenario: receiver-first shutdown reaches a topic receiver while it is
+    /// blocked trying to forward into a full downstream channel.
+    /// Guarantees: `DrainIngress` keeps control responsiveness, aborts the
+    /// unsent topic message, and exits promptly instead of deadlocking on the
+    /// blocked send.
+    #[test]
+    fn drain_ingress_interrupts_blocked_forward_when_ack_propagation_is_disabled() {
+        let (rt, local_tasks) = setup_test_runtime();
+        rt.block_on(local_tasks.run_until(async move {
+            let broker = TopicBroker::<OtapPdata>::new();
+            let topic_name =
+                otap_df_config::TopicName::parse("ingress").expect("topic name should parse");
+            let handle = broker
+                .create_in_memory_topic(
+                    topic_name.clone(),
+                    TopicOptions::Mixed {
+                        balanced_capacity: 16,
+                        broadcast_capacity: 16,
+                        on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                    },
+                )
+                .expect("topic should be created");
+
+            let receiver_set = TopicSet::new("receiver-set");
+            _ = receiver_set.insert(
+                topic_name.clone(),
+                PipelineTopicBinding::from(handle.clone()),
+            );
+
+            let mut receiver_ctx = create_test_pipeline_context();
+            receiver_ctx.set_topic_set(receiver_set);
+
+            let receiver_node = test_node("topic_receiver");
+            let mut receiver_user_cfg = NodeUserConfig::new_receiver_config(TOPIC_RECEIVER_URN);
+            receiver_user_cfg.config = json!({
+                "topic": "ingress",
+                "subscription": {
+                    "mode": "balanced",
+                    "group": "sut-workers"
+                }
+            });
+
+            let mut receiver = (TOPIC_RECEIVER.create)(
+                receiver_ctx,
+                receiver_node.clone(),
+                Arc::new(receiver_user_cfg),
+                &ReceiverConfig::new("topic_receiver"),
+            )
+            .expect("topic receiver should be created");
+
+            let (receiver_output_tx, _receiver_output_rx) = create_not_send_channel::<OtapPdata>(1);
+            receiver
+                .set_pdata_sender(
+                    receiver_node.clone(),
+                    "".into(),
+                    PDataSender::Local(LocalSender::mpsc(receiver_output_tx)),
+                )
+                .expect("receiver output channel should be wired");
+
+            let receiver_ctrl = receiver.control_sender();
+            let (runtime_ctrl_tx, _runtime_ctrl_rx) = runtime_ctrl_msg_channel::<OtapPdata>(32);
+            let (pipeline_completion_tx, _pipeline_completion_rx) =
+                pipeline_completion_msg_channel::<OtapPdata>(32);
+            let (_metrics_rx, metrics_reporter) = MetricsReporter::create_new_and_receiver(64);
+            let receiver_task = tokio::task::spawn_local(async move {
+                receiver
+                    .start(
+                        runtime_ctrl_tx,
+                        pipeline_completion_tx,
+                        metrics_reporter,
+                        otap_df_engine::Interests::empty(),
+                    )
+                    .await
+            });
+
+            handle
+                .publish(Arc::new(create_test_pdata()))
+                .await
+                .expect("first publish should succeed");
+            tokio::time::sleep(Duration::from_millis(100)).await;
+
+            handle
+                .publish(Arc::new(create_test_pdata()))
+                .await
+                .expect("second publish should succeed");
+            tokio::time::sleep(Duration::from_millis(100)).await;
+
+            receiver_ctrl
+                .send(NodeControlMsg::DrainIngress {
+                    deadline: Instant::now() + Duration::from_secs(1),
+                    reason: "test drain".to_owned(),
+                })
+                .await
+                .expect("receiver drain should be sent");
+
+            let receiver_result = tokio::time::timeout(Duration::from_secs(2), receiver_task)
+                .await
+                .expect("receiver should exit promptly after interrupting a blocked forward")
+                .expect("receiver task should join");
+            assert!(receiver_result.is_ok(), "receiver should stop cleanly");
         }));
     }
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/topic_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/topic_receiver/mod.rs
@@ -21,7 +21,9 @@ use otap_df_engine::local::receiver as local;
 use otap_df_engine::node::NodeId;
 use otap_df_engine::receiver::ReceiverWrapper;
 use otap_df_engine::terminal_state::TerminalState;
-use otap_df_engine::topic::{RecvItem, SubscriberOptions, Subscription, SubscriptionMode};
+use otap_df_engine::topic::{
+    Delivery, RecvDelivery, SubscriberOptions, Subscription, SubscriptionMode,
+};
 use otap_df_engine::{
     Interests, MessageSourceLocalEffectHandlerExtension, ProducerEffectHandlerExtension,
 };
@@ -35,7 +37,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use smallvec::smallvec;
 use std::collections::HashSet;
-use std::future;
+use std::future::{self, Future};
+use std::pin::Pin;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -136,14 +139,11 @@ pub struct TopicReceiver {
 /// Message received from the topic runtime but not yet admitted to the
 /// downstream pipeline.
 struct PendingForward {
-    pdata: OtapPdata,
+    delivery: Delivery<OtapPdata>,
     tracked_message_id: Option<u64>,
     send_started_at: Instant,
+    future: Pin<Box<dyn Future<Output = Result<(), otap_df_engine::error::TypedError<OtapPdata>>>>>,
 }
-
-/// Retry cadence while a downstream channel remains full after an immediate
-/// fast-path forward attempt already failed.
-const PENDING_FORWARD_RETRY_DELAY: Duration = Duration::from_millis(1);
 
 /// Declares the topic receiver as a local receiver factory.
 #[allow(unsafe_code)]
@@ -336,65 +336,183 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                     }
                 }
 
-                if let Some(pending) = pending_forward.take() {
-                    match effect_handler.try_send_message_with_source_node(pending.pdata) {
-                        Ok(()) => {
-                            if let Some(message_id) = pending.tracked_message_id {
-                                _ = pending_tracked_message_ids.insert(message_id);
+                if let Some(pending) = pending_forward.as_mut() {
+                    let current_draining_deadline = draining_deadline;
+                    let mut drain_sleep = std::pin::pin!(async move {
+                        if let Some(deadline) = current_draining_deadline {
+                            tokio::time::sleep_until(tokio::time::Instant::from_std(deadline))
+                                .await;
+                        } else {
+                            future::pending::<()>().await;
+                        }
+                    });
+
+                    tokio::select! {
+                        biased;
+
+                        ctrl = ctrl_msg_recv.recv() => {
+                            match ctrl {
+                                Ok(NodeControlMsg::CollectTelemetry {
+                                    mut metrics_reporter,
+                                }) => {
+                                    _ = metrics_reporter.report(&mut metrics);
+                                }
+                                Ok(NodeControlMsg::Ack(ack)) => {
+                                    if ack_propagation_mode != TopicAckPropagationMode::Auto {
+                                        metrics
+                                            .bridge_controls_ignored_propagation_disabled
+                                            .add(1);
+                                    } else if let Some(message_id) =
+                                        Self::decode_topic_message_id(&ack.unwind.route.calldata)
+                                    {
+                                        let _ = pending_tracked_message_ids.remove(&message_id);
+                                        match subscription.ack(message_id) {
+                                            Ok(()) => metrics.bridged_downstream_acks.add(1),
+                                            Err(Error::MessageNotTracked) => {
+                                                metrics.bridge_invalid_or_untracked_id.add(1);
+                                                otel_warn!(
+                                                    "topic_receiver.bridge_ack_untracked_or_invalid_id",
+                                                    node = receiver_id.name.as_ref(),
+                                                    topic = config.topic.as_ref(),
+                                                    message_id = message_id,
+                                                    message = "Failed to ack topic message because the downstream control referenced an untracked or invalid message id"
+                                                );
+                                            }
+                                            Err(e) => {
+                                                metrics.bridge_runtime_failures.add(1);
+                                                otel_warn!(
+                                                    "topic_receiver.bridge_ack_failed",
+                                                    node = receiver_id.name.as_ref(),
+                                                    topic = config.topic.as_ref(),
+                                                    error = e.to_string(),
+                                                    message = "Failed to ack topic message from downstream ack control"
+                                                );
+                                            }
+                                        }
+                                    } else {
+                                        metrics.bridge_missing_calldata.add(1);
+                                        otel_warn!(
+                                            "topic_receiver.bridge_ack_missing_calldata",
+                                            node = receiver_id.name.as_ref(),
+                                            topic = config.topic.as_ref(),
+                                            message = "Downstream ack missing topic message id calldata"
+                                        );
+                                    }
+                                }
+                                Ok(NodeControlMsg::DrainIngress { deadline, reason }) => {
+                                    if draining_deadline.is_none() {
+                                        // Receiver-first shutdown stops polling the topic
+                                        // subscription immediately. If Ack/Nack propagation is
+                                        // enabled, keep the receiver alive only long enough to bridge
+                                        // terminal outcomes for tracked messages that were already
+                                        // forwarded downstream.
+                                        draining_deadline = Some(deadline);
+                                        draining_reason = Some(reason);
+                                    }
+                                }
+                                Ok(NodeControlMsg::Nack(nack)) => {
+                                    if ack_propagation_mode != TopicAckPropagationMode::Auto {
+                                        metrics
+                                            .bridge_controls_ignored_propagation_disabled
+                                            .add(1);
+                                    } else if let Some(message_id) =
+                                        Self::decode_topic_message_id(&nack.unwind.route.calldata)
+                                    {
+                                        let _ = pending_tracked_message_ids.remove(&message_id);
+                                        match subscription.nack(message_id, nack.reason.as_str()) {
+                                            Ok(()) => metrics.bridged_downstream_nacks.add(1),
+                                            Err(Error::MessageNotTracked) => {
+                                                metrics.bridge_invalid_or_untracked_id.add(1);
+                                                otel_warn!(
+                                                    "topic_receiver.bridge_nack_untracked_or_invalid_id",
+                                                    node = receiver_id.name.as_ref(),
+                                                    topic = config.topic.as_ref(),
+                                                    message_id = message_id,
+                                                    message = "Failed to nack topic message because the downstream control referenced an untracked or invalid message id"
+                                                );
+                                            }
+                                            Err(e) => {
+                                                metrics.bridge_runtime_failures.add(1);
+                                                otel_warn!(
+                                                    "topic_receiver.bridge_nack_failed",
+                                                    node = receiver_id.name.as_ref(),
+                                                    topic = config.topic.as_ref(),
+                                                    error = e.to_string(),
+                                                    message = "Failed to nack topic message from downstream nack control"
+                                                );
+                                            }
+                                        }
+                                    } else {
+                                        metrics.bridge_missing_calldata.add(1);
+                                        otel_warn!(
+                                            "topic_receiver.bridge_nack_missing_calldata",
+                                            node = receiver_id.name.as_ref(),
+                                            topic = config.topic.as_ref(),
+                                            message = "Downstream nack missing topic message id calldata"
+                                        );
+                                    }
+                                }
+                                Ok(NodeControlMsg::Shutdown { deadline, .. }) => {
+                                    if let Some(handle) = telemetry_cancel_handle.take() {
+                                        _ = handle.cancel().await;
+                                    }
+                                    return Ok(TerminalState::new(deadline, [metrics.snapshot()]));
+                                }
+                                Ok(_) => {}
+                                Err(e) => return Err(Error::ChannelRecvError(e)),
                             }
-                            metrics.forwarded_messages.add(1);
-                            let blocked_for = pending.send_started_at.elapsed();
-                            if blocked_for.as_millis() >= 500 {
-                                metrics.downstream_backpressure_events.add(1);
-                                metrics
-                                    .downstream_blocked_ms
-                                    .add(blocked_for.as_millis() as u64);
-                                otel_warn!(
-                                    "topic_receiver.downstream_backpressure",
-                                    node = receiver_id.name.as_ref(),
-                                    topic = config.topic.as_ref(),
-                                    blocked_ms = blocked_for.as_millis() as u64,
-                                    message = "Topic receiver blocked while forwarding to downstream pipeline channel"
-                                );
+                        }
+
+                        result = pending.future.as_mut() => {
+                            let pending = pending_forward
+                                .take()
+                                .expect("pending forward should still exist");
+                            match result {
+                                Ok(()) => {
+                                    pending.delivery.commit();
+                                    if let Some(message_id) = pending.tracked_message_id {
+                                        _ = pending_tracked_message_ids.insert(message_id);
+                                    }
+                                    metrics.forwarded_messages.add(1);
+                                    let blocked_for = pending.send_started_at.elapsed();
+                                    if blocked_for.as_millis() >= 500 {
+                                        metrics.downstream_backpressure_events.add(1);
+                                        metrics
+                                            .downstream_blocked_ms
+                                            .add(blocked_for.as_millis() as u64);
+                                        otel_warn!(
+                                            "topic_receiver.downstream_backpressure",
+                                            node = receiver_id.name.as_ref(),
+                                            topic = config.topic.as_ref(),
+                                            blocked_ms = blocked_for.as_millis() as u64,
+                                            message = "Topic receiver blocked while forwarding to downstream pipeline channel"
+                                        );
+                                    }
+                                    tokio::task::consume_budget().await;
+                                }
+                                Err(e) => {
+                                    metrics.forward_failures.add(1);
+                                    otel_warn!(
+                                        "topic_receiver.forward_failed",
+                                        node = receiver_id.name.as_ref(),
+                                        topic = config.topic.as_ref(),
+                                        error = e.to_string(),
+                                        message = "Topic receiver failed forwarding to downstream channel"
+                                    );
+                                    return Err(Error::from(e));
+                                }
                             }
-                            tokio::task::consume_budget().await;
-                            continue;
                         }
-                        Err(otap_df_engine::error::TypedError::ChannelSendError(
-                            SendError::Full(pdata),
-                        )) => {
-                            pending_forward = Some(PendingForward {
-                                pdata,
-                                tracked_message_id: pending.tracked_message_id,
-                                send_started_at: pending.send_started_at,
-                            });
-                        }
-                        Err(e) => {
-                            metrics.forward_failures.add(1);
-                            otel_warn!(
-                                "topic_receiver.forward_failed",
-                                node = receiver_id.name.as_ref(),
-                                topic = config.topic.as_ref(),
-                                error = e.to_string(),
-                                message = "Topic receiver failed forwarding to downstream channel"
-                            );
-                            return Err(Error::from(e));
-                        }
+
+                        _ = &mut drain_sleep => {}
                     }
+                    continue;
                 }
 
                 let current_draining_deadline = draining_deadline;
                 let mut drain_sleep = std::pin::pin!(async move {
                     if let Some(deadline) = current_draining_deadline {
                         tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)).await;
-                    } else {
-                        future::pending::<()>().await;
-                    }
-                });
-                let should_retry_pending_send = pending_forward.is_some();
-                let mut retry_pending_send = std::pin::pin!(async {
-                    if should_retry_pending_send {
-                        tokio::time::sleep(PENDING_FORWARD_RETRY_DELAY).await;
                     } else {
                         future::pending::<()>().await;
                     }
@@ -516,21 +634,22 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                         }
                     }
 
-                    recv = subscription.recv(), if draining_deadline.is_none() && pending_forward.is_none() => {
+                    recv = subscription.recv_delivery(), if draining_deadline.is_none() => {
                         match recv {
-                            Ok(RecvItem::Message(env)) => {
+                            Ok(RecvDelivery::Message(delivery)) => {
                                 // Topic hop is a transport boundary: reset in-process
                                 // Ack/Nack routing context before forwarding.
                                 // Use source-tag-aware send so fan-in wiring can attribute source node.
-                                let mut pdata = env.payload.clone_without_context();
+                                let mut pdata = delivery.envelope().payload.clone_without_context();
                                 let tracked_message_id =
                                     (ack_propagation_mode == TopicAckPropagationMode::Auto
-                                        && env.tracked)
-                                        .then_some(env.id);
+                                        && delivery.tracked())
+                                        .then_some(delivery.message_id());
                                 if ack_propagation_mode == TopicAckPropagationMode::Auto
-                                    && env.tracked
+                                    && delivery.tracked()
                                 {
-                                    let topic_message_calldata = smallvec![Context8u8::from(env.id)];
+                                    let topic_message_calldata =
+                                        smallvec![Context8u8::from(delivery.message_id())];
                                     effect_handler.subscribe_to(
                                         Interests::ACKS | Interests::NACKS,
                                         topic_message_calldata,
@@ -540,6 +659,7 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                                 let send_started_at = Instant::now();
                                 match effect_handler.try_send_message_with_source_node(pdata) {
                                     Ok(()) => {
+                                        delivery.commit();
                                         if let Some(message_id) = tracked_message_id {
                                             _ = pending_tracked_message_ids.insert(message_id);
                                         }
@@ -549,10 +669,14 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                                     Err(otap_df_engine::error::TypedError::ChannelSendError(
                                         SendError::Full(pdata),
                                     )) => {
+                                        let effect_handler = effect_handler.clone();
                                         pending_forward = Some(PendingForward {
-                                            pdata,
+                                            delivery,
                                             tracked_message_id,
                                             send_started_at,
+                                            future: Box::pin(async move {
+                                                effect_handler.send_message_with_source_node(pdata).await
+                                            }),
                                         });
                                     }
                                     Err(e) => {
@@ -568,7 +692,7 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                                     }
                                 }
                             }
-                            Ok(RecvItem::Lagged { missed }) => {
+                            Ok(RecvDelivery::Lagged { missed }) => {
                                 metrics.lagged_notifications.add(1);
                                 metrics.lagged_messages.add(missed);
                                 if broadcast_on_lag == Some(TopicBroadcastOnLagPolicy::Disconnect) {
@@ -593,8 +717,6 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                             Err(e) => return Err(e),
                         }
                     }
-
-                    _ = &mut retry_pending_send => {}
 
                     _ = &mut drain_sleep => {}
                 }

--- a/rust/otap-dataflow/crates/engine/src/topic/README.md
+++ b/rust/otap-dataflow/crates/engine/src/topic/README.md
@@ -285,8 +285,9 @@ let _topic = broker.create_topic(
 - `try_publish(msg)`
   - Never awaits.
   - Returns `PublishOutcome::Published` or `PublishOutcome::DroppedOnFull`.
-- In `Mixed` mode, `try_publish` can return `DroppedOnFull` because
-  balanced queues are full while broadcast delivery may still succeed.
+- In `Mixed` mode, `try_publish` is all-or-nothing across balanced and
+  broadcast delivery. If any balanced queue is full, it returns
+  `DroppedOnFull` and does not publish to broadcast.
 - Messages are not retained for future subscribers: subscribing later
   does not replay pre-subscribe history.
 

--- a/rust/otap-dataflow/crates/engine/src/topic/backend.rs
+++ b/rust/otap-dataflow/crates/engine/src/topic/backend.rs
@@ -34,10 +34,11 @@ use std::task::{Context, Poll};
 use std::time::Duration;
 
 use crate::error::Error;
+use crate::topic::subscription::RecvDelivery;
 use crate::topic::topic::TopicInner;
 use crate::topic::types::{
-    PublishOutcome, RecvItem, SubscriberOptions, TopicOptions, TrackedPublishPermit,
-    TrackedPublishReceipt, TrackedTryPublishOutcome,
+    PublishOutcome, SubscriberOptions, TopicOptions, TrackedPublishPermit, TrackedPublishReceipt,
+    TrackedTryPublishOutcome,
 };
 use otap_df_config::topic::TopicBroadcastOnLagPolicy;
 use otap_df_config::{SubscriptionGroupName, TopicName};
@@ -123,8 +124,8 @@ pub trait TopicState<T: Send + Sync + 'static>: Send + Sync {
 /// `Send` (not `Sync`) -- owned by one `Subscription`, `poll_recv` takes
 /// `&mut self`. `ack`/`nack` take `&self` which is fine.
 pub trait SubscriptionBackend<T: Send + Sync + 'static>: Send {
-    /// Poll for the next receive item.
-    fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Result<RecvItem<T>, Error>>;
+    /// Poll for the next receive item with explicit delivery ownership.
+    fn poll_recv_delivery(&mut self, cx: &mut Context<'_>) -> Poll<Result<RecvDelivery<T>, Error>>;
     /// Ack a previously received message id.
     fn ack(&self, id: u64) -> Result<(), Error>;
     /// `reason` is `Arc<str>` (not `impl Into<Arc<str>>`) for object safety.

--- a/rust/otap-dataflow/crates/engine/src/topic/backend.rs
+++ b/rust/otap-dataflow/crates/engine/src/topic/backend.rs
@@ -117,6 +117,10 @@ pub trait TopicState<T: Send + Sync + 'static>: Send + Sync {
     fn broadcast_on_lag_policy(&self) -> TopicBroadcastOnLagPolicy;
     /// Close the topic. Existing subscriptions eventually observe closure.
     fn close(&self);
+
+    #[cfg(test)]
+    /// Snapshot the currently available balanced permits by consumer group.
+    fn debug_balanced_available_permits(&self) -> Vec<(SubscriptionGroupName, usize)>;
 }
 
 /// Per-subscription operations. Exclusively owned by one `Subscription`.

--- a/rust/otap-dataflow/crates/engine/src/topic/handle.rs
+++ b/rust/otap-dataflow/crates/engine/src/topic/handle.rs
@@ -135,6 +135,13 @@ impl<T: Send + Sync + 'static> TopicHandle<T> {
     pub fn broadcast_on_lag_policy(&self) -> TopicBroadcastOnLagPolicy {
         self.inner.broadcast_on_lag_policy()
     }
+
+    #[cfg(test)]
+    pub(crate) fn debug_balanced_available_permits(
+        &self,
+    ) -> Vec<(crate::topic::SubscriptionGroupName, usize)> {
+        self.inner.debug_balanced_available_permits()
+    }
 }
 
 impl<T: Send + Sync + 'static> TrackedTopicPublisher<T> {

--- a/rust/otap-dataflow/crates/engine/src/topic/mod.rs
+++ b/rust/otap-dataflow/crates/engine/src/topic/mod.rs
@@ -24,7 +24,7 @@ pub use otap_df_config::topic::{
     TopicAckPropagationMode, TopicBroadcastOnLagPolicy, TopicQueueOnFullPolicy,
 };
 pub use otap_df_config::{SubscriptionGroupName, TopicName};
-pub use subscription::Subscription;
+pub use subscription::{Delivery, RecvDelivery, Subscription};
 pub use topic_set::TopicSet;
 pub use types::{
     Envelope, PublishOutcome, RecvItem, SubscriberOptions, SubscriptionMode, TopicOptions,

--- a/rust/otap-dataflow/crates/engine/src/topic/subscription.rs
+++ b/rust/otap-dataflow/crates/engine/src/topic/subscription.rs
@@ -11,8 +11,9 @@
 //!
 //! # Receive
 //!
-//! `recv()` delegates to `poll_fn(|cx| self.inner.poll_recv(cx))`. Zero
-//! allocation per call — the `poll_fn` future is stack-allocated.
+//! `recv()` delegates to `poll_fn(|cx| self.inner.poll_recv_delivery(cx))`.
+//! The future itself is stack-allocated. In-memory delivery leases also avoid
+//! per-message heap allocation on the common path.
 //!
 //! # Ack/Nack
 //!
@@ -22,12 +23,157 @@
 
 use crate::error::Error;
 use crate::topic::backend::SubscriptionBackend;
-use crate::topic::types::RecvItem;
+use crate::topic::topic::InMemoryDeliveryFinalizer;
+#[cfg(test)]
+use crate::topic::topic::InMemoryDeliveryKind;
+use crate::topic::types::{Envelope, RecvItem};
 use std::sync::Arc;
 
 /// A subscription handle. Call `recv()` to receive messages.
 pub struct Subscription<T: Send + Sync + 'static> {
     inner: Box<dyn SubscriptionBackend<T>>,
+}
+
+/// A receive result that keeps ownership of one delivered topic message until
+/// the caller either commits or aborts it.
+pub enum RecvDelivery<T: Send + Sync + 'static> {
+    /// One delivered topic message.
+    Message(Delivery<T>),
+    /// Notification that this broadcast subscriber lagged and missed messages.
+    Lagged {
+        /// Number of dropped messages for this subscriber.
+        missed: u64,
+    },
+}
+
+// Reserved fallback hook for non-in-memory topic backends. The current tree
+// only ships the in-memory backend, so normal builds do not instantiate this
+// path yet.
+#[allow(dead_code)]
+pub(crate) trait DeliveryBackend<T: Send + Sync + 'static> {
+    fn envelope(&self) -> &Envelope<T>;
+
+    fn commit(&mut self);
+
+    fn abort(&mut self, reason: Arc<str>) -> Result<(), Error>;
+
+    fn abandon(&mut self);
+}
+
+/// A topic delivery that has been received from a subscription but not yet
+/// finalized.
+///
+/// Callers should either:
+/// - `commit()` after the message has been handed off successfully, or
+/// - `abort(...)` if the message must be rejected before handoff.
+///
+/// Dropping an unresolved delivery abandons it. For tracked messages this
+/// resolves the topic-side delivery as a negative outcome so the topic runtime
+/// does not retain it indefinitely.
+pub struct Delivery<T: Send + Sync + 'static> {
+    envelope: Envelope<T>,
+    finalizer: DeliveryFinalizer<T>,
+}
+
+enum DeliveryFinalizer<T: Send + Sync + 'static> {
+    InMemory(InMemoryDeliveryFinalizer),
+    // Keep the opaque finalizer path available so a future backend can attach
+    // its own delivery lease implementation without changing the public
+    // subscription API. The in-memory backend no longer uses this variant.
+    #[allow(dead_code)]
+    Opaque(Box<dyn DeliveryBackend<T>>),
+    Finished,
+}
+
+impl<T: Send + Sync + 'static> Delivery<T> {
+    pub(crate) fn new_in_memory(
+        envelope: Envelope<T>,
+        finalizer: InMemoryDeliveryFinalizer,
+    ) -> Self {
+        Self {
+            envelope,
+            finalizer: DeliveryFinalizer::InMemory(finalizer),
+        }
+    }
+
+    // Keep this constructor available for future non-in-memory backends. It is
+    // only used by tests today because the in-memory backend now constructs
+    // specialized inline deliveries directly.
+    #[allow(dead_code)]
+    pub(crate) fn new_opaque(inner: Box<dyn DeliveryBackend<T>>) -> Self {
+        let envelope = inner.envelope().clone();
+        Self {
+            envelope,
+            finalizer: DeliveryFinalizer::Opaque(inner),
+        }
+    }
+
+    /// Inspect the delivered message envelope.
+    #[must_use]
+    pub fn envelope(&self) -> &Envelope<T> {
+        &self.envelope
+    }
+
+    /// Topic-assigned message id.
+    #[must_use]
+    pub fn message_id(&self) -> u64 {
+        self.envelope().id
+    }
+
+    /// Whether this delivery participates in tracked topic outcomes.
+    #[must_use]
+    pub fn tracked(&self) -> bool {
+        self.envelope().tracked
+    }
+
+    /// Finalize the delivery after successful handoff.
+    pub fn commit(mut self) {
+        match std::mem::replace(&mut self.finalizer, DeliveryFinalizer::Finished) {
+            DeliveryFinalizer::InMemory(mut finalizer) => finalizer.commit(),
+            DeliveryFinalizer::Opaque(mut inner) => inner.commit(),
+            DeliveryFinalizer::Finished => {}
+        }
+    }
+
+    /// Reject the delivery before successful handoff.
+    pub fn abort(mut self, reason: impl Into<Arc<str>>) -> Result<(), Error> {
+        let reason = reason.into();
+        match std::mem::replace(&mut self.finalizer, DeliveryFinalizer::Finished) {
+            DeliveryFinalizer::InMemory(mut finalizer) => finalizer.abort(&self.envelope, reason),
+            DeliveryFinalizer::Opaque(mut inner) => inner.abort(reason),
+            DeliveryFinalizer::Finished => Ok(()),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn storage_kind(&self) -> DeliveryStorageKind {
+        match &self.finalizer {
+            DeliveryFinalizer::InMemory(finalizer) => match finalizer.kind() {
+                InMemoryDeliveryKind::Balanced => DeliveryStorageKind::Balanced,
+                InMemoryDeliveryKind::Broadcast => DeliveryStorageKind::Broadcast,
+            },
+            DeliveryFinalizer::Opaque(_) => DeliveryStorageKind::Opaque,
+            DeliveryFinalizer::Finished => panic!("finished deliveries should not be inspected"),
+        }
+    }
+}
+
+impl<T: Send + Sync + 'static> Drop for Delivery<T> {
+    fn drop(&mut self) {
+        match std::mem::replace(&mut self.finalizer, DeliveryFinalizer::Finished) {
+            DeliveryFinalizer::InMemory(mut finalizer) => finalizer.abandon(&self.envelope),
+            DeliveryFinalizer::Opaque(mut inner) => inner.abandon(),
+            DeliveryFinalizer::Finished => {}
+        }
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DeliveryStorageKind {
+    Balanced,
+    Broadcast,
+    Opaque,
 }
 
 impl<T: Send + Sync + 'static> Subscription<T> {
@@ -43,7 +189,20 @@ impl<T: Send + Sync + 'static> Subscription<T> {
     /// still-available message. With `disconnect`, the next call returns
     /// `Error::SubscriptionClosed`.
     pub async fn recv(&mut self) -> Result<RecvItem<T>, Error> {
-        std::future::poll_fn(|cx| self.inner.poll_recv(cx)).await
+        match self.recv_delivery().await? {
+            RecvDelivery::Message(delivery) => {
+                let envelope = delivery.envelope().clone();
+                delivery.commit();
+                Ok(RecvItem::Message(envelope))
+            }
+            RecvDelivery::Lagged { missed } => Ok(RecvItem::Lagged { missed }),
+        }
+    }
+
+    /// Receive the next delivery while keeping ownership of the topic-side
+    /// delivery state until the caller commits or aborts it.
+    pub async fn recv_delivery(&mut self) -> Result<RecvDelivery<T>, Error> {
+        std::future::poll_fn(|cx| self.inner.poll_recv_delivery(cx)).await
     }
 
     /// Acknowledge successful processing of a message.

--- a/rust/otap-dataflow/crates/engine/src/topic/subscription.rs
+++ b/rust/otap-dataflow/crates/engine/src/topic/subscription.rs
@@ -12,7 +12,7 @@
 //! # Receive
 //!
 //! `recv()` delegates to `poll_fn(|cx| self.inner.poll_recv_delivery(cx))`.
-//! The future itself is stack-allocated. In-memory delivery leases also avoid
+//! The future itself is stack-allocated. In-memory delivery permits also avoid
 //! per-message heap allocation on the common path.
 //!
 //! # Ack/Nack
@@ -78,7 +78,7 @@ pub struct Delivery<T: Send + Sync + 'static> {
 enum DeliveryFinalizer<T: Send + Sync + 'static> {
     InMemory(InMemoryDeliveryFinalizer),
     // Keep the opaque finalizer path available so a future backend can attach
-    // its own delivery lease implementation without changing the public
+    // its own delivery permit implementation without changing the public
     // subscription API. The in-memory backend no longer uses this variant.
     #[allow(dead_code)]
     Opaque(Box<dyn DeliveryBackend<T>>),

--- a/rust/otap-dataflow/crates/engine/src/topic/tests.rs
+++ b/rust/otap-dataflow/crates/engine/src/topic/tests.rs
@@ -550,6 +550,88 @@ async fn mixed_async_publish_waits_for_balanced_admission_before_broadcast() {
     topic.close();
 }
 
+// A blocked mixed publish must not reserve capacity on balanced groups that
+// were otherwise ready to admit the message.
+#[tokio::test]
+async fn mixed_async_publish_does_not_reserve_free_groups_while_waiting() {
+    let broker = TopicBroker::<u64>::new();
+    let topic = broker
+        .create_topic(
+            "mixed-no-convoy",
+            TopicOptions::Mixed {
+                balanced_capacity: 1,
+                broadcast_capacity: 16,
+                on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+            },
+            InMemoryBackend,
+        )
+        .unwrap();
+
+    let mut fast = topic
+        .subscribe(
+            SubscriptionMode::Balanced {
+                group: SubscriptionGroupName::from("fast"),
+            },
+            SubscriberOptions::default(),
+        )
+        .unwrap();
+    let mut slow = topic
+        .subscribe(
+            SubscriptionMode::Balanced {
+                group: SubscriptionGroupName::from("slow"),
+            },
+            SubscriberOptions::default(),
+        )
+        .unwrap();
+
+    topic.publish(Arc::new(1u64)).await.unwrap();
+
+    match fast.recv().await.unwrap() {
+        RecvItem::Message(env) => assert_eq!(*env.payload, 1),
+        other => panic!("unexpected first fast item: {other:?}"),
+    }
+
+    let topic_clone = topic.clone();
+    let blocked_publish = tokio::spawn(async move {
+        topic_clone.publish(Arc::new(2u64)).await.unwrap();
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(
+        !blocked_publish.is_finished(),
+        "publish should still be blocked by the slow group"
+    );
+
+    let mut permits = topic.debug_balanced_available_permits();
+    permits.sort_by(|(left, _), (right, _)| left.as_ref().cmp(right.as_ref()));
+    assert_eq!(
+        permits,
+        vec![
+            (SubscriptionGroupName::from("fast"), 1),
+            (SubscriptionGroupName::from("slow"), 0),
+        ],
+        "blocked mixed publish should not hold the fast group's permit"
+    );
+
+    match slow.recv().await.unwrap() {
+        RecvItem::Message(env) => assert_eq!(*env.payload, 1),
+        other => panic!("unexpected first slow item: {other:?}"),
+    }
+
+    blocked_publish.await.unwrap();
+
+    match fast.recv().await.unwrap() {
+        RecvItem::Message(env) => assert_eq!(*env.payload, 2),
+        other => panic!("unexpected second fast item: {other:?}"),
+    }
+    match slow.recv().await.unwrap() {
+        RecvItem::Message(env) => assert_eq!(*env.payload, 2),
+        other => panic!("unexpected second slow item: {other:?}"),
+    }
+
+    topic.close();
+}
+
 // Dropping a blocked async mixed-topic publish must not partially publish to
 // broadcast subscribers before balanced admission succeeds.
 #[tokio::test]
@@ -1799,11 +1881,11 @@ async fn try_publish_balanced_only_reports_drop_on_full() {
     );
 }
 
-// On mixed topics, broadcast delivery stays non-blocking even when balanced
-// queues are full: try_publish can return DroppedOnFull while broadcast
-// subscribers still receive the message.
+// On mixed topics, try_publish is all-or-nothing across balanced and
+// broadcast delivery. A balanced drop-on-full result must not leak a message
+// to broadcast subscribers.
 #[tokio::test]
-async fn try_publish_mixed_keeps_broadcast_non_blocking() {
+async fn try_publish_mixed_rejects_broadcast_when_balanced_is_full() {
     let broker = TopicBroker::<u64>::new();
     let topic = broker
         .create_topic(
@@ -1846,7 +1928,7 @@ async fn try_publish_mixed_keeps_broadcast_non_blocking() {
             received.push(*env.payload);
         }
     }
-    assert_eq!(received, vec![10, 20]);
+    assert_eq!(received, vec![10]);
 }
 
 // =========================================================================

--- a/rust/otap-dataflow/crates/engine/src/topic/tests.rs
+++ b/rust/otap-dataflow/crates/engine/src/topic/tests.rs
@@ -24,17 +24,20 @@
 //!   remove-does-not-close, clone-shares-state.
 
 use crate::error::Error;
-use crate::topic::backend::InMemoryBackend;
+use crate::topic::backend::{InMemoryBackend, SubscriptionBackend};
+use crate::topic::subscription::{DeliveryBackend, DeliveryStorageKind};
 use crate::topic::types::{
-    PublishOutcome, RecvItem, SubscriberOptions, SubscriptionMode, TopicOptions,
+    Envelope, PublishOutcome, RecvItem, SubscriberOptions, SubscriptionMode, TopicOptions,
     TopicPublishOutcomeConfig, TrackedPublishOutcome, TrackedPublishPermit, TrackedPublishTracker,
     TrackedTryPublishOutcome,
 };
-use crate::topic::{TopicBroker, TopicSet};
+use crate::topic::{Delivery, RecvDelivery, Subscription, TopicBroker, TopicSet};
 use otap_df_config::topic::TopicBroadcastOnLagPolicy;
 use otap_df_config::{SubscriptionGroupName, TopicName};
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::task::{Context, Poll};
 use std::time::Duration;
 use tokio::sync::Semaphore;
 
@@ -457,10 +460,11 @@ async fn broadcast_disconnects_slow_subscriber_on_lag() {
     assert!(matches!(sub.recv().await, Err(Error::SubscriptionClosed)));
 }
 
-// In Mixed mode, broadcast delivery remains non-blocking even if balanced
-// consumer-group backpressure stalls publish completion.
+// In Mixed mode, async publish now waits for full topic admission. Balanced
+// backpressure therefore delays both publish completion and broadcast
+// visibility, while `try_publish` remains the non-blocking API.
 #[tokio::test]
-async fn mixed_broadcast_not_blocked_by_balanced_backpressure() {
+async fn mixed_async_publish_waits_for_balanced_admission_before_broadcast() {
     let broker = TopicBroker::new();
     let topic = broker
         .create_topic(
@@ -489,8 +493,8 @@ async fn mixed_broadcast_not_blocked_by_balanced_backpressure() {
     // Fill the balanced queue.
     topic.publish(Arc::new(1u64)).await.unwrap();
 
-    // Second publish should block on balanced delivery, but broadcast should
-    // still observe it promptly.
+    // Second publish should block on balanced delivery, so broadcast should
+    // not observe it until balanced admission succeeds.
     let topic_clone = topic.clone();
     let second_publish = tokio::spawn(async move {
         topic_clone.publish(Arc::new(2u64)).await.unwrap();
@@ -502,7 +506,33 @@ async fn mixed_broadcast_not_blocked_by_balanced_backpressure() {
         other => panic!("unexpected: {:?}", other),
     }
 
-    // Second message should arrive before balanced queue is drained.
+    // Second message should not arrive before balanced queue is drained.
+    assert!(
+        tokio::time::timeout(Duration::from_millis(200), async {
+            loop {
+                match broadcast.recv().await {
+                    Ok(RecvItem::Message(env)) => break *env.payload,
+                    Ok(RecvItem::Lagged { .. }) => continue,
+                    Err(e) => panic!("unexpected recv error: {e:?}"),
+                }
+            }
+        })
+        .await
+        .is_err(),
+        "broadcast delivery should wait for balanced admission on async publish"
+    );
+
+    // Publisher task should still be blocked on balanced queue.
+    assert!(
+        !second_publish.is_finished(),
+        "second publish should still be blocked by balanced backpressure"
+    );
+
+    // Drain balanced queue to unblock publisher and then observe the second
+    // broadcast message.
+    _ = balanced.recv().await.unwrap();
+    second_publish.await.unwrap();
+
     let second = tokio::time::timeout(Duration::from_millis(200), async {
         loop {
             match broadcast.recv().await {
@@ -513,20 +543,348 @@ async fn mixed_broadcast_not_blocked_by_balanced_backpressure() {
         }
     })
     .await
-    .expect("broadcast delivery should not wait on balanced backpressure");
+    .expect("broadcast delivery should resume after balanced admission succeeds");
     assert_eq!(second, 2);
 
-    // Publisher task should still be blocked on balanced queue.
+    _ = balanced.recv().await.unwrap();
+    topic.close();
+}
+
+// Dropping a blocked async mixed-topic publish must not partially publish to
+// broadcast subscribers before balanced admission succeeds.
+#[tokio::test]
+async fn mixed_async_publish_drop_does_not_publish_to_broadcast() {
+    let broker = TopicBroker::<u64>::new();
+    let topic = broker
+        .create_topic(
+            "mixed-cancel-no-broadcast",
+            TopicOptions::Mixed {
+                balanced_capacity: 1,
+                broadcast_capacity: 16,
+                on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+            },
+            InMemoryBackend,
+        )
+        .unwrap();
+
+    let mut balanced = topic
+        .subscribe(
+            SubscriptionMode::Balanced {
+                group: SubscriptionGroupName::from("g1"),
+            },
+            SubscriberOptions::default(),
+        )
+        .unwrap();
+    let mut broadcast = topic
+        .subscribe(SubscriptionMode::Broadcast, SubscriberOptions::default())
+        .unwrap();
+
+    topic.publish(Arc::new(1u64)).await.unwrap();
+
+    let mut publish = Box::pin(topic.publish(Arc::new(2u64)));
     assert!(
-        !second_publish.is_finished(),
-        "second publish should still be blocked by balanced backpressure"
+        tokio::time::timeout(Duration::from_millis(200), publish.as_mut())
+            .await
+            .is_err(),
+        "second publish should block while balanced capacity is full"
     );
 
-    // Drain balanced queue to unblock publisher.
-    _ = balanced.recv().await.unwrap();
-    _ = balanced.recv().await.unwrap();
-    second_publish.await.unwrap();
-    topic.close();
+    match broadcast.recv().await.unwrap() {
+        RecvItem::Message(env) => assert_eq!(*env.payload, 1),
+        other => panic!("unexpected first broadcast item: {other:?}"),
+    }
+    drop(publish);
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(200), async {
+            loop {
+                match broadcast.recv().await {
+                    Ok(RecvItem::Message(env)) => break *env.payload,
+                    Ok(RecvItem::Lagged { .. }) => continue,
+                    Err(e) => panic!("unexpected recv error: {e:?}"),
+                }
+            }
+        })
+        .await
+        .is_err(),
+        "dropping a blocked publish must not leak a broadcast delivery"
+    );
+
+    match balanced.recv().await.unwrap() {
+        RecvItem::Message(env) => assert_eq!(*env.payload, 1),
+        other => panic!("unexpected balanced item: {other:?}"),
+    }
+}
+
+// Dropping a blocked tracked publish must release the publisher's in-flight
+// slot so later non-blocking attempts fail only on topic capacity, not leaked
+// tracked publisher capacity.
+#[tokio::test]
+async fn blocked_tracked_publish_drop_releases_in_flight_capacity() {
+    let broker = TopicBroker::<u64>::new();
+    let topic = broker
+        .create_topic(
+            "tracked-publish-drop",
+            TopicOptions::BalancedOnly { capacity: 1 },
+            InMemoryBackend,
+        )
+        .unwrap();
+
+    let _balanced = topic
+        .subscribe(
+            SubscriptionMode::Balanced {
+                group: SubscriptionGroupName::from("g1"),
+            },
+            SubscriberOptions::default(),
+        )
+        .unwrap();
+    topic.publish(Arc::new(1u64)).await.unwrap();
+
+    let tracked = topic.tracked_publisher_with_config(TopicPublishOutcomeConfig {
+        max_in_flight: 1,
+        timeout: Duration::from_secs(30),
+    });
+    let mut blocked = Box::pin(tracked.publish(Arc::new(2u64)));
+    assert!(
+        tokio::time::timeout(Duration::from_millis(200), blocked.as_mut())
+            .await
+            .is_err(),
+        "tracked publish should block while balanced capacity is full"
+    );
+    drop(blocked);
+
+    assert!(
+        matches!(
+            tracked.try_publish(Arc::new(3u64)).unwrap(),
+            TrackedTryPublishOutcome::DroppedOnFull
+        ),
+        "dropping the blocked tracked publish should release the in-flight slot"
+    );
+}
+
+// Broadcast delivery leases keep ownership of one message until the caller
+// commits it, preventing the subscription from advancing past the leased item.
+#[tokio::test]
+async fn broadcast_delivery_commit_advances_to_next_message() {
+    let broker = TopicBroker::<u64>::new();
+    let topic = broker
+        .create_topic(
+            "broadcast-delivery-lease",
+            TopicOptions::BroadcastOnly {
+                capacity: 16,
+                on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+            },
+            InMemoryBackend,
+        )
+        .unwrap();
+
+    let mut sub = topic
+        .subscribe(SubscriptionMode::Broadcast, SubscriberOptions::default())
+        .unwrap();
+
+    topic.publish(Arc::new(1u64)).await.unwrap();
+    topic.publish(Arc::new(2u64)).await.unwrap();
+
+    let first = match sub.recv_delivery().await.unwrap() {
+        RecvDelivery::Message(delivery) => delivery,
+        RecvDelivery::Lagged { .. } => panic!("unexpected lag notification"),
+    };
+    assert_eq!(first.message_id(), 1);
+    assert_eq!(*first.envelope().payload, 1);
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(200), sub.recv_delivery())
+            .await
+            .is_err(),
+        "second delivery should stay blocked while the first delivery lease is held"
+    );
+
+    first.commit();
+
+    let second = match sub.recv_delivery().await.unwrap() {
+        RecvDelivery::Message(delivery) => delivery,
+        RecvDelivery::Lagged { .. } => panic!("unexpected lag notification"),
+    };
+    assert_eq!(second.message_id(), 2);
+    assert_eq!(*second.envelope().payload, 2);
+    second.commit();
+}
+
+// Balanced deliveries from the in-memory backend use the specialized inline
+// finalizer path instead of the opaque fallback.
+#[tokio::test]
+async fn balanced_delivery_uses_specialized_inline_storage() {
+    let broker = TopicBroker::<u64>::new();
+    let topic = broker
+        .create_topic(
+            "balanced-inline-delivery",
+            TopicOptions::default(),
+            InMemoryBackend,
+        )
+        .unwrap();
+
+    let mut sub = topic
+        .subscribe(
+            SubscriptionMode::Balanced {
+                group: SubscriptionGroupName::from("g1"),
+            },
+            SubscriberOptions::default(),
+        )
+        .unwrap();
+
+    topic.publish(Arc::new(7u64)).await.unwrap();
+
+    let delivery = match sub.recv_delivery().await.unwrap() {
+        RecvDelivery::Message(delivery) => delivery,
+        RecvDelivery::Lagged { .. } => panic!("unexpected lag notification"),
+    };
+    assert_eq!(delivery.storage_kind(), DeliveryStorageKind::Balanced);
+    delivery.commit();
+}
+
+// Broadcast deliveries from the in-memory backend use the specialized inline
+// finalizer path instead of the opaque fallback.
+#[tokio::test]
+async fn broadcast_delivery_uses_specialized_inline_storage() {
+    let broker = TopicBroker::<u64>::new();
+    let topic = broker
+        .create_topic(
+            "broadcast-inline-delivery",
+            TopicOptions::BroadcastOnly {
+                capacity: 16,
+                on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+            },
+            InMemoryBackend,
+        )
+        .unwrap();
+
+    let mut sub = topic
+        .subscribe(SubscriptionMode::Broadcast, SubscriberOptions::default())
+        .unwrap();
+
+    topic.publish(Arc::new(11u64)).await.unwrap();
+
+    let delivery = match sub.recv_delivery().await.unwrap() {
+        RecvDelivery::Message(delivery) => delivery,
+        RecvDelivery::Lagged { .. } => panic!("unexpected lag notification"),
+    };
+    assert_eq!(delivery.storage_kind(), DeliveryStorageKind::Broadcast);
+    delivery.commit();
+}
+
+// Custom backends still work through the opaque delivery fallback even though
+// the in-memory backend now uses specialized inline storage.
+#[tokio::test]
+async fn opaque_delivery_fallback_still_works() {
+    struct OpaqueDelivery {
+        envelope: Envelope<u64>,
+        aborted: Arc<AtomicBool>,
+    }
+
+    impl DeliveryBackend<u64> for OpaqueDelivery {
+        fn envelope(&self) -> &Envelope<u64> {
+            &self.envelope
+        }
+
+        fn commit(&mut self) {}
+
+        fn abort(&mut self, _reason: Arc<str>) -> Result<(), Error> {
+            self.aborted.store(true, Ordering::SeqCst);
+            Ok(())
+        }
+
+        fn abandon(&mut self) {}
+    }
+
+    struct OpaqueSubscription {
+        yielded: bool,
+        aborted: Arc<AtomicBool>,
+    }
+
+    impl SubscriptionBackend<u64> for OpaqueSubscription {
+        fn poll_recv_delivery(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<RecvDelivery<u64>, Error>> {
+            if self.yielded {
+                Poll::Ready(Err(Error::SubscriptionClosed))
+            } else {
+                self.yielded = true;
+                Poll::Ready(Ok(RecvDelivery::Message(Delivery::new_opaque(Box::new(
+                    OpaqueDelivery {
+                        envelope: Envelope {
+                            id: 41,
+                            payload: Arc::new(99u64),
+                            tracked: false,
+                        },
+                        aborted: Arc::clone(&self.aborted),
+                    },
+                )))))
+            }
+        }
+
+        fn ack(&self, _id: u64) -> Result<(), Error> {
+            Ok(())
+        }
+
+        fn nack(&self, _id: u64, _reason: Arc<str>) -> Result<(), Error> {
+            Ok(())
+        }
+    }
+
+    let aborted = Arc::new(AtomicBool::new(false));
+    let mut subscription = Subscription::new(Box::new(OpaqueSubscription {
+        yielded: false,
+        aborted: Arc::clone(&aborted),
+    }));
+
+    let delivery = match subscription.recv_delivery().await.unwrap() {
+        RecvDelivery::Message(delivery) => delivery,
+        RecvDelivery::Lagged { .. } => panic!("unexpected lag notification"),
+    };
+    assert_eq!(delivery.storage_kind(), DeliveryStorageKind::Opaque);
+    delivery.abort("opaque fallback abort").unwrap();
+    assert!(aborted.load(Ordering::SeqCst));
+}
+
+// Aborting an unforwarded tracked delivery must resolve its tracked publish as
+// a Nack owned by the delivery object itself.
+#[tokio::test]
+async fn tracked_delivery_abort_resolves_publish_outcome() {
+    let broker = TopicBroker::<u64>::new();
+    let topic = broker
+        .create_topic(
+            "tracked-delivery-abort",
+            TopicOptions::default(),
+            InMemoryBackend,
+        )
+        .unwrap();
+
+    let tracked = topic.tracked_publisher();
+    let mut sub = topic
+        .subscribe(
+            SubscriptionMode::Balanced {
+                group: SubscriptionGroupName::from("g1"),
+            },
+            SubscriberOptions::default(),
+        )
+        .unwrap();
+
+    let receipt = tracked.publish(Arc::new(42u64)).await.unwrap();
+    let delivery = match sub.recv_delivery().await.unwrap() {
+        RecvDelivery::Message(delivery) => delivery,
+        RecvDelivery::Lagged { .. } => panic!("unexpected lag notification"),
+    };
+
+    delivery
+        .abort("downstream rejected before forward")
+        .unwrap();
+    assert_eq!(
+        receipt.wait_for_outcome().await,
+        TrackedPublishOutcome::Nack {
+            reason: Arc::from("downstream rejected before forward"),
+        }
+    );
 }
 
 // In Mixed mode, a lagging broadcast subscriber can be disconnected without

--- a/rust/otap-dataflow/crates/engine/src/topic/tests.rs
+++ b/rust/otap-dataflow/crates/engine/src/topic/tests.rs
@@ -744,14 +744,14 @@ async fn blocked_tracked_publish_drop_releases_in_flight_capacity() {
     );
 }
 
-// Broadcast delivery leases keep ownership of one message until the caller
-// commits it, preventing the subscription from advancing past the leased item.
+// Broadcast delivery permits keep ownership of one message until the caller
+// commits it, preventing the subscription from advancing past the permitted item.
 #[tokio::test]
 async fn broadcast_delivery_commit_advances_to_next_message() {
     let broker = TopicBroker::<u64>::new();
     let topic = broker
         .create_topic(
-            "broadcast-delivery-lease",
+            "broadcast-delivery-permit",
             TopicOptions::BroadcastOnly {
                 capacity: 16,
                 on_lag: TopicBroadcastOnLagPolicy::DropOldest,
@@ -778,7 +778,7 @@ async fn broadcast_delivery_commit_advances_to_next_message() {
         tokio::time::timeout(Duration::from_millis(200), sub.recv_delivery())
             .await
             .is_err(),
-        "second delivery should stay blocked while the first delivery lease is held"
+        "second delivery should stay blocked while the first delivery permit is held"
     );
 
     first.commit();

--- a/rust/otap-dataflow/crates/engine/src/topic/topic.rs
+++ b/rust/otap-dataflow/crates/engine/src/topic/topic.rs
@@ -15,24 +15,33 @@ use crate::error::Error::{
     SubscribeSingleGroupViolation, SubscriptionClosed, TopicClosed,
 };
 use crate::topic::backend::{PublishFuture, PublishTrackedFuture, SubscriptionBackend, TopicState};
+use crate::topic::subscription::{Delivery, RecvDelivery};
 use crate::topic::types::{
-    Envelope, PublishOutcome, RecvItem, SubscriberOptions, TopicOptions, TrackedPublishOutcome,
+    Envelope, PublishOutcome, SubscriberOptions, TopicOptions, TrackedPublishOutcome,
     TrackedPublishPermit, TrackedPublishReceipt, TrackedPublishTracker, TrackedTryPublishOutcome,
 };
 use futures_core::Stream;
 use otap_df_config::topic::TopicBroadcastOnLagPolicy;
 use otap_df_config::{SubscriptionGroupName, TopicName};
 use parking_lot::{Mutex, RwLock};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+struct QueuedEnvelope<T> {
+    envelope: Envelope<T>,
+    _admission_permit: OwnedSemaphorePermit,
+}
 
 struct ConsumerGroup<T> {
-    tx: async_channel::Sender<Envelope<T>>,
-    rx: async_channel::Receiver<Envelope<T>>,
+    tx: async_channel::Sender<QueuedEnvelope<T>>,
+    rx: async_channel::Receiver<QueuedEnvelope<T>>,
+    admission: Arc<Semaphore>,
 }
 
 struct SingleGroup<T> {
     group_name: SubscriptionGroupName,
-    tx: async_channel::Sender<Envelope<T>>,
-    rx: async_channel::Receiver<Envelope<T>>,
+    tx: async_channel::Sender<QueuedEnvelope<T>>,
+    rx: async_channel::Receiver<QueuedEnvelope<T>>,
+    admission: Arc<Semaphore>,
 }
 
 pub(crate) enum BroadcastReadResult<T> {
@@ -79,6 +88,43 @@ impl WakerSet {
         for waker in wakers {
             waker.wake();
         }
+    }
+}
+
+fn send_queued_envelope<T>(
+    sender: &async_channel::Sender<QueuedEnvelope<T>>,
+    envelope: Envelope<T>,
+    permit: OwnedSemaphorePermit,
+) -> Result<(), Error> {
+    match sender.try_send(QueuedEnvelope {
+        envelope,
+        _admission_permit: permit,
+    }) {
+        Ok(()) => Ok(()),
+        Err(async_channel::TrySendError::Full(_)) => {
+            panic!("reserved topic admission permit should guarantee queue capacity")
+        }
+        Err(async_channel::TrySendError::Closed(_)) => Err(TopicClosed),
+    }
+}
+
+async fn acquire_balanced_permit(
+    admission: &Arc<Semaphore>,
+) -> Result<OwnedSemaphorePermit, Error> {
+    admission
+        .clone()
+        .acquire_owned()
+        .await
+        .map_err(|_| TopicClosed)
+}
+
+fn try_acquire_balanced_permit(
+    admission: &Arc<Semaphore>,
+) -> Result<Option<OwnedSemaphorePermit>, Error> {
+    match admission.clone().try_acquire_owned() {
+        Ok(permit) => Ok(Some(permit)),
+        Err(tokio::sync::TryAcquireError::NoPermits) => Ok(None),
+        Err(tokio::sync::TryAcquireError::Closed) => Err(TopicClosed),
     }
 }
 
@@ -353,12 +399,13 @@ impl<T: Send + Sync + 'static> BalancedOnlyTopic<T> {
 
         let id = self.next_message_id();
         if let Some(group) = self.group.get() {
+            let permit = acquire_balanced_permit(&group.admission).await?;
             let envelope = Envelope {
                 id,
                 tracked: false,
                 payload: msg,
             };
-            group.tx.send(envelope).await.map_err(|_| TopicClosed)?;
+            send_queued_envelope(&group.tx, envelope, permit)?;
         }
         Ok(id)
     }
@@ -374,23 +421,19 @@ impl<T: Send + Sync + 'static> BalancedOnlyTopic<T> {
         }
 
         let id = self.next_message_id();
-        let receipt = self.outcomes.register(id, timeout, permit);
         if let Some(group) = self.group.get() {
+            let admission_permit = acquire_balanced_permit(&group.admission).await?;
+            let receipt = self.outcomes.register(id, timeout, permit);
             let envelope = Envelope {
                 id,
                 tracked: true,
                 payload: msg,
             };
-            if group.tx.send(envelope).await.is_err() {
-                let discarded = self.outcomes.discard(id);
-                debug_assert!(
-                    discarded,
-                    "freshly registered tracked publish should still be discardable when balanced send fails"
-                );
-                return Err(TopicClosed);
-            }
+            send_queued_envelope(&group.tx, envelope, admission_permit)?;
+            Ok(receipt)
+        } else {
+            Ok(self.outcomes.register(id, timeout, permit))
         }
-        Ok(receipt)
     }
 
     fn try_publish(&self, msg: Arc<T>) -> Result<(PublishOutcome, u64), Error> {
@@ -400,18 +443,15 @@ impl<T: Send + Sync + 'static> BalancedOnlyTopic<T> {
 
         let id = self.next_message_id();
         if let Some(group) = self.group.get() {
+            let Some(permit) = try_acquire_balanced_permit(&group.admission)? else {
+                return Ok((PublishOutcome::DroppedOnFull, id));
+            };
             let envelope = Envelope {
                 id,
                 tracked: false,
                 payload: msg,
             };
-            match group.tx.try_send(envelope) {
-                Ok(()) => {}
-                Err(async_channel::TrySendError::Full(_)) => {
-                    return Ok((PublishOutcome::DroppedOnFull, id));
-                }
-                Err(async_channel::TrySendError::Closed(_)) => return Err(TopicClosed),
-            }
+            send_queued_envelope(&group.tx, envelope, permit)?;
         }
         Ok((PublishOutcome::Published, id))
     }
@@ -427,34 +467,23 @@ impl<T: Send + Sync + 'static> BalancedOnlyTopic<T> {
         }
 
         let id = self.next_message_id();
-        let receipt = self.outcomes.register(id, timeout, permit);
         if let Some(group) = self.group.get() {
+            let Some(admission_permit) = try_acquire_balanced_permit(&group.admission)? else {
+                return Ok(TrackedTryPublishOutcome::DroppedOnFull);
+            };
+            let receipt = self.outcomes.register(id, timeout, permit);
             let envelope = Envelope {
                 id,
                 tracked: true,
                 payload: msg,
             };
-            match group.tx.try_send(envelope) {
-                Ok(()) => {}
-                Err(async_channel::TrySendError::Full(_)) => {
-                    let discarded = self.outcomes.discard(id);
-                    debug_assert!(
-                        discarded,
-                        "freshly registered tracked publish should still be discardable when balanced try_send reports full"
-                    );
-                    return Ok(TrackedTryPublishOutcome::DroppedOnFull);
-                }
-                Err(async_channel::TrySendError::Closed(_)) => {
-                    let discarded = self.outcomes.discard(id);
-                    debug_assert!(
-                        discarded,
-                        "freshly registered tracked publish should still be discardable when balanced try_send reports closed"
-                    );
-                    return Err(TopicClosed);
-                }
-            }
+            send_queued_envelope(&group.tx, envelope, admission_permit)?;
+            Ok(TrackedTryPublishOutcome::Published(receipt))
+        } else {
+            Ok(TrackedTryPublishOutcome::Published(
+                self.outcomes.register(id, timeout, permit),
+            ))
         }
-        Ok(TrackedTryPublishOutcome::Published(receipt))
     }
 
     fn subscribe_balanced(
@@ -472,6 +501,7 @@ impl<T: Send + Sync + 'static> BalancedOnlyTopic<T> {
                 group_name: group.clone(),
                 tx,
                 rx,
+                admission: Arc::new(Semaphore::new(self.balanced_capacity)),
             }
         });
 
@@ -491,6 +521,7 @@ impl<T: Send + Sync + 'static> BalancedOnlyTopic<T> {
         self.closed.store(true, Ordering::Relaxed);
         self.outcomes.close_all();
         if let Some(group) = self.group.get() {
+            group.admission.close();
             let _ = group.tx.close();
         }
     }
@@ -579,10 +610,14 @@ impl<T: Send + Sync + 'static> BroadcastOnlyTopic<T> {
         let start_seq = self.broadcast_ring.current_seq() + 1;
         BroadcastSub {
             ring: Arc::clone(&self.broadcast_ring),
-            read_seq: start_seq,
+            cursor: Arc::new(Mutex::new(BroadcastCursor {
+                read_seq: start_seq,
+                leased_seq: None,
+                disconnected_on_lag: false,
+                spun: false,
+                lease_waiters: WakerSet::new(),
+            })),
             on_lag: self.broadcast_on_lag,
-            disconnected_on_lag: false,
-            spun: false,
             ack_state: AckState {
                 outcomes: self.outcomes.clone(),
             },
@@ -599,8 +634,8 @@ impl<T: Send + Sync + 'static> BroadcastOnlyTopic<T> {
 pub(crate) struct MixedTopic<T: Send + Sync + 'static> {
     name: TopicName,
     next_id: AtomicU64,
-    groups: RwLock<Vec<(SubscriptionGroupName, ConsumerGroup<T>)>>,
-    group_senders: RwLock<Arc<[async_channel::Sender<Envelope<T>>]>>,
+    groups: RwLock<Vec<(SubscriptionGroupName, Arc<ConsumerGroup<T>>)>>,
+    group_handles: RwLock<Arc<[Arc<ConsumerGroup<T>>]>>,
     has_balanced_groups: AtomicBool,
     balanced_capacity: usize,
     broadcast_ring: Arc<FastBroadcastRing<T>>,
@@ -620,7 +655,7 @@ impl<T: Send + Sync + 'static> MixedTopic<T> {
             name,
             next_id: AtomicU64::new(1),
             groups: RwLock::new(Vec::new()),
-            group_senders: RwLock::new(Arc::from(Vec::new())),
+            group_handles: RwLock::new(Arc::from(Vec::new())),
             has_balanced_groups: AtomicBool::new(false),
             balanced_capacity: balanced_capacity.max(1),
             broadcast_ring: Arc::new(FastBroadcastRing::new(broadcast_capacity)),
@@ -641,26 +676,27 @@ impl<T: Send + Sync + 'static> MixedTopic<T> {
         }
 
         let id = self.next_message_id();
-        self.broadcast_ring.publish(Envelope {
-            id,
-            tracked: false,
-            payload: Arc::clone(&msg),
-        });
-
         if self.has_balanced_groups.load(Ordering::Acquire) {
-            let senders = self.group_senders.read().clone();
+            let groups = self.group_handles.read().clone();
+            let mut permits = Vec::with_capacity(groups.len());
+            for group in groups.as_ref() {
+                permits.push(acquire_balanced_permit(&group.admission).await?);
+            }
             let envelope = Envelope {
                 id,
                 tracked: false,
                 payload: Arc::clone(&msg),
             };
-            for sender in senders.as_ref() {
-                sender
-                    .send(envelope.clone())
-                    .await
-                    .map_err(|_| TopicClosed)?;
+            for (group, permit) in groups.as_ref().iter().zip(permits.into_iter()) {
+                send_queued_envelope(&group.tx, envelope.clone(), permit)?;
             }
         }
+
+        self.broadcast_ring.publish(Envelope {
+            id,
+            tracked: false,
+            payload: Arc::clone(&msg),
+        });
 
         Ok(id)
     }
@@ -676,35 +712,36 @@ impl<T: Send + Sync + 'static> MixedTopic<T> {
         }
 
         let id = self.next_message_id();
-        let receipt = self.outcomes.register(id, timeout, permit);
-        self.broadcast_ring.publish(Envelope {
-            id,
-            tracked: true,
-            payload: Arc::clone(&msg),
-        });
-
         if self.has_balanced_groups.load(Ordering::Acquire) {
-            let senders = self.group_senders.read().clone();
+            let groups = self.group_handles.read().clone();
+            let mut permits = Vec::with_capacity(groups.len());
+            for group in groups.as_ref() {
+                permits.push(acquire_balanced_permit(&group.admission).await?);
+            }
+            let receipt = self.outcomes.register(id, timeout, permit);
             let envelope = Envelope {
                 id,
                 tracked: true,
                 payload: Arc::clone(&msg),
             };
-            for sender in senders.as_ref() {
-                if sender.send(envelope.clone()).await.is_err() {
-                    let resolved = self
-                        .outcomes
-                        .resolve(id, TrackedPublishOutcome::TopicClosed);
-                    debug_assert!(
-                        resolved,
-                        "freshly registered tracked publish should still resolve when mixed balanced send fails"
-                    );
-                    return Err(TopicClosed);
-                }
+            for (group, admission_permit) in groups.as_ref().iter().zip(permits.into_iter()) {
+                send_queued_envelope(&group.tx, envelope.clone(), admission_permit)?;
             }
+            self.broadcast_ring.publish(Envelope {
+                id,
+                tracked: true,
+                payload: Arc::clone(&msg),
+            });
+            Ok(receipt)
+        } else {
+            let receipt = self.outcomes.register(id, timeout, permit);
+            self.broadcast_ring.publish(Envelope {
+                id,
+                tracked: true,
+                payload: Arc::clone(&msg),
+            });
+            Ok(receipt)
         }
-
-        Ok(receipt)
     }
 
     fn try_publish(&self, msg: Arc<T>) -> Result<(PublishOutcome, u64), Error> {
@@ -723,24 +760,30 @@ impl<T: Send + Sync + 'static> MixedTopic<T> {
             return Ok((PublishOutcome::Published, id));
         }
 
-        let senders = self.group_senders.read().clone();
+        let groups = self.group_handles.read().clone();
         let envelope = Envelope {
             id,
             tracked: false,
             payload: Arc::clone(&msg),
         };
         let mut dropped_on_full = false;
-        for sender in senders.as_ref() {
-            match sender.try_send(envelope.clone()) {
-                Ok(()) => {}
-                Err(async_channel::TrySendError::Full(_)) => dropped_on_full = true,
-                Err(async_channel::TrySendError::Closed(_)) => return Err(TopicClosed),
+        let mut permits = Vec::with_capacity(groups.len());
+        for group in groups.as_ref() {
+            match try_acquire_balanced_permit(&group.admission)? {
+                Some(permit) => permits.push(permit),
+                None => {
+                    dropped_on_full = true;
+                    break;
+                }
             }
         }
 
         if dropped_on_full {
             Ok((PublishOutcome::DroppedOnFull, id))
         } else {
+            for (group, permit) in groups.as_ref().iter().zip(permits.into_iter()) {
+                send_queued_envelope(&group.tx, envelope.clone(), permit)?;
+            }
             Ok((PublishOutcome::Published, id))
         }
     }
@@ -756,44 +799,39 @@ impl<T: Send + Sync + 'static> MixedTopic<T> {
         }
 
         let id = self.next_message_id();
-        let receipt = self.outcomes.register(id, timeout, permit);
-
         if self.has_balanced_groups.load(Ordering::Acquire) {
-            let senders = self.group_senders.read().clone();
+            let groups = self.group_handles.read().clone();
+            let mut permits = Vec::with_capacity(groups.len());
+            for group in groups.as_ref() {
+                match try_acquire_balanced_permit(&group.admission)? {
+                    Some(permit) => permits.push(permit),
+                    None => return Ok(TrackedTryPublishOutcome::DroppedOnFull),
+                }
+            }
+            let receipt = self.outcomes.register(id, timeout, permit);
             let envelope = Envelope {
                 id,
                 tracked: true,
                 payload: Arc::clone(&msg),
             };
-            for sender in senders.as_ref() {
-                match sender.try_send(envelope.clone()) {
-                    Ok(()) => {}
-                    Err(async_channel::TrySendError::Full(_)) => {
-                        let discarded = self.outcomes.discard(id);
-                        debug_assert!(
-                            discarded,
-                            "freshly registered tracked publish should still be discardable when mixed balanced try_send reports full"
-                        );
-                        return Ok(TrackedTryPublishOutcome::DroppedOnFull);
-                    }
-                    Err(async_channel::TrySendError::Closed(_)) => {
-                        let discarded = self.outcomes.discard(id);
-                        debug_assert!(
-                            discarded,
-                            "freshly registered tracked publish should still be discardable when mixed balanced try_send reports closed"
-                        );
-                        return Err(TopicClosed);
-                    }
-                }
+            for (group, admission_permit) in groups.as_ref().iter().zip(permits.into_iter()) {
+                send_queued_envelope(&group.tx, envelope.clone(), admission_permit)?;
             }
+            self.broadcast_ring.publish(Envelope {
+                id,
+                tracked: true,
+                payload: msg,
+            });
+            Ok(TrackedTryPublishOutcome::Published(receipt))
+        } else {
+            let receipt = self.outcomes.register(id, timeout, permit);
+            self.broadcast_ring.publish(Envelope {
+                id,
+                tracked: true,
+                payload: msg,
+            });
+            Ok(TrackedTryPublishOutcome::Published(receipt))
         }
-
-        self.broadcast_ring.publish(Envelope {
-            id,
-            tracked: true,
-            payload: msg,
-        });
-        Ok(TrackedTryPublishOutcome::Published(receipt))
     }
 
     fn subscribe_balanced(
@@ -811,13 +849,18 @@ impl<T: Send + Sync + 'static> MixedTopic<T> {
                 group_entry.rx.clone()
             } else {
                 let (tx, rx) = async_channel::bounded(self.balanced_capacity);
-                groups.push((group.clone(), ConsumerGroup { tx, rx: rx.clone() }));
-                let snapshot: Arc<[async_channel::Sender<Envelope<T>>]> = groups
+                let group_entry = Arc::new(ConsumerGroup {
+                    tx,
+                    rx: rx.clone(),
+                    admission: Arc::new(Semaphore::new(self.balanced_capacity)),
+                });
+                groups.push((group.clone(), Arc::clone(&group_entry)));
+                let snapshot: Arc<[Arc<ConsumerGroup<T>>]> = groups
                     .iter()
-                    .map(|(_, group_entry)| group_entry.tx.clone())
+                    .map(|(_, group_entry)| Arc::clone(group_entry))
                     .collect::<Vec<_>>()
                     .into();
-                *self.group_senders.write() = snapshot;
+                *self.group_handles.write() = snapshot;
                 self.has_balanced_groups.store(true, Ordering::Release);
                 rx
             }
@@ -835,10 +878,14 @@ impl<T: Send + Sync + 'static> MixedTopic<T> {
         let start_seq = self.broadcast_ring.current_seq() + 1;
         BroadcastSub {
             ring: Arc::clone(&self.broadcast_ring),
-            read_seq: start_seq,
+            cursor: Arc::new(Mutex::new(BroadcastCursor {
+                read_seq: start_seq,
+                leased_seq: None,
+                disconnected_on_lag: false,
+                spun: false,
+                lease_waiters: WakerSet::new(),
+            })),
             on_lag: self.broadcast_on_lag,
-            disconnected_on_lag: false,
-            spun: false,
             ack_state: AckState {
                 outcomes: self.outcomes.clone(),
             },
@@ -848,9 +895,10 @@ impl<T: Send + Sync + 'static> MixedTopic<T> {
     fn close(&self) {
         self.closed.store(true, Ordering::Relaxed);
         self.outcomes.close_all();
-        let senders = self.group_senders.read().clone();
-        for sender in senders.as_ref() {
-            let _ = sender.close();
+        let groups = self.group_handles.read().clone();
+        for group in groups.as_ref() {
+            group.admission.close();
+            let _ = group.tx.close();
         }
         self.has_balanced_groups.store(false, Ordering::Release);
         self.broadcast_ring.close();
@@ -858,14 +906,19 @@ impl<T: Send + Sync + 'static> MixedTopic<T> {
 }
 
 pub(crate) struct BalancedSub<T: Send + Sync + 'static> {
-    rx: Pin<Box<async_channel::Receiver<Envelope<T>>>>,
+    rx: Pin<Box<async_channel::Receiver<QueuedEnvelope<T>>>>,
     ack_state: AckState,
 }
 
 impl<T: Send + Sync + 'static> SubscriptionBackend<T> for BalancedSub<T> {
-    fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Result<RecvItem<T>, Error>> {
+    fn poll_recv_delivery(&mut self, cx: &mut Context<'_>) -> Poll<Result<RecvDelivery<T>, Error>> {
         match self.rx.as_mut().poll_next(cx) {
-            Poll::Ready(Some(envelope)) => Poll::Ready(Ok(RecvItem::Message(envelope))),
+            Poll::Ready(Some(queued)) => {
+                Poll::Ready(Ok(RecvDelivery::Message(Delivery::new_in_memory(
+                    queued.envelope,
+                    InMemoryDeliveryFinalizer::balanced(self.ack_state.clone()),
+                ))))
+            }
             Poll::Ready(None) => Poll::Ready(Err(SubscriptionClosed)),
             Poll::Pending => Poll::Pending,
         }
@@ -882,69 +935,60 @@ impl<T: Send + Sync + 'static> SubscriptionBackend<T> for BalancedSub<T> {
 
 pub(crate) struct BroadcastSub<T: Send + Sync + 'static> {
     ring: Arc<FastBroadcastRing<T>>,
-    read_seq: u64,
+    cursor: Arc<Mutex<BroadcastCursor>>,
     on_lag: TopicBroadcastOnLagPolicy,
-    disconnected_on_lag: bool,
-    spun: bool,
     ack_state: AckState,
 }
 
 impl<T: Send + Sync + 'static> SubscriptionBackend<T> for BroadcastSub<T> {
-    fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Result<RecvItem<T>, Error>> {
-        if self.disconnected_on_lag {
-            return Poll::Ready(Err(SubscriptionClosed));
-        }
-
-        match self.ring.try_read(self.read_seq) {
-            BroadcastReadResult::Ready(envelope) => {
-                self.read_seq += 1;
-                self.spun = false;
-                return Poll::Ready(Ok(RecvItem::Message(envelope)));
+    fn poll_recv_delivery(&mut self, cx: &mut Context<'_>) -> Poll<Result<RecvDelivery<T>, Error>> {
+        {
+            let cursor = self.cursor.lock();
+            if cursor.disconnected_on_lag {
+                return Poll::Ready(Err(SubscriptionClosed));
             }
-            BroadcastReadResult::Lagged {
-                missed,
-                new_read_seq,
-            } => return Poll::Ready(Ok(self.handle_lag(missed, new_read_seq))),
-            BroadcastReadResult::NotReady => {}
+            if cursor.leased_seq.is_some() {
+                cursor.lease_waiters.register(cx.waker());
+                return Poll::Pending;
+            }
         }
 
-        if !self.spun {
-            self.spun = true;
+        if let Some(result) = self.try_read_delivery() {
+            return Poll::Ready(result);
+        }
+
+        let should_spin = {
+            let mut cursor = self.cursor.lock();
+            if cursor.spun {
+                false
+            } else {
+                cursor.spun = true;
+                true
+            }
+        };
+
+        if should_spin {
             for _ in 0..32 {
                 std::hint::spin_loop();
-                if self.ring.current_seq() >= self.read_seq {
-                    match self.ring.try_read(self.read_seq) {
-                        BroadcastReadResult::Ready(envelope) => {
-                            self.read_seq += 1;
-                            self.spun = false;
-                            return Poll::Ready(Ok(RecvItem::Message(envelope)));
-                        }
-                        BroadcastReadResult::Lagged {
-                            missed,
-                            new_read_seq,
-                        } => return Poll::Ready(Ok(self.handle_lag(missed, new_read_seq))),
-                        BroadcastReadResult::NotReady => {}
-                    }
+                if let Some(result) = self.try_read_delivery() {
+                    return Poll::Ready(result);
                 }
             }
         }
 
         self.ring.register_waker(cx.waker());
+        {
+            let cursor = self.cursor.lock();
+            if cursor.leased_seq.is_some() {
+                cursor.lease_waiters.register(cx.waker());
+                return Poll::Pending;
+            }
+        }
 
-        match self.ring.try_read(self.read_seq) {
-            BroadcastReadResult::Ready(envelope) => {
-                self.read_seq += 1;
-                self.spun = false;
-                Poll::Ready(Ok(RecvItem::Message(envelope)))
-            }
-            BroadcastReadResult::Lagged {
-                missed,
-                new_read_seq,
-            } => Poll::Ready(Ok(self.handle_lag(missed, new_read_seq))),
-            BroadcastReadResult::NotReady if self.ring.is_closed() => {
-                Poll::Ready(Err(SubscriptionClosed))
-            }
-            BroadcastReadResult::NotReady => Poll::Pending,
+        match self.try_read_delivery() {
+            Some(result) => Poll::Ready(result),
+            None if self.ring.is_closed() => Poll::Ready(Err(SubscriptionClosed)),
+            None => Poll::Pending,
         }
     }
 
@@ -958,16 +1002,169 @@ impl<T: Send + Sync + 'static> SubscriptionBackend<T> for BroadcastSub<T> {
 }
 
 impl<T: Send + Sync + 'static> BroadcastSub<T> {
-    fn handle_lag(&mut self, missed: u64, new_read_seq: u64) -> RecvItem<T> {
-        self.read_seq = new_read_seq;
-        self.spun = false;
-        if self.on_lag == TopicBroadcastOnLagPolicy::Disconnect {
-            self.disconnected_on_lag = true;
+    fn try_read_delivery(&self) -> Option<Result<RecvDelivery<T>, Error>> {
+        let read_seq = {
+            let cursor = self.cursor.lock();
+            if cursor.disconnected_on_lag || cursor.leased_seq.is_some() {
+                return None;
+            }
+            cursor.read_seq
+        };
+
+        match self.ring.try_read(read_seq) {
+            BroadcastReadResult::Ready(envelope) => {
+                let mut cursor = self.cursor.lock();
+                if cursor.disconnected_on_lag || cursor.leased_seq.is_some() {
+                    return None;
+                }
+                cursor.leased_seq = Some(read_seq);
+                cursor.spun = false;
+                Some(Ok(RecvDelivery::Message(Delivery::new_in_memory(
+                    envelope,
+                    InMemoryDeliveryFinalizer::broadcast(
+                        read_seq,
+                        Arc::clone(&self.cursor),
+                        self.ack_state.clone(),
+                    ),
+                ))))
+            }
+            BroadcastReadResult::Lagged {
+                missed,
+                new_read_seq,
+            } => {
+                let mut cursor = self.cursor.lock();
+                cursor.read_seq = new_read_seq;
+                cursor.spun = false;
+                if self.on_lag == TopicBroadcastOnLagPolicy::Disconnect {
+                    cursor.disconnected_on_lag = true;
+                }
+                Some(Ok(RecvDelivery::Lagged { missed }))
+            }
+            BroadcastReadResult::NotReady => None,
         }
-        RecvItem::Lagged { missed }
     }
 }
 
+pub(crate) struct BroadcastCursor {
+    read_seq: u64,
+    leased_seq: Option<u64>,
+    disconnected_on_lag: bool,
+    spun: bool,
+    lease_waiters: WakerSet,
+}
+
+fn finish_broadcast_delivery(cursor: &Arc<Mutex<BroadcastCursor>>, seq: u64) {
+    let mut cursor = cursor.lock();
+    if cursor.leased_seq == Some(seq) {
+        cursor.read_seq = seq + 1;
+        cursor.leased_seq = None;
+        cursor.spun = false;
+        cursor.lease_waiters.wake_all();
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InMemoryDeliveryKind {
+    Balanced,
+    Broadcast,
+}
+
+pub(crate) enum InMemoryDeliveryFinalizer {
+    Balanced {
+        ack_state: AckState,
+    },
+    Broadcast {
+        seq: u64,
+        cursor: Arc<Mutex<BroadcastCursor>>,
+        ack_state: AckState,
+    },
+}
+
+impl InMemoryDeliveryFinalizer {
+    pub(crate) fn balanced(ack_state: AckState) -> Self {
+        Self::Balanced { ack_state }
+    }
+
+    pub(crate) fn broadcast(
+        seq: u64,
+        cursor: Arc<Mutex<BroadcastCursor>>,
+        ack_state: AckState,
+    ) -> Self {
+        Self::Broadcast {
+            seq,
+            cursor,
+            ack_state,
+        }
+    }
+
+    pub(crate) fn commit(&mut self) {
+        if let Self::Broadcast { seq, cursor, .. } = self {
+            finish_broadcast_delivery(cursor, *seq);
+        }
+    }
+
+    pub(crate) fn abort<T: Send + Sync + 'static>(
+        &mut self,
+        envelope: &Envelope<T>,
+        reason: Arc<str>,
+    ) -> Result<(), Error> {
+        match self {
+            Self::Balanced { ack_state } => {
+                if envelope.tracked {
+                    _ = ack_state.send_nack(envelope.id, reason);
+                }
+            }
+            Self::Broadcast {
+                seq,
+                cursor,
+                ack_state,
+            } => {
+                if envelope.tracked {
+                    _ = ack_state.send_nack(envelope.id, reason);
+                }
+                finish_broadcast_delivery(cursor, *seq);
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn abandon<T: Send + Sync + 'static>(&mut self, envelope: &Envelope<T>) {
+        match self {
+            Self::Balanced { ack_state } => {
+                if envelope.tracked {
+                    _ = ack_state.send_nack(
+                        envelope.id,
+                        Arc::<str>::from("topic delivery abandoned before forward"),
+                    );
+                }
+            }
+            Self::Broadcast {
+                seq,
+                cursor,
+                ack_state,
+            } => {
+                if envelope.tracked {
+                    _ = ack_state.send_nack(
+                        envelope.id,
+                        Arc::<str>::from("topic delivery abandoned before forward"),
+                    );
+                }
+                finish_broadcast_delivery(cursor, *seq);
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn kind(&self) -> InMemoryDeliveryKind {
+        match self {
+            Self::Balanced { .. } => InMemoryDeliveryKind::Balanced,
+            Self::Broadcast { .. } => InMemoryDeliveryKind::Broadcast,
+        }
+    }
+}
+
+#[derive(Clone)]
 pub(crate) struct AckState {
     pub(crate) outcomes: TrackedPublishTracker,
 }

--- a/rust/otap-dataflow/crates/engine/src/topic/topic.rs
+++ b/rust/otap-dataflow/crates/engine/src/topic/topic.rs
@@ -24,6 +24,7 @@ use futures_core::Stream;
 use otap_df_config::topic::TopicBroadcastOnLagPolicy;
 use otap_df_config::{SubscriptionGroupName, TopicName};
 use parking_lot::{Mutex, RwLock};
+use smallvec::SmallVec;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 struct QueuedEnvelope<T> {
@@ -127,6 +128,8 @@ fn try_acquire_balanced_permit(
         Err(tokio::sync::TryAcquireError::Closed) => Err(TopicClosed),
     }
 }
+
+type BalancedPermitVec = SmallVec<[OwnedSemaphorePermit; 4]>;
 
 pub(crate) struct FastBroadcastRing<T: Send + Sync + 'static> {
     slots: Box<[Mutex<Option<(u64, Envelope<T>)>>]>,
@@ -362,6 +365,24 @@ impl<T: Send + Sync + 'static> TopicState<T> for TopicInner<T> {
             TopicInner::BalancedOnly(topic) => topic.close(),
             TopicInner::BroadcastOnly(topic) => topic.close(),
             TopicInner::Mixed(topic) => topic.close(),
+        }
+    }
+
+    #[cfg(test)]
+    fn debug_balanced_available_permits(&self) -> Vec<(SubscriptionGroupName, usize)> {
+        match self {
+            TopicInner::BalancedOnly(topic) => topic
+                .group
+                .get()
+                .map(|group| {
+                    vec![(
+                        group.group_name.clone(),
+                        group.admission.available_permits(),
+                    )]
+                })
+                .unwrap_or_default(),
+            TopicInner::BroadcastOnly(_) => Vec::new(),
+            TopicInner::Mixed(topic) => topic.balanced_available_permits(),
         }
     }
 }
@@ -670,6 +691,47 @@ impl<T: Send + Sync + 'static> MixedTopic<T> {
         self.next_id.fetch_add(1, Ordering::Relaxed)
     }
 
+    // Acquire balanced-group capacity atomically from the publisher's point of
+    // view: if one group is full, drop any partial acquisitions before waiting
+    // and retry from a fresh mixed-topic snapshot.
+    async fn acquire_balanced_admission(
+        &self,
+    ) -> Result<(Arc<[Arc<ConsumerGroup<T>>]>, BalancedPermitVec), Error> {
+        loop {
+            let groups = self.group_handles.read().clone();
+            let (permits, blocking_group) = Self::try_acquire_balanced_admission(&groups)?;
+            if let Some(group) = blocking_group {
+                drop(permits);
+                let permit = acquire_balanced_permit(&group.admission).await?;
+                drop(permit);
+            } else {
+                return Ok((groups, permits));
+            }
+        }
+    }
+
+    fn try_acquire_balanced_admission(
+        groups: &Arc<[Arc<ConsumerGroup<T>>]>,
+    ) -> Result<(BalancedPermitVec, Option<Arc<ConsumerGroup<T>>>), Error> {
+        let mut permits = BalancedPermitVec::with_capacity(groups.len());
+        for group in groups.as_ref() {
+            match try_acquire_balanced_permit(&group.admission)? {
+                Some(permit) => permits.push(permit),
+                None => return Ok((permits, Some(Arc::clone(group)))),
+            }
+        }
+        Ok((permits, None))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn balanced_available_permits(&self) -> Vec<(SubscriptionGroupName, usize)> {
+        self.groups
+            .read()
+            .iter()
+            .map(|(name, group)| (name.clone(), group.admission.available_permits()))
+            .collect()
+    }
+
     async fn publish(&self, msg: Arc<T>) -> Result<u64, Error> {
         if self.closed.load(Ordering::Relaxed) {
             return Err(TopicClosed);
@@ -677,11 +739,7 @@ impl<T: Send + Sync + 'static> MixedTopic<T> {
 
         let id = self.next_message_id();
         if self.has_balanced_groups.load(Ordering::Acquire) {
-            let groups = self.group_handles.read().clone();
-            let mut permits = Vec::with_capacity(groups.len());
-            for group in groups.as_ref() {
-                permits.push(acquire_balanced_permit(&group.admission).await?);
-            }
+            let (groups, permits) = self.acquire_balanced_admission().await?;
             let envelope = Envelope {
                 id,
                 tracked: false,
@@ -713,11 +771,7 @@ impl<T: Send + Sync + 'static> MixedTopic<T> {
 
         let id = self.next_message_id();
         if self.has_balanced_groups.load(Ordering::Acquire) {
-            let groups = self.group_handles.read().clone();
-            let mut permits = Vec::with_capacity(groups.len());
-            for group in groups.as_ref() {
-                permits.push(acquire_balanced_permit(&group.admission).await?);
-            }
+            let (groups, permits) = self.acquire_balanced_admission().await?;
             let receipt = self.outcomes.register(id, timeout, permit);
             let envelope = Envelope {
                 id,
@@ -750,13 +804,12 @@ impl<T: Send + Sync + 'static> MixedTopic<T> {
         }
 
         let id = self.next_message_id();
-        self.broadcast_ring.publish(Envelope {
-            id,
-            tracked: false,
-            payload: Arc::clone(&msg),
-        });
-
         if !self.has_balanced_groups.load(Ordering::Acquire) {
+            self.broadcast_ring.publish(Envelope {
+                id,
+                tracked: false,
+                payload: Arc::clone(&msg),
+            });
             return Ok((PublishOutcome::Published, id));
         }
 
@@ -766,24 +819,18 @@ impl<T: Send + Sync + 'static> MixedTopic<T> {
             tracked: false,
             payload: Arc::clone(&msg),
         };
-        let mut dropped_on_full = false;
-        let mut permits = Vec::with_capacity(groups.len());
-        for group in groups.as_ref() {
-            match try_acquire_balanced_permit(&group.admission)? {
-                Some(permit) => permits.push(permit),
-                None => {
-                    dropped_on_full = true;
-                    break;
-                }
-            }
-        }
-
-        if dropped_on_full {
+        let (permits, blocking_group) = Self::try_acquire_balanced_admission(&groups)?;
+        if blocking_group.is_some() {
             Ok((PublishOutcome::DroppedOnFull, id))
         } else {
             for (group, permit) in groups.as_ref().iter().zip(permits.into_iter()) {
                 send_queued_envelope(&group.tx, envelope.clone(), permit)?;
             }
+            self.broadcast_ring.publish(Envelope {
+                id,
+                tracked: false,
+                payload: Arc::clone(&msg),
+            });
             Ok((PublishOutcome::Published, id))
         }
     }
@@ -801,12 +848,9 @@ impl<T: Send + Sync + 'static> MixedTopic<T> {
         let id = self.next_message_id();
         if self.has_balanced_groups.load(Ordering::Acquire) {
             let groups = self.group_handles.read().clone();
-            let mut permits = Vec::with_capacity(groups.len());
-            for group in groups.as_ref() {
-                match try_acquire_balanced_permit(&group.admission)? {
-                    Some(permit) => permits.push(permit),
-                    None => return Ok(TrackedTryPublishOutcome::DroppedOnFull),
-                }
+            let (permits, blocking_group) = Self::try_acquire_balanced_admission(&groups)?;
+            if blocking_group.is_some() {
+                return Ok(TrackedTryPublishOutcome::DroppedOnFull);
             }
             let receipt = self.outcomes.register(id, timeout, permit);
             let envelope = Envelope {

--- a/rust/otap-dataflow/crates/engine/src/topic/topic.rs
+++ b/rust/otap-dataflow/crates/engine/src/topic/topic.rs
@@ -633,10 +633,10 @@ impl<T: Send + Sync + 'static> BroadcastOnlyTopic<T> {
             ring: Arc::clone(&self.broadcast_ring),
             cursor: Arc::new(Mutex::new(BroadcastCursor {
                 read_seq: start_seq,
-                leased_seq: None,
+                permitted_seq: None,
                 disconnected_on_lag: false,
                 spun: false,
-                lease_waiters: WakerSet::new(),
+                permit_waiters: WakerSet::new(),
             })),
             on_lag: self.broadcast_on_lag,
             ack_state: AckState {
@@ -924,10 +924,10 @@ impl<T: Send + Sync + 'static> MixedTopic<T> {
             ring: Arc::clone(&self.broadcast_ring),
             cursor: Arc::new(Mutex::new(BroadcastCursor {
                 read_seq: start_seq,
-                leased_seq: None,
+                permitted_seq: None,
                 disconnected_on_lag: false,
                 spun: false,
-                lease_waiters: WakerSet::new(),
+                permit_waiters: WakerSet::new(),
             })),
             on_lag: self.broadcast_on_lag,
             ack_state: AckState {
@@ -991,8 +991,8 @@ impl<T: Send + Sync + 'static> SubscriptionBackend<T> for BroadcastSub<T> {
             if cursor.disconnected_on_lag {
                 return Poll::Ready(Err(SubscriptionClosed));
             }
-            if cursor.leased_seq.is_some() {
-                cursor.lease_waiters.register(cx.waker());
+            if cursor.permitted_seq.is_some() {
+                cursor.permit_waiters.register(cx.waker());
                 return Poll::Pending;
             }
         }
@@ -1023,8 +1023,8 @@ impl<T: Send + Sync + 'static> SubscriptionBackend<T> for BroadcastSub<T> {
         self.ring.register_waker(cx.waker());
         {
             let cursor = self.cursor.lock();
-            if cursor.leased_seq.is_some() {
-                cursor.lease_waiters.register(cx.waker());
+            if cursor.permitted_seq.is_some() {
+                cursor.permit_waiters.register(cx.waker());
                 return Poll::Pending;
             }
         }
@@ -1049,7 +1049,7 @@ impl<T: Send + Sync + 'static> BroadcastSub<T> {
     fn try_read_delivery(&self) -> Option<Result<RecvDelivery<T>, Error>> {
         let read_seq = {
             let cursor = self.cursor.lock();
-            if cursor.disconnected_on_lag || cursor.leased_seq.is_some() {
+            if cursor.disconnected_on_lag || cursor.permitted_seq.is_some() {
                 return None;
             }
             cursor.read_seq
@@ -1058,10 +1058,10 @@ impl<T: Send + Sync + 'static> BroadcastSub<T> {
         match self.ring.try_read(read_seq) {
             BroadcastReadResult::Ready(envelope) => {
                 let mut cursor = self.cursor.lock();
-                if cursor.disconnected_on_lag || cursor.leased_seq.is_some() {
+                if cursor.disconnected_on_lag || cursor.permitted_seq.is_some() {
                     return None;
                 }
-                cursor.leased_seq = Some(read_seq);
+                cursor.permitted_seq = Some(read_seq);
                 cursor.spun = false;
                 Some(Ok(RecvDelivery::Message(Delivery::new_in_memory(
                     envelope,
@@ -1091,19 +1091,19 @@ impl<T: Send + Sync + 'static> BroadcastSub<T> {
 
 pub(crate) struct BroadcastCursor {
     read_seq: u64,
-    leased_seq: Option<u64>,
+    permitted_seq: Option<u64>,
     disconnected_on_lag: bool,
     spun: bool,
-    lease_waiters: WakerSet,
+    permit_waiters: WakerSet,
 }
 
 fn finish_broadcast_delivery(cursor: &Arc<Mutex<BroadcastCursor>>, seq: u64) {
     let mut cursor = cursor.lock();
-    if cursor.leased_seq == Some(seq) {
+    if cursor.permitted_seq == Some(seq) {
         cursor.read_seq = seq + 1;
-        cursor.leased_seq = None;
+        cursor.permitted_seq = None;
         cursor.spun = false;
-        cursor.lease_waiters.wake_all();
+        cursor.permit_waiters.wake_all();
     }
 }
 

--- a/rust/otap-dataflow/crates/engine/src/topic/types.rs
+++ b/rust/otap-dataflow/crates/engine/src/topic/types.rs
@@ -54,8 +54,9 @@ pub enum PublishOutcome {
     Published,
     /// Message was dropped because at least one balanced queue was full.
     ///
-    /// For mixed topics, broadcast delivery may still succeed even when this
-    /// outcome is returned.
+    /// In mixed topics, `try_publish` is all-or-nothing: returning this
+    /// outcome means the message was not published to either the balanced or
+    /// broadcast side.
     DroppedOnFull,
 }
 


### PR DESCRIPTION
## Change Summary

This PR extracts the topic-runtime fixes and refactorings from the larger live-reconfiguration branch into a standalone change.

The core design decision in this PR is to move topic-specific waiting and delivery semantics back into the topic runtime instead of emulating them in the topic receiver and topic exporter. Before this change, the node layer carried its own retry/wait loops to handle blocked publish, downstream backpressure, and shutdown/drain behavior. **That made shutdown under load fragile and allowed topic semantics to diverge across code paths**.

Concretely, this PR does four things:

1. It makes the topic runtime own blocked publish waiting.
   - `publish(...)` / `publish_tracked(...)` now wait inside the topic implementation instead of relying on node-side polling loops.
   - This removes the old timer-driven retry behavior from the topic exporter hot path and keeps `queue_on_full: block` wake-driven and shutdown-responsive.

2. It introduces delivery leases on the subscribe side and uses them in the topic receiver.
   - The receiver now distinguishes “the topic produced a message” from “the receiver successfully handed it downstream”.
   - That allows `DrainIngress` to stop polling the topic immediately while still waiting for already-forwarded tracked messages to reach their terminal Ack/Nack outcome.
   - This fixes the previous shutdown bug where the topic receiver could report drained state while continuing to run under load.

3. It tightens mixed-topic semantics so publish behavior is consistent across code paths.
   - Mixed `try_publish` is now all-or-nothing across balanced and broadcast delivery.
   - If balanced delivery cannot admit a message, broadcast subscribers do not receive it either.
   - Mixed async publish was also changed to avoid holding balanced-group permits while waiting on another full group, which removes the previous partial-permit convoy behavior.

4. It keeps the refactor performance-oriented rather than purely structural.
   - The topic receiver/exporter fast paths still try immediate forward/publish first.
   - The in-memory delivery-lease path now uses specialized inline storage instead of per-message boxing on the common path.
   - The opaque fallback is still preserved for future non-in-memory backends, but the in-memory backend no longer pays that allocation cost per delivered message.

**This PR does not add new public routes, config knobs, or admin APIs.** The existing topic publish/subscribe APIs remain source-compatible; the main changes are semantic correctness under backpressure/shutdown and simplification of where the waiting logic lives.

## What issue does this PR close?

* Closes [#2630](https://github.com/open-telemetry/otel-arrow/issues/2630)

## How are these changes tested?

- `cargo xtask check`

Key topic/runtime guarantees covered by tests:
- Balanced topics deliver each message exactly once within a subscriber group.
- Balanced topics preserve per-subscriber ordering.
- Broadcast topics deliver all messages to all subscribers in order.
- Broadcast lag handling is isolated to the lagging subscriber and does not block healthy subscribers.
- Mixed async publish does not expose a message to broadcast subscribers before balanced admission succeeds.
- Mixed `try_publish` is all-or-nothing: if balanced admission fails, broadcast delivery does not happen.
- Mixed async publish does not reserve permits in unrelated balanced groups while waiting on a full group.
- Dropping a blocked mixed publish does not leak a partial broadcast delivery.
- Blocking tracked publish does not leak in-flight capacity when canceled.
- Delivery leases preserve tracked message outcome semantics, including abort-to-nack behavior.
- The in-memory delivery lease fast path uses specialized inline storage, while the opaque fallback path still works.
- Topic receiver `DrainIngress` exits promptly when Ack/Nack propagation is disabled.
- Topic receiver `DrainIngress` waits for already-forwarded tracked work to complete when Ack/Nack propagation is enabled.
- Topic receiver drain can interrupt a blocked downstream forward without hanging shutdown.
- Topic exporter shutdown interrupts blocked untracked publish under `queue_on_full: block`.
- Topic exporter shutdown interrupts blocked tracked publish under `queue_on_full: block`.
- Topic exporter shutdown force-resolves buffered in-flight pdata it still owns instead of hanging.
- End-to-end topic exporter -> topic receiver flow still transfers pdata correctly.
- End-to-end topic receiver source tagging still works when enabled.

In addition, this topic work was exercised in the larger live-reconfiguration branch against the scenario that originally exposed the shutdown issue (`topic_multitenant_isolation.yaml`), including replace rollout, per-pipeline shutdown, and group shutdown flows.

## Are there any user-facing changes?

Yes.

- Topic-based pipelines shut down more reliably under backpressure.
- Topic receiver drain behavior is now stricter and better aligned with Ack/Nack propagation semantics.
- Mixed-topic publish is now all-or-nothing across balanced and broadcast delivery.
- There are no new public APIs, config knobs, or route changes in this PR.