### PR TITLE
feat(orchestrator): Allow providing a `--tests` flag to filter the tests to be run

### DIFF
--- a/tools/pipeline_perf_test/orchestrator/lib/cli/main.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/cli/main.py
@@ -35,6 +35,18 @@ def main():
     tr = setup_telemetry(args)
 
     tsc = load_config_from_file(args.config)
+
+    if args.tests:
+        requested = [t.strip() for t in args.tests.split(",")]
+        available = [t.name for t in tsc.tests]
+        unknown = set(requested) - set(available)
+        if unknown:
+            parser.error(
+                f"Unknown test(s): {', '.join(sorted(unknown))}. "
+                f"Available: {', '.join(available)}"
+            )
+        tsc.tests = [t for t in tsc.tests if t.name in requested]
+
     ts = build_test_suite(tsc, tr, args)
 
     ts.run()

--- a/tools/pipeline_perf_test/orchestrator/lib/cli/parser.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/cli/parser.py
@@ -32,6 +32,16 @@ def build_parser() -> argparse.ArgumentParser:
         "--config", "-c", required=True, help="Path to test suite YAML config."
     )
     parser.add_argument(
+        "--tests",
+        type=str,
+        default=None,
+        help=(
+            "Comma-separated list of test names to run "
+            "(e.g. 'OTLP-ATTR-OTLP,OTAP-BATCH-OTAP'). "
+            "If omitted, all tests in the config are run."
+        ),
+    )
+    parser.add_argument(
         "--debug", action="store_true", help="Enable debug mode (verbose output, etc.)."
     )
     otlp = parser.add_argument_group("OTLP Export")


### PR DESCRIPTION
# Change Summary

When working on benchmarks I often need to run or re-run just a single test of a much larger suite. Rather than play around with commenting stuff in and out, especially when templates are involved, it's much easier to pass this argument.

## What issue does this PR close?

None :(

## How are these changes tested?

I've been running this daily locally.

## Are there any user-facing changes?

Just for the orchestrator - New `--tests` flag.