### PR TITLE
Set default log level to info in config files

### DIFF
--- a/rust/otap-dataflow/configs/fake-batch-console.yaml
+++ b/rust/otap-dataflow/configs/fake-batch-console.yaml
@@ -2,7 +2,7 @@ version: otel_dataflow/v1
 engine:
   telemetry:
     logs:
-      level: debug
+      level: info
       providers:
         engine: console_async
         global: console_async

--- a/rust/otap-dataflow/configs/internal-telemetry.yaml
+++ b/rust/otap-dataflow/configs/internal-telemetry.yaml
@@ -19,7 +19,7 @@ engine:
                 port: 9090
                 path: "/metrics"
     logs:
-      level: "debug"
+      level: "info"
       providers:
         global: its
         engine: its


### PR DESCRIPTION
Debug log level in config files causes excessive noise from internal crates and dependencies (e.g., `h2`), flooding the console and even overwhelming the internal telemetry channel (causing `Channel full, dropping observed event` errors).

**Changes:**
- `rust/otap-dataflow/configs/fake-batch-console.yaml`: Change log level from `debug` to `info`
- `rust/otap-dataflow/configs/internal-telemetry.yaml`: Change log level from `debug` to `info`