### PR TITLE
docs: Expand SIG meeting welcoming language

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,9 +189,11 @@ We meet weekly, alternating between Tuesday at 4:00 PM PT and Thursday
 at 8:00 AM PT. Check the [OpenTelemetry community calendar][OTELCAL]
 for dates and Zoom links.
 
-Whether you're a seasoned OpenTelemetry developer, just starting your
-journey, or simply curious about the work we do, you're more than
-welcome to participate!
+The meeting is open for all to join. We invite everyone to join our
+meeting, regardless of your experience level. Whether you're a
+seasoned OpenTelemetry developer, just starting your journey, or
+simply curious about the work we do, you're more than welcome to
+participate!
 
 - [Contribution guidelines](CONTRIBUTING.md)
 - [Meeting notes](https://docs.google.com/document/d/1z8_Ra-ALDaYNa88mMj1gOZtOpLZLRk0-dZEmDjPmcUs)


### PR DESCRIPTION
## Changes

The Contributing section already has welcoming language for the SIG meeting, but is missing the explicit opening that the meeting is open to all. Adding two short sentences brings the wording in line with the same text used in [opentelemetry-rust](https://github.com/open-telemetry/opentelemetry-rust#contributing), [opentelemetry-dotnet](https://github.com/open-telemetry/opentelemetry-dotnet#contributing), and [weaver](https://github.com/open-telemetry/weaver/blob/main/CONTRIBUTING.md).

Per the discussion in [open-telemetry/community#1805](https://github.com/open-telemetry/community/issues/1805), explicit welcoming language on SIG meeting invitations helps lower the implicit gatekeeping that the word "meeting" can convey to newcomers.

Scope is limited to the welcoming paragraph; the broader "meetings vs. office hours / public meetings" naming discussion in community#1805 is intentionally out of scope here.