### PR TITLE
[query-engine] Slice expression bug fix

### DIFF
--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/tests/otlp_kql_recordset.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/tests/otlp_kql_recordset.rs
@@ -564,6 +564,8 @@ fn test_substring_function() {
 
     run_test("substring(attributes['greeting'], 6)", "world");
     run_test("substring(attributes['greeting'], 0, 5)", "hello");
+    run_test("substring(attributes['greeting'], 1, 4)", "ello");
+    run_test("substring(attributes['greeting'], 0, 50)", "hello world");
 }
 
 #[test]

--- a/rust/experimental/query_engine/engine-recordset/src/scalars/scalar_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/scalars/scalar_expressions.rs
@@ -262,7 +262,7 @@ where
                 )?,
                 None => 0,
             };
-            let range_end_exclusive = match s.get_range_end_exclusive() {
+            let range_end_exclusive = match s.get_range_length() {
                 Some(end) => Some(SliceScalarExpression::validate_resolved_range_value(
                     end.get_query_location(),
                     "end",
@@ -1673,7 +1673,7 @@ mod tests {
                     IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
                 ))),
             ),
-            Value::String(&StringValueStorage::new("".into())),
+            Value::String(&StringValueStorage::new("ん".into())),
         );
 
         run_test_success(
@@ -1687,7 +1687,7 @@ mod tests {
                     IntegerScalarExpression::new(QueryLocation::new_fake(), 2),
                 ))),
             ),
-            Value::String(&StringValueStorage::new("ん".into())),
+            Value::String(&StringValueStorage::new("んに".into())),
         );
 
         run_test_success(
@@ -1719,7 +1719,7 @@ mod tests {
                 QueryLocation::new_fake(),
                 string_source.clone(),
                 Some(ScalarExpression::Static(StaticScalarExpression::Integer(
-                    IntegerScalarExpression::new(QueryLocation::new_fake(), 2),
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 5),
                 ))),
                 Some(ScalarExpression::Static(StaticScalarExpression::Integer(
                     IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
@@ -1727,24 +1727,7 @@ mod tests {
             ),
             ExpressionError::ValidationFailure(
                 QueryLocation::new_fake(),
-                "String slice index starts at '2' but ends at '1'".into(),
-            ),
-        );
-
-        run_test_failure(
-            SliceScalarExpression::new(
-                QueryLocation::new_fake(),
-                string_source.clone(),
-                Some(ScalarExpression::Static(StaticScalarExpression::Integer(
-                    IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
-                ))),
-                Some(ScalarExpression::Static(StaticScalarExpression::Integer(
-                    IntegerScalarExpression::new(QueryLocation::new_fake(), 6),
-                ))),
-            ),
-            ExpressionError::ValidationFailure(
-                QueryLocation::new_fake(),
-                "String slice index ends at '6' which is beyond the length of '5'".into(),
+                "String slice index starts at '5' but target ends at index '4'".into(),
             ),
         );
     }
@@ -1856,7 +1839,7 @@ mod tests {
             ),
             Value::Array(&ArrayScalarExpression::new(
                 QueryLocation::new_fake(),
-                array_values.clone().drain(1..1).collect(),
+                array_values.clone().drain(1..2).collect(),
             )),
         );
 
@@ -1873,7 +1856,7 @@ mod tests {
             ),
             Value::Array(&ArrayScalarExpression::new(
                 QueryLocation::new_fake(),
-                array_values.clone().drain(1..2).collect(),
+                array_values.clone().drain(1..3).collect(),
             )),
         );
 
@@ -1912,7 +1895,7 @@ mod tests {
                 QueryLocation::new_fake(),
                 array_source.clone(),
                 Some(ScalarExpression::Static(StaticScalarExpression::Integer(
-                    IntegerScalarExpression::new(QueryLocation::new_fake(), 2),
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 5),
                 ))),
                 Some(ScalarExpression::Static(StaticScalarExpression::Integer(
                     IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
@@ -1920,24 +1903,7 @@ mod tests {
             ),
             ExpressionError::ValidationFailure(
                 QueryLocation::new_fake(),
-                "Array slice index starts at '2' but ends at '1'".into(),
-            ),
-        );
-
-        run_test_failure(
-            SliceScalarExpression::new(
-                QueryLocation::new_fake(),
-                array_source.clone(),
-                Some(ScalarExpression::Static(StaticScalarExpression::Integer(
-                    IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
-                ))),
-                Some(ScalarExpression::Static(StaticScalarExpression::Integer(
-                    IntegerScalarExpression::new(QueryLocation::new_fake(), 6),
-                ))),
-            ),
-            ExpressionError::ValidationFailure(
-                QueryLocation::new_fake(),
-                "Array slice index ends at '6' which is beyond the length of '5'".into(),
+                "Array slice index starts at '5' but target ends at index '4'".into(),
             ),
         );
     }

--- a/rust/experimental/query_engine/engine-recordset/src/scalars/scalar_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/scalars/scalar_expressions.rs
@@ -1572,7 +1572,7 @@ mod tests {
             ),
             ExpressionError::ValidationFailure(
                 QueryLocation::new_fake(),
-                "Range end for a slice expression cannot be a negative value".into(),
+                "Range length for a slice expression cannot be a negative value".into(),
             ),
         );
 
@@ -1587,7 +1587,7 @@ mod tests {
             ),
             ExpressionError::TypeMismatch(
                 QueryLocation::new_fake(),
-                "Range end for a slice expression should be an integer type".into(),
+                "Range length for a slice expression should be an integer type".into(),
             ),
         );
     }

--- a/rust/experimental/query_engine/engine-recordset/src/scalars/scalar_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/scalars/scalar_expressions.rs
@@ -254,7 +254,7 @@ where
         ScalarExpression::Slice(s) => {
             let inner_value = execute_scalar_expression(execution_context, s.get_source())?;
 
-            let range_start_inclusive = match s.get_range_start_inclusive() {
+            let range_start_inclusive = match s.get_range_start() {
                 Some(start) => SliceScalarExpression::validate_resolved_range_value(
                     start.get_query_location(),
                     "start",
@@ -262,11 +262,11 @@ where
                 )?,
                 None => 0,
             };
-            let range_end_exclusive = match s.get_range_length() {
-                Some(end) => Some(SliceScalarExpression::validate_resolved_range_value(
-                    end.get_query_location(),
-                    "end",
-                    execute_scalar_expression(execution_context, end)?.to_value(),
+            let length = match s.get_range_length() {
+                Some(length) => Some(SliceScalarExpression::validate_resolved_range_value(
+                    length.get_query_location(),
+                    "length",
+                    execute_scalar_expression(execution_context, length)?.to_value(),
                 )?),
                 None => None,
             };
@@ -278,7 +278,7 @@ where
                         "String",
                         string_value.get_value().chars().count(),
                         range_start_inclusive,
-                        range_end_exclusive,
+                        length,
                     )?;
 
                     ResolvedValue::Slice(Slice::String(StringSlice::from_char_range(
@@ -294,7 +294,7 @@ where
                             "Array",
                             array_value.len(),
                             range_start_inclusive,
-                            range_end_exclusive,
+                            length,
                         )?;
 
                         ResolvedValue::Slice(Slice::Array(ArraySlice::new(

--- a/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
@@ -1007,7 +1007,7 @@ impl Expression for LengthScalarExpression {
 pub struct SliceScalarExpression {
     query_location: QueryLocation,
     source: Box<ScalarExpression>,
-    range_start_inclusive: Option<Box<ScalarExpression>>,
+    range_start: Option<Box<ScalarExpression>>,
     range_length: Option<Box<ScalarExpression>>,
 }
 
@@ -1015,13 +1015,13 @@ impl SliceScalarExpression {
     pub fn new(
         query_location: QueryLocation,
         source: ScalarExpression,
-        range_start_inclusive: Option<ScalarExpression>,
+        range_start: Option<ScalarExpression>,
         range_length: Option<ScalarExpression>,
     ) -> SliceScalarExpression {
         Self {
             query_location,
             source: source.into(),
-            range_start_inclusive: range_start_inclusive.map(|v| v.into()),
+            range_start: range_start.map(|v| v.into()),
             range_length: range_length.map(|v| v.into()),
         }
     }
@@ -1030,8 +1030,8 @@ impl SliceScalarExpression {
         &self.source
     }
 
-    pub fn get_range_start_inclusive(&self) -> Option<&ScalarExpression> {
-        self.range_start_inclusive.as_deref()
+    pub fn get_range_start(&self) -> Option<&ScalarExpression> {
+        self.range_start.as_deref()
     }
 
     pub fn get_range_length(&self) -> Option<&ScalarExpression> {
@@ -1061,7 +1061,7 @@ impl SliceScalarExpression {
         &mut self,
         scope: &PipelineResolutionScope,
     ) -> ScalarStaticResolutionResult<'_> {
-        let range_start_inclusive = match &mut self.range_start_inclusive {
+        let range_start_inclusive = match &mut self.range_start {
             Some(s) => {
                 let location = s.get_query_location().clone();
 
@@ -1082,7 +1082,7 @@ impl SliceScalarExpression {
                 match s.try_resolve_static(scope)? {
                     Some(v) => Some(Self::validate_resolved_range_value(
                         &location,
-                        "end",
+                        "length",
                         v.to_value(),
                     )?),
                     None => return Ok(None),
@@ -1174,14 +1174,14 @@ impl SliceScalarExpression {
         query_location: &QueryLocation,
         name: &str,
         target_length: usize,
-        range_start_inclusive: usize,
+        range_start: usize,
         range_length: Option<usize>,
     ) -> Result<usize, ExpressionError> {
-        if range_start_inclusive >= target_length {
+        if range_start >= target_length {
             return Err(ExpressionError::ValidationFailure(
                 query_location.clone(),
                 format!(
-                    "{name} slice index starts at '{range_start_inclusive}' but target ends at index '{}'",
+                    "{name} slice index starts at '{range_start}' but target ends at index '{}'",
                     target_length - 1
                 ),
             ));
@@ -1189,7 +1189,7 @@ impl SliceScalarExpression {
 
         let end = match range_length {
             None => target_length,
-            Some(length) => std::cmp::min(range_start_inclusive + length, target_length),
+            Some(length) => std::cmp::min(range_start + length, target_length),
         };
 
         Ok(end)
@@ -1224,13 +1224,13 @@ impl Expression for SliceScalarExpression {
         self.source
             .fmt_with_indent(f, format!("{indent}│                   ").as_str())?;
 
-        match &self.range_start_inclusive {
+        match &self.range_start {
             Some(s) => {
-                write!(f, "{indent}├── StartInclusive(Scalar): ")?;
-                s.fmt_with_indent(f, format!("{indent}│                           ").as_str())?;
+                write!(f, "{indent}├── Start(Scalar): ")?;
+                s.fmt_with_indent(f, format!("{indent}│                  ").as_str())?;
             }
             None => {
-                writeln!(f, "{indent}├── StartInclusive: None")?;
+                writeln!(f, "{indent}├── Start: None")?;
             }
         }
 

--- a/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
@@ -1008,7 +1008,7 @@ pub struct SliceScalarExpression {
     query_location: QueryLocation,
     source: Box<ScalarExpression>,
     range_start_inclusive: Option<Box<ScalarExpression>>,
-    range_end_exclusive: Option<Box<ScalarExpression>>,
+    range_length: Option<Box<ScalarExpression>>,
 }
 
 impl SliceScalarExpression {
@@ -1016,13 +1016,13 @@ impl SliceScalarExpression {
         query_location: QueryLocation,
         source: ScalarExpression,
         range_start_inclusive: Option<ScalarExpression>,
-        range_end_exclusive: Option<ScalarExpression>,
+        range_length: Option<ScalarExpression>,
     ) -> SliceScalarExpression {
         Self {
             query_location,
             source: source.into(),
             range_start_inclusive: range_start_inclusive.map(|v| v.into()),
-            range_end_exclusive: range_end_exclusive.map(|v| v.into()),
+            range_length: range_length.map(|v| v.into()),
         }
     }
 
@@ -1034,8 +1034,8 @@ impl SliceScalarExpression {
         self.range_start_inclusive.as_deref()
     }
 
-    pub fn get_range_end_exclusive(&self) -> Option<&ScalarExpression> {
-        self.range_end_exclusive.as_deref()
+    pub fn get_range_length(&self) -> Option<&ScalarExpression> {
+        self.range_length.as_deref()
     }
 
     pub(crate) fn try_resolve_value_type(
@@ -1075,7 +1075,7 @@ impl SliceScalarExpression {
             None => 0,
         };
 
-        let range_end_exclusive = match &mut self.range_end_exclusive {
+        let range_length = match &mut self.range_length {
             Some(s) => {
                 let location = s.get_query_location().clone();
 
@@ -1101,7 +1101,7 @@ impl SliceScalarExpression {
                         "Array",
                         a.len(),
                         range_start_inclusive,
-                        range_end_exclusive,
+                        range_length,
                     )?;
 
                     // Note: We don't return an array slice statically. This
@@ -1116,7 +1116,7 @@ impl SliceScalarExpression {
                         "String",
                         s.get_value().chars().count(),
                         range_start_inclusive,
-                        range_end_exclusive,
+                        range_length,
                     )?;
 
                     // Note: We only return statically small string slices. The
@@ -1175,26 +1175,22 @@ impl SliceScalarExpression {
         name: &str,
         target_length: usize,
         range_start_inclusive: usize,
-        range_end_exclusive: Option<usize>,
+        range_length: Option<usize>,
     ) -> Result<usize, ExpressionError> {
-        let end = range_end_exclusive.unwrap_or(target_length);
+        if range_start_inclusive >= target_length {
+            return Err(ExpressionError::ValidationFailure(
+                query_location.clone(),
+                format!(
+                    "{name} slice index starts at '{range_start_inclusive}' but target ends at index '{}'",
+                    target_length - 1
+                ),
+            ));
+        }
 
-        if range_start_inclusive > end {
-            return Err(ExpressionError::ValidationFailure(
-                query_location.clone(),
-                format!(
-                    "{name} slice index starts at '{range_start_inclusive}' but ends at '{end}'"
-                ),
-            ));
-        }
-        if end > target_length {
-            return Err(ExpressionError::ValidationFailure(
-                query_location.clone(),
-                format!(
-                    "{name} slice index ends at '{end}' which is beyond the length of '{target_length}'"
-                ),
-            ));
-        }
+        let end = match range_length {
+            None => target_length,
+            Some(length) => std::cmp::min(range_start_inclusive + length, target_length),
+        };
 
         Ok(end)
     }
@@ -1238,13 +1234,13 @@ impl Expression for SliceScalarExpression {
             }
         }
 
-        match &self.range_end_exclusive {
+        match &self.range_length {
             Some(s) => {
-                write!(f, "{indent}└── EndExclusive(Scalar): ")?;
-                s.fmt_with_indent(f, format!("{indent}                          ").as_str())?;
+                write!(f, "{indent}└── Length(Scalar): ")?;
+                s.fmt_with_indent(f, format!("{indent}                    ").as_str())?;
             }
             None => {
-                writeln!(f, "{indent}└── EndExclusive: None")?;
+                writeln!(f, "{indent}└── Length: None")?;
             }
         }
 
@@ -1576,7 +1572,7 @@ impl InvokeFunctionScalarExpression {
             }
 
             if return_count == 1
-                // safety: we can "expect" one return_statement here because if return_count is 
+                // safety: we can "expect" one return_statement here because if return_count is
                 // non-zero, then we've set this variable to `Some` in the loop above
                 && let ScalarExpression::Static(s) = return_statement.expect("return_statement not None")
             {
@@ -2740,7 +2736,7 @@ mod tests {
                     IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
                 ))),
                 Some(ScalarExpression::Static(StaticScalarExpression::Integer(
-                    IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 0),
                 ))),
             ),
             Some(ValueType::String),
@@ -2764,7 +2760,7 @@ mod tests {
             Some(ValueType::String),
             Some(Value::String(&StringScalarExpression::new(
                 QueryLocation::new_fake(),
-                "ん",
+                "んに",
             ))),
         );
 
@@ -2800,18 +2796,22 @@ mod tests {
             ))),
         );
 
-        run_test_failure(
+        run_test_success(
             SliceScalarExpression::new(
                 QueryLocation::new_fake(),
                 small_string_source.clone(),
                 Some(ScalarExpression::Static(StaticScalarExpression::Integer(
-                    IntegerScalarExpression::new(QueryLocation::new_fake(), 2),
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 0),
                 ))),
                 Some(ScalarExpression::Static(StaticScalarExpression::Integer(
-                    IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 50),
                 ))),
             ),
-            "String slice index starts at '2' but ends at '1'",
+            Some(ValueType::String),
+            Some(Value::String(&StringScalarExpression::new(
+                QueryLocation::new_fake(),
+                "こんにちは",
+            ))),
         );
 
         run_test_failure(
@@ -2819,13 +2819,13 @@ mod tests {
                 QueryLocation::new_fake(),
                 small_string_source.clone(),
                 Some(ScalarExpression::Static(StaticScalarExpression::Integer(
-                    IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 50),
                 ))),
                 Some(ScalarExpression::Static(StaticScalarExpression::Integer(
-                    IntegerScalarExpression::new(QueryLocation::new_fake(), 6),
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 50),
                 ))),
             ),
-            "String slice index ends at '6' which is beyond the length of '5'",
+            "String slice index starts at '50' but target ends at index '4'",
         );
 
         let large_string_source = ScalarExpression::Static(StaticScalarExpression::String(
@@ -2927,27 +2927,13 @@ mod tests {
                 QueryLocation::new_fake(),
                 array_source.clone(),
                 Some(ScalarExpression::Static(StaticScalarExpression::Integer(
-                    IntegerScalarExpression::new(QueryLocation::new_fake(), 2),
+                    IntegerScalarExpression::new(QueryLocation::new_fake(), 5),
                 ))),
                 Some(ScalarExpression::Static(StaticScalarExpression::Integer(
                     IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
                 ))),
             ),
-            "Array slice index starts at '2' but ends at '1'",
-        );
-
-        run_test_failure(
-            SliceScalarExpression::new(
-                QueryLocation::new_fake(),
-                array_source.clone(),
-                Some(ScalarExpression::Static(StaticScalarExpression::Integer(
-                    IntegerScalarExpression::new(QueryLocation::new_fake(), 1),
-                ))),
-                Some(ScalarExpression::Static(StaticScalarExpression::Integer(
-                    IntegerScalarExpression::new(QueryLocation::new_fake(), 6),
-                ))),
-            ),
-            "Array slice index ends at '6' which is beyond the length of '5'",
+            "Array slice index starts at '5' but target ends at index '4'",
         );
     }
 

--- a/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
@@ -2632,7 +2632,7 @@ mod tests {
             ),
             ExpressionError::ValidationFailure(
                 QueryLocation::new_fake(),
-                "Range end for a slice expression cannot be a negative value".into(),
+                "Range length for a slice expression cannot be a negative value".into(),
             ),
         );
 
@@ -2647,7 +2647,7 @@ mod tests {
             ),
             ExpressionError::TypeMismatch(
                 QueryLocation::new_fake(),
-                "Range end for a slice expression should be an integer type".into(),
+                "Range length for a slice expression should be an integer type".into(),
             ),
         );
     }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
@@ -379,13 +379,12 @@ impl ExprLogicalPlanner {
                 };
 
                 // plan the expression for substring start
-                let start_scalar_expr =
-                    slice_scalar_expr
-                        .get_range_start()
-                        .ok_or_else(|| Error::InvalidPipelineError {
-                            cause: "start index is required for substring".into(),
-                            query_location: Some(slice_scalar_expr.get_query_location().clone()),
-                        })?;
+                let start_scalar_expr = slice_scalar_expr.get_range_start().ok_or_else(|| {
+                    Error::InvalidPipelineError {
+                        cause: "start index is required for substring".into(),
+                        query_location: Some(slice_scalar_expr.get_query_location().clone()),
+                    }
+                })?;
                 source_scope = plan_range_index_expr(start_scalar_expr, source_scope)?;
 
                 // plan the expression for substring end

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
@@ -335,7 +335,7 @@ impl ExprLogicalPlanner {
             },
             ScalarExpression::Slice(slice_scalar_expr) => {
                 let mut num_args = 2;
-                if slice_scalar_expr.get_range_start_inclusive().is_some() {
+                if slice_scalar_expr.get_range_start().is_some() {
                     num_args = 3;
                 }
                 let mut arg_exprs = Vec::with_capacity(num_args);
@@ -381,7 +381,7 @@ impl ExprLogicalPlanner {
                 // plan the expression for substring start
                 let start_scalar_expr =
                     slice_scalar_expr
-                        .get_range_start_inclusive()
+                        .get_range_start()
                         .ok_or_else(|| Error::InvalidPipelineError {
                             cause: "start index is required for substring".into(),
                             query_location: Some(slice_scalar_expr.get_query_location().clone()),
@@ -389,8 +389,8 @@ impl ExprLogicalPlanner {
                 source_scope = plan_range_index_expr(start_scalar_expr, source_scope)?;
 
                 // plan the expression for substring end
-                if let Some(end_scalar_expr) = slice_scalar_expr.get_range_end_exclusive() {
-                    source_scope = plan_range_index_expr(end_scalar_expr, source_scope)?;
+                if let Some(length_scalar_expr) = slice_scalar_expr.get_range_length() {
+                    source_scope = plan_range_index_expr(length_scalar_expr, source_scope)?;
                 }
 
                 Ok(ScopedLogicalExpr {


### PR DESCRIPTION
## Changes

* Switch `Slice` expression (arrays and strings) to use `Slice(source, start, [length])` instead of `Slice(source, start_inclusive, [end_exclusive])` to match KQL [substring](https://learn.microsoft.com/kusto/query/substring-function?view=azure-data-explorer) behavior.

/cc @albertlockett @drewrelmas 