### PR TITLE
[CI] Fix binary size display

### DIFF
--- a/.github/workflows/dataflow-engine-binary-size.yml
+++ b/.github/workflows/dataflow-engine-binary-size.yml
@@ -104,9 +104,8 @@ jobs:
           echo "|----------|------|"
           for json in all-reports/*.json; do
             PLATFORM=$(jq -r '.[0].name' "$json" | sed 's/-binary-size//')
-            SIZE_BYTES=$(jq -r '.[0].value' "$json")
-            SIZE_HR=$(numfmt --to=iec-i --suffix=B $SIZE_BYTES)
-            echo "| $PLATFORM | $SIZE_HR |"
+            SIZE_MB=$(jq -r '.[0].value' "$json")
+            echo "| $PLATFORM | ${SIZE_MB} MB |"
           done
 
       - name: Update binary size benchmarks


### PR DESCRIPTION
# Change Summary

Follow-up to #1689 

- The JSON report stores the value in MB, but the summary step was passing it to `numfmt` as if it were bytes, causing the display to show `102B` instead of `102 MB`.