### PR TITLE
Added debug assertions for negative values in counter and histograms

### DIFF
--- a/rust/otap-dataflow/crates/telemetry/src/instrument.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/instrument.rs
@@ -102,6 +102,7 @@ impl AddAssign<u64> for Counter<u64> {
 
 impl AddAssign<f64> for Counter<f64> {
     fn add_assign(&mut self, rhs: f64) {
+        debug_assert!(rhs >= 0.0, "Counter += called with negative value: {rhs}");
         self.0 += rhs;
     }
 }
@@ -144,6 +145,7 @@ impl Counter<f64> {
     /// Adds `v` to the counter.
     #[inline]
     pub fn add(&mut self, v: f64) {
+        debug_assert!(v >= 0.0, "Counter::add called with negative value: {v}");
         self.0 += v;
     }
 }
@@ -504,6 +506,10 @@ impl Mmsc {
     /// Records a single observation, updating min/max/sum/count.
     #[inline]
     pub fn record(&mut self, value: f64) {
+        debug_assert!(
+            value >= 0.0,
+            "Mmsc::record called with negative value: {value}"
+        );
         if value < self.min {
             self.min = value;
         }
@@ -693,17 +699,28 @@ mod tests {
         assert_eq!(snap.count, 0);
     }
 
+    #[cfg(debug_assertions)]
     #[test]
-    fn test_mmsc_negative_values() {
+    #[should_panic(expected = "Mmsc::record called with negative value")]
+    fn test_mmsc_record_rejects_negative() {
         let mut mmsc = Mmsc::default();
-        mmsc.record(-5.0);
-        mmsc.record(-10.0);
         mmsc.record(-1.0);
-        let snap = mmsc.get();
-        assert_eq!(snap.min, -10.0);
-        assert_eq!(snap.max, -1.0);
-        assert_eq!(snap.sum, -16.0);
-        assert_eq!(snap.count, 3);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "Counter::add called with negative value")]
+    fn test_counter_f64_add_rejects_negative() {
+        let mut counter = Counter::new(0.0f64);
+        counter.add(-1.0);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "Counter += called with negative value")]
+    fn test_counter_f64_add_assign_rejects_negative() {
+        let mut counter = Counter::new(0.0f64);
+        counter += -1.0;
     }
 
     #[test]


### PR DESCRIPTION
# Change Summary

Add `debug_assert!` checks to enforce non-negative values in `Counter<f64>` and `Mmsc` (Histogram bridge) instruments in `otap_df_telemetry`. Counters and Histogram-based instruments must only receive non-negative deltas for correctness. Their sums are exported as Prometheus counters, which require monotonicity.

Three guards added:
- `Counter<f64>::add(v)` — asserts `v >= 0.0`
- `AddAssign<f64> for Counter<f64>` — asserts `rhs >= 0.0`
- `Mmsc::record(value)` — asserts `value >= 0.0`

These use `debug_assert!` (zero cost in release builds) per the issue discussion.

## What issue does this PR close?
#2100

## How are these changes tested?

- Replaced the existing `test_mmsc_negative_values` test (which validated now-invalid behavior) with three `#[cfg(debug_assertions)] #[should_panic]` tests that verify the assertions fire on negative input:
  - `test_mmsc_record_rejects_negative`
  - `test_counter_f64_add_rejects_negative`
  - `test_counter_f64_add_assign_rejects_negative`
- Tests in `otap-df-telemetry` continue to pass.

## Are there any user-facing changes?

No. `debug_assert!` is stripped in release builds. In debug builds, passing a negative value to `Counter<f64>::add()`, `Counter<f64> +=`, or `Mmsc::record()` will now panic with a descriptive message, catching incorrect usage during development.