### PR TITLE
Validate otel_* event names at compile time

### DIFF
--- a/rust/otap-dataflow/crates/controller/src/lib.rs
+++ b/rust/otap-dataflow/crates/controller/src/lib.rs
@@ -1368,12 +1368,14 @@ impl<
         ) {
             (false, true) => {
                 otel_warn!(
-                    "ITS provider requested yet engine.observability.pipeline is not defined"
+                    "controller.its_provider_without_pipeline",
+                    message = "ITS provider requested yet engine.observability.pipeline is not defined"
                 )
             }
             (true, false) => {
                 otel_warn!(
-                    "engine.observability.pipeline is defined yet ITS provider is not requested"
+                    "controller.pipeline_without_its_provider",
+                    message = "engine.observability.pipeline is defined yet ITS provider is not requested"
                 )
             }
             _ => {}

--- a/rust/otap-dataflow/crates/controller/src/lib.rs
+++ b/rust/otap-dataflow/crates/controller/src/lib.rs
@@ -1369,7 +1369,8 @@ impl<
             (false, true) => {
                 otel_warn!(
                     "controller.its_provider_without_pipeline",
-                    message = "ITS provider requested yet engine.observability.pipeline is not defined"
+                    message =
+                        "ITS provider requested yet engine.observability.pipeline is not defined"
                 )
             }
             (true, false) => {

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/host_metrics_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/host_metrics_receiver/mod.rs
@@ -556,7 +556,10 @@ impl local::Receiver<OtapPdata> for HostMetricsReceiver {
                                         metrics.send_failures.add(1);
                                         metrics.scrape_duration_ns.record(elapsed_nanos(scrape_start));
                                     }
-                                    otel_warn!("host metrics dropped due to downstream backpressure");
+                                    otel_warn!(
+                                        "host_metrics.dropped_backpressure",
+                                        message = "host metrics dropped due to downstream backpressure"
+                                    );
                                 }
                                 Err(other) => {
                                     if let Some(metrics) = metrics.as_mut() {
@@ -580,7 +583,8 @@ impl local::Receiver<OtapPdata> for HostMetricsReceiver {
                                 metrics.scrape_duration_ns.record(elapsed_nanos(scrape_start));
                             }
                             otel_warn!(
-                                "host metrics scrape failed; receiver will retry",
+                                "host_metrics.scrape_failed",
+                                message = "host metrics scrape failed; receiver will retry",
                                 error = err.to_string()
                             );
                         }

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/mod.rs
@@ -176,8 +176,8 @@ impl TrafficGeneratorReceiver {
                                 .smooth_behind_remaining_items
                                 .record(remaining_items as f64);
                             otel_warn!(
-                                "Data generator is falling behind and didn't finish the current run. For highest
-                                possible throughput, use production_mode: open",
+                                "traffic_generator.smooth_run_behind",
+                                message = "Data generator is falling behind and didn't finish the current run. For highest possible throughput, use production_mode: open",
                                 remaining=remaining_batches,
                                 remaining_items,
                             );
@@ -283,7 +283,8 @@ impl TrafficGeneratorReceiver {
 
                     _ = run_ticker.tick() => {
                         otel_debug!(
-                            "Data generator is falling behind and didn't finish the current run.",
+                            "traffic_generator.open_run_behind",
+                            message = "Data generator is falling behind and didn't finish the current run.",
                             remaining=current_run.len(),
                         );
 
@@ -556,7 +557,8 @@ impl local::Receiver<OtapPdata> for TrafficGeneratorReceiver {
                     .await
                 } else {
                     otel_warn!(
-                        "Falling back to Open production mode because smooth batch interval is zero"
+                        "traffic_generator.smooth_fallback_open",
+                        reason = "smooth batch interval is zero"
                     );
                     self.run_open(
                         ctrl_msg_recv,

--- a/rust/otap-dataflow/crates/otap/tests/mtls_tests.rs
+++ b/rust/otap-dataflow/crates/otap/tests/mtls_tests.rs
@@ -165,7 +165,11 @@ async fn test_mtls_missing_client_cert() {
         match tls_acceptor.accept(stream).await {
             Ok(_) => true,
             Err(e) => {
-                otel_info!("Server correctly rejected client", error = ?e);
+                otel_info!(
+                    "mtls_test.server_rejected_client",
+                    message = "Server correctly rejected client",
+                    error = ?e
+                );
                 false
             }
         }
@@ -274,7 +278,11 @@ async fn test_mtls_wrong_client_cert() {
         match tls_acceptor.accept(stream).await {
             Ok(_) => true,
             Err(e) => {
-                otel_info!("Server correctly rejected untrusted client", error = ?e);
+                otel_info!(
+                    "mtls_test.server_rejected_untrusted_client",
+                    message = "Server correctly rejected untrusted client",
+                    error = ?e
+                );
                 false
             }
         }
@@ -610,7 +618,10 @@ async fn test_mtls_ca_hot_reload() {
         );
     }
 
-    otel_info!("mTLS CA hot-reload test completed successfully");
+    otel_info!(
+        "mtls_test.ca_hot_reload_completed",
+        message = "mTLS CA hot-reload test completed successfully"
+    );
 }
 
 /// Test that server keeps accepting clients when CA file is replaced with invalid/corrupted content.

--- a/rust/otap-dataflow/crates/telemetry/src/event.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/event.rs
@@ -84,7 +84,8 @@ impl ObservedEventReporter {
         if let Some(engine_sender) = &self.engine_sender {
             if let Err(e) = engine_sender.send(event) {
                 crate::raw_error!(
-                    "Engine channel disconnected, dropping engine event",
+                    "engine.channel.disconnected",
+                    message = "Engine channel disconnected, dropping engine event",
                     event = ?e.into_inner()
                 );
             }
@@ -115,10 +116,10 @@ impl ObservedEventReporter {
                     }
                     match err {
                         flume::TrySendError::Full(event) => {
-                            crate::raw_error!("Channel full, dropping observed event", event = ?event);
+                            crate::raw_error!("observed.channel.full", message = "Channel full, dropping observed event", event = ?event);
                         }
                         flume::TrySendError::Disconnected(event) => {
-                            crate::raw_error!("Disconnect, dropping observed event", event = ?event);
+                            crate::raw_error!("observed.channel.disconnected", message = "Disconnect, dropping observed event", event = ?event);
                         }
                     }
                 }
@@ -136,10 +137,10 @@ impl ObservedEventReporter {
                     }
                     match err {
                         flume::SendTimeoutError::Timeout(event) => {
-                            crate::raw_error!("Timeout, dropping observed event", event = ?event);
+                            crate::raw_error!("observed.channel.timeout", message = "Timeout, dropping observed event", event = ?event);
                         }
                         flume::SendTimeoutError::Disconnected(event) => {
-                            crate::raw_error!("Disconnect, dropping observed event", event = ?event);
+                            crate::raw_error!("observed.channel.disconnected", message = "Disconnect, dropping observed event", event = ?event);
                         }
                     }
                 }

--- a/rust/otap-dataflow/crates/telemetry/src/internal_events.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/internal_events.rs
@@ -232,6 +232,7 @@ macro_rules! otel_event {
 #[macro_export]
 macro_rules! raw_error {
     ($name:expr $(, $($fields:tt)*)?) => {{
+        const _: () = $crate::_private::validate_event_name($name);
         use $crate::self_tracing::ConsoleWriter;
         let now = std::time::SystemTime::now();
         let record = $crate::__log_record_impl!($crate::_private::Level::ERROR, $name $(, $($fields)*)?);
@@ -276,8 +277,8 @@ mod tests {
     #[test]
     fn test_raw_error() {
         let err = Error::ConfigurationError("bad config".into());
-        raw_error!("raw error message", error = ?err);
-        raw_error!("simple error message");
+        raw_error!("test.raw_error", message = "raw error message", error = ?err);
+        raw_error!("test.raw_error.simple", message = "simple error message");
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/telemetry/src/internal_events.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/internal_events.rs
@@ -17,6 +17,32 @@ pub mod _private {
     pub use tracing::metadata::Kind;
     pub use tracing::{Event, Level};
     pub use tracing::{callsite2, debug, error, info, trace, valueset, warn};
+
+    /// Compile-time validator for OpenTelemetry event names used by the
+    /// `otel_info!` / `otel_warn!` / `otel_debug!` / `otel_error!` /
+    /// `otel_event!` macros.
+    ///
+    /// Event names must be short, stable identifiers (e.g.
+    /// `receiver.start`, `channel.full`) — not free-form sentences. This
+    /// function is called from a `const` context so any violation surfaces
+    /// as a compile error at the macro call site, not at runtime.
+    ///
+    /// Rules enforced:
+    /// - non-empty
+    /// - no ASCII whitespace (space, tab, newline, carriage return)
+    pub const fn validate_event_name(name: &str) {
+        let bytes = name.as_bytes();
+        assert!(!bytes.is_empty(), "otel event name must not be empty");
+        let mut i = 0;
+        while i < bytes.len() {
+            let b = bytes[i];
+            assert!(
+                b != b' ' && b != b'\t' && b != b'\n' && b != b'\r',
+                "otel event name must not contain whitespace; use a short stable identifier (e.g. \"component.action\")"
+            );
+            i += 1;
+        }
+    }
 }
 
 /// Macro for logging informational messages.
@@ -33,15 +59,17 @@ pub mod _private {
 /// ```
 #[macro_export]
 macro_rules! otel_info {
-    ($name:expr, $($fields:tt)+) => {
+    ($name:expr, $($fields:tt)+) => {{
+        const _: () = $crate::_private::validate_event_name($name);
         $crate::_private::info!(name: $name, target: env!("CARGO_PKG_NAME"), $($fields)+);
-    };
+    }};
     // The trailing "" is required because tracing macros need at least a format
     // string or fields. The encoder skips empty strings so no body is encoded.
     // See: `DirectFieldVisitor::encode_body_string` in encoder.rs.
-    ($name:expr) => {
+    ($name:expr) => {{
+        const _: () = $crate::_private::validate_event_name($name);
         $crate::_private::info!(name: $name, target: env!("CARGO_PKG_NAME"), "");
-    };
+    }};
 }
 
 /// Macro for logging warning messages.
@@ -58,13 +86,15 @@ macro_rules! otel_info {
 /// ```
 #[macro_export]
 macro_rules! otel_warn {
-    ($name:expr, $($fields:tt)+) => {
+    ($name:expr, $($fields:tt)+) => {{
+        const _: () = $crate::_private::validate_event_name($name);
         $crate::_private::warn!(name: $name, target: env!("CARGO_PKG_NAME"), $($fields)+);
-    };
+    }};
     // See otel_info! for why "" is needed here.
-    ($name:expr) => {
+    ($name:expr) => {{
+        const _: () = $crate::_private::validate_event_name($name);
         $crate::_private::warn!(name: $name, target: env!("CARGO_PKG_NAME"), "");
-    };
+    }};
 }
 
 /// Macro for logging debug messages.
@@ -81,13 +111,15 @@ macro_rules! otel_warn {
 /// ```
 #[macro_export]
 macro_rules! otel_debug {
-    ($name:expr, $($fields:tt)+) => {
+    ($name:expr, $($fields:tt)+) => {{
+        const _: () = $crate::_private::validate_event_name($name);
         $crate::_private::debug!(name: $name, target: env!("CARGO_PKG_NAME"), $($fields)+);
-    };
+    }};
     // See otel_info! for why "" is needed here.
-    ($name:expr) => {
+    ($name:expr) => {{
+        const _: () = $crate::_private::validate_event_name($name);
         $crate::_private::debug!(name: $name, target: env!("CARGO_PKG_NAME"), "");
-    };
+    }};
 }
 
 /// Macro for logging error messages.
@@ -104,13 +136,15 @@ macro_rules! otel_debug {
 /// ```
 #[macro_export]
 macro_rules! otel_error {
-    ($name:expr, $($fields:tt)+) => {
+    ($name:expr, $($fields:tt)+) => {{
+        const _: () = $crate::_private::validate_event_name($name);
         $crate::_private::error!(name: $name, target: env!("CARGO_PKG_NAME"), $($fields)+);
-    };
+    }};
     // See otel_info! for why "" is needed here.
-    ($name:expr) => {
+    ($name:expr) => {{
+        const _: () = $crate::_private::validate_event_name($name);
         $crate::_private::error!(name: $name, target: env!("CARGO_PKG_NAME"), "");
-    };
+    }};
 }
 
 /// Macro for logging messages at a runtime-selectable severity level.
@@ -139,7 +173,8 @@ macro_rules! otel_error {
 /// ```
 #[macro_export]
 macro_rules! otel_event {
-    ($level:expr, $name:expr, $($fields:tt)+) => {
+    ($level:expr, $name:expr, $($fields:tt)+) => {{
+        const _: () = $crate::_private::validate_event_name($name);
         match $level {
             $crate::_private::Level::TRACE => {
                 $crate::_private::trace!(name: $name, target: env!("CARGO_PKG_NAME"), $($fields)+);
@@ -157,8 +192,9 @@ macro_rules! otel_event {
                 $crate::_private::error!(name: $name, target: env!("CARGO_PKG_NAME"), $($fields)+);
             }
         }
-    };
-    ($level:expr, $name:expr) => {
+    }};
+    ($level:expr, $name:expr) => {{
+        const _: () = $crate::_private::validate_event_name($name);
         match $level {
             $crate::_private::Level::TRACE => {
                 $crate::_private::trace!(name: $name, target: env!("CARGO_PKG_NAME"), "");
@@ -176,7 +212,7 @@ macro_rules! otel_event {
                 $crate::_private::error!(name: $name, target: env!("CARGO_PKG_NAME"), "");
             }
         }
-    };
+    }};
 }
 
 /// Log an error message directly to stderr, bypassing the tracing dispatcher.

--- a/rust/otap-dataflow/crates/telemetry/src/lib.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/lib.rs
@@ -513,7 +513,7 @@ mod tests {
 
             // Emit a log using the engine tracing setup (which uses ITS)
             its.engine_tracing_setup().with_subscriber_ignoring_env(|| {
-                crate::otel_info!("test log message");
+                crate::otel_info!("telemetry.test_log", message = "test log message");
             });
 
             // Receiver should have the log

--- a/rust/otap-dataflow/crates/telemetry/src/self_tracing/encoder.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/self_tracing/encoder.rs
@@ -446,7 +446,7 @@ fn encode_resource_attribute(
                 }
                 _ => {
                     // TODO: share the encoding logic used somewhere else, somehow.
-                    crate::raw_error!("cannot encode SDK resource value", value = ?value);
+                    crate::raw_error!("encoder.sdk_resource_value", message = "cannot encode SDK resource value", value = ?value);
                 }
             }
             Ok(())


### PR DESCRIPTION
Adds a `const fn validate_event_name` invoked from each `otel_info!` / `otel_warn!` / `otel_debug!` / `otel_error!` / `otel_event!` macro arm, so calls with empty or whitespace-containing event names fail `cargo check` instead of silently producing logs whose entire description is shoved into `event.name`.

Zero runtime cost (compile-time only). Existing call sites that violated the rule are updated to use a short identifier with the descriptive text moved to a `message = "..."` field.

The local macro copies in the `quiver` crate are intentionally left for a follow-up.
