### PR TITLE
Fix: skip boolean column when all values are false for optional arrays

### DIFF
--- a/rust/otap-dataflow/crates/pdata/src/encode/mod.rs
+++ b/rust/otap-dataflow/crates/pdata/src/encode/mod.rs
@@ -1311,7 +1311,6 @@ mod test {
                     DataType::Dictionary(Box::new(DataType::UInt8), Box::new(DataType::Int32)),
                     true,
                 ),
-                Field::new("is_monotonic", DataType::Boolean, true),
             ])),
             vec![
                 // id
@@ -1426,14 +1425,6 @@ mod test {
                     UInt8Array::from(vec![None, Some(0), None, Some(1), Some(2)]),
                     Arc::new(Int32Array::from_iter(vec![2, 1, 0])),
                 )),
-                // is_monotonic
-                Arc::new(BooleanArray::from_iter(vec![
-                    None,
-                    Some(false),
-                    None,
-                    None,
-                    None,
-                ])),
             ],
         )
         .unwrap();

--- a/rust/otap-dataflow/crates/pdata/src/encode/record/array/boolean.rs
+++ b/rust/otap-dataflow/crates/pdata/src/encode/record/array/boolean.rs
@@ -18,18 +18,28 @@ pub struct AdaptiveBooleanArrayBuilder {
     // this many nulls
     nulls_prefix: usize,
 
-    // whether any `true` value has been appended. When `optional` is true, the builder
+    // whether any `true` value has been appended. When `skip_all_false` is true, the builder
     // skips producing an array if all values are `false` or null (the boolean default).
     has_true_value: bool,
 
     // whether this builder was created with optional = true
     optional: bool,
+
+    // whether to skip producing an array when all values are false or null.
+    // Use true for structural fields (e.g. is_monotonic) where false is the default.
+    // Use false for data fields (e.g. bool attribute values) where false is meaningful.
+    skip_all_false: bool,
 }
 
 pub struct BooleanBuilderOptions {
     // Whether the array that's being constructed is "optional". If optional = false, we'll produce
     // the boolean array regardless of whether all the values are null.
     pub optional: bool,
+
+    // Whether to skip producing an array when all values are false or null.
+    // Use true for structural fields (e.g. is_monotonic) where false is the default.
+    // Use false for data fields (e.g. bool attribute values) where false is meaningful.
+    pub skip_all_false: bool,
 }
 
 impl AdaptiveBooleanArrayBuilder {
@@ -45,6 +55,7 @@ impl AdaptiveBooleanArrayBuilder {
             nulls_prefix: 0,
             has_true_value: false,
             optional: options.optional,
+            skip_all_false: options.skip_all_false,
         }
     }
 
@@ -102,7 +113,7 @@ impl AdaptiveBooleanArrayBuilder {
     }
 
     pub fn finish(&mut self) -> Option<ArrayRef> {
-        if self.optional && !self.has_true_value {
+        if self.optional && self.skip_all_false && !self.has_true_value {
             return None;
         }
         self.inner
@@ -120,8 +131,10 @@ mod test {
 
     #[test]
     fn test_adaptive_boolean_builder() {
-        let mut builder =
-            AdaptiveBooleanArrayBuilder::new(BooleanBuilderOptions { optional: true });
+        let mut builder = AdaptiveBooleanArrayBuilder::new(BooleanBuilderOptions {
+            optional: true,
+            skip_all_false: true,
+        });
         builder.append_value(true);
         builder.append_value(false);
         builder.append_null();
@@ -147,8 +160,10 @@ mod test {
 
     #[test]
     fn test_adaptive_boolean_builder_all_null() {
-        let mut builder =
-            AdaptiveBooleanArrayBuilder::new(BooleanBuilderOptions { optional: true });
+        let mut builder = AdaptiveBooleanArrayBuilder::new(BooleanBuilderOptions {
+            optional: true,
+            skip_all_false: true,
+        });
         builder.append_null();
         builder.append_nulls(2);
         // expect we've returned None because there are no values
@@ -157,8 +172,10 @@ mod test {
 
     #[test]
     fn test_adaptive_boolean_builder_null_prefix() {
-        let mut builder =
-            AdaptiveBooleanArrayBuilder::new(BooleanBuilderOptions { optional: true });
+        let mut builder = AdaptiveBooleanArrayBuilder::new(BooleanBuilderOptions {
+            optional: true,
+            skip_all_false: true,
+        });
         builder.append_null();
         builder.append_nulls(2);
         builder.append_value(true);
@@ -175,8 +192,10 @@ mod test {
 
     #[test]
     fn test_adaptive_boolean_builder_empty() {
-        let mut builder =
-            AdaptiveBooleanArrayBuilder::new(BooleanBuilderOptions { optional: true });
+        let mut builder = AdaptiveBooleanArrayBuilder::new(BooleanBuilderOptions {
+            optional: true,
+            skip_all_false: true,
+        });
         // expect we've returned None because there are no values
         assert!(builder.finish().is_none());
 
@@ -188,8 +207,10 @@ mod test {
 
     #[test]
     fn test_adaptive_boolean_builder_all_false() {
-        let mut builder =
-            AdaptiveBooleanArrayBuilder::new(BooleanBuilderOptions { optional: true });
+        let mut builder = AdaptiveBooleanArrayBuilder::new(BooleanBuilderOptions {
+            optional: true,
+            skip_all_false: true,
+        });
         builder.append_value(false);
         builder.append_value(false);
         builder.append_value(false);
@@ -199,8 +220,10 @@ mod test {
 
     #[test]
     fn test_adaptive_boolean_builder_false_and_null() {
-        let mut builder =
-            AdaptiveBooleanArrayBuilder::new(BooleanBuilderOptions { optional: true });
+        let mut builder = AdaptiveBooleanArrayBuilder::new(BooleanBuilderOptions {
+            optional: true,
+            skip_all_false: true,
+        });
         builder.append_null();
         builder.append_value(false);
         builder.append_nulls(2);
@@ -211,12 +234,16 @@ mod test {
 
     #[test]
     fn test_adaptive_boolean_builder_false_then_true() {
-        let mut builder =
-            AdaptiveBooleanArrayBuilder::new(BooleanBuilderOptions { optional: true });
+        let mut builder = AdaptiveBooleanArrayBuilder::new(BooleanBuilderOptions {
+            optional: true,
+            skip_all_false: true,
+        });
         builder.append_value(false);
         builder.append_null();
         builder.append_value(true);
-        let result = builder.finish().expect("should produce array when true is present");
+        let result = builder
+            .finish()
+            .expect("should produce array when true is present");
         let boolean_array = result
             .as_any()
             .downcast_ref::<BooleanArray>()
@@ -229,12 +256,16 @@ mod test {
 
     #[test]
     fn test_adaptive_boolean_builder_all_false_non_optional() {
-        let mut builder =
-            AdaptiveBooleanArrayBuilder::new(BooleanBuilderOptions { optional: false });
+        let mut builder = AdaptiveBooleanArrayBuilder::new(BooleanBuilderOptions {
+            optional: false,
+            skip_all_false: true,
+        });
         builder.append_value(false);
         builder.append_value(false);
         // non-optional builders always produce an array, even if all false
-        let result = builder.finish().expect("non-optional should always produce array");
+        let result = builder
+            .finish()
+            .expect("non-optional should always produce array");
         let boolean_array = result
             .as_any()
             .downcast_ref::<BooleanArray>()

--- a/rust/otap-dataflow/crates/pdata/src/encode/record/array/boolean.rs
+++ b/rust/otap-dataflow/crates/pdata/src/encode/record/array/boolean.rs
@@ -17,6 +17,13 @@ pub struct AdaptiveBooleanArrayBuilder {
     // used as a counter until the underlying builder possibly gets initialized, then we prepend
     // this many nulls
     nulls_prefix: usize,
+
+    // whether any `true` value has been appended. When `optional` is true, the builder
+    // skips producing an array if all values are `false` or null (the boolean default).
+    has_true_value: bool,
+
+    // whether this builder was created with optional = true
+    optional: bool,
 }
 
 pub struct BooleanBuilderOptions {
@@ -36,10 +43,16 @@ impl AdaptiveBooleanArrayBuilder {
         Self {
             inner,
             nulls_prefix: 0,
+            has_true_value: false,
+            optional: options.optional,
         }
     }
 
     pub fn append_value(&mut self, value: bool) {
+        if value {
+            self.has_true_value = true;
+        }
+
         if self.inner.is_none() {
             self.inner = Some(BooleanBuilder::new());
             if self.nulls_prefix > 0 {
@@ -89,6 +102,9 @@ impl AdaptiveBooleanArrayBuilder {
     }
 
     pub fn finish(&mut self) -> Option<ArrayRef> {
+        if self.optional && !self.has_true_value {
+            return None;
+        }
         self.inner
             .as_mut()
             .map(|inner| Arc::new(inner.finish()) as ArrayRef)
@@ -168,5 +184,63 @@ mod test {
         // a builder and finishing it returns a result
         builder.append_value(true);
         assert!(builder.finish().is_some());
+    }
+
+    #[test]
+    fn test_adaptive_boolean_builder_all_false() {
+        let mut builder =
+            AdaptiveBooleanArrayBuilder::new(BooleanBuilderOptions { optional: true });
+        builder.append_value(false);
+        builder.append_value(false);
+        builder.append_value(false);
+        // all values are the boolean default (false), so skip producing an array
+        assert!(builder.finish().is_none());
+    }
+
+    #[test]
+    fn test_adaptive_boolean_builder_false_and_null() {
+        let mut builder =
+            AdaptiveBooleanArrayBuilder::new(BooleanBuilderOptions { optional: true });
+        builder.append_null();
+        builder.append_value(false);
+        builder.append_nulls(2);
+        builder.append_value(false);
+        // mix of false and null — still all defaults, so skip producing an array
+        assert!(builder.finish().is_none());
+    }
+
+    #[test]
+    fn test_adaptive_boolean_builder_false_then_true() {
+        let mut builder =
+            AdaptiveBooleanArrayBuilder::new(BooleanBuilderOptions { optional: true });
+        builder.append_value(false);
+        builder.append_null();
+        builder.append_value(true);
+        let result = builder.finish().expect("should produce array when true is present");
+        let boolean_array = result
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .expect("should downcast to BooleanArray");
+        assert_eq!(boolean_array.len(), 3);
+        assert!(!boolean_array.value(0));
+        assert!(!boolean_array.is_valid(1));
+        assert!(boolean_array.value(2));
+    }
+
+    #[test]
+    fn test_adaptive_boolean_builder_all_false_non_optional() {
+        let mut builder =
+            AdaptiveBooleanArrayBuilder::new(BooleanBuilderOptions { optional: false });
+        builder.append_value(false);
+        builder.append_value(false);
+        // non-optional builders always produce an array, even if all false
+        let result = builder.finish().expect("non-optional should always produce array");
+        let boolean_array = result
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .expect("should downcast to BooleanArray");
+        assert_eq!(boolean_array.len(), 2);
+        assert!(!boolean_array.value(0));
+        assert!(!boolean_array.value(1));
     }
 }

--- a/rust/otap-dataflow/crates/pdata/src/encode/record/attributes.rs
+++ b/rust/otap-dataflow/crates/pdata/src/encode/record/attributes.rs
@@ -233,7 +233,10 @@ impl AnyValuesRecordsBuilder {
                 dictionary_options: None,
                 ..Default::default()
             }),
-            bool_value: AdaptiveBooleanArrayBuilder::new(BooleanBuilderOptions { optional: true }),
+            bool_value: AdaptiveBooleanArrayBuilder::new(BooleanBuilderOptions {
+                optional: true,
+                skip_all_false: false,
+            }),
             bytes_value: BinaryArrayBuilder::new(ArrayOptions {
                 optional: true,
                 dictionary_options: Some(DictionaryOptions::dict16()),

--- a/rust/otap-dataflow/crates/pdata/src/encode/record/metrics.rs
+++ b/rust/otap-dataflow/crates/pdata/src/encode/record/metrics.rs
@@ -95,6 +95,7 @@ impl MetricsRecordBatchBuilder {
             }),
             is_monotonic: AdaptiveBooleanArrayBuilder::new(BooleanBuilderOptions {
                 optional: true,
+                skip_all_false: true,
             }),
         }
     }


### PR DESCRIPTION
# Change Summary

Fix `AdaptiveBooleanArrayBuilder` to skip producing an array when all values are `false` or null for optional columns. Previously, the builder only skipped on all-null:`false` values triggered array creation even though `false` is the boolean default value. This makes boolean columns consistent with how integer (`0`) and string (`""`) columns handle defaults.

Changes:
- Added `has_true_value` and `optional` fields to `AdaptiveBooleanArrayBuilder`
- `finish()` now returns `None` when `optional` and  `!has_true_value`
- Updated `test_metrics_round_trip` to reflect that the `is_monotonic` column (all `false`/null) is now correctly omitted

## What issue does this PR close?
closes #1449

## How are these changes tested?

- Added 4 new unit tests in `boolean.rs`:
  - `test_adaptive_boolean_builder_all_false` — all-false optional → `None`
  - `test_adaptive_boolean_builder_false_and_null` — mixed false+null optional → `None`
  - `test_adaptive_boolean_builder_false_then_true` — false then true → `Some(array)` with correct values
  - `test_adaptive_boolean_builder_all_false_non_optional` — non-optional always produces array
- All existing tests in `otap-df-pdata` continue to pass (including the updated `test_metrics_round_trip`).

## Are there any user-facing changes?

No. This is an internal encoding optimization. Optional boolean columns that contain only default values (`false`/null) are no longer included in Arrow record batches, reducing payload size.
