### PR TITLE
Fix: move test only helpers, remove unnecessary lint suppressions

### DIFF
--- a/rust/otap-dataflow/crates/channel/src/mpmc.rs
+++ b/rust/otap-dataflow/crates/channel/src/mpmc.rs
@@ -280,7 +280,6 @@ impl<T> Sender<T> {
     }
 
     /// Attempts to send a value to the channel (async method).
-    #[allow(dead_code)]
     pub async fn send_async(&self, value: T) -> Result<(), SendError<T>> {
         // Fast path: avoid creating/polling a future when there is capacity.
         match self.send(value) {
@@ -298,7 +297,6 @@ impl<T> Sender<T> {
     }
 
     /// Closes the channel, preventing further sends.
-    #[allow(dead_code)]
     pub fn close(&self) {
         let mut state = self.channel.state.borrow_mut();
         state.is_closed = true;
@@ -339,7 +337,6 @@ impl<T> Receiver<T> {
     }
 
     /// Attempts to receive a value from the channel (async method).
-    #[allow(dead_code)]
     pub async fn recv(&self) -> Result<T, RecvError> {
         RecvFuture { receiver: self }.await
     }

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs
@@ -132,29 +132,6 @@ struct Config {
 }
 
 impl Config {
-    /// Creates a new Config for TCP.
-    #[must_use]
-    #[allow(dead_code)]
-    const fn new_tcp(listening_addr: SocketAddr) -> Self {
-        Self {
-            protocol: Protocol::Tcp(TcpConfig {
-                listening_addr,
-                tls: None,
-            }),
-            batch: None,
-        }
-    }
-
-    /// Creates a new Config for UDP.
-    #[must_use]
-    #[allow(dead_code)]
-    const fn new_udp(listening_addr: SocketAddr) -> Self {
-        Self {
-            protocol: Protocol::Udp(UdpConfig { listening_addr }),
-            batch: None,
-        }
-    }
-
     /// Returns the effective max batch duration, using the configured value or the default.
     fn max_batch_duration(&self) -> Duration {
         self.batch
@@ -1019,6 +996,30 @@ pub struct SyslogCefReceiverMetrics {
     /// Number of TCP connections rejected or closed due to process-wide memory pressure.
     #[metric(unit = "{conn}")]
     pub tcp_connections_rejected_memory_pressure: Counter<u64>,
+}
+
+#[cfg(test)]
+impl Config {
+    /// Creates a new Config for TCP. Test-only helper.
+    #[must_use]
+    const fn new_tcp(listening_addr: SocketAddr) -> Self {
+        Self {
+            protocol: Protocol::Tcp(TcpConfig {
+                listening_addr,
+                tls: None,
+            }),
+            batch: None,
+        }
+    }
+
+    /// Creates a new Config for UDP. Test-only helper.
+    #[must_use]
+    const fn new_udp(listening_addr: SocketAddr) -> Self {
+        Self {
+            protocol: Protocol::Udp(UdpConfig { listening_addr }),
+            batch: None,
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
move test only helpers, remove unnecessary lint suppressions public APIs

# Change Summary

1. Move test only helpers behind `#[cfg(test)]`, removes unnecessary `#[allow(dead_code)]`
2. Remove unnecessary lint suppressions on public APIs

## What issue does this PR close?
Quick lint fixes for code hygiene

## How are these changes tested?
Verified using `cargo check` and `cargo test`

- `cargo check -p otap-df-channel`
- `cargo check -p otap-df-core-nodes`
- `cargo test -p otap-df-core-nodes -- syslog`

## Are there any user-facing changes?
No
