### PR TITLE
Add try_into_with_options with empty ConversionOptions struct

### DIFF
--- a/rust/otap-dataflow/benchmarks/benches/otap_logs_view/main.rs
+++ b/rust/otap-dataflow/benchmarks/benches/otap_logs_view/main.rs
@@ -160,7 +160,7 @@ fn bench_otap_logs_view(c: &mut Criterion) {
                 b.iter(|| {
                     // 1. Convert OTAP -> OTLP bytes
                     let mut logs_encoder = LogsProtoBytesEncoder::new();
-                    let mut buffer = ProtoBuffer::new();
+                    let mut buffer = ProtoBuffer::default();
                     let mut input_clone = input.clone();
                     logs_encoder
                         .encode(&mut input_clone, &mut buffer)

--- a/rust/otap-dataflow/benchmarks/benches/otlp_bytes/main.rs
+++ b/rust/otap-dataflow/benchmarks/benches/otlp_bytes/main.rs
@@ -128,7 +128,7 @@ fn otap_to_bytes_logs(c: &mut Criterion) {
 
     let logs = create_logs_data();
     let otap_batch = otlp_to_otap(&OtlpProtoMessage::Logs(logs));
-    let mut proto_buffer = ProtoBuffer::new();
+    let mut proto_buffer = ProtoBuffer::default();
     let mut encoder = LogsProtoBytesEncoder::new();
 
     _ = group.bench_function("proto encode", |b| {

--- a/rust/otap-dataflow/benchmarks/benches/self_tracing/main.rs
+++ b/rust/otap-dataflow/benchmarks/benches/self_tracing/main.rs
@@ -179,7 +179,7 @@ where
                 }
             }
             BenchOp::EncodeProto => {
-                let mut buf = ProtoBuffer::new();
+                let mut buf = ProtoBuffer::default();
                 let mut encoder = DirectLogRecordEncoder::new(&mut buf);
 
                 for _ in 0..self.iterations {

--- a/rust/otap-dataflow/crates/config/src/conversion.rs
+++ b/rust/otap-dataflow/crates/config/src/conversion.rs
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Options for protocol conversion.
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Options for protocol conversion.
+///
+/// Currently empty; intended as a placeholder for future per-conversion
+/// configuration (e.g., size limits) to be threaded through pipeline config.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
+#[serde(deny_unknown_fields)]
+pub struct ConversionOptions {}

--- a/rust/otap-dataflow/crates/config/src/lib.rs
+++ b/rust/otap-dataflow/crates/config/src/lib.rs
@@ -19,6 +19,7 @@ use std::hash::Hash;
 pub mod byte_units;
 /// Config URI providers for resolving configuration from file:, env:, or bare paths.
 pub mod config_provider;
+pub mod conversion;
 pub mod engine;
 /// Environment variable substitution for raw config text.
 pub mod env_substitution;
@@ -49,6 +50,8 @@ pub use topic::{
 };
 /// Validation helpers for node configuration.
 pub mod validation;
+
+pub use conversion::ConversionOptions;
 
 /// Signal types
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/mod.rs
@@ -40,6 +40,7 @@ use otap_df_engine::local::exporter::{EffectHandler, Exporter};
 use otap_df_engine::message::{ExporterInbox, Message};
 use otap_df_engine::node::NodeId;
 use otap_df_engine::terminal_state::TerminalState;
+use otap_df_pdata::TryIntoWithOptions;
 use otap_df_pdata::otlp::OtlpProtoBytes;
 // Zero-copy view import (currently unused, for future optimization)
 // use otap_df_pdata::views::otap::OtapLogsView;
@@ -508,7 +509,7 @@ impl GenevaExporter {
 
                         let otlp_bytes: OtlpProtoBytes =
                             OtapPayload::OtapArrowRecords(OtapArrowRecords::Logs(otap_records))
-                                .try_into()
+                                .try_into_with_default()
                                 .map_err(|e| {
                                     self.metrics.conversion_errors.inc();
                                     format!("Failed to convert OTAP to OTLP: {:?}", e)
@@ -558,7 +559,7 @@ impl GenevaExporter {
 
                         let otlp_bytes: OtlpProtoBytes =
                             OtapPayload::OtapArrowRecords(OtapArrowRecords::Traces(otap_records))
-                                .try_into()
+                                .try_into_with_default()
                                 .map_err(|e| {
                                     self.metrics.conversion_errors.inc();
                                     format!("Failed to convert OTAP to OTLP: {:?}", e)

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/condense_attributes_processor/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/condense_attributes_processor/mod.rs
@@ -29,6 +29,7 @@ use otap_df_engine::message::Message;
 use otap_df_engine::node::NodeId;
 use otap_df_engine::process_duration::ComputeDuration;
 use otap_df_engine::processor::ProcessorWrapper;
+use otap_df_pdata::TryIntoWithOptions;
 use otap_df_pdata::encode::record::attributes::StrKeysAttributesRecordBatchBuilder;
 use otap_df_pdata::otlp::attributes::AttributeValueType;
 use otap_df_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
@@ -623,7 +624,7 @@ impl local::Processor<OtapPdata> for CondenseAttributesProcessor {
                     OtapPayload::empty(signal)
                 };
 
-                let mut records: OtapArrowRecords = payload.try_into()?;
+                let mut records: OtapArrowRecords = payload.try_into_with_default()?;
 
                 let input_items = records.num_items() as u64;
 
@@ -758,7 +759,8 @@ mod condense_tests {
                 let out = ctx.drain_pdata().await;
                 let (_, first) = out.into_iter().next().expect("one output").into_parts();
 
-                let otlp_bytes: OtlpProtoBytes = first.try_into().expect("convert to otlp");
+                let otlp_bytes: OtlpProtoBytes =
+                    first.try_into_with_default().expect("convert to otlp");
                 let bytes = match otlp_bytes {
                     OtlpProtoBytes::ExportLogsRequest(b) => b,
                     _ => panic!("unexpected otlp variant"),
@@ -880,7 +882,8 @@ mod condense_tests {
         let mut bytes = BytesMut::new();
         input.encode(&mut bytes).expect("encode input");
         let payload: OtapPayload = OtlpProtoBytes::ExportLogsRequest(bytes.freeze()).into();
-        let mut records: OtapArrowRecords = payload.try_into().expect("convert to records");
+        let mut records: OtapArrowRecords =
+            payload.try_into_with_default().expect("convert to records");
 
         let before_batch = records
             .get(ArrowPayloadType::LogAttrs)
@@ -1292,7 +1295,9 @@ mod condense_tests {
 
                 let out = ctx.drain_pdata().await;
                 let (_, first_payload) = out.into_iter().next().expect("one output").into_parts();
-                let otlp_bytes: OtlpProtoBytes = first_payload.try_into().expect("convert to otlp");
+                let otlp_bytes: OtlpProtoBytes = first_payload
+                    .try_into_with_default()
+                    .expect("convert to otlp");
                 let bytes = match otlp_bytes {
                     OtlpProtoBytes::ExportLogsRequest(b) => b,
                     _ => panic!("unexpected otlp variant"),
@@ -1334,8 +1339,9 @@ mod condense_tests {
 
                 let out = ctx.drain_pdata().await;
                 let (_, second_payload) = out.into_iter().next().expect("one output").into_parts();
-                let otlp_bytes: OtlpProtoBytes =
-                    second_payload.try_into().expect("convert to otlp");
+                let otlp_bytes: OtlpProtoBytes = second_payload
+                    .try_into_with_default()
+                    .expect("convert to otlp");
                 let bytes = match otlp_bytes {
                     OtlpProtoBytes::ExportLogsRequest(b) => b,
                     _ => panic!("unexpected otlp variant"),

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/processor.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/processor.rs
@@ -24,6 +24,7 @@ use otap_df_engine::{
     message::Message,
     process_duration::ComputeDuration,
 };
+use otap_df_pdata::TryIntoWithOptions;
 use otap_df_pdata::{OtapPayload, OtlpProtoBytes};
 
 /// URN identifier for the processor
@@ -129,7 +130,7 @@ impl RecordsetKqlProcessor {
 
         // Extract context and payload, convert to OTLP bytes
         let (ctx, payload) = data.into_parts();
-        let otlp_bytes: OtlpProtoBytes = payload.try_into()?;
+        let otlp_bytes: OtlpProtoBytes = payload.try_into_with_default()?;
 
         // Process based on signal type (timed).
         let result = effect_handler.timed(&self.compute_duration, || match otlp_bytes {
@@ -389,7 +390,8 @@ mod tests {
                 let out = ctx.drain_pdata().await;
                 let first = out.into_iter().next().expect("one output").payload();
 
-                let otlp_bytes: OtlpProtoBytes = first.try_into().expect("convert to otlp");
+                let otlp_bytes: OtlpProtoBytes =
+                    first.try_into_with_default().expect("convert to otlp");
                 let bytes = match otlp_bytes {
                     OtlpProtoBytes::ExportLogsRequest(b) => b,
                     _ => panic!("unexpected otlp variant"),

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/resource_validator_processor/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/resource_validator_processor/mod.rs
@@ -61,6 +61,9 @@ use otap_df_engine::node::NodeId;
 use otap_df_engine::processor::ProcessorWrapper;
 use otap_df_pdata::OtapArrowRecords;
 use otap_df_pdata::OtapPayload;
+use otap_df_pdata::TryFromWithOptions;
+#[cfg(test)]
+use otap_df_pdata::TryIntoWithOptions;
 use otap_df_pdata::otlp::OtlpProtoBytes;
 use otap_df_pdata::views::otap::OtapLogsView;
 use otap_df_pdata::views::otlp::bytes::logs::RawLogsData;
@@ -508,7 +511,7 @@ impl local::Processor<OtapPdata> for ResourceValidatorProcessor {
                         // Metrics/Traces Arrow views not yet available - convert to OTLP
                         // TODO: Implement OtapMetricsView/OtapTracesView to avoid clone + conversion
                         SignalType::Metrics | SignalType::Traces => {
-                            match OtlpProtoBytes::try_from(arrow_records.clone()) {
+                            match OtlpProtoBytes::try_from_with_default(arrow_records.clone()) {
                                 Ok(OtlpProtoBytes::ExportMetricsRequest(bytes)) => {
                                     let data = RawMetricsData::new(bytes.as_ref());
                                     self.validate_metrics(&data, &allowed_values)
@@ -914,7 +917,9 @@ mod tests {
     fn create_arrow_logs_with_resource(attrs: Vec<KeyValue>) -> OtapArrowRecords {
         let logs_bytes = create_logs_request_with_resource(attrs);
         let otlp_bytes = OtlpProtoBytes::ExportLogsRequest(logs_bytes);
-        otlp_bytes.try_into().expect("Failed to convert to Arrow")
+        otlp_bytes
+            .try_into_with_default()
+            .expect("Failed to convert to Arrow")
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/mod.rs
@@ -26,6 +26,7 @@ use otap_df_otap::OTAP_EXPORTER_FACTORIES;
 use otap_df_otap::metrics::ExporterPDataMetrics;
 use otap_df_otap::pdata::OtapPdata;
 use otap_df_pdata::Producer;
+use otap_df_pdata::TryIntoWithOptions;
 use otap_df_pdata::encode::producer::ProducerOptions;
 use otap_df_pdata::otap::OtapArrowRecords;
 use otap_df_pdata::proto::opentelemetry::arrow::v1::{BatchArrowRecords, BatchStatus};
@@ -466,7 +467,7 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
                         self.pdata_metrics.inc_consumed(signal_type);
                         let payload = pdata.take_payload();
 
-                        let message: OtapArrowRecords = match payload.try_into() {
+                        let message: OtapArrowRecords = match payload.try_into_with_default() {
                             Ok(m) => m,
                             Err(e) => {
                                 self.pdata_metrics.inc_failed(signal_type);
@@ -936,6 +937,7 @@ mod tests {
         test_node,
     };
     use otap_df_otap::compression::CompressionMethod;
+    use otap_df_pdata::TryIntoWithOptions;
     use otap_df_pdata::otap::OtapArrowRecords;
     use otap_df_pdata::proto::opentelemetry::arrow::v1::{
         ArrowPayloadType, BatchArrowRecords, BatchStatus,
@@ -1025,7 +1027,7 @@ mod tests {
                         .expect("Timed out waiting for message")
                         .expect("No message received")
                         .payload()
-                        .try_into()
+                        .try_into_with_default()
                         .expect("Could convert pdata to OTAPData");
 
                 // Assert that the message received is what the exporter sent
@@ -1039,7 +1041,7 @@ mod tests {
                         .expect("Timed out waiting for message")
                         .expect("No message received")
                         .payload()
-                        .try_into()
+                        .try_into_with_default()
                         .expect("Could convert pdata to OTAPData");
                 let _expected_logs_message =
                     create_otap_batch(LOG_BATCH_ID, ArrowPayloadType::Logs);
@@ -1051,7 +1053,7 @@ mod tests {
                         .expect("Timed out waiting for message")
                         .expect("No message received")
                         .payload()
-                        .try_into()
+                        .try_into_with_default()
                         .expect("Could convert pdata to OTAPData");
 
                 let _expected_trace_message =
@@ -1584,7 +1586,7 @@ mod tests {
         let pdata = OtapPdata::new_default(log_message.into());
         let payload = pdata.clone();
         batches_tx
-            .send((pdata, payload.payload().try_into().unwrap()))
+            .send((pdata, payload.payload().try_into_with_default().unwrap()))
             .await
             .unwrap();
         // Drop sender so the function exits after processing
@@ -1644,7 +1646,7 @@ mod tests {
             let pdata = OtapPdata::new_default(log_message.into());
             let payload = pdata.clone();
             batches_tx
-                .send((pdata, payload.payload().try_into().unwrap()))
+                .send((pdata, payload.payload().try_into_with_default().unwrap()))
                 .await
                 .unwrap();
         }

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs
@@ -37,6 +37,8 @@ use otap_df_engine::node::NodeId;
 use otap_df_engine::terminal_state::TerminalState;
 use otap_df_engine::wiring_contract::WiringContract;
 use otap_df_engine::{ConsumerEffectHandlerExtension, ExporterFactory};
+#[cfg(test)]
+use otap_df_pdata::TryIntoWithOptions;
 use otap_df_pdata::otlp::logs::LogsProtoBytesEncoder;
 use otap_df_pdata::otlp::metrics::MetricsProtoBytesEncoder;
 use otap_df_pdata::otlp::traces::TracesProtoBytesEncoder;
@@ -245,7 +247,7 @@ impl Exporter<OtapPdata> for OtlpHttpExporter {
         let mut logs_proto_encoder = LogsProtoBytesEncoder::new();
         let mut metrics_proto_encoder = MetricsProtoBytesEncoder::new();
         let mut traces_proto_encoder = TracesProtoBytesEncoder::new();
-        let mut proto_buffer = ProtoBuffer::with_capacity(8 * 1024);
+        let mut proto_buffer = ProtoBuffer::default();
 
         loop {
             // Opportunistically drain completions before we park on a recv.
@@ -1217,7 +1219,7 @@ mod test {
                         match pdata.signal_type() {
                             SignalType::Logs => {
                                 let pdata: OtlpProtoBytes =
-                                    pdata.take_payload().try_into().unwrap();
+                                    pdata.take_payload().try_into_with_default().unwrap();
                                 let pdata_decoded = LogsData::decode(pdata.as_bytes()).unwrap();
                                 assert_equivalent(
                                     &[OtlpProtoMessage::Logs(pdata_decoded)],
@@ -1226,7 +1228,7 @@ mod test {
                             }
                             SignalType::Metrics => {
                                 let pdata: OtlpProtoBytes =
-                                    pdata.take_payload().try_into().unwrap();
+                                    pdata.take_payload().try_into_with_default().unwrap();
                                 let pdata_decoded = MetricsData::decode(pdata.as_bytes()).unwrap();
                                 assert_equivalent(
                                     &[OtlpProtoMessage::Metrics(pdata_decoded)],
@@ -1235,7 +1237,7 @@ mod test {
                             }
                             SignalType::Traces => {
                                 let pdata: OtlpProtoBytes =
-                                    pdata.take_payload().try_into().unwrap();
+                                    pdata.take_payload().try_into_with_default().unwrap();
                                 let pdata_decoded = TracesData::decode(pdata.as_bytes()).unwrap();
                                 assert_equivalent(
                                     &[OtlpProtoMessage::Traces(pdata_decoded)],
@@ -1878,7 +1880,7 @@ mod test {
                         match pdata.signal_type() {
                             SignalType::Logs => {
                                 let pdata: OtlpProtoBytes =
-                                    pdata.take_payload().try_into().unwrap();
+                                    pdata.take_payload().try_into_with_default().unwrap();
                                 let pdata_decoded = LogsData::decode(pdata.as_bytes()).unwrap();
                                 assert_equivalent(
                                     &[OtlpProtoMessage::Logs(pdata_decoded)],
@@ -1887,7 +1889,7 @@ mod test {
                             }
                             SignalType::Metrics => {
                                 let pdata: OtlpProtoBytes =
-                                    pdata.take_payload().try_into().unwrap();
+                                    pdata.take_payload().try_into_with_default().unwrap();
                                 let pdata_decoded = MetricsData::decode(pdata.as_bytes()).unwrap();
                                 assert_equivalent(
                                     &[OtlpProtoMessage::Metrics(pdata_decoded)],
@@ -1896,7 +1898,7 @@ mod test {
                             }
                             SignalType::Traces => {
                                 let pdata: OtlpProtoBytes =
-                                    pdata.take_payload().try_into().unwrap();
+                                    pdata.take_payload().try_into_with_default().unwrap();
                                 let pdata_decoded = TracesData::decode(pdata.as_bytes()).unwrap();
                                 assert_equivalent(
                                     &[OtlpProtoMessage::Traces(pdata_decoded)],
@@ -1998,7 +2000,8 @@ mod test {
                     // ensure we got back all the signals we expected, from the correct servers.
 
                     let mut pdata = logs_pdata_rx.recv().await.unwrap();
-                    let otlp_bytes: OtlpProtoBytes = pdata.take_payload().try_into().unwrap();
+                    let otlp_bytes: OtlpProtoBytes =
+                        pdata.take_payload().try_into_with_default().unwrap();
                     let pdata_decoded = LogsData::decode(otlp_bytes.as_bytes()).unwrap();
                     assert_equivalent(
                         &[OtlpProtoMessage::Logs(pdata_decoded)],
@@ -2006,7 +2009,8 @@ mod test {
                     );
 
                     let mut pdata = metrics_pdata_rx.recv().await.unwrap();
-                    let otlp_bytes: OtlpProtoBytes = pdata.take_payload().try_into().unwrap();
+                    let otlp_bytes: OtlpProtoBytes =
+                        pdata.take_payload().try_into_with_default().unwrap();
                     let pdata_decoded = MetricsData::decode(otlp_bytes.as_bytes()).unwrap();
                     assert_equivalent(
                         &[OtlpProtoMessage::Metrics(pdata_decoded)],
@@ -2014,7 +2018,8 @@ mod test {
                     );
 
                     let mut pdata = traces_pdata_rx.recv().await.unwrap();
-                    let otlp_bytes: OtlpProtoBytes = pdata.take_payload().try_into().unwrap();
+                    let otlp_bytes: OtlpProtoBytes =
+                        pdata.take_payload().try_into_with_default().unwrap();
                     let pdata_decoded = TracesData::decode(otlp_bytes.as_bytes()).unwrap();
                     assert_equivalent(
                         &[OtlpProtoMessage::Traces(pdata_decoded)],
@@ -2088,8 +2093,10 @@ mod test {
                     server_cancellation_token.cancel();
 
                     // assert the pdata sent was the pdata received
-                    let pdata: OtlpProtoBytes =
-                        pdatas_received[0].take_payload().try_into().unwrap();
+                    let pdata: OtlpProtoBytes = pdatas_received[0]
+                        .take_payload()
+                        .try_into_with_default()
+                        .unwrap();
                     let pdata_decoded = LogsData::decode(pdata.as_bytes()).unwrap();
                     assert_equivalent(
                         &[OtlpProtoMessage::Logs(pdata_decoded)],

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/parquet_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/parquet_exporter/mod.rs
@@ -54,6 +54,7 @@ use otap_df_engine::terminal_state::TerminalState;
 use otap_df_otap::OTAP_EXPORTER_FACTORIES;
 use otap_df_otap::metrics::ExporterPDataMetrics;
 use otap_df_otap::pdata::OtapPdata;
+use otap_df_pdata::TryIntoWithOptions;
 use otap_df_pdata::otap::OtapArrowRecords;
 use otap_df_telemetry::metrics::{MetricSet, MetricSetHandler};
 use std::io::ErrorKind;
@@ -297,7 +298,7 @@ impl Exporter<OtapPdata> for ParquetExporter {
                     }
 
                     let mut otap_batch: OtapArrowRecords =
-                        payload.try_into().inspect_err(|_| {
+                        payload.try_into_with_default().inspect_err(|_| {
                             if let Some(metrics) = self.pdata_metrics.as_mut() {
                                 metrics.inc_failed(signal_type);
                             }
@@ -482,6 +483,7 @@ mod test {
     use otap_df_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
     use otap_df_pdata::proto::opentelemetry::common::v1::{AnyValue, KeyValue, any_value::Value};
     use otap_df_pdata::schema::consts;
+    use otap_df_pdata::{TryFromWithOptions, TryIntoWithOptions};
     use parquet::arrow::async_reader::ParquetRecordBatchStreamBuilder;
     use tokio::fs::File;
     use tokio::time::sleep;
@@ -577,7 +579,7 @@ mod test {
                         })
                     }
                     let pdata3 = fixtures::create_single_logs_pdata_with_attrs(attrs3).payload();
-                    let mut otap_batch = OtapArrowRecords::try_from(pdata3).unwrap();
+                    let mut otap_batch = OtapArrowRecords::try_from_with_default(pdata3).unwrap();
                     let mut attrs_batch =
                         otap_batch.get(ArrowPayloadType::LogAttrs).unwrap().clone();
                     let old_column = attrs_batch.remove_column(
@@ -653,7 +655,7 @@ mod test {
                             value: Some(AnyValue::new_string("terry")),
                         }])
                         .payload()
-                        .try_into()
+                        .try_into_with_default()
                         .unwrap();
 
                     let batch2: OtapArrowRecords =
@@ -662,7 +664,7 @@ mod test {
                             value: Some(AnyValue::new_int(418)),
                         }])
                         .payload()
-                        .try_into()
+                        .try_into_with_default()
                         .unwrap();
 
                     // double check that these contain schemas that are not the same ...

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/perf_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/perf_exporter/mod.rs
@@ -41,6 +41,7 @@ use otap_df_engine::terminal_state::TerminalState;
 use otap_df_otap::OTAP_EXPORTER_FACTORIES;
 use otap_df_otap::metrics::ExporterPDataMetrics;
 use otap_df_otap::pdata::OtapPdata;
+use otap_df_pdata::TryIntoWithOptions;
 use otap_df_pdata::otap::OtapArrowRecords;
 use otap_df_telemetry::metrics::{MetricSet, MetricSetHandler};
 use otap_df_telemetry::otel_info;
@@ -173,7 +174,7 @@ impl local::Exporter<OtapPdata> for PerfExporter {
                     let payload = pdata.take_payload();
                     let _ = effect_handler.notify_ack(AckMsg::new(pdata)).await?;
 
-                    let batch: OtapArrowRecords = match payload.try_into() {
+                    let batch: OtapArrowRecords = match payload.try_into_with_default() {
                         Ok(batch) => batch,
                         Err(_) => {
                             self.pdata_metrics.inc_failed(signal_type);

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/attributes_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/attributes_processor/mod.rs
@@ -48,6 +48,7 @@ use otap_df_engine::node::NodeId;
 use otap_df_engine::process_duration::ComputeDuration;
 use otap_df_engine::processor::ProcessorWrapper;
 use otap_df_otap::{OTAP_PROCESSOR_FACTORIES, pdata::OtapPdata};
+use otap_df_pdata::TryIntoWithOptions;
 use otap_df_pdata::otap::transform::apply_attribute_transform;
 use otap_df_pdata::otap::{
     OtapArrowRecords,
@@ -359,7 +360,7 @@ impl local::Processor<OtapPdata> for AttributesProcessor {
                 let signal = pdata.signal_type();
                 let (context, payload) = pdata.into_parts();
 
-                let mut records: OtapArrowRecords = payload.try_into()?;
+                let mut records: OtapArrowRecords = payload.try_into_with_default()?;
 
                 // Update domain counters (count once per message when domains are enabled)
                 if self.has_resource_domain {
@@ -684,7 +685,8 @@ mod tests {
                 let first = out.into_iter().next().expect("one output").payload();
 
                 // Convert output to OTLP bytes for easy assertions
-                let otlp_bytes: OtlpProtoBytes = first.try_into().expect("convert to otlp");
+                let otlp_bytes: OtlpProtoBytes =
+                    first.try_into_with_default().expect("convert to otlp");
                 let bytes = match otlp_bytes {
                     OtlpProtoBytes::ExportLogsRequest(b) => b,
                     _ => panic!("unexpected otlp variant"),
@@ -762,7 +764,8 @@ mod tests {
                 let out = ctx.drain_pdata().await;
                 let first = out.into_iter().next().expect("one output").payload();
 
-                let otlp_bytes: OtlpProtoBytes = first.try_into().expect("convert to otlp");
+                let otlp_bytes: OtlpProtoBytes =
+                    first.try_into_with_default().expect("convert to otlp");
                 let bytes = match otlp_bytes {
                     OtlpProtoBytes::ExportLogsRequest(b) => b,
                     _ => panic!("unexpected otlp variant"),
@@ -829,7 +832,7 @@ mod tests {
                 let out = ctx.drain_pdata().await;
                 let first = out.into_iter().next().expect("one output").payload();
 
-                let otlp_bytes: OtlpProtoBytes = first.try_into().expect("convert to otlp");
+                let otlp_bytes: OtlpProtoBytes = first.try_into_with_default().expect("convert to otlp");
                 let bytes = match otlp_bytes {
                     OtlpProtoBytes::ExportLogsRequest(b) => b,
                     _ => panic!("unexpected otlp variant"),
@@ -916,7 +919,8 @@ mod tests {
                 let out = ctx.drain_pdata().await;
                 let first = out.into_iter().next().expect("one output").payload();
 
-                let otlp_bytes: OtlpProtoBytes = first.try_into().expect("convert to otlp");
+                let otlp_bytes: OtlpProtoBytes =
+                    first.try_into_with_default().expect("convert to otlp");
                 let bytes = match otlp_bytes {
                     OtlpProtoBytes::ExportLogsRequest(b) => b,
                     _ => panic!("unexpected otlp variant"),
@@ -1009,7 +1013,8 @@ mod tests {
                 let out = ctx.drain_pdata().await;
                 let first = out.into_iter().next().expect("one output").payload();
 
-                let otlp_bytes: OtlpProtoBytes = first.try_into().expect("convert to otlp");
+                let otlp_bytes: OtlpProtoBytes =
+                    first.try_into_with_default().expect("convert to otlp");
                 let bytes = match otlp_bytes {
                     OtlpProtoBytes::ExportLogsRequest(b) => b,
                     _ => panic!("unexpected otlp variant"),
@@ -1081,7 +1086,8 @@ mod tests {
                 let out = ctx.drain_pdata().await;
                 let first = out.into_iter().next().expect("one output").payload();
 
-                let otlp_bytes: OtlpProtoBytes = first.try_into().expect("convert to otlp");
+                let otlp_bytes: OtlpProtoBytes =
+                    first.try_into_with_default().expect("convert to otlp");
                 let bytes = match otlp_bytes {
                     OtlpProtoBytes::ExportLogsRequest(b) => b,
                     _ => panic!("unexpected otlp variant"),
@@ -1169,7 +1175,8 @@ mod tests {
                 let out = ctx.drain_pdata().await;
                 let first = out.into_iter().next().expect("one output").payload();
 
-                let otlp_bytes: OtlpProtoBytes = first.try_into().expect("convert to otlp");
+                let otlp_bytes: OtlpProtoBytes =
+                    first.try_into_with_default().expect("convert to otlp");
                 let bytes = match otlp_bytes {
                     OtlpProtoBytes::ExportMetricsRequest(b) => b,
                     _ => panic!("unexpected otlp variant"),
@@ -1258,7 +1265,8 @@ mod tests {
                 let out = ctx.drain_pdata().await;
                 let first = out.into_iter().next().expect("one output").payload();
 
-                let otlp_bytes: OtlpProtoBytes = first.try_into().expect("convert to otlp");
+                let otlp_bytes: OtlpProtoBytes =
+                    first.try_into_with_default().expect("convert to otlp");
                 let bytes = match otlp_bytes {
                     OtlpProtoBytes::ExportMetricsRequest(b) => b,
                     _ => panic!("unexpected otlp variant"),
@@ -1330,7 +1338,8 @@ mod tests {
                 let out = ctx.drain_pdata().await;
                 let first = out.into_iter().next().expect("one output").payload();
 
-                let otlp_bytes: OtlpProtoBytes = first.try_into().expect("convert to otlp");
+                let otlp_bytes: OtlpProtoBytes =
+                    first.try_into_with_default().expect("convert to otlp");
                 let bytes = match otlp_bytes {
                     OtlpProtoBytes::ExportLogsRequest(b) => b,
                     _ => panic!("unexpected otlp variant"),
@@ -1400,7 +1409,7 @@ mod tests {
                 let out = ctx.drain_pdata().await;
                 let first = out.into_iter().next().expect("one output").payload();
 
-                let otlp_bytes: OtlpProtoBytes = first.try_into().expect("convert to otlp");
+                let otlp_bytes: OtlpProtoBytes = first.try_into_with_default().expect("convert to otlp");
                 let bytes = match otlp_bytes {
                     OtlpProtoBytes::ExportLogsRequest(b) => b,
                     _ => panic!("unexpected otlp variant"),
@@ -1468,7 +1477,7 @@ mod tests {
                 let out = ctx.drain_pdata().await;
                 let first = out.into_iter().next().expect("one output").payload();
 
-                let otlp_bytes: OtlpProtoBytes = first.try_into().expect("convert to otlp");
+                let otlp_bytes: OtlpProtoBytes = first.try_into_with_default().expect("convert to otlp");
                 let bytes = match otlp_bytes {
                     OtlpProtoBytes::ExportLogsRequest(b) => b,
                     _ => panic!("unexpected otlp variant"),
@@ -1539,7 +1548,8 @@ mod tests {
                 let out = ctx.drain_pdata().await;
                 let first = out.into_iter().next().expect("one output").payload();
 
-                let otlp_bytes: OtlpProtoBytes = first.try_into().expect("convert to otlp");
+                let otlp_bytes: OtlpProtoBytes =
+                    first.try_into_with_default().expect("convert to otlp");
                 let bytes = match otlp_bytes {
                     OtlpProtoBytes::ExportLogsRequest(b) => b,
                     _ => panic!("unexpected otlp variant"),
@@ -1623,7 +1633,8 @@ mod tests {
                 let out = ctx.drain_pdata().await;
                 let first = out.into_iter().next().expect("one output").payload();
 
-                let otlp_bytes: OtlpProtoBytes = first.try_into().expect("convert to otlp");
+                let otlp_bytes: OtlpProtoBytes =
+                    first.try_into_with_default().expect("convert to otlp");
                 let bytes = match otlp_bytes {
                     OtlpProtoBytes::ExportLogsRequest(b) => b,
                     _ => panic!("unexpected otlp variant"),
@@ -1692,7 +1703,8 @@ mod tests {
 
                 let out = ctx.drain_pdata().await;
                 let first = out.into_iter().next().expect("one output").payload();
-                let otlp_bytes: OtlpProtoBytes = first.try_into().expect("convert to otlp");
+                let otlp_bytes: OtlpProtoBytes =
+                    first.try_into_with_default().expect("convert to otlp");
                 let bytes = match otlp_bytes {
                     OtlpProtoBytes::ExportLogsRequest(b) => b,
                     _ => panic!("unexpected otlp variant"),
@@ -1768,7 +1780,8 @@ mod tests {
 
                 let out = ctx.drain_pdata().await;
                 let first = out.into_iter().next().expect("one output").payload();
-                let otlp_bytes: OtlpProtoBytes = first.try_into().expect("convert to otlp");
+                let otlp_bytes: OtlpProtoBytes =
+                    first.try_into_with_default().expect("convert to otlp");
                 let bytes = match otlp_bytes {
                     OtlpProtoBytes::ExportLogsRequest(b) => b,
                     _ => panic!("unexpected otlp variant"),
@@ -1848,7 +1861,8 @@ mod tests {
 
                 let out = ctx.drain_pdata().await;
                 let first = out.into_iter().next().expect("one output").payload();
-                let otlp_bytes: OtlpProtoBytes = first.try_into().expect("convert to otlp");
+                let otlp_bytes: OtlpProtoBytes =
+                    first.try_into_with_default().expect("convert to otlp");
                 let bytes = match otlp_bytes {
                     OtlpProtoBytes::ExportLogsRequest(b) => b,
                     _ => panic!("unexpected otlp variant"),
@@ -1985,7 +1999,8 @@ mod tests {
                 let out = ctx.drain_pdata().await;
                 let first = out.into_iter().next().expect("one output").payload();
 
-                let otlp_bytes: OtlpProtoBytes = first.try_into().expect("convert to otlp");
+                let otlp_bytes: OtlpProtoBytes =
+                    first.try_into_with_default().expect("convert to otlp");
                 let bytes = match otlp_bytes {
                     OtlpProtoBytes::ExportLogsRequest(b) => b,
                     _ => panic!("unexpected otlp variant"),
@@ -2052,7 +2067,8 @@ mod tests {
                 let out = ctx.drain_pdata().await;
                 let first = out.into_iter().next().expect("one output").payload();
 
-                let otlp_bytes: OtlpProtoBytes = first.try_into().expect("convert to otlp");
+                let otlp_bytes: OtlpProtoBytes =
+                    first.try_into_with_default().expect("convert to otlp");
                 let bytes = match otlp_bytes {
                     OtlpProtoBytes::ExportLogsRequest(b) => b,
                     _ => panic!("unexpected otlp variant"),
@@ -2138,7 +2154,8 @@ mod tests {
                 let out = ctx.drain_pdata().await;
                 let first = out.into_iter().next().expect("one output").payload();
 
-                let otlp_bytes: OtlpProtoBytes = first.try_into().expect("convert to otlp");
+                let otlp_bytes: OtlpProtoBytes =
+                    first.try_into_with_default().expect("convert to otlp");
                 let bytes = match otlp_bytes {
                     OtlpProtoBytes::ExportLogsRequest(b) => b,
                     _ => panic!("unexpected otlp variant"),

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
@@ -49,6 +49,7 @@ use otap_df_engine::{
 use otap_df_otap::OTAP_PROCESSOR_FACTORIES;
 use otap_df_otap::accessory::slots::{Key as SlotKey, State as SlotState};
 use otap_df_otap::pdata::{Context, OtapPdata};
+use otap_df_pdata::TryIntoWithOptions;
 use otap_df_pdata::{
     OtapArrowRecords, OtapPayload, OtapPayloadHelpers, OtlpProtoBytes, error::Error as PDataError,
     otap::batching::make_item_batches, otlp::batching::make_bytes_batches,
@@ -775,7 +776,7 @@ impl BatchProcessor {
                 } else if let Some(mut otlp_format) = self.otlp_format() {
                     otlp_format
                         .for_signal(signal)
-                        .accept_payload(effect, ctx, otap.try_into()?, items)
+                        .accept_payload(effect, ctx, otap.try_into_with_default()?, items)
                         .await?
                 } else {
                     return Err(Self::no_active_format_error());
@@ -790,7 +791,7 @@ impl BatchProcessor {
                 } else if let Some(mut otap_format) = self.otap_format() {
                     otap_format
                         .for_signal(signal)
-                        .accept_payload(effect, ctx, otlp.try_into()?, items)
+                        .accept_payload(effect, ctx, otlp.try_into_with_default()?, items)
                         .await?
                 } else {
                     return Err(Self::no_active_format_error());
@@ -1894,7 +1895,8 @@ mod tests {
             self.outputs
                 .get(i)
                 .map(|d| {
-                    let payload: OtlpProtoBytes = d.clone().payload().try_into().expect("ok");
+                    let payload: OtlpProtoBytes =
+                        d.clone().payload().try_into_with_default().expect("ok");
                     payload.try_into().expect("ok")
                 })
                 .expect("ok")
@@ -1902,7 +1904,7 @@ mod tests {
     }
 
     fn otap_pdata_to_message(data: &OtapPdata) -> OtlpProtoMessage {
-        let rec: OtapArrowRecords = data.clone().payload().try_into().unwrap();
+        let rec: OtapArrowRecords = data.clone().payload().try_into_with_default().unwrap();
         otap_to_otlp(&rec)
     }
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/content_router/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/content_router/mod.rs
@@ -85,6 +85,7 @@ use otap_df_engine::{
 use otap_df_otap::OTAP_PROCESSOR_FACTORIES;
 use otap_df_otap::pdata::OtapPdata;
 use otap_df_pdata::OtapPayload;
+use otap_df_pdata::TryFromWithOptions;
 use otap_df_pdata::otlp::OtlpProtoBytes;
 use otap_df_pdata::views::otap::OtapLogsView;
 use otap_df_pdata::views::otlp::bytes::logs::RawLogsData;
@@ -533,7 +534,7 @@ impl ContentRouter {
                     SignalType::Logs => self.resolve_arrow_logs_route(arrow_records),
                     // Metrics/Traces Arrow views not yet available — convert to OTLP.
                     // TODO: Use OtapMetricsView/OtapTracesView when available.
-                    _ => match OtlpProtoBytes::try_from(arrow_records.clone()) {
+                    _ => match OtlpProtoBytes::try_from_with_default(arrow_records.clone()) {
                         Ok(OtlpProtoBytes::ExportMetricsRequest(bytes)) => {
                             let data = RawMetricsData::new(bytes.as_ref());
                             self.resolve_metrics_route(&data)

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/debug_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/debug_processor/mod.rs
@@ -30,6 +30,7 @@ use otap_df_engine::{ConsumerEffectHandlerExtension, MessageSourceLocalEffectHan
 use otap_df_engine::{Interests, ProducerEffectHandlerExtension};
 use otap_df_otap::{OTAP_PROCESSOR_FACTORIES, pdata::OtapPdata};
 use otap_df_pdata::OtlpProtoBytes;
+use otap_df_pdata::TryIntoWithOptions;
 use otap_df_pdata::proto::opentelemetry::{
     logs::v1::LogsData,
     metrics::v1::{MetricsData, metric::Data},
@@ -336,7 +337,7 @@ impl local::Processor<OtapPdata> for DebugProcessor {
                 }
 
                 let (_context, payload) = pdata.into_parts();
-                let otlp_bytes: OtlpProtoBytes = payload.try_into()?;
+                let otlp_bytes: OtlpProtoBytes = payload.try_into_with_default()?;
 
                 match otlp_bytes {
                     OtlpProtoBytes::ExportLogsRequest(bytes) => {

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
@@ -93,6 +93,7 @@ use otap_df_telemetry::{otel_debug, otel_error, otel_info, otel_warn};
 
 use otap_df_otap::OTAP_PROCESSOR_FACTORIES;
 use otap_df_otap::pdata::OtapPdata;
+use otap_df_pdata::TryIntoWithOptions;
 
 use bundle_adapter::{
     OtapRecordBundleAdapter, OtlpBytesAdapter, convert_bundle_to_pdata, signal_type_from_slot_id,
@@ -1108,7 +1109,7 @@ impl DurableBuffer {
                         // Clone bytes for NACK on conversion failure (conversion consumes the input).
                         let bytes_for_nack = otlp_bytes.clone();
                         let conversion_result: Result<OtapArrowRecords, _> =
-                            OtapPayload::OtlpBytes(otlp_bytes).try_into();
+                            OtapPayload::OtlpBytes(otlp_bytes).try_into_with_default();
                         match conversion_result {
                             Ok(records) => {
                                 // Count items from Arrow data (cheap - just num_rows)

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/mod.rs
@@ -26,6 +26,7 @@ use otap_df_engine::node::NodeId;
 use otap_df_engine::process_duration::ComputeDuration;
 use otap_df_engine::processor::ProcessorWrapper;
 use otap_df_otap::{OTAP_PROCESSOR_FACTORIES, pdata::OtapPdata};
+use otap_df_pdata::TryIntoWithOptions;
 use otap_df_pdata::otap::OtapArrowRecords;
 use otap_df_telemetry::metrics::MetricSet;
 use serde_json::Value;
@@ -129,7 +130,7 @@ impl local::Processor<OtapPdata> for FilterProcessor {
                 // convert to arrow records
                 let (context, payload) = pdata.into_parts();
 
-                let mut arrow_records: OtapArrowRecords = payload.try_into()?;
+                let mut arrow_records: OtapArrowRecords = payload.try_into_with_default()?;
                 arrow_records.decode_transport_optimized_ids()?;
 
                 let (filtered_arrow_records, signals_consumed, signals_filtered): (
@@ -214,6 +215,7 @@ mod tests {
     use otap_df_engine::testing::test_node;
     use otap_df_otap::pdata::OtapPdata;
     use otap_df_pdata::OtlpProtoBytes;
+    use otap_df_pdata::TryIntoWithOptions;
     use otap_df_pdata::otap::filter::{
         AnyValue as AnyValueFilter, KeyValue as KeyValueFilter, MatchType,
         logs::{LogFilter, LogMatchProperties, LogSeverityNumberMatchProperties},
@@ -667,7 +669,7 @@ mod tests {
                 let received_logs_data = &msgs[0];
                 let (_, payload) = received_logs_data.clone().into_parts();
                 let otlp_bytes: OtlpProtoBytes = payload
-                    .try_into()
+                    .try_into_with_default()
                     .expect("failed to convert to OtlpProtoBytes");
                 let received_logs_data = match otlp_bytes {
                     OtlpProtoBytes::ExportLogsRequest(bytes) => LogsData::decode(bytes.as_ref())
@@ -703,7 +705,7 @@ mod tests {
                 let received_traces_data = &msgs[0];
                 let (_, payload) = received_traces_data.clone().into_parts();
                 let otlp_bytes: OtlpProtoBytes = payload
-                    .try_into()
+                    .try_into_with_default()
                     .expect("failed to convert to OtlpProtoBytes");
                 let received_traces_data = match otlp_bytes {
                     OtlpProtoBytes::ExportTracesRequest(bytes) => {

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/log_sampling_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/log_sampling_processor/mod.rs
@@ -35,6 +35,7 @@ use otap_df_engine::processor::ProcessorWrapper;
 use otap_df_otap::OTAP_PROCESSOR_FACTORIES;
 use otap_df_otap::pdata::OtapPdata;
 use otap_df_pdata::OtapPayload;
+use otap_df_pdata::TryIntoWithOptions;
 use otap_df_pdata::otap::OtapArrowRecords;
 use otap_df_pdata::otap::filter::{IdBitmapPool, filter_otap_batch};
 use otap_df_telemetry::metrics::MetricSet;
@@ -100,7 +101,7 @@ impl LogSamplingProcessor {
 
         // Convert to Arrow records (no-op if already Arrow)
         let (context, payload) = pdata.into_parts();
-        let mut records: OtapArrowRecords = payload.try_into()?;
+        let mut records: OtapArrowRecords = payload.try_into_with_default()?;
         records.decode_transport_optimized_ids()?;
 
         // Prepare the filter buffer.

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
@@ -38,6 +38,7 @@ use otap_df_otap::{
     accessory::slots::Key,
     pdata::{Context, OtapPdata},
 };
+use otap_df_pdata::TryIntoWithOptions;
 use otap_df_pdata::{
     OtapArrowRecords, OtapPayload, otap::transform::sanitize::sanitize_otap_batch,
 };
@@ -410,7 +411,7 @@ impl Processor<OtapPdata> for TransformProcessor {
                         .send_message_with_source_node(OtapPdata::new(context, payload))
                         .await?;
                 } else {
-                    let mut otap_batch: OtapArrowRecords = payload.try_into()?;
+                    let mut otap_batch: OtapArrowRecords = payload.try_into_with_default()?;
                     otap_batch.decode_transport_optimized_ids()?;
                     let result = self
                         .pipeline
@@ -464,6 +465,7 @@ mod test {
         },
     };
     use otap_df_pdata::{
+        TryFromWithOptions,
         otap::Logs,
         proto::{
             OtlpProtoMessage,
@@ -629,7 +631,7 @@ mod test {
                     .await
                     .into_iter()
                     .map(OtapPdata::payload)
-                    .map(OtapArrowRecords::try_from)
+                    .map(OtapArrowRecords::try_from_with_default)
                     .map(Result::unwrap);
                 let otap_batch = out.into_iter().next().unwrap();
 
@@ -727,7 +729,7 @@ mod test {
                     .await
                     .into_iter()
                     .map(OtapPdata::payload)
-                    .map(OtapArrowRecords::try_from)
+                    .map(OtapArrowRecords::try_from_with_default)
                     .map(Result::unwrap);
                 let otap_batch = out.into_iter().next().unwrap();
                 let result = otap_to_otlp(&otap_batch);
@@ -808,7 +810,7 @@ mod test {
                     .await
                     .into_iter()
                     .map(OtapPdata::payload)
-                    .map(OtapArrowRecords::try_from)
+                    .map(OtapArrowRecords::try_from_with_default)
                     .map(Result::unwrap);
                 let otap_batch = out.into_iter().next().unwrap();
                 let result = otap_to_otlp(&otap_batch);
@@ -902,7 +904,7 @@ mod test {
                     .await
                     .into_iter()
                     .map(OtapPdata::payload)
-                    .map(OtapArrowRecords::try_from)
+                    .map(OtapArrowRecords::try_from_with_default)
                     .map(Result::unwrap);
                 let traces_batch = processed_pdata.next().expect("sent traces batch");
                 let metrics_batch = processed_pdata.next().expect("sent metrics batch");
@@ -937,7 +939,7 @@ mod test {
                     .await
                     .into_iter()
                     .map(OtapPdata::payload)
-                    .map(OtapArrowRecords::try_from)
+                    .map(OtapArrowRecords::try_from_with_default)
                     .map(Result::unwrap);
                 let traces_batch = processed_pdata.next().expect("sent traces batch");
                 let metrics_batch = processed_pdata.next().expect("sent metrics batch");
@@ -1009,7 +1011,7 @@ mod test {
                     .await
                     .into_iter()
                     .map(OtapPdata::payload)
-                    .map(OtapArrowRecords::try_from)
+                    .map(OtapArrowRecords::try_from_with_default)
                     .map(Result::unwrap);
                 let result = out.into_iter().next().expect("one result");
 
@@ -1110,7 +1112,7 @@ mod test {
                     .await
                     .into_iter()
                     .map(OtapPdata::payload)
-                    .map(OtapArrowRecords::try_from)
+                    .map(OtapArrowRecords::try_from_with_default)
                     .map(Result::unwrap)
                     .map(|otap_batch| otap_to_otlp(&otap_batch));
 
@@ -1211,7 +1213,7 @@ mod test {
                     .await
                     .into_iter()
                     .map(OtapPdata::payload)
-                    .map(OtapArrowRecords::try_from)
+                    .map(OtapArrowRecords::try_from_with_default)
                     .map(Result::unwrap);
                 let default_result = out.into_iter().next().expect("one result");
                 assert_logs_records_equal(default_result, other_log_record);
@@ -2007,7 +2009,7 @@ mod test {
                     .await
                     .into_iter()
                     .map(OtapPdata::payload)
-                    .map(OtapArrowRecords::try_from)
+                    .map(OtapArrowRecords::try_from_with_default)
                     .map(Result::unwrap);
                 let default_result = out.into_iter().next().expect("one result");
                 // check we skipped the sanitization on the default output

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/mod.rs
@@ -27,6 +27,8 @@ use otap_df_engine::{
 use otap_df_otap::OTAP_RECEIVER_FACTORIES;
 use otap_df_otap::pdata::OtapPdata;
 use otap_df_pdata::OtapPayload;
+#[cfg(test)]
+use otap_df_pdata::TryIntoWithOptions;
 use otap_df_telemetry::metrics::MetricSet;
 use otap_df_telemetry::{otel_debug, otel_info, otel_warn};
 use serde_json::Value;
@@ -637,7 +639,7 @@ mod tests {
     fn pdata_to_otlp_message(value: OtapPdata) -> OtlpProtoMessage {
         let otlp_bytes: OtlpProtoBytes = value
             .payload()
-            .try_into()
+            .try_into_with_default()
             .expect("can convert signal to otlp bytes");
         match otlp_bytes {
             OtlpProtoBytes::ExportLogsRequest(bytes) => {

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/producer.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/fake_data_generator/producer.rs
@@ -5,6 +5,8 @@ use std::collections::HashMap;
 
 use otap_df_config::SignalType;
 use otap_df_pdata::OtapPayload;
+#[cfg(test)]
+use otap_df_pdata::TryIntoWithOptions;
 use otap_df_pdata::proto::OtlpProtoMessage;
 use prost::EncodeError;
 use weaver_forge::registry::ResolvedRegistry;
@@ -739,7 +741,9 @@ mod tests {
 
         // Helper: extract the tenant.id attribute value from a log payload.
         let extract_tenant_id = |payload: OtapPayload| -> Option<String> {
-            let otlp_bytes: OtlpProtoBytes = payload.try_into().expect("convert to otlp bytes");
+            let otlp_bytes: OtlpProtoBytes = payload
+                .try_into_with_default()
+                .expect("convert to otlp bytes");
             let bytes = match otlp_bytes {
                 OtlpProtoBytes::ExportLogsRequest(b) => b,
                 _ => panic!("expected logs"),
@@ -825,7 +829,9 @@ mod tests {
 
         // Neither payload should carry a tenant.id attribute.
         for (i, batch) in [batch_1, batch_2].into_iter().enumerate() {
-            let otlp_bytes: OtlpProtoBytes = batch.try_into().expect("convert to otlp bytes");
+            let otlp_bytes: OtlpProtoBytes = batch
+                .try_into_with_default()
+                .expect("convert to otlp bytes");
             let bytes = match otlp_bytes {
                 OtlpProtoBytes::ExportLogsRequest(b) => b,
                 _ => panic!("expected logs"),

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/otap_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/otap_receiver/mod.rs
@@ -580,6 +580,7 @@ mod tests {
     use otap_df_otap::pdata::OtapPdata;
     use otap_df_otap::testing::{next_ack, next_nack};
     use otap_df_pdata::Producer;
+    use otap_df_pdata::TryIntoWithOptions;
     use otap_df_pdata::otap::OtapArrowRecords;
     use otap_df_pdata::proto::opentelemetry::arrow::v1::{
         ArrowPayloadType, arrow_logs_service_client::ArrowLogsServiceClient,
@@ -713,7 +714,7 @@ mod tests {
                     let metrics_records: OtapArrowRecords = metrics_pdata
                         .clone()
                         .payload()
-                        .try_into()
+                        .try_into_with_default()
                         .expect("Could convert pdata to OTAPData");
 
                     // Assert that the message received is what the test client sent.
@@ -739,7 +740,7 @@ mod tests {
                     let logs_records: OtapArrowRecords = logs_pdata
                         .clone()
                         .payload()
-                        .try_into()
+                        .try_into_with_default()
                         .expect("Could convert pdata to OTAPData");
 
                     // Assert that the message received is what the test client sent.
@@ -765,7 +766,7 @@ mod tests {
                     let traces_records: OtapArrowRecords = traces_pdata
                         .clone()
                         .payload()
-                        .try_into()
+                        .try_into_with_default()
                         .expect("Could convert pdata to OTAPData");
 
                     // Assert that the message received is what the test client sent.

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/otlp_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/otlp_receiver/mod.rs
@@ -23,6 +23,8 @@ use otap_df_otap::otap_grpc::otlp::server_new::{
 };
 use otap_df_otap::pdata::OtapPdata;
 use otap_df_otap::tls_utils::{build_tls_acceptor, create_tls_stream};
+#[cfg(test)]
+use otap_df_pdata::TryIntoWithOptions;
 
 use async_trait::async_trait;
 use linkme::distributed_slice;
@@ -1789,7 +1791,7 @@ mod tests {
                 let logs_proto: OtlpProtoBytes = logs_pdata
                     .clone()
                     .payload()
-                    .try_into()
+                    .try_into_with_default()
                     .expect("can convert to OtlpProtoBytes");
                 assert!(matches!(logs_proto, OtlpProtoBytes::ExportLogsRequest(_)));
 
@@ -1815,7 +1817,7 @@ mod tests {
                 let metrics_proto: OtlpProtoBytes = metrics_pdata
                     .clone()
                     .payload()
-                    .try_into()
+                    .try_into_with_default()
                     .expect("can convert to OtlpProtoBytes");
                 assert!(matches!(
                     metrics_proto,
@@ -1844,7 +1846,7 @@ mod tests {
                 let trace_proto: OtlpProtoBytes = trace_pdata
                     .clone()
                     .payload()
-                    .try_into()
+                    .try_into_with_default()
                     .expect("can convert to OtlpProtoBytes");
                 assert!(matches!(
                     trace_proto,
@@ -1981,7 +1983,7 @@ mod tests {
                 let logs_proto: OtlpProtoBytes = logs_pdata
                     .clone()
                     .payload()
-                    .try_into()
+                    .try_into_with_default()
                     .expect("can convert to OtlpProtoBytes");
                 assert!(matches!(logs_proto, OtlpProtoBytes::ExportLogsRequest(_)));
 
@@ -2074,7 +2076,7 @@ mod tests {
                 let logs_proto: OtlpProtoBytes = logs_pdata
                     .clone()
                     .payload()
-                    .try_into()
+                    .try_into_with_default()
                     .expect("can convert to OtlpProtoBytes");
                 assert!(matches!(logs_proto, OtlpProtoBytes::ExportLogsRequest(_)));
 

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/syslog_cef_receiver/arrow_records_encoder.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/syslog_cef_receiver/arrow_records_encoder.rs
@@ -179,7 +179,7 @@ mod tests {
 
     fn otap_logs_to_otlp(mut logs_otap_batch: OtapArrowRecords) -> ExportLogsServiceRequest {
         let mut logs_encoder = LogsProtoBytesEncoder::new();
-        let mut buffer = ProtoBuffer::new();
+        let mut buffer = ProtoBuffer::default();
         logs_encoder
             .encode(&mut logs_otap_batch, &mut buffer)
             .unwrap();

--- a/rust/otap-dataflow/crates/pdata/src/decode/decoder.rs
+++ b/rust/otap-dataflow/crates/pdata/src/decode/decoder.rs
@@ -15,6 +15,7 @@ use crate::proto::opentelemetry::collector::trace::v1::ExportTraceServiceRequest
 use arrow::array::RecordBatch;
 use arrow::error::ArrowError;
 use arrow::ipc::reader::StreamReader;
+use otap_df_config::ConversionOptions;
 use prost::Message;
 use std::collections::HashMap;
 use std::io::Cursor;
@@ -55,6 +56,12 @@ pub struct Consumer {
 }
 
 impl Consumer {
+    /// Construct a consumer with conversion options.
+    #[must_use]
+    pub fn with_options(_opts: ConversionOptions) -> Self {
+        Self::default()
+    }
+
     /// consume and deserialize record batches
     pub fn consume_bar(&mut self, bar: &mut BatchArrowRecords) -> Result<Vec<RecordMessage>> {
         let mut records = Vec::with_capacity(bar.arrow_payloads.len());

--- a/rust/otap-dataflow/crates/pdata/src/encode/cbor.rs
+++ b/rust/otap-dataflow/crates/pdata/src/encode/cbor.rs
@@ -191,7 +191,7 @@ mod test {
             serialize_any_values(vec![ObjAny::new(&source)].into_iter(), &mut serialized_val)
                 .unwrap();
 
-            let mut proto_buffer = ProtoBuffer::new();
+            let mut proto_buffer = ProtoBuffer::default();
             proto_encode_cbor_bytes(&serialized_val, &mut proto_buffer).unwrap();
             let result = AnyValue::decode(proto_buffer.as_ref()).unwrap();
             assert_eq!(
@@ -261,7 +261,7 @@ mod test {
             )
             .unwrap();
 
-            let mut proto_buffer = ProtoBuffer::new();
+            let mut proto_buffer = ProtoBuffer::default();
             proto_encode_cbor_bytes(&serialized_val, &mut proto_buffer).unwrap();
             let result = AnyValue::decode(proto_buffer.as_ref()).unwrap();
             assert_eq!(

--- a/rust/otap-dataflow/crates/pdata/src/encode/mod.rs
+++ b/rust/otap-dataflow/crates/pdata/src/encode/mod.rs
@@ -4026,7 +4026,7 @@ mod test {
         assert!(otap_batch.get(ArrowPayloadType::LogAttrs).is_none());
 
         // check the serialized values are what is expected
-        let mut proto_buf = ProtoBuffer::new();
+        let mut proto_buf = ProtoBuffer::default();
         proto_encode_cbor_bytes(&expected_serialized_array, &mut proto_buf).unwrap();
         let deserialized_array = AnyValue::decode(proto_buf.as_ref()).unwrap();
 
@@ -4270,7 +4270,7 @@ mod test {
         assert_eq!(logs_attrs, &expected_attrs);
 
         // check the serialized values are what is expected
-        let mut proto_buf = ProtoBuffer::new();
+        let mut proto_buf = ProtoBuffer::default();
         proto_encode_cbor_bytes(&expected_serialized_array, &mut proto_buf).unwrap();
         let deserialized_array = AnyValue::decode(proto_buf.as_ref()).unwrap();
         assert_eq!(

--- a/rust/otap-dataflow/crates/pdata/src/lib.rs
+++ b/rust/otap-dataflow/crates/pdata/src/lib.rs
@@ -47,6 +47,11 @@ pub trait TryFromWithOptions<T>: Sized {
 
     /// Performs the conversion
     fn try_from_with_options(value: T, opts: ConversionOptions) -> Result<Self, Self::Error>;
+
+    /// Performs a default conversion
+    fn try_from_with_default(value: T) -> Result<Self, Self::Error> {
+        TryFromWithOptions::<T>::try_from_with_options(value, ConversionOptions::default())
+    }
 }
 
 /// Try to convert with options, including limits.
@@ -56,6 +61,11 @@ pub trait TryIntoWithOptions<T>: Sized {
 
     /// Performs the conversion
     fn try_into_with_options(self, opts: ConversionOptions) -> Result<T, Self::Error>;
+
+    /// Performs a default conversion
+    fn try_into_with_default(self) -> Result<T, Self::Error> {
+        self.try_into_with_options(ConversionOptions::default())
+    }
 }
 
 impl<T, U> TryIntoWithOptions<U> for T

--- a/rust/otap-dataflow/crates/pdata/src/lib.rs
+++ b/rust/otap-dataflow/crates/pdata/src/lib.rs
@@ -38,6 +38,38 @@ mod validation;
 pub use decode::decoder::Consumer;
 pub use encode::producer::Producer;
 
+use otap_df_config::ConversionOptions;
+
+/// Try to convert with options, including limits.
+pub trait TryFromWithOptions<T>: Sized {
+    /// The error type.
+    type Error;
+
+    /// Performs the conversion
+    fn try_from_with_options(value: T, opts: ConversionOptions) -> Result<Self, Self::Error>;
+}
+
+/// Try to convert with options, including limits.
+pub trait TryIntoWithOptions<T>: Sized {
+    /// The error type.
+    type Error;
+
+    /// Performs the conversion
+    fn try_into_with_options(self, opts: ConversionOptions) -> Result<T, Self::Error>;
+}
+
+impl<T, U> TryIntoWithOptions<U> for T
+where
+    U: TryFromWithOptions<T>,
+{
+    type Error = U::Error;
+
+    #[inline]
+    fn try_into_with_options(self, opts: ConversionOptions) -> Result<U, Self::Error> {
+        U::try_from_with_options(self, opts)
+    }
+}
+
 /// TraceID identifier of a Trace
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Default)]
 pub struct TraceID([u8; 16]);

--- a/rust/otap-dataflow/crates/pdata/src/otlp/attributes.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/attributes.rs
@@ -221,7 +221,7 @@ mod test {
         );
 
         let any_val_arrays = AnyValueArrays::try_from(&rb).unwrap();
-        let mut protobuf = ProtoBuffer::new();
+        let mut protobuf = ProtoBuffer::default();
 
         for i in 0..rb.num_rows() {
             if let Some(value_type) = any_val_arrays.attr_type.value_at(i) {

--- a/rust/otap-dataflow/crates/pdata/src/otlp/logs.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/logs.rs
@@ -644,7 +644,7 @@ mod test {
         otap_batch
             .set(ArrowPayloadType::ScopeAttrs, attrs_record_batch.clone())
             .unwrap();
-        let mut result_buf = ProtoBuffer::new();
+        let mut result_buf = ProtoBuffer::default();
         let mut encoder = LogsProtoBytesEncoder::new();
         encoder.encode(&mut otap_batch, &mut result_buf).unwrap();
 
@@ -790,7 +790,7 @@ mod test {
             .set(ArrowPayloadType::Logs, logs_record_batch)
             .unwrap();
 
-        let mut result_buf = ProtoBuffer::new();
+        let mut result_buf = ProtoBuffer::default();
         let mut encoder = LogsProtoBytesEncoder::new();
         encoder.encode(&mut otap_batch, &mut result_buf).unwrap();
 
@@ -866,7 +866,7 @@ mod test {
         otap_batch
             .set(ArrowPayloadType::LogAttrs, log_attrs_batch)
             .unwrap();
-        let mut result_buf = ProtoBuffer::new();
+        let mut result_buf = ProtoBuffer::default();
         let mut encoder = LogsProtoBytesEncoder::new();
         encoder.encode(&mut otap_batch, &mut result_buf).unwrap();
         let result = LogsData::decode(result_buf.as_ref()).unwrap();

--- a/rust/otap-dataflow/crates/pdata/src/otlp/metrics.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/metrics.rs
@@ -1503,7 +1503,7 @@ mod test {
             .unwrap();
 
         let mut encoder = MetricsProtoBytesEncoder::new();
-        let mut result_buf = ProtoBuffer::new();
+        let mut result_buf = ProtoBuffer::default();
         encoder.encode(&mut otap_batch, &mut result_buf).unwrap();
         let result = MetricsData::decode(result_buf.as_ref()).unwrap();
 

--- a/rust/otap-dataflow/crates/pdata/src/otlp/traces.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/traces.rs
@@ -778,7 +778,7 @@ mod test {
             .set(ArrowPayloadType::SpanLinkAttrs, attr_32_rb.clone())
             .unwrap();
 
-        let mut result_buf = ProtoBuffer::new();
+        let mut result_buf = ProtoBuffer::default();
         let mut encoder = TracesProtoBytesEncoder::new();
         encoder.encode(&mut otap_batch, &mut result_buf).unwrap();
 

--- a/rust/otap-dataflow/crates/pdata/src/payload.rs
+++ b/rust/otap-dataflow/crates/pdata/src/payload.rs
@@ -352,13 +352,16 @@ impl From<OtlpProtoBytes> for OtapPayload {
     }
 }
 
-impl TryFrom<OtapPayload> for OtapArrowRecords {
+impl TryFromWithOptions<OtapPayload> for OtapArrowRecords {
     type Error = crate::encode::Error;
 
-    fn try_from(value: OtapPayload) -> Result<Self, Self::Error> {
+    fn try_from_with_options(
+        value: OtapPayload,
+        opts: ConversionOptions,
+    ) -> Result<Self, Self::Error> {
         match value {
             OtapPayload::OtapArrowRecords(value) => Ok(value),
-            OtapPayload::OtlpBytes(value) => value.try_into(),
+            OtapPayload::OtlpBytes(value) => value.try_into_with_options(opts),
         }
     }
 }
@@ -411,10 +414,13 @@ impl TryFromWithOptions<OtapArrowRecords> for OtlpProtoBytes {
     }
 }
 
-impl TryFrom<OtlpProtoBytes> for OtapArrowRecords {
+impl TryFromWithOptions<OtlpProtoBytes> for OtapArrowRecords {
     type Error = crate::encode::Error;
 
-    fn try_from(value: OtlpProtoBytes) -> Result<Self, Self::Error> {
+    fn try_from_with_options(
+        value: OtlpProtoBytes,
+        _opts: ConversionOptions,
+    ) -> Result<Self, Self::Error> {
         match value {
             OtlpProtoBytes::ExportLogsRequest(bytes) => {
                 let logs_data_view = RawLogsData::new(bytes.as_ref());
@@ -501,19 +507,19 @@ mod test {
         let pdata: OtapPayload = OtlpProtoBytes::ExportLogsRequest(otlp_bytes.into()).into();
 
         // test can go OtlpProtoBytes -> OtapBatch & back
-        let otap_batch: OtapArrowRecords = pdata.try_into().unwrap();
+        let otap_batch: OtapArrowRecords = pdata.try_into_with_default().unwrap();
         assert!(matches!(otap_batch, OtapArrowRecords::Logs(_)));
         let pdata: OtapPayload = otap_batch.into();
 
-        let otlp_bytes: OtlpProtoBytes = pdata.try_into().unwrap();
+        let otlp_bytes: OtlpProtoBytes = pdata.try_into_with_default().unwrap();
         assert!(matches!(otlp_bytes, OtlpProtoBytes::ExportLogsRequest(_)));
         let pdata: OtapPayload = otlp_bytes.into();
 
-        let otlp_bytes: OtlpProtoBytes = pdata.try_into().unwrap();
+        let otlp_bytes: OtlpProtoBytes = pdata.try_into_with_default().unwrap();
         assert!(matches!(otlp_bytes, OtlpProtoBytes::ExportLogsRequest(_)));
         let pdata: OtapPayload = otlp_bytes.into();
 
-        let otap_batch: OtapArrowRecords = pdata.try_into().unwrap();
+        let otap_batch: OtapArrowRecords = pdata.try_into_with_default().unwrap();
         assert!(matches!(otap_batch, OtapArrowRecords::Logs(_)));
     }
 
@@ -527,11 +533,11 @@ mod test {
         let pdata: OtapPayload = OtlpProtoBytes::ExportLogsRequest(otlp_bytes.into()).into();
 
         // test can go OtlpProtoBytes (written by prost) -> OtapBatch & back (using prost)
-        let otap_batch: OtapArrowRecords = pdata.try_into().unwrap();
+        let otap_batch: OtapArrowRecords = pdata.try_into_with_default().unwrap();
         assert!(matches!(otap_batch, OtapArrowRecords::Logs(_)));
         let pdata: OtapPayload = otap_batch.clone().into();
 
-        let otlp_bytes: OtlpProtoBytes = pdata.try_into().unwrap();
+        let otlp_bytes: OtlpProtoBytes = pdata.try_into_with_default().unwrap();
         let bytes = match &otlp_bytes {
             OtlpProtoBytes::ExportLogsRequest(bytes) => bytes.clone(),
             _ => panic!("unexpected otlp bytes pdata variant"),
@@ -543,7 +549,7 @@ mod test {
         // check that we can also re-decode the OTLP proto bytes that we encode directly
         // from OTAP, that we get the same result
         let pdata: OtapPayload = otlp_bytes.into();
-        let otap_batch2: OtapArrowRecords = pdata.try_into().unwrap();
+        let otap_batch2: OtapArrowRecords = pdata.try_into_with_default().unwrap();
         assert_eq!(otap_batch, otap_batch2);
     }
 
@@ -553,11 +559,11 @@ mod test {
         let pdata: OtapPayload = OtlpProtoBytes::ExportTracesRequest(otlp_bytes.into()).into();
 
         // test can go OtlpBytes (written by prost) -> OtapBatch & back (using prost)
-        let otap_batch: OtapArrowRecords = pdata.try_into().unwrap();
+        let otap_batch: OtapArrowRecords = pdata.try_into_with_default().unwrap();
         assert!(matches!(otap_batch, OtapArrowRecords::Traces(_)));
         let pdata: OtapPayload = otap_batch.clone().into();
 
-        let otlp_bytes: OtlpProtoBytes = pdata.try_into().unwrap();
+        let otlp_bytes: OtlpProtoBytes = pdata.try_into_with_default().unwrap();
         let bytes = match &otlp_bytes {
             OtlpProtoBytes::ExportTracesRequest(bytes) => bytes.clone(),
             _ => panic!("unexpected otlp bytes pdata variant"),
@@ -569,7 +575,7 @@ mod test {
         // check that we can also re-decode the OTLP proto bytes that we encode directly
         // from OTAP, that we get the same result
         let pdata: OtapPayload = otlp_bytes.into();
-        let otap_batch2: OtapArrowRecords = pdata.try_into().unwrap();
+        let otap_batch2: OtapArrowRecords = pdata.try_into_with_default().unwrap();
         assert_eq!(otap_batch, otap_batch2);
     }
 
@@ -579,11 +585,11 @@ mod test {
         let pdata: OtapPayload = OtlpProtoBytes::ExportMetricsRequest(otlp_bytes.into()).into();
 
         // test can go OtlpBytes (written by prost) to OTAP & back (using prost)
-        let otap_batch: OtapArrowRecords = pdata.try_into().unwrap();
+        let otap_batch: OtapArrowRecords = pdata.try_into_with_default().unwrap();
         assert!(matches!(otap_batch, OtapArrowRecords::Metrics(_)));
         let pdata: OtapPayload = otap_batch.clone().into();
 
-        let otlp_bytes: OtlpProtoBytes = pdata.try_into().unwrap();
+        let otlp_bytes: OtlpProtoBytes = pdata.try_into_with_default().unwrap();
         let bytes = match &otlp_bytes {
             OtlpProtoBytes::ExportMetricsRequest(bytes) => bytes.clone(),
             _ => panic!("unexpected otlp bytes pdata variant"),
@@ -595,7 +601,7 @@ mod test {
         // check that we can also re-decode the OTLP proto bytes that we encode directly
         // from OTAP, that we get the same result
         let pdata: OtapPayload = otlp_bytes.into();
-        let otap_batch2: OtapArrowRecords = pdata.try_into().unwrap();
+        let otap_batch2: OtapArrowRecords = pdata.try_into_with_default().unwrap();
         assert_eq!(otap_batch, otap_batch2);
     }
 

--- a/rust/otap-dataflow/crates/pdata/src/payload.rs
+++ b/rust/otap-dataflow/crates/pdata/src/payload.rs
@@ -93,8 +93,9 @@ use crate::proto::OtlpProtoMessage;
 use crate::views::otlp::bytes::logs::RawLogsData;
 use crate::views::otlp::bytes::metrics::RawMetricsData;
 use crate::views::otlp::bytes::traces::RawTraceData;
+use crate::{TryFromWithOptions, TryIntoWithOptions};
 use bytes::BytesMut;
-use otap_df_config::{SignalFormat, SignalType};
+use otap_df_config::{ConversionOptions, SignalFormat, SignalType};
 use prost::{EncodeError, Message};
 
 /// Container for the various representations of the telemetry data
@@ -362,21 +363,27 @@ impl TryFrom<OtapPayload> for OtapArrowRecords {
     }
 }
 
-impl TryFrom<OtapPayload> for OtlpProtoBytes {
+impl TryFromWithOptions<OtapPayload> for OtlpProtoBytes {
     type Error = Error;
 
-    fn try_from(value: OtapPayload) -> Result<Self, Self::Error> {
+    fn try_from_with_options(
+        value: OtapPayload,
+        opts: ConversionOptions,
+    ) -> Result<Self, Self::Error> {
         match value {
-            OtapPayload::OtapArrowRecords(value) => value.try_into(),
+            OtapPayload::OtapArrowRecords(value) => value.try_into_with_options(opts),
             OtapPayload::OtlpBytes(value) => Ok(value),
         }
     }
 }
 
-impl TryFrom<OtapArrowRecords> for OtlpProtoBytes {
+impl TryFromWithOptions<OtapArrowRecords> for OtlpProtoBytes {
     type Error = Error;
 
-    fn try_from(mut value: OtapArrowRecords) -> Result<Self, Self::Error> {
+    fn try_from_with_options(
+        mut value: OtapArrowRecords,
+        _opts: ConversionOptions,
+    ) -> Result<Self, Self::Error> {
         match value {
             OtapArrowRecords::Logs(_) => {
                 // TODO it'd be nice to expose a better API where we can make it easier to pass the encoder

--- a/rust/otap-dataflow/crates/pdata/src/payload.rs
+++ b/rust/otap-dataflow/crates/pdata/src/payload.rs
@@ -25,7 +25,7 @@
 //!     logs::v1::{LogRecord, ResourceLogs, ScopeLogs, SeverityNumber},
 //!     resource::v1::Resource
 //! };
-//! # use otap_df_pdata::{OtapPayload, OtlpProtoBytes};
+//! # use otap_df_pdata::{OtapPayload, OtlpProtoBytes, TryIntoWithOptions};
 //! # use prost::Message;
 //! # use bytes::Bytes;
 //! let otlp_service_req = ExportLogsServiceRequest::new(vec![
@@ -53,7 +53,7 @@
 //! let payload: OtapPayload = OtlpProtoBytes::ExportLogsRequest(Bytes::from(buf)).into();
 //!
 //! // Convert to OTAP records
-//! let otap_arrow_records: OtapArrowRecords = payload.try_into().unwrap();
+//! let otap_arrow_records: OtapArrowRecords = payload.try_into_with_default().unwrap();
 //! ```
 //!
 //! Internally, conversions are happening using various utility functions:

--- a/rust/otap-dataflow/crates/pdata/src/testing/round_trip.rs
+++ b/rust/otap-dataflow/crates/pdata/src/testing/round_trip.rs
@@ -17,6 +17,7 @@ use crate::proto::opentelemetry::metrics::v1::{
 };
 use crate::proto::opentelemetry::trace::v1::{ResourceSpans, ScopeSpans, Span, TracesData};
 use crate::testing::equiv::assert_equivalent;
+use crate::{ConversionOptions, TryIntoWithOptions};
 use prost::Message as ProstMessage;
 
 /// Transcode a protocol message object to OTAP records.
@@ -65,7 +66,9 @@ pub fn otlp_bytes_to_message(msg: OtlpProtoBytes) -> OtlpProtoMessage {
 #[must_use]
 pub fn otap_to_otlp(otap: &OtapArrowRecords) -> OtlpProtoMessage {
     let pdata: OtapPayload = otap.clone().into();
-    let otlp_bytes: OtlpProtoBytes = pdata.try_into().expect("convert to OTLP bytes");
+    let otlp_bytes: OtlpProtoBytes = pdata
+        .try_into_with_options(ConversionOptions::default())
+        .expect("convert to OTLP bytes");
     match otlp_bytes {
         OtlpProtoBytes::ExportLogsRequest(bytes) => {
             LogsData::decode(bytes.as_ref()).map(OtlpProtoMessage::Logs)
@@ -94,7 +97,9 @@ pub fn encode_logs(logs: &LogsData) -> OtapArrowRecords {
 #[must_use]
 pub fn decode_logs(otap: OtapArrowRecords) -> LogsData {
     let pdata: OtapPayload = otap.into();
-    let otlp_bytes: OtlpProtoBytes = pdata.try_into().expect("convert to OTLP bytes");
+    let otlp_bytes: OtlpProtoBytes = pdata
+        .try_into_with_options(ConversionOptions::default())
+        .expect("convert to OTLP bytes");
     match otlp_bytes {
         OtlpProtoBytes::ExportLogsRequest(bytes) => {
             LogsData::decode(bytes.as_ref()).expect("decode should succeed")
@@ -145,7 +150,9 @@ pub fn encode_traces(traces: &TracesData) -> OtapArrowRecords {
 #[must_use]
 pub fn decode_traces(otap: OtapArrowRecords) -> TracesData {
     let pdata: OtapPayload = otap.into();
-    let otlp_bytes: OtlpProtoBytes = pdata.try_into().expect("convert to OTLP bytes");
+    let otlp_bytes: OtlpProtoBytes = pdata
+        .try_into_with_options(ConversionOptions::default())
+        .expect("convert to OTLP bytes");
     match otlp_bytes {
         OtlpProtoBytes::ExportTracesRequest(bytes) => {
             TracesData::decode(bytes.as_ref()).expect("decode should succeed")
@@ -199,7 +206,9 @@ pub fn encode_metrics(metrics: &MetricsData) -> OtapArrowRecords {
 #[must_use]
 pub fn decode_metrics(otap: OtapArrowRecords) -> MetricsData {
     let pdata: OtapPayload = otap.into();
-    let otlp_bytes: OtlpProtoBytes = pdata.try_into().expect("convert to OTLP bytes");
+    let otlp_bytes: OtlpProtoBytes = pdata
+        .try_into_with_options(ConversionOptions::default())
+        .expect("convert to OTLP bytes");
     match otlp_bytes {
         OtlpProtoBytes::ExportMetricsRequest(bytes) => {
             MetricsData::decode(bytes.as_ref()).expect("decode should succeed")

--- a/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/metrics.rs
+++ b/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/metrics.rs
@@ -2154,7 +2154,7 @@ mod test {
         // be "packed" encoded: bucket_counts and explicit_bounds. However, proto docs say we need
         // to support maybe reading these as packed & expanded, so we test for this
 
-        let mut buffer = ProtoBuffer::new();
+        let mut buffer = ProtoBuffer::default();
 
         // first write packed encoded
         buffer.encode_field_tag(HISTOGRAM_DP_BUCKET_COUNTS, wire_types::LEN);
@@ -2229,7 +2229,7 @@ mod test {
         // ExponentialHistogramDataPoint Bucket's bucket_counts field which
         // contains a repeated uint64
 
-        let mut buffer = ProtoBuffer::new();
+        let mut buffer = ProtoBuffer::default();
 
         // test packed encoding
         buffer.encode_field_tag(EXP_HISTOGRAM_BUCKET_BUCKET_COUNTS, wire_types::LEN);

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline.rs
@@ -388,25 +388,26 @@ mod test {
     use crate::parser::default_parser_options;
 
     use super::*;
+    use otap_df_pdata::TryIntoWithOptions;
 
     /// helper function for converting [`OtapArrowRecords`] to [`LogsData`]
     pub fn otap_to_logs_data(otap_batch: OtapArrowRecords) -> LogsData {
         let otap_payload: OtapPayload = otap_batch.into();
-        let otlp_bytes: OtlpProtoBytes = otap_payload.try_into().unwrap();
+        let otlp_bytes: OtlpProtoBytes = otap_payload.try_into_with_default().unwrap();
         LogsData::decode(otlp_bytes.as_bytes()).unwrap()
     }
 
     /// helper function for converting [`OtapArrowRecords`] to [`TracesData`]
     pub fn otap_to_traces_data(otap_batch: OtapArrowRecords) -> TracesData {
         let otap_payload: OtapPayload = otap_batch.into();
-        let otlp_bytes: OtlpProtoBytes = otap_payload.try_into().unwrap();
+        let otlp_bytes: OtlpProtoBytes = otap_payload.try_into_with_default().unwrap();
         TracesData::decode(otlp_bytes.as_bytes()).unwrap()
     }
 
     /// helper function for converting [`OtapArrowRecords`] to [`MetricsData`]
     pub fn otap_to_metrics_data(otap_batch: OtapArrowRecords) -> MetricsData {
         let otap_payload: OtapPayload = otap_batch.into();
-        let otlp_bytes: OtlpProtoBytes = otap_payload.try_into().unwrap();
+        let otlp_bytes: OtlpProtoBytes = otap_payload.try_into_with_default().unwrap();
         MetricsData::decode(otlp_bytes.as_bytes()).unwrap()
     }
 

--- a/rust/otap-dataflow/crates/validation/src/validation_exporter.rs
+++ b/rust/otap-dataflow/crates/validation/src/validation_exporter.rs
@@ -23,6 +23,7 @@ use otap_df_engine::node::NodeId;
 use otap_df_engine::terminal_state::TerminalState;
 use otap_df_otap::OTAP_EXPORTER_FACTORIES;
 use otap_df_otap::pdata::OtapPdata;
+use otap_df_pdata::TryFromWithOptions;
 use otap_df_pdata::otlp::OtlpProtoBytes;
 use otap_df_pdata::proto::OtlpProtoMessage;
 use otap_df_telemetry::metrics::MetricSet;
@@ -223,7 +224,7 @@ impl Exporter<OtapPdata> for ValidationExporter {
                     let (context, payload) = pdata.into_parts();
                     let source_node = context.source_node();
                     let transport_headers = context.transport_headers().cloned();
-                    let msg = OtlpProtoBytes::try_from(payload)
+                    let msg = OtlpProtoBytes::try_from_with_default(payload)
                         .ok()
                         .and_then(|bytes| OtlpProtoMessage::try_from(bytes).ok());
 


### PR DESCRIPTION
# Change Summary

Replaces TryInto by a new TryIntoWithOptions and a default path, then mechanically converts the code.

## What issue does this PR close?

Part of #2725 
Split from #2792 

## Are there any user-facing changes?

None.
