### PR TITLE
Otap exporter stream concurrency

### DIFF
--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/config.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/config.rs
@@ -36,6 +36,13 @@ pub struct Config {
     )]
     pub stream_queue_capacity: usize,
 
+    /// Number of independent gRPC streams to run for each signal type.
+    #[serde(
+        default = "default_streams_per_signal",
+        deserialize_with = "deserialize_positive_streams_per_signal"
+    )]
+    pub streams_per_signal: usize,
+
     /// Timeout for RPC requests. If not specified, no timeout is applied.
     /// Format: humantime format (e.g., "30s", "5m", "1h", "500ms")
     #[serde(default, with = "humantime_serde")]
@@ -91,6 +98,10 @@ const fn default_stream_queue_capacity() -> usize {
     64
 }
 
+const fn default_streams_per_signal() -> usize {
+    1
+}
+
 fn deserialize_positive_usize<'de, D>(deserializer: D, field_name: &str) -> Result<usize, D::Error>
 where
     D: Deserializer<'de>,
@@ -109,6 +120,13 @@ where
     D: Deserializer<'de>,
 {
     deserialize_positive_usize(deserializer, "stream_queue_capacity")
+}
+
+fn deserialize_positive_streams_per_signal<'de, D>(deserializer: D) -> Result<usize, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserialize_positive_usize(deserializer, "streams_per_signal")
 }
 
 /// helper method to deserialize the text "none" as the None option. This is needed to override

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/config.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/config.rs
@@ -5,6 +5,7 @@
 
 use otap_df_otap::compression::CompressionMethod;
 use otap_df_otap::otap_grpc::client_settings::GrpcClientSettings;
+use serde::de::Error as SerdeError;
 use serde::{Deserialize, Deserializer};
 use std::time::Duration;
 
@@ -27,6 +28,13 @@ pub struct Config {
     /// Configuration for the arrow payloads
     #[serde(default)]
     pub arrow: ArrowConfig,
+
+    /// Capacity of each per-signal queue feeding the gRPC stream task.
+    #[serde(
+        default = "default_stream_queue_capacity",
+        deserialize_with = "deserialize_positive_stream_queue_capacity"
+    )]
+    pub stream_queue_capacity: usize,
 
     /// Timeout for RPC requests. If not specified, no timeout is applied.
     /// Format: humantime format (e.g., "30s", "5m", "1h", "500ms")
@@ -77,6 +85,30 @@ const fn default_compression_method() -> Option<CompressionMethod> {
 
 const fn default_arrow_payload_compression() -> Option<ArrowPayloadCompression> {
     Some(ArrowPayloadCompression::Zstd)
+}
+
+const fn default_stream_queue_capacity() -> usize {
+    64
+}
+
+fn deserialize_positive_usize<'de, D>(deserializer: D, field_name: &str) -> Result<usize, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = usize::deserialize(deserializer)?;
+    if value == 0 {
+        return Err(D::Error::custom(format!(
+            "{field_name} must be greater than 0"
+        )));
+    }
+    Ok(value)
+}
+
+fn deserialize_positive_stream_queue_capacity<'de, D>(deserializer: D) -> Result<usize, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserialize_positive_usize(deserializer, "stream_queue_capacity")
 }
 
 /// helper method to deserialize the text "none" as the None option. This is needed to override

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/mod.rs
@@ -371,9 +371,14 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
                 .accept_compressed(encoding);
         }
 
-        // TODO comment on the purpose of these
-        // TODO import so can use as just "channel" here
-        // TODO check if we can use our local channel since we are already using `tokio::task::spawn_local`.
+        // Each signal type is exported through one or more long-lived stream
+        // workers. The exporter task only converts incoming pdata and enqueues
+        // it into a bounded per-stream queue; the worker owns the gRPC request
+        // stream and response correlation for that queue.
+        //
+        // Keeping these queues bounded preserves backpressure. Increasing
+        // `streams_per_signal` adds independently progressing gRPC streams
+        // instead of hiding pressure behind a deeper single queue.
         let stream_queue_capacity = self.config.stream_queue_capacity;
         let streams_per_signal = self.config.streams_per_signal;
         let (pdata_metrics_tx, mut pdata_metrics_rx) = tokio::sync::mpsc::channel(64);
@@ -384,7 +389,9 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
         )
         .then(|| arrow_ipc::CompressionType::ZSTD);
 
-        // TODO check if we can expose/use spawn_local method in the effect handler
+        // Tonic clients are cheap to clone because they share the underlying
+        // Channel. Each clone below is used by exactly one worker, which lets
+        // the workers drive separate streaming RPCs concurrently.
         let (logs_senders, logs_handles) = spawn_stream_workers(
             arrow_logs_client,
             SignalType::Logs,
@@ -468,6 +475,10 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
                             }
                         };
 
+                        // Route each batch to the stream with the smallest
+                        // local backlog. This is intentionally based on queue
+                        // occupancy, not response latency: queue depth is the
+                        // backpressure signal available before enqueueing.
                         let sender = match signal_type {
                             SignalType::Logs => least_loaded_stream_sender(&logs_senders),
                             SignalType::Metrics => least_loaded_stream_sender(&metrics_senders),
@@ -501,6 +512,12 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
     }
 }
 
+/// Starts the per-signal stream worker pool.
+///
+/// Each worker receives batches through its own bounded queue and turns those
+/// batches into one streaming RPC. Multiple workers therefore mean multiple
+/// independent HTTP/2 request/response streams for the same signal type. That
+/// is the behavior controlled by `streams_per_signal`.
 fn spawn_stream_workers<T>(
     client: T,
     signal_type: SignalType,
@@ -517,6 +534,9 @@ where
     let mut handles = Vec::with_capacity(streams_per_signal);
 
     for _ in 0..streams_per_signal {
+        // The queue is per stream, not shared across the pool. This keeps
+        // backpressure local to the stream that is lagging and gives the
+        // exporter a useful depth signal for least-loaded routing.
         let (sender, receiver) = tokio::sync::mpsc::channel::<StreamBatch>(stream_queue_capacity);
         senders.push(sender);
         handles.push(tokio::task::spawn_local(stream_arrow_batches(
@@ -532,6 +552,11 @@ where
     (senders, handles)
 }
 
+/// Selects the stream queue with the smallest current backlog.
+///
+/// `tokio::sync::mpsc::Sender` exposes remaining capacity rather than length,
+/// so occupancy is computed as `max_capacity - capacity`. The config rejects
+/// `streams_per_signal = 0`, which makes the final `expect` an invariant check.
 fn least_loaded_stream_sender(senders: &[Sender<StreamBatch>]) -> &Sender<StreamBatch> {
     senders
         .iter()
@@ -539,6 +564,11 @@ fn least_loaded_stream_sender(senders: &[Sender<StreamBatch>]) -> &Sender<Stream
         .expect("streams_per_signal validation must create at least one stream")
 }
 
+/// Waits for all stream workers belonging to one signal type.
+///
+/// Worker errors are already represented through pdata ACK/NACK updates where
+/// possible; a join failure during shutdown should not prevent the exporter
+/// from completing its terminal-state path.
 async fn await_stream_handles(handles: Vec<JoinHandle<()>>) {
     for handle in handles {
         _ = handle.await;

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/mod.rs
@@ -34,11 +34,13 @@ use otap_df_pdata::proto::opentelemetry::arrow::v1::{
     arrow_metrics_service_client::ArrowMetricsServiceClient,
     arrow_traces_service_client::ArrowTracesServiceClient,
 };
+use otap_df_telemetry::instrument::{Gauge, Mmsc};
 use otap_df_telemetry::metrics::MetricSet;
 use otap_df_telemetry::{otel_error, otel_info};
+use otap_df_telemetry_macros::metric_set;
 use serde_json::Value;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::mpsc::{Receiver, Sender};
 use tonic::transport::Channel;
 use tonic::{IntoStreamingRequest, Response, Status, Streaming};
@@ -53,6 +55,96 @@ use config::Config;
 pub struct OTAPExporter {
     config: Config,
     pdata_metrics: MetricSet<ExporterPDataMetrics>,
+    async_metrics: MetricSet<OtapGrpcAsyncMetrics>,
+    export_latency_window: ExportLatencyWindow,
+}
+
+type StreamBatch = (OtapPdata, OtapArrowRecords);
+
+/// Async wait attribution for the OTAP gRPC export stream.
+#[metric_set(name = "otap.exporter.grpc.async")]
+#[derive(Debug, Default, Clone)]
+pub struct OtapGrpcAsyncMetrics {
+    /// End-to-end duration from yielding a batch to receiving the matching OTAP stream response.
+    #[metric(name = "export.rpc.duration", unit = "ns")]
+    pub export_rpc_duration_ns: Mmsc,
+    /// Time spent waiting to enqueue a batch into the per-signal stream task.
+    #[metric(name = "stream.enqueue.duration", unit = "ns")]
+    pub stream_enqueue_duration_ns: Mmsc,
+    /// Occupancy of the per-signal stream task queue before enqueueing a batch.
+    #[metric(name = "stream.enqueue.depth", unit = "{batch}")]
+    pub stream_enqueue_depth: Mmsc,
+    /// Time spent encoding an OTAP batch into outbound Arrow batch records.
+    #[metric(name = "stream.encode.duration", unit = "ns")]
+    pub stream_encode_duration_ns: Mmsc,
+    /// Time spent enqueueing a yielded batch into the response correlation queue.
+    #[metric(name = "stream.correlation.enqueue.duration", unit = "ns")]
+    pub stream_correlation_enqueue_duration_ns: Mmsc,
+    /// Occupancy of the response correlation queue before enqueueing a yielded batch.
+    #[metric(name = "stream.correlation.depth", unit = "{batch}")]
+    pub stream_correlation_depth: Mmsc,
+    /// Time spent waiting for the next server response on an OTAP stream.
+    #[metric(name = "stream.response.wait.duration", unit = "ns")]
+    pub stream_response_wait_duration_ns: Mmsc,
+    /// Number of yielded batches awaiting a matching server response.
+    #[metric(name = "stream.response.inflight", unit = "{batch}")]
+    pub stream_response_inflight: Mmsc,
+    /// Median outbound gRPC export response duration for the latest telemetry interval.
+    #[metric(name = "export.rpc.duration.p50", unit = "ns")]
+    pub export_rpc_duration_p50_ns: Gauge<f64>,
+    /// 90th percentile outbound gRPC export response duration for the latest telemetry interval.
+    #[metric(name = "export.rpc.duration.p90", unit = "ns")]
+    pub export_rpc_duration_p90_ns: Gauge<f64>,
+    /// 99th percentile outbound gRPC export response duration for the latest telemetry interval.
+    #[metric(name = "export.rpc.duration.p99", unit = "ns")]
+    pub export_rpc_duration_p99_ns: Gauge<f64>,
+}
+
+#[inline]
+fn elapsed_nanos(start: Instant) -> f64 {
+    start.elapsed().as_secs_f64() * 1e9
+}
+
+#[derive(Debug, Default)]
+struct ExportLatencyWindow {
+    samples_ns: Vec<f64>,
+}
+
+impl ExportLatencyWindow {
+    #[inline]
+    fn record(&mut self, duration_ns: f64) {
+        self.samples_ns.push(duration_ns);
+    }
+
+    fn report_into(&mut self, metrics: &mut MetricSet<OtapGrpcAsyncMetrics>) {
+        if self.samples_ns.is_empty() {
+            metrics.export_rpc_duration_p50_ns.set(0.0);
+            metrics.export_rpc_duration_p90_ns.set(0.0);
+            metrics.export_rpc_duration_p99_ns.set(0.0);
+            return;
+        }
+
+        self.samples_ns.sort_by(f64::total_cmp);
+        metrics
+            .export_rpc_duration_p50_ns
+            .set(Self::quantile_sorted(&self.samples_ns, 0.50));
+        metrics
+            .export_rpc_duration_p90_ns
+            .set(Self::quantile_sorted(&self.samples_ns, 0.90));
+        metrics
+            .export_rpc_duration_p99_ns
+            .set(Self::quantile_sorted(&self.samples_ns, 0.99));
+        self.samples_ns.clear();
+    }
+
+    fn quantile_sorted(samples_ns: &[f64], q: f64) -> f64 {
+        debug_assert!(!samples_ns.is_empty());
+        let len = samples_ns.len();
+        let index = ((len as f64 * q).ceil() as usize)
+            .saturating_sub(1)
+            .min(len - 1);
+        samples_ns[index]
+    }
 }
 
 /// Declares the OTAP exporter as a local exporter factory
@@ -82,10 +174,13 @@ impl OTAPExporter {
     /// Creates a new OTAPExporter
     #[must_use]
     pub fn new(pipeline_ctx: PipelineContext, config: Config) -> Self {
-        let batch_metrics = pipeline_ctx.register_metrics::<ExporterPDataMetrics>();
+        let pdata_metrics = pipeline_ctx.register_metrics::<ExporterPDataMetrics>();
+        let async_metrics = pipeline_ctx.register_metrics::<OtapGrpcAsyncMetrics>();
         OTAPExporter {
             config,
-            pdata_metrics: batch_metrics,
+            pdata_metrics,
+            async_metrics,
+            export_latency_window: ExportLatencyWindow::default(),
         }
     }
 
@@ -100,6 +195,126 @@ impl OTAPExporter {
             }
         })?;
         Ok(OTAPExporter::new(pipeline_ctx, config))
+    }
+
+    async fn handle_pdata_metrics_update(
+        &mut self,
+        update: PDataMetricsUpdate,
+        effect_handler: &local::EffectHandler<OtapPdata>,
+    ) -> Result<(), Error> {
+        match update {
+            PDataMetricsUpdate::IncFailed(signal_type, pdata, response_duration_ns) => {
+                if let Some(duration_ns) = response_duration_ns {
+                    self.async_metrics
+                        .export_rpc_duration_ns
+                        .record(duration_ns);
+                    self.export_latency_window.record(duration_ns);
+                }
+                self.pdata_metrics.inc_failed(signal_type);
+                effect_handler
+                    .notify_nack(NackMsg::new("export failed", pdata))
+                    .await?;
+            }
+            PDataMetricsUpdate::IncExported(signal_type, pdata, response_duration_ns) => {
+                self.async_metrics
+                    .export_rpc_duration_ns
+                    .record(response_duration_ns);
+                self.export_latency_window.record(response_duration_ns);
+                self.pdata_metrics.inc_exported(signal_type);
+                effect_handler.notify_ack(AckMsg::new(pdata)).await?;
+            }
+            PDataMetricsUpdate::RecordStreamEncodeDuration(duration_ns) => {
+                self.async_metrics
+                    .stream_encode_duration_ns
+                    .record(duration_ns);
+            }
+            PDataMetricsUpdate::RecordCorrelationEnqueue { duration_ns, depth } => {
+                self.async_metrics
+                    .stream_correlation_enqueue_duration_ns
+                    .record(duration_ns);
+                self.async_metrics
+                    .stream_correlation_depth
+                    .record(depth as f64);
+            }
+            PDataMetricsUpdate::RecordResponseWait {
+                duration_ns,
+                inflight,
+            } => {
+                self.async_metrics
+                    .stream_response_wait_duration_ns
+                    .record(duration_ns);
+                self.async_metrics
+                    .stream_response_inflight
+                    .record(inflight as f64);
+            }
+        }
+        Ok(())
+    }
+
+    async fn enqueue_stream_batch(
+        &mut self,
+        sender: &Sender<StreamBatch>,
+        pdata: OtapPdata,
+        message: OtapArrowRecords,
+        pdata_metrics_rx: &mut Receiver<PDataMetricsUpdate>,
+        effect_handler: &local::EffectHandler<OtapPdata>,
+    ) -> Result<(), Error> {
+        let queue_depth = sender.max_capacity() - sender.capacity();
+        self.async_metrics
+            .stream_enqueue_depth
+            .record(queue_depth as f64);
+        let enqueue_start = Instant::now();
+        let mut pending = Some((pdata, message));
+
+        loop {
+            let item = pending
+                .take()
+                .expect("stream enqueue loop must retain the pending batch");
+            match sender.try_send(item) {
+                Ok(()) => {
+                    self.async_metrics
+                        .stream_enqueue_duration_ns
+                        .record(elapsed_nanos(enqueue_start));
+                    return Ok(());
+                }
+                Err(tokio::sync::mpsc::error::TrySendError::Full(item)) => {
+                    pending = Some(item);
+                }
+                Err(tokio::sync::mpsc::error::TrySendError::Closed(_item)) => {
+                    self.async_metrics
+                        .stream_enqueue_duration_ns
+                        .record(elapsed_nanos(enqueue_start));
+                    return Ok(());
+                }
+            }
+
+            tokio::select! {
+                permit = sender.reserve() => {
+                    match permit {
+                        Ok(permit) => {
+                            permit.send(pending
+                                .take()
+                                .expect("stream enqueue reserve must retain the pending batch"));
+                            self.async_metrics
+                                .stream_enqueue_duration_ns
+                                .record(elapsed_nanos(enqueue_start));
+                            return Ok(());
+                        }
+                        Err(_) => {
+                            self.async_metrics
+                                .stream_enqueue_duration_ns
+                                .record(elapsed_nanos(enqueue_start));
+                            return Ok(());
+                        }
+                    }
+                }
+                metrics_update = pdata_metrics_rx.recv() => {
+                    if let Some(update) = metrics_update {
+                        self.handle_pdata_metrics_update(update, effect_handler).await?;
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -158,12 +373,13 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
         // TODO comment on the purpose of these
         // TODO import so can use as just "channel" here
         // TODO check if we can use our local channel since we are already using `tokio::task::spawn_local`.
+        let stream_queue_capacity = self.config.stream_queue_capacity;
         let (logs_sender, logs_receiver) =
-            tokio::sync::mpsc::channel::<(OtapPdata, OtapArrowRecords)>(64);
+            tokio::sync::mpsc::channel::<StreamBatch>(stream_queue_capacity);
         let (metrics_sender, metrics_receiver) =
-            tokio::sync::mpsc::channel::<(OtapPdata, OtapArrowRecords)>(64);
+            tokio::sync::mpsc::channel::<StreamBatch>(stream_queue_capacity);
         let (traces_sender, traces_receiver) =
-            tokio::sync::mpsc::channel::<(OtapPdata, OtapArrowRecords)>(64);
+            tokio::sync::mpsc::channel::<StreamBatch>(stream_queue_capacity);
         let (pdata_metrics_tx, mut pdata_metrics_rx) = tokio::sync::mpsc::channel(64);
         let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
         let ipc_compression = matches!(
@@ -208,7 +424,10 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
                     Message::Control(NodeControlMsg::CollectTelemetry {
                         mut metrics_reporter,
                     }) => {
+                        self.export_latency_window
+                            .report_into(&mut self.async_metrics);
                         _ = metrics_reporter.report(&mut self.pdata_metrics);
+                        _ = metrics_reporter.report(&mut self.async_metrics);
                     }
                     // shutdown the exporter
                     Message::Control(NodeControlMsg::Shutdown { deadline, .. }) => {
@@ -227,7 +446,12 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
                         _ = metrics_handle.await;
                         _ = traces_handle.await;
                         _ = timer_cancel_handle.cancel().await;
-                        return Ok(TerminalState::new(deadline, [self.pdata_metrics]))
+                        self.export_latency_window
+                            .report_into(&mut self.async_metrics);
+                        return Ok(TerminalState::new(
+                            deadline,
+                            [self.pdata_metrics.snapshot(), self.async_metrics.snapshot()],
+                        ))
                     }
                     //send data
                     Message::PData(mut pdata) => {
@@ -245,11 +469,19 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
                             }
                         };
 
-                        _ = match signal_type {
-                            SignalType::Logs => logs_sender.send((pdata, message)).await,
-                            SignalType::Metrics => metrics_sender.send((pdata, message)).await,
-                            SignalType::Traces => traces_sender.send((pdata, message)).await,
+                        let sender = match signal_type {
+                            SignalType::Logs => &logs_sender,
+                            SignalType::Metrics => &metrics_sender,
+                            SignalType::Traces => &traces_sender,
                         };
+                        self.enqueue_stream_batch(
+                            sender,
+                            pdata,
+                            message,
+                            &mut pdata_metrics_rx,
+                            &effect_handler,
+                        )
+                        .await?;
                     }
                     _ => {
                         return Err(Error::ExporterError {
@@ -260,16 +492,10 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
                         });
                     }
                 },
-                metrics_update = pdata_metrics_rx.recv() => match metrics_update {
-                    Some(PDataMetricsUpdate::IncFailed(signal_type, pdata)) => {
-                        self.pdata_metrics.inc_failed(signal_type);
-                        effect_handler.notify_nack(NackMsg::new("export failed", pdata)).await?;
-                    },
-                    Some(PDataMetricsUpdate::IncExported(signal_type, pdata)) => {
-                        self.pdata_metrics.inc_exported(signal_type);
-                        effect_handler.notify_ack(AckMsg::new(pdata)).await?;
-                    },
-                    _ => {}
+                metrics_update = pdata_metrics_rx.recv() => {
+                    if let Some(update) = metrics_update {
+                        self.handle_pdata_metrics_update(update, &effect_handler).await?;
+                    }
                 }
             }
         }
@@ -315,8 +541,16 @@ impl StreamingArrowService for ArrowTracesServiceClient<Channel> {
 }
 
 enum PDataMetricsUpdate {
-    IncExported(SignalType, OtapPdata),
-    IncFailed(SignalType, OtapPdata),
+    IncExported(SignalType, OtapPdata, f64),
+    IncFailed(SignalType, OtapPdata, Option<f64>),
+    RecordStreamEncodeDuration(f64),
+    RecordCorrelationEnqueue { duration_ns: f64, depth: usize },
+    RecordResponseWait { duration_ns: f64, inflight: usize },
+}
+
+struct CorrelatedPdata {
+    pdata: OtapPdata,
+    sent_at: Instant,
 }
 
 async fn stream_arrow_batches<T: StreamingArrowService>(
@@ -354,7 +588,7 @@ async fn stream_arrow_batches<T: StreamingArrowService>(
 
                 // correlation channel: req_stream sends OtapPdata for each batch yielded,
                 // res_stream receives them to pair with server responses.
-                let (correlation_tx, mut correlation_rx) = tokio::sync::mpsc::channel::<OtapPdata>(64);
+                let (correlation_tx, mut correlation_rx) = tokio::sync::mpsc::channel::<CorrelatedPdata>(64);
 
                 // Clone first_pdata before moving it into the stream, so we can
                 // NACK it if the connection fails before the stream is polled.
@@ -389,13 +623,25 @@ async fn stream_arrow_batches<T: StreamingArrowService>(
                         // drain any pdata that was already correlated
                         drop(correlation_tx);
                         let mut drained = false;
-                        while let Ok(pdata) = correlation_rx.try_recv() {
+                        while let Ok(correlated) = correlation_rx.try_recv() {
                             drained = true;
-                            _ = pdata_metrics_tx.send(PDataMetricsUpdate::IncFailed(signal_type, pdata)).await;
+                            _ = pdata_metrics_tx
+                                .send(PDataMetricsUpdate::IncFailed(
+                                    signal_type,
+                                    correlated.pdata,
+                                    Some(elapsed_nanos(correlated.sent_at)),
+                                ))
+                                .await;
                         }
                         // if first_pdata wasn't sent to correlation channel, fail the fallback
                         if !drained {
-                            _ = pdata_metrics_tx.send(PDataMetricsUpdate::IncFailed(signal_type, first_pdata_fallback)).await;
+                            _ = pdata_metrics_tx
+                                .send(PDataMetricsUpdate::IncFailed(
+                                    signal_type,
+                                    first_pdata_fallback,
+                                    None,
+                                ))
+                                .await;
                         }
                         otel_error!(
                             "otap_exporter.request_failed",
@@ -432,7 +678,7 @@ fn create_req_stream(
     signal_type: SignalType,
     ipc_compression: Option<arrow_ipc::CompressionType>,
     pdata_metrics_tx: Sender<PDataMetricsUpdate>,
-    correlation_tx: Sender<OtapPdata>,
+    correlation_tx: Sender<CorrelatedPdata>,
 ) -> impl IntoStreamingRequest<Message = BatchArrowRecords> {
     stream! {
         let mut producer = Producer::new_with_options(ProducerOptions {
@@ -440,26 +686,81 @@ fn create_req_stream(
         });
 
         // send the first batch
-        match producer.produce_bar(&mut first_batch) {
+        let encode_start = Instant::now();
+        let bar_result = producer.produce_bar(&mut first_batch);
+        _ = pdata_metrics_tx.try_send(PDataMetricsUpdate::RecordStreamEncodeDuration(
+            elapsed_nanos(encode_start),
+        ));
+        match bar_result {
             Ok(bar) => {
-                _ = correlation_tx.send(first_pdata).await;
-                yield bar;
+                let correlation_depth =
+                    correlation_tx.max_capacity() - correlation_tx.capacity();
+                let correlation_start = Instant::now();
+                match correlation_tx.reserve().await {
+                    Ok(permit) => {
+                        _ =
+                            pdata_metrics_tx.try_send(PDataMetricsUpdate::RecordCorrelationEnqueue {
+                                duration_ns: elapsed_nanos(correlation_start),
+                                depth: correlation_depth,
+                            });
+                        permit.send(CorrelatedPdata {
+                            pdata: first_pdata,
+                            sent_at: Instant::now(),
+                        });
+                        yield bar;
+                    }
+                    Err(_) => {
+                        _ = pdata_metrics_tx
+                            .send(PDataMetricsUpdate::IncFailed(
+                                signal_type,
+                                first_pdata,
+                                None,
+                            ))
+                            .await;
+                    }
+                }
             }
             Err(_) => {
-                _ = pdata_metrics_tx.send(PDataMetricsUpdate::IncFailed(signal_type, first_pdata)).await;
+                _ = pdata_metrics_tx.send(PDataMetricsUpdate::IncFailed(signal_type, first_pdata, None)).await;
             }
         };
 
         let mut rx = remaining_batches_rx.lock().await;
         // send the remaining batches
         while let Some((pdata, mut otap_batch)) = rx.recv().await {
-            match producer.produce_bar(&mut otap_batch) {
+            let encode_start = Instant::now();
+            let bar_result = producer.produce_bar(&mut otap_batch);
+            _ = pdata_metrics_tx.try_send(PDataMetricsUpdate::RecordStreamEncodeDuration(
+                elapsed_nanos(encode_start),
+            ));
+            match bar_result {
                 Ok(bar) => {
-                    _ = correlation_tx.send(pdata).await;
-                    yield bar;
+                    let correlation_depth =
+                        correlation_tx.max_capacity() - correlation_tx.capacity();
+                    let correlation_start = Instant::now();
+                    match correlation_tx.reserve().await {
+                        Ok(permit) => {
+                            _ = pdata_metrics_tx.try_send(
+                                PDataMetricsUpdate::RecordCorrelationEnqueue {
+                                    duration_ns: elapsed_nanos(correlation_start),
+                                    depth: correlation_depth,
+                                },
+                            );
+                            permit.send(CorrelatedPdata {
+                                pdata,
+                                sent_at: Instant::now(),
+                            });
+                            yield bar;
+                        }
+                        Err(_) => {
+                            _ = pdata_metrics_tx
+                                .send(PDataMetricsUpdate::IncFailed(signal_type, pdata, None))
+                                .await;
+                        }
+                    }
                 }
                 Err(_) => {
-                    _ = pdata_metrics_tx.send(PDataMetricsUpdate::IncFailed(signal_type, pdata)).await;
+                    _ = pdata_metrics_tx.send(PDataMetricsUpdate::IncFailed(signal_type, pdata, None)).await;
                 }
             }
         }
@@ -471,18 +772,33 @@ async fn handle_res_stream(
     pdata_metrics_tx: Sender<PDataMetricsUpdate>,
     signal_type: SignalType,
     mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
-    mut correlation_rx: Receiver<OtapPdata>,
+    mut correlation_rx: Receiver<CorrelatedPdata>,
 ) -> bool {
     let mut shutdown = false;
 
     // handle streaming responses until shutdown
     while !shutdown {
         tokio::select! {
-            res = res_stream.message() => {
+            res = async {
+                let response_wait_start = Instant::now();
+                let res = res_stream.message().await;
+                (res, elapsed_nanos(response_wait_start))
+            } => {
+                let (res, duration_ns) = res;
+                _ = pdata_metrics_tx.try_send(PDataMetricsUpdate::RecordResponseWait {
+                    duration_ns,
+                    inflight: correlation_rx.len(),
+                });
                 match res {
                     Ok(Some(_val)) => {
-                        if let Some(pdata) = correlation_rx.recv().await {
-                            _ = pdata_metrics_tx.send(PDataMetricsUpdate::IncExported(signal_type, pdata)).await;
+                        if let Some(correlated) = correlation_rx.recv().await {
+                            _ = pdata_metrics_tx
+                                .send(PDataMetricsUpdate::IncExported(
+                                    signal_type,
+                                    correlated.pdata,
+                                    elapsed_nanos(correlated.sent_at),
+                                ))
+                                .await;
                         }
                     },
                     Ok(None) => {
@@ -490,8 +806,14 @@ async fn handle_res_stream(
                         break
                     }
                     Err(_grpc_status) => {
-                        if let Some(pdata) = correlation_rx.recv().await {
-                            _ = pdata_metrics_tx.send(PDataMetricsUpdate::IncFailed(signal_type, pdata)).await;
+                        if let Some(correlated) = correlation_rx.recv().await {
+                            _ = pdata_metrics_tx
+                                .send(PDataMetricsUpdate::IncFailed(
+                                    signal_type,
+                                    correlated.pdata,
+                                    Some(elapsed_nanos(correlated.sent_at)),
+                                ))
+                                .await;
                         }
                         break
                     }
@@ -508,6 +830,7 @@ async fn handle_res_stream(
 
 #[cfg(test)]
 mod tests {
+    use crate::exporters::otap_exporter::ExportLatencyWindow;
     use crate::exporters::otap_exporter::OTAP_EXPORTER_URN;
     use crate::exporters::otap_exporter::OTAPExporter;
     use crate::exporters::otap_exporter::config::ArrowPayloadCompression;
@@ -565,6 +888,15 @@ mod tests {
     const METRIC_BATCH_ID: i64 = 0;
     const LOG_BATCH_ID: i64 = 1;
     const TRACE_BATCH_ID: i64 = 2;
+
+    #[test]
+    fn export_latency_quantile_uses_nearest_rank() {
+        let samples = [1.0, 2.0, 3.0, 4.0, 5.0, 100.0];
+
+        assert_eq!(ExportLatencyWindow::quantile_sorted(&samples, 0.50), 3.0);
+        assert_eq!(ExportLatencyWindow::quantile_sorted(&samples, 0.90), 100.0);
+        assert_eq!(ExportLatencyWindow::quantile_sorted(&samples, 0.99), 100.0);
+    }
 
     /// Test closure that simulates a typical test scenario by sending timer ticks, config,
     /// data message, and shutdown control messages.
@@ -739,6 +1071,7 @@ mod tests {
             OTAPExporter::from_config(pipeline_ctx, &json_config).expect("Config should be valid");
 
         assert_eq!(exporter.config.grpc.grpc_endpoint, "http://localhost:4317");
+        assert_eq!(exporter.config.stream_queue_capacity, 64);
         match exporter.config.compression_method {
             Some(ref method) => match method {
                 CompressionMethod::Gzip => {} // success
@@ -770,6 +1103,40 @@ mod tests {
         let exporter = OTAPExporter::from_config(pipeline_ctx, &config_with_timeout_ms)
             .expect("Config should be valid");
         assert_eq!(exporter.config.timeout, Some(Duration::from_millis(250)));
+    }
+
+    #[test]
+    fn test_from_config_with_stream_queue_capacity() {
+        let telemetry_registry_handle = TelemetryRegistryHandle::new();
+        let controller_ctx = ControllerContext::new(telemetry_registry_handle);
+        let pipeline_ctx =
+            controller_ctx.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+
+        let json_config = json!({
+            "grpc_endpoint": "http://localhost:4317",
+            "stream_queue_capacity": 256
+        });
+        let exporter =
+            OTAPExporter::from_config(pipeline_ctx, &json_config).expect("Config should be valid");
+        assert_eq!(exporter.config.stream_queue_capacity, 256);
+    }
+
+    #[test]
+    fn test_from_config_rejects_zero_stream_queue_capacity() {
+        let telemetry_registry_handle = TelemetryRegistryHandle::new();
+        let controller_ctx = ControllerContext::new(telemetry_registry_handle);
+        let pipeline_ctx =
+            controller_ctx.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+
+        let json_config = json!({
+            "grpc_endpoint": "http://localhost:4317",
+            "stream_queue_capacity": 0
+        });
+        let err = match OTAPExporter::from_config(pipeline_ctx, &json_config) {
+            Ok(_) => panic!("zero stream queue capacity should fail"),
+            Err(err) => err,
+        };
+        assert!(format!("{err}").contains("stream_queue_capacity must be greater than 0"));
     }
 
     #[test]
@@ -1125,15 +1492,20 @@ mod tests {
         )
         .await;
 
-        // The drained pdata should come through as Failed
-        let update = timeout(Duration::from_secs(1), metrics_rx.recv())
-            .await
-            .expect("timed out")
-            .expect("channel closed");
-        assert!(
-            matches!(update, PDataMetricsUpdate::IncFailed(SignalType::Logs, _)),
-            "expected IncFailed, got something else"
-        );
+        // The drained pdata should come through as Failed. Attribution metrics
+        // can be emitted before the failure update.
+        timeout(Duration::from_secs(1), async {
+            loop {
+                if matches!(
+                    metrics_rx.recv().await.expect("channel closed"),
+                    PDataMetricsUpdate::IncFailed(SignalType::Logs, ..)
+                ) {
+                    break;
+                }
+            }
+        })
+        .await
+        .expect("timed out waiting for IncFailed");
     }
 
     /// A stream-creation failure may leave the OTAP exporter in reconnect backoff.
@@ -1181,7 +1553,7 @@ mod tests {
         for attempt in 0..4 {
             let update = metrics_rx.recv().await.expect("metrics channel closed");
             assert!(
-                matches!(update, PDataMetricsUpdate::IncFailed(SignalType::Logs, _)),
+                matches!(update, PDataMetricsUpdate::IncFailed(SignalType::Logs, ..)),
                 "expected IncFailed update for failed stream attempt #{attempt}"
             );
         }

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/mod.rs
@@ -42,6 +42,7 @@ use serde_json::Value;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::task::JoinHandle;
 use tonic::transport::Channel;
 use tonic::{IntoStreamingRequest, Response, Status, Streaming};
 
@@ -374,12 +375,7 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
         // TODO import so can use as just "channel" here
         // TODO check if we can use our local channel since we are already using `tokio::task::spawn_local`.
         let stream_queue_capacity = self.config.stream_queue_capacity;
-        let (logs_sender, logs_receiver) =
-            tokio::sync::mpsc::channel::<StreamBatch>(stream_queue_capacity);
-        let (metrics_sender, metrics_receiver) =
-            tokio::sync::mpsc::channel::<StreamBatch>(stream_queue_capacity);
-        let (traces_sender, traces_receiver) =
-            tokio::sync::mpsc::channel::<StreamBatch>(stream_queue_capacity);
+        let streams_per_signal = self.config.streams_per_signal;
         let (pdata_metrics_tx, mut pdata_metrics_rx) = tokio::sync::mpsc::channel(64);
         let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
         let ipc_compression = matches!(
@@ -389,30 +385,33 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
         .then(|| arrow_ipc::CompressionType::ZSTD);
 
         // TODO check if we can expose/use spawn_local method in the effect handler
-        let logs_handle = tokio::task::spawn_local(stream_arrow_batches(
+        let (logs_senders, logs_handles) = spawn_stream_workers(
             arrow_logs_client,
             SignalType::Logs,
             ipc_compression,
-            logs_receiver,
+            stream_queue_capacity,
+            streams_per_signal,
             pdata_metrics_tx.clone(),
             shutdown_rx.clone(),
-        ));
-        let metrics_handle = tokio::task::spawn_local(stream_arrow_batches(
+        );
+        let (metrics_senders, metrics_handles) = spawn_stream_workers(
             arrow_metrics_client,
             SignalType::Metrics,
             ipc_compression,
-            metrics_receiver,
+            stream_queue_capacity,
+            streams_per_signal,
             pdata_metrics_tx.clone(),
             shutdown_rx.clone(),
-        ));
-        let traces_handle = tokio::task::spawn_local(stream_arrow_batches(
+        );
+        let (traces_senders, traces_handles) = spawn_stream_workers(
             arrow_traces_client,
             SignalType::Traces,
             ipc_compression,
-            traces_receiver,
+            stream_queue_capacity,
+            streams_per_signal,
             pdata_metrics_tx.clone(),
             shutdown_rx.clone(),
-        ));
+        );
 
         // Loop until a Shutdown event is received.
         loop {
@@ -442,9 +441,9 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
                             message = "OTAP Exporter shutting down"
                         );
                         _ = shutdown_tx.send_replace(true);
-                        _ = logs_handle.await;
-                        _ = metrics_handle.await;
-                        _ = traces_handle.await;
+                        await_stream_handles(logs_handles).await;
+                        await_stream_handles(metrics_handles).await;
+                        await_stream_handles(traces_handles).await;
                         _ = timer_cancel_handle.cancel().await;
                         self.export_latency_window
                             .report_into(&mut self.async_metrics);
@@ -470,9 +469,9 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
                         };
 
                         let sender = match signal_type {
-                            SignalType::Logs => &logs_sender,
-                            SignalType::Metrics => &metrics_sender,
-                            SignalType::Traces => &traces_sender,
+                            SignalType::Logs => least_loaded_stream_sender(&logs_senders),
+                            SignalType::Metrics => least_loaded_stream_sender(&metrics_senders),
+                            SignalType::Traces => least_loaded_stream_sender(&traces_senders),
                         };
                         self.enqueue_stream_batch(
                             sender,
@@ -499,6 +498,50 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
                 }
             }
         }
+    }
+}
+
+fn spawn_stream_workers<T>(
+    client: T,
+    signal_type: SignalType,
+    ipc_compression: Option<arrow_ipc::CompressionType>,
+    stream_queue_capacity: usize,
+    streams_per_signal: usize,
+    pdata_metrics_tx: Sender<PDataMetricsUpdate>,
+    shutdown_rx: tokio::sync::watch::Receiver<bool>,
+) -> (Vec<Sender<StreamBatch>>, Vec<JoinHandle<()>>)
+where
+    T: StreamingArrowService + Clone + 'static,
+{
+    let mut senders = Vec::with_capacity(streams_per_signal);
+    let mut handles = Vec::with_capacity(streams_per_signal);
+
+    for _ in 0..streams_per_signal {
+        let (sender, receiver) = tokio::sync::mpsc::channel::<StreamBatch>(stream_queue_capacity);
+        senders.push(sender);
+        handles.push(tokio::task::spawn_local(stream_arrow_batches(
+            client.clone(),
+            signal_type,
+            ipc_compression,
+            receiver,
+            pdata_metrics_tx.clone(),
+            shutdown_rx.clone(),
+        )));
+    }
+
+    (senders, handles)
+}
+
+fn least_loaded_stream_sender(senders: &[Sender<StreamBatch>]) -> &Sender<StreamBatch> {
+    senders
+        .iter()
+        .min_by_key(|sender| sender.max_capacity() - sender.capacity())
+        .expect("streams_per_signal validation must create at least one stream")
+}
+
+async fn await_stream_handles(handles: Vec<JoinHandle<()>>) {
+    for handle in handles {
+        _ = handle.await;
     }
 }
 
@@ -1072,6 +1115,7 @@ mod tests {
 
         assert_eq!(exporter.config.grpc.grpc_endpoint, "http://localhost:4317");
         assert_eq!(exporter.config.stream_queue_capacity, 64);
+        assert_eq!(exporter.config.streams_per_signal, 1);
         match exporter.config.compression_method {
             Some(ref method) => match method {
                 CompressionMethod::Gzip => {} // success
@@ -1122,6 +1166,22 @@ mod tests {
     }
 
     #[test]
+    fn test_from_config_with_streams_per_signal() {
+        let telemetry_registry_handle = TelemetryRegistryHandle::new();
+        let controller_ctx = ControllerContext::new(telemetry_registry_handle);
+        let pipeline_ctx =
+            controller_ctx.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+
+        let json_config = json!({
+            "grpc_endpoint": "http://localhost:4317",
+            "streams_per_signal": 4
+        });
+        let exporter =
+            OTAPExporter::from_config(pipeline_ctx, &json_config).expect("Config should be valid");
+        assert_eq!(exporter.config.streams_per_signal, 4);
+    }
+
+    #[test]
     fn test_from_config_rejects_zero_stream_queue_capacity() {
         let telemetry_registry_handle = TelemetryRegistryHandle::new();
         let controller_ctx = ControllerContext::new(telemetry_registry_handle);
@@ -1137,6 +1197,24 @@ mod tests {
             Err(err) => err,
         };
         assert!(format!("{err}").contains("stream_queue_capacity must be greater than 0"));
+    }
+
+    #[test]
+    fn test_from_config_rejects_zero_streams_per_signal() {
+        let telemetry_registry_handle = TelemetryRegistryHandle::new();
+        let controller_ctx = ControllerContext::new(telemetry_registry_handle);
+        let pipeline_ctx =
+            controller_ctx.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+
+        let json_config = json!({
+            "grpc_endpoint": "http://localhost:4317",
+            "streams_per_signal": 0
+        });
+        let err = match OTAPExporter::from_config(pipeline_ctx, &json_config) {
+            Ok(_) => panic!("zero streams per signal should fail"),
+            Err(err) => err,
+        };
+        assert!(format!("{err}").contains("streams_per_signal must be greater than 0"));
     }
 
     #[test]


### PR DESCRIPTION
# Change Summary

Improves OTAP exporter progress under backpressure by draining completion updates while waiting for stream queue capacity. Adds async attribution metrics for stream enqueue, encode, correlation, response wait, inflight depth, and latest-window export latency percentiles.

## What issue does this PR close?

Part of https://github.com/open-telemetry/otel-arrow/issues/1324

## How are these changes tested?

## Are there any user-facing changes?

