### PR TITLE
Support function calls where args have differing row orders

### DIFF
--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
@@ -1198,6 +1198,11 @@ fn validate_attribute_assign_cardinality(
             validate_attribute_assign_cardinality(dest_attrs_id, dest_query_location, left)?;
             validate_attribute_assign_cardinality(dest_attrs_id, dest_query_location, right)?;
         }
+        LogicalExprDataSource::MultiJoin(children) => {
+            for child in children {
+                validate_attribute_assign_cardinality(dest_attrs_id, dest_query_location, child)?;
+            }
+        }
     }
 
     Ok(())

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
@@ -79,7 +79,7 @@ use otap_df_pdata::schema::consts;
 
 use crate::consts::{ENCODE_FUNC_NAME, REGEXP_SUBSTR_FUNC_NAME, SHA256_FUNC_NAME};
 use crate::error::{Error, Result};
-use crate::pipeline::expr::join::join;
+use crate::pipeline::expr::join::{join, multi_join};
 use crate::pipeline::expr::types::{
     ExprLogicalType, coerce_arithmetic, nested_struct_field_type, root_field_type,
 };
@@ -158,7 +158,10 @@ pub(crate) enum LogicalExprDataSource {
     /// This indicates the input to the expression data from the incoming OTAP batch
     DataSource(DataScope),
 
-    /// The input to the expression is the result of joining two child expressions
+    /// The input to the expression is the result of joining two child expressions.
+    ///
+    /// Used when there are binary expressions such as in arithmetic or comparing two columns.
+    /// The results are joined into a single record batch with columns named "left" and "right".
     Join(Box<ScopedLogicalExpr>, Box<ScopedLogicalExpr>),
 
     /// The input to the expression is the result of joining multiple child expressions.
@@ -365,9 +368,6 @@ impl ExprLogicalPlanner {
                     }
                 })?;
 
-                // Collect the scalar sub-expressions for the slice: source, start, and
-                // optionally end. We delegate to plan_function_args which handles both
-                // the same-scope and cross-scope cases.
                 let mut slice_arg_exprs: Vec<&ScalarExpression> =
                     vec![slice_scalar_expr.get_source(), start_scalar_expr];
 
@@ -590,13 +590,11 @@ impl ExprLogicalPlanner {
         arg_exprs: impl Iterator<Item = &'a ScalarExpression>,
         functions: &[PipelineFunction],
     ) -> Result<(Vec<Expr>, LogicalExprDataSource, bool)> {
-        // Plan all argument expressions, collecting them as full ScopedLogicalExprs
-        // so we have both their logical_expr and source information.
-        let planned_args: Vec<ScopedLogicalExpr> = arg_exprs
+        let scoped_logical_args: Vec<ScopedLogicalExpr> = arg_exprs
             .map(|arg| self.plan_scalar_expr(arg, functions))
             .collect::<Result<Vec<_>>>()?;
 
-        if planned_args.is_empty() {
+        if scoped_logical_args.is_empty() {
             return Ok((
                 Vec::new(),
                 LogicalExprDataSource::DataSource(DataScope::StaticScalar),
@@ -609,13 +607,12 @@ impl ExprLogicalPlanner {
         let mut all_combinable = true;
         let mut requires_dict_downcast = false;
 
-        for planned_arg in &planned_args {
-            requires_dict_downcast |= planned_arg.requires_dict_downcast;
+        for scoped_logical_arg in &scoped_logical_args {
+            requires_dict_downcast |= scoped_logical_arg.requires_dict_downcast;
 
-            let arg_scope = match &planned_arg.source {
+            let arg_scope = match &scoped_logical_arg.source {
                 LogicalExprDataSource::DataSource(scope) => scope,
-                // If any arg already requires a join (e.g. it's a nested cross-scope arithmetic
-                // expr), we can't combine scopes and must use a multi-join.
+                // If any arg already requires a join, we can't combine scopes so must multi join
                 _ => {
                     all_combinable = false;
                     break;
@@ -641,22 +638,26 @@ impl ExprLogicalPlanner {
 
         if all_combinable {
             // All arguments share a compatible scope. Return their logical exprs directly.
-            let logical_exprs = planned_args.into_iter().map(|a| a.logical_expr).collect();
+            let arg_logical_exprs = scoped_logical_args
+                .into_iter()
+                .map(|a| a.logical_expr)
+                .collect();
             let scope = LogicalExprDataSource::DataSource(
                 combined_scope.unwrap_or(DataScope::StaticScalar),
             );
-            Ok((logical_exprs, scope, requires_dict_downcast))
+            Ok((arg_logical_exprs, scope, requires_dict_downcast))
         } else {
             // Arguments come from different scopes. Create a MultiJoin: each argument
             // becomes a child expression in the join, and the function's argument Exprs
             // are rewritten to reference the join result columns ("arg_0", "arg_1", ...).
-            let requires_dict_downcast = planned_args.iter().any(|a| a.requires_dict_downcast);
+            let requires_dict_downcast =
+                scoped_logical_args.iter().any(|a| a.requires_dict_downcast);
 
-            let arg_col_exprs: Vec<Expr> = (0..planned_args.len())
+            let arg_col_exprs: Vec<Expr> = (0..scoped_logical_args.len())
                 .map(|i| col(arg_column_name(i)))
                 .collect();
 
-            let source = LogicalExprDataSource::MultiJoin(planned_args);
+            let source = LogicalExprDataSource::MultiJoin(scoped_logical_args);
             Ok((arg_col_exprs, source, requires_dict_downcast))
         }
     }
@@ -954,7 +955,7 @@ impl ScopedPhysicalExpr {
                         None => return Ok(None),
                     }
                 }
-                let (joined_rb, result_data_scope) = join::multi_join(&results, otap_batch)?;
+                let (joined_rb, result_data_scope) = multi_join(&results, otap_batch)?;
                 (Some(Cow::Owned(joined_rb)), result_data_scope)
             }
         };
@@ -3666,11 +3667,20 @@ mod test {
         run_scalar_expr_success_test(input_expr, &otap_batch, expected_col);
     }
 
-    /// Tests that the logical planner produces a MultiJoin for InvokeFunction when args come
-    /// from different scopes. Uses sha256(attributes["k1"]) (Attributes scope) alongside a
-    /// root-scope arg, verifying the plan structure.
+    /// Verifies that InvokeFunction planning correctly produces a MultiJoin when child
+    /// InvokeFunction results come from different scopes.
+    ///
+    /// We build: encode(sha256(attributes["k1"]), "hex") which nests sha256 (Attributes scope)
+    /// inside encode with a scalar arg. Since Attributes + Scalar can combine, this should NOT
+    /// produce a MultiJoin. This serves as a sanity check that the planner doesn't over-eagerly
+    /// create MultiJoin nodes for same-scope function args.
+    ///
+    /// Note: a full end-to-end execution test for cross-scope InvokeFunction args is not
+    /// straightforward because DataFusion's built-in multi-arg functions (like encode) require
+    /// some arguments to be scalars. The concat/join_text/replace tests cover the cross-scope
+    /// MultiJoin execution path thoroughly.
     #[test]
-    fn test_function_invocation_cross_scope_produces_multi_join_plan() {
+    fn test_function_invocation_same_scope_does_not_produce_multi_join() {
         // sha256(attributes["k1"]) - Attributes scope
         let attr_sha_expr = ScalarExpression::InvokeFunction(InvokeFunctionScalarExpression::new(
             QueryLocation::new_fake(),
@@ -3694,46 +3704,7 @@ mod test {
             ))],
         ));
 
-        // encode(sha256(attributes["k1"]), "hex") combined with a root-scope arg
-        // We test this by nesting the sha256 call inside another function call that
-        // also takes a root-scope argument.
-        //
-        // We'll use a simple wrapper:
-        // encode(sha256(attributes["k1"]), "hex") produces a value from Attributes scope.
-        // Then we want to combine it with severity_text (Root scope) via concat.
-        // But for InvokeFunction specifically: the planner should produce MultiJoin
-        // when an InvokeFunction's args span different scopes.
-        //
-        // So let's plan: encode(sha256(severity_text), "hex")
-        // This keeps both args in Root+Scalar scope (should combine, NOT MultiJoin).
-        // Then: encode(sha256(attributes["k1"]), "hex")
-        // This keeps both in Attributes+Scalar scope (should combine, NOT MultiJoin).
-        //
-        // The real cross-scope case would need a function that accepts multiple array args
-        // from different scopes. DataFusion's `encode` requires scalar encoding format.
-        // So we verify the planning step only: that a function call with mixed scopes
-        // correctly produces a MultiJoin plan.
-
-        // Build: some_func(sha256(attributes["k1"]), sha256(severity_text))
-        // Both sha256 calls produce values, but from different scopes.
-        let root_sha_expr = ScalarExpression::InvokeFunction(InvokeFunctionScalarExpression::new(
-            QueryLocation::new_fake(),
-            None,
-            0,
-            vec![InvokeFunctionArgument::Scalar(ScalarExpression::Source(
-                SourceScalarExpression::new(
-                    QueryLocation::new_fake(),
-                    ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
-                        StaticScalarExpression::String(StringScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            consts::SEVERITY_TEXT,
-                        )),
-                    )]),
-                ),
-            ))],
-        ));
-
-        // encode(sha256(attributes["k1"]), "hex") - Attributes scope + Scalar
+        // encode(sha256(attributes["k1"]), "hex") - Attributes scope + Scalar = Attributes scope
         let encode_attr_expr =
             ScalarExpression::InvokeFunction(InvokeFunctionScalarExpression::new(
                 QueryLocation::new_fake(),
@@ -3750,23 +3721,6 @@ mod test {
                 ],
             ));
 
-        // encode(sha256(severity_text), "hex") - Root scope + Scalar
-        let _encode_root_expr =
-            ScalarExpression::InvokeFunction(InvokeFunctionScalarExpression::new(
-                QueryLocation::new_fake(),
-                None,
-                1,
-                vec![
-                    InvokeFunctionArgument::Scalar(root_sha_expr),
-                    InvokeFunctionArgument::Scalar(ScalarExpression::Static(
-                        StaticScalarExpression::String(StringScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            "hex",
-                        )),
-                    )),
-                ],
-            ));
-
         let functions = [
             PipelineFunction::new_external("sha256", vec![], None),
             PipelineFunction::new_external("encode", vec![], None),
@@ -3774,67 +3728,15 @@ mod test {
 
         let planner = ExprLogicalPlanner {};
 
-        // Verify that encode(sha256(attrs), "hex") does NOT produce MultiJoin
-        // (both args combine: Attributes + Scalar = Attributes scope)
-        let single_scope = planner
+        // Attributes + Scalar should combine without needing a MultiJoin
+        let planned = planner
             .plan_scalar_expr(&encode_attr_expr, &functions)
             .unwrap();
         assert!(
-            !matches!(single_scope.source, LogicalExprDataSource::MultiJoin(_)),
-            "Expected non-MultiJoin for same-scope function args"
+            !matches!(planned.source, LogicalExprDataSource::MultiJoin(_)),
+            "Expected non-MultiJoin for same-scope function args, got {:?}",
+            planned.source
         );
-
-        // Now test an arithmetic expression that combines the two encode results,
-        // forcing a cross-scope join at the arithmetic level.
-        // This tests that the overall tree properly uses the join infrastructure.
-        let input_expr = ScalarExpression::Math(MathScalarExpression::Add(
-            BinaryMathematicalScalarExpression::new(
-                QueryLocation::new_fake(),
-                // left: severity_number (Root scope)
-                ScalarExpression::Source(SourceScalarExpression::new(
-                    QueryLocation::new_fake(),
-                    ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
-                        StaticScalarExpression::String(StringScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            consts::SEVERITY_NUMBER,
-                        )),
-                    )]),
-                )),
-                // right: attributes["k1"] (Attributes scope)
-                ScalarExpression::Source(SourceScalarExpression::new(
-                    QueryLocation::new_fake(),
-                    ValueAccessor::new_with_selectors(vec![
-                        ScalarExpression::Static(StaticScalarExpression::String(
-                            StringScalarExpression::new(
-                                QueryLocation::new_fake(),
-                                ATTRIBUTES_FIELD_NAME,
-                            ),
-                        )),
-                        ScalarExpression::Static(StaticScalarExpression::String(
-                            StringScalarExpression::new(QueryLocation::new_fake(), "k1"),
-                        )),
-                    ]),
-                )),
-            ),
-        ));
-
-        let logs = to_logs_data(vec![
-            LogRecord::build()
-                .severity_text("ERROR")
-                .severity_number(10)
-                .attributes(vec![KeyValue::new("k1", AnyValue::new_int(5))])
-                .finish(),
-            LogRecord::build()
-                .severity_text("INFO")
-                .severity_number(20)
-                .attributes(vec![KeyValue::new("k1", AnyValue::new_int(3))])
-                .finish(),
-        ]);
-        let otap_batch = otlp_to_otap(&OtlpProtoMessage::Logs(logs));
-
-        // This uses the binary join (not MultiJoin), but verifies the overall machinery works
-        let expected_col = Arc::new(Int64Array::from(vec![15, 23]));
-        run_scalar_expr_success_test(input_expr, &otap_batch, expected_col);
     }
 
     /// Tests replace(severity_text, attributes["needle"], attributes["replacement"])

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
@@ -94,6 +94,15 @@ pub(crate) const VALUE_COLUMN_NAME: &str = "value";
 pub(crate) const LEFT_COLUMN_NAME: &str = "left";
 pub(crate) const RIGHT_COLUMN_NAME: &str = "right";
 
+/// Returns a column name for a multi-join argument at the given index.
+///
+/// Used when function arguments come from different data scopes and need to be joined
+/// before the function can be evaluated. Each argument in the join result gets a column
+/// named "arg_0", "arg_1", etc.
+pub(crate) fn arg_column_name(index: usize) -> String {
+    format!("arg_{index}")
+}
+
 /// Identifies OTAP data either consumed or produced by some expression.
 ///
 /// OTAP batches contain multiple [`RecordBatch`]s, and within a given record batch, some expression
@@ -151,6 +160,13 @@ pub(crate) enum LogicalExprDataSource {
 
     /// The input to the expression is the result of joining two child expressions
     Join(Box<ScopedLogicalExpr>, Box<ScopedLogicalExpr>),
+
+    /// The input to the expression is the result of joining multiple child expressions.
+    ///
+    /// This is used when a function call has arguments from different data scopes. Each child
+    /// expression is evaluated independently, and the results are joined pairwise into a single
+    /// record batch with columns named "arg_0", "arg_1", ..., "arg_{N-1}".
+    MultiJoin(Vec<ScopedLogicalExpr>),
 }
 
 /// Represents an expression during the logical planning phase.
@@ -204,6 +220,13 @@ impl ScopedLogicalExpr {
                 Box::new(left.into_physical()?),
                 Box::new(right.into_physical()?),
             ),
+            LogicalExprDataSource::MultiJoin(children) => {
+                let physical_children = children
+                    .into_iter()
+                    .map(|child| child.into_physical())
+                    .collect::<Result<Vec<_>>>()?;
+                PhysicalExprDataSource::MultiJoin(physical_children)
+            }
         };
         let projection = Projection::try_new(&self.logical_expr)?;
 
@@ -334,50 +357,6 @@ impl ExprLogicalPlanner {
                 }),
             },
             ScalarExpression::Slice(slice_scalar_expr) => {
-                let mut num_args = 2;
-                if slice_scalar_expr.get_range_start().is_some() {
-                    num_args = 3;
-                }
-                let mut arg_exprs = Vec::with_capacity(num_args);
-
-                let start_arg_expr =
-                    self.plan_scalar_expr(slice_scalar_expr.get_source(), functions)?;
-                arg_exprs.push(start_arg_expr.logical_expr);
-                let mut source_scope = start_arg_expr.source;
-                let mut requires_dict_downcast = start_arg_expr.requires_dict_downcast;
-
-                let mut plan_range_index_expr = |scalar_expr, mut source_scope| {
-                    let arg_expr = self.plan_scalar_expr(scalar_expr, functions)?;
-                    let combined_scope = match (arg_expr.source, source_scope) {
-                        (
-                            LogicalExprDataSource::DataSource(left_scope),
-                            LogicalExprDataSource::DataSource(right_scope),
-                        ) => left_scope.can_combine(&right_scope).then_some(
-                            if !left_scope.is_scalar() {
-                                left_scope
-                            } else {
-                                right_scope
-                            },
-                        ),
-                        _ => None,
-                    };
-                    if let Some(combined_scope) = combined_scope {
-                        source_scope = LogicalExprDataSource::DataSource(combined_scope);
-                    } else {
-                        // TODO: eventually we'll create a new join expr node and invoke the function
-                        // on result of the join.
-                        return Err(Error::NotYetSupportedError {
-                            message:
-                                "Functions arguments with differing data scopes not yet supported"
-                                    .into(),
-                        });
-                    }
-                    requires_dict_downcast |= arg_expr.requires_dict_downcast;
-                    arg_exprs.push(arg_expr.logical_expr);
-
-                    Ok(source_scope)
-                };
-
                 // plan the expression for substring start
                 let start_scalar_expr = slice_scalar_expr.get_range_start().ok_or_else(|| {
                     Error::InvalidPipelineError {
@@ -385,12 +364,19 @@ impl ExprLogicalPlanner {
                         query_location: Some(slice_scalar_expr.get_query_location().clone()),
                     }
                 })?;
-                source_scope = plan_range_index_expr(start_scalar_expr, source_scope)?;
 
-                // plan the expression for substring end
-                if let Some(length_scalar_expr) = slice_scalar_expr.get_range_length() {
-                    source_scope = plan_range_index_expr(length_scalar_expr, source_scope)?;
+                // Collect the scalar sub-expressions for the slice: source, start, and
+                // optionally end. We delegate to plan_function_args which handles both
+                // the same-scope and cross-scope cases.
+                let mut slice_arg_exprs: Vec<&ScalarExpression> =
+                    vec![slice_scalar_expr.get_source(), start_scalar_expr];
+
+                if let Some(end_scalar_expr) = slice_scalar_expr.get_range_length() {
+                    slice_arg_exprs.push(end_scalar_expr);
                 }
+
+                let (arg_exprs, source_scope, requires_dict_downcast) =
+                    self.plan_function_args(slice_arg_exprs.into_iter(), functions)?;
 
                 Ok(ScopedLogicalExpr {
                     logical_expr: Expr::ScalarFunction(ScalarFunction::new_udf(
@@ -601,66 +587,78 @@ impl ExprLogicalPlanner {
 
     fn plan_function_args<'a>(
         &self,
-        mut arg_exprs: impl Iterator<Item = &'a ScalarExpression>,
+        arg_exprs: impl Iterator<Item = &'a ScalarExpression>,
         functions: &[PipelineFunction],
     ) -> Result<(Vec<Expr>, LogicalExprDataSource, bool)> {
-        let mut planned_arg_exprs = Vec::new();
+        // Plan all argument expressions, collecting them as full ScopedLogicalExprs
+        // so we have both their logical_expr and source information.
+        let planned_args: Vec<ScopedLogicalExpr> = arg_exprs
+            .map(|arg| self.plan_scalar_expr(arg, functions))
+            .collect::<Result<Vec<_>>>()?;
 
-        let first_arg = match arg_exprs.next() {
-            Some(arg) => arg,
-            None => {
-                return Ok((
-                    Vec::new(),
-                    LogicalExprDataSource::DataSource(DataScope::StaticScalar),
-                    false,
-                ));
-            }
-        };
-
-        let first_arg_expr = self.plan_scalar_expr(first_arg, functions)?;
-        planned_arg_exprs.push(first_arg_expr.logical_expr);
-        let mut source_scope = first_arg_expr.source;
-        let mut source_requires_dict_downcast = first_arg_expr.requires_dict_downcast;
-
-        for arg_expr in arg_exprs {
-            let planned_arg_expr = self.plan_scalar_expr(arg_expr, functions)?;
-            // check if the data scope of the argument can be combined without doing a join.
-            // We would need to join data from different scopes if the arguments have would
-            // require it, such as in function calls like:
-            // some_func(severity_text, attributes["x"])
-            let combined_scope = match (planned_arg_expr.source, source_scope) {
-                (
-                    LogicalExprDataSource::DataSource(left_scope),
-                    LogicalExprDataSource::DataSource(right_scope),
-                ) => left_scope
-                    .can_combine(&right_scope)
-                    .then_some(if !left_scope.is_scalar() {
-                        left_scope
-                    } else {
-                        right_scope
-                    }),
-                _ => None,
-            };
-
-            if let Some(combined_scope) = combined_scope {
-                source_scope = LogicalExprDataSource::DataSource(combined_scope);
-            } else {
-                // TODO: eventually we'll create a new join expr node and invoke the function
-                // on result of the join.
-                return Err(Error::NotYetSupportedError {
-                    message: "Functions arguments with differing data scopes not yet supported"
-                        .into(),
-                });
-            }
-            source_requires_dict_downcast |= planned_arg_expr.requires_dict_downcast;
-            planned_arg_exprs.push(planned_arg_expr.logical_expr);
+        if planned_args.is_empty() {
+            return Ok((
+                Vec::new(),
+                LogicalExprDataSource::DataSource(DataScope::StaticScalar),
+                false,
+            ));
         }
 
-        Ok((
-            planned_arg_exprs,
-            source_scope,
-            source_requires_dict_downcast,
-        ))
+        // Check if all arguments can be combined into a single scope without joining.
+        let mut combined_scope: Option<DataScope> = None;
+        let mut all_combinable = true;
+        let mut requires_dict_downcast = false;
+
+        for planned_arg in &planned_args {
+            requires_dict_downcast |= planned_arg.requires_dict_downcast;
+
+            let arg_scope = match &planned_arg.source {
+                LogicalExprDataSource::DataSource(scope) => scope,
+                // If any arg already requires a join (e.g. it's a nested cross-scope arithmetic
+                // expr), we can't combine scopes and must use a multi-join.
+                _ => {
+                    all_combinable = false;
+                    break;
+                }
+            };
+
+            combined_scope = match combined_scope.take() {
+                None => Some(arg_scope.clone()),
+                Some(existing) => {
+                    if existing.can_combine(arg_scope) {
+                        Some(if !existing.is_scalar() {
+                            existing
+                        } else {
+                            arg_scope.clone()
+                        })
+                    } else {
+                        all_combinable = false;
+                        break;
+                    }
+                }
+            };
+        }
+
+        if all_combinable {
+            // All arguments share a compatible scope. Return their logical exprs directly.
+            let logical_exprs = planned_args.into_iter().map(|a| a.logical_expr).collect();
+            let scope = LogicalExprDataSource::DataSource(
+                combined_scope.unwrap_or(DataScope::StaticScalar),
+            );
+            Ok((logical_exprs, scope, requires_dict_downcast))
+        } else {
+            // Arguments come from different scopes. Create a MultiJoin: each argument
+            // becomes a child expression in the join, and the function's argument Exprs
+            // are rewritten to reference the join result columns ("arg_0", "arg_1", ...).
+            let requires_dict_downcast = planned_args.iter().any(|a| a.requires_dict_downcast);
+
+            let arg_col_exprs: Vec<Expr> = (0..planned_args.len())
+                .map(|i| col(arg_column_name(i)))
+                .collect();
+
+            let source = LogicalExprDataSource::MultiJoin(planned_args);
+            Ok((arg_col_exprs, source, requires_dict_downcast))
+        }
     }
 
     fn plan_join_text_expr(
@@ -885,6 +883,10 @@ enum PhysicalExprDataSource {
 
     /// Source the data by evaluating left/right child expressions and joining the results
     Join(Box<ScopedPhysicalExpr>, Box<ScopedPhysicalExpr>),
+
+    /// Source the data by evaluating multiple child expressions and joining the results
+    /// pairwise into a single record batch with columns named "arg_0", "arg_1", etc.
+    MultiJoin(Vec<ScopedPhysicalExpr>),
 }
 
 /// To evaluate expressions that only produce scalar values, we need to pass some RecordBatch into
@@ -943,6 +945,17 @@ impl ScopedPhysicalExpr {
                     }
                     _ => return Ok(None),
                 }
+            }
+            PhysicalExprDataSource::MultiJoin(children) => {
+                let mut results = Vec::with_capacity(children.len());
+                for child in children.iter_mut() {
+                    match child.execute(otap_batch, session_context)? {
+                        Some(result) => results.push(result),
+                        None => return Ok(None),
+                    }
+                }
+                let (joined_rb, result_data_scope) = join::multi_join(&results, otap_batch)?;
+                (Some(Cow::Owned(joined_rb)), result_data_scope)
             }
         };
 
@@ -3367,5 +3380,533 @@ mod test {
         ]);
 
         assert_eq!(result_arr.as_ref(), &expected);
+    }
+
+    // ----- Tests for multi-scope function arguments (MultiJoin) -----
+
+    /// Tests concat(severity_text, attributes["k1"]) where args come from Root and Attributes
+    /// scopes respectively.
+    #[test]
+    fn test_concat_with_root_and_attribute_args() {
+        use data_engine_expressions::ListScalarExpression;
+
+        let root_arg = ScalarExpression::Source(SourceScalarExpression::new(
+            QueryLocation::new_fake(),
+            ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                StaticScalarExpression::String(StringScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    consts::SEVERITY_TEXT,
+                )),
+            )]),
+        ));
+
+        let attr_arg = ScalarExpression::Source(SourceScalarExpression::new(
+            QueryLocation::new_fake(),
+            ValueAccessor::new_with_selectors(vec![
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), ATTRIBUTES_FIELD_NAME),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "k1"),
+                )),
+            ]),
+        ));
+
+        let input_expr =
+            ScalarExpression::Text(TextScalarExpression::Concat(CombineScalarExpression::new(
+                QueryLocation::new_fake(),
+                ScalarExpression::Collection(CollectionScalarExpression::List(
+                    ListScalarExpression::new(QueryLocation::new_fake(), vec![root_arg, attr_arg]),
+                )),
+            )));
+
+        let logs = to_logs_data(vec![
+            LogRecord::build()
+                .severity_text("ERROR")
+                .attributes(vec![KeyValue::new("k1", AnyValue::new_string("_a"))])
+                .finish(),
+            LogRecord::build()
+                .severity_text("INFO")
+                .attributes(vec![KeyValue::new("k1", AnyValue::new_string("_b"))])
+                .finish(),
+            LogRecord::build()
+                .severity_text("DEBUG")
+                .attributes(vec![KeyValue::new("k1", AnyValue::new_string("_c"))])
+                .finish(),
+        ]);
+
+        let otap_batch = otlp_to_otap(&OtlpProtoMessage::Logs(logs));
+        let expected_col = Arc::new(StringArray::from(vec!["ERROR_a", "INFO_b", "DEBUG_c"]));
+        run_scalar_expr_success_test(input_expr, &otap_batch, expected_col);
+    }
+
+    /// Tests concat(attributes["k1"], attributes["k2"]) where both args come from different
+    /// attribute scopes (different keys from the same payload type). This triggers a multi-join
+    /// because the data scopes differ (different filtered rows).
+    #[test]
+    fn test_concat_with_two_different_attribute_args() {
+        use data_engine_expressions::ListScalarExpression;
+
+        let attr_k1 = ScalarExpression::Source(SourceScalarExpression::new(
+            QueryLocation::new_fake(),
+            ValueAccessor::new_with_selectors(vec![
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), ATTRIBUTES_FIELD_NAME),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "k1"),
+                )),
+            ]),
+        ));
+
+        let attr_k2 = ScalarExpression::Source(SourceScalarExpression::new(
+            QueryLocation::new_fake(),
+            ValueAccessor::new_with_selectors(vec![
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), ATTRIBUTES_FIELD_NAME),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "k2"),
+                )),
+            ]),
+        ));
+
+        let input_expr =
+            ScalarExpression::Text(TextScalarExpression::Concat(CombineScalarExpression::new(
+                QueryLocation::new_fake(),
+                ScalarExpression::Collection(CollectionScalarExpression::List(
+                    ListScalarExpression::new(QueryLocation::new_fake(), vec![attr_k1, attr_k2]),
+                )),
+            )));
+
+        let logs = to_logs_data(vec![
+            LogRecord::build()
+                .attributes(vec![
+                    KeyValue::new("k1", AnyValue::new_string("hello")),
+                    KeyValue::new("k2", AnyValue::new_string("_world")),
+                ])
+                .finish(),
+            LogRecord::build()
+                .attributes(vec![
+                    KeyValue::new("k1", AnyValue::new_string("foo")),
+                    KeyValue::new("k2", AnyValue::new_string("_bar")),
+                ])
+                .finish(),
+        ]);
+
+        let otap_batch = otlp_to_otap(&OtlpProtoMessage::Logs(logs));
+        let expected_col = Arc::new(StringArray::from(vec!["hello_world", "foo_bar"]));
+        run_scalar_expr_success_test(input_expr, &otap_batch, expected_col);
+    }
+
+    /// Tests concat with 3 args from different scopes: root, attribute, and resource attribute.
+    /// This validates that the pairwise multi-join correctly handles more than 2 children.
+    #[test]
+    fn test_concat_with_three_different_scope_args() {
+        use data_engine_expressions::ListScalarExpression;
+
+        let root_arg = ScalarExpression::Source(SourceScalarExpression::new(
+            QueryLocation::new_fake(),
+            ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                StaticScalarExpression::String(StringScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    consts::SEVERITY_TEXT,
+                )),
+            )]),
+        ));
+
+        let attr_arg = ScalarExpression::Source(SourceScalarExpression::new(
+            QueryLocation::new_fake(),
+            ValueAccessor::new_with_selectors(vec![
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), ATTRIBUTES_FIELD_NAME),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "k1"),
+                )),
+            ]),
+        ));
+
+        let resource_attr_arg = ScalarExpression::Source(SourceScalarExpression::new(
+            QueryLocation::new_fake(),
+            ValueAccessor::new_with_selectors(vec![
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), RESOURCES_FIELD_NAME),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), ATTRIBUTES_FIELD_NAME),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "rk"),
+                )),
+            ]),
+        ));
+
+        let input_expr =
+            ScalarExpression::Text(TextScalarExpression::Concat(CombineScalarExpression::new(
+                QueryLocation::new_fake(),
+                ScalarExpression::Collection(CollectionScalarExpression::List(
+                    ListScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        vec![root_arg, attr_arg, resource_attr_arg],
+                    ),
+                )),
+            )));
+
+        let logs = LogsData::new(vec![
+            ResourceLogs {
+                resource: Some(
+                    Resource::build()
+                        .attributes(vec![KeyValue::new("rk", AnyValue::new_string("[R1]"))])
+                        .finish(),
+                ),
+                scope_logs: vec![ScopeLogs::new(
+                    InstrumentationScope {
+                        name: "scope1".into(),
+                        ..Default::default()
+                    },
+                    vec![
+                        LogRecord::build()
+                            .severity_text("ERROR")
+                            .attributes(vec![KeyValue::new("k1", AnyValue::new_string("-a"))])
+                            .finish(),
+                        LogRecord::build()
+                            .severity_text("INFO")
+                            .attributes(vec![KeyValue::new("k1", AnyValue::new_string("-b"))])
+                            .finish(),
+                    ],
+                )],
+                ..Default::default()
+            },
+            ResourceLogs {
+                resource: Some(
+                    Resource::build()
+                        .attributes(vec![KeyValue::new("rk", AnyValue::new_string("[R2]"))])
+                        .finish(),
+                ),
+                scope_logs: vec![ScopeLogs::new(
+                    InstrumentationScope {
+                        name: "scope1".into(),
+                        ..Default::default()
+                    },
+                    vec![
+                        LogRecord::build()
+                            .severity_text("DEBUG")
+                            .attributes(vec![KeyValue::new("k1", AnyValue::new_string("-c"))])
+                            .finish(),
+                    ],
+                )],
+                ..Default::default()
+            },
+        ]);
+
+        let otap_batch = otlp_to_otap(&OtlpProtoMessage::Logs(logs));
+        let expected_col = Arc::new(StringArray::from(vec![
+            "ERROR-a[R1]",
+            "INFO-b[R1]",
+            "DEBUG-c[R2]",
+        ]));
+        run_scalar_expr_success_test(input_expr, &otap_batch, expected_col);
+    }
+
+    /// Tests that join_text (concat_ws) works with args from different scopes.
+    /// This validates: concat_ws("-", severity_text, attributes["k1"])
+    #[test]
+    fn test_join_text_with_root_and_attribute_args() {
+        use data_engine_expressions::ListScalarExpression;
+
+        let separator = ScalarExpression::Static(StaticScalarExpression::String(
+            StringScalarExpression::new(QueryLocation::new_fake(), "-"),
+        ));
+
+        let root_arg = ScalarExpression::Source(SourceScalarExpression::new(
+            QueryLocation::new_fake(),
+            ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                StaticScalarExpression::String(StringScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    consts::SEVERITY_TEXT,
+                )),
+            )]),
+        ));
+
+        let attr_arg = ScalarExpression::Source(SourceScalarExpression::new(
+            QueryLocation::new_fake(),
+            ValueAccessor::new_with_selectors(vec![
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), ATTRIBUTES_FIELD_NAME),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "k1"),
+                )),
+            ]),
+        ));
+
+        let input_expr =
+            ScalarExpression::Text(TextScalarExpression::Join(JoinTextScalarExpression::new(
+                QueryLocation::new_fake(),
+                separator,
+                ScalarExpression::Collection(CollectionScalarExpression::List(
+                    ListScalarExpression::new(QueryLocation::new_fake(), vec![root_arg, attr_arg]),
+                )),
+            )));
+
+        let logs = to_logs_data(vec![
+            LogRecord::build()
+                .severity_text("ERROR")
+                .attributes(vec![KeyValue::new("k1", AnyValue::new_string("a"))])
+                .finish(),
+            LogRecord::build()
+                .severity_text("INFO")
+                .attributes(vec![KeyValue::new("k1", AnyValue::new_string("b"))])
+                .finish(),
+        ]);
+
+        let otap_batch = otlp_to_otap(&OtlpProtoMessage::Logs(logs));
+        let expected_col = Arc::new(StringArray::from(vec!["ERROR-a", "INFO-b"]));
+        run_scalar_expr_success_test(input_expr, &otap_batch, expected_col);
+    }
+
+    /// Tests that the logical planner produces a MultiJoin for InvokeFunction when args come
+    /// from different scopes. Uses sha256(attributes["k1"]) (Attributes scope) alongside a
+    /// root-scope arg, verifying the plan structure.
+    #[test]
+    fn test_function_invocation_cross_scope_produces_multi_join_plan() {
+        // sha256(attributes["k1"]) - Attributes scope
+        let attr_sha_expr = ScalarExpression::InvokeFunction(InvokeFunctionScalarExpression::new(
+            QueryLocation::new_fake(),
+            None,
+            0,
+            vec![InvokeFunctionArgument::Scalar(ScalarExpression::Source(
+                SourceScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    ValueAccessor::new_with_selectors(vec![
+                        ScalarExpression::Static(StaticScalarExpression::String(
+                            StringScalarExpression::new(
+                                QueryLocation::new_fake(),
+                                ATTRIBUTES_FIELD_NAME,
+                            ),
+                        )),
+                        ScalarExpression::Static(StaticScalarExpression::String(
+                            StringScalarExpression::new(QueryLocation::new_fake(), "k1"),
+                        )),
+                    ]),
+                ),
+            ))],
+        ));
+
+        // encode(sha256(attributes["k1"]), "hex") combined with a root-scope arg
+        // We test this by nesting the sha256 call inside another function call that
+        // also takes a root-scope argument.
+        //
+        // We'll use a simple wrapper:
+        // encode(sha256(attributes["k1"]), "hex") produces a value from Attributes scope.
+        // Then we want to combine it with severity_text (Root scope) via concat.
+        // But for InvokeFunction specifically: the planner should produce MultiJoin
+        // when an InvokeFunction's args span different scopes.
+        //
+        // So let's plan: encode(sha256(severity_text), "hex")
+        // This keeps both args in Root+Scalar scope (should combine, NOT MultiJoin).
+        // Then: encode(sha256(attributes["k1"]), "hex")
+        // This keeps both in Attributes+Scalar scope (should combine, NOT MultiJoin).
+        //
+        // The real cross-scope case would need a function that accepts multiple array args
+        // from different scopes. DataFusion's `encode` requires scalar encoding format.
+        // So we verify the planning step only: that a function call with mixed scopes
+        // correctly produces a MultiJoin plan.
+
+        // Build: some_func(sha256(attributes["k1"]), sha256(severity_text))
+        // Both sha256 calls produce values, but from different scopes.
+        let root_sha_expr = ScalarExpression::InvokeFunction(InvokeFunctionScalarExpression::new(
+            QueryLocation::new_fake(),
+            None,
+            0,
+            vec![InvokeFunctionArgument::Scalar(ScalarExpression::Source(
+                SourceScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                        StaticScalarExpression::String(StringScalarExpression::new(
+                            QueryLocation::new_fake(),
+                            consts::SEVERITY_TEXT,
+                        )),
+                    )]),
+                ),
+            ))],
+        ));
+
+        // encode(sha256(attributes["k1"]), "hex") - Attributes scope + Scalar
+        let encode_attr_expr =
+            ScalarExpression::InvokeFunction(InvokeFunctionScalarExpression::new(
+                QueryLocation::new_fake(),
+                None,
+                1,
+                vec![
+                    InvokeFunctionArgument::Scalar(attr_sha_expr),
+                    InvokeFunctionArgument::Scalar(ScalarExpression::Static(
+                        StaticScalarExpression::String(StringScalarExpression::new(
+                            QueryLocation::new_fake(),
+                            "hex",
+                        )),
+                    )),
+                ],
+            ));
+
+        // encode(sha256(severity_text), "hex") - Root scope + Scalar
+        let _encode_root_expr =
+            ScalarExpression::InvokeFunction(InvokeFunctionScalarExpression::new(
+                QueryLocation::new_fake(),
+                None,
+                1,
+                vec![
+                    InvokeFunctionArgument::Scalar(root_sha_expr),
+                    InvokeFunctionArgument::Scalar(ScalarExpression::Static(
+                        StaticScalarExpression::String(StringScalarExpression::new(
+                            QueryLocation::new_fake(),
+                            "hex",
+                        )),
+                    )),
+                ],
+            ));
+
+        let functions = [
+            PipelineFunction::new_external("sha256", vec![], None),
+            PipelineFunction::new_external("encode", vec![], None),
+        ];
+
+        let planner = ExprLogicalPlanner {};
+
+        // Verify that encode(sha256(attrs), "hex") does NOT produce MultiJoin
+        // (both args combine: Attributes + Scalar = Attributes scope)
+        let single_scope = planner
+            .plan_scalar_expr(&encode_attr_expr, &functions)
+            .unwrap();
+        assert!(
+            !matches!(single_scope.source, LogicalExprDataSource::MultiJoin(_)),
+            "Expected non-MultiJoin for same-scope function args"
+        );
+
+        // Now test an arithmetic expression that combines the two encode results,
+        // forcing a cross-scope join at the arithmetic level.
+        // This tests that the overall tree properly uses the join infrastructure.
+        let input_expr = ScalarExpression::Math(MathScalarExpression::Add(
+            BinaryMathematicalScalarExpression::new(
+                QueryLocation::new_fake(),
+                // left: severity_number (Root scope)
+                ScalarExpression::Source(SourceScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                        StaticScalarExpression::String(StringScalarExpression::new(
+                            QueryLocation::new_fake(),
+                            consts::SEVERITY_NUMBER,
+                        )),
+                    )]),
+                )),
+                // right: attributes["k1"] (Attributes scope)
+                ScalarExpression::Source(SourceScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    ValueAccessor::new_with_selectors(vec![
+                        ScalarExpression::Static(StaticScalarExpression::String(
+                            StringScalarExpression::new(
+                                QueryLocation::new_fake(),
+                                ATTRIBUTES_FIELD_NAME,
+                            ),
+                        )),
+                        ScalarExpression::Static(StaticScalarExpression::String(
+                            StringScalarExpression::new(QueryLocation::new_fake(), "k1"),
+                        )),
+                    ]),
+                )),
+            ),
+        ));
+
+        let logs = to_logs_data(vec![
+            LogRecord::build()
+                .severity_text("ERROR")
+                .severity_number(10)
+                .attributes(vec![KeyValue::new("k1", AnyValue::new_int(5))])
+                .finish(),
+            LogRecord::build()
+                .severity_text("INFO")
+                .severity_number(20)
+                .attributes(vec![KeyValue::new("k1", AnyValue::new_int(3))])
+                .finish(),
+        ]);
+        let otap_batch = otlp_to_otap(&OtlpProtoMessage::Logs(logs));
+
+        // This uses the binary join (not MultiJoin), but verifies the overall machinery works
+        let expected_col = Arc::new(Int64Array::from(vec![15, 23]));
+        run_scalar_expr_success_test(input_expr, &otap_batch, expected_col);
+    }
+
+    /// Tests replace(severity_text, attributes["needle"], attributes["replacement"])
+    /// where the first arg is from Root scope and the other two are from different Attribute
+    /// scopes. This exercises a real 3-arg cross-scope function call via MultiJoin.
+    #[test]
+    fn test_replace_text_with_cross_scope_args() {
+        use data_engine_expressions::ReplaceTextScalarExpression;
+
+        let haystack = ScalarExpression::Source(SourceScalarExpression::new(
+            QueryLocation::new_fake(),
+            ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                StaticScalarExpression::String(StringScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    consts::SEVERITY_TEXT,
+                )),
+            )]),
+        ));
+
+        let needle = ScalarExpression::Source(SourceScalarExpression::new(
+            QueryLocation::new_fake(),
+            ValueAccessor::new_with_selectors(vec![
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), ATTRIBUTES_FIELD_NAME),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "needle"),
+                )),
+            ]),
+        ));
+
+        let replacement = ScalarExpression::Source(SourceScalarExpression::new(
+            QueryLocation::new_fake(),
+            ValueAccessor::new_with_selectors(vec![
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), ATTRIBUTES_FIELD_NAME),
+                )),
+                ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(QueryLocation::new_fake(), "repl"),
+                )),
+            ]),
+        ));
+
+        let input_expr = ScalarExpression::Text(TextScalarExpression::Replace(
+            ReplaceTextScalarExpression::new(
+                QueryLocation::new_fake(),
+                haystack,
+                needle,
+                replacement,
+                false,
+            ),
+        ));
+
+        let logs = to_logs_data(vec![
+            LogRecord::build()
+                .severity_text("hello world")
+                .attributes(vec![
+                    KeyValue::new("needle", AnyValue::new_string("world")),
+                    KeyValue::new("repl", AnyValue::new_string("rust")),
+                ])
+                .finish(),
+            LogRecord::build()
+                .severity_text("foo bar baz")
+                .attributes(vec![
+                    KeyValue::new("needle", AnyValue::new_string("bar")),
+                    KeyValue::new("repl", AnyValue::new_string("qux")),
+                ])
+                .finish(),
+        ]);
+
+        let otap_batch = otlp_to_otap(&OtlpProtoMessage::Logs(logs));
+        let expected_col = Arc::new(StringArray::from(vec!["hello rust", "foo qux baz"]));
+        run_scalar_expr_success_test(input_expr, &otap_batch, expected_col);
     }
 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/join.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/join.rs
@@ -1229,3 +1229,50 @@ impl IdJoinLookup {
         self.lookup[outer].as_ref().and_then(|page| page[inner])
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use arrow::array::Int64Array;
+    use otap_df_pdata::otap::Logs;
+
+    fn empty_otap_batch() -> OtapArrowRecords {
+        OtapArrowRecords::Logs(Logs::default())
+    }
+
+    /// Helper to build a minimal PhysicalExprEvalResult with the given values and scope.
+    fn make_result(values: ArrayRef, scope: DataScope) -> PhysicalExprEvalResult {
+        PhysicalExprEvalResult {
+            values: ColumnarValue::Array(values),
+            data_scope: Rc::new(scope),
+            ids: None,
+            parent_ids: None,
+            scope_ids: None,
+            resource_ids: None,
+        }
+    }
+
+    #[test]
+    fn test_multi_join_empty_results_returns_error() {
+        let otap_batch = empty_otap_batch();
+        let err = multi_join(&[], &otap_batch);
+        assert!(err.is_err(), "expected error for empty results");
+    }
+
+    #[test]
+    fn test_multi_join_single_result_returns_single_column() {
+        let otap_batch = empty_otap_batch();
+        let values: ArrayRef = Arc::new(Int64Array::from(vec![10, 20, 30]));
+        let result = make_result(values, DataScope::Root);
+
+        let (rb, scope) = multi_join(&[result], &otap_batch).unwrap();
+
+        assert_eq!(*scope, DataScope::Root);
+        assert_eq!(rb.num_columns(), 1);
+        assert_eq!(rb.num_rows(), 3);
+        assert_eq!(rb.schema().field(0).name(), "arg_0");
+
+        let col = rb.column(0).as_any().downcast_ref::<Int64Array>().unwrap();
+        assert_eq!(col.values(), &[10, 20, 30]);
+    }
+}

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/join.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/join.rs
@@ -237,7 +237,33 @@ pub fn multi_join(
     results: &[PhysicalExprEvalResult],
     otap_batch: &OtapArrowRecords,
 ) -> Result<(RecordBatch, Rc<DataScope>)> {
-    assert!(results.len() >= 2, "multi_join requires at least 2 results");
+    if results.is_empty() {
+        return Err(Error::ExecutionError {
+            cause: "multi_join called with no results".into(),
+        });
+    }
+
+    // If there's only one result, produce a single-column record batch directly.
+    // This shouldn't happen in practice (the planner only creates MultiJoin when there
+    // are incompatible scopes across 2+ args), but we handle it defensively.
+    if results.len() == 1 {
+        let result = &results[0];
+        let values = result.values.to_array(
+            result
+                .parent_ids
+                .as_ref()
+                .map(|a| a.len())
+                .or_else(|| result.ids.as_ref().map(|a| a.len()))
+                .unwrap_or(1),
+        )?;
+        let schema = Schema::new(vec![Field::new(
+            arg_column_name(0),
+            values.data_type().clone(),
+            true,
+        )]);
+        let rb = RecordBatch::try_new(Arc::new(schema), vec![values])?;
+        return Ok((rb, result.data_scope.clone()));
+    }
 
     // Start with the first result as the accumulator.
     let first = &results[0];

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/join.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/join.rs
@@ -36,6 +36,7 @@ use arrow::array::{Array, ArrayRef, Int32Array, RecordBatch, StructArray, UInt16
 use arrow::compute::take;
 use arrow::datatypes::{DataType, Field, Fields, Schema};
 use datafusion::logical_expr::ColumnarValue;
+use datafusion::scalar::ScalarValue;
 use otap_df_pdata::OtapArrowRecords;
 use otap_df_pdata::arrays::get_required_struct_array;
 use otap_df_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
@@ -43,7 +44,7 @@ use otap_df_pdata::schema::consts;
 
 use crate::error::{Error, Result};
 use crate::pipeline::expr::{
-    DataScope, LEFT_COLUMN_NAME, PhysicalExprEvalResult, RIGHT_COLUMN_NAME,
+    DataScope, LEFT_COLUMN_NAME, PhysicalExprEvalResult, RIGHT_COLUMN_NAME, arg_column_name,
 };
 use crate::pipeline::planner::AttributesIdentifier;
 
@@ -133,6 +134,266 @@ pub fn is_one_to_many(
             *left == ArrowPayloadType::ResourceAttrs && *right == ArrowPayloadType::ScopeAttrs
         }
     }
+}
+
+/// Describes how two sides of a join are aligned after computing the join.
+enum JoinAlignment {
+    /// Both sides have the same data scope and row order; no reordering needed.
+    EqualScope,
+    /// The left side's row order is preserved; the right side is reordered by the given indices.
+    LeftPreserved(Int32Array),
+    /// The right side's row order is preserved; the left side is reordered by the given indices.
+    RightPreserved(Int32Array),
+}
+
+/// Determines the alignment strategy for joining two expression results, returning which side's
+/// row order is preserved and the take-indices for reordering the other side.
+fn compute_join_alignment(
+    left: &PhysicalExprEvalResult,
+    right: &PhysicalExprEvalResult,
+    otap_batch: &OtapArrowRecords,
+) -> Result<(JoinAlignment, Rc<DataScope>)> {
+    if left.data_scope == right.data_scope {
+        return Ok((JoinAlignment::EqualScope, left.data_scope.clone()));
+    }
+
+    // Static scalars can broadcast to any row count without reordering.
+    if left.data_scope.is_scalar() {
+        return Ok((JoinAlignment::EqualScope, right.data_scope.clone()));
+    }
+    if right.data_scope.is_scalar() {
+        return Ok((JoinAlignment::EqualScope, left.data_scope.clone()));
+    }
+
+    match (left.data_scope.as_ref(), right.data_scope.as_ref()) {
+        (DataScope::Attributes(left_attrs_id, _), DataScope::Attributes(right_attrs_id, _)) => {
+            if left_attrs_id == right_attrs_id {
+                let exec = AttributeToSameAttributeJoin::new();
+                let indices = exec.rows_to_take(left, right, otap_batch)?;
+                Ok((
+                    JoinAlignment::LeftPreserved(indices),
+                    left.data_scope.clone(),
+                ))
+            } else if is_one_to_many(left_attrs_id, right_attrs_id) {
+                let exec =
+                    AttributeToDifferentAttributeReverseJoin::new(*left_attrs_id, *right_attrs_id);
+                let indices = exec.rows_to_take(left, right, otap_batch)?;
+                Ok((
+                    JoinAlignment::RightPreserved(indices),
+                    right.data_scope.clone(),
+                ))
+            } else {
+                let exec = AttributeToDifferentAttributeJoin::new(*left_attrs_id, *right_attrs_id);
+                let indices = exec.rows_to_take(left, right, otap_batch)?;
+                Ok((
+                    JoinAlignment::LeftPreserved(indices),
+                    left.data_scope.clone(),
+                ))
+            }
+        }
+        (DataScope::Root, DataScope::Attributes(attr_id, _)) => {
+            let exec = RootToAttributesJoin::new(*attr_id);
+            let indices = exec.rows_to_take(left, right, otap_batch)?;
+            Ok((
+                JoinAlignment::LeftPreserved(indices),
+                left.data_scope.clone(),
+            ))
+        }
+        (DataScope::Attributes(attr_id, _), DataScope::Root) => match attr_id {
+            AttributesIdentifier::Root => {
+                let exec = RootAttrsToRootJoin::new();
+                let indices = exec.rows_to_take(left, right, otap_batch)?;
+                Ok((
+                    JoinAlignment::LeftPreserved(indices),
+                    left.data_scope.clone(),
+                ))
+            }
+            AttributesIdentifier::NonRoot(payload_type) => {
+                let exec = NonRootAttrsToRootReverseJoin::new(*payload_type);
+                let indices = exec.rows_to_take(left, right, otap_batch)?;
+                Ok((
+                    JoinAlignment::RightPreserved(indices),
+                    right.data_scope.clone(),
+                ))
+            }
+        },
+        (left, right) => Err(Error::ExecutionError {
+            cause: format!("invalid data scopes for join: left {left:?} right {right:?}"),
+        }),
+    }
+}
+
+/// Joins multiple expression evaluation results into a single record batch.
+///
+/// The resulting record batch contains columns named "arg_0", "arg_1", ..., "arg_{N-1}"
+/// (one per input result), plus ID columns (id, parent_id, resource, scope) from whichever
+/// side's row order is preserved.
+///
+/// The implementation works by iteratively joining each new result against the accumulated
+/// row order. When a join preserves the left (accumulated) side, the accumulated value arrays
+/// keep their order and only the new argument needs reordering. When a reverse join preserves
+/// the right (new) side, all previously accumulated value arrays are reordered.
+pub fn multi_join(
+    results: &[PhysicalExprEvalResult],
+    otap_batch: &OtapArrowRecords,
+) -> Result<(RecordBatch, Rc<DataScope>)> {
+    assert!(results.len() >= 2, "multi_join requires at least 2 results");
+
+    // Start with the first result as the accumulator.
+    let first = &results[0];
+    let first_values = first.values.to_array(
+        first
+            .parent_ids
+            .as_ref()
+            .map(|a| a.len())
+            .or_else(|| first.ids.as_ref().map(|a| a.len()))
+            .unwrap_or(1),
+    )?;
+    let mut accumulated_values: Vec<ArrayRef> = vec![first_values];
+    let mut accum_scope = first.data_scope.clone();
+    let mut accum_ids = first.ids.clone();
+    let mut accum_parent_ids = first.parent_ids.clone();
+    let mut accum_resource_ids = first.resource_ids.clone();
+    let mut accum_scope_ids = first.scope_ids.clone();
+
+    for result in results.iter().skip(1) {
+        // Build a temporary PhysicalExprEvalResult for the accumulator to pass to
+        // compute_join_alignment. We use the first accumulated value as the "values" field
+        // (the alignment only depends on the data scope and ID columns, not the actual values).
+        let accum_result = PhysicalExprEvalResult {
+            values: ColumnarValue::Array(accumulated_values[0].clone()),
+            data_scope: accum_scope.clone(),
+            ids: accum_ids.clone(),
+            parent_ids: accum_parent_ids.clone(),
+            scope_ids: accum_scope_ids.clone(),
+            resource_ids: accum_resource_ids.clone(),
+        };
+
+        let (alignment, new_scope) = compute_join_alignment(&accum_result, result, otap_batch)?;
+
+        match alignment {
+            JoinAlignment::EqualScope => {
+                if accum_scope.is_scalar() && !result.data_scope.is_scalar() {
+                    // Transitioning from scalar to non-scalar. Adopt the new result's
+                    // IDs and re-broadcast any previously accumulated scalar values to
+                    // match the new result's row count.
+                    let new_len = result
+                        .parent_ids
+                        .as_ref()
+                        .map(|a| a.len())
+                        .or_else(|| result.ids.as_ref().map(|a| a.len()))
+                        .unwrap_or(1);
+                    for arr in accumulated_values.iter_mut() {
+                        *arr = ColumnarValue::Scalar(ScalarValue::try_from_array(arr, 0)?)
+                            .to_array(new_len)?;
+                    }
+                    let new_values = result.values.to_array(new_len)?;
+                    accumulated_values.push(new_values);
+                    accum_ids = result.ids.clone();
+                    accum_parent_ids = result.parent_ids.clone();
+                    accum_resource_ids = result.resource_ids.clone();
+                    accum_scope_ids = result.scope_ids.clone();
+                } else {
+                    // Same row order - just add the new arg's values directly.
+                    let new_values = result.values.to_array(accumulated_values[0].len())?;
+                    accumulated_values.push(new_values);
+                }
+            }
+            JoinAlignment::LeftPreserved(right_take_indices) => {
+                // Left (accumulator) order preserved. Reorder the new arg's values.
+                let new_arr_len = result
+                    .parent_ids
+                    .as_ref()
+                    .map(|a| a.len())
+                    .or_else(|| result.ids.as_ref().map(|a| a.len()))
+                    .unwrap_or(1);
+                let new_values = result.values.to_array(new_arr_len)?;
+                let aligned_new = take(&new_values, &right_take_indices, None)?;
+                accumulated_values.push(aligned_new);
+                // Scope and IDs stay with the accumulator (left side preserved).
+            }
+            JoinAlignment::RightPreserved(left_take_indices) => {
+                // Right (new arg) order preserved. Reorder ALL accumulated values.
+                for arr in accumulated_values.iter_mut() {
+                    *arr = take(arr, &left_take_indices, None)?;
+                }
+                // Add the new arg's values directly (right side order is preserved).
+                let new_arr_len = result
+                    .parent_ids
+                    .as_ref()
+                    .map(|a| a.len())
+                    .or_else(|| result.ids.as_ref().map(|a| a.len()))
+                    .unwrap_or(1);
+                let new_values = result.values.to_array(new_arr_len)?;
+                accumulated_values.push(new_values);
+                // Update IDs to the right (new) side since its row order is preserved.
+                accum_ids = result.ids.clone();
+                accum_parent_ids = result.parent_ids.clone();
+                accum_resource_ids = result.resource_ids.clone();
+                accum_scope_ids = result.scope_ids.clone();
+            }
+        }
+        accum_scope = new_scope;
+    }
+
+    // Build the final RecordBatch with "arg_0", "arg_1", ..., "arg_{N-1}" columns + ID columns.
+    let num_args = accumulated_values.len();
+    let mut fields = Vec::with_capacity(num_args + 4);
+    let mut columns: Vec<ArrayRef> = Vec::with_capacity(num_args + 4);
+
+    for (i, values) in accumulated_values.into_iter().enumerate() {
+        fields.push(Field::new(
+            arg_column_name(i),
+            values.data_type().clone(),
+            true,
+        ));
+        columns.push(values);
+    }
+
+    if let Some(ids) = &accum_ids {
+        fields.push(Field::new(consts::ID, ids.data_type().clone(), true));
+        columns.push(ids.clone());
+    }
+
+    if let Some(parent_ids) = &accum_parent_ids {
+        fields.push(Field::new(
+            consts::PARENT_ID,
+            parent_ids.data_type().clone(),
+            false,
+        ));
+        columns.push(parent_ids.clone());
+    }
+
+    if let Some(col) = &accum_resource_ids {
+        let struct_arr = StructArray::new(
+            Fields::from(vec![Field::new(consts::ID, col.data_type().clone(), true)]),
+            vec![col.clone()],
+            None,
+        );
+        fields.push(Field::new(
+            consts::RESOURCE,
+            struct_arr.data_type().clone(),
+            true,
+        ));
+        columns.push(Arc::new(struct_arr));
+    }
+
+    if let Some(col) = &accum_scope_ids {
+        let struct_arr = StructArray::new(
+            Fields::from(vec![Field::new(consts::ID, col.data_type().clone(), true)]),
+            vec![col.clone()],
+            None,
+        );
+        fields.push(Field::new(
+            consts::SCOPE,
+            struct_arr.data_type().clone(),
+            true,
+        ));
+        columns.push(Arc::new(struct_arr));
+    }
+
+    let record_batch = RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)?;
+    Ok((record_batch, accum_scope))
 }
 
 // helper functions for producing errors from results. Normally, we wouldn't produce these errors

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/planner.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/planner.rs
@@ -691,6 +691,9 @@ impl PipelinePlanner {
                     let right = source_references_col_or_key(right.as_ref(), referenced);
                     left | right
                 }
+                LogicalExprDataSource::MultiJoin(children) => children
+                    .iter()
+                    .any(|child| source_references_col_or_key(child, referenced)),
             }
         }
 


### PR DESCRIPTION
# Change Summary

<!--
Replace with a brief summary of the change in this PR
-->

Adds capability to the columnar query engine to invoke functions where the columns passed as arguments have a different "row order"..

Consider calling a function in OPL or KQL like `my_func(severity_text, attributes["x"])`. In these cases, the `severity_text` would have the "row order" of the root record batch, where `attributes["x"]` would have the "row order" of however the `parent_id`s  were sorted in the Log Attrs batch rows where `key == "x"`. 

(We can think of "row order" here as order we'd encounter a row belonging to some signal (e.g. log, span, etc.) represented as we scan the column).

Currently the columnar query engine doesn't handle the case where function args have different "row order" and will just return an error. This PR resolves the issue. 

It does this by determining if the arguments to some function have different "row order" (in the parlance of the engine's expressions planning, we say they have incompatible `DataScope`s), and if the scopes are incompatible we must align the rows in each column by performing one or more joins before calling the function.

Noe: the engine's planned expressions are a tree of "scoped exprs" where each node in the tree represents a datafusion expression operating on a single data scope. While evaluating the tree at each node, we take data from the source and possibly perform "joins" on the input (depending on the data source for this node), to create an input record batch for the datafusion expression. A 2-way join was already implemented for binary expressions (using in arithmetic, for example).

This PR adds a new kind of data source called `MultiJoin` representing an arbitrary number of input expressions that must be joined, and having the convention that the resulting record batch columns will be named like "arg0", "arg1", ... "argn". The planner is changed to create this kind of join for as the data source to a scoped expr node that evaluates a function if any of the args have incompatible `DataScope`s. The scoped expr node now has logic to perform this `MultiJoin` when it encounters data source of this type. The mutli join logic is implemented in the `pipeline::expr::join` module, using the same join utilities we use for binary expressions.

## What issue does this PR close?

<!--
We highly recommend correlation of every PR to an issue
-->

* Closes #2634

## How are these changes tested?

Unit tests

## Are there any user-facing changes?

Yes, users of transform processor can now pass to functions columns as arguments that in OTAP would have different row orders.

 <!-- If yes, provide further info below -->
