### PR TITLE
fix: update shutdown endpoint URL in perf test templates

### DIFF
--- a/tools/pipeline_perf_test/test_suites/integration/templates/test_steps/df-loadgen-steps-docker-filtered.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/templates/test_steps/df-loadgen-steps-docker-filtered.yaml
@@ -116,7 +116,7 @@ steps:
       run:
         pre:
           - send_http_request:
-              url: http://localhost:8085/api/v1/pipeline-groups/shutdown?wait=true&timeout_secs={{drain_timeout_secs | default(60)}}
+              url: http://localhost:8085/api/v1/groups/shutdown?wait=true&timeout_secs={{drain_timeout_secs | default(60)}}
               method: POST
               headers:
                 "Content-Type": "application/json"
@@ -129,7 +129,7 @@ steps:
       run:
         pre:
           - send_http_request:
-              url: http://localhost:8086/api/v1/pipeline-groups/shutdown?wait=true&timeout_secs={{drain_timeout_secs | default(60)}}
+              url: http://localhost:8086/api/v1/groups/shutdown?wait=true&timeout_secs={{drain_timeout_secs | default(60)}}
               method: POST
               headers:
                 "Content-Type": "application/json"
@@ -142,7 +142,7 @@ steps:
       run:
         pre:
           - send_http_request:
-              url: http://localhost:8087/api/v1/pipeline-groups/shutdown?wait=true&timeout_secs={{drain_timeout_secs | default(60)}}
+              url: http://localhost:8087/api/v1/groups/shutdown?wait=true&timeout_secs={{drain_timeout_secs | default(60)}}
               method: POST
               headers:
                 "Content-Type": "application/json"

--- a/tools/pipeline_perf_test/test_suites/integration/templates/test_steps/df-loadgen-steps-docker-otel.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/templates/test_steps/df-loadgen-steps-docker-otel.yaml
@@ -93,7 +93,7 @@ steps:
       run:
         pre:
           - send_http_request:
-              url: http://localhost:8085/api/v1/pipeline-groups/shutdown?wait=true&timeout_secs={{drain_timeout_secs | default(60)}}
+              url: http://localhost:8085/api/v1/groups/shutdown?wait=true&timeout_secs={{drain_timeout_secs | default(60)}}
               method: POST
               headers:
                 "Content-Type": "application/json"

--- a/tools/pipeline_perf_test/test_suites/integration/templates/test_steps/df-loadgen-steps-docker.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/templates/test_steps/df-loadgen-steps-docker.yaml
@@ -118,7 +118,7 @@ steps:
       run:
         pre:
           - send_http_request:
-              url: http://localhost:8085/api/v1/pipeline-groups/shutdown?wait=true&timeout_secs={{drain_timeout_secs | default(60)}}
+              url: http://localhost:8085/api/v1/groups/shutdown?wait=true&timeout_secs={{drain_timeout_secs | default(60)}}
               method: POST
               headers:
                 "Content-Type": "application/json"
@@ -131,7 +131,7 @@ steps:
       run:
         pre:
           - send_http_request:
-              url: http://localhost:8086/api/v1/pipeline-groups/shutdown?wait=true&timeout_secs={{drain_timeout_secs | default(60)}}
+              url: http://localhost:8086/api/v1/groups/shutdown?wait=true&timeout_secs={{drain_timeout_secs | default(60)}}
               method: POST
               headers:
                 "Content-Type": "application/json"
@@ -144,7 +144,7 @@ steps:
       run:
         pre:
           - send_http_request:
-              url: http://localhost:8087/api/v1/pipeline-groups/shutdown?wait=true&timeout_secs={{drain_timeout_secs | default(60)}}
+              url: http://localhost:8087/api/v1/groups/shutdown?wait=true&timeout_secs={{drain_timeout_secs | default(60)}}
               method: POST
               headers:
                 "Content-Type": "application/json"


### PR DESCRIPTION
## What issue does this PR close?

Closes #2774

## Change Summary

The shutdown API endpoint was renamed from `/api/v1/pipeline-groups/shutdown` to `/api/v1/groups/shutdown`, causing pipeline perf tests to fail with 404 on the shutdown endpoint.

This PR updates all 3 perf test template files:
- `df-loadgen-steps-docker-filtered.yaml` (3 URLs)
- `df-loadgen-steps-docker-otel.yaml` (1 URL)
- `df-loadgen-steps-docker.yaml` (3 URLs)

## How are these changes tested?

The pipeline perf test CI job will validate the fix.

## Are there any user-facing changes?

No.