### PR TITLE
ci(codecov): set after_n_builds to 4 (matrix-expanded upload count)

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -5,13 +5,20 @@ codecov:
     # upload arrives, before the other test jobs have even finished.
     #
     # IMPORTANT: this number must match the total count of
-    # `codecov/codecov-action` upload steps across all workflows.
+    # `codecov/codecov-action` upload invocations across all workflows
+    # AFTER matrix expansion. A single upload step inside a matrix job
+    # counts once per matrix combination that actually executes it.
     # Currently:
-    #   - .github/workflows/rust-ci.yml `test` (Linux x86_64)
-    #   - .github/workflows/rust-ci.yml `coverage`
-    #   - .github/workflows/go-ci.yml   `test_and_coverage`
-    # If you add or remove a codecov upload, update this number.
-    after_n_builds: 3
+    #   - .github/workflows/rust-ci.yml `experimental_tests`
+    #     (gated on `matrix.os == 'ubuntu-latest'`, expands across the
+    #      `folder` matrix): 2 uploads
+    #       * experimental/query_abstraction
+    #       * experimental/query_engine
+    #   - .github/workflows/rust-ci.yml `coverage`:                 1 upload
+    #   - .github/workflows/go-ci.yml   `test_and_coverage`:        1 upload
+    # If you add or remove a codecov upload, or change a matrix that
+    # contains one, update this number.
+    after_n_builds: 4
 
 coverage:
   status:


### PR DESCRIPTION
# Change Summary

`codecov.notify.after_n_builds` was set to 3 but CI actually produces 4 coverage uploads. Codecov was therefore posting status as soon as the 3rd report landed -- often before the slowest job (`coverage`) had finished -- producing the premature/partial status shown in #2890.

The original miscount treated `experimental_tests` as a single upload, but its `folder` matrix expands to two uploads on `ubuntu-latest` (`experimental/query_abstraction`, `experimental/query_engine`).

## What issue does this PR close?

<!--
We highly recommend correlation of every PR to an issue
-->

* Closes #2890 

## How are these changes tested?

## Are there any user-facing changes?

 <!-- If yes, provide further info below -->
