### PR TITLE
Address new rust 1.95 clippy errors

### DIFF
--- a/rust/experimental/query_engine/engine-recordset/src/transform/reduce_map_transform_expression.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/transform/reduce_map_transform_expression.rs
@@ -48,8 +48,8 @@ pub fn execute_map_reduce_transform_expression<'a, TRecord: Record>(
                     if let Some(inner_reduction) = reduction.keys.get(&MapReductionKey::Key(k)) {
                         let v = v.to_static_value_mut();
                         let remove = match v {
-                            Some(StaticValueMut::Map(m)) => {
-                                if !inner_reduction.key_patterns.is_empty() || !inner_reduction.keys.is_empty() {
+                            Some(StaticValueMut::Map(m))
+                                if (!inner_reduction.key_patterns.is_empty() || !inner_reduction.keys.is_empty()) => {
                                     execution_context.add_diagnostic_if_enabled(
                                         RecordSetEngineDiagnosticLevel::Verbose,
                                         r,
@@ -58,12 +58,8 @@ pub fn execute_map_reduce_transform_expression<'a, TRecord: Record>(
                                     remove_from_map(execution_context, r, m, inner_reduction);
                                     false
                                 }
-                                else {
-                                    true
-                                }
-                            }
-                            Some(StaticValueMut::Array(a)) => {
-                                if !inner_reduction.indices.is_empty() {
+                            Some(StaticValueMut::Array(a))
+                                if !inner_reduction.indices.is_empty() => {
                                     execution_context.add_diagnostic_if_enabled(
                                         RecordSetEngineDiagnosticLevel::Verbose,
                                         r,
@@ -72,10 +68,6 @@ pub fn execute_map_reduce_transform_expression<'a, TRecord: Record>(
                                     remove_from_array(execution_context, r, a, inner_reduction);
                                     false
                                 }
-                                else {
-                                    true
-                                }
-                            }
                             _ => true
                         };
 
@@ -125,8 +117,8 @@ pub fn execute_map_reduce_transform_expression<'a, TRecord: Record>(
                     if let Some(inner_reduction) = reduction.keys.get(&MapReductionKey::Key(k)) {
                         let v = v.to_static_value_mut();
                         match v {
-                            Some(StaticValueMut::Map(m)) => {
-                                if !inner_reduction.key_patterns.is_empty() || !inner_reduction.keys.is_empty() {
+                            Some(StaticValueMut::Map(m))
+                                if (!inner_reduction.key_patterns.is_empty() || !inner_reduction.keys.is_empty()) => {
                                     execution_context.add_diagnostic_if_enabled(
                                         RecordSetEngineDiagnosticLevel::Verbose,
                                         r,
@@ -134,9 +126,8 @@ pub fn execute_map_reduce_transform_expression<'a, TRecord: Record>(
                                     );
                                     keep_in_map(execution_context, r, m, inner_reduction);
                                 }
-                            }
-                            Some(StaticValueMut::Array(a)) => {
-                                if !inner_reduction.indices.is_empty() {
+                            Some(StaticValueMut::Array(a))
+                                if !inner_reduction.indices.is_empty() => {
                                     execution_context.add_diagnostic_if_enabled(
                                         RecordSetEngineDiagnosticLevel::Verbose,
                                         r,
@@ -144,7 +135,6 @@ pub fn execute_map_reduce_transform_expression<'a, TRecord: Record>(
                                     );
                                     keep_in_array(execution_context, r, a, inner_reduction);
                                 }
-                            }
                             _ => {}
                         }
 
@@ -416,8 +406,8 @@ fn remove_from_map<'a, TRecord: Record + 'static>(
         if let Some(inner_reduction) = reduction.keys.get(&MapReductionKey::Key(k)) {
             let v = v.to_static_value_mut();
             let remove = match v {
-                Some(StaticValueMut::Map(m)) => {
-                    if !inner_reduction.key_patterns.is_empty() || !inner_reduction.keys.is_empty() {
+                Some(StaticValueMut::Map(m))
+                    if (!inner_reduction.key_patterns.is_empty() || !inner_reduction.keys.is_empty()) => {
                         execution_context.add_diagnostic_if_enabled(
                             RecordSetEngineDiagnosticLevel::Verbose,
                             expression,
@@ -426,12 +416,8 @@ fn remove_from_map<'a, TRecord: Record + 'static>(
                         remove_from_map(execution_context, expression, m, inner_reduction);
                         false
                     }
-                    else {
-                        true
-                    }
-                }
-                Some(StaticValueMut::Array(a)) => {
-                    if !inner_reduction.indices.is_empty() {
+                Some(StaticValueMut::Array(a))
+                    if !inner_reduction.indices.is_empty() => {
                         execution_context.add_diagnostic_if_enabled(
                             RecordSetEngineDiagnosticLevel::Verbose,
                             expression,
@@ -440,10 +426,6 @@ fn remove_from_map<'a, TRecord: Record + 'static>(
                         remove_from_array(execution_context, expression, a, inner_reduction);
                         false
                     }
-                    else {
-                        true
-                    }
-                }
                 _ => true
             };
 
@@ -494,8 +476,8 @@ fn remove_from_array<'a, TRecord: Record + 'static>(
         if let Some(inner_reduction) = elements.get(&i) {
             let v = v.to_static_value_mut();
             let remove = match v {
-                Some(StaticValueMut::Map(m)) => {
-                    if !inner_reduction.key_patterns.is_empty() || !inner_reduction.keys.is_empty() {
+                Some(StaticValueMut::Map(m))
+                    if (!inner_reduction.key_patterns.is_empty() || !inner_reduction.keys.is_empty()) => {
                         execution_context.add_diagnostic_if_enabled(
                             RecordSetEngineDiagnosticLevel::Verbose,
                             expression,
@@ -504,12 +486,8 @@ fn remove_from_array<'a, TRecord: Record + 'static>(
                         remove_from_map(execution_context, expression, m, inner_reduction);
                         false
                     }
-                    else {
-                        true
-                    }
-                }
-                Some(StaticValueMut::Array(a)) => {
-                    if !inner_reduction.indices.is_empty() {
+                Some(StaticValueMut::Array(a))
+                    if !inner_reduction.indices.is_empty() => {
                         execution_context.add_diagnostic_if_enabled(
                             RecordSetEngineDiagnosticLevel::Verbose,
                             expression,
@@ -518,10 +496,6 @@ fn remove_from_array<'a, TRecord: Record + 'static>(
                         remove_from_array(execution_context, expression, a, inner_reduction);
                         false
                     }
-                    else {
-                        true
-                    }
-                }
                 _ => true
             };
 
@@ -557,8 +531,8 @@ fn keep_in_map<'a, TRecord: Record + 'static>(
         if let Some(inner_reduction) = reduction.keys.get(&MapReductionKey::Key(k)) {
             let v = v.to_static_value_mut();
             match v {
-                Some(StaticValueMut::Map(m)) => {
-                    if !inner_reduction.key_patterns.is_empty() || !inner_reduction.keys.is_empty() {
+                Some(StaticValueMut::Map(m))
+                    if (!inner_reduction.key_patterns.is_empty() || !inner_reduction.keys.is_empty()) => {
                         execution_context.add_diagnostic_if_enabled(
                             RecordSetEngineDiagnosticLevel::Verbose,
                             expression,
@@ -566,9 +540,8 @@ fn keep_in_map<'a, TRecord: Record + 'static>(
                         );
                         keep_in_map(execution_context, expression, m, inner_reduction);
                     }
-                }
-                Some(StaticValueMut::Array(a)) => {
-                    if !inner_reduction.indices.is_empty() {
+                Some(StaticValueMut::Array(a))
+                    if !inner_reduction.indices.is_empty() => {
                         execution_context.add_diagnostic_if_enabled(
                             RecordSetEngineDiagnosticLevel::Verbose,
                             expression,
@@ -576,7 +549,6 @@ fn keep_in_map<'a, TRecord: Record + 'static>(
                         );
                         keep_in_array(execution_context, expression, a, inner_reduction);
                     }
-                }
                 _ => { }
             }
 
@@ -627,8 +599,8 @@ fn keep_in_array<'a, TRecord: Record + 'static>(
         if let Some(inner_reduction) = elements.get(&i) {
             let v = v.to_static_value_mut();
             match v {
-                Some(StaticValueMut::Map(m)) => {
-                    if !inner_reduction.key_patterns.is_empty() || !inner_reduction.keys.is_empty() {
+                Some(StaticValueMut::Map(m))
+                    if (!inner_reduction.key_patterns.is_empty() || !inner_reduction.keys.is_empty()) => {
                         execution_context.add_diagnostic_if_enabled(
                             RecordSetEngineDiagnosticLevel::Verbose,
                             expression,
@@ -636,9 +608,8 @@ fn keep_in_array<'a, TRecord: Record + 'static>(
                         );
                         keep_in_map(execution_context, expression, m, inner_reduction);
                     }
-                }
-                Some(StaticValueMut::Array(a)) => {
-                    if !inner_reduction.indices.is_empty() {
+                Some(StaticValueMut::Array(a))
+                    if !inner_reduction.indices.is_empty() => {
                         execution_context.add_diagnostic_if_enabled(
                             RecordSetEngineDiagnosticLevel::Verbose,
                             expression,
@@ -646,7 +617,6 @@ fn keep_in_array<'a, TRecord: Record + 'static>(
                         );
                         keep_in_array(execution_context, expression, a, inner_reduction);
                     }
-                }
                 _ => {}
             }
 

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/config.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/config.rs
@@ -265,10 +265,9 @@ impl Config {
 
         for (key, value) in &self.api.schema.log_record_mapping {
             match value {
-                Value::String(s)
-                    if !seen.insert(s.clone()) => {
-                        _ = duplicates.insert(s.clone());
-                    }
+                Value::String(s) if !seen.insert(s.clone()) => {
+                    _ = duplicates.insert(s.clone());
+                }
                 Value::Object(map) => {
                     if key != "attributes" {
                         return Err(Error::Config(

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/config.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/config.rs
@@ -265,11 +265,10 @@ impl Config {
 
         for (key, value) in &self.api.schema.log_record_mapping {
             match value {
-                Value::String(s) => {
-                    if !seen.insert(s.clone()) {
+                Value::String(s)
+                    if !seen.insert(s.clone()) => {
                         _ = duplicates.insert(s.clone());
                     }
-                }
                 Value::Object(map) => {
                     if key != "attributes" {
                         return Err(Error::Config(

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/otap_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/otap_receiver/mod.rs
@@ -465,8 +465,8 @@ impl shared::Receiver<OtapPdata> for OTAPReceiver {
 
                 ctrl_msg = ctrl_msg_recv.recv() => {
                     match ctrl_msg {
-                        Ok(NodeControlMsg::DrainIngress { deadline, reason }) => {
-                            if draining_deadline.is_none() {
+                        Ok(NodeControlMsg::DrainIngress { deadline, reason })
+                            if draining_deadline.is_none() => {
                                 otap_df_telemetry::otel_info!("otap_receiver.drain_ingress");
                                 // Latch the first drain request and close ingress.
                                 // This stops new admissions, but does not yet report
@@ -476,7 +476,6 @@ impl shared::Receiver<OtapPdata> for OTAPReceiver {
                                 draining_reason = Some(reason);
                                 grpc_shutdown.cancel();
                             }
-                        }
                         Ok(NodeControlMsg::Shutdown { deadline, reason }) => {
                             otap_df_telemetry::otel_info!("otap_receiver.shutdown");
                             grpc_shutdown.cancel();

--- a/rust/otap-dataflow/crates/engine/src/lib.rs
+++ b/rust/otap-dataflow/crates/engine/src/lib.rs
@@ -1780,7 +1780,7 @@ where
         // sent each message.
         let multi_source = self.sources.len() > 1;
 
-        for (source, sender) in self.sources.into_iter().zip(self.senders.into_iter()) {
+        for (source, sender) in self.sources.into_iter().zip(self.senders) {
             let src_node = pipeline
                 .get_mut_node_with_pdata_sender(source.node_id.index)
                 .ok_or_else(|| Error::UnknownNode {

--- a/rust/otap-dataflow/crates/engine/src/topic/topic.rs
+++ b/rust/otap-dataflow/crates/engine/src/topic/topic.rs
@@ -745,7 +745,7 @@ impl<T: Send + Sync + 'static> MixedTopic<T> {
                 tracked: false,
                 payload: Arc::clone(&msg),
             };
-            for (group, permit) in groups.as_ref().iter().zip(permits.into_iter()) {
+            for (group, permit) in groups.as_ref().iter().zip(permits) {
                 send_queued_envelope(&group.tx, envelope.clone(), permit)?;
             }
         }
@@ -778,7 +778,7 @@ impl<T: Send + Sync + 'static> MixedTopic<T> {
                 tracked: true,
                 payload: Arc::clone(&msg),
             };
-            for (group, admission_permit) in groups.as_ref().iter().zip(permits.into_iter()) {
+            for (group, admission_permit) in groups.as_ref().iter().zip(permits) {
                 send_queued_envelope(&group.tx, envelope.clone(), admission_permit)?;
             }
             self.broadcast_ring.publish(Envelope {
@@ -823,7 +823,7 @@ impl<T: Send + Sync + 'static> MixedTopic<T> {
         if blocking_group.is_some() {
             Ok((PublishOutcome::DroppedOnFull, id))
         } else {
-            for (group, permit) in groups.as_ref().iter().zip(permits.into_iter()) {
+            for (group, permit) in groups.as_ref().iter().zip(permits) {
                 send_queued_envelope(&group.tx, envelope.clone(), permit)?;
             }
             self.broadcast_ring.publish(Envelope {
@@ -858,7 +858,7 @@ impl<T: Send + Sync + 'static> MixedTopic<T> {
                 tracked: true,
                 payload: Arc::clone(&msg),
             };
-            for (group, admission_permit) in groups.as_ref().iter().zip(permits.into_iter()) {
+            for (group, admission_permit) in groups.as_ref().iter().zip(permits) {
                 send_queued_envelope(&group.tx, envelope.clone(), admission_permit)?;
             }
             self.broadcast_ring.publish(Envelope {

--- a/rust/otap-dataflow/crates/pdata/src/otap/transform.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/transform.rs
@@ -2906,7 +2906,7 @@ pub(crate) fn sort_to_indices(sort_columns: &[SortColumn]) -> arrow::error::Resu
             .convert_columns(&sort_arrays)
             .expect("error converting columns for sorting");
         let mut sort: Vec<_> = rows.iter().enumerate().collect();
-        sort.sort_unstable_by(|(_, a), (_, b)| a.cmp(b));
+        sort.sort_unstable_by_key(|(_, a)| *a);
 
         let indices = UInt32Array::from_iter_values(sort.iter().map(|(i, _)| *i as u32));
         Ok(indices)

--- a/rust/otap-dataflow/crates/pdata/src/otap/transform/transport_optimize/attributes.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/transform/transport_optimize/attributes.rs
@@ -569,7 +569,7 @@ fn sort_attrs_type_and_keys_to_indices(
                 }
 
                 let mut with_indices = to_sort.into_iter().enumerate().collect::<Vec<_>>();
-                with_indices.sort_unstable_by(|a, b| a.1.cmp(&b.1));
+                with_indices.sort_unstable_by_key(|a| a.1);
 
                 Ok(PrimitiveArray::from_iter_values(
                     with_indices.into_iter().map(|(rank, _)| rank as u32),
@@ -600,7 +600,7 @@ fn sort_attrs_type_and_keys_to_indices(
                 }
 
                 let mut with_indices = to_sort.into_iter().enumerate().collect::<Vec<_>>();
-                with_indices.sort_unstable_by(|a, b| a.1.cmp(&b.1));
+                with_indices.sort_unstable_by_key(|a| a.1);
 
                 Ok(PrimitiveArray::from_iter_values(
                     with_indices.into_iter().map(|(rank, _)| rank as u32),
@@ -642,7 +642,7 @@ fn sort_attrs_type_and_keys_to_indices(
             }
 
             let mut with_indices = to_sort.into_iter().enumerate().collect::<Vec<_>>();
-            with_indices.sort_unstable_by(|a, b| a.1.cmp(&b.1));
+            with_indices.sort_unstable_by_key(|a| a.1);
 
             Ok(PrimitiveArray::from_iter_values(
                 with_indices.into_iter().map(|(rank, _)| rank as u32),
@@ -1178,7 +1178,7 @@ impl AttrValuesSorter {
                         }
                     });
                 } else {
-                    self.rank_sort.sort_unstable_by(|a, b| a.1.cmp(&b.1));
+                    self.rank_sort.sort_unstable_by_key(|a| a.1);
                 }
 
                 // take the sorted values segment
@@ -2824,12 +2824,10 @@ mod test {
         let mut parent_id_keys = Vec::new();
         let mut values = Vec::new();
         let mut current_id = 1u32;
-        let mut gap = 1;
-        for i in 0u8..=255u8 {
+        for (gap, i) in (1..).zip(0u8..=255u8) {
             parent_id_keys.push(i);
             parent_ids.push(current_id);
             current_id += gap;
-            gap += 1;
             values.push("a".to_string());
         }
         values.push("b".into());

--- a/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/common.rs
+++ b/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/common.rs
@@ -165,22 +165,20 @@ impl FieldRanges for InstrumentationScopeFieldOffsets {
         };
 
         match field_num {
-            INSTRUMENTATION_SCOPE_NAME
-                if wire_type == wire_types::LEN => {
-                    self.name.set(range);
-                }
-            INSTRUMENTATION_SCOPE_VERSION
-                if wire_type == wire_types::LEN => {
-                    self.version.set(range);
-                }
-            INSTRUMENTATION_DROPPED_ATTRIBUTES_COUNT
-                if wire_type == wire_types::VARINT => {
-                    self.dropped_attributes_count.set(range);
-                }
+            INSTRUMENTATION_SCOPE_NAME if wire_type == wire_types::LEN => {
+                self.name.set(range);
+            }
+            INSTRUMENTATION_SCOPE_VERSION if wire_type == wire_types::LEN => {
+                self.version.set(range);
+            }
+            INSTRUMENTATION_DROPPED_ATTRIBUTES_COUNT if wire_type == wire_types::VARINT => {
+                self.dropped_attributes_count.set(range);
+            }
             INSTRUMENTATION_SCOPE_ATTRIBUTES
-                if self.first_attribute.get().is_none() && wire_type == wire_types::LEN => {
-                    self.first_attribute.set(range);
-                }
+                if self.first_attribute.get().is_none() && wire_type == wire_types::LEN =>
+            {
+                self.first_attribute.set(range);
+            }
             _ => {
                 // ignore unknown field_num
             }

--- a/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/common.rs
+++ b/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/common.rs
@@ -165,26 +165,22 @@ impl FieldRanges for InstrumentationScopeFieldOffsets {
         };
 
         match field_num {
-            INSTRUMENTATION_SCOPE_NAME => {
-                if wire_type == wire_types::LEN {
+            INSTRUMENTATION_SCOPE_NAME
+                if wire_type == wire_types::LEN => {
                     self.name.set(range);
                 }
-            }
-            INSTRUMENTATION_SCOPE_VERSION => {
-                if wire_type == wire_types::LEN {
+            INSTRUMENTATION_SCOPE_VERSION
+                if wire_type == wire_types::LEN => {
                     self.version.set(range);
                 }
-            }
-            INSTRUMENTATION_DROPPED_ATTRIBUTES_COUNT => {
-                if wire_type == wire_types::VARINT {
+            INSTRUMENTATION_DROPPED_ATTRIBUTES_COUNT
+                if wire_type == wire_types::VARINT => {
                     self.dropped_attributes_count.set(range);
                 }
-            }
-            INSTRUMENTATION_SCOPE_ATTRIBUTES => {
-                if self.first_attribute.get().is_none() && wire_type == wire_types::LEN {
+            INSTRUMENTATION_SCOPE_ATTRIBUTES
+                if self.first_attribute.get().is_none() && wire_type == wire_types::LEN => {
                     self.first_attribute.set(range);
                 }
-            }
             _ => {
                 // ignore unknown field_num
             }

--- a/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/logs.rs
+++ b/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/logs.rs
@@ -101,11 +101,10 @@ impl FieldRanges for ResourceLogsFieldOffsets {
             match field_num {
                 RESOURCE_LOGS_RESOURCE => self.resource.set(range),
                 RESOURCE_LOGS_SCHEMA_URL => self.schema_url.set(range),
-                RESOURCE_LOGS_SCOPE_LOGS => {
-                    if self.first_scope_logs.get().is_none() {
+                RESOURCE_LOGS_SCOPE_LOGS
+                    if self.first_scope_logs.get().is_none() => {
                         self.first_scope_logs.set(range);
                     }
-                }
                 _ => { /* ignore */ }
             }
         }
@@ -153,11 +152,10 @@ impl FieldRanges for ScopeLogsFieldOffsets {
             match field_num {
                 SCOPE_LOG_SCOPE => self.scope.set(range),
                 SCOPE_LOGS_SCHEMA_URL => self.schema_url.set(range),
-                SCOPE_LOGS_LOG_RECORDS => {
-                    if self.first_log_record.get().is_none() {
+                SCOPE_LOGS_LOG_RECORDS
+                    if self.first_log_record.get().is_none() => {
                         self.first_log_record.set(range)
                     }
-                }
                 _ => { /* ignore unknown field */ }
             }
         }

--- a/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/logs.rs
+++ b/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/logs.rs
@@ -101,10 +101,9 @@ impl FieldRanges for ResourceLogsFieldOffsets {
             match field_num {
                 RESOURCE_LOGS_RESOURCE => self.resource.set(range),
                 RESOURCE_LOGS_SCHEMA_URL => self.schema_url.set(range),
-                RESOURCE_LOGS_SCOPE_LOGS
-                    if self.first_scope_logs.get().is_none() => {
-                        self.first_scope_logs.set(range);
-                    }
+                RESOURCE_LOGS_SCOPE_LOGS if self.first_scope_logs.get().is_none() => {
+                    self.first_scope_logs.set(range);
+                }
                 _ => { /* ignore */ }
             }
         }
@@ -152,10 +151,9 @@ impl FieldRanges for ScopeLogsFieldOffsets {
             match field_num {
                 SCOPE_LOG_SCOPE => self.scope.set(range),
                 SCOPE_LOGS_SCHEMA_URL => self.schema_url.set(range),
-                SCOPE_LOGS_LOG_RECORDS
-                    if self.first_log_record.get().is_none() => {
-                        self.first_log_record.set(range)
-                    }
+                SCOPE_LOGS_LOG_RECORDS if self.first_log_record.get().is_none() => {
+                    self.first_log_record.set(range)
+                }
                 _ => { /* ignore unknown field */ }
             }
         }

--- a/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/metrics.rs
+++ b/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/metrics.rs
@@ -103,11 +103,10 @@ impl FieldRanges for ResourceMetricsFieldRanges {
             match field_num {
                 RESOURCE_METRICS_RESOURCE => self.resource.set(Some(range)),
                 RESOURCE_METRICS_SCHEMA_URL => self.schema_url.set(Some(range)),
-                RESOURCE_METRICS_SCOPE_METRICS => {
-                    if self.first_scope_metrics.get().is_none() {
+                RESOURCE_METRICS_SCOPE_METRICS
+                    if self.first_scope_metrics.get().is_none() => {
                         self.first_scope_metrics.set(Some(range))
                     }
-                }
                 _ => { /* ignore */ }
             }
         }
@@ -156,11 +155,10 @@ impl FieldRanges for ScopeMetricsFieldRanges {
             match field_num {
                 SCOPE_METRICS_SCOPE => self.scope.set(Some(range)),
                 SCOPE_METRICS_SCHEMA_URL => self.schema_url.set(Some(range)),
-                SCOPE_METRICS_METRICS => {
-                    if self.first_metric.get().is_none() {
+                SCOPE_METRICS_METRICS
+                    if self.first_metric.get().is_none() => {
                         self.first_metric.set(Some(range))
                     }
-                }
                 _ => { /* ignore */ }
             }
         }
@@ -232,11 +230,10 @@ impl FieldRanges for MetricFieldRanges {
                 | METRIC_HISTOGRAM
                 | METRIC_EXPONENTIAL_HISTOGRAM
                 | METRIC_SUMMARY => self.data.set(Some((range, field_num))),
-                METRIC_METADATA => {
-                    if self.first_metadata.get().is_none() {
+                METRIC_METADATA
+                    if self.first_metadata.get().is_none() => {
                         self.first_metadata.set(Some(range))
                     }
-                }
                 _ => { /* ignore */ }
             }
         }
@@ -282,11 +279,10 @@ impl FieldRanges for GaugeFieldRanges {
             };
 
             match field_num {
-                GAUGE_DATA_POINTS => {
-                    if self.first_data_point.get().is_none() {
+                GAUGE_DATA_POINTS
+                    if self.first_data_point.get().is_none() => {
                         self.first_data_point.set(Some(range))
                     }
-                }
                 _ => { /* ignore */ }
             }
         }
@@ -332,21 +328,18 @@ impl FieldRanges for SumFieldRanges {
         };
 
         match field_num {
-            SUM_AGGREGATION_TEMPORALITY => {
-                if wire_type == wire_types::VARINT {
+            SUM_AGGREGATION_TEMPORALITY
+                if wire_type == wire_types::VARINT => {
                     self.aggregation_temporality.set(Some(range))
                 }
-            }
-            SUM_IS_MONOTONIC => {
-                if wire_type == wire_types::VARINT {
+            SUM_IS_MONOTONIC
+                if wire_type == wire_types::VARINT => {
                     self.is_monotonic.set(Some(range))
                 }
-            }
-            SUM_DATA_POINTS => {
-                if wire_type == wire_types::LEN && self.first_data_point.get().is_none() {
+            SUM_DATA_POINTS
+                if wire_type == wire_types::LEN && self.first_data_point.get().is_none() => {
                     self.first_data_point.set(Some(range))
                 }
-            }
             _ => { /* ignore */ }
         }
     }
@@ -389,16 +382,14 @@ impl FieldRanges for HistogramFieldRanges {
         };
 
         match field_num {
-            HISTOGRAM_AGGREGATION_TEMPORALITY => {
-                if wire_type == wire_types::VARINT {
+            HISTOGRAM_AGGREGATION_TEMPORALITY
+                if wire_type == wire_types::VARINT => {
                     self.aggregation_temporality.set(Some(range))
                 }
-            }
-            HISTOGRAM_DATA_POINTS => {
-                if wire_type == wire_types::LEN && self.first_data_point.get().is_none() {
+            HISTOGRAM_DATA_POINTS
+                if wire_type == wire_types::LEN && self.first_data_point.get().is_none() => {
                     self.first_data_point.set(Some(range))
                 }
-            }
             _ => { /* ignore */ }
         }
     }
@@ -441,16 +432,14 @@ impl FieldRanges for ExpHistogramFieldRanges {
         };
 
         match field_num {
-            EXPONENTIAL_HISTOGRAM_AGGREGATION_TEMPORALITY => {
-                if wire_type == wire_types::VARINT {
+            EXPONENTIAL_HISTOGRAM_AGGREGATION_TEMPORALITY
+                if wire_type == wire_types::VARINT => {
                     self.aggregation_temporality.set(Some(range))
                 }
-            }
-            EXPONENTIAL_HISTOGRAM_DATA_POINTS => {
-                if wire_type == wire_types::LEN && self.first_data_point.get().is_none() {
+            EXPONENTIAL_HISTOGRAM_DATA_POINTS
+                if wire_type == wire_types::LEN && self.first_data_point.get().is_none() => {
                     self.first_data_point.set(Some(range))
                 }
-            }
             _ => { /* ignore */ }
         }
     }
@@ -488,11 +477,10 @@ impl FieldRanges for SummaryFieldRanges {
         };
 
         match field_num {
-            SUMMARY_DATA_POINTS => {
-                if wire_type == wire_types::LEN && self.first_data_point.get().is_none() {
+            SUMMARY_DATA_POINTS
+                if wire_type == wire_types::LEN && self.first_data_point.get().is_none() => {
                     self.first_data_point.set(Some(range))
                 }
-            }
             _ => { /* ignore */ }
         }
     }
@@ -554,38 +542,32 @@ impl FieldRanges for NumberDataPointFieldRanges {
         };
 
         match field_num {
-            NUMBER_DP_START_TIME_UNIX_NANO => {
-                if wire_type == wire_types::FIXED64 {
+            NUMBER_DP_START_TIME_UNIX_NANO
+                if wire_type == wire_types::FIXED64 => {
                     self.start_time_unix_nano.set(Some(range))
                 }
-            }
-            NUMBER_DP_TIME_UNIX_NANO => {
-                if wire_type == wire_types::FIXED64 {
+            NUMBER_DP_TIME_UNIX_NANO
+                if wire_type == wire_types::FIXED64 => {
                     self.time_unix_nano.set(Some(range))
                 }
-            }
 
-            NUMBER_DP_AS_DOUBLE | NUMBER_DP_AS_INT => {
-                if wire_type == wire_types::FIXED64 {
+            NUMBER_DP_AS_DOUBLE | NUMBER_DP_AS_INT
+                if wire_type == wire_types::FIXED64 => {
                     self.value.set(Some((range, field_num)));
                 }
-            }
-            NUMBER_DP_ATTRIBUTES => {
-                if wire_type == wire_types::LEN && self.first_attribute.get().is_none() {
+            NUMBER_DP_ATTRIBUTES
+                if wire_type == wire_types::LEN && self.first_attribute.get().is_none() => {
                     self.first_attribute.set(Some(range))
                 }
-            }
-            NUMBER_DP_EXEMPLARS => {
-                if wire_type == wire_types::LEN && self.first_exemplar.get().is_none() {
+            NUMBER_DP_EXEMPLARS
+                if wire_type == wire_types::LEN && self.first_exemplar.get().is_none() => {
                     self.first_exemplar.set(Some(range))
                 }
-            }
 
-            NUMBER_DP_FLAGS => {
-                if wire_type == wire_types::VARINT {
+            NUMBER_DP_FLAGS
+                if wire_type == wire_types::VARINT => {
                     self.flags.set(Some(range))
                 }
-            }
             _ => { /* ignore */ }
         }
     }
@@ -649,67 +631,56 @@ impl FieldRanges for HistogramDataPointFieldRanges {
         };
 
         match field_num {
-            HISTOGRAM_DP_START_TIME_UNIX_NANO => {
-                if wire_type == wire_types::FIXED64 {
+            HISTOGRAM_DP_START_TIME_UNIX_NANO
+                if wire_type == wire_types::FIXED64 => {
                     self.start_time_unix_nano.set(Some(range));
                 }
-            }
-            HISTOGRAM_DP_TIME_UNIX_NANO => {
-                if wire_type == wire_types::FIXED64 {
+            HISTOGRAM_DP_TIME_UNIX_NANO
+                if wire_type == wire_types::FIXED64 => {
                     self.time_unix_nano.set(Some(range))
                 }
-            }
-            HISTOGRAM_DP_COUNT => {
-                if wire_type == wire_types::FIXED64 {
+            HISTOGRAM_DP_COUNT
+                if wire_type == wire_types::FIXED64 => {
                     self.count.set(Some(range))
                 }
-            }
-            HISTOGRAM_DP_SUM => {
-                if wire_type == wire_types::FIXED64 {
+            HISTOGRAM_DP_SUM
+                if wire_type == wire_types::FIXED64 => {
                     self.sum.set(Some(range))
                 }
-            }
-            HISTOGRAM_DP_FLAGS => {
-                if wire_type == wire_types::VARINT {
+            HISTOGRAM_DP_FLAGS
+                if wire_type == wire_types::VARINT => {
                     self.flags.set(Some(range))
                 }
-            }
-            HISTOGRAM_DP_EXPLICIT_BOUNDS => {
+            HISTOGRAM_DP_EXPLICIT_BOUNDS
                 if (wire_type == wire_types::LEN || wire_type == wire_types::FIXED64)
                     && self.first_explicit_bounds.get().is_none()
-                {
+                => {
                     let packed = wire_type == wire_types::LEN;
                     self.first_explicit_bounds.set(Some((range, packed)));
                 }
-            }
-            HISTOGRAM_DP_BUCKET_COUNTS => {
+            HISTOGRAM_DP_BUCKET_COUNTS
                 if (wire_type == wire_types::LEN || wire_type == wire_types::FIXED64)
                     && self.first_bucket_counts.get().is_none()
-                {
+                => {
                     let packed = wire_type == wire_types::LEN;
                     self.first_bucket_counts.set(Some((range, packed)));
                 }
-            }
-            HISTOGRAM_DP_MIN => {
-                if wire_type == wire_types::FIXED64 {
+            HISTOGRAM_DP_MIN
+                if wire_type == wire_types::FIXED64 => {
                     self.min.set(Some(range))
                 }
-            }
-            HISTOGRAM_DP_MAX => {
-                if wire_type == wire_types::FIXED64 {
+            HISTOGRAM_DP_MAX
+                if wire_type == wire_types::FIXED64 => {
                     self.max.set(Some(range))
                 }
-            }
-            HISTOGRAM_DP_ATTRIBUTES => {
-                if wire_type == wire_types::LEN && self.first_attributes.get().is_none() {
+            HISTOGRAM_DP_ATTRIBUTES
+                if wire_type == wire_types::LEN && self.first_attributes.get().is_none() => {
                     self.first_attributes.set(Some(range))
                 }
-            }
-            HISTOGRAM_DP_EXEMPLARS => {
-                if wire_type == wire_types::LEN && self.first_exemplar.get().is_none() {
+            HISTOGRAM_DP_EXEMPLARS
+                if wire_type == wire_types::LEN && self.first_exemplar.get().is_none() => {
                     self.first_exemplar.set(Some(range))
                 }
-            }
 
             _ => { /* ignore */ }
         }
@@ -790,76 +761,62 @@ impl FieldRanges for ExpHistogramDataPointFieldRanges {
         };
 
         match field_num {
-            EXP_HISTOGRAM_DP_START_TIME_UNIX_NANO => {
-                if wire_type == wire_types::FIXED64 {
+            EXP_HISTOGRAM_DP_START_TIME_UNIX_NANO
+                if wire_type == wire_types::FIXED64 => {
                     self.start_time_unix_nano.set(Some(range))
                 }
-            }
-            EXP_HISTOGRAM_DP_TIME_UNIX_NANO => {
-                if wire_type == wire_types::FIXED64 {
+            EXP_HISTOGRAM_DP_TIME_UNIX_NANO
+                if wire_type == wire_types::FIXED64 => {
                     self.time_unix_nano.set(Some(range))
                 }
-            }
-            EXP_HISTOGRAM_DP_COUNT => {
-                if wire_type == wire_types::FIXED64 {
+            EXP_HISTOGRAM_DP_COUNT
+                if wire_type == wire_types::FIXED64 => {
                     self.count.set(Some(range))
                 }
-            }
-            EXP_HISTOGRAM_DP_SUM => {
-                if wire_type == wire_types::FIXED64 {
+            EXP_HISTOGRAM_DP_SUM
+                if wire_type == wire_types::FIXED64 => {
                     self.sum.set(Some(range))
                 }
-            }
-            EXP_HISTOGRAM_DP_SCALE => {
-                if wire_type == wire_types::VARINT {
+            EXP_HISTOGRAM_DP_SCALE
+                if wire_type == wire_types::VARINT => {
                     self.scale.set(Some(range))
                 }
-            }
-            EXP_HISTOGRAM_DP_ZERO_COUNT => {
-                if wire_type == wire_types::FIXED64 {
+            EXP_HISTOGRAM_DP_ZERO_COUNT
+                if wire_type == wire_types::FIXED64 => {
                     self.zero_count.set(Some(range))
                 }
-            }
-            EXP_HISTOGRAM_DP_NEGATIVE => {
-                if wire_type == wire_types::LEN {
+            EXP_HISTOGRAM_DP_NEGATIVE
+                if wire_type == wire_types::LEN => {
                     self.negative.set(Some(range))
                 }
-            }
-            EXP_HISTOGRAM_DP_POSITIVE => {
-                if wire_type == wire_types::LEN {
+            EXP_HISTOGRAM_DP_POSITIVE
+                if wire_type == wire_types::LEN => {
                     self.positive.set(Some(range))
                 }
-            }
-            EXP_HISTOGRAM_DP_FLAGS => {
-                if wire_type == wire_types::VARINT {
+            EXP_HISTOGRAM_DP_FLAGS
+                if wire_type == wire_types::VARINT => {
                     self.flags.set(Some(range))
                 }
-            }
-            EXP_HISTOGRAM_DP_MIN => {
-                if wire_type == wire_types::FIXED64 {
+            EXP_HISTOGRAM_DP_MIN
+                if wire_type == wire_types::FIXED64 => {
                     self.min.set(Some(range))
                 }
-            }
-            EXP_HISTOGRAM_DP_MAX => {
-                if wire_type == wire_types::FIXED64 {
+            EXP_HISTOGRAM_DP_MAX
+                if wire_type == wire_types::FIXED64 => {
                     self.max.set(Some(range))
                 }
-            }
-            EXP_HISTOGRAM_DP_ZERO_THRESHOLD => {
-                if wire_type == wire_types::FIXED64 {
+            EXP_HISTOGRAM_DP_ZERO_THRESHOLD
+                if wire_type == wire_types::FIXED64 => {
                     self.zero_threshold.set(Some(range))
                 }
-            }
-            EXP_HISTOGRAM_DP_ATTRIBUTES => {
-                if wire_type == wire_types::LEN && self.first_attributes.get().is_none() {
+            EXP_HISTOGRAM_DP_ATTRIBUTES
+                if wire_type == wire_types::LEN && self.first_attributes.get().is_none() => {
                     self.first_attributes.set(Some(range))
                 }
-            }
-            EXP_HISTOGRAM_DP_EXEMPLARS => {
-                if wire_type == wire_types::LEN && self.first_exemplar.get().is_none() {
+            EXP_HISTOGRAM_DP_EXEMPLARS
+                if wire_type == wire_types::LEN && self.first_exemplar.get().is_none() => {
                     self.first_exemplar.set(Some(range))
                 }
-            }
             _ => { /* ignore */ }
         }
     }
@@ -904,19 +861,17 @@ impl FieldRanges for BucketsFieldRanges {
         };
 
         match field_num {
-            EXP_HISTOGRAM_BUCKET_OFFSET => {
-                if wire_type == wire_types::VARINT {
+            EXP_HISTOGRAM_BUCKET_OFFSET
+                if wire_type == wire_types::VARINT => {
                     self.offset.set(Some(range));
                 }
-            }
-            EXP_HISTOGRAM_BUCKET_BUCKET_COUNTS => {
+            EXP_HISTOGRAM_BUCKET_BUCKET_COUNTS
                 if (wire_type == wire_types::LEN || wire_type == wire_types::VARINT)
                     && self.first_bucket_count.get().is_none()
-                {
+                => {
                     let packed = wire_type == wire_types::LEN;
                     self.first_bucket_count.set(Some((range, packed)))
                 }
-            }
             _ => { /* ignore */ }
         }
     }
@@ -979,41 +934,34 @@ impl FieldRanges for SummaryDataPointFieldRanges {
         };
 
         match field_num {
-            SUMMARY_DP_START_TIME_UNIX_NANO => {
-                if wire_type == wire_types::FIXED64 {
+            SUMMARY_DP_START_TIME_UNIX_NANO
+                if wire_type == wire_types::FIXED64 => {
                     self.start_time_unix_nano.set(Some(range))
                 }
-            }
-            SUMMARY_DP_TIME_UNIX_NANO => {
-                if wire_type == wire_types::FIXED64 {
+            SUMMARY_DP_TIME_UNIX_NANO
+                if wire_type == wire_types::FIXED64 => {
                     self.time_unix_nano.set(Some(range))
                 }
-            }
-            SUMMARY_DP_COUNT => {
-                if wire_type == wire_types::FIXED64 {
+            SUMMARY_DP_COUNT
+                if wire_type == wire_types::FIXED64 => {
                     self.count.set(Some(range))
                 }
-            }
-            SUMMARY_DP_SUM => {
-                if wire_type == wire_types::FIXED64 {
+            SUMMARY_DP_SUM
+                if wire_type == wire_types::FIXED64 => {
                     self.sum.set(Some(range))
                 }
-            }
-            SUMMARY_DP_FLAGS => {
-                if wire_type == wire_types::VARINT {
+            SUMMARY_DP_FLAGS
+                if wire_type == wire_types::VARINT => {
                     self.flags.set(Some(range))
                 }
-            }
-            SUMMARY_DP_ATTRIBUTES => {
-                if wire_type == wire_types::LEN && self.first_attribute.get().is_none() {
+            SUMMARY_DP_ATTRIBUTES
+                if wire_type == wire_types::LEN && self.first_attribute.get().is_none() => {
                     self.first_attribute.set(Some(range))
                 }
-            }
-            SUMMARY_DP_QUANTILE_VALUES => {
-                if wire_type == wire_types::LEN && self.first_quantile_value.get().is_none() {
+            SUMMARY_DP_QUANTILE_VALUES
+                if wire_type == wire_types::LEN && self.first_quantile_value.get().is_none() => {
                     self.first_quantile_value.set(Some(range))
                 }
-            }
             _ => { /* ignore */ }
         }
     }
@@ -1110,31 +1058,26 @@ impl FieldRanges for ExemplarFieldRanges {
         };
 
         match field_num {
-            EXEMPLAR_TIME_UNIX_NANO => {
-                if wire_type == wire_types::FIXED64 {
+            EXEMPLAR_TIME_UNIX_NANO
+                if wire_type == wire_types::FIXED64 => {
                     self.time_unix_nano.set(Some(range))
                 }
-            }
-            EXEMPLAR_SPAN_ID => {
-                if wire_type == wire_types::LEN {
+            EXEMPLAR_SPAN_ID
+                if wire_type == wire_types::LEN => {
                     self.span_id.set(Some(range))
                 }
-            }
-            EXEMPLAR_TRACE_ID => {
-                if wire_type == wire_types::LEN {
+            EXEMPLAR_TRACE_ID
+                if wire_type == wire_types::LEN => {
                     self.trace_id.set(Some(range))
                 }
-            }
-            EXEMPLAR_AS_DOUBLE | EXEMPLAR_AS_INT => {
-                if wire_type == wire_types::FIXED64 {
+            EXEMPLAR_AS_DOUBLE | EXEMPLAR_AS_INT
+                if wire_type == wire_types::FIXED64 => {
                     self.value.set(Some((range, field_num)));
                 }
-            }
-            EXEMPLAR_FILTERED_ATTRIBUTES => {
-                if wire_type == wire_types::LEN && self.first_filtered_attribute.get().is_none() {
+            EXEMPLAR_FILTERED_ATTRIBUTES
+                if wire_type == wire_types::LEN && self.first_filtered_attribute.get().is_none() => {
                     self.first_filtered_attribute.set(Some(range))
                 }
-            }
             _ => { /* ignore */ }
         }
     }

--- a/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/metrics.rs
+++ b/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/metrics.rs
@@ -103,10 +103,9 @@ impl FieldRanges for ResourceMetricsFieldRanges {
             match field_num {
                 RESOURCE_METRICS_RESOURCE => self.resource.set(Some(range)),
                 RESOURCE_METRICS_SCHEMA_URL => self.schema_url.set(Some(range)),
-                RESOURCE_METRICS_SCOPE_METRICS
-                    if self.first_scope_metrics.get().is_none() => {
-                        self.first_scope_metrics.set(Some(range))
-                    }
+                RESOURCE_METRICS_SCOPE_METRICS if self.first_scope_metrics.get().is_none() => {
+                    self.first_scope_metrics.set(Some(range))
+                }
                 _ => { /* ignore */ }
             }
         }
@@ -155,10 +154,9 @@ impl FieldRanges for ScopeMetricsFieldRanges {
             match field_num {
                 SCOPE_METRICS_SCOPE => self.scope.set(Some(range)),
                 SCOPE_METRICS_SCHEMA_URL => self.schema_url.set(Some(range)),
-                SCOPE_METRICS_METRICS
-                    if self.first_metric.get().is_none() => {
-                        self.first_metric.set(Some(range))
-                    }
+                SCOPE_METRICS_METRICS if self.first_metric.get().is_none() => {
+                    self.first_metric.set(Some(range))
+                }
                 _ => { /* ignore */ }
             }
         }
@@ -230,10 +228,9 @@ impl FieldRanges for MetricFieldRanges {
                 | METRIC_HISTOGRAM
                 | METRIC_EXPONENTIAL_HISTOGRAM
                 | METRIC_SUMMARY => self.data.set(Some((range, field_num))),
-                METRIC_METADATA
-                    if self.first_metadata.get().is_none() => {
-                        self.first_metadata.set(Some(range))
-                    }
+                METRIC_METADATA if self.first_metadata.get().is_none() => {
+                    self.first_metadata.set(Some(range))
+                }
                 _ => { /* ignore */ }
             }
         }
@@ -279,10 +276,9 @@ impl FieldRanges for GaugeFieldRanges {
             };
 
             match field_num {
-                GAUGE_DATA_POINTS
-                    if self.first_data_point.get().is_none() => {
-                        self.first_data_point.set(Some(range))
-                    }
+                GAUGE_DATA_POINTS if self.first_data_point.get().is_none() => {
+                    self.first_data_point.set(Some(range))
+                }
                 _ => { /* ignore */ }
             }
         }
@@ -328,18 +324,17 @@ impl FieldRanges for SumFieldRanges {
         };
 
         match field_num {
-            SUM_AGGREGATION_TEMPORALITY
-                if wire_type == wire_types::VARINT => {
-                    self.aggregation_temporality.set(Some(range))
-                }
-            SUM_IS_MONOTONIC
-                if wire_type == wire_types::VARINT => {
-                    self.is_monotonic.set(Some(range))
-                }
+            SUM_AGGREGATION_TEMPORALITY if wire_type == wire_types::VARINT => {
+                self.aggregation_temporality.set(Some(range))
+            }
+            SUM_IS_MONOTONIC if wire_type == wire_types::VARINT => {
+                self.is_monotonic.set(Some(range))
+            }
             SUM_DATA_POINTS
-                if wire_type == wire_types::LEN && self.first_data_point.get().is_none() => {
-                    self.first_data_point.set(Some(range))
-                }
+                if wire_type == wire_types::LEN && self.first_data_point.get().is_none() =>
+            {
+                self.first_data_point.set(Some(range))
+            }
             _ => { /* ignore */ }
         }
     }
@@ -382,14 +377,14 @@ impl FieldRanges for HistogramFieldRanges {
         };
 
         match field_num {
-            HISTOGRAM_AGGREGATION_TEMPORALITY
-                if wire_type == wire_types::VARINT => {
-                    self.aggregation_temporality.set(Some(range))
-                }
+            HISTOGRAM_AGGREGATION_TEMPORALITY if wire_type == wire_types::VARINT => {
+                self.aggregation_temporality.set(Some(range))
+            }
             HISTOGRAM_DATA_POINTS
-                if wire_type == wire_types::LEN && self.first_data_point.get().is_none() => {
-                    self.first_data_point.set(Some(range))
-                }
+                if wire_type == wire_types::LEN && self.first_data_point.get().is_none() =>
+            {
+                self.first_data_point.set(Some(range))
+            }
             _ => { /* ignore */ }
         }
     }
@@ -432,14 +427,14 @@ impl FieldRanges for ExpHistogramFieldRanges {
         };
 
         match field_num {
-            EXPONENTIAL_HISTOGRAM_AGGREGATION_TEMPORALITY
-                if wire_type == wire_types::VARINT => {
-                    self.aggregation_temporality.set(Some(range))
-                }
+            EXPONENTIAL_HISTOGRAM_AGGREGATION_TEMPORALITY if wire_type == wire_types::VARINT => {
+                self.aggregation_temporality.set(Some(range))
+            }
             EXPONENTIAL_HISTOGRAM_DATA_POINTS
-                if wire_type == wire_types::LEN && self.first_data_point.get().is_none() => {
-                    self.first_data_point.set(Some(range))
-                }
+                if wire_type == wire_types::LEN && self.first_data_point.get().is_none() =>
+            {
+                self.first_data_point.set(Some(range))
+            }
             _ => { /* ignore */ }
         }
     }
@@ -478,9 +473,10 @@ impl FieldRanges for SummaryFieldRanges {
 
         match field_num {
             SUMMARY_DATA_POINTS
-                if wire_type == wire_types::LEN && self.first_data_point.get().is_none() => {
-                    self.first_data_point.set(Some(range))
-                }
+                if wire_type == wire_types::LEN && self.first_data_point.get().is_none() =>
+            {
+                self.first_data_point.set(Some(range))
+            }
             _ => { /* ignore */ }
         }
     }
@@ -542,32 +538,28 @@ impl FieldRanges for NumberDataPointFieldRanges {
         };
 
         match field_num {
-            NUMBER_DP_START_TIME_UNIX_NANO
-                if wire_type == wire_types::FIXED64 => {
-                    self.start_time_unix_nano.set(Some(range))
-                }
-            NUMBER_DP_TIME_UNIX_NANO
-                if wire_type == wire_types::FIXED64 => {
-                    self.time_unix_nano.set(Some(range))
-                }
+            NUMBER_DP_START_TIME_UNIX_NANO if wire_type == wire_types::FIXED64 => {
+                self.start_time_unix_nano.set(Some(range))
+            }
+            NUMBER_DP_TIME_UNIX_NANO if wire_type == wire_types::FIXED64 => {
+                self.time_unix_nano.set(Some(range))
+            }
 
-            NUMBER_DP_AS_DOUBLE | NUMBER_DP_AS_INT
-                if wire_type == wire_types::FIXED64 => {
-                    self.value.set(Some((range, field_num)));
-                }
+            NUMBER_DP_AS_DOUBLE | NUMBER_DP_AS_INT if wire_type == wire_types::FIXED64 => {
+                self.value.set(Some((range, field_num)));
+            }
             NUMBER_DP_ATTRIBUTES
-                if wire_type == wire_types::LEN && self.first_attribute.get().is_none() => {
-                    self.first_attribute.set(Some(range))
-                }
+                if wire_type == wire_types::LEN && self.first_attribute.get().is_none() =>
+            {
+                self.first_attribute.set(Some(range))
+            }
             NUMBER_DP_EXEMPLARS
-                if wire_type == wire_types::LEN && self.first_exemplar.get().is_none() => {
-                    self.first_exemplar.set(Some(range))
-                }
+                if wire_type == wire_types::LEN && self.first_exemplar.get().is_none() =>
+            {
+                self.first_exemplar.set(Some(range))
+            }
 
-            NUMBER_DP_FLAGS
-                if wire_type == wire_types::VARINT => {
-                    self.flags.set(Some(range))
-                }
+            NUMBER_DP_FLAGS if wire_type == wire_types::VARINT => self.flags.set(Some(range)),
             _ => { /* ignore */ }
         }
     }
@@ -631,56 +623,41 @@ impl FieldRanges for HistogramDataPointFieldRanges {
         };
 
         match field_num {
-            HISTOGRAM_DP_START_TIME_UNIX_NANO
-                if wire_type == wire_types::FIXED64 => {
-                    self.start_time_unix_nano.set(Some(range));
-                }
-            HISTOGRAM_DP_TIME_UNIX_NANO
-                if wire_type == wire_types::FIXED64 => {
-                    self.time_unix_nano.set(Some(range))
-                }
-            HISTOGRAM_DP_COUNT
-                if wire_type == wire_types::FIXED64 => {
-                    self.count.set(Some(range))
-                }
-            HISTOGRAM_DP_SUM
-                if wire_type == wire_types::FIXED64 => {
-                    self.sum.set(Some(range))
-                }
-            HISTOGRAM_DP_FLAGS
-                if wire_type == wire_types::VARINT => {
-                    self.flags.set(Some(range))
-                }
+            HISTOGRAM_DP_START_TIME_UNIX_NANO if wire_type == wire_types::FIXED64 => {
+                self.start_time_unix_nano.set(Some(range));
+            }
+            HISTOGRAM_DP_TIME_UNIX_NANO if wire_type == wire_types::FIXED64 => {
+                self.time_unix_nano.set(Some(range))
+            }
+            HISTOGRAM_DP_COUNT if wire_type == wire_types::FIXED64 => self.count.set(Some(range)),
+            HISTOGRAM_DP_SUM if wire_type == wire_types::FIXED64 => self.sum.set(Some(range)),
+            HISTOGRAM_DP_FLAGS if wire_type == wire_types::VARINT => self.flags.set(Some(range)),
             HISTOGRAM_DP_EXPLICIT_BOUNDS
                 if (wire_type == wire_types::LEN || wire_type == wire_types::FIXED64)
-                    && self.first_explicit_bounds.get().is_none()
-                => {
-                    let packed = wire_type == wire_types::LEN;
-                    self.first_explicit_bounds.set(Some((range, packed)));
-                }
+                    && self.first_explicit_bounds.get().is_none() =>
+            {
+                let packed = wire_type == wire_types::LEN;
+                self.first_explicit_bounds.set(Some((range, packed)));
+            }
             HISTOGRAM_DP_BUCKET_COUNTS
                 if (wire_type == wire_types::LEN || wire_type == wire_types::FIXED64)
-                    && self.first_bucket_counts.get().is_none()
-                => {
-                    let packed = wire_type == wire_types::LEN;
-                    self.first_bucket_counts.set(Some((range, packed)));
-                }
-            HISTOGRAM_DP_MIN
-                if wire_type == wire_types::FIXED64 => {
-                    self.min.set(Some(range))
-                }
-            HISTOGRAM_DP_MAX
-                if wire_type == wire_types::FIXED64 => {
-                    self.max.set(Some(range))
-                }
+                    && self.first_bucket_counts.get().is_none() =>
+            {
+                let packed = wire_type == wire_types::LEN;
+                self.first_bucket_counts.set(Some((range, packed)));
+            }
+            HISTOGRAM_DP_MIN if wire_type == wire_types::FIXED64 => self.min.set(Some(range)),
+            HISTOGRAM_DP_MAX if wire_type == wire_types::FIXED64 => self.max.set(Some(range)),
             HISTOGRAM_DP_ATTRIBUTES
-                if wire_type == wire_types::LEN && self.first_attributes.get().is_none() => {
-                    self.first_attributes.set(Some(range))
-                }
+                if wire_type == wire_types::LEN && self.first_attributes.get().is_none() =>
+            {
+                self.first_attributes.set(Some(range))
+            }
             HISTOGRAM_DP_EXEMPLARS
-                if wire_type == wire_types::LEN && self.first_exemplar.get().is_none() => {
-                    self.first_exemplar.set(Some(range))
-                }
+                if wire_type == wire_types::LEN && self.first_exemplar.get().is_none() =>
+            {
+                self.first_exemplar.set(Some(range))
+            }
 
             _ => { /* ignore */ }
         }
@@ -761,62 +738,46 @@ impl FieldRanges for ExpHistogramDataPointFieldRanges {
         };
 
         match field_num {
-            EXP_HISTOGRAM_DP_START_TIME_UNIX_NANO
-                if wire_type == wire_types::FIXED64 => {
-                    self.start_time_unix_nano.set(Some(range))
-                }
-            EXP_HISTOGRAM_DP_TIME_UNIX_NANO
-                if wire_type == wire_types::FIXED64 => {
-                    self.time_unix_nano.set(Some(range))
-                }
-            EXP_HISTOGRAM_DP_COUNT
-                if wire_type == wire_types::FIXED64 => {
-                    self.count.set(Some(range))
-                }
-            EXP_HISTOGRAM_DP_SUM
-                if wire_type == wire_types::FIXED64 => {
-                    self.sum.set(Some(range))
-                }
-            EXP_HISTOGRAM_DP_SCALE
-                if wire_type == wire_types::VARINT => {
-                    self.scale.set(Some(range))
-                }
-            EXP_HISTOGRAM_DP_ZERO_COUNT
-                if wire_type == wire_types::FIXED64 => {
-                    self.zero_count.set(Some(range))
-                }
-            EXP_HISTOGRAM_DP_NEGATIVE
-                if wire_type == wire_types::LEN => {
-                    self.negative.set(Some(range))
-                }
-            EXP_HISTOGRAM_DP_POSITIVE
-                if wire_type == wire_types::LEN => {
-                    self.positive.set(Some(range))
-                }
-            EXP_HISTOGRAM_DP_FLAGS
-                if wire_type == wire_types::VARINT => {
-                    self.flags.set(Some(range))
-                }
-            EXP_HISTOGRAM_DP_MIN
-                if wire_type == wire_types::FIXED64 => {
-                    self.min.set(Some(range))
-                }
-            EXP_HISTOGRAM_DP_MAX
-                if wire_type == wire_types::FIXED64 => {
-                    self.max.set(Some(range))
-                }
-            EXP_HISTOGRAM_DP_ZERO_THRESHOLD
-                if wire_type == wire_types::FIXED64 => {
-                    self.zero_threshold.set(Some(range))
-                }
+            EXP_HISTOGRAM_DP_START_TIME_UNIX_NANO if wire_type == wire_types::FIXED64 => {
+                self.start_time_unix_nano.set(Some(range))
+            }
+            EXP_HISTOGRAM_DP_TIME_UNIX_NANO if wire_type == wire_types::FIXED64 => {
+                self.time_unix_nano.set(Some(range))
+            }
+            EXP_HISTOGRAM_DP_COUNT if wire_type == wire_types::FIXED64 => {
+                self.count.set(Some(range))
+            }
+            EXP_HISTOGRAM_DP_SUM if wire_type == wire_types::FIXED64 => self.sum.set(Some(range)),
+            EXP_HISTOGRAM_DP_SCALE if wire_type == wire_types::VARINT => {
+                self.scale.set(Some(range))
+            }
+            EXP_HISTOGRAM_DP_ZERO_COUNT if wire_type == wire_types::FIXED64 => {
+                self.zero_count.set(Some(range))
+            }
+            EXP_HISTOGRAM_DP_NEGATIVE if wire_type == wire_types::LEN => {
+                self.negative.set(Some(range))
+            }
+            EXP_HISTOGRAM_DP_POSITIVE if wire_type == wire_types::LEN => {
+                self.positive.set(Some(range))
+            }
+            EXP_HISTOGRAM_DP_FLAGS if wire_type == wire_types::VARINT => {
+                self.flags.set(Some(range))
+            }
+            EXP_HISTOGRAM_DP_MIN if wire_type == wire_types::FIXED64 => self.min.set(Some(range)),
+            EXP_HISTOGRAM_DP_MAX if wire_type == wire_types::FIXED64 => self.max.set(Some(range)),
+            EXP_HISTOGRAM_DP_ZERO_THRESHOLD if wire_type == wire_types::FIXED64 => {
+                self.zero_threshold.set(Some(range))
+            }
             EXP_HISTOGRAM_DP_ATTRIBUTES
-                if wire_type == wire_types::LEN && self.first_attributes.get().is_none() => {
-                    self.first_attributes.set(Some(range))
-                }
+                if wire_type == wire_types::LEN && self.first_attributes.get().is_none() =>
+            {
+                self.first_attributes.set(Some(range))
+            }
             EXP_HISTOGRAM_DP_EXEMPLARS
-                if wire_type == wire_types::LEN && self.first_exemplar.get().is_none() => {
-                    self.first_exemplar.set(Some(range))
-                }
+                if wire_type == wire_types::LEN && self.first_exemplar.get().is_none() =>
+            {
+                self.first_exemplar.set(Some(range))
+            }
             _ => { /* ignore */ }
         }
     }
@@ -861,17 +822,16 @@ impl FieldRanges for BucketsFieldRanges {
         };
 
         match field_num {
-            EXP_HISTOGRAM_BUCKET_OFFSET
-                if wire_type == wire_types::VARINT => {
-                    self.offset.set(Some(range));
-                }
+            EXP_HISTOGRAM_BUCKET_OFFSET if wire_type == wire_types::VARINT => {
+                self.offset.set(Some(range));
+            }
             EXP_HISTOGRAM_BUCKET_BUCKET_COUNTS
                 if (wire_type == wire_types::LEN || wire_type == wire_types::VARINT)
-                    && self.first_bucket_count.get().is_none()
-                => {
-                    let packed = wire_type == wire_types::LEN;
-                    self.first_bucket_count.set(Some((range, packed)))
-                }
+                    && self.first_bucket_count.get().is_none() =>
+            {
+                let packed = wire_type == wire_types::LEN;
+                self.first_bucket_count.set(Some((range, packed)))
+            }
             _ => { /* ignore */ }
         }
     }
@@ -934,34 +894,25 @@ impl FieldRanges for SummaryDataPointFieldRanges {
         };
 
         match field_num {
-            SUMMARY_DP_START_TIME_UNIX_NANO
-                if wire_type == wire_types::FIXED64 => {
-                    self.start_time_unix_nano.set(Some(range))
-                }
-            SUMMARY_DP_TIME_UNIX_NANO
-                if wire_type == wire_types::FIXED64 => {
-                    self.time_unix_nano.set(Some(range))
-                }
-            SUMMARY_DP_COUNT
-                if wire_type == wire_types::FIXED64 => {
-                    self.count.set(Some(range))
-                }
-            SUMMARY_DP_SUM
-                if wire_type == wire_types::FIXED64 => {
-                    self.sum.set(Some(range))
-                }
-            SUMMARY_DP_FLAGS
-                if wire_type == wire_types::VARINT => {
-                    self.flags.set(Some(range))
-                }
+            SUMMARY_DP_START_TIME_UNIX_NANO if wire_type == wire_types::FIXED64 => {
+                self.start_time_unix_nano.set(Some(range))
+            }
+            SUMMARY_DP_TIME_UNIX_NANO if wire_type == wire_types::FIXED64 => {
+                self.time_unix_nano.set(Some(range))
+            }
+            SUMMARY_DP_COUNT if wire_type == wire_types::FIXED64 => self.count.set(Some(range)),
+            SUMMARY_DP_SUM if wire_type == wire_types::FIXED64 => self.sum.set(Some(range)),
+            SUMMARY_DP_FLAGS if wire_type == wire_types::VARINT => self.flags.set(Some(range)),
             SUMMARY_DP_ATTRIBUTES
-                if wire_type == wire_types::LEN && self.first_attribute.get().is_none() => {
-                    self.first_attribute.set(Some(range))
-                }
+                if wire_type == wire_types::LEN && self.first_attribute.get().is_none() =>
+            {
+                self.first_attribute.set(Some(range))
+            }
             SUMMARY_DP_QUANTILE_VALUES
-                if wire_type == wire_types::LEN && self.first_quantile_value.get().is_none() => {
-                    self.first_quantile_value.set(Some(range))
-                }
+                if wire_type == wire_types::LEN && self.first_quantile_value.get().is_none() =>
+            {
+                self.first_quantile_value.set(Some(range))
+            }
             _ => { /* ignore */ }
         }
     }
@@ -1058,26 +1009,20 @@ impl FieldRanges for ExemplarFieldRanges {
         };
 
         match field_num {
-            EXEMPLAR_TIME_UNIX_NANO
-                if wire_type == wire_types::FIXED64 => {
-                    self.time_unix_nano.set(Some(range))
-                }
-            EXEMPLAR_SPAN_ID
-                if wire_type == wire_types::LEN => {
-                    self.span_id.set(Some(range))
-                }
-            EXEMPLAR_TRACE_ID
-                if wire_type == wire_types::LEN => {
-                    self.trace_id.set(Some(range))
-                }
-            EXEMPLAR_AS_DOUBLE | EXEMPLAR_AS_INT
-                if wire_type == wire_types::FIXED64 => {
-                    self.value.set(Some((range, field_num)));
-                }
+            EXEMPLAR_TIME_UNIX_NANO if wire_type == wire_types::FIXED64 => {
+                self.time_unix_nano.set(Some(range))
+            }
+            EXEMPLAR_SPAN_ID if wire_type == wire_types::LEN => self.span_id.set(Some(range)),
+            EXEMPLAR_TRACE_ID if wire_type == wire_types::LEN => self.trace_id.set(Some(range)),
+            EXEMPLAR_AS_DOUBLE | EXEMPLAR_AS_INT if wire_type == wire_types::FIXED64 => {
+                self.value.set(Some((range, field_num)));
+            }
             EXEMPLAR_FILTERED_ATTRIBUTES
-                if wire_type == wire_types::LEN && self.first_filtered_attribute.get().is_none() => {
-                    self.first_filtered_attribute.set(Some(range))
-                }
+                if wire_type == wire_types::LEN
+                    && self.first_filtered_attribute.get().is_none() =>
+            {
+                self.first_filtered_attribute.set(Some(range))
+            }
             _ => { /* ignore */ }
         }
     }

--- a/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/resource.rs
+++ b/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/resource.rs
@@ -65,14 +65,14 @@ impl FieldRanges for ResourceFieldOffsets {
         };
 
         match field_num {
-            RESOURCE_DROPPED_ATTRIBUTES_COUNT
-                if wire_type == wire_types::VARINT => {
-                    self.dropped_attributes_count.set(range);
-                }
+            RESOURCE_DROPPED_ATTRIBUTES_COUNT if wire_type == wire_types::VARINT => {
+                self.dropped_attributes_count.set(range);
+            }
             RESOURCE_ATTRIBUTES
-                if self.first_attribute.get().is_none() && wire_type == wire_types::LEN => {
-                    self.first_attribute.set(range);
-                }
+                if self.first_attribute.get().is_none() && wire_type == wire_types::LEN =>
+            {
+                self.first_attribute.set(range);
+            }
             _ => {
                 // ignore unknown fields
             }

--- a/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/resource.rs
+++ b/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/resource.rs
@@ -65,16 +65,14 @@ impl FieldRanges for ResourceFieldOffsets {
         };
 
         match field_num {
-            RESOURCE_DROPPED_ATTRIBUTES_COUNT => {
-                if wire_type == wire_types::VARINT {
+            RESOURCE_DROPPED_ATTRIBUTES_COUNT
+                if wire_type == wire_types::VARINT => {
                     self.dropped_attributes_count.set(range);
                 }
-            }
-            RESOURCE_ATTRIBUTES => {
-                if self.first_attribute.get().is_none() && wire_type == wire_types::LEN {
+            RESOURCE_ATTRIBUTES
+                if self.first_attribute.get().is_none() && wire_type == wire_types::LEN => {
                     self.first_attribute.set(range);
                 }
-            }
             _ => {
                 // ignore unknown fields
             }

--- a/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/traces.rs
+++ b/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/traces.rs
@@ -96,10 +96,9 @@ impl FieldRanges for ResourceSpansFieldRanges {
             match field_num {
                 RESOURCE_SPANS_RESOURCE => self.resource.set(Some(range)),
                 RESOURCE_SPANS_SCHEMA_URL => self.schema_url.set(Some(range)),
-                RESOURCE_SPANS_SCOPE_SPANS
-                    if self.first_scope_spans.get().is_none() => {
-                        self.first_scope_spans.set(Some(range));
-                    }
+                RESOURCE_SPANS_SCOPE_SPANS if self.first_scope_spans.get().is_none() => {
+                    self.first_scope_spans.set(Some(range));
+                }
                 _ => { /* ignore  */ }
             }
         }
@@ -148,10 +147,9 @@ impl FieldRanges for ScopeSpansFieldRanges {
             match field_num {
                 SCOPE_SPANS_SCOPE => self.scope.set(Some(range)),
                 SCOPE_SPANS_SCHEMA_URL => self.schema_url.set(Some(range)),
-                SCOPE_SPANS_SPANS
-                    if self.first_span.get().is_none() => {
-                        self.first_span.set(Some(range));
-                    }
+                SCOPE_SPANS_SPANS if self.first_span.get().is_none() => {
+                    self.first_span.set(Some(range));
+                }
                 _ => { /* ignore  */ }
             }
         }
@@ -289,22 +287,18 @@ impl FieldRanges for SpanEventFieldRanges {
         };
 
         match field_num {
-            SPAN_EVENT_TIME_UNIX_NANO
-                if wire_type == wire_types::FIXED64 => {
-                    self.time_unix_nano.set(Some(range))
-                }
-            SPAN_EVENT_NAME
-                if wire_type == wire_types::LEN => {
-                    self.name.set(Some(range))
-                }
-            SPAN_EVENT_DROPPED_ATTRIBUTES_COUNTS
-                if wire_type == wire_types::VARINT => {
-                    self.dropped_attributes_count.set(Some(range))
-                }
+            SPAN_EVENT_TIME_UNIX_NANO if wire_type == wire_types::FIXED64 => {
+                self.time_unix_nano.set(Some(range))
+            }
+            SPAN_EVENT_NAME if wire_type == wire_types::LEN => self.name.set(Some(range)),
+            SPAN_EVENT_DROPPED_ATTRIBUTES_COUNTS if wire_type == wire_types::VARINT => {
+                self.dropped_attributes_count.set(Some(range))
+            }
             SPAN_EVENT_ATTRIBUTES
-                if self.first_attribute.get().is_none() && wire_type == wire_types::LEN => {
-                    self.first_attribute.set(Some(range))
-                }
+                if self.first_attribute.get().is_none() && wire_type == wire_types::LEN =>
+            {
+                self.first_attribute.set(Some(range))
+            }
             _ => { /* ignore */ }
         }
     }
@@ -358,30 +352,20 @@ impl FieldRanges for SpanLinkFieldRanges {
         };
 
         match field_num {
-            SPAN_LINK_TRACE_ID
-                if wire_type == wire_types::LEN => {
-                    self.trace_id.set(Some(range))
-                }
-            SPAN_LINK_SPAN_ID
-                if wire_type == wire_types::LEN => {
-                    self.span_id.set(Some(range))
-                }
-            SPAN_LINK_TRACE_STATE
-                if wire_type == wire_types::LEN => {
-                    self.trace_state.set(Some(range))
-                }
-            SPAN_LINK_DROPPED_ATTRIBUTES_COUNT
-                if wire_type == wire_types::VARINT => {
-                    self.dropped_attributes_count.set(Some(range))
-                }
-            SPAN_LINK_FLAGS
-                if wire_type == wire_types::FIXED32 => {
-                    self.flags.set(Some(range))
-                }
+            SPAN_LINK_TRACE_ID if wire_type == wire_types::LEN => self.trace_id.set(Some(range)),
+            SPAN_LINK_SPAN_ID if wire_type == wire_types::LEN => self.span_id.set(Some(range)),
+            SPAN_LINK_TRACE_STATE if wire_type == wire_types::LEN => {
+                self.trace_state.set(Some(range))
+            }
+            SPAN_LINK_DROPPED_ATTRIBUTES_COUNT if wire_type == wire_types::VARINT => {
+                self.dropped_attributes_count.set(Some(range))
+            }
+            SPAN_LINK_FLAGS if wire_type == wire_types::FIXED32 => self.flags.set(Some(range)),
             SPAN_LINK_ATTRIBUTES
-                if self.first_attribute.get().is_none() && wire_type == wire_types::LEN => {
-                    self.first_attribute.set(Some(range))
-                }
+                if self.first_attribute.get().is_none() && wire_type == wire_types::LEN =>
+            {
+                self.first_attribute.set(Some(range))
+            }
             _ => { /* ignore */ }
         }
     }
@@ -422,14 +406,8 @@ impl FieldRanges for SpanStatusFieldRanges {
         };
 
         match field_num {
-            SPAN_STATUS_MESSAGE
-                if wire_type == wire_types::LEN => {
-                    self.message.set(Some(range))
-                }
-            SPAN_STATUS_CODE
-                if wire_type == wire_types::VARINT => {
-                    self.code.set(Some(range))
-                }
+            SPAN_STATUS_MESSAGE if wire_type == wire_types::LEN => self.message.set(Some(range)),
+            SPAN_STATUS_CODE if wire_type == wire_types::VARINT => self.code.set(Some(range)),
             _ => { /* ignore */ }
         }
     }

--- a/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/traces.rs
+++ b/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/traces.rs
@@ -96,11 +96,10 @@ impl FieldRanges for ResourceSpansFieldRanges {
             match field_num {
                 RESOURCE_SPANS_RESOURCE => self.resource.set(Some(range)),
                 RESOURCE_SPANS_SCHEMA_URL => self.schema_url.set(Some(range)),
-                RESOURCE_SPANS_SCOPE_SPANS => {
-                    if self.first_scope_spans.get().is_none() {
+                RESOURCE_SPANS_SCOPE_SPANS
+                    if self.first_scope_spans.get().is_none() => {
                         self.first_scope_spans.set(Some(range));
                     }
-                }
                 _ => { /* ignore  */ }
             }
         }
@@ -149,11 +148,10 @@ impl FieldRanges for ScopeSpansFieldRanges {
             match field_num {
                 SCOPE_SPANS_SCOPE => self.scope.set(Some(range)),
                 SCOPE_SPANS_SCHEMA_URL => self.schema_url.set(Some(range)),
-                SCOPE_SPANS_SPANS => {
-                    if self.first_span.get().is_none() {
+                SCOPE_SPANS_SPANS
+                    if self.first_span.get().is_none() => {
                         self.first_span.set(Some(range));
                     }
-                }
                 _ => { /* ignore  */ }
             }
         }
@@ -291,26 +289,22 @@ impl FieldRanges for SpanEventFieldRanges {
         };
 
         match field_num {
-            SPAN_EVENT_TIME_UNIX_NANO => {
-                if wire_type == wire_types::FIXED64 {
+            SPAN_EVENT_TIME_UNIX_NANO
+                if wire_type == wire_types::FIXED64 => {
                     self.time_unix_nano.set(Some(range))
                 }
-            }
-            SPAN_EVENT_NAME => {
-                if wire_type == wire_types::LEN {
+            SPAN_EVENT_NAME
+                if wire_type == wire_types::LEN => {
                     self.name.set(Some(range))
                 }
-            }
-            SPAN_EVENT_DROPPED_ATTRIBUTES_COUNTS => {
-                if wire_type == wire_types::VARINT {
+            SPAN_EVENT_DROPPED_ATTRIBUTES_COUNTS
+                if wire_type == wire_types::VARINT => {
                     self.dropped_attributes_count.set(Some(range))
                 }
-            }
-            SPAN_EVENT_ATTRIBUTES => {
-                if self.first_attribute.get().is_none() && wire_type == wire_types::LEN {
+            SPAN_EVENT_ATTRIBUTES
+                if self.first_attribute.get().is_none() && wire_type == wire_types::LEN => {
                     self.first_attribute.set(Some(range))
                 }
-            }
             _ => { /* ignore */ }
         }
     }
@@ -364,36 +358,30 @@ impl FieldRanges for SpanLinkFieldRanges {
         };
 
         match field_num {
-            SPAN_LINK_TRACE_ID => {
-                if wire_type == wire_types::LEN {
+            SPAN_LINK_TRACE_ID
+                if wire_type == wire_types::LEN => {
                     self.trace_id.set(Some(range))
                 }
-            }
-            SPAN_LINK_SPAN_ID => {
-                if wire_type == wire_types::LEN {
+            SPAN_LINK_SPAN_ID
+                if wire_type == wire_types::LEN => {
                     self.span_id.set(Some(range))
                 }
-            }
-            SPAN_LINK_TRACE_STATE => {
-                if wire_type == wire_types::LEN {
+            SPAN_LINK_TRACE_STATE
+                if wire_type == wire_types::LEN => {
                     self.trace_state.set(Some(range))
                 }
-            }
-            SPAN_LINK_DROPPED_ATTRIBUTES_COUNT => {
-                if wire_type == wire_types::VARINT {
+            SPAN_LINK_DROPPED_ATTRIBUTES_COUNT
+                if wire_type == wire_types::VARINT => {
                     self.dropped_attributes_count.set(Some(range))
                 }
-            }
-            SPAN_LINK_FLAGS => {
-                if wire_type == wire_types::FIXED32 {
+            SPAN_LINK_FLAGS
+                if wire_type == wire_types::FIXED32 => {
                     self.flags.set(Some(range))
                 }
-            }
-            SPAN_LINK_ATTRIBUTES => {
-                if self.first_attribute.get().is_none() && wire_type == wire_types::LEN {
+            SPAN_LINK_ATTRIBUTES
+                if self.first_attribute.get().is_none() && wire_type == wire_types::LEN => {
                     self.first_attribute.set(Some(range))
                 }
-            }
             _ => { /* ignore */ }
         }
     }
@@ -434,16 +422,14 @@ impl FieldRanges for SpanStatusFieldRanges {
         };
 
         match field_num {
-            SPAN_STATUS_MESSAGE => {
-                if wire_type == wire_types::LEN {
+            SPAN_STATUS_MESSAGE
+                if wire_type == wire_types::LEN => {
                     self.message.set(Some(range))
                 }
-            }
-            SPAN_STATUS_CODE => {
-                if wire_type == wire_types::VARINT {
+            SPAN_STATUS_CODE
+                if wire_type == wire_types::VARINT => {
                     self.code.set(Some(range))
                 }
-            }
             _ => { /* ignore */ }
         }
     }

--- a/rust/otap-dataflow/xtask/src/diagnostics.rs
+++ b/rust/otap-dataflow/xtask/src/diagnostics.rs
@@ -243,7 +243,7 @@ impl DiagnosticsCollector {
         }
 
         let mut binaries = self.test_binaries.clone();
-        binaries.sort_by(|left, right| right.duration.cmp(&left.duration));
+        binaries.sort_by_key(|b| std::cmp::Reverse(b.duration));
 
         for (index, binary) in binaries.iter().take(HOTSPOT_LIMIT).enumerate() {
             let color = hotspot_rank_color(index);


### PR DESCRIPTION
# Change Summary

Rust 1.95 flagged new clippy warnings from our main branch, blocking new PRs from going in

## What issue does this PR close?

* Closes #2687

## How are these changes tested?

## Are there any user-facing changes?

 <!-- If yes, provide further info below -->
