### PR TITLE
OPL parse datetimes as tagged literal containing ISO 8601 datetime

### DIFF
--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -103,6 +103,7 @@ hashbrown = { version = "0.17", features = ["equivalent"] }
 http = "1.4"
 humantime = "2.3.0"
 humantime-serde = "1.1.1"
+iso8601 = "0.6.3"
 itoa = "1"
 itertools = "0.14.0"
 k8s-openapi = { version = "0.27.0", features = ["latest"] }

--- a/rust/otap-dataflow/crates/opl/Cargo.toml
+++ b/rust/otap-dataflow/crates/opl/Cargo.toml
@@ -13,12 +13,13 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
+chrono = { workspace = true }
+iso8601 = { workspace = true }
 data_engine_parser_abstractions = { workspace = true }
 data_engine_expressions = { workspace = true }
 pest = { workspace = true }
 pest_derive = { workspace = true }
 
 [dev-dependencies]
-chrono = { workspace = true }
 chrono-tz = { workspace = true }
 pretty_assertions = { workspace = true }

--- a/rust/otap-dataflow/crates/opl/src/opl.pest
+++ b/rust/otap-dataflow/crates/opl/src/opl.pest
@@ -20,8 +20,7 @@ string_literal = {
   | ("'" ~ single_quote_string_char* ~ "'")
 }
 
-datetime_literal    = { (ASCII_ALPHANUMERIC | "-" | "+" | ":" | "/" | "." | ",")+ }
-datetime_expression = { "datetime(" ~ (string_literal | datetime_literal) ~ ")" }
+datetime_expression = { "date_time" ~ string_literal }
 
 identifier_expression = {
     ident

--- a/rust/otap-dataflow/crates/opl/src/parser/expression.rs
+++ b/rust/otap-dataflow/crates/opl/src/parser/expression.rs
@@ -1032,21 +1032,14 @@ mod test {
                 StaticScalarExpression::Null(NullScalarExpression::new(QueryLocation::new_fake())),
             ),
             (
-                "datetime(2026-02-04)",
+                "date_time\"2026-02-04T00:00:00Z\"",
                 StaticScalarExpression::DateTime(DateTimeScalarExpression::new(
                     QueryLocation::new_fake(),
                     create_utc(2026, 2, 4, 0, 0, 0, 0),
                 )),
             ),
             (
-                "datetime(\"2026-02-04\")",
-                StaticScalarExpression::DateTime(DateTimeScalarExpression::new(
-                    QueryLocation::new_fake(),
-                    create_utc(2026, 2, 4, 0, 0, 0, 0),
-                )),
-            ),
-            (
-                "datetime('2026-02-04')",
+                "date_time'2026-02-04T00:00:00Z'",
                 StaticScalarExpression::DateTime(DateTimeScalarExpression::new(
                     QueryLocation::new_fake(),
                     create_utc(2026, 2, 4, 0, 0, 0, 0),

--- a/rust/otap-dataflow/crates/opl/src/parser/temporal.rs
+++ b/rust/otap-dataflow/crates/opl/src/parser/temporal.rs
@@ -81,8 +81,18 @@ fn parse_date_time(
                     format!("Invalid date {parsed_date:?}"),
                 )
             })?,
-        _ => {
-            todo!()
+        other => {
+            let format_name = match other {
+                iso8601::Date::Ordinal { .. } => "Ordinal",
+                iso8601::Date::Week { .. } => "Week",
+                // safety: this case handled by outer match statement
+                _ => unreachable!("unreachable"),
+            };
+            // Currently Week or Ordinal date format not yet supported
+            return Err(ParserError::SyntaxNotSupported(
+                query_location.clone(),
+                format!("Date format {format_name} not yet supported"),
+            ));
         }
     };
     // Convert time
@@ -236,5 +246,17 @@ mod test {
     fn test_parse_from_invalid_datetime_literal() {
         let err = run_test_failure("date_time\"halloween\""); // not a valid datetime format
         assert_eq!("Invalid datetime literal \"halloween\"", err.to_string())
+    }
+
+    /// Test some "valid" iso 8601 date formats that we don't support yet
+    #[test]
+    fn test_parse_from_ordinal_and_week_datetime_literal() {
+        // Ordinal date format = 74th day of 2024 = March 14, 2024
+        let err = run_test_failure("date_time\"2024074T00:00:00\"");
+        assert_eq!("Date format Ordinal not yet supported", err.to_string());
+
+        // Week date format = 2024, week 11, Friday = March 15, 2024
+        let err = run_test_failure("date_time\"2024-W11-5T00:00:00\"");
+        assert_eq!("Date format Week not yet supported", err.to_string());
     }
 }

--- a/rust/otap-dataflow/crates/opl/src/parser/temporal.rs
+++ b/rust/otap-dataflow/crates/opl/src/parser/temporal.rs
@@ -78,7 +78,7 @@ fn parse_date_time(
             .ok_or_else(|| {
                 ParserError::SyntaxError(
                     query_location.clone(),
-                    format!("Invalid date {parsed_date:?}"),
+                    format!("Invalid date {parsed_date}"),
                 )
             })?,
         other => {
@@ -105,7 +105,7 @@ fn parse_date_time(
     .ok_or_else(|| {
         ParserError::SyntaxError(
             query_location.clone(),
-            format!("Invalid time {parsed_date:?}"),
+            format!("Invalid time {parsed_time}"),
         )
     })?;
 
@@ -246,6 +246,27 @@ mod test {
     fn test_parse_from_invalid_datetime_literal() {
         let err = run_test_failure("date_time\"halloween\""); // not a valid datetime format
         assert_eq!("Invalid datetime literal \"halloween\"", err.to_string())
+    }
+
+    #[test]
+    fn test_parse_from_invalid_date_literal() {
+        // Feb 30th an invalid day
+        let err = run_test_failure("date_time\"2026-02-30T05:30:00\"");
+        assert_eq!("Invalid date 2026-02-30", err.to_string())
+    }
+
+    #[test]
+    fn test_parse_from_invalid_time_literal() {
+        // 24:00 o'clock, an invalid time
+        let err = run_test_failure("date_time\"2026-02-04T24:00:00\"");
+        assert_eq!("Invalid time 24:00:00.0+00:00", err.to_string())
+    }
+
+    #[test]
+    fn test_invalid_timezone() {
+        // timezone 24 hours and 1 minute behind UTC = invalid
+        let err = run_test_failure("date_time\"2026-02-04T05:30:00-24:01\"");
+        assert_eq!("Invalid offset -86460", err.to_string())
     }
 
     /// Test some "valid" iso 8601 date formats that we don't support yet

--- a/rust/otap-dataflow/crates/opl/src/parser/temporal.rs
+++ b/rust/otap-dataflow/crates/opl/src/parser/temporal.rs
@@ -1,18 +1,22 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use data_engine_expressions::date_utils::parse_date_time;
-use data_engine_expressions::{DateTimeScalarExpression, StaticScalarExpression, StringValue};
+use chrono::{DateTime, FixedOffset, NaiveDate, NaiveTime, TimeZone, Utc};
+use data_engine_expressions::{
+    DateTimeScalarExpression, QueryLocation, StaticScalarExpression, StringValue,
+};
 use data_engine_parser_abstractions::{
     ParserError, parse_standard_string_literal, to_query_location,
 };
 use pest::iterators::Pair;
 
-#[cfg(test)]
-use chrono::{DateTime, FixedOffset, NaiveDate, Utc};
-
 use crate::parser::invalid_child_rule_error;
 use crate::parser::{Rule, expression::no_inner_rule_error};
+
+/// Number of milliseconds in a nanosecond
+const MINUTES_PER_SECOND: i32 = 60;
+const SECONDS_PER_HOUR: i32 = 3600;
+const MILLIS_PER_NANO_SECOND: u32 = 1_000_000;
 
 pub(crate) fn parse_datetime_expression(
     datetime_expression_rule: Pair<'_, Rule>,
@@ -25,26 +29,12 @@ pub(crate) fn parse_datetime_expression(
     let rule_query_location = to_query_location(&rule);
 
     let datetime_value = match rule.as_rule() {
-        Rule::datetime_literal => {
-            let datetime_value = rule.as_str();
-            parse_date_time(datetime_value).map_err(|_e| {
-                ParserError::SyntaxError(
-                    rule_query_location.clone(),
-                    format!("Invalid datetime literal {datetime_value}"),
-                )
-            })?
-        }
         Rule::string_literal => {
             let static_str_scalar_expr = parse_standard_string_literal(rule);
             match static_str_scalar_expr {
                 StaticScalarExpression::String(str) => {
                     let str_value = str.get_value();
-                    parse_date_time(str_value).map_err(|_e| {
-                        ParserError::SyntaxError(
-                            rule_query_location.clone(),
-                            format!("Invalid datetime string literal {str_value:?}"),
-                        )
-                    })?
+                    parse_date_time(str_value, &rule_query_location)?
                 }
                 invalid_expr => {
                     return Err(ParserError::SyntaxError(
@@ -66,6 +56,78 @@ pub(crate) fn parse_datetime_expression(
     Ok(StaticScalarExpression::DateTime(
         DateTimeScalarExpression::new(rule_query_location, datetime_value),
     ))
+}
+
+fn parse_date_time(
+    str_value: &str,
+    query_location: &QueryLocation,
+) -> Result<DateTime<FixedOffset>, ParserError> {
+    let Ok(iso8601::DateTime {
+        date: parsed_date,
+        time: parsed_time,
+    }) = iso8601::datetime(str_value)
+    else {
+        return Err(ParserError::SyntaxError(
+            query_location.clone(),
+            format!("Invalid datetime literal {str_value:?}"),
+        ));
+    };
+
+    let naive_date = match parsed_date {
+        iso8601::Date::YMD { year, month, day } => NaiveDate::from_ymd_opt(year, month, day)
+            .ok_or_else(|| {
+                ParserError::SyntaxError(
+                    query_location.clone(),
+                    format!("Invalid date {parsed_date:?}"),
+                )
+            })?,
+        _ => {
+            todo!()
+        }
+    };
+    // Convert time
+    let naive_time = NaiveTime::from_hms_nano_opt(
+        parsed_time.hour,
+        parsed_time.minute,
+        parsed_time.second,
+        parsed_time.millisecond * MILLIS_PER_NANO_SECOND,
+    )
+    .ok_or_else(|| {
+        ParserError::SyntaxError(
+            query_location.clone(),
+            format!("Invalid time {parsed_date:?}"),
+        )
+    })?;
+
+    let naive_dt = naive_date.and_time(naive_time);
+
+    // Convert timezone
+    let dt = match parsed_time.tz_offset_hours {
+        0 if parsed_time.tz_offset_minutes == 0 => {
+            // UTC
+            Utc.from_utc_datetime(&naive_dt).fixed_offset()
+        }
+        _ => {
+            let offset_secs = parsed_time.tz_offset_hours * SECONDS_PER_HOUR
+                + parsed_time.tz_offset_minutes * MINUTES_PER_SECOND;
+            let offset = FixedOffset::east_opt(offset_secs).ok_or_else(|| {
+                ParserError::SyntaxError(
+                    query_location.clone(),
+                    format!("Invalid offset {offset_secs:?}"),
+                )
+            })?;
+            offset
+                .from_local_datetime(&naive_dt)
+                .single()
+                .ok_or_else(|| {
+                    ParserError::SyntaxError(
+                        query_location.clone(),
+                        format!("Invalid offset {naive_dt:?}"),
+                    )
+                })?
+        }
+    };
+    Ok(dt)
 }
 
 /// test helper for creating [`DateTime`]s
@@ -124,22 +186,10 @@ mod test {
     /// utility to which [`parse_datetime_expression`] delegates
     fn valid_test_cases() -> Vec<(&'static str, DateTime<FixedOffset>)> {
         vec![
-            // mid-endian (US) date format
-            ("02/04/2026", create_utc(2026, 2, 4, 0, 0, 0, 0)),
-            // mid-endian (US) date format with time
-            ("02/04/2026 5:30 AM", create_utc(2026, 2, 4, 5, 30, 0, 0)),
-            // ISO 8601
-            ("2026-02-04", create_utc(2026, 2, 4, 0, 0, 0, 0)),
             // ISO 8601 with time
             ("2026-02-04T05:30:00", create_utc(2026, 2, 4, 5, 30, 0, 0)),
-            // RFC 822
-            ("4 Feb 26 15:05", create_utc(2026, 2, 4, 15, 5, 0, 0)),
-            // RFC 822 with time and day of week
-            (
-                "Wed, 4 Feb 26 15:05:02 GMT",
-                create_utc(2026, 2, 4, 15, 5, 2, 0),
-            ),
-            // Explicit timezone offsets
+            // Explicit timezone offsets - for good measure test one  case during daylight savings
+            // and one case not during daylight savings ...
             (
                 "2026-02-04T05:30:00-05:00",
                 create_with_tz(2026, 2, 4, 5, 30, 0, 0, Canada::Eastern),
@@ -148,12 +198,6 @@ mod test {
                 "2026-07-31T11:15-04:00",
                 create_with_tz(2026, 7, 31, 11, 15, 0, 0, Canada::Eastern),
             ),
-            // TODO reenable this test case when TZ parsing bug fixed:
-            // https://github.com/open-telemetry/otel-arrow/issues/2047
-            // (
-            //     "Wed, 4 Feb 26 15:05:02 EST",
-            //     create_with_tz(2026, 02, 04, 15, 5, 2, 0, Canada::Eastern),
-            // ),
         ]
     }
 
@@ -177,31 +221,20 @@ mod test {
     #[test]
     fn test_parse_from_datetime_literal() {
         for (input, expected) in valid_test_cases() {
-            let expr = format!("datetime({input})");
+            let expr = format!("date_time\"{input}\"");
             run_test_success(&expr, expected);
         }
+    }
+
+    #[test]
+    fn test_parse_from_invalid_datetime_date_only() {
+        let err = run_test_failure("date_time\"2026-02-04\""); // not a valid datetime format
+        assert_eq!("Invalid datetime literal \"2026-02-04\"", err.to_string())
     }
 
     #[test]
     fn test_parse_from_invalid_datetime_literal() {
-        let err = run_test_failure("datetime(halloween)"); // not a valid date format
-        assert_eq!("Invalid datetime literal halloween", err.to_string())
-    }
-
-    #[test]
-    fn test_parse_from_string_literal() {
-        for (input, expected) in valid_test_cases() {
-            let expr = format!("datetime('{input}')");
-            run_test_success(&expr, expected);
-        }
-    }
-
-    #[test]
-    fn test_parse_from_invalid_string_literal() {
-        let err = run_test_failure("datetime('monday')"); // not a valid date format
-        assert_eq!(
-            "Invalid datetime string literal \"monday\"",
-            err.to_string()
-        )
+        let err = run_test_failure("date_time\"halloween\""); // not a valid datetime format
+        assert_eq!("Invalid datetime literal \"halloween\"", err.to_string())
     }
 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
@@ -1928,7 +1928,7 @@ mod test {
         exec_logs_pipeline, otap_to_logs_data, otap_to_metrics_data, otap_to_traces_data,
     };
 
-    async fn test_simple_filter<P: Parser>() {
+    async fn test_simple_filter<P: Parser, F: Fn(&str) -> String>(date_time_formatter: F) {
         let ns_per_second: u64 = 1000 * 1000 * 1000;
         let log_records = vec![
             LogRecord::build()
@@ -1993,7 +1993,10 @@ mod test {
         );
 
         let result = exec_logs_pipeline::<P>(
-            "logs | where time_unix_nano > datetime(1970-01-01 00:00:01.1)",
+            &format!(
+                "logs | where time_unix_nano > {} ",
+                date_time_formatter("1970-01-01T00:00:01.1")
+            ),
             to_logs_data(log_records.clone()),
         )
         .await;
@@ -2003,7 +2006,10 @@ mod test {
         );
 
         let result = exec_logs_pipeline::<P>(
-            "logs | where datetime(1970-01-01 00:00:01.1) > time_unix_nano",
+            &format!(
+                "logs | where {} > time_unix_nano",
+                date_time_formatter("1970-01-01T00:00:01.1")
+            ),
             to_logs_data(log_records.clone()),
         )
         .await;
@@ -2027,12 +2033,12 @@ mod test {
 
     #[tokio::test]
     async fn test_simple_filter_kql_parser() {
-        test_simple_filter::<KqlParser>().await;
+        test_simple_filter::<KqlParser, _>(|dt| format!("datetime({dt})")).await;
     }
 
     #[tokio::test]
-    async fn test_simple_filter_op_parser() {
-        test_simple_filter::<OplParser>().await
+    async fn test_simple_filter_opl_parser() {
+        test_simple_filter::<OplParser, _>(|dt| format!("date_time\"{dt}\"")).await
     }
 
     async fn test_simple_attrs_filter<P: Parser>() {


### PR DESCRIPTION
# Change Summary

<!--
Replace with a brief summary of the change in this PR
-->

Change the parsing of datetime literals in OPL to use a tagged string literal that contains an ISO 8601 date time. For example: `date_time"1991-01-01T00:00:00-0400"`.

The motivation for the syntax change: We want something that is clearly validated at compile time. The old syntax where we were using an a function, seems like a function which are usually executed at runtime. It seemed strange to have this one datetime function be special evalutated at compile time.

We'll also use the same tagged string pattern for regex in a future PR.

The motivation behind the format change: I felt it was best to be restrictive in the date formats we support. KQL has to support many additional formats for compatibility with the existing implementation, but OPL does not have this restriction so we can be more specific about the format supported.

## What issue does this PR close?

<!--
We highly recommend correlation of every PR to an issue
-->

* Part of #2657

## How are these changes tested?

Unit tests

## Are there any user-facing changes?

Yes - OPL programs in transform processor config with date literals will need to migrate the syntax from `datetime(1991-01-01)` to `date_time"1991-01-01T00:00:00"`. 

 <!-- If yes, provide further info below -->
