### PR TITLE
Rename core-nodes receiver meters to drop redundant .metrics suffix

### DIFF
--- a/rust/otap-dataflow/configs/fake-debug-noop-prometheus-telemetry.yaml
+++ b/rust/otap-dataflow/configs/fake-debug-noop-prometheus-telemetry.yaml
@@ -12,7 +12,7 @@ engine:
                 path: "/metrics"
       views:
         - selector:
-            scope_name: "traffic_generator.receiver.metrics"
+            scope_name: "traffic_generator.receiver"
             instrument_name: "logs.produced"
           stream:
             name: "otlp.logs.produced.count"

--- a/rust/otap-dataflow/configs/fake-debug-noop-telemetry.yaml
+++ b/rust/otap-dataflow/configs/fake-debug-noop-telemetry.yaml
@@ -13,7 +13,7 @@ engine:
                 endpoint: "http://127.0.0.1:43480"
       views:
         - selector:
-            scope_name: "traffic_generator.receiver.metrics"
+            scope_name: "traffic_generator.receiver"
             instrument_name: "logs.produced"
           stream:
             name: "otlp.logs.produced.count"

--- a/rust/otap-dataflow/crates/admin/ui/js/inter-pipeline-topology.js
+++ b/rust/otap-dataflow/crates/admin/ui/js/inter-pipeline-topology.js
@@ -149,7 +149,7 @@ export function buildInterPipelineTopology(metricSets) {
   const endpointIds = new Set();
 
   for (const set of metricSets || []) {
-    if (set.name !== "topic.exporter.metrics" && set.name !== "topic.receiver.metrics") {
+    if (set.name !== "topic.exporter.metrics" && set.name !== "topic.receiver") {
       continue;
     }
 

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/otap_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/otap_receiver/mod.rs
@@ -253,7 +253,7 @@ impl OTAPReceiver {
 }
 
 /// OTAP receiver metrics.
-#[metric_set(name = "otap.receiver.metrics")]
+#[metric_set(name = "otap.receiver")]
 #[derive(Debug, Default, Clone)]
 pub struct OtapReceiverMetrics {
     /// Number of acks sent.

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs
@@ -953,7 +953,7 @@ impl local::Receiver<OtapPdata> for SyslogCefReceiver {
 }
 
 /// RFC-aligned metrics for Syslog CEF receiver.
-#[metric_set(name = "syslog_cef.receiver.metrics")]
+#[metric_set(name = "syslog_cef.receiver")]
 #[derive(Debug, Default, Clone)]
 pub struct SyslogCefReceiverMetrics {
     /// Number of log records successfully forwarded downstream

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/syslog_cef_receiver/telemetry.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/syslog_cef_receiver/telemetry.md
@@ -8,17 +8,17 @@ by the component and log events emitted via `otel_*` log macros.
 
 ## Metrics
 
-Metrics are registered under the metric set name `syslog_cef.receiver.metrics`.
+Metrics are registered under the metric set name `syslog_cef.receiver`.
 
 | Metric name | Type | Unit | Description | Produced in file |
 | --- | --- | --- | --- | --- |
-| `syslog_cef.receiver.metrics.received_logs_total` | Counter | `{item}` | Total number of log records observed at the socket before parsing. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
-| `syslog_cef.receiver.metrics.received_logs_forwarded` | Counter | `{item}` | Number of log records successfully forwarded downstream. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
-| `syslog_cef.receiver.metrics.received_logs_invalid` | Counter | `{item}` | Number of log records rejected because their payload is zero-length. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
-| `syslog_cef.receiver.metrics.received_logs_truncated` | Counter | `{item}` | Number of log records whose raw message exceeded the maximum message size and were truncated before parsing. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
-| `syslog_cef.receiver.metrics.received_logs_forward_failed` | Counter | `{item}` | Number of log records refused by downstream (backpressure/unavailable). | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
-| `syslog_cef.receiver.metrics.tcp_connections_active` | UpDownCounter | `{conn}` | Number of currently active TCP connections. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
-| `syslog_cef.receiver.metrics.tls_handshake_failures` | Counter | `{error}` | Number of TLS handshake failures. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
+| `syslog_cef.receiver.received_logs_total` | Counter | `{item}` | Total number of log records observed at the socket before parsing. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
+| `syslog_cef.receiver.received_logs_forwarded` | Counter | `{item}` | Number of log records successfully forwarded downstream. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
+| `syslog_cef.receiver.received_logs_invalid` | Counter | `{item}` | Number of log records rejected because their payload is zero-length. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
+| `syslog_cef.receiver.received_logs_truncated` | Counter | `{item}` | Number of log records whose raw message exceeded the maximum message size and were truncated before parsing. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
+| `syslog_cef.receiver.received_logs_forward_failed` | Counter | `{item}` | Number of log records refused by downstream (backpressure/unavailable). | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
+| `syslog_cef.receiver.tcp_connections_active` | UpDownCounter | `{conn}` | Number of currently active TCP connections. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
+| `syslog_cef.receiver.tls_handshake_failures` | Counter | `{error}` | Number of TLS handshake failures. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
 
 ## Logs
 
@@ -37,10 +37,10 @@ When adding or changing telemetry in this component:
 
 1. **Metrics**
    - If you add a field under
-     `#[metric_set(name = "syslog_cef.receiver.metrics")]`, add or
+     `#[metric_set(name = "syslog_cef.receiver")]`, add or
      update its row in the **Metrics** table.
    - Use metric names in the form
-     `syslog_cef.receiver.metrics.<field_name>` unless the field has
+     `syslog_cef.receiver.<field_name>` unless the field has
      an explicit metric-name override.
 
 2. **Logs**

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/topic_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/topic_receiver/mod.rs
@@ -46,7 +46,7 @@ use std::time::{Duration, Instant};
 pub const TOPIC_RECEIVER_URN: &str = "urn:otel:receiver:topic";
 
 /// Telemetry metrics for the topic receiver.
-#[metric_set(name = "topic.receiver.metrics")]
+#[metric_set(name = "topic.receiver")]
 #[derive(Debug, Default, Clone)]
 pub struct TopicReceiverMetrics {
     /// Number of messages forwarded to downstream.

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/metrics.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/metrics.rs
@@ -7,7 +7,7 @@ use otap_df_telemetry::instrument::{Counter, Gauge, Mmsc};
 use otap_df_telemetry_macros::metric_set;
 
 /// Pdata-oriented metrics for the traffic generator receiver.
-#[metric_set(name = "traffic_generator.receiver.metrics")]
+#[metric_set(name = "traffic_generator.receiver")]
 #[derive(Debug, Default, Clone)]
 pub struct TrafficGeneratorReceiverMetrics {
     /// Number of logs generated.

--- a/rust/otap-dataflow/crates/validation/src/metrics_types.rs
+++ b/rust/otap-dataflow/crates/validation/src/metrics_types.rs
@@ -99,7 +99,7 @@ mod tests {
         let snapshot = MetricsSnapshot {
             timestamp: "2024-01-01T00:00:00Z".to_string(),
             metric_sets: vec![MetricSetSnapshot {
-                name: "traffic_generator.receiver.metrics".into(),
+                name: "traffic_generator.receiver".into(),
                 brief: "loadgen metrics".into(),
                 attributes: HashMap::from([(
                     "role".into(),
@@ -119,7 +119,7 @@ mod tests {
 
         let rendered = format!("{snapshot}");
         assert!(rendered.contains("timestamp: 2024-01-01T00:00:00Z"));
-        assert!(rendered.contains("metric_set: traffic_generator.receiver.metrics"));
+        assert!(rendered.contains("metric_set: traffic_generator.receiver"));
         assert!(rendered.contains("logs.produced [{log}]")); // unit shows up in brackets
         assert!(rendered.contains("value=123"));
     }

--- a/rust/otap-dataflow/crates/validation/src/simulate.rs
+++ b/rust/otap-dataflow/crates/validation/src/simulate.rs
@@ -13,7 +13,7 @@ use otap_df_otap::OTAP_PIPELINE_FACTORY;
 use std::collections::HashMap;
 use tokio::time::{Duration, sleep};
 
-const LOADGEN_METRIC_SET: &str = "traffic_generator.receiver.metrics";
+const LOADGEN_METRIC_SET: &str = "traffic_generator.receiver";
 const LOADGEN_METRIC_NAME_LOGS: &str = "logs.produced";
 const LOADGEN_METRIC_NAME_METRICS: &str = "metrics.produced";
 const LOADGEN_TRACE_NAME_SPANS: &str = "spans.produced";

--- a/rust/otap-dataflow/docs/admin/architecture.md
+++ b/rust/otap-dataflow/docs/admin/architecture.md
@@ -81,7 +81,7 @@ Main consumed metric-set families:
 - `channel.sender`
 - `channel.receiver`
 - `topic.exporter.metrics`
-- `topic.receiver.metrics`
+- `topic.receiver`
 - node metric sets keyed by `node.id`
 
 ## State model

--- a/rust/otap-dataflow/docs/memory-limiter-phase1.md
+++ b/rust/otap-dataflow/docs/memory-limiter-phase1.md
@@ -371,10 +371,10 @@ All engine metrics are registered under the `engine` metric-set.
 | --- | --- | --- |
 | `otlp.receiver.refused_memory_pressure` | OTLP (gRPC + HTTP) | Requests rejected due to memory pressure |
 | `otlp.receiver.rejected_requests` | OTLP (gRPC + HTTP) | Total rejected requests (includes memory pressure) |
-| `otap.receiver.metrics.refused_memory_pressure` | OTAP gRPC | Requests rejected due to memory pressure |
-| `otap.receiver.metrics.rejected_requests` | OTAP gRPC | Total rejected requests (includes memory pressure) |
-| `syslog_cef.receiver.metrics.tcp_connections_rejected_memory_pressure` | Syslog / CEF TCP | Connections rejected or closed |
-| `syslog_cef.receiver.metrics.received_logs_rejected_memory_pressure` | Syslog / CEF | Log records dropped under pressure |
+| `otap.receiver.refused_memory_pressure` | OTAP gRPC | Requests rejected due to memory pressure |
+| `otap.receiver.rejected_requests` | OTAP gRPC | Total rejected requests (includes memory pressure) |
+| `syslog_cef.receiver.tcp_connections_rejected_memory_pressure` | Syslog / CEF TCP | Connections rejected or closed |
+| `syslog_cef.receiver.received_logs_rejected_memory_pressure` | Syslog / CEF | Log records dropped under pressure |
 <!-- markdownlint-enable MD013 -->
 
 ### Structured log events

--- a/rust/otap-dataflow/scripts/engine-metrics.py
+++ b/rust/otap-dataflow/scripts/engine-metrics.py
@@ -270,7 +270,7 @@ def classify(name):
     'engine'
     >>> classify('channel.sender')
     'channel'
-    >>> classify('syslog_cef.receiver.metrics')
+    >>> classify('syslog_cef.receiver')
     'receiver'
     >>> classify('otap.processor.batch')
     'processor'


### PR DESCRIPTION
Drops the redundant trailing `.metrics` from core-nodes receiver meter/scope names:

- `traffic_generator.receiver.metrics` → `traffic_generator.receiver`
- `topic.receiver.metrics` → `topic.receiver`
- `otap.receiver.metrics` → `otap.receiver`
- `syslog_cef.receiver.metrics` → `syslog_cef.receiver`

A meter name already names a set of metrics, so the trailing `.metrics` was tautological in scrape output and view selectors. Instrument names are unchanged — only the scope/meter names.

Part of #2531. Follow-up to #2879 (`otlp.receiver`) and #2888 (`engine`, `pipeline`). The remaining per-component renames (core-nodes processors/exporters, contrib-nodes, validation, docs sweep) will land as separate smaller PRs.

## Breaking change for downstream consumers

Anything that selects metrics by **scope/meter name** must be updated. Instrument names are unchanged.

Examples that need updating:

- View configurations that filter by `ScopeName` (e.g. `ScopeName: "traffic_generator.receiver.metrics"` → `ScopeName: "traffic_generator.receiver"`).
- Prometheus relabeling/alerting that keys off the `set="…"` label.
- Dashboards or queries that group by OTLP scope name.

Effective emitted name mapping (`<scope>.<instrument>`), examples:

| Before | After |
|---|---|
| `traffic_generator.receiver.metrics.logs.produced` | `traffic_generator.receiver.logs.produced` |
| `topic.receiver.metrics.forwarded_messages` | `topic.receiver.forwarded_messages` |
| `otap.receiver.metrics.refused_memory_pressure` | `otap.receiver.refused_memory_pressure` |
| `syslog_cef.receiver.metrics.received_logs_total` | `syslog_cef.receiver.received_logs_total` |
