### PR TITLE
fix(tests): increase shutdown deadlines from 200ms to 1s in parquet adaptive_schema tests

### DIFF
--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/parquet_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/parquet_exporter/mod.rs
@@ -677,12 +677,9 @@ mod test {
                         .await
                         .unwrap();
 
-                    ctx.send_shutdown(
-                        Instant::now().add(Duration::from_secs(1)),
-                        "test completed",
-                    )
-                    .await
-                    .unwrap();
+                    ctx.send_shutdown(Instant::now().add(Duration::from_secs(1)), "test completed")
+                        .await
+                        .unwrap();
                 })
             })
             .run_validation(move |_ctx, exporter_result| {

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/parquet_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/parquet_exporter/mod.rs
@@ -610,7 +610,7 @@ mod test {
                         .await
                         .unwrap();
 
-                    let deadline = Instant::now().add(Duration::from_millis(200));
+                    let deadline = Instant::now().add(Duration::from_secs(1));
                     ctx.send_shutdown(deadline, "test completed").await.unwrap();
                 })
             })
@@ -678,7 +678,7 @@ mod test {
                         .unwrap();
 
                     ctx.send_shutdown(
-                        Instant::now().add(Duration::from_millis(200)),
+                        Instant::now().add(Duration::from_secs(1)),
                         "test completed",
                     )
                     .await


### PR DESCRIPTION
# Change Summary

Increase shutdown timeouts in parquet adaptive_schema tests to address test flakiness on slow CI runs.

## What issue does this PR close?

* Addresses a flaky test reported in #2720 

## How are these changes tested?

* Verified tests pass locally

## Are there any user-facing changes?

No. This is a test-only change.