### PR TITLE
docs: consolidate CLAUDE.md and copilot-instructions.md into AGENTS.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,0 @@
-# Copilot Instructions
-
-If working on Rust code (i.e., the `rust/` directory), read and follow all
-instructions in [rust/otap-dataflow/AGENTS.md](../rust/otap-dataflow/AGENTS.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Agent Instructions
+
+If working on Rust code (i.e., the `rust/` directory), read and follow all
+instructions in [rust/otap-dataflow/AGENTS.md](rust/otap-dataflow/AGENTS.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,3 @@
 # CLAUDE.md
 
-If working on Rust code (i.e., the `rust/` directory), read and follow all
-instructions in [rust/otap-dataflow/AGENTS.md](rust/otap-dataflow/AGENTS.md).
+See [AGENTS.md](AGENTS.md).


### PR DESCRIPTION
Both `CLAUDE.md` and `.github/copilot-instructions.md` were stubs that simply redirected to [rust/otap-dataflow/AGENTS.md](rust/otap-dataflow/AGENTS.md).

Modern AI coding agents (Claude Code, GitHub Copilot, Cursor, etc.) all support a single top-level `AGENTS.md` file, so this consolidates the two stubs into one.