### PR TITLE
fix(otlp_grpc_exporter): Set accept_compressed in addition to send_compressed

### DIFF
--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/mod.rs
@@ -820,6 +820,7 @@ impl GrpcClientPool {
         let mut client = LogsServiceClient::new(self.base_channel.clone());
         if let Some(encoding) = self.compression {
             client = client.send_compressed(encoding);
+            client = client.accept_compressed(encoding);
         }
         client
     }
@@ -828,6 +829,7 @@ impl GrpcClientPool {
         let mut client = MetricsServiceClient::new(self.base_channel.clone());
         if let Some(encoding) = self.compression {
             client = client.send_compressed(encoding);
+            client = client.accept_compressed(encoding);
         }
         client
     }
@@ -836,6 +838,7 @@ impl GrpcClientPool {
         let mut client = TraceServiceClient::new(self.base_channel.clone());
         if let Some(encoding) = self.compression {
             client = client.send_compressed(encoding);
+            client = client.accept_compressed(encoding);
         }
         client
     }


### PR DESCRIPTION
# Change Summary

Set `accept_compressed` so that we can process responses if the replies are compressed with the same codec.

## What issue does this PR close?


* Closes #2828

## How are these changes tested?

I tried them locally and verified the warnings in the issue went away.

## Are there any user-facing changes?

No.