### PR TITLE
test: improve test_lazy_reload_resolver polling mechanism to address test flakiness

### DIFF
--- a/rust/otap-dataflow/crates/otap/src/tls_utils.rs
+++ b/rust/otap-dataflow/crates/otap/src/tls_utils.rs
@@ -1666,7 +1666,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_lazy_reload_resolver() {
         crate::crypto::ensure_crypto_provider();
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
@@ -1705,11 +1705,19 @@ mod tests {
         let reloaded = resolver.check_and_reload_if_interval_expired();
         assert!(!reloaded, "Async reload returns false immediately");
 
-        // 6. Wait for async reload to complete
-        tokio::time::sleep(Duration::from_millis(100)).await;
-
-        let new_cert = resolver.current_cert_key();
-        assert_ne!(initial_cert.cert, new_cert.cert, "Cert should have changed");
+        // 6. Poll for async reload to complete (avoids flaky fixed-duration sleep)
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let new_cert = resolver.current_cert_key();
+            if initial_cert.cert != new_cert.cert {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "Cert should have changed within 5s timeout"
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
 
         // 7. Trigger again immediately - should not reload (interval not expired)
         let reloaded_again = resolver.check_and_reload_if_interval_expired();


### PR DESCRIPTION
# Change Summary

Addresses flaky `test_lazy_reload_resolver` by changing from a fixed duration sleep to instead poll for the certificate to change up to a longer timeout.

## What issue does this PR close?

* Addresses a flaky test report identified via #2720

## How are these changes tested?

Validated that test passes locally through several iterations

## Are there any user-facing changes?

No. This is a test-only change.