### PR TITLE
feat(comparison_dashboard): Add all the dfe suites and define a DFE engine baseline comparison

### DIFF
--- a/tools/comparison_dashboard/comparisons/dfe_baselines.yaml
+++ b/tools/comparison_dashboard/comparisons/dfe_baselines.yaml
@@ -1,0 +1,37 @@
+slug: dfe_baselines
+name: DFE Baselines
+description: Baseline DFE logs runs across OTAP, OTLP, and OTLP/HTTP with no, gzip, and zstd compression.
+
+suites:
+  # OTAP
+  - name: DFE OTAP Baseline (None)
+    slug: dfe_logs_otap_none_baseline
+    short: OTAP/None
+  - name: DFE OTAP Baseline (Gzip)
+    slug: dfe_logs_otap_gzip_baseline
+    short: OTAP/Gzip
+  - name: DFE OTAP Baseline (Zstd)
+    slug: dfe_logs_otap_zstd_baseline
+    short: OTAP/Zstd
+
+  # OTLP
+  - name: DFE OTLP Baseline (None)
+    slug: dfe_logs_otlp_none_baseline
+    short: OTLP/None
+  - name: DFE OTLP Baseline (Gzip)
+    slug: dfe_logs_otlp_gzip_baseline
+    short: OTLP/Gzip
+  - name: DFE OTLP Baseline (Zstd)
+    slug: dfe_logs_otlp_zstd_baseline
+    short: OTLP/Zstd
+
+  # OTLP/HTTP
+  - name: DFE OTLP/HTTP Baseline (None)
+    slug: dfe_logs_otlphttp_none_baseline
+    short: OTLP-HTTP/None
+  - name: DFE OTLP/HTTP Baseline (Gzip)
+    slug: dfe_logs_otlphttp_gzip_baseline
+    short: OTLP-HTTP/Gzip
+  - name: DFE OTLP/HTTP Baseline (Zstd)
+    slug: dfe_logs_otlphttp_zstd_baseline
+    short: OTLP-HTTP/Zstd

--- a/tools/comparison_dashboard/comparisons/dfe_baselines.yaml
+++ b/tools/comparison_dashboard/comparisons/dfe_baselines.yaml
@@ -1,6 +1,6 @@
 slug: dfe_baselines
-name: DFE Baselines
-description: Baseline DFE logs runs across OTAP, OTLP, and OTLP/HTTP with no, gzip, and zstd compression.
+name: Dataflow Engine Baselines
+description: Baseline DFE logs runs across OTAP, OTLP, and OTLP/HTTP with none, gzip, and zstd compression.
 
 suites:
   # OTAP

--- a/tools/comparison_dashboard/dashboard.py
+++ b/tools/comparison_dashboard/dashboard.py
@@ -1006,7 +1006,7 @@ def generate_index_html(comparisons: list, suites: dict, paths: BuildPaths) -> N
         '<head>',
         '  <meta charset="utf-8">',
         '  <meta name="viewport" content="width=device-width, initial-scale=1">',
-        '  <title>Telemetry Engine Benchmark Dashboard</title>',
+        '  <title>Telemetry Engine Benchmarks</title>',
         f'  <link rel="stylesheet" href="{shared_rel}/styles.css">',
         '</head>',
         '<body>',

--- a/tools/comparison_dashboard/dashboard.py
+++ b/tools/comparison_dashboard/dashboard.py
@@ -1017,7 +1017,7 @@ def generate_index_html(comparisons: list, suites: dict, paths: BuildPaths) -> N
         '  </div>',
         '  <div class="wrap">',
         '    <h1>Telemetry Engine Benchmark Dashboard</h1>',
-        '    <div class="sub">Suite-based comparison of OTel Dataflow Engine (DFE) and OTel Collector (OTC) benchmark results.</div>',
+        '    <div class="sub">Compare telemetry engines across a variety of use-cases and protocols.</div>',
         '    <div id="app"></div>',
         '    <div id="comparison-cards"></div>',
         '  </div>',

--- a/tools/comparison_dashboard/manifest.yaml
+++ b/tools/comparison_dashboard/manifest.yaml
@@ -47,4 +47,5 @@ suites:
 
 # Comparison definitions, listed by path. Each entry must point at an
 # existing YAML file with `slug` and `suites` (a list of suite refs).
-comparisons: []
+comparisons:
+  - comparisons/dfe_baselines.yaml

--- a/tools/comparison_dashboard/manifest.yaml
+++ b/tools/comparison_dashboard/manifest.yaml
@@ -31,6 +31,12 @@ suites:
   - suites/dfe/dfe-logs-otap-none-baseline.yaml
   - suites/dfe/dfe-logs-otap-gzip-baseline.yaml
   - suites/dfe/dfe-logs-otap-zstd-baseline.yaml
+  - suites/dfe/dfe-logs-otlp-none-baseline.yaml
+  - suites/dfe/dfe-logs-otlp-gzip-baseline.yaml
+  - suites/dfe/dfe-logs-otlp-zstd-baseline.yaml
+  - suites/dfe/dfe-logs-otlphttp-none-baseline.yaml
+  - suites/dfe/dfe-logs-otlphttp-gzip-baseline.yaml
+  - suites/dfe/dfe-logs-otlphttp-zstd-baseline.yaml
   - suites/otc/otc-logs-otap-none-baseline.yaml
   - suites/otc/otc-logs-otap-gzip-baseline.yaml
   - suites/otc/otc-logs-otap-zstd-baseline.yaml


### PR DESCRIPTION
# Change Summary

This PR adds all the DFE baseline logs suites to the dashboard and defines a comparison of all the DFE baseline suites for further testing of the site. No data checked in yet so it will look blank until we add some.

## What issue does this PR close?

* Closes #2892

## How are these changes tested?

Locally: 

<img width="2449" height="994" alt="image" src="https://github.com/user-attachments/assets/d362d7de-194f-4a1d-a5ec-e29dc8bfdda0" />

## Are there any user-facing changes?

Yes, stub of a DFE comparison.