### PR TITLE
cargo xtask check: synchronize rust-ci.yaml and clippy settings, fix default malloc selection; avoid openss-sys in Windows build

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -434,13 +434,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: stable
-      - name: Install OpenSSL (Windows)
-        if: runner.os == 'Windows'
-        # Required for the crypto-openssl feature (rustls-openssl -> openssl-sys).
-        run: |
-          vcpkg install openssl:x64-windows-static-md
-          echo "OPENSSL_DIR=$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows-static-md" >> $env:GITHUB_ENV
-        shell: pwsh
       - name: Install SymCrypt (Windows)
         if: runner.os == 'Windows'
         uses: ./.github/actions/install-symcrypt
@@ -464,7 +457,12 @@ jobs:
         uses: taiki-e/install-action@d858f8113943481093e02986a7586a4819a3bfd6 # v2.71.2
         with:
           tool: cargo-nextest
-      - name: Build and archive tests
+      - name: Build and archive tests (Incomplete)
+        if: runner.os == 'Windows'
+        run: cargo nextest archive --no-default-features --features=crypto-symcrypt,mimalloc,azure,aws,azure-monitor-exporter,contrib-processors,unsafe-optimizations --workspace --archive-file nextest-archive.tar.zst
+        working-directory: ./rust/${{ matrix.folder }}
+      - name: Build and archive tests (Complete)
+        if: runner.os != 'Windows'
         run: cargo nextest archive --all-features --workspace --archive-file nextest-archive.tar.zst
         working-directory: ./rust/${{ matrix.folder }}
       - name: Upload nextest archive

--- a/rust/otap-dataflow/deny.toml
+++ b/rust/otap-dataflow/deny.toml
@@ -189,6 +189,9 @@ allow = [
 ]
 # List of crates to deny
 deny = [
+    # We do not allow source builds of openssl, prefer any other choice.
+    "openssl-sys",
+    
     #"ansi_term@0.11.0",
     #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is banned" },
     # Wrapper crates can optionally be specified to allow the crate when it

--- a/rust/otap-dataflow/deny.toml
+++ b/rust/otap-dataflow/deny.toml
@@ -189,9 +189,6 @@ allow = [
 ]
 # List of crates to deny
 deny = [
-    # We do not allow source builds of openssl, prefer any other choice.
-    "openssl-sys",
-    
     #"ansi_term@0.11.0",
     #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is banned" },
     # Wrapper crates can optionally be specified to allow the crate when it

--- a/rust/otap-dataflow/src/main.rs
+++ b/rust/otap-dataflow/src/main.rs
@@ -61,10 +61,10 @@ use {
     std::sync::{LazyLock, Mutex},
 };
 
-#[cfg(all(not(clippy), feature = "mimalloc"))]
+#[cfg(feature = "mimalloc")]
 use mimalloc::MiMalloc;
 
-#[cfg(all(not(clippy), not(windows), feature = "jemalloc"))]
+#[cfg(all(not(windows), feature = "jemalloc"))]
 use tikv_jemallocator::Jemalloc;
 
 // -----------------------------------------------------------------------------

--- a/rust/otap-dataflow/src/main.rs
+++ b/rust/otap-dataflow/src/main.rs
@@ -61,10 +61,10 @@ use {
     std::sync::{LazyLock, Mutex},
 };
 
-#[cfg(feature = "mimalloc")]
+#[cfg(all(windows, not(feature = "dhat-heap"), feature = "mimalloc"))]
 use mimalloc::MiMalloc;
 
-#[cfg(all(not(windows), feature = "jemalloc"))]
+#[cfg(all(not(windows), not(feature = "dhat-heap"), feature = "jemalloc"))]
 use tikv_jemallocator::Jemalloc;
 
 // -----------------------------------------------------------------------------
@@ -88,7 +88,7 @@ cfg_if! {
         }
 
     // Windows default: mimalloc
-    } else if #[cfg(feature = "mimalloc")] {
+    } else if #[cfg(all(windows, feature = "mimalloc"))] {
         #[global_allocator]
         static GLOBAL: MiMalloc = MiMalloc;
 

--- a/rust/otap-dataflow/xtask/src/main.rs
+++ b/rust/otap-dataflow/xtask/src/main.rs
@@ -188,7 +188,11 @@ fn clippy_all(
     let mut args = vec![
         "clippy".to_owned(),
         "--workspace".to_owned(),
+        "--all-features".to_owned(),
         "--all-targets".to_owned(),
+        "--".to_owned(),
+        "-D".to_owned(),
+        "warnings".to_owned(),
     ];
     if options.diagnostics {
         args.push("--timings".to_owned());


### PR DESCRIPTION
# Change Summary

Enables clippy in the conditional for Jemalloc in src/main.rs, with @sapatrjv.

## What issue does this PR close?

Introduced in #2420.

Adds `--all-features --workspace -- -D warnings` to the clippy step in `cargo xtask check`.

https://cloud-native.slack.com/archives/C08RRSJR7FD/p1776408892537689

Part of #2591 

## How are these changes tested?

Ran `cargo xtask clippy` on Ubuntu, not sure this actually works in Windows.

## Are there any user-facing changes?

No
