### PR TITLE
[Web Admin UI] Feature gate admin live log WebSocket

### DIFF
--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -251,7 +251,7 @@ geneva-uploader = "0.4.0"
 
 [features]
 # ToDo When jemalloc is enabled, we could use jemalloc_pprof to profile where memory is allocated. See https://crates.io/crates/jemalloc_pprof
-default = ["jemalloc", "crypto-ring", "dev-tools"]
+default = ["jemalloc", "crypto-ring", "dev-tools", "admin-live-logs-ws"]
 jemalloc = ["dep:tikv-jemallocator", "otap-df-engine/jemalloc"]
 mimalloc = ["dep:mimalloc"]
 azure = ["otap-df-otap/azure"]
@@ -265,6 +265,9 @@ dhat-heap = [
 
 # Dev/test tooling (fake data generator).
 dev-tools = ["otap-df-core-nodes/dev-tools"]
+
+# Admin UI live log streaming over WebSocket.
+admin-live-logs-ws = ["otap-df-controller/admin-live-logs-ws"]
 
 # Cryptographic provider selection (mutually exclusive).
 # Exactly one must be enabled when using TLS or any rustls-backed dependency (e.g. reqwest).

--- a/rust/otap-dataflow/crates/admin/Cargo.toml
+++ b/rust/otap-dataflow/crates/admin/Cargo.toml
@@ -12,6 +12,10 @@ rust-version.workspace = true
 [lints]
 workspace = true
 
+[features]
+default = []
+live-logs-ws = ["axum/ws"]
+
 [dependencies]
 otap-df-admin-types = { workspace = true }
 otap-df-config = { workspace = true }
@@ -25,7 +29,7 @@ serde_json = { workspace = true }
 tokio = { workspace = true }
 chrono = { workspace = true }
 tokio-util = { workspace = true }
-axum = { workspace = true, features = ["ws"] }
+axum = { workspace = true }
 tower = { workspace = true }
 include_dir = { workspace = true }
 mime_guess = { workspace = true }

--- a/rust/otap-dataflow/crates/admin/src/dashboard.rs
+++ b/rust/otap-dataflow/crates/admin/src/dashboard.rs
@@ -88,6 +88,13 @@ async fn index() -> Response {
             .into_response();
     };
 
+    let live_logs_ws = if cfg!(feature = "live-logs-ws") {
+        "true"
+    } else {
+        "false"
+    };
+    let index_html = index_html.replace("__LIVE_LOGS_WS__", live_logs_ws);
+
     let headers = build_ui_headers(Some("text/html; charset=utf-8"));
     (headers, Html(index_html)).into_response()
 }

--- a/rust/otap-dataflow/crates/admin/src/telemetry.rs
+++ b/rust/otap-dataflow/crates/admin/src/telemetry.rs
@@ -11,6 +11,7 @@
 
 use crate::AppState;
 use crate::convert::json_shape;
+#[cfg(feature = "live-logs-ws")]
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::{Query, State};
 use axum::http::{StatusCode, header};
@@ -30,18 +31,24 @@ use serde::{Deserialize, Serialize};
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
+#[cfg(feature = "live-logs-ws")]
 use std::sync::Arc;
+#[cfg(feature = "live-logs-ws")]
 use tokio::sync::broadcast;
 
 /// All the routes for telemetry.
 pub(crate) fn routes() -> Router<AppState> {
-    Router::new()
+    let router = Router::new()
         .route("/telemetry/live-schema", get(get_live_schema))
         .route("/telemetry/logs", get(get_logs))
-        .route("/telemetry/logs/stream", get(ws_logs_stream))
         .route("/telemetry/metrics", get(get_metrics))
         .route("/telemetry/metrics/aggregate", get(get_metrics_aggregate))
-        .route("/metrics", get(get_metrics))
+        .route("/metrics", get(get_metrics));
+
+    #[cfg(feature = "live-logs-ws")]
+    let router = router.route("/telemetry/logs/stream", get(ws_logs_stream));
+
+    router
 }
 
 /// All metric sets.
@@ -1297,6 +1304,7 @@ fn level_severity(level: &str) -> u8 {
 }
 
 /// Map a `tracing::Level` to the same severity scale used by [`level_severity`].
+#[cfg_attr(not(feature = "live-logs-ws"), allow(dead_code))]
 fn tracing_level_severity(level: &otap_df_telemetry::Level) -> u8 {
     match *level {
         otap_df_telemetry::Level::ERROR => 4,
@@ -1312,6 +1320,7 @@ fn tracing_level_severity(level: &otap_df_telemetry::Level) -> u8 {
 /// Applied after rendering so that `search_query` can match against the fully
 /// formatted message text as well as metadata fields (level, target, etc.).
 #[derive(Default)]
+#[cfg_attr(not(feature = "live-logs-ws"), allow(dead_code))]
 struct LogFilter {
     /// Case-insensitive substring matched against: rendered message, level,
     /// target, event_name, and file path.
@@ -1323,6 +1332,7 @@ struct LogFilter {
     minimum_level: Option<u8>,
 }
 
+#[cfg_attr(not(feature = "live-logs-ws"), allow(dead_code))]
 impl LogFilter {
     /// Returns `true` when the rendered log entry passes all active criteria.
     fn matches(&self, entry: &LogEntry) -> bool {
@@ -1410,6 +1420,7 @@ impl LogFilter {
 }
 
 /// Client to server WebSocket messages.
+#[cfg(feature = "live-logs-ws")]
 #[derive(Deserialize)]
 #[serde(tag = "type", rename_all = "camelCase")]
 enum WsClientMsg {
@@ -1456,6 +1467,7 @@ enum WsClientMsg {
 }
 
 /// Server to client WebSocket messages.
+#[cfg(feature = "live-logs-ws")]
 #[derive(Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 enum WsServerMsg {
@@ -1490,6 +1502,7 @@ enum WsServerMsg {
 }
 
 /// Upgrade handler for `GET /api/v1/telemetry/logs/stream`.
+#[cfg(feature = "live-logs-ws")]
 async fn ws_logs_stream(State(state): State<AppState>, ws: WebSocketUpgrade) -> Response {
     ws.on_upgrade(move |socket| handle_ws_logs(socket, state))
 }
@@ -1497,6 +1510,7 @@ async fn ws_logs_stream(State(state): State<AppState>, ws: WebSocketUpgrade) -> 
 /// Send a serialized `WsServerMsg` as a WebSocket text frame.
 ///
 /// Returns `false` if the socket is closed and the caller should stop sending.
+#[cfg(feature = "live-logs-ws")]
 async fn ws_send(ws: &mut WebSocket, msg: &WsServerMsg) -> bool {
     match serde_json::to_string(msg) {
         Ok(text) => ws.send(Message::Text(text.into())).await.is_ok(),
@@ -1508,6 +1522,7 @@ async fn ws_send(ws: &mut WebSocket, msg: &WsServerMsg) -> bool {
 ///
 /// Applies `filter` to the rendered entries so that snapshot and backfill
 /// responses are consistent with what the live stream sends for the same filter.
+#[cfg(feature = "live-logs-ws")]
 async fn ws_send_snapshot(
     ws: &mut WebSocket,
     registry: &TelemetryRegistryHandle,
@@ -1545,6 +1560,7 @@ async fn ws_send_snapshot(
 /// 5. If the client falls more than `SUBSCRIBER_CHANNEL_CAPACITY` events
 ///    behind, the broadcast channel drops the overflow; the server notifies the
 ///    client with an `error` message so it can issue a `backfill`.
+#[cfg(feature = "live-logs-ws")]
 async fn handle_ws_logs(mut ws: WebSocket, state: AppState) {
     let Some(log_tap) = state.log_tap.as_ref() else {
         let _ = ws_send(
@@ -1885,6 +1901,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "live-logs-ws")]
     #[tokio::test]
     async fn telemetry_routes_include_logs_stream_websocket_endpoint() {
         let response = routes()
@@ -1899,6 +1916,23 @@ mod tests {
             .expect("route should respond");
 
         assert_ne!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[cfg(not(feature = "live-logs-ws"))]
+    #[tokio::test]
+    async fn telemetry_routes_exclude_logs_stream_websocket_endpoint_without_feature() {
+        let response = routes()
+            .with_state(test_app_state())
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/telemetry/logs/stream")
+                    .body(Body::empty())
+                    .expect("request should build"),
+            )
+            .await
+            .expect("route should respond");
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 
     /// Ensures aggregate group ordering is deterministic: metric-set name first,
@@ -2487,6 +2521,7 @@ mod tests {
     // WebSocket / HTTP schema alignment tests
     // ---------------------------------------------------------------------------
 
+    #[cfg(feature = "live-logs-ws")]
     #[test]
     fn ws_log_msg_serializes_same_fields_as_api_log_entry() {
         let entry = make_log_entry("hello", "INFO", "admin", "2026-01-01T00:00:00Z");
@@ -2515,6 +2550,7 @@ mod tests {
         assert_eq!(roundtrip.rendered, "hello");
     }
 
+    #[cfg(feature = "live-logs-ws")]
     #[test]
     fn ws_snapshot_logs_use_api_log_entry_shape() {
         let entry = make_log_entry("hello", "INFO", "admin", "2026-01-01T00:00:00Z");

--- a/rust/otap-dataflow/crates/admin/ui/index.html
+++ b/rust/otap-dataflow/crates/admin/ui/index.html
@@ -540,7 +540,7 @@
   </div>
 
   <!-- Live log stream panel -->
-  <section id="logs-section" class="card rounded-2xl p-4 shadow-lg">
+  <section id="logs-section" class="card rounded-2xl p-4 shadow-lg" data-live-logs-ws="__LIVE_LOGS_WS__">
     <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
       <h2 class="text-lg font-semibold tracking-tight">Internal Logs</h2>
       <div class="flex flex-wrap items-center gap-2 text-xs">

--- a/rust/otap-dataflow/crates/admin/ui/js/main.js
+++ b/rust/otap-dataflow/crates/admin/ui/js/main.js
@@ -4219,7 +4219,20 @@
   // the metrics polling loop.
   const logsSection = document.getElementById("logs-section");
   if (logsSection) {
-    createLogsController({ containerEl: logsSection });
+    if (logsSection.dataset.liveLogsWs === "true") {
+      createLogsController({ containerEl: logsSection });
+    } else {
+      const logsStatus = document.getElementById("logs-status");
+      const logsConnectBtn = document.getElementById("logs-connect-btn");
+      const logsPauseBtn = document.getElementById("logs-pause-btn");
+      const logsBackfillBtn = document.getElementById("logs-backfill-btn");
+      if (logsStatus) {
+        logsStatus.textContent = "Live log streaming disabled";
+      }
+      for (const button of [logsConnectBtn, logsPauseBtn, logsBackfillBtn]) {
+        if (button) button.disabled = true;
+      }
+    }
   }
 
   void fetchAndUpdate();

--- a/rust/otap-dataflow/crates/controller/Cargo.toml
+++ b/rust/otap-dataflow/crates/controller/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 
 [features]
 testing = []
+admin-live-logs-ws = ["otap-df-admin/live-logs-ws"]
 
 [dependencies]
 otap-df-config = { workspace = true }


### PR DESCRIPTION
# Change Summary

This change adds a feature flag around the admin UI live log WebSocket path.

The WebSocket protocol requires `SHA-1` as part of the opening handshake to compute `Sec-WebSocket-Accept`. This is protocol validation, not use of `SHA-1` as a cryptographic security primitive. However, automated scanning systems can sometimes flag the transitive `sha1` crate because they cannot reliably distinguish this protocol-mandated use from general-purpose cryptographic use.

Making this path optional lets builds that do not need live log streaming avoid pulling in the WebSocket dependency chain.

  The feature remains enabled by default for normal development builds. When disabled, retained logs remain controlled by `engine.telemetry.logs.tap.enabled` and can still be queried through the HTTP logs endpoint when configured; only the live WebSocket streaming path is gated. In the admin UI, the Internal Logs panel is still rendered, but the live-stream controls are disabled when the WebSocket feature is not compiled in.


This is intended as a short-term containment change. We should separately evaluate the longer-term design: keep WebSockets with this feature boundary, move the log stream to SSE plus HTTP controls, use HTTP polling, or choose another approach that better fits the deployment requirements.


## How are these changes tested?

Manual test for admin UI - with and without flag.

## Are there any user-facing changes?

Yes - if the flag is disabled, the Internal Logs panel is still rendered, but the live-stream controls are disabled.

