### PR TITLE
fix crate name in otap-dataflow readme

### DIFF
--- a/rust/otap-dataflow/README.md
+++ b/rust/otap-dataflow/README.md
@@ -187,8 +187,8 @@ A simple component to produce synthetic data from semantic convention registries
 #### Batch processor
 
 A batching processor that works directly with OTAP records. This is
-[based on lower-level support in the `otal_arrow_rust`
-crate](../otel-arrow-rust/src/otap/batching.rs).
+[based on lower-level support in the `otap-df-pdata`
+crate](./crates/pdata/src/otap/batching.rs).
 
 #### OTAP exporter
 


### PR DESCRIPTION
# Change Summary

fix crate name in otap-dataflow readme.

## What issue does this PR close?

minor nit.

## How are these changes tested?

N/A

## Are there any user-facing changes?

N/A