### PR TITLE
Add ltrim and rtrim functions to query engine

### DIFF
--- a/rust/otap-dataflow/crates/query-engine/src/consts.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/consts.rs
@@ -9,7 +9,9 @@ pub(crate) const VALUE_FIELD_NAME: &str = "value";
 
 pub(crate) const ENCODE_FUNC_NAME: &str = "encode";
 pub(crate) const FORMAT_DATETIME_FUNC_NAME: &str = "format_datetime";
+pub(crate) const LTRIM_FUNC_NAME: &str = "ltrim";
 pub(crate) const REGEXP_SUBSTR_FUNC_NAME: &str = "regexp_substr";
+pub(crate) const RTRIM_FUNC_NAME: &str = "rtrim";
 pub(crate) const SHA256_FUNC_NAME: &str = "sha256";
 pub(crate) const UUID_FUNC_NAME: &str = "uuid";
 pub(crate) const UUIDV7_FUNC_NAME: &str = "uuidv7";

--- a/rust/otap-dataflow/crates/query-engine/src/parser.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/parser.rs
@@ -11,8 +11,9 @@ use data_engine_expressions::{
 use data_engine_parser_abstractions::ParserOptions;
 
 use crate::consts::{
-    ENCODE_FUNC_NAME, FORMAT_DATETIME_FUNC_NAME, LOWER_CASE_FUNC_NAME, REGEXP_SUBSTR_FUNC_NAME,
-    SHA256_FUNC_NAME, UPPER_CASE_FUNC_NAME, UUID_FUNC_NAME, UUIDV7_FUNC_NAME, LTRIM_FUNC_NAME, RTRIM_FUNC_NAME
+    ENCODE_FUNC_NAME, FORMAT_DATETIME_FUNC_NAME, LOWER_CASE_FUNC_NAME, LTRIM_FUNC_NAME,
+    REGEXP_SUBSTR_FUNC_NAME, RTRIM_FUNC_NAME, SHA256_FUNC_NAME, UPPER_CASE_FUNC_NAME,
+    UUID_FUNC_NAME, UUIDV7_FUNC_NAME,
 };
 
 /// Create parser options that can be used when parsing an expression that will be executed with

--- a/rust/otap-dataflow/crates/query-engine/src/parser.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/parser.rs
@@ -12,7 +12,7 @@ use data_engine_parser_abstractions::ParserOptions;
 
 use crate::consts::{
     ENCODE_FUNC_NAME, FORMAT_DATETIME_FUNC_NAME, LOWER_CASE_FUNC_NAME, REGEXP_SUBSTR_FUNC_NAME,
-    SHA256_FUNC_NAME, UPPER_CASE_FUNC_NAME, UUID_FUNC_NAME, UUIDV7_FUNC_NAME,
+    SHA256_FUNC_NAME, UPPER_CASE_FUNC_NAME, UUID_FUNC_NAME, UUIDV7_FUNC_NAME, LTRIM_FUNC_NAME, RTRIM_FUNC_NAME
 };
 
 /// Create parser options that can be used when parsing an expression that will be executed with
@@ -40,6 +40,8 @@ pub fn default_parser_options() -> ParserOptions {
         .with_external_function(UUIDV7_FUNC_NAME, param_placeholders(0), None)
         .with_external_function(UPPER_CASE_FUNC_NAME, param_placeholders(1), None)
         .with_external_function(LOWER_CASE_FUNC_NAME, param_placeholders(1), None)
+        .with_external_function(LTRIM_FUNC_NAME, param_placeholders(2), None)
+        .with_external_function(RTRIM_FUNC_NAME, param_placeholders(2), None)
         .with_external_function(
             REGEXP_SUBSTR_FUNC_NAME,
             vec![

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
@@ -5658,4 +5658,84 @@ mod test {
     async fn test_update_attr_to_lower_case_function_call_kql_parser() {
         test_update_attr_to_lower_case_function_call::<KqlParser>().await
     }
+
+    async fn test_update_attr_using_ltrim<P: Parser>() {
+        let logs_data = to_logs_data(vec![
+            LogRecord::build()
+                .attributes(vec![KeyValue::new(
+                    "attr",
+                    AnyValue::new_string("   hello world"),
+                )])
+                .finish(),
+        ]);
+
+        let query =
+            r#"logs | extend attributes["attr"] = ltrim(attributes["attr"], " ")"#;
+        let pipeline_expr = P::parse_with_options(query, default_parser_options())
+            .unwrap()
+            .pipeline;
+        let mut pipeline = Pipeline::new(pipeline_expr);
+
+        let input = otlp_to_otap(&OtlpProtoMessage::Logs(logs_data));
+
+        let result = pipeline.execute(input).await.unwrap();
+        let OtlpProtoMessage::Logs(result_logs_data) = otap_to_otlp(&result) else {
+            panic!("invalid signal type");
+        };
+        let log_0 = &result_logs_data.resource_logs[0].scope_logs[0].log_records[0];
+        assert_eq!(
+            log_0.attributes,
+            vec![KeyValue::new("attr", AnyValue::new_string("hello world"))]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_attr_using_ltrim_opl_parser() {
+        test_update_attr_using_ltrim::<OplParser>().await
+    }
+
+    #[tokio::test]
+    async fn test_update_attr_using_ltrim_kql_parser() {
+        test_update_attr_using_ltrim::<KqlParser>().await
+    }
+
+    async fn test_update_attr_using_rtrim<P: Parser>() {
+        let logs_data = to_logs_data(vec![
+            LogRecord::build()
+                .attributes(vec![KeyValue::new(
+                    "attr",
+                    AnyValue::new_string("hello world\n\n"),
+                )])
+                .finish(),
+        ]);
+
+        let query =
+            r#"logs | extend attributes["attr"] = rtrim(attributes["attr"], "\n")"#;
+        let pipeline_expr = P::parse_with_options(query, default_parser_options())
+            .unwrap()
+            .pipeline;
+        let mut pipeline = Pipeline::new(pipeline_expr);
+
+        let input = otlp_to_otap(&OtlpProtoMessage::Logs(logs_data));
+
+        let result = pipeline.execute(input).await.unwrap();
+        let OtlpProtoMessage::Logs(result_logs_data) = otap_to_otlp(&result) else {
+            panic!("invalid signal type");
+        };
+        let log_0 = &result_logs_data.resource_logs[0].scope_logs[0].log_records[0];
+        assert_eq!(
+            log_0.attributes,
+            vec![KeyValue::new("attr", AnyValue::new_string("hello world"))]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_attr_using_rtrim_opl_parser() {
+        test_update_attr_using_rtrim::<OplParser>().await
+    }
+
+    #[tokio::test]
+    async fn test_update_attr_using_rtrim_kql_parser() {
+        test_update_attr_using_rtrim::<KqlParser>().await
+    }
 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
@@ -5669,8 +5669,7 @@ mod test {
                 .finish(),
         ]);
 
-        let query =
-            r#"logs | extend attributes["attr"] = ltrim(attributes["attr"], " ")"#;
+        let query = r#"logs | extend attributes["attr"] = ltrim(attributes["attr"], " ")"#;
         let pipeline_expr = P::parse_with_options(query, default_parser_options())
             .unwrap()
             .pipeline;
@@ -5709,8 +5708,7 @@ mod test {
                 .finish(),
         ]);
 
-        let query =
-            r#"logs | extend attributes["attr"] = rtrim(attributes["attr"], "\n")"#;
+        let query = r#"logs | extend attributes["attr"] = rtrim(attributes["attr"], "\n")"#;
         let pipeline_expr = P::parse_with_options(query, default_parser_options())
             .unwrap()
             .pipeline;

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
@@ -62,7 +62,7 @@ use datafusion::functions::core::expr_ext::FieldAccessor;
 use datafusion::functions::crypto::sha256;
 use datafusion::functions::datetime::to_char;
 use datafusion::functions::encoding::encode;
-use datafusion::functions::string::{concat, concat_ws, lower, replace, upper, uuid, ltrim, rtrim};
+use datafusion::functions::string::{concat, concat_ws, lower, ltrim, replace, rtrim, upper, uuid};
 use datafusion::logical_expr::expr::ScalarFunction;
 use datafusion::logical_expr::{
     BinaryExpr, ColumnarValue, Expr, Operator, ScalarUDF, cast, col, lit,
@@ -78,8 +78,9 @@ use otap_df_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
 use otap_df_pdata::schema::consts;
 
 use crate::consts::{
-    ENCODE_FUNC_NAME, FORMAT_DATETIME_FUNC_NAME, LOWER_CASE_FUNC_NAME, REGEXP_SUBSTR_FUNC_NAME,
-    SHA256_FUNC_NAME, UPPER_CASE_FUNC_NAME, UUID_FUNC_NAME, UUIDV7_FUNC_NAME, LTRIM_FUNC_NAME, RTRIM_FUNC_NAME
+    ENCODE_FUNC_NAME, FORMAT_DATETIME_FUNC_NAME, LOWER_CASE_FUNC_NAME, LTRIM_FUNC_NAME,
+    REGEXP_SUBSTR_FUNC_NAME, RTRIM_FUNC_NAME, SHA256_FUNC_NAME, UPPER_CASE_FUNC_NAME,
+    UUID_FUNC_NAME, UUIDV7_FUNC_NAME,
 };
 use crate::error::{Error, Result};
 use crate::pipeline::expr::join::{join, multi_join};

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
@@ -62,7 +62,7 @@ use datafusion::functions::core::expr_ext::FieldAccessor;
 use datafusion::functions::crypto::sha256;
 use datafusion::functions::datetime::to_char;
 use datafusion::functions::encoding::encode;
-use datafusion::functions::string::{concat, concat_ws, lower, replace, upper, uuid};
+use datafusion::functions::string::{concat, concat_ws, lower, replace, upper, uuid, ltrim, rtrim};
 use datafusion::logical_expr::expr::ScalarFunction;
 use datafusion::logical_expr::{
     BinaryExpr, ColumnarValue, Expr, Operator, ScalarUDF, cast, col, lit,
@@ -79,7 +79,7 @@ use otap_df_pdata::schema::consts;
 
 use crate::consts::{
     ENCODE_FUNC_NAME, FORMAT_DATETIME_FUNC_NAME, LOWER_CASE_FUNC_NAME, REGEXP_SUBSTR_FUNC_NAME,
-    SHA256_FUNC_NAME, UPPER_CASE_FUNC_NAME, UUID_FUNC_NAME, UUIDV7_FUNC_NAME,
+    SHA256_FUNC_NAME, UPPER_CASE_FUNC_NAME, UUID_FUNC_NAME, UUIDV7_FUNC_NAME, LTRIM_FUNC_NAME, RTRIM_FUNC_NAME
 };
 use crate::error::{Error, Result};
 use crate::pipeline::expr::join::{join, multi_join};
@@ -831,10 +831,12 @@ impl DataFusionFunctionDef {
         // upstream in datafusion_functions)
         Some(match func_name {
             ENCODE_FUNC_NAME => Self::new(encode(), ExprLogicalType::String, false, None),
+            LTRIM_FUNC_NAME => Self::new(ltrim(), ExprLogicalType::String, true, None),
             REGEXP_SUBSTR_FUNC_NAME => {
                 Self::new(regexp_substr(), ExprLogicalType::String, false, None)
             }
             FORMAT_DATETIME_FUNC_NAME => Self::new(to_char(), ExprLogicalType::String, false, None),
+            RTRIM_FUNC_NAME => Self::new(rtrim(), ExprLogicalType::String, true, None),
             SHA256_FUNC_NAME => Self::new(sha256(), ExprLogicalType::Binary, true, None),
             UUID_FUNC_NAME => Self::new(uuid(), ExprLogicalType::String, false, None),
             UUIDV7_FUNC_NAME => Self::new(uuidv7(), ExprLogicalType::String, false, None),


### PR DESCRIPTION
# Change Summary

Add ltrim and rtrim functions to the query engine

## What issue does this PR close?

* Closes #2820

## How are these changes tested?

Added 4 unit tests in pipeline/assign.rs covering both ltrim and rtrim with OPL and KQL parsers.

## Are there any user-facing changes? 

Yes. Users can now use ltrim and rtrim in OPL queries: 

`logs | set attributes["x"] = ltrim(attributes["x"], " ")`
`logs | set attributes["y"] = rtrim(attributes["y"], "\n")`
