### PR TITLE
derive PartialEq for OtelDataflowSpec

### DIFF
--- a/rust/otap-dataflow/crates/config/src/engine.rs
+++ b/rust/otap-dataflow/crates/config/src/engine.rs
@@ -33,7 +33,7 @@ pub const ENGINE_CONFIG_VERSION_V1: &str = "otel_dataflow/v1";
 
 /// Root configuration for the pipeline engine.
 /// Contains engine-level settings and all pipeline groups.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct OtelDataflowSpec {
     /// Version of the engine configuration schema.
@@ -56,7 +56,7 @@ pub struct OtelDataflowSpec {
 }
 
 /// Top-level engine configuration section.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct EngineConfig {
     /// Optional HTTP admin server configuration.
@@ -89,7 +89,7 @@ pub struct EngineTopicsConfig {
 }
 
 /// Engine observability declarations.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct EngineObservabilityConfig {
     /// Optional dedicated observability pipeline for the engine.
@@ -98,7 +98,7 @@ pub struct EngineObservabilityConfig {
 }
 
 /// Configuration for the dedicated engine observability pipeline.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct EngineObservabilityPipelineConfig {
     /// Optional policy set for this observability pipeline.
@@ -132,7 +132,7 @@ impl EngineObservabilityPipelineConfig {
 /// Policy declarations allowed on the dedicated engine observability pipeline.
 ///
 /// Note: `resources` is intentionally not supported yet for observability.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct EngineObservabilityPolicies {
     /// Channel capacity policy.
@@ -165,7 +165,7 @@ impl EngineObservabilityPolicies {
 }
 
 /// Configuration for the HTTP admin endpoints.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct HttpAdminSettings {
     /// The address to bind the HTTP server to (e.g., "127.0.0.1:8080").
@@ -1832,5 +1832,56 @@ groups:
         let from_yaml: OtelDataflowCrd =
             serde_yaml::from_str(&yaml_str).expect("deserialize from YAML");
         assert_eq!(from_yaml.spec.version, original.version);
+    }
+
+    #[test]
+    fn configs_with_different_values_are_not_equal() {
+        let yaml = valid_engine_yaml(ENGINE_CONFIG_VERSION_V1);
+        let mut config1 = OtelDataflowSpec::from_yaml(&yaml).expect("should parse");
+        let config2 = OtelDataflowSpec::from_yaml(&yaml).expect("should parse");
+
+        config1.version = "v999".to_string();
+        assert_ne!(config1, config2);
+    }
+
+    #[test]
+    fn nested_config_changes_are_not_equal() {
+        let yaml = valid_engine_yaml(ENGINE_CONFIG_VERSION_V1);
+        let config1 = OtelDataflowSpec::from_yaml(&yaml).expect("should parse");
+        let mut config2 = OtelDataflowSpec::from_yaml(&yaml).expect("should parse");
+
+        // Mutate something buried a few levels deep
+        _ = config2
+            .groups
+            .values_mut()
+            .next()
+            .unwrap()
+            .topics
+            .insert("fake_topic".into(), TopicSpec::default());
+
+        assert_ne!(config1, config2);
+    }
+
+    #[test]
+    fn yaml_field_ordering_does_not_affect_equality() {
+        // Same logical config, different YAML key ordering
+        let yaml1 = format!(
+            r#"
+            version: "{ENGINE_CONFIG_VERSION_V1}"
+            engine: {{}}
+            groups: {{}}
+        "#
+        );
+        let yaml2 = format!(
+            r#"
+            groups: {{}}
+            version: "{ENGINE_CONFIG_VERSION_V1}"
+            engine: {{}}
+        "#
+        );
+
+        let config1 = OtelDataflowSpec::from_yaml(&yaml1).expect("should parse");
+        let config2 = OtelDataflowSpec::from_yaml(&yaml2).expect("should parse");
+        assert_eq!(config1, config2);
     }
 }

--- a/rust/otap-dataflow/crates/config/src/node.rs
+++ b/rust/otap-dataflow/crates/config/src/node.rs
@@ -59,7 +59,7 @@ where
 }
 
 /// User configuration for a node in the pipeline.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct NodeUserConfig {
     /// The node type URN identifying the plugin (factory) to use for this node.
@@ -348,7 +348,7 @@ impl NodeUserConfig {
 
 /// Entity configuration for a node, aligned with the semantic conventions model.
 /// See https://opentelemetry.io/docs/specs/otel/entities/data-model/.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct NodeEntity {
     /// Extensions to the entity's attribute sets.
@@ -358,7 +358,7 @@ pub struct NodeEntity {
 
 /// Node entity extensions, including user-provided identifying attributes.
 /// See https://opentelemetry.io/docs/specs/otel/entities/data-model/.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct ExtendedNodeEntity {
     /// Attributes that identify this node in telemetry emitted

--- a/rust/otap-dataflow/crates/config/src/observed_state.rs
+++ b/rust/otap-dataflow/crates/config/src/observed_state.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
 /// Configuration for the observed state store.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct ObservedStateSettings {
     /// Size of the bounded channel used for lossy observed events such as
     /// async internal logs.
@@ -29,7 +29,7 @@ pub struct ObservedStateSettings {
 }
 
 /// How to act when an asynchronous event can't be sent.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct SendPolicy {
     /// If set, wait for a timeout.
     pub blocking_timeout: Option<Duration>,

--- a/rust/otap-dataflow/crates/config/src/pipeline.rs
+++ b/rust/otap-dataflow/crates/config/src/pipeline.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 ///
 /// Use `PipelineConfig::from_yaml` or `PipelineConfig::from_json` instead of
 /// deserializing directly with serde to ensure plugin URNs are normalized.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct PipelineConfig {
     /// Type of the pipeline, which determines the type of PData it processes.
@@ -71,7 +71,7 @@ const fn default_pipeline_type() -> PipelineType {
 
 /// The type of pipeline, which can be either OTLP (OpenTelemetry Protocol) or
 /// OTAP (OpenTelemetry with Apache Arrow Protocol).
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum PipelineType {
     /// OpenTelemetry Protocol (OTLP) pipeline.
@@ -348,7 +348,7 @@ pub enum DispatchPolicy {
 ///
 /// Note: We use `Arc<NodeUserConfig>` to allow sharing the same pipeline configuration
 /// across multiple cores/threads without cloning the entire configuration.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, PartialEq)]
 #[serde(transparent)]
 pub struct PipelineNodes(HashMap<NodeId, Arc<NodeUserConfig>>);
 

--- a/rust/otap-dataflow/crates/config/src/pipeline/telemetry.rs
+++ b/rust/otap-dataflow/crates/config/src/pipeline/telemetry.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use std::{collections::HashMap, time::Duration};
 
 /// Telemetry backend configuration.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct TelemetryConfig {
     /// The size of the reporting channel, measured in the number of internal metric events shared across all cores.
     #[serde(default = "default_reporting_channel_size")]

--- a/rust/otap-dataflow/crates/config/src/pipeline/telemetry/metrics.rs
+++ b/rust/otap-dataflow/crates/config/src/pipeline/telemetry/metrics.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use crate::pipeline::telemetry::metrics::views::ViewConfig;
 
 /// OpenTelemetry Metrics configuration.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, PartialEq)]
 pub struct MetricsConfig {
     /// The list of metrics readers to configure.
     #[serde(default)]

--- a/rust/otap-dataflow/crates/config/src/pipeline/telemetry/metrics/readers.rs
+++ b/rust/otap-dataflow/crates/config/src/pipeline/telemetry/metrics/readers.rs
@@ -16,7 +16,7 @@ use crate::pipeline::telemetry::metrics::readers::{
 };
 
 /// OpenTelemetry Metrics Reader configuration.
-#[derive(Debug, Clone, Serialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, JsonSchema, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum MetricsReaderConfig {
     /// Periodic reader that exports metrics at regular intervals.
@@ -36,7 +36,7 @@ impl MetricsReaderConfig {
 }
 
 /// OpenTelemetry Metrics Periodic Reader configuration.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct MetricsReaderPeriodicConfig {
     /// The metrics exporter to use.
     pub exporter: MetricsPeriodicExporterConfig,
@@ -86,7 +86,7 @@ impl<'de> Deserialize<'de> for MetricsReaderConfig {
 }
 
 /// OpenTelemetry Metrics Pull Reader configuration.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct MetricsReaderPullConfig {
     /// The metrics exporter to use.
     pub exporter: MetricsPullExporterConfig,

--- a/rust/otap-dataflow/crates/config/src/pipeline/telemetry/metrics/readers/pull.rs
+++ b/rust/otap-dataflow/crates/config/src/pipeline/telemetry/metrics/readers/pull.rs
@@ -41,7 +41,7 @@ pub struct MetricsPullExporterConfig {
 }
 
 /// Prometheus Exporter configuration.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct PrometheusExporterConfig {
     /// The host address where the Prometheus exporter will expose metrics.

--- a/rust/otap-dataflow/crates/config/src/pipeline/telemetry/metrics/readers/pull.rs
+++ b/rust/otap-dataflow/crates/config/src/pipeline/telemetry/metrics/readers/pull.rs
@@ -41,7 +41,7 @@ pub struct MetricsPullExporterConfig {
 }
 
 /// Prometheus Exporter configuration.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct PrometheusExporterConfig {
     /// The host address where the Prometheus exporter will expose metrics.

--- a/rust/otap-dataflow/crates/config/src/pipeline/telemetry/metrics/views.rs
+++ b/rust/otap-dataflow/crates/config/src/pipeline/telemetry/metrics/views.rs
@@ -7,7 +7,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// OpenTelemetry Metrics View configuration.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct ViewConfig {
     /// Selector to match instruments for this view transformation.
     pub selector: MetricSelector,
@@ -17,7 +17,7 @@ pub struct ViewConfig {
 }
 
 /// OpenTelemetry Metric Selector configuration.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct MetricSelector {
     /// The name of the instrument to match.
     pub instrument_name: Option<String>,
@@ -27,7 +27,7 @@ pub struct MetricSelector {
 }
 
 /// OpenTelemetry Metric Stream configuration.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct MetricStream {
     /// The new name of the instrument matching the selector.
     pub name: Option<String>,

--- a/rust/otap-dataflow/crates/config/src/pipeline_group.rs
+++ b/rust/otap-dataflow/crates/config/src/pipeline_group.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 
 /// Configuration for a single pipeline group.
 /// Contains group-specific policies and all its pipelines.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct PipelineGroupConfig {
     /// Optional policy set for this pipeline group.

--- a/rust/otap-dataflow/crates/config/src/settings/telemetry/logs.rs
+++ b/rust/otap-dataflow/crates/config/src/settings/telemetry/logs.rs
@@ -8,7 +8,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// Internal logs configuration.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct LogsConfig {
     /// The log level for internal engine logs.
     ///
@@ -36,7 +36,7 @@ pub struct LogsConfig {
 }
 
 /// Configuration for the internal log tap used by admin/MCP-style consumers.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct InternalLogTapConfig {
     /// Enable the internal in-memory log tap.
     #[serde(default)]
@@ -81,7 +81,7 @@ impl LogLevel {
 }
 
 /// Logging providers for different execution contexts.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct LoggingProviders {
     /// Provider mode for non-engine threads. This defines the global Tokio
     /// `tracing` subscriber. Default is ConsoleAsync.


### PR DESCRIPTION
# Change Summary

Derive `PartialEq` on `OtelDataflowSpec` and its nested config
structs (where missing) to enable direct structural comparison of parsed
configurations without needing to serialize to YAML.

## What issue does this PR close?

* Closes #2644

## How are these changes tested?

Several new unit tests against expected equal and non-equal cases.

## Are there any user-facing changes?

No. This is a purely internal change. `PartialEq` is now available on
config types for programmatic comparison, but there are no changes to
configuration schema, behavior, or APIs.
