### PR TITLE
chore: Rename flow_metric to flow_metrics and remove extra instrument name

### DIFF
--- a/rust/otap-dataflow/configs/fake-flow-metrics-demo.yaml
+++ b/rust/otap-dataflow/configs/fake-flow-metrics-demo.yaml
@@ -14,9 +14,9 @@
 # inbound channels.
 #
 # Metrics emitted on the `flow` metric set:
-#   - flow.compute.duration (MMSC histogram, nanoseconds)
-#   - flow.signals.incoming   (MMSC, items observed at the start node)
-#   - flow.signals.outgoing   (MMSC, items observed at the end node)
+#   - compute.duration (MMSC histogram, nanoseconds)
+#   - signals.incoming   (MMSC, items observed at the start node)
+#   - signals.outgoing   (MMSC, items observed at the end node)
 #
 # With the sampler in place, `signals.incoming` (at sampler) reflects the full
 # input volume while `signals.outgoing` (at attr4) reflects roughly 1/3 of it,

--- a/rust/otap-dataflow/crates/engine/src/flow_metrics.rs
+++ b/rust/otap-dataflow/crates/engine/src/flow_metrics.rs
@@ -33,7 +33,7 @@ use otap_df_config::policy::{FlowMetric, TelemetryPolicy};
 pub struct FlowSignalsIncomingMetrics {
     /// Number of signal items (log records, spans, or metric data points)
     /// entering the flow range.
-    #[metric(name = "flow.signals.incoming", unit = "{item}")]
+    #[metric(name = "signals.incoming", unit = "{item}")]
     pub signals_incoming: Mmsc,
 }
 
@@ -42,7 +42,7 @@ pub struct FlowSignalsIncomingMetrics {
 #[derive(Debug, Default, Clone)]
 pub struct FlowDurationMetrics {
     /// Sum of per-node compute durations (nanoseconds) for messages traversing the flow range.
-    #[metric(name = "flow.compute.duration", unit = "ns")]
+    #[metric(name = "compute.duration", unit = "ns")]
     pub compute_duration: Mmsc,
 }
 
@@ -51,7 +51,7 @@ pub struct FlowDurationMetrics {
 #[derive(Debug, Default, Clone)]
 pub struct FlowSignalsOutgoingMetrics {
     /// Number of signal items (log records, spans, or metric data points) leaving the flow range.
-    #[metric(name = "flow.signals.outgoing", unit = "{item}")]
+    #[metric(name = "signals.outgoing", unit = "{item}")]
     pub signals_outgoing: Mmsc,
 }
 

--- a/rust/otap-dataflow/crates/engine/src/lib.rs
+++ b/rust/otap-dataflow/crates/engine/src/lib.rs
@@ -75,7 +75,7 @@ mod control_plane_metrics;
 pub mod effect_handler;
 pub mod engine_metrics;
 pub mod entity_context;
-pub mod flow_metric;
+pub mod flow_metrics;
 pub(crate) mod indexed_min_heap;
 pub mod local;
 pub mod memory_limiter;

--- a/rust/otap-dataflow/crates/engine/src/local/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/local/processor.rs
@@ -40,7 +40,7 @@ use crate::effect_handler::{
     EffectHandlerCore, SourceTagging, TelemetryTimerCancelHandle, TimerCancelHandle,
 };
 use crate::error::{Error, TypedError};
-use crate::flow_metric::{
+use crate::flow_metrics::{
     EndFlowMetrics, FlowDurationMetrics, FlowSignalsIncomingMetrics, FlowSignalsOutgoingMetrics,
     IncomingFlowMetrics, LocalFlowMetricState, nanos_u64,
 };
@@ -992,7 +992,7 @@ mod tests {
     #[test]
     fn flow_accumulate_then_report() {
         use crate::context::ControllerContext;
-        use crate::flow_metric::{
+        use crate::flow_metrics::{
             FlowAttributeSet, FlowDurationMetrics, FlowSignalsIncomingMetrics,
             FlowSignalsOutgoingMetrics,
         };

--- a/rust/otap-dataflow/crates/engine/src/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/processor.rs
@@ -20,7 +20,7 @@ use crate::control::{
 use crate::effect_handler::SourceTagging;
 use crate::entity_context::NodeTelemetryGuard;
 use crate::error::{Error, ProcessorErrorKind};
-use crate::flow_metric::{
+use crate::flow_metrics::{
     FlowDurationMetrics, FlowSignalsIncomingMetrics, FlowSignalsOutgoingMetrics,
 };
 use crate::local::message::{LocalReceiver, LocalSender};
@@ -874,7 +874,7 @@ mod tests {
         NodeControlMsg::{Config, Shutdown, TimerTick},
         pipeline_completion_msg_channel, runtime_ctrl_msg_channel,
     };
-    use crate::flow_metric::{
+    use crate::flow_metrics::{
         FlowAttributeSet, FlowDurationMetrics, FlowSignalsIncomingMetrics,
         FlowSignalsOutgoingMetrics,
     };

--- a/rust/otap-dataflow/crates/engine/src/runtime_pipeline.rs
+++ b/rust/otap-dataflow/crates/engine/src/runtime_pipeline.rs
@@ -17,7 +17,7 @@ use crate::control::{
 };
 use crate::entity_context::{NodeTaskContext, NodeTelemetryHandle, instrument_with_node_context};
 use crate::error::{Error, TypedError};
-use crate::flow_metric::{
+use crate::flow_metrics::{
     FlowDurationMetrics, FlowSignalsIncomingMetrics, FlowSignalsOutgoingMetrics,
     build_flow_metric_state,
 };

--- a/rust/otap-dataflow/crates/engine/src/shared/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/shared/processor.rs
@@ -39,7 +39,7 @@ use crate::effect_handler::{
     EffectHandlerCore, SourceTagging, TelemetryTimerCancelHandle, TimerCancelHandle,
 };
 use crate::error::{Error, TypedError};
-use crate::flow_metric::{
+use crate::flow_metrics::{
     EndFlowMetrics, FlowDurationMetrics, FlowSignalsIncomingMetrics, FlowSignalsOutgoingMetrics,
     IncomingFlowMetrics, SharedFlowMetricState, nanos_u64,
 };
@@ -557,7 +557,7 @@ impl<PData: crate::Unwindable> crate::_private::AckNackRouting<PData> for Effect
 mod tests {
     #![allow(missing_docs)]
     use super::*;
-    use crate::flow_metric::{FlowAttributeSet, FlowSignalsOutgoingMetrics};
+    use crate::flow_metrics::{FlowAttributeSet, FlowSignalsOutgoingMetrics};
     use crate::shared::message::SharedSender;
     use crate::testing::{test_node, test_pipeline_ctx};
     use otap_df_channel::error::SendError;

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -360,12 +360,12 @@ impl FlowMetricAccumulation for OtapPdata {
         // that share a start or end node, but it does NOT yet detect
         // interleaved ranges with distinct endpoints (e.g. 1→3 + 2→4 on the
         // path 1→2→3→4). Until that gap is closed (see TODO(flow_metric-interleave)
-        // in engine/src/flow_metric.rs), keep a defensive runtime warning so a
+        // in engine/src/flow_metrics.rs), keep a defensive runtime warning so a
         // misconfigured pipeline is diagnosable instead of silently producing
         // truncated histograms.
         if self.context.flow_compute_ns.is_some() {
             otap_df_telemetry::otel_warn!(
-                "flow_metric.overlap",
+                "flow_metrics.overlap",
                 "start_flow_metric called while another flow_metric is active; \
                  overlapping ranges are not supported — previous accumulator discarded"
             );


### PR DESCRIPTION
# Change Summary

Address small comment here: https://github.com/open-telemetry/otel-arrow/issues/2859#issuecomment-4393428306 as well as following pattern observed in #2888 to simplify instrument names. The extra `flow.` prefix was unnecessary.

The customer-facing config was already `flow_metrics`, this PR just brings the code in line with that terminology.

## What issue does this PR close?

N/A, minor rename

## How are these changes tested?

## Are there any user-facing changes?

Slight changes to Flow metric instrument names
