### PR TITLE
Fix benchmark pages crash when bench.extra is missing

### DIFF
--- a/docs/benchmarks/binary-size/index.html
+++ b/docs/benchmarks/binary-size/index.html
@@ -226,10 +226,11 @@
         }
         for (const bench of benches) {
           const result = { commit, date, tool, bench };
-          let byName = byGroup.get(bench.extra);
+          const groupKey = bench.extra ?? '';
+          let byName = byGroup.get(groupKey);
           if (byName === undefined) {
             byName = new Map();
-            byGroup.set(bench.extra, byName);
+            byGroup.set(groupKey, byName);
           }
           let byCommitId = byName.get(bench.name);
           if (byCommitId === undefined) {
@@ -254,6 +255,7 @@
         }
 
         for (const bench of benches) {
+          if (!bench.extra) continue;
           const extraParts = bench.extra.split('/');
           if (extraParts.length !== 2) continue;
 

--- a/docs/benchmarks/continuous-idle-state/index.html
+++ b/docs/benchmarks/continuous-idle-state/index.html
@@ -226,10 +226,11 @@
         }
         for (const bench of benches) {
           const result = { commit, date, tool, bench };
-          let byName = byGroup.get(bench.extra);
+          const groupKey = bench.extra ?? '';
+          let byName = byGroup.get(groupKey);
           if (byName === undefined) {
             byName = new Map();
-            byGroup.set(bench.extra, byName);
+            byGroup.set(groupKey, byName);
           }
           let byCommitId = byName.get(bench.name);
           if (byCommitId === undefined) {
@@ -254,6 +255,7 @@
         }
 
         for (const bench of benches) {
+          if (!bench.extra) continue;
           const extraParts = bench.extra.split('/');
           if (extraParts.length !== 2) continue;
 

--- a/docs/benchmarks/continuous-passthrough/index.html
+++ b/docs/benchmarks/continuous-passthrough/index.html
@@ -226,10 +226,11 @@
         }
         for (const bench of benches) {
           const result = { commit, date, tool, bench };
-          let byName = byGroup.get(bench.extra);
+          const groupKey = bench.extra ?? '';
+          let byName = byGroup.get(groupKey);
           if (byName === undefined) {
             byName = new Map();
-            byGroup.set(bench.extra, byName);
+            byGroup.set(groupKey, byName);
           }
           let byCommitId = byName.get(bench.name);
           if (byCommitId === undefined) {
@@ -254,6 +255,7 @@
         }
 
         for (const bench of benches) {
+          if (!bench.extra) continue;
           const extraParts = bench.extra.split('/');
           if (extraParts.length !== 2) continue;
 

--- a/docs/benchmarks/continuous-saturation/index.html
+++ b/docs/benchmarks/continuous-saturation/index.html
@@ -226,10 +226,11 @@
         }
         for (const bench of benches) {
           const result = { commit, date, tool, bench };
-          let byName = byGroup.get(bench.extra);
+          const groupKey = bench.extra ?? '';
+          let byName = byGroup.get(groupKey);
           if (byName === undefined) {
             byName = new Map();
-            byGroup.set(bench.extra, byName);
+            byGroup.set(groupKey, byName);
           }
           let byCommitId = byName.get(bench.name);
           if (byCommitId === undefined) {
@@ -254,6 +255,7 @@
         }
 
         for (const bench of benches) {
+          if (!bench.extra) continue;
           const extraParts = bench.extra.split('/');
           if (extraParts.length !== 2) continue;
 

--- a/docs/benchmarks/continuous-scaling-efficiency/index.html
+++ b/docs/benchmarks/continuous-scaling-efficiency/index.html
@@ -226,10 +226,11 @@
         }
         for (const bench of benches) {
           const result = { commit, date, tool, bench };
-          let byName = byGroup.get(bench.extra);
+          const groupKey = bench.extra ?? '';
+          let byName = byGroup.get(groupKey);
           if (byName === undefined) {
             byName = new Map();
-            byGroup.set(bench.extra, byName);
+            byGroup.set(groupKey, byName);
           }
           let byCommitId = byName.get(bench.name);
           if (byCommitId === undefined) {
@@ -254,6 +255,7 @@
         }
 
         for (const bench of benches) {
+          if (!bench.extra) continue;
           const extraParts = bench.extra.split('/');
           if (extraParts.length !== 2) continue;
 

--- a/docs/benchmarks/continuous/index.html
+++ b/docs/benchmarks/continuous/index.html
@@ -226,10 +226,11 @@
         }
         for (const bench of benches) {
           const result = { commit, date, tool, bench };
-          let byName = byGroup.get(bench.extra);
+          const groupKey = bench.extra ?? '';
+          let byName = byGroup.get(groupKey);
           if (byName === undefined) {
             byName = new Map();
-            byGroup.set(bench.extra, byName);
+            byGroup.set(groupKey, byName);
           }
           let byCommitId = byName.get(bench.name);
           if (byCommitId === undefined) {
@@ -254,6 +255,7 @@
         }
 
         for (const bench of benches) {
+          if (!bench.extra) continue;
           const extraParts = bench.extra.split('/');
           if (extraParts.length !== 2) continue;
 

--- a/docs/benchmarks/nightly/backpressure/index.html
+++ b/docs/benchmarks/nightly/backpressure/index.html
@@ -248,10 +248,11 @@
         for (const bench of benches) {
           const result = { commit, date, tool, bench };
 
-          let byExtraGroup = byGroup.get(bench.extra);
+          const groupKey = bench.extra ?? '';
+          let byExtraGroup = byGroup.get(groupKey);
           if (byExtraGroup === undefined) {
             byExtraGroup = new Map();
-            byGroup.set(bench.extra, byExtraGroup);
+            byGroup.set(groupKey, byExtraGroup);
           }
 
           let byBenchName = byExtraGroup.get(bench.name);
@@ -283,6 +284,7 @@
         }
 
         for (const bench of benches) {
+          if (!bench.extra) continue;
           const extraParts = bench.extra.split('/');
           if (extraParts.length !== 2) continue;
 

--- a/docs/benchmarks/nightly/batch-processor/index.html
+++ b/docs/benchmarks/nightly/batch-processor/index.html
@@ -402,10 +402,11 @@
         for (const bench of benches) {
           const result = { commit, date, tool, bench };
 
-          let byExtraGroup = byGroup.get(bench.extra);
+          const groupKey = bench.extra ?? '';
+          let byExtraGroup = byGroup.get(groupKey);
           if (byExtraGroup === undefined) {
             byExtraGroup = new Map();
-            byGroup.set(bench.extra, byExtraGroup);
+            byGroup.set(groupKey, byExtraGroup);
           }
 
           let byBenchName = byExtraGroup.get(bench.name);
@@ -437,6 +438,7 @@
         }
 
         for (const bench of benches) {
+          if (!bench.extra) continue;
           const extraParts = bench.extra.split('/');
           if (extraParts.length !== 2) continue;
 

--- a/docs/benchmarks/nightly/filter/index.html
+++ b/docs/benchmarks/nightly/filter/index.html
@@ -248,10 +248,11 @@
         for (const bench of benches) {
           const result = { commit, date, tool, bench };
 
-          let byExtraGroup = byGroup.get(bench.extra);
+          const groupKey = bench.extra ?? '';
+          let byExtraGroup = byGroup.get(groupKey);
           if (byExtraGroup === undefined) {
             byExtraGroup = new Map();
-            byGroup.set(bench.extra, byExtraGroup);
+            byGroup.set(groupKey, byExtraGroup);
           }
 
           let byBenchName = byExtraGroup.get(bench.name);
@@ -283,6 +284,7 @@
         }
 
         for (const bench of benches) {
+          if (!bench.extra) continue;
           const extraParts = bench.extra.split('/');
           if (extraParts.length !== 2) continue;
 

--- a/docs/benchmarks/nightly/saturation/index.html
+++ b/docs/benchmarks/nightly/saturation/index.html
@@ -238,10 +238,11 @@
         for (const bench of benches) {
           const result = { commit, date, tool, bench };
 
-          let byExtraGroup = byGroup.get(bench.extra);
+          const groupKey = bench.extra ?? '';
+          let byExtraGroup = byGroup.get(groupKey);
           if (byExtraGroup === undefined) {
             byExtraGroup = new Map();
-            byGroup.set(bench.extra, byExtraGroup);
+            byGroup.set(groupKey, byExtraGroup);
           }
 
           let byBenchName = byExtraGroup.get(bench.name);
@@ -273,6 +274,7 @@
         }
 
         for (const bench of benches) {
+          if (!bench.extra) continue;
           const extraParts = bench.extra.split('/');
           if (extraParts.length !== 2) continue;
 

--- a/docs/benchmarks/nightly/scaling-efficiency/index.html
+++ b/docs/benchmarks/nightly/scaling-efficiency/index.html
@@ -238,10 +238,11 @@
         for (const bench of benches) {
           const result = { commit, date, tool, bench };
 
-          let byExtraGroup = byGroup.get(bench.extra);
+          const groupKey = bench.extra ?? '';
+          let byExtraGroup = byGroup.get(groupKey);
           if (byExtraGroup === undefined) {
             byExtraGroup = new Map();
-            byGroup.set(bench.extra, byExtraGroup);
+            byGroup.set(groupKey, byExtraGroup);
           }
 
           let byBenchName = byExtraGroup.get(bench.name);
@@ -273,6 +274,7 @@
         }
 
         for (const bench of benches) {
+          if (!bench.extra) continue;
           const extraParts = bench.extra.split('/');
           if (extraParts.length !== 2) continue;
 

--- a/docs/benchmarks/nightly/standardload-batch-size/index.html
+++ b/docs/benchmarks/nightly/standardload-batch-size/index.html
@@ -238,10 +238,11 @@
         for (const bench of benches) {
           const result = { commit, date, tool, bench };
 
-          let byExtraGroup = byGroup.get(bench.extra);
+          const groupKey = bench.extra ?? '';
+          let byExtraGroup = byGroup.get(groupKey);
           if (byExtraGroup === undefined) {
             byExtraGroup = new Map();
-            byGroup.set(bench.extra, byExtraGroup);
+            byGroup.set(groupKey, byExtraGroup);
           }
 
           let byBenchName = byExtraGroup.get(bench.name);
@@ -273,6 +274,7 @@
         }
 
         for (const bench of benches) {
+          if (!bench.extra) continue;
           const extraParts = bench.extra.split('/');
           if (extraParts.length !== 2) continue;
 

--- a/docs/benchmarks/nightly/syslog-tcp/index.html
+++ b/docs/benchmarks/nightly/syslog-tcp/index.html
@@ -238,10 +238,11 @@
         for (const bench of benches) {
           const result = { commit, date, tool, bench };
 
-          let byExtraGroup = byGroup.get(bench.extra);
+          const groupKey = bench.extra ?? '';
+          let byExtraGroup = byGroup.get(groupKey);
           if (byExtraGroup === undefined) {
             byExtraGroup = new Map();
-            byGroup.set(bench.extra, byExtraGroup);
+            byGroup.set(groupKey, byExtraGroup);
           }
 
           let byBenchName = byExtraGroup.get(bench.name);
@@ -273,6 +274,7 @@
         }
 
         for (const bench of benches) {
+          if (!bench.extra) continue;
           const extraParts = bench.extra.split('/');
           if (extraParts.length !== 2) continue;
 

--- a/docs/benchmarks/nightly/syslog/index.html
+++ b/docs/benchmarks/nightly/syslog/index.html
@@ -260,10 +260,11 @@
         for (const bench of benches) {
           const result = { commit, date, tool, bench };
 
-          let byExtraGroup = byGroup.get(bench.extra);
+          const groupKey = bench.extra ?? '';
+          let byExtraGroup = byGroup.get(groupKey);
           if (byExtraGroup === undefined) {
             byExtraGroup = new Map();
-            byGroup.set(bench.extra, byExtraGroup);
+            byGroup.set(groupKey, byExtraGroup);
           }
 
           let byBenchName = byExtraGroup.get(bench.name);
@@ -295,6 +296,7 @@
         }
 
         for (const bench of benches) {
+          if (!bench.extra) continue;
           const extraParts = bench.extra.split('/');
           if (extraParts.length !== 2) continue;
 


### PR DESCRIPTION
binary-size page was empty because its data has no extra field, causing a crash in collectAggregatedBenchmarks.