### PR TITLE
ci(codecov): wait for all uploads; use auto project target; raise patch to 80%

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -1,11 +1,22 @@
+codecov:
+  notify:
+    # Wait for all coverage uploads before posting status. We currently
+    # upload from three jobs: rust-ci `test` (Linux x86_64), rust-ci
+    # `coverage`, and go-ci `test_and_coverage`. Without this, codecov
+    # posts a (failing) partial status as soon as the first upload
+    # arrives, before the other test jobs have even finished.
+    after_n_builds: 3
+    wait_for_ci: true
+
 coverage:
   status:
     project: # Overall repo coverage
       default:
-        target: 85%
+        target: auto      # compare against the base commit
+        threshold: 1%     # allow a small drop without failing
     patch: # Changed lines in PR
       default:
-        target: 70%
+        target: 80%
 
 ignore:
   - "rust/otap-dataflow/crates/quiver-e2e/**" # Test tool, not production code

--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -1,12 +1,17 @@
 codecov:
   notify:
-    # Wait for all coverage uploads before posting status. We currently
-    # upload from three jobs: rust-ci `test` (Linux x86_64), rust-ci
-    # `coverage`, and go-ci `test_and_coverage`. Without this, codecov
-    # posts a (failing) partial status as soon as the first upload
-    # arrives, before the other test jobs have even finished.
+    # Wait for all coverage uploads before posting status. Without this,
+    # codecov posts a (failing) partial status as soon as the first
+    # upload arrives, before the other test jobs have even finished.
+    #
+    # IMPORTANT: this number must match the total count of
+    # `codecov/codecov-action` upload steps across all workflows.
+    # Currently:
+    #   - .github/workflows/rust-ci.yml `test` (Linux x86_64)
+    #   - .github/workflows/rust-ci.yml `coverage`
+    #   - .github/workflows/go-ci.yml   `test_and_coverage`
+    # If you add or remove a codecov upload, update this number.
     after_n_builds: 3
-    wait_for_ci: true
 
 coverage:
   status:

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Run tests with coverage
         run: go test -cover -coverprofile=coverage.txt -covermode=atomic -coverpkg=./... ./...
         working-directory: ./go/${{ matrix.folder }}
+      # NOTE: when adding or removing a codecov upload step anywhere in
+      # the repo, update `codecov.notify.after_n_builds` in
+      # .github/codecov.yaml so codecov waits for the new total.
       - name: Upload to codecov.io
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         env:

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -83,6 +83,9 @@ jobs:
         if: runner.os == 'macOS'
         run: cargo nextest run --all-features --workspace
         working-directory: ./rust/${{ matrix.folder }}
+      # NOTE: when adding or removing a codecov upload step anywhere in
+      # the repo, update `codecov.notify.after_n_builds` in
+      # .github/codecov.yaml so codecov waits for the new total.
       - name: Upload to codecov.io
         if: matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
@@ -577,6 +580,9 @@ jobs:
       - name: Run tests with coverage
         run: cargo llvm-cov nextest --profile ci --all-features --workspace --lcov --output-path lcov.info
         working-directory: ./rust/otap-dataflow
+      # NOTE: when adding or removing a codecov upload step anywhere in
+      # the repo, update `codecov.notify.after_n_builds` in
+      # .github/codecov.yaml so codecov waits for the new total.
       - name: Upload to codecov.io
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         env:


### PR DESCRIPTION
Codecov was reporting a failing project status (e.g. 56% vs target 85%) before all test jobs had even finished, because it computed the status from the first upload that arrived. We upload coverage from three jobs: rust-ci 'test' (Linux x86_64), rust-ci 'coverage', and go-ci 'test_and_coverage'. Set codecov.notify.after_n_builds: 3 (with wait_for_ci: true) so the status is computed only after all three reports have been received.

Also relax the thresholds:
- project: switch to 'target: auto' with a 1% threshold so PRs only fail if they meaningfully decrease overall coverage, rather than needing the whole repo to hit a fixed 85%.
- patch: raise to 80% (from 70%) for changed lines in a PR.

Fixes #2591 