### PR TITLE
fix(tests): increase timeout duration for logs and metrics watch tests

### DIFF
--- a/rust/otap-dataflow/crates/enginectl/src/commands/tests.rs
+++ b/rust/otap-dataflow/crates/enginectl/src/commands/tests.rs
@@ -729,7 +729,7 @@ async fn logs_watch_uses_next_seq_as_after_cursor() {
 
     let mut stdout = Vec::new();
     let result = tokio::time::timeout(
-        Duration::from_millis(10),
+        Duration::from_millis(200),
         watch_logs(
             &client,
             &mut stdout,
@@ -789,7 +789,7 @@ async fn metrics_watch_human_color_always_styles_stream_header() {
 
     let mut stdout = Vec::new();
     let result = tokio::time::timeout(
-        Duration::from_millis(10),
+        Duration::from_millis(200),
         watch_metrics(
             &client,
             &mut stdout,


### PR DESCRIPTION
# Change Summary

The `metrics_watch_human_color_always_styles_stream_header` and `logs_watch_uses_next_seq_as_after_cursor` tests were using a 10ms timeout that was too tight for HTTP requests to the mock server.

 Increase the timeouts from 10ms to 200ms to provide sufficient time for:
 - Mock server HTTP connection establishment
 - Request/response round-trip
 - Output rendering and writing to stdout

## What issue does this PR close?

* Addresses flaky test `metrics_watch_human_color_always_styles_stream_header` from #2720

## How are these changes tested?

Validated that tests pass locally

## Are there any user-facing changes?

No. This is a test only change.