### PR TITLE
Honor the console_fallback setting for engine.observed_state.logging_events send policy

### DIFF
--- a/rust/otap-dataflow/crates/controller/src/lib.rs
+++ b/rust/otap-dataflow/crates/controller/src/lib.rs
@@ -1182,7 +1182,7 @@ impl<
             .logs
             .providers
             .uses_console_async_provider()
-            .then(|| obs_state_store.reporter(engine.observed_state.logging_events));
+            .then(|| obs_state_store.reporter(engine.observed_state.logging_events.clone()));
 
         // Create the telemetry system. The console_async_reporter is passed when any
         // providers use ConsoleAsync. The its_logs_receiver is passed when any
@@ -1191,6 +1191,7 @@ impl<
             telemetry_config,
             telemetry_registry.clone(),
             console_async_reporter,
+            engine.observed_state.logging_events.clone(),
             engine_context,
             log_tap_handle.clone(),
         )?;

--- a/rust/otap-dataflow/crates/telemetry/src/event.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/event.rs
@@ -68,6 +68,13 @@ impl ObservedEventReporter {
         self
     }
 
+    /// Returns the configured send policy. Test-only accessor used to verify
+    /// that the policy was threaded through correctly during construction.
+    #[cfg(test)]
+    pub(crate) fn policy(&self) -> &SendPolicy {
+        &self.policy
+    }
+
     /// Report an engine event.
     ///
     /// When a dedicated engine sender is configured, the event is delivered

--- a/rust/otap-dataflow/crates/telemetry/src/lib.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/lib.rs
@@ -234,6 +234,7 @@ impl InternalTelemetrySystem {
         config: &TelemetryConfig,
         telemetry_registry: TelemetryRegistryHandle,
         console_async_reporter: Option<ObservedEventReporter>,
+        its_reporter_policy: SendPolicy,
         context_fn: LogContextFn,
         log_tap_handle: Option<log_tap::InternalLogTapHandle>,
     ) -> Result<Self, Error> {
@@ -261,10 +262,10 @@ impl InternalTelemetrySystem {
         let (its_reporter, its_settings) = if config.logs.providers.uses_its_provider() {
             let (sender, logs_receiver) = flume::bounded(config.reporting_channel_size);
             let reporter = if let Some(log_tap) = &log_tap_handle {
-                ObservedEventReporter::new(SendPolicy::default(), sender)
+                ObservedEventReporter::new(its_reporter_policy.clone(), sender)
                     .with_drop_counter(log_tap.ingest_drop_counter())
             } else {
-                ObservedEventReporter::new(SendPolicy::default(), sender)
+                ObservedEventReporter::new(its_reporter_policy.clone(), sender)
             };
             let resource_bytes = otel_sdk::encode_resource_bytes(&config.resource);
             (
@@ -423,6 +424,7 @@ impl Default for InternalTelemetrySystem {
             &config,
             TelemetryRegistryHandle::new(),
             Some(dummy_reporter),
+            SendPolicy::default(),
             LogContext::new,
             None,
         )
@@ -468,6 +470,7 @@ mod tests {
                 &TelemetryConfig::default(),
                 TelemetryRegistryHandle::new(),
                 Some(test_reporter()),
+                SendPolicy::default(),
                 LogContext::new,
                 None,
             )
@@ -488,6 +491,7 @@ mod tests {
                 &config_with_providers(providers),
                 TelemetryRegistryHandle::new(),
                 Some(test_reporter()),
+                SendPolicy::default(),
                 LogContext::new,
                 None,
             )
@@ -529,6 +533,7 @@ mod tests {
             &config,
             TelemetryRegistryHandle::new(),
             Some(test_reporter()),
+            SendPolicy::default(),
             LogContext::new,
             None,
         )

--- a/rust/otap-dataflow/crates/telemetry/src/lib.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/lib.rs
@@ -370,6 +370,13 @@ impl InternalTelemetrySystem {
         self.log_tap_handle.clone()
     }
 
+    /// Test-only accessor for the ITS reporter, used to verify that the
+    /// configured logging send policy is threaded through during construction.
+    #[cfg(test)]
+    pub(crate) fn its_reporter(&self) -> Option<&ObservedEventReporter> {
+        self.its_reporter.as_ref()
+    }
+
     /// Returns the configured log level.
     #[must_use]
     pub const fn log_level(&self) -> &LogLevel {
@@ -438,7 +445,9 @@ mod tests {
     use otap_df_config::pipeline::telemetry::{
         AttributeValue::I64 as OTelI64, AttributeValue::String as OTelString,
     };
-    use otap_df_config::settings::telemetry::logs::{LoggingProviders, LogsConfig, ProviderMode};
+    use otap_df_config::settings::telemetry::logs::{
+        InternalLogTapConfig, LoggingProviders, LogsConfig, ProviderMode,
+    };
     use otap_df_pdata::proto::OtlpProtoMessage;
     use otap_df_pdata::proto::opentelemetry::common::v1::{AnyValue, KeyValue};
     use otap_df_pdata::proto::opentelemetry::logs::{v1::LogsData, v1::ResourceLogs};
@@ -514,6 +523,73 @@ mod tests {
             assert!(matches!(recv, ObservedEvent::Log(_)));
             let text = recv.to_string();
             assert!(text.contains("test log message"), "log message is {}", text);
+        });
+    }
+
+    #[test]
+    fn its_reporter_honors_configured_logging_send_policy() {
+        // Verifies the fix that threads `engine.observed_state.logging_events`
+        // through to the ITS reporter, covering both code paths:
+        //   1. log_tap_handle: None
+        //   2. log_tap_handle: Some(_)  (sets the drop counter on the reporter)
+        //
+        // Before the fix, both paths constructed the ITS reporter with
+        // `SendPolicy::default()` (which has `console_fallback: true`),
+        // so a user-provided `console_fallback: false` was silently ignored.
+        with_cleared_rust_log(|| {
+            let providers = LoggingProviders {
+                global: ProviderMode::Noop,
+                engine: ProviderMode::ITS,
+                internal: ProviderMode::Noop,
+                admin: ProviderMode::Noop,
+            };
+            let custom_policy = SendPolicy {
+                blocking_timeout: Some(Duration::from_millis(7)),
+                console_fallback: false,
+            };
+
+            // Case 1: no log tap handle.
+            let its = InternalTelemetrySystem::new(
+                &config_with_providers(providers.clone()),
+                TelemetryRegistryHandle::new(),
+                Some(test_reporter()),
+                custom_policy.clone(),
+                LogContext::new,
+                None,
+            )
+            .expect("should create");
+            let policy = its
+                .its_reporter()
+                .expect("ITS provider configured")
+                .policy();
+            assert_eq!(
+                policy, &custom_policy,
+                "ITS reporter (no log tap) must use configured logging_events policy"
+            );
+
+            // Case 2: with a log tap handle (reporter additionally gets the drop counter).
+            let log_tap = log_tap::build(&InternalLogTapConfig {
+                enabled: true,
+                max_entries: 1,
+                max_bytes: usize::MAX,
+            });
+            let its = InternalTelemetrySystem::new(
+                &config_with_providers(providers),
+                TelemetryRegistryHandle::new(),
+                Some(test_reporter()),
+                custom_policy.clone(),
+                LogContext::new,
+                Some(log_tap),
+            )
+            .expect("should create");
+            let policy = its
+                .its_reporter()
+                .expect("ITS provider configured")
+                .policy();
+            assert_eq!(
+                policy, &custom_policy,
+                "ITS reporter (with log tap) must use configured logging_events policy"
+            );
         });
     }
 

--- a/rust/otap-dataflow/crates/telemetry/src/lib.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/lib.rs
@@ -234,7 +234,7 @@ impl InternalTelemetrySystem {
         config: &TelemetryConfig,
         telemetry_registry: TelemetryRegistryHandle,
         console_async_reporter: Option<ObservedEventReporter>,
-        its_reporter_policy: SendPolicy,
+        logging_send_policy: SendPolicy,
         context_fn: LogContextFn,
         log_tap_handle: Option<log_tap::InternalLogTapHandle>,
     ) -> Result<Self, Error> {
@@ -262,10 +262,10 @@ impl InternalTelemetrySystem {
         let (its_reporter, its_settings) = if config.logs.providers.uses_its_provider() {
             let (sender, logs_receiver) = flume::bounded(config.reporting_channel_size);
             let reporter = if let Some(log_tap) = &log_tap_handle {
-                ObservedEventReporter::new(its_reporter_policy.clone(), sender)
+                ObservedEventReporter::new(logging_send_policy.clone(), sender)
                     .with_drop_counter(log_tap.ingest_drop_counter())
             } else {
-                ObservedEventReporter::new(its_reporter_policy.clone(), sender)
+                ObservedEventReporter::new(logging_send_policy.clone(), sender)
             };
             let resource_bytes = otel_sdk::encode_resource_bytes(&config.resource);
             (


### PR DESCRIPTION
# Change Summary

`console_fallback: false`

would not disable telemetry from logging calls that overflow, due to a default setting.

The correct field `engine.observed_state.logging_events`.

Fixes https://github.com/open-telemetry/otel-arrow/issues/2916