### PR TITLE
Fix: correct typos in rust source files

### DIFF
--- a/collector/examples/metadata-bridge/edge-collector.yaml
+++ b/collector/examples/metadata-bridge/edge-collector.yaml
@@ -65,7 +65,7 @@ exporters:
       # disable_downgrade forces this connection to use Arrow.
       disable_downgrade: true
 
-      # num_streams can be set to the the number of available CPUs
+      # num_streams can be set to the number of available CPUs
       # to maximize throughput.
       num_streams: 4
 

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs
@@ -345,7 +345,7 @@ impl Exporter<OtapPdata> for OtlpHttpExporter {
                                 };
 
                             if !context.may_return_payload() {
-                                // drop the original OTAP batch if the the context indicates it
+                                // drop the original OTAP batch if the context indicates it
                                 // does not wish it to be returned
                                 _ = otap_batch.take_payload();
                             }

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/parquet_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/parquet_exporter/mod.rs
@@ -435,7 +435,7 @@ impl Exporter<OtapPdata> for ParquetExporter {
 /// This calculates the period at which we instruct the [`WriterManager`] to flush any writers
 /// older than the threshold.
 fn calculate_flush_timeout_check_period(configured_threshold: Duration) -> Duration {
-    // try to choose a period that is relatively close the the configured threshold.
+    // try to choose a period that is relatively close the configured threshold.
     // this avoids the check happening long after the file writer is beyond the threshold.
     let period = configured_threshold / 60;
 

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/parquet_exporter/schema.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/parquet_exporter/schema.rs
@@ -255,7 +255,7 @@ fn get_all_default_value_column(
     })
 }
 
-/// creates a a struct where all the columns are all null, or all default value if non-nullable.
+/// creates a struct where all the columns are all null, or all default value if non-nullable.
 /// the intention is that this will be a stand-in for the struct column of a record batch that is
 /// missing some struct column.
 fn get_struct_full_of_nulls_or_defaults(

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/debug_processor/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/debug_processor/README.md
@@ -58,7 +58,7 @@ Multiple filter rules can be definied and will be applied in order
 
 ### Output
 
-The DebugProcessor is a pass-through processor which allows the the normal
+The DebugProcessor is a pass-through processor which allows the normal
 flow of signals, this processor outputs various debug information on the
 signals/batches passing through. You can configure how the debug information
 is received.

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/debug_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/debug_processor/mod.rs
@@ -608,7 +608,7 @@ mod tests {
                 let file = File::open(output_file).expect("failed to open file");
                 let reader = read_to_string(BufReader::new(file)).expect("failed to get string");
 
-                // check the the processor has received the expected number of messages
+                // check the processor has received the expected number of messages
                 assert!(reader.contains("Received 1 resource metrics"));
                 assert!(reader.contains("Received 1 metrics"));
                 assert!(reader.contains("Received 1 data points"));
@@ -956,7 +956,7 @@ mod tests {
                 let file = File::open(output_file).expect("failed to open file");
                 let reader = read_to_string(BufReader::new(file)).expect("failed to get string");
 
-                // check the the processor has received the expected number of messages
+                // check the processor has received the expected number of messages
                 assert!(!reader.contains("Received 1 resource metrics"));
                 assert!(!reader.contains("Received 1 metrics"));
                 assert!(!reader.contains("Received 1 data points"));
@@ -1015,7 +1015,7 @@ mod tests {
                 let file = File::open(output_file).expect("failed to open file");
                 let reader = read_to_string(BufReader::new(file)).expect("failed to get string");
 
-                // check the the processor has received the expected number of messages
+                // check the processor has received the expected number of messages
                 assert!(reader.contains("Received 1 resource metrics"));
                 assert!(reader.contains("Received 1 metrics"));
                 assert!(reader.contains("Received 1 data points"));
@@ -1074,7 +1074,7 @@ mod tests {
                 let file = File::open(output_file).expect("failed to open file");
                 let reader = read_to_string(BufReader::new(file)).expect("failed to get string");
 
-                // check the the processor has received the expected number of messages
+                // check the processor has received the expected number of messages
                 assert!(!reader.contains("Received 1 resource metrics"));
                 assert!(!reader.contains("Received 1 metrics"));
                 assert!(!reader.contains("Received 1 data points"));
@@ -1099,7 +1099,7 @@ mod tests {
                 let file = File::open(output_file).expect("failed to open file");
                 let reader = read_to_string(BufReader::new(file)).expect("failed to get string");
 
-                // check the the processor has received the expected number of messages
+                // check the processor has received the expected number of messages
                 assert!(reader.contains("Received 1 resource metrics"));
                 assert!(reader.contains("Received 1 metrics"));
                 assert!(reader.contains("Received 1 data points"));
@@ -1128,7 +1128,7 @@ mod tests {
                 let file = File::open(output_file).expect("failed to open file");
                 let reader = read_to_string(BufReader::new(file)).expect("failed to get string");
 
-                // check the the processor has received the expected number of messages
+                // check the processor has received the expected number of messages
                 assert!(reader.contains("Received 1 resource metrics"));
                 assert!(reader.contains("Received 1 metrics"));
                 assert!(reader.contains("Received 1 data points"));

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
@@ -1697,7 +1697,7 @@ mod test {
                     .expect_err("process error");
                 assert!(err.to_string().contains("outbound slots not available"));
 
-                // now drain and ack the the messages from the first batch to clear out the slot map
+                // now drain and ack the messages from the first batch to clear out the slot map
                 let (outbound_ctx_default, _) = ctx.drain_pdata().await.pop().unwrap().into_parts();
                 let (outbound_ctx_routed, _) = error_port_rx.recv().await.unwrap().into_parts();
 

--- a/rust/otap-dataflow/crates/engine/src/effect_handler.rs
+++ b/rust/otap-dataflow/crates/engine/src/effect_handler.rs
@@ -27,7 +27,7 @@ use tokio::net::{TcpListener, UdpSocket};
 #[derive(Clone, Copy)]
 pub enum SourceTagging {
     /// Disabled means no source node-id will be automatically
-    /// inserted for nodes that do not not otherwise subscribe to
+    /// inserted for nodes that do not otherwise subscribe to
     /// Ack/Nack.
     Disabled,
 

--- a/rust/otap-dataflow/crates/otap/src/metrics.rs
+++ b/rust/otap-dataflow/crates/otap/src/metrics.rs
@@ -69,7 +69,7 @@ impl ExporterPDataMetrics {
         self.add_failed(st, 1);
     }
 
-    /// Add to the number of of pdata messages consumed.
+    /// Add to the number of pdata messages consumed.
     pub const fn add_consumed(&mut self, st: SignalType, count: u64) {
         if count == 0 {
             return;

--- a/rust/otap-dataflow/crates/otap/tests/common/flaky_exporter.rs
+++ b/rust/otap-dataflow/crates/otap/tests/common/flaky_exporter.rs
@@ -187,7 +187,7 @@ impl Exporter<OtapPdata> for FlakyExporter {
                         .unwrap_or(false);
 
                     // The counters are used by tests for shutdown triggers,
-                    // so we need to ensure the the ACK/NACK is queued before observers
+                    // so we need to ensure the ACK/NACK is queued before observers
                     // see the counters change.
                     if should_ack {
                         // ACK mode: acknowledge first, then count.

--- a/rust/otap-dataflow/crates/pdata-views/src/views/logs.rs
+++ b/rust/otap-dataflow/crates/pdata-views/src/views/logs.rs
@@ -48,7 +48,7 @@ pub trait ResourceLogsView {
     where
         Self: 'scp;
 
-    /// The associated iterator type for this impl of the the trait. The iterator will yield
+    /// The associated iterator type for this impl of the trait. The iterator will yield
     /// borrowed references that must live as long as the lifetime 'scp
     type ScopesIter<'scp>: Iterator<Item = Self::ScopeLogs<'scp>>
     where
@@ -77,7 +77,7 @@ pub trait ScopeLogsView {
     where
         Self: 'rec;
 
-    /// The associated iterator type for this impl of the the trait. The iterator will yield
+    /// The associated iterator type for this impl of the trait. The iterator will yield
     /// borrowed references that must live as long as the lifetime 'scp
     type LogRecordsIter<'rec>: Iterator<Item = Self::LogRecord<'rec>>
     where

--- a/rust/otap-dataflow/crates/pdata-views/src/views/resource.rs
+++ b/rust/otap-dataflow/crates/pdata-views/src/views/resource.rs
@@ -13,7 +13,7 @@ pub trait ResourceView {
     where
         Self: 'att;
 
-    /// The associated iterator type for this impl of the the trait. The iterator will yield
+    /// The associated iterator type for this impl of the trait. The iterator will yield
     /// borrowed references that must live as long as the lifetime 'att
     type AttributesIter<'att>: Iterator<Item = Self::Attribute<'att>>
     where

--- a/rust/otap-dataflow/crates/pdata-views/src/views/trace.rs
+++ b/rust/otap-dataflow/crates/pdata-views/src/views/trace.rs
@@ -55,7 +55,7 @@ pub trait ResourceSpansView {
     where
         Self: 'scp;
 
-    /// The associated iterator type for this impl of the the trait. The iterator will yield
+    /// The associated iterator type for this impl of the trait. The iterator will yield
     /// borrowed references that must live as long as the lifetime 'scp
     type ScopesIter<'scp>: Iterator<Item = Self::ScopeSpans<'scp>>
     where
@@ -84,7 +84,7 @@ pub trait ScopeSpansView {
     where
         Self: 'sp;
 
-    /// The associated iterator type for this impl of the the trait. The iterator will yield
+    /// The associated iterator type for this impl of the trait. The iterator will yield
     /// borrowed references that must live as long as the lifetime 'sp
     type SpanIter<'sp>: Iterator<Item = Self::Span<'sp>>
     where
@@ -121,7 +121,7 @@ pub trait SpanView {
     where
         Self: 'ev;
 
-    /// The associated iterator type for this impl of the the trait. The iterator will yield
+    /// The associated iterator type for this impl of the trait. The iterator will yield
     /// borrowed references that must live as long as the lifetime 'scp
     type EventsIter<'ev>: Iterator<Item = Self::Event<'ev>>
     where
@@ -132,7 +132,7 @@ pub trait SpanView {
     where
         Self: 'ln;
 
-    /// The associated iterator type for this impl of the the trait. The iterator will yield
+    /// The associated iterator type for this impl of the trait. The iterator will yield
     /// borrowed references that must live as long as the lifetime 'scp
     type LinksIter<'ln>: Iterator<Item = Self::Link<'ln>>
     where

--- a/rust/otap-dataflow/crates/pdata/src/otap/transform.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/transform.rs
@@ -1804,7 +1804,7 @@ fn transform_keys(
 struct DictionaryKeysTransformResult<K: ArrowDictionaryKeyType> {
     new_keys: DictionaryArray<K>,
 
-    /// Ranges of of the additional columns which should be kept.
+    /// Ranges of the additional columns which should be kept.
     keep_ranges: Option<Vec<Range<usize>>>,
 
     /// Ranges of the original record batch to which the transformation was applied. This can be used

--- a/rust/otap-dataflow/crates/pdata/src/otap/transform/concatenate.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/transform/concatenate.rs
@@ -161,7 +161,7 @@ fn concatenate_with_def<const N: usize>(
     Ok(result)
 }
 
-/// Convert the columns from one schema to another. The arguments deal in in
+/// Convert the columns from one schema to another. The arguments deal in
 /// fields and columns rather than schemas and record batches so that this
 /// code can work with either struct arrays or record batches.
 fn convert(

--- a/rust/otap-dataflow/crates/pdata/src/otap/transform/reindex.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/transform/reindex.rs
@@ -1415,7 +1415,7 @@ mod tests {
     #[test]
     #[rustfmt::skip]
     fn test_logs_greedy_all_offset() {
-        // Checking scenario where we skip all compaction becuase 
+        // Checking scenario where we skip all compaction because 
         // all batches have gaps (span > len) but sum(span) fits
         // in U16 range. Every batch qualifies for the offset fast-path.
         //

--- a/rust/otap-dataflow/crates/pdata/src/otap/transform/transport_optimize/attributes.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/transform/transport_optimize/attributes.rs
@@ -557,7 +557,7 @@ fn sort_attrs_type_and_keys_to_indices(
                 // will only return error for types that don't support rank, which utf8 does
                 let val_ranks = rank(dict_arr.values(), None).expect("can rank string array");
 
-                // concat the type and key rank into a a u16 vec where the higher end byte of each
+                // concat the type and key rank into a u16 vec where the higher end byte of each
                 // element is the type, and the lower end is the key's rank
                 let mut to_sort = vec![0u16; len];
                 for i in 0..len {

--- a/rust/otap-dataflow/crates/pdata/src/views/otlp.rs
+++ b/rust/otap-dataflow/crates/pdata/src/views/otlp.rs
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//! This module contains implementation of the Views traits for various types of of OTLP data.
+//! This module contains implementation of the Views traits for various types of OTLP data.
 
 pub mod bytes;
 pub mod proto;

--- a/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/decode.rs
+++ b/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/decode.rs
@@ -160,7 +160,7 @@ where
     }
 
     /// Advances the parser to find one of the fields specified in the `field_nums` argument.
-    /// If found, it returns the the byte slice containing the value for this field and the
+    /// If found, it returns the byte slice containing the value for this field and the
     /// field number as a tuple.
     #[must_use]
     pub fn advance_to_find_oneof(&self, field_nums: &[u64]) -> Option<(&'a [u8], u64)> {

--- a/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/metrics.rs
+++ b/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/metrics.rs
@@ -855,7 +855,7 @@ pub struct RawSummaryDataPoint<'a> {
     byte_parser: ProtoBytesParser<'a, SummaryDataPointFieldRanges>,
 }
 
-/// Known field ranges for for fields in `SummaryDataPoint` message
+/// Known field ranges for fields in `SummaryDataPoint` message
 #[derive(Default)]
 pub struct SummaryDataPointFieldRanges {
     start_time_unix_nano: Cell<Option<(NonZeroUsize, NonZeroUsize)>>,

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
@@ -82,7 +82,7 @@ pub struct Assignment<'a> {
 /// Pipeline stage for assigning the result of an expression evaluation to an OTAP column.
 ///
 /// This can do more than one assignment to a given record batch at a time. This minimizes the
-/// overhead of of materializing intermediate results multiple times when there are multiple
+/// overhead of materializing intermediate results multiple times when there are multiple
 /// assignments to be made.
 pub(crate) struct AssignPipelineStage {
     /// Identifier of the destination column
@@ -585,7 +585,7 @@ impl AssignPipelineStage {
                 // the resulting record batch.
                 let ColumnarValue::Array(result_values) = &eval_result.values else {
                     // safety: this is the else block of an if statement where we've tried to check if
-                    // this is is a scalar. Since we've determined it's not scalar, it must be array.
+                    // this is a scalar. Since we've determined it's not scalar, it must be array.
                     unreachable!("expected ColumnarResult::Array")
                 };
                 let left_join_input = &PhysicalExprEvalResult::new_with_parent_ids(

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/conditional.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/conditional.rs
@@ -479,7 +479,7 @@ mod test {
         ];
 
         // internally, try_fold must be called on the match expression here to convert the string
-        // argument into a regex scalar expression. This test is is to help avoid regressions of
+        // argument into a regex scalar expression. This test is to help avoid regressions of
         // cases where try_fold might not be called on the condition statements
         let result = exec_logs_pipeline::<OplParser>(
             r#"

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
@@ -1635,7 +1635,7 @@ impl AttributeFilterExec {
 }
 
 impl Composite<AttributeFilterExec> {
-    /// Executes the base filter, and combines the the parent_id to using the logical expression
+    /// Executes the base filter, and combines the parent_id to using the logical expression
     /// defined by the composite tree. The reason we do here, instead of say combining everything
     /// in `Composite<FilterExec>`, is that this saves us from doing additional conversions between
     /// the parent_id bitmap to a selection vector for the parent record batch.

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/project/anyval.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/project/anyval.rs
@@ -244,7 +244,7 @@ pub(crate) fn wrap_as_any_value_struct(values: &ArrayRef) -> Result<ArrayRef> {
     let (type_val, field_name) = arrow_type_to_any_value_type(values.data_type())?;
     let num_rows = values.len();
 
-    // lift the nulls off the original column for use in the the struct
+    // lift the nulls off the original column for use in the struct
     let nulls = values.nulls().cloned();
 
     // Build uniform type discriminant column

--- a/tools/pipeline_perf_test/orchestrator/lib/core/framework/report.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/core/framework/report.py
@@ -270,7 +270,7 @@ class Report:
 
     def display_template(self):
         """
-        Fetch the display template for the the TestReport given the current aggregation.
+        Fetch the display template for the TestReport given the current aggregation.
         """
         return self.get_template(mode=ReportAggregation.NONE)
 


### PR DESCRIPTION
# Change Summary

This PR fixes few typos in rust source files
It improves readability of the code documentation
## What issue does this PR close?

<!--
We highly recommend correlation of every PR to an issue
-->

* Closes #2770

## How are these changes tested?

## Are there any user-facing changes?
No

