### PR TITLE
bugfix: Rename pending_sends_buffered metrics to disambiguate them.

### DIFF
--- a/rust/otap-dataflow/crates/engine/src/control_plane_metrics.rs
+++ b/rust/otap-dataflow/crates/engine/src/control_plane_metrics.rs
@@ -73,7 +73,7 @@ pub(crate) struct RuntimeControlMetrics {
     /// full node-control inboxes instead of blocking the runtime.
     ///
     /// Level: `basic`.
-    #[metric(name = "pending_sends.buffered", unit = "{message}")]
+    #[metric(name = "control_pending_sends.buffered", unit = "{message}")]
     pub pending_sends_buffered: Gauge<u64>,
     /// Number of ordinary per-node timers currently registered.
     ///
@@ -250,7 +250,7 @@ pub(crate) struct PipelineCompletionMetrics {
     /// blocking, but it also indicates unwind traffic is under pressure.
     ///
     /// Level: `basic`.
-    #[metric(name = "pending_sends.buffered", unit = "{message}")]
+    #[metric(name = "completion_pending_sends.buffered", unit = "{message}")]
     pub pending_sends_buffered: Gauge<u64>,
     /// Count of `DeliverAck` messages received by the completion dispatcher.
     ///


### PR DESCRIPTION

# Change Summary
Rename pending_sends_buffered metrics to disambiguate them and remove its conflict.

## What issue does this PR close?

* Closes [#2734](https://github.com/open-telemetry/otel-arrow/issues/2734)

## How are these changes tested?

Locally running the collector.

## Are there any user-facing changes?

No
