### PR TITLE
Fix: Remove allow unused annotations for dead code warnings

### DIFF
--- a/rust/otap-dataflow/crates/engine/src/lib.rs
+++ b/rust/otap-dataflow/crates/engine/src/lib.rs
@@ -1935,7 +1935,6 @@ where
 struct HyperEdgeRuntime {
     sources: Vec<NodeIdPortName>,
 
-    #[allow(dead_code)]
     dispatch_policy: DispatchPolicy,
 
     // names are from the configuration, not yet resolved

--- a/rust/otap-dataflow/crates/pdata/src/encode/record/array.rs
+++ b/rust/otap-dataflow/crates/pdata/src/encode/record/array.rs
@@ -708,7 +708,6 @@ pub type Float64ArrayBuilder = PrimitiveArrayBuilder<Float64Type>;
 pub type UInt8ArrayBuilder = PrimitiveArrayBuilder<UInt8Type>;
 pub type UInt16ArrayBuilder = PrimitiveArrayBuilder<UInt16Type>;
 pub type UInt32ArrayBuilder = PrimitiveArrayBuilder<UInt32Type>;
-#[allow(dead_code)]
 pub type UInt64ArrayBuilder = PrimitiveArrayBuilder<UInt64Type>;
 #[allow(dead_code)]
 pub type Int8ArrayBuilder = PrimitiveArrayBuilder<Int8Type>;
@@ -717,7 +716,6 @@ pub type Int16ArrayBuilder = PrimitiveArrayBuilder<Int16Type>;
 pub type Int32ArrayBuilder = PrimitiveArrayBuilder<Int32Type>;
 pub type Int64ArrayBuilder = PrimitiveArrayBuilder<Int64Type>;
 pub type TimestampNanosecondArrayBuilder = PrimitiveArrayBuilder<TimestampNanosecondType>;
-#[allow(dead_code)]
 pub type DurationNanosecondArrayBuilder = PrimitiveArrayBuilder<DurationNanosecondType>;
 
 /// Convert an array containing binary data to one which contains UTF-8 Data. This will handle

--- a/rust/otap-dataflow/crates/pdata/src/otap/transform.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/transform.rs
@@ -170,7 +170,6 @@ where
 ///
 /// This returns a new RecordBatch with the parent_id column replaced with the materialized id.
 ///
-#[allow(unused)] // TODO -- remove allow(unused) when we use this to optimize decoding OTAP
 pub fn materialize_parent_id_for_attributes<T>(record_batch: &RecordBatch) -> Result<RecordBatch>
 where
     T: ParentId,


### PR DESCRIPTION
# Change Summary
 Remove allow unused annotations for dead code warnings

## What issue does this PR close?
* Closes #NNN

## How are these changes tested?
`cargo check -p otap-df-channel -p otap-df-engine -p otap-df-pdata -p otap-df-query-engine`
## Are there any user-facing changes?
No
