### PR TITLE
fix: use loopback address in tests to avoid Windows Firewall prompts

### DIFF
--- a/rust/otap-dataflow/crates/config/src/node.rs
+++ b/rust/otap-dataflow/crates/config/src/node.rs
@@ -544,7 +544,7 @@ header_capture:
     - match_names: ["x-request-id"]
       store_as: request_id
 config:
-  listening_addr: "0.0.0.0:50051"
+  listening_addr: "127.0.0.1:50051"
 "#;
         let cfg: NodeUserConfig = serde_yaml::from_str(yaml).unwrap();
         assert!(matches!(cfg.kind(), NodeKind::Receiver));

--- a/rust/otap-dataflow/crates/controller/src/startup.rs
+++ b/rust/otap-dataflow/crates/controller/src/startup.rs
@@ -319,10 +319,10 @@ groups:
 
     #[test]
     fn http_admin_bind_override_sets_custom_bind() {
-        let settings = http_admin_bind_override(Some("0.0.0.0:18080".to_string()));
+        let settings = http_admin_bind_override(Some("127.0.0.1:18080".to_string()));
         assert_eq!(
             settings.map(|s| s.bind_address),
-            Some("0.0.0.0:18080".to_string())
+            Some("127.0.0.1:18080".to_string())
         );
     }
 
@@ -335,7 +335,7 @@ groups:
     fn apply_cli_overrides_updates_top_level_resources_and_http_admin() {
         let mut cfg =
             OtelDataflowSpec::from_yaml(minimal_engine_yaml()).expect("base config should parse");
-        apply_cli_overrides(&mut cfg, Some(3), None, Some("0.0.0.0:28080".to_string()));
+        apply_cli_overrides(&mut cfg, Some(3), None, Some("127.0.0.1:28080".to_string()));
 
         assert_eq!(
             Policies::resolve([&cfg.policies]).resources.core_allocation,
@@ -346,7 +346,7 @@ groups:
                 .http_admin
                 .as_ref()
                 .map(|s| s.bind_address.as_str()),
-            Some("0.0.0.0:28080")
+            Some("127.0.0.1:28080")
         );
 
         let resolved = cfg.resolve();

--- a/rust/otap-dataflow/crates/telemetry/src/otel_sdk/meter_provider/prometheus_exporter_provider.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/otel_sdk/meter_provider/prometheus_exporter_provider.rs
@@ -133,7 +133,7 @@ mod tests {
     #[test]
     fn test_prometheus_exporter_provider_configure_exporter() {
         let prometheus_config = PrometheusExporterConfig {
-            host: "0.0.0.0".to_string(),
+            host: "127.0.0.1".to_string(),
             port: 9090,
             path: "/metrics".to_string(),
         };

--- a/rust/otap-dataflow/crates/validation/src/pipeline.rs
+++ b/rust/otap-dataflow/crates/validation/src/pipeline.rs
@@ -323,13 +323,13 @@ nodes:
     config:
       protocols:
         grpc:
-          listening_addr: "0.0.0.0:4317"
+          listening_addr: "127.0.0.1:4317"
   exporter:
     config:
       grpc_endpoint: "http://default-export"
   otap_recv:
     config:
-      listening_addr: "0.0.0.0:4420"
+      listening_addr: "127.0.0.1:4420"
   otap_exp:
     config:
       grpc_endpoint: "http://default-otap-export"

--- a/rust/otap-dataflow/crates/validation/src/scenario.rs
+++ b/rust/otap-dataflow/crates/validation/src/scenario.rs
@@ -485,13 +485,13 @@ nodes:
     config:
       protocols:
         grpc:
-          listening_addr: "0.0.0.0:4317"
+          listening_addr: "127.0.0.1:4317"
   exporter:
     config:
       grpc_endpoint: "http://default-export"
   otap_recv:
     config:
-      listening_addr: "0.0.0.0:4420"
+      listening_addr: "127.0.0.1:4420"
   otap_exp:
     config:
       grpc_endpoint: "http://default-otap-export"
@@ -622,7 +622,7 @@ nodes:
     config:
       protocols:
         grpc:
-          listening_addr: "0.0.0.0:4317"
+          listening_addr: "127.0.0.1:4317"
   kafka_sink:
     config:
       broker: "placeholder:9092"
@@ -724,7 +724,7 @@ nodes:
     config:
       protocols:
         grpc:
-          listening_addr: "0.0.0.0:4317"
+          listening_addr: "127.0.0.1:4317"
   kafka_sink:
     config:
       broker: "placeholder:9092"


### PR DESCRIPTION
# Change Summary

Replace `0.0.0.0` with `127.0.0.1` in test configurations that create or could create TCP listeners. Binding to `0.0.0.0` (all interfaces) triggers a Windows Firewall allow/block prompt on every `cargo test` run -- and because each recompile produces a new binary hash, the prompt recurs even after clicking "Allow".

## What issue does this PR close?

<!--
We highly recommend correlation of every PR to an issue
-->

* Closes #2660 

## How are these changes tested?

Tested locally.

## Are there any user-facing changes?

 <!-- If yes, provide further info below -->
