### PR TITLE
fix(benchmarks): Bump max_decoding_message_size to 32MiB to fix batch processor benchmarks

### DIFF
--- a/tools/pipeline_perf_test/test_suites/integration/templates/configs/backend/config.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/integration/templates/configs/backend/config.yaml.j2
@@ -42,6 +42,7 @@ groups:
               {%- if receiver_type == "otlp" %}
               protocols:
                 grpc:
+                  max_decoding_message_size: 32MiB 
                   listening_addr: "{{ listen_addr }}"
                   {%- for k, v in extra_config.items() %}
                   {{ k }}: {{ v }}


### PR DESCRIPTION
# Change Summary

Batch processor benchmarks had 100% signal drop rate due to being over the decompression limit on the backend engine. Bumping the limit fixes the issue for both continuous and nightly.

## What issue does this PR close?

* Closes #2729

## How are these changes tested?

Ran all scenarios locally and observed the dropped rate being 0 (or less):

<img width="1891" height="466" alt="image" src="https://github.com/user-attachments/assets/6af43bf9-2e61-4af9-a48b-8285f8768a92" />

## Are there any user-facing changes?

No