### PR TITLE
Rename otlp.receiver meter to receiver.otlp

### DIFF
--- a/rust/otap-dataflow/crates/otap/src/otlp_metrics.rs
+++ b/rust/otap-dataflow/crates/otap/src/otlp_metrics.rs
@@ -7,7 +7,7 @@ use otap_df_telemetry::instrument::Counter;
 use otap_df_telemetry_macros::metric_set;
 
 /// OTLP receiver metrics.
-#[metric_set(name = "otlp.receiver")]
+#[metric_set(name = "receiver.otlp")]
 #[derive(Debug, Default, Clone)]
 pub struct OtlpReceiverMetrics {
     /// Number of acks received from downstream (routed back to the caller).


### PR DESCRIPTION
Using this small, fully self-contained rename to gauge agreement on the direction proposed in #2926 (just opened). If folks are aligned with the URN-order convention, I'll follow up with the remaining per-component PRs (core-nodes receivers/processors/exporters, contrib-nodes, validation, docs sweep). If not, this is small enough to revert.

Flips the OTLP receiver meter/scope name from `<component_name>.<component_kind>` to `<component_kind>.<component_name>` so it matches the order used by component URNs (`urn:otel:receiver:otlp`).

- `otlp.receiver` → `receiver.otlp`

Pattern mirrors the previous `.metrics` suffix removal series (#2879 / #2888 / #2912 / #2917). Instrument names are unchanged — only the scope/meter name.

## Breaking change for downstream consumers

Anything that selects metrics by **scope/meter name** must be updated. Instrument names are unchanged.

Examples that need updating:

- View configurations that filter by `ScopeName` (e.g. `ScopeName: "otlp.receiver"` → `ScopeName: "receiver.otlp"`).
- Prometheus alerting/relabeling that keys off the `otel_scope_name="…"` label.
- Dashboards or queries that group by OTLP scope name.

## Before/after — Prometheus `/metrics` scrape

Before:

```
acks_received{otel_scope_name="otlp.receiver",pipeline_id="main",node_id="otlp_receiver",core_id="0"} 1234
requests_started{otel_scope_name="otlp.receiver",pipeline_id="main",node_id="otlp_receiver",core_id="0"} 567
request_bytes{otel_scope_name="otlp.receiver",pipeline_id="main",node_id="otlp_receiver",core_id="0"} 9876543
```

After:

```
acks_received{otel_scope_name="receiver.otlp",pipeline_id="main",node_id="otlp_receiver",core_id="0"} 1234
requests_started{otel_scope_name="receiver.otlp",pipeline_id="main",node_id="otlp_receiver",core_id="0"} 567
request_bytes{otel_scope_name="receiver.otlp",pipeline_id="main",node_id="otlp_receiver",core_id="0"} 9876543
```

Only the `otel_scope_name` label value changes; metric names and other labels are identical.