### PR TITLE
docs: clean up traffic generator naming

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -16,7 +16,7 @@ demonstration purposes including a set of core components. In this
 form, the engine is configured with YAML configuration expression the
 set of nodes and edges in the graph. The core components: OTLP
 receiver and exporter, OTAP receiver and exporter, batch and retry
-processors, debug processor, fake data generator, Parquet exporter,
+processors, debug processor, traffic generator, Parquet exporter,
 and a few more.
 
 The primary data type of the OTAP dataflow engine is OTAP records

--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -268,7 +268,7 @@ dhat-heap = [
     "dep:dhat",
 ]
 
-# Dev/test tooling (fake data generator) and the otap integration tests
+# Dev/test tooling (traffic generator) and the otap integration tests
 # that exercise it. Activating this from the workspace default keeps
 # `cargo test` running the full suite locally; CI jobs that drop
 # `dev-tools` (e.g. the Linux ARM `build_nonrequired` job) avoid the

--- a/rust/otap-dataflow/README.md
+++ b/rust/otap-dataflow/README.md
@@ -180,7 +180,7 @@ fail.
 
 A simple component that returns success. All requests succeed.
 
-#### Fake Data Generator
+#### Traffic Generator
 
 A simple component to produce synthetic data from semantic convention registries.
 

--- a/rust/otap-dataflow/configs/fake-durable-buffer-noop.yaml
+++ b/rust/otap-dataflow/configs/fake-durable-buffer-noop.yaml
@@ -6,7 +6,7 @@ groups:
       main:
         # Fake Data -> Durable Buffer -> Noop pipeline for throughput testing
         #
-        # This configuration uses the fake data generator to produce synthetic OTAP data,
+        # This configuration uses the traffic generator to produce synthetic OTAP data,
         # persists it through Quiver, and sends to noop exporter.
         #
         # Build with: cargo build --release

--- a/rust/otap-dataflow/crates/admin-api/src/http_backend.rs
+++ b/rust/otap-dataflow/crates/admin-api/src/http_backend.rs
@@ -747,7 +747,7 @@ mod tests {
             "type": "otap",
             "nodes": {
                 "recv": {
-                    "type": "receiver:fake",
+                    "type": "receiver:traffic_generator",
                     "config": {}
                 }
             }

--- a/rust/otap-dataflow/crates/admin-types/src/pipelines.rs
+++ b/rust/otap-dataflow/crates/admin-types/src/pipelines.rs
@@ -857,7 +857,7 @@ mod tests {
                 "type": "otap",
                 "nodes": {
                     "recv": {
-                        "type": "urn:otel:receiver:fake",
+                        "type": "urn:otel:receiver:traffic_generator",
                         "config": {}
                     }
                 }
@@ -881,7 +881,7 @@ mod tests {
                 "type": "otap",
                 "nodes": {
                     "recv": {
-                        "type": "urn:otel:receiver:fake",
+                        "type": "urn:otel:receiver:traffic_generator",
                         "config": {}
                     }
                 }

--- a/rust/otap-dataflow/crates/admin/src/pipeline.rs
+++ b/rust/otap-dataflow/crates/admin/src/pipeline.rs
@@ -521,7 +521,7 @@ mod tests {
                 "type": "otap",
                 "nodes": {
                     "recv": {
-                        "type": "receiver:fake",
+                        "type": "receiver:traffic_generator",
                         "config": {}
                     }
                 }

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/trafficgen-ame-local.yaml
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/trafficgen-ame-local.yaml
@@ -8,7 +8,7 @@
 #      cargo run --example mock_la_server -p otap-df-contrib-nodes --features azure-monitor-exporter -- --port 9999
 #
 #   2. Run the pipeline:
-#      cargo run --release --features azure-monitor-exporter -- --config crates/contrib-nodes/src/exporters/azure_monitor_exporter/fakegen-ame-local.yaml --num-cores 1
+#      cargo run --release --features azure-monitor-exporter -- --config crates/contrib-nodes/src/exporters/azure_monitor_exporter/trafficgen-ame-local.yaml --num-cores 1
 #
 # Error simulation examples:
 #   cargo run --example mock_la_server -p otap-df-contrib-nodes --features azure-monitor-exporter -- --fail-rate 0.1                  # 10% -> 500
@@ -35,7 +35,7 @@ groups:
     pipelines:
       main:
         nodes:
-          fake-data-generator:
+          traffic-generator:
             type: "urn:otel:receiver:traffic_generator"
             config:
               data_source: static
@@ -74,5 +74,5 @@ groups:
                 method: "dev"
 
         connections:
-          - from: fake-data-generator
+          - from: traffic-generator
             to: azure-monitor-exporter

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/trafficgen-ame.yaml
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/trafficgen-ame.yaml
@@ -1,10 +1,10 @@
-# Azure Monitor Exporter with Fake Data Generator
+# Azure Monitor Exporter with Traffic Generator
 #
 # Uses the built-in traffic generator for quick self-contained testing of the
 # Azure Monitor Exporter.
 #
 # Usage:
-#   cargo run -- --config fakegen-ame.yaml
+#   cargo run -- --config trafficgen-ame.yaml
 
 version: otel_dataflow/v1
 
@@ -25,7 +25,7 @@ groups:
     pipelines:
       main:
         nodes:
-          fake-data-generator:
+          traffic-generator:
             type: "urn:otel:receiver:traffic_generator"
             config:
               data_source: static
@@ -68,5 +68,5 @@ groups:
                 method: "dev"
 
         connections:
-          - from: fake-data-generator
+          - from: traffic-generator
             to: azure-monitor-exporter

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/mod.rs
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-/// Traffic generator receiver (a.k.a. fake data generator).
+/// Traffic generator receiver.
 #[cfg(feature = "dev-tools")]
 pub mod traffic_generator;
 

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/README.md
@@ -1,25 +1,25 @@
-# Fake Data Generator -- SUT Saturation Benchmarks
+# Traffic Generator -- SUT Saturation Benchmarks
 
 ## Purpose
 
-Verify that a **single fake-gen sender core can saturate a single
+Verify that a **single traffic-gen sender core can saturate a single
 `df_engine` (SUT) core** over OTLP gRPC, so that performance tests
 don't need multiple load-generator cores.
 
 ```text
   sender (1 core)           SUT (1 core)            backend (1 core)
-  fake-gen -> OTLP-export --> OTLP-recv -> OTLP-export --> OTLP-recv -> noop
+  traffic-gen -> OTLP-export --> OTLP-recv -> OTLP-export --> OTLP-recv -> noop
        :8080                     :8081                      :8082
 ```
 
 ## Configs (`bench/`)
 
-| File                        | Role        | Pipeline                          |
-|-----------------------------|-------------|-----------------------------------|
-| `sender-static-fresh.yaml`  | Load gen    | fake-gen(fresh) -> OTLP export    |
-| `sender-static-pregen.yaml` | Load gen    | fake-gen(pregen) -> OTLP export   |
-| `sut-otlp-forward.yaml`     | SUT         | OTLP recv -> OTLP export          |
-| `backend-noop.yaml`         | Backend     | OTLP recv -> noop                 |
+| File                        | Role        | Pipeline                           |
+|-----------------------------|-------------|------------------------------------|
+| `sender-static-fresh.yaml`  | Load gen    | traffic-gen(fresh) -> OTLP export  |
+| `sender-static-pregen.yaml` | Load gen    | traffic-gen(pregen) -> OTLP export |
+| `sut-otlp-forward.yaml`     | SUT         | OTLP recv -> OTLP export           |
+| `backend-noop.yaml`         | Backend     | OTLP recv -> noop                  |
 
 ## Quick start
 

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/bench/bench.sh
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/bench/bench.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Fake Data Generator — SUT saturation benchmark.
-# Measures whether 1 sender core (fake-gen → OTLP export) can saturate
+# Traffic Generator - SUT saturation benchmark.
+# Measures whether 1 sender core (traffic-gen -> OTLP export) can saturate
 # 1 SUT core (OTLP recv → OTLP export forwarding) over gRPC.
 #
 # Setup: 3 processes, 1 core each:

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/mod.rs
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//! A fake data generator receiver.
+//! A traffic generator receiver.
 //! Note: This receiver will be replaced in the future with a more sophisticated implementation.
 //!
 
@@ -53,14 +53,14 @@ pub mod semconv_signal;
 /// Static hardcoded signal generators for lightweight load testing
 pub mod static_signal;
 
-/// The URN for the traffic generator receiver (a.k.a. fake data generator).
+/// The URN for the traffic generator receiver.
 pub const TRAFFIC_GENERATOR_RECEIVER_URN: &str = "urn:otel:receiver:traffic_generator";
 
 const NANOS_PER_SECOND: u128 = 1_000_000_000;
 
 /// A Receiver that generates fake OTAP data for testing purposes.
 pub struct TrafficGeneratorReceiver {
-    /// Configuration for the fake data generator
+    /// Configuration for the traffic generator
     config: Config,
 
     /// Metrics for the traffic generator
@@ -116,7 +116,7 @@ impl TrafficGeneratorReceiver {
         Self { config, metrics }
     }
 
-    /// Creates a new fake data generator from a configuration object
+    /// Creates a new traffic generator from a configuration object
     pub fn from_config(
         pipeline_ctx: PipelineContext,
         config: &Value,

--- a/rust/otap-dataflow/crates/otap/tests/durable_buffer_processor_tests.rs
+++ b/rust/otap-dataflow/crates/otap/tests/durable_buffer_processor_tests.rs
@@ -1732,7 +1732,7 @@ fn test_durable_buffer_otlp_item_count_metrics() {
     let pipeline_group_id: PipelineGroupId = "item-count-test".into();
     let pipeline_id: PipelineId = "item-count-pipeline".into();
 
-    // The fake data generator sends signals in order (metrics, traces, logs) per
+    // The traffic generator sends signals in order (metrics, traces, logs) per
     // iteration. Using equal weights with max_batch_size=30 ensures exactly 10 of
     // each signal type per iteration (30 total). No rate limit — the budget is
     // governed entirely by max_signal_count.
@@ -1823,7 +1823,7 @@ fn test_durable_buffer_otlp_item_count_metrics() {
         "Metrics should have non-zero item_count in manifest (got {metric_items})"
     );
 
-    // For OTLP pass-through, each signal from the fake data generator is 1 item
+    // For OTLP pass-through, each signal from the traffic generator is 1 item
     // (1 log record, 1 span, or 1 metric data point). The total should match.
     assert_eq!(
         total_manifest_items, phase1_signals,

--- a/rust/otap-dataflow/crates/otap/tests/pipeline_tests.rs
+++ b/rust/otap-dataflow/crates/otap/tests/pipeline_tests.rs
@@ -3,7 +3,7 @@
 
 //! Verifies pipeline entity lifecycle handling across build/run/shutdown.
 //!
-//! This test constructs a minimal pipeline (fake data generator -> noop exporter),
+//! This test constructs a minimal pipeline (traffic generator -> noop exporter),
 //! asserts that pipeline/node/channel entities are registered after build, runs the
 //! pipeline until a graceful shutdown, and then confirms that all related entities
 //! and metric sets are unregistered to avoid registry leaks.

--- a/rust/otap-dataflow/crates/pdata/src/proto/mod.rs
+++ b/rust/otap-dataflow/crates/pdata/src/proto/mod.rs
@@ -92,7 +92,7 @@ pub mod opentelemetry {
 /// into OtapArrowRecords, this type does not.
 ///
 /// Note this could be considered for #[cfg(test)], however we are
-/// aware of uses in otap-df-otap's fake_signal_generator and
+/// aware of uses in otap-df-otap's traffic generator and
 /// debug_processor.
 #[derive(Clone, Debug)]
 pub enum OtlpProtoMessage {

--- a/rust/otap-dataflow/crates/validation/README.md
+++ b/rust/otap-dataflow/crates/validation/README.md
@@ -192,7 +192,7 @@ e.g. `receiver`, `exporter`.
 - `with_transport_headers(headers)` - configure transport headers to inject
   into generated traffic
   - each key is a header name; the value is an optional fixed string
-  - when the value is `None`, the fake data generator assigns a random value
+  - when the value is `None`, the traffic generator assigns a random value
     at startup
   - only meaningful when the pipeline uses OTLP receivers/exporters
 - `to_container(ContainerConnection)` - use a custom exporter that sends to a

--- a/rust/otap-dataflow/crates/validation/src/traffic.rs
+++ b/rust/otap-dataflow/crates/validation/src/traffic.rs
@@ -228,7 +228,7 @@ pub struct Generator {
     ///
     /// Keys are header names. Values are optional fixed strings; when left
     /// empty (`None`), a random value is generated once at startup by the
-    /// fake data generator.
+    /// traffic generator.
     pub(crate) transport_headers: HashMap<String, Option<String>>,
 
     /// Optional connection to a test container. When set, the generator's
@@ -367,7 +367,7 @@ impl Generator {
     /// Configure transport headers to inject into generated traffic.
     ///
     /// Each key is a header name; the value is an optional fixed string.
-    /// When the value is `None`, the fake data generator assigns a random
+    /// When the value is `None`, the traffic generator assigns a random
     /// value at startup.
     #[must_use]
     pub fn with_transport_headers(

--- a/rust/otap-dataflow/docs/host-metrics-receiver.md
+++ b/rust/otap-dataflow/docs/host-metrics-receiver.md
@@ -632,7 +632,7 @@ macros. Use `otel_info!`, `otel_warn!`, and `otel_debug!` from
 Use `MetricSet` for receiver self-observability.
 
 Use `Mmsc` with `ns` units for duration distribution fields to match existing
-repo MetricSet duration metrics such as the fake data generator and OTAP
+repo MetricSet duration metrics such as the traffic generator and OTAP
 exporter. Use `Gauge` only if the implementation intentionally keeps a
 last-value metric instead of a distribution.
 

--- a/rust/otap-dataflow/scripts/engine-metrics.py
+++ b/rust/otap-dataflow/scripts/engine-metrics.py
@@ -17,7 +17,7 @@ Kinds (for -k / --kind):
     pipeline   per-pipeline metrics (memory, CPU, uptime, context switches)
     tokio      per-pipeline Tokio runtime stats
     channel    inter-node channel sender/receiver counters
-    receiver   receiver component metrics (otap, syslog/cef, fake_data_gen, ...)
+    receiver   receiver component metrics (otap, syslog/cef, traffic_generator, ...)
     processor  processor component metrics (batch, retry, router, filter, ...)
     exporter   exporter component metrics (otap, parquet, geneva, ...)
 


### PR DESCRIPTION
Removes remaining fake-data-generator wording from docs, comments, examples, and test fixtures now that the receiver is named traffic_generator.