### PR TITLE
feat(otap-dataflow): Add stopwatch `signals.incoming` and `signals.outgoing` metrics

### DIFF
--- a/rust/otap-dataflow/configs/fake-stopwatch-demo.yaml
+++ b/rust/otap-dataflow/configs/fake-stopwatch-demo.yaml
@@ -3,7 +3,7 @@
 # Five attribute processors form a sequential processing chain, with a 1-in-3
 # log sampler in the middle so that produced < consumed:
 #
-#   stopwatch "ingest_pipeline" - covers attr1 through attr5 (full chain)
+#   stopwatch "ingest_pipeline" - covers attr1 through attr4 (full chain)
 #
 # Stopwatches sum per-processor wall-clock compute time across each node in the
 # range. The engine arms an Instant send-marker before each `process()` call
@@ -75,7 +75,7 @@ groups:
                   value: "2"
 
           # Drops ~2 of every 3 log records so that items.produced
-          # at attr5 is visibly smaller than items.consumed at attr1.
+          # at attr4 is visibly smaller than items.consumed at attr1.
           sampler:
             type: processor:log_sampling
             config:
@@ -97,8 +97,8 @@ groups:
             config:
               actions:
                 - action: insert
-                  key: pipeline.stage5
-                  value: "5"
+                  key: pipeline.stage4
+                  value: "4"
 
           noop:
             type: exporter:noop

--- a/rust/otap-dataflow/configs/fake-stopwatch-demo.yaml
+++ b/rust/otap-dataflow/configs/fake-stopwatch-demo.yaml
@@ -19,7 +19,7 @@
 #   - stopwatch.items.produced   (MMSC, items observed at the stop node)
 #
 # With the sampler in place, `items.consumed` (at attr1) reflects the full
-# input volume while `items.produced` (at attr5) reflects roughly 1/3 of it,
+# input volume while `items.produced` (at attr4) reflects roughly 1/3 of it,
 # so the difference is directly visible.
 #
 # Note: only non-overlapping stopwatch ranges are supported. A message can be

--- a/rust/otap-dataflow/configs/fake-stopwatch-demo.yaml
+++ b/rust/otap-dataflow/configs/fake-stopwatch-demo.yaml
@@ -1,7 +1,7 @@
 # Demonstrates the distributed stopwatch feature.
 #
-# Five attribute processors form a sequential processing chain. A stopwatch
-# measures aggregate synchronous compute duration across the full chain:
+# Five attribute processors form a sequential processing chain, with a 1-in-3
+# log sampler in the middle so that produced < consumed:
 #
 #   stopwatch "ingest_pipeline" - covers attr1 through attr5 (full chain)
 #
@@ -12,8 +12,15 @@
 # captures synchronous compute plus any await/I/O that occurs inside
 # `process()` between sends; it excludes time the message spends queued in
 # inbound channels.
-# Metrics appear as stopwatch.compute.duration (MMSC histograms in
-# nanoseconds).
+#
+# Metrics emitted on the `stopwatch` metric set:
+#   - stopwatch.compute.duration (MMSC histogram, nanoseconds)
+#   - stopwatch.items.consumed   (MMSC, items observed at the start node)
+#   - stopwatch.items.produced   (MMSC, items observed at the stop node)
+#
+# With the sampler in place, `items.consumed` (at attr1) reflects the full
+# input volume while `items.produced` (at attr5) reflects roughly 1/3 of it,
+# so the difference is directly visible.
 #
 # Note: only non-overlapping stopwatch ranges are supported. A message can be
 # inside at most one stopwatch range at a time.
@@ -39,7 +46,7 @@ groups:
             stopwatches:
               - name: ingest_pipeline
                 start_node: attr1
-                stop_node: attr5
+                stop_node: attr4
 
         nodes:
           receiver:
@@ -67,15 +74,17 @@ groups:
                   key: pipeline.stage2
                   value: "2"
 
-          attr3:
-            type: processor:attribute
+          # Drops ~2 of every 3 log records so that items.produced
+          # at attr5 is visibly smaller than items.consumed at attr1.
+          sampler:
+            type: processor:log_sampling
             config:
-              actions:
-                - action: insert
-                  key: pipeline.stage3
-                  value: "3"
+              policy:
+                ratio:
+                  emit: 1
+                  out_of: 3
 
-          attr4:
+          attr3:
             type: processor:attribute
             config:
               actions:
@@ -83,7 +92,7 @@ groups:
                   key: pipeline.stage4
                   value: "4"
 
-          attr5:
+          attr4:
             type: processor:attribute
             config:
               actions:
@@ -101,10 +110,10 @@ groups:
           - from: attr1
             to: attr2
           - from: attr2
+            to: sampler
+          - from: sampler
             to: attr3
           - from: attr3
             to: attr4
           - from: attr4
-            to: attr5
-          - from: attr5
             to: noop

--- a/rust/otap-dataflow/configs/fake-stopwatch-demo.yaml
+++ b/rust/otap-dataflow/configs/fake-stopwatch-demo.yaml
@@ -15,11 +15,11 @@
 #
 # Metrics emitted on the `stopwatch` metric set:
 #   - stopwatch.compute.duration (MMSC histogram, nanoseconds)
-#   - stopwatch.items.consumed   (MMSC, items observed at the start node)
-#   - stopwatch.items.produced   (MMSC, items observed at the stop node)
+#   - stopwatch.signals.incoming   (MMSC, items observed at the start node)
+#   - stopwatch.signals.outgoing   (MMSC, items observed at the stop node)
 #
-# With the sampler in place, `items.consumed` (at attr1) reflects the full
-# input volume while `items.produced` (at attr4) reflects roughly 1/3 of it,
+# With the sampler in place, `signals.incoming` (at attr1) reflects the full
+# input volume while `signals.outgoing` (at attr4) reflects roughly 1/3 of it,
 # so the difference is directly visible.
 #
 # Note: only non-overlapping stopwatch ranges are supported. A message can be
@@ -45,7 +45,7 @@ groups:
             runtime_metrics: normal
             stopwatches:
               - name: ingest_pipeline
-                start_node: attr1
+                start_node: sampler
                 stop_node: attr4
 
         nodes:
@@ -57,6 +57,18 @@ groups:
                 signals_per_second: 10
                 log_weight: 100
               registry_path: https://github.com/open-telemetry/semantic-conventions.git[model]
+
+          # Drops ~2 of every 3 log records so that signals.outgoing
+          # at attr4 is visibly smaller than signals.incoming at sampler.
+          # Used as beginning of stopwatch range to prove that signals.incoming
+          # is reported before start node's process() begins.
+          sampler:
+            type: processor:log_sampling
+            config:
+              policy:
+                ratio:
+                  emit: 1
+                  out_of: 3
 
           attr1:
             type: processor:attribute
@@ -73,16 +85,6 @@ groups:
                 - action: insert
                   key: pipeline.stage2
                   value: "2"
-
-          # Drops ~2 of every 3 log records so that items.produced
-          # at attr4 is visibly smaller than items.consumed at attr1.
-          sampler:
-            type: processor:log_sampling
-            config:
-              policy:
-                ratio:
-                  emit: 1
-                  out_of: 3
 
           attr3:
             type: processor:attribute
@@ -106,12 +108,12 @@ groups:
 
         connections:
           - from: receiver
+            to: sampler
+          - from: sampler
             to: attr1
           - from: attr1
             to: attr2
           - from: attr2
-            to: sampler
-          - from: sampler
             to: attr3
           - from: attr3
             to: attr4

--- a/rust/otap-dataflow/configs/fake-stopwatch-demo.yaml
+++ b/rust/otap-dataflow/configs/fake-stopwatch-demo.yaml
@@ -89,8 +89,8 @@ groups:
             config:
               actions:
                 - action: insert
-                  key: pipeline.stage4
-                  value: "4"
+                  key: pipeline.stage3
+                  value: "3"
 
           attr4:
             type: processor:attribute

--- a/rust/otap-dataflow/crates/controller/src/lib.rs
+++ b/rust/otap-dataflow/crates/controller/src/lib.rs
@@ -80,6 +80,7 @@ use otap_df_engine::memory_limiter::{
     EffectiveMemoryLimiter, MemoryLimiterTick, MemoryPressureBehaviorConfig, MemoryPressureChanged,
     MemoryPressureLevel,
 };
+use otap_df_engine::processor::FlowMeasurementHook;
 use otap_df_engine::topic::{
     InMemoryBackend, PipelineTopicBinding, TopicBroker, TopicOptions, TopicPublishOutcomeConfig,
     TopicSet,
@@ -273,8 +274,16 @@ fn engine_context() -> LogContext {
     }
 }
 
-impl<PData: 'static + Clone + Send + Sync + std::fmt::Debug + ReceivedAtNode + Unwindable>
-    Controller<PData>
+impl<
+    PData: 'static
+        + Clone
+        + Send
+        + Sync
+        + std::fmt::Debug
+        + ReceivedAtNode
+        + Unwindable
+        + FlowMeasurementHook,
+> Controller<PData>
 {
     /// Creates a new controller with the given pipeline factory.
     pub const fn new(pipeline_factory: &'static PipelineFactory<PData>) -> Self {

--- a/rust/otap-dataflow/crates/controller/src/live_control/execution.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control/execution.rs
@@ -10,8 +10,16 @@
 
 use super::*;
 
-impl<PData: 'static + Clone + Send + Sync + std::fmt::Debug + ReceivedAtNode + Unwindable>
-    ControllerRuntime<PData>
+impl<
+    PData: 'static
+        + Clone
+        + Send
+        + Sync
+        + std::fmt::Debug
+        + ReceivedAtNode
+        + Unwindable
+        + FlowMeasurementHook,
+> ControllerRuntime<PData>
 {
     /// Emits the internal telemetry event for a rollout/shutdown worker panic.
     pub(super) fn report_controller_worker_panic(

--- a/rust/otap-dataflow/crates/controller/src/live_control/mod.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control/mod.rs
@@ -105,8 +105,16 @@ pub(super) struct LaunchedPipelineThread<PData> {
     pub(super) _marker: std::marker::PhantomData<PData>,
 }
 
-impl<PData: 'static + Clone + Send + Sync + std::fmt::Debug + ReceivedAtNode + Unwindable>
-    ControllerRuntime<PData>
+impl<
+    PData: 'static
+        + Clone
+        + Send
+        + Sync
+        + std::fmt::Debug
+        + ReceivedAtNode
+        + Unwindable
+        + FlowMeasurementHook,
+> ControllerRuntime<PData>
 {
     #[allow(clippy::too_many_arguments)]
     /// Builds the resident controller runtime used by live reconfiguration.
@@ -441,8 +449,16 @@ impl<PData: 'static + Clone + Send + Sync + std::fmt::Debug + ReceivedAtNode + U
     }
 }
 
-impl<PData: 'static + Clone + Send + Sync + std::fmt::Debug + ReceivedAtNode + Unwindable>
-    ControlPlane for ControllerControlPlane<PData>
+impl<
+    PData: 'static
+        + Clone
+        + Send
+        + Sync
+        + std::fmt::Debug
+        + ReceivedAtNode
+        + Unwindable
+        + FlowMeasurementHook,
+> ControlPlane for ControllerControlPlane<PData>
 {
     fn shutdown_all(&self, timeout_secs: u64) -> Result<(), ControlPlaneError> {
         self.runtime.request_shutdown_all(timeout_secs)

--- a/rust/otap-dataflow/crates/controller/src/live_control/planning.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control/planning.rs
@@ -10,8 +10,16 @@
 
 use super::*;
 
-impl<PData: 'static + Clone + Send + Sync + std::fmt::Debug + ReceivedAtNode + Unwindable>
-    ControllerRuntime<PData>
+impl<
+    PData: 'static
+        + Clone
+        + Send
+        + Sync
+        + std::fmt::Debug
+        + ReceivedAtNode
+        + Unwindable
+        + FlowMeasurementHook,
+> ControllerRuntime<PData>
 {
     /// Resolves the concrete core ids selected by a pipeline resource policy.
     pub(super) fn assigned_cores_for_resolved(

--- a/rust/otap-dataflow/crates/controller/src/live_control/runtime.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control/runtime.rs
@@ -21,8 +21,16 @@ fn deployed_instance_label(deployed_key: &DeployedPipelineKey) -> String {
     )
 }
 
-impl<PData: 'static + Clone + Send + Sync + std::fmt::Debug + ReceivedAtNode + Unwindable>
-    ControllerRuntime<PData>
+impl<
+    PData: 'static
+        + Clone
+        + Send
+        + Sync
+        + std::fmt::Debug
+        + ReceivedAtNode
+        + Unwindable
+        + FlowMeasurementHook,
+> ControllerRuntime<PData>
 {
     /// Launches one regular pipeline instance on a specific core and generation.
     pub(super) fn launch_regular_pipeline_instance(

--- a/rust/otap-dataflow/crates/engine/src/lib.rs
+++ b/rust/otap-dataflow/crates/engine/src/lib.rs
@@ -383,6 +383,13 @@ impl ReceivedAtNode for () {
 impl ReceivedAtNode for String {
     fn received_at_node(&mut self, _node_id: usize, _node_interests: Interests) {}
 }
+// `FlowMeasurementHook` is a bound on the `PData` generic of `ProcessorWrapper::start*`,
+// `RuntimePipeline`, and the controller. Test code uses `()` and `String` as stand-in PData
+// types (e.g. `Controller<()>`); these blanket no-op impls let those tests compile without
+// requiring every test PData type to define hook behavior. Real PData types (e.g. `OtapPdata`)
+// override these methods to drive stopwatch signal counting and compute-duration accumulation.
+impl processor::FlowMeasurementHook for () {}
+impl processor::FlowMeasurementHook for String {}
 
 /// Trait for setting exit information in the Context, for PData consumers.
 pub trait StampOutputPort {

--- a/rust/otap-dataflow/crates/engine/src/local/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/local/processor.rs
@@ -45,7 +45,10 @@ use crate::node::NodeId;
 use crate::output_router::OutputRouter;
 use crate::process_duration::ComputeDuration;
 use crate::processor::ProcessorRuntimeRequirements;
-use crate::stopwatch::{LocalStopwatchState, StopMeasurements, StopwatchMetrics, nanos_u64};
+use crate::stopwatch::{
+    LocalStopwatchState, StartMeasurements, StopMeasurements, StopwatchStartMetrics,
+    StopwatchStopMetrics, nanos_u64,
+};
 use crate::{WakeupError, WakeupSetOutcome};
 use async_trait::async_trait;
 use otap_df_config::PortName;
@@ -223,14 +226,20 @@ impl<PData> EffectHandler<PData> {
     pub(crate) fn set_stopwatch_roles(
         &mut self,
         is_start: bool,
-        stop_metric: Option<MetricSet<StopwatchMetrics>>,
+        start_metric: Option<MetricSet<StopwatchStartMetrics>>,
+        stop_metric: Option<MetricSet<StopwatchStopMetrics>>,
         stopwatches_active: bool,
     ) {
         self.stopwatch.is_start = is_start;
         self.stopwatch.active = stopwatches_active;
+        self.stopwatch.start = start_metric.map(|metrics| StartMeasurements {
+            metrics,
+            items_consumed_acc: Cell::new(Mmsc::default()),
+        });
         self.stopwatch.stop = stop_metric.map(|metrics| StopMeasurements {
             metrics,
             duration_acc: Cell::new(Mmsc::default()),
+            items_produced_acc: Cell::new(Mmsc::default()),
         });
     }
 
@@ -261,15 +270,42 @@ impl<PData> EffectHandler<PData> {
         stop.duration_acc.set(acc);
     }
 
+    /// Record signal-item count into the local start-side stopwatch accumulator.
+    pub fn record_stopwatch_start_items(&self, items: u64) {
+        let Some(start) = self.stopwatch.start.as_ref() else {
+            return;
+        };
+        let mut acc = start.items_consumed_acc.get();
+        acc.record(items as f64);
+        start.items_consumed_acc.set(acc);
+    }
+
+    /// Record signal-item count into the local stop-side stopwatch accumulator.
+    pub fn record_stopwatch_stop_items(&self, items: u64) {
+        let Some(stop) = self.stopwatch.stop.as_ref() else {
+            return;
+        };
+        let mut acc = stop.items_produced_acc.get();
+        acc.record(items as f64);
+        stop.items_produced_acc.set(acc);
+    }
+
     /// Drain accumulated stopwatch observations into the MetricSet and
     /// report to the telemetry collector.
     ///
     /// Called by the engine on periodic `CollectTelemetry` and at
     /// shutdown — the same cadence as `ComputeDuration::report`.
     pub(crate) fn report_stopwatch(&mut self) {
+        if let Some(start) = self.stopwatch.start.as_mut() {
+            let acc = start.items_consumed_acc.replace(Mmsc::default());
+            start.metrics.items_consumed.merge(acc);
+            let _ = self.core.metrics_reporter.report(&mut start.metrics);
+        }
         if let Some(stop) = self.stopwatch.stop.as_mut() {
-            let acc = stop.duration_acc.replace(Mmsc::default());
-            stop.metrics.compute_duration.merge(acc);
+            let duration_acc = stop.duration_acc.replace(Mmsc::default());
+            stop.metrics.compute_duration.merge(duration_acc);
+            let items_acc = stop.items_produced_acc.replace(Mmsc::default());
+            stop.metrics.items_produced.merge(items_acc);
             let _ = self.core.metrics_reporter.report(&mut stop.metrics);
         }
     }
@@ -491,6 +527,14 @@ impl<PData> crate::processor::StopwatchEffectHandler for EffectHandler<PData> {
     #[inline]
     fn record_stopwatch_stop(&self, total: u64) {
         EffectHandler::record_stopwatch_stop(self, total);
+    }
+    #[inline]
+    fn record_stopwatch_start_items(&self, items: u64) {
+        EffectHandler::record_stopwatch_start_items(self, items);
+    }
+    #[inline]
+    fn record_stopwatch_stop_items(&self, items: u64) {
+        EffectHandler::record_stopwatch_stop_items(self, items);
     }
 }
 
@@ -932,12 +976,14 @@ mod tests {
         assert_eq!(counts, (0, 0));
     }
 
-    /// Verify that record_stopwatch_stop accumulates into the local Mmsc
-    /// and report_stopwatch drains into the MetricSet and reports.
+    /// Verify that stopwatch duration and item counts accumulate into local Mmsc
+    /// values and report_stopwatch drains into MetricSets.
     #[test]
     fn stopwatch_accumulate_then_report() {
         use crate::context::ControllerContext;
-        use crate::stopwatch::{StopwatchAttributeSet, StopwatchMetrics};
+        use crate::stopwatch::{
+            StopwatchAttributeSet, StopwatchStartMetrics, StopwatchStopMetrics,
+        };
         use otap_df_config::node::NodeKind;
         use otap_df_telemetry::registry::TelemetryRegistryHandle;
 
@@ -955,11 +1001,14 @@ mod tests {
         let entity_key = pipeline_ctx
             .metrics_registry()
             .register_entity(StopwatchAttributeSet::default());
-        let metric_set = pipeline_ctx
+        let start_metric_set = pipeline_ctx
             .metrics_registry()
-            .register_metric_set_for_entity::<StopwatchMetrics>(entity_key);
+            .register_metric_set_for_entity::<StopwatchStartMetrics>(entity_key);
+        let stop_metric_set = pipeline_ctx
+            .metrics_registry()
+            .register_metric_set_for_entity::<StopwatchStopMetrics>(entity_key);
 
-        // Create an EffectHandler with the stopwatch stop role.
+        // Create an EffectHandler with both stopwatch roles.
         let (_snapshot_rx, metrics_reporter) = MetricsReporter::create_new_and_receiver(64);
         let mut eh = EffectHandler::<u64>::new(
             test_node("stop_node"),
@@ -967,16 +1016,47 @@ mod tests {
             None,
             metrics_reporter,
         );
-        eh.set_stopwatch_roles(false, Some(metric_set), true);
+        eh.set_stopwatch_roles(true, Some(start_metric_set), Some(stop_metric_set), true);
 
         // Record two observations — should accumulate in the local Mmsc,
         // not touch the MetricSet yet.
+        eh.record_stopwatch_start_items(10);
+        eh.record_stopwatch_start_items(20);
         eh.record_stopwatch_stop(1000);
         eh.record_stopwatch_stop(2000);
+        eh.record_stopwatch_stop_items(7);
+        eh.record_stopwatch_stop_items(8);
+
+        let start_acc = eh
+            .stopwatch
+            .start
+            .as_ref()
+            .unwrap()
+            .items_consumed_acc
+            .get()
+            .get();
+        assert_eq!(
+            start_acc.count, 2,
+            "start item Mmsc should have 2 observations"
+        );
+        assert!((start_acc.sum - 30.0).abs() < f64::EPSILON);
 
         let acc = eh.stopwatch.stop.as_ref().unwrap().duration_acc.get().get();
         assert_eq!(acc.count, 2, "local Mmsc should have 2 observations");
         assert!((acc.sum - 3000.0).abs() < f64::EPSILON);
+        let produced_acc = eh
+            .stopwatch
+            .stop
+            .as_ref()
+            .unwrap()
+            .items_produced_acc
+            .get()
+            .get();
+        assert_eq!(
+            produced_acc.count, 2,
+            "stop item Mmsc should have 2 observations"
+        );
+        assert!((produced_acc.sum - 15.0).abs() < f64::EPSILON);
 
         // MetricSet should still be empty before report.
         let ms_snap = eh
@@ -992,9 +1072,33 @@ mod tests {
         // report_stopwatch drains the accumulator into the MetricSet.
         eh.report_stopwatch();
 
-        // Accumulator should be drained.
+        // Accumulators should be drained.
+        let start_acc_after = eh
+            .stopwatch
+            .start
+            .as_ref()
+            .unwrap()
+            .items_consumed_acc
+            .get()
+            .get();
+        assert_eq!(
+            start_acc_after.count, 0,
+            "start accumulator should be drained"
+        );
         let acc_after = eh.stopwatch.stop.as_ref().unwrap().duration_acc.get().get();
-        assert_eq!(acc_after.count, 0, "accumulator should be drained");
+        assert_eq!(acc_after.count, 0, "duration accumulator should be drained");
+        let produced_acc_after = eh
+            .stopwatch
+            .stop
+            .as_ref()
+            .unwrap()
+            .items_produced_acc
+            .get()
+            .get();
+        assert_eq!(
+            produced_acc_after.count, 0,
+            "stop item accumulator should be drained"
+        );
 
         // Another record + report cycle should work independently.
         eh.record_stopwatch_stop(500);
@@ -1013,7 +1117,7 @@ mod tests {
         let (_metrics_rx, metrics_reporter) = MetricsReporter::create_new_and_receiver(1);
         let mut eh =
             EffectHandler::<u64>::new(test_node("proc"), HashMap::new(), None, metrics_reporter);
-        eh.set_stopwatch_roles(true, None, true);
+        eh.set_stopwatch_roles(true, None, None, true);
         assert!(eh.stopwatch.active);
 
         eh.begin_process_timing();
@@ -1040,7 +1144,7 @@ mod tests {
         let (_metrics_rx, metrics_reporter) = MetricsReporter::create_new_and_receiver(1);
         let mut eh =
             EffectHandler::<u64>::new(test_node("proc"), HashMap::new(), None, metrics_reporter);
-        eh.set_stopwatch_roles(true, None, true);
+        eh.set_stopwatch_roles(true, None, None, true);
         assert_eq!(eh.take_elapsed_since_send_marker_ns(), 0);
     }
 }

--- a/rust/otap-dataflow/crates/engine/src/local/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/local/processor.rs
@@ -234,12 +234,12 @@ impl<PData> EffectHandler<PData> {
         self.stopwatch.active = stopwatches_active;
         self.stopwatch.start = start_metric.map(|metrics| StartMeasurements {
             metrics,
-            items_consumed_acc: Cell::new(Mmsc::default()),
+            signals_incoming_acc: Cell::new(Mmsc::default()),
         });
         self.stopwatch.stop = stop_metric.map(|metrics| StopMeasurements {
             metrics,
             duration_acc: Cell::new(Mmsc::default()),
-            items_produced_acc: Cell::new(Mmsc::default()),
+            signals_outgoing_acc: Cell::new(Mmsc::default()),
         });
     }
 
@@ -271,23 +271,23 @@ impl<PData> EffectHandler<PData> {
     }
 
     /// Record signal-item count into the local start-side stopwatch accumulator.
-    pub fn record_stopwatch_start_items(&self, items: u64) {
+    pub fn record_stopwatch_start_signals(&self, signals: u64) {
         let Some(start) = self.stopwatch.start.as_ref() else {
             return;
         };
-        let mut acc = start.items_consumed_acc.get();
-        acc.record(items as f64);
-        start.items_consumed_acc.set(acc);
+        let mut acc = start.signals_incoming_acc.get();
+        acc.record(signals as f64);
+        start.signals_incoming_acc.set(acc);
     }
 
     /// Record signal-item count into the local stop-side stopwatch accumulator.
-    pub fn record_stopwatch_stop_items(&self, items: u64) {
+    pub fn record_stopwatch_stop_signals(&self, signals: u64) {
         let Some(stop) = self.stopwatch.stop.as_ref() else {
             return;
         };
-        let mut acc = stop.items_produced_acc.get();
-        acc.record(items as f64);
-        stop.items_produced_acc.set(acc);
+        let mut acc = stop.signals_outgoing_acc.get();
+        acc.record(signals as f64);
+        stop.signals_outgoing_acc.set(acc);
     }
 
     /// Drain accumulated stopwatch observations into the MetricSet and
@@ -297,15 +297,15 @@ impl<PData> EffectHandler<PData> {
     /// shutdown — the same cadence as `ComputeDuration::report`.
     pub(crate) fn report_stopwatch(&mut self) {
         if let Some(start) = self.stopwatch.start.as_mut() {
-            let acc = start.items_consumed_acc.replace(Mmsc::default());
-            start.metrics.items_consumed.merge(acc);
+            let acc = start.signals_incoming_acc.replace(Mmsc::default());
+            start.metrics.signals_incoming.merge(acc);
             let _ = self.core.metrics_reporter.report(&mut start.metrics);
         }
         if let Some(stop) = self.stopwatch.stop.as_mut() {
             let duration_acc = stop.duration_acc.replace(Mmsc::default());
             stop.metrics.compute_duration.merge(duration_acc);
-            let items_acc = stop.items_produced_acc.replace(Mmsc::default());
-            stop.metrics.items_produced.merge(items_acc);
+            let signals_acc = stop.signals_outgoing_acc.replace(Mmsc::default());
+            stop.metrics.signals_outgoing.merge(signals_acc);
             let _ = self.core.metrics_reporter.report(&mut stop.metrics);
         }
     }
@@ -343,7 +343,7 @@ impl<PData> EffectHandler<PData> {
     #[inline]
     pub async fn send_message(&self, mut data: PData) -> Result<(), TypedError<PData>>
     where
-        PData: crate::processor::ProcessorSendHook,
+        PData: crate::processor::FlowMeasurementHook,
     {
         data.before_processor_send(self);
         self.router.send_default(data).await
@@ -362,7 +362,7 @@ impl<PData> EffectHandler<PData> {
     #[inline]
     pub fn try_send_message(&self, mut data: PData) -> Result<(), TypedError<PData>>
     where
-        PData: crate::processor::ProcessorSendHook,
+        PData: crate::processor::FlowMeasurementHook,
     {
         data.before_processor_send(self);
         self.router.try_send_default(data)
@@ -382,7 +382,7 @@ impl<PData> EffectHandler<PData> {
     ) -> Result<(), TypedError<PData>>
     where
         P: Into<PortName>,
-        PData: crate::processor::ProcessorSendHook,
+        PData: crate::processor::FlowMeasurementHook,
     {
         data.before_processor_send(self);
         self.router.send_to(port, data).await
@@ -402,7 +402,7 @@ impl<PData> EffectHandler<PData> {
     pub fn try_send_message_to<P>(&self, port: P, mut data: PData) -> Result<(), TypedError<PData>>
     where
         P: Into<PortName>,
-        PData: crate::processor::ProcessorSendHook,
+        PData: crate::processor::FlowMeasurementHook,
     {
         data.before_processor_send(self);
         self.router.try_send_to(port, data)
@@ -529,12 +529,12 @@ impl<PData> crate::processor::StopwatchEffectHandler for EffectHandler<PData> {
         EffectHandler::record_stopwatch_stop(self, total);
     }
     #[inline]
-    fn record_stopwatch_start_items(&self, items: u64) {
-        EffectHandler::record_stopwatch_start_items(self, items);
+    fn record_stopwatch_start_signals(&self, signals: u64) {
+        EffectHandler::record_stopwatch_start_signals(self, signals);
     }
     #[inline]
-    fn record_stopwatch_stop_items(&self, items: u64) {
-        EffectHandler::record_stopwatch_stop_items(self, items);
+    fn record_stopwatch_stop_signals(&self, signals: u64) {
+        EffectHandler::record_stopwatch_stop_signals(self, signals);
     }
 }
 
@@ -576,7 +576,7 @@ mod tests {
         mpsc::Channel::new(capacity)
     }
 
-    impl crate::processor::ProcessorSendHook for u64 {}
+    impl crate::processor::FlowMeasurementHook for u64 {}
 
     #[derive(Clone, Debug)]
     struct TestPData {
@@ -1020,19 +1020,19 @@ mod tests {
 
         // Record two observations — should accumulate in the local Mmsc,
         // not touch the MetricSet yet.
-        eh.record_stopwatch_start_items(10);
-        eh.record_stopwatch_start_items(20);
+        eh.record_stopwatch_start_signals(10);
+        eh.record_stopwatch_start_signals(20);
         eh.record_stopwatch_stop(1000);
         eh.record_stopwatch_stop(2000);
-        eh.record_stopwatch_stop_items(7);
-        eh.record_stopwatch_stop_items(8);
+        eh.record_stopwatch_stop_signals(7);
+        eh.record_stopwatch_stop_signals(8);
 
         let start_acc = eh
             .stopwatch
             .start
             .as_ref()
             .unwrap()
-            .items_consumed_acc
+            .signals_incoming_acc
             .get()
             .get();
         assert_eq!(
@@ -1049,7 +1049,7 @@ mod tests {
             .stop
             .as_ref()
             .unwrap()
-            .items_produced_acc
+            .signals_outgoing_acc
             .get()
             .get();
         assert_eq!(
@@ -1078,7 +1078,7 @@ mod tests {
             .start
             .as_ref()
             .unwrap()
-            .items_consumed_acc
+            .signals_incoming_acc
             .get()
             .get();
         assert_eq!(
@@ -1092,7 +1092,7 @@ mod tests {
             .stop
             .as_ref()
             .unwrap()
-            .items_produced_acc
+            .signals_outgoing_acc
             .get()
             .get();
         assert_eq!(

--- a/rust/otap-dataflow/crates/engine/src/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/processor.rs
@@ -42,7 +42,7 @@ use std::time::Duration;
 ///
 /// Implemented by both `local::processor::EffectHandler<PData>` and
 /// `shared::processor::EffectHandler<PData>` so that PData-side stopwatch
-/// hooks (see [`ProcessorSendHook`]) can be written once, generic over
+/// hooks (see [`FlowMeasurementHook`]) can be written once, generic over
 /// handler kind.
 pub trait StopwatchEffectHandler {
     /// Whether this node is the start of a stopwatch range.
@@ -57,29 +57,48 @@ pub trait StopwatchEffectHandler {
     /// stop node's local accumulator.
     fn record_stopwatch_stop(&self, total: u64);
     /// Record signal-item count into the start node's local accumulator.
-    fn record_stopwatch_start_items(&self, items: u64);
+    fn record_stopwatch_start_signals(&self, signals: u64);
     /// Record signal-item count into the stop node's local accumulator.
-    fn record_stopwatch_stop_items(&self, items: u64);
+    fn record_stopwatch_stop_signals(&self, signals: u64);
 }
 
-/// Per-`PData` hook called immediately before a processor `EffectHandler`
-/// forwards a message to the output router.
+/// Per-`PData` hooks straddling a processor's `process()` call: an
+/// `after_processor_receive` notification fires immediately after a
+/// `Message::PData` is dequeued (before `process()` runs), and a
+/// `before_processor_send` notification fires immediately before the
+/// effect handler forwards a message to the output router.
 ///
-/// Covers **both** the plain `send_message[_to]` family and the
-/// `send_message_with_source_node[_to]` family — every send method on
-/// every processor handler invokes this hook exactly once. The default
-/// impl is a no-op; PData types with bookkeeping needs (e.g. stopwatch
-/// accumulation on `OtapPdata`) override `before_processor_send`.
+/// The send-side hook covers **both** the plain `send_message[_to]`
+/// family and the `send_message_with_source_node[_to]` family — every
+/// send method on every processor handler invokes it exactly once.
+/// Both methods default to no-ops; PData types with bookkeeping needs
+/// (e.g. stopwatch accumulation on `OtapPdata`) override one or both.
 ///
 /// `EffectHandler<PData>` is generic but lives in the engine crate, while
 /// some `PData` types need bookkeeping defined in their own crate.
 /// Inherent methods shadow extension-trait methods, so we route
 /// per-`PData` behavior through this trait. PData types with nothing to
-/// do can simply write `impl ProcessorSendHook for MyPData {}`.
-pub trait ProcessorSendHook: Sized {
+/// do can simply write `impl FlowMeasurementHook for MyPData {}`.
+///
+/// NOTE: This trait currently lives in `processor.rs` and only fires from
+/// processor run loops / processor effect handlers because processors are
+/// the only nodes that need pre-process and pre-send hooks today (for
+/// stopwatch flow measurement). If receivers or exporters ever need
+/// analogous `before_*` / `after_*` hooks on PData, this trait should be
+/// hoisted to a more generic location (e.g. a top-level `flow_hook` module
+/// or `crate::lib`) and its `H: StopwatchEffectHandler` bound generalized
+/// so it can be invoked from receiver/exporter handlers as well.
+pub trait FlowMeasurementHook: Sized {
     /// Invoked once per message immediately before the processor handler
     /// forwards it to the output router.
     fn before_processor_send<H: StopwatchEffectHandler>(&mut self, _handler: &H) {}
+
+    /// Invoked once per `Message::PData` immediately after it is dequeued
+    /// by a processor's run loop and before `process()` runs. Lets PData
+    /// types observe the *pre-process* state of the data — e.g. counting
+    /// items entering a stopwatch start node before any filter or drop
+    /// inside `process()`. Default impl is a no-op.
+    fn after_processor_receive<H: StopwatchEffectHandler>(&mut self, _handler: &H) {}
 }
 
 /// Processor-local wakeup requirements declared by a processor implementation.
@@ -550,7 +569,7 @@ impl<PData> ProcessorWrapper<PData> {
         node_interests: Interests,
     ) -> Result<(), Error>
     where
-        PData: ReceivedAtNode,
+        PData: ReceivedAtNode + FlowMeasurementHook,
     {
         self.start_with_completion_metrics(
             runtime_ctrl_msg_tx,
@@ -579,7 +598,7 @@ impl<PData> ProcessorWrapper<PData> {
         stopwatches_active: bool,
     ) -> Result<(), Error>
     where
-        PData: ReceivedAtNode,
+        PData: ReceivedAtNode + FlowMeasurementHook,
     {
         let runtime = self
             .prepare_runtime(metrics_reporter.clone(), node_interests)
@@ -613,16 +632,19 @@ impl<PData> ProcessorWrapper<PData> {
                     .start_periodic_telemetry(Duration::from_secs(1))
                     .await?;
 
-                while let Ok(msg) = inbox.recv_when(processor.accept_pdata()).await {
+                while let Ok(mut msg) = inbox.recv_when(processor.accept_pdata()).await {
                     if effect_handler.stopwatches_active() {
-                        match &msg {
+                        match &mut msg {
                             Message::Control(NodeControlMsg::CollectTelemetry { .. })
                                 if effect_handler.is_stopwatch_start()
                                     || effect_handler.is_stopwatch_stop() =>
                             {
                                 effect_handler.report_stopwatch();
                             }
-                            Message::PData(_) => effect_handler.begin_process_timing(),
+                            Message::PData(data) => {
+                                data.after_processor_receive(&effect_handler);
+                                effect_handler.begin_process_timing();
+                            }
                             _ => {}
                         }
                     }
@@ -668,16 +690,19 @@ impl<PData> ProcessorWrapper<PData> {
                     .start_periodic_telemetry(Duration::from_secs(1))
                     .await?;
 
-                while let Ok(msg) = inbox.recv_when(processor.accept_pdata()).await {
+                while let Ok(mut msg) = inbox.recv_when(processor.accept_pdata()).await {
                     if effect_handler.stopwatches_active() {
-                        match &msg {
+                        match &mut msg {
                             Message::Control(NodeControlMsg::CollectTelemetry { .. })
                                 if effect_handler.is_stopwatch_start()
                                     || effect_handler.is_stopwatch_stop() =>
                             {
                                 effect_handler.report_stopwatch();
                             }
-                            Message::PData(_) => effect_handler.begin_process_timing(),
+                            Message::PData(data) => {
+                                data.after_processor_receive(&effect_handler);
+                                effect_handler.begin_process_timing();
+                            }
                             _ => {}
                         }
                     }
@@ -1095,7 +1120,7 @@ mod tests {
         fn received_at_node(&mut self, _node_id: usize, _node_interests: crate::Interests) {}
     }
 
-    impl crate::processor::ProcessorSendHook for StopwatchTestPData {
+    impl crate::processor::FlowMeasurementHook for StopwatchTestPData {
         fn before_processor_send<H: crate::processor::StopwatchEffectHandler>(
             &mut self,
             handler: &H,
@@ -1109,7 +1134,6 @@ mod tests {
 
             if handler.is_stopwatch_start() {
                 self.stopwatch_active = true;
-                handler.record_stopwatch_start_items(1);
             }
 
             self.stopwatch_compute_ns = self
@@ -1119,9 +1143,18 @@ mod tests {
             if handler.is_stopwatch_stop() && self.stopwatch_active && self.stopwatch_compute_ns > 0
             {
                 handler.record_stopwatch_stop(self.stopwatch_compute_ns);
-                handler.record_stopwatch_stop_items(1);
+                handler.record_stopwatch_stop_signals(1);
                 self.stopwatch_compute_ns = 0;
                 self.stopwatch_active = false;
+            }
+        }
+
+        fn after_processor_receive<H: crate::processor::StopwatchEffectHandler>(
+            &mut self,
+            handler: &H,
+        ) {
+            if handler.is_stopwatch_start() {
+                handler.record_stopwatch_start_signals(1);
             }
         }
     }
@@ -1245,11 +1278,11 @@ mod tests {
                 processor_task.abort();
                 let _ = processor_task.await;
 
-                let [MetricValue::Mmsc(items_consumed)] = snapshot.get_metrics() else {
+                let [MetricValue::Mmsc(signals_incoming)] = snapshot.get_metrics() else {
                     panic!("expected one start stopwatch MMSC metric");
                 };
-                assert_eq!(items_consumed.count, 1);
-                assert!((items_consumed.sum - 1.0).abs() < f64::EPSILON);
+                assert_eq!(signals_incoming.count, 1);
+                assert!((signals_incoming.sum - 1.0).abs() < f64::EPSILON);
 
                 let snapshot =
                     tokio::time::timeout(Duration::from_secs(1), metrics_rx.recv_async())
@@ -1258,10 +1291,10 @@ mod tests {
                         .expect("metrics channel should remain open");
                 let [
                     MetricValue::Mmsc(compute_duration),
-                    MetricValue::Mmsc(items_produced),
+                    MetricValue::Mmsc(signals_outgoing),
                 ] = snapshot.get_metrics()
                 else {
-                    panic!("expected stopwatch duration and produced MMSC metrics");
+                    panic!("expected stopwatch duration and outgoing MMSC metrics");
                 };
                 assert!(
                     compute_duration.count >= 1,
@@ -1271,8 +1304,8 @@ mod tests {
                     compute_duration.sum > 0.0,
                     "stopwatch compute duration sum should be non-zero"
                 );
-                assert_eq!(items_produced.count, 1);
-                assert!((items_produced.sum - 1.0).abs() < f64::EPSILON);
+                assert_eq!(signals_outgoing.count, 1);
+                assert!((signals_outgoing.sum - 1.0).abs() < f64::EPSILON);
             })
             .await;
     }

--- a/rust/otap-dataflow/crates/engine/src/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/processor.rs
@@ -27,7 +27,7 @@ use crate::node::{Node, NodeId, NodeWithPDataReceiver, NodeWithPDataSender};
 use crate::node_local_scheduler::NodeLocalSchedulerHandle;
 use crate::shared::message::{SharedReceiver, SharedSender};
 use crate::shared::processor as shared;
-use crate::stopwatch::StopwatchMetrics;
+use crate::stopwatch::{StopwatchStartMetrics, StopwatchStopMetrics};
 use otap_df_channel::error::SendError;
 use otap_df_channel::mpsc;
 use otap_df_config::PortName;
@@ -56,6 +56,10 @@ pub trait StopwatchEffectHandler {
     /// Record a complete stopwatch transit total (nanoseconds) into the
     /// stop node's local accumulator.
     fn record_stopwatch_stop(&self, total: u64);
+    /// Record signal-item count into the start node's local accumulator.
+    fn record_stopwatch_start_items(&self, items: u64);
+    /// Record signal-item count into the stop node's local accumulator.
+    fn record_stopwatch_stop_items(&self, items: u64);
 }
 
 /// Per-`PData` hook called immediately before a processor `EffectHandler`
@@ -556,6 +560,7 @@ impl<PData> ProcessorWrapper<PData> {
             None,
             false,
             None,
+            None,
             false,
         )
         .await
@@ -569,7 +574,8 @@ impl<PData> ProcessorWrapper<PData> {
         node_interests: Interests,
         completion_emission_metrics: Option<CompletionEmissionMetricsHandle>,
         stopwatch_is_start: bool,
-        stopwatch_stop_metric: Option<MetricSet<StopwatchMetrics>>,
+        stopwatch_start_metric: Option<MetricSet<StopwatchStartMetrics>>,
+        stopwatch_stop_metric: Option<MetricSet<StopwatchStopMetrics>>,
         stopwatches_active: bool,
     ) -> Result<(), Error>
     where
@@ -597,6 +603,7 @@ impl<PData> ProcessorWrapper<PData> {
                     .set_completion_emission_metrics(completion_emission_metrics.clone());
                 effect_handler.set_stopwatch_roles(
                     stopwatch_is_start,
+                    stopwatch_start_metric.clone(),
                     stopwatch_stop_metric.clone(),
                     stopwatches_active,
                 );
@@ -610,7 +617,8 @@ impl<PData> ProcessorWrapper<PData> {
                     if effect_handler.stopwatches_active() {
                         match &msg {
                             Message::Control(NodeControlMsg::CollectTelemetry { .. })
-                                if effect_handler.is_stopwatch_stop() =>
+                                if effect_handler.is_stopwatch_start()
+                                    || effect_handler.is_stopwatch_stop() =>
                             {
                                 effect_handler.report_stopwatch();
                             }
@@ -623,7 +631,7 @@ impl<PData> ProcessorWrapper<PData> {
                 // Cancel periodic collection
                 _ = telemetry_cancel_handle.cancel().await;
                 // Collect final metrics before exiting
-                if effect_handler.is_stopwatch_stop() {
+                if effect_handler.is_stopwatch_start() || effect_handler.is_stopwatch_stop() {
                     effect_handler.report_stopwatch();
                 }
                 processor
@@ -650,6 +658,7 @@ impl<PData> ProcessorWrapper<PData> {
                     .set_completion_emission_metrics(completion_emission_metrics);
                 effect_handler.set_stopwatch_roles(
                     stopwatch_is_start,
+                    stopwatch_start_metric.clone(),
                     stopwatch_stop_metric.clone(),
                     stopwatches_active,
                 );
@@ -663,7 +672,8 @@ impl<PData> ProcessorWrapper<PData> {
                     if effect_handler.stopwatches_active() {
                         match &msg {
                             Message::Control(NodeControlMsg::CollectTelemetry { .. })
-                                if effect_handler.is_stopwatch_stop() =>
+                                if effect_handler.is_stopwatch_start()
+                                    || effect_handler.is_stopwatch_stop() =>
                             {
                                 effect_handler.report_stopwatch();
                             }
@@ -676,7 +686,7 @@ impl<PData> ProcessorWrapper<PData> {
                 // Cancel periodic collection
                 _ = telemetry_cancel_handle.cancel().await;
                 // Collect final metrics before exiting
-                if effect_handler.is_stopwatch_stop() {
+                if effect_handler.is_stopwatch_start() || effect_handler.is_stopwatch_stop() {
                     effect_handler.report_stopwatch();
                 }
                 processor
@@ -851,7 +861,7 @@ mod tests {
         Error, ProcessorRuntimeRequirements, ProcessorWrapper, validate_local_wakeup_requirements,
     };
     use crate::shared::processor as shared;
-    use crate::stopwatch::{StopwatchAttributeSet, StopwatchMetrics};
+    use crate::stopwatch::{StopwatchAttributeSet, StopwatchStartMetrics, StopwatchStopMetrics};
     use crate::testing::processor::TestRuntime;
     use crate::testing::processor::{TestContext, ValidateContext};
     use crate::testing::{CtrlMsgCounters, TestMsg, test_node};
@@ -1099,6 +1109,7 @@ mod tests {
 
             if handler.is_stopwatch_start() {
                 self.stopwatch_active = true;
+                handler.record_stopwatch_start_items(1);
             }
 
             self.stopwatch_compute_ns = self
@@ -1108,6 +1119,7 @@ mod tests {
             if handler.is_stopwatch_stop() && self.stopwatch_active && self.stopwatch_compute_ns > 0
             {
                 handler.record_stopwatch_stop(self.stopwatch_compute_ns);
+                handler.record_stopwatch_stop_items(1);
                 self.stopwatch_compute_ns = 0;
                 self.stopwatch_active = false;
             }
@@ -1142,14 +1154,19 @@ mod tests {
     #[tokio::test]
     async fn stopwatch_auto_measures_process_without_timed() {
         let (pipeline_ctx, _) = crate::testing::test_pipeline_ctx();
-        let metric_set = pipeline_ctx
+        let attrs = StopwatchAttributeSet {
+            stopwatch_name: "auto_measure".into(),
+            start_node: "auto_measure_processor".into(),
+            stop_node: "auto_measure_processor".into(),
+            pipeline_attrs: pipeline_ctx.pipeline_attribute_set(),
+        };
+        let entity_key = pipeline_ctx.metrics_registry().register_entity(attrs);
+        let start_metric_set = pipeline_ctx
             .metrics_registry()
-            .register_metric_set::<StopwatchMetrics>(StopwatchAttributeSet {
-                stopwatch_name: "auto_measure".into(),
-                start_node: "auto_measure_processor".into(),
-                stop_node: "auto_measure_processor".into(),
-                pipeline_attrs: pipeline_ctx.pipeline_attribute_set(),
-            });
+            .register_metric_set_for_entity::<StopwatchStartMetrics>(entity_key);
+        let stop_metric_set = pipeline_ctx
+            .metrics_registry()
+            .register_metric_set_for_entity::<StopwatchStopMetrics>(entity_key);
 
         let config = crate::config::ProcessorConfig::new("auto_measure_processor");
         let node_id = test_node(config.name.clone());
@@ -1199,7 +1216,8 @@ mod tests {
                             crate::Interests::PROCESS_DURATION,
                             None,
                             true,
-                            Some(metric_set),
+                            Some(start_metric_set),
+                            Some(stop_metric_set),
                             true,
                         )
                         .await
@@ -1227,8 +1245,23 @@ mod tests {
                 processor_task.abort();
                 let _ = processor_task.await;
 
-                let [MetricValue::Mmsc(compute_duration)] = snapshot.get_metrics() else {
-                    panic!("expected one stopwatch MMSC metric");
+                let [MetricValue::Mmsc(items_consumed)] = snapshot.get_metrics() else {
+                    panic!("expected one start stopwatch MMSC metric");
+                };
+                assert_eq!(items_consumed.count, 1);
+                assert!((items_consumed.sum - 1.0).abs() < f64::EPSILON);
+
+                let snapshot =
+                    tokio::time::timeout(Duration::from_secs(1), metrics_rx.recv_async())
+                        .await
+                        .expect("stopwatch stop metric should be reported")
+                        .expect("metrics channel should remain open");
+                let [
+                    MetricValue::Mmsc(compute_duration),
+                    MetricValue::Mmsc(items_produced),
+                ] = snapshot.get_metrics()
+                else {
+                    panic!("expected stopwatch duration and produced MMSC metrics");
                 };
                 assert!(
                     compute_duration.count >= 1,
@@ -1238,6 +1271,8 @@ mod tests {
                     compute_duration.sum > 0.0,
                     "stopwatch compute duration sum should be non-zero"
                 );
+                assert_eq!(items_produced.count, 1);
+                assert!((items_produced.sum - 1.0).abs() < f64::EPSILON);
             })
             .await;
     }

--- a/rust/otap-dataflow/crates/engine/src/runtime_pipeline.rs
+++ b/rust/otap-dataflow/crates/engine/src/runtime_pipeline.rs
@@ -23,7 +23,7 @@ use crate::pipeline_ctrl::{
     NodeMetricHandles, PipelineCompletionMsgDispatcher, RuntimeCtrlMsgManager,
     report_node_metrics_with_handles,
 };
-use crate::stopwatch::{StopwatchMetrics, build_stopwatch_state};
+use crate::stopwatch::{StopwatchStartMetrics, StopwatchStopMetrics, build_stopwatch_state};
 use crate::terminal_state::TerminalState;
 use crate::{exporter::ExporterWrapper, processor::ProcessorWrapper, receiver::ReceiverWrapper};
 use otap_df_config::DeployedPipelineKey;
@@ -237,7 +237,6 @@ impl<PData: 'static + Debug + Clone + ReceivedAtNode + Unwindable> RuntimePipeli
             &telemetry_policy,
             &node_name_to_index,
             &processor_indices,
-            node_interests,
             &pipeline_context,
         )?;
 
@@ -327,11 +326,15 @@ impl<PData: 'static + Debug + Clone + ReceivedAtNode + Unwindable> RuntimePipeli
             let pipeline_completion_msg_tx = pipeline_completion_msg_tx.clone();
             let metrics_reporter = metrics_reporter.clone();
             // Extract stopwatch roles for this processor node.
-            let sw_is_start = stopwatch_state.start_nodes.contains(&node_id.index);
-            let sw_stop_metric: Option<MetricSet<StopwatchMetrics>> = stopwatch_state
+            let sw_is_start = stopwatch_state.start_nodes.contains_key(&node_id.index);
+            let sw_start_metric: Option<MetricSet<StopwatchStartMetrics>> = stopwatch_state
+                .start_nodes
+                .get(&node_id.index)
+                .map(|&id| stopwatch_state.start_metrics[id].clone());
+            let sw_stop_metric: Option<MetricSet<StopwatchStopMetrics>> = stopwatch_state
                 .stop_nodes
                 .get(&node_id.index)
-                .map(|&id| stopwatch_state.metrics[id].clone());
+                .map(|&id| stopwatch_state.stop_metrics[id].clone());
             let sw_active = !stopwatch_state.start_nodes.is_empty();
             let fut = async move {
                 let result = processor
@@ -342,6 +345,7 @@ impl<PData: 'static + Debug + Clone + ReceivedAtNode + Unwindable> RuntimePipeli
                         node_interests,
                         completion_emission_metrics,
                         sw_is_start,
+                        sw_start_metric,
                         sw_stop_metric,
                         sw_active,
                     )

--- a/rust/otap-dataflow/crates/engine/src/runtime_pipeline.rs
+++ b/rust/otap-dataflow/crates/engine/src/runtime_pipeline.rs
@@ -23,6 +23,7 @@ use crate::pipeline_ctrl::{
     NodeMetricHandles, PipelineCompletionMsgDispatcher, RuntimeCtrlMsgManager,
     report_node_metrics_with_handles,
 };
+use crate::processor::FlowMeasurementHook;
 use crate::stopwatch::{StopwatchStartMetrics, StopwatchStopMetrics, build_stopwatch_state};
 use crate::terminal_state::TerminalState;
 use crate::{exporter::ExporterWrapper, processor::ProcessorWrapper, receiver::ReceiverWrapper};
@@ -174,7 +175,9 @@ impl<PData: 'static + Debug + Clone> RuntimePipeline<PData> {
     }
 }
 
-impl<PData: 'static + Debug + Clone + ReceivedAtNode + Unwindable> RuntimePipeline<PData> {
+impl<PData: 'static + Debug + Clone + ReceivedAtNode + Unwindable + FlowMeasurementHook>
+    RuntimePipeline<PData>
+{
     /// Runs the pipeline forever, starting all nodes and handling their tasks.
     /// Returns an error if any node fails to start or if any task encounters an error.
     pub fn run_forever(

--- a/rust/otap-dataflow/crates/engine/src/shared/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/shared/processor.rs
@@ -206,12 +206,12 @@ impl<PData> EffectHandler<PData> {
         self.stopwatch.active = stopwatches_active;
         self.stopwatch.start = start_metric.map(|metrics| StartMeasurements {
             metrics,
-            items_consumed_acc: Arc::new(Mutex::new(Mmsc::default())),
+            signals_incoming_acc: Arc::new(Mutex::new(Mmsc::default())),
         });
         self.stopwatch.stop = stop_metric.map(|metrics| StopMeasurements {
             metrics,
             duration_acc: Arc::new(Mutex::new(Mmsc::default())),
-            items_produced_acc: Arc::new(Mutex::new(Mmsc::default())),
+            signals_outgoing_acc: Arc::new(Mutex::new(Mmsc::default())),
         });
     }
 
@@ -281,27 +281,27 @@ impl<PData> EffectHandler<PData> {
     }
 
     /// Record signal-item count into the shared start-side stopwatch accumulator.
-    pub fn record_stopwatch_start_items(&self, items: u64) {
+    pub fn record_stopwatch_start_signals(&self, signals: u64) {
         let Some(start) = self.stopwatch.start.as_ref() else {
             return;
         };
         let mut acc = start
-            .items_consumed_acc
+            .signals_incoming_acc
             .lock()
-            .expect("stopwatch items_consumed_acc poisoned");
-        acc.record(items as f64);
+            .expect("stopwatch signals_incoming_acc poisoned");
+        acc.record(signals as f64);
     }
 
     /// Record signal-item count into the shared stop-side stopwatch accumulator.
-    pub fn record_stopwatch_stop_items(&self, items: u64) {
+    pub fn record_stopwatch_stop_signals(&self, signals: u64) {
         let Some(stop) = self.stopwatch.stop.as_ref() else {
             return;
         };
         let mut acc = stop
-            .items_produced_acc
+            .signals_outgoing_acc
             .lock()
-            .expect("stopwatch items_produced_acc poisoned");
-        acc.record(items as f64);
+            .expect("stopwatch signals_outgoing_acc poisoned");
+        acc.record(signals as f64);
     }
 
     /// Drain accumulated stopwatch observations into the MetricSet and report.
@@ -309,12 +309,12 @@ impl<PData> EffectHandler<PData> {
         if let Some(start) = self.stopwatch.start.as_mut() {
             let drained = {
                 let mut guard = start
-                    .items_consumed_acc
+                    .signals_incoming_acc
                     .lock()
-                    .expect("stopwatch items_consumed_acc poisoned");
+                    .expect("stopwatch signals_incoming_acc poisoned");
                 std::mem::take(&mut *guard)
             };
-            start.metrics.items_consumed.merge(drained);
+            start.metrics.signals_incoming.merge(drained);
             let _ = self.core.metrics_reporter.report(&mut start.metrics);
         }
         if let Some(stop) = self.stopwatch.stop.as_mut() {
@@ -326,14 +326,14 @@ impl<PData> EffectHandler<PData> {
                 std::mem::take(&mut *guard)
             };
             stop.metrics.compute_duration.merge(duration_drained);
-            let items_drained = {
+            let signals_drained = {
                 let mut guard = stop
-                    .items_produced_acc
+                    .signals_outgoing_acc
                     .lock()
-                    .expect("stopwatch items_produced_acc poisoned");
+                    .expect("stopwatch signals_outgoing_acc poisoned");
                 std::mem::take(&mut *guard)
             };
-            stop.metrics.items_produced.merge(items_drained);
+            stop.metrics.signals_outgoing.merge(signals_drained);
             let _ = self.core.metrics_reporter.report(&mut stop.metrics);
         }
     }
@@ -346,7 +346,7 @@ impl<PData> EffectHandler<PData> {
     #[inline]
     pub async fn send_message(&self, mut data: PData) -> Result<(), TypedError<PData>>
     where
-        PData: crate::processor::ProcessorSendHook + Send,
+        PData: crate::processor::FlowMeasurementHook + Send,
     {
         data.before_processor_send(self);
         self.router.send_default(data).await
@@ -365,7 +365,7 @@ impl<PData> EffectHandler<PData> {
     #[inline]
     pub fn try_send_message(&self, mut data: PData) -> Result<(), TypedError<PData>>
     where
-        PData: crate::processor::ProcessorSendHook + Send,
+        PData: crate::processor::FlowMeasurementHook + Send,
     {
         data.before_processor_send(self);
         self.router.try_send_default(data)
@@ -380,7 +380,7 @@ impl<PData> EffectHandler<PData> {
     ) -> Result<(), TypedError<PData>>
     where
         P: Into<PortName>,
-        PData: crate::processor::ProcessorSendHook + Send,
+        PData: crate::processor::FlowMeasurementHook + Send,
     {
         data.before_processor_send(self);
         self.router.send_to(port, data).await
@@ -400,7 +400,7 @@ impl<PData> EffectHandler<PData> {
     pub fn try_send_message_to<P>(&self, port: P, mut data: PData) -> Result<(), TypedError<PData>>
     where
         P: Into<PortName>,
-        PData: crate::processor::ProcessorSendHook + Send,
+        PData: crate::processor::FlowMeasurementHook + Send,
     {
         data.before_processor_send(self);
         self.router.try_send_to(port, data)
@@ -527,12 +527,12 @@ impl<PData> crate::processor::StopwatchEffectHandler for EffectHandler<PData> {
         EffectHandler::record_stopwatch_stop(self, total);
     }
     #[inline]
-    fn record_stopwatch_start_items(&self, items: u64) {
-        EffectHandler::record_stopwatch_start_items(self, items);
+    fn record_stopwatch_start_signals(&self, signals: u64) {
+        EffectHandler::record_stopwatch_start_signals(self, signals);
     }
     #[inline]
-    fn record_stopwatch_stop_items(&self, items: u64) {
-        EffectHandler::record_stopwatch_stop_items(self, items);
+    fn record_stopwatch_stop_signals(&self, signals: u64) {
+        EffectHandler::record_stopwatch_stop_signals(self, signals);
     }
 }
 
@@ -559,7 +559,7 @@ mod tests {
     use otap_df_telemetry::reporter::MetricsReporter;
     use std::collections::HashMap;
 
-    // Note: `impl ProcessorSendHook for u64` lives in `crate::local::processor`
+    // Note: `impl FlowMeasurementHook for u64` lives in `crate::local::processor`
     // tests; trait impls are crate-wide so we share it across test modules.
 
     #[test]
@@ -721,20 +721,20 @@ mod tests {
         assert!(eh.is_stopwatch_start());
         assert!(eh.is_stopwatch_stop());
 
-        eh.record_stopwatch_start_items(10);
-        eh.record_stopwatch_start_items(20);
+        eh.record_stopwatch_start_signals(10);
+        eh.record_stopwatch_start_signals(20);
         for ns in [1000, 2000, 3000] {
             eh.record_stopwatch_stop(ns);
         }
-        eh.record_stopwatch_stop_items(7);
-        eh.record_stopwatch_stop_items(8);
+        eh.record_stopwatch_stop_signals(7);
+        eh.record_stopwatch_stop_signals(8);
 
         let start_before_report = eh
             .stopwatch
             .start
             .as_ref()
             .unwrap()
-            .items_consumed_acc
+            .signals_incoming_acc
             .lock()
             .unwrap()
             .get();
@@ -757,7 +757,7 @@ mod tests {
             .stop
             .as_ref()
             .unwrap()
-            .items_produced_acc
+            .signals_outgoing_acc
             .lock()
             .unwrap()
             .get();
@@ -771,7 +771,7 @@ mod tests {
             .start
             .as_ref()
             .unwrap()
-            .items_consumed_acc
+            .signals_incoming_acc
             .lock()
             .unwrap()
             .get();
@@ -795,7 +795,7 @@ mod tests {
             .stop
             .as_ref()
             .unwrap()
-            .items_produced_acc
+            .signals_outgoing_acc
             .lock()
             .unwrap()
             .get();
@@ -821,7 +821,7 @@ mod tests {
             MetricValue::Mmsc(produced_snapshot),
         ] = snapshot.get_metrics()
         else {
-            panic!("expected stopwatch duration and produced MMSC metrics");
+            panic!("expected stopwatch duration and outgoing MMSC metrics");
         };
         assert_eq!(duration_snapshot.count, 3);
         assert!((duration_snapshot.sum - 6000.0).abs() < f64::EPSILON);

--- a/rust/otap-dataflow/crates/engine/src/shared/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/shared/processor.rs
@@ -44,7 +44,10 @@ use crate::node::NodeId;
 use crate::output_router::OutputRouter;
 use crate::processor::ProcessorRuntimeRequirements;
 use crate::shared::message::SharedSender;
-use crate::stopwatch::{SharedStopwatchState, StopMeasurements, StopwatchMetrics, nanos_u64};
+use crate::stopwatch::{
+    SharedStopwatchState, StartMeasurements, StopMeasurements, StopwatchStartMetrics,
+    StopwatchStopMetrics, nanos_u64,
+};
 use crate::{WakeupError, WakeupSetOutcome};
 use async_trait::async_trait;
 use otap_df_config::PortName;
@@ -195,14 +198,20 @@ impl<PData> EffectHandler<PData> {
     pub(crate) fn set_stopwatch_roles(
         &mut self,
         is_start: bool,
-        stop_metric: Option<MetricSet<StopwatchMetrics>>,
+        start_metric: Option<MetricSet<StopwatchStartMetrics>>,
+        stop_metric: Option<MetricSet<StopwatchStopMetrics>>,
         stopwatches_active: bool,
     ) {
         self.stopwatch.is_start = is_start;
         self.stopwatch.active = stopwatches_active;
+        self.stopwatch.start = start_metric.map(|metrics| StartMeasurements {
+            metrics,
+            items_consumed_acc: Arc::new(Mutex::new(Mmsc::default())),
+        });
         self.stopwatch.stop = stop_metric.map(|metrics| StopMeasurements {
             metrics,
             duration_acc: Arc::new(Mutex::new(Mmsc::default())),
+            items_produced_acc: Arc::new(Mutex::new(Mmsc::default())),
         });
     }
 
@@ -271,17 +280,60 @@ impl<PData> EffectHandler<PData> {
         acc.record(total as f64);
     }
 
+    /// Record signal-item count into the shared start-side stopwatch accumulator.
+    pub fn record_stopwatch_start_items(&self, items: u64) {
+        let Some(start) = self.stopwatch.start.as_ref() else {
+            return;
+        };
+        let mut acc = start
+            .items_consumed_acc
+            .lock()
+            .expect("stopwatch items_consumed_acc poisoned");
+        acc.record(items as f64);
+    }
+
+    /// Record signal-item count into the shared stop-side stopwatch accumulator.
+    pub fn record_stopwatch_stop_items(&self, items: u64) {
+        let Some(stop) = self.stopwatch.stop.as_ref() else {
+            return;
+        };
+        let mut acc = stop
+            .items_produced_acc
+            .lock()
+            .expect("stopwatch items_produced_acc poisoned");
+        acc.record(items as f64);
+    }
+
     /// Drain accumulated stopwatch observations into the MetricSet and report.
     pub(crate) fn report_stopwatch(&mut self) {
-        if let Some(stop) = self.stopwatch.stop.as_mut() {
+        if let Some(start) = self.stopwatch.start.as_mut() {
             let drained = {
+                let mut guard = start
+                    .items_consumed_acc
+                    .lock()
+                    .expect("stopwatch items_consumed_acc poisoned");
+                std::mem::take(&mut *guard)
+            };
+            start.metrics.items_consumed.merge(drained);
+            let _ = self.core.metrics_reporter.report(&mut start.metrics);
+        }
+        if let Some(stop) = self.stopwatch.stop.as_mut() {
+            let duration_drained = {
                 let mut guard = stop
                     .duration_acc
                     .lock()
                     .expect("stopwatch duration_acc poisoned");
                 std::mem::take(&mut *guard)
             };
-            stop.metrics.compute_duration.merge(drained);
+            stop.metrics.compute_duration.merge(duration_drained);
+            let items_drained = {
+                let mut guard = stop
+                    .items_produced_acc
+                    .lock()
+                    .expect("stopwatch items_produced_acc poisoned");
+                std::mem::take(&mut *guard)
+            };
+            stop.metrics.items_produced.merge(items_drained);
             let _ = self.core.metrics_reporter.report(&mut stop.metrics);
         }
     }
@@ -474,6 +526,14 @@ impl<PData> crate::processor::StopwatchEffectHandler for EffectHandler<PData> {
     fn record_stopwatch_stop(&self, total: u64) {
         EffectHandler::record_stopwatch_stop(self, total);
     }
+    #[inline]
+    fn record_stopwatch_start_items(&self, items: u64) {
+        EffectHandler::record_stopwatch_start_items(self, items);
+    }
+    #[inline]
+    fn record_stopwatch_stop_items(&self, items: u64) {
+        EffectHandler::record_stopwatch_stop_items(self, items);
+    }
 }
 
 #[async_trait(?Send)]
@@ -622,7 +682,7 @@ mod tests {
         let (_metrics_rx, metrics_reporter) = MetricsReporter::create_new_and_receiver(1);
         let mut eh =
             EffectHandler::<u64>::new(test_node("proc"), HashMap::new(), None, metrics_reporter);
-        eh.set_stopwatch_roles(true, None, true);
+        eh.set_stopwatch_roles(true, None, None, true);
         assert!(eh.is_stopwatch_start());
         assert!(eh.stopwatches_active());
 
@@ -647,19 +707,39 @@ mod tests {
         let entity_key = ctx
             .metrics_registry()
             .register_entity(StopwatchAttributeSet::default());
-        let metric_set = ctx
+        let start_metric_set = ctx
             .metrics_registry()
-            .register_metric_set_for_entity::<StopwatchMetrics>(entity_key);
+            .register_metric_set_for_entity::<StopwatchStartMetrics>(entity_key);
+        let stop_metric_set = ctx
+            .metrics_registry()
+            .register_metric_set_for_entity::<StopwatchStopMetrics>(entity_key);
 
-        let (metrics_rx, metrics_reporter) = MetricsReporter::create_new_and_receiver(1);
+        let (metrics_rx, metrics_reporter) = MetricsReporter::create_new_and_receiver(2);
         let mut eh =
             EffectHandler::<u64>::new(test_node("proc"), HashMap::new(), None, metrics_reporter);
-        eh.set_stopwatch_roles(false, Some(metric_set), true);
+        eh.set_stopwatch_roles(true, Some(start_metric_set), Some(stop_metric_set), true);
+        assert!(eh.is_stopwatch_start());
         assert!(eh.is_stopwatch_stop());
 
+        eh.record_stopwatch_start_items(10);
+        eh.record_stopwatch_start_items(20);
         for ns in [1000, 2000, 3000] {
             eh.record_stopwatch_stop(ns);
         }
+        eh.record_stopwatch_stop_items(7);
+        eh.record_stopwatch_stop_items(8);
+
+        let start_before_report = eh
+            .stopwatch
+            .start
+            .as_ref()
+            .unwrap()
+            .items_consumed_acc
+            .lock()
+            .unwrap()
+            .get();
+        assert_eq!(start_before_report.count, 2);
+        assert!((start_before_report.sum - 30.0).abs() < f64::EPSILON);
 
         let before_report = eh
             .stopwatch
@@ -672,8 +752,33 @@ mod tests {
             .get();
         assert_eq!(before_report.count, 3);
         assert!((before_report.sum - 6000.0).abs() < f64::EPSILON);
+        let produced_before_report = eh
+            .stopwatch
+            .stop
+            .as_ref()
+            .unwrap()
+            .items_produced_acc
+            .lock()
+            .unwrap()
+            .get();
+        assert_eq!(produced_before_report.count, 2);
+        assert!((produced_before_report.sum - 15.0).abs() < f64::EPSILON);
 
         eh.report_stopwatch();
+
+        let start_drained = eh
+            .stopwatch
+            .start
+            .as_ref()
+            .unwrap()
+            .items_consumed_acc
+            .lock()
+            .unwrap()
+            .get();
+        assert_eq!(
+            start_drained.count, 0,
+            "start accumulator should be drained"
+        );
 
         let drained = eh
             .stopwatch
@@ -684,18 +789,43 @@ mod tests {
             .lock()
             .unwrap()
             .get();
-        assert_eq!(drained.count, 0, "stop accumulator should be drained");
+        assert_eq!(drained.count, 0, "duration accumulator should be drained");
+        let produced_drained = eh
+            .stopwatch
+            .stop
+            .as_ref()
+            .unwrap()
+            .items_produced_acc
+            .lock()
+            .unwrap()
+            .get();
+        assert_eq!(
+            produced_drained.count, 0,
+            "stop item accumulator should be drained"
+        );
 
         let snapshot = metrics_rx
             .try_recv()
-            .expect("stopwatch metric should be reported");
-        let [MetricValue::Mmsc(metric_snapshot)] = snapshot.get_metrics() else {
-            panic!("expected one stopwatch MMSC metric");
+            .expect("start stopwatch metric should be reported");
+        let [MetricValue::Mmsc(consumed_snapshot)] = snapshot.get_metrics() else {
+            panic!("expected one start stopwatch MMSC metric");
         };
-        assert!(
-            metric_snapshot.count >= 1,
-            "reported metric set should contain at least one observation"
-        );
-        assert!((metric_snapshot.sum - 6000.0).abs() < f64::EPSILON);
+        assert_eq!(consumed_snapshot.count, 2);
+        assert!((consumed_snapshot.sum - 30.0).abs() < f64::EPSILON);
+
+        let snapshot = metrics_rx
+            .try_recv()
+            .expect("stop stopwatch metric should be reported");
+        let [
+            MetricValue::Mmsc(duration_snapshot),
+            MetricValue::Mmsc(produced_snapshot),
+        ] = snapshot.get_metrics()
+        else {
+            panic!("expected stopwatch duration and produced MMSC metrics");
+        };
+        assert_eq!(duration_snapshot.count, 3);
+        assert!((duration_snapshot.sum - 6000.0).abs() < f64::EPSILON);
+        assert_eq!(produced_snapshot.count, 2);
+        assert!((produced_snapshot.sum - 15.0).abs() < f64::EPSILON);
     }
 }

--- a/rust/otap-dataflow/crates/engine/src/stopwatch.rs
+++ b/rust/otap-dataflow/crates/engine/src/stopwatch.rs
@@ -32,9 +32,10 @@ use otap_df_config::policy::TelemetryPolicy;
 #[metric_set(name = "stopwatch")]
 #[derive(Debug, Default, Clone)]
 pub struct StopwatchStartMetrics {
-    /// Number of signal items entering the stopwatch range.
-    #[metric(name = "stopwatch.items.consumed", unit = "{item}")]
-    pub items_consumed: Mmsc,
+    /// Number of signal items (log records, spans, or metric data points)
+    /// entering the stopwatch range.
+    #[metric(name = "stopwatch.signals.incoming", unit = "{item}")]
+    pub signals_incoming: Mmsc,
 }
 
 /// Metric set emitted by the stop node of a stopwatch range.
@@ -45,9 +46,10 @@ pub struct StopwatchStopMetrics {
     /// for messages traversing the stopwatch range.
     #[metric(name = "stopwatch.compute.duration", unit = "ns")]
     pub compute_duration: Mmsc,
-    /// Number of signal items leaving the stopwatch range.
-    #[metric(name = "stopwatch.items.produced", unit = "{item}")]
-    pub items_produced: Mmsc,
+    /// Number of signal items (log records, spans, or metric data points)
+    /// leaving the stopwatch range.
+    #[metric(name = "stopwatch.signals.outgoing", unit = "{item}")]
+    pub signals_outgoing: Mmsc,
 }
 
 /// Entity attributes that scope a stopwatch metric set.
@@ -104,7 +106,7 @@ pub(crate) struct StartMeasurements<Accumulator> {
     pub metrics: MetricSet<StopwatchStartMetrics>,
     /// Accumulator for signal-item count observations at the start node.
     /// Drained into `metrics` on periodic telemetry collection.
-    pub items_consumed_acc: Accumulator,
+    pub signals_incoming_acc: Accumulator,
 }
 
 /// Stop-side measurements for a node that terminates a stopwatch range.
@@ -122,7 +124,7 @@ pub(crate) struct StopMeasurements<Accumulator> {
     pub duration_acc: Accumulator,
     /// Accumulator for signal-item count observations at the stop node.
     /// Drained into `metrics` on periodic telemetry collection.
-    pub items_produced_acc: Accumulator,
+    pub signals_outgoing_acc: Accumulator,
 }
 
 /// Per-`EffectHandler` stopwatch state.
@@ -389,16 +391,16 @@ mod tests {
     #[test]
     fn direct_record_increments_items_mmsc() {
         let mut state = one_stopwatch_state();
-        state.start_metrics[0].items_consumed.record(10.0);
-        state.start_metrics[0].items_consumed.record(20.0);
-        state.stop_metrics[0].items_produced.record(7.0);
-        state.stop_metrics[0].items_produced.record(8.0);
+        state.start_metrics[0].signals_incoming.record(10.0);
+        state.start_metrics[0].signals_incoming.record(20.0);
+        state.stop_metrics[0].signals_outgoing.record(7.0);
+        state.stop_metrics[0].signals_outgoing.record(8.0);
 
-        let consumed = state.start_metrics[0].items_consumed.get();
+        let consumed = state.start_metrics[0].signals_incoming.get();
         assert_eq!(consumed.count, 2);
         assert!((consumed.sum - 30.0).abs() < f64::EPSILON);
 
-        let produced = state.stop_metrics[0].items_produced.get();
+        let produced = state.stop_metrics[0].signals_outgoing.get();
         assert_eq!(produced.count, 2);
         assert!((produced.sum - 15.0).abs() < f64::EPSILON);
     }

--- a/rust/otap-dataflow/crates/engine/src/stopwatch.rs
+++ b/rust/otap-dataflow/crates/engine/src/stopwatch.rs
@@ -9,8 +9,9 @@
 //! per-message compute time is measured by the EffectHandler's
 //! `Instant`-based send marker (advanced by `take_elapsed_since_send_marker_ns`
 //! at each `send_message` call) and accumulated onto the PData's
-//! `stopwatch_compute_ns` field. The stop node takes the total and records it
-//! into the stopwatch metric entity.
+//! `stopwatch_compute_ns` field. The start and stop nodes record item counts,
+//! and the stop node records the total compute duration, into the stopwatch
+//! metric entity.
 
 use std::borrow::Cow;
 use std::cell::Cell;
@@ -23,24 +24,30 @@ use otap_df_telemetry::instrument::Mmsc;
 use otap_df_telemetry::metrics::MetricSet;
 use otap_df_telemetry_macros::{attribute_set, metric_set};
 
-use crate::Interests;
 use crate::attributes::PipelineAttributeSet;
 use crate::context::PipelineContext;
 use otap_df_config::policy::TelemetryPolicy;
 
-/// Metric set for a single stopwatch.
-///
-/// Future extension: this set could also record signal-item counts
-/// at the start and stop nodes — `stopwatch.items.consumed` (Mmsc,
-/// observed at the start node from `OtapPdata::num_items()`) and
-/// `stopwatch.items.produced` (observed at the stop node).
+/// Metric set emitted by the start node of a stopwatch range.
 #[metric_set(name = "stopwatch")]
 #[derive(Debug, Default, Clone)]
-pub struct StopwatchMetrics {
+pub struct StopwatchStartMetrics {
+    /// Number of signal items entering the stopwatch range.
+    #[metric(name = "stopwatch.items.consumed", unit = "{item}")]
+    pub items_consumed: Mmsc,
+}
+
+/// Metric set emitted by the stop node of a stopwatch range.
+#[metric_set(name = "stopwatch")]
+#[derive(Debug, Default, Clone)]
+pub struct StopwatchStopMetrics {
     /// Sum of per-node compute durations (nanoseconds)
     /// for messages traversing the stopwatch range.
     #[metric(name = "stopwatch.compute.duration", unit = "ns")]
     pub compute_duration: Mmsc,
+    /// Number of signal items leaving the stopwatch range.
+    #[metric(name = "stopwatch.items.produced", unit = "{item}")]
+    pub items_produced: Mmsc,
 }
 
 /// Entity attributes that scope a stopwatch metric set.
@@ -71,30 +78,51 @@ pub type StopwatchId = usize;
 /// shared) at build time; reporting happens from the processor's own
 /// telemetry path, not from this state.
 pub(crate) struct PipelineStopwatchState {
-    /// Metric sets indexed by internal stopwatch index.
+    /// Start metric sets indexed by internal stopwatch index.
     /// Cloned to processors at build time; not reported from here.
-    pub metrics: Vec<MetricSet<StopwatchMetrics>>,
+    pub start_metrics: Vec<MetricSet<StopwatchStartMetrics>>,
+    /// Stop metric sets indexed by internal stopwatch index.
+    /// Cloned to processors at build time; not reported from here.
+    pub stop_metrics: Vec<MetricSet<StopwatchStopMetrics>>,
     /// Mapping from node index → stopwatch metric index where this node is
     /// the **stop** node (recording happens here on the forward path).
     pub stop_nodes: HashMap<usize, usize>,
-    /// Set of node indices that are **start** nodes.
-    pub start_nodes: HashSet<usize>,
+    /// Mapping from node index → stopwatch metric index where this node is
+    /// the **start** node (item-count recording happens here on the forward path).
+    pub start_nodes: HashMap<usize, usize>,
+}
+
+/// Start-side measurements for a node that begins a stopwatch range.
+///
+/// Groups the metric set and its accumulator so that they share the
+/// `Option` on `StopwatchState` — non-start nodes pay no allocation for
+/// either.
+#[derive(Clone)]
+pub(crate) struct StartMeasurements<Accumulator> {
+    /// Metric set registered for this stopwatch entity.
+    /// Reported periodically via `report_stopwatch`, not on every message.
+    pub metrics: MetricSet<StopwatchStartMetrics>,
+    /// Accumulator for signal-item count observations at the start node.
+    /// Drained into `metrics` on periodic telemetry collection.
+    pub items_consumed_acc: Accumulator,
 }
 
 /// Stop-side measurements for a node that terminates a stopwatch range.
 ///
-/// Groups the metric set and its accumulator so that they share the
+/// Groups the metric set and its accumulators so that they share the
 /// `Option` on `StopwatchState` — non-stop nodes pay no allocation for
-/// either. When item-counts ship, this struct grows a `produced_acc`
-/// field next to `duration_acc`.
+/// either.
 #[derive(Clone)]
 pub(crate) struct StopMeasurements<Accumulator> {
     /// Metric set registered for this stopwatch entity.
     /// Reported periodically via `report_stopwatch`, not on every message.
-    pub metrics: MetricSet<StopwatchMetrics>,
+    pub metrics: MetricSet<StopwatchStopMetrics>,
     /// Accumulator for stopwatch duration observations.
     /// Drained into `metrics` on periodic telemetry collection.
     pub duration_acc: Accumulator,
+    /// Accumulator for signal-item count observations at the stop node.
+    /// Drained into `metrics` on periodic telemetry collection.
+    pub items_produced_acc: Accumulator,
 }
 
 /// Per-`EffectHandler` stopwatch state.
@@ -106,8 +134,9 @@ pub(crate) struct StopMeasurements<Accumulator> {
 /// `Cell<_>`, the shared (`Send + Sync`) handler with
 /// `Arc<Mutex<_>>` / `Arc<Mutex<_>>`. The plain fields
 /// (`is_start`, `active`) are identical in both instantiations and
-/// live here once. Stop-side state lives in [`StopMeasurements`] and
-/// is `None` for nodes that are not the stop endpoint of a stopwatch.
+/// live here once. Start- and stop-side state lives in
+/// [`StartMeasurements`] and [`StopMeasurements`] and is `None` for nodes
+/// that are not the corresponding endpoint of a stopwatch.
 ///
 /// All fields are `pub(crate)` so the local/shared `EffectHandler`
 /// methods can read and write them directly through the
@@ -127,9 +156,13 @@ pub(crate) struct StopwatchState<Marker, Accumulator> {
     /// When false, `begin_process_timing` and
     /// `take_elapsed_since_send_marker_ns` are no-ops.
     pub active: bool,
+    /// Start-side measurements (metric set + accumulator).
+    /// `None` when this node is not a stopwatch start node — non-start
+    /// nodes pay no allocation cost for the metric set or accumulator.
+    pub start: Option<StartMeasurements<Accumulator>>,
     /// Stop-side measurements (metric set + accumulators).
     /// `None` when this node is not a stopwatch stop node — non-stop
-    /// nodes pay no allocation cost for the metric set or accumulator.
+    /// nodes pay no allocation cost for the metric set or accumulators.
     pub stop: Option<StopMeasurements<Accumulator>>,
 }
 
@@ -147,6 +180,7 @@ impl Default for LocalStopwatchState {
             last_send_marker: Rc::new(Cell::new(None)),
             is_start: false,
             active: false,
+            start: None,
             stop: None,
         }
     }
@@ -158,6 +192,7 @@ impl Default for SharedStopwatchState {
             last_send_marker: Arc::new(Mutex::new(None)),
             is_start: false,
             active: false,
+            start: None,
             stop: None,
         }
     }
@@ -170,14 +205,9 @@ impl Default for SharedStopwatchState {
 /// exporters are rejected) and ranges don't overlap, registers metric
 /// entities, and builds the lookup tables used for processor wiring.
 ///
-/// Stopwatches require the per-node `PROCESS_DURATION` interest to be
-/// enabled in metric reporting (so the per-message timing path runs).
-/// If `node_interests` does not include `PROCESS_DURATION`
-/// (e.g. `runtime_metrics: basic` or `none`), all configured stopwatches
-/// are skipped with a single warning so users see a clear signal rather
-/// than silent zero-duration metrics. This is a deliberate global
-/// telemetry-level setting, not a stopwatch misconfiguration, so it does
-/// not produce an error.
+/// Stopwatches are explicit opt-in via the telemetry policy YAML and require
+/// no separate metric-level gating. When configured, the engine wires both
+/// item-count and duration accumulation for the declared range.
 ///
 /// Returns `Err(Error::ConfigError(InvalidUserConfig))` if any stopwatch
 /// references an unknown node, has a non-processor endpoint, or overlaps
@@ -187,27 +217,12 @@ pub(crate) fn build_stopwatch_state(
     telemetry_policy: &TelemetryPolicy,
     node_name_to_index: &HashMap<String, usize>,
     processor_indices: &HashSet<usize>,
-    node_interests: Interests,
     pipeline_context: &PipelineContext,
 ) -> Result<PipelineStopwatchState, crate::error::Error> {
-    let mut metrics = Vec::new();
+    let mut start_metrics = Vec::new();
+    let mut stop_metrics = Vec::new();
     let mut stop_nodes: HashMap<usize, usize> = HashMap::new();
-    let mut start_nodes: HashSet<usize> = HashSet::new();
-
-    if !telemetry_policy.stopwatches.is_empty()
-        && !node_interests.contains(Interests::PROCESS_DURATION)
-    {
-        otap_df_telemetry::otel_warn!(
-            "stopwatch.config.metric_level_disabled",
-            count = telemetry_policy.stopwatches.len() as u64,
-            "Stopwatches require runtime_metrics level that enables PROCESS_DURATION (normal or detailed); skipping all configured stopwatches"
-        );
-        return Ok(PipelineStopwatchState {
-            metrics,
-            stop_nodes,
-            start_nodes,
-        });
-    }
+    let mut start_nodes: HashMap<usize, usize> = HashMap::new();
 
     let pipeline_attrs = pipeline_context.pipeline_attribute_set();
 
@@ -243,9 +258,9 @@ pub(crate) fn build_stopwatch_state(
         // `connections` are available on the surrounding `PipelineConfig`).
         // Until then, `OtapPdata::start_stopwatch` keeps a defensive runtime
         // warning so misconfigured pipelines remain diagnosable.
-        if start_nodes.contains(&start_idx)
+        if start_nodes.contains_key(&start_idx)
             || stop_nodes.contains_key(&start_idx)
-            || start_nodes.contains(&stop_idx)
+            || start_nodes.contains_key(&stop_idx)
             || stop_nodes.contains_key(&stop_idx)
         {
             return Err(invalid_stopwatch_config(format!(
@@ -262,18 +277,23 @@ pub(crate) fn build_stopwatch_state(
         };
 
         let entity_key = pipeline_context.metrics_registry().register_entity(attrs);
-        let metric_set = pipeline_context
+        let start_metric_set = pipeline_context
             .metrics_registry()
-            .register_metric_set_for_entity::<StopwatchMetrics>(entity_key);
+            .register_metric_set_for_entity::<StopwatchStartMetrics>(entity_key);
+        let stop_metric_set = pipeline_context
+            .metrics_registry()
+            .register_metric_set_for_entity::<StopwatchStopMetrics>(entity_key);
 
-        let id = metrics.len();
-        metrics.push(metric_set);
+        let id = stop_metrics.len();
+        start_metrics.push(start_metric_set);
+        stop_metrics.push(stop_metric_set);
         let _ = stop_nodes.insert(stop_idx, id);
-        let _ = start_nodes.insert(start_idx);
+        let _ = start_nodes.insert(start_idx, id);
     }
 
     Ok(PipelineStopwatchState {
-        metrics,
+        start_metrics,
+        stop_metrics,
         stop_nodes,
         start_nodes,
     })
@@ -302,9 +322,10 @@ impl PipelineStopwatchState {
     #[allow(dead_code)]
     pub fn empty() -> Self {
         Self {
-            metrics: Vec::new(),
+            start_metrics: Vec::new(),
+            stop_metrics: Vec::new(),
             stop_nodes: HashMap::new(),
-            start_nodes: HashSet::new(),
+            start_nodes: HashMap::new(),
         }
     }
 
@@ -312,7 +333,7 @@ impl PipelineStopwatchState {
     #[must_use]
     #[allow(dead_code)]
     pub fn is_active(&self) -> bool {
-        !self.metrics.is_empty()
+        !self.stop_metrics.is_empty()
     }
 }
 
@@ -326,13 +347,17 @@ mod tests {
         let entity_key = ctx
             .metrics_registry()
             .register_entity(StopwatchAttributeSet::default());
-        let metric_set = ctx
+        let start_metric_set = ctx
             .metrics_registry()
-            .register_metric_set_for_entity::<StopwatchMetrics>(entity_key);
+            .register_metric_set_for_entity::<StopwatchStartMetrics>(entity_key);
+        let stop_metric_set = ctx
+            .metrics_registry()
+            .register_metric_set_for_entity::<StopwatchStopMetrics>(entity_key);
         PipelineStopwatchState {
-            metrics: vec![metric_set],
+            start_metrics: vec![start_metric_set],
+            stop_metrics: vec![stop_metric_set],
             stop_nodes: HashMap::from([(2, 0)]),
-            start_nodes: HashSet::from([0]),
+            start_nodes: HashMap::from([(0, 0)]),
         }
     }
 
@@ -351,14 +376,31 @@ mod tests {
     #[test]
     fn direct_record_increments_mmsc() {
         let mut state = one_stopwatch_state();
-        state.metrics[0].compute_duration.record(100.0);
-        state.metrics[0].compute_duration.record(200.0);
+        state.stop_metrics[0].compute_duration.record(100.0);
+        state.stop_metrics[0].compute_duration.record(200.0);
 
-        let snap = state.metrics[0].compute_duration.get();
+        let snap = state.stop_metrics[0].compute_duration.get();
         assert_eq!(snap.count, 2);
         assert!((snap.min - 100.0).abs() < f64::EPSILON);
         assert!((snap.max - 200.0).abs() < f64::EPSILON);
         assert!((snap.sum - 300.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn direct_record_increments_items_mmsc() {
+        let mut state = one_stopwatch_state();
+        state.start_metrics[0].items_consumed.record(10.0);
+        state.start_metrics[0].items_consumed.record(20.0);
+        state.stop_metrics[0].items_produced.record(7.0);
+        state.stop_metrics[0].items_produced.record(8.0);
+
+        let consumed = state.start_metrics[0].items_consumed.get();
+        assert_eq!(consumed.count, 2);
+        assert!((consumed.sum - 30.0).abs() < f64::EPSILON);
+
+        let produced = state.stop_metrics[0].items_produced.get();
+        assert_eq!(produced.count, 2);
+        assert!((produced.sum - 15.0).abs() < f64::EPSILON);
     }
 
     // -- build_stopwatch_state validation tests --
@@ -425,12 +467,11 @@ mod tests {
         let (names, procs) = test_maps(&["a", "b", "c"], &[]);
         let policy = policy_with(vec![sw("sw1", "a", "c")]);
 
-        let state =
-            build_stopwatch_state(&policy, &names, &procs, Interests::PROCESS_DURATION, &ctx)
-                .expect("valid config should build");
+        let state = build_stopwatch_state(&policy, &names, &procs, &ctx)
+            .expect("valid config should build");
 
-        assert_eq!(state.metrics.len(), 1);
-        assert!(state.start_nodes.contains(&0)); // "a" = index 0
+        assert_eq!(state.stop_metrics.len(), 1);
+        assert!(state.start_nodes.contains_key(&0)); // "a" = index 0
         assert_eq!(state.stop_nodes.get(&2), Some(&0)); // "c" = index 2
     }
 
@@ -440,7 +481,7 @@ mod tests {
         let (names, procs) = test_maps(&["a", "b"], &[]);
         let policy = policy_with(vec![sw("sw1", "a", "missing")]);
 
-        let err = build_stopwatch_state(&policy, &names, &procs, Interests::PROCESS_DURATION, &ctx)
+        let err = build_stopwatch_state(&policy, &names, &procs, &ctx)
             .err()
             .expect("expected Err");
 
@@ -453,7 +494,7 @@ mod tests {
         let (names, procs) = test_maps(&["recv", "proc1", "proc2"], &["recv"]);
         let policy = policy_with(vec![sw("sw1", "recv", "proc2")]);
 
-        let err = build_stopwatch_state(&policy, &names, &procs, Interests::PROCESS_DURATION, &ctx)
+        let err = build_stopwatch_state(&policy, &names, &procs, &ctx)
             .err()
             .expect("expected Err");
 
@@ -466,7 +507,7 @@ mod tests {
         let (names, procs) = test_maps(&["proc1", "proc2", "exp"], &["exp"]);
         let policy = policy_with(vec![sw("sw1", "proc1", "exp")]);
 
-        let err = build_stopwatch_state(&policy, &names, &procs, Interests::PROCESS_DURATION, &ctx)
+        let err = build_stopwatch_state(&policy, &names, &procs, &ctx)
             .err()
             .expect("expected Err");
 
@@ -480,7 +521,7 @@ mod tests {
         // Two stopwatches share "a" as start node.
         let policy = policy_with(vec![sw("sw1", "a", "b"), sw("sw2", "a", "d")]);
 
-        let err = build_stopwatch_state(&policy, &names, &procs, Interests::PROCESS_DURATION, &ctx)
+        let err = build_stopwatch_state(&policy, &names, &procs, &ctx)
             .err()
             .expect("expected Err");
 
@@ -494,7 +535,7 @@ mod tests {
         // Two stopwatches share "d" as stop node.
         let policy = policy_with(vec![sw("sw1", "a", "d"), sw("sw2", "c", "d")]);
 
-        let err = build_stopwatch_state(&policy, &names, &procs, Interests::PROCESS_DURATION, &ctx)
+        let err = build_stopwatch_state(&policy, &names, &procs, &ctx)
             .err()
             .expect("expected Err");
 
@@ -507,7 +548,7 @@ mod tests {
         let (names, procs) = test_maps(&["a", "b", "c"], &[]);
         let policy = policy_with(vec![sw("sw1", "a", "b"), sw("sw2", "b", "c")]);
 
-        let err = build_stopwatch_state(&policy, &names, &procs, Interests::PROCESS_DURATION, &ctx)
+        let err = build_stopwatch_state(&policy, &names, &procs, &ctx)
             .err()
             .expect("expected Err");
 
@@ -521,31 +562,13 @@ mod tests {
         // Non-overlapping: a→b and c→d.
         let policy = policy_with(vec![sw("sw1", "a", "b"), sw("sw2", "c", "d")]);
 
-        let state =
-            build_stopwatch_state(&policy, &names, &procs, Interests::PROCESS_DURATION, &ctx)
-                .expect("disjoint config should build");
+        let state = build_stopwatch_state(&policy, &names, &procs, &ctx)
+            .expect("disjoint config should build");
 
-        assert_eq!(state.metrics.len(), 2);
-        assert!(state.start_nodes.contains(&0)); // "a"
-        assert!(state.start_nodes.contains(&2)); // "c"
+        assert_eq!(state.stop_metrics.len(), 2);
+        assert!(state.start_nodes.contains_key(&0)); // "a"
+        assert!(state.start_nodes.contains_key(&2)); // "c"
         assert_eq!(state.stop_nodes.get(&1), Some(&0)); // "b" → sw1
         assert_eq!(state.stop_nodes.get(&3), Some(&1)); // "d" → sw2
-    }
-
-    #[test]
-    fn stopwatches_skipped_when_process_duration_disabled() {
-        let (ctx, _) = test_pipeline_ctx();
-        let (names, procs) = test_maps(&["a", "b"], &[]);
-        let policy = policy_with(vec![sw("sw1", "a", "b")]);
-
-        // Empty interests => PROCESS_DURATION not set; all stopwatches skipped
-        // (this is a deliberate global telemetry-level setting, not a misconfig,
-        // so it is not an error).
-        let state = build_stopwatch_state(&policy, &names, &procs, Interests::empty(), &ctx)
-            .expect("metric-level skip should not error");
-
-        assert!(state.metrics.is_empty());
-        assert!(state.start_nodes.is_empty());
-        assert!(state.stop_nodes.is_empty());
     }
 }

--- a/rust/otap-dataflow/crates/engine/src/testing/mod.rs
+++ b/rust/otap-dataflow/crates/engine/src/testing/mod.rs
@@ -63,7 +63,7 @@ impl crate::ReceivedAtNode for TestMsg {
     fn received_at_node(&mut self, _node_id: usize, _node_interests: crate::Interests) {}
 }
 
-impl crate::processor::ProcessorSendHook for TestMsg {}
+impl crate::processor::FlowMeasurementHook for TestMsg {}
 
 impl TestMsg {
     /// Creates a new test message with the given content.

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -20,7 +20,7 @@ use otap_df_config::PortName;
 use otap_df_config::{SignalFormat, SignalType};
 use otap_df_engine::control::{AckMsg, CallData, Frame, NackMsg, RouteData, nanos_since_birth};
 use otap_df_engine::error::{Error, TypedError};
-use otap_df_engine::processor::{ProcessorSendHook, StopwatchEffectHandler};
+use otap_df_engine::processor::{FlowMeasurementHook, StopwatchEffectHandler};
 use otap_df_engine::{
     ConsumerEffectHandlerExtension, Interests, MessageSourceLocalEffectHandlerExtension,
     MessageSourceSharedEffectHandlerExtension, ProducerEffectHandlerExtension,
@@ -388,7 +388,7 @@ impl StopwatchAccumulation for OtapPdata {
         self.context
             .stopwatch_compute_ns
             .take()
-            .map(|acc| acc.get())
+            .map(|acc| acc.get() - 1)
     }
 }
 
@@ -703,7 +703,7 @@ impl_consumer_ext!(otap_df_engine::shared::exporter::EffectHandler<OtapPdata>);
 /* --------  effect handler extensions (shared, local) -------- */
 
 /// Forward-path stopwatch accumulation for non-overlapping ranges.
-/// Invoked by local and shared processor handlers (via `ProcessorSendHook`);
+/// Invoked by local and shared processor handlers (via `FlowMeasurementHook`);
 /// receivers and exporters do not measure stopwatches.
 fn stopwatch_accumulate<H: StopwatchEffectHandler>(handler: &H, data: &mut OtapPdata) {
     let is_start = handler.is_stopwatch_start();
@@ -713,30 +713,41 @@ fn stopwatch_accumulate<H: StopwatchEffectHandler>(handler: &H, data: &mut OtapP
     }
     let delta_ns = handler.take_elapsed_since_send_marker_ns();
 
-    // Note that num_items() is only called when required at stopwatch start and stop.
-    // It is intentionally not called on every node to minimize performance overhead.
     if is_start {
-        let items: u64 = data.num_items() as u64;
         data.start_stopwatch();
-        if items > 0 {
-            handler.record_stopwatch_start_items(items);
-        }
     }
     data.add_stopwatch_compute(delta_ns);
     if is_stop {
         if let Some(total) = data.take_stopwatch_compute() {
             handler.record_stopwatch_stop(total);
         }
-        let items: u64 = data.num_items() as u64;
-        if items > 0 {
-            handler.record_stopwatch_stop_items(items);
+        // num_items() is only called at stopwatch boundaries to keep
+        // overhead off the per-node hot path. At the stop node this
+        // reflects the post-process count — what is actually leaving
+        // the stopwatch range.
+        let signals: u64 = data.num_items() as u64;
+        if signals > 0 {
+            handler.record_stopwatch_stop_signals(signals);
         }
     }
 }
 
-impl ProcessorSendHook for OtapPdata {
+impl FlowMeasurementHook for OtapPdata {
     fn before_processor_send<H: StopwatchEffectHandler>(&mut self, handler: &H) {
         stopwatch_accumulate(handler, self);
+    }
+
+    /// At the stopwatch start node, count items *entering* the range —
+    /// i.e. before `process()` runs and may filter or drop them. This
+    /// gives the true input volume to compare against the stop-node
+    /// output volume recorded in [`stopwatch_accumulate`].
+    fn after_processor_receive<H: StopwatchEffectHandler>(&mut self, handler: &H) {
+        if handler.is_stopwatch_start() {
+            let signals: u64 = self.num_items() as u64;
+            if signals > 0 {
+                handler.record_stopwatch_start_signals(signals);
+            }
+        }
     }
 }
 
@@ -880,8 +891,8 @@ mod test {
         is_stop: bool,
         elapsed_ns: u64,
         stop_total: Cell<u64>,
-        start_items: Cell<u64>,
-        stop_items: Cell<u64>,
+        start_signals: Cell<u64>,
+        stop_signals: Cell<u64>,
     }
 
     impl FakeStopwatchHandler {
@@ -891,8 +902,8 @@ mod test {
                 is_stop: false,
                 elapsed_ns,
                 stop_total: Cell::new(0),
-                start_items: Cell::new(0),
-                stop_items: Cell::new(0),
+                start_signals: Cell::new(0),
+                stop_signals: Cell::new(0),
             }
         }
 
@@ -902,8 +913,8 @@ mod test {
                 is_stop: true,
                 elapsed_ns,
                 stop_total: Cell::new(0),
-                start_items: Cell::new(0),
-                stop_items: Cell::new(0),
+                start_signals: Cell::new(0),
+                stop_signals: Cell::new(0),
             }
         }
     }
@@ -925,29 +936,33 @@ mod test {
             self.stop_total.set(total);
         }
 
-        fn record_stopwatch_start_items(&self, items: u64) {
-            self.start_items.set(items);
+        fn record_stopwatch_start_signals(&self, signals: u64) {
+            self.start_signals.set(signals);
         }
 
-        fn record_stopwatch_stop_items(&self, items: u64) {
-            self.stop_items.set(items);
+        fn record_stopwatch_stop_signals(&self, signals: u64) {
+            self.stop_signals.set(signals);
         }
     }
 
     #[test]
-    fn stopwatch_accumulate_records_start_and_stop_item_counts() {
+    fn stopwatch_hooks_record_start_and_stop_signal_counts() {
         let mut pdata = create_test_pdata();
-        let items = pdata.num_items() as u64;
-        assert!(items > 0, "test pdata must contain signal items");
+        let signals = pdata.num_items() as u64;
+        assert!(signals > 0, "test pdata must contain signal items");
 
         let start_handler = FakeStopwatchHandler::start(5);
-        stopwatch_accumulate(&start_handler, &mut pdata);
-        assert_eq!(start_handler.start_items.get(), items);
-        assert_eq!(start_handler.stop_items.get(), 0);
+        // Incoming count is recorded by after_processor_receive (pre-process).
+        pdata.after_processor_receive(&start_handler);
+        // The send hook still drives compute-duration accumulation.
+        pdata.before_processor_send(&start_handler);
+        assert_eq!(start_handler.start_signals.get(), signals);
+        assert_eq!(start_handler.stop_signals.get(), 0);
 
         let stop_handler = FakeStopwatchHandler::stop(7);
-        stopwatch_accumulate(&stop_handler, &mut pdata);
-        assert_eq!(stop_handler.stop_items.get(), items);
+        pdata.after_processor_receive(&stop_handler);
+        pdata.before_processor_send(&stop_handler);
+        assert_eq!(stop_handler.stop_signals.get(), signals);
         assert!(stop_handler.stop_total.get() > 0);
     }
 
@@ -2192,7 +2207,7 @@ mod test {
         assert!(pdata.has_active_stopwatch());
         pdata.add_stopwatch_compute(100);
         pdata.add_stopwatch_compute(200);
-        assert_eq!(pdata.take_stopwatch_compute(), Some(301));
+        assert_eq!(pdata.take_stopwatch_compute(), Some(300));
 
         // Accumulator consumed.
         assert!(!pdata.has_active_stopwatch());
@@ -2223,9 +2238,9 @@ mod test {
         pdata.start_stopwatch();
         assert!(pdata.has_active_stopwatch());
 
-        // Only the second stopwatch's compute plus its sentinel should be present.
+        // Only the second stopwatch's compute should be present.
         pdata.add_stopwatch_compute(50);
-        assert_eq!(pdata.take_stopwatch_compute(), Some(51));
+        assert_eq!(pdata.take_stopwatch_compute(), Some(50));
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -711,9 +711,12 @@ fn stopwatch_accumulate<H: StopwatchEffectHandler>(handler: &H, data: &mut OtapP
     if !is_start && !is_stop && !data.has_active_stopwatch() {
         return;
     }
-    let items = data.num_items() as u64;
     let delta_ns = handler.take_elapsed_since_send_marker_ns();
+
+    // Note that num_items() is only called when required at stopwatch start and stop.
+    // It is intentionally not called on every node to minimize performance overhead.
     if is_start {
+        let items: u64 = data.num_items() as u64;
         data.start_stopwatch();
         if items > 0 {
             handler.record_stopwatch_start_items(items);
@@ -724,6 +727,7 @@ fn stopwatch_accumulate<H: StopwatchEffectHandler>(handler: &H, data: &mut OtapP
         if let Some(total) = data.take_stopwatch_compute() {
             handler.record_stopwatch_stop(total);
         }
+        let items: u64 = data.num_items() as u64;
         if items > 0 {
             handler.record_stopwatch_stop_items(items);
         }

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -711,14 +711,21 @@ fn stopwatch_accumulate<H: StopwatchEffectHandler>(handler: &H, data: &mut OtapP
     if !is_start && !is_stop && !data.has_active_stopwatch() {
         return;
     }
+    let items = data.num_items() as u64;
     let delta_ns = handler.take_elapsed_since_send_marker_ns();
     if is_start {
         data.start_stopwatch();
+        if items > 0 {
+            handler.record_stopwatch_start_items(items);
+        }
     }
     data.add_stopwatch_compute(delta_ns);
     if is_stop {
         if let Some(total) = data.take_stopwatch_compute() {
             handler.record_stopwatch_stop(total);
+        }
+        if items > 0 {
+            handler.record_stopwatch_stop_items(items);
         }
     }
 }
@@ -856,11 +863,88 @@ mod test {
     use otap_df_engine::shared::receiver::EffectHandler as SharedReceiverEffectHandler;
     use otap_df_telemetry::reporter::MetricsReporter;
     use pretty_assertions::assert_eq;
+    use std::cell::Cell;
     use std::collections::HashMap;
     use tokio::sync::mpsc;
 
     fn create_test() -> (TestCallData, OtapPdata) {
         (TestCallData::default(), create_test_pdata())
+    }
+
+    struct FakeStopwatchHandler {
+        is_start: bool,
+        is_stop: bool,
+        elapsed_ns: u64,
+        stop_total: Cell<u64>,
+        start_items: Cell<u64>,
+        stop_items: Cell<u64>,
+    }
+
+    impl FakeStopwatchHandler {
+        fn start(elapsed_ns: u64) -> Self {
+            Self {
+                is_start: true,
+                is_stop: false,
+                elapsed_ns,
+                stop_total: Cell::new(0),
+                start_items: Cell::new(0),
+                stop_items: Cell::new(0),
+            }
+        }
+
+        fn stop(elapsed_ns: u64) -> Self {
+            Self {
+                is_start: false,
+                is_stop: true,
+                elapsed_ns,
+                stop_total: Cell::new(0),
+                start_items: Cell::new(0),
+                stop_items: Cell::new(0),
+            }
+        }
+    }
+
+    impl StopwatchEffectHandler for FakeStopwatchHandler {
+        fn is_stopwatch_start(&self) -> bool {
+            self.is_start
+        }
+
+        fn is_stopwatch_stop(&self) -> bool {
+            self.is_stop
+        }
+
+        fn take_elapsed_since_send_marker_ns(&self) -> u64 {
+            self.elapsed_ns
+        }
+
+        fn record_stopwatch_stop(&self, total: u64) {
+            self.stop_total.set(total);
+        }
+
+        fn record_stopwatch_start_items(&self, items: u64) {
+            self.start_items.set(items);
+        }
+
+        fn record_stopwatch_stop_items(&self, items: u64) {
+            self.stop_items.set(items);
+        }
+    }
+
+    #[test]
+    fn stopwatch_accumulate_records_start_and_stop_item_counts() {
+        let mut pdata = create_test_pdata();
+        let items = pdata.num_items() as u64;
+        assert!(items > 0, "test pdata must contain signal items");
+
+        let start_handler = FakeStopwatchHandler::start(5);
+        stopwatch_accumulate(&start_handler, &mut pdata);
+        assert_eq!(start_handler.start_items.get(), items);
+        assert_eq!(start_handler.stop_items.get(), 0);
+
+        let stop_handler = FakeStopwatchHandler::stop(7);
+        stopwatch_accumulate(&stop_handler, &mut pdata);
+        assert_eq!(stop_handler.stop_items.get(), items);
+        assert!(stop_handler.stop_total.get() > 0);
     }
 
     #[tokio::test]

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -724,11 +724,10 @@ fn stopwatch_accumulate<H: StopwatchEffectHandler>(handler: &H, data: &mut OtapP
         // num_items() is only called at stopwatch boundaries to keep
         // overhead off the per-node hot path. At the stop node this
         // reflects the post-process count — what is actually leaving
-        // the stopwatch range.
-        let signals: u64 = data.num_items() as u64;
-        if signals > 0 {
-            handler.record_stopwatch_stop_signals(signals);
-        }
+        // the stopwatch range. Recorded unconditionally (including 0)
+        // so signals.outgoing.count stays in lockstep with
+        // compute.duration.count and 0-out traversals stay visible.
+        handler.record_stopwatch_stop_signals(data.num_items() as u64);
     }
 }
 
@@ -740,13 +739,13 @@ impl FlowMeasurementHook for OtapPdata {
     /// At the stopwatch start node, count items *entering* the range —
     /// i.e. before `process()` runs and may filter or drop them. This
     /// gives the true input volume to compare against the stop-node
-    /// output volume recorded in [`stopwatch_accumulate`].
+    /// output volume recorded in [`stopwatch_accumulate`]. Recorded
+    /// unconditionally (including 0) so signals.incoming.count stays in
+    /// lockstep with compute.duration.count and 0-in traversals stay
+    /// visible.
     fn after_processor_receive<H: StopwatchEffectHandler>(&mut self, handler: &H) {
         if handler.is_stopwatch_start() {
-            let signals: u64 = self.num_items() as u64;
-            if signals > 0 {
-                handler.record_stopwatch_start_signals(signals);
-            }
+            handler.record_stopwatch_start_signals(self.num_items() as u64);
         }
     }
 }
@@ -859,7 +858,9 @@ impl otap_df_engine::ReceivedAtNode for OtapPdata {
 mod test {
     use super::*;
 
-    use crate::testing::{TestCallData, create_test_pdata, next_ack, next_nack};
+    use crate::testing::{
+        TestCallData, create_empty_test_pdata, create_test_pdata, next_ack, next_nack,
+    };
     use otap_df_channel::mpsc::Channel as LocalChannel;
     use otap_df_engine::ConsumerEffectHandlerExtension;
     use otap_df_engine::control::{
@@ -891,8 +892,11 @@ mod test {
         is_stop: bool,
         elapsed_ns: u64,
         stop_total: Cell<u64>,
+        stop_total_calls: Cell<u32>,
         start_signals: Cell<u64>,
+        start_signals_calls: Cell<u32>,
         stop_signals: Cell<u64>,
+        stop_signals_calls: Cell<u32>,
     }
 
     impl FakeStopwatchHandler {
@@ -902,8 +906,11 @@ mod test {
                 is_stop: false,
                 elapsed_ns,
                 stop_total: Cell::new(0),
+                stop_total_calls: Cell::new(0),
                 start_signals: Cell::new(0),
+                start_signals_calls: Cell::new(0),
                 stop_signals: Cell::new(0),
+                stop_signals_calls: Cell::new(0),
             }
         }
 
@@ -913,8 +920,11 @@ mod test {
                 is_stop: true,
                 elapsed_ns,
                 stop_total: Cell::new(0),
+                stop_total_calls: Cell::new(0),
                 start_signals: Cell::new(0),
+                start_signals_calls: Cell::new(0),
                 stop_signals: Cell::new(0),
+                stop_signals_calls: Cell::new(0),
             }
         }
     }
@@ -934,14 +944,19 @@ mod test {
 
         fn record_stopwatch_stop(&self, total: u64) {
             self.stop_total.set(total);
+            self.stop_total_calls.set(self.stop_total_calls.get() + 1);
         }
 
         fn record_stopwatch_start_signals(&self, signals: u64) {
             self.start_signals.set(signals);
+            self.start_signals_calls
+                .set(self.start_signals_calls.get() + 1);
         }
 
         fn record_stopwatch_stop_signals(&self, signals: u64) {
             self.stop_signals.set(signals);
+            self.stop_signals_calls
+                .set(self.stop_signals_calls.get() + 1);
         }
     }
 
@@ -963,6 +978,39 @@ mod test {
         pdata.after_processor_receive(&stop_handler);
         pdata.before_processor_send(&stop_handler);
         assert_eq!(stop_handler.stop_signals.get(), signals);
+        assert!(stop_handler.stop_total.get() > 0);
+    }
+
+    /// A 0-item batch must still produce one record() call on each MMSC,
+    /// so signals.incoming.count, signals.outgoing.count, and
+    /// compute.duration.count stay in lockstep with the number of
+    /// traversals. Hiding 0-item batches would diverge the counts and
+    /// erase a useful starvation/over-filter signal.
+    #[test]
+    fn stopwatch_hooks_record_zero_item_batches() {
+        let mut pdata = create_empty_test_pdata();
+        assert_eq!(pdata.num_items(), 0);
+
+        // Start node: after_processor_receive must record (incoming = 0)
+        // even though the batch is empty.
+        let start_handler = FakeStopwatchHandler::start(5);
+        pdata.after_processor_receive(&start_handler);
+        pdata.before_processor_send(&start_handler);
+        assert_eq!(start_handler.start_signals_calls.get(), 1);
+        assert_eq!(start_handler.start_signals.get(), 0);
+        assert_eq!(start_handler.stop_signals_calls.get(), 0);
+
+        // Stop node: before_processor_send must record both
+        // compute.duration AND outgoing = 0, in lockstep.
+        let stop_handler = FakeStopwatchHandler::stop(7);
+        pdata.after_processor_receive(&stop_handler);
+        pdata.before_processor_send(&stop_handler);
+        assert_eq!(
+            stop_handler.stop_total_calls.get(),
+            stop_handler.stop_signals_calls.get(),
+            "compute.duration and signals.outgoing must record together for parity"
+        );
+        assert_eq!(stop_handler.stop_signals.get(), 0);
         assert!(stop_handler.stop_total.get() > 0);
     }
 

--- a/rust/otap-dataflow/crates/otap/src/testing/mod.rs
+++ b/rust/otap-dataflow/crates/otap/src/testing/mod.rs
@@ -107,6 +107,17 @@ pub fn create_test_pdata() -> OtapPdata {
     OtapPdata::new_default(OtlpProtoBytes::ExportLogsRequest(Bytes::from(otlp_bytes)).into())
 }
 
+/// Create empty test pdata (a logs request with zero log records).
+#[must_use]
+pub fn create_empty_test_pdata() -> OtapPdata {
+    let empty = otap_df_pdata::proto::opentelemetry::logs::v1::LogsData::new(vec![]);
+    let mut otlp_bytes = vec![];
+    empty
+        .encode(&mut otlp_bytes)
+        .expect("failed to encode empty OTLP ExportLogsServiceRequest");
+    OtapPdata::new_default(OtlpProtoBytes::ExportLogsRequest(Bytes::from(otlp_bytes)).into())
+}
+
 /// Simple exporter test where there is NO subscribe_to() in the context.
 pub fn test_exporter_no_subscription(factory: &ExporterFactory<OtapPdata>, config: Value) {
     let test_runtime = TestRuntime::new();


### PR DESCRIPTION
# Change Summary

Follow-up to #2747

Adds two MMSC metrics on the existing `stopwatch` metric set so operators can compare signal volume in vs. out across a stopwatch range, alongside the existing combined compute duration. "Signals" here means individual log records, spans, or metric data points (`OtapPdata::num_items()`).

| Metric | Recorded | Why |
|---|---|---|
| `stopwatch.signals.incoming` | At the start node, **before** `process()` runs | Any filter/drop in the start processor itself does not undercount entry volume. |
| `stopwatch.signals.outgoing` | At the stop node, **after** `process()` completes | Reflects what actually leaves the range. |

Implemented as two metric set types (`StopwatchStartMetrics`, `StopwatchStopMetrics`) sharing one entity per stopwatch — mirrors the `ChannelSenderMetrics` / `ChannelReceiverMetrics` precedent. Each role registers its own `MetricSet` against the same entity and drains its own accumulator on the periodic `CollectTelemetry` tick and at shutdown.

To capture the incoming count pre-process, the existing `ProcessorSendHook` trait is renamed to `FlowMeasurementHook` and gains a default-no-op `after_processor_receive` method. The engine run loops (Local + Shared) call it immediately after `inbox.recv_when(...)` returns a `Message::PData`, before `begin_process_timing` and `process()`. `OtapPdata` overrides it to drive the start-side counter; test PData stand-ins (`()`, `String`, `TestMsg`) get blanket no-op impls.

The two hooks fire from different surfaces by design, matching the asymmetric flow control of a processor:

| Hook | Fires from | Cardinality per `process()` | Captures |
|---|---|---|---|
| `after_processor_receive` | Engine run loop | Exactly 1 (1 dequeue per iteration) | True pre-process input volume |
| `before_processor_send` | Effect handler `send_message[_to]` | 0..N (drop, pass-through, or fan out) | What actually leaves |

**Behavior change:** removed the `PROCESS_DURATION` gate in `build_stopwatch_state`. Stopwatches are already explicit opt-in via the telemetry policy YAML; the gate was redundant and signal counts don't need the timing path. Pipelines with stopwatches under `runtime_metrics: basic`/`none` will now run them instead of silently skipping.

## Demo

`configs/fake-stopwatch-demo.yaml` now includes a 1-in-3 `processor:log_sampling` node inside the stopwatch range so `signals.outgoing` is visibly smaller than `signals.incoming`.

```bash
cargo run --bin df_engine -- --config configs/fake-stopwatch-demo.yaml
curl -s 'http://127.0.0.1:8080/api/v1/telemetry/metrics?format=json' \
  | jq '.metric_sets[] | select(.name == "stopwatch")'
```

Sample output (truncated, after ~38 collection cycles at 10 signals/sec):

```json
{
  "name": "stopwatch.signals.incoming",
  "value": { "min": 10.0, "max": 10.0, "sum": 380.0, "count": 38 }
}
{
  "name": "stopwatch.compute.duration",
  "value": { "min": 2859829.0, "max": 6619768.0, "sum": 170014602.0, "count": 38 }
}
{
  "name": "stopwatch.signals.outgoing",
  "value": { "min": 3.0, "max": 4.0, "sum": 127.0, "count": 38 }
}
```

Reading: 380 signals entered the range (38 batches × 10 signals), 127 left it (≈1/3, matching the sampler ratio), and `compute.duration` averages ~4.47 ms per batch across the chain (170014602 ns / 38). Both signal-count metrics share the same `stopwatch.name` / `start_node` / `stop_node` attributes as the duration metric, so they correlate without joins.

## What issue does this PR close?

* Related to #2782 
* Closes #2837 

## How are these changes tested?

Unit Tests / Local runs

## Are there any user-facing changes?

1. Stopwatch duration metric will now be tracked and emitted even on `runtime_metrics: basic/none`.
2. New Stopwatch metrics for `consumed` and `produced`