### PR TITLE
feat(comparison_dashboard): Add DFE orchestrator and step templates

### DIFF
--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/orchestrator/dfe-single-core-multi-rate.yaml
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/orchestrator/dfe-single-core-multi-rate.yaml
@@ -1,0 +1,219 @@
+name: {{suite_name}}
+components:
+  load-generator:
+    deployment:
+      docker:
+        image: {{df_engine_image}}
+        network: testbed
+        ports:
+          - "8085:8080"
+        volumes:
+          - '{{data_dir}}/loadgen-config.rendered.yaml:/home/nonroot/config.yaml:ro'
+        command:
+          - "--config"
+          - "./config.yaml"
+          - "--http-admin-bind"
+          - "0.0.0.0:8080"
+    monitoring:
+      docker_component:
+        allocated_cores: 1
+      prometheus:
+        endpoint: http://localhost:8085/api/v1/telemetry/metrics?format=prometheus&reset=false
+  df-engine:
+    deployment:
+      docker:
+        image: {{df_engine_image}}
+        network: testbed
+        ports:
+          - "8086:8080"
+        volumes:
+          - '{{data_dir}}/engine-config.rendered.yaml:/home/nonroot/config.yaml:ro'
+        command:
+          - "--config"
+          - "./config.yaml"
+          - "--http-admin-bind"
+          - "0.0.0.0:8080"
+    monitoring:
+      docker_component:
+        allocated_cores: 1
+      prometheus:
+        endpoint: http://localhost:8086/api/v1/telemetry/metrics?format=prometheus&reset=false
+  backend-service:
+    deployment:
+      docker:
+        image: {{df_engine_image}}
+        network: testbed
+        ports:
+          - "8087:8080"
+        volumes:
+          - '{{data_dir}}/backend-config.rendered.yaml:/home/nonroot/config.yaml:ro'
+        command:
+          - "--config"
+          - "./config.yaml"
+          - "--http-admin-bind"
+          - "0.0.0.0:8080"
+    monitoring:
+      docker_component:
+        allocated_cores: 1
+      prometheus:
+        endpoint: http://localhost:8087/api/v1/telemetry/metrics?format=prometheus&reset=false
+
+{%- set signal = variables.signal | default("logs") %}
+{%- if signal == "logs" %}
+{%- set log_weight = 100 %}{%- set metric_weight = 0 %}{%- set trace_weight = 0 %}
+{%- elif signal == "metrics" %}
+{%- set log_weight = 0 %}{%- set metric_weight = 100 %}{%- set trace_weight = 0 %}
+{%- elif signal == "traces" %}
+{%- set log_weight = 0 %}{%- set metric_weight = 0 %}{%- set trace_weight = 100 %}
+{%- endif %}
+
+{# Spread every suite-defined variable as a flat key (so step/leaf templates can
+reference them by bare name) and forward the whole `variables` dict so any
+downstream template can also use namespaced access (`variables.X`). Per-test
+overrides below the spread win on key collision. #}
+{% macro forward_variables() -%}
+{%- for k, v in variables.items() %}
+        {{ k }}: {{ v | tojson }}
+{%- endfor %}
+        variables: {{ variables | tojson }}
+{%- endmacro -%}
+
+tests:
+  # 100k: 1 loadgen core
+  - name: 100k
+    from_template:
+      path: dashboard/templates/steps/df-engine.yaml
+      variables:{{ forward_variables() }}
+        data_dir: {{data_dir}}
+        test_dir: {{data_dir}}/tests/100k
+        report_name: "DF Engine 100k - {{suite_name}}"
+        observation_interval: {{observation_interval}}
+        signals_per_second: 100000
+        log_weight: {{log_weight}}
+        metric_weight: {{metric_weight}}
+        trace_weight: {{trace_weight}}
+        engine_core_start: 0
+        engine_core_end: 0
+        backend_core_start: 1
+        backend_core_end: 1
+        loadgen_core_start: 2
+        loadgen_core_end: 2
+
+  # 200k: 2 loadgen cores
+  - name: 200k
+    from_template:
+      path: dashboard/templates/steps/df-engine.yaml
+      variables:{{ forward_variables() }}
+        data_dir: {{data_dir}}
+        test_dir: {{data_dir}}/tests/200k
+        report_name: "DF Engine 200k - {{suite_name}}"
+        observation_interval: {{observation_interval}}
+        signals_per_second: 100000
+        log_weight: {{log_weight}}
+        metric_weight: {{metric_weight}}
+        trace_weight: {{trace_weight}}
+        engine_core_start: 0
+        engine_core_end: 0
+        backend_core_start: 1
+        backend_core_end: 1
+        loadgen_core_start: 2
+        loadgen_core_end: 3
+
+  # 300k: 3 loadgen cores
+  - name: 300k
+    from_template:
+      path: dashboard/templates/steps/df-engine.yaml
+      variables:{{ forward_variables() }}
+        data_dir: {{data_dir}}
+        test_dir: {{data_dir}}/tests/300k
+        report_name: "DF Engine 300k - {{suite_name}}"
+        observation_interval: {{observation_interval}}
+        signals_per_second: 100000
+        log_weight: {{log_weight}}
+        metric_weight: {{metric_weight}}
+        trace_weight: {{trace_weight}}
+        engine_core_start: 0
+        engine_core_end: 0
+        backend_core_start: 1
+        backend_core_end: 1
+        loadgen_core_start: 2
+        loadgen_core_end: 4
+
+  # 400k: 4 loadgen cores
+  - name: 400k
+    from_template:
+      path: dashboard/templates/steps/df-engine.yaml
+      variables:{{ forward_variables() }}
+        data_dir: {{data_dir}}
+        test_dir: {{data_dir}}/tests/400k
+        report_name: "DF Engine 400k - {{suite_name}}"
+        observation_interval: {{observation_interval}}
+        signals_per_second: 100000
+        log_weight: {{log_weight}}
+        metric_weight: {{metric_weight}}
+        trace_weight: {{trace_weight}}
+        engine_core_start: 0
+        engine_core_end: 0
+        backend_core_start: 1
+        backend_core_end: 1
+        loadgen_core_start: 2
+        loadgen_core_end: 5
+
+  - name: 600k
+    from_template:
+      path: dashboard/templates/steps/df-engine.yaml
+      variables:{{ forward_variables() }}
+        data_dir: {{data_dir}}
+        test_dir: {{data_dir}}/tests/600k
+        report_name: "DF Engine 600k - {{suite_name}}"
+        observation_interval: {{observation_interval}}
+        signals_per_second: 100000
+        log_weight: {{log_weight}}
+        metric_weight: {{metric_weight}}
+        trace_weight: {{trace_weight}}
+        engine_core_start: 0
+        engine_core_end: 0
+        backend_core_start: 1
+        backend_core_end: 1
+        loadgen_core_start: 2
+        loadgen_core_end: 7
+
+  - name: 800k
+    from_template:
+      path: dashboard/templates/steps/df-engine.yaml
+      variables:{{ forward_variables() }}
+        data_dir: {{data_dir}}
+        test_dir: {{data_dir}}/tests/800k
+        report_name: "DF Engine 800k - {{suite_name}}"
+        observation_interval: {{observation_interval}}
+        signals_per_second: 100000
+        log_weight: {{log_weight}}
+        metric_weight: {{metric_weight}}
+        trace_weight: {{trace_weight}}
+        engine_core_start: 0
+        engine_core_end: 0
+        backend_core_start: 1
+        backend_core_end: 1
+        loadgen_core_start: 2
+        loadgen_core_end: 9
+
+  - name: 1000k
+    from_template:
+      path: dashboard/templates/steps/df-engine.yaml
+      variables:{{ forward_variables() }}
+        data_dir: {{data_dir}}
+        test_dir: {{data_dir}}/tests/1000k
+        report_name: "DF Engine 1000k - {{suite_name}}"
+        observation_interval: {{observation_interval}}
+        signals_per_second: 100000
+        loadgen_max_batch_size: 1000
+        log_weight: {{log_weight}}
+        metric_weight: {{metric_weight}}
+        trace_weight: {{trace_weight}}
+        engine_core_start: 0
+        engine_core_end: 0
+        backend_core_start: 1
+        backend_core_end: 1
+        loadgen_core_start: 2
+        loadgen_core_end: 11
+

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/steps/df-engine.yaml
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/steps/df-engine.yaml
@@ -1,0 +1,203 @@
+{# Spread every suite-defined variable as a flat key (so leaf templates can
+reference them by bare name) and forward the whole `variables` dict so any
+leaf can also use namespaced access (`variables.X`). Per-hook overrides
+below the spread win on key collision. #}
+{% macro forward_variables() -%}
+{%- for k, v in variables.items() %}
+                {{ k }}: {{ v | tojson }}
+{%- endfor %}
+                variables: {{ variables | tojson }}
+{%- endmacro -%}
+steps:
+  - name: Deploy Backend Engine
+    action:
+      component_action:
+        phase: deploy
+        target: backend-service
+    hooks:
+      run:
+        pre:
+          - render_template:
+              template_path: '{{backend_config}}'
+              output_path: '{{test_dir}}/backend-config.rendered.yaml'
+              variables:{{ forward_variables() }}
+                core_start: {{backend_core_start}}
+                core_end: {{backend_core_end}}
+                compression_method: {{compression_method | default(null)}}
+          - run_command:
+              command: 'cp {{test_dir}}/backend-config.rendered.yaml {{data_dir}}/backend-config.rendered.yaml'
+        post:
+          - ready_check_http:
+              url: http://localhost:8087/api/v1/telemetry/metrics?reset=false
+              method: GET
+              expected_status_code: 200
+  - name: Deploy Dataflow Engine
+    action:
+      component_action:
+        phase: deploy
+        target: df-engine
+    hooks:
+      run:
+        pre:
+          - render_template:
+              template_path: '{{engine_config}}'
+              output_path: '{{test_dir}}/engine-config.rendered.yaml'
+              variables:{{ forward_variables() }}
+                backend_hostname: backend-service
+                core_start: {{engine_core_start}}
+                core_end: {{engine_core_end}}
+                compression_method: {{compression_method | default("none")}}
+                payload_compression: {{payload_compression | default("none")}}
+          - run_command:
+              command: 'cp {{test_dir}}/engine-config.rendered.yaml {{data_dir}}/engine-config.rendered.yaml'
+        post:
+          - ready_check_http:
+              url: http://localhost:8086/api/v1/telemetry/metrics?reset=false
+              method: GET
+              expected_status_code: 200
+  - name: Deploy Load Generator
+    action:
+      component_action:
+        phase: deploy
+        target: load-generator
+    hooks:
+      run:
+        pre:
+          - render_template:
+              template_path: '{{loadgen_config}}'
+              output_path: '{{test_dir}}/loadgen-config.rendered.yaml'
+              variables:{{ forward_variables() }}
+                loadgen_max_batch_size: {{loadgen_max_batch_size | default(1000)}}
+                signals_per_second: {{ 'null' if signals_per_second is none else (signals_per_second | default(100000)) }}
+                metric_weight: {{metric_weight | default(0)}}
+                trace_weight: {{trace_weight | default(0)}}
+                log_weight: {{log_weight | default(100)}}
+                engine_hostname: df-engine
+                core_start: {{loadgen_core_start}}
+                core_end: {{loadgen_core_end}}
+                compression_method: {{compression_method | default("none")}}
+                payload_compression: {{payload_compression | default("none")}}
+          - run_command:
+              command: 'cp {{test_dir}}/loadgen-config.rendered.yaml {{data_dir}}/loadgen-config.rendered.yaml'
+        post:
+          - ready_check_http:
+              url: http://localhost:8085/api/v1/telemetry/metrics?reset=false
+              method: GET
+              expected_status_code: 200
+
+  - name: Monitor All
+    action:
+      multi_component_action:
+        phase: start_monitoring
+        targets:
+          - backend-service
+          - load-generator
+          - df-engine
+  - name: Wait for data
+    action:
+      wait:
+        delay_seconds: {{wait_for_data_interval | default(10)}}
+  - name: Observe Load
+    action:
+      wait:
+        delay_seconds: {{observation_interval | default(20)}}
+    hooks:
+      run:
+        pre:
+          - record_event:
+              name: observation_start
+        post:
+          - record_event:
+              name: observation_stop
+  - name: Wait Before Drain
+    action:
+      wait:
+        delay_seconds: {{drain_wait_secs | default(10)}}
+  - name: Stop Load Generator
+    hooks:
+      run:
+        pre:
+          - send_http_request:
+              url: http://localhost:8085/api/v1/groups/shutdown?wait=true&timeout_secs={{drain_timeout_secs | default(5)}}
+              method: POST
+              headers:
+                "Content-Type": "application/json"
+              timeout: {{drain_timeout_secs | default(5) | int + 5}}
+              raise_for_status: false
+    action:
+      no_op: {}
+  - name: Stop Engine
+    hooks:
+      run:
+        pre:
+          - send_http_request:
+              url: http://localhost:8085/api/v1/groups/shutdown?wait=true&timeout_secs={{drain_timeout_secs | default(5)}}
+              method: POST
+              headers:
+                "Content-Type": "application/json"
+              timeout: {{drain_timeout_secs | default(5) | int + 5}}
+              raise_for_status: false
+    action:
+      no_op: {}
+  - name: Stop Backend
+    hooks:
+      run:
+        pre:
+          - send_http_request:
+              url: http://localhost:8086/api/v1/groups/shutdown?wait=true&timeout_secs={{drain_timeout_secs | default(5)}}
+              method: POST
+              headers:
+                "Content-Type": "application/json"
+              timeout: {{drain_timeout_secs | default(5) | int + 5}}
+              raise_for_status: false
+    action:
+      no_op: {}
+  - name: Wait For Metrics Update
+    action:
+      wait:
+        delay_seconds: 1
+  - name: Stop Monitoring All
+    action:
+      multi_component_action:
+        phase: stop_monitoring
+        targets:
+          - backend-service
+          - load-generator
+          - df-engine
+  - name: Destroy All
+    action:
+      multi_component_action:
+        phase: destroy
+        targets:
+          - load-generator
+          - df-engine
+          - backend-service
+  - name: Run Report
+    action:
+      wait:
+        delay_seconds: 0
+    hooks:
+      run:
+        post:
+          - print_container_logs: {}
+          - sql_report:
+              name: '{{report_name | default("Dashboard Report")}}'
+              report_config_file: '{{report}}'
+              output:
+                - format:
+                    template: {}
+                  destination:
+                    console: {}
+                - format:
+                    template:
+                      path: ./test_suites/integration/templates/reports/gh-action-sqlreport.j2
+                  destination:
+                    file:
+                      directory: '{{test_dir}}'
+                - format:
+                    template:
+                      path: ./dashboard/templates/reports/dashboard-timeseries.j2
+                  destination:
+                    file:
+                      directory: '{{test_dir}}'
+                      name: timeseries


### PR DESCRIPTION
# Change Summary

This is the next PR which adds DFE orchestrator and step templates. These templates define the multi-rate tests and are what I've used across all comparisons so far.

They're designed to be used with just a single core for the SUT, however we can definitely imagine them being adjusted in the future to be more generic on that front.

This is one layer up the stack from and depends on #2870. 

## What issue does this PR close?

* Closes #2866 

## How are these changes tested?

This is a port from my private branch. We will need one more PR after this one to have visible results here, so please bear with me as I'm trying to stack the PR diffs in a way that's easier to review and highlights the dependency chain.

## Are there any user-facing changes?

No.