### PR TITLE
Use latest weaver build that has the exclusion of openssl build in case of windows platforms. In case of windows platforms it uses SChannel TLS instead of natively building openssl.

### DIFF
--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -208,11 +208,11 @@ trybuild = "1.0"
 unsync = "0.1.2"
 url = "2.5.7"
 uuid = { version = "1.17.0", features = ["v4", "v7"] }
-weaver_common = { git = "https://github.com/open-telemetry/weaver.git", tag = "v0.21.2"}
-weaver_forge = { git = "https://github.com/open-telemetry/weaver.git", tag = "v0.21.2" }
-weaver_resolved_schema = { git = "https://github.com/open-telemetry/weaver.git", tag = "v0.21.2"}
-weaver_resolver = { git = "https://github.com/open-telemetry/weaver.git", tag = "v0.21.2"}
-weaver_semconv = { git = "https://github.com/open-telemetry/weaver.git", tag = "v0.21.2"}
+weaver_common = { git = "https://github.com/open-telemetry/weaver.git", tag = "v0.23.0"}
+weaver_forge = { git = "https://github.com/open-telemetry/weaver.git", tag = "v0.23.0" }
+weaver_resolved_schema = { git = "https://github.com/open-telemetry/weaver.git", tag = "v0.23.0"}
+weaver_resolver = { git = "https://github.com/open-telemetry/weaver.git", tag = "v0.23.0"}
+weaver_semconv = { git = "https://github.com/open-telemetry/weaver.git", tag = "v0.23.0"}
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 zip = "=4.6.1"
 byte-unit = { version = "5.2.0", features = ["serde"] }

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/config.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/config.rs
@@ -244,10 +244,11 @@ impl Config {
     /// Provide a reference to the ResolvedRegistry.
     /// Returns None if data_source is Static.
     pub fn get_registry(&self) -> Result<Option<ResolvedRegistry>, String> {
+        let mut semconv_errors = Vec::new();
         match self.data_source {
             DataSource::Static => Ok(None),
             DataSource::SemanticConventions => {
-                let registry_repo = RegistryRepo::try_new("main", &self.registry_path)
+                let registry_repo = RegistryRepo::try_new(None, &self.registry_path, &mut semconv_errors)
                     .map_err(|err| err.to_string())?;
 
                 // Load the semantic convention registry.

--- a/rust/otap-dataflow/crates/otap/Cargo.toml
+++ b/rust/otap-dataflow/crates/otap/Cargo.toml
@@ -40,6 +40,7 @@ bytes = { workspace = true }
 parking_lot = { workspace = true }
 base64 = { workspace = true }
 tracing = { workspace = true }
+cfg-if.workspace = true
 
 data_engine_kql_parser = { workspace = true }
 data_engine_expressions = { workspace =  true }

--- a/rust/otap-dataflow/crates/otap/src/crypto.rs
+++ b/rust/otap-dataflow/crates/otap/src/crypto.rs
@@ -30,72 +30,37 @@
 ///
 /// Returns `Err` if a provider was already installed (non-fatal in most cases).
 /// Returns `Ok(())` if installation succeeds or if no crypto feature is enabled.
+use cfg_if::cfg_if;
+
+/// Installs the selected rustls `CryptoProvider` as the process-wide default.
+///
 pub fn install_crypto_provider() -> Result<(), String> {
-    // Priority order when multiple features are enabled (e.g. --all-features):
-    // ring > aws-lc-rs > openssl > symcrypt.
-    #[cfg(feature = "crypto-ring")]
-    {
-        rustls::crypto::ring::default_provider()
+    cfg_if! {
+        // If you're using rustls, you must install a rustls CryptoProvider.
+        if #[cfg(all(feature = "crypto-ring"))] {
+            rustls::crypto::ring::default_provider()
+                .install_default()
+                .map_err(|_| "crypto provider already installed (ring)".to_string())?;
+        } else if #[cfg(all(feature = "crypto-aws-lc-rs"))] {
+            rustls::crypto::aws_lc_rs::default_provider()
             .install_default()
-            .map_err(|_| {
-                "failed to install crypto provider (ring): a crypto provider is already installed"
-                    .to_string()
-            })?;
-    }
-
-    #[cfg(all(feature = "crypto-aws-lc", not(feature = "crypto-ring")))]
-    {
-        rustls::crypto::aws_lc_rs::default_provider()
+            .map_err(|_| "crypto provider already installed (aws-lc-rs)".to_string())?;
+        } else if #[cfg(all(feature = "crypto-openssl"))] {
+            rustls_openssl::default_provider()
             .install_default()
-            .map_err(|_| {
-                "failed to install crypto provider (aws-lc-rs): a crypto provider is already installed"
-                    .to_string()
-            })?;
-    }
-
-    #[cfg(all(
-        feature = "crypto-openssl",
-        not(feature = "crypto-ring"),
-        not(feature = "crypto-aws-lc")
-    ))]
-    {
-        rustls_openssl::default_provider()
-            .install_default()
-            .map_err(|_| {
-                "failed to install crypto provider (openssl): a crypto provider is already installed"
-                    .to_string()
-            })?;
-    }
-
-    #[cfg(all(
-        feature = "crypto-symcrypt",
-        not(feature = "crypto-ring"),
-        not(feature = "crypto-aws-lc"),
-        not(feature = "crypto-openssl")
-    ))]
-    {
-        rustls_symcrypt::default_symcrypt_provider()
-            .install_default()
-            .map_err(|_| {
-                "failed to install crypto provider (symcrypt): a crypto provider is already installed"
-                    .to_string()
-            })?;
-    }
-
-    #[cfg(not(any(
-        feature = "crypto-ring",
-        feature = "crypto-aws-lc",
-        feature = "crypto-symcrypt",
-        feature = "crypto-openssl"
-    )))]
-    {
-        otap_df_telemetry::otel_warn!(
+            .map_err(|_| "crypto provider already installed (openssl)".to_string())?;
+        } else if #[cfg(feature = "crypto-native-tls")] {
+            // native-tls uses the platform's TLS stack (SChannel/OpenSSL/Security.framework)
+            // and does not require a rustls CryptoProvider.
+        } else {
+            otap_df_telemetry::otel_warn!(
             "crypto.no_provider",
             message = "no crypto-* feature enabled: TLS operations will fail at runtime. \
-                       Enable exactly one of: crypto-ring, crypto-aws-lc, crypto-symcrypt, crypto-openssl"
-        );
+                       Enable exactly one of: crypto-ring, crypto-aws-lc, crypto-openssl, \
+                       crypto-native-tls"
+            );
+        }
     }
-
     Ok(())
 }
 


### PR DESCRIPTION
# Change Summary

<!--
Use latest weaver build that has the exclusion of openssl build in case of windows platforms. In case of windows platforms it uses SChannel TLS instead of natively building openssl.
 It also includes simplification of crypto library selection.
-->

## What issue does this PR close?

<!--
Part of https://github.com/open-telemetry/otel-arrow/issues/2697.
-- >

## How are these changes tested?

## Are there any user-facing changes?

 <!-- If yes, provide further info below -->
