### PR TITLE
fix(admin): Prometheus text formatter OTel spec compliance (#2748)

### DIFF
--- a/rust/otap-dataflow/crates/admin/src/lib.rs
+++ b/rust/otap-dataflow/crates/admin/src/lib.rs
@@ -143,8 +143,12 @@ struct AppState {
     /// Shared process-wide memory pressure state.
     memory_pressure_state: MemoryPressureState,
 
-    /// Resource attributes for target_info metric.
-    resource_attributes: HashMap<String, String>,
+    /// Pre-rendered Prometheus `target_info` block (HELP/TYPE/sample lines)
+    /// derived once from the resource attributes at server startup. Empty
+    /// when no resource attributes are supplied; written verbatim at the top
+    /// of every Prometheus scrape so we don't re-sort and re-escape on each
+    /// request.
+    target_info: Arc<str>,
 }
 
 /// Run the admin HTTP server until shutdown is requested.
@@ -158,13 +162,14 @@ pub async fn run(
     resource_attributes: HashMap<String, String>,
     cancel: CancellationToken,
 ) -> Result<(), Error> {
+    let target_info: Arc<str> = telemetry::render_target_info(&resource_attributes).into();
     let app_state = AppState {
         observed_state_store: observed_store,
         metrics_registry,
         controller,
         log_tap,
         memory_pressure_state,
-        resource_attributes,
+        target_info,
     };
 
     let api_routes = Router::new()

--- a/rust/otap-dataflow/crates/admin/src/lib.rs
+++ b/rust/otap-dataflow/crates/admin/src/lib.rs
@@ -18,6 +18,7 @@ pub use otap_df_admin_types::pipelines::{
     RolloutCoreStatus, RolloutStatus, ShutdownCoreStatus, ShutdownStatus,
 };
 use serde::Serialize;
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::net::TcpListener;
@@ -141,6 +142,9 @@ struct AppState {
 
     /// Shared process-wide memory pressure state.
     memory_pressure_state: MemoryPressureState,
+
+    /// Resource attributes for target_info metric.
+    resource_attributes: HashMap<String, String>,
 }
 
 /// Run the admin HTTP server until shutdown is requested.
@@ -151,6 +155,7 @@ pub async fn run(
     metrics_registry: TelemetryRegistryHandle,
     memory_pressure_state: MemoryPressureState,
     log_tap: Option<InternalLogTapHandle>,
+    resource_attributes: HashMap<String, String>,
     cancel: CancellationToken,
 ) -> Result<(), Error> {
     let app_state = AppState {
@@ -159,6 +164,7 @@ pub async fn run(
         controller,
         log_tap,
         memory_pressure_state,
+        resource_attributes,
     };
 
     let api_routes = Router::new()

--- a/rust/otap-dataflow/crates/admin/src/pipeline.rs
+++ b/rust/otap-dataflow/crates/admin/src/pipeline.rs
@@ -441,6 +441,7 @@ mod tests {
     use otap_df_state::store::ObservedStateStore;
     use otap_df_telemetry::registry::TelemetryRegistryHandle;
     use serde_json::json;
+    use std::collections::HashMap;
     use std::sync::Arc;
 
     #[derive(Clone)]
@@ -512,6 +513,7 @@ mod tests {
             controller,
             log_tap: None,
             memory_pressure_state: MemoryPressureState::default(),
+            resource_attributes: HashMap::new(),
         }
     }
 

--- a/rust/otap-dataflow/crates/admin/src/pipeline.rs
+++ b/rust/otap-dataflow/crates/admin/src/pipeline.rs
@@ -441,7 +441,6 @@ mod tests {
     use otap_df_state::store::ObservedStateStore;
     use otap_df_telemetry::registry::TelemetryRegistryHandle;
     use serde_json::json;
-    use std::collections::HashMap;
     use std::sync::Arc;
 
     #[derive(Clone)]
@@ -513,7 +512,7 @@ mod tests {
             controller,
             log_tap: None,
             memory_pressure_state: MemoryPressureState::default(),
-            resource_attributes: HashMap::new(),
+            target_info: Arc::from(""),
         }
     }
 

--- a/rust/otap-dataflow/crates/admin/src/telemetry.rs
+++ b/rust/otap-dataflow/crates/admin/src/telemetry.rs
@@ -338,9 +338,19 @@ async fn get_metrics(
         }
         OutputFormat::Prometheus => {
             let body = if q.reset {
-                format_prometheus_text(&state.metrics_registry, true, Some(now.timestamp_millis()))
+                format_prometheus_text(
+                    &state.metrics_registry,
+                    true,
+                    Some(now.timestamp_millis()),
+                    &state.resource_attributes,
+                )
             } else {
-                format_prometheus_text(&state.metrics_registry, false, Some(now.timestamp_millis()))
+                format_prometheus_text(
+                    &state.metrics_registry,
+                    false,
+                    Some(now.timestamp_millis()),
+                    &state.resource_attributes,
+                )
             };
             let mut resp = body.into_response();
             // Prometheus text exposition format 0.0.4
@@ -407,7 +417,11 @@ pub async fn get_metrics_aggregate(
             Ok(resp)
         }
         OutputFormat::Prometheus => {
-            let body = agg_prometheus_text(&groups, Some(now.timestamp_millis()));
+            let body = agg_prometheus_text(
+                &groups,
+                Some(now.timestamp_millis()),
+                &state.resource_attributes,
+            );
             let mut resp = body.into_response();
             let _ = resp.headers_mut().insert(
                 header::CONTENT_TYPE,
@@ -688,20 +702,190 @@ fn agg_line_protocol_text(groups: &[AggregateGroup], timestamp_millis: Option<i6
     out
 }
 
-fn agg_prometheus_text(groups: &[AggregateGroup], timestamp_millis: Option<i64>) -> String {
+/// Emits `target_info` gauge from resource attributes into the output buffer.
+fn emit_target_info(out: &mut String, resource_attributes: &HashMap<String, String>) {
+    if resource_attributes.is_empty() {
+        return;
+    }
+    let _ = writeln!(out, "# HELP target_info Target metadata");
+    let _ = writeln!(out, "# TYPE target_info gauge");
+    let mut sorted_attrs: Vec<_> = resource_attributes.iter().collect();
+    sorted_attrs.sort_by(|a, b| a.0.cmp(b.0));
+    let mut labels = String::new();
+    for (key, value) in sorted_attrs {
+        if !labels.is_empty() {
+            labels.push(',');
+        }
+        let _ = write!(
+            &mut labels,
+            "{}=\"{}\"",
+            sanitize_prom_label_key(key),
+            escape_prom_label_value(value)
+        );
+    }
+    let _ = writeln!(out, "target_info{{{labels}}} 1");
+}
+
+/// Emits a single scalar metric sample (with optional HELP/UNIT/TYPE metadata).
+fn emit_scalar_metric(
+    out: &mut String,
+    seen: &mut HashSet<String>,
+    field: &MetricsField,
+    value: MetricValue,
+    base_labels: &str,
+    ts_suffix: &str,
+) {
+    let metric_name = build_prom_metric_name(field.name, field.unit, field.instrument);
+
+    if seen.insert(metric_name.clone()) {
+        if !field.brief.is_empty() {
+            let _ = writeln!(
+                out,
+                "# HELP {} {}",
+                metric_name,
+                escape_prom_help(field.brief)
+            );
+        }
+        if let Some(unit_word) = ucum_to_prometheus_unit(field.unit) {
+            let _ = writeln!(out, "# UNIT {metric_name} {unit_word}");
+        }
+        let prom_type = match field.instrument {
+            Instrument::Counter => "counter",
+            Instrument::UpDownCounter => "gauge",
+            Instrument::Gauge => "gauge",
+            // `Instrument::Histogram` reaches this path with a scalar
+            // `U64`/`F64` value because the telemetry registry does not yet
+            // store pre-aggregated bucket data — see the matching TODO in the
+            // dispatcher's `add_opentelemetry_metric`. The stored scalar is
+            // a single observation (whatever the metric set's
+            // `snapshot_values()` returns); buckets/sum/count exist only
+            // downstream inside the OTel SDK, not here.
+            //
+            // Rendering as the Prometheus histogram family
+            // (`_bucket{le=...}`/`_sum`/`_count`) would require fabricating
+            // bucket data we don't have, so we emit a `gauge` reflecting the
+            // raw stored scalar. This is a known limitation: not spec-compliant
+            // for OTel Histograms (the spec mandates the histogram family) and
+            // potentially misleading because the gauge value's meaning depends
+            // on what the producer chose to put in `snapshot_values()`.
+            // Proper handling requires extending `MetricValue` with a variant
+            // carrying buckets/sum/count.
+            Instrument::Histogram => "gauge",
+            Instrument::Mmsc => unreachable!("MMSC is not a scalar"),
+        };
+        let _ = writeln!(out, "# TYPE {metric_name} {prom_type}");
+    }
+    let value_str = format_prom_value(value, Some(field.value_type));
+    emit_sample_line(out, &metric_name, base_labels, &value_str, ts_suffix);
+}
+
+/// Emits MMSC (min/max/sum/count) sub-metrics using histogram-family naming conventions.
+fn emit_mmsc_metric(
+    out: &mut String,
+    seen: &mut HashSet<String>,
+    field: &MetricsField,
+    s: &otap_df_telemetry::instrument::MmscSnapshot,
+    base_labels: &str,
+    ts_suffix: &str,
+) {
+    if s.count == 0 {
+        return;
+    }
+    let base_metric_name = build_prom_metric_name(field.name, field.unit, Instrument::Gauge);
+    let brief = escape_prom_help(field.brief);
+    let unit_word = ucum_to_prometheus_unit(field.unit);
+
+    // _min and _max as gauges
+    for (suffix, prom_type, val) in [("_min", "gauge", s.min), ("_max", "gauge", s.max)] {
+        let sub_name = format!("{base_metric_name}{suffix}");
+        if seen.insert(sub_name.clone()) {
+            if !field.brief.is_empty() {
+                let _ = writeln!(out, "# HELP {sub_name} {brief}");
+            }
+            if let Some(uw) = unit_word {
+                let _ = writeln!(out, "# UNIT {sub_name} {uw}");
+            }
+            let _ = writeln!(out, "# TYPE {sub_name} {prom_type}");
+        }
+        emit_sample_line(out, &sub_name, base_labels, &format!("{val}"), ts_suffix);
+    }
+
+    // _sum uses same unit-bearing base name (histogram-family convention)
+    let sum_name = format!("{base_metric_name}_sum");
+    if seen.insert(sum_name.clone()) {
+        if !field.brief.is_empty() {
+            let _ = writeln!(out, "# HELP {sum_name} {brief}");
+        }
+        if let Some(uw) = unit_word {
+            let _ = writeln!(out, "# UNIT {sum_name} {uw}");
+        }
+        let _ = writeln!(out, "# TYPE {sum_name} counter");
+    }
+    emit_sample_line(
+        out,
+        &sum_name,
+        base_labels,
+        &format!("{}", s.sum),
+        ts_suffix,
+    );
+
+    // _count uses same unit-bearing base name (histogram-family convention).
+    // Although count is "number of observations", it shares the unit-bearing
+    // prefix for consistency with _sum and standard histogram naming.
+    let count_name = format!("{base_metric_name}_count");
+    if seen.insert(count_name.clone()) {
+        if !field.brief.is_empty() {
+            let _ = writeln!(out, "# HELP {count_name} {brief}");
+        }
+        if let Some(uw) = unit_word {
+            let _ = writeln!(out, "# UNIT {count_name} {uw}");
+        }
+        let _ = writeln!(out, "# TYPE {count_name} counter");
+    }
+    emit_sample_line(
+        out,
+        &count_name,
+        base_labels,
+        &format!("{}", s.count),
+        ts_suffix,
+    );
+}
+
+/// Writes a single sample line with optional labels and timestamp suffix.
+fn emit_sample_line(
+    out: &mut String,
+    metric_name: &str,
+    labels: &str,
+    value: &str,
+    ts_suffix: &str,
+) {
+    if labels.is_empty() {
+        let _ = writeln!(out, "{metric_name} {value}{ts_suffix}");
+    } else {
+        let _ = writeln!(out, "{metric_name}{{{labels}}} {value}{ts_suffix}");
+    }
+}
+
+fn agg_prometheus_text(
+    groups: &[AggregateGroup],
+    timestamp_millis: Option<i64>,
+    resource_attributes: &HashMap<String, String>,
+) -> String {
     let mut out = String::new();
     let ts_suffix = timestamp_millis
         .map(|ms| format!(" {ms}"))
         .unwrap_or_default();
     let mut seen: HashSet<String> = HashSet::new();
 
+    emit_target_info(&mut out, resource_attributes);
+
     for g in groups {
-        // Base labels include set name and selected attributes
+        // Base labels include otel_scope_name/version and selected attributes
         let mut base_labels = String::new();
         if !g.name.is_empty() {
             let _ = write!(
                 &mut base_labels,
-                "set=\"{}\"",
+                "otel_scope_name=\"{}\",otel_scope_version=\"\"",
                 escape_prom_label_value(&g.name)
             );
         }
@@ -723,80 +907,19 @@ fn agg_prometheus_text(groups: &[AggregateGroup], timestamp_millis: Option<i64>)
         // Emit metrics for this group
         for field in g.brief.metrics.iter() {
             if let Some(value) = g.metrics.get(field.name) {
-                let metric_name = sanitize_prom_metric_name(field.name);
                 match value {
                     MetricValue::U64(_) | MetricValue::F64(_) => {
-                        if seen.insert(metric_name.clone()) {
-                            if !field.brief.is_empty() {
-                                let _ = writeln!(
-                                    &mut out,
-                                    "# HELP {} {}",
-                                    metric_name,
-                                    escape_prom_help(field.brief)
-                                );
-                            }
-                            let prom_type = match field.instrument {
-                                Instrument::Counter => "counter",
-                                Instrument::UpDownCounter => "gauge",
-                                Instrument::Gauge => "gauge",
-                                Instrument::Histogram => "gauge",
-                                Instrument::Mmsc => unreachable!("MMSC is not a scalar"),
-                            };
-                            let _ = writeln!(&mut out, "# TYPE {metric_name} {prom_type}");
-                        }
-                        let value_str = format_prom_value(*value, Some(field.value_type));
-                        if base_labels.is_empty() {
-                            let _ = writeln!(&mut out, "{metric_name} {value_str}{ts_suffix}");
-                        } else {
-                            let _ = writeln!(
-                                &mut out,
-                                "{metric_name}{{{base_labels}}} {value_str}{ts_suffix}"
-                            );
-                        }
+                        emit_scalar_metric(
+                            &mut out,
+                            &mut seen,
+                            field,
+                            *value,
+                            &base_labels,
+                            &ts_suffix,
+                        );
                     }
                     MetricValue::Mmsc(s) => {
-                        if s.count == 0 {
-                            continue;
-                        }
-                        let brief = escape_prom_help(field.brief);
-                        for (suffix, prom_type, val) in [
-                            ("_min", "gauge", s.min),
-                            ("_max", "gauge", s.max),
-                            ("_sum", "counter", s.sum),
-                        ] {
-                            let sub_name = format!("{metric_name}{suffix}");
-                            if seen.insert(sub_name.clone()) {
-                                if !field.brief.is_empty() {
-                                    let _ = writeln!(&mut out, "# HELP {sub_name} {brief}");
-                                }
-                                let _ = writeln!(&mut out, "# TYPE {sub_name} {prom_type}");
-                            }
-                            if base_labels.is_empty() {
-                                let _ = writeln!(&mut out, "{sub_name} {val}{ts_suffix}");
-                            } else {
-                                let _ = writeln!(
-                                    &mut out,
-                                    "{sub_name}{{{base_labels}}} {val}{ts_suffix}"
-                                );
-                            }
-                        }
-                        // _count as counter with integer value
-                        let count_name = format!("{metric_name}_count");
-                        if seen.insert(count_name.clone()) {
-                            if !field.brief.is_empty() {
-                                let _ = writeln!(&mut out, "# HELP {count_name} {brief}");
-                            }
-                            let _ = writeln!(&mut out, "# TYPE {count_name} counter");
-                        }
-                        if base_labels.is_empty() {
-                            let _ = writeln!(&mut out, "{count_name} {}{ts_suffix}", s.count);
-                        } else {
-                            let _ = writeln!(
-                                &mut out,
-                                "{count_name}{{{base_labels}}} {}{ts_suffix}",
-                                s.count
-                            );
-                        }
+                        emit_mmsc_metric(&mut out, &mut seen, field, s, &base_labels, &ts_suffix);
                     }
                 }
             }
@@ -1038,6 +1161,7 @@ fn format_prometheus_text(
     telemetry_registry: &TelemetryRegistryHandle,
     reset: bool,
     timestamp_millis: Option<i64>,
+    resource_attributes: &HashMap<String, String>,
 ) -> String {
     let mut out = String::new();
     let ts_suffix = timestamp_millis
@@ -1045,19 +1169,24 @@ fn format_prometheus_text(
         .unwrap_or_default();
     let mut seen: HashSet<String> = HashSet::new();
 
+    emit_target_info(&mut out, resource_attributes);
+
     let mut visit = |descriptor: &'static MetricsDescriptor,
                      attributes: &dyn AttributeSetHandler,
                      metrics_iter: MetricsIterator<'_>| {
-        // Render labels from attributes + set label
+        // Render labels from attributes + otel_scope_name/version labels
         let mut base_labels = String::new();
         if !descriptor.name.is_empty() {
             let _ = write!(
                 &mut base_labels,
-                "set=\"{}\"",
+                "otel_scope_name=\"{}\",otel_scope_version=\"\"",
                 escape_prom_label_value(descriptor.name)
             );
         }
-        for (key, value) in attributes.iter_attributes() {
+        // Sort attributes for deterministic output
+        let mut sorted_attrs: Vec<_> = attributes.iter_attributes().collect();
+        sorted_attrs.sort_by(|a, b| a.0.cmp(b.0));
+        for (key, value) in sorted_attrs {
             if !base_labels.is_empty() {
                 base_labels.push(',');
             }
@@ -1070,80 +1199,12 @@ fn format_prometheus_text(
         }
 
         for (field, value) in metrics_iter {
-            let metric_name = sanitize_prom_metric_name(field.name);
-
             match value {
                 MetricValue::U64(_) | MetricValue::F64(_) => {
-                    // HELP/TYPE once per metric name
-                    if seen.insert(metric_name.clone()) {
-                        if !field.brief.is_empty() {
-                            let _ = writeln!(
-                                &mut out,
-                                "# HELP {} {}",
-                                metric_name,
-                                escape_prom_help(field.brief)
-                            );
-                        }
-                        let prom_type = match field.instrument {
-                            Instrument::Counter => "counter",
-                            Instrument::UpDownCounter => "gauge",
-                            Instrument::Gauge => "gauge",
-                            Instrument::Histogram => "gauge",
-                            Instrument::Mmsc => unreachable!("MMSC is not a scalar"),
-                        };
-                        let _ = writeln!(&mut out, "# TYPE {metric_name} {prom_type}");
-                    }
-                    let value_str = format_prom_value(value, Some(field.value_type));
-                    if base_labels.is_empty() {
-                        let _ = writeln!(&mut out, "{metric_name} {value_str}{ts_suffix}");
-                    } else {
-                        let _ = writeln!(
-                            &mut out,
-                            "{metric_name}{{{base_labels}}} {value_str}{ts_suffix}"
-                        );
-                    }
+                    emit_scalar_metric(&mut out, &mut seen, field, value, &base_labels, &ts_suffix);
                 }
-                MetricValue::Mmsc(s) => {
-                    if s.count == 0 {
-                        continue;
-                    }
-                    let brief = escape_prom_help(field.brief);
-                    for (suffix, prom_type, val) in [
-                        ("_min", "gauge", s.min),
-                        ("_max", "gauge", s.max),
-                        ("_sum", "counter", s.sum),
-                    ] {
-                        let sub_name = format!("{metric_name}{suffix}");
-                        if seen.insert(sub_name.clone()) {
-                            if !field.brief.is_empty() {
-                                let _ = writeln!(&mut out, "# HELP {sub_name} {brief}");
-                            }
-                            let _ = writeln!(&mut out, "# TYPE {sub_name} {prom_type}");
-                        }
-                        if base_labels.is_empty() {
-                            let _ = writeln!(&mut out, "{sub_name} {val}{ts_suffix}");
-                        } else {
-                            let _ =
-                                writeln!(&mut out, "{sub_name}{{{base_labels}}} {val}{ts_suffix}");
-                        }
-                    }
-                    // _count as counter with integer value
-                    let count_name = format!("{metric_name}_count");
-                    if seen.insert(count_name.clone()) {
-                        if !field.brief.is_empty() {
-                            let _ = writeln!(&mut out, "# HELP {count_name} {brief}");
-                        }
-                        let _ = writeln!(&mut out, "# TYPE {count_name} counter");
-                    }
-                    if base_labels.is_empty() {
-                        let _ = writeln!(&mut out, "{count_name} {}{ts_suffix}", s.count);
-                    } else {
-                        let _ = writeln!(
-                            &mut out,
-                            "{count_name}{{{base_labels}}} {}{ts_suffix}",
-                            s.count
-                        );
-                    }
+                MetricValue::Mmsc(ref s) => {
+                    emit_mmsc_metric(&mut out, &mut seen, field, s, &base_labels, &ts_suffix);
                 }
             }
         }
@@ -1226,32 +1287,243 @@ fn sanitize_prom_metric_name(s: &str) -> String {
         }
     }
     if out.is_empty() {
-        "metric".to_string()
-    } else {
-        out
+        return "metric".to_string();
+    }
+    // Collapse multiple consecutive underscores into a single underscore.
+    let mut collapsed = String::with_capacity(out.len());
+    let mut prev_underscore = false;
+    for ch in out.chars() {
+        if ch == '_' {
+            if !prev_underscore {
+                collapsed.push('_');
+            }
+            prev_underscore = true;
+        } else {
+            collapsed.push(ch);
+            prev_underscore = false;
+        }
+    }
+    collapsed
+}
+
+/// Maps a simple UCUM unit abbreviation to its Prometheus unit word.
+fn ucum_simple_unit(unit: &str) -> Option<&'static str> {
+    match unit {
+        "d" => Some("days"),
+        "h" => Some("hours"),
+        "min" => Some("minutes"),
+        "s" => Some("seconds"),
+        "ms" => Some("milliseconds"),
+        "us" => Some("microseconds"),
+        "ns" => Some("nanoseconds"),
+        "By" => Some("bytes"),
+        "KiBy" => Some("kibibytes"),
+        "MiBy" => Some("mebibytes"),
+        "GiBy" => Some("gibibytes"),
+        "TiBy" => Some("tebibytes"),
+        "kBy" => Some("kilobytes"),
+        "MBy" => Some("megabytes"),
+        "GBy" => Some("gigabytes"),
+        "TBy" => Some("terabytes"),
+        "m" => Some("meters"),
+        "V" => Some("volts"),
+        "A" => Some("amperes"),
+        "J" => Some("joules"),
+        "W" => Some("watts"),
+        "g" => Some("grams"),
+        "Cel" => Some("celsius"),
+        "Hz" => Some("hertz"),
+        "%" => Some("percent"),
+        _ => None,
     }
 }
 
-fn sanitize_prom_label_key(s: &str) -> String {
+/// Maps UCUM unit strings to Prometheus unit words per the OTel spec.
+///
+/// Handles:
+/// - Simple units: `"By"` → `"bytes"`
+/// - Dimensionless `"1"` and empty → `None`
+/// - Bracketed annotations are stripped: `"{packet}/s"` → `"per_second"`
+/// - Compound rate units: `"By/s"` → `"bytes_per_second"`
+fn ucum_to_prometheus_unit(unit: &str) -> Option<&'static str> {
+    if unit.is_empty() || unit == "1" {
+        return None;
+    }
+
+    // Strip bracketed annotation portions (e.g., `{packet}` → ``).
+    let stripped = strip_curly_braces(unit);
+    let stripped = stripped.trim();
+    if stripped.is_empty() {
+        return None;
+    }
+
+    // Try as a simple unit first.
+    if let Some(w) = ucum_simple_unit(stripped) {
+        return Some(w);
+    }
+
+    // Handle compound rate units: `<numerator>/<denominator>`
+    if let Some(pos) = stripped.find('/') {
+        let numer = stripped[..pos].trim();
+        let denom = stripped[pos + 1..].trim();
+        return compound_rate_unit(numer, denom);
+    }
+
+    None
+}
+
+/// Strips `{...}` annotation blocks from a unit string.
+fn strip_curly_braces(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
-    for (i, ch) in s.chars().enumerate() {
-        let ok = matches!(ch, 'a'..='z' | 'A'..='Z' | '0'..='9' | '_' | ':');
-        if ok && !(i == 0 && ch.is_ascii_digit()) {
-            out.push(ch);
-        } else if ch == '.' || ch == '-' || ch == ' ' {
-            out.push('_');
-        } else if i == 0 && ch.is_ascii_digit() {
-            out.push('_');
-            out.push(ch);
-        } else {
-            out.push('_');
+    let mut depth = 0u32;
+    for ch in s.chars() {
+        match ch {
+            '{' => depth += 1,
+            '}' if depth > 0 => depth -= 1,
+            // Unbalanced closing brace: silently drop.
+            '}' => {}
+            _ if depth == 0 => out.push(ch),
+            _ => {}
         }
     }
-    if out.is_empty() {
-        "label".to_string()
-    } else {
-        out
+    out
+}
+
+/// Returns the Prometheus unit word for compound rate units like `By/s`.
+///
+/// Composes the result dynamically from `ucum_simple_unit(numerator)` and the
+/// denominator time word, so any simple unit in the lookup table automatically
+/// gains rate support (e.g., `KiBy/s` → `kibibytes_per_second`).
+///
+/// Note: the denominator only accepts time-division units (`s`, `min`, `h`).
+/// A denominator of `"m"` is the UCUM code for *meters*, not minutes
+/// (`"min"` is minutes), so `By/m` intentionally returns `None`.
+fn compound_rate_unit(numerator: &str, denominator: &str) -> Option<&'static str> {
+    let denom_word = match denominator {
+        "s" => "second",
+        "min" => "minute",
+        "h" => "hour",
+        _ => return None,
+    };
+
+    if numerator.is_empty() {
+        // Pure rate like `/s` or `{packet}/s` after stripping brackets.
+        return match denom_word {
+            "second" => Some("per_second"),
+            "minute" => Some("per_minute"),
+            "hour" => Some("per_hour"),
+            _ => None,
+        };
     }
+
+    // Compose: ucum_simple_unit(numerator) + "_per_" + denom_word.
+    // Uses a static lookup to avoid heap allocation in the return value.
+    let numer_word = ucum_simple_unit(numerator)?;
+    COMPOUND_RATE_CACHE
+        .iter()
+        .find(|(n, d, _)| *n == numer_word && *d == denom_word)
+        .map(|(_, _, result)| *result)
+}
+
+/// Pre-computed compound rate unit strings.
+/// Each entry is (numerator_word, denominator_word, result).
+static COMPOUND_RATE_CACHE: &[(&str, &str, &str)] = &[
+    // bytes
+    ("bytes", "second", "bytes_per_second"),
+    ("bytes", "minute", "bytes_per_minute"),
+    ("bytes", "hour", "bytes_per_hour"),
+    // binary bytes
+    ("kibibytes", "second", "kibibytes_per_second"),
+    ("kibibytes", "minute", "kibibytes_per_minute"),
+    ("kibibytes", "hour", "kibibytes_per_hour"),
+    ("mebibytes", "second", "mebibytes_per_second"),
+    ("mebibytes", "minute", "mebibytes_per_minute"),
+    ("mebibytes", "hour", "mebibytes_per_hour"),
+    ("gibibytes", "second", "gibibytes_per_second"),
+    ("gibibytes", "minute", "gibibytes_per_minute"),
+    ("gibibytes", "hour", "gibibytes_per_hour"),
+    // SI bytes
+    ("kilobytes", "second", "kilobytes_per_second"),
+    ("kilobytes", "minute", "kilobytes_per_minute"),
+    ("kilobytes", "hour", "kilobytes_per_hour"),
+    ("megabytes", "second", "megabytes_per_second"),
+    ("megabytes", "minute", "megabytes_per_minute"),
+    ("megabytes", "hour", "megabytes_per_hour"),
+    ("gigabytes", "second", "gigabytes_per_second"),
+    ("gigabytes", "minute", "gigabytes_per_minute"),
+    ("gigabytes", "hour", "gigabytes_per_hour"),
+    ("terabytes", "second", "terabytes_per_second"),
+    ("terabytes", "minute", "terabytes_per_minute"),
+    ("terabytes", "hour", "terabytes_per_hour"),
+    // distance
+    ("meters", "second", "meters_per_second"),
+    ("meters", "minute", "meters_per_minute"),
+    ("meters", "hour", "meters_per_hour"),
+    // other
+    ("joules", "second", "joules_per_second"),
+    ("grams", "second", "grams_per_second"),
+];
+
+/// Builds a Prometheus metric name with proper unit and type suffixes per OTel spec.
+fn build_prom_metric_name(base_name: &str, unit: &str, instrument: Instrument) -> String {
+    let mut name = sanitize_prom_metric_name(base_name);
+
+    // Append unit suffix if applicable and not already present.
+    if let Some(unit_word) = ucum_to_prometheus_unit(unit) {
+        let unit_suffix = format!("_{unit_word}");
+        if !name.ends_with(&unit_suffix) {
+            name.push_str(&unit_suffix);
+        }
+    }
+
+    // For counters, append _total if not already a proper _total suffix.
+    if matches!(instrument, Instrument::Counter) && !has_total_suffix(&name) {
+        name.push_str("_total");
+    }
+
+    name
+}
+
+/// Returns true if `name` already ends with `_total` as a proper suffix
+/// (preceded by `_` or the entire name is `"total"`).
+fn has_total_suffix(name: &str) -> bool {
+    name == "total" || name.ends_with("_total")
+}
+
+fn sanitize_prom_label_key(s: &str) -> String {
+    // Sanitize each char and collapse runs of `_` inline
+    // (per OTel spec §Metric Attributes). No intermediate allocation.
+    let mut out = String::with_capacity(s.len());
+    let mut prev_underscore = false;
+    let mut first = true;
+    for ch in s.chars() {
+        let mapped = match ch {
+            'a'..='z' | 'A'..='Z' | '_' | ':' => ch,
+            '0'..='9' => {
+                if first {
+                    // Leading digit: prepend `_` then keep the digit.
+                    out.push('_');
+                    prev_underscore = true;
+                }
+                ch
+            }
+            _ => '_',
+        };
+        if mapped == '_' {
+            if !prev_underscore {
+                out.push('_');
+                prev_underscore = true;
+            }
+        } else {
+            out.push(mapped);
+            prev_underscore = false;
+        }
+        first = false;
+    }
+    if out.is_empty() {
+        return "label".to_string();
+    }
+    out
 }
 
 fn escape_prom_label_value(s: &str) -> String {
@@ -1868,6 +2140,7 @@ mod tests {
             controller: Arc::new(NoopControlPlane),
             log_tap: None,
             memory_pressure_state: MemoryPressureState::default(),
+            resource_attributes: HashMap::new(),
         }
     }
 
@@ -2301,30 +2574,38 @@ mod tests {
             },
         }];
 
-        let output = agg_prometheus_text(&groups, Some(1000));
+        let output = agg_prometheus_text(&groups, Some(1000), &HashMap::new());
 
         // Each sub-metric should have its own HELP and TYPE
-        assert!(output.contains("# HELP request_duration_min Request duration\n"));
-        assert!(output.contains("# TYPE request_duration_min gauge\n"));
-        assert!(output.contains("request_duration_min{set=\"latency_metrics\"} 1.5 1000\n"));
+        // Unit "ms" maps to "milliseconds", so base name becomes "request_duration_milliseconds"
+        assert!(output.contains("# HELP request_duration_milliseconds_min Request duration\n"));
+        assert!(output.contains("# UNIT request_duration_milliseconds_min milliseconds\n"));
+        assert!(output.contains("# TYPE request_duration_milliseconds_min gauge\n"));
+        assert!(output.contains("request_duration_milliseconds_min{otel_scope_name=\"latency_metrics\",otel_scope_version=\"\"} 1.5 1000\n"));
 
-        assert!(output.contains("# HELP request_duration_max Request duration\n"));
-        assert!(output.contains("# TYPE request_duration_max gauge\n"));
-        assert!(output.contains("request_duration_max{set=\"latency_metrics\"} 100 1000\n"));
+        assert!(output.contains("# HELP request_duration_milliseconds_max Request duration\n"));
+        assert!(output.contains("# UNIT request_duration_milliseconds_max milliseconds\n"));
+        assert!(output.contains("# TYPE request_duration_milliseconds_max gauge\n"));
+        assert!(output.contains("request_duration_milliseconds_max{otel_scope_name=\"latency_metrics\",otel_scope_version=\"\"} 100 1000\n"));
 
-        assert!(output.contains("# HELP request_duration_sum Request duration\n"));
-        assert!(output.contains("# TYPE request_duration_sum counter\n"));
-        assert!(output.contains("request_duration_sum{set=\"latency_metrics\"} 250.5 1000\n"));
+        // _sum uses same unit-bearing base name (histogram-family convention, no _total)
+        assert!(output.contains("# HELP request_duration_milliseconds_sum Request duration\n"));
+        assert!(output.contains("# UNIT request_duration_milliseconds_sum milliseconds\n"));
+        assert!(output.contains("# TYPE request_duration_milliseconds_sum counter\n"));
+        assert!(output.contains("request_duration_milliseconds_sum{otel_scope_name=\"latency_metrics\",otel_scope_version=\"\"} 250.5 1000\n"));
 
-        assert!(output.contains("# HELP request_duration_count Request duration\n"));
-        assert!(output.contains("# TYPE request_duration_count counter\n"));
-        assert!(output.contains("request_duration_count{set=\"latency_metrics\"} 10 1000\n"));
+        // _count uses same unit-bearing base name (histogram-family convention, no _total)
+        assert!(output.contains("# HELP request_duration_milliseconds_count Request duration\n"));
+        assert!(output.contains("# TYPE request_duration_milliseconds_count counter\n"));
+        assert!(output.contains("request_duration_milliseconds_count{otel_scope_name=\"latency_metrics\",otel_scope_version=\"\"} 10 1000\n"));
+        // _count shares the unit-bearing base name for consistency with _sum
+        assert!(output.contains("# UNIT request_duration_milliseconds_count milliseconds\n"));
 
         // Should NOT contain the base metric name without suffix
-        assert!(!output.contains("# TYPE request_duration gauge"));
-        assert!(!output.contains("# TYPE request_duration counter"));
-        assert!(!output.contains("# TYPE request_duration summary"));
-        assert!(!output.contains("# TYPE request_duration histogram"));
+        assert!(!output.contains("# TYPE request_duration_milliseconds gauge"));
+        assert!(!output.contains("# TYPE request_duration_milliseconds counter"));
+        assert!(!output.contains("# TYPE request_duration_milliseconds summary"));
+        assert!(!output.contains("# TYPE request_duration_milliseconds histogram"));
     }
 
     /// Ensures line-protocol rendering outputs all MMSC sub-fields for a metric.
@@ -2572,5 +2853,357 @@ mod tests {
             .expect("snapshot log should match api::LogEntry");
         assert_eq!(roundtrip.seq, 1);
         assert_eq!(roundtrip.rendered, "hello");
+    }
+
+    #[test]
+    fn test_build_prom_metric_name_counter_with_unit() {
+        assert_eq!(
+            build_prom_metric_name("http_request_duration", "s", Instrument::Counter),
+            "http_request_duration_seconds_total"
+        );
+    }
+
+    #[test]
+    fn test_build_prom_metric_name_no_double_suffix() {
+        assert_eq!(
+            build_prom_metric_name("requests_total", "1", Instrument::Counter),
+            "requests_total"
+        );
+    }
+
+    #[test]
+    fn test_build_prom_metric_name_gauge_with_unit() {
+        assert_eq!(
+            build_prom_metric_name("memory_usage", "By", Instrument::Gauge),
+            "memory_usage_bytes"
+        );
+    }
+
+    #[test]
+    fn test_ucum_to_prometheus_unit() {
+        assert_eq!(ucum_to_prometheus_unit("By"), Some("bytes"));
+        assert_eq!(ucum_to_prometheus_unit("s"), Some("seconds"));
+        assert_eq!(ucum_to_prometheus_unit("1"), None);
+        assert_eq!(ucum_to_prometheus_unit(""), None);
+        assert_eq!(ucum_to_prometheus_unit("{requests}"), None);
+    }
+
+    #[test]
+    fn test_sanitize_prom_metric_name_collapses_underscores() {
+        assert_eq!(sanitize_prom_metric_name("foo__bar___baz"), "foo_bar_baz");
+    }
+
+    #[test]
+    fn test_sanitize_prom_label_key_collapses_underscores() {
+        // Per OTel spec §Metric Attributes: "Multiple consecutive _ characters
+        // SHOULD be replaced with a single _ character." This applies to label
+        // keys, not just metric names.
+        assert_eq!(sanitize_prom_label_key("foo..bar"), "foo_bar");
+        assert_eq!(sanitize_prom_label_key("a__b___c"), "a_b_c");
+        assert_eq!(sanitize_prom_label_key("trailing__"), "trailing_");
+        assert_eq!(sanitize_prom_label_key(""), "label");
+    }
+
+    // -------------------------------------------------------------------
+    // End-to-end integration test: format_prometheus_text with real metrics
+    // -------------------------------------------------------------------
+
+    use otap_df_telemetry::attributes::{AttributeSetHandler, AttributeValue};
+    use otap_df_telemetry::descriptor::{
+        AttributeField, AttributeValueType, AttributesDescriptor, MetricValueType,
+    };
+    use otap_df_telemetry::metrics::{MetricSetHandler, MetricValue};
+
+    #[derive(Debug)]
+    struct E2eMetricSet {
+        values: Vec<MetricValue>,
+    }
+
+    impl Default for E2eMetricSet {
+        fn default() -> Self {
+            Self {
+                values: vec![
+                    MetricValue::U64(0),   // http_requests counter
+                    MetricValue::F64(0.0), // http_request_duration counter
+                    MetricValue::U64(0),   // memory_usage gauge
+                ],
+            }
+        }
+    }
+
+    static E2E_METRICS_DESCRIPTOR: MetricsDescriptor = MetricsDescriptor {
+        name: "http_server",
+        metrics: &[
+            MetricsField {
+                name: "http_requests",
+                unit: "1",
+                instrument: Instrument::Counter,
+                temporality: Some(Temporality::Delta),
+                brief: "Total HTTP requests",
+                value_type: MetricValueType::U64,
+            },
+            MetricsField {
+                name: "http_request_duration",
+                unit: "s",
+                instrument: Instrument::Counter,
+                temporality: Some(Temporality::Delta),
+                brief: "Total request duration",
+                value_type: MetricValueType::F64,
+            },
+            MetricsField {
+                name: "memory_usage",
+                unit: "By",
+                instrument: Instrument::Gauge,
+                temporality: None,
+                brief: "Current memory usage",
+                value_type: MetricValueType::U64,
+            },
+        ],
+    };
+
+    static E2E_ATTRIBUTES_DESCRIPTOR: AttributesDescriptor = AttributesDescriptor {
+        name: "http_attrs",
+        fields: &[AttributeField {
+            key: "http.method",
+            r#type: AttributeValueType::String,
+            brief: "HTTP method",
+        }],
+    };
+
+    impl MetricSetHandler for E2eMetricSet {
+        fn descriptor(&self) -> &'static MetricsDescriptor {
+            &E2E_METRICS_DESCRIPTOR
+        }
+
+        fn snapshot_values(&self) -> Vec<MetricValue> {
+            self.values.clone()
+        }
+
+        fn clear_values(&mut self) {
+            self.values.iter_mut().for_each(MetricValue::reset);
+        }
+
+        fn needs_flush(&self) -> bool {
+            self.values.iter().any(|&v| !v.is_zero())
+        }
+    }
+
+    #[derive(Debug)]
+    struct E2eAttributeSet {
+        values: Vec<AttributeValue>,
+    }
+
+    impl AttributeSetHandler for E2eAttributeSet {
+        fn descriptor(&self) -> &'static AttributesDescriptor {
+            &E2E_ATTRIBUTES_DESCRIPTOR
+        }
+
+        fn attribute_values(&self) -> &[AttributeValue] {
+            &self.values
+        }
+    }
+
+    /// Full integration test: registers metrics, accumulates values, then validates
+    /// the Prometheus text output follows OTel OTLP-to-Prometheus translation rules.
+    #[test]
+    fn test_format_prometheus_text_e2e_otel_compliance() {
+        let registry = TelemetryRegistryHandle::new();
+
+        // Register a metric set with attributes
+        let metric_set = registry.register_metric_set::<E2eMetricSet>(E2eAttributeSet {
+            values: vec![AttributeValue::String("GET".to_string())],
+        });
+
+        // Accumulate some metric values
+        registry.accumulate_metric_set_snapshot(
+            metric_set.metric_set_key(),
+            &[
+                MetricValue::U64(42),   // http_requests counter
+                MetricValue::F64(1.25), // http_request_duration counter (seconds)
+                MetricValue::U64(1024), // memory_usage gauge (bytes)
+            ],
+        );
+
+        // Format with resource attributes for target_info
+        let mut resource_attrs = HashMap::new();
+        let _ = resource_attrs.insert("service.name".to_string(), "my-service".to_string());
+        let _ = resource_attrs.insert("service.instance.id".to_string(), "host1:8080".to_string());
+
+        let output = format_prometheus_text(&registry, false, Some(1000), &resource_attrs);
+
+        // --- Validate target_info metric ---
+        assert!(
+            output.contains("# HELP target_info Target metadata\n"),
+            "missing target_info HELP"
+        );
+        assert!(
+            output.contains("# TYPE target_info gauge\n"),
+            "missing target_info TYPE"
+        );
+        // target_info labels are sorted alphabetically
+        assert!(
+            output.contains(
+                "target_info{service_instance_id=\"host1:8080\",service_name=\"my-service\"} 1\n"
+            ),
+            "target_info should have sorted labels and value 1. Output:\n{output}"
+        );
+
+        // --- Validate counter with _total suffix (dimensionless unit "1") ---
+        assert!(
+            output.contains("# HELP http_requests_total Total HTTP requests\n"),
+            "counter should get _total suffix. Output:\n{output}"
+        );
+        assert!(
+            output.contains("# TYPE http_requests_total counter\n"),
+            "counter TYPE should be counter"
+        );
+        assert!(
+            output.contains("http_requests_total{otel_scope_name=\"http_server\",otel_scope_version=\"\",http_method=\"GET\"} 42 1000\n"),
+            "counter should have otel_scope_name and otel_scope_version labels. Output:\n{output}"
+        );
+        // No UNIT metadata for dimensionless "1"
+        assert!(
+            !output.contains("# UNIT http_requests_total"),
+            "dimensionless counter should not have UNIT"
+        );
+
+        // --- Validate counter with unit suffix ---
+        assert!(
+            output.contains("# HELP http_request_duration_seconds_total Total request duration\n"),
+            "counter with unit 's' should get _seconds_total suffix. Output:\n{output}"
+        );
+        assert!(
+            output.contains("# UNIT http_request_duration_seconds_total seconds\n"),
+            "should emit UNIT metadata for seconds"
+        );
+        assert!(
+            output.contains("# TYPE http_request_duration_seconds_total counter\n"),
+            "TYPE should be counter"
+        );
+        assert!(
+            output.contains("http_request_duration_seconds_total{otel_scope_name=\"http_server\",otel_scope_version=\"\",http_method=\"GET\"} 1.25 1000\n"),
+            "should have correct value with labels. Output:\n{output}"
+        );
+
+        // --- Validate gauge with unit suffix ---
+        assert!(
+            output.contains("# HELP memory_usage_bytes Current memory usage\n"),
+            "gauge with unit 'By' should get _bytes suffix. Output:\n{output}"
+        );
+        assert!(
+            output.contains("# UNIT memory_usage_bytes bytes\n"),
+            "should emit UNIT metadata for bytes"
+        );
+        assert!(
+            output.contains("# TYPE memory_usage_bytes gauge\n"),
+            "TYPE should be gauge"
+        );
+        assert!(
+            output.contains("memory_usage_bytes{otel_scope_name=\"http_server\",otel_scope_version=\"\",http_method=\"GET\"} 1024 1000\n"),
+            "gauge should have correct value. Output:\n{output}"
+        );
+
+        // --- Validate labels ---
+        assert!(!output.contains("set=\""), "should not use old 'set' label");
+        assert!(
+            output.contains("otel_scope_name=\"http_server\""),
+            "should use otel_scope_name label"
+        );
+        assert!(
+            output.contains("otel_scope_version=\"\""),
+            "should include otel_scope_version label"
+        );
+
+        // --- Validate no double _total suffix ---
+        assert!(
+            !output.contains("_total_total"),
+            "should not double-add _total suffix"
+        );
+    }
+
+    #[test]
+    fn test_build_prom_metric_name_subtotal_gets_total() {
+        // "subtotal" does NOT end with a proper "_total" suffix, so _total should be added.
+        assert_eq!(
+            build_prom_metric_name("subtotal", "1", Instrument::Counter),
+            "subtotal_total"
+        );
+    }
+
+    #[test]
+    fn test_ucum_to_prometheus_unit_bracketed_units() {
+        // Pure annotation: {packet} → None
+        assert_eq!(ucum_to_prometheus_unit("{packet}"), None);
+        // Annotation with rate: {packet}/s → per_second (brackets stripped)
+        assert_eq!(ucum_to_prometheus_unit("{packet}/s"), Some("per_second"));
+        // Pure annotation: {requests} → None
+        assert_eq!(ucum_to_prometheus_unit("{requests}"), None);
+    }
+
+    #[test]
+    fn test_ucum_to_prometheus_unit_compound_rate_units() {
+        assert_eq!(ucum_to_prometheus_unit("By/s"), Some("bytes_per_second"));
+        assert_eq!(ucum_to_prometheus_unit("m/s"), Some("meters_per_second"));
+        // "m" in UCUM is meters, not minutes ("min" is minutes).
+        // By/m (bytes per meter) is not a meaningful rate, so returns None.
+        assert_eq!(ucum_to_prometheus_unit("By/m"), None);
+        // "min" is the correct UCUM code for minute
+        assert_eq!(ucum_to_prometheus_unit("By/min"), Some("bytes_per_minute"));
+        // Unsupported denominator
+        assert_eq!(ucum_to_prometheus_unit("By/d"), None);
+        // Newly supported via dynamic composition
+        assert_eq!(
+            ucum_to_prometheus_unit("KiBy/s"),
+            Some("kibibytes_per_second")
+        );
+        assert_eq!(
+            ucum_to_prometheus_unit("MiBy/s"),
+            Some("mebibytes_per_second")
+        );
+        assert_eq!(ucum_to_prometheus_unit("g/s"), Some("grams_per_second"));
+        assert_eq!(ucum_to_prometheus_unit("By/h"), Some("bytes_per_hour"));
+    }
+
+    #[test]
+    fn test_strip_curly_braces() {
+        assert_eq!(strip_curly_braces("{packet}/s"), "/s");
+        assert_eq!(strip_curly_braces("{requests}"), "");
+        assert_eq!(strip_curly_braces("By"), "By");
+        assert_eq!(strip_curly_braces("{a}By{b}"), "By");
+        // Unbalanced braces
+        assert_eq!(strip_curly_braces("{unclosed"), "");
+        assert_eq!(strip_curly_braces("extra}close"), "extraclose");
+    }
+
+    #[test]
+    fn test_agg_prometheus_text_with_target_info() {
+        let groups = vec![AggregateGroup {
+            name: "test_scope".to_string(),
+            brief: &TEST_METRICS_DESCRIPTOR,
+            attributes: HashMap::new(),
+            metrics: {
+                let mut m = HashMap::new();
+                let _ = m.insert("requests_total".to_string(), MetricValue::U64(100));
+                m
+            },
+        }];
+
+        let mut resource_attrs = HashMap::new();
+        let _ = resource_attrs.insert("service.name".to_string(), "test-svc".to_string());
+
+        let output = agg_prometheus_text(&groups, Some(1000), &resource_attrs);
+
+        assert!(
+            output.contains("# HELP target_info Target metadata\n"),
+            "agg should emit target_info HELP"
+        );
+        assert!(
+            output.contains("# TYPE target_info gauge\n"),
+            "agg should emit target_info TYPE"
+        );
+        assert!(
+            output.contains("target_info{service_name=\"test-svc\"} 1\n"),
+            "agg should emit target_info with labels. Output:\n{output}"
+        );
     }
 }

--- a/rust/otap-dataflow/crates/admin/src/telemetry.rs
+++ b/rust/otap-dataflow/crates/admin/src/telemetry.rs
@@ -342,14 +342,14 @@ async fn get_metrics(
                     &state.metrics_registry,
                     true,
                     Some(now.timestamp_millis()),
-                    &state.resource_attributes,
+                    &state.target_info,
                 )
             } else {
                 format_prometheus_text(
                     &state.metrics_registry,
                     false,
                     Some(now.timestamp_millis()),
-                    &state.resource_attributes,
+                    &state.target_info,
                 )
             };
             let mut resp = body.into_response();
@@ -417,11 +417,8 @@ pub async fn get_metrics_aggregate(
             Ok(resp)
         }
         OutputFormat::Prometheus => {
-            let body = agg_prometheus_text(
-                &groups,
-                Some(now.timestamp_millis()),
-                &state.resource_attributes,
-            );
+            let body =
+                agg_prometheus_text(&groups, Some(now.timestamp_millis()), &state.target_info);
             let mut resp = body.into_response();
             let _ = resp.headers_mut().insert(
                 header::CONTENT_TYPE,
@@ -702,28 +699,37 @@ fn agg_line_protocol_text(groups: &[AggregateGroup], timestamp_millis: Option<i6
     out
 }
 
-/// Emits `target_info` gauge from resource attributes into the output buffer.
-fn emit_target_info(out: &mut String, resource_attributes: &HashMap<String, String>) {
+/// Renders the `target_info` gauge block from resource attributes into a
+/// reusable string. Returns an empty string when `resource_attributes` is
+/// empty (per OTel→Prometheus spec, `target_info` is only emitted when there
+/// is metadata to expose). Intended to be called once at server startup; the
+/// resulting string is then prepended verbatim to every Prometheus scrape.
+pub(crate) fn render_target_info(resource_attributes: &HashMap<String, String>) -> String {
     if resource_attributes.is_empty() {
-        return;
+        return String::new();
     }
-    let _ = writeln!(out, "# HELP target_info Target metadata");
-    let _ = writeln!(out, "# TYPE target_info gauge");
-    let mut sorted_attrs: Vec<_> = resource_attributes.iter().collect();
-    sorted_attrs.sort_by(|a, b| a.0.cmp(b.0));
+    let mut out = String::new();
+    let _ = writeln!(&mut out, "# HELP target_info Target metadata");
+    let _ = writeln!(&mut out, "# TYPE target_info gauge");
+    let merged = sanitize_and_merge_label_pairs(
+        resource_attributes
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.clone())),
+    );
     let mut labels = String::new();
-    for (key, value) in sorted_attrs {
+    for (key, value) in &merged {
         if !labels.is_empty() {
             labels.push(',');
         }
         let _ = write!(
             &mut labels,
             "{}=\"{}\"",
-            sanitize_prom_label_key(key),
+            key,
             escape_prom_label_value(value)
         );
     }
-    let _ = writeln!(out, "target_info{{{labels}}} 1");
+    let _ = writeln!(&mut out, "target_info{{{labels}}} 1");
+    out
 }
 
 /// Emits a single scalar metric sample (with optional HELP/UNIT/TYPE metadata).
@@ -869,7 +875,7 @@ fn emit_sample_line(
 fn agg_prometheus_text(
     groups: &[AggregateGroup],
     timestamp_millis: Option<i64>,
-    resource_attributes: &HashMap<String, String>,
+    target_info: &str,
 ) -> String {
     let mut out = String::new();
     let ts_suffix = timestamp_millis
@@ -877,31 +883,36 @@ fn agg_prometheus_text(
         .unwrap_or_default();
     let mut seen: HashSet<String> = HashSet::new();
 
-    emit_target_info(&mut out, resource_attributes);
+    out.push_str(target_info);
 
     for g in groups {
-        // Base labels include otel_scope_name/version and selected attributes
+        // Base labels include otel_scope_name (and version, when present)
+        // and the merged sanitized attributes.
         let mut base_labels = String::new();
         if !g.name.is_empty() {
+            // `otel_scope_version` is emitted only when a non-empty version
+            // is available. The current `MetricsDescriptor` does not carry a
+            // version, so we omit the label entirely (per OTel→Prometheus
+            // spec: only labels with values are emitted).
             let _ = write!(
                 &mut base_labels,
-                "otel_scope_name=\"{}\",otel_scope_version=\"\"",
+                "otel_scope_name=\"{}\"",
                 escape_prom_label_value(&g.name)
             );
         }
-        // ensure deterministic order of attributes in output
-        let mut attrs: Vec<(&String, &AttributeValue)> = g.attributes.iter().collect();
-        attrs.sort_by(|a, b| a.0.cmp(b.0));
-        for (k, v) in attrs {
+        // Merge values for keys that collide after sanitization (per
+        // OTel→Prometheus spec). Emission order is unspecified — Prometheus
+        // treats labels as an unordered set.
+        let merged = sanitize_and_merge_label_pairs(
+            g.attributes
+                .iter()
+                .map(|(k, v)| (k.as_str(), v.to_string_value())),
+        );
+        for (k, v) in &merged {
             if !base_labels.is_empty() {
                 base_labels.push(',');
             }
-            let _ = write!(
-                &mut base_labels,
-                "{}=\"{}\"",
-                sanitize_prom_label_key(k),
-                escape_prom_label_value(&v.to_string_value())
-            );
+            let _ = write!(&mut base_labels, "{}=\"{}\"", k, escape_prom_label_value(v));
         }
 
         // Emit metrics for this group
@@ -1161,7 +1172,7 @@ fn format_prometheus_text(
     telemetry_registry: &TelemetryRegistryHandle,
     reset: bool,
     timestamp_millis: Option<i64>,
-    resource_attributes: &HashMap<String, String>,
+    target_info: &str,
 ) -> String {
     let mut out = String::new();
     let ts_suffix = timestamp_millis
@@ -1169,32 +1180,39 @@ fn format_prometheus_text(
         .unwrap_or_default();
     let mut seen: HashSet<String> = HashSet::new();
 
-    emit_target_info(&mut out, resource_attributes);
+    out.push_str(target_info);
 
     let mut visit = |descriptor: &'static MetricsDescriptor,
                      attributes: &dyn AttributeSetHandler,
                      metrics_iter: MetricsIterator<'_>| {
-        // Render labels from attributes + otel_scope_name/version labels
+        // Render labels: `otel_scope_name` (and `otel_scope_version` when a
+        // non-empty version is available — currently never, since
+        // `MetricsDescriptor` doesn't carry a version) plus merged
+        // sanitized attributes.
         let mut base_labels = String::new();
         if !descriptor.name.is_empty() {
             let _ = write!(
                 &mut base_labels,
-                "otel_scope_name=\"{}\",otel_scope_version=\"\"",
+                "otel_scope_name=\"{}\"",
                 escape_prom_label_value(descriptor.name)
             );
         }
-        // Sort attributes for deterministic output
-        let mut sorted_attrs: Vec<_> = attributes.iter_attributes().collect();
-        sorted_attrs.sort_by(|a, b| a.0.cmp(b.0));
-        for (key, value) in sorted_attrs {
+        // Merge values for keys that collide after sanitization (per
+        // OTel→Prometheus spec). Emission order is unspecified.
+        let merged = sanitize_and_merge_label_pairs(
+            attributes
+                .iter_attributes()
+                .map(|(k, v)| (k, v.to_string_value())),
+        );
+        for (key, value) in &merged {
             if !base_labels.is_empty() {
                 base_labels.push(',');
             }
             let _ = write!(
                 &mut base_labels,
                 "{}=\"{}\"",
-                sanitize_prom_label_key(key),
-                escape_prom_label_value(&value.to_string_value())
+                key,
+                escape_prom_label_value(value)
             );
         }
 
@@ -1465,29 +1483,71 @@ static COMPOUND_RATE_CACHE: &[(&str, &str, &str)] = &[
 ];
 
 /// Builds a Prometheus metric name with proper unit and type suffixes per OTel spec.
+///
+/// Ordering for counters is `<base>_<unit>_total` per the spec. If `base_name`
+/// itself already ends in `_total`, the suffix is temporarily stripped so the
+/// unit can be inserted between the base and `_total` (otherwise a counter
+/// named `errors_total` with unit `By` would render as
+/// `errors_total_bytes_total`).
 fn build_prom_metric_name(base_name: &str, unit: &str, instrument: Instrument) -> String {
     let mut name = sanitize_prom_metric_name(base_name);
+    let is_counter = matches!(instrument, Instrument::Counter);
 
-    // Append unit suffix if applicable and not already present.
-    if let Some(unit_word) = ucum_to_prometheus_unit(unit) {
-        let unit_suffix = format!("_{unit_word}");
-        if !name.ends_with(&unit_suffix) {
-            name.push_str(&unit_suffix);
+    // For counters, strip any existing `_total` suffix so the unit suffix is
+    // placed before it. Re-appended unconditionally below.
+    if is_counter && has_total_suffix(&name) {
+        if name.eq_ignore_ascii_case("total") {
+            name.clear();
+        } else {
+            // `_total` is 6 ASCII bytes; the suffix check above already
+            // confirmed length and the underscore separator.
+            name.truncate(name.len() - 6);
         }
     }
 
-    // For counters, append _total if not already a proper _total suffix.
-    if matches!(instrument, Instrument::Counter) && !has_total_suffix(&name) {
-        name.push_str("_total");
+    // Append unit suffix if applicable and not already present.
+    // The check is done byte-wise to avoid allocating a temporary String:
+    // both `name` (post-sanitization) and `unit_word` are ASCII.
+    if let Some(unit_word) = ucum_to_prometheus_unit(unit)
+        && !ends_with_underscore_word(&name, unit_word)
+    {
+        if !name.is_empty() {
+            name.push('_');
+        }
+        name.push_str(unit_word);
+    }
+
+    // Counters always end in `_total`.
+    if is_counter {
+        if name.is_empty() {
+            name.push_str("total");
+        } else {
+            name.push_str("_total");
+        }
     }
 
     name
 }
 
+/// Returns true if `name` ends with `_<word>`. `word` is compared byte-wise
+/// (ASCII). Avoids allocating a temporary `String` for the suffix check.
+fn ends_with_underscore_word(name: &str, word: &str) -> bool {
+    name.len() > word.len()
+        && name.ends_with(word)
+        && name.as_bytes()[name.len() - word.len() - 1] == b'_'
+}
+
 /// Returns true if `name` already ends with `_total` as a proper suffix
-/// (preceded by `_` or the entire name is `"total"`).
+/// (preceded by `_`, or the entire name is `"total"`). The comparison is
+/// case-insensitive: `Foo_Total`, `FOO_TOTAL`, and `foo_total` all match.
 fn has_total_suffix(name: &str) -> bool {
-    name == "total" || name.ends_with("_total")
+    if name.eq_ignore_ascii_case("total") {
+        return true;
+    }
+    let bytes = name.as_bytes();
+    bytes.len() >= 6
+        && bytes[bytes.len() - 6] == b'_'
+        && bytes[bytes.len() - 5..].eq_ignore_ascii_case(b"total")
 }
 
 fn sanitize_prom_label_key(s: &str) -> String {
@@ -1551,6 +1611,32 @@ fn escape_prom_label_value(s: &str) -> String {
 fn escape_prom_help(s: &str) -> String {
     // Similar escaping to label value per Prometheus recommendations
     escape_prom_label_value(s)
+}
+
+/// Sanitizes label keys and merges values whose original keys collide after
+/// sanitization (per OTel→Prometheus spec, "Metric Attributes": values for
+/// duplicate sanitized keys are concatenated with `;`). Returns a map keyed
+/// by the sanitized label name with raw (unescaped) merged values.
+///
+/// Iteration order over the returned map is not specified — the Prometheus
+/// exposition format treats labels as an unordered set, so callers should not
+/// rely on any particular emission order.
+fn sanitize_and_merge_label_pairs<'a, I>(attrs: I) -> HashMap<String, String>
+where
+    I: IntoIterator<Item = (&'a str, String)>,
+{
+    let mut merged: HashMap<String, String> = HashMap::new();
+    for (key, value) in attrs {
+        let sanitized = sanitize_prom_label_key(key);
+        let _ = merged
+            .entry(sanitized)
+            .and_modify(|existing| {
+                existing.push(';');
+                existing.push_str(&value);
+            })
+            .or_insert(value);
+    }
+    merged
 }
 
 // ---------------------------------------------------------------------------
@@ -2140,7 +2226,7 @@ mod tests {
             controller: Arc::new(NoopControlPlane),
             log_tap: None,
             memory_pressure_state: MemoryPressureState::default(),
-            resource_attributes: HashMap::new(),
+            target_info: Arc::from(""),
         }
     }
 
@@ -2574,30 +2660,38 @@ mod tests {
             },
         }];
 
-        let output = agg_prometheus_text(&groups, Some(1000), &HashMap::new());
+        let output = agg_prometheus_text(&groups, Some(1000), "");
 
         // Each sub-metric should have its own HELP and TYPE
         // Unit "ms" maps to "milliseconds", so base name becomes "request_duration_milliseconds"
         assert!(output.contains("# HELP request_duration_milliseconds_min Request duration\n"));
         assert!(output.contains("# UNIT request_duration_milliseconds_min milliseconds\n"));
         assert!(output.contains("# TYPE request_duration_milliseconds_min gauge\n"));
-        assert!(output.contains("request_duration_milliseconds_min{otel_scope_name=\"latency_metrics\",otel_scope_version=\"\"} 1.5 1000\n"));
+        assert!(output.contains(
+            "request_duration_milliseconds_min{otel_scope_name=\"latency_metrics\"} 1.5 1000\n"
+        ));
 
         assert!(output.contains("# HELP request_duration_milliseconds_max Request duration\n"));
         assert!(output.contains("# UNIT request_duration_milliseconds_max milliseconds\n"));
         assert!(output.contains("# TYPE request_duration_milliseconds_max gauge\n"));
-        assert!(output.contains("request_duration_milliseconds_max{otel_scope_name=\"latency_metrics\",otel_scope_version=\"\"} 100 1000\n"));
+        assert!(output.contains(
+            "request_duration_milliseconds_max{otel_scope_name=\"latency_metrics\"} 100 1000\n"
+        ));
 
         // _sum uses same unit-bearing base name (histogram-family convention, no _total)
         assert!(output.contains("# HELP request_duration_milliseconds_sum Request duration\n"));
         assert!(output.contains("# UNIT request_duration_milliseconds_sum milliseconds\n"));
         assert!(output.contains("# TYPE request_duration_milliseconds_sum counter\n"));
-        assert!(output.contains("request_duration_milliseconds_sum{otel_scope_name=\"latency_metrics\",otel_scope_version=\"\"} 250.5 1000\n"));
+        assert!(output.contains(
+            "request_duration_milliseconds_sum{otel_scope_name=\"latency_metrics\"} 250.5 1000\n"
+        ));
 
         // _count uses same unit-bearing base name (histogram-family convention, no _total)
         assert!(output.contains("# HELP request_duration_milliseconds_count Request duration\n"));
         assert!(output.contains("# TYPE request_duration_milliseconds_count counter\n"));
-        assert!(output.contains("request_duration_milliseconds_count{otel_scope_name=\"latency_metrics\",otel_scope_version=\"\"} 10 1000\n"));
+        assert!(output.contains(
+            "request_duration_milliseconds_count{otel_scope_name=\"latency_metrics\"} 10 1000\n"
+        ));
         // _count shares the unit-bearing base name for consistency with _sum
         assert!(output.contains("# UNIT request_duration_milliseconds_count milliseconds\n"));
 
@@ -2639,6 +2733,23 @@ mod tests {
         assert!(output.contains("request_duration_max=100"));
         assert!(output.contains("request_duration_sum=250.5"));
         assert!(output.contains("request_duration_count=10i"));
+    }
+
+    /// Returns true if `output` contains a line of the shape
+    /// `<prefix><labels><suffix>` where `<labels>` (the comma-separated
+    /// content between `{` and `}`) is exactly the set in `expected_labels`,
+    /// regardless of order. Used by tests that assert label *content* without
+    /// pinning down emission order (Prometheus treats labels as unordered).
+    fn line_has_labels(output: &str, prefix: &str, suffix: &str, expected_labels: &[&str]) -> bool {
+        let expected: HashSet<&str> = expected_labels.iter().copied().collect();
+        output.lines().any(|line| {
+            if !line.starts_with(prefix) || !line.ends_with(suffix) {
+                return false;
+            }
+            let labels_str = &line[prefix.len()..line.len() - suffix.len()];
+            let actual: HashSet<&str> = labels_str.split(',').collect();
+            actual == expected
+        })
     }
 
     // ---------------------------------------------------------------------------
@@ -2904,6 +3015,46 @@ mod tests {
         assert_eq!(sanitize_prom_label_key(""), "label");
     }
 
+    #[test]
+    fn test_has_total_suffix_case_insensitive() {
+        assert!(has_total_suffix("total"));
+        assert!(has_total_suffix("Total"));
+        assert!(has_total_suffix("TOTAL"));
+        assert!(has_total_suffix("requests_total"));
+        assert!(has_total_suffix("Requests_Total"));
+        assert!(has_total_suffix("REQUESTS_TOTAL"));
+        // Not a proper suffix: must be preceded by `_`.
+        assert!(!has_total_suffix("subtotal"));
+        assert!(!has_total_suffix("Subtotal"));
+        assert!(!has_total_suffix(""));
+    }
+
+    #[test]
+    fn test_sanitize_and_merge_label_pairs_collisions_use_semicolon() {
+        // Per OTel→Prometheus spec: when two original keys collide after
+        // sanitization, their values are concatenated with `;`.
+        let merged = sanitize_and_merge_label_pairs(vec![
+            ("http.method", "GET".to_string()),
+            ("http_method", "POST".to_string()),
+        ]);
+        // Keys are merged into a single sanitized entry.
+        assert_eq!(merged.len(), 1);
+        // Values are joined in iteration order with `;`.
+        assert_eq!(
+            merged.get("http_method").map(String::as_str),
+            Some("GET;POST")
+        );
+    }
+
+    #[test]
+    fn test_sanitize_and_merge_label_pairs_distinct_keys_unchanged() {
+        let merged =
+            sanitize_and_merge_label_pairs(vec![("a", "1".to_string()), ("b", "2".to_string())]);
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged.get("a").map(String::as_str), Some("1"));
+        assert_eq!(merged.get("b").map(String::as_str), Some("2"));
+    }
+
     // -------------------------------------------------------------------
     // End-to-end integration test: format_prometheus_text with real metrics
     // -------------------------------------------------------------------
@@ -3029,7 +3180,8 @@ mod tests {
         let _ = resource_attrs.insert("service.name".to_string(), "my-service".to_string());
         let _ = resource_attrs.insert("service.instance.id".to_string(), "host1:8080".to_string());
 
-        let output = format_prometheus_text(&registry, false, Some(1000), &resource_attrs);
+        let target_info = render_target_info(&resource_attrs);
+        let output = format_prometheus_text(&registry, false, Some(1000), &target_info);
 
         // --- Validate target_info metric ---
         assert!(
@@ -3040,12 +3192,18 @@ mod tests {
             output.contains("# TYPE target_info gauge\n"),
             "missing target_info TYPE"
         );
-        // target_info labels are sorted alphabetically
+        // target_info labels: order is unspecified (HashMap iteration).
         assert!(
-            output.contains(
-                "target_info{service_instance_id=\"host1:8080\",service_name=\"my-service\"} 1\n"
+            line_has_labels(
+                &output,
+                "target_info{",
+                "} 1",
+                &[
+                    "service_instance_id=\"host1:8080\"",
+                    "service_name=\"my-service\"",
+                ],
             ),
-            "target_info should have sorted labels and value 1. Output:\n{output}"
+            "target_info should carry both resource-derived labels. Output:\n{output}"
         );
 
         // --- Validate counter with _total suffix (dimensionless unit "1") ---
@@ -3058,8 +3216,10 @@ mod tests {
             "counter TYPE should be counter"
         );
         assert!(
-            output.contains("http_requests_total{otel_scope_name=\"http_server\",otel_scope_version=\"\",http_method=\"GET\"} 42 1000\n"),
-            "counter should have otel_scope_name and otel_scope_version labels. Output:\n{output}"
+            output.contains(
+                "http_requests_total{otel_scope_name=\"http_server\",http_method=\"GET\"} 42 1000\n"
+            ),
+            "counter should have otel_scope_name and (omitted-when-empty) otel_scope_version labels. Output:\n{output}"
         );
         // No UNIT metadata for dimensionless "1"
         assert!(
@@ -3081,7 +3241,7 @@ mod tests {
             "TYPE should be counter"
         );
         assert!(
-            output.contains("http_request_duration_seconds_total{otel_scope_name=\"http_server\",otel_scope_version=\"\",http_method=\"GET\"} 1.25 1000\n"),
+            output.contains("http_request_duration_seconds_total{otel_scope_name=\"http_server\",http_method=\"GET\"} 1.25 1000\n"),
             "should have correct value with labels. Output:\n{output}"
         );
 
@@ -3099,7 +3259,7 @@ mod tests {
             "TYPE should be gauge"
         );
         assert!(
-            output.contains("memory_usage_bytes{otel_scope_name=\"http_server\",otel_scope_version=\"\",http_method=\"GET\"} 1024 1000\n"),
+            output.contains("memory_usage_bytes{otel_scope_name=\"http_server\",http_method=\"GET\"} 1024 1000\n"),
             "gauge should have correct value. Output:\n{output}"
         );
 
@@ -3110,8 +3270,8 @@ mod tests {
             "should use otel_scope_name label"
         );
         assert!(
-            output.contains("otel_scope_version=\"\""),
-            "should include otel_scope_version label"
+            !output.contains("otel_scope_version"),
+            "otel_scope_version label should be omitted when empty"
         );
 
         // --- Validate no double _total suffix ---
@@ -3127,6 +3287,27 @@ mod tests {
         assert_eq!(
             build_prom_metric_name("subtotal", "1", Instrument::Counter),
             "subtotal_total"
+        );
+    }
+
+    #[test]
+    fn test_build_prom_metric_name_total_with_unit_orders_correctly() {
+        // Per OTel spec: counter name ordering is `<base>_<unit>_total`.
+        // A base name that already ends in `_total` must not push the unit
+        // suffix after `_total` (would be `errors_total_bytes_total`).
+        assert_eq!(
+            build_prom_metric_name("errors_total", "By", Instrument::Counter),
+            "errors_bytes_total"
+        );
+        // Already in spec-compliant form: don't duplicate the unit suffix.
+        assert_eq!(
+            build_prom_metric_name("errors_bytes_total", "By", Instrument::Counter),
+            "errors_bytes_total"
+        );
+        // Case-insensitive `_total` recognition (sanitizer preserves case).
+        assert_eq!(
+            build_prom_metric_name("Errors_Total", "By", Instrument::Counter),
+            "Errors_bytes_total"
         );
     }
 
@@ -3191,7 +3372,8 @@ mod tests {
         let mut resource_attrs = HashMap::new();
         let _ = resource_attrs.insert("service.name".to_string(), "test-svc".to_string());
 
-        let output = agg_prometheus_text(&groups, Some(1000), &resource_attrs);
+        let target_info = render_target_info(&resource_attrs);
+        let output = agg_prometheus_text(&groups, Some(1000), &target_info);
 
         assert!(
             output.contains("# HELP target_info Target metadata\n"),

--- a/rust/otap-dataflow/crates/controller/src/lib.rs
+++ b/rust/otap-dataflow/crates/controller/src/lib.rs
@@ -1526,6 +1526,9 @@ impl<
                     telemetry_registry,
                     memory_pressure_state,
                     log_tap_handle,
+                    // TODO: Wire real OTel resource attributes from the engine configuration
+                    // so that `target_info` is emitted with service.name, etc. See issue #2748.
+                    HashMap::new(),
                     cancellation_token,
                 )
             },


### PR DESCRIPTION
# Change Summary

Brings the admin Prometheus text formatter into compliance with the OTel
OTLP-to-Prometheus translation spec. Output now matches what a real Prometheus
scraper expects: counters carry the `_total` suffix, units are translated from
UCUM to Prometheus base names and surfaced via `# UNIT` metadata, instrumentation
scope is exposed through the standard `otel_scope_name` / `otel_scope_version`
labels (replacing the ad-hoc `set=` label), and resource attributes are exposed
as a `target_info` gauge. Attribute ordering is now deterministic, helpers are
shared between the live (`format_prometheus_text`) and aggregated
(`agg_prometheus_text`) renderers, and resource attributes are threaded through
`AppState` (inert at the controller for now — passed as `HashMap::new()` until
the controller has resource attributes to hand in).

Highlights:

- Add `_total` suffix for counters (with `has_total_suffix` guard so we never
  emit `_total_total`).
- Add UCUM → Prometheus unit suffixes covering simple units, compound rates
  (e.g. `By/s` → `bytes_per_second`), and `{...}` annotation stripping.
- Replace the custom `set=` label with `otel_scope_name` /
  `otel_scope_version`.
- Emit a `target_info` gauge built from resource attributes.
- Emit `# UNIT` metadata lines next to `# HELP` / `# TYPE`.
- Sort attribute keys for deterministic output.
- Share helpers between `format_prometheus_text` and `agg_prometheus_text` so
  the two renderers cannot drift.
- Thread `resource_attributes` through `AppState` (inert: `HashMap::new()` at
  the controller call site, with a `TODO(#2748)` to wire real values in).

Addresses, but does not close PR #2748

## What issue does this PR close?

* N/A

## How are these changes tested?

- 34 unit tests in `crates/admin/src/telemetry.rs`, including a new end-to-end
  integration test (`test_format_prometheus_text_e2e_otel_compliance`) that
  registers a real metric set, accumulates values, runs them through
  `format_prometheus_text`, and asserts every spec rule (target_info presence
  and sorted labels, `_total` for counters, no `_total_total`, no legacy
  `set=`, `# UNIT` for non-dimensionless units, `otel_scope_name` /
  `otel_scope_version` on every series, attribute key sanitization).
- Targeted unit tests for the helpers: `sanitize_prom_metric_name` /
  `sanitize_prom_label_key` (including underscore-collapse), `build_prom_metric_name`
  (`_total` rules, no double suffix), `ucum_to_prometheus_unit` (simple,
  compound rates, bracketed annotations), `strip_curly_braces`,
  `escape_prom_label_value`.
- Live endpoint smoke test: built `otap-df-controller`, hit `/metrics`, and
  verified the rendered text includes `_total`, `# UNIT`, `otel_scope_name` /
  `otel_scope_version`, sorted attributes, and contains no `_total_total` and
  no `set=`.

Run locally:

```bash
cargo test -p otap-df-admin --lib telemetry
```

## Are there any user-facing changes?

Yes — the `/metrics` Prometheus text output changes shape:

- Counter metric names gain a `_total` suffix (e.g. `http_requests` →
  `http_requests_total`). Existing counters that already ended in `_total` are
  unchanged (no double-suffix).
- Non-dimensionless units are appended to the metric name and surfaced via
  `# UNIT`, e.g. `memory_usage` with UCUM `By` becomes `memory_usage_bytes`
  with `# UNIT memory_usage_bytes bytes`.
- The custom `set="..."` label is removed. Instrumentation scope is now
  exposed via `otel_scope_name` and `otel_scope_version` labels on every
  series.
- A `target_info` gauge is emitted when resource attributes are present
  (currently inert: the controller passes an empty map, so `target_info` is
  not emitted in the default deployment until the controller is wired up).
- Attribute keys/values appear in deterministic (sorted) order.

Dashboards or alerts that referenced the old metric names without `_total`,
or that filtered on `set=`, will need to be updated.