### PR TITLE
Remove outlier bytes-unit entry from binary-size data

### DIFF
--- a/docs/benchmarks/binary-size/data.js
+++ b/docs/benchmarks/binary-size/data.js
@@ -6,38 +6,6 @@ window.BENCHMARK_DATA = {
       {
         "commit": {
           "author": {
-            "name": "Drew Relmas",
-            "username": "drewrelmas",
-            "email": "drewrelmas@gmail.com"
-          },
-          "committer": {
-            "name": "GitHub",
-            "username": "web-flow",
-            "email": "noreply@github.com"
-          },
-          "id": "9892ed711f59b7276e28cccc8b4e8ad0f9ebf884",
-          "message": "Upgrade Collector dependencies to 0.142.0 and misc Go modules (#1682)\n\nSupersedes #1677, #1676, and #1675.\n\nTouched manually since already upgrading Collector dependencies.",
-          "timestamp": "2025-12-22T21:24:59Z",
-          "url": "https://github.com/open-telemetry/otel-arrow/commit/9892ed711f59b7276e28cccc8b4e8ad0f9ebf884"
-        },
-        "date": 1766449209265,
-        "tool": "customSmallerIsBetter",
-        "benches": [
-          {
-            "name": "linux-amd64-binary-size",
-            "value": 83585512,
-            "unit": "bytes"
-          },
-          {
-            "name": "linux-arm64-binary-size",
-            "value": 70575968,
-            "unit": "bytes"
-          }
-        ]
-      },
-      {
-        "commit": {
-          "author": {
             "name": "albertlockett",
             "username": "albertlockett",
             "email": "a.lockett@f5.com"


### PR DESCRIPTION
First data point used bytes (83M) instead of MB, squishing the arm64 line to zero.