### PR TITLE
Rename remaining meters to URN order: <kind>.<name>

### DIFF
--- a/rust/otap-dataflow/configs/fake-debug-noop-prometheus-telemetry.yaml
+++ b/rust/otap-dataflow/configs/fake-debug-noop-prometheus-telemetry.yaml
@@ -12,13 +12,13 @@ engine:
                 path: "/metrics"
       views:
         - selector:
-            scope_name: "traffic_generator.receiver"
+            scope_name: "receiver.traffic_generator"
             instrument_name: "logs.produced"
           stream:
             name: "otlp.logs.produced.count"
             description: "Count of logs produced"
         - selector:
-            scope_name: "debug.processor.pdata"
+            scope_name: "processor.debug.pdata"
             instrument_name: "logs.consumed"
           stream:
             name: "debug.logs.consumed.count"

--- a/rust/otap-dataflow/configs/fake-debug-noop-telemetry.yaml
+++ b/rust/otap-dataflow/configs/fake-debug-noop-telemetry.yaml
@@ -13,13 +13,13 @@ engine:
                 endpoint: "http://127.0.0.1:43480"
       views:
         - selector:
-            scope_name: "traffic_generator.receiver"
+            scope_name: "receiver.traffic_generator"
             instrument_name: "logs.produced"
           stream:
             name: "otlp.logs.produced.count"
             description: "Count of logs produced"
         - selector:
-            scope_name: "debug.processor.pdata"
+            scope_name: "processor.debug.pdata"
             instrument_name: "logs.consumed"
           stream:
             name: "debug.logs.consumed.count"

--- a/rust/otap-dataflow/crates/admin/ui/js/inter-pipeline-topology.js
+++ b/rust/otap-dataflow/crates/admin/ui/js/inter-pipeline-topology.js
@@ -149,11 +149,11 @@ export function buildInterPipelineTopology(metricSets) {
   const endpointIds = new Set();
 
   for (const set of metricSets || []) {
-    if (set.name !== "topic.exporter" && set.name !== "topic.receiver") {
+    if (set.name !== "exporter.topic" && set.name !== "receiver.topic") {
       continue;
     }
 
-    const role = set.name === "topic.exporter" ? "exporter" : "receiver";
+    const role = set.name === "exporter.topic" ? "exporter" : "receiver";
     const endpoint = buildTopicEndpoint(set, role);
     if (!endpoint) continue;
 

--- a/rust/otap-dataflow/crates/config/src/pipeline/telemetry/metrics/views.rs
+++ b/rust/otap-dataflow/crates/config/src/pipeline/telemetry/metrics/views.rs
@@ -105,7 +105,7 @@ mod tests {
         let yaml_str = r#"
             selector:
               instrument_name: "successful_rows"
-              scope_name: "azure_monitor_exporter"
+              scope_name: "exporter.azure_monitor"
             stream:
               name: "exporter_sent_log_records"
               description: "Number of log records successfully sent by the exporter."
@@ -117,7 +117,7 @@ mod tests {
         );
         assert_eq!(
             config.selector.scope_name.as_deref(),
-            Some("azure_monitor_exporter")
+            Some("exporter.azure_monitor")
         );
         assert_eq!(
             config.stream.name.as_deref(),

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/metrics.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/metrics.rs
@@ -19,7 +19,7 @@ use otap_df_telemetry_macros::metric_set;
 pub type AzureMonitorExporterMetricsRc = Rc<RefCell<AzureMonitorExporterMetricsTracker>>;
 
 /// Telemetry metrics for the Azure Monitor Exporter.
-#[metric_set(name = "azure_monitor_exporter")]
+#[metric_set(name = "exporter.azure_monitor")]
 #[derive(Debug, Default, Clone)]
 pub struct AzureMonitorExporterMetrics {
     /// Number of rows successfully exported.

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/telemetry.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/telemetry.md
@@ -8,29 +8,29 @@ by the crate and log events emitted via `otel_*` log macros.
 
 | Metric name | Description | Produced in file |
 | --- | --- | --- |
-| `azure_monitor_exporter.successful_rows` | Number of rows successfully exported. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
-| `azure_monitor_exporter.successful_batches` | Number of batches successfully exported. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
-| `azure_monitor_exporter.successful_messages` | Number of messages successfully exported. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
-| `azure_monitor_exporter.failed_rows` | Number of rows that failed to export. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
-| `azure_monitor_exporter.failed_batches` | Number of batches that failed to export. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
-| `azure_monitor_exporter.failed_messages` | Number of messages that failed to export. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
-| `azure_monitor_exporter.laclient_http_success_latency` | HTTP client success latency in milliseconds (min/max/sum/count). | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs` |
-| `azure_monitor_exporter.laclient_http_2xx` | Number of HTTP 2xx responses. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs` |
-| `azure_monitor_exporter.laclient_http_401` | Number of HTTP 401 responses. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs` |
-| `azure_monitor_exporter.laclient_http_403` | Number of HTTP 403 responses. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs` |
-| `azure_monitor_exporter.laclient_http_413` | Number of HTTP 413 responses. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs` |
-| `azure_monitor_exporter.laclient_http_429` | Number of HTTP 429 responses. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs` |
-| `azure_monitor_exporter.laclient_http_5xx` | Number of HTTP 5xx responses. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs` |
-| `azure_monitor_exporter.auth_failures` | Number of failed authentication attempts. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/auth.rs` |
-| `azure_monitor_exporter.auth_success_latency` | Authentication success latency in milliseconds (min/max/sum/count). | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/auth.rs` |
-| `azure_monitor_exporter.batch_size` | Compressed batch size in bytes (min/max/sum/count). | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs` |
-| `azure_monitor_exporter.batch_uncompressed_size` | Uncompressed batch size in bytes (min/max/sum/count). | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
-| `azure_monitor_exporter.in_flight_exports` | Current number of in-flight export requests. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
-| `azure_monitor_exporter.batch_to_msg_count` | Current number of batch-to-message mappings. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
-| `azure_monitor_exporter.msg_to_batch_count` | Current number of message-to-batch mappings. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
-| `azure_monitor_exporter.msg_to_data_count` | Current number of message-to-data mappings. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
-| `azure_monitor_exporter.log_entries_too_large` | Number of log entries rejected for exceeding batch size limit. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
-| `azure_monitor_exporter.heartbeats` | Number of heartbeat sends attempted/successful. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
+| `exporter.azure_monitor.successful_rows` | Number of rows successfully exported. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
+| `exporter.azure_monitor.successful_batches` | Number of batches successfully exported. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
+| `exporter.azure_monitor.successful_messages` | Number of messages successfully exported. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
+| `exporter.azure_monitor.failed_rows` | Number of rows that failed to export. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
+| `exporter.azure_monitor.failed_batches` | Number of batches that failed to export. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
+| `exporter.azure_monitor.failed_messages` | Number of messages that failed to export. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
+| `exporter.azure_monitor.laclient_http_success_latency` | HTTP client success latency in milliseconds (min/max/sum/count). | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs` |
+| `exporter.azure_monitor.laclient_http_2xx` | Number of HTTP 2xx responses. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs` |
+| `exporter.azure_monitor.laclient_http_401` | Number of HTTP 401 responses. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs` |
+| `exporter.azure_monitor.laclient_http_403` | Number of HTTP 403 responses. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs` |
+| `exporter.azure_monitor.laclient_http_413` | Number of HTTP 413 responses. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs` |
+| `exporter.azure_monitor.laclient_http_429` | Number of HTTP 429 responses. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs` |
+| `exporter.azure_monitor.laclient_http_5xx` | Number of HTTP 5xx responses. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs` |
+| `exporter.azure_monitor.auth_failures` | Number of failed authentication attempts. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/auth.rs` |
+| `exporter.azure_monitor.auth_success_latency` | Authentication success latency in milliseconds (min/max/sum/count). | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/auth.rs` |
+| `exporter.azure_monitor.batch_size` | Compressed batch size in bytes (min/max/sum/count). | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs` |
+| `exporter.azure_monitor.batch_uncompressed_size` | Uncompressed batch size in bytes (min/max/sum/count). | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
+| `exporter.azure_monitor.in_flight_exports` | Current number of in-flight export requests. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
+| `exporter.azure_monitor.batch_to_msg_count` | Current number of batch-to-message mappings. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
+| `exporter.azure_monitor.msg_to_batch_count` | Current number of message-to-batch mappings. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
+| `exporter.azure_monitor.msg_to_data_count` | Current number of message-to-data mappings. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
+| `exporter.azure_monitor.log_entries_too_large` | Number of log entries rejected for exceeding batch size limit. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
+| `exporter.azure_monitor.heartbeats` | Number of heartbeat sends attempted/successful. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
 
 ## Logs
 
@@ -66,10 +66,10 @@ When adding or changing telemetry in this crate:
 
 1. **Metrics**
    - If you add a field under
-     `#[metric_set(name = "azure_monitor_exporter")]`, add or
+     `#[metric_set(name = "exporter.azure_monitor")]`, add or
      update its row in the **Metrics** table.
    - Use metric names in the form
-     `azure_monitor_exporter.<field_name>` unless the field has
+     `exporter.azure_monitor.<field_name>` unless the field has
      an explicit metric-name override.
 
 2. **Logs**

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/resource_validator_processor/metrics.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/resource_validator_processor/metrics.rs
@@ -11,7 +11,7 @@ use otap_df_telemetry_macros::metric_set;
 /// Tracks both batch-level and item-level counts. Validation is pass/fail for
 /// the entire batch — if any resource fails, the whole batch is NACKed. Item
 /// counts capture the magnitude of data loss on rejection.
-#[metric_set(name = "resource_validator.processor")]
+#[metric_set(name = "processor.resource_validator")]
 #[derive(Debug, Default, Clone)]
 pub struct ResourceValidatorMetrics {
     /// Number of batches that passed validation

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/perf_exporter/metrics.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/perf_exporter/metrics.rs
@@ -7,7 +7,7 @@ use otap_df_telemetry::instrument::Counter;
 use otap_df_telemetry_macros::metric_set;
 
 /// Pdata-oriented metrics for the OTAP PerfExporter.
-#[metric_set(name = "perf.exporter.pdata")]
+#[metric_set(name = "exporter.perf.pdata")]
 #[derive(Debug, Default, Clone)]
 pub struct PerfExporterPdataMetrics {
     /// Number of invalid pdata batches received.

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/topic_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/topic_exporter/mod.rs
@@ -42,7 +42,7 @@ use std::time::Duration;
 pub const TOPIC_EXPORTER_URN: &str = "urn:otel:exporter:topic";
 
 /// Telemetry metrics for the topic exporter.
-#[metric_set(name = "topic.exporter")]
+#[metric_set(name = "exporter.topic")]
 #[derive(Debug, Default, Clone)]
 pub struct TopicExporterMetrics {
     /// Number of messages published to the topic.

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/attributes_processor/metrics.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/attributes_processor/metrics.rs
@@ -7,7 +7,7 @@ use otap_df_telemetry::instrument::Counter;
 use otap_df_telemetry_macros::metric_set;
 
 /// Metrics for the AttributesProcessor node.
-#[metric_set(name = "attributes.processor")]
+#[metric_set(name = "processor.attributes")]
 #[derive(Debug, Default, Clone)]
 pub struct AttributesProcessorMetrics {
     /// Number of failed transform attempts.

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/attributes_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/attributes_processor/mod.rs
@@ -2317,7 +2317,7 @@ mod telemetry_tests {
                 let mut found_domain_signal = false;
 
                 telemetry_registry.visit_current_metrics(|desc, _attrs, iter| {
-                    if desc.name == "attributes.processor" {
+                    if desc.name == "processor.attributes" {
                         for (field, v) in iter {
                             match (field.name, v.to_u64_lossy()) {
                                 ("renamed.entries", x) if x >= 1 => found_renamed_entries = true,

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/content_router/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/content_router/mod.rs
@@ -134,7 +134,7 @@ impl std::fmt::Display for RoutingKeyExpr {
 }
 
 /// Metrics for the ContentRouter processor.
-#[metric_set(name = "content_router.processor")]
+#[metric_set(name = "processor.content_router")]
 #[derive(Debug, Default, Clone)]
 pub struct ContentRouterMetrics {
     /// Number of messages routed to a named port.

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/debug_processor/metrics.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/debug_processor/metrics.rs
@@ -7,7 +7,7 @@ use otap_df_telemetry::instrument::Counter;
 use otap_df_telemetry_macros::metric_set;
 
 /// Pdata-oriented metrics for the OTAP DebugProcessor
-#[metric_set(name = "debug.processor.pdata")]
+#[metric_set(name = "processor.debug.pdata")]
 #[derive(Debug, Default, Clone)]
 pub struct DebugPdataMetrics {
     /// Number of log signals consumed

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/fanout_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/fanout_processor/mod.rs
@@ -362,7 +362,7 @@ struct Inflight {
     next_send_queue: DestinationIndexQueue,
 }
 
-#[metric_set(name = "fanout.processor")]
+#[metric_set(name = "processor.fanout")]
 #[derive(Debug, Default, Clone)]
 struct FanoutMetrics {
     /// Requests dispatched. Note: This is a convenience metric that overlaps with

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/metrics.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/metrics.rs
@@ -6,7 +6,7 @@ use otap_df_telemetry::instrument::Counter;
 use otap_df_telemetry_macros::metric_set;
 
 /// Pdata-oriented metrics for the OTAP FilterProcessor
-#[metric_set(name = "filter.processor.pdata")]
+#[metric_set(name = "processor.filter.pdata")]
 #[derive(Debug, Default, Clone)]
 pub struct FilterPdataMetrics {
     /// Number of log signals consumed

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/log_sampling_processor/metrics.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/log_sampling_processor/metrics.rs
@@ -7,7 +7,7 @@ use otap_df_telemetry::instrument::Counter;
 use otap_df_telemetry_macros::metric_set;
 
 /// Metrics for the log sampling processor.
-#[metric_set(name = "log_sampling.processor.pdata")]
+#[metric_set(name = "processor.log_sampling.pdata")]
 #[derive(Debug, Default, Clone)]
 pub struct LogSamplingMetrics {
     /// Total log records received by the processor.

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/retry_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/retry_processor/mod.rs
@@ -198,7 +198,7 @@ impl RetryConfig {
 }
 
 /// Telemetry metrics for the RetryProcessor (RFC-aligned items + component counters).
-#[metric_set(name = "retry.processor")]
+#[metric_set(name = "processor.retry")]
 #[derive(Debug, Default, Clone)]
 pub struct RetryProcessorMetrics {
     // RFC-aligned: consumed items by signal and outcome

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/signal_type_router/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/signal_type_router/mod.rs
@@ -83,7 +83,7 @@ pub const PORT_METRICS: &str = "metrics";
 pub const PORT_LOGS: &str = "logs";
 
 /// Metrics for the SignalTypeRouter processor.
-#[metric_set(name = "signal_type_router.processor")]
+#[metric_set(name = "processor.signal_type_router")]
 #[derive(Debug, Default, Clone)]
 pub struct SignalTypeRouterMetrics {
     /// Number of log messages received by the router.

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/telemetry.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/telemetry.rs
@@ -20,7 +20,7 @@ pub const INVALID_CALLDATA_EVENT: &str = "temporal_reaggregation.calldata.invali
 pub const ERRONEOUS_ACK_EVENT: &str = "temporal_reaggregation.ack.erroneous";
 
 /// Metrics for the temporal reaggregation processor.
-#[metric_set(name = "temporal_reaggregation.processor.pdata")]
+#[metric_set(name = "processor.temporal_reaggregation.pdata")]
 #[derive(Debug, Default, Clone)]
 pub struct TemporalReaggregationMetrics {
     /// Number of flushes triggered by the regular timer.

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/metrics.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/metrics.rs
@@ -7,7 +7,7 @@ use otap_df_telemetry::instrument::Counter;
 use otap_df_telemetry_macros::metric_set;
 
 /// Metrics for the TransformProcessor node.
-#[metric_set(name = "transform.processor")]
+#[metric_set(name = "processor.transform")]
 #[derive(Debug, Default, Clone)]
 pub struct Metrics {
     /// Number of messages successfully transformed.

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
@@ -679,7 +679,7 @@ mod test {
                 let mut msgs_transformed = 0;
                 let mut msgs_transform_failed = 0;
                 telemetry_registry.visit_current_metrics(|desc, _attrs, iter| {
-                    if desc.name == "transform.processor" {
+                    if desc.name == "processor.transform" {
                         for (field, v) in iter {
                             let val = v.to_u64_lossy();
                             match field.name {

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/host_metrics_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/host_metrics_receiver/mod.rs
@@ -79,7 +79,7 @@ use config::{RuntimeFamily, effective_root_path, normalized_root_path};
 pub const HOST_METRICS_RECEIVER_URN: &str = "urn:otel:receiver:host_metrics";
 
 /// Telemetry metrics for the host metrics receiver.
-#[metric_set(name = "host_metrics.receiver")]
+#[metric_set(name = "receiver.host_metrics")]
 #[derive(Debug, Default, Clone)]
 pub struct HostMetricsReceiverMetrics {
     /// Number of scrape ticks started.

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/otap_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/otap_receiver/mod.rs
@@ -253,7 +253,7 @@ impl OTAPReceiver {
 }
 
 /// OTAP receiver metrics.
-#[metric_set(name = "otap.receiver")]
+#[metric_set(name = "receiver.otap")]
 #[derive(Debug, Default, Clone)]
 pub struct OtapReceiverMetrics {
     /// Number of acks sent.

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs
@@ -953,7 +953,7 @@ impl local::Receiver<OtapPdata> for SyslogCefReceiver {
 }
 
 /// RFC-aligned metrics for Syslog CEF receiver.
-#[metric_set(name = "syslog_cef.receiver")]
+#[metric_set(name = "receiver.syslog_cef")]
 #[derive(Debug, Default, Clone)]
 pub struct SyslogCefReceiverMetrics {
     /// Number of log records successfully forwarded downstream

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/syslog_cef_receiver/telemetry.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/syslog_cef_receiver/telemetry.md
@@ -8,17 +8,17 @@ by the component and log events emitted via `otel_*` log macros.
 
 ## Metrics
 
-Metrics are registered under the metric set name `syslog_cef.receiver`.
+Metrics are registered under the metric set name `receiver.syslog_cef`.
 
 | Metric name | Type | Unit | Description | Produced in file |
 | --- | --- | --- | --- | --- |
-| `syslog_cef.receiver.received_logs_total` | Counter | `{item}` | Total number of log records observed at the socket before parsing. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
-| `syslog_cef.receiver.received_logs_forwarded` | Counter | `{item}` | Number of log records successfully forwarded downstream. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
-| `syslog_cef.receiver.received_logs_invalid` | Counter | `{item}` | Number of log records rejected because their payload is zero-length. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
-| `syslog_cef.receiver.received_logs_truncated` | Counter | `{item}` | Number of log records whose raw message exceeded the maximum message size and were truncated before parsing. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
-| `syslog_cef.receiver.received_logs_forward_failed` | Counter | `{item}` | Number of log records refused by downstream (backpressure/unavailable). | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
-| `syslog_cef.receiver.tcp_connections_active` | UpDownCounter | `{conn}` | Number of currently active TCP connections. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
-| `syslog_cef.receiver.tls_handshake_failures` | Counter | `{error}` | Number of TLS handshake failures. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
+| `receiver.syslog_cef.received_logs_total` | Counter | `{item}` | Total number of log records observed at the socket before parsing. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
+| `receiver.syslog_cef.received_logs_forwarded` | Counter | `{item}` | Number of log records successfully forwarded downstream. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
+| `receiver.syslog_cef.received_logs_invalid` | Counter | `{item}` | Number of log records rejected because their payload is zero-length. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
+| `receiver.syslog_cef.received_logs_truncated` | Counter | `{item}` | Number of log records whose raw message exceeded the maximum message size and were truncated before parsing. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
+| `receiver.syslog_cef.received_logs_forward_failed` | Counter | `{item}` | Number of log records refused by downstream (backpressure/unavailable). | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
+| `receiver.syslog_cef.tcp_connections_active` | UpDownCounter | `{conn}` | Number of currently active TCP connections. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
+| `receiver.syslog_cef.tls_handshake_failures` | Counter | `{error}` | Number of TLS handshake failures. | `crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs` |
 
 ## Logs
 
@@ -37,10 +37,10 @@ When adding or changing telemetry in this component:
 
 1. **Metrics**
    - If you add a field under
-     `#[metric_set(name = "syslog_cef.receiver")]`, add or
+     `#[metric_set(name = "receiver.syslog_cef")]`, add or
      update its row in the **Metrics** table.
    - Use metric names in the form
-     `syslog_cef.receiver.<field_name>` unless the field has
+     `receiver.syslog_cef.<field_name>` unless the field has
      an explicit metric-name override.
 
 2. **Logs**

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/topic_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/topic_receiver/mod.rs
@@ -46,7 +46,7 @@ use std::time::{Duration, Instant};
 pub const TOPIC_RECEIVER_URN: &str = "urn:otel:receiver:topic";
 
 /// Telemetry metrics for the topic receiver.
-#[metric_set(name = "topic.receiver")]
+#[metric_set(name = "receiver.topic")]
 #[derive(Debug, Default, Clone)]
 pub struct TopicReceiverMetrics {
     /// Number of messages forwarded to downstream.

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/metrics.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/metrics.rs
@@ -7,7 +7,7 @@ use otap_df_telemetry::instrument::{Counter, Gauge, Mmsc};
 use otap_df_telemetry_macros::metric_set;
 
 /// Pdata-oriented metrics for the traffic generator receiver.
-#[metric_set(name = "traffic_generator.receiver")]
+#[metric_set(name = "receiver.traffic_generator")]
 #[derive(Debug, Default, Clone)]
 pub struct TrafficGeneratorReceiverMetrics {
     /// Number of logs generated.

--- a/rust/otap-dataflow/crates/telemetry-macros/README.md
+++ b/rust/otap-dataflow/crates/telemetry-macros/README.md
@@ -34,7 +34,7 @@ use otap_df_telemetry::instrument::{Counter, Gauge};
 use otap_df_telemetry_macros::metric_set;
 
 /// Pdata-oriented metrics for the OTAP PerfExporter.
-#[metric_set(name = "perf.exporter.pdata")]
+#[metric_set(name = "exporter.perf.pdata")]
 #[derive(Debug, Default, Clone)]
 pub struct PerfExporterPdataMetrics {
     /// Number of pdata batches received.
@@ -81,7 +81,7 @@ implementation roughly like this:
 ```rust
 #[repr(C, align(64))]
 #[derive(Debug, Default, Clone, otap_df_telemetry_macros::MetricSetHandler)]
-#[metric_set(name = "perf.exporter.pdata")]
+#[metric_set(name = "exporter.perf.pdata")]
 pub struct PerfExporterPdataMetrics {
     // same fields as above
     pub batches: otap_df_telemetry::instrument::Counter<u64>,
@@ -92,7 +92,7 @@ pub struct PerfExporterPdataMetrics {
 impl otap_df_telemetry::metrics::MetricSetHandler for PerfExporterPdataMetrics {
     fn descriptor(&self) -> &'static otap_df_telemetry::descriptor::MetricsDescriptor {
         static DESCRIPTOR: otap_df_telemetry::descriptor::MetricsDescriptor = otap_df_telemetry::descriptor::MetricsDescriptor {
-            name: "perf.exporter.pdata",
+            name: "exporter.perf.pdata",
                 metrics: &[
                     otap_df_telemetry::descriptor::MetricsField {
                         name: "batches",

--- a/rust/otap-dataflow/crates/telemetry/src/otel_sdk/meter_provider/views_provider.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/otel_sdk/meter_provider/views_provider.rs
@@ -198,7 +198,7 @@ mod tests {
         let view_config = ViewConfig {
             selector: MetricSelector {
                 instrument_name: None,
-                scope_name: Some("azure_monitor_exporter".to_string()),
+                scope_name: Some("exporter.azure_monitor".to_string()),
                 scope_attributes: HashMap::new(),
             },
             stream: MetricStream {

--- a/rust/otap-dataflow/crates/validation/src/fanout_processor.rs
+++ b/rust/otap-dataflow/crates/validation/src/fanout_processor.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 /// URN that identifies the temporary fanout processor used in validation pipelines.
 pub const FANOUT_PROCESSOR_URN: &str = "urn:otel:processor:fanout_temp";
 
-#[metric_set(name = "fanout.processor")]
+#[metric_set(name = "processor.fanout")]
 #[derive(Debug, Default, Clone)]
 struct FanoutMetrics {
     /// Number of messages forwarded.

--- a/rust/otap-dataflow/crates/validation/src/metrics_types.rs
+++ b/rust/otap-dataflow/crates/validation/src/metrics_types.rs
@@ -99,7 +99,7 @@ mod tests {
         let snapshot = MetricsSnapshot {
             timestamp: "2024-01-01T00:00:00Z".to_string(),
             metric_sets: vec![MetricSetSnapshot {
-                name: "traffic_generator.receiver".into(),
+                name: "receiver.traffic_generator".into(),
                 brief: "loadgen metrics".into(),
                 attributes: HashMap::from([(
                     "role".into(),
@@ -119,7 +119,7 @@ mod tests {
 
         let rendered = format!("{snapshot}");
         assert!(rendered.contains("timestamp: 2024-01-01T00:00:00Z"));
-        assert!(rendered.contains("metric_set: traffic_generator.receiver"));
+        assert!(rendered.contains("metric_set: receiver.traffic_generator"));
         assert!(rendered.contains("logs.produced [{log}]")); // unit shows up in brackets
         assert!(rendered.contains("value=123"));
     }

--- a/rust/otap-dataflow/crates/validation/src/simulate.rs
+++ b/rust/otap-dataflow/crates/validation/src/simulate.rs
@@ -13,11 +13,11 @@ use otap_df_otap::OTAP_PIPELINE_FACTORY;
 use std::collections::HashMap;
 use tokio::time::{Duration, sleep};
 
-const LOADGEN_METRIC_SET: &str = "traffic_generator.receiver";
+const LOADGEN_METRIC_SET: &str = "receiver.traffic_generator";
 const LOADGEN_METRIC_NAME_LOGS: &str = "logs.produced";
 const LOADGEN_METRIC_NAME_METRICS: &str = "metrics.produced";
 const LOADGEN_TRACE_NAME_SPANS: &str = "spans.produced";
-const VALIDATION_METRIC_SET: &str = "validation.exporter";
+const VALIDATION_METRIC_SET: &str = "exporter.validation";
 const VALIDATION_METRIC_NAME: &str = "valid";
 const VALIDATION_FINISHED_METRIC_NAME: &str = "finished";
 

--- a/rust/otap-dataflow/crates/validation/src/validation_exporter.rs
+++ b/rust/otap-dataflow/crates/validation/src/validation_exporter.rs
@@ -59,7 +59,7 @@ fn default_idle_timeout_secs() -> u64 {
     DEFAULT_IDLE_TIMEOUT_SECS
 }
 
-#[metric_set(name = "validation.exporter")]
+#[metric_set(name = "exporter.validation")]
 #[derive(Debug, Default, Clone)]
 struct ValidationExporterMetrics {
     /// Number of validation checks that did not match expectation

--- a/rust/otap-dataflow/docs/admin/architecture.md
+++ b/rust/otap-dataflow/docs/admin/architecture.md
@@ -80,8 +80,8 @@ Main consumed metric-set families:
 - `tokio.runtime`
 - `channel.sender`
 - `channel.receiver`
-- `topic.exporter`
-- `topic.receiver`
+- `exporter.topic`
+- `receiver.topic`
 - node metric sets keyed by `node.id`
 
 ## State model

--- a/rust/otap-dataflow/docs/memory-limiter-phase1.md
+++ b/rust/otap-dataflow/docs/memory-limiter-phase1.md
@@ -369,12 +369,12 @@ All engine metrics are registered under the `engine` metric-set.
 <!-- markdownlint-disable MD013 -->
 | Metric | Receiver | Description |
 | --- | --- | --- |
-| `otlp.receiver.refused_memory_pressure` | OTLP (gRPC + HTTP) | Requests rejected due to memory pressure |
-| `otlp.receiver.rejected_requests` | OTLP (gRPC + HTTP) | Total rejected requests (includes memory pressure) |
-| `otap.receiver.refused_memory_pressure` | OTAP gRPC | Requests rejected due to memory pressure |
-| `otap.receiver.rejected_requests` | OTAP gRPC | Total rejected requests (includes memory pressure) |
-| `syslog_cef.receiver.tcp_connections_rejected_memory_pressure` | Syslog / CEF TCP | Connections rejected or closed |
-| `syslog_cef.receiver.received_logs_rejected_memory_pressure` | Syslog / CEF | Log records dropped under pressure |
+| `receiver.otlp.refused_memory_pressure` | OTLP (gRPC + HTTP) | Requests rejected due to memory pressure |
+| `receiver.otlp.rejected_requests` | OTLP (gRPC + HTTP) | Total rejected requests (includes memory pressure) |
+| `receiver.otap.refused_memory_pressure` | OTAP gRPC | Requests rejected due to memory pressure |
+| `receiver.otap.rejected_requests` | OTAP gRPC | Total rejected requests (includes memory pressure) |
+| `receiver.syslog_cef.tcp_connections_rejected_memory_pressure` | Syslog / CEF TCP | Connections rejected or closed |
+| `receiver.syslog_cef.received_logs_rejected_memory_pressure` | Syslog / CEF | Log records dropped under pressure |
 <!-- markdownlint-enable MD013 -->
 
 ### Structured log events

--- a/rust/otap-dataflow/scripts/engine-metrics.py
+++ b/rust/otap-dataflow/scripts/engine-metrics.py
@@ -270,11 +270,11 @@ def classify(name):
     'engine'
     >>> classify('channel.sender')
     'channel'
-    >>> classify('syslog_cef.receiver')
+    >>> classify('receiver.syslog_cef')
     'receiver'
     >>> classify('otap.processor.batch')
     'processor'
-    >>> classify('azure_monitor_exporter')
+    >>> classify('exporter.azure_monitor')
     'exporter'
     """
     n = name.lower()


### PR DESCRIPTION
Follow-up to #2928 to flip every remaining meter/scope name from `<component_name>.<component_kind>` to `<component_kind>.<component_name>`, matching the order used by component URNs (`urn:otel:<kind>:<name>`).

Closes #2926.

## Renames in this PR

Receivers:

- `traffic_generator.receiver` → `receiver.traffic_generator`
- `topic.receiver` → `receiver.topic`
- `otap.receiver` → `receiver.otap`
- `syslog_cef.receiver` → `receiver.syslog_cef`
- `host_metrics.receiver` → `receiver.host_metrics`

Processors:

- `attributes.processor` → `processor.attributes`
- `debug.processor.pdata` → `processor.debug.pdata`
- `temporal_reaggregation.processor.pdata` → `processor.temporal_reaggregation.pdata`
- `content_router.processor` → `processor.content_router`
- `signal_type_router.processor` → `processor.signal_type_router`
- `log_sampling.processor.pdata` → `processor.log_sampling.pdata`
- `filter.processor.pdata` → `processor.filter.pdata`
- `retry.processor` → `processor.retry`
- `fanout.processor` → `processor.fanout`
- `transform.processor` → `processor.transform`
- `resource_validator.processor` → `processor.resource_validator`

Exporters:

- `perf.exporter.pdata` → `exporter.perf.pdata`
- `topic.exporter` → `exporter.topic`
- `validation.exporter` → `exporter.validation`
- `azure_monitor_exporter` → `exporter.azure_monitor` (also splits the previously underscore-joined token)

The `.pdata` qualifier is preserved as a trailing suffix where present.

## Out of scope

Already kind-first or kind-in-middle (left as-is): `engine`, `pipeline`, `pipeline.runtime_control`, `pipeline.completion`, `tokio.runtime`, `flow`, `processor.compute`, `exporter.pdata`, `channel.sender`, `channel.receiver`, `node.consumer`, `node.producer`, `node.completion_emission`, `node.local_wakeup.scheduler`. The `otap.<kind>.<name>` signal-namespaced sets (`otap.exporter.geneva`, `otap.exporter.grpc.async`, `otap.exporter.parquet`, `otap.processor.batch`, `otap.processor.durable_buffer`) are also left as-is — restructuring `<signal>.<kind>.<name>` is a separate decision.

Log event names that share the `*.metrics.*` shape (e.g. `azure_monitor_exporter.metrics.collect`, `pipeline.metrics.reporting.fail`) are intentionally preserved — they are log events, not meter names, matching the convention kept by #2888 / #2912 / #2917.

## Breaking change for downstream consumers

Anything that selects metrics by **scope/meter name** must be updated. Instrument names are unchanged.

Examples:

- View configurations that filter by `ScopeName` (e.g. `ScopeName: "topic.exporter"` → `ScopeName: "exporter.topic"`).
- Prometheus alerting/relabeling that keys off the `otel_scope_name="…"` label.
- Dashboards or queries that group by OTLP scope name.