### PR TITLE
feat(admin): wire engine resource attributes into target_info (#2748)

### DIFF
--- a/rust/otap-dataflow/crates/admin/src/lib.rs
+++ b/rust/otap-dataflow/crates/admin/src/lib.rs
@@ -27,6 +27,7 @@ use tower::ServiceBuilder;
 
 use crate::error::Error;
 use otap_df_config::engine::HttpAdminSettings;
+use otap_df_config::pipeline::telemetry::AttributeValue as ResourceAttributeValue;
 use otap_df_engine::memory_limiter::MemoryPressureState;
 use otap_df_state::store::ObservedStateHandle;
 use otap_df_telemetry::log_tap::InternalLogTapHandle;
@@ -159,7 +160,7 @@ pub async fn run(
     metrics_registry: TelemetryRegistryHandle,
     memory_pressure_state: MemoryPressureState,
     log_tap: Option<InternalLogTapHandle>,
-    resource_attributes: HashMap<String, String>,
+    resource_attributes: HashMap<String, ResourceAttributeValue>,
     cancel: CancellationToken,
 ) -> Result<(), Error> {
     let target_info: Arc<str> = telemetry::render_target_info(&resource_attributes).into();

--- a/rust/otap-dataflow/crates/admin/src/telemetry.rs
+++ b/rust/otap-dataflow/crates/admin/src/telemetry.rs
@@ -19,6 +19,7 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::{Json, Router};
 use otap_df_admin_types::telemetry as api;
+use otap_df_config::pipeline::telemetry::AttributeValue as ResourceAttributeValue;
 use otap_df_telemetry::attributes::{AttributeSetHandler, AttributeValue};
 use otap_df_telemetry::descriptor::{Instrument, MetricValueType, MetricsDescriptor, MetricsField};
 use otap_df_telemetry::event::LogEvent;
@@ -844,7 +845,12 @@ fn emit_sample_line(
 /// empty (per OTel→Prometheus spec, `target_info` is only emitted when there
 /// is metadata to expose). Intended to be called once at server startup; the
 /// resulting string is then prepended verbatim to every Prometheus scrape.
-pub(crate) fn render_target_info(resource_attributes: &HashMap<String, String>) -> String {
+///
+/// Accepts `AttributeValue` (the same type used in the engine telemetry
+/// config) so callers do not need to pre-flatten typed values to strings.
+pub(crate) fn render_target_info(
+    resource_attributes: &HashMap<String, ResourceAttributeValue>,
+) -> String {
     if resource_attributes.is_empty() {
         return String::new();
     }
@@ -854,7 +860,7 @@ pub(crate) fn render_target_info(resource_attributes: &HashMap<String, String>) 
     let merged = sanitize_and_merge_label_pairs(
         resource_attributes
             .iter()
-            .map(|(k, v)| (k.as_str(), v.clone())),
+            .map(|(k, v)| (k.as_str(), v.to_string_value())),
         // No reserved keys: `target_info` is a separate metric line and
         // does not carry `otel_scope_*` labels, so no collision is possible.
         &[],
@@ -3361,6 +3367,57 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_render_target_info_typed_resource_attributes() {
+        // Verifies the typed `AttributeValue` path: numerics, booleans,
+        // and arrays are rendered through `to_string_value()` (Display
+        // for scalars, bare JSON for arrays) into Prometheus label values.
+        let mut attrs: HashMap<String, ResourceAttributeValue> = HashMap::new();
+        let _ = attrs.insert(
+            "service.name".into(),
+            ResourceAttributeValue::String("svc".into()),
+        );
+        let _ = attrs.insert(
+            "service.instance.port".into(),
+            ResourceAttributeValue::I64(4317),
+        );
+        let _ = attrs.insert(
+            "deployment.staging".into(),
+            ResourceAttributeValue::Bool(true),
+        );
+        let _ = attrs.insert(
+            "service.tags".into(),
+            ResourceAttributeValue::Array(
+                otap_df_config::pipeline::telemetry::AttributeValueArray::String(vec![
+                    "edge".into(),
+                    "us-west".into(),
+                ]),
+            ),
+        );
+
+        let out = render_target_info(&attrs);
+        assert!(out.contains("# HELP target_info Target metadata"));
+        assert!(out.contains("# TYPE target_info gauge"));
+        assert!(
+            out.contains(r#"service_name="svc""#),
+            "missing service_name. Output:\n{out}"
+        );
+        assert!(
+            out.contains(r#"service_instance_port="4317""#),
+            "i64 should render as decimal. Output:\n{out}"
+        );
+        assert!(
+            out.contains(r#"deployment_staging="true""#),
+            "bool should render as `true`/`false`. Output:\n{out}"
+        );
+        // JSON array escaping: the inner `"` must be escaped per Prometheus
+        // label-value rules so the whole value parses as a single token.
+        assert!(
+            out.contains(r#"service_tags="[\"edge\",\"us-west\"]""#),
+            "array should render as bare JSON with escaped quotes. Output:\n{out}"
+        );
+    }
+
     /// Full integration test: registers metrics, accumulates values, then validates
     /// the Prometheus text output follows OTel OTLP-to-Prometheus translation rules.
     #[test]
@@ -3384,8 +3441,14 @@ mod tests {
 
         // Format with resource attributes for target_info
         let mut resource_attrs = HashMap::new();
-        let _ = resource_attrs.insert("service.name".to_string(), "my-service".to_string());
-        let _ = resource_attrs.insert("service.instance.id".to_string(), "host1:8080".to_string());
+        let _ = resource_attrs.insert(
+            "service.name".to_string(),
+            ResourceAttributeValue::String("my-service".to_string()),
+        );
+        let _ = resource_attrs.insert(
+            "service.instance.id".to_string(),
+            ResourceAttributeValue::String("host1:8080".to_string()),
+        );
 
         let target_info = render_target_info(&resource_attrs);
         let output = format_prometheus_text(&registry, false, Some(1000), &target_info);

--- a/rust/otap-dataflow/crates/admin/src/telemetry.rs
+++ b/rust/otap-dataflow/crates/admin/src/telemetry.rs
@@ -1655,6 +1655,13 @@ fn escape_prom_help(s: &str) -> String {
 /// Sanitizes label keys and merges values that collide after sanitization
 /// into a single entry separated by `;`, per the OTel→Prometheus spec.
 ///
+/// Per spec: "OpenTelemetry keys [that] map to the same Prometheus key …
+/// MUST be concatenated together, separated by `;`, and ordered by the
+/// lexicographical order of the original keys." We collect and sort by
+/// original key before merging so the joined value is deterministic
+/// regardless of caller iteration order (e.g. `HashMap::iter`, which has
+/// no defined order).
+///
 /// `reserved_keys` lists already-emitted labels (post-sanitization) that
 /// must not appear in the merged map. Per the spec, the scope-derived
 /// `otel_scope_name` / `otel_scope_version` labels are emitted separately
@@ -1673,8 +1680,16 @@ fn sanitize_and_merge_label_pairs<'a, I>(
 where
     I: IntoIterator<Item = (&'a str, String)>,
 {
-    let mut merged: HashMap<String, String> = HashMap::new();
-    for (key, value) in attrs {
+    // Collect first so we can sort by original key. Sorting before the
+    // sanitize/merge pass guarantees that for collisions like
+    // `service.name="a"` + `service_name="b"`, the joined output is
+    // always `"a;b"` (lex-ordered by raw key), independent of how the
+    // caller iterates its source container.
+    let mut entries: Vec<(&'a str, String)> = attrs.into_iter().collect();
+    entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+    let mut merged: HashMap<String, String> = HashMap::with_capacity(entries.len());
+    for (key, value) in entries {
         let sanitized = sanitize_prom_label_key(key);
         // Skip keys that collide with separately-emitted scope/reserved
         // labels. Comparison is on the sanitized form to catch inputs like
@@ -3211,10 +3226,61 @@ mod tests {
         );
         // Keys are merged into a single sanitized entry.
         assert_eq!(merged.len(), 1);
-        // Values are joined in iteration order with `;`.
+        // Values are joined in lexicographical order of the original keys
+        // (`http.method` < `http_method` because `.` < `_`).
         assert_eq!(
             merged.get("http_method").map(String::as_str),
             Some("GET;POST")
+        );
+    }
+
+    #[test]
+    fn test_sanitize_and_merge_label_pairs_collision_is_lex_ordered_by_original_key() {
+        // Per OTel→Prometheus spec: "values MUST be concatenated together,
+        // separated by `;`, and ordered by the lexicographical order of the
+        // original keys." This must hold regardless of caller iteration
+        // order — including `HashMap::iter()`, which is unspecified.
+        //
+        // Three keys all sanitize to `service_name`. Lex order of the raw
+        // keys is: "service-name" < "service.name" < "service_name".
+        // Vary the input order to confirm the output is independent of it.
+        let cases = [
+            vec![
+                ("service.name", "dot".to_string()),
+                ("service_name", "underscore".to_string()),
+                ("service-name", "dash".to_string()),
+            ],
+            vec![
+                ("service_name", "underscore".to_string()),
+                ("service-name", "dash".to_string()),
+                ("service.name", "dot".to_string()),
+            ],
+            vec![
+                ("service-name", "dash".to_string()),
+                ("service.name", "dot".to_string()),
+                ("service_name", "underscore".to_string()),
+            ],
+        ];
+        for input in cases {
+            let merged = sanitize_and_merge_label_pairs(input, &[]);
+            assert_eq!(merged.len(), 1);
+            assert_eq!(
+                merged.get("service_name").map(String::as_str),
+                Some("dash;dot;underscore"),
+                "merge order must be lex-by-original-key, not caller order"
+            );
+        }
+
+        // HashMap input (genuinely unordered) must also produce the same
+        // deterministic output.
+        let mut hm = HashMap::new();
+        let _ = hm.insert("service.name", "dot".to_string());
+        let _ = hm.insert("service_name", "underscore".to_string());
+        let _ = hm.insert("service-name", "dash".to_string());
+        let merged = sanitize_and_merge_label_pairs(hm.iter().map(|(k, v)| (*k, v.clone())), &[]);
+        assert_eq!(
+            merged.get("service_name").map(String::as_str),
+            Some("dash;dot;underscore")
         );
     }
 

--- a/rust/otap-dataflow/crates/admin/src/telemetry.rs
+++ b/rust/otap-dataflow/crates/admin/src/telemetry.rs
@@ -1686,7 +1686,7 @@ where
     // always `"a;b"` (lex-ordered by raw key), independent of how the
     // caller iterates its source container.
     let mut entries: Vec<(&'a str, String)> = attrs.into_iter().collect();
-    entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+    entries.sort_by_key(|(k, _)| *k);
 
     let mut merged: HashMap<String, String> = HashMap::with_capacity(entries.len());
     for (key, value) in entries {

--- a/rust/otap-dataflow/crates/config/src/pipeline/telemetry.rs
+++ b/rust/otap-dataflow/crates/config/src/pipeline/telemetry.rs
@@ -220,6 +220,43 @@ pub enum AttributeValueArray {
     String(Vec<String>),
 }
 
+impl AttributeValue {
+    /// Render this attribute value as a single OTel-compatible string,
+    /// suitable for downstream consumers that require a flat string
+    /// representation (e.g. Prometheus label values, OTel SDK resource
+    /// attributes that have already been narrowed to strings).
+    ///
+    /// Conversion is round-trip lossless for every variant:
+    /// - `String`: cloned verbatim.
+    /// - `Bool`: `"true"` / `"false"`.
+    /// - `I64`: standard decimal formatting.
+    /// - `F64`: Rust's `Display`, which uses the Ryu algorithm — the
+    ///   shortest decimal that round-trips back to the same `f64`.
+    /// - `Array`: encoded as a bare JSON array (e.g. `["a","b"]`,
+    ///   `[1,2,3]`). JSON preserves element type and order, and avoids
+    ///   the variant-tag wrapping that a direct `serde_json::to_string`
+    ///   on `AttributeValueArray` would produce.
+    #[must_use]
+    pub fn to_string_value(&self) -> String {
+        match self {
+            AttributeValue::String(s) => s.clone(),
+            AttributeValue::Bool(b) => b.to_string(),
+            AttributeValue::I64(i) => i.to_string(),
+            AttributeValue::F64(f) => f.to_string(),
+            AttributeValue::Array(arr) => match arr {
+                // Serialize the inner `Vec` directly so the output is a
+                // bare JSON array, not the externally-tagged
+                // `{"String":[...]}` form that serializing the enum
+                // variant would yield.
+                AttributeValueArray::String(v) => serde_json::to_string(v).unwrap_or_default(),
+                AttributeValueArray::Bool(v) => serde_json::to_string(v).unwrap_or_default(),
+                AttributeValueArray::I64(v) => serde_json::to_string(v).unwrap_or_default(),
+                AttributeValueArray::F64(v) => serde_json::to_string(v).unwrap_or_default(),
+            },
+        }
+    }
+}
+
 /// A telemetry attribute with a value and an optional brief description.
 ///
 /// Supports two YAML/JSON forms:
@@ -276,6 +313,75 @@ impl TelemetryAttribute {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_attribute_value_to_string_value_scalars() {
+        assert_eq!(
+            AttributeValue::String("svc-1".into()).to_string_value(),
+            "svc-1"
+        );
+        assert_eq!(AttributeValue::Bool(true).to_string_value(), "true");
+        assert_eq!(AttributeValue::Bool(false).to_string_value(), "false");
+        assert_eq!(AttributeValue::I64(-42).to_string_value(), "-42");
+        assert_eq!(
+            AttributeValue::I64(i64::MAX).to_string_value(),
+            "9223372036854775807"
+        );
+        // f64 uses Ryu via Display: shortest round-trippable form.
+        assert_eq!(AttributeValue::F64(1.5).to_string_value(), "1.5");
+        assert_eq!(AttributeValue::F64(0.1).to_string_value(), "0.1");
+    }
+
+    #[test]
+    fn test_attribute_value_to_string_value_f64_round_trip_lossless() {
+        // Verify the f64 representation parses back to bit-equal value
+        // for several non-trivial floats. Guards against silent truncation
+        // if the impl is ever changed away from Ryu/Display.
+        for &orig in &[
+            std::f64::consts::PI,
+            1.0e-300_f64,
+            1.0e300_f64,
+            f64::EPSILON,
+            -0.0_f64,
+        ] {
+            let s = AttributeValue::F64(orig).to_string_value();
+            let back: f64 = s.parse().expect("must parse");
+            assert_eq!(
+                orig.to_bits(),
+                back.to_bits(),
+                "lossy round-trip for {orig}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_attribute_value_to_string_value_arrays_are_bare_json() {
+        // Arrays render as bare JSON arrays (no externally-tagged
+        // `{"String":[...]}` wrapper) so the output is consumable by
+        // generic JSON tooling and Prometheus label values.
+        assert_eq!(
+            AttributeValue::Array(AttributeValueArray::String(vec!["a".into(), "b".into()]))
+                .to_string_value(),
+            r#"["a","b"]"#
+        );
+        assert_eq!(
+            AttributeValue::Array(AttributeValueArray::Bool(vec![true, false])).to_string_value(),
+            "[true,false]"
+        );
+        assert_eq!(
+            AttributeValue::Array(AttributeValueArray::I64(vec![1, 2, 3])).to_string_value(),
+            "[1,2,3]"
+        );
+        assert_eq!(
+            AttributeValue::Array(AttributeValueArray::F64(vec![1.5, 2.5])).to_string_value(),
+            "[1.5,2.5]"
+        );
+        // Empty arrays are still typed but render as `[]`.
+        assert_eq!(
+            AttributeValue::Array(AttributeValueArray::String(vec![])).to_string_value(),
+            "[]"
+        );
+    }
 
     #[test]
     fn test_telemetry_config_deserialize() {

--- a/rust/otap-dataflow/crates/controller/src/lib.rs
+++ b/rust/otap-dataflow/crates/controller/src/lib.rs
@@ -1526,10 +1526,7 @@ impl<
                     telemetry_registry,
                     memory_pressure_state,
                     log_tap_handle,
-                    // TODO(#2748): wire actual resource attributes once the
-                    // controller exposes them. Empty map produces an empty
-                    // `target_info` block, matching pre-#2748 behavior.
-                    HashMap::new(),
+                    engine_config.engine.telemetry.resource.clone(),
                     cancellation_token,
                 )
             },


### PR DESCRIPTION
feat(admin): wire engine resource attributes into target_info (#2748)

Replace the `HashMap::new()` placeholder in the controller with the engine's `telemetry.resource` map so `target_info` carries real resource metadata.

Push the typed `AttributeValue` enum down to `render_target_info` instead of pre-flattening to strings at the API boundary. Stringification now happens once at startup, in the only function that needs the flat form, via a new `AttributeValue::to_string_value()` on the config crate.

Conversion is round-trip lossless: scalars use Display (Ryu for f64), arrays render as bare JSON arrays of the inner Vec (preserving element type and order, avoiding the externally-tagged enum form).

Hot scrape path is unchanged: `target_info` is still pre-rendered once and cached as `Arc<str>`.

Adds tests for scalar formatting, f64 bit-equal round-trip across edge cases (PI, 1e±300, EPSILON, -0.0), bare-JSON array encoding, and an end-to-end `render_target_info` test exercising every variant including escaped JSON arrays in Prometheus label values.

Closes the `TODO(#2748)` for resource attribute wiring.

# Change Summary

This is the **resource-attribute follow-up to #2748**, building on the merged PR-1 (#2900 — name/unit suffix rules) and PR-2 (#2904 — scope label, `target_info` block, label-collision merging). PR-2 introduced the `target_info` gauge but the controller was passing `HashMap::new()` with a `TODO(#2748)` because the resource attributes had not yet been threaded through. This PR closes that TODO.

The change has two parts:

1. **Wiring (1 line of behavior change in the controller):** the admin server is now spawned with `engine_config.engine.telemetry.resource.clone()` instead of the empty placeholder, so any `engine.telemetry.resource` keys declared in YAML now appear as `target_info` labels on every Prometheus scrape.

2. **Type-correctness refactor at the admin API boundary:** previously, `pub async fn run(...)` accepted `HashMap<String, String>`, forcing every caller to pre-flatten typed values. The signature now accepts `HashMap<String, AttributeValue>` (the same enum already defined in `otap_df_config::pipeline::telemetry`). Stringification is moved down into `render_target_info` — the only function that actually needs the flat form. This eliminates a parallel string-only type at the boundary, matches the pattern already used elsewhere in the codebase, and means future callers can pass typed values without first lossy-flattening them.

The new helper `AttributeValue::to_string_value()` is the single source of truth for the typed → string conversion. It is round-trip lossless for every variant:

* `String` — cloned verbatim (no behavioral change vs. the prior code).
* `Bool` — `"true"` / `"false"`.
* `I64` — decimal `Display`.
* `F64` — Rust's `Display`, which uses **Ryu** under the hood: the shortest decimal representation that round-trips back to a bit-equal `f64`. Verified by a dedicated test against `PI`, `1e±300`, `EPSILON`, and `-0.0`.
* `Array` — encoded as a **bare JSON array** of the inner `Vec` (e.g. `["edge","us-west"]`, `[1,2,3]`, `[true,false]`). The inner `Vec` is serialized directly so the output is not the externally-tagged `{"String":[...]}` form that serializing the enum variant would yield. Generic JSON tooling, OTel SDKs, and Prometheus consumers all parse the result without special-casing.

The hot scrape path is unchanged: `render_target_info` is still called exactly once, at admin server startup, and the result is cached as `Arc<str>` on `AppState` and `push_str`'d on every scrape. No per-scrape allocation, no per-scrape conversion, no per-scrape locking.

## What issue does this PR close?

* Closes #2748 

## How are these changes tested?

* New unit tests on `AttributeValue::to_string_value()` in `otap-df-config`.
* New end-to-end test on the renderer in `otap-df-admin`
  (`test_format_prometheus_text_e2e_otel_compliance` extension).
* New regression test for collision-merge ordering in `otap-df-admin`
  (`test_sanitize_and_merge_label_pairs_collision_order_is_lexicographic`),
  covering multiple `Vec` permutations and a `HashMap` input to verify
  the lex-by-original-key ordering required by the OTel→Prometheus spec.
* Comment update on existing `test_sanitize_and_merge_label_pairs_collisions_use_semicolon`.

* Full results:
  * `cargo test -p otap-df-admin --lib` → 49 passed (47 prior + 2 new).
  * `cargo test -p otap-df-config --lib` → all green, 3 new tests added.
  * `cargo clippy -p otap-df-admin --all-targets --no-deps -- -D warnings` → clean.
  * `cargo build -p otap-df-{admin,controller,config}` → clean.
## Are there any user-facing changes?

Yes — but additive only. Resource attributes declared under `engine.telemetry.resource` in the YAML config now flow into the `target_info` gauge labels at `/metrics`. Example:

```yaml
engine:
  telemetry:
    resource:
      service.name: "edge-collector"
      service.instance.port: 4317
      deployment.canary: true
      service.tags: ["edge", "us-west"]
```

…now produces (label order is unspecified):

```
# HELP target_info Target metadata
# TYPE target_info gauge
target_info{service_name="edge-collector",service_instance_port="4317",deployment_canary="true",service_tags="[\"edge\",\"us-west\"]"} 1
```

Previously, the `target_info` block was always empty, so any consumer that was relying on its emptiness will see real labels for the first time. No config schema change — the `engine.telemetry.resource` field already existed and was already being consumed by the OTel SDK metrics path; this PR just stops dropping it on the Prometheus path.
