### PR TITLE
Add capability in query-engine to filter by type of signal

### DIFF
--- a/rust/experimental/query_engine/engine-recordset/src/scalars/scalar_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/scalars/scalar_expressions.rs
@@ -326,6 +326,12 @@ where
         ScalarExpression::Math(m) => {
             return execute_math_scalar_expression(execution_context, m);
         }
+        ScalarExpression::GetRecordType(r) => {
+            return Err(ExpressionError::NotSupported(
+                r.get_query_location().clone(),
+                format!("{} not yet supported  in RecordSet engine", r.get_name()),
+            ));
+        }
         ScalarExpression::GetType(g) => {
             let value_type =
                 execute_scalar_expression(execution_context, g.get_value())?.get_value_type();

--- a/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/scalar_expressions.rs
@@ -43,6 +43,9 @@ pub enum ScalarExpression {
     /// Returns the type string for the inner expression.
     GetType(GetTypeScalarExpression),
 
+    /// Returns the type string for the record.
+    GetRecordType(GetRecordTypeScalarExpression),
+
     /// Invoke a user-defined function.
     InvokeFunction(InvokeFunctionScalarExpression),
 
@@ -101,6 +104,7 @@ impl ScalarExpression {
             ScalarExpression::Constant(c) => c.try_resolve_value_type(scope),
             ScalarExpression::Collection(c) => c.try_resolve_value_type(scope),
             ScalarExpression::GetType(_) => Ok(Some(ValueType::String)),
+            ScalarExpression::GetRecordType(_) => Ok(Some(ValueType::String)),
             ScalarExpression::Logical(_) => Ok(Some(ValueType::Boolean)),
             ScalarExpression::Coalesce(c) => c.try_resolve_value_type(scope),
             ScalarExpression::Conditional(c) => c.try_resolve_value_type(scope),
@@ -205,6 +209,7 @@ impl ScalarExpression {
             ScalarExpression::Case(c) => c.try_resolve_static(scope),
             ScalarExpression::Convert(c) => c.try_resolve_static(scope),
             ScalarExpression::GetType(g) => g.try_resolve_static(scope),
+            ScalarExpression::GetRecordType(g) => g.try_resolve_static(scope),
             ScalarExpression::Length(l) => l.try_resolve_static(scope),
             ScalarExpression::Slice(s) => s.try_resolve_static(scope),
             ScalarExpression::Parse(p) => p.try_resolve_static(scope),
@@ -231,6 +236,7 @@ impl Expression for ScalarExpression {
             ScalarExpression::Constant(c) => c.get_query_location(),
             ScalarExpression::Collection(c) => c.get_query_location(),
             ScalarExpression::GetType(g) => g.get_query_location(),
+            ScalarExpression::GetRecordType(g) => g.get_query_location(),
             ScalarExpression::Logical(l) => l.get_query_location(),
             ScalarExpression::Coalesce(c) => c.get_query_location(),
             ScalarExpression::Conditional(c) => c.get_query_location(),
@@ -256,6 +262,7 @@ impl Expression for ScalarExpression {
             ScalarExpression::Static(s) => s.get_name(),
             ScalarExpression::Collection(_) => "ScalarExpression(Collection)",
             ScalarExpression::GetType(_) => "ScalarExpression(GetType)",
+            ScalarExpression::GetRecordType(_) => "ScalarExpression(GetRecordType)",
             ScalarExpression::Logical(_) => "ScalarExpression(Logical)",
             ScalarExpression::Coalesce(_) => "ScalarExpression(Coalesce)",
             ScalarExpression::Conditional(_) => "ScalarExpression(Conditional)",
@@ -284,6 +291,7 @@ impl Expression for ScalarExpression {
             ScalarExpression::Conditional(c) => c.fmt_with_indent(f, indent),
             ScalarExpression::Convert(c) => c.fmt_with_indent(f, indent),
             ScalarExpression::GetType(g) => g.fmt_with_indent(f, indent),
+            ScalarExpression::GetRecordType(g) => g.fmt_with_indent(f, indent),
             ScalarExpression::Temporal(t) => t.fmt_with_indent(f, indent),
             ScalarExpression::Length(l) => l.fmt_with_indent(f, indent),
             ScalarExpression::Logical(l) => l.fmt_with_indent(f, indent),
@@ -1303,6 +1311,39 @@ impl Expression for GetTypeScalarExpression {
         write!(f, "GetType(Scalar): ")?;
         self.value.fmt_with_indent(f, indent)?;
 
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct GetRecordTypeScalarExpression {
+    query_location: QueryLocation,
+}
+
+impl GetRecordTypeScalarExpression {
+    pub fn new(query_location: QueryLocation) -> GetRecordTypeScalarExpression {
+        Self { query_location }
+    }
+
+    pub(crate) fn try_resolve_static(
+        &mut self,
+        _scope: &PipelineResolutionScope,
+    ) -> ScalarStaticResolutionResult<'_> {
+        ScalarStaticResolutionResult::Ok(None)
+    }
+}
+
+impl Expression for GetRecordTypeScalarExpression {
+    fn get_query_location(&self) -> &QueryLocation {
+        &self.query_location
+    }
+
+    fn get_name(&self) -> &'static str {
+        "GetRecordTypeScalarExpression"
+    }
+
+    fn fmt_with_indent(&self, f: &mut std::fmt::Formatter<'_>, _indent: &str) -> std::fmt::Result {
+        writeln!(f, "GetRecordTypeScalarExpression")?;
         Ok(())
     }
 }

--- a/rust/experimental/query_engine/kql-parser/src/scalar_expression.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_expression.rs
@@ -659,6 +659,7 @@ pub(crate) fn try_resolve_identifier(
         ScalarExpression::Slice(_) => Ok(None),
         ScalarExpression::Static(_) => Ok(None),
         ScalarExpression::Text(_) => Ok(None),
+        ScalarExpression::GetRecordType(_) => Ok(None),
         ScalarExpression::GetType(g) => {
             if let Some(mut i) = try_resolve_identifier(g.get_value(), scope)? {
                 i.insert(0, "type".into());
@@ -667,6 +668,7 @@ pub(crate) fn try_resolve_identifier(
 
             Ok(None)
         }
+
         ScalarExpression::Select(s) => {
             if let Some(mut value) = try_resolve_identifier(s.get_value(), scope)?
                 && let ScalarExpression::Static(StaticScalarExpression::Array(selectors)) =

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
@@ -473,7 +473,7 @@ mod test {
                 logs::v1::{LogRecord, LogsData, ResourceLogs, ScopeLogs},
                 metrics::v1::{Metric, MetricsData, ResourceMetrics, ScopeMetrics},
                 resource::v1::Resource,
-                trace::v1::{ResourceSpans, ScopeSpans, Span, TracesData},
+                trace::v1::{ResourceSpans, ScopeSpans, Span, Status, TracesData},
             },
         },
         schema::consts,
@@ -1038,7 +1038,7 @@ mod test {
     fn test_conditional_on_signal_type() {
         // test ensure it will only operate on all signals
         let runtime = TestRuntime::<OtapPdata>::new();
-        let query = r#"logs| 
+        let query = r#"signals | 
             if (is Log) {
                 set attributes["is_log"] = true
             } else if (is Metric) {
@@ -1066,7 +1066,15 @@ mod test {
                     .await
                     .expect("no process error");
 
-                let span = Span::build().name("hello").finish();
+                let span = Span::build()
+                    .name("hello")
+                    .trace_id([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+                    .span_id([0, 0, 0, 0, 0, 0, 0, 0])
+                    .status(Status {
+                        message: "hello".into(),
+                        code: 0,
+                    })
+                    .finish();
                 let input = otlp_to_otap(&OtlpProtoMessage::Traces(TracesData {
                     resource_spans: vec![ResourceSpans::new(
                         Resource::default(),
@@ -1118,50 +1126,29 @@ mod test {
                     }
                 );
 
-                // let default_result = out.into_iter().next().expect("one result");
-                // assert_logs_records_equal(default_result, other_log_record);
+                let result = out.next().unwrap();
+                let OtlpProtoMessage::Traces(output_traces) = result else {
+                    panic!("expected trace, got {result:?}")
+                };
+                assert_eq!(
+                    &output_traces.resource_spans[0].scope_spans[0].spans[0],
+                    &Span {
+                        attributes: vec![KeyValue::new("is_span", AnyValue::new_bool(true))],
+                        ..span
+                    }
+                );
 
-                // // check error log record got routed to correct out port
-                // let mut routed = Vec::new();
-                // while let Ok(msg) = error_port_rx.try_recv() {
-                //     routed.push(msg);
-                // }
-                // assert_eq!(routed.len(), 1);
-                // let (_context, payload) = routed.pop().unwrap().into_parts();
-                // match payload {
-                //     OtapPayload::OtapArrowRecords(result) => {
-                //         // ensure the routed record was "sanitized"
-                //         let logs_batch = result.get(ArrowPayloadType::Logs).unwrap();
-                //         let severity_text_col = logs_batch
-                //             .column_by_name(consts::SEVERITY_TEXT)
-                //             .unwrap()
-                //             .as_any()
-                //             .downcast_ref::<DictionaryArray<UInt8Type>>()
-                //             .unwrap();
-                //         let eq_filtered_val =
-                //             eq(severity_text_col.values(), &StringArray::new_scalar("INFO"))
-                //                 .unwrap();
-                //         assert_eq!(eq_filtered_val.true_count(), 0);
-
-                //         // ensure the routed record equals what was expected
-                //         assert_logs_records_equal(result, log_record);
-                //     }
-                //     _ => panic!("unexpected payload type"),
-                // }
-
-                // // check info log record got routed to correct out port
-                // let mut routed = Vec::new();
-                // while let Ok(msg) = info_port_rx.try_recv() {
-                //     routed.push(msg);
-                // }
-                // assert_eq!(routed.len(), 1);
-                // let (_context, payload) = routed.pop().unwrap().into_parts();
-                // match payload {
-                //     OtapPayload::OtapArrowRecords(result) => {
-                //         assert_logs_records_equal(result, info_log_record);
-                //     }
-                //     _ => panic!("unexpected payload type"),
-                // }
+                let result = out.next().unwrap();
+                let OtlpProtoMessage::Metrics(output_metrics) = result else {
+                    panic!("expected metric, got {result:?}")
+                };
+                assert_eq!(
+                    &output_metrics.resource_metrics[0].scope_metrics[0].metrics[0],
+                    &Metric {
+                        metadata: vec![KeyValue::new("is_metric", AnyValue::new_bool(true))],
+                        ..metric
+                    }
+                )
             })
             .validate(|_ctx| async move {})
     }

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
@@ -1035,6 +1035,138 @@ mod test {
     }
 
     #[test]
+    fn test_conditional_on_signal_type() {
+        // test ensure it will only operate on all signals
+        let runtime = TestRuntime::<OtapPdata>::new();
+        let query = r#"logs| 
+            if (is Log) {
+                set attributes["is_log"] = true
+            } else if (is Metric) {
+                set attributes["is_metric"] = true
+            } else if (is Span) {
+                set attributes["is_span"] = true
+            }"#;
+        let processor = try_create_with_opl_query(query, &runtime).expect("created processor");
+
+        runtime
+            .set_processor(processor)
+            .run_test(|mut ctx| async move {
+                let log_record = LogRecord::build().severity_text("ERROR").finish();
+                let input = otlp_to_otap(&OtlpProtoMessage::Logs(LogsData {
+                    resource_logs: vec![ResourceLogs::new(
+                        Resource::default(),
+                        vec![ScopeLogs::new(
+                            InstrumentationScope::default(),
+                            vec![log_record.clone()],
+                        )],
+                    )],
+                }));
+                let pdata = OtapPdata::new_default(input.clone().into());
+                ctx.process(Message::PData(pdata))
+                    .await
+                    .expect("no process error");
+
+                let span = Span::build().name("hello").finish();
+                let input = otlp_to_otap(&OtlpProtoMessage::Traces(TracesData {
+                    resource_spans: vec![ResourceSpans::new(
+                        Resource::default(),
+                        vec![ScopeSpans::new(
+                            InstrumentationScope::default(),
+                            vec![span.clone()],
+                        )],
+                    )],
+                }));
+                let pdata = OtapPdata::new_default(input.clone().into());
+                ctx.process(Message::PData(pdata))
+                    .await
+                    .expect("no process error");
+
+                let metric = Metric::build().name("my_metric").finish();
+                let input = otlp_to_otap(&OtlpProtoMessage::Metrics(MetricsData {
+                    resource_metrics: vec![ResourceMetrics::new(
+                        Resource::default(),
+                        vec![ScopeMetrics::new(
+                            InstrumentationScope::default(),
+                            vec![metric.clone()],
+                        )],
+                    )],
+                }));
+                let pdata = OtapPdata::new_default(input.clone().into());
+                ctx.process(Message::PData(pdata))
+                    .await
+                    .expect("no process error");
+
+                // check anything not routed get outputted to the default port
+                let mut out = ctx
+                    .drain_pdata()
+                    .await
+                    .into_iter()
+                    .map(OtapPdata::payload)
+                    .map(OtapArrowRecords::try_from)
+                    .map(Result::unwrap)
+                    .map(|otap_batch| otap_to_otlp(&otap_batch));
+
+                let result = out.next().unwrap();
+                let OtlpProtoMessage::Logs(output_logs) = result else {
+                    panic!("expected logs, got {result:?}")
+                };
+                assert_eq!(
+                    &output_logs.resource_logs[0].scope_logs[0].log_records[0],
+                    &LogRecord {
+                        attributes: vec![KeyValue::new("is_log", AnyValue::new_bool(true))],
+                        ..log_record
+                    }
+                );
+
+                // let default_result = out.into_iter().next().expect("one result");
+                // assert_logs_records_equal(default_result, other_log_record);
+
+                // // check error log record got routed to correct out port
+                // let mut routed = Vec::new();
+                // while let Ok(msg) = error_port_rx.try_recv() {
+                //     routed.push(msg);
+                // }
+                // assert_eq!(routed.len(), 1);
+                // let (_context, payload) = routed.pop().unwrap().into_parts();
+                // match payload {
+                //     OtapPayload::OtapArrowRecords(result) => {
+                //         // ensure the routed record was "sanitized"
+                //         let logs_batch = result.get(ArrowPayloadType::Logs).unwrap();
+                //         let severity_text_col = logs_batch
+                //             .column_by_name(consts::SEVERITY_TEXT)
+                //             .unwrap()
+                //             .as_any()
+                //             .downcast_ref::<DictionaryArray<UInt8Type>>()
+                //             .unwrap();
+                //         let eq_filtered_val =
+                //             eq(severity_text_col.values(), &StringArray::new_scalar("INFO"))
+                //                 .unwrap();
+                //         assert_eq!(eq_filtered_val.true_count(), 0);
+
+                //         // ensure the routed record equals what was expected
+                //         assert_logs_records_equal(result, log_record);
+                //     }
+                //     _ => panic!("unexpected payload type"),
+                // }
+
+                // // check info log record got routed to correct out port
+                // let mut routed = Vec::new();
+                // while let Ok(msg) = info_port_rx.try_recv() {
+                //     routed.push(msg);
+                // }
+                // assert_eq!(routed.len(), 1);
+                // let (_context, payload) = routed.pop().unwrap().into_parts();
+                // match payload {
+                //     OtapPayload::OtapArrowRecords(result) => {
+                //         assert_logs_records_equal(result, info_log_record);
+                //     }
+                //     _ => panic!("unexpected payload type"),
+                // }
+            })
+            .validate(|_ctx| async move {})
+    }
+
+    #[test]
     fn test_conditional_route_to() {
         // test ensure it will only operate on all signals
         let runtime = TestRuntime::<OtapPdata>::new();

--- a/rust/otap-dataflow/crates/opl/src/opl.pest
+++ b/rust/otap-dataflow/crates/opl/src/opl.pest
@@ -139,10 +139,21 @@ rel_expression = {
     additive_expression ~ (rel_op ~ rel_expression)*
 }
 
+type_name = {
+    "Log" | "Metric" | "Span"
+}
+
+type_check_op = @{ "is" }
+
+type_check_expression = {
+      type_check_op ~ type_name
+    | rel_expression ~ (type_check_op ~ type_name)?
+}
+
 // TODO add bitwise expressions
 
 and_expression = {
-    rel_expression ~ ("and" ~ and_expression)*
+    type_check_expression ~ ("and" ~ and_expression)*
 }
 
 or_expression = {

--- a/rust/otap-dataflow/crates/opl/src/opl.pest
+++ b/rust/otap-dataflow/crates/opl/src/opl.pest
@@ -140,14 +140,16 @@ rel_expression = {
 }
 
 type_name = {
-    "Log" | "Metric" | "Span"
+    "Log"
+  | "Metric"
+  | "Span"
 }
 
 type_check_op = @{ "is" }
 
 type_check_expression = {
-      type_check_op ~ type_name
-    | rel_expression ~ (type_check_op ~ type_name)?
+    type_check_op ~ type_name
+  | rel_expression ~ (type_check_op ~ type_name)?
 }
 
 // TODO add bitwise expressions

--- a/rust/otap-dataflow/crates/opl/src/opl.pest
+++ b/rust/otap-dataflow/crates/opl/src/opl.pest
@@ -139,6 +139,8 @@ rel_expression = {
     additive_expression ~ (rel_op ~ rel_expression)*
 }
 
+// TODO add bitwise expressions
+
 type_name = {
     "Log"
   | "Metric"
@@ -151,8 +153,6 @@ type_check_expression = {
     type_check_op ~ type_name
   | rel_expression ~ (type_check_op ~ type_name)?
 }
-
-// TODO add bitwise expressions
 
 and_expression = {
     type_check_expression ~ ("and" ~ and_expression)*

--- a/rust/otap-dataflow/crates/opl/src/parser/expression.rs
+++ b/rust/otap-dataflow/crates/opl/src/parser/expression.rs
@@ -7,9 +7,9 @@ use data_engine_expressions::{
     AndLogicalExpression, BinaryMathematicalScalarExpression, BooleanScalarExpression,
     CaptureTextScalarExpression, CollectionScalarExpression, CombineScalarExpression,
     ContainsLogicalExpression, DateTimeScalarExpression, DoubleScalarExpression, DoubleValue,
-    EqualToLogicalExpression, Expression, GetTypeScalarExpression, GreaterThanLogicalExpression,
-    GreaterThanOrEqualToLogicalExpression, IntegerScalarExpression, IntegerValue,
-    InvokeFunctionArgument, InvokeFunctionScalarExpression, JoinTextScalarExpression,
+    EqualToLogicalExpression, Expression, GetRecordTypeScalarExpression,
+    GreaterThanLogicalExpression, GreaterThanOrEqualToLogicalExpression, IntegerScalarExpression,
+    IntegerValue, InvokeFunctionArgument, InvokeFunctionScalarExpression, JoinTextScalarExpression,
     ListScalarExpression, LogicalExpression, MatchesLogicalExpression, MathScalarExpression,
     NotLogicalExpression, NullScalarExpression, OrLogicalExpression, QueryLocation,
     RegexScalarExpression, ReplaceTextScalarExpression, ScalarExpression, SliceScalarExpression,
@@ -215,13 +215,9 @@ pub(crate) fn parse_type_check_expression(
         // IF there are two rules, we have an expression like (is <Type>) meaning we're checking
         // that an element of the stream is some type
         2 => {
-            let type_check_expr = ScalarExpression::GetType(GetTypeScalarExpression::new(
-                type_check_rule_query_location.clone(),
-                ScalarExpression::Source(SourceScalarExpression::new(
-                    type_check_rule_query_location.clone(),
-                    ValueAccessor::new_with_selectors(Vec::new()),
-                )),
-            ));
+            let type_check_expr = ScalarExpression::GetRecordType(
+                GetRecordTypeScalarExpression::new(type_check_rule_query_location.clone()),
+            );
 
             let type_name_rule = inner_rules.nth(1).expect("two rules");
             let type_check_expected_type = ScalarExpression::Static(

--- a/rust/otap-dataflow/crates/opl/src/parser/expression.rs
+++ b/rust/otap-dataflow/crates/opl/src/parser/expression.rs
@@ -7,7 +7,7 @@ use data_engine_expressions::{
     AndLogicalExpression, BinaryMathematicalScalarExpression, BooleanScalarExpression,
     CaptureTextScalarExpression, CollectionScalarExpression, CombineScalarExpression,
     ContainsLogicalExpression, DateTimeScalarExpression, DoubleScalarExpression, DoubleValue,
-    EqualToLogicalExpression, Expression, GreaterThanLogicalExpression,
+    EqualToLogicalExpression, Expression, GetTypeScalarExpression, GreaterThanLogicalExpression,
     GreaterThanOrEqualToLogicalExpression, IntegerScalarExpression, IntegerValue,
     InvokeFunctionArgument, InvokeFunctionScalarExpression, JoinTextScalarExpression,
     ListScalarExpression, LogicalExpression, MatchesLogicalExpression, MathScalarExpression,
@@ -137,8 +137,8 @@ pub(crate) fn parse_and_expression(
     let left_expr = parse_next_child_rule(
         pipeline_builder,
         &mut inner_rules,
-        Rule::rel_expression,
-        parse_rel_expression,
+        Rule::type_check_expression,
+        parse_type_check_expression,
     )
     .transpose()?
     .ok_or_else(|| no_inner_rule_error(query_location.clone()))?;
@@ -194,6 +194,61 @@ impl From<LogicalOrScalarExpr> for ScalarExpression {
         match value {
             LogicalOrScalarExpr::Logical(l) => Self::Logical(Box::new(l)),
             LogicalOrScalarExpr::Scalar(s) => s,
+        }
+    }
+}
+
+pub(crate) fn parse_type_check_expression(
+    rule: Pair<'_, Rule>,
+    pipeline_builder: &dyn PipelineBuilder,
+) -> Result<LogicalOrScalarExpr, ParserError> {
+    let type_check_rule_query_location = to_query_location(&rule);
+    let mut inner_rules = rule.into_inner();
+
+    // Determine what to do based on the number of rules here. The rule syntax is defined as:
+    // rel_expression? ~ (type_check_op ~ type_name)?
+
+    match inner_rules.len() {
+        // If there is one rule, it's simply a relative expression.
+        1 => {
+            // we have a simple relative expression, with
+            let inner_rule = inner_rules.next().expect("one rule");
+            parse_rel_expression(inner_rule, pipeline_builder)
+        }
+        // IF there are two rules, we have an expression like (is <Type>) meaning we're checking
+        // that an element of the stream is some type
+        2 => {
+            let type_check_expr = ScalarExpression::GetType(GetTypeScalarExpression::new(
+                type_check_rule_query_location.clone(),
+                ScalarExpression::Source(SourceScalarExpression::new(
+                    type_check_rule_query_location.clone(),
+                    ValueAccessor::new_with_selectors(Vec::new()),
+                )),
+            ));
+
+            let type_name_rule = inner_rules.nth(1).expect("two rules");
+            let type_check_expected_type = ScalarExpression::Static(
+                StaticScalarExpression::String(StringScalarExpression::new(
+                    to_query_location(&type_name_rule),
+                    type_name_rule.as_str(),
+                )),
+            );
+            Ok(LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                type_check_rule_query_location.clone(),
+                type_check_expr,
+                type_check_expected_type,
+                false,
+            ))
+            .into())
+        }
+        // If there are three rules, we have an expression like (<field> is <Type>) meaning we're
+        // checking that some field on the stream element is some type
+        3 => {
+            todo!()
+        }
+
+        other_len => {
+            todo!("handle other len {other_len:?}")
         }
     }
 }

--- a/rust/otap-dataflow/crates/opl/src/parser/expression.rs
+++ b/rust/otap-dataflow/crates/opl/src/parser/expression.rs
@@ -205,9 +205,6 @@ pub(crate) fn parse_type_check_expression(
     let type_check_rule_query_location = to_query_location(&rule);
     let mut inner_rules = rule.into_inner();
 
-    // Determine what to do based on the number of rules here. The rule syntax is defined as:
-    // rel_expression? ~ (type_check_op ~ type_name)?
-
     match inner_rules.len() {
         // If there is one rule, it's simply a relative expression.
         1 => {
@@ -244,12 +241,20 @@ pub(crate) fn parse_type_check_expression(
         // If there are three rules, we have an expression like (<field> is <Type>) meaning we're
         // checking that some field on the stream element is some type
         3 => {
-            todo!()
+            // TODO - we will support this soon
+            Err(ParserError::SyntaxNotSupported(
+                type_check_rule_query_location,
+                "Checking if a field of stream element is a type is not yet supported".into(),
+            ))
         }
 
-        other_len => {
-            todo!("handle other len {other_len:?}")
-        }
+        other_len => Err(ParserError::SyntaxError(
+            type_check_rule_query_location,
+            format!(
+                "Invalid number of expressions in type_check_expression. \
+                Found {other_len}, expected 1, 2 or 3"
+            ),
+        )),
     }
 }
 

--- a/rust/otap-dataflow/crates/query-engine/Cargo.toml
+++ b/rust/otap-dataflow/crates/query-engine/Cargo.toml
@@ -23,6 +23,7 @@ thiserror = { workspace = true }
 data_engine_expressions = { workspace = true }
 data_engine_parser_abstractions = { workspace = true }
 
+otap-df-config = { workspace = true }
 otap-df-pdata = { workspace = true, features = ["testing"] }
 
 [dev-dependencies]

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
@@ -44,11 +44,12 @@ use datafusion::logical_expr::{BinaryExpr, ColumnarValue, Expr, Operator, col, l
 use datafusion::physical_expr::{PhysicalExprRef, create_physical_expr};
 use datafusion::prelude::binary_expr;
 use datafusion::scalar::ScalarValue;
-use otap_df_pdata::OtapArrowRecords;
+use otap_df_config::SignalType;
 use otap_df_pdata::arrays::MaybeDictArrayAccessor;
 use otap_df_pdata::otap::filter::{ChildBatchFilterIdHelper, IdBitmap, IdBitmapPool};
 use otap_df_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
 use otap_df_pdata::schema::consts;
+use otap_df_pdata::{OtapArrowRecords, OtapPayloadHelpers};
 
 mod compare;
 pub mod optimize;
@@ -166,7 +167,7 @@ impl<T> From<T> for Composite<T> {
 /// to evaluating the expression which may involve realigning data from sub-expressions using the
 /// expression evaluation's join mechanics.
 ///
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Default, Debug, PartialEq)]
 pub struct FilterPlan {
     /// filters that will be applied to the root record batch
     pub source_filter: Option<Expr>,
@@ -183,14 +184,17 @@ pub struct FilterPlan {
     /// This uses the same expression evaluation infrastructure as `set` expressions, including
     /// support for joins across data scopes.
     pub expr_filter: Option<ExprFilterPlan>,
+
+    /// filter will be applied to check if an element of the stream passing through the filter is
+    /// this type
+    pub element_type_filter: Option<ElementTypeFilter>,
 }
 
 impl From<Expr> for FilterPlan {
     fn from(expr: Expr) -> Self {
         Self {
             source_filter: Some(expr),
-            attribute_filter: None,
-            expr_filter: None,
+            ..Default::default()
         }
     }
 }
@@ -198,9 +202,8 @@ impl From<Expr> for FilterPlan {
 impl From<AttributesFilterPlan> for FilterPlan {
     fn from(attrs_filter: AttributesFilterPlan) -> Self {
         Self {
-            source_filter: None,
             attribute_filter: Some(attrs_filter.into()),
-            expr_filter: None,
+            ..Default::default()
         }
     }
 }
@@ -208,9 +211,17 @@ impl From<AttributesFilterPlan> for FilterPlan {
 impl From<Composite<AttributesFilterPlan>> for FilterPlan {
     fn from(attrs_filter: Composite<AttributesFilterPlan>) -> Self {
         Self {
-            source_filter: None,
             attribute_filter: Some(attrs_filter),
-            expr_filter: None,
+            ..Default::default()
+        }
+    }
+}
+
+impl From<ElementTypeFilter> for FilterPlan {
+    fn from(element_type_filter: ElementTypeFilter) -> Self {
+        Self {
+            element_type_filter: Some(element_type_filter),
+            ..Default::default()
         }
     }
 }
@@ -219,9 +230,8 @@ impl FilterPlan {
     /// Create a FilterPlan that uses the general expression evaluation path.
     fn from_expr(expr: ExprFilterPlan) -> Self {
         Self {
-            source_filter: None,
-            attribute_filter: None,
             expr_filter: Some(expr),
+            ..Default::default()
         }
     }
 }
@@ -476,6 +486,15 @@ impl FilterPlan {
         right_expr: &ScalarExpression,
         functions: &[PipelineFunction],
     ) -> Result<Self> {
+        // try as filter on the type of signal passing through the filter. These filters can be
+        // quickly evaluated without any expression evaluation by checking the signal type of the
+        // batch itself
+        if let Some(element_type_filter) =
+            Self::try_as_type_check(left_expr, binary_op, right_expr)?
+        {
+            return Ok(element_type_filter);
+        }
+
         let planner = ExprLogicalPlanner::default();
 
         // build the comparison expression using the expr system's scoping logic
@@ -486,6 +505,52 @@ impl FilterPlan {
                 right: planner.plan_scalar_expr(right_expr, functions)?,
             },
         )))
+    }
+
+    /// Try to plan as a filter checks if either an element of the stream or a signal is some type
+    fn try_as_type_check(
+        left_expr: &ScalarExpression,
+        binary_op: Operator,
+        right_expr: &ScalarExpression,
+    ) -> Result<Option<Self>> {
+        match (left_expr, binary_op, right_expr) {
+            (
+                ScalarExpression::GetType(get_type_expr),
+                Operator::Eq,
+                ScalarExpression::Static(StaticScalarExpression::String(typename_expr)),
+            ) => {
+                let source_value_accessor = match get_type_expr.get_value() {
+                    ScalarExpression::Source(source_scalar_expr) => {
+                        source_scalar_expr.get_value_accessor()
+                    }
+                    _ => {
+                        // not yet supported
+                        todo!()
+                    }
+                };
+
+                if !source_value_accessor.has_selectors() {
+                    // since the source accessor has no selectors, it means we're checking the type
+                    // of elements of the stream for this pipeline. We'll try to determine if the
+                    // type name is a stream type that is handled by this query engine ...
+                    let type_name = typename_expr.get_value();
+                    let stream_element_type =
+                        StreamElementType::from_str(type_name).ok_or_else(|| {
+                            Error::InvalidPipelineError {
+                                cause: format!("Unknown stream type name {type_name}"),
+                                query_location: Some(right_expr.get_query_location().clone()),
+                            }
+                        })?;
+
+                    Ok(Some(FilterPlan::from(ElementTypeFilter::new(
+                        stream_element_type,
+                    ))))
+                } else {
+                    todo!()
+                }
+            }
+            _ => Ok(None),
+        }
     }
 
     fn try_from_contains_expr(
@@ -905,6 +970,7 @@ impl ToExec for FilterPlan {
         Ok(FilterExec {
             predicate: physical_expr,
             attributes_filter: attrs_filter,
+            element_type_filter: self.element_type_filter.clone(),
             expr_predicate,
             missing_attrs_pass,
         })
@@ -1011,6 +1077,39 @@ pub struct ExprBinaryFilterPlan {
     right: ScopedLogicalExpr,
 }
 
+/// Filter representing a predicate that checks whether an element of the stream being filtered is
+/// some type
+#[derive(Clone, Debug, PartialEq)]
+pub struct ElementTypeFilter {
+    is_type: StreamElementType,
+}
+
+impl ElementTypeFilter {
+    fn new(stream_type: StreamElementType) -> Self {
+        Self {
+            is_type: stream_type,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+enum StreamElementType {
+    Log,
+    Metric,
+    Span,
+}
+
+impl StreamElementType {
+    fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "Log" => Some(Self::Log),
+            "Metric" => Some(Self::Metric),
+            "Span" => Some(Self::Span),
+            _ => None,
+        }
+    }
+}
+
 fn to_physical_exprs(
     expr: &Expr,
     record_batch: &RecordBatch,
@@ -1040,6 +1139,10 @@ pub struct FilterExec {
     /// row not to pass the filter, unless this is true which it should be set it as for filters/
     /// like `attributes["x"] == null`
     missing_attrs_pass: bool,
+
+    /// filter will be applied to check if an element of the stream passing through the filter is
+    /// this type
+    pub element_type_filter: Option<ElementTypeFilter>,
 }
 
 impl From<AdaptivePhysicalExprExec> for FilterExec {
@@ -1048,6 +1151,7 @@ impl From<AdaptivePhysicalExprExec> for FilterExec {
             predicate: Some(predicate),
             attributes_filter: None,
             expr_predicate: None,
+            element_type_filter: None,
             missing_attrs_pass: false,
         }
     }
@@ -1072,6 +1176,23 @@ impl FilterExec {
                 });
             }
         };
+
+        // if only certain signal types are supposed to pass this filter, check the signal type
+        if let Some(element_type_filter) = &self.element_type_filter {
+            let signal_type = otap_batch.signal_type();
+            let is_valid_signal_type = match element_type_filter.is_type {
+                StreamElementType::Log => signal_type == SignalType::Logs,
+                StreamElementType::Span => signal_type == SignalType::Traces,
+                StreamElementType::Metric => signal_type == SignalType::Metrics,
+            };
+
+            if !is_valid_signal_type {
+                return Ok(BooleanArray::new(
+                    BooleanBuffer::new_unset(root_rb.num_rows()),
+                    None,
+                ));
+            }
+        }
 
         // evaluate predicate on the root batch
         let mut selection_vec = self

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
@@ -515,46 +515,25 @@ impl FilterPlan {
     ) -> Result<Option<Self>> {
         match (left_expr, binary_op, right_expr) {
             (
-                ScalarExpression::GetType(get_type_expr),
+                ScalarExpression::GetRecordType(_),
                 Operator::Eq,
                 ScalarExpression::Static(StaticScalarExpression::String(typename_expr)),
             ) => {
-                let source_value_accessor = match get_type_expr.get_value() {
-                    ScalarExpression::Source(source_scalar_expr) => {
-                        source_scalar_expr.get_value_accessor()
-                    }
-                    _ => {
-                        // the source for the get type expression isn't something that we can check
-                        // determine to statically be the identifier of a type, defer to expression
-                        // evaluation for this filter
-                        return Ok(None);
-                    }
-                };
+                // since the source accessor has no selectors, it means we're checking the type
+                // of elements of the stream for this pipeline. We'll try to determine if the
+                // type name is a stream type that is handled by this query engine ...
+                let type_name = typename_expr.get_value();
+                let stream_element_type =
+                    StreamElementType::from_str(type_name).ok_or_else(|| {
+                        Error::InvalidPipelineError {
+                            cause: format!("Unknown stream type name {type_name}"),
+                            query_location: Some(right_expr.get_query_location().clone()),
+                        }
+                    })?;
 
-                if !source_value_accessor.has_selectors() {
-                    // since the source accessor has no selectors, it means we're checking the type
-                    // of elements of the stream for this pipeline. We'll try to determine if the
-                    // type name is a stream type that is handled by this query engine ...
-                    let type_name = typename_expr.get_value();
-                    let stream_element_type =
-                        StreamElementType::from_str(type_name).ok_or_else(|| {
-                            Error::InvalidPipelineError {
-                                cause: format!("Unknown stream type name {type_name}"),
-                                query_location: Some(right_expr.get_query_location().clone()),
-                            }
-                        })?;
-
-                    Ok(Some(FilterPlan::from(ElementTypeFilter::new(
-                        stream_element_type,
-                    ))))
-                } else {
-                    // TODO - we will support this soon
-                    Err(Error::NotYetSupportedError {
-                        message:
-                            "Checking if a field of stream element is a type is not yet supported"
-                                .into(),
-                    })
-                }
+                Ok(Some(FilterPlan::from(ElementTypeFilter::new(
+                    stream_element_type,
+                ))))
             }
             _ => Ok(None),
         }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
@@ -524,8 +524,10 @@ impl FilterPlan {
                         source_scalar_expr.get_value_accessor()
                     }
                     _ => {
-                        // not yet supported
-                        todo!()
+                        // the source for the get type expression isn't something that we can check
+                        // determine to statically be the identifier of a type, defer to expression
+                        // evaluation for this filter
+                        return Ok(None);
                     }
                 };
 
@@ -546,7 +548,12 @@ impl FilterPlan {
                         stream_element_type,
                     ))))
                 } else {
-                    todo!()
+                    // TODO - we will support this soon
+                    Err(Error::NotYetSupportedError {
+                        message:
+                            "Checking if a field of stream element is a type is not yet supported"
+                                .into(),
+                    })
                 }
             }
             _ => Ok(None),

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
@@ -2140,7 +2140,7 @@ mod test {
     use data_engine_kql_parser::{KqlParser, Parser};
     use datafusion::physical_plan::PhysicalExpr;
     use otap_df_opl::parser::OplParser;
-    use otap_df_pdata::otap::Logs;
+    use otap_df_pdata::otap::{Logs, Traces};
     use otap_df_pdata::proto::OtlpProtoMessage;
     use otap_df_pdata::proto::opentelemetry::common::v1::{
         AnyValue, InstrumentationScope, KeyValue,
@@ -2158,6 +2158,7 @@ mod test {
     use otap_df_pdata::proto::opentelemetry::trace::v1::{Span, Status};
     use otap_df_pdata::testing::round_trip::{
         otap_to_otlp, otlp_to_otap, to_logs_data, to_otap_logs, to_otap_metrics, to_otap_traces,
+        to_traces_data,
     };
 
     use crate::pipeline::test::{
@@ -6480,5 +6481,59 @@ mod test {
             r#"logs | where contains(attributes["haystack"], attributes["needle"])"#,
         )
         .await;
+    }
+
+    #[tokio::test]
+    async fn test_filter_check_signal_types() {
+        let log_records = vec![
+            LogRecord::build()
+                .event_name("1")
+                .attributes(vec![])
+                .finish(),
+        ];
+
+        let query = "signals | where is Log";
+        let pipeline_expr = OplParser::parse(query).unwrap().pipeline;
+        let mut pipeline = Pipeline::new(pipeline_expr);
+
+        let logs_input = otlp_to_otap(&OtlpProtoMessage::Logs(to_logs_data(log_records)));
+        let logs_ouptut = pipeline.execute(logs_input.clone()).await.unwrap();
+
+        assert_eq!(logs_input, logs_ouptut);
+
+        let traces_input = otlp_to_otap(&OtlpProtoMessage::Traces(to_traces_data(vec![
+            Span::default(),
+        ])));
+        let traces_ouptut = pipeline.execute(traces_input).await.unwrap();
+
+        // assert it returns empty traces
+        assert_eq!(traces_ouptut, OtapArrowRecords::Traces(Traces::default()));
+    }
+
+    #[tokio::test]
+    async fn test_filter_check_signal_type_inverted() {
+        let log_records = vec![
+            LogRecord::build()
+                .event_name("1")
+                .attributes(vec![])
+                .finish(),
+        ];
+
+        let query = "signals | where not(is Log)";
+        let pipeline_expr = OplParser::parse(query).unwrap().pipeline;
+        let mut pipeline = Pipeline::new(pipeline_expr);
+
+        let logs_input = otlp_to_otap(&OtlpProtoMessage::Logs(to_logs_data(log_records)));
+        let logs_ouptut = pipeline.execute(logs_input).await.unwrap();
+
+        // assert it returns empty traces
+        assert_eq!(logs_ouptut, OtapArrowRecords::Logs(Logs::default()));
+
+        let traces_input = otlp_to_otap(&OtlpProtoMessage::Traces(to_traces_data(vec![
+            Span::default(),
+        ])));
+        let traces_ouptut = pipeline.execute(traces_input.clone()).await.unwrap();
+
+        assert_eq!(traces_input, traces_ouptut);
     }
 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter/optimize.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter/optimize.rs
@@ -366,7 +366,7 @@ pub mod test {
             Self {
                 source_filter,
                 attribute_filter: attribute_filter.map(T::into),
-                expr_filter: None,
+                ..Default::default()
             }
         }
     }


### PR DESCRIPTION
# Change Summary

<!--
Replace with a brief summary of the change in this PR
-->

Adds the capability to use a syntax like `is <signal type>` in logical expressions in OPL. This can be used for example when we want to have a single program that does different operations to each signal:
```kotlin
signals |
if (is Log) {
 // ...
} else  if (is Metric) {
  // ...
} else if (is Span) {
  // ...
}
```

Alternatively, we can also do things like this to just keep/drop certain signal types:
```kql
signals | where is Log
signals | where not(is Log)
```

## What issue does this PR close?

<!--
We highly recommend correlation of every PR to an issue
-->

* Part of #2752

## How are these changes tested?

Unit tests

## Are there any user-facing changes?

Yes this syntax is now available for use in transform processor

 <!-- If yes, provide further info below -->

## Future work:

In a followup, I'll add support for checking where a particular field is of some type. 
```
logs | if (attributes["x"] is String) {
  // ...
```
There are some TODOs in this PR to add support for this in the near future.

Also, when we eventually add more capability to the parser/planner to be type aware, it may have the capability to reject the use of invalid field accesses for certain signal types, and the syntax in this PR will allow users to get around these compile time checks. However, that's not implemented as part of this PR.
