### PR TITLE
feat: Make fake data generator pacing more reliable and update sql reports to query correct time frame

### DIFF
--- a/rust/otap-dataflow/configs/fake-batch-debug-noop.yaml
+++ b/rust/otap-dataflow/configs/fake-batch-debug-noop.yaml
@@ -17,9 +17,8 @@ groups:
             type: receiver:traffic_generator
             config:
               traffic_config:
-                max_signal_count: 10000
-                max_batch_size: 100
-                signals_per_second: 100
+                max_batch_size: 10
+                signals_per_second: 1000
                 log_weight: 100
               registry_path: https://github.com/open-telemetry/semantic-conventions.git[model]
           batch:
@@ -35,7 +34,7 @@ groups:
           debug:
             type: processor:debug
             config:
-              verbosity: detailed
+              verbosity: basic
               mode: signal
           noop:
             type: exporter:noop

--- a/rust/otap-dataflow/configs/fake-batch-debug-noop.yaml
+++ b/rust/otap-dataflow/configs/fake-batch-debug-noop.yaml
@@ -17,7 +17,6 @@ groups:
             type: receiver:traffic_generator
             config:
               traffic_config:
-                production_mode: open
                 max_batch_size: 10
                 signals_per_second: 1000
                 log_weight: 100

--- a/rust/otap-dataflow/configs/fake-batch-debug-noop.yaml
+++ b/rust/otap-dataflow/configs/fake-batch-debug-noop.yaml
@@ -17,6 +17,7 @@ groups:
             type: receiver:traffic_generator
             config:
               traffic_config:
+                production_mode: open
                 max_batch_size: 10
                 signals_per_second: 1000
                 log_weight: 100

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/config.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/config.rs
@@ -404,6 +404,20 @@ impl TrafficConfig {
     pub const fn num_data_points_per_metric(&self) -> Option<usize> {
         self.num_data_points_per_metric
     }
+
+    /// Validate semantic invariants that serde cannot express.
+    ///
+    /// Currently checks that at least one signal weight is non-zero so the
+    /// producer has something to generate.
+    pub fn validate(&self) -> Result<(), otap_df_config::error::Error> {
+        if self.metric_weight + self.trace_weight + self.log_weight == 0 {
+            return Err(otap_df_config::error::Error::InvalidUserConfig {
+                error: "at least one of metric_weight, trace_weight, or log_weight must be > 0"
+                    .to_string(),
+            });
+        }
+        Ok(())
+    }
 }
 
 const fn default_signals_per_second() -> Option<usize> {
@@ -758,5 +772,30 @@ mod tests {
             Some(&None),
             "null value should parse as None"
         );
+    }
+
+    #[test]
+    fn validate_rejects_all_zero_weights() {
+        let cfg = super::TrafficConfig::new(Some(10), None, 100, 0, 0, 0);
+        let result = cfg.validate();
+        assert!(
+            result.is_err(),
+            "all-zero signal weights should be rejected"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_at_least_one_nonzero_weight() {
+        let cfg = super::TrafficConfig::new(Some(10), None, 100, 0, 0, 1);
+        cfg.validate().expect("one non-zero weight should pass");
+
+        let cfg = super::TrafficConfig::new(Some(10), None, 100, 1, 0, 0);
+        cfg.validate().expect("one non-zero weight should pass");
+
+        let cfg = super::TrafficConfig::new(Some(10), None, 100, 0, 1, 0);
+        cfg.validate().expect("one non-zero weight should pass");
+
+        let cfg = super::TrafficConfig::new(Some(10), None, 100, 1, 1, 1);
+        cfg.validate().expect("all non-zero weights should pass");
     }
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/config.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/config.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Implementation of the configuration of the fake signal receiver
-//!
 
 use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
@@ -49,14 +48,21 @@ pub enum GenerationStrategy {
     /// - Timestamps and IDs will repeat (stale)
     /// - Lowest CPU cost, maximum throughput
     PreGenerated,
+    // Future: Templates variant — pre-generate signal templates, clone and update
+    // timestamps/IDs per batch for moderate CPU cost with fresh data per batch.
+    // Not yet implemented.
+    // Templates,
+}
 
-    /// Pre-generate signal templates, clone and update timestamps/IDs per batch
-    /// - Templates cloned per batch
-    /// - Fresh timestamps and unique IDs
-    /// - Moderate CPU cost, good balance
-    ///
-    /// TODO: Not yet implemented - currently behaves like Fresh
-    Templates,
+/// Controls how signal batches are paced within each one-second production run.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ProductionMode {
+    /// Spread batches evenly across the second using a fixed-interval ticker.
+    #[default]
+    Smooth,
+    /// Produce all batches as fast as possible without pacing.
+    Open,
 }
 
 /// A single resource-attribute set with an optional batch weight.
@@ -154,18 +160,28 @@ pub struct Config {
 #[derive(Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TrafficConfig {
+    /// How signal batches are paced within each production run.
+    #[serde(default)]
+    pub production_mode: ProductionMode,
+    /// Target number of signals to produce per second across all signal types.
+    /// When `None`, defaults to `max_batch_size` (one full batch per second).
     #[serde(default = "default_signals_per_second")]
-    signals_per_second: Option<usize>,
+    pub signals_per_second: Option<usize>,
+    /// Maximum total signals to produce before stopping. `None` means unlimited.
     #[serde(default = "default_max_signal")]
-    max_signal_count: Option<u64>,
+    pub max_signal_count: Option<u64>,
+    /// Maximum number of signals in a single batch.
     #[serde(default = "default_max_batch_size")]
-    max_batch_size: usize,
+    pub max_batch_size: usize,
+    /// Relative weight for metric signal production (0 disables metrics).
     #[serde(default = "default_weight")]
-    metric_weight: u32,
+    pub metric_weight: u32,
+    /// Relative weight for trace signal production (0 disables traces).
     #[serde(default = "default_weight")]
-    trace_weight: u32,
+    pub trace_weight: u32,
+    /// Relative weight for log signal production (0 disables logs).
     #[serde(default = "default_weight")]
-    log_weight: u32,
+    pub log_weight: u32,
 
     /// Target size of each log record body in bytes (Static data source only).
     /// When set, pre-generates a pool of 50 distinct body strings of this size;
@@ -173,30 +189,30 @@ pub struct TrafficConfig {
     /// When 0, the body is omitted entirely.
     /// When unset, cycles through ~50 default log message templates.
     #[serde(default)]
-    log_body_size_bytes: Option<usize>,
+    pub log_body_size_bytes: Option<usize>,
 
     /// Number of attributes to attach to each log record (Static data source only).
     /// When set, generates this many key-value string attributes.
     /// When unset, uses the default 2 attributes (thread.id, thread.name).
     #[serde(default)]
-    num_log_attributes: Option<usize>,
+    pub num_log_attributes: Option<usize>,
 
     /// When true, each log record gets a unique random trace_id and span_id,
     /// matching real log-to-trace correlation and adding per-record entropy.
     #[serde(default)]
-    use_trace_context: bool,
+    pub use_trace_context: bool,
 
     /// Number of attributes to attach to each metric data point (Static data source only).
     /// When set, generates this many key-value attributes per data point.
     /// When unset, uses the default 3 attributes (http.method, http.route, http.status_code).
     #[serde(default)]
-    num_metric_attributes: Option<usize>,
+    pub num_metric_attributes: Option<usize>,
 
     /// Number of data points per metric (Static data source only).
     /// When set, generates this many data points per metric.
     /// When unset, uses the default of 1 data point per metric.
     #[serde(default)]
-    num_data_points_per_metric: Option<usize>,
+    pub num_data_points_per_metric: Option<usize>,
 }
 
 impl Config {
@@ -326,6 +342,7 @@ impl TrafficConfig {
         log_weight: u32,
     ) -> Self {
         Self {
+            production_mode: ProductionMode::Smooth,
             signals_per_second,
             max_signal_count,
             max_batch_size,
@@ -478,7 +495,7 @@ fn default_resource_weight() -> NonZeroU32 {
 ///
 /// Two entries with weights 3 and 1 produce `[0, 0, 0, 1]`.
 ///
-/// TODO: replace with smooth weighted round-robin to avoid bursty traffic shape.
+/// Future improvement: replace with smooth weighted round-robin to avoid bursty traffic shape.
 #[must_use]
 pub(crate) fn build_rotation_table(entries: &[ResourceAttributeSet]) -> Vec<usize> {
     entries

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/config.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/config.rs
@@ -363,51 +363,6 @@ impl TrafficConfig {
         self.signals_per_second
     }
 
-    /// get the config describing how big the metric signal is
-    #[must_use]
-    pub fn calculate_signal_count(&self) -> (usize, usize, usize) {
-        if let Some(rate_limit) = self.signals_per_second {
-            // ToDo: Handle case where the total signal count don't add up the signals being sent per second
-            let total_weight: f32 =
-                (self.trace_weight + self.metric_weight + self.log_weight) as f32;
-
-            let metric_percent: f32 = self.metric_weight as f32 / total_weight;
-            let trace_percent: f32 = self.trace_weight as f32 / total_weight;
-            let log_percent: f32 = self.log_weight as f32 / total_weight;
-
-            let metric_count: usize = (metric_percent * rate_limit as f32) as usize;
-            let trace_count: usize = (trace_percent * rate_limit as f32) as usize;
-            let log_count: usize = (log_percent * rate_limit as f32) as usize;
-
-            let _remaining_count = rate_limit - (metric_count + trace_count + log_count);
-            // ToDo: Update signal count using by distributing the remaining count
-            // if remaining_count > 0 {
-            //     // we need to add to the remaining signal counts here to the counts
-
-            // }
-
-            (metric_count, trace_count, log_count)
-        } else {
-            // if no rate limit is set, use max_batch_size distributed by weights
-            let total_weight: f32 =
-                (self.trace_weight + self.metric_weight + self.log_weight) as f32;
-
-            if total_weight == 0.0 {
-                return (0, 0, 0);
-            }
-
-            let metric_percent: f32 = self.metric_weight as f32 / total_weight;
-            let trace_percent: f32 = self.trace_weight as f32 / total_weight;
-            let log_percent: f32 = self.log_weight as f32 / total_weight;
-
-            let metric_count: usize = (metric_percent * self.max_batch_size as f32) as usize;
-            let trace_count: usize = (trace_percent * self.max_batch_size as f32) as usize;
-            let log_count: usize = (log_percent * self.max_batch_size as f32) as usize;
-
-            (metric_count, trace_count, log_count)
-        }
-    }
-
     /// returns the max amounts of signals that should be sent
     #[must_use]
     pub const fn get_max_signal_count(&self) -> Option<u64> {

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/mod.rs
@@ -5,21 +5,18 @@
 //! Note: This receiver will be replaced in the future with a more sophisticated implementation.
 //!
 
-use crate::receivers::fake_data_generator::config::{
-    Config, DataSource, GenerationStrategy, ResourceAttributeSet, build_rotation_table,
-};
+use crate::receivers::fake_data_generator::config::Config;
 use async_trait::async_trait;
 use linkme::distributed_slice;
 use metrics::FakeSignalReceiverMetrics;
 use otap_df_channel::error::RecvError;
-use otap_df_config::SignalType;
 use otap_df_config::node::NodeUserConfig;
 use otap_df_config::transport_headers::{TransportHeader, TransportHeaders};
 use otap_df_engine::MessageSourceLocalEffectHandlerExtension;
 use otap_df_engine::config::ReceiverConfig;
 use otap_df_engine::context::PipelineContext;
 use otap_df_engine::control::CallData;
-use otap_df_engine::error::{Error, ReceiverErrorKind, format_error_sources};
+use otap_df_engine::error::{Error, ReceiverErrorKind};
 use otap_df_engine::local::receiver as local;
 use otap_df_engine::node::NodeId;
 use otap_df_engine::receiver::ReceiverWrapper;
@@ -29,14 +26,14 @@ use otap_df_engine::{
 };
 use otap_df_otap::OTAP_RECEIVER_FACTORIES;
 use otap_df_otap::pdata::OtapPdata;
-use otap_df_pdata::proto::OtlpProtoMessage;
+use otap_df_pdata::OtapPayload;
 use otap_df_telemetry::metrics::MetricSet;
-use otap_df_telemetry::{otel_debug, otel_info, otel_warn};
+use otap_df_telemetry::{otel_info, otel_warn};
 use serde_json::Value;
-use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::time::{Duration, Instant, sleep};
-use weaver_forge::registry::ResolvedRegistry;
+use tokio::time::{Duration, Interval, interval};
+
+use self::producer::{GenerateError, TrafficProducer};
 
 pub mod attributes;
 /// allows the user to configure their fake signal receiver
@@ -45,6 +42,8 @@ pub mod config;
 pub mod fake_data;
 /// fake signal metrics implementation
 pub mod metrics;
+/// Signal generation abstractions
+pub mod producer;
 /// generates signals based on OTel semantic conventions registry
 pub mod semconv_signal;
 /// Static hardcoded signal generators for lightweight load testing
@@ -108,212 +107,153 @@ impl FakeGeneratorReceiver {
         ))
     }
 
-    fn create_signal_generator(&self, id: NodeId) -> Result<SignalGenerator, Error> {
-        let traffic_config = self.config.get_traffic_config();
-        let signal_generator = match self.config.data_source() {
-            DataSource::SemanticConventions => {
-                let registry = self
-                    .config
-                    .get_registry()
-                    .map_err(|err| Error::ReceiverError {
-                        receiver: id,
-                        kind: ReceiverErrorKind::Configuration,
-                        error: err,
-                        source_detail: String::new(),
-                    })?
-                    .expect("SemanticConventions data source should return Some registry");
-                SignalGenerator::SemanticConventions(registry)
-            }
-            DataSource::Static => {
-                let entries = self.config.resource_attributes().to_vec();
-                let rotation = build_rotation_table(&entries);
-                SignalGenerator::Static {
-                    entries,
-                    rotation,
-                    log_body_size_bytes: traffic_config.log_body_size_bytes(),
-                    num_log_attributes: traffic_config.num_log_attributes(),
-                    use_trace_context: traffic_config.use_trace_context(),
-                    num_metric_attributes: traffic_config.num_metric_attributes(),
-                    num_data_points_per_metric: traffic_config.num_data_points_per_metric(),
+    async fn run_smooth(
+        mut self: Box<Self>,
+        mut ctrl_msg_recv: local::ControlChannel<OtapPdata>,
+        handler: &local::EffectHandler<OtapPdata>,
+        mut producer: TrafficProducer,
+        mut run_ticker: Interval,
+        mut batch_ticker: Interval,
+    ) -> Result<TerminalState, Error> {
+        let mut current_run = producer.next_run();
+        loop {
+            tokio::select! {
+                biased;
+
+                msg = ctrl_msg_recv.recv() => {
+                    if let Some(terminal) = handle_control_msg(msg, handler, &mut self.metrics).await? {
+                        return Ok(terminal);
+                    }
+                }
+
+                _ = run_ticker.tick() => {
+                    if current_run.len() > 0 {
+                        otel_warn!(
+                            "Data generator is falling behind and didn't finish the current run",
+                            remaining=current_run.len(),
+                        )
+                    }
+
+                    current_run = producer.next_run();
+                }
+
+                _ = batch_ticker.tick() => {
+                    let Some(payload) = current_run.next() else {
+                        continue;
+                    };
+
+                    self.handle_payload(handler, payload)?;
                 }
             }
+        }
+    }
+
+    async fn run_open(
+        mut self: Box<Self>,
+        mut ctrl_msg_recv: local::ControlChannel<OtapPdata>,
+        handler: &local::EffectHandler<OtapPdata>,
+        mut producer: TrafficProducer,
+        mut run_ticker: Interval,
+    ) -> Result<TerminalState, Error> {
+        'start: loop {
+            // This is the start of each traffic run which has two phases
+            let mut current_run = producer.next_run();
+
+            // First phase is the open export phase where we pump data as fast as
+            // possible one chunk at a time while checking for control messages
+            // inbetween. If we hit backpressure then we just skip that chunk of data
+            // until we get through the entire iterator.
+            loop {
+                // In the first select statement, we try to drain the entire run
+                tokio::select! {
+                    biased;
+
+                    msg = ctrl_msg_recv.recv() => {
+                        if let Some(terminal) = handle_control_msg(msg, handler, &mut self.metrics).await? {
+                            return Ok(terminal);
+                        }
+                    }
+
+                    _ = run_ticker.tick() => {
+                        otel_warn!(
+                            "Data generator is falling behind and didn't finish the current run",
+                            remaining=current_run.len(),
+                        );
+
+                        continue 'start;
+                    }
+
+                    else => {
+
+                        let Some(payload) = current_run.next() else {
+                            break;
+                        };
+
+                        self.handle_payload(handler, payload)?;
+                    }
+                }
+
+                // The second phase starts once we exhaust a traffic run. At this point
+                // we only process control messages while we wait for a tick at which point
+                // we start the next run.
+                tokio::select! {
+                    biased;
+
+                    msg = ctrl_msg_recv.recv() => {
+                        if let Some(terminal) = handle_control_msg(msg, handler, &mut self.metrics).await? {
+                            return Ok(terminal);
+                        }
+                    }
+
+                    _ = run_ticker.tick() => {
+                        continue 'start;
+                    }
+                }
+            }
+        }
+    }
+
+    fn handle_payload(
+        &mut self,
+        handler: &local::EffectHandler<OtapPdata>,
+        payload: Result<OtapPayload, GenerateError>,
+    ) -> Result<(), Error> {
+        let payload = match payload {
+            Ok(payload) => payload,
+            Err(e) => {
+                return Err(Error::ReceiverError {
+                    receiver: handler.receiver_id(),
+                    kind: ReceiverErrorKind::Other,
+                    error: format!("Failed to generate data: {}", e),
+                    source_detail: String::new(),
+                });
+            }
         };
 
-        Ok(signal_generator)
-    }
-}
-
-/// Abstraction over signal generation to support different data sources
-enum SignalGenerator {
-    /// Uses semantic conventions registry via weaver
-    SemanticConventions(ResolvedRegistry),
-    /// Uses static hardcoded signals with weighted per-batch resource attribute
-    /// rotation and optional payload customization.
-    Static {
-        entries: Vec<ResourceAttributeSet>,
-        rotation: Vec<usize>,
-        /// Target log body size in bytes (None = default body)
-        log_body_size_bytes: Option<usize>,
-        /// Number of log attributes (None = default attributes)
-        num_log_attributes: Option<usize>,
-        /// Whether to populate trace_id/span_id on log records
-        use_trace_context: bool,
-        /// Number of metric attributes per data point (None = default attributes)
-        num_metric_attributes: Option<usize>,
-        /// Number of data points per metric (None = default)
-        num_data_points_per_metric: Option<usize>,
-    },
-}
-
-impl SignalGenerator {
-    /// Return the resource attributes for the current batch, or `None` when no
-    /// custom attributes are configured.
-    ///
-    /// The slot is selected as `rotation[batch_index % rotation.len()]`, which
-    /// gives each entry a share of batches proportional to its weight.
-    fn attrs_for_batch(&self, batch_index: u64) -> Option<&HashMap<String, String>> {
-        match self {
-            SignalGenerator::Static {
-                entries, rotation, ..
-            } if !rotation.is_empty() => {
-                let slot = rotation[batch_index as usize % rotation.len()];
-                Some(&entries[slot].attrs)
-            }
-            _ => None,
-        }
-    }
-
-    /// Generate OTLP traces
-    fn generate_traces(&self, count: usize, batch_index: u64) -> OtlpProtoMessage {
-        match self {
-            SignalGenerator::SemanticConventions(registry) => {
-                OtlpProtoMessage::Traces(semconv_signal::semconv_otlp_traces(count, registry))
-            }
-            SignalGenerator::Static { .. } => OtlpProtoMessage::Traces(
-                static_signal::static_otlp_traces(count, self.attrs_for_batch(batch_index)),
-            ),
-        }
-    }
-
-    /// Generate OTLP metrics
-    fn generate_metrics(&self, count: usize, batch_index: u64) -> OtlpProtoMessage {
-        match self {
-            SignalGenerator::SemanticConventions(registry) => {
-                OtlpProtoMessage::Metrics(semconv_signal::semconv_otlp_metrics(count, registry))
-            }
-            SignalGenerator::Static {
-                num_metric_attributes,
-                num_data_points_per_metric,
-                ..
-            } => OtlpProtoMessage::Metrics(static_signal::static_otlp_metrics_with_config(
-                count,
-                *num_metric_attributes,
-                *num_data_points_per_metric,
-                self.attrs_for_batch(batch_index),
-            )),
-        }
-    }
-
-    /// Generate OTLP logs
-    fn generate_logs(&self, count: usize, batch_index: u64) -> OtlpProtoMessage {
-        match self {
-            SignalGenerator::SemanticConventions(registry) => {
-                OtlpProtoMessage::Logs(semconv_signal::semconv_otlp_logs(count, registry))
-            }
-            SignalGenerator::Static {
-                log_body_size_bytes,
-                num_log_attributes,
-                use_trace_context,
-                ..
-            } => OtlpProtoMessage::Logs(static_signal::static_otlp_logs_with_config(
-                count,
-                *log_body_size_bytes,
-                *num_log_attributes,
-                *use_trace_context,
-                self.attrs_for_batch(batch_index),
-            )),
-        }
-    }
-}
-
-/// Pre-generated batch cache for high-throughput load testing.
-/// A single batch is generated once at startup and cloned at runtime.
-/// Clone is O(1) since OtapPdata contains Bytes which is ref-counted.
-struct BatchCache {
-    /// Pre-generated metrics batch
-    metrics: Option<OtapPdata>,
-    /// Pre-generated traces batch
-    traces: Option<OtapPdata>,
-    /// Pre-generated logs batch
-    logs: Option<OtapPdata>,
-    /// Number of records in the metrics batch
-    metrics_batch_size: usize,
-    /// Number of records in the traces batch
-    traces_batch_size: usize,
-    /// Number of records in the logs batch
-    logs_batch_size: usize,
-}
-
-impl BatchCache {
-    /// Create a new batch cache by pre-generating a single batch for each signal type.
-    /// The batch contains up to `batch_size` records, which will be sent multiple times
-    /// per iteration to match the total signal count.
-    ///
-    /// **Note:** Cached batches always use the first resource-attribute set (slot 0).
-    /// Resource attribute rotation is not supported with `pre_generated` strategy;
-    /// use `fresh` or `templates` for per-batch attribute rotation.
-    fn new(
-        generator: &SignalGenerator,
-        batch_size: usize,
-        metric_count: usize,
-        trace_count: usize,
-        log_count: usize,
-    ) -> Result<Self, Error> {
-        // Pre-generate single metrics batch
-        let metrics_batch_size = metric_count.min(batch_size);
-        let metrics = if metric_count > 0 {
-            Some(
-                generator
-                    .generate_metrics(metrics_batch_size, 0)
-                    .try_into()?,
-            )
-        } else {
-            None
-        };
-
-        // Pre-generate single traces batch
-        let traces_batch_size = trace_count.min(batch_size);
-        let traces = if trace_count > 0 {
-            Some(generator.generate_traces(traces_batch_size, 0).try_into()?)
-        } else {
-            None
-        };
-
-        // Pre-generate single logs batch
-        let logs_batch_size = log_count.min(batch_size);
-        let logs = if log_count > 0 {
-            let pdata: OtapPdata = generator.generate_logs(logs_batch_size, 0).try_into()?;
-            let (_, payload) = pdata.clone().into_parts();
-            let size = payload.num_bytes().unwrap_or(0);
-            otel_info!(
-                "fake_data_generator.batch_cache.logsize",
-                log_record_count = logs_batch_size,
-                batch_size_bytes = size,
-                message = "Pre-generated log batch ready"
+        let mut pdata = OtapPdata::new_todo_context(payload);
+        if self.config.enable_ack_nack() {
+            handler.subscribe_to(
+                Interests::ACKS | Interests::NACKS,
+                CallData::default(),
+                &mut pdata,
             );
-            Some(pdata)
-        } else {
-            None
-        };
+        }
 
-        Ok(Self {
-            metrics,
-            traces,
-            logs,
-            metrics_batch_size,
-            traces_batch_size,
-            logs_batch_size,
-        })
+        let signal = pdata.signal_type();
+        let count = pdata.num_items() as u64;
+        match handler.try_send_message_with_source_node(pdata) {
+            Ok(()) => {
+                match signal {
+                    otap_df_config::SignalType::Traces => self.metrics.spans_produced.add(count),
+                    otap_df_config::SignalType::Metrics => self.metrics.metrics_produced.add(count),
+                    otap_df_config::SignalType::Logs => self.metrics.logs_produced.add(count),
+                };
+            }
+            Err(e) => {
+                otel_warn!("Failed to send pdata", error=?e);
+            }
+        }
+        Ok(())
     }
 }
 
@@ -407,651 +347,55 @@ async fn handle_control_msg(
 impl local::Receiver<OtapPdata> for FakeGeneratorReceiver {
     async fn start(
         mut self: Box<Self>,
-        mut ctrl_msg_recv: local::ControlChannel<OtapPdata>,
+        ctrl_msg_recv: local::ControlChannel<OtapPdata>,
         effect_handler: local::EffectHandler<OtapPdata>,
     ) -> Result<TerminalState, Error> {
-        let traffic_config = self.config.get_traffic_config();
-        let generation_strategy = self.config.generation_strategy().clone();
-
-        // Create the appropriate signal generator based on data source
-        let signal_generator = self.create_signal_generator(effect_handler.receiver_id())?;
-        let (metric_count, trace_count, log_count) = traffic_config.calculate_signal_count();
-        let max_signal_count = traffic_config.get_max_signal_count();
-        let signals_per_second = traffic_config.get_signal_rate();
-        let max_batch_size = traffic_config.get_max_batch_size();
-        let enable_ack_nack = self.config.enable_ack_nack();
-        let rate_limit_status = match signals_per_second {
-            Some(rate) => format!("{} signals/sec", rate),
-            None => "uncapped".to_string(),
-        };
-        otel_info!(
-            "fake_data_generator.start",
-            signals_per_second = rate_limit_status,
-            max_batch_size = max_batch_size,
-            metrics_per_iteration = metric_count,
-            traces_per_iteration = trace_count,
-            logs_per_iteration = log_count,
-            data_source = format!("{:?}", self.config.data_source()),
-            generation_strategy = format!("{:?}", generation_strategy),
-            message = "Fake data generator receiver started"
-        );
-
-        // Create batch cache if using PreGenerated strategy
-        let batch_cache = match generation_strategy {
-            GenerationStrategy::PreGenerated => {
-                if !self.config.resource_attributes().is_empty() {
-                    otel_warn!(
-                        "fake_data_generator.config_warning",
-                        message = "resource_attributes rotation is not supported with pre_generated strategy; \
-                                   only the first attribute set will be used. Use 'fresh' or 'templates' for rotation."
-                    );
-                }
-                otel_info!(
-                    "fake_data_generator.pre_generate",
-                    message = "Pre-generating batch for high-throughput mode"
-                );
-                Some(
-                    BatchCache::new(
-                        &signal_generator,
-                        max_batch_size,
-                        metric_count,
-                        trace_count,
-                        log_count,
-                    )
-                    .map_err(|e| Error::ReceiverError {
-                        receiver: effect_handler.receiver_id(),
-                        kind: ReceiverErrorKind::Configuration,
-                        error: format!("Failed to pre-generate batch: {}", e),
-                        source_detail: String::new(),
-                    })?,
-                )
-            }
-            GenerationStrategy::Fresh | GenerationStrategy::Templates => None,
-        };
-
-        let prebuilt_transport_headers = build_transport_headers(self.config.transport_headers());
-        let mut signal_count: u64 = 0;
-        let mut batch_rotation_index: u64 = 0;
-        let one_second_duration = Duration::from_secs(1);
+        let producer =
+            TrafficProducer::from_config(&self.config).map_err(|e| Error::ReceiverError {
+                receiver: effect_handler.receiver_id(),
+                kind: ReceiverErrorKind::Configuration,
+                error: format!("Failed to generate producer: {}", e),
+                source_detail: String::new(),
+            })?;
 
         let _ = effect_handler
             .start_periodic_telemetry(Duration::from_secs(1))
             .await?;
 
-        loop {
-            let wait_till = Instant::now() + one_second_duration;
+        let run_len = producer.run_len();
+        let batch_duration_millis = 1000u64.div_euclid(run_len as u64);
+        let run_ticker = interval(Duration::from_secs(1));
 
-            if max_signal_count.is_none_or(|max| max > signal_count) {
-                // Pin the send future so it survives across select iterations.
-                // Non-terminal control messages (e.g. CollectTelemetry) are
-                // serviced while the send is blocked on backpressure, but the
-                // send itself is never cancelled — only DrainIngress/Shutdown
-                // abort early via the `return Ok(terminal)` path.
-                let send_fut = send_signals(
-                    effect_handler.clone(),
-                    max_signal_count,
-                    &mut signal_count,
-                    &mut batch_rotation_index,
-                    max_batch_size,
-                    metric_count,
-                    trace_count,
-                    log_count,
-                    &signal_generator,
-                    &batch_cache,
-                    enable_ack_nack,
-                    &prebuilt_transport_headers,
-                );
-                tokio::pin!(send_fut);
-
-                let signal_status = loop {
-                    tokio::select! {
-                        biased;
-                        ctrl_msg = ctrl_msg_recv.recv() => {
-                            if let Some(terminal) = handle_control_msg(ctrl_msg, &effect_handler, &mut self.metrics).await? {
-                                return Ok(terminal);
-                            }
-                            // Non-terminal message handled; continue polling
-                            // send_fut on the next iteration.
-                        }
-                        result = &mut send_fut => {
-                            break result;
-                        }
-                    }
-                };
-
-                match signal_status {
-                    Ok(produced) => {
-                        // Apply the accumulated counts to the metric set now that
-                        // the send future has completed and released its borrows.
-                        self.metrics.logs_produced.add(produced.logs);
-                        self.metrics.metrics_produced.add(produced.metrics);
-                        self.metrics.spans_produced.add(produced.traces);
-
-                        if signals_per_second.is_some() {
-                            // check if need to sleep
-                            let remaining_time = wait_till - Instant::now();
-                            if remaining_time.as_secs_f64() > 0.0 {
-                                otel_debug!(
-                                    "fake_data_generator.rate_limit.sleep",
-                                    sleep_duration_ms = remaining_time.as_millis() as u64,
-                                    "Sleeping to maintain configured signal rate"
-                                );
-                                // Keep the original sleep deadline if non-terminal control
-                                // messages arrive. Only DrainIngress/Shutdown should interrupt
-                                // the rate-limit wait early.
-                                let sleep_until = sleep(remaining_time);
-                                tokio::pin!(sleep_until);
-
-                                loop {
-                                    tokio::select! {
-                                        biased;
-                                        ctrl_msg = ctrl_msg_recv.recv() => {
-                                            if let Some(terminal) = handle_control_msg(ctrl_msg, &effect_handler, &mut self.metrics).await? {
-                                                return Ok(terminal);
-                                            }
-                                        }
-                                        _ = &mut sleep_until => break,
-                                    }
-                                }
-                            }
-                            // ToDo: Handle negative time, not able to keep up with specified rate limit
-                        } else {
-                            otel_debug!(
-                                "fake_data_generator.rate_limit.uncapped",
-                                "Rate limiting disabled, continuing immediately"
-                            );
-                        }
-                    }
-                    Err(e) => {
-                        let source_detail = format_error_sources(&e);
-                        return Err(Error::ReceiverError {
-                            receiver: effect_handler.receiver_id(),
-                            kind: ReceiverErrorKind::Other,
-                            error: e.to_string(),
-                            source_detail,
-                        });
-                    }
-                }
-            } else {
-                // max_signal_count reached — only service control messages
-                // (needed for graceful shutdown).
-                let ctrl_msg = ctrl_msg_recv.recv().await;
-                if let Some(terminal) =
-                    handle_control_msg(ctrl_msg, &effect_handler, &mut self.metrics).await?
-                {
-                    return Ok(terminal);
+        match self.config.get_traffic_config().production_mode {
+            config::ProductionMode::Smooth => {
+                if batch_duration_millis > 0 {
+                    let batch_ticker =
+                        interval(Duration::from_millis(1000u64.div_euclid(run_len as u64)));
+                    self.run_smooth(
+                        ctrl_msg_recv,
+                        &effect_handler,
+                        producer,
+                        run_ticker,
+                        batch_ticker,
+                    )
+                    .await
+                } else {
+                    otel_warn!("Falling back to Open production mode as batch interval is sub 1ms");
+                    self.run_open(ctrl_msg_recv, &effect_handler, producer, run_ticker)
+                        .await
                 }
             }
-        }
-    }
-}
-
-/// Accumulator for counts of items actually sent downstream.
-/// Used to decouple metric recording from the send path, avoiding
-/// borrow conflicts with the `MetricSet` in the main event loop.
-#[derive(Default)]
-struct ProducedCounts {
-    logs: u64,
-    metrics: u64,
-    traces: u64,
-}
-
-impl std::ops::AddAssign for ProducedCounts {
-    fn add_assign(&mut self, rhs: Self) {
-        self.logs += rhs.logs;
-        self.metrics += rhs.metrics;
-        self.traces += rhs.traces;
-    }
-}
-
-/// Send signals using either pre-generated cache or fresh generation
-async fn send_signals(
-    effect_handler: local::EffectHandler<OtapPdata>,
-    max_signal_count: Option<u64>,
-    signal_count: &mut u64,
-    batch_rotation_index: &mut u64,
-    max_batch_size: usize,
-    metric_count: usize,
-    trace_count: usize,
-    log_count: usize,
-    generator: &SignalGenerator,
-    batch_cache: &Option<BatchCache>,
-    enable_ack_nack: bool,
-    prebuilt_transport_headers: &Option<TransportHeaders>,
-) -> Result<ProducedCounts, Error> {
-    match batch_cache {
-        Some(cache) => {
-            send_cached_signals(
-                effect_handler,
-                max_signal_count,
-                signal_count,
-                metric_count,
-                trace_count,
-                log_count,
-                cache,
-                enable_ack_nack,
-                prebuilt_transport_headers,
-            )
-            .await
-        }
-        None => {
-            generate_signal_fresh(
-                effect_handler,
-                max_signal_count,
-                signal_count,
-                batch_rotation_index,
-                max_batch_size,
-                metric_count,
-                trace_count,
-                log_count,
-                generator,
-                enable_ack_nack,
-                prebuilt_transport_headers,
-            )
-            .await
-        }
-    }
-}
-
-/// Send one generated pdata message, optionally subscribing to Ack/Nack interests.
-///
-/// On success returns a [`ProducedCounts`] with the **actual** item count from
-/// the payload (not the configured count), so the metric accurately reflects
-/// what was delivered downstream.
-async fn send_generated_pdata(
-    effect_handler: &local::EffectHandler<OtapPdata>,
-    mut pdata: OtapPdata,
-    enable_ack_nack: bool,
-    prebuilt_transport_headers: &Option<TransportHeaders>,
-) -> Result<ProducedCounts, Error> {
-    let signal_type = pdata.signal_type();
-    let num_items = pdata.num_items() as u64;
-
-    if let Some(headers) = prebuilt_transport_headers {
-        pdata.set_transport_headers(headers.clone());
-    }
-    if enable_ack_nack {
-        effect_handler.subscribe_to(
-            Interests::ACKS | Interests::NACKS,
-            CallData::default(),
-            &mut pdata,
-        );
-    }
-    effect_handler.send_message_with_source_node(pdata).await?;
-
-    let mut counts = ProducedCounts::default();
-    match signal_type {
-        SignalType::Logs => counts.logs = num_items,
-        SignalType::Metrics => counts.metrics = num_items,
-        SignalType::Traces => counts.traces = num_items,
-    }
-
-    Ok(counts)
-}
-
-/// Send signals from pre-generated cache (PreGenerated strategy).
-/// Sends the cached batch multiple times to match the total signal count.
-async fn send_cached_signals(
-    effect_handler: local::EffectHandler<OtapPdata>,
-    max_signal_count: Option<u64>,
-    signal_count: &mut u64,
-    metric_count: usize,
-    trace_count: usize,
-    log_count: usize,
-    cache: &BatchCache,
-    enable_ack_nack: bool,
-    prebuilt_transport_headers: &Option<TransportHeaders>,
-) -> Result<ProducedCounts, Error> {
-    let total_per_iteration = (metric_count + trace_count + log_count) as u64;
-    let mut produced = ProducedCounts::default();
-
-    // Check if we've reached max signal count
-    if let Some(max_count) = max_signal_count {
-        if *signal_count >= max_count {
-            return Ok(produced);
-        }
-    }
-
-    // Send cached metrics (multiple times if needed)
-    if metric_count > 0 && cache.metrics_batch_size > 0 {
-        if let Some(batch) = &cache.metrics {
-            let send_count = metric_count / cache.metrics_batch_size;
-            for _ in 0..send_count {
-                produced += send_generated_pdata(
-                    &effect_handler,
-                    batch.clone(),
-                    enable_ack_nack,
-                    prebuilt_transport_headers,
-                )
-                .await?;
+            config::ProductionMode::Open => {
+                self.run_open(ctrl_msg_recv, &effect_handler, producer, run_ticker)
+                    .await
             }
         }
     }
-
-    // Send cached traces (multiple times if needed)
-    if trace_count > 0 && cache.traces_batch_size > 0 {
-        if let Some(batch) = &cache.traces {
-            let send_count = trace_count / cache.traces_batch_size;
-            for _ in 0..send_count {
-                produced += send_generated_pdata(
-                    &effect_handler,
-                    batch.clone(),
-                    enable_ack_nack,
-                    prebuilt_transport_headers,
-                )
-                .await?;
-            }
-        }
-    }
-
-    // Send cached logs (multiple times if needed)
-    if log_count > 0 && cache.logs_batch_size > 0 {
-        if let Some(batch) = &cache.logs {
-            let send_count = log_count / cache.logs_batch_size;
-            for _ in 0..send_count {
-                produced += send_generated_pdata(
-                    &effect_handler,
-                    batch.clone(),
-                    enable_ack_nack,
-                    prebuilt_transport_headers,
-                )
-                .await?;
-            }
-        }
-    }
-
-    *signal_count += total_per_iteration;
-    Ok(produced)
-}
-
-/// generate and send signals (Fresh strategy - original behavior)
-async fn generate_signal_fresh(
-    effect_handler: local::EffectHandler<OtapPdata>,
-    max_signal_count: Option<u64>,
-    signal_count: &mut u64,
-    batch_rotation_index: &mut u64,
-    max_batch_size: usize,
-    metric_count: usize,
-    trace_count: usize,
-    log_count: usize,
-    generator: &SignalGenerator,
-    enable_ack_nack: bool,
-    prebuilt_transport_headers: &Option<TransportHeaders>,
-) -> Result<ProducedCounts, Error> {
-    let mut produced = ProducedCounts::default();
-    // nothing to send
-    if max_batch_size == 0 {
-        return Ok(produced);
-    }
-
-    let metric_count_split = metric_count / max_batch_size;
-    let metric_count_remainder = metric_count % max_batch_size;
-    let trace_count_split = trace_count / max_batch_size;
-    let trace_count_remainder = trace_count % max_batch_size;
-    let log_count_split = log_count / max_batch_size;
-    let log_count_remainder = log_count % max_batch_size;
-
-    if let Some(max_count) = max_signal_count {
-        // don't generate signals if we reached max signal
-        let mut current_count = *signal_count;
-        if current_count >= max_count {
-            return Ok(produced);
-        }
-        // update the counts here to allow us to reach the max_signal_count
-
-        for _ in 0..metric_count_split {
-            if max_count >= current_count + max_batch_size as u64 {
-                produced += send_generated_pdata(
-                    &effect_handler,
-                    generator
-                        .generate_metrics(max_batch_size, *batch_rotation_index)
-                        .try_into()?,
-                    enable_ack_nack,
-                    prebuilt_transport_headers,
-                )
-                .await?;
-                *batch_rotation_index += 1;
-                current_count += max_batch_size as u64;
-            } else {
-                // generate last remaining signals
-                let remaining_count: usize =
-                    (max_count - current_count)
-                        .try_into()
-                        .map_err(|_| Error::ReceiverError {
-                            receiver: effect_handler.receiver_id(),
-                            kind: ReceiverErrorKind::Other,
-                            error: "failed to convert u64 to usize".to_string(),
-                            source_detail: String::new(),
-                        })?;
-                produced += send_generated_pdata(
-                    &effect_handler,
-                    generator
-                        .generate_metrics(remaining_count, *batch_rotation_index)
-                        .try_into()?,
-                    enable_ack_nack,
-                    prebuilt_transport_headers,
-                )
-                .await?;
-                *batch_rotation_index += 1;
-
-                // no more signals we have reached the max
-                *signal_count = max_count;
-                return Ok(produced);
-            }
-        }
-        if metric_count_remainder > 0 && max_count >= current_count + metric_count_remainder as u64
-        {
-            produced += send_generated_pdata(
-                &effect_handler,
-                generator
-                    .generate_metrics(metric_count_remainder, *batch_rotation_index)
-                    .try_into()?,
-                enable_ack_nack,
-                prebuilt_transport_headers,
-            )
-            .await?;
-            *batch_rotation_index += 1;
-            current_count += metric_count_remainder as u64;
-        }
-
-        // generate and send traces
-        for _ in 0..trace_count_split {
-            if max_count >= current_count + max_batch_size as u64 {
-                produced += send_generated_pdata(
-                    &effect_handler,
-                    generator
-                        .generate_traces(max_batch_size, *batch_rotation_index)
-                        .try_into()?,
-                    enable_ack_nack,
-                    prebuilt_transport_headers,
-                )
-                .await?;
-                *batch_rotation_index += 1;
-                current_count += max_batch_size as u64;
-            } else {
-                let remaining_count: usize =
-                    (max_count - current_count)
-                        .try_into()
-                        .map_err(|_| Error::ReceiverError {
-                            receiver: effect_handler.receiver_id(),
-                            kind: ReceiverErrorKind::Other,
-                            error: "failed to convert u64 to usize".to_string(),
-                            source_detail: String::new(),
-                        })?;
-                produced += send_generated_pdata(
-                    &effect_handler,
-                    generator
-                        .generate_traces(remaining_count, *batch_rotation_index)
-                        .try_into()?,
-                    enable_ack_nack,
-                    prebuilt_transport_headers,
-                )
-                .await?;
-                *batch_rotation_index += 1;
-                // no more signals we have reached the max
-                *signal_count = max_count;
-                return Ok(produced);
-            }
-        }
-        if trace_count_remainder > 0 && max_count >= current_count + trace_count_remainder as u64 {
-            produced += send_generated_pdata(
-                &effect_handler,
-                generator
-                    .generate_traces(trace_count_remainder, *batch_rotation_index)
-                    .try_into()?,
-                enable_ack_nack,
-                prebuilt_transport_headers,
-            )
-            .await?;
-            *batch_rotation_index += 1;
-            current_count += trace_count_remainder as u64;
-        }
-
-        // generate and send logs
-        for _ in 0..log_count_split {
-            if max_count >= current_count + max_batch_size as u64 {
-                produced += send_generated_pdata(
-                    &effect_handler,
-                    generator
-                        .generate_logs(max_batch_size, *batch_rotation_index)
-                        .try_into()?,
-                    enable_ack_nack,
-                    prebuilt_transport_headers,
-                )
-                .await?;
-                *batch_rotation_index += 1;
-                current_count += max_batch_size as u64;
-            } else {
-                let remaining_count: usize =
-                    (max_count - current_count)
-                        .try_into()
-                        .map_err(|_| Error::ReceiverError {
-                            receiver: effect_handler.receiver_id(),
-                            kind: ReceiverErrorKind::Other,
-                            error: "failed to convert u64 to usize".to_string(),
-                            source_detail: String::new(),
-                        })?;
-                produced += send_generated_pdata(
-                    &effect_handler,
-                    generator
-                        .generate_logs(remaining_count, *batch_rotation_index)
-                        .try_into()?,
-                    enable_ack_nack,
-                    prebuilt_transport_headers,
-                )
-                .await?;
-                *batch_rotation_index += 1;
-                // no more signals we have reached the max
-                *signal_count = max_count;
-                return Ok(produced);
-            }
-        }
-        if log_count_remainder > 0 && max_count >= current_count + log_count_remainder as u64 {
-            produced += send_generated_pdata(
-                &effect_handler,
-                generator
-                    .generate_logs(log_count_remainder, *batch_rotation_index)
-                    .try_into()?,
-                enable_ack_nack,
-                prebuilt_transport_headers,
-            )
-            .await?;
-            *batch_rotation_index += 1;
-            current_count += log_count_remainder as u64;
-        }
-
-        *signal_count = current_count;
-    } else {
-        // generate and send metric
-        for _ in 0..metric_count_split {
-            produced += send_generated_pdata(
-                &effect_handler,
-                generator
-                    .generate_metrics(max_batch_size, *batch_rotation_index)
-                    .try_into()?,
-                enable_ack_nack,
-                prebuilt_transport_headers,
-            )
-            .await?;
-            *batch_rotation_index += 1;
-            *signal_count += max_batch_size as u64;
-        }
-        if metric_count_remainder > 0 {
-            produced += send_generated_pdata(
-                &effect_handler,
-                generator
-                    .generate_metrics(metric_count_remainder, *batch_rotation_index)
-                    .try_into()?,
-                enable_ack_nack,
-                prebuilt_transport_headers,
-            )
-            .await?;
-            *batch_rotation_index += 1;
-            *signal_count += metric_count_remainder as u64;
-        }
-
-        // generate and send traces
-        for _ in 0..trace_count_split {
-            produced += send_generated_pdata(
-                &effect_handler,
-                generator
-                    .generate_traces(max_batch_size, *batch_rotation_index)
-                    .try_into()?,
-                enable_ack_nack,
-                prebuilt_transport_headers,
-            )
-            .await?;
-            *batch_rotation_index += 1;
-            *signal_count += max_batch_size as u64;
-        }
-        if trace_count_remainder > 0 {
-            produced += send_generated_pdata(
-                &effect_handler,
-                generator
-                    .generate_traces(trace_count_remainder, *batch_rotation_index)
-                    .try_into()?,
-                enable_ack_nack,
-                prebuilt_transport_headers,
-            )
-            .await?;
-            *batch_rotation_index += 1;
-            *signal_count += trace_count_remainder as u64;
-        }
-
-        // generate and send logs
-        for _ in 0..log_count_split {
-            produced += send_generated_pdata(
-                &effect_handler,
-                generator
-                    .generate_logs(max_batch_size, *batch_rotation_index)
-                    .try_into()?,
-                enable_ack_nack,
-                prebuilt_transport_headers,
-            )
-            .await?;
-            *batch_rotation_index += 1;
-            *signal_count += max_batch_size as u64;
-        }
-        if log_count_remainder > 0 {
-            produced += send_generated_pdata(
-                &effect_handler,
-                generator
-                    .generate_logs(log_count_remainder, *batch_rotation_index)
-                    .try_into()?,
-                enable_ack_nack,
-                prebuilt_transport_headers,
-            )
-            .await?;
-            *batch_rotation_index += 1;
-            *signal_count += log_count_remainder as u64;
-        }
-    }
-
-    Ok(produced)
 }
 
 #[cfg(test)]
 mod tests {
+    use super::config::{DataSource, GenerationStrategy};
     use super::*;
 
     use crate::receivers::fake_data_generator::config::{Config, TrafficConfig};
@@ -1707,397 +1051,4 @@ mod tests {
             .run_validation(ctrl_validation);
     }
 
-    #[test]
-    fn test_resource_attribute_rotation_across_batches() {
-        use crate::receivers::fake_data_generator::config::ResourceAttributeSet;
-        use std::collections::HashMap;
-        use std::num::NonZeroU32;
-
-        let make_entry = |tenant: &str| ResourceAttributeSet {
-            attrs: HashMap::from([("tenant.id".to_string(), tenant.to_string())]),
-            weight: NonZeroU32::new(1).unwrap(),
-        };
-        let entries = vec![make_entry("prod"), make_entry("staging")];
-        let rotation = build_rotation_table(&entries);
-        let generator = SignalGenerator::Static {
-            entries,
-            rotation,
-            log_body_size_bytes: None,
-            num_log_attributes: None,
-            use_trace_context: false,
-            num_metric_attributes: None,
-            num_data_points_per_metric: None,
-        };
-
-        // attrs_for_batch should rotate through the two sets
-        assert_eq!(generator.attrs_for_batch(0).unwrap()["tenant.id"], "prod");
-        assert_eq!(
-            generator.attrs_for_batch(1).unwrap()["tenant.id"],
-            "staging"
-        );
-        assert_eq!(generator.attrs_for_batch(2).unwrap()["tenant.id"], "prod");
-        assert_eq!(
-            generator.attrs_for_batch(3).unwrap()["tenant.id"],
-            "staging"
-        );
-
-        // Verify generated signals carry the rotated attributes
-        let logs_batch_0 = match generator.generate_logs(1, 0) {
-            OtlpProtoMessage::Logs(logs) => logs,
-            _ => panic!("expected logs"),
-        };
-        let logs_batch_1 = match generator.generate_logs(1, 1) {
-            OtlpProtoMessage::Logs(logs) => logs,
-            _ => panic!("expected logs"),
-        };
-
-        let get_tenant_id = |logs: &LogsData| -> String {
-            logs.resource_logs[0]
-                .resource
-                .as_ref()
-                .unwrap()
-                .attributes
-                .iter()
-                .find(|kv| kv.key == "tenant.id")
-                .expect("tenant.id attribute missing")
-                .value
-                .as_ref()
-                .unwrap()
-                .to_string()
-        };
-
-        assert_ne!(
-            get_tenant_id(&logs_batch_0),
-            get_tenant_id(&logs_batch_1),
-            "consecutive batches should use different resource attribute sets"
-        );
-    }
-
-    #[test]
-    fn test_resource_attribute_rotation_empty_attrs() {
-        let generator = SignalGenerator::Static {
-            entries: vec![],
-            rotation: vec![],
-            log_body_size_bytes: None,
-            num_log_attributes: None,
-            use_trace_context: false,
-            num_metric_attributes: None,
-            num_data_points_per_metric: None,
-        };
-        assert!(generator.attrs_for_batch(0).is_none());
-        assert!(generator.attrs_for_batch(1).is_none());
-    }
-
-    // -- Transport header tests -----------------------------------------------
-
-    /// Verifies that pdata messages contain transport headers with fixed values
-    /// when `transport_headers` is configured with explicit values.
-    #[test]
-    fn test_fake_data_transport_headers_fixed_value() {
-        let test_runtime = TestRuntime::new();
-
-        let registry_path = VirtualDirectoryPath::GitRepo {
-            url: "https://github.com/open-telemetry/semantic-conventions.git".to_owned(),
-            sub_folder: Some("model".to_owned()),
-            refspec: None,
-        };
-
-        let traffic_config = TrafficConfig::new(
-            Some(MESSAGE_PER_SECOND),
-            Some(MAX_SIGNALS),
-            MAX_BATCH,
-            0,
-            0,
-            1,
-        );
-        let config = Config::new(traffic_config, registry_path)
-            .with_data_source(DataSource::Static)
-            .with_generation_strategy(GenerationStrategy::Fresh)
-            .with_transport_headers(HashMap::from([(
-                "x-tenant-id".to_string(),
-                Some("acme".to_string()),
-            )]));
-
-        let node_config = Arc::new(NodeUserConfig::new_receiver_config(
-            OTAP_FAKE_DATA_GENERATOR_URN,
-        ));
-        let telemetry_registry_handle = TelemetryRegistryHandle::new();
-        let controller_ctx = ControllerContext::new(telemetry_registry_handle);
-        let pipeline_ctx =
-            controller_ctx.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
-
-        let receiver = ReceiverWrapper::local(
-            FakeGeneratorReceiver::new(pipeline_ctx, config),
-            test_node("fake_receiver_transport_headers"),
-            node_config,
-            test_runtime.config(),
-        );
-
-        let scenario = move |ctx: TestContext<OtapPdata>| {
-            Box::pin(async move {
-                sleep(Duration::from_millis(RUN_TILL_SHUTDOWN)).await;
-                ctx.send_shutdown(std::time::Instant::now(), "Test complete")
-                    .await
-                    .expect("Failed to send shutdown");
-            }) as Pin<Box<dyn Future<Output = ()>>>
-        };
-
-        let validation = |mut ctx: NotSendValidateContext<OtapPdata>| {
-            Box::pin(async move {
-                let pdata = ctx.recv().await.expect("should receive at least one pdata");
-
-                let headers = pdata
-                    .transport_headers()
-                    .expect("pdata should have transport headers");
-                let tenant: Vec<_> = headers.find_by_name("x-tenant-id").collect();
-                assert_eq!(
-                    tenant.len(),
-                    1,
-                    "should have exactly one x-tenant-id header"
-                );
-                assert_eq!(
-                    tenant[0].value_as_str(),
-                    Some("acme"),
-                    "fixed header value should be 'acme'"
-                );
-            }) as Pin<Box<dyn Future<Output = ()>>>
-        };
-
-        test_runtime
-            .set_receiver(receiver)
-            .run_test(scenario)
-            .run_validation(validation);
-    }
-
-    /// Verifies that pdata messages contain transport headers with random values
-    /// when `transport_headers` is configured with null values.
-    #[test]
-    fn test_fake_data_transport_headers_random_value() {
-        let test_runtime = TestRuntime::new();
-
-        let registry_path = VirtualDirectoryPath::GitRepo {
-            url: "https://github.com/open-telemetry/semantic-conventions.git".to_owned(),
-            sub_folder: Some("model".to_owned()),
-            refspec: None,
-        };
-
-        let traffic_config = TrafficConfig::new(
-            Some(MESSAGE_PER_SECOND),
-            Some(MAX_SIGNALS),
-            MAX_BATCH,
-            0,
-            0,
-            1,
-        );
-        let config = Config::new(traffic_config, registry_path)
-            .with_data_source(DataSource::Static)
-            .with_generation_strategy(GenerationStrategy::Fresh)
-            .with_transport_headers(HashMap::from([("x-request-id".to_string(), None)]));
-
-        let node_config = Arc::new(NodeUserConfig::new_receiver_config(
-            OTAP_FAKE_DATA_GENERATOR_URN,
-        ));
-        let telemetry_registry_handle = TelemetryRegistryHandle::new();
-        let controller_ctx = ControllerContext::new(telemetry_registry_handle);
-        let pipeline_ctx =
-            controller_ctx.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
-
-        let receiver = ReceiverWrapper::local(
-            FakeGeneratorReceiver::new(pipeline_ctx, config),
-            test_node("fake_receiver_random_headers"),
-            node_config,
-            test_runtime.config(),
-        );
-
-        let scenario = move |ctx: TestContext<OtapPdata>| {
-            Box::pin(async move {
-                sleep(Duration::from_millis(RUN_TILL_SHUTDOWN)).await;
-                ctx.send_shutdown(std::time::Instant::now(), "Test complete")
-                    .await
-                    .expect("Failed to send shutdown");
-            }) as Pin<Box<dyn Future<Output = ()>>>
-        };
-
-        let validation = |mut ctx: NotSendValidateContext<OtapPdata>| {
-            Box::pin(async move {
-                let pdata = ctx.recv().await.expect("should receive at least one pdata");
-
-                let headers = pdata
-                    .transport_headers()
-                    .expect("pdata should have transport headers");
-                let request_id: Vec<_> = headers.find_by_name("x-request-id").collect();
-                assert_eq!(
-                    request_id.len(),
-                    1,
-                    "should have exactly one x-request-id header"
-                );
-                assert_eq!(
-                    request_id[0].value.len(),
-                    16,
-                    "random value should be 16 bytes"
-                );
-                assert_eq!(
-                    request_id[0].value_kind,
-                    ValueKind::Text,
-                    "non-bin key should produce a Text header"
-                );
-                assert!(
-                    request_id[0].value_as_str().is_some(),
-                    "text header random value should be valid UTF-8 (printable)"
-                );
-            }) as Pin<Box<dyn Future<Output = ()>>>
-        };
-
-        test_runtime
-            .set_receiver(receiver)
-            .run_test(scenario)
-            .run_validation(validation);
-    }
-
-    /// Verifies that pdata messages contain binary transport headers with random
-    /// values when `transport_headers` is configured with null values and keys
-    /// ending in `-bin`.
-    #[test]
-    fn test_fake_data_transport_headers_binary_random_value() {
-        let test_runtime = TestRuntime::new();
-
-        let registry_path = VirtualDirectoryPath::GitRepo {
-            url: "https://github.com/open-telemetry/semantic-conventions.git".to_owned(),
-            sub_folder: Some("model".to_owned()),
-            refspec: None,
-        };
-
-        let traffic_config = TrafficConfig::new(
-            Some(MESSAGE_PER_SECOND),
-            Some(MAX_SIGNALS),
-            MAX_BATCH,
-            0,
-            0,
-            1,
-        );
-        let config = Config::new(traffic_config, registry_path)
-            .with_data_source(DataSource::Static)
-            .with_generation_strategy(GenerationStrategy::Fresh)
-            .with_transport_headers(HashMap::from([("x-trace-bin".to_string(), None)]));
-
-        let node_config = Arc::new(NodeUserConfig::new_receiver_config(
-            OTAP_FAKE_DATA_GENERATOR_URN,
-        ));
-        let telemetry_registry_handle = TelemetryRegistryHandle::new();
-        let controller_ctx = ControllerContext::new(telemetry_registry_handle);
-        let pipeline_ctx =
-            controller_ctx.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
-
-        let receiver = ReceiverWrapper::local(
-            FakeGeneratorReceiver::new(pipeline_ctx, config),
-            test_node("fake_receiver_binary_headers"),
-            node_config,
-            test_runtime.config(),
-        );
-
-        let scenario = move |ctx: TestContext<OtapPdata>| {
-            Box::pin(async move {
-                sleep(Duration::from_millis(RUN_TILL_SHUTDOWN)).await;
-                ctx.send_shutdown(std::time::Instant::now(), "Test complete")
-                    .await
-                    .expect("Failed to send shutdown");
-            }) as Pin<Box<dyn Future<Output = ()>>>
-        };
-
-        let validation = |mut ctx: NotSendValidateContext<OtapPdata>| {
-            Box::pin(async move {
-                let pdata = ctx.recv().await.expect("should receive at least one pdata");
-
-                let headers = pdata
-                    .transport_headers()
-                    .expect("pdata should have transport headers");
-                let trace_bin: Vec<_> = headers.find_by_name("x-trace-bin").collect();
-                assert_eq!(
-                    trace_bin.len(),
-                    1,
-                    "should have exactly one x-trace-bin header"
-                );
-                assert_eq!(
-                    trace_bin[0].value.len(),
-                    16,
-                    "random binary value should be 16 bytes"
-                );
-                assert_eq!(
-                    trace_bin[0].value_kind,
-                    ValueKind::Binary,
-                    "-bin key should produce a Binary header"
-                );
-            }) as Pin<Box<dyn Future<Output = ()>>>
-        };
-
-        test_runtime
-            .set_receiver(receiver)
-            .run_test(scenario)
-            .run_validation(validation);
-    }
-
-    /// Verifies that pdata messages do NOT have transport headers when
-    /// `transport_headers` is absent from the config.
-    #[test]
-    fn test_fake_data_transport_headers_empty_by_default() {
-        let test_runtime = TestRuntime::new();
-
-        let registry_path = VirtualDirectoryPath::GitRepo {
-            url: "https://github.com/open-telemetry/semantic-conventions.git".to_owned(),
-            sub_folder: Some("model".to_owned()),
-            refspec: None,
-        };
-
-        let traffic_config = TrafficConfig::new(
-            Some(MESSAGE_PER_SECOND),
-            Some(MAX_SIGNALS),
-            MAX_BATCH,
-            0,
-            0,
-            1,
-        );
-        let config = Config::new(traffic_config, registry_path)
-            .with_data_source(DataSource::Static)
-            .with_generation_strategy(GenerationStrategy::Fresh);
-
-        let node_config = Arc::new(NodeUserConfig::new_receiver_config(
-            OTAP_FAKE_DATA_GENERATOR_URN,
-        ));
-        let telemetry_registry_handle = TelemetryRegistryHandle::new();
-        let controller_ctx = ControllerContext::new(telemetry_registry_handle);
-        let pipeline_ctx =
-            controller_ctx.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
-
-        let receiver = ReceiverWrapper::local(
-            FakeGeneratorReceiver::new(pipeline_ctx, config),
-            test_node("fake_receiver_no_headers"),
-            node_config,
-            test_runtime.config(),
-        );
-
-        let scenario = move |ctx: TestContext<OtapPdata>| {
-            Box::pin(async move {
-                sleep(Duration::from_millis(RUN_TILL_SHUTDOWN)).await;
-                ctx.send_shutdown(std::time::Instant::now(), "Test complete")
-                    .await
-                    .expect("Failed to send shutdown");
-            }) as Pin<Box<dyn Future<Output = ()>>>
-        };
-
-        let validation = |mut ctx: NotSendValidateContext<OtapPdata>| {
-            Box::pin(async move {
-                let pdata = ctx.recv().await.expect("should receive at least one pdata");
-
-                assert!(
-                    pdata.transport_headers().is_none(),
-                    "pdata should NOT have transport headers when config has no transport_headers"
-                );
-            }) as Pin<Box<dyn Future<Output = ()>>>
-        };
-
-        test_runtime
-            .set_receiver(receiver)
-            .run_test(scenario)
-            .run_validation(validation);
-    }
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/mod.rs
@@ -98,14 +98,13 @@ impl FakeGeneratorReceiver {
         pipeline_ctx: PipelineContext,
         config: &Value,
     ) -> Result<Self, otap_df_config::error::Error> {
-        Ok(FakeGeneratorReceiver::new(
-            pipeline_ctx,
-            serde_json::from_value(config.clone()).map_err(|e| {
-                otap_df_config::error::Error::InvalidUserConfig {
-                    error: e.to_string(),
-                }
-            })?,
-        ))
+        let config: Config = serde_json::from_value(config.clone()).map_err(|e| {
+            otap_df_config::error::Error::InvalidUserConfig {
+                error: e.to_string(),
+            }
+        })?;
+        config.get_traffic_config().validate()?;
+        Ok(FakeGeneratorReceiver::new(pipeline_ctx, config))
     }
 
     async fn run_smooth(

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/mod.rs
@@ -121,7 +121,6 @@ impl FakeGeneratorReceiver {
 
         loop {
             producer.record_production(run_produced);
-            otel_info!("Produced", run_produced);
             run_produced = 0;
 
             let Ok(Some(mut current_run)) = producer.next_run() else {
@@ -203,7 +202,8 @@ impl FakeGeneratorReceiver {
 
                     _ = run_ticker.tick() => {
                         otel_warn!(
-                            "Data generator is falling behind and didn't finish the current run",
+                            "Data generator is falling behind and didn't finish the current run. For highest
+                            possible throughput, use production_mode: open",
                             remaining=current_run.len(),
                         );
 
@@ -450,7 +450,11 @@ impl local::Receiver<OtapPdata> for FakeGeneratorReceiver {
 
         let run_len = producer.run_len();
         let batch_duration_millis = 1000u64.div_euclid(run_len as u64);
-        let run_ticker = interval(Duration::from_secs(1));
+
+        // We consume one tick here because it's always immediately ready and would
+        // make us think we're lagging;
+        let mut run_ticker = interval(Duration::from_secs(1));
+        _ = run_ticker.tick().await;
 
         match self.config.get_traffic_config().production_mode {
             config::ProductionMode::Smooth => {

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/mod.rs
@@ -28,7 +28,7 @@ use otap_df_otap::OTAP_RECEIVER_FACTORIES;
 use otap_df_otap::pdata::OtapPdata;
 use otap_df_pdata::OtapPayload;
 use otap_df_telemetry::metrics::MetricSet;
-use otap_df_telemetry::{otel_info, otel_warn};
+use otap_df_telemetry::{otel_debug, otel_info, otel_warn};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -140,9 +140,10 @@ impl FakeGeneratorReceiver {
                     _ = run_ticker.tick() => {
                         if current_run.len() > 0 {
                             otel_warn!(
-                                "Data generator is falling behind and didn't finish the current run",
+                                "Data generator is falling behind and didn't finish the current run. For highest
+                                possible throughput, use production_mode: open",
                                 remaining=current_run.len(),
-                            )
+                            );
                         }
                         break;
                     }
@@ -201,9 +202,8 @@ impl FakeGeneratorReceiver {
                     }
 
                     _ = run_ticker.tick() => {
-                        otel_warn!(
-                            "Data generator is falling behind and didn't finish the current run. For highest
-                            possible throughput, use production_mode: open",
+                        otel_debug!(
+                            "Data generator is falling behind and didn't finish the current run.",
                             remaining=current_run.len(),
                         );
 

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/mod.rs
@@ -124,7 +124,7 @@ impl FakeGeneratorReceiver {
             otel_info!("Produced", run_produced);
             run_produced = 0;
 
-            let Some(mut current_run) = producer.next_run() else {
+            let Ok(Some(mut current_run)) = producer.next_run() else {
                 return wait_for_terminal(ctrl_msg_recv, handler, &mut self.metrics).await;
             };
 
@@ -174,7 +174,7 @@ impl FakeGeneratorReceiver {
             producer.record_production(run_produced);
             run_produced = 0;
 
-            let Some(mut current_run) = producer.next_run() else {
+            let Ok(Some(mut current_run)) = producer.next_run() else {
                 return wait_for_terminal(ctrl_msg_recv, handler, &mut self.metrics).await;
             };
 

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/mod.rs
@@ -1050,5 +1050,4 @@ mod tests {
             .run_test(ctrl_scenario)
             .run_validation(ctrl_validation);
     }
-
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/mod.rs
@@ -161,7 +161,7 @@ impl FakeGeneratorReceiver {
 
             // First phase is the open export phase where we pump data as fast as
             // possible one chunk at a time while checking for control messages
-            // inbetween. If we hit backpressure then we just skip that chunk of data
+            // in between. If we hit backpressure then we just skip that chunk of data
             // until we get through the entire iterator.
             loop {
                 // In the first select statement, we try to drain the entire run

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/mod.rs
@@ -30,6 +30,7 @@ use otap_df_pdata::OtapPayload;
 use otap_df_telemetry::metrics::MetricSet;
 use otap_df_telemetry::{otel_info, otel_warn};
 use serde_json::Value;
+use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::time::{Duration, Interval, interval};
 
@@ -114,35 +115,47 @@ impl FakeGeneratorReceiver {
         mut producer: TrafficProducer,
         mut run_ticker: Interval,
         mut batch_ticker: Interval,
+        transport_headers: Option<TransportHeaders>,
     ) -> Result<TerminalState, Error> {
-        let mut current_run = producer.next_run();
+        let mut run_produced: u64 = 0;
+
         loop {
-            tokio::select! {
-                biased;
+            producer.record_production(run_produced);
+            otel_info!("Produced", run_produced);
+            run_produced = 0;
 
-                msg = ctrl_msg_recv.recv() => {
-                    if let Some(terminal) = handle_control_msg(msg, handler, &mut self.metrics).await? {
-                        return Ok(terminal);
+            let Some(mut current_run) = producer.next_run() else {
+                return wait_for_terminal(ctrl_msg_recv, handler, &mut self.metrics).await;
+            };
+
+            loop {
+                tokio::select! {
+                    biased;
+
+                    msg = ctrl_msg_recv.recv() => {
+                        if let Some(terminal) = handle_control_msg(msg, handler, &mut self.metrics).await? {
+                            return Ok(terminal);
+                        }
                     }
-                }
 
-                _ = run_ticker.tick() => {
-                    if current_run.len() > 0 {
-                        otel_warn!(
-                            "Data generator is falling behind and didn't finish the current run",
-                            remaining=current_run.len(),
-                        )
+                    _ = run_ticker.tick() => {
+                        if current_run.len() > 0 {
+                            otel_warn!(
+                                "Data generator is falling behind and didn't finish the current run",
+                                remaining=current_run.len(),
+                            )
+                        }
+                        break;
                     }
 
-                    current_run = producer.next_run();
-                }
+                    _ = batch_ticker.tick() => {
+                        let Some(payload) = current_run.next() else {
+                            continue;
+                        };
 
-                _ = batch_ticker.tick() => {
-                    let Some(payload) = current_run.next() else {
-                        continue;
-                    };
-
-                    self.handle_payload(handler, payload)?;
+                        let count = self.handle_payload(handler, payload, &transport_headers)?;
+                        run_produced += count;
+                    }
                 }
             }
         }
@@ -154,10 +167,16 @@ impl FakeGeneratorReceiver {
         handler: &local::EffectHandler<OtapPdata>,
         mut producer: TrafficProducer,
         mut run_ticker: Interval,
+        transport_headers: Option<TransportHeaders>,
     ) -> Result<TerminalState, Error> {
+        let mut run_produced: u64 = 0;
         'start: loop {
-            // This is the start of each traffic run which has two phases
-            let mut current_run = producer.next_run();
+            producer.record_production(run_produced);
+            run_produced = 0;
+
+            let Some(mut current_run) = producer.next_run() else {
+                return wait_for_terminal(ctrl_msg_recv, handler, &mut self.metrics).await;
+            };
 
             // First phase is the open export phase where we pump data as fast as
             // possible one chunk at a time while checking for control messages
@@ -189,7 +208,8 @@ impl FakeGeneratorReceiver {
                             break;
                         };
 
-                        self.handle_payload(handler, payload)?;
+                        let count = self.handle_payload(handler, payload, &transport_headers)?;
+                        run_produced += count;
                     }
                 }
 
@@ -217,7 +237,8 @@ impl FakeGeneratorReceiver {
         &mut self,
         handler: &local::EffectHandler<OtapPdata>,
         payload: Result<OtapPayload, GenerateError>,
-    ) -> Result<(), Error> {
+        transport_headers: &Option<TransportHeaders>,
+    ) -> Result<u64, Error> {
         let payload = match payload {
             Ok(payload) => payload,
             Err(e) => {
@@ -231,6 +252,9 @@ impl FakeGeneratorReceiver {
         };
 
         let mut pdata = OtapPdata::new_todo_context(payload);
+        if let Some(headers) = transport_headers {
+            pdata.set_transport_headers(headers.clone());
+        }
         if self.config.enable_ack_nack() {
             handler.subscribe_to(
                 Interests::ACKS | Interests::NACKS,
@@ -248,12 +272,13 @@ impl FakeGeneratorReceiver {
                     otap_df_config::SignalType::Metrics => self.metrics.metrics_produced.add(count),
                     otap_df_config::SignalType::Logs => self.metrics.logs_produced.add(count),
                 };
+                Ok(count)
             }
             Err(e) => {
                 otel_warn!("Failed to send pdata", error=?e);
+                Ok(0)
             }
         }
-        Ok(())
     }
 }
 
@@ -311,6 +336,23 @@ fn build_transport_headers(
     Some(headers)
 }
 
+/// Waits for a terminal control message after the producer has finished.
+///
+/// This is used when `max_signal_count` has been reached and the receiver has
+/// no more data to produce, but must remain alive for graceful shutdown.
+async fn wait_for_terminal(
+    mut ctrl_msg_recv: local::ControlChannel<OtapPdata>,
+    handler: &local::EffectHandler<OtapPdata>,
+    metrics: &mut MetricSet<FakeSignalReceiverMetrics>,
+) -> Result<TerminalState, Error> {
+    loop {
+        let msg = ctrl_msg_recv.recv().await;
+        if let Some(terminal) = handle_control_msg(msg, handler, metrics).await? {
+            return Ok(terminal);
+        }
+    }
+}
+
 /// Handle a control message received on the control channel.
 ///
 /// Returns `Ok(Some(terminal_state))` when the receiver should exit,
@@ -358,6 +400,8 @@ impl local::Receiver<OtapPdata> for FakeGeneratorReceiver {
                 source_detail: String::new(),
             })?;
 
+        let transport_headers = build_transport_headers(self.config.transport_headers());
+
         let _ = effect_handler
             .start_periodic_telemetry(Duration::from_secs(1))
             .await?;
@@ -377,17 +421,30 @@ impl local::Receiver<OtapPdata> for FakeGeneratorReceiver {
                         producer,
                         run_ticker,
                         batch_ticker,
+                        transport_headers,
                     )
                     .await
                 } else {
                     otel_warn!("Falling back to Open production mode as batch interval is sub 1ms");
-                    self.run_open(ctrl_msg_recv, &effect_handler, producer, run_ticker)
-                        .await
+                    self.run_open(
+                        ctrl_msg_recv,
+                        &effect_handler,
+                        producer,
+                        run_ticker,
+                        transport_headers,
+                    )
+                    .await
                 }
             }
             config::ProductionMode::Open => {
-                self.run_open(ctrl_msg_recv, &effect_handler, producer, run_ticker)
-                    .await
+                self.run_open(
+                    ctrl_msg_recv,
+                    &effect_handler,
+                    producer,
+                    run_ticker,
+                    transport_headers,
+                )
+                .await
             }
         }
     }
@@ -1049,5 +1106,316 @@ mod tests {
             .set_receiver(receiver)
             .run_test(ctrl_scenario)
             .run_validation(ctrl_validation);
+    }
+
+    /// Verifies that pdata messages contain transport headers with fixed values
+    /// when `transport_headers` is configured with explicit values.
+    #[test]
+    fn test_fake_data_transport_headers_fixed_value() {
+        let test_runtime = TestRuntime::new();
+
+        let registry_path = VirtualDirectoryPath::GitRepo {
+            url: "https://github.com/open-telemetry/semantic-conventions.git".to_owned(),
+            sub_folder: Some("model".to_owned()),
+            refspec: None,
+        };
+
+        let traffic_config = TrafficConfig::new(
+            Some(MESSAGE_PER_SECOND),
+            Some(MAX_SIGNALS),
+            MAX_BATCH,
+            0,
+            0,
+            1,
+        );
+        let config = Config::new(traffic_config, registry_path)
+            .with_data_source(DataSource::Static)
+            .with_generation_strategy(GenerationStrategy::Fresh)
+            .with_transport_headers(HashMap::from([(
+                "x-tenant-id".to_string(),
+                Some("acme".to_string()),
+            )]));
+
+        let node_config = Arc::new(NodeUserConfig::new_receiver_config(
+            OTAP_FAKE_DATA_GENERATOR_URN,
+        ));
+        let telemetry_registry_handle = TelemetryRegistryHandle::new();
+        let controller_ctx = ControllerContext::new(telemetry_registry_handle);
+        let pipeline_ctx =
+            controller_ctx.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+
+        let receiver = ReceiverWrapper::local(
+            FakeGeneratorReceiver::new(pipeline_ctx, config),
+            test_node("fake_receiver_transport_headers"),
+            node_config,
+            test_runtime.config(),
+        );
+
+        let scenario = move |ctx: TestContext<OtapPdata>| {
+            Box::pin(async move {
+                sleep(Duration::from_millis(RUN_TILL_SHUTDOWN)).await;
+                ctx.send_shutdown(std::time::Instant::now(), "Test complete")
+                    .await
+                    .expect("Failed to send shutdown");
+            }) as Pin<Box<dyn Future<Output = ()>>>
+        };
+
+        let validation = |mut ctx: NotSendValidateContext<OtapPdata>| {
+            Box::pin(async move {
+                let pdata = ctx.recv().await.expect("should receive at least one pdata");
+
+                let headers = pdata
+                    .transport_headers()
+                    .expect("pdata should have transport headers");
+                let tenant: Vec<_> = headers.find_by_name("x-tenant-id").collect();
+                assert_eq!(
+                    tenant.len(),
+                    1,
+                    "should have exactly one x-tenant-id header"
+                );
+                assert_eq!(
+                    tenant[0].value_as_str(),
+                    Some("acme"),
+                    "fixed header value should be 'acme'"
+                );
+            }) as Pin<Box<dyn Future<Output = ()>>>
+        };
+
+        test_runtime
+            .set_receiver(receiver)
+            .run_test(scenario)
+            .run_validation(validation);
+    }
+
+    /// Verifies that pdata messages contain transport headers with random values
+    /// when `transport_headers` is configured with null values.
+    #[test]
+    fn test_fake_data_transport_headers_random_value() {
+        let test_runtime = TestRuntime::new();
+
+        let registry_path = VirtualDirectoryPath::GitRepo {
+            url: "https://github.com/open-telemetry/semantic-conventions.git".to_owned(),
+            sub_folder: Some("model".to_owned()),
+            refspec: None,
+        };
+
+        let traffic_config = TrafficConfig::new(
+            Some(MESSAGE_PER_SECOND),
+            Some(MAX_SIGNALS),
+            MAX_BATCH,
+            0,
+            0,
+            1,
+        );
+        let config = Config::new(traffic_config, registry_path)
+            .with_data_source(DataSource::Static)
+            .with_generation_strategy(GenerationStrategy::Fresh)
+            .with_transport_headers(HashMap::from([("x-request-id".to_string(), None)]));
+
+        let node_config = Arc::new(NodeUserConfig::new_receiver_config(
+            OTAP_FAKE_DATA_GENERATOR_URN,
+        ));
+        let telemetry_registry_handle = TelemetryRegistryHandle::new();
+        let controller_ctx = ControllerContext::new(telemetry_registry_handle);
+        let pipeline_ctx =
+            controller_ctx.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+
+        let receiver = ReceiverWrapper::local(
+            FakeGeneratorReceiver::new(pipeline_ctx, config),
+            test_node("fake_receiver_random_headers"),
+            node_config,
+            test_runtime.config(),
+        );
+
+        let scenario = move |ctx: TestContext<OtapPdata>| {
+            Box::pin(async move {
+                sleep(Duration::from_millis(RUN_TILL_SHUTDOWN)).await;
+                ctx.send_shutdown(std::time::Instant::now(), "Test complete")
+                    .await
+                    .expect("Failed to send shutdown");
+            }) as Pin<Box<dyn Future<Output = ()>>>
+        };
+
+        let validation = |mut ctx: NotSendValidateContext<OtapPdata>| {
+            Box::pin(async move {
+                let pdata = ctx.recv().await.expect("should receive at least one pdata");
+
+                let headers = pdata
+                    .transport_headers()
+                    .expect("pdata should have transport headers");
+                let request_id: Vec<_> = headers.find_by_name("x-request-id").collect();
+                assert_eq!(
+                    request_id.len(),
+                    1,
+                    "should have exactly one x-request-id header"
+                );
+                assert_eq!(
+                    request_id[0].value.len(),
+                    16,
+                    "random value should be 16 bytes"
+                );
+                assert_eq!(
+                    request_id[0].value_kind,
+                    ValueKind::Text,
+                    "non-bin key should produce a Text header"
+                );
+                assert!(
+                    request_id[0].value_as_str().is_some(),
+                    "text header random value should be valid UTF-8 (printable)"
+                );
+            }) as Pin<Box<dyn Future<Output = ()>>>
+        };
+
+        test_runtime
+            .set_receiver(receiver)
+            .run_test(scenario)
+            .run_validation(validation);
+    }
+
+    /// Verifies that pdata messages contain binary transport headers with random
+    /// values when `transport_headers` is configured with null values and keys
+    /// ending in `-bin`.
+    #[test]
+    fn test_fake_data_transport_headers_binary_random_value() {
+        let test_runtime = TestRuntime::new();
+
+        let registry_path = VirtualDirectoryPath::GitRepo {
+            url: "https://github.com/open-telemetry/semantic-conventions.git".to_owned(),
+            sub_folder: Some("model".to_owned()),
+            refspec: None,
+        };
+
+        let traffic_config = TrafficConfig::new(
+            Some(MESSAGE_PER_SECOND),
+            Some(MAX_SIGNALS),
+            MAX_BATCH,
+            0,
+            0,
+            1,
+        );
+        let config = Config::new(traffic_config, registry_path)
+            .with_data_source(DataSource::Static)
+            .with_generation_strategy(GenerationStrategy::Fresh)
+            .with_transport_headers(HashMap::from([("x-trace-bin".to_string(), None)]));
+
+        let node_config = Arc::new(NodeUserConfig::new_receiver_config(
+            OTAP_FAKE_DATA_GENERATOR_URN,
+        ));
+        let telemetry_registry_handle = TelemetryRegistryHandle::new();
+        let controller_ctx = ControllerContext::new(telemetry_registry_handle);
+        let pipeline_ctx =
+            controller_ctx.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+
+        let receiver = ReceiverWrapper::local(
+            FakeGeneratorReceiver::new(pipeline_ctx, config),
+            test_node("fake_receiver_binary_headers"),
+            node_config,
+            test_runtime.config(),
+        );
+
+        let scenario = move |ctx: TestContext<OtapPdata>| {
+            Box::pin(async move {
+                sleep(Duration::from_millis(RUN_TILL_SHUTDOWN)).await;
+                ctx.send_shutdown(std::time::Instant::now(), "Test complete")
+                    .await
+                    .expect("Failed to send shutdown");
+            }) as Pin<Box<dyn Future<Output = ()>>>
+        };
+
+        let validation = |mut ctx: NotSendValidateContext<OtapPdata>| {
+            Box::pin(async move {
+                let pdata = ctx.recv().await.expect("should receive at least one pdata");
+
+                let headers = pdata
+                    .transport_headers()
+                    .expect("pdata should have transport headers");
+                let trace_bin: Vec<_> = headers.find_by_name("x-trace-bin").collect();
+                assert_eq!(
+                    trace_bin.len(),
+                    1,
+                    "should have exactly one x-trace-bin header"
+                );
+                assert_eq!(
+                    trace_bin[0].value.len(),
+                    16,
+                    "random binary value should be 16 bytes"
+                );
+                assert_eq!(
+                    trace_bin[0].value_kind,
+                    ValueKind::Binary,
+                    "-bin key should produce a Binary header"
+                );
+            }) as Pin<Box<dyn Future<Output = ()>>>
+        };
+
+        test_runtime
+            .set_receiver(receiver)
+            .run_test(scenario)
+            .run_validation(validation);
+    }
+
+    /// Verifies that pdata messages do NOT have transport headers when
+    /// `transport_headers` is absent from the config.
+    #[test]
+    fn test_fake_data_transport_headers_empty_by_default() {
+        let test_runtime = TestRuntime::new();
+
+        let registry_path = VirtualDirectoryPath::GitRepo {
+            url: "https://github.com/open-telemetry/semantic-conventions.git".to_owned(),
+            sub_folder: Some("model".to_owned()),
+            refspec: None,
+        };
+
+        let traffic_config = TrafficConfig::new(
+            Some(MESSAGE_PER_SECOND),
+            Some(MAX_SIGNALS),
+            MAX_BATCH,
+            0,
+            0,
+            1,
+        );
+        let config = Config::new(traffic_config, registry_path)
+            .with_data_source(DataSource::Static)
+            .with_generation_strategy(GenerationStrategy::Fresh);
+
+        let node_config = Arc::new(NodeUserConfig::new_receiver_config(
+            OTAP_FAKE_DATA_GENERATOR_URN,
+        ));
+        let telemetry_registry_handle = TelemetryRegistryHandle::new();
+        let controller_ctx = ControllerContext::new(telemetry_registry_handle);
+        let pipeline_ctx =
+            controller_ctx.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+
+        let receiver = ReceiverWrapper::local(
+            FakeGeneratorReceiver::new(pipeline_ctx, config),
+            test_node("fake_receiver_no_headers"),
+            node_config,
+            test_runtime.config(),
+        );
+
+        let scenario = move |ctx: TestContext<OtapPdata>| {
+            Box::pin(async move {
+                sleep(Duration::from_millis(RUN_TILL_SHUTDOWN)).await;
+                ctx.send_shutdown(std::time::Instant::now(), "Test complete")
+                    .await
+                    .expect("Failed to send shutdown");
+            }) as Pin<Box<dyn Future<Output = ()>>>
+        };
+
+        let validation = |mut ctx: NotSendValidateContext<OtapPdata>| {
+            Box::pin(async move {
+                let pdata = ctx.recv().await.expect("should receive at least one pdata");
+
+                assert!(
+                    pdata.transport_headers().is_none(),
+                    "pdata should NOT have transport headers when config has no transport_headers"
+                );
+            }) as Pin<Box<dyn Future<Output = ()>>>
+        };
+
+        test_runtime
+            .set_receiver(receiver)
+            .run_test(scenario)
+            .run_validation(validation);
     }
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/mod.rs
@@ -212,7 +212,9 @@ impl FakeGeneratorReceiver {
                         run_produced += count;
                     }
                 }
+            }
 
+            loop {
                 // The second phase starts once we exhaust a traffic run. At this point
                 // we only process control messages while we wait for a tick at which point
                 // we start the next run.

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/mod.rs
@@ -9,14 +9,14 @@ use crate::receivers::fake_data_generator::config::Config;
 use async_trait::async_trait;
 use linkme::distributed_slice;
 use metrics::FakeSignalReceiverMetrics;
-use otap_df_channel::error::RecvError;
+use otap_df_channel::error::{RecvError, SendError};
 use otap_df_config::node::NodeUserConfig;
 use otap_df_config::transport_headers::{TransportHeader, TransportHeaders};
 use otap_df_engine::MessageSourceLocalEffectHandlerExtension;
 use otap_df_engine::config::ReceiverConfig;
 use otap_df_engine::context::PipelineContext;
 use otap_df_engine::control::CallData;
-use otap_df_engine::error::{Error, ReceiverErrorKind};
+use otap_df_engine::error::{Error, ReceiverErrorKind, TypedError};
 use otap_df_engine::local::receiver as local;
 use otap_df_engine::node::NodeId;
 use otap_df_engine::receiver::ReceiverWrapper;
@@ -149,12 +149,20 @@ impl FakeGeneratorReceiver {
                     }
 
                     _ = batch_ticker.tick() => {
+
                         let Some(payload) = current_run.next() else {
                             continue;
                         };
 
-                        let count = self.handle_payload(handler, payload, &transport_headers)?;
-                        run_produced += count;
+                        let channel_result = self.handle_payload(handler, payload, &transport_headers)?;
+                        match channel_result {
+                            Ok(count) => {
+                                run_produced += count;
+                            }
+                            Err(e) => {
+                                otel_warn!("Failed to push in smooth mode, skipping tick", err=?e);
+                            }
+                        }
                     }
                 }
             }
@@ -180,8 +188,8 @@ impl FakeGeneratorReceiver {
 
             // First phase is the open export phase where we pump data as fast as
             // possible one chunk at a time while checking for control messages
-            // in between. If we hit backpressure then we just skip that chunk of data
-            // until we get through the entire iterator.
+            // in between.
+            let mut next_pdata: Option<OtapPdata> = None;
             loop {
                 // In the first select statement, we try to drain the entire run
                 tokio::select! {
@@ -203,13 +211,28 @@ impl FakeGeneratorReceiver {
                     }
 
                     _ = std::future::ready(()) => {
+                        let channel_result = match next_pdata.take() {
+                            Some(pdata) => {
+                                self.export_pdata(handler, pdata)?
+                            }
+                            None => {
+                                let Some(payload) = current_run.next() else {
+                                    break;
+                                };
 
-                        let Some(payload) = current_run.next() else {
-                            break;
+                               self.handle_payload(handler, payload, &transport_headers)?
+                            }
                         };
 
-                        let count = self.handle_payload(handler, payload, &transport_headers)?;
-                        run_produced += count;
+                        match channel_result {
+                            Ok(count) => {
+                                run_produced += count;
+                            }
+                            Err(pdata) => {
+                                next_pdata = Some(pdata);
+                                tokio::task::yield_now().await;
+                            }
+                        }
                     }
                 }
             }
@@ -235,12 +258,13 @@ impl FakeGeneratorReceiver {
         }
     }
 
+    // There are two failure modes here
     fn handle_payload(
         &mut self,
         handler: &local::EffectHandler<OtapPdata>,
         payload: Result<OtapPayload, GenerateError>,
         transport_headers: &Option<TransportHeaders>,
-    ) -> Result<u64, Error> {
+    ) -> Result<Result<u64, OtapPdata>, Error> {
         let payload = match payload {
             Ok(payload) => payload,
             Err(e) => {
@@ -265,6 +289,14 @@ impl FakeGeneratorReceiver {
             );
         }
 
+        self.export_pdata(handler, pdata)
+    }
+
+    fn export_pdata(
+        &mut self,
+        handler: &local::EffectHandler<OtapPdata>,
+        pdata: OtapPdata,
+    ) -> Result<Result<u64, OtapPdata>, Error> {
         let signal = pdata.signal_type();
         let count = pdata.num_items() as u64;
         match handler.try_send_message_with_source_node(pdata) {
@@ -274,11 +306,19 @@ impl FakeGeneratorReceiver {
                     otap_df_config::SignalType::Metrics => self.metrics.metrics_produced.add(count),
                     otap_df_config::SignalType::Logs => self.metrics.logs_produced.add(count),
                 };
-                Ok(count)
+                Ok(Ok(count))
             }
             Err(e) => {
-                otel_warn!("Failed to send pdata", error=?e);
-                Ok(0)
+                let TypedError::ChannelSendError(SendError::Full(pdata)) = e else {
+                    return Err(Error::ReceiverError {
+                        receiver: handler.receiver_id(),
+                        kind: ReceiverErrorKind::Other,
+                        error: format!("Failed to generate data: {}", e),
+                        source_detail: String::new(),
+                    });
+                };
+
+                Ok(Err(pdata))
             }
         }
     }

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/mod.rs
@@ -202,7 +202,7 @@ impl FakeGeneratorReceiver {
                         continue 'start;
                     }
 
-                    else => {
+                    _ = std::future::ready(()) => {
 
                         let Some(payload) = current_run.next() else {
                             break;

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/producer.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/producer.rs
@@ -17,7 +17,15 @@ use super::{semconv_signal, static_signal};
 /// reasonably smooth curve.
 pub struct TrafficProducer {
     strategy: ProductionStrategy,
+    /// The canonical shape from config, used for Replay truncation to determine
+    /// the signal type of the batch that needs a fresh partial payload.
+    shape: TrafficShape,
     generator: Box<dyn SignalGenerator>,
+    /// Optional upper bound on the total number of signals this producer may
+    /// emit across its lifetime.
+    max_signal_count: Option<u64>,
+    /// Running total of signals confirmed exported by the receiver.
+    produced_count: u64,
 }
 
 /// Describes the shape of traffic for one production run (one second of signals).
@@ -64,16 +72,33 @@ impl TrafficProducer {
         // Build the production strategy.
         let shape = create_shape(traffic_config);
         let strategy = match config.generation_strategy() {
-            GenerationStrategy::Fresh => ProductionStrategy::Fresh(shape),
+            GenerationStrategy::Fresh => {
+                let num_batches = shape.len();
+                let signal_count = shape.iter().map(|(_, c)| c).sum();
+                ProductionStrategy::Fresh {
+                    shape: shape.clone(),
+                    num_batches,
+                    signal_count,
+                }
+            }
             GenerationStrategy::PreGenerated => {
                 let payloads = create_fresh_payloads(&mut *generator, &shape)?;
-                ProductionStrategy::Replay(payloads)
+                let num_batches = payloads.len();
+                let signal_count = payloads.iter().map(|p| p.num_items()).sum();
+                ProductionStrategy::Replay {
+                    payloads,
+                    num_batches,
+                    signal_count,
+                }
             }
         };
 
         Ok(Self {
             strategy,
+            shape,
             generator,
+            max_signal_count: traffic_config.get_max_signal_count(),
+            produced_count: 0,
         })
     }
 
@@ -89,13 +114,92 @@ impl TrafficProducer {
         self.strategy.signal_count()
     }
 
+    /// Record that the receiver successfully exported `count` signals.
+    ///
+    /// Called between runs (after the [`TrafficRun`] is dropped) so there is
+    /// no borrow conflict with the generator.
+    pub fn record_production(&mut self, count: u64) {
+        self.produced_count += count;
+    }
+
     /// Return a [`TrafficRun`] iterator that yields the payloads needed for
-    /// one second of traffic.
-    pub fn next_run(&mut self) -> TrafficRun<'_> {
-        TrafficRun {
+    /// one second of traffic, or `None` if the producer has reached
+    /// `max_signal_count` and should stop.
+    ///
+    /// When a limit is set and the current strategy would exceed the remaining
+    /// budget, the strategy is truncated in-place before the run is created.
+    pub fn next_run(&mut self) -> Option<TrafficRun<'_>> {
+        match self.max_signal_count {
+            Some(max) if self.produced_count >= max => return None,
+            Some(max) => {
+                let remaining = max - self.produced_count;
+                if (self.strategy.signal_count() as u64) > remaining {
+                    self.truncate_strategy(remaining);
+                }
+            }
+            None => {}
+        }
+
+        Some(TrafficRun {
             generator: &mut *self.generator,
             strategy: &self.strategy,
             idx: 0,
+        })
+    }
+
+    /// Truncate the current strategy so it produces at most `max_signals`.
+    ///
+    /// For `Fresh`: truncates the shape vector, keeping whole entries that fit
+    /// and appending a partial entry for the remainder.
+    ///
+    /// For `Replay`: keeps whole pre-generated payloads that fit, then
+    /// generates one fresh partial payload for the remainder using the
+    /// signal type from the original shape.
+    fn truncate_strategy(&mut self, max_signals: u64) {
+        match &mut self.strategy {
+            ProductionStrategy::Fresh {
+                shape,
+                num_batches,
+                signal_count,
+            } => {
+                *shape = truncate_shape(shape, max_signals);
+                *num_batches = shape.len();
+                *signal_count = shape.iter().map(|(_, c)| c).sum();
+            }
+            ProductionStrategy::Replay {
+                payloads,
+                num_batches,
+                signal_count,
+            } => {
+                let mut remaining = max_signals;
+                let mut keep = 0;
+                for p in payloads.iter() {
+                    let items = p.num_items() as u64;
+                    if items <= remaining {
+                        remaining -= items;
+                        keep += 1;
+                    } else {
+                        break;
+                    }
+                }
+                payloads.truncate(keep);
+
+                // Generate a fresh partial payload for the remainder.
+                if remaining > 0 && keep < self.shape.len() {
+                    let (signal_type, _) = self.shape[keep];
+                    let partial = match signal_type {
+                        SignalType::Traces => self.generator.generate_traces(remaining as usize),
+                        SignalType::Metrics => self.generator.generate_metrics(remaining as usize),
+                        SignalType::Logs => self.generator.generate_logs(remaining as usize),
+                    };
+                    if let Ok(payload) = partial {
+                        payloads.push(payload);
+                    }
+                }
+
+                *num_batches = payloads.len();
+                *signal_count = payloads.iter().map(|p| p.num_items()).sum();
+            }
         }
     }
 }
@@ -117,16 +221,16 @@ impl<'a> Iterator for TrafficRun<'a> {
             return None;
         }
 
-        let next = match self.strategy {
-            ProductionStrategy::Fresh(v) => {
-                let shape = v[self.idx];
-                match shape.0 {
-                    SignalType::Traces => self.generator.generate_traces(shape.1),
-                    SignalType::Metrics => self.generator.generate_metrics(shape.1),
-                    SignalType::Logs => self.generator.generate_logs(shape.1),
+        let next = match &self.strategy {
+            ProductionStrategy::Fresh { shape, .. } => {
+                let (signal_type, count) = shape[self.idx];
+                match signal_type {
+                    SignalType::Traces => self.generator.generate_traces(count),
+                    SignalType::Metrics => self.generator.generate_metrics(count),
+                    SignalType::Logs => self.generator.generate_logs(count),
                 }
             }
-            ProductionStrategy::Replay(v) => Ok(v[self.idx].clone()),
+            ProductionStrategy::Replay { payloads, .. } => Ok(payloads[self.idx].clone()),
         };
 
         self.idx += 1;
@@ -256,23 +360,57 @@ fn create_fresh_payloads(
         .collect()
 }
 
+/// Truncate a traffic shape so that the total signal count is at most `budget`.
+///
+/// Whole batches from the front are kept until adding the next batch would
+/// exceed the budget, then a single partial batch with the remaining count is
+/// appended.
+fn truncate_shape(shape: &[(SignalType, usize)], budget: u64) -> TrafficShape {
+    let mut result = Vec::new();
+    let mut remaining = budget;
+
+    for &(signal_type, count) in shape {
+        let count_u64 = count as u64;
+        if count_u64 <= remaining {
+            result.push((signal_type, count));
+            remaining -= count_u64;
+        } else {
+            // Partial batch for the remainder.
+            if remaining > 0 {
+                result.push((signal_type, remaining as usize));
+            }
+            break;
+        }
+    }
+
+    result
+}
+
 enum ProductionStrategy {
-    Fresh(Vec<(SignalType, usize)>),
-    Replay(Vec<OtapPayload>),
+    Fresh {
+        shape: TrafficShape,
+        num_batches: usize,
+        signal_count: usize,
+    },
+    Replay {
+        payloads: Vec<OtapPayload>,
+        num_batches: usize,
+        signal_count: usize,
+    },
 }
 
 impl ProductionStrategy {
     fn len(&self) -> usize {
         match self {
-            ProductionStrategy::Fresh(v) => v.len(),
-            ProductionStrategy::Replay(v) => v.len(),
+            ProductionStrategy::Fresh { num_batches, .. } => *num_batches,
+            ProductionStrategy::Replay { num_batches, .. } => *num_batches,
         }
     }
 
     fn signal_count(&self) -> usize {
         match self {
-            ProductionStrategy::Fresh(v) => v.iter().map(|x| x.1).sum(),
-            ProductionStrategy::Replay(v) => v.iter().map(|x| x.num_items()).sum(),
+            ProductionStrategy::Fresh { signal_count, .. } => *signal_count,
+            ProductionStrategy::Replay { signal_count, .. } => *signal_count,
         }
     }
 }
@@ -476,7 +614,7 @@ mod tests {
             .map(|(_, c)| c)
             .sum();
         assert!(
-            trace_total >= 48 && trace_total <= 52,
+            (48..=52).contains(&trace_total),
             "traces should get ~50 signals, got {trace_total}"
         );
     }
@@ -494,13 +632,21 @@ mod tests {
 
         let shape = create_shape(&cfg);
         let expected_batches = shape.len();
+        let signal_count = shape.iter().map(|(_, c)| c).sum();
 
         let mut producer = TrafficProducer {
-            strategy: ProductionStrategy::Fresh(shape),
+            strategy: ProductionStrategy::Fresh {
+                shape: shape.clone(),
+                num_batches: expected_batches,
+                signal_count,
+            },
+            shape,
             generator: Box::new(static_generator()),
+            max_signal_count: None,
+            produced_count: 0,
         };
 
-        let run = producer.next_run();
+        let run = producer.next_run().expect("should get a run");
 
         // ExactSizeIterator should report the right length up front.
         assert_eq!(
@@ -539,12 +685,22 @@ mod tests {
             create_fresh_payloads(&mut generator, &shape).expect("pre-generation should succeed");
         let expected_count = payloads.len();
 
+        let shape_copy = shape.clone();
+        let num_batches = payloads.len();
+        let signal_count = payloads.iter().map(|p| p.num_items()).sum();
         let mut producer = TrafficProducer {
-            strategy: ProductionStrategy::Replay(payloads.clone()),
+            strategy: ProductionStrategy::Replay {
+                payloads: payloads.clone(),
+                num_batches,
+                signal_count,
+            },
+            shape: shape_copy,
             generator: Box::new(static_generator()),
+            max_signal_count: None,
+            produced_count: 0,
         };
 
-        let results: Vec<GenerateResult> = producer.next_run().collect();
+        let results: Vec<GenerateResult> = producer.next_run().expect("should get a run").collect();
         assert_eq!(results.len(), expected_count);
 
         // Each replayed payload should match the original pre-generated payload.
@@ -689,5 +845,116 @@ mod tests {
                 "batch {i} should not have tenant.id when no attrs configured"
             );
         }
+    }
+
+    /// Helper to build a `TrafficProducer` with a Fresh strategy from a config.
+    fn fresh_producer(cfg: &TrafficConfig, max_signal_count: Option<u64>) -> TrafficProducer {
+        let shape = create_shape(cfg);
+        let num_batches = shape.len();
+        let signal_count = shape.iter().map(|(_, c)| c).sum();
+        TrafficProducer {
+            strategy: ProductionStrategy::Fresh {
+                shape: shape.clone(),
+                num_batches,
+                signal_count,
+            },
+            shape,
+            generator: Box::new(static_generator()),
+            max_signal_count,
+            produced_count: 0,
+        }
+    }
+
+    #[test]
+    fn test_producer_no_limit_always_returns_run() {
+        let cfg = TrafficConfig::new(Some(10), None, 10, 1, 0, 0);
+        let mut producer = fresh_producer(&cfg, None);
+
+        // Without a limit, next_run should always return Some.
+        assert!(producer.next_run().is_some());
+        producer.record_production(100);
+        assert!(producer.next_run().is_some());
+        producer.record_production(1_000_000);
+        assert!(producer.next_run().is_some());
+    }
+
+    #[test]
+    fn test_producer_limit_reached_returns_none() {
+        let cfg = TrafficConfig::new(Some(10), None, 10, 1, 0, 0);
+        let mut producer = fresh_producer(&cfg, Some(10));
+
+        // First run should be available (produced 0 of 10).
+        assert!(producer.next_run().is_some());
+
+        // After producing exactly the limit, next_run returns None.
+        producer.record_production(10);
+        assert!(producer.next_run().is_none());
+
+        // Over the limit also returns None.
+        producer.record_production(5);
+        assert!(producer.next_run().is_none());
+    }
+
+    #[test]
+    fn test_producer_truncates_run_to_fit_limit() {
+        // Shape: 10 metrics per second, max_batch=5 → shape is 2 batches of 5
+        let cfg = TrafficConfig::new(Some(10), None, 5, 1, 0, 0);
+        let mut producer = fresh_producer(&cfg, Some(7));
+
+        assert_eq!(producer.run_count(), 10, "full run should have 10 signals");
+
+        // First run should be truncated to 7 signals.
+        let run = producer.next_run().expect("should get a run");
+        let payloads: Vec<_> = run.collect();
+        let total: usize = payloads
+            .iter()
+            .map(|r| r.as_ref().unwrap().num_items())
+            .sum();
+        assert_eq!(total, 7, "truncated run should have exactly 7 signals");
+
+        // After producing 7, no more runs.
+        producer.record_production(7);
+        assert!(producer.next_run().is_none());
+    }
+
+    #[test]
+    fn test_producer_zero_limit_returns_none_immediately() {
+        let cfg = TrafficConfig::new(Some(10), None, 10, 1, 0, 0);
+        let mut producer = fresh_producer(&cfg, Some(0));
+
+        assert!(
+            producer.next_run().is_none(),
+            "zero limit should immediately return None"
+        );
+    }
+
+    #[test]
+    fn test_truncate_shape_exact_fit() {
+        let shape = vec![(SignalType::Metrics, 5), (SignalType::Logs, 5)];
+
+        // Budget exactly matches full shape — no truncation.
+        let result = truncate_shape(&shape, 10);
+        assert_eq!(result.len(), 2);
+        let total: usize = result.iter().map(|(_, c)| c).sum();
+        assert_eq!(total, 10);
+    }
+
+    #[test]
+    fn test_truncate_shape_partial_batch() {
+        let shape = vec![(SignalType::Metrics, 5), (SignalType::Logs, 5)];
+
+        // Budget of 7: first batch (5) fits, second batch truncated to 2.
+        let result = truncate_shape(&shape, 7);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0], (SignalType::Metrics, 5));
+        assert_eq!(result[1], (SignalType::Logs, 2));
+    }
+
+    #[test]
+    fn test_truncate_shape_zero_budget() {
+        let shape = vec![(SignalType::Metrics, 5)];
+
+        let result = truncate_shape(&shape, 0);
+        assert!(result.is_empty(), "zero budget should produce empty shape");
     }
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/producer.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/producer.rs
@@ -73,21 +73,17 @@ impl TrafficProducer {
         let shape = create_shape(traffic_config);
         let strategy = match config.generation_strategy() {
             GenerationStrategy::Fresh => {
-                let num_batches = shape.len();
                 let signal_count = shape.iter().map(|(_, c)| c).sum();
                 ProductionStrategy::Fresh {
                     shape: shape.clone(),
-                    num_batches,
                     signal_count,
                 }
             }
             GenerationStrategy::PreGenerated => {
                 let payloads = create_fresh_payloads(&mut *generator, &shape)?;
-                let num_batches = payloads.len();
                 let signal_count = payloads.iter().map(|p| p.num_items()).sum();
                 ProductionStrategy::Replay {
                     payloads,
-                    num_batches,
                     signal_count,
                 }
             }
@@ -159,16 +155,13 @@ impl TrafficProducer {
         match &mut self.strategy {
             ProductionStrategy::Fresh {
                 shape,
-                num_batches,
                 signal_count,
             } => {
                 *shape = truncate_shape(shape, max_signals);
-                *num_batches = shape.len();
                 *signal_count = shape.iter().map(|(_, c)| c).sum();
             }
             ProductionStrategy::Replay {
                 payloads,
-                num_batches,
                 signal_count,
             } => {
                 let mut remaining = max_signals;
@@ -197,7 +190,6 @@ impl TrafficProducer {
                     }
                 }
 
-                *num_batches = payloads.len();
                 *signal_count = payloads.iter().map(|p| p.num_items()).sum();
             }
         }
@@ -389,12 +381,10 @@ fn truncate_shape(shape: &[(SignalType, usize)], budget: u64) -> TrafficShape {
 enum ProductionStrategy {
     Fresh {
         shape: TrafficShape,
-        num_batches: usize,
         signal_count: usize,
     },
     Replay {
         payloads: Vec<OtapPayload>,
-        num_batches: usize,
         signal_count: usize,
     },
 }
@@ -402,8 +392,8 @@ enum ProductionStrategy {
 impl ProductionStrategy {
     fn len(&self) -> usize {
         match self {
-            ProductionStrategy::Fresh { num_batches, .. } => *num_batches,
-            ProductionStrategy::Replay { num_batches, .. } => *num_batches,
+            ProductionStrategy::Fresh { shape, .. } => shape.len(),
+            ProductionStrategy::Replay { payloads, .. } => payloads.len(),
         }
     }
 
@@ -637,7 +627,6 @@ mod tests {
         let mut producer = TrafficProducer {
             strategy: ProductionStrategy::Fresh {
                 shape: shape.clone(),
-                num_batches: expected_batches,
                 signal_count,
             },
             shape,
@@ -691,7 +680,6 @@ mod tests {
         let mut producer = TrafficProducer {
             strategy: ProductionStrategy::Replay {
                 payloads: payloads.clone(),
-                num_batches,
                 signal_count,
             },
             shape: shape_copy,
@@ -855,7 +843,6 @@ mod tests {
         TrafficProducer {
             strategy: ProductionStrategy::Fresh {
                 shape: shape.clone(),
-                num_batches,
                 signal_count,
             },
             shape,

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/producer.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/producer.rs
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 
 use otap_df_config::SignalType;

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/producer.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/producer.rs
@@ -1,0 +1,693 @@
+use std::collections::HashMap;
+
+use otap_df_config::SignalType;
+use otap_df_pdata::OtapPayload;
+use otap_df_pdata::proto::OtlpProtoMessage;
+use prost::EncodeError;
+use weaver_forge::registry::ResolvedRegistry;
+
+use super::config::{
+    Config, DataSource, GenerationStrategy, ResourceAttributeSet, TrafficConfig,
+    build_rotation_table,
+};
+use super::{semconv_signal, static_signal};
+
+/// A SignalProducer yields the signals that need to be exported in a given
+/// second in order to meet the data volume production requirements with a
+/// reasonably smooth curve.
+pub struct TrafficProducer {
+    strategy: ProductionStrategy,
+    generator: Box<dyn SignalGenerator>,
+}
+
+/// Describes the shape of traffic for one production run (one second of signals).
+///
+/// Each entry is a `(SignalType, count)` pair indicating how many signals of that
+/// type to produce in a single batch. The entries are processed in order by the
+/// [`TrafficRun`] iterator.
+pub type TrafficShape = Vec<(SignalType, usize)>;
+
+impl TrafficProducer {
+    /// Build a `TrafficProducer` from the receiver configuration.
+    ///
+    /// This selects the appropriate `SignalGenerator` implementation based on
+    /// `data_source` and builds either a `Fresh` or `Replay` production
+    /// strategy from `generation_strategy`.
+    pub fn from_config(config: &Config) -> Result<Self, GenerateError> {
+        let traffic_config = config.get_traffic_config();
+
+        // Build the concrete SignalGenerator based on the data source.
+        let mut generator: Box<dyn SignalGenerator> = match config.data_source() {
+            DataSource::SemanticConventions => {
+                let registry = config
+                    .get_registry()
+                    .map_err(GenerateError::Configuration)?
+                    .expect("SemanticConventions data source should return Some registry");
+                Box::new(WeaverGenerator { registry })
+            }
+            DataSource::Static => {
+                let entries = config.resource_attributes().to_vec();
+                let rotation = build_rotation_table(&entries);
+                Box::new(StaticGenerator {
+                    idx: 0,
+                    entries,
+                    rotation,
+                    log_body_size_bytes: traffic_config.log_body_size_bytes(),
+                    num_log_attributes: traffic_config.num_log_attributes(),
+                    use_trace_context: traffic_config.use_trace_context(),
+                    num_metric_attributes: traffic_config.num_metric_attributes(),
+                    num_data_points_per_metric: traffic_config.num_data_points_per_metric(),
+                })
+            }
+        };
+
+        // Build the production strategy.
+        let shape = create_shape(traffic_config);
+        let strategy = match config.generation_strategy() {
+            GenerationStrategy::Fresh => ProductionStrategy::Fresh(shape),
+            GenerationStrategy::PreGenerated => {
+                let payloads = create_fresh_payloads(&mut *generator, &shape)?;
+                ProductionStrategy::Replay(payloads)
+            }
+        };
+
+        Ok(Self {
+            strategy,
+            generator,
+        })
+    }
+
+    /// The number of batches in a run
+    #[must_use]
+    pub fn run_len(&self) -> usize {
+        self.strategy.len()
+    }
+
+    /// The total number of signals in a run
+    #[must_use]
+    pub fn run_count(&self) -> usize {
+        self.strategy.signal_count()
+    }
+
+    /// Return a [`TrafficRun`] iterator that yields the payloads needed for
+    /// one second of traffic.
+    pub fn next_run(&mut self) -> TrafficRun<'_> {
+        TrafficRun {
+            generator: &mut *self.generator,
+            strategy: &self.strategy,
+            idx: 0,
+        }
+    }
+}
+
+/// A traffic run is a fixed size iterator of payloads that need to be delivered
+/// in the current second. Consumers of this are expected to process every item
+/// in the iterator within a second and grab a new iterator for the next second.
+pub struct TrafficRun<'a> {
+    generator: &'a mut dyn SignalGenerator,
+    strategy: &'a ProductionStrategy,
+    idx: usize,
+}
+
+impl<'a> Iterator for TrafficRun<'a> {
+    type Item = GenerateResult;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.len() == 0 {
+            return None;
+        }
+
+        let next = match self.strategy {
+            ProductionStrategy::Fresh(v) => {
+                let shape = v[self.idx];
+                match shape.0 {
+                    SignalType::Traces => self.generator.generate_traces(shape.1),
+                    SignalType::Metrics => self.generator.generate_metrics(shape.1),
+                    SignalType::Logs => self.generator.generate_logs(shape.1),
+                }
+            }
+            ProductionStrategy::Replay(v) => Ok(v[self.idx].clone()),
+        };
+
+        self.idx += 1;
+        Some(next)
+    }
+}
+
+impl<'a> ExactSizeIterator for TrafficRun<'a> {
+    fn len(&self) -> usize {
+        self.strategy.len() - self.idx
+    }
+}
+
+fn create_shape(cfg: &TrafficConfig) -> TrafficShape {
+    let total_weight = cfg.log_weight + cfg.trace_weight + cfg.metric_weight;
+    assert!(total_weight > 0);
+
+    let log_percent = signal_percent(cfg.log_weight, total_weight);
+    let metric_percent = signal_percent(cfg.metric_weight, total_weight);
+    let trace_percent = signal_percent(cfg.trace_weight, total_weight);
+
+    let signals_per_second = cfg.signals_per_second.unwrap_or(cfg.max_batch_size) as u32;
+    let logs_per_second = signal_per_second(signals_per_second, log_percent);
+    let metrics_per_second = signal_per_second(signals_per_second, metric_percent);
+    let traces_per_second = signal_per_second(signals_per_second, trace_percent);
+    let total_per_second = logs_per_second + metrics_per_second + traces_per_second;
+
+    // At this point total_per_second is within 3 of signals_per_second as we
+    // could have clamped down at most 3 times and up at most 3 times.
+    let mut per_second = [
+        (SignalType::Logs, logs_per_second),
+        (SignalType::Metrics, metrics_per_second),
+        (SignalType::Traces, traces_per_second),
+    ];
+    per_second.sort_unstable_by_key(|x| x.1);
+    per_second.reverse();
+
+    // Add the extras to each signal, prioritizing the signals with the
+    // highest share.
+    let deficit = signals_per_second as i64 - total_per_second as i64;
+    if deficit >= 1 {
+        per_second[0].1 += 1
+    }
+
+    if deficit >= 2 {
+        per_second[1].1 += 1
+    }
+
+    if deficit >= 3 {
+        per_second[2].1 += 1
+    }
+
+    // Figure out approximately how to interweave the three signals so that we get
+    // roughly even distribution of each's total payload within a given second
+    let ratio1 = per_second[0].1 / per_second[2].1.max(1);
+    let ratio2 = per_second[1].1 / per_second[2].1.max(1);
+    let ratio3 = per_second[2].1 / per_second[2].1.max(1);
+
+    let shape1 = get_traffic_shape(cfg.max_batch_size, per_second[0]);
+    let shape2 = get_traffic_shape(cfg.max_batch_size, per_second[1]);
+    let shape3 = get_traffic_shape(cfg.max_batch_size, per_second[2]);
+
+    let mut shape1_i = shape1.iter();
+    let mut shape2_i = shape2.iter();
+    let mut shape3_i = shape3.iter();
+
+    let mut result = Vec::new();
+    loop {
+        let before = result.len();
+
+        result.extend(shape1_i.by_ref().take(ratio1));
+        result.extend(shape2_i.by_ref().take(ratio2));
+        result.extend(shape3_i.by_ref().take(ratio3));
+
+        let after = result.len();
+        if before == after {
+            break;
+        }
+    }
+
+    assert!(shape1_i.next().is_none());
+    assert!(shape2_i.next().is_none());
+    assert!(shape3_i.next().is_none());
+
+    result
+}
+
+fn get_traffic_shape(max_batch_size: usize, per_second: (SignalType, usize)) -> TrafficShape {
+    let full_buckets = per_second.1.div_euclid(max_batch_size);
+    let mut result = Vec::new();
+    for _ in 0..full_buckets {
+        result.push((per_second.0, max_batch_size));
+    }
+
+    let remainder = per_second.1 % max_batch_size;
+    if remainder > 0 {
+        result.push((per_second.0, per_second.1 % max_batch_size));
+    }
+
+    result
+}
+
+fn signal_per_second(signals_per_second: u32, signal_percent: f32) -> usize {
+    let mut signals = (signal_percent * signals_per_second as f32).floor() as usize;
+    if signal_percent > 0.0 && signals == 0 {
+        signals = 1
+    }
+
+    signals
+}
+
+fn signal_percent(signal_weight: u32, total_weight: u32) -> f32 {
+    signal_weight as f32 / total_weight as f32
+}
+
+fn create_fresh_payloads(
+    generator: &mut dyn SignalGenerator,
+    shape: &TrafficShape,
+) -> Result<Vec<OtapPayload>, GenerateError> {
+    shape
+        .iter()
+        .map(|(signal_type, count)| match signal_type {
+            SignalType::Traces => generator.generate_traces(*count),
+            SignalType::Metrics => generator.generate_metrics(*count),
+            SignalType::Logs => generator.generate_logs(*count),
+        })
+        .collect()
+}
+
+enum ProductionStrategy {
+    Fresh(Vec<(SignalType, usize)>),
+    Replay(Vec<OtapPayload>),
+}
+
+impl ProductionStrategy {
+    fn len(&self) -> usize {
+        match self {
+            ProductionStrategy::Fresh(v) => v.len(),
+            ProductionStrategy::Replay(v) => v.len(),
+        }
+    }
+
+    fn signal_count(&self) -> usize {
+        match self {
+            ProductionStrategy::Fresh(v) => v.iter().map(|x| x.1).sum(),
+            ProductionStrategy::Replay(v) => v.iter().map(|x| x.num_items()).sum(),
+        }
+    }
+}
+
+/// Result type for signal generation operations.
+pub type GenerateResult = Result<OtapPayload, GenerateError>;
+
+/// Errors that can occur during signal generation.
+#[derive(thiserror::Error, Debug)]
+pub enum GenerateError {
+    /// Failed to encode the generated signal into the OTAP payload format.
+    #[error("Failed to encode: {source:?}")]
+    Encoding {
+        /// The underlying encoding error.
+        #[from]
+        source: EncodeError,
+    },
+    /// A configuration error prevented producer construction.
+    #[error("Configuration error: {0}")]
+    Configuration(String),
+}
+
+/// Trait for generating OTAP payloads containing telemetry signals.
+///
+/// Implementations produce synthetic logs, metrics, or traces and encode them
+/// into [`OtapPayload`] values. In practice encoding is infallible because
+/// the only failure mode is insufficient buffer capacity, and `BytesMut` can
+/// grow up to `isize::MAX`.
+pub trait SignalGenerator {
+    /// Generate a log payload containing `count` log records.
+    fn generate_logs(&mut self, count: usize) -> GenerateResult;
+    /// Generate a metrics payload containing `count` data points.
+    fn generate_metrics(&mut self, count: usize) -> GenerateResult;
+    /// Generate a traces payload containing `count` spans.
+    fn generate_traces(&mut self, count: usize) -> GenerateResult;
+}
+
+/// Signal generator backed by the Weaver semantic conventions registry.
+///
+/// Produces signals whose attributes are derived from the resolved registry,
+/// giving realistic cardinality and naming.
+pub struct WeaverGenerator {
+    registry: ResolvedRegistry,
+}
+
+impl SignalGenerator for WeaverGenerator {
+    fn generate_logs(&mut self, count: usize) -> GenerateResult {
+        let payload = semconv_signal::semconv_otlp_logs(count, &self.registry);
+        let payload = OtlpProtoMessage::Logs(payload);
+        Ok(payload.try_into()?)
+    }
+
+    fn generate_metrics(&mut self, count: usize) -> GenerateResult {
+        let payload = semconv_signal::semconv_otlp_metrics(count, &self.registry);
+        let payload = OtlpProtoMessage::Metrics(payload);
+        Ok(payload.try_into()?)
+    }
+
+    fn generate_traces(&mut self, count: usize) -> GenerateResult {
+        let payload = semconv_signal::semconv_otlp_traces(count, &self.registry);
+        let payload = OtlpProtoMessage::Traces(payload);
+        Ok(payload.try_into()?)
+    }
+}
+
+/// Signal generator that produces signals from hardcoded static templates.
+///
+/// Resource attributes are rotated across batches according to a weighted
+/// round-robin table built from the configured [`ResourceAttributeSet`] entries.
+pub struct StaticGenerator {
+    idx: usize,
+    entries: Vec<ResourceAttributeSet>,
+    rotation: Vec<usize>,
+    /// Target log body size in bytes (None = default body)
+    log_body_size_bytes: Option<usize>,
+    /// Number of log attributes (None = default attributes)
+    num_log_attributes: Option<usize>,
+    /// Whether to populate trace_id/span_id on log records
+    use_trace_context: bool,
+    /// Number of metric attributes per data point (None = default attributes)
+    num_metric_attributes: Option<usize>,
+    /// Number of data points per metric (None = default)
+    num_data_points_per_metric: Option<usize>,
+}
+
+impl StaticGenerator {
+    /// Return the resource attributes for the current batch, or `None` when no
+    /// custom attributes are configured.
+    ///
+    /// The slot is selected as `rotation[batch_index % rotation.len()]`, which
+    /// gives each entry a share of batches proportional to its weight.
+    fn attrs_for_batch(&self) -> Option<&HashMap<String, String>> {
+        match self.rotation.is_empty() {
+            true => None,
+            false => {
+                let slot = self.rotation[self.idx % self.rotation.len()];
+                // self.idx += 1;
+                Some(&self.entries[slot].attrs)
+            }
+        }
+    }
+}
+
+impl SignalGenerator for StaticGenerator {
+    fn generate_logs(&mut self, count: usize) -> GenerateResult {
+        self.idx += 1;
+
+        let attrs = self.attrs_for_batch();
+        let payload = static_signal::static_otlp_logs_with_config(
+            count,
+            self.log_body_size_bytes,
+            self.num_log_attributes,
+            self.use_trace_context,
+            attrs,
+        );
+        let payload = OtlpProtoMessage::Logs(payload);
+
+        Ok(payload.try_into()?)
+    }
+
+    fn generate_metrics(&mut self, count: usize) -> GenerateResult {
+        self.idx += 1;
+
+        let attrs = self.attrs_for_batch();
+        let payload = static_signal::static_otlp_metrics_with_config(
+            count,
+            self.num_metric_attributes,
+            self.num_data_points_per_metric,
+            attrs,
+        );
+        let payload = OtlpProtoMessage::Metrics(payload);
+
+        Ok(payload.try_into()?)
+    }
+
+    fn generate_traces(&mut self, count: usize) -> GenerateResult {
+        self.idx += 1;
+
+        let attrs = self.attrs_for_batch();
+        let payload = static_signal::static_otlp_traces(count, attrs);
+        let payload = OtlpProtoMessage::Traces(payload);
+
+        Ok(payload.try_into()?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::config::TrafficConfig;
+    use super::*;
+
+    /// Helper to build a minimal `StaticGenerator` with no resource attributes.
+    fn static_generator() -> StaticGenerator {
+        StaticGenerator {
+            idx: 0,
+            entries: Vec::new(),
+            rotation: Vec::new(),
+            log_body_size_bytes: None,
+            num_log_attributes: None,
+            use_trace_context: false,
+            num_metric_attributes: None,
+            num_data_points_per_metric: None,
+        }
+    }
+
+    #[test]
+    fn test_create_shape_distributes_signals() {
+        let cfg = TrafficConfig::new(
+            Some(100), // signals_per_second
+            None,      // max_signal_count
+            50,        // max_batch_size
+            1,         // metric_weight
+            2,         // trace_weight
+            1,         // log_weight
+        );
+
+        let shape = create_shape(&cfg);
+
+        // Every entry must respect max_batch_size.
+        for (_, count) in &shape {
+            assert!(*count <= 50, "batch size {count} exceeds max_batch_size 50");
+        }
+
+        // Total signals across all entries should equal signals_per_second.
+        let total: usize = shape.iter().map(|(_, c)| c).sum();
+        assert_eq!(total, 100, "total signals should equal signals_per_second");
+
+        // All three signal types must be represented.
+        let has_logs = shape.iter().any(|(s, _)| *s == SignalType::Logs);
+        let has_metrics = shape.iter().any(|(s, _)| *s == SignalType::Metrics);
+        let has_traces = shape.iter().any(|(s, _)| *s == SignalType::Traces);
+        assert!(has_logs, "shape should contain Logs");
+        assert!(has_metrics, "shape should contain Metrics");
+        assert!(has_traces, "shape should contain Traces");
+
+        // Traces have weight 2 (50%), metrics and logs each have weight 1 (25%).
+        // Verify traces get ~50 signals and the others get ~25 each.
+        let trace_total: usize = shape
+            .iter()
+            .filter(|(s, _)| *s == SignalType::Traces)
+            .map(|(_, c)| c)
+            .sum();
+        assert!(
+            trace_total >= 48 && trace_total <= 52,
+            "traces should get ~50 signals, got {trace_total}"
+        );
+    }
+
+    #[test]
+    fn test_traffic_producer_fresh_yields_correct_count() {
+        let cfg = TrafficConfig::new(
+            Some(30), // signals_per_second
+            None,     // max_signal_count
+            10,       // max_batch_size
+            1,        // metric_weight
+            1,        // trace_weight
+            1,        // log_weight
+        );
+
+        let shape = create_shape(&cfg);
+        let expected_batches = shape.len();
+
+        let mut producer = TrafficProducer {
+            strategy: ProductionStrategy::Fresh(shape),
+            generator: Box::new(static_generator()),
+        };
+
+        let run = producer.next_run();
+
+        // ExactSizeIterator should report the right length up front.
+        assert_eq!(
+            run.len(),
+            expected_batches,
+            "ExactSizeIterator::len should match shape length"
+        );
+
+        let results: Vec<_> = run.collect();
+        assert_eq!(
+            results.len(),
+            expected_batches,
+            "iterator should yield exactly shape.len() items"
+        );
+
+        // Every result should be Ok.
+        for (i, r) in results.iter().enumerate() {
+            assert!(r.is_ok(), "payload {i} should be Ok, got {:?}", r);
+        }
+    }
+
+    #[test]
+    fn test_traffic_producer_replay_clones_payloads() {
+        let cfg = TrafficConfig::new(
+            Some(15), // signals_per_second
+            None,     // max_signal_count
+            10,       // max_batch_size
+            1,        // metric_weight
+            1,        // trace_weight
+            1,        // log_weight
+        );
+
+        let shape = create_shape(&cfg);
+        let mut generator = static_generator();
+        let payloads =
+            create_fresh_payloads(&mut generator, &shape).expect("pre-generation should succeed");
+        let expected_count = payloads.len();
+
+        let mut producer = TrafficProducer {
+            strategy: ProductionStrategy::Replay(payloads.clone()),
+            generator: Box::new(static_generator()),
+        };
+
+        let results: Vec<GenerateResult> = producer.next_run().collect();
+        assert_eq!(results.len(), expected_count);
+
+        // Each replayed payload should match the original pre-generated payload.
+        for (i, (result, original)) in results.iter().zip(payloads.iter()).enumerate() {
+            let payload = result.as_ref().expect("replay should always succeed");
+            assert_eq!(
+                payload.num_bytes(),
+                original.num_bytes(),
+                "payload {i} size should match the pre-generated original"
+            );
+        }
+    }
+
+    #[test]
+    fn test_resource_attribute_rotation_across_batches() {
+        use super::super::config::{ResourceAttributeSet, build_rotation_table};
+        use otap_df_pdata::OtlpProtoBytes;
+        use otap_df_pdata::proto::opentelemetry::logs::v1::LogsData;
+        use prost::Message;
+        use std::num::NonZeroU32;
+
+        let make_entry = |tenant: &str| ResourceAttributeSet {
+            attrs: HashMap::from([("tenant.id".to_string(), tenant.to_string())]),
+            weight: NonZeroU32::new(1).unwrap(),
+        };
+        let entries = vec![make_entry("prod"), make_entry("staging")];
+        let rotation = build_rotation_table(&entries);
+
+        let mut generator = StaticGenerator {
+            idx: 0,
+            entries,
+            rotation,
+            log_body_size_bytes: None,
+            num_log_attributes: None,
+            use_trace_context: false,
+            num_metric_attributes: None,
+            num_data_points_per_metric: None,
+        };
+
+        // Helper: extract the tenant.id attribute value from a log payload.
+        let extract_tenant_id = |payload: OtapPayload| -> Option<String> {
+            let otlp_bytes: OtlpProtoBytes = payload.try_into().expect("convert to otlp bytes");
+            let bytes = match otlp_bytes {
+                OtlpProtoBytes::ExportLogsRequest(b) => b,
+                _ => panic!("expected logs"),
+            };
+            let logs = LogsData::decode(bytes.as_ref()).expect("decode logs");
+            logs.resource_logs
+                .first()?
+                .resource
+                .as_ref()?
+                .attributes
+                .iter()
+                .find(|kv| kv.key == "tenant.id")
+                .and_then(|kv| kv.value.as_ref())
+                .and_then(|v| {
+                    use otap_df_pdata::proto::opentelemetry::common::v1::any_value::Value;
+                    match v.value.as_ref()? {
+                        Value::StringValue(s) => Some(s.clone()),
+                        _ => None,
+                    }
+                })
+        };
+
+        let tenant_1 = extract_tenant_id(generator.generate_logs(1).expect("batch 1"))
+            .expect("batch 1 should have tenant.id");
+        let tenant_2 = extract_tenant_id(generator.generate_logs(1).expect("batch 2"))
+            .expect("batch 2 should have tenant.id");
+        let tenant_3 = extract_tenant_id(generator.generate_logs(1).expect("batch 3"))
+            .expect("batch 3 should have tenant.id");
+        let tenant_4 = extract_tenant_id(generator.generate_logs(1).expect("batch 4"))
+            .expect("batch 4 should have tenant.id");
+
+        // With a two-entry rotation [0, 1], consecutive batches alternate attribute sets.
+        assert_ne!(
+            tenant_1, tenant_2,
+            "consecutive batches should use different attribute sets"
+        );
+        assert_eq!(
+            tenant_1, tenant_3,
+            "batches 1 and 3 should share the same attribute set"
+        );
+        assert_eq!(
+            tenant_2, tenant_4,
+            "batches 2 and 4 should share the same attribute set"
+        );
+
+        // Both configured values must appear.
+        let tenants = [&tenant_1, &tenant_2];
+        assert!(
+            tenants.contains(&&"prod".to_string()),
+            "prod should appear in the rotation"
+        );
+        assert!(
+            tenants.contains(&&"staging".to_string()),
+            "staging should appear in the rotation"
+        );
+    }
+
+    #[test]
+    fn test_resource_attribute_rotation_empty_attrs() {
+        use otap_df_pdata::OtlpProtoBytes;
+        use otap_df_pdata::proto::opentelemetry::logs::v1::LogsData;
+        use prost::Message;
+
+        // static_generator() has empty entries and rotation — no custom resource attrs.
+        let mut generator = static_generator();
+
+        let batch_1 = generator
+            .generate_logs(1)
+            .expect("batch 1 with empty attrs");
+        let batch_2 = generator
+            .generate_logs(1)
+            .expect("batch 2 with empty attrs");
+
+        // Both payloads should be valid and non-empty.
+        assert!(
+            batch_1.num_bytes().unwrap_or(0) > 0,
+            "batch 1 should be non-empty"
+        );
+        assert!(
+            batch_2.num_bytes().unwrap_or(0) > 0,
+            "batch 2 should be non-empty"
+        );
+
+        // Neither payload should carry a tenant.id attribute.
+        for (i, batch) in [batch_1, batch_2].into_iter().enumerate() {
+            let otlp_bytes: OtlpProtoBytes = batch.try_into().expect("convert to otlp bytes");
+            let bytes = match otlp_bytes {
+                OtlpProtoBytes::ExportLogsRequest(b) => b,
+                _ => panic!("expected logs"),
+            };
+            let logs = LogsData::decode(bytes.as_ref()).expect("decode logs");
+            let has_tenant = logs
+                .resource_logs
+                .first()
+                .and_then(|rl| rl.resource.as_ref())
+                .map(|r| r.attributes.iter().any(|kv| kv.key == "tenant.id"))
+                .unwrap_or(false);
+            assert!(
+                !has_tenant,
+                "batch {i} should not have tenant.id when no attrs configured"
+            );
+        }
+    }
+}

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/producer.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/producer.rs
@@ -17,9 +17,7 @@ use super::{semconv_signal, static_signal};
 /// reasonably smooth curve.
 pub struct TrafficProducer {
     strategy: ProductionStrategy,
-    /// The canonical shape from config, used for Replay truncation to determine
-    /// the signal type of the batch that needs a fresh partial payload.
-    shape: TrafficShape,
+    signal_count: u64,
     generator: Box<dyn SignalGenerator>,
     /// Optional upper bound on the total number of signals this producer may
     /// emit across its lifetime.
@@ -72,26 +70,19 @@ impl TrafficProducer {
         // Build the production strategy.
         let shape = create_shape(traffic_config);
         let strategy = match config.generation_strategy() {
-            GenerationStrategy::Fresh => {
-                let signal_count = shape.iter().map(|(_, c)| c).sum();
-                ProductionStrategy::Fresh {
-                    shape: shape.clone(),
-                    signal_count,
-                }
-            }
+            GenerationStrategy::Fresh => ProductionStrategy::Fresh {
+                shape: shape.clone(),
+            },
             GenerationStrategy::PreGenerated => {
                 let payloads = create_fresh_payloads(&mut *generator, &shape)?;
-                let signal_count = payloads.iter().map(|p| p.num_items()).sum();
-                ProductionStrategy::Replay {
-                    payloads,
-                    signal_count,
-                }
+                ProductionStrategy::Replay { payloads }
             }
         };
 
+        let signal_count = strategy.signal_count();
         Ok(Self {
             strategy,
-            shape,
+            signal_count,
             generator,
             max_signal_count: traffic_config.get_max_signal_count(),
             produced_count: 0,
@@ -106,8 +97,8 @@ impl TrafficProducer {
 
     /// The total number of signals in a run
     #[must_use]
-    pub fn run_count(&self) -> usize {
-        self.strategy.signal_count()
+    pub fn run_count(&self) -> u64 {
+        self.signal_count
     }
 
     /// Record that the receiver successfully exported `count` signals.
@@ -124,23 +115,23 @@ impl TrafficProducer {
     ///
     /// When a limit is set and the current strategy would exceed the remaining
     /// budget, the strategy is truncated in-place before the run is created.
-    pub fn next_run(&mut self) -> Option<TrafficRun<'_>> {
+    pub fn next_run(&mut self) -> Result<Option<TrafficRun<'_>>, GenerateError> {
         match self.max_signal_count {
-            Some(max) if self.produced_count >= max => return None,
+            Some(max) if self.produced_count >= max => return Ok(None),
             Some(max) => {
                 let remaining = max - self.produced_count;
-                if (self.strategy.signal_count() as u64) > remaining {
-                    self.truncate_strategy(remaining);
+                if self.signal_count > remaining {
+                    self.cap_strategy(remaining)?;
                 }
             }
             None => {}
         }
 
-        Some(TrafficRun {
+        Ok(Some(TrafficRun {
             generator: &mut *self.generator,
             strategy: &self.strategy,
             idx: 0,
-        })
+        }))
     }
 
     /// Truncate the current strategy so it produces at most `max_signals`.
@@ -151,48 +142,47 @@ impl TrafficProducer {
     /// For `Replay`: keeps whole pre-generated payloads that fit, then
     /// generates one fresh partial payload for the remainder using the
     /// signal type from the original shape.
-    fn truncate_strategy(&mut self, max_signals: u64) {
-        match &mut self.strategy {
-            ProductionStrategy::Fresh {
-                shape,
-                signal_count,
-            } => {
-                *shape = truncate_shape(shape, max_signals);
-                *signal_count = shape.iter().map(|(_, c)| c).sum();
+    fn cap_strategy(&mut self, max_signals: u64) -> Result<(), GenerateError> {
+        let mut to_keep: usize = 0;
+        let mut total = 0u64;
+
+        for i in 0..self.strategy.len() {
+            let curr_size = self.strategy.size_at(i) as u64;
+            if total + curr_size > max_signals {
+                break;
             }
-            ProductionStrategy::Replay {
-                payloads,
-                signal_count,
-            } => {
-                let mut remaining = max_signals;
-                let mut keep = 0;
-                for p in payloads.iter() {
-                    let items = p.num_items() as u64;
-                    if items <= remaining {
-                        remaining -= items;
-                        keep += 1;
-                    } else {
-                        break;
-                    }
-                }
-                payloads.truncate(keep);
 
-                // Generate a fresh partial payload for the remainder.
-                if remaining > 0 && keep < self.shape.len() {
-                    let (signal_type, _) = self.shape[keep];
-                    let partial = match signal_type {
-                        SignalType::Traces => self.generator.generate_traces(remaining as usize),
-                        SignalType::Metrics => self.generator.generate_metrics(remaining as usize),
-                        SignalType::Logs => self.generator.generate_logs(remaining as usize),
-                    };
-                    if let Ok(payload) = partial {
-                        payloads.push(payload);
-                    }
-                }
+            to_keep += 1;
+            total += curr_size;
+        }
 
-                *signal_count = payloads.iter().map(|p| p.num_items()).sum();
+        // If it's an exact fit we can just truncate
+        if total == max_signals {
+            self.strategy.truncate(to_keep);
+            return Ok(());
+        }
+
+        // Otherwise we compute the leftover amount and append that on
+        assert!(self.strategy.len() >= 1);
+        let leftover_signal = self.strategy.signal_at(to_keep);
+        let leftover_count = (max_signals - total) as usize;
+        self.strategy.truncate(to_keep);
+        match self.strategy {
+            ProductionStrategy::Fresh { ref mut shape } => {
+                shape.push((leftover_signal, leftover_count));
+            }
+            ProductionStrategy::Replay { ref mut payloads } => {
+                let new_batch = match leftover_signal {
+                    SignalType::Traces => self.generator.generate_traces(leftover_count),
+                    SignalType::Metrics => self.generator.generate_metrics(leftover_count),
+                    SignalType::Logs => self.generator.generate_logs(leftover_count),
+                }?;
+
+                payloads.push(new_batch);
             }
         }
+
+        Ok(())
     }
 }
 
@@ -352,41 +342,9 @@ fn create_fresh_payloads(
         .collect()
 }
 
-/// Truncate a traffic shape so that the total signal count is at most `budget`.
-///
-/// Whole batches from the front are kept until adding the next batch would
-/// exceed the budget, then a single partial batch with the remaining count is
-/// appended.
-fn truncate_shape(shape: &[(SignalType, usize)], budget: u64) -> TrafficShape {
-    let mut result = Vec::new();
-    let mut remaining = budget;
-
-    for &(signal_type, count) in shape {
-        let count_u64 = count as u64;
-        if count_u64 <= remaining {
-            result.push((signal_type, count));
-            remaining -= count_u64;
-        } else {
-            // Partial batch for the remainder.
-            if remaining > 0 {
-                result.push((signal_type, remaining as usize));
-            }
-            break;
-        }
-    }
-
-    result
-}
-
 enum ProductionStrategy {
-    Fresh {
-        shape: TrafficShape,
-        signal_count: usize,
-    },
-    Replay {
-        payloads: Vec<OtapPayload>,
-        signal_count: usize,
-    },
+    Fresh { shape: TrafficShape },
+    Replay { payloads: Vec<OtapPayload> },
 }
 
 impl ProductionStrategy {
@@ -397,10 +355,33 @@ impl ProductionStrategy {
         }
     }
 
-    fn signal_count(&self) -> usize {
+    fn signal_count(&self) -> u64 {
         match self {
-            ProductionStrategy::Fresh { signal_count, .. } => *signal_count,
-            ProductionStrategy::Replay { signal_count, .. } => *signal_count,
+            ProductionStrategy::Fresh { shape, .. } => shape.iter().map(|x| x.1 as u64).sum(),
+            ProductionStrategy::Replay { payloads, .. } => {
+                payloads.iter().map(|x| x.num_items() as u64).sum()
+            }
+        }
+    }
+
+    fn size_at(&self, idx: usize) -> usize {
+        match self {
+            ProductionStrategy::Fresh { shape, .. } => shape[idx].1,
+            ProductionStrategy::Replay { payloads, .. } => payloads[idx].num_items(),
+        }
+    }
+
+    fn truncate(&mut self, len: usize) {
+        match self {
+            ProductionStrategy::Fresh { shape, .. } => shape.truncate(len),
+            ProductionStrategy::Replay { payloads, .. } => payloads.truncate(len),
+        }
+    }
+
+    fn signal_at(&mut self, idx: usize) -> SignalType {
+        match self {
+            ProductionStrategy::Fresh { shape, .. } => shape[idx].0,
+            ProductionStrategy::Replay { payloads, .. } => payloads[idx].signal_type(),
         }
     }
 }
@@ -538,7 +519,6 @@ impl SignalGenerator for StaticGenerator {
 
     fn generate_traces(&mut self, count: usize) -> GenerateResult {
         self.idx += 1;
-
         let attrs = self.attrs_for_batch();
         let payload = static_signal::static_otlp_traces(count, attrs);
         let payload = OtlpProtoMessage::Traces(payload);
@@ -547,401 +527,393 @@ impl SignalGenerator for StaticGenerator {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::super::config::TrafficConfig;
-    use super::*;
-
-    /// Helper to build a minimal `StaticGenerator` with no resource attributes.
-    fn static_generator() -> StaticGenerator {
-        StaticGenerator {
-            idx: 0,
-            entries: Vec::new(),
-            rotation: Vec::new(),
-            log_body_size_bytes: None,
-            num_log_attributes: None,
-            use_trace_context: false,
-            num_metric_attributes: None,
-            num_data_points_per_metric: None,
-        }
-    }
-
-    #[test]
-    fn test_create_shape_distributes_signals() {
-        let cfg = TrafficConfig::new(
-            Some(100), // signals_per_second
-            None,      // max_signal_count
-            50,        // max_batch_size
-            1,         // metric_weight
-            2,         // trace_weight
-            1,         // log_weight
-        );
-
-        let shape = create_shape(&cfg);
-
-        // Every entry must respect max_batch_size.
-        for (_, count) in &shape {
-            assert!(*count <= 50, "batch size {count} exceeds max_batch_size 50");
-        }
-
-        // Total signals across all entries should equal signals_per_second.
-        let total: usize = shape.iter().map(|(_, c)| c).sum();
-        assert_eq!(total, 100, "total signals should equal signals_per_second");
-
-        // All three signal types must be represented.
-        let has_logs = shape.iter().any(|(s, _)| *s == SignalType::Logs);
-        let has_metrics = shape.iter().any(|(s, _)| *s == SignalType::Metrics);
-        let has_traces = shape.iter().any(|(s, _)| *s == SignalType::Traces);
-        assert!(has_logs, "shape should contain Logs");
-        assert!(has_metrics, "shape should contain Metrics");
-        assert!(has_traces, "shape should contain Traces");
-
-        // Traces have weight 2 (50%), metrics and logs each have weight 1 (25%).
-        // Verify traces get ~50 signals and the others get ~25 each.
-        let trace_total: usize = shape
-            .iter()
-            .filter(|(s, _)| *s == SignalType::Traces)
-            .map(|(_, c)| c)
-            .sum();
-        assert!(
-            (48..=52).contains(&trace_total),
-            "traces should get ~50 signals, got {trace_total}"
-        );
-    }
-
-    #[test]
-    fn test_traffic_producer_fresh_yields_correct_count() {
-        let cfg = TrafficConfig::new(
-            Some(30), // signals_per_second
-            None,     // max_signal_count
-            10,       // max_batch_size
-            1,        // metric_weight
-            1,        // trace_weight
-            1,        // log_weight
-        );
-
-        let shape = create_shape(&cfg);
-        let expected_batches = shape.len();
-        let signal_count = shape.iter().map(|(_, c)| c).sum();
-
-        let mut producer = TrafficProducer {
-            strategy: ProductionStrategy::Fresh {
-                shape: shape.clone(),
-                signal_count,
-            },
-            shape,
-            generator: Box::new(static_generator()),
-            max_signal_count: None,
-            produced_count: 0,
-        };
-
-        let run = producer.next_run().expect("should get a run");
-
-        // ExactSizeIterator should report the right length up front.
-        assert_eq!(
-            run.len(),
-            expected_batches,
-            "ExactSizeIterator::len should match shape length"
-        );
-
-        let results: Vec<_> = run.collect();
-        assert_eq!(
-            results.len(),
-            expected_batches,
-            "iterator should yield exactly shape.len() items"
-        );
-
-        // Every result should be Ok.
-        for (i, r) in results.iter().enumerate() {
-            assert!(r.is_ok(), "payload {i} should be Ok, got {:?}", r);
-        }
-    }
-
-    #[test]
-    fn test_traffic_producer_replay_clones_payloads() {
-        let cfg = TrafficConfig::new(
-            Some(15), // signals_per_second
-            None,     // max_signal_count
-            10,       // max_batch_size
-            1,        // metric_weight
-            1,        // trace_weight
-            1,        // log_weight
-        );
-
-        let shape = create_shape(&cfg);
-        let mut generator = static_generator();
-        let payloads =
-            create_fresh_payloads(&mut generator, &shape).expect("pre-generation should succeed");
-        let expected_count = payloads.len();
-
-        let shape_copy = shape.clone();
-        let num_batches = payloads.len();
-        let signal_count = payloads.iter().map(|p| p.num_items()).sum();
-        let mut producer = TrafficProducer {
-            strategy: ProductionStrategy::Replay {
-                payloads: payloads.clone(),
-                signal_count,
-            },
-            shape: shape_copy,
-            generator: Box::new(static_generator()),
-            max_signal_count: None,
-            produced_count: 0,
-        };
-
-        let results: Vec<GenerateResult> = producer.next_run().expect("should get a run").collect();
-        assert_eq!(results.len(), expected_count);
-
-        // Each replayed payload should match the original pre-generated payload.
-        for (i, (result, original)) in results.iter().zip(payloads.iter()).enumerate() {
-            let payload = result.as_ref().expect("replay should always succeed");
-            assert_eq!(
-                payload.num_bytes(),
-                original.num_bytes(),
-                "payload {i} size should match the pre-generated original"
-            );
-        }
-    }
-
-    #[test]
-    fn test_resource_attribute_rotation_across_batches() {
-        use super::super::config::{ResourceAttributeSet, build_rotation_table};
-        use otap_df_pdata::OtlpProtoBytes;
-        use otap_df_pdata::proto::opentelemetry::logs::v1::LogsData;
-        use prost::Message;
-        use std::num::NonZeroU32;
-
-        let make_entry = |tenant: &str| ResourceAttributeSet {
-            attrs: HashMap::from([("tenant.id".to_string(), tenant.to_string())]),
-            weight: NonZeroU32::new(1).unwrap(),
-        };
-        let entries = vec![make_entry("prod"), make_entry("staging")];
-        let rotation = build_rotation_table(&entries);
-
-        let mut generator = StaticGenerator {
-            idx: 0,
-            entries,
-            rotation,
-            log_body_size_bytes: None,
-            num_log_attributes: None,
-            use_trace_context: false,
-            num_metric_attributes: None,
-            num_data_points_per_metric: None,
-        };
-
-        // Helper: extract the tenant.id attribute value from a log payload.
-        let extract_tenant_id = |payload: OtapPayload| -> Option<String> {
-            let otlp_bytes: OtlpProtoBytes = payload.try_into().expect("convert to otlp bytes");
-            let bytes = match otlp_bytes {
-                OtlpProtoBytes::ExportLogsRequest(b) => b,
-                _ => panic!("expected logs"),
-            };
-            let logs = LogsData::decode(bytes.as_ref()).expect("decode logs");
-            logs.resource_logs
-                .first()?
-                .resource
-                .as_ref()?
-                .attributes
-                .iter()
-                .find(|kv| kv.key == "tenant.id")
-                .and_then(|kv| kv.value.as_ref())
-                .and_then(|v| {
-                    use otap_df_pdata::proto::opentelemetry::common::v1::any_value::Value;
-                    match v.value.as_ref()? {
-                        Value::StringValue(s) => Some(s.clone()),
-                        _ => None,
-                    }
-                })
-        };
-
-        let tenant_1 = extract_tenant_id(generator.generate_logs(1).expect("batch 1"))
-            .expect("batch 1 should have tenant.id");
-        let tenant_2 = extract_tenant_id(generator.generate_logs(1).expect("batch 2"))
-            .expect("batch 2 should have tenant.id");
-        let tenant_3 = extract_tenant_id(generator.generate_logs(1).expect("batch 3"))
-            .expect("batch 3 should have tenant.id");
-        let tenant_4 = extract_tenant_id(generator.generate_logs(1).expect("batch 4"))
-            .expect("batch 4 should have tenant.id");
-
-        // With a two-entry rotation [0, 1], consecutive batches alternate attribute sets.
-        assert_ne!(
-            tenant_1, tenant_2,
-            "consecutive batches should use different attribute sets"
-        );
-        assert_eq!(
-            tenant_1, tenant_3,
-            "batches 1 and 3 should share the same attribute set"
-        );
-        assert_eq!(
-            tenant_2, tenant_4,
-            "batches 2 and 4 should share the same attribute set"
-        );
-
-        // Both configured values must appear.
-        let tenants = [&tenant_1, &tenant_2];
-        assert!(
-            tenants.contains(&&"prod".to_string()),
-            "prod should appear in the rotation"
-        );
-        assert!(
-            tenants.contains(&&"staging".to_string()),
-            "staging should appear in the rotation"
-        );
-    }
-
-    #[test]
-    fn test_resource_attribute_rotation_empty_attrs() {
-        use otap_df_pdata::OtlpProtoBytes;
-        use otap_df_pdata::proto::opentelemetry::logs::v1::LogsData;
-        use prost::Message;
-
-        // static_generator() has empty entries and rotation — no custom resource attrs.
-        let mut generator = static_generator();
-
-        let batch_1 = generator
-            .generate_logs(1)
-            .expect("batch 1 with empty attrs");
-        let batch_2 = generator
-            .generate_logs(1)
-            .expect("batch 2 with empty attrs");
-
-        // Both payloads should be valid and non-empty.
-        assert!(
-            batch_1.num_bytes().unwrap_or(0) > 0,
-            "batch 1 should be non-empty"
-        );
-        assert!(
-            batch_2.num_bytes().unwrap_or(0) > 0,
-            "batch 2 should be non-empty"
-        );
-
-        // Neither payload should carry a tenant.id attribute.
-        for (i, batch) in [batch_1, batch_2].into_iter().enumerate() {
-            let otlp_bytes: OtlpProtoBytes = batch.try_into().expect("convert to otlp bytes");
-            let bytes = match otlp_bytes {
-                OtlpProtoBytes::ExportLogsRequest(b) => b,
-                _ => panic!("expected logs"),
-            };
-            let logs = LogsData::decode(bytes.as_ref()).expect("decode logs");
-            let has_tenant = logs
-                .resource_logs
-                .first()
-                .and_then(|rl| rl.resource.as_ref())
-                .map(|r| r.attributes.iter().any(|kv| kv.key == "tenant.id"))
-                .unwrap_or(false);
-            assert!(
-                !has_tenant,
-                "batch {i} should not have tenant.id when no attrs configured"
-            );
-        }
-    }
-
-    /// Helper to build a `TrafficProducer` with a Fresh strategy from a config.
-    fn fresh_producer(cfg: &TrafficConfig, max_signal_count: Option<u64>) -> TrafficProducer {
-        let shape = create_shape(cfg);
-        let num_batches = shape.len();
-        let signal_count = shape.iter().map(|(_, c)| c).sum();
-        TrafficProducer {
-            strategy: ProductionStrategy::Fresh {
-                shape: shape.clone(),
-                signal_count,
-            },
-            shape,
-            generator: Box::new(static_generator()),
-            max_signal_count,
-            produced_count: 0,
-        }
-    }
-
-    #[test]
-    fn test_producer_no_limit_always_returns_run() {
-        let cfg = TrafficConfig::new(Some(10), None, 10, 1, 0, 0);
-        let mut producer = fresh_producer(&cfg, None);
-
-        // Without a limit, next_run should always return Some.
-        assert!(producer.next_run().is_some());
-        producer.record_production(100);
-        assert!(producer.next_run().is_some());
-        producer.record_production(1_000_000);
-        assert!(producer.next_run().is_some());
-    }
-
-    #[test]
-    fn test_producer_limit_reached_returns_none() {
-        let cfg = TrafficConfig::new(Some(10), None, 10, 1, 0, 0);
-        let mut producer = fresh_producer(&cfg, Some(10));
-
-        // First run should be available (produced 0 of 10).
-        assert!(producer.next_run().is_some());
-
-        // After producing exactly the limit, next_run returns None.
-        producer.record_production(10);
-        assert!(producer.next_run().is_none());
-
-        // Over the limit also returns None.
-        producer.record_production(5);
-        assert!(producer.next_run().is_none());
-    }
-
-    #[test]
-    fn test_producer_truncates_run_to_fit_limit() {
-        // Shape: 10 metrics per second, max_batch=5 → shape is 2 batches of 5
-        let cfg = TrafficConfig::new(Some(10), None, 5, 1, 0, 0);
-        let mut producer = fresh_producer(&cfg, Some(7));
-
-        assert_eq!(producer.run_count(), 10, "full run should have 10 signals");
-
-        // First run should be truncated to 7 signals.
-        let run = producer.next_run().expect("should get a run");
-        let payloads: Vec<_> = run.collect();
-        let total: usize = payloads
-            .iter()
-            .map(|r| r.as_ref().unwrap().num_items())
-            .sum();
-        assert_eq!(total, 7, "truncated run should have exactly 7 signals");
-
-        // After producing 7, no more runs.
-        producer.record_production(7);
-        assert!(producer.next_run().is_none());
-    }
-
-    #[test]
-    fn test_producer_zero_limit_returns_none_immediately() {
-        let cfg = TrafficConfig::new(Some(10), None, 10, 1, 0, 0);
-        let mut producer = fresh_producer(&cfg, Some(0));
-
-        assert!(
-            producer.next_run().is_none(),
-            "zero limit should immediately return None"
-        );
-    }
-
-    #[test]
-    fn test_truncate_shape_exact_fit() {
-        let shape = vec![(SignalType::Metrics, 5), (SignalType::Logs, 5)];
-
-        // Budget exactly matches full shape — no truncation.
-        let result = truncate_shape(&shape, 10);
-        assert_eq!(result.len(), 2);
-        let total: usize = result.iter().map(|(_, c)| c).sum();
-        assert_eq!(total, 10);
-    }
-
-    #[test]
-    fn test_truncate_shape_partial_batch() {
-        let shape = vec![(SignalType::Metrics, 5), (SignalType::Logs, 5)];
-
-        // Budget of 7: first batch (5) fits, second batch truncated to 2.
-        let result = truncate_shape(&shape, 7);
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0], (SignalType::Metrics, 5));
-        assert_eq!(result[1], (SignalType::Logs, 2));
-    }
-
-    #[test]
-    fn test_truncate_shape_zero_budget() {
-        let shape = vec![(SignalType::Metrics, 5)];
-
-        let result = truncate_shape(&shape, 0);
-        assert!(result.is_empty(), "zero budget should produce empty shape");
-    }
-}
+// #[cfg(test)]
+// mod tests {
+//     use super::super::config::TrafficConfig;
+//     use super::*;
+//
+//     /// Helper to build a minimal `StaticGenerator` with no resource attributes.
+//     fn static_generator() -> StaticGenerator {
+//         StaticGenerator {
+//             idx: 0,
+//             entries: Vec::new(),
+//             rotation: Vec::new(),
+//             log_body_size_bytes: None,
+//             num_log_attributes: None,
+//             use_trace_context: false,
+//             num_metric_attributes: None,
+//             num_data_points_per_metric: None,
+//         }
+//     }
+//
+//     #[test]
+//     fn test_create_shape_distributes_signals() {
+//         let cfg = TrafficConfig::new(
+//             Some(100), // signals_per_second
+//             None,      // max_signal_count
+//             50,        // max_batch_size
+//             1,         // metric_weight
+//             2,         // trace_weight
+//             1,         // log_weight
+//         );
+//
+//         let shape = create_shape(&cfg);
+//
+//         // Every entry must respect max_batch_size.
+//         for (_, count) in &shape {
+//             assert!(*count <= 50, "batch size {count} exceeds max_batch_size 50");
+//         }
+//
+//         // Total signals across all entries should equal signals_per_second.
+//         let total: usize = shape.iter().map(|(_, c)| c).sum();
+//         assert_eq!(total, 100, "total signals should equal signals_per_second");
+//
+//         // All three signal types must be represented.
+//         let has_logs = shape.iter().any(|(s, _)| *s == SignalType::Logs);
+//         let has_metrics = shape.iter().any(|(s, _)| *s == SignalType::Metrics);
+//         let has_traces = shape.iter().any(|(s, _)| *s == SignalType::Traces);
+//         assert!(has_logs, "shape should contain Logs");
+//         assert!(has_metrics, "shape should contain Metrics");
+//         assert!(has_traces, "shape should contain Traces");
+//
+//         // Traces have weight 2 (50%), metrics and logs each have weight 1 (25%).
+//         // Verify traces get ~50 signals and the others get ~25 each.
+//         let trace_total: usize = shape
+//             .iter()
+//             .filter(|(s, _)| *s == SignalType::Traces)
+//             .map(|(_, c)| c)
+//             .sum();
+//         assert!(
+//             (48..=52).contains(&trace_total),
+//             "traces should get ~50 signals, got {trace_total}"
+//         );
+//     }
+//
+//     #[test]
+//     fn test_traffic_producer_fresh_yields_correct_count() {
+//         let cfg = TrafficConfig::new(
+//             Some(30), // signals_per_second
+//             None,     // max_signal_count
+//             10,       // max_batch_size
+//             1,        // metric_weight
+//             1,        // trace_weight
+//             1,        // log_weight
+//         );
+//
+//         let shape = create_shape(&cfg);
+//         let shape_len = shape.len();
+//         let strategy = ProductionStrategy::Fresh { shape };
+//         let signal_count = strategy.signal_count();
+//         let mut producer = TrafficProducer {
+//             strategy,
+//             signal_count,
+//             generator: Box::new(static_generator()),
+//             max_signal_count: None,
+//             produced_count: 0,
+//         };
+//
+//         let run = producer
+//             .next_run()
+//             .expect("should get a run")
+//             .expect("valid");
+//
+//         // ExactSizeIterator should report the right length up front.
+//         assert_eq!(
+//             run.len(),
+//             shape_len,
+//             "ExactSizeIterator::len should match shape length"
+//         );
+//
+//         let results: Vec<_> = run.collect();
+//         assert_eq!(
+//             results.len(),
+//             shape_len,
+//             "iterator should yield exactly shape.len() items"
+//         );
+//
+//         // Every result should be Ok.
+//         for (i, r) in results.iter().enumerate() {
+//             assert!(r.is_ok(), "payload {i} should be Ok, got {:?}", r);
+//         }
+//     }
+//
+//     // #[test]
+//     // fn test_traffic_producer_replay_clones_payloads() {
+//     //     let cfg = TrafficConfig::new(
+//     //         Some(15), // signals_per_second
+//     //         None,     // max_signal_count
+//     //         10,       // max_batch_size
+//     //         1,        // metric_weight
+//     //         1,        // trace_weight
+//     //         1,        // log_weight
+//     //     );
+//     //
+//     //     let shape = create_shape(&cfg);
+//     //     let shape_len = shape.len();
+//     //     let strategy = ProductionStrategy::Fresh { shape };
+//     //     let signal_count = strategy.signal_count();
+//     //     let expected_count = signal_count;
+//     //     let mut producer = TrafficProducer {
+//     //         strategy,
+//     //         signal_count,
+//     //         generator: Box::new(static_generator()),
+//     //         max_signal_count: None,
+//     //         produced_count: 0,
+//     //     };
+//     //
+//     //     let results: Vec<GenerateResult> = producer.next_run().expect("should get a run").collect();
+//     //     assert_eq!(results.len(), expected_count);
+//     //
+//     //     // Each replayed payload should match the original pre-generated payload.
+//     //     for (i, (result, original)) in results.iter().zip(payloads.iter()).enumerate() {
+//     //         let payload = result.as_ref().expect("replay should always succeed");
+//     //         assert_eq!(
+//     //             payload.num_bytes(),
+//     //             original.num_bytes(),
+//     //             "payload {i} size should match the pre-generated original"
+//     //         );
+//     //     }
+//     // }
+//
+//     #[test]
+//     fn test_resource_attribute_rotation_across_batches() {
+//         use super::super::config::{ResourceAttributeSet, build_rotation_table};
+//         use otap_df_pdata::OtlpProtoBytes;
+//         use otap_df_pdata::proto::opentelemetry::logs::v1::LogsData;
+//         use prost::Message;
+//         use std::num::NonZeroU32;
+//
+//         let make_entry = |tenant: &str| ResourceAttributeSet {
+//             attrs: HashMap::from([("tenant.id".to_string(), tenant.to_string())]),
+//             weight: NonZeroU32::new(1).unwrap(),
+//         };
+//         let entries = vec![make_entry("prod"), make_entry("staging")];
+//         let rotation = build_rotation_table(&entries);
+//
+//         let mut generator = StaticGenerator {
+//             idx: 0,
+//             entries,
+//             rotation,
+//             log_body_size_bytes: None,
+//             num_log_attributes: None,
+//             use_trace_context: false,
+//             num_metric_attributes: None,
+//             num_data_points_per_metric: None,
+//         };
+//
+//         // Helper: extract the tenant.id attribute value from a log payload.
+//         let extract_tenant_id = |payload: OtapPayload| -> Option<String> {
+//             let otlp_bytes: OtlpProtoBytes = payload.try_into().expect("convert to otlp bytes");
+//             let bytes = match otlp_bytes {
+//                 OtlpProtoBytes::ExportLogsRequest(b) => b,
+//                 _ => panic!("expected logs"),
+//             };
+//             let logs = LogsData::decode(bytes.as_ref()).expect("decode logs");
+//             logs.resource_logs
+//                 .first()?
+//                 .resource
+//                 .as_ref()?
+//                 .attributes
+//                 .iter()
+//                 .find(|kv| kv.key == "tenant.id")
+//                 .and_then(|kv| kv.value.as_ref())
+//                 .and_then(|v| {
+//                     use otap_df_pdata::proto::opentelemetry::common::v1::any_value::Value;
+//                     match v.value.as_ref()? {
+//                         Value::StringValue(s) => Some(s.clone()),
+//                         _ => None,
+//                     }
+//                 })
+//         };
+//
+//         let tenant_1 = extract_tenant_id(generator.generate_logs(1).expect("batch 1"))
+//             .expect("batch 1 should have tenant.id");
+//         let tenant_2 = extract_tenant_id(generator.generate_logs(1).expect("batch 2"))
+//             .expect("batch 2 should have tenant.id");
+//         let tenant_3 = extract_tenant_id(generator.generate_logs(1).expect("batch 3"))
+//             .expect("batch 3 should have tenant.id");
+//         let tenant_4 = extract_tenant_id(generator.generate_logs(1).expect("batch 4"))
+//             .expect("batch 4 should have tenant.id");
+//
+//         // With a two-entry rotation [0, 1], consecutive batches alternate attribute sets.
+//         assert_ne!(
+//             tenant_1, tenant_2,
+//             "consecutive batches should use different attribute sets"
+//         );
+//         assert_eq!(
+//             tenant_1, tenant_3,
+//             "batches 1 and 3 should share the same attribute set"
+//         );
+//         assert_eq!(
+//             tenant_2, tenant_4,
+//             "batches 2 and 4 should share the same attribute set"
+//         );
+//
+//         // Both configured values must appear.
+//         let tenants = [&tenant_1, &tenant_2];
+//         assert!(
+//             tenants.contains(&&"prod".to_string()),
+//             "prod should appear in the rotation"
+//         );
+//         assert!(
+//             tenants.contains(&&"staging".to_string()),
+//             "staging should appear in the rotation"
+//         );
+//     }
+//
+//     #[test]
+//     fn test_resource_attribute_rotation_empty_attrs() {
+//         use otap_df_pdata::OtlpProtoBytes;
+//         use otap_df_pdata::proto::opentelemetry::logs::v1::LogsData;
+//         use prost::Message;
+//
+//         // static_generator() has empty entries and rotation — no custom resource attrs.
+//         let mut generator = static_generator();
+//
+//         let batch_1 = generator
+//             .generate_logs(1)
+//             .expect("batch 1 with empty attrs");
+//         let batch_2 = generator
+//             .generate_logs(1)
+//             .expect("batch 2 with empty attrs");
+//
+//         // Both payloads should be valid and non-empty.
+//         assert!(
+//             batch_1.num_bytes().unwrap_or(0) > 0,
+//             "batch 1 should be non-empty"
+//         );
+//         assert!(
+//             batch_2.num_bytes().unwrap_or(0) > 0,
+//             "batch 2 should be non-empty"
+//         );
+//
+//         // Neither payload should carry a tenant.id attribute.
+//         for (i, batch) in [batch_1, batch_2].into_iter().enumerate() {
+//             let otlp_bytes: OtlpProtoBytes = batch.try_into().expect("convert to otlp bytes");
+//             let bytes = match otlp_bytes {
+//                 OtlpProtoBytes::ExportLogsRequest(b) => b,
+//                 _ => panic!("expected logs"),
+//             };
+//             let logs = LogsData::decode(bytes.as_ref()).expect("decode logs");
+//             let has_tenant = logs
+//                 .resource_logs
+//                 .first()
+//                 .and_then(|rl| rl.resource.as_ref())
+//                 .map(|r| r.attributes.iter().any(|kv| kv.key == "tenant.id"))
+//                 .unwrap_or(false);
+//             assert!(
+//                 !has_tenant,
+//                 "batch {i} should not have tenant.id when no attrs configured"
+//             );
+//         }
+//     }
+//
+//     /// Helper to build a `TrafficProducer` with a Fresh strategy from a config.
+//     fn fresh_producer(cfg: &TrafficConfig, max_signal_count: Option<u64>) -> TrafficProducer {
+//         let shape = create_shape(cfg);
+//         let num_batches = shape.len();
+//         let signal_count = shape.signal_count();
+//         TrafficProducer {
+//             strategy: ProductionStrategy::Fresh {
+//                 shape: shape.clone(),
+//             },
+//             signal_count,
+//             generator: Box::new(static_generator()),
+//             max_signal_count,
+//             produced_count: 0,
+//         }
+//     }
+//
+//     #[test]
+//     fn test_producer_no_limit_always_returns_run() {
+//         let cfg = TrafficConfig::new(Some(10), None, 10, 1, 0, 0);
+//         let mut producer = fresh_producer(&cfg, None);
+//
+//         // Without a limit, next_run should always return Some.
+//         assert!(producer.next_run().is_some());
+//         producer.record_production(100);
+//         assert!(producer.next_run().is_some());
+//         producer.record_production(1_000_000);
+//         assert!(producer.next_run().is_some());
+//     }
+//
+//     #[test]
+//     fn test_producer_limit_reached_returns_none() {
+//         let cfg = TrafficConfig::new(Some(10), None, 10, 1, 0, 0);
+//         let mut producer = fresh_producer(&cfg, Some(10));
+//
+//         // First run should be available (produced 0 of 10).
+//         assert!(producer.next_run().is_some());
+//
+//         // After producing exactly the limit, next_run returns None.
+//         producer.record_production(10);
+//         assert!(producer.next_run().is_none());
+//
+//         // Over the limit also returns None.
+//         producer.record_production(5);
+//         assert!(producer.next_run().is_none());
+//     }
+//
+//     #[test]
+//     fn test_producer_truncates_run_to_fit_limit() {
+//         // Shape: 10 metrics per second, max_batch=5 → shape is 2 batches of 5
+//         let cfg = TrafficConfig::new(Some(10), None, 5, 1, 0, 0);
+//         let mut producer = fresh_producer(&cfg, Some(7));
+//
+//         assert_eq!(producer.run_count(), 10, "full run should have 10 signals");
+//
+//         // First run should be truncated to 7 signals.
+//         let run = producer.next_run().expect("should get a run");
+//         let payloads: Vec<_> = run.collect();
+//         let total: usize = payloads
+//             .iter()
+//             .map(|r| r.as_ref().unwrap().num_items())
+//             .sum();
+//         assert_eq!(total, 7, "truncated run should have exactly 7 signals");
+//
+//         // After producing 7, no more runs.
+//         producer.record_production(7);
+//         assert!(producer.next_run().is_none());
+//     }
+//
+//     #[test]
+//     fn test_producer_zero_limit_returns_none_immediately() {
+//         let cfg = TrafficConfig::new(Some(10), None, 10, 1, 0, 0);
+//         let mut producer = fresh_producer(&cfg, Some(0));
+//
+//         assert!(
+//             producer.next_run().is_none(),
+//             "zero limit should immediately return None"
+//         );
+//     }
+//
+//     #[test]
+//     fn test_truncate_shape_exact_fit() {
+//         let shape = vec![(SignalType::Metrics, 5), (SignalType::Logs, 5)];
+//
+//         // Budget exactly matches full shape — no truncation.
+//         let result = truncate_shape(&shape, 10);
+//         assert_eq!(result.len(), 2);
+//         let total: usize = result.iter().map(|(_, c)| c).sum();
+//         assert_eq!(total, 10);
+//     }
+//
+//     #[test]
+//     fn test_truncate_shape_partial_batch() {
+//         let shape = vec![(SignalType::Metrics, 5), (SignalType::Logs, 5)];
+//
+//         // Budget of 7: first batch (5) fits, second batch truncated to 2.
+//         let result = truncate_shape(&shape, 7);
+//         assert_eq!(result.len(), 2);
+//         assert_eq!(result[0], (SignalType::Metrics, 5));
+//         assert_eq!(result[1], (SignalType::Logs, 2));
+//     }
+//
+//     #[test]
+//     fn test_truncate_shape_zero_budget() {
+//         let shape = vec![(SignalType::Metrics, 5)];
+//
+//         let result = truncate_shape(&shape, 0);
+//         assert!(result.is_empty(), "zero budget should produce empty shape");
+//     }
+// }

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/producer.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/producer.rs
@@ -159,6 +159,7 @@ impl TrafficProducer {
         // If it's an exact fit we can just truncate
         if total == max_signals {
             self.strategy.truncate(to_keep);
+            self.signal_count = self.strategy.signal_count();
             return Ok(());
         }
 
@@ -181,6 +182,8 @@ impl TrafficProducer {
                 payloads.push(new_batch);
             }
         }
+
+        self.signal_count = self.strategy.signal_count();
 
         Ok(())
     }
@@ -527,393 +530,411 @@ impl SignalGenerator for StaticGenerator {
     }
 }
 
-// #[cfg(test)]
-// mod tests {
-//     use super::super::config::TrafficConfig;
-//     use super::*;
-//
-//     /// Helper to build a minimal `StaticGenerator` with no resource attributes.
-//     fn static_generator() -> StaticGenerator {
-//         StaticGenerator {
-//             idx: 0,
-//             entries: Vec::new(),
-//             rotation: Vec::new(),
-//             log_body_size_bytes: None,
-//             num_log_attributes: None,
-//             use_trace_context: false,
-//             num_metric_attributes: None,
-//             num_data_points_per_metric: None,
-//         }
-//     }
-//
-//     #[test]
-//     fn test_create_shape_distributes_signals() {
-//         let cfg = TrafficConfig::new(
-//             Some(100), // signals_per_second
-//             None,      // max_signal_count
-//             50,        // max_batch_size
-//             1,         // metric_weight
-//             2,         // trace_weight
-//             1,         // log_weight
-//         );
-//
-//         let shape = create_shape(&cfg);
-//
-//         // Every entry must respect max_batch_size.
-//         for (_, count) in &shape {
-//             assert!(*count <= 50, "batch size {count} exceeds max_batch_size 50");
-//         }
-//
-//         // Total signals across all entries should equal signals_per_second.
-//         let total: usize = shape.iter().map(|(_, c)| c).sum();
-//         assert_eq!(total, 100, "total signals should equal signals_per_second");
-//
-//         // All three signal types must be represented.
-//         let has_logs = shape.iter().any(|(s, _)| *s == SignalType::Logs);
-//         let has_metrics = shape.iter().any(|(s, _)| *s == SignalType::Metrics);
-//         let has_traces = shape.iter().any(|(s, _)| *s == SignalType::Traces);
-//         assert!(has_logs, "shape should contain Logs");
-//         assert!(has_metrics, "shape should contain Metrics");
-//         assert!(has_traces, "shape should contain Traces");
-//
-//         // Traces have weight 2 (50%), metrics and logs each have weight 1 (25%).
-//         // Verify traces get ~50 signals and the others get ~25 each.
-//         let trace_total: usize = shape
-//             .iter()
-//             .filter(|(s, _)| *s == SignalType::Traces)
-//             .map(|(_, c)| c)
-//             .sum();
-//         assert!(
-//             (48..=52).contains(&trace_total),
-//             "traces should get ~50 signals, got {trace_total}"
-//         );
-//     }
-//
-//     #[test]
-//     fn test_traffic_producer_fresh_yields_correct_count() {
-//         let cfg = TrafficConfig::new(
-//             Some(30), // signals_per_second
-//             None,     // max_signal_count
-//             10,       // max_batch_size
-//             1,        // metric_weight
-//             1,        // trace_weight
-//             1,        // log_weight
-//         );
-//
-//         let shape = create_shape(&cfg);
-//         let shape_len = shape.len();
-//         let strategy = ProductionStrategy::Fresh { shape };
-//         let signal_count = strategy.signal_count();
-//         let mut producer = TrafficProducer {
-//             strategy,
-//             signal_count,
-//             generator: Box::new(static_generator()),
-//             max_signal_count: None,
-//             produced_count: 0,
-//         };
-//
-//         let run = producer
-//             .next_run()
-//             .expect("should get a run")
-//             .expect("valid");
-//
-//         // ExactSizeIterator should report the right length up front.
-//         assert_eq!(
-//             run.len(),
-//             shape_len,
-//             "ExactSizeIterator::len should match shape length"
-//         );
-//
-//         let results: Vec<_> = run.collect();
-//         assert_eq!(
-//             results.len(),
-//             shape_len,
-//             "iterator should yield exactly shape.len() items"
-//         );
-//
-//         // Every result should be Ok.
-//         for (i, r) in results.iter().enumerate() {
-//             assert!(r.is_ok(), "payload {i} should be Ok, got {:?}", r);
-//         }
-//     }
-//
-//     // #[test]
-//     // fn test_traffic_producer_replay_clones_payloads() {
-//     //     let cfg = TrafficConfig::new(
-//     //         Some(15), // signals_per_second
-//     //         None,     // max_signal_count
-//     //         10,       // max_batch_size
-//     //         1,        // metric_weight
-//     //         1,        // trace_weight
-//     //         1,        // log_weight
-//     //     );
-//     //
-//     //     let shape = create_shape(&cfg);
-//     //     let shape_len = shape.len();
-//     //     let strategy = ProductionStrategy::Fresh { shape };
-//     //     let signal_count = strategy.signal_count();
-//     //     let expected_count = signal_count;
-//     //     let mut producer = TrafficProducer {
-//     //         strategy,
-//     //         signal_count,
-//     //         generator: Box::new(static_generator()),
-//     //         max_signal_count: None,
-//     //         produced_count: 0,
-//     //     };
-//     //
-//     //     let results: Vec<GenerateResult> = producer.next_run().expect("should get a run").collect();
-//     //     assert_eq!(results.len(), expected_count);
-//     //
-//     //     // Each replayed payload should match the original pre-generated payload.
-//     //     for (i, (result, original)) in results.iter().zip(payloads.iter()).enumerate() {
-//     //         let payload = result.as_ref().expect("replay should always succeed");
-//     //         assert_eq!(
-//     //             payload.num_bytes(),
-//     //             original.num_bytes(),
-//     //             "payload {i} size should match the pre-generated original"
-//     //         );
-//     //     }
-//     // }
-//
-//     #[test]
-//     fn test_resource_attribute_rotation_across_batches() {
-//         use super::super::config::{ResourceAttributeSet, build_rotation_table};
-//         use otap_df_pdata::OtlpProtoBytes;
-//         use otap_df_pdata::proto::opentelemetry::logs::v1::LogsData;
-//         use prost::Message;
-//         use std::num::NonZeroU32;
-//
-//         let make_entry = |tenant: &str| ResourceAttributeSet {
-//             attrs: HashMap::from([("tenant.id".to_string(), tenant.to_string())]),
-//             weight: NonZeroU32::new(1).unwrap(),
-//         };
-//         let entries = vec![make_entry("prod"), make_entry("staging")];
-//         let rotation = build_rotation_table(&entries);
-//
-//         let mut generator = StaticGenerator {
-//             idx: 0,
-//             entries,
-//             rotation,
-//             log_body_size_bytes: None,
-//             num_log_attributes: None,
-//             use_trace_context: false,
-//             num_metric_attributes: None,
-//             num_data_points_per_metric: None,
-//         };
-//
-//         // Helper: extract the tenant.id attribute value from a log payload.
-//         let extract_tenant_id = |payload: OtapPayload| -> Option<String> {
-//             let otlp_bytes: OtlpProtoBytes = payload.try_into().expect("convert to otlp bytes");
-//             let bytes = match otlp_bytes {
-//                 OtlpProtoBytes::ExportLogsRequest(b) => b,
-//                 _ => panic!("expected logs"),
-//             };
-//             let logs = LogsData::decode(bytes.as_ref()).expect("decode logs");
-//             logs.resource_logs
-//                 .first()?
-//                 .resource
-//                 .as_ref()?
-//                 .attributes
-//                 .iter()
-//                 .find(|kv| kv.key == "tenant.id")
-//                 .and_then(|kv| kv.value.as_ref())
-//                 .and_then(|v| {
-//                     use otap_df_pdata::proto::opentelemetry::common::v1::any_value::Value;
-//                     match v.value.as_ref()? {
-//                         Value::StringValue(s) => Some(s.clone()),
-//                         _ => None,
-//                     }
-//                 })
-//         };
-//
-//         let tenant_1 = extract_tenant_id(generator.generate_logs(1).expect("batch 1"))
-//             .expect("batch 1 should have tenant.id");
-//         let tenant_2 = extract_tenant_id(generator.generate_logs(1).expect("batch 2"))
-//             .expect("batch 2 should have tenant.id");
-//         let tenant_3 = extract_tenant_id(generator.generate_logs(1).expect("batch 3"))
-//             .expect("batch 3 should have tenant.id");
-//         let tenant_4 = extract_tenant_id(generator.generate_logs(1).expect("batch 4"))
-//             .expect("batch 4 should have tenant.id");
-//
-//         // With a two-entry rotation [0, 1], consecutive batches alternate attribute sets.
-//         assert_ne!(
-//             tenant_1, tenant_2,
-//             "consecutive batches should use different attribute sets"
-//         );
-//         assert_eq!(
-//             tenant_1, tenant_3,
-//             "batches 1 and 3 should share the same attribute set"
-//         );
-//         assert_eq!(
-//             tenant_2, tenant_4,
-//             "batches 2 and 4 should share the same attribute set"
-//         );
-//
-//         // Both configured values must appear.
-//         let tenants = [&tenant_1, &tenant_2];
-//         assert!(
-//             tenants.contains(&&"prod".to_string()),
-//             "prod should appear in the rotation"
-//         );
-//         assert!(
-//             tenants.contains(&&"staging".to_string()),
-//             "staging should appear in the rotation"
-//         );
-//     }
-//
-//     #[test]
-//     fn test_resource_attribute_rotation_empty_attrs() {
-//         use otap_df_pdata::OtlpProtoBytes;
-//         use otap_df_pdata::proto::opentelemetry::logs::v1::LogsData;
-//         use prost::Message;
-//
-//         // static_generator() has empty entries and rotation — no custom resource attrs.
-//         let mut generator = static_generator();
-//
-//         let batch_1 = generator
-//             .generate_logs(1)
-//             .expect("batch 1 with empty attrs");
-//         let batch_2 = generator
-//             .generate_logs(1)
-//             .expect("batch 2 with empty attrs");
-//
-//         // Both payloads should be valid and non-empty.
-//         assert!(
-//             batch_1.num_bytes().unwrap_or(0) > 0,
-//             "batch 1 should be non-empty"
-//         );
-//         assert!(
-//             batch_2.num_bytes().unwrap_or(0) > 0,
-//             "batch 2 should be non-empty"
-//         );
-//
-//         // Neither payload should carry a tenant.id attribute.
-//         for (i, batch) in [batch_1, batch_2].into_iter().enumerate() {
-//             let otlp_bytes: OtlpProtoBytes = batch.try_into().expect("convert to otlp bytes");
-//             let bytes = match otlp_bytes {
-//                 OtlpProtoBytes::ExportLogsRequest(b) => b,
-//                 _ => panic!("expected logs"),
-//             };
-//             let logs = LogsData::decode(bytes.as_ref()).expect("decode logs");
-//             let has_tenant = logs
-//                 .resource_logs
-//                 .first()
-//                 .and_then(|rl| rl.resource.as_ref())
-//                 .map(|r| r.attributes.iter().any(|kv| kv.key == "tenant.id"))
-//                 .unwrap_or(false);
-//             assert!(
-//                 !has_tenant,
-//                 "batch {i} should not have tenant.id when no attrs configured"
-//             );
-//         }
-//     }
-//
-//     /// Helper to build a `TrafficProducer` with a Fresh strategy from a config.
-//     fn fresh_producer(cfg: &TrafficConfig, max_signal_count: Option<u64>) -> TrafficProducer {
-//         let shape = create_shape(cfg);
-//         let num_batches = shape.len();
-//         let signal_count = shape.signal_count();
-//         TrafficProducer {
-//             strategy: ProductionStrategy::Fresh {
-//                 shape: shape.clone(),
-//             },
-//             signal_count,
-//             generator: Box::new(static_generator()),
-//             max_signal_count,
-//             produced_count: 0,
-//         }
-//     }
-//
-//     #[test]
-//     fn test_producer_no_limit_always_returns_run() {
-//         let cfg = TrafficConfig::new(Some(10), None, 10, 1, 0, 0);
-//         let mut producer = fresh_producer(&cfg, None);
-//
-//         // Without a limit, next_run should always return Some.
-//         assert!(producer.next_run().is_some());
-//         producer.record_production(100);
-//         assert!(producer.next_run().is_some());
-//         producer.record_production(1_000_000);
-//         assert!(producer.next_run().is_some());
-//     }
-//
-//     #[test]
-//     fn test_producer_limit_reached_returns_none() {
-//         let cfg = TrafficConfig::new(Some(10), None, 10, 1, 0, 0);
-//         let mut producer = fresh_producer(&cfg, Some(10));
-//
-//         // First run should be available (produced 0 of 10).
-//         assert!(producer.next_run().is_some());
-//
-//         // After producing exactly the limit, next_run returns None.
-//         producer.record_production(10);
-//         assert!(producer.next_run().is_none());
-//
-//         // Over the limit also returns None.
-//         producer.record_production(5);
-//         assert!(producer.next_run().is_none());
-//     }
-//
-//     #[test]
-//     fn test_producer_truncates_run_to_fit_limit() {
-//         // Shape: 10 metrics per second, max_batch=5 → shape is 2 batches of 5
-//         let cfg = TrafficConfig::new(Some(10), None, 5, 1, 0, 0);
-//         let mut producer = fresh_producer(&cfg, Some(7));
-//
-//         assert_eq!(producer.run_count(), 10, "full run should have 10 signals");
-//
-//         // First run should be truncated to 7 signals.
-//         let run = producer.next_run().expect("should get a run");
-//         let payloads: Vec<_> = run.collect();
-//         let total: usize = payloads
-//             .iter()
-//             .map(|r| r.as_ref().unwrap().num_items())
-//             .sum();
-//         assert_eq!(total, 7, "truncated run should have exactly 7 signals");
-//
-//         // After producing 7, no more runs.
-//         producer.record_production(7);
-//         assert!(producer.next_run().is_none());
-//     }
-//
-//     #[test]
-//     fn test_producer_zero_limit_returns_none_immediately() {
-//         let cfg = TrafficConfig::new(Some(10), None, 10, 1, 0, 0);
-//         let mut producer = fresh_producer(&cfg, Some(0));
-//
-//         assert!(
-//             producer.next_run().is_none(),
-//             "zero limit should immediately return None"
-//         );
-//     }
-//
-//     #[test]
-//     fn test_truncate_shape_exact_fit() {
-//         let shape = vec![(SignalType::Metrics, 5), (SignalType::Logs, 5)];
-//
-//         // Budget exactly matches full shape — no truncation.
-//         let result = truncate_shape(&shape, 10);
-//         assert_eq!(result.len(), 2);
-//         let total: usize = result.iter().map(|(_, c)| c).sum();
-//         assert_eq!(total, 10);
-//     }
-//
-//     #[test]
-//     fn test_truncate_shape_partial_batch() {
-//         let shape = vec![(SignalType::Metrics, 5), (SignalType::Logs, 5)];
-//
-//         // Budget of 7: first batch (5) fits, second batch truncated to 2.
-//         let result = truncate_shape(&shape, 7);
-//         assert_eq!(result.len(), 2);
-//         assert_eq!(result[0], (SignalType::Metrics, 5));
-//         assert_eq!(result[1], (SignalType::Logs, 2));
-//     }
-//
-//     #[test]
-//     fn test_truncate_shape_zero_budget() {
-//         let shape = vec![(SignalType::Metrics, 5)];
-//
-//         let result = truncate_shape(&shape, 0);
-//         assert!(result.is_empty(), "zero budget should produce empty shape");
-//     }
-// }
+#[cfg(test)]
+mod tests {
+    use super::super::config::TrafficConfig;
+    use super::*;
+
+    /// Helper to build a minimal `StaticGenerator` with no resource attributes.
+    fn static_generator() -> StaticGenerator {
+        StaticGenerator {
+            idx: 0,
+            entries: Vec::new(),
+            rotation: Vec::new(),
+            log_body_size_bytes: None,
+            num_log_attributes: None,
+            use_trace_context: false,
+            num_metric_attributes: None,
+            num_data_points_per_metric: None,
+        }
+    }
+
+    /// Helper to build a `TrafficProducer` with a Fresh strategy from a config.
+    fn fresh_producer(cfg: &TrafficConfig, max_signal_count: Option<u64>) -> TrafficProducer {
+        let shape = create_shape(cfg);
+        let strategy = ProductionStrategy::Fresh { shape };
+        let signal_count = strategy.signal_count();
+        TrafficProducer {
+            strategy,
+            signal_count,
+            generator: Box::new(static_generator()),
+            max_signal_count,
+            produced_count: 0,
+        }
+    }
+
+    #[test]
+    fn test_create_shape_distributes_signals() {
+        let cfg = TrafficConfig::new(
+            Some(100), // signals_per_second
+            None,      // max_signal_count
+            50,        // max_batch_size
+            1,         // metric_weight
+            2,         // trace_weight
+            1,         // log_weight
+        );
+
+        let shape = create_shape(&cfg);
+
+        // Every entry must respect max_batch_size.
+        for (_, count) in &shape {
+            assert!(*count <= 50, "batch size {count} exceeds max_batch_size 50");
+        }
+
+        // Total signals across all entries should equal signals_per_second.
+        let total: usize = shape.iter().map(|(_, c)| c).sum();
+        assert_eq!(total, 100, "total signals should equal signals_per_second");
+
+        // All three signal types must be represented.
+        let has_logs = shape.iter().any(|(s, _)| *s == SignalType::Logs);
+        let has_metrics = shape.iter().any(|(s, _)| *s == SignalType::Metrics);
+        let has_traces = shape.iter().any(|(s, _)| *s == SignalType::Traces);
+        assert!(has_logs, "shape should contain Logs");
+        assert!(has_metrics, "shape should contain Metrics");
+        assert!(has_traces, "shape should contain Traces");
+
+        // Traces have weight 2 (50%), metrics and logs each have weight 1 (25%).
+        // Verify traces get ~50 signals and the others get ~25 each.
+        let trace_total: usize = shape
+            .iter()
+            .filter(|(s, _)| *s == SignalType::Traces)
+            .map(|(_, c)| c)
+            .sum();
+        assert!(
+            (48..=52).contains(&trace_total),
+            "traces should get ~50 signals, got {trace_total}"
+        );
+    }
+
+    #[test]
+    fn test_traffic_producer_fresh_yields_correct_count() {
+        let cfg = TrafficConfig::new(
+            Some(30), // signals_per_second
+            None,     // max_signal_count
+            10,       // max_batch_size
+            1,        // metric_weight
+            1,        // trace_weight
+            1,        // log_weight
+        );
+
+        let shape = create_shape(&cfg);
+        let expected_batches = shape.len();
+        let strategy = ProductionStrategy::Fresh { shape };
+        let signal_count = strategy.signal_count();
+        let mut producer = TrafficProducer {
+            strategy,
+            signal_count,
+            generator: Box::new(static_generator()),
+            max_signal_count: None,
+            produced_count: 0,
+        };
+
+        let run = producer
+            .next_run()
+            .expect("generation should succeed")
+            .expect("should get a run");
+
+        // ExactSizeIterator should report the right length up front.
+        assert_eq!(
+            run.len(),
+            expected_batches,
+            "ExactSizeIterator::len should match shape length"
+        );
+
+        let results: Vec<_> = run.collect();
+        assert_eq!(
+            results.len(),
+            expected_batches,
+            "iterator should yield exactly shape.len() items"
+        );
+
+        // Every result should be Ok.
+        for (i, r) in results.iter().enumerate() {
+            assert!(r.is_ok(), "payload {i} should be Ok, got {:?}", r);
+        }
+    }
+
+    #[test]
+    fn test_traffic_producer_replay_clones_payloads() {
+        let cfg = TrafficConfig::new(
+            Some(15), // signals_per_second
+            None,     // max_signal_count
+            10,       // max_batch_size
+            1,        // metric_weight
+            1,        // trace_weight
+            1,        // log_weight
+        );
+
+        let shape = create_shape(&cfg);
+        let mut generator = static_generator();
+        let payloads =
+            create_fresh_payloads(&mut generator, &shape).expect("pre-generation should succeed");
+        let expected_count = payloads.len();
+
+        let strategy = ProductionStrategy::Replay {
+            payloads: payloads.clone(),
+        };
+        let signal_count = strategy.signal_count();
+        let mut producer = TrafficProducer {
+            strategy,
+            signal_count,
+            generator: Box::new(static_generator()),
+            max_signal_count: None,
+            produced_count: 0,
+        };
+
+        let results: Vec<GenerateResult> = producer
+            .next_run()
+            .expect("generation should succeed")
+            .expect("should get a run")
+            .collect();
+        assert_eq!(results.len(), expected_count);
+
+        // Each replayed payload should match the original pre-generated payload.
+        for (i, (result, original)) in results.iter().zip(payloads.iter()).enumerate() {
+            let payload = result.as_ref().expect("replay should always succeed");
+            assert_eq!(
+                payload.num_bytes(),
+                original.num_bytes(),
+                "payload {i} size should match the pre-generated original"
+            );
+        }
+    }
+
+    #[test]
+    fn test_resource_attribute_rotation_across_batches() {
+        use super::super::config::{ResourceAttributeSet, build_rotation_table};
+        use otap_df_pdata::OtlpProtoBytes;
+        use otap_df_pdata::proto::opentelemetry::logs::v1::LogsData;
+        use prost::Message;
+        use std::num::NonZeroU32;
+
+        let make_entry = |tenant: &str| ResourceAttributeSet {
+            attrs: HashMap::from([("tenant.id".to_string(), tenant.to_string())]),
+            weight: NonZeroU32::new(1).unwrap(),
+        };
+        let entries = vec![make_entry("prod"), make_entry("staging")];
+        let rotation = build_rotation_table(&entries);
+
+        let mut generator = StaticGenerator {
+            idx: 0,
+            entries,
+            rotation,
+            log_body_size_bytes: None,
+            num_log_attributes: None,
+            use_trace_context: false,
+            num_metric_attributes: None,
+            num_data_points_per_metric: None,
+        };
+
+        // Helper: extract the tenant.id attribute value from a log payload.
+        let extract_tenant_id = |payload: OtapPayload| -> Option<String> {
+            let otlp_bytes: OtlpProtoBytes = payload.try_into().expect("convert to otlp bytes");
+            let bytes = match otlp_bytes {
+                OtlpProtoBytes::ExportLogsRequest(b) => b,
+                _ => panic!("expected logs"),
+            };
+            let logs = LogsData::decode(bytes.as_ref()).expect("decode logs");
+            logs.resource_logs
+                .first()?
+                .resource
+                .as_ref()?
+                .attributes
+                .iter()
+                .find(|kv| kv.key == "tenant.id")
+                .and_then(|kv| kv.value.as_ref())
+                .and_then(|v| {
+                    use otap_df_pdata::proto::opentelemetry::common::v1::any_value::Value;
+                    match v.value.as_ref()? {
+                        Value::StringValue(s) => Some(s.clone()),
+                        _ => None,
+                    }
+                })
+        };
+
+        let tenant_1 = extract_tenant_id(generator.generate_logs(1).expect("batch 1"))
+            .expect("batch 1 should have tenant.id");
+        let tenant_2 = extract_tenant_id(generator.generate_logs(1).expect("batch 2"))
+            .expect("batch 2 should have tenant.id");
+        let tenant_3 = extract_tenant_id(generator.generate_logs(1).expect("batch 3"))
+            .expect("batch 3 should have tenant.id");
+        let tenant_4 = extract_tenant_id(generator.generate_logs(1).expect("batch 4"))
+            .expect("batch 4 should have tenant.id");
+
+        // With a two-entry rotation [0, 1], consecutive batches alternate attribute sets.
+        assert_ne!(
+            tenant_1, tenant_2,
+            "consecutive batches should use different attribute sets"
+        );
+        assert_eq!(
+            tenant_1, tenant_3,
+            "batches 1 and 3 should share the same attribute set"
+        );
+        assert_eq!(
+            tenant_2, tenant_4,
+            "batches 2 and 4 should share the same attribute set"
+        );
+
+        // Both configured values must appear.
+        let tenants = [&tenant_1, &tenant_2];
+        assert!(
+            tenants.contains(&&"prod".to_string()),
+            "prod should appear in the rotation"
+        );
+        assert!(
+            tenants.contains(&&"staging".to_string()),
+            "staging should appear in the rotation"
+        );
+    }
+
+    #[test]
+    fn test_resource_attribute_rotation_empty_attrs() {
+        use otap_df_pdata::OtlpProtoBytes;
+        use otap_df_pdata::proto::opentelemetry::logs::v1::LogsData;
+        use prost::Message;
+
+        // static_generator() has empty entries and rotation — no custom resource attrs.
+        let mut generator = static_generator();
+
+        let batch_1 = generator
+            .generate_logs(1)
+            .expect("batch 1 with empty attrs");
+        let batch_2 = generator
+            .generate_logs(1)
+            .expect("batch 2 with empty attrs");
+
+        // Both payloads should be valid and non-empty.
+        assert!(
+            batch_1.num_bytes().unwrap_or(0) > 0,
+            "batch 1 should be non-empty"
+        );
+        assert!(
+            batch_2.num_bytes().unwrap_or(0) > 0,
+            "batch 2 should be non-empty"
+        );
+
+        // Neither payload should carry a tenant.id attribute.
+        for (i, batch) in [batch_1, batch_2].into_iter().enumerate() {
+            let otlp_bytes: OtlpProtoBytes = batch.try_into().expect("convert to otlp bytes");
+            let bytes = match otlp_bytes {
+                OtlpProtoBytes::ExportLogsRequest(b) => b,
+                _ => panic!("expected logs"),
+            };
+            let logs = LogsData::decode(bytes.as_ref()).expect("decode logs");
+            let has_tenant = logs
+                .resource_logs
+                .first()
+                .and_then(|rl| rl.resource.as_ref())
+                .map(|r| r.attributes.iter().any(|kv| kv.key == "tenant.id"))
+                .unwrap_or(false);
+            assert!(
+                !has_tenant,
+                "batch {i} should not have tenant.id when no attrs configured"
+            );
+        }
+    }
+
+    #[test]
+    fn test_producer_no_limit_always_returns_run() {
+        let cfg = TrafficConfig::new(Some(10), None, 10, 1, 0, 0);
+        let mut producer = fresh_producer(&cfg, None);
+
+        // Without a limit, next_run should always return Some.
+        assert!(producer.next_run().unwrap().is_some());
+        producer.record_production(100);
+        assert!(producer.next_run().unwrap().is_some());
+        producer.record_production(1_000_000);
+        assert!(producer.next_run().unwrap().is_some());
+    }
+
+    #[test]
+    fn test_producer_limit_reached_returns_none() {
+        let cfg = TrafficConfig::new(Some(10), None, 10, 1, 0, 0);
+        let mut producer = fresh_producer(&cfg, Some(10));
+
+        // First run should be available (produced 0 of 10).
+        assert!(producer.next_run().unwrap().is_some());
+
+        // After producing exactly the limit, next_run returns None.
+        producer.record_production(10);
+        assert!(producer.next_run().unwrap().is_none());
+
+        // Over the limit also returns None.
+        producer.record_production(5);
+        assert!(producer.next_run().unwrap().is_none());
+    }
+
+    #[test]
+    fn test_producer_truncates_run_to_fit_limit() {
+        // Shape: 10 metrics per second, max_batch=5 -> shape is 2 batches of 5
+        let cfg = TrafficConfig::new(Some(10), None, 5, 1, 0, 0);
+        let mut producer = fresh_producer(&cfg, Some(7));
+
+        assert_eq!(producer.run_count(), 10, "full run should have 10 signals");
+
+        // First run should be truncated to 7 signals.
+        let run = producer
+            .next_run()
+            .expect("generation should succeed")
+            .expect("should get a run");
+        let payloads: Vec<_> = run.collect();
+        let total: usize = payloads
+            .iter()
+            .map(|r| r.as_ref().unwrap().num_items())
+            .sum();
+        assert_eq!(total, 7, "truncated run should have exactly 7 signals");
+
+        // After producing 7, no more runs.
+        producer.record_production(7);
+        assert!(producer.next_run().unwrap().is_none());
+    }
+
+    #[test]
+    fn test_producer_zero_limit_returns_none_immediately() {
+        let cfg = TrafficConfig::new(Some(10), None, 10, 1, 0, 0);
+        let mut producer = fresh_producer(&cfg, Some(0));
+
+        assert!(
+            producer.next_run().unwrap().is_none(),
+            "zero limit should immediately return None"
+        );
+    }
+
+    #[test]
+    fn test_cap_strategy_exact_fit() {
+        // 2 batches of 5 metrics = 10 total. Cap to 10 should be a no-op.
+        let cfg = TrafficConfig::new(Some(10), None, 5, 1, 0, 0);
+        let mut producer = fresh_producer(&cfg, Some(10));
+
+        let run = producer
+            .next_run()
+            .expect("generation should succeed")
+            .expect("should get a run");
+        let total: u64 = run.map(|r| r.unwrap().num_items() as u64).sum();
+        assert_eq!(total, 10);
+    }
+
+    #[test]
+    fn test_cap_strategy_partial_batch() {
+        // 2 batches of 5 metrics = 10 total. Cap to 7: keep first batch (5)
+        // + partial second batch (2).
+        let cfg = TrafficConfig::new(Some(10), None, 5, 1, 0, 0);
+        let mut producer = fresh_producer(&cfg, Some(7));
+
+        let run = producer
+            .next_run()
+            .expect("generation should succeed")
+            .expect("should get a run");
+        let items: Vec<usize> = run.map(|r| r.unwrap().num_items()).collect();
+        assert_eq!(items, vec![5, 2]);
+    }
+
+    #[test]
+    fn test_cap_strategy_zero_budget() {
+        // Cap to 0 signals should return None (checked in next_run before cap).
+        let cfg = TrafficConfig::new(Some(10), None, 5, 1, 0, 0);
+        let mut producer = fresh_producer(&cfg, Some(0));
+
+        assert!(producer.next_run().unwrap().is_none());
+    }
+}

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/producer.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/producer.rs
@@ -481,7 +481,6 @@ impl StaticGenerator {
             true => None,
             false => {
                 let slot = self.rotation[self.idx % self.rotation.len()];
-                // self.idx += 1;
                 Some(&self.entries[slot].attrs)
             }
         }
@@ -490,8 +489,6 @@ impl StaticGenerator {
 
 impl SignalGenerator for StaticGenerator {
     fn generate_logs(&mut self, count: usize) -> GenerateResult {
-        self.idx += 1;
-
         let attrs = self.attrs_for_batch();
         let payload = static_signal::static_otlp_logs_with_config(
             count,
@@ -502,12 +499,11 @@ impl SignalGenerator for StaticGenerator {
         );
         let payload = OtlpProtoMessage::Logs(payload);
 
+        self.idx += 1;
         Ok(payload.try_into()?)
     }
 
     fn generate_metrics(&mut self, count: usize) -> GenerateResult {
-        self.idx += 1;
-
         let attrs = self.attrs_for_batch();
         let payload = static_signal::static_otlp_metrics_with_config(
             count,
@@ -517,15 +513,16 @@ impl SignalGenerator for StaticGenerator {
         );
         let payload = OtlpProtoMessage::Metrics(payload);
 
+        self.idx += 1;
         Ok(payload.try_into()?)
     }
 
     fn generate_traces(&mut self, count: usize) -> GenerateResult {
-        self.idx += 1;
         let attrs = self.attrs_for_batch();
         let payload = static_signal::static_otlp_traces(count, attrs);
         let payload = OtlpProtoMessage::Traces(payload);
 
+        self.idx += 1;
         Ok(payload.try_into()?)
     }
 }

--- a/rust/otap-dataflow/crates/otap/src/pdata_conversions.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata_conversions.rs
@@ -2,36 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::pdata::OtapPdata;
-use bytes::BytesMut;
 use otap_df_engine::error::Error;
-use otap_df_pdata::OtlpProtoBytes;
 use otap_df_pdata::proto::OtlpProtoMessage;
-use prost::Message;
 
 impl TryFrom<OtlpProtoMessage> for OtapPdata {
     type Error = Error;
 
     fn try_from(value: OtlpProtoMessage) -> Result<Self, Self::Error> {
-        let mut bytes = BytesMut::new();
-        Ok(match value {
-            OtlpProtoMessage::Logs(logs_data) => {
-                logs_data.encode(&mut bytes)?;
-                OtapPdata::new_todo_context(
-                    OtlpProtoBytes::ExportLogsRequest(bytes.freeze()).into(),
-                )
-            }
-            OtlpProtoMessage::Metrics(metrics_data) => {
-                metrics_data.encode(&mut bytes)?;
-                OtapPdata::new_todo_context(
-                    OtlpProtoBytes::ExportMetricsRequest(bytes.freeze()).into(),
-                )
-            }
-            OtlpProtoMessage::Traces(trace_data) => {
-                trace_data.encode(&mut bytes)?;
-                OtapPdata::new_todo_context(
-                    OtlpProtoBytes::ExportTracesRequest(bytes.freeze()).into(),
-                )
-            }
-        })
+        Ok(OtapPdata::new_todo_context(value.try_into()?))
     }
 }

--- a/rust/otap-dataflow/crates/pdata/src/payload.rs
+++ b/rust/otap-dataflow/crates/pdata/src/payload.rs
@@ -89,10 +89,13 @@ use crate::otlp::logs::LogsProtoBytesEncoder;
 use crate::otlp::metrics::MetricsProtoBytesEncoder;
 use crate::otlp::traces::TracesProtoBytesEncoder;
 use crate::otlp::{OtlpProtoBytes, ProtoBuffer, ProtoBytesEncoder};
+use crate::proto::OtlpProtoMessage;
 use crate::views::otlp::bytes::logs::RawLogsData;
 use crate::views::otlp::bytes::metrics::RawMetricsData;
 use crate::views::otlp::bytes::traces::RawTraceData;
+use bytes::BytesMut;
 use otap_df_config::{SignalFormat, SignalType};
+use prost::{EncodeError, Message};
 
 /// Container for the various representations of the telemetry data
 #[derive(Clone, Debug)]
@@ -425,6 +428,28 @@ impl TryFrom<OtlpProtoBytes> for OtapArrowRecords {
                 Ok(otap_batch)
             }
         }
+    }
+}
+
+impl TryFrom<OtlpProtoMessage> for OtapPayload {
+    type Error = EncodeError;
+
+    fn try_from(value: OtlpProtoMessage) -> Result<Self, Self::Error> {
+        let mut bytes = BytesMut::new();
+        Ok(match value {
+            OtlpProtoMessage::Logs(logs_data) => {
+                logs_data.encode(&mut bytes)?;
+                OtapPayload::OtlpBytes(OtlpProtoBytes::ExportLogsRequest(bytes.freeze()))
+            }
+            OtlpProtoMessage::Metrics(metrics_data) => {
+                metrics_data.encode(&mut bytes)?;
+                OtapPayload::OtlpBytes(OtlpProtoBytes::ExportMetricsRequest(bytes.freeze()))
+            }
+            OtlpProtoMessage::Traces(trace_data) => {
+                trace_data.encode(&mut bytes)?;
+                OtapPayload::OtlpBytes(OtlpProtoBytes::ExportTracesRequest(bytes.freeze()))
+            }
+        })
     }
 }
 

--- a/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_logs.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_logs.yaml
@@ -77,7 +77,7 @@ queries:
         SELECT
           component_name,
           metric_name,
-          MAX(value) AS total_increase,
+          MAX(value) - MIN(value) AS total_increase,
           AVG(rate) AS average_rate
         FROM
           observation_only AS ow
@@ -139,15 +139,16 @@ queries:
             ON wr.timestamp BETWEEN ow.start_ts AND ow.stop_ts
         ),
 
-        full_range_aggregates AS (
+        observation_window_aggregates AS (
           SELECT
-            component_name,
-            metric_name,
-            core_id,
-            MAX(value) AS max_value,
-            MIN(value) AS min_value
-          FROM with_rate
-          GROUP BY component_name, metric_name, core_id
+            wr.component_name,
+            wr.metric_name,
+            wr.core_id,
+            MAX(wr.value) - MIN(wr.value) AS total_increase
+          FROM with_rate wr
+          JOIN observation_only ow
+            ON wr.timestamp BETWEEN ow.start_ts AND ow.stop_ts
+          GROUP BY wr.component_name, wr.metric_name, wr.core_id
         )
 
         -- Final Aggregation
@@ -155,14 +156,14 @@ queries:
           t.component_name,
           t.metric_name,
           t.core_id,
-          f.max_value AS total_increase,
+          f.total_increase,
           AVG(t.rate) AS average_rate
         FROM trimmed_rates t
-        JOIN full_range_aggregates f
+        JOIN observation_window_aggregates f
           ON t.component_name = f.component_name
           AND t.metric_name = f.metric_name
           AND t.core_id = f.core_id
-        GROUP BY t.component_name, t.metric_name, t.core_id, f.max_value, f.min_value
+        GROUP BY t.component_name, t.metric_name, t.core_id, f.total_increase
         ORDER BY t.component_name, t.metric_name, t.core_id;
 
   - name: Component Metric Rates

--- a/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_metrics.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_metrics.yaml
@@ -77,7 +77,7 @@ queries:
         SELECT
           component_name,
           metric_name,
-          MAX(value) AS total_increase,
+          MAX(value) - MIN(value) AS total_increase,
           AVG(rate) AS average_rate
         FROM
           observation_only AS ow
@@ -139,15 +139,16 @@ queries:
             ON wr.timestamp BETWEEN ow.start_ts AND ow.stop_ts
         ),
 
-        full_range_aggregates AS (
+        observation_window_aggregates AS (
           SELECT
-            component_name,
-            metric_name,
-            core_id,
-            MAX(value) AS max_value,
-            MIN(value) AS min_value
-          FROM with_rate
-          GROUP BY component_name, metric_name, core_id
+            wr.component_name,
+            wr.metric_name,
+            wr.core_id,
+            MAX(wr.value) - MIN(wr.value) AS total_increase
+          FROM with_rate wr
+          JOIN observation_only ow
+            ON wr.timestamp BETWEEN ow.start_ts AND ow.stop_ts
+          GROUP BY wr.component_name, wr.metric_name, wr.core_id
         )
 
         -- Final Aggregation
@@ -155,14 +156,14 @@ queries:
           t.component_name,
           t.metric_name,
           t.core_id,
-          f.max_value AS total_increase,
+          f.total_increase,
           AVG(t.rate) AS average_rate
         FROM trimmed_rates t
-        JOIN full_range_aggregates f
+        JOIN observation_window_aggregates f
           ON t.component_name = f.component_name
           AND t.metric_name = f.metric_name
           AND t.core_id = f.core_id
-        GROUP BY t.component_name, t.metric_name, t.core_id, f.max_value, f.min_value
+        GROUP BY t.component_name, t.metric_name, t.core_id, f.total_increase
         ORDER BY t.component_name, t.metric_name, t.core_id;
 
   - name: Component Metric Rates

--- a/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_traces.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_traces.yaml
@@ -77,7 +77,7 @@ queries:
         SELECT
           component_name,
           metric_name,
-          MAX(value) AS total_increase,
+          MAX(value) - MIN(value) AS total_increase,
           AVG(rate) AS average_rate
         FROM
           observation_only AS ow
@@ -139,15 +139,16 @@ queries:
             ON wr.timestamp BETWEEN ow.start_ts AND ow.stop_ts
         ),
 
-        full_range_aggregates AS (
+        observation_window_aggregates AS (
           SELECT
-            component_name,
-            metric_name,
-            core_id,
-            MAX(value) AS max_value,
-            MIN(value) AS min_value
-          FROM with_rate
-          GROUP BY component_name, metric_name, core_id
+            wr.component_name,
+            wr.metric_name,
+            wr.core_id,
+            MAX(wr.value) - MIN(wr.value) AS total_increase
+          FROM with_rate wr
+          JOIN observation_only ow
+            ON wr.timestamp BETWEEN ow.start_ts AND ow.stop_ts
+          GROUP BY wr.component_name, wr.metric_name, wr.core_id
         )
 
         -- Final Aggregation
@@ -155,14 +156,14 @@ queries:
           t.component_name,
           t.metric_name,
           t.core_id,
-          f.max_value AS total_increase,
+          f.total_increase,
           AVG(t.rate) AS average_rate
         FROM trimmed_rates t
-        JOIN full_range_aggregates f
+        JOIN observation_window_aggregates f
           ON t.component_name = f.component_name
           AND t.metric_name = f.metric_name
           AND t.core_id = f.core_id
-        GROUP BY t.component_name, t.metric_name, t.core_id, f.max_value, f.min_value
+        GROUP BY t.component_name, t.metric_name, t.core_id, f.total_increase
         ORDER BY t.component_name, t.metric_name, t.core_id;
 
   - name: Component Metric Rates

--- a/tools/pipeline_perf_test/test_suites/integration/templates/configs/loadgen/config.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/integration/templates/configs/loadgen/config.yaml.j2
@@ -19,6 +19,7 @@ groups:
               data_source: semantic_conventions
               generation_strategy: {{ generation_strategy | default("pre_generated") }}
               traffic_config:
+                production_mode: open
                 max_batch_size: {{ max_batch_size | default(1000) }}
                 signals_per_second: {% if signals_per_second is none %}null{% else %}{{ signals_per_second | default(100000) }}{% endif %}
                 metric_weight: {{ metric_weight | default(0) }}

--- a/tools/pipeline_perf_test/test_suites/integration/templates/configs/loadgen/config.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/integration/templates/configs/loadgen/config.yaml.j2
@@ -19,7 +19,6 @@ groups:
               data_source: semantic_conventions
               generation_strategy: {{ generation_strategy | default("pre_generated") }}
               traffic_config:
-                production_mode: open
                 max_batch_size: {{ max_batch_size | default(1000) }}
                 signals_per_second: {% if signals_per_second is none %}null{% else %}{{ signals_per_second | default(100000) }}{% endif %}
                 metric_weight: {{ metric_weight | default(0) }}


### PR DESCRIPTION
# Change Summary

This PR is an attempt to solve #2713 with three connected changes.

The first is to make the reported data production rate coming out of the fake data generator smoother and more reliable especially under backpressure by using tokio intervals which are less prone to drift and have a catch-up mechanism.

The second makes sure we report metrics in smaller increments after every batch is exported. #2685 made some progress in this area, but as noted there it was an incomplete solution which held back metrics for prolonged periods of time in addition to having to heap allocate the send futures. I went after the full solution to the problem in this PR. Now we exclusively do non-blocking sends one batch at a time and always bump counters in-between on successful sends.

The third is against the rate calculations which were using the total produced signals from the run, but computing the rate from the observation time interval only. This means that we artificially inflated the overall rate by making it look like it took a shorter time to achieve than it did. We correct this by computing the rate for the observation window only. 

Other small fixes:

- Added two production modes for the fake data generator which can do either a smooth production loop or an open loop in case the interval to do a smooth loop is too small.
- Updated some try_from implementations.

## What issue does this PR close?

* Closes #2713

## How are these changes tested?

Ran the benchmarks locally and we can see that the produced and received rates are _very_ close to 100klrps now as opposed to 120k.

<img width="1393" height="310" alt="image" src="https://github.com/user-attachments/assets/1360f96e-8b23-48ef-98e7-f3a73cd27721" />


## Are there any user-facing changes?

New fake data generator `production_mode` setting.