### PR TITLE
[query-engine] Rename log-specific methods in bridge

### DIFF
--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/benches/extend.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/benches/extend.rs
@@ -81,7 +81,7 @@ fn bench_log_pipeline(
         let benchmark_id = BenchmarkId::new("batch_size", batch_size);
         let _ = group.bench_with_input(benchmark_id, batch_size, |b, batch_size| {
             let batch = generate_logs_batch(*batch_size);
-            let pipeline = parse_kql_query_into_pipeline(bench_pipeline_kql, None)
+            let pipeline = parse_kql_logs_query_into_pipeline(bench_pipeline_kql, None)
                 .expect("can parse pipeline");
             b.iter(|| {
                 process_protobuf_otlp_export_logs_service_request_using_pipeline(

--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/bridge.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/bridge.rs
@@ -424,7 +424,9 @@ fn push_value(
     }
 }
 
-fn build_parser_options_for_logs_query(options: &mut BridgeOptions) -> Result<ParserOptions, ParserError> {
+fn build_parser_options_for_logs_query(
+    options: &mut BridgeOptions,
+) -> Result<ParserOptions, ParserError> {
     let mut parser_options = ParserOptions::new().with_attached_data_names(&[
         "resource",
         "instrumentation_scope",
@@ -694,7 +696,8 @@ mod tests {
 
         {
             // Drop everything
-            let pipeline_id = register_pipeline_for_kql_logs_query("s | where false", None).unwrap();
+            let pipeline_id =
+                register_pipeline_for_kql_logs_query("s | where false", None).unwrap();
 
             let (_, dropped) =
                 process_protobuf_otlp_export_logs_service_request_using_registered_pipeline(

--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/bridge.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/src/bridge.rs
@@ -113,13 +113,13 @@ impl BridgeResponse {
     }
 }
 
-pub fn parse_kql_query_into_pipeline(
+pub fn parse_kql_logs_query_into_pipeline(
     query: &str,
     options: Option<BridgeOptions>,
 ) -> Result<BridgePipeline, Vec<ParserError>> {
     let mut options = options.unwrap_or_default();
 
-    let parser_options = build_parser_options(&mut options).map_err(|e| vec![e])?;
+    let parser_options = build_parser_options_for_logs_query(&mut options).map_err(|e| vec![e])?;
     let attributes_schema = match parser_options
         .get_source_map_schema()
         .and_then(|s| s.get_schema_for_key("Attributes"))
@@ -135,11 +135,11 @@ pub fn parse_kql_query_into_pipeline(
     })
 }
 
-pub fn register_pipeline_for_kql_query(
+pub fn register_pipeline_for_kql_logs_query(
     query: &str,
     options: Option<BridgeOptions>,
 ) -> Result<usize, Vec<ParserError>> {
-    let pipeline = parse_kql_query_into_pipeline(query, options)?;
+    let pipeline = parse_kql_logs_query_into_pipeline(query, options)?;
 
     let mut expressions = EXPRESSIONS.write().unwrap();
     expressions.push(pipeline);
@@ -424,7 +424,7 @@ fn push_value(
     }
 }
 
-fn build_parser_options(options: &mut BridgeOptions) -> Result<ParserOptions, ParserError> {
+fn build_parser_options_for_logs_query(options: &mut BridgeOptions) -> Result<ParserOptions, ParserError> {
     let mut parser_options = ParserOptions::new().with_attached_data_names(&[
         "resource",
         "instrumentation_scope",
@@ -675,7 +675,7 @@ mod tests {
 
         {
             // Include everything
-            let pipeline_id = register_pipeline_for_kql_query("s | where true", None).unwrap();
+            let pipeline_id = register_pipeline_for_kql_logs_query("s | where true", None).unwrap();
 
             let (included, _) =
                 process_protobuf_otlp_export_logs_service_request_using_registered_pipeline(
@@ -694,7 +694,7 @@ mod tests {
 
         {
             // Drop everything
-            let pipeline_id = register_pipeline_for_kql_query("s | where false", None).unwrap();
+            let pipeline_id = register_pipeline_for_kql_logs_query("s | where false", None).unwrap();
 
             let (_, dropped) =
                 process_protobuf_otlp_export_logs_service_request_using_registered_pipeline(
@@ -713,7 +713,7 @@ mod tests {
 
         {
             // Drop everything but turn off include dropped records
-            let pipeline_id = register_pipeline_for_kql_query(
+            let pipeline_id = register_pipeline_for_kql_logs_query(
                 "s | where false",
                 Some(BridgeOptions::new().set_include_dropped_records(false)),
             )
@@ -738,7 +738,7 @@ mod tests {
             ResourceLogs::new().with_scope_logs(ScopeLogs::new().with_log_record(LogRecord::new())),
         );
 
-        let pipeline = parse_kql_query_into_pipeline("source | where false", None).unwrap();
+        let pipeline = parse_kql_logs_query_into_pipeline("source | where false", None).unwrap();
 
         let response = process_export_logs_service_request_using_pipeline(
             &pipeline,
@@ -762,7 +762,7 @@ mod tests {
             ResourceLogs::new().with_scope_logs(ScopeLogs::new().with_log_record(LogRecord::new())),
         );
 
-        let pipeline = parse_kql_query_into_pipeline("source | where true", None).unwrap();
+        let pipeline = parse_kql_logs_query_into_pipeline("source | where true", None).unwrap();
 
         let response = process_export_logs_service_request_using_pipeline(
             &pipeline,
@@ -787,7 +787,7 @@ mod tests {
         );
 
         let pipeline =
-            parse_kql_query_into_pipeline("source | summarize Count = count()", None).unwrap();
+            parse_kql_logs_query_into_pipeline("source | summarize Count = count()", None).unwrap();
 
         let response = process_export_logs_service_request_using_pipeline(
             &pipeline,
@@ -815,7 +815,7 @@ mod tests {
             ),
         );
 
-        let pipeline = parse_kql_query_into_pipeline(
+        let pipeline = parse_kql_logs_query_into_pipeline(
             "source | summarize Count = count() by severityText",
             None,
         )
@@ -896,7 +896,7 @@ mod tests {
         );
 
         let pipeline =
-            parse_kql_query_into_pipeline("source | summarize Count = count() by severityText | extend body = 'hello world', attr1 = 'goodbye world'", None).unwrap();
+            parse_kql_logs_query_into_pipeline("source | summarize Count = count() by severityText | extend body = 'hello world', attr1 = 'goodbye world'", None).unwrap();
 
         let mut response = process_export_logs_service_request_using_pipeline(
             &pipeline,
@@ -997,7 +997,7 @@ mod tests {
         let run_test_success = |query: &str| {
             println!("Testing: {query}");
 
-            parse_kql_query_into_pipeline(
+            parse_kql_logs_query_into_pipeline(
                 query,
                 Some(
                     BridgeOptions::new().with_attributes_schema(
@@ -1013,7 +1013,7 @@ mod tests {
         let run_test_failure = |query: &str| {
             println!("Testing: {query}");
 
-            parse_kql_query_into_pipeline(
+            parse_kql_logs_query_into_pipeline(
                 query,
                 Some(
                     BridgeOptions::new().with_attributes_schema(
@@ -1070,7 +1070,7 @@ mod tests {
             )),
         );
 
-        let pipeline = parse_kql_query_into_pipeline(
+        let pipeline = parse_kql_logs_query_into_pipeline(
             "source | where gettype(TimeGenerated) == 'datetime'",
             Some(
                 BridgeOptions::new().with_attributes_schema(
@@ -1100,7 +1100,7 @@ mod tests {
     #[test]
     fn test_parse_kql_query_into_pipeline_with_attributes_schema_and_allow_undefined_keys() {
         let run_test_success = |query: &str| {
-            parse_kql_query_into_pipeline(
+            parse_kql_logs_query_into_pipeline(
                 query,
                 Some(
                     BridgeOptions::new().with_attributes_schema(
@@ -1123,7 +1123,7 @@ mod tests {
 
     #[test]
     fn test_parse_kql_query_into_pipeline_with_attributes_schema_error() {
-        let e = parse_kql_query_into_pipeline(
+        let e = parse_kql_logs_query_into_pipeline(
             "",
             Some(BridgeOptions::new().with_attributes_schema(
                 ParserMapSchema::new().with_key_definition("body", ParserMapKeySchema::Map(None)),
@@ -1138,7 +1138,7 @@ mod tests {
     #[test]
     fn test_parse_kql_query_with_field_aliases() {
         let run_test = |query: &str| {
-            parse_kql_query_into_pipeline(query, None).unwrap();
+            parse_kql_logs_query_into_pipeline(query, None).unwrap();
         };
 
         // Test canonical names
@@ -1167,7 +1167,7 @@ mod tests {
     fn test_attributes_schema_removes_top_level_aliases() {
         // Test that when user provides an attributes schema with aliases
         // of top-level fields, they get removed properly
-        let result = parse_kql_query_into_pipeline(
+        let result = parse_kql_logs_query_into_pipeline(
             "source | extend SeverityText = 'Debug'",
             Some(
                 BridgeOptions::new().with_attributes_schema(
@@ -1183,7 +1183,7 @@ mod tests {
         assert!(result.is_ok());
 
         // Test with canonical name (snake_case) too
-        let result = parse_kql_query_into_pipeline(
+        let result = parse_kql_logs_query_into_pipeline(
             "source | extend severity_text = 'Debug'",
             Some(
                 BridgeOptions::new().with_attributes_schema(
@@ -1212,7 +1212,7 @@ mod tests {
             ))
         };
 
-        let pipeline_canonical = parse_kql_query_into_pipeline(
+        let pipeline_canonical = parse_kql_logs_query_into_pipeline(
             "source | where severity_text == 'Info' and severity_number == 9",
             None,
         )
@@ -1224,7 +1224,7 @@ mod tests {
         )
         .unwrap();
 
-        let pipeline_with_aliases = parse_kql_query_into_pipeline(
+        let pipeline_with_aliases = parse_kql_logs_query_into_pipeline(
             "source | where SeverityText == 'Info' and SeverityNumber == 9",
             None,
         )

--- a/rust/experimental/query_engine/engine-recordset-otlp-bridge/tests/otlp_kql_recordset.rs
+++ b/rust/experimental/query_engine/engine-recordset-otlp-bridge/tests/otlp_kql_recordset.rs
@@ -24,7 +24,7 @@ fn test_project_keep() {
     let query = "source\n | project-keep key*";
 
     let pipeline =
-        data_engine_recordset_otlp_bridge::parse_kql_query_into_pipeline(query, None).unwrap();
+        data_engine_recordset_otlp_bridge::parse_kql_logs_query_into_pipeline(query, None).unwrap();
 
     let engine = RecordSetEngine::new_with_options(
         RecordSetEngineOptions::new()
@@ -62,7 +62,7 @@ fn test_project_away() {
     let query = "source\n | project-away key*";
 
     let pipeline =
-        data_engine_recordset_otlp_bridge::parse_kql_query_into_pipeline(query, None).unwrap();
+        data_engine_recordset_otlp_bridge::parse_kql_logs_query_into_pipeline(query, None).unwrap();
 
     let engine = RecordSetEngine::new_with_options(
         RecordSetEngineOptions::new()
@@ -99,7 +99,7 @@ fn test_summarize_count_only() {
     let query = "source | summarize Count = count()";
 
     let pipeline =
-        data_engine_recordset_otlp_bridge::parse_kql_query_into_pipeline(query, None).unwrap();
+        data_engine_recordset_otlp_bridge::parse_kql_logs_query_into_pipeline(query, None).unwrap();
 
     let engine = RecordSetEngine::new_with_options(
         RecordSetEngineOptions::new()
@@ -154,7 +154,7 @@ fn test_summarize_count_and_group_by() {
     let query = "source | summarize Count = count() by body";
 
     let pipeline =
-        data_engine_recordset_otlp_bridge::parse_kql_query_into_pipeline(query, None).unwrap();
+        data_engine_recordset_otlp_bridge::parse_kql_logs_query_into_pipeline(query, None).unwrap();
 
     let engine = RecordSetEngine::new_with_options(
         RecordSetEngineOptions::new()
@@ -234,7 +234,7 @@ fn test_summarize_count_and_group_by_with_bin() {
     let query = "source | summarize Count = count() by time_unix_nano=bin(time_unix_nano, 1d)";
 
     let pipeline =
-        data_engine_recordset_otlp_bridge::parse_kql_query_into_pipeline(query, None).unwrap();
+        data_engine_recordset_otlp_bridge::parse_kql_logs_query_into_pipeline(query, None).unwrap();
 
     let engine = RecordSetEngine::new_with_options(
         RecordSetEngineOptions::new()
@@ -314,7 +314,7 @@ fn test_summarize_with_pipeline() {
     let query = "let BatchTime = now(); source | summarize Count = count() by body | where Count > 1 | extend ProcessedTime = now(), BatchTime = BatchTime";
 
     let pipeline =
-        data_engine_recordset_otlp_bridge::parse_kql_query_into_pipeline(query, None).unwrap();
+        data_engine_recordset_otlp_bridge::parse_kql_logs_query_into_pipeline(query, None).unwrap();
 
     let engine = RecordSetEngine::new_with_options(
         RecordSetEngineOptions::new()
@@ -380,7 +380,7 @@ fn test_strlen_function() {
     let query = "source\n | extend name_length = strlen(event_name), text_length = strlen(text)";
 
     let pipeline =
-        data_engine_recordset_otlp_bridge::parse_kql_query_into_pipeline(query, None).unwrap();
+        data_engine_recordset_otlp_bridge::parse_kql_logs_query_into_pipeline(query, None).unwrap();
 
     let engine = RecordSetEngine::new_with_options(
         RecordSetEngineOptions::new()
@@ -435,7 +435,7 @@ fn test_strcat_function() {
     let query = "source\n | extend a = strcat('hello', event_name, text, Unknown)";
 
     let pipeline =
-        data_engine_recordset_otlp_bridge::parse_kql_query_into_pipeline(query, None).unwrap();
+        data_engine_recordset_otlp_bridge::parse_kql_logs_query_into_pipeline(query, None).unwrap();
 
     let engine = RecordSetEngine::new_with_options(
         RecordSetEngineOptions::new()
@@ -483,7 +483,7 @@ fn test_replace_string_function() {
      modified_text = replace_string(text, "hello", "hi")"#;
 
     let pipeline =
-        data_engine_recordset_otlp_bridge::parse_kql_query_into_pipeline(query, None).unwrap();
+        data_engine_recordset_otlp_bridge::parse_kql_logs_query_into_pipeline(query, None).unwrap();
 
     let engine = RecordSetEngine::new_with_options(
         RecordSetEngineOptions::new()
@@ -538,7 +538,7 @@ fn test_substring_function() {
             ResourceLogs::new().with_scope_logs(ScopeLogs::new().with_log_record(log)),
         );
 
-        let pipeline = data_engine_recordset_otlp_bridge::parse_kql_query_into_pipeline(
+        let pipeline = data_engine_recordset_otlp_bridge::parse_kql_logs_query_into_pipeline(
             format!("source | extend e = {statement}").as_str(),
             None,
         )
@@ -584,7 +584,7 @@ fn test_coalesce_function() {
             ResourceLogs::new().with_scope_logs(ScopeLogs::new().with_log_record(log)),
         );
 
-        let pipeline = data_engine_recordset_otlp_bridge::parse_kql_query_into_pipeline(
+        let pipeline = data_engine_recordset_otlp_bridge::parse_kql_logs_query_into_pipeline(
             format!("source | extend e = {statement}").as_str(),
             None,
         )
@@ -636,7 +636,7 @@ fn test_now_global_variable() {
     let query = "let batch_start_time = now();\nsource\n | extend batch_start = batch_start_time, record_start = now()";
 
     let pipeline =
-        data_engine_recordset_otlp_bridge::parse_kql_query_into_pipeline(query, None).unwrap();
+        data_engine_recordset_otlp_bridge::parse_kql_logs_query_into_pipeline(query, None).unwrap();
 
     let engine = RecordSetEngine::new_with_options(
         RecordSetEngineOptions::new()

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/processor.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/processor.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use data_engine_recordset::RecordSetEngineDiagnosticLevel;
 use data_engine_recordset_otlp_bridge::{
     BridgeDiagnosticOptions, BridgeError, BridgeOptions, BridgePipeline,
-    parse_kql_query_into_pipeline,
+    parse_kql_logs_query_into_pipeline,
     process_protobuf_otlp_export_logs_service_request_using_pipeline,
 };
 use linkme::distributed_slice;
@@ -53,7 +53,7 @@ impl RecordsetKqlProcessor {
         config: RecordsetKqlProcessorConfig,
     ) -> Result<Self, ConfigError> {
         let parsed_bridge_options = Self::parse_bridge_options(&config.bridge_options)?;
-        let pipeline = parse_kql_query_into_pipeline(
+        let pipeline = parse_kql_logs_query_into_pipeline(
             &config.query,
             Some(Self::apply_bridge_options_defaults(parsed_bridge_options)),
         )
@@ -245,7 +245,7 @@ impl Processor<OtapPdata> for RecordsetKqlProcessor {
                                         Ok(v) => v,
                                     };
 
-                                match parse_kql_query_into_pipeline(
+                                match parse_kql_logs_query_into_pipeline(
                                     &new_config.query,
                                     Some(Self::apply_bridge_options_defaults(
                                         parsed_bridge_options,


### PR DESCRIPTION
Relates to #2736

# Changes

* Adds "logs" into names of bridge methods which are specific to logs processing

# Details

Prepping for #2736 which seems like it will require "metrics" APIs in bridge.