### PR TITLE
fix: revert weaver to v0.21.2 to fix downstream build failures

### DIFF
--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -208,11 +208,11 @@ trybuild = "1.0"
 unsync = "0.1.2"
 url = "2.5.7"
 uuid = { version = "1.17.0", features = ["v4", "v7"] }
-weaver_common = { git = "https://github.com/open-telemetry/weaver.git", tag = "v0.23.0"}
-weaver_forge = { git = "https://github.com/open-telemetry/weaver.git", tag = "v0.23.0" }
-weaver_resolved_schema = { git = "https://github.com/open-telemetry/weaver.git", tag = "v0.23.0"}
-weaver_resolver = { git = "https://github.com/open-telemetry/weaver.git", tag = "v0.23.0"}
-weaver_semconv = { git = "https://github.com/open-telemetry/weaver.git", tag = "v0.23.0"}
+weaver_common = { git = "https://github.com/open-telemetry/weaver.git", tag = "v0.21.2"}
+weaver_forge = { git = "https://github.com/open-telemetry/weaver.git", tag = "v0.21.2" }
+weaver_resolved_schema = { git = "https://github.com/open-telemetry/weaver.git", tag = "v0.21.2"}
+weaver_resolver = { git = "https://github.com/open-telemetry/weaver.git", tag = "v0.21.2"}
+weaver_semconv = { git = "https://github.com/open-telemetry/weaver.git", tag = "v0.21.2"}
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 zip = "=4.6.1"
 byte-unit = { version = "5.2.0", features = ["serde"] }

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/config.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/config.rs
@@ -284,13 +284,11 @@ impl Config {
     /// Provide a reference to the ResolvedRegistry.
     /// Returns None if data_source is Static.
     pub fn get_registry(&self) -> Result<Option<ResolvedRegistry>, String> {
-        let mut semconv_errors = Vec::new();
         match self.data_source {
             DataSource::Static => Ok(None),
             DataSource::SemanticConventions => {
-                let registry_repo =
-                    RegistryRepo::try_new(None, &self.registry_path, &mut semconv_errors)
-                        .map_err(|err| err.to_string())?;
+                let registry_repo = RegistryRepo::try_new("main", &self.registry_path)
+                    .map_err(|err| err.to_string())?;
 
                 // Load the semantic convention registry.
                 let registry = match SchemaResolver::load_semconv_repository(registry_repo, false) {

--- a/rust/otap-dataflow/crates/validation/src/encode_decode.rs
+++ b/rust/otap-dataflow/crates/validation/src/encode_decode.rs
@@ -77,15 +77,13 @@ mod test {
     const ITERATIONS: usize = 10;
 
     fn get_registry() -> ResolvedRegistry {
-        let mut semconv_errors = Vec::new();
         let registry_repo = RegistryRepo::try_new(
-            None,
+            "main",
             &VirtualDirectoryPath::GitRepo {
                 url: "https://github.com/open-telemetry/semantic-conventions.git".to_owned(),
                 sub_folder: Some("model".to_owned()),
                 refspec: None,
             },
-            &mut semconv_errors,
         )
         .expect("all registries are definied under the model folder in semantic convention repo");
 


### PR DESCRIPTION
## Summary

Reverts weaver from v0.23.0 back to v0.21.2 to fix build failures for downstream consumers of the `otap-df-*` crates.

Fixes #2750

## Problem

Commit `da7688be` (#2740) updated weaver to v0.23.0, which pulls `gix ^0.81.0`. When downstream projects consume `otap-df-*` crates as git dependencies and generate fresh lockfiles, cargo resolves `gix 0.81.0` whose subcrates have incompatible winnow versions:

- `gix-config v0.54.0` uses `winnow 0.7`
- `gix-actor v0.40.1` uses `winnow 1.0`

This causes a compilation error in `gix-object`:

```
error[E0308]: mismatched types
   --> gix-object-0.58.0/src/parse.rs:87:55
    note: two different versions of crate `winnow` are being used
```

The otel-arrow workspace builds because `Cargo.lock` still pins `gix 0.78.0` (from before the weaver update). But downstream consumers generate fresh lockfiles and get the broken `gix 0.81.0` resolution.

## Changes

- Revert weaver dependencies from `v0.23.0` to `v0.21.2` in `rust/otap-dataflow/Cargo.toml`
- Restore `RegistryRepo::try_new` call sites to the v0.21.2 API signature (2 args instead of 3) in:
  - `crates/core-nodes/src/receivers/fake_data_generator/config.rs`
  - `crates/validation/src/encode_decode.rs`

## Verification

- Full workspace `cargo check` passes
- `cargo check -p otap-df-otap --features crypto-openssl --no-default-features` passes
- `cargo check -p otap-df-core-nodes --features dev-tools` passes

## Note

This is a temporary revert. The proper fix is to either:
1. Wait for a `gix 0.81.x` patch release that unifies winnow versions across subcrates
2. Pin winnow to a single version in the workspace
3. Update to a weaver version that uses a gix version without the winnow conflict

Once the winnow conflict is resolved upstream, weaver can be re-upgraded to v0.23.0+.