### PR TITLE
[fix] correct filter using expressions where each side returns nulls and/or mixed types

### DIFF
--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
@@ -61,8 +61,8 @@ use crate::pipeline::expr::{
 };
 use crate::pipeline::planner::{AttributesIdentifier, ColumnAccessor};
 use crate::pipeline::project::anyval::{
-    fill_null_type_as_empty, is_any_value_data_type, project_any_value_columns,
-    wrap_as_any_value_struct,
+    attempt_coerce_value_column_from_any_value_struct_column, fill_null_type_as_empty,
+    is_any_value_data_type, wrap_as_any_value_struct,
 };
 use crate::pipeline::project::{ProjectedSchemaColumn, Projection};
 use crate::pipeline::state::ExecutionState;
@@ -1658,32 +1658,6 @@ fn coerce_to_any_value_struct_column(values: ArrayRef) -> Result<ArrayRef> {
         }
         _ => Ok(values), // not dict-encoded, use as-is
     }
-}
-
-/// Attempt to coerce the values array (a struct array representing an AnyValue) into the concrete
-/// values type. If the passed array contains multiple types, the original array is returned
-/// because coercion was not successful.
-fn attempt_coerce_value_column_from_any_value_struct_column(values: &ArrayRef) -> Result<ArrayRef> {
-    // build a temporary record batch containing the column to maybe partition by type
-    let rb = RecordBatch::try_new(
-        Arc::new(Schema::new(vec![Field::new(
-            "",
-            values.data_type().clone(),
-            true,
-        )])),
-        vec![Arc::clone(values)],
-    )?;
-
-    // attempt to partition the AnyValue column by type
-    let partitions = project_any_value_columns(&rb, &[0])?;
-    let result = if partitions.len() == 1 {
-        partitions[0].batch.column(0)
-    } else {
-        // just return the original array
-        values
-    };
-
-    Ok(Arc::clone(result))
 }
 
 /// Inserts the column into the record batch if the column does not exist, otherwise replaces the

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
@@ -175,7 +175,6 @@ pub struct FilterPlan {
     /// rows of the root batch
     pub attribute_filter: Option<Composite<AttributesFilterPlan>>,
 
-    // TODO revisit these comments which might no longer make sense
     /// General-purpose expression-based filter. Used for cases that cannot be handled by the
     /// fast-path `source_filter` and `attribute_filter`, such as comparing two fields,
     /// cross-scope comparisons (e.g. `severity_number == attributes["x"]`), function calls
@@ -480,7 +479,6 @@ impl FilterPlan {
         let planner = ExprLogicalPlanner::default();
 
         // build the comparison expression using the expr system's scoping logic
-        // let expr = Self::build_scoped_comparison_expr(left, binary_op, right)?;
         Ok(FilterPlan::from_expr(ExprFilterPlan::Binary(
             ExprBinaryFilterPlan {
                 left: planner.plan_scalar_expr(left_expr, functions)?,
@@ -888,7 +886,6 @@ impl ToExec for FilterPlan {
             .as_ref()
             .map(|logical_expr| {
                 // clone the logical expr since into_physical consumes it
-                // TODO - reconsider this cloning?
                 ExprFilterExec::try_from_plan(logical_expr.clone())
             })
             .transpose()?;
@@ -1003,7 +1000,7 @@ pub enum ExprFilterPlan {
     /// A unary expression evaluation that should create boolean value
     Unary(ScopedLogicalExpr),
 
-    /// The selection vector will be created by evaluating both sides and doing a comparison
+    /// The selection vector will be created by evaluating both sides comparing the results
     Binary(ExprBinaryFilterPlan),
 }
 
@@ -1177,8 +1174,7 @@ impl FilterExec {
         Ok(result)
     }
 
-    // TODO double check the comments still make sense after I refactor it ...
-    /// Evaluates a [`ScopedPhysicalExpr`] and converts the result to a `BooleanArray` selection
+    /// Evaluates a [`ExprFilterExec`] and converts the result to a `BooleanArray` selection
     /// vector aligned to the root record batch.
     ///
     /// The expression may produce results from any data scope (root, attributes, join result, or
@@ -1232,6 +1228,8 @@ impl FilterExec {
                     }
                 }
 
+                // Check if the results of the left & right expressions effectively have
+                // equivalent row orders. If not, we need to align them by performing a join.
                 if !left_result.data_scope.can_combine(&right_result.data_scope) {
                     let (join_rb, joined_scope) = join(&left_result, &right_result, otap_batch)?;
                     // safety: we can expect here because `join` will always create columns with

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
@@ -6,10 +6,13 @@ use std::sync::Arc;
 use crate::consts::BODY_FIELD_NAME;
 use crate::error::{Error, Result};
 use crate::pipeline::PipelineStage;
+use crate::pipeline::expr::types::coerce_arithmetic;
 use crate::pipeline::expr::{
-    DataScope, ExprLogicalPlanner, ExprPhysicalPlanner, LogicalExprDataSource, ScopedLogicalExpr,
-    ScopedPhysicalExpr,
+    DataScope, ExprLogicalPlanner, ExprPhysicalPlanner, LogicalExprDataSource,
+    PhysicalExprEvalResult, ScopedLogicalExpr, ScopedPhysicalExpr, join::join,
 };
+use crate::pipeline::expr::{LEFT_COLUMN_NAME, RIGHT_COLUMN_NAME};
+use crate::pipeline::filter::compare::compare;
 use crate::pipeline::functions::expr_fn::contains;
 use crate::pipeline::planner::{
     AttributesIdentifier, BinaryArg, ColumnAccessor, try_attrs_value_filter_from_literal,
@@ -17,6 +20,9 @@ use crate::pipeline::planner::{
     try_static_scalar_to_literal_for_column,
 };
 use crate::pipeline::project::Projection;
+use crate::pipeline::project::anyval::{
+    attempt_coerce_value_column_from_any_value_struct_column, is_any_value_data_type,
+};
 use crate::pipeline::state::ExecutionState;
 use arrow::array::{Array, BooleanArray, BooleanBufferBuilder, RecordBatch, UInt16Array};
 use arrow::buffer::BooleanBuffer;
@@ -44,6 +50,7 @@ use otap_df_pdata::otap::filter::{ChildBatchFilterIdHelper, IdBitmap, IdBitmapPo
 use otap_df_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
 use otap_df_pdata::schema::consts;
 
+mod compare;
 pub mod optimize;
 
 /// A compositional tree structure for combining expressions with boolean operators.
@@ -168,6 +175,7 @@ pub struct FilterPlan {
     /// rows of the root batch
     pub attribute_filter: Option<Composite<AttributesFilterPlan>>,
 
+    // TODO revisit these comments which might no longer make sense
     /// General-purpose expression-based filter. Used for cases that cannot be handled by the
     /// fast-path `source_filter` and `attribute_filter`, such as comparing two fields,
     /// cross-scope comparisons (e.g. `severity_number == attributes["x"]`), function calls
@@ -175,7 +183,7 @@ pub struct FilterPlan {
     ///
     /// This uses the same expression evaluation infrastructure as `set` expressions, including
     /// support for joins across data scopes.
-    pub expr_filter: Option<ScopedLogicalExpr>,
+    pub expr_filter: Option<ExprFilterPlan>,
 }
 
 impl From<Expr> for FilterPlan {
@@ -210,7 +218,7 @@ impl From<Composite<AttributesFilterPlan>> for FilterPlan {
 
 impl FilterPlan {
     /// Create a FilterPlan that uses the general expression evaluation path.
-    fn from_expr(expr: ScopedLogicalExpr) -> Self {
+    fn from_expr(expr: ExprFilterPlan) -> Self {
         Self {
             source_filter: None,
             attribute_filter: None,
@@ -470,73 +478,16 @@ impl FilterPlan {
         functions: &[PipelineFunction],
     ) -> Result<Self> {
         let planner = ExprLogicalPlanner::default();
-        let left = planner.plan_scalar_expr(left_expr, functions)?;
-        let right = planner.plan_scalar_expr(right_expr, functions)?;
 
         // build the comparison expression using the expr system's scoping logic
-        let expr = Self::build_scoped_comparison_expr(left, binary_op, right)?;
-        Ok(FilterPlan::from_expr(expr))
-    }
-
-    /// Build a `ScopedLogicalExpr` that performs a boolean comparison (eq, gt, etc.) on the
-    /// results of two child expressions. Handles both same-scope and cross-scope cases.
-    ///
-    /// Type coercion is applied to ensure both sides have compatible types for the comparison
-    /// (e.g., Int32 vs Int64 will have the narrower side cast to Int64).
-    fn build_scoped_comparison_expr(
-        mut left: ScopedLogicalExpr,
-        binary_op: Operator,
-        mut right: ScopedLogicalExpr,
-    ) -> Result<ScopedLogicalExpr> {
-        use crate::pipeline::expr::types::{ExprLogicalType, coerce_arithmetic};
-        use crate::pipeline::expr::{LEFT_COLUMN_NAME, RIGHT_COLUMN_NAME};
-
-        // Apply type coercion so both sides of the comparison have compatible types.
-        // We reuse the arithmetic coercion rules (which handle Int32 vs Int64, AnyValue vs
-        // concrete types, etc.) -- the side-effect of adding cast expressions is what we need.
-        // We ignore the returned result type since comparisons always produce Boolean.
-        let _ = coerce_arithmetic(&mut left, &mut right);
-
-        // check if both sides can be evaluated in the same scope (no join needed)
-        let possible_combined_scope = match (&left.source, &right.source) {
-            (
-                LogicalExprDataSource::DataSource(left_scope),
-                LogicalExprDataSource::DataSource(right_scope),
-            ) => left_scope
-                .can_combine(right_scope)
-                .then_some(if !left_scope.is_scalar() {
-                    left_scope
-                } else {
-                    right_scope
-                }),
-            _ => None,
-        };
-
-        if let Some(combined_scope) = possible_combined_scope {
-            let dict_downcast = left.requires_dict_downcast || right.requires_dict_downcast;
-            Ok(ScopedLogicalExpr {
-                logical_expr: Expr::BinaryExpr(BinaryExpr::new(
-                    Box::new(left.logical_expr),
-                    binary_op,
-                    Box::new(right.logical_expr),
-                )),
-                source: LogicalExprDataSource::DataSource(combined_scope.clone()),
-                expr_type: ExprLogicalType::Boolean,
-                requires_dict_downcast: dict_downcast,
-            })
-        } else {
-            // different scopes -- need a join
-            Ok(ScopedLogicalExpr {
-                logical_expr: Expr::BinaryExpr(BinaryExpr::new(
-                    Box::new(col(LEFT_COLUMN_NAME)),
-                    binary_op,
-                    Box::new(col(RIGHT_COLUMN_NAME)),
-                )),
-                source: LogicalExprDataSource::Join(Box::new(left), Box::new(right)),
-                expr_type: ExprLogicalType::Boolean,
-                requires_dict_downcast: true,
-            })
-        }
+        // let expr = Self::build_scoped_comparison_expr(left, binary_op, right)?;
+        Ok(FilterPlan::from_expr(ExprFilterPlan::Binary(
+            ExprBinaryFilterPlan {
+                left: planner.plan_scalar_expr(left_expr, functions)?,
+                operator: binary_op,
+                right: planner.plan_scalar_expr(right_expr, functions)?,
+            },
+        )))
     }
 
     fn try_from_contains_expr(
@@ -613,7 +564,7 @@ impl FilterPlan {
 
         // Build a contains function call as a ScopedLogicalExpr
         let expr = Self::build_scoped_contains_expr(haystack, needle)?;
-        Ok(FilterPlan::from_expr(expr))
+        Ok(FilterPlan::from_expr(ExprFilterPlan::Unary(expr)))
     }
 
     /// Build a `ScopedLogicalExpr` that performs a contains check on two expressions.
@@ -904,7 +855,9 @@ impl Composite<FilterPlan> {
                 other => {
                     let planner = ExprLogicalPlanner::default();
                     let expr = planner.plan_scalar_expr(other, functions)?;
-                    Ok(Self::from(FilterPlan::from_expr(expr)))
+                    Ok(Self::from(FilterPlan::from_expr(ExprFilterPlan::Unary(
+                        expr,
+                    ))))
                 }
             },
         }
@@ -934,9 +887,9 @@ impl ToExec for FilterPlan {
             .expr_filter
             .as_ref()
             .map(|logical_expr| {
-                let planner = ExprPhysicalPlanner::default();
                 // clone the logical expr since into_physical consumes it
-                planner.plan(logical_expr.clone())
+                // TODO - reconsider this cloning?
+                ExprFilterExec::try_from_plan(logical_expr.clone())
             })
             .transpose()?;
 
@@ -1043,6 +996,24 @@ impl Composite<AttributesFilterPlan> {
     }
 }
 
+/// Filter plan representing a selection vector that will be created from the result of expression
+/// evaluations.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ExprFilterPlan {
+    /// A unary expression evaluation that should create boolean value
+    Unary(ScopedLogicalExpr),
+
+    /// The selection vector will be created by evaluating both sides and doing a comparison
+    Binary(ExprBinaryFilterPlan),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprBinaryFilterPlan {
+    left: ScopedLogicalExpr,
+    operator: Operator,
+    right: ScopedLogicalExpr,
+}
+
 fn to_physical_exprs(
     expr: &Expr,
     record_batch: &RecordBatch,
@@ -1066,7 +1037,7 @@ pub struct FilterExec {
     /// General-purpose expression-based predicate. Evaluated using the expression evaluation
     /// system (supporting joins across data scopes). The result is converted to a
     /// `BooleanArray` aligned to the root record batch.
-    expr_predicate: Option<ScopedPhysicalExpr>,
+    expr_predicate: Option<ExprFilterExec>,
 
     /// determines how we treat rows that where there are no attributes. if false, this cause the
     /// row not to pass the filter, unless this is true which it should be set it as for filters/
@@ -1206,6 +1177,7 @@ impl FilterExec {
         Ok(result)
     }
 
+    // TODO double check the comments still make sense after I refactor it ...
     /// Evaluates a [`ScopedPhysicalExpr`] and converts the result to a `BooleanArray` selection
     /// vector aligned to the root record batch.
     ///
@@ -1215,18 +1187,86 @@ impl FilterExec {
     /// - Scalar scope: broadcast the scalar boolean to all rows
     /// - Attributes scope: use parent_id -> root join to align
     fn evaluate_expr_predicate(
-        expr_pred: &mut ScopedPhysicalExpr,
+        expr_pred: &mut ExprFilterExec,
         otap_batch: &OtapArrowRecords,
         session_ctx: &SessionContext,
         root_rb: &RecordBatch,
     ) -> Result<BooleanArray> {
         let num_rows = root_rb.num_rows();
 
-        let eval_result = match expr_pred.execute(otap_batch, session_ctx)? {
-            Some(result) => result,
-            None => {
-                // expression result was null/absent -- treat as all rows failing the filter
-                return Ok(BooleanArray::new(BooleanBuffer::new_unset(num_rows), None));
+        let eval_result = match expr_pred {
+            ExprFilterExec::Unary(expr_pred) => {
+                match expr_pred.execute(otap_batch, session_ctx)? {
+                    Some(result) => result,
+                    None => {
+                        // expression result was null/absent -- treat as all rows failing the filter
+                        return Ok(BooleanArray::new(BooleanBuffer::new_unset(num_rows), None));
+                    }
+                }
+            }
+            ExprFilterExec::Binary(expr_pred) => {
+                let mut left_result = expr_pred
+                    .left
+                    .execute(otap_batch, session_ctx)?
+                    .unwrap_or(PhysicalExprEvalResult::new_scalar(ScalarValue::Null));
+                let mut right_result = expr_pred
+                    .right
+                    .execute(otap_batch, session_ctx)?
+                    .unwrap_or(PhysicalExprEvalResult::new_scalar(ScalarValue::Null));
+
+                // coerce the any-value structs that may have been returned from either side of
+                // the operation into a single column of values if the type distribution is uniform
+                // across all rows ...
+                if let ColumnarValue::Array(arr) = &left_result.values {
+                    if is_any_value_data_type(arr.data_type()) {
+                        let coerced_value_col =
+                            attempt_coerce_value_column_from_any_value_struct_column(arr)?;
+                        left_result.values = ColumnarValue::Array(coerced_value_col);
+                    }
+                }
+                if let ColumnarValue::Array(arr) = &right_result.values {
+                    if is_any_value_data_type(arr.data_type()) {
+                        let coerced_value_col =
+                            attempt_coerce_value_column_from_any_value_struct_column(arr)?;
+                        right_result.values = ColumnarValue::Array(coerced_value_col);
+                    }
+                }
+
+                if !left_result.data_scope.can_combine(&right_result.data_scope) {
+                    let (join_rb, joined_scope) = join(&left_result, &right_result, otap_batch)?;
+                    // safety: we can expect here because `join` will always create columns with
+                    // names "left" and "right"
+                    let left = join_rb
+                        .column_by_name(LEFT_COLUMN_NAME)
+                        .expect("left column present");
+                    let right = join_rb
+                        .column_by_name(RIGHT_COLUMN_NAME)
+                        .expect("right column present");
+                    let left = ColumnarValue::Array(Arc::clone(left));
+                    let right = ColumnarValue::Array(Arc::clone(right));
+                    let selection_vec = compare(&left, expr_pred.operator, &right)?;
+                    PhysicalExprEvalResult::new(
+                        ColumnarValue::Array(Arc::new(selection_vec)),
+                        joined_scope,
+                        &join_rb,
+                    )
+                } else {
+                    let selection_vec = compare(
+                        &left_result.values,
+                        expr_pred.operator,
+                        &right_result.values,
+                    )?;
+                    let result = ColumnarValue::Array(Arc::new(selection_vec));
+
+                    // reuse the existing result after comparison
+                    if left_result.data_scope.is_scalar() {
+                        right_result.values = result;
+                        right_result
+                    } else {
+                        left_result.values = result;
+                        left_result
+                    }
+                }
             }
         };
 
@@ -1309,7 +1349,7 @@ impl FilterExec {
     /// predicate.
     fn align_attrs_result_to_root(
         boolean_arr: &BooleanArray,
-        eval_result: &crate::pipeline::expr::PhysicalExprEvalResult,
+        eval_result: &PhysicalExprEvalResult,
         attrs_id: AttributesIdentifier,
         otap_batch: &OtapArrowRecords,
         root_rb: &RecordBatch,
@@ -1691,6 +1731,41 @@ impl Composite<AttributeFilterExec> {
             Self::And(left, _) => left.payload_type(),
             Self::Or(left, _) => left.payload_type(),
         }
+    }
+}
+
+#[allow(clippy::large_enum_variant)]
+pub enum ExprFilterExec {
+    Unary(ScopedPhysicalExpr),
+    Binary(ExprBinaryFilterExec),
+}
+
+pub struct ExprBinaryFilterExec {
+    left: ScopedPhysicalExpr,
+    operator: Operator,
+    right: ScopedPhysicalExpr,
+}
+
+impl ExprFilterExec {
+    fn try_from_plan(logical_expr: ExprFilterPlan) -> Result<Self> {
+        let planner = ExprPhysicalPlanner::default();
+
+        Ok(match logical_expr.clone() {
+            ExprFilterPlan::Unary(plan) => Self::Unary(planner.plan(plan)?),
+            ExprFilterPlan::Binary(mut binary_plan) => {
+                // Apply type coercion so both sides of the comparison have compatible types. We
+                // We reuse the arithmetic coercion rules (which handle Int32 vs Int64, AnyValue vs
+                // concrete types, etc.). The side-effect of adding cast expressions is what we
+                // need. We ignore the returned result type since comparisons always produce bool.
+                _ = coerce_arithmetic(&mut binary_plan.left, &mut binary_plan.right);
+
+                Self::Binary(ExprBinaryFilterExec {
+                    left: planner.plan(binary_plan.left)?,
+                    operator: binary_plan.operator,
+                    right: planner.plan(binary_plan.right)?,
+                })
+            }
+        })
     }
 }
 

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter/compare.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter/compare.rs
@@ -1,0 +1,1547 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use arrow::array::{Array, ArrayRef, AsArray, Datum, UInt8Array, make_array};
+use arrow::buffer::NullBuffer;
+use arrow::compute::kernels::cmp::{distinct, eq, gt, gt_eq, lt, lt_eq, neq, not_distinct};
+use arrow::compute::{and, not, or};
+use arrow::datatypes::DataType;
+use arrow::error::ArrowError;
+use arrow::{array::BooleanArray, buffer::BooleanBuffer};
+use datafusion::logical_expr::{ColumnarValue, Operator};
+use datafusion::scalar::ScalarValue;
+use otap_df_pdata::otlp::attributes::AttributeValueType;
+use otap_df_pdata::schema::consts;
+
+use crate::error::{Error, Result};
+use crate::pipeline::project::anyval::{
+    arrow_type_to_any_value_type, extract_type_from_any_value_struct, is_any_value_data_type,
+};
+
+/// This kernel implements comparing two [`ColumnarValue`]s using the given operation, with some
+/// additional edge case handling beyond what is found in [`arrow::compute::kernels:cmp`]. The
+/// motivation is that this can be used in cases where we're comparing OTAP columns which:
+///
+/// - may resolve to different types that are not known at compile time (for example, comparing two
+///   attributes in expressions like `attributes["x"] == attributes["y"]`). In this case, if the
+///   types do not match, the expression will always resolve to false unless the operator is
+///   [`NotEq`](Operator::NotEq). The exception to this is if one or both sides are a struct
+///   representing an `AnyValue`, in which case it will compare the appropriate values columns.
+///
+/// - may resolve to `null` on one or both sides. Arrow's `cmp` kernels typically return `null` for
+///   these cases. By contrast, this function will always return `false` for comparisons where at
+///   least one side is null, except for the special case of `null == null` in which case it
+///   returns `true`.
+///
+/// Not all [`Operator`] variants are supported. Currently this only supports: [`Eq`](Operator::Eq),
+/// [`Gt`](Operator::Gt), [`GtEq`](Operator::GtEq), [`Lt`](Operator::Lt), [`LtEq`](Operator::LtEq),
+/// and [`NotEq`](Operator::NotEq). Passing any other operator variant will cause this to return
+/// an error.
+///
+/// This function also does not, currently, perform any type coercion internally. It is the
+/// responsibility of the caller to have already coerced the types if necessary.
+///
+pub(crate) fn compare(
+    left: &ColumnarValue,
+    operator: Operator,
+    right: &ColumnarValue,
+) -> Result<BooleanArray> {
+    let left_data_type = left.data_type();
+    let right_data_type = right.data_type();
+
+    let num_rows = match (left, right) {
+        (ColumnarValue::Array(arr), _) | (_, ColumnarValue::Array(arr)) => arr.len(),
+        _ => 1,
+    };
+
+    match (
+        is_any_value_data_type(&left_data_type),
+        is_any_value_data_type(&right_data_type),
+    ) {
+        (false, false) => {
+            match (&left_data_type, &right_data_type) {
+                (DataType::Null, DataType::Null) => compare_with_null(
+                    &ColumnarValue::Scalar(ScalarValue::Null),
+                    operator,
+                    num_rows,
+                ),
+                (_, DataType::Null) => compare_with_null(left, operator, num_rows),
+                (DataType::Null, _) => compare_with_null(right, operator, num_rows),
+                _ => {
+                    if !are_concrete_types_comparable(&left_data_type, &right_data_type) {
+                        // the types are not the same - the comparison is false for all rows
+                        return Ok(all_false(num_rows));
+                    }
+
+                    let mut result_bool_arr = match operator {
+                        // for `Eq` and `NotEq` we are using `not_distinct` and `distinct`
+                        // respectively here because these are effectively the same behaviour
+                        // as `eq` and `neq` kernels, except internally they handle nulls with the
+                        // behaviour we want which is `null == null` produces true and
+                        // `null != null` produces false.
+                        Operator::Eq => apply_cmp(left, right, not_distinct),
+                        Operator::NotEq => apply_cmp(left, right, distinct),
+
+                        Operator::Gt => apply_cmp(left, right, gt),
+                        Operator::GtEq => apply_cmp(left, right, gt_eq),
+                        Operator::Lt => apply_cmp(left, right, lt),
+                        Operator::LtEq => apply_cmp(left, right, lt_eq),
+                        _ => {
+                            return Err(Error::InvalidPipelineError {
+                                cause: format!("Unsupported operation for compare: {operator}"),
+                                query_location: None,
+                            });
+                        }
+                    }?;
+
+                    // for any comparison operations other than `eq` and `neq`, if there is a null
+                    // on one side, we evaluate the comparison as false. The compute kernels we've
+                    // used to produce the result in these cases will have inserted nulls into
+                    // positions where one side is null, so here we combine the null buffer with
+                    // the values buffer to get the desired comparison behaviour.
+                    if !matches!(operator, Operator::Eq | Operator::NotEq) {
+                        result_bool_arr = nulls_as_false(result_bool_arr);
+                    }
+
+                    Ok(result_bool_arr)
+                }
+            }
+        }
+        (true, false) => {
+            let left_arr = left.to_array(num_rows)?;
+
+            if right_data_type == DataType::Null {
+                return compare_anyvalue_with_null(&left_arr, operator, num_rows);
+            }
+
+            let Ok((type_to_compare, value_field_name)) =
+                arrow_type_to_any_value_type(&right_data_type)
+            else {
+                // type can't be in an anyvalue, so can't be compared. Always false, except for
+                // NotEq case where a type mismatch is evaluated as true
+                return Ok(match operator {
+                    Operator::NotEq => all_true(num_rows),
+                    _ => all_false(num_rows),
+                });
+            };
+
+            // create the mask of which rows in the AnyValue column have a type matching the type
+            // of which we're comparing
+            let type_col = extract_type_from_any_value_struct(&left_arr)?;
+            let type_cmp_result = eq(&type_col, &UInt8Array::new_scalar(type_to_compare as u8))?;
+
+            let left_val_to_compare =
+                extract_values_column_for_comparison(value_field_name, &left_arr)?;
+            let values_cmp_result = compare(&left_val_to_compare, operator, right)?;
+
+            let result = match operator {
+                // when not equal - consider not equal if the types don't match
+                Operator::NotEq => or(&not(&type_cmp_result)?, &values_cmp_result)?,
+                // for all other comparisons, types must match or it evaluates to false
+                _ => and(&type_cmp_result, &values_cmp_result)?,
+            };
+
+            Ok(result)
+        }
+        (false, true) => {
+            let right_arr = right.to_array(num_rows)?;
+
+            if left_data_type == DataType::Null {
+                return compare_anyvalue_with_null(&right_arr, operator, num_rows);
+            }
+
+            let Ok((type_to_compare, value_field_name)) =
+                arrow_type_to_any_value_type(&left_data_type)
+            else {
+                // type can't be in an anyvalue, so can't be compared. Always false, except for
+                // NotEq case where a type mismatch is evaluated as true
+                return Ok(match operator {
+                    Operator::NotEq => all_true(num_rows),
+                    _ => all_false(num_rows),
+                });
+            };
+
+            // create the mask of which rows in the AnyValue column have a type matching the type
+            // of which we're comparing
+            let type_col = extract_type_from_any_value_struct(&right_arr)?;
+            let type_cmp_result = eq(&type_col, &UInt8Array::new_scalar(type_to_compare as u8))?;
+
+            let right_val_to_compare =
+                extract_values_column_for_comparison(value_field_name, &right_arr)?;
+            let values_cmp_result = compare(left, operator, &right_val_to_compare)?;
+
+            let result = match operator {
+                // when not equal - consider not equal if the types don't match
+                Operator::NotEq => or(&not(&type_cmp_result)?, &values_cmp_result)?,
+                // for all other comparisons, types must match or it evaluates to false
+                _ => and(&type_cmp_result, &values_cmp_result)?,
+            };
+
+            // get the values column
+            Ok(result)
+        }
+        (true, true) => {
+            // Iterate through each values column and check which rows pass the comparison. We'll
+            // combine the results for each type later on.
+            //
+            // Perf note: Admittedly, this isn't the most well optimized way to do this, as it does
+            // the comparison for the entire length of the  array for all types, including for rows
+            // that aren't of the given type. This would be inefficient if some types are present
+            // sparsely. However, I expect this code path to be quite rare, as most useful
+            // comparisons involving `AnyValue` would be an attribute on one or both sides and  for
+            // a given attribute key there's a convention that all values will have the same type
+            // and in these cases, the engine will have already have coerced the AnyValue struct
+            // into a scalar we'll have taken a different branch in this function.
+            let left_arr = left.to_array(num_rows)?;
+            let left_fields = left_arr.as_struct().fields();
+            let mut value_type_comparisons = Vec::with_capacity(left_fields.len() + 1);
+            for (field_id, field) in left_fields.iter().enumerate() {
+                if field.name() == consts::ATTRIBUTE_TYPE {
+                    continue;
+                }
+                if field.name() == consts::ATTRIBUTE_SER {
+                    return Err(Error::NotYetSupportedError {
+                        message: "comparisons on complex attribute type not yet supported".into(),
+                    });
+                }
+
+                let values_col = left_arr.as_struct().column(field_id);
+
+                let type_compare_result = compare(
+                    &ColumnarValue::Array(Arc::clone(values_col)),
+                    operator,
+                    right,
+                )?;
+                value_type_comparisons.push(type_compare_result);
+            }
+
+            // compare all the nulls on the left side with right side
+            if let Some(nulls_and_empties) = anyval_validity(&left_arr)? {
+                let right_compare_with_null =
+                    compare(&ColumnarValue::Scalar(ScalarValue::Null), operator, right)?;
+
+                let compare_nulls = match operator {
+                    Operator::NotEq => or(&nulls_and_empties, &right_compare_with_null),
+                    _ => and(&not(&nulls_and_empties)?, &right_compare_with_null),
+                }?;
+
+                value_type_comparisons.push(compare_nulls);
+            }
+
+            // combine the results
+            let mut result = value_type_comparisons.pop().expect("not empty");
+            for next_result in value_type_comparisons {
+                let combine_op = match operator {
+                    Operator::NotEq => and,
+                    _ => or,
+                };
+                result = combine_op(&result, &next_result)?;
+            }
+
+            Ok(result)
+        }
+    }
+}
+
+/// Create a boolean array of given size that is full of true values
+fn all_true(num_rows: usize) -> BooleanArray {
+    BooleanArray::new(BooleanBuffer::new_set(num_rows), None)
+}
+
+/// Create a boolean array of the given size that is full of false values
+fn all_false(num_rows: usize) -> BooleanArray {
+    BooleanArray::new(BooleanBuffer::new_unset(num_rows), None)
+}
+
+/// Return the effective validity buffer of an `AnyValue` struct array. Validity in this case
+/// means the AnyValue is not null.
+///
+/// Note, there are three ways to represent a null AnyValue:
+/// - the struct is null at some position
+/// - the struct has [`AttributeValueType::Empty`] in the `type` column
+/// - the struct has a null in the values column selected by the type discriminant
+///
+/// The effective validity buffer will be `false` in positions where one of these criterion are met
+fn anyval_validity(anyval_arr: &ArrayRef) -> Result<Option<BooleanArray>> {
+    let struct_and_empty_validity = anyval_struct_or_empty_validity(anyval_arr)?;
+    let value_col_validity = anyval_value_validity(anyval_arr)?;
+
+    let validity = match (struct_and_empty_validity, value_col_validity) {
+        (Some(l), Some(r)) => {
+            let combined_validity = and_boolean_buffers(l.values(), r.values());
+            Some(BooleanArray::new(combined_validity, None))
+        }
+        (Some(v), _) | (_, Some(v)) => Some(v),
+        _ => None,
+    };
+
+    Ok(validity)
+}
+
+/// Returns the combined validity buffer for the selected values columns from an `AnyValue` struct
+/// array. This means it returns a boolean array that is `false` if the type column selects some
+/// values column and the selected values column is null in this position.
+///
+/// For example if we had a struct array like:
+/// ```text
+/// type | str  | int
+/// -----|------|-----
+/// Str  | "a"  | null
+/// Str  | null | null
+/// Int  | null |  0
+/// Int  | null | null
+/// ```
+/// The result would be `[true, false, true, false]`
+///
+fn anyval_value_validity(anyval_arr: &ArrayRef) -> Result<Option<BooleanArray>> {
+    let type_col = extract_type_from_any_value_struct(anyval_arr)?;
+    let anyval_struct_arr = anyval_arr.as_struct();
+
+    let mut result = all_false(anyval_arr.len());
+
+    for (field_name, attr_type) in [
+        (consts::ATTRIBUTE_STR, AttributeValueType::Str),
+        (consts::ATTRIBUTE_BOOL, AttributeValueType::Bool),
+        (consts::ATTRIBUTE_INT, AttributeValueType::Int),
+        (consts::ATTRIBUTE_DOUBLE, AttributeValueType::Double),
+        (consts::ATTRIBUTE_BYTES, AttributeValueType::Bytes),
+    ] {
+        if let Some(value_col) = anyval_struct_arr.column_by_name(field_name) {
+            let mut valid_for_type = eq(&type_col, &UInt8Array::new_scalar(attr_type as u8))?;
+            if let Some(nulls) = value_col.nulls() {
+                valid_for_type = BooleanArray::new(
+                    and_boolean_buffers(nulls.inner(), valid_for_type.values()),
+                    None,
+                );
+            }
+            result = or(&result, &valid_for_type)?;
+        }
+    }
+
+    // handle the special serialized column
+    if let Some(value_col) = anyval_struct_arr.column_by_name(consts::ATTRIBUTE_SER) {
+        let valid_for_map = eq(
+            &type_col,
+            &UInt8Array::new_scalar(AttributeValueType::Map as u8),
+        )?;
+        let valid_for_slice = eq(
+            &type_col,
+            &UInt8Array::new_scalar(AttributeValueType::Slice as u8),
+        )?;
+        let mut valid_for_type = or(&valid_for_map, &valid_for_slice)?;
+
+        if let Some(nulls) = value_col.nulls() {
+            valid_for_type = BooleanArray::new(
+                and_boolean_buffers(nulls.inner(), valid_for_type.values()),
+                None,
+            );
+        }
+        result = or(&result, &valid_for_type)?;
+    }
+
+    Ok(result.has_false().then_some(result))
+}
+
+/// Returns the effective validity bitmap for a struct array containing an `AnyValue` considering
+/// the null buffer of the struct array and any values identified as type `Empty` by the type
+/// column.
+///
+/// For example if we had:
+/// ```text
+/// nulls | type  | ...
+/// ----- | ----- | ...
+/// true  | Str   | ...
+/// true  | Empty | ...
+/// false | Str   | ...
+/// ```
+///
+/// This would return `[true, false, false]`
+///
+/// This can be combined with the result of [`any_value_validity`] to get the overall effective
+/// validity for the column.
+fn anyval_struct_or_empty_validity(anyval_struct_arr: &ArrayRef) -> Result<Option<BooleanArray>> {
+    let type_col = extract_type_from_any_value_struct(anyval_struct_arr)?;
+    let type_validity = neq(
+        &type_col,
+        &UInt8Array::new_scalar(AttributeValueType::Empty as u8),
+    )?;
+
+    let validity = if type_validity.has_false() || anyval_struct_arr.nulls().is_some() {
+        let validity = match anyval_struct_arr.nulls().map(|b| b.inner()) {
+            Some(struct_validity) => {
+                let type_validity = type_validity.values();
+                let combined_validity = and_boolean_buffers(type_validity, struct_validity);
+                BooleanArray::new(combined_validity, None)
+            }
+            None => type_validity,
+        };
+
+        Some(validity)
+    } else {
+        None
+    };
+
+    Ok(validity)
+}
+
+fn and_boolean_buffers(left: &BooleanBuffer, right: &BooleanBuffer) -> BooleanBuffer {
+    BooleanBuffer::from_bitwise_binary_op(
+        left.inner(),
+        left.offset(),
+        right.inner(),
+        right.offset(),
+        left.len(),
+        |a, b| a & b,
+    )
+}
+
+/// Helper determine if the two datatypes can be compared - returns `true` if the types represent
+/// the same logical data type.
+fn are_concrete_types_comparable(left: &DataType, right: &DataType) -> bool {
+    match (left, right) {
+        (DataType::Dictionary(_, v), _) => are_concrete_types_comparable(v.as_ref(), right),
+        (_, DataType::Dictionary(_, v)) => are_concrete_types_comparable(left, v.as_ref()),
+        (_, _) => left == right,
+    }
+}
+
+fn apply_cmp<F>(left: &ColumnarValue, right: &ColumnarValue, cmp: F) -> Result<BooleanArray>
+where
+    F: Fn(&dyn Datum, &dyn Datum) -> std::result::Result<BooleanArray, ArrowError>,
+{
+    let cmp_result = match (left, right) {
+        (ColumnarValue::Array(left_arr), ColumnarValue::Array(right_arr)) => {
+            cmp(left_arr, right_arr)
+        }
+        (ColumnarValue::Scalar(left_scalar), ColumnarValue::Array(right_arr)) => {
+            cmp(&left_scalar.to_scalar()?, right_arr)
+        }
+        (ColumnarValue::Array(left_arr), ColumnarValue::Scalar(right_scalar)) => {
+            cmp(left_arr, &right_scalar.to_scalar()?)
+        }
+        (ColumnarValue::Scalar(left_scalar), ColumnarValue::Scalar(right_scalar)) => {
+            cmp(&left_scalar.to_scalar()?, &right_scalar.to_scalar()?)
+        }
+    };
+
+    Ok(cmp_result?)
+}
+
+/// Takes any null in from the boolean array's null buffer and combines them with the values
+/// to produce a new array where nulls in the input array become false values.
+///
+/// For example if we had:
+/// ```text
+/// nulls | values
+/// ------|-------
+/// true  | false
+/// false | true
+/// false | false
+/// true  | true
+/// ```
+///
+/// the result would be `[false, false, false, true]`
+///  
+fn nulls_as_false(arr: BooleanArray) -> BooleanArray {
+    match arr.nulls() {
+        Some(nulls) => {
+            let selection_vec_bool_buff = arr.values();
+            let validity_bool_buff = nulls.inner();
+            let nulls_as_false_bool_buff =
+                and_boolean_buffers(selection_vec_bool_buff, validity_bool_buff);
+            BooleanArray::new(nulls_as_false_bool_buff, None)
+        }
+        None => {
+            // no nulls - just return the original
+            arr
+        }
+    }
+}
+
+/// Perform the comparison with value column where the value on the other side is null.
+///
+/// When the operator is `==`, this will return `true`` for all indices where the input column is
+/// also null. Conversely, when the operator is `!=`, this returns `true` for all indices where the
+/// input value is not null. For all other operators, it produces an all `false` result.
+fn compare_with_null(
+    value: &ColumnarValue,
+    operator: Operator,
+    num_rows: usize,
+) -> Result<BooleanArray> {
+    match value {
+        ColumnarValue::Scalar(scalar) => {
+            let set = match operator {
+                Operator::Eq => scalar.is_null(),
+                Operator::NotEq => !scalar.is_null(),
+                // Other operations (>, >=, <, <=, etc.) evaluate to false when either side null:
+                _ => false,
+            };
+
+            Ok(if set {
+                all_true(num_rows)
+            } else {
+                all_false(num_rows)
+            })
+        }
+        ColumnarValue::Array(arr) => {
+            match operator {
+                Operator::Eq => {
+                    let validity_bitmap_buffer = arr.nulls().map(|b| b.inner()).cloned();
+                    let inverted_validity = match validity_bitmap_buffer {
+                        // invert to get which rows are null:
+                        Some(validity_bitmap_buffer) => BooleanBuffer::from_bitwise_unary_op(
+                            validity_bitmap_buffer.inner(),
+                            validity_bitmap_buffer.offset(),
+                            validity_bitmap_buffer.len(),
+                            |v| !v,
+                        ),
+                        None => {
+                            // all false, because there are no nulls ...
+                            BooleanBuffer::new_unset(arr.len())
+                        }
+                    };
+
+                    Ok(BooleanArray::new(inverted_validity, None))
+                }
+                Operator::NotEq => {
+                    let validity_bitmap =
+                        arr.nulls().map(|b| b.inner()).cloned().unwrap_or_else(|| {
+                            // all true because there are no null rows
+                            BooleanBuffer::new_set(arr.len())
+                        });
+                    Ok(BooleanArray::new(validity_bitmap, None))
+                }
+                // Other operations (>, >=, <, <=, etc.) evaluate to false when either side null:
+                _ => Ok(all_false(arr.len())),
+            }
+        }
+    }
+}
+
+fn compare_anyvalue_with_null(
+    anyval_arr: &ArrayRef,
+    operator: Operator,
+    num_rows: usize,
+) -> Result<BooleanArray> {
+    let validity = anyval_validity(anyval_arr)?;
+
+    Ok(match operator {
+        Operator::Eq => {
+            // null == null -> true, false otherwise, so we invert the validity bitmap
+            if let Some(validity) = validity {
+                not(&validity)?
+            } else {
+                // nothing null - all false
+                all_false(num_rows)
+            }
+        }
+        Operator::NotEq => {
+            if let Some(validity) = validity {
+                // null != null -> true
+                validity
+            } else {
+                // nothing null, so everything is not equal to null
+                all_true(num_rows)
+            }
+        }
+        // Other operations (>, >=, <, <=, etc.) evaluate to false when either side null:
+        _ => all_false(num_rows),
+    })
+}
+
+/// take the field identified by `value_field_name` from the struct, and possibly adjust the nulls
+/// to account for any effectively null attributes that may be marked as null based on either the
+/// struct validity, or the type column with a value of `Empty`. The goal is the produce a values
+/// column that can be compared another non-struct column value with a concrete type.
+fn extract_values_column_for_comparison(
+    value_field_name: Option<&'static str>,
+    anyvalue_struct_arr: &ArrayRef,
+) -> Result<ColumnarValue> {
+    match value_field_name
+        .and_then(|field_name| anyvalue_struct_arr.as_struct().column_by_name(field_name))
+    {
+        None => Ok(ColumnarValue::Scalar(ScalarValue::Null)),
+        Some(value_column) => {
+            // combine any nulls resulting from null rows or nulls in the column's validity
+            // bitmap into the nulls for the value column before comparing
+            let extra_validity = anyval_struct_or_empty_validity(anyvalue_struct_arr)?;
+            let value_column = merge_validity(extra_validity.as_ref(), value_column)?;
+            Ok(ColumnarValue::Array(value_column))
+        }
+    }
+}
+
+/// Merges the extra validity buffer (if not `None`) into the existing columns validity buffer
+/// and returns the original values_column with new validity. This can be used to mark some
+/// additional rows in values_column as null.
+fn merge_validity(
+    extra_validity: Option<&BooleanArray>,
+    value_column: &ArrayRef,
+) -> Result<ArrayRef> {
+    let result = match (
+        extra_validity.as_ref().map(|b| b.values()),
+        value_column.nulls().map(|b| b.inner()),
+    ) {
+        (Some(extra), Some(values)) => {
+            // combine the validity buffers and replace
+            let nulls = and_boolean_buffers(extra, values);
+            let new_data = value_column
+                .to_data()
+                .into_builder()
+                .nulls(Some(NullBuffer::new(nulls)))
+                .build()?;
+            make_array(new_data)
+        }
+        (Some(extra), None) => {
+            // insert the new validity buffer
+            let new_data = value_column
+                .to_data()
+                .into_builder()
+                .nulls(Some(NullBuffer::new(extra.clone())))
+                .build()?;
+            make_array(new_data)
+        }
+        // no new nulls to insert, just return the original column:
+        _ => Arc::clone(value_column),
+    };
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use std::sync::Arc;
+
+    use arrow::{
+        array::{
+            DictionaryArray, Int64Array, NullArray, StringArray, StructArray,
+            TimestampNanosecondArray, UInt16Array,
+        },
+        buffer::{BooleanBuffer, NullBuffer},
+        compute::not,
+        datatypes::Field,
+    };
+    use datafusion::scalar::ScalarValue;
+    use otap_df_pdata::{otlp::attributes::AttributeValueType, schema::consts};
+
+    // helper function for testing when the operation is commutative
+    fn test_commutative(
+        left: ColumnarValue,
+        operator: Operator,
+        right: ColumnarValue,
+        expected: BooleanArray,
+    ) {
+        let result = compare(&left, operator, &right).unwrap();
+        assert_eq!(&result, &expected);
+
+        // check that it returns expected when the operators are on the other side
+        let result = compare(&right, operator, &left).unwrap();
+        assert_eq!(&result, &expected);
+    }
+
+    #[test]
+    fn test_null_eq_concrete_column_with_nulls() {
+        let left = StringArray::from_iter([Some("a"), None, Some("b")]);
+        let expected = BooleanArray::new(BooleanBuffer::from(vec![false, true, false]), None);
+
+        // test with null scalar
+        test_commutative(
+            ColumnarValue::Array(Arc::new(left.clone())),
+            Operator::Eq,
+            ColumnarValue::Scalar(ScalarValue::Null),
+            expected.clone(),
+        );
+
+        // test with null array
+        test_commutative(
+            ColumnarValue::Array(Arc::new(left)),
+            Operator::Eq,
+            ColumnarValue::Array(Arc::new(NullArray::new(3))),
+            expected,
+        );
+    }
+
+    #[test]
+    fn test_null_scalar_eq_concrete_column_without_nulls() {
+        let left = StringArray::from_iter_values(["a", "b", "c"]);
+        let expected = BooleanArray::new(BooleanBuffer::from(vec![false, false, false]), None);
+        // test with null scalar
+        test_commutative(
+            ColumnarValue::Array(Arc::new(left.clone())),
+            Operator::Eq,
+            ColumnarValue::Scalar(ScalarValue::Null),
+            expected.clone(),
+        );
+
+        // test with null array
+        test_commutative(
+            ColumnarValue::Array(Arc::new(left.clone())),
+            Operator::Eq,
+            ColumnarValue::Array(Arc::new(NullArray::new(3))),
+            expected,
+        );
+    }
+
+    #[test]
+    fn test_null_quantity_comparison_with_concrete_column() {
+        let left = StringArray::from_iter([Some("a"), None, Some("b")]);
+        let expected = BooleanArray::new(BooleanBuffer::from(vec![false, false, false]), None);
+
+        for operator in [Operator::Gt, Operator::GtEq, Operator::Lt, Operator::LtEq] {
+            // test with null scalar
+            let result = compare(
+                &ColumnarValue::Array(Arc::new(left.clone())),
+                operator,
+                &ColumnarValue::Scalar(ScalarValue::Null),
+            )
+            .unwrap();
+            assert_eq!(&result, &expected);
+
+            // test with null array
+            let result = compare(
+                &ColumnarValue::Array(Arc::new(left.clone())),
+                operator,
+                &ColumnarValue::Array(Arc::new(NullArray::new(3))),
+            )
+            .unwrap();
+            assert_eq!(&result, &expected);
+        }
+    }
+
+    #[test]
+    fn test_null_scalar_neq_concrete_column_with_nulls() {
+        let left = StringArray::from_iter([Some("a"), None, Some("b")]);
+        let expected = BooleanArray::new(BooleanBuffer::from(vec![true, false, true]), None);
+        // test with null scalar
+        test_commutative(
+            ColumnarValue::Array(Arc::new(left.clone())),
+            Operator::NotEq,
+            ColumnarValue::Scalar(ScalarValue::Null),
+            expected.clone(),
+        );
+
+        // test with null array
+        test_commutative(
+            ColumnarValue::Array(Arc::new(left)),
+            Operator::NotEq,
+            ColumnarValue::Array(Arc::new(NullArray::new(3))),
+            expected,
+        );
+    }
+
+    #[test]
+    fn test_null_scalar_neq_concrete_column_without_nulls() {
+        let left = StringArray::from_iter_values(["a", "b", "c"]);
+        let expected = BooleanArray::new(BooleanBuffer::from(vec![true, true, true]), None);
+        // test with null scalar
+        test_commutative(
+            ColumnarValue::Array(Arc::new(left.clone())),
+            Operator::NotEq,
+            ColumnarValue::Scalar(ScalarValue::Null),
+            expected.clone(),
+        );
+
+        // test with null array
+        test_commutative(
+            ColumnarValue::Array(Arc::new(left)),
+            Operator::NotEq,
+            ColumnarValue::Array(Arc::new(NullArray::new(3))),
+            expected,
+        );
+    }
+
+    #[test]
+    fn test_null_scalar_eq_scalar() {
+        test_commutative(
+            ColumnarValue::Scalar(ScalarValue::Null),
+            Operator::Eq,
+            ColumnarValue::Scalar(ScalarValue::Utf8(Some("hello".into()))),
+            BooleanArray::new(BooleanBuffer::new_unset(1), None),
+        );
+
+        test_commutative(
+            ColumnarValue::Scalar(ScalarValue::Null),
+            Operator::Eq,
+            ColumnarValue::Scalar(ScalarValue::Utf8(None)),
+            BooleanArray::new(BooleanBuffer::new_set(1), None),
+        );
+
+        test_commutative(
+            ColumnarValue::Scalar(ScalarValue::Null),
+            Operator::Eq,
+            ColumnarValue::Scalar(ScalarValue::Null),
+            BooleanArray::new(BooleanBuffer::new_set(1), None),
+        );
+    }
+
+    #[test]
+    fn test_null_scalar_neq_scalar() {
+        test_commutative(
+            ColumnarValue::Scalar(ScalarValue::Null),
+            Operator::NotEq,
+            ColumnarValue::Scalar(ScalarValue::Utf8(Some("hello".into()))),
+            BooleanArray::new(BooleanBuffer::new_set(1), None),
+        );
+
+        test_commutative(
+            ColumnarValue::Scalar(ScalarValue::Null),
+            Operator::NotEq,
+            ColumnarValue::Scalar(ScalarValue::Utf8(None)),
+            BooleanArray::new(BooleanBuffer::new_unset(1), None),
+        );
+
+        test_commutative(
+            ColumnarValue::Scalar(ScalarValue::Null),
+            Operator::NotEq,
+            ColumnarValue::Scalar(ScalarValue::Null),
+            BooleanArray::new(BooleanBuffer::new_unset(1), None),
+        );
+    }
+
+    #[test]
+    fn test_null_scalar_quantitative_compare_with_scalar() {
+        for operator in [Operator::Lt, Operator::Gt, Operator::GtEq, Operator::LtEq] {
+            let result = compare(
+                &ColumnarValue::Scalar(ScalarValue::Null),
+                operator,
+                &ColumnarValue::Scalar(ScalarValue::Int64(Some(5))),
+            )
+            .unwrap();
+            let expected = BooleanArray::from(vec![false]);
+            assert_eq!(&result, &expected);
+
+            let result = compare(
+                &ColumnarValue::Scalar(ScalarValue::Int64(Some(5))),
+                operator,
+                &ColumnarValue::Scalar(ScalarValue::Null),
+            )
+            .unwrap();
+            let expected = BooleanArray::from(vec![false]);
+            assert_eq!(&result, &expected);
+        }
+    }
+
+    #[test]
+    fn test_concrete_type_arr_eq_concrete_type_array_with_nulls() {
+        let left = StringArray::from_iter([Some("a"), None, Some("b"), None, Some("c")]);
+        let right = StringArray::from_iter([Some("a"), Some("b"), Some("c"), None, Some("c")]);
+        let expected = BooleanArray::new(
+            BooleanBuffer::from(vec![true, false, false, true, true]),
+            None,
+        );
+
+        test_commutative(
+            ColumnarValue::Array(Arc::new(left)),
+            Operator::Eq,
+            ColumnarValue::Array(Arc::new(right)),
+            expected,
+        );
+    }
+
+    #[test]
+    fn test_concrete_type_arr_neq_concrete_type_array_with_nulls() {
+        let left = StringArray::from_iter([Some("a"), None, Some("b"), None, Some("c")]);
+        let right = StringArray::from_iter([Some("a"), Some("b"), Some("c"), None, Some("c")]);
+        let expected = BooleanArray::new(
+            BooleanBuffer::from(vec![false, true, true, false, false]),
+            None,
+        );
+
+        test_commutative(
+            ColumnarValue::Array(Arc::new(left)),
+            Operator::NotEq,
+            ColumnarValue::Array(Arc::new(right)),
+            expected,
+        );
+    }
+
+    #[test]
+    fn test_concrete_type_arr_gt_concrete_type_array_with_nulls() {
+        let left = Int64Array::from_iter([Some(2), Some(1), Some(1), None, None]);
+        let right = Int64Array::from_iter([Some(1), Some(2), Some(1), Some(1), None]);
+        let expected = BooleanArray::new(
+            BooleanBuffer::from(vec![true, false, false, false, false]),
+            None,
+        );
+
+        let result = compare(
+            &ColumnarValue::Array(Arc::new(left)),
+            Operator::Gt,
+            &ColumnarValue::Array(Arc::new(right)),
+        )
+        .unwrap();
+        assert_eq!(&result, &expected);
+    }
+
+    #[test]
+    fn test_concrete_type_arr_gte_concrete_type_array_with_nulls() {
+        let left = Int64Array::from_iter([Some(2), Some(1), Some(1), None, None]);
+        let right = Int64Array::from_iter([Some(1), Some(2), Some(1), Some(1), None]);
+        let expected = BooleanArray::new(
+            BooleanBuffer::from(vec![true, false, true, false, false]),
+            None,
+        );
+        let result = compare(
+            &ColumnarValue::Array(Arc::new(left)),
+            Operator::GtEq,
+            &ColumnarValue::Array(Arc::new(right)),
+        )
+        .unwrap();
+        assert_eq!(&result, &expected);
+    }
+
+    #[test]
+    fn test_concrete_type_arr_lt_concrete_type_array_with_nulls() {
+        let left = Int64Array::from_iter([Some(2), Some(1), Some(1), None, None]);
+        let right = Int64Array::from_iter([Some(1), Some(2), Some(1), Some(1), None]);
+        let expected = BooleanArray::new(
+            BooleanBuffer::from(vec![false, true, false, false, false]),
+            None,
+        );
+
+        let result = compare(
+            &ColumnarValue::Array(Arc::new(left)),
+            Operator::Lt,
+            &ColumnarValue::Array(Arc::new(right)),
+        )
+        .unwrap();
+        assert_eq!(&result, &expected);
+    }
+
+    #[test]
+    fn test_concrete_type_arr_lte_concrete_type_array_with_nulls() {
+        let left = Int64Array::from_iter([Some(2), Some(1), Some(1), None, None]);
+        let right = Int64Array::from_iter([Some(1), Some(2), Some(1), Some(1), None]);
+        let expected = BooleanArray::new(
+            BooleanBuffer::from(vec![false, true, true, false, false]),
+            None,
+        );
+        let result = compare(
+            &ColumnarValue::Array(Arc::new(left)),
+            Operator::LtEq,
+            &ColumnarValue::Array(Arc::new(right)),
+        )
+        .unwrap();
+        assert_eq!(&result, &expected);
+    }
+
+    #[test]
+    fn test_non_matching_types_return_all_false_when_compared() {
+        let result = compare(
+            &ColumnarValue::Array(Arc::new(StringArray::from_iter_values(["a", "b", "c"]))),
+            Operator::Eq,
+            &ColumnarValue::Array(Arc::new(Int64Array::from_iter_values([1, 2, 3]))),
+        )
+        .unwrap();
+        let expected = BooleanArray::from(vec![false, false, false]);
+        assert_eq!(&result, &expected)
+    }
+
+    #[test]
+    fn test_unsupported_operator_returns_error() {
+        let err = compare(
+            &ColumnarValue::Array(Arc::new(StringArray::from_iter_values(["a", "b", "c"]))),
+            Operator::And,
+            &ColumnarValue::Array(Arc::new(StringArray::from_iter_values(["a", "b", "c"]))),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Unsupported operation for compare:"),
+            "unexpected error message {}",
+            err
+        )
+    }
+
+    #[test]
+    fn test_all_null_eq_anyvalue_with_nulls() {
+        let right = StructArray::new(
+            vec![
+                Field::new(consts::ATTRIBUTE_TYPE, DataType::UInt8, false),
+                Field::new(
+                    consts::ATTRIBUTE_STR,
+                    DataType::Dictionary(Box::new(DataType::UInt16), Box::new(DataType::Utf8)),
+                    true,
+                ),
+            ]
+            .into(),
+            vec![
+                Arc::new(UInt8Array::from_iter_values(vec![
+                    AttributeValueType::Str as u8,
+                    AttributeValueType::Str as u8,
+                    AttributeValueType::Str as u8,
+                    AttributeValueType::Empty as u8,
+                    AttributeValueType::Str as u8,
+                ])),
+                Arc::new(DictionaryArray::new(
+                    UInt16Array::from_iter([Some(0), Some(1), None, Some(0), Some(0)]),
+                    Arc::new(StringArray::from_iter_values(["a", "b"])),
+                )),
+            ],
+            Some(NullBuffer::new(BooleanBuffer::from(vec![
+                true, true, true, true, false,
+            ]))),
+        );
+
+        // compare with null array
+        let result = compare(
+            &ColumnarValue::Array(Arc::new(NullArray::new(5))),
+            Operator::Eq,
+            &ColumnarValue::Array(Arc::new(right.clone())),
+        )
+        .unwrap();
+        let expected = BooleanArray::from(vec![false, false, true, true, true]);
+        assert_eq!(&result, &expected);
+
+        // compare with null scalar
+        let result = compare(
+            &ColumnarValue::Scalar(ScalarValue::Null),
+            Operator::Eq,
+            &ColumnarValue::Array(Arc::new(right.clone())),
+        )
+        .unwrap();
+        assert_eq!(&result, &expected);
+
+        // check not equals as well, should be the opposite
+        let result = compare(
+            &ColumnarValue::Array(Arc::new(NullArray::new(5))),
+            Operator::NotEq,
+            &ColumnarValue::Array(Arc::new(right.clone())),
+        )
+        .unwrap();
+        let expected = not(&expected).unwrap();
+        assert_eq!(&result, &expected);
+
+        let result = compare(
+            &ColumnarValue::Scalar(ScalarValue::Null),
+            Operator::NotEq,
+            &ColumnarValue::Array(Arc::new(right)),
+        )
+        .unwrap();
+        assert_eq!(&result, &expected);
+    }
+
+    // TODO
+    // - same test as below where left is scalar
+    // - same test as below where left has nulls
+    // - ^^ maybe these are already covered?
+    #[test]
+    fn test_non_null_string_eq_anyvalue_no_nulls() {
+        let left = StringArray::from_iter_values(["a", "a", "a"]);
+        let right = StructArray::new(
+            vec![
+                Field::new(consts::ATTRIBUTE_TYPE, DataType::UInt8, false),
+                Field::new(
+                    consts::ATTRIBUTE_STR,
+                    DataType::Dictionary(Box::new(DataType::UInt16), Box::new(DataType::Utf8)),
+                    true,
+                ),
+            ]
+            .into(),
+            vec![
+                Arc::new(UInt8Array::from_iter_values(vec![
+                    AttributeValueType::Str as u8,
+                    AttributeValueType::Str as u8,
+                    AttributeValueType::Int as u8,
+                ])),
+                Arc::new(DictionaryArray::new(
+                    UInt16Array::from_iter_values([0, 1, 0]),
+                    Arc::new(StringArray::from_iter_values(["a", "b"])),
+                )),
+            ],
+            None,
+        );
+
+        let expected = BooleanArray::from(vec![true, false, false]);
+        test_commutative(
+            ColumnarValue::Array(Arc::new(left.clone())),
+            Operator::Eq,
+            ColumnarValue::Array(Arc::new(right.clone())),
+            expected.clone(),
+        );
+
+        // check not equals as well, should be the opposite
+        test_commutative(
+            ColumnarValue::Array(Arc::new(left.clone())),
+            Operator::NotEq,
+            ColumnarValue::Array(Arc::new(right.clone())),
+            not(&expected).unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_non_null_string_eq_anyvalue_with_nulls() {
+        let left = StringArray::from_iter_values(["a", "a", "a", "a", "a"]);
+        let right = StructArray::new(
+            vec![
+                Field::new(consts::ATTRIBUTE_TYPE, DataType::UInt8, false),
+                Field::new(
+                    consts::ATTRIBUTE_STR,
+                    DataType::Dictionary(Box::new(DataType::UInt16), Box::new(DataType::Utf8)),
+                    true,
+                ),
+            ]
+            .into(),
+            vec![
+                Arc::new(UInt8Array::from_iter_values(vec![
+                    AttributeValueType::Str as u8,
+                    AttributeValueType::Str as u8,
+                    AttributeValueType::Str as u8,
+                    AttributeValueType::Empty as u8,
+                    AttributeValueType::Str as u8,
+                ])),
+                Arc::new(DictionaryArray::new(
+                    UInt16Array::from_iter([Some(0), Some(1), None, Some(0), Some(0)]),
+                    Arc::new(StringArray::from_iter_values(["a", "b"])),
+                )),
+            ],
+            Some(NullBuffer::new(BooleanBuffer::from(vec![
+                true, true, true, true, false,
+            ]))),
+        );
+
+        let expected = BooleanArray::from(vec![true, false, false, false, false]);
+        test_commutative(
+            ColumnarValue::Array(Arc::new(left.clone())),
+            Operator::Eq,
+            ColumnarValue::Array(Arc::new(right.clone())),
+            expected.clone(),
+        );
+
+        // check not equals as well, should be the opposite
+        test_commutative(
+            ColumnarValue::Array(Arc::new(left.clone())),
+            Operator::NotEq,
+            ColumnarValue::Array(Arc::new(right.clone())),
+            not(&expected).unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_int_quantity_compare_with_anyvalue_no_nulls() {
+        let left = Int64Array::from_iter_values([1, 1, 1]);
+        let right = StructArray::new(
+            vec![
+                Field::new(consts::ATTRIBUTE_TYPE, DataType::UInt8, false),
+                Field::new(
+                    consts::ATTRIBUTE_INT,
+                    DataType::Dictionary(Box::new(DataType::UInt16), Box::new(DataType::Int64)),
+                    true,
+                ),
+            ]
+            .into(),
+            vec![
+                Arc::new(UInt8Array::from_iter_values(vec![
+                    AttributeValueType::Int as u8,
+                    AttributeValueType::Int as u8,
+                    AttributeValueType::Str as u8,
+                ])),
+                Arc::new(DictionaryArray::new(
+                    UInt16Array::from_iter_values([0, 1, 2]),
+                    Arc::new(Int64Array::from_iter_values([0, 1, 2])),
+                )),
+            ],
+            None,
+        );
+
+        let result = compare(
+            &ColumnarValue::Array(Arc::new(left.clone())),
+            Operator::Gt,
+            &ColumnarValue::Array(Arc::new(right.clone())),
+        )
+        .unwrap();
+        let expected = BooleanArray::from(vec![true, false, false]);
+        assert_eq!(&result, &expected);
+
+        let result = compare(
+            &ColumnarValue::Array(Arc::new(left.clone())),
+            Operator::GtEq,
+            &ColumnarValue::Array(Arc::new(right.clone())),
+        )
+        .unwrap();
+        let expected = BooleanArray::from(vec![true, true, false]);
+        assert_eq!(&result, &expected);
+
+        let result = compare(
+            &ColumnarValue::Array(Arc::new(left.clone())),
+            Operator::Lt,
+            &ColumnarValue::Array(Arc::new(right.clone())),
+        )
+        .unwrap();
+        let expected = BooleanArray::from(vec![false, false, false]);
+        assert_eq!(&result, &expected);
+
+        let result = compare(
+            &ColumnarValue::Array(Arc::new(left.clone())),
+            Operator::LtEq,
+            &ColumnarValue::Array(Arc::new(right.clone())),
+        )
+        .unwrap();
+        let expected = BooleanArray::from(vec![false, true, false]);
+        assert_eq!(&result, &expected);
+    }
+
+    #[test]
+    fn test_int_quantity_compare_with_anyvalue_with_nulls() {
+        let left = Int64Array::from_iter_values([1, 1, 1, 1, 1]);
+        let right = StructArray::new(
+            vec![
+                Field::new(consts::ATTRIBUTE_TYPE, DataType::UInt8, false),
+                Field::new(
+                    consts::ATTRIBUTE_INT,
+                    DataType::Dictionary(Box::new(DataType::UInt16), Box::new(DataType::Int64)),
+                    true,
+                ),
+            ]
+            .into(),
+            vec![
+                Arc::new(UInt8Array::from_iter_values(vec![
+                    AttributeValueType::Int as u8,
+                    AttributeValueType::Int as u8,
+                    AttributeValueType::Int as u8,
+                    AttributeValueType::Empty as u8,
+                    AttributeValueType::Int as u8,
+                ])),
+                Arc::new(DictionaryArray::new(
+                    UInt16Array::from_iter([Some(0), Some(1), None, Some(2), Some(3)]),
+                    Arc::new(Int64Array::from_iter_values([0, 1, 2, 3])),
+                )),
+            ],
+            Some(NullBuffer::new(BooleanBuffer::from(vec![
+                true, true, true, true, false,
+            ]))),
+        );
+
+        let result = compare(
+            &ColumnarValue::Array(Arc::new(left.clone())),
+            Operator::Gt,
+            &ColumnarValue::Array(Arc::new(right.clone())),
+        )
+        .unwrap();
+        let expected = BooleanArray::from(vec![true, false, false, false, false]);
+        assert_eq!(&result, &expected);
+
+        // test comparison in opposite direction
+        let result = compare(
+            &ColumnarValue::Array(Arc::new(right.clone())),
+            Operator::Gt,
+            &ColumnarValue::Array(Arc::new(left.clone())),
+        )
+        .unwrap();
+        let expected = BooleanArray::from(vec![false, false, false, false, false]);
+        assert_eq!(&result, &expected);
+
+        let result = compare(
+            &ColumnarValue::Array(Arc::new(left.clone())),
+            Operator::GtEq,
+            &ColumnarValue::Array(Arc::new(right.clone())),
+        )
+        .unwrap();
+        let expected = BooleanArray::from(vec![true, true, false, false, false]);
+        assert_eq!(&result, &expected);
+
+        let result = compare(
+            &ColumnarValue::Array(Arc::new(right.clone())),
+            Operator::GtEq,
+            &ColumnarValue::Array(Arc::new(left.clone())),
+        )
+        .unwrap();
+        let expected = BooleanArray::from(vec![false, true, false, false, false]);
+        assert_eq!(&result, &expected);
+
+        let result = compare(
+            &ColumnarValue::Array(Arc::new(left.clone())),
+            Operator::Lt,
+            &ColumnarValue::Array(Arc::new(right.clone())),
+        )
+        .unwrap();
+        let expected = BooleanArray::from(vec![false, false, false, false, false]);
+        assert_eq!(&result, &expected);
+
+        let result = compare(
+            &ColumnarValue::Array(Arc::new(left.clone())),
+            Operator::LtEq,
+            &ColumnarValue::Array(Arc::new(right.clone())),
+        )
+        .unwrap();
+        let expected = BooleanArray::from(vec![false, true, false, false, false]);
+        assert_eq!(&result, &expected);
+    }
+
+    #[test]
+    fn test_invalid_type_compare_with_anyvalue() {
+        let left = TimestampNanosecondArray::from_iter_values([1, 1]);
+        let right = StructArray::new(
+            vec![Field::new(consts::ATTRIBUTE_TYPE, DataType::UInt8, false)].into(),
+            vec![Arc::new(UInt8Array::from_iter_values(vec![
+                AttributeValueType::Int as u8,
+                AttributeValueType::Int as u8,
+            ]))],
+            None,
+        );
+
+        test_commutative(
+            ColumnarValue::Array(Arc::new(left.clone())),
+            Operator::Eq,
+            ColumnarValue::Array(Arc::new(right.clone())),
+            BooleanArray::from(vec![false, false]),
+        );
+
+        test_commutative(
+            ColumnarValue::Array(Arc::new(left.clone())),
+            Operator::NotEq,
+            ColumnarValue::Array(Arc::new(right.clone())),
+            BooleanArray::from(vec![true, true]),
+        );
+    }
+
+    #[test]
+    fn test_compare_both_sides_anyvalues_equality_no_nulls() {
+        let left = StructArray::new(
+            vec![
+                Field::new(consts::ATTRIBUTE_TYPE, DataType::UInt8, false),
+                Field::new(consts::ATTRIBUTE_STR, DataType::Utf8, true),
+                Field::new(consts::ATTRIBUTE_INT, DataType::Int64, true),
+            ]
+            .into(),
+            vec![
+                Arc::new(UInt8Array::from_iter_values(vec![
+                    AttributeValueType::Str as u8,
+                    AttributeValueType::Str as u8,
+                    AttributeValueType::Int as u8,
+                    AttributeValueType::Int as u8,
+                    AttributeValueType::Str as u8,
+                ])),
+                Arc::new(StringArray::from_iter([
+                    Some("a"),
+                    Some("a"),
+                    None,
+                    None,
+                    Some("a"),
+                ])),
+                Arc::new(Int64Array::from_iter([None, None, Some(0), Some(0), None])),
+            ],
+            None,
+        );
+        let right = StructArray::new(
+            vec![
+                Field::new(consts::ATTRIBUTE_TYPE, DataType::UInt8, false),
+                Field::new(consts::ATTRIBUTE_STR, DataType::Utf8, true),
+                Field::new(consts::ATTRIBUTE_INT, DataType::Int64, true),
+            ]
+            .into(),
+            vec![
+                Arc::new(UInt8Array::from_iter_values(vec![
+                    AttributeValueType::Str as u8,
+                    AttributeValueType::Str as u8,
+                    AttributeValueType::Int as u8,
+                    AttributeValueType::Int as u8,
+                    AttributeValueType::Str as u8,
+                ])),
+                Arc::new(StringArray::from_iter([
+                    Some("a"),
+                    Some("b"),
+                    None,
+                    None,
+                    Some("c"),
+                ])),
+                Arc::new(Int64Array::from_iter([None, None, Some(0), Some(1), None])),
+            ],
+            None,
+        );
+
+        let expected = BooleanArray::from(vec![true, false, true, false, false]);
+        test_commutative(
+            ColumnarValue::Array(Arc::new(left.clone())),
+            Operator::Eq,
+            ColumnarValue::Array(Arc::new(right.clone())),
+            expected.clone(),
+        );
+
+        // check not equals as well, should be the opposite
+        test_commutative(
+            ColumnarValue::Array(Arc::new(left.clone())),
+            Operator::NotEq,
+            ColumnarValue::Array(Arc::new(right.clone())),
+            not(&expected).unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_compare_both_sides_anyvalues_equality_some_nulls() {
+        // left         Right   Equals (expected)
+        // ----         -----   -----------------
+        // Str(a)       Str(a)  True
+        // Int(0)       Int(0)  True
+        // Str(a)       Str(a)  True
+        // Empty        Empty   True
+        // Str(a)       Empty   False
+        // Str(Null)    Empty   True
+        // Str(Null)    Null    True
+        // Empty        Null    True
+
+        let left = StructArray::new(
+            vec![
+                Field::new(consts::ATTRIBUTE_TYPE, DataType::UInt8, false),
+                Field::new(consts::ATTRIBUTE_STR, DataType::Utf8, true),
+                Field::new(consts::ATTRIBUTE_INT, DataType::Int64, true),
+            ]
+            .into(),
+            vec![
+                Arc::new(UInt8Array::from_iter_values(vec![
+                    AttributeValueType::Str as u8,
+                    AttributeValueType::Int as u8,
+                    AttributeValueType::Str as u8,
+                    AttributeValueType::Empty as u8,
+                    AttributeValueType::Str as u8,
+                    AttributeValueType::Str as u8,
+                    AttributeValueType::Str as u8,
+                    AttributeValueType::Empty as u8,
+                ])),
+                Arc::new(StringArray::from_iter([
+                    Some("a"),
+                    None,
+                    Some("a"),
+                    None,
+                    Some("a"),
+                    None,
+                    None,
+                    None,
+                ])),
+                Arc::new(Int64Array::from_iter([
+                    None,
+                    Some(0),
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                ])),
+            ],
+            Some(NullBuffer::new(BooleanBuffer::from(vec![
+                true, true, true, true, true, true, true, false,
+            ]))),
+        );
+        let right = StructArray::new(
+            vec![
+                Field::new(consts::ATTRIBUTE_TYPE, DataType::UInt8, false),
+                Field::new(consts::ATTRIBUTE_STR, DataType::Utf8, true),
+                Field::new(consts::ATTRIBUTE_INT, DataType::Int64, true),
+            ]
+            .into(),
+            vec![
+                Arc::new(UInt8Array::from_iter_values(vec![
+                    AttributeValueType::Str as u8,
+                    AttributeValueType::Int as u8,
+                    AttributeValueType::Str as u8,
+                    AttributeValueType::Empty as u8,
+                    AttributeValueType::Empty as u8,
+                    AttributeValueType::Empty as u8,
+                    AttributeValueType::Str as u8,
+                    AttributeValueType::Empty as u8,
+                ])),
+                Arc::new(StringArray::from_iter([
+                    Some("a"),
+                    None,
+                    Some("a"),
+                    None,
+                    None,
+                    None,
+                    Some("n/a"), // will be set to null in null bitmask
+                    None,
+                ])),
+                Arc::new(Int64Array::from_iter([
+                    None,
+                    Some(0),
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                ])),
+            ],
+            Some(NullBuffer::new(BooleanBuffer::from(vec![
+                true, true, true, true, true, true, false, true,
+            ]))),
+        );
+
+        let expected = BooleanArray::from(vec![true, true, true, true, false, true, true, true]);
+        test_commutative(
+            ColumnarValue::Array(Arc::new(left.clone())),
+            Operator::Eq,
+            ColumnarValue::Array(Arc::new(right.clone())),
+            expected.clone(),
+        );
+
+        // check not equals as well, should be the opposite
+        test_commutative(
+            ColumnarValue::Array(Arc::new(left.clone())),
+            Operator::NotEq,
+            ColumnarValue::Array(Arc::new(right.clone())),
+            not(&expected).unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_compare_one_side_all_empty() {
+        let left = StructArray::new(
+            vec![Field::new(consts::ATTRIBUTE_TYPE, DataType::UInt8, false)].into(),
+            vec![Arc::new(UInt8Array::from_iter_values(vec![
+                AttributeValueType::Empty as u8,
+                AttributeValueType::Empty as u8,
+                AttributeValueType::Empty as u8,
+                AttributeValueType::Empty as u8,
+                AttributeValueType::Empty as u8,
+            ]))],
+            None,
+        );
+        let right = StructArray::new(
+            vec![
+                Field::new(consts::ATTRIBUTE_TYPE, DataType::UInt8, false),
+                Field::new(consts::ATTRIBUTE_STR, DataType::Utf8, true),
+                Field::new(consts::ATTRIBUTE_INT, DataType::Int64, true),
+            ]
+            .into(),
+            vec![
+                Arc::new(UInt8Array::from_iter_values(vec![
+                    AttributeValueType::Str as u8,
+                    AttributeValueType::Str as u8,
+                    AttributeValueType::Int as u8,
+                    AttributeValueType::Int as u8,
+                    AttributeValueType::Empty as u8,
+                ])),
+                Arc::new(StringArray::from_iter([
+                    Some("a"),
+                    Some("b"),
+                    None,
+                    None,
+                    Some("c"),
+                ])),
+                Arc::new(Int64Array::from_iter([None, None, Some(0), Some(1), None])),
+            ],
+            None,
+        );
+
+        let expected = BooleanArray::from(vec![false, false, false, false, true]);
+        test_commutative(
+            ColumnarValue::Array(Arc::new(left.clone())),
+            Operator::Eq,
+            ColumnarValue::Array(Arc::new(right.clone())),
+            expected.clone(),
+        );
+
+        // check not equals as well, should be the opposite
+        test_commutative(
+            ColumnarValue::Array(Arc::new(left.clone())),
+            Operator::NotEq,
+            ColumnarValue::Array(Arc::new(right.clone())),
+            not(&expected).unwrap(),
+        );
+    }
+}

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter/compare.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter/compare.rs
@@ -20,28 +20,33 @@ use crate::pipeline::project::anyval::{
     arrow_type_to_any_value_type, extract_type_from_any_value_struct, is_any_value_data_type,
 };
 
-/// This kernel implements comparing two [`ColumnarValue`]s using the given operation, with some
-/// additional edge case handling beyond what is found in [`arrow::compute::kernels:cmp`]. The
-/// motivation is that this can be used in cases where we're comparing OTAP columns which:
+/// This kernel implements comparing two [`ColumnarValue`]s using the given [`Operation`], with
+/// some additional edge case handling beyond what is found in [`arrow::compute::kernels:cmp`].
+/// The motivation is that this can be used in cases where we're comparing OTAP columns which:
 ///
 /// - may resolve to different types that are not known at compile time (for example, comparing two
-///   attributes in expressions like `attributes["x"] == attributes["y"]`). In this case, if the
+///   attributes in expressions like `attributes["x"] == attributes["y"]`). In such cases, if the
 ///   types do not match, the expression will always resolve to false unless the operator is
 ///   [`NotEq`](Operator::NotEq). The exception to this is if one or both sides are a struct
-///   representing an `AnyValue`, in which case it will compare the appropriate values columns.
+///   representing an `AnyValue`, in which case it will compare the appropriate values columns
 ///
 /// - may resolve to `null` on one or both sides. Arrow's `cmp` kernels typically return `null` for
 ///   these cases. By contrast, this function will always return `false` for comparisons where at
-///   least one side is null, except for the special case of `null == null` in which case it
-///   returns `true`.
+///   least one side is null, except for special cases of `null == null` and `<not null> != null`
+///   in which cases it will return `true`
 ///
-/// Not all [`Operator`] variants are supported. Currently this only supports: [`Eq`](Operator::Eq),
-/// [`Gt`](Operator::Gt), [`GtEq`](Operator::GtEq), [`Lt`](Operator::Lt), [`LtEq`](Operator::LtEq),
-/// and [`NotEq`](Operator::NotEq). Passing any other operator variant will cause this to return
-/// an error.
+/// Not all [`Operator`] variants are supported. Currently this only supports:
+/// - [`Eq`](Operator::Eq)
+/// - [`Gt`](Operator::Gt)
+/// - [`GtEq`](Operator::GtEq)
+/// - [`Lt`](Operator::Lt)
+/// - [`LtEq`](Operator::LtEq)
+/// - [`NotEq`](Operator::NotEq)
+///
+/// Passing any other operator variant will cause this to return an error.
 ///
 /// This function also does not, currently, perform any type coercion internally. It is the
-/// responsibility of the caller to have already coerced the types if necessary.
+/// responsibility of the caller to have already coerced the types for comparison if necessary.
 ///
 pub(crate) fn compare(
     left: &ColumnarValue,
@@ -186,14 +191,15 @@ pub(crate) fn compare(
             // Iterate through each values column and check which rows pass the comparison. We'll
             // combine the results for each type later on.
             //
-            // Perf note: Admittedly, this isn't the most well optimized way to do this, as it does
-            // the comparison for the entire length of the  array for all types, including for rows
+            // Perf note: this isn't the most well optimized way to do this, as it does the
+            // comparison for the entire length of the  array for all types, including for rows
             // that aren't of the given type. This would be inefficient if some types are present
             // sparsely. However, I expect this code path to be quite rare, as most useful
-            // comparisons involving `AnyValue` would be an attribute on one or both sides and  for
-            // a given attribute key there's a convention that all values will have the same type
-            // and in these cases, the engine will have already have coerced the AnyValue struct
-            // into a scalar we'll have taken a different branch in this function.
+            // comparisons involving `AnyValue` would be an attribute on one or both sides and for
+            // a given attribute key there's a convention that all values will have the same type.
+            // In such cases where the type is homogenous, the engine will have already have
+            // coerced the struct into a simple column array containing only the values and we'll
+            // have already taken a different code path.
             let left_arr = left.to_array(num_rows)?;
             let left_fields = left_arr.as_struct().fields();
             let mut value_type_comparisons = Vec::with_capacity(left_fields.len() + 1);

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/project/anyval.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/project/anyval.rs
@@ -215,7 +215,7 @@ fn any_value_type_to_column_name(type_val: AttributeValueType) -> Result<&'stati
 ///
 /// This is the reverse of [`any_value_type_to_column_name`] — given an expression result's
 /// Arrow type, determine which AnyValue field it belongs in.
-fn arrow_type_to_any_value_type(
+pub(crate) fn arrow_type_to_any_value_type(
     dt: &DataType,
 ) -> Result<(AttributeValueType, Option<&'static str>)> {
     match dt {
@@ -281,6 +281,34 @@ pub(crate) fn wrap_as_any_value_struct(values: &ArrayRef) -> Result<ArrayRef> {
 
     let struct_arr = StructArray::try_new(fields.into(), columns, nulls)?;
     Ok(Arc::new(struct_arr))
+}
+
+/// Attempt to coerce the values array (a struct array representing an AnyValue) into the concrete
+/// values type. If the passed array contains multiple types, the original array is returned
+/// because coercion was not successful.
+pub(crate) fn attempt_coerce_value_column_from_any_value_struct_column(
+    values: &ArrayRef,
+) -> Result<ArrayRef> {
+    // build a temporary record batch containing the column to maybe partition by type
+    let rb = RecordBatch::try_new(
+        Arc::new(Schema::new(vec![Field::new(
+            "",
+            values.data_type().clone(),
+            true,
+        )])),
+        vec![Arc::clone(values)],
+    )?;
+
+    // attempt to partition the AnyValue column by type
+    let partitions = project_any_value_columns(&rb, &[0])?;
+    let result = if partitions.len() == 1 {
+        partitions[0].batch.column(0)
+    } else {
+        // just return the original array
+        values
+    };
+
+    Ok(Arc::clone(result))
 }
 
 /// Replace a single AnyValue struct column in a batch with its concrete typed field.


### PR DESCRIPTION
# Change Summary

<!--
Replace with a brief summary of the change in this PR
-->

Corrects the behaviour of filtering expressions where each side of a relative expression returns either nulls, types that are not equivalent and/or struct columns representing `AnyValues`.

For example, in a program like this:
```kql
logs | where attributes["x"] == attributes["y"]
```

In this case, we don't know at compile time what is the type of the left or right side of the `==` expression, so we evaluate the expressions on either side and then attempt to compare the results. Before this change, we were effectively just naively using the `eq` compute kernel (technically this would get called inside the [`BinaryExpr`](https://docs.rs/datafusion/latest/datafusion/physical_expr/expressions/struct.BinaryExpr.html)). This means that we'd produce incorrect results or errors in cases where:
- the type on the left / right were not the same (we returned an error)
- both sides were null (we return `false`, but `null == null`should return `true`)
- if one side was a struct representing an `AnyValue` (such as log body, although attributes may also be coerced into a struct like this), we would also just return an error.

This PR changes the implementation to use a special `compare` kernel which handles all these cases. Effectively the logic it applies for each row would be:
- if the types do not match, evaluate as false
- null handling:
  - if both sides are `null` and the operator is `==`, return `true`
  - if exactly one side is `null` and the operator is `!=` return `true`
  - otherwise return `false`

The `compare` handles comparing the appropriate values columns for `AnyValue`s represented as struct columns. It also makes the determination if one side is effectively a `null` for purpose of comparison -- it considers the row null when any of the following conditions are met:
- the struct column is null
- the value in the type column is `Empty`
- the value columns elected by a non-`Empty` type column value is null

## What issue does this PR close?

<!--
We highly recommend correlation of every PR to an issue
-->

* Closes #2659
* Closes #1394

## How are these changes tested?

Unit tests

## Are there any user-facing changes?

No - this is basically just a bug fix for how OTAP query engine handles some filter expressions.

 <!-- If yes, provide further info below -->
