### PR TITLE
Include response body in RateLimited/ServerError Display for azure_monitor_exporter

### DIFF
--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/error.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/error.rs
@@ -58,7 +58,7 @@ pub enum Error {
     PayloadTooLarge,
 
     /// Rate limited (429).
-    #[error("Rate limited")]
+    #[error("Rate limited: {body}")]
     RateLimited {
         /// The response body.
         body: String,
@@ -67,7 +67,7 @@ pub enum Error {
     },
 
     /// Server error (5xx).
-    #[error("Server error ({status})")]
+    #[error("Server error ({status}): {body}")]
     ServerError {
         /// The HTTP status code.
         status: StatusCode,
@@ -397,7 +397,7 @@ mod tests {
             body: "too many requests".to_string(),
             retry_after: Some(std::time::Duration::from_secs(30)),
         };
-        assert_eq!(error.to_string(), "Rate limited");
+        assert_eq!(error.to_string(), "Rate limited: too many requests");
         assert_eq!(
             error.retry_after(),
             Some(std::time::Duration::from_secs(30))
@@ -413,7 +413,7 @@ mod tests {
         };
         assert_eq!(
             error.to_string(),
-            "Server error (500 Internal Server Error)"
+            "Server error (500 Internal Server Error): internal error"
         );
     }
 

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs
@@ -584,7 +584,7 @@ impl Exporter<OtapPdata> for AzureMonitorExporter {
                     if let Some(ref mut hb) = self.heartbeat {
                         match hb.send().await {
                             Ok(_) => otel_debug!("azure_monitor_exporter.heartbeat.sent"),
-                            Err(e) => otel_warn!("azure_monitor_exporter.heartbeat.send_failed", error = ?e),
+                            Err(e) => otel_warn!("azure_monitor_exporter.heartbeat.send_failed", error = %e),
                         }
                     }
                 }


### PR DESCRIPTION
The `Display` impl for `Error::RateLimited` and `Error::ServerError` previously omitted the HTTP response body, losing actionable details when these errors were logged at WARN level via Display formatting (`%`).

For example, when the main export path exhausts retries on a 429, the WARN log showed:
```
Export failed after 5 attempts: Rate limited
```

With this change it now shows:
```
Export failed after 5 attempts: Rate limited: {"error":{"code":"QuotaLimitExceeded","message":"Allowed data-rate per data collection rule: 2GB/minute"}}
```

This lets operators identify *which* Azure Monitor quota was hit (data-rate vs request-rate per DCR) without enabling debug logging.

Additionally, the heartbeat failure WARN log in `exporter.rs` is changed from Debug format (`?e`) to Display format (`%e`), aligning with the project's [events guide](rust/otap-dataflow/docs/telemetry/events-guide.md) recommendation to prefer Display for `thiserror` types at warn/error severity.

**Changes:**
- `error.rs`: Include `{body}` in `#[error(...)]` for `RateLimited` and `ServerError` variants; update corresponding test assertions.
- `exporter.rs`: Change heartbeat send failure WARN log from `error = ?e` (Debug) to `error = %e` (Display).