### PR TITLE
Fix batch byte sizing and wakeup state

### DIFF
--- a/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
@@ -53,7 +53,7 @@ use otap_df_pdata::{
     OtapArrowRecords, OtapPayload, OtapPayloadHelpers, OtlpProtoBytes, error::Error as PDataError,
     otap::batching::make_item_batches, otlp::batching::make_bytes_batches,
 };
-use otap_df_telemetry::instrument::Counter;
+use otap_df_telemetry::instrument::{Counter, Mmsc};
 use otap_df_telemetry::metrics::MetricSet;
 use otap_df_telemetry_macros::metric_set;
 use serde::{Deserialize, Serialize};
@@ -446,6 +446,9 @@ struct SignalBuffer<T: OtapPayloadHelpers> {
     /// Arrival time of the oldest data. This is reset whenever the number in the
     /// pending Inputs becomes non-empty.
     arrival: Option<Instant>,
+
+    /// Whether the local scheduler currently has a live wakeup for this signal.
+    wakeup_armed: bool,
 }
 
 /// Local (!Send) batch processor
@@ -538,6 +541,31 @@ pub struct BatchProcessorMetrics {
     /// Number of flushes triggered by timer (all signals)
     #[metric(unit = "{flush}")]
     flushes_timer: Counter<u64>,
+
+    /// Number of input requests pending at flush time
+    #[metric(unit = "{request}")]
+    flush_pending_requests: Mmsc,
+    /// Number of primary signal items pending at flush time
+    #[metric(unit = "{item}")]
+    flush_pending_items: Mmsc,
+    /// Number of bytes pending at flush time when byte size is known
+    #[metric(unit = "By")]
+    flush_pending_bytes: Mmsc,
+    /// Time from first pending input arrival to actual flush start
+    #[metric(unit = "ns")]
+    flush_age_duration: Mmsc,
+    /// Delay between scheduled timer wakeup and actual timer flush start
+    #[metric(unit = "ns")]
+    flush_timer_lateness_duration: Mmsc,
+    /// Number of output batches emitted by each flush
+    #[metric(unit = "{batch}")]
+    flush_output_batches: Mmsc,
+    /// Number of primary signal items emitted by each flush
+    #[metric(unit = "{item}")]
+    flush_output_items: Mmsc,
+    /// Number of bytes emitted by each flush when byte size is known
+    #[metric(unit = "By")]
+    flush_output_bytes: Mmsc,
 
     /// Number of messages dropped due to conversion failures
     #[metric(unit = "{msg}")]
@@ -879,23 +907,29 @@ where
             None
         };
 
-        // Set the arrival time when the current input is empty.
+        // Record the arrival time when the current input is empty. Defer
+        // scheduling the wakeup until after measuring the accepted payload, so
+        // one-request size flushes do not pay set/cancel timer overhead.
         let timeout = self.config.max_batch_duration;
-        let mut arrival: Option<Instant> = None;
-        if timeout != Duration::ZERO && self.buffer.inputs.is_empty() {
-            let now = Instant::now();
-            arrival = Some(now);
-            self.buffer
-                .set_arrival(self.signal, now, timeout, effect)
-                .await?;
-        }
+        let arrival = if timeout != Duration::ZERO && self.buffer.inputs.is_empty() {
+            Some(Instant::now())
+        } else {
+            None
+        };
 
         self.buffer
             .inputs
             .accept(payload, BatchPortion::new(inkey, items));
 
+        let pending_size = self.buffer.inputs.size_by(self.fmtcfg.sizer)?;
+
         // Flush based on size when the batch reaches the lower limit.
-        if timeout != Duration::ZERO && self.buffer.inputs.items < self.fmtcfg.lower_limit() {
+        if timeout != Duration::ZERO && pending_size < self.fmtcfg.lower_limit() {
+            if let Some(now) = arrival {
+                self.buffer
+                    .set_arrival(self.signal, now, timeout, effect)
+                    .await?;
+            }
             Ok(())
         } else {
             self.flush_signal_impl(
@@ -920,22 +954,54 @@ where
         now: Instant,
         reason: FlushReason,
     ) -> Result<(), EngineError> {
+        // Timer wakeups are already popped from the local scheduler before
+        // delivery. Only size/shutdown flushes need to cancel an armed timer.
+        if reason == FlushReason::Timer {
+            self.buffer.wakeup_armed = false;
+        }
+
         // If the input is empty.
         if self.buffer.inputs.is_empty() {
             return Ok(());
         }
 
-        let _ = effect.cancel_wakeup(SignalBuffer::<T>::wakeup_slot(self.signal));
+        if reason != FlushReason::Timer && self.buffer.wakeup_armed {
+            let _ = effect.cancel_wakeup(SignalBuffer::<T>::wakeup_slot(self.signal));
+            self.buffer.wakeup_armed = false;
+        }
 
         // If this is a timer-based flush and we were called too soon,
         // skip. this may happen if the batch for which the timer was set
         // flushes for size before the timer.
         if reason == FlushReason::Timer
             && self.config.max_batch_duration != Duration::ZERO
-            && now.duration_since(self.buffer.arrival.expect("timed"))
-                < self.config.max_batch_duration
+            && self
+                .buffer
+                .arrival
+                .is_some_and(|arrival| now.duration_since(arrival) < self.config.max_batch_duration)
         {
             return Ok(());
+        }
+
+        let flush_started = Instant::now();
+        self.metrics
+            .flush_pending_requests
+            .record(self.buffer.inputs.requests() as f64);
+        self.metrics
+            .flush_pending_items
+            .record(self.buffer.inputs.items as f64);
+        if let Some(bytes) = self.buffer.inputs.known_bytes() {
+            self.metrics.flush_pending_bytes.record(bytes as f64);
+        }
+        if let Some(arrival) = self.buffer.arrival {
+            self.metrics
+                .flush_age_duration
+                .record(flush_started.duration_since(arrival).as_nanos() as f64);
+        }
+        if reason == FlushReason::Timer {
+            self.metrics
+                .flush_timer_lateness_duration
+                .record(flush_started.saturating_duration_since(now).as_nanos() as f64);
         }
 
         let mut inputs = self.buffer.inputs.drain();
@@ -967,6 +1033,8 @@ where
 
         // If size-triggered and we requested splitting (upper_limit is Some), re-buffer the last partial
         // output if it is smaller than the configured lower_limit. Timer/Shutdown flush everything.
+        let mut retained_partial = false;
+
         if self.config.max_batch_duration != Duration::ZERO
             && reason == FlushReason::Size
             && self.fmtcfg.max_size.is_some()
@@ -1004,7 +1072,21 @@ where
                 self.buffer
                     .set_arrival(self.signal, now, self.config.max_batch_duration, effect)
                     .await?;
+                retained_partial = true;
             }
+        }
+
+        self.metrics
+            .flush_output_batches
+            .record(output_batches.len() as f64);
+        self.metrics.flush_output_items.record(
+            output_batches
+                .iter()
+                .map(OtapPayloadHelpers::num_items)
+                .sum::<usize>() as f64,
+        );
+        if let Some(bytes) = known_total_bytes(&output_batches) {
+            self.metrics.flush_output_bytes.record(bytes as f64);
         }
 
         let mut input_context = inputs.take_context();
@@ -1065,6 +1147,11 @@ where
             }
 
             effect.send_message_with_source_node(pdata).await?;
+        }
+
+        if !retained_partial {
+            self.buffer.arrival = None;
+            self.buffer.wakeup_armed = false;
         }
 
         Ok(())
@@ -1181,11 +1268,18 @@ impl local::Processor<OtapPdata> for BatchProcessor {
                     }
                     NodeControlMsg::CollectTelemetry {
                         mut metrics_reporter,
-                    } => metrics_reporter.report(&mut self.metrics).map_err(|e| {
-                        EngineError::InternalError {
-                            message: e.to_string(),
-                        }
-                    }),
+                    } => {
+                        effect
+                            .report_local_scheduler_metrics(&mut metrics_reporter)
+                            .map_err(|e| EngineError::InternalError {
+                                message: e.to_string(),
+                            })?;
+                        metrics_reporter.report(&mut self.metrics).map_err(|e| {
+                            EngineError::InternalError {
+                                message: e.to_string(),
+                            }
+                        })
+                    }
                     NodeControlMsg::Wakeup { slot, when, .. } => {
                         let Some((format, signal)) = signal_from_wakeup_slot(slot) else {
                             return Ok(());
@@ -1311,6 +1405,20 @@ impl<T: OtapPayloadHelpers> Inputs<T> {
         self.pending.len()
     }
 
+    fn known_bytes(&self) -> Option<usize> {
+        known_total_bytes(&self.pending)
+    }
+
+    fn size_by(&self, sizer: Sizer) -> Result<usize, PDataError> {
+        match sizer {
+            Sizer::Requests => Ok(self.requests()),
+            Sizer::Items => Ok(self.items),
+            Sizer::Bytes => self.known_bytes().ok_or_else(|| PDataError::Format {
+                error: "bytes encoding not known".into(),
+            }),
+        }
+    }
+
     fn accept(&mut self, batch: T, part: BatchPortion) {
         self.items += part.items;
         self.pending.push(batch);
@@ -1326,6 +1434,12 @@ impl<T: OtapPayloadHelpers> Inputs<T> {
     }
 }
 
+fn known_total_bytes<T: OtapPayloadHelpers>(payloads: &[T]) -> Option<usize> {
+    payloads.iter().try_fold(0usize, |total, payload| {
+        payload.num_bytes().map(|bytes| total + bytes)
+    })
+}
+
 impl<T: OtapPayloadHelpers> SignalBuffer<T>
 where
     Inputs<T>: Default,
@@ -1337,6 +1451,7 @@ where
             inbound: SlotState::new(cfg.inbound_request_limit.get()),
             outbound: SlotState::new(cfg.outbound_request_limit.get()),
             arrival: None,
+            wakeup_armed: false,
         }
     }
 
@@ -1441,11 +1556,12 @@ where
         timeout: Duration,
         effect: &mut local::EffectHandler<OtapPdata>,
     ) -> Result<(), EngineError> {
-        self.arrival = Some(now);
-
         effect
             .set_wakeup(Self::wakeup_slot(signal), now + timeout)
-            .map(|_| ())
+            .map(|_| {
+                self.arrival = Some(now);
+                self.wakeup_armed = true;
+            })
             .map_err(|_| EngineError::ProcessorError {
                 processor: effect.processor_id(),
                 kind: ProcessorErrorKind::Other,
@@ -1608,6 +1724,27 @@ mod tests {
         );
         assert!(produced_batches != 0, "produced_batches != 0");
         assert!(consumed_batches != 0, "consumed_batches != 0");
+    }
+
+    fn mmsc_metric_count(
+        telemetry_registry: &TelemetryRegistryHandle,
+        set_name: &str,
+        metric_name: &str,
+    ) -> u64 {
+        let mut count = 0u64;
+        telemetry_registry.visit_current_metrics(|desc, _attrs, iter| {
+            if desc.name == set_name {
+                for (field, metric_value) in iter {
+                    if field.name == metric_name
+                        && let otap_df_telemetry::metrics::MetricValue::Mmsc(snapshot) =
+                            metric_value
+                    {
+                        count = snapshot.count;
+                    }
+                }
+            }
+        });
+        count
     }
 
     #[test]
@@ -2224,6 +2361,75 @@ mod tests {
             .validate(move |_| async move {
                 tokio::time::sleep(Duration::from_millis(50)).await;
                 verify_item_metrics(&telemetry_registry, SignalType::Logs, 9);
+            });
+    }
+
+    /// A size flush that empties the buffer must clear timer state. Otherwise
+    /// later one-request size flushes try to cancel a wakeup that is no longer
+    /// live, which inflates scheduler cancel-miss telemetry.
+    #[test]
+    fn test_size_flush_clears_timer_state_after_full_drain() {
+        fn logs_with_count(base_id: usize, count: usize) -> LogsData {
+            let base_time = 1_000_000_000 + (base_id * 1000) as u64;
+            LogsData {
+                resource_logs: vec![ResourceLogs {
+                    scope_logs: vec![ScopeLogs {
+                        log_records: (0..count)
+                            .map(|i| LogRecord {
+                                time_unix_nano: base_time + i as u64,
+                                ..Default::default()
+                            })
+                            .collect(),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }],
+            }
+        }
+
+        let (telemetry_registry, metrics_reporter, phase) = setup_test_runtime(json!({
+            "otap": {
+                "min_size": 5,
+                "max_size": 10,
+                "sizer": "items",
+            },
+            "max_batch_duration": "1s"
+        }));
+
+        phase
+            .run_test(move |mut ctx| async move {
+                for (index, count) in [3, 3, 6, 6].into_iter().enumerate() {
+                    let rec = encode_logs_otap_batch(&logs_with_count(index, count))
+                        .expect("encode logs");
+                    ctx.process(Message::PData(OtapPdata::new_default(rec.into())))
+                        .await
+                        .expect("process input");
+
+                    let outputs = ctx.drain_pdata().await;
+                    match index {
+                        0 => assert!(outputs.is_empty(), "first input should arm the timer"),
+                        _ => assert_eq!(outputs.len(), 1, "input {index} should size-flush"),
+                    }
+                }
+
+                ctx.process(Message::Control(NodeControlMsg::CollectTelemetry {
+                    metrics_reporter,
+                }))
+                .await
+                .expect("collect telemetry");
+            })
+            .validate(move |_| async move {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                verify_item_metrics(&telemetry_registry, SignalType::Logs, 18);
+                assert_eq!(
+                    mmsc_metric_count(
+                        &telemetry_registry,
+                        "otap.processor.batch",
+                        "flush.age.duration"
+                    ),
+                    1,
+                    "only the flush of the timer-armed partial batch should use timer age"
+                );
             });
     }
 
@@ -2906,6 +3112,56 @@ mod tests {
     #[test]
     fn test_logs_nack_ordering_position_3() {
         test_split_with_nack_ordering(create_marked_logs, extract_log_markers, 3);
+    }
+
+    /// OTLP min_size is byte-based. The size flush decision must compare the
+    /// configured threshold against pending bytes, not against log-record count.
+    #[test]
+    fn test_otlp_byte_min_size_triggers_size_flush() {
+        let (telemetry_registry, metrics_reporter, phase) = setup_test_runtime(json!({
+            "format": "otlp",
+            "otlp": {
+                "min_size": 4,
+                "sizer": "bytes",
+            },
+            "max_batch_duration": "1s"
+        }));
+
+        phase
+            .run_test(move |mut ctx| async move {
+                let mut datagen = DataGenerator::new(1);
+                let logs: OtlpProtoMessage = datagen.generate_logs().into();
+                let input_bytes = otlp_message_to_bytes(&logs);
+                assert!(
+                    input_bytes.num_bytes() >= 4,
+                    "generated OTLP request should exceed the byte threshold"
+                );
+
+                ctx.process(Message::PData(OtapPdata::new_default(input_bytes.into())))
+                    .await
+                    .expect("process otlp bytes");
+
+                let outputs = ctx.drain_pdata().await;
+                assert_eq!(
+                    outputs.len(),
+                    1,
+                    "byte min_size should trigger an immediate size flush"
+                );
+                assert_eq!(outputs[0].signal_format(), SignalFormat::OtlpBytes);
+
+                let output_messages: Vec<_> = outputs.iter().map(otap_pdata_to_message).collect();
+                assert_equivalent(&[logs], &output_messages);
+
+                ctx.process(Message::Control(NodeControlMsg::CollectTelemetry {
+                    metrics_reporter,
+                }))
+                .await
+                .expect("collect telemetry");
+            })
+            .validate(move |_| async move {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                verify_item_metrics(&telemetry_registry, SignalType::Logs, 3);
+            });
     }
 
     /// Test Preserve mode: this can't use the same test harness used above because it

--- a/rust/otap-dataflow/crates/engine/src/effect_handler.rs
+++ b/rust/otap-dataflow/crates/engine/src/effect_handler.rs
@@ -266,6 +266,18 @@ impl<PData> EffectHandlerCore<PData> {
         self.metrics_reporter.report(metrics)
     }
 
+    /// Reports processor-local wakeup scheduler metrics, if this processor uses
+    /// the local wakeup service.
+    pub fn report_local_scheduler_metrics(
+        &self,
+        metrics_reporter: &mut MetricsReporter,
+    ) -> Result<(), TelemetryError> {
+        if let Some(scheduler) = &self.local_scheduler {
+            scheduler.report_metrics(metrics_reporter)?;
+        }
+        Ok(())
+    }
+
     /// Re-usable function to send a runtime control message. This returns a reference
     /// to the sender to place in a cancelation, for example.
     async fn send_runtime_ctrl_msg(

--- a/rust/otap-dataflow/crates/engine/src/local/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/local/processor.rs
@@ -323,6 +323,14 @@ impl<PData> EffectHandler<PData> {
         self.core.report_metrics(metrics)
     }
 
+    /// Reports processor-local wakeup scheduler metrics, if enabled.
+    pub fn report_local_scheduler_metrics(
+        &self,
+        metrics_reporter: &mut MetricsReporter,
+    ) -> Result<(), TelemetryError> {
+        self.core.report_local_scheduler_metrics(metrics_reporter)
+    }
+
     /// Sets the runtime control message sender for this effect handler.
     ///
     /// Primarily used by tests and manual harnesses that construct an EffectHandler directly;

--- a/rust/otap-dataflow/crates/engine/src/node_local_scheduler.rs
+++ b/rust/otap-dataflow/crates/engine/src/node_local_scheduler.rs
@@ -4,7 +4,13 @@
 //! Node-local wakeup scheduling for processor inboxes.
 
 use crate::control::{WakeupRevision, WakeupSlot};
+use crate::entity_context::current_node_telemetry_handle;
 use crate::indexed_min_heap::IndexedMinHeap;
+use otap_df_telemetry::error::Error as TelemetryError;
+use otap_df_telemetry::instrument::{Counter, Gauge};
+use otap_df_telemetry::metrics::MetricSet;
+use otap_df_telemetry::reporter::MetricsReporter;
+use otap_df_telemetry_macros::metric_set;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use tokio::sync::Notify;
@@ -45,6 +51,45 @@ impl WakeupSetOutcome {
     }
 }
 
+/// Metrics for processor-local wakeup scheduler activity.
+#[metric_set(name = "node.local_wakeup.scheduler")]
+#[derive(Debug, Default, Clone)]
+pub(crate) struct NodeLocalWakeupSchedulerMetrics {
+    /// Count of newly inserted wakeups.
+    #[metric(name = "set.inserted", unit = "{wakeup}")]
+    set_inserted: Counter<u64>,
+    /// Count of wakeups that replaced an existing live slot.
+    #[metric(name = "set.replaced", unit = "{wakeup}")]
+    set_replaced: Counter<u64>,
+    /// Count of set attempts rejected because the live-slot capacity was full.
+    #[metric(name = "set.error_capacity", unit = "{attempt}")]
+    set_error_capacity: Counter<u64>,
+    /// Count of set attempts rejected after shutdown was latched.
+    #[metric(name = "set.error_shutdown", unit = "{attempt}")]
+    set_error_shutdown: Counter<u64>,
+    /// Count of cancel attempts that removed a live wakeup.
+    #[metric(name = "cancel.removed", unit = "{wakeup}")]
+    cancel_removed: Counter<u64>,
+    /// Count of cancel attempts that found no live wakeup in the slot.
+    #[metric(name = "cancel.missed", unit = "{attempt}")]
+    cancel_missed: Counter<u64>,
+    /// Count of cancel attempts ignored after shutdown was latched.
+    #[metric(name = "cancel.ignored_shutdown", unit = "{attempt}")]
+    cancel_ignored_shutdown: Counter<u64>,
+    /// Count of wakeups popped for delivery to the processor.
+    #[metric(name = "pop.due", unit = "{wakeup}")]
+    pop_due: Counter<u64>,
+    /// Count of live wakeups dropped when shutdown was latched.
+    #[metric(name = "shutdown.cleared", unit = "{wakeup}")]
+    shutdown_cleared: Counter<u64>,
+    /// Current number of live wakeups.
+    #[metric(name = "live", unit = "{wakeup}")]
+    live: Gauge<u64>,
+    /// Configured live wakeup slot capacity.
+    #[metric(name = "capacity", unit = "{wakeup}")]
+    capacity: Gauge<u64>,
+}
+
 /// Priority key for the wakeup heap.  Ordered by wall-clock time first,
 /// then by revision to break ties deterministically.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -72,15 +117,25 @@ struct NodeLocalScheduler {
     next_revision: WakeupRevision,
     heap: IndexedMinHeap<WakeupSlot, WakeupPriority>,
     shutting_down: bool,
+    metrics: Option<MetricSet<NodeLocalWakeupSchedulerMetrics>>,
 }
 
 impl NodeLocalScheduler {
+    #[cfg(test)]
     fn new(wakeup_capacity: usize) -> Self {
+        Self::new_with_metrics(wakeup_capacity, None)
+    }
+
+    fn new_with_metrics(
+        wakeup_capacity: usize,
+        metrics: Option<MetricSet<NodeLocalWakeupSchedulerMetrics>>,
+    ) -> Self {
         Self {
             wakeup_capacity,
             next_revision: 0,
             heap: IndexedMinHeap::new(),
             shutting_down: false,
+            metrics,
         }
     }
 
@@ -90,12 +145,22 @@ impl NodeLocalScheduler {
         next
     }
 
+    fn refresh_gauges(&mut self) {
+        if let Some(metrics) = &mut self.metrics {
+            metrics.live.set(self.heap.len() as u64);
+            metrics.capacity.set(self.wakeup_capacity as u64);
+        }
+    }
+
     fn set_wakeup(
         &mut self,
         slot: WakeupSlot,
         when: Instant,
     ) -> Result<WakeupSetOutcome, WakeupError> {
         if self.shutting_down {
+            if let Some(metrics) = &mut self.metrics {
+                metrics.set_error_shutdown.inc();
+            }
             return Err(WakeupError::ShuttingDown);
         }
 
@@ -103,23 +168,46 @@ impl NodeLocalScheduler {
             let revision = self.next_revision();
             let priority = WakeupPriority { when, revision };
             let _ = self.heap.insert(slot, priority);
+            if let Some(metrics) = &mut self.metrics {
+                metrics.set_replaced.inc();
+            }
+            self.refresh_gauges();
             Ok(WakeupSetOutcome::Replaced { revision })
         } else {
             if self.heap.len() >= self.wakeup_capacity {
+                if let Some(metrics) = &mut self.metrics {
+                    metrics.set_error_capacity.inc();
+                }
                 return Err(WakeupError::Capacity);
             }
             let revision = self.next_revision();
             let priority = WakeupPriority { when, revision };
             let _ = self.heap.insert(slot, priority);
+            if let Some(metrics) = &mut self.metrics {
+                metrics.set_inserted.inc();
+            }
+            self.refresh_gauges();
             Ok(WakeupSetOutcome::Inserted { revision })
         }
     }
 
     fn cancel_wakeup(&mut self, slot: WakeupSlot) -> bool {
         if self.shutting_down {
+            if let Some(metrics) = &mut self.metrics {
+                metrics.cancel_ignored_shutdown.inc();
+            }
             return false;
         }
-        self.heap.remove(&slot).is_some()
+        let removed = self.heap.remove(&slot).is_some();
+        if let Some(metrics) = &mut self.metrics {
+            if removed {
+                metrics.cancel_removed.inc();
+            } else {
+                metrics.cancel_missed.inc();
+            }
+        }
+        self.refresh_gauges();
+        removed
     }
 
     fn next_expiry(&mut self) -> Option<Instant> {
@@ -138,6 +226,10 @@ impl NodeLocalScheduler {
         }
 
         let (slot, priority) = self.heap.pop().expect("due wakeup should exist");
+        if let Some(metrics) = &mut self.metrics {
+            metrics.pop_due.inc();
+        }
+        self.refresh_gauges();
         Some((slot, priority.when, priority.revision))
     }
 
@@ -151,6 +243,10 @@ impl NodeLocalScheduler {
         self.heap.assert_consistent();
 
         let (slot, priority) = self.heap.pop()?;
+        if let Some(metrics) = &mut self.metrics {
+            metrics.pop_due.inc();
+        }
+        self.refresh_gauges();
         Some((slot, priority.when, priority.revision))
     }
 
@@ -159,11 +255,27 @@ impl NodeLocalScheduler {
             return;
         }
         self.shutting_down = true;
+        let cleared = self.heap.len();
+        if let Some(metrics) = &mut self.metrics {
+            metrics.shutdown_cleared.add(cleared as u64);
+        }
         self.heap.clear();
+        self.refresh_gauges();
     }
 
     fn is_drained(&self) -> bool {
         self.heap.is_empty()
+    }
+
+    fn report_metrics(
+        &mut self,
+        metrics_reporter: &mut MetricsReporter,
+    ) -> Result<(), TelemetryError> {
+        self.refresh_gauges();
+        if let Some(metrics) = &mut self.metrics {
+            metrics_reporter.report(metrics)?;
+        }
+        Ok(())
     }
 }
 
@@ -184,8 +296,14 @@ impl Clone for NodeLocalSchedulerHandle {
 
 impl NodeLocalSchedulerHandle {
     pub(crate) fn new(wakeup_capacity: usize) -> Self {
+        let metrics = current_node_telemetry_handle()
+            .map(|telemetry| telemetry.register_metric_set::<NodeLocalWakeupSchedulerMetrics>());
+
         Self {
-            inner: Arc::new(Mutex::new(NodeLocalScheduler::new(wakeup_capacity))),
+            inner: Arc::new(Mutex::new(NodeLocalScheduler::new_with_metrics(
+                wakeup_capacity,
+                metrics,
+            ))),
             notify: Arc::new(Notify::new()),
         }
     }
@@ -243,6 +361,13 @@ impl NodeLocalSchedulerHandle {
 
     pub(crate) fn is_drained(&self) -> bool {
         self.with_scheduler(|scheduler| scheduler.is_drained())
+    }
+
+    pub(crate) fn report_metrics(
+        &self,
+        metrics_reporter: &mut MetricsReporter,
+    ) -> Result<(), TelemetryError> {
+        self.with_scheduler(|scheduler| scheduler.report_metrics(metrics_reporter))
     }
 
     pub(crate) async fn wait_for_change(&self) {
@@ -316,6 +441,49 @@ mod tests {
         assert!(!scheduler.cancel_wakeup(WakeupSlot(5)));
         assert_eq!(scheduler.next_expiry(), None);
         assert_eq!(scheduler.pop_due(when), None);
+    }
+
+    #[test]
+    fn scheduler_metrics_count_wakeup_lifecycle() {
+        let registry = otap_df_telemetry::registry::TelemetryRegistryHandle::default();
+        let metrics: MetricSet<NodeLocalWakeupSchedulerMetrics> =
+            registry.register_metric_set(otap_df_telemetry::testing::EmptyAttributes());
+        let mut scheduler = NodeLocalScheduler::new_with_metrics(1, Some(metrics));
+        let now = Instant::now();
+        let later = now + Duration::from_secs(1);
+        let sooner = now + Duration::from_millis(10);
+
+        assert_eq!(
+            scheduler.set_wakeup(WakeupSlot(0), later),
+            Ok(WakeupSetOutcome::Inserted { revision: 0 })
+        );
+        assert_eq!(
+            scheduler.set_wakeup(WakeupSlot(0), sooner),
+            Ok(WakeupSetOutcome::Replaced { revision: 1 })
+        );
+        assert_eq!(
+            scheduler.set_wakeup(WakeupSlot(1), later),
+            Err(WakeupError::Capacity)
+        );
+        assert!(!scheduler.cancel_wakeup(WakeupSlot(9)));
+        assert!(scheduler.cancel_wakeup(WakeupSlot(0)));
+        assert!(!scheduler.cancel_wakeup(WakeupSlot(0)));
+        assert_eq!(
+            scheduler.set_wakeup(WakeupSlot(0), later),
+            Ok(WakeupSetOutcome::Inserted { revision: 2 })
+        );
+        assert_eq!(scheduler.pop_due(now), None);
+        assert_eq!(scheduler.pop_due(later), Some((WakeupSlot(0), later, 2)));
+
+        let metrics = scheduler.metrics.as_ref().expect("metrics enabled");
+        assert_eq!(metrics.set_inserted.get(), 2);
+        assert_eq!(metrics.set_replaced.get(), 1);
+        assert_eq!(metrics.set_error_capacity.get(), 1);
+        assert_eq!(metrics.cancel_removed.get(), 1);
+        assert_eq!(metrics.cancel_missed.get(), 2);
+        assert_eq!(metrics.pop_due.get(), 1);
+        assert_eq!(metrics.live.get(), 0);
+        assert_eq!(metrics.capacity.get(), 1);
     }
 
     /// Scenario: a wakeup is rescheduled after heap reordering and then

--- a/rust/otap-dataflow/crates/engine/src/shared/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/shared/processor.rs
@@ -296,6 +296,14 @@ impl<PData> EffectHandler<PData> {
         self.core.report_metrics(metrics)
     }
 
+    /// Reports processor-local wakeup scheduler metrics, if enabled.
+    pub fn report_local_scheduler_metrics(
+        &self,
+        metrics_reporter: &mut MetricsReporter,
+    ) -> Result<(), TelemetryError> {
+        self.core.report_local_scheduler_metrics(metrics_reporter)
+    }
+
     /// Sets the runtime control message sender for this effect handler.
     ///
     /// Primarily used by tests and manual harnesses that construct an EffectHandler directly;

--- a/rust/otap-dataflow/crates/otap/tests/core_node_liveness_tests.rs
+++ b/rust/otap-dataflow/crates/otap/tests/core_node_liveness_tests.rs
@@ -28,6 +28,7 @@ use otap_df_engine::testing::liveness::wait_for_condition;
 use otap_df_otap::OTAP_PIPELINE_FACTORY;
 use otap_df_state::store::ObservedStateStore;
 use otap_df_telemetry::InternalTelemetrySystem;
+use otap_df_telemetry::metrics::MetricValue;
 use serde_json::json;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -310,6 +311,10 @@ fn capture_batch_metrics(
     registry.visit_current_metrics(|desc, _attrs, iter| {
         if desc.name == "otap.processor.batch" {
             for (field, value) in iter {
+                if let MetricValue::Mmsc(_) = value {
+                    continue;
+                }
+
                 let _ = snapshot
                     .fields
                     .insert(field.name.to_owned(), value.to_u64_lossy());
@@ -462,7 +467,7 @@ fn test_retry_pipeline_eventually_recovers_after_transient_nacks() {
         config,
         &pipeline_group_id,
         &pipeline_id,
-        Duration::from_secs(2),
+        Duration::from_secs(5),
         Duration::from_secs(1),
         Some({
             let delivered_items = delivered_items.clone();


### PR DESCRIPTION
# Change Summary

Fixes batch processor behavior for OTLP byte-sized batches by comparing `min_size` against pending bytes instead of item count. Also avoids unnecessary wakeup set/cancel work for immediate size flushes, clears stale timer state after full drains, and adds wakeup scheduler metrics for attribution.

## What issue does this PR close?

* Closes #NNN

## How are these changes tested?

- cargo xtask check
- controlled benchmark

## Are there any user-facing changes?

 
