### PR TITLE
feat(comparison_dashboard): Record, display, and validate environment details for suite runs

### DIFF
--- a/tools/comparison_dashboard/dashboard.py
+++ b/tools/comparison_dashboard/dashboard.py
@@ -299,19 +299,42 @@ def _require_psutil():
 
 
 def env_fingerprint(env: dict | None) -> dict | None:
-    """Return the equality-check subset of an env dict, or None if `env` is None."""
+    """
+    Return the equality-check subset of an env dict, or None if `env` is None.
+
+    OS portion intentionally uses `system` + distro name+version (e.g.
+    "Linux" + "Ubuntu 24.04") rather than the kernel release. A kernel
+    point upgrade should not invalidate hours of comparison data; the
+    kernel release is still captured in `run_env.json` and shown in the
+    per-test detail pane.
+    """
     if env is None:
         return None
     cpu = env.get("cpu") or {}
     mem = env.get("memory") or {}
-    os_info = env.get("os") or {}
     return {
         "cpu_model": cpu.get("model"),
         "architecture": cpu.get("architecture"),
         "physical_cores": cpu.get("physical_cores"),
         "total_gib_rounded": mem.get("total_gib_rounded"),
-        "os_release": os_info.get("release"),
+        "os_system": (env.get("os") or {}).get("system"),
+        "os_distro": _distro_label(env.get("os") or {}),
     }
+
+
+def _distro_label(os_info: dict) -> str | None:
+    """Build a "NAME VERSION_ID" string from os.distro for fingerprinting.
+
+    Returns None if no distro info was captured (common on macOS / Windows
+    or pre-py3.10 Linux). Two None values compare equal -- so two macOS
+    runs on the same hardware still match.
+    """
+    distro = os_info.get("distro") or {}
+    name = distro.get("NAME")
+    version = distro.get("VERSION_ID") or distro.get("VERSION")
+    if not name and not version:
+        return None
+    return " ".join(part for part in (name, version) if part)
 
 
 def env_fingerprint_str(fp: dict | None) -> str:
@@ -328,9 +351,13 @@ def env_fingerprint_str(fp: dict | None) -> str:
     gib = fp.get("total_gib_rounded")
     if gib is not None:
         parts.append(f"{gib} GiB")
-    release = fp.get("os_release")
-    if release:
-        parts.append(release)
+    distro = fp.get("os_distro")
+    if distro:
+        parts.append(distro)
+    else:
+        system = fp.get("os_system")
+        if system:
+            parts.append(system)
     return " / ".join(parts)
 
 
@@ -1197,73 +1224,67 @@ def check_comparison_env_consistency(
     allow_mismatch: bool,
 ) -> None:
     """
-    Reject (or warn about) comparisons that mix suites collected on different
+    Reject (or warn about) comparisons that mix data collected on different
     hardware. Issue #2949: "never compare across different hardware."
 
-    For each comparison, gather the env fingerprint of every referenced suite
-    that has a `run_env.json`. If any two fingerprints disagree -- or any
-    referenced suite is missing env data -- the comparison is flagged.
-
-    With `allow_mismatch=False` (default), flagged comparisons cause
-    sys.exit(1). With `allow_mismatch=True`, the function instead attaches
-    `comparison["envMismatch"]` (a dict consumed by the frontend banner)
-    and the build proceeds.
+    Per-comparison single-pass check: every suite in the comparison that
+    actually has published test data must share one env fingerprint. Suites
+    with no published tests contribute no data points to the chart and are
+    skipped entirely. The first fingerprint encountered is the reference;
+    the first subsequent fingerprint that differs short-circuits the check
+    and identifies the offending pair (we do not enumerate every conflict).
     """
-    errors: list[str] = []
+    errors: list[tuple[str, dict]] = []
 
     for comp in comparisons:
         slug = comp.get("slug", "?")
-        refs = comp.get("suites", [])
-        per_suite: list[tuple[str, dict | None]] = []
-        for ref in refs:
+        reference: tuple[str, dict | None] | None = None
+        conflict: tuple[str, dict | None] | None = None
+
+        for ref in comp.get("suites", []):
             ref_slug = ref.get("slug")
             if ref_slug is None:
                 continue
-            suite = suites.get(ref_slug)
-            env = suite.get("env") if suite else None
-            per_suite.append((ref_slug, env))
+            suite = suites.get(ref_slug) or {}
+            if not suite.get("tests"):
+                # No data published -> the suite contributes nothing to the
+                # comparison's actual content; its env is irrelevant here.
+                continue
+            fp = env_fingerprint(suite.get("env"))
+            if reference is None:
+                reference = (ref_slug, fp)
+                continue
+            if fp != reference[1]:
+                conflict = (ref_slug, fp)
+                break
 
-        missing = [s for s, e in per_suite if e is None]
-        fingerprints = {
-            s: env_fingerprint(e) for s, e in per_suite if e is not None
-        }
-        unique_fps = {json.dumps(fp, sort_keys=True) for fp in fingerprints.values()}
-
-        is_mismatch = len(unique_fps) > 1
-        is_missing = bool(missing) and fingerprints  # mix of known + unknown
-
-        if not is_mismatch and not is_missing:
+        if conflict is None:
             continue
 
-        reasons = []
-        if is_mismatch:
-            reasons.append("differing hardware fingerprints")
-        if is_missing:
-            reasons.append(f"missing run_env.json for: {', '.join(missing)}")
-        reason_str = "; ".join(reasons)
-
-        # Build a human-readable per-suite summary used in CLI output AND
-        # passed through to the frontend so the mismatch banner can list
-        # exactly which suites disagree.
-        summary = [
-            {
-                "slug": s,
-                "fingerprint": env_fingerprint(e),
-                "fingerprintStr": env_fingerprint_str(env_fingerprint(e))
-                if e else "no env recorded",
-            }
-            for s, e in per_suite
-        ]
+        ref_slug, ref_fp = reference
+        con_slug, con_fp = conflict
+        payload = {
+            "reference": {
+                "slug": ref_slug,
+                "fingerprint": ref_fp,
+                "fingerprintStr": env_fingerprint_str(ref_fp)
+                if ref_fp is not None else "no env recorded",
+            },
+            "conflict": {
+                "slug": con_slug,
+                "fingerprint": con_fp,
+                "fingerprintStr": env_fingerprint_str(con_fp)
+                if con_fp is not None else "no env recorded",
+            },
+        }
 
         if allow_mismatch:
-            comp["envMismatch"] = {"reason": reason_str, "suites": summary}
-            print(f"  WARNING: comparison '{slug}': {reason_str}")
-            for entry in summary:
-                print(f"    - {entry['slug']}: {entry['fingerprintStr']}")
+            comp["envMismatch"] = payload
+            print(f"  WARNING: comparison '{slug}': env mismatch")
+            print(f"    reference: {ref_slug}: {payload['reference']['fingerprintStr']}")
+            print(f"    conflict:  {con_slug}: {payload['conflict']['fingerprintStr']}")
         else:
-            errors.append(f"comparison '{slug}': {reason_str}")
-            for entry in summary:
-                errors.append(f"    {entry['slug']}: {entry['fingerprintStr']}")
+            errors.append((slug, payload))
 
     if errors:
         print(
@@ -1274,8 +1295,16 @@ def check_comparison_env_consistency(
             "Pass --allow-env-mismatch to render a warning banner and proceed anyway.",
             file=sys.stderr,
         )
-        for msg in errors:
-            print(f"  - {msg}", file=sys.stderr)
+        for slug, p in errors:
+            print(f"  - comparison '{slug}':", file=sys.stderr)
+            print(
+                f"      reference: {p['reference']['slug']}: {p['reference']['fingerprintStr']}",
+                file=sys.stderr,
+            )
+            print(
+                f"      conflict:  {p['conflict']['slug']}: {p['conflict']['fingerprintStr']}",
+                file=sys.stderr,
+            )
         sys.exit(1)
 
 

--- a/tools/comparison_dashboard/dashboard.py
+++ b/tools/comparison_dashboard/dashboard.py
@@ -155,7 +155,6 @@ def simplify_suite_yaml(suite: dict) -> dict:
 #   memory.total_gib_rounded, os.release
 # Times are captured/displayed but not part of equality.
 # ---------------------------------------------------------------------------
-RUN_ENV_SCHEMA_VERSION = 1
 
 
 def now_utc_iso() -> str:
@@ -172,7 +171,6 @@ def collect_run_env(started_at: str, ended_at: str) -> dict:
     assert isinstance(started_at, str) and started_at, "started_at must be a non-empty ISO 8601 string"
     assert isinstance(ended_at, str) and ended_at, "ended_at must be a non-empty ISO 8601 string"
     return {
-        "schema_version": RUN_ENV_SCHEMA_VERSION,
         "started_at": started_at,
         "ended_at": ended_at,
         "cpu": _collect_cpu(),
@@ -184,6 +182,8 @@ def collect_run_env(started_at: str, ended_at: str) -> dict:
 def _collect_cpu() -> dict:
     """CPU details: model, arch, physical/logical cores, max frequency."""
     psutil = _require_psutil()
+    cpuinfo = _require_cpuinfo()
+    info = cpuinfo.get_cpu_info() or {}
     physical = psutil.cpu_count(logical=False)
     logical = psutil.cpu_count(logical=True)
     try:
@@ -192,58 +192,12 @@ def _collect_cpu() -> dict:
     except Exception:
         max_freq_mhz = None
     return {
-        "model": _cpu_model(),
+        "model": info.get("brand_raw") or "unknown",
         "architecture": platform.machine() or "unknown",
         "physical_cores": int(physical) if physical else None,
         "logical_cores": int(logical) if logical else None,
         "max_freq_mhz": max_freq_mhz,
     }
-
-
-def _cpu_model() -> str:
-    """Best-effort cross-platform CPU model name."""
-    system = platform.system()
-    if system == "Linux":
-        model = _cpu_model_from_proc_cpuinfo()
-        if model:
-            return model
-    elif system == "Darwin":
-        model = _cpu_model_from_sysctl()
-        if model:
-            return model
-    # Windows and fallback
-    return platform.processor() or "unknown"
-
-
-def _cpu_model_from_proc_cpuinfo() -> str | None:
-    """Read the first 'model name' entry from /proc/cpuinfo."""
-    path = Path("/proc/cpuinfo")
-    if not path.exists():
-        return None
-    try:
-        for line in path.read_text().splitlines():
-            if line.startswith("model name"):
-                _, _, value = line.partition(":")
-                value = value.strip()
-                if value:
-                    return value
-    except OSError:
-        return None
-    return None
-
-
-def _cpu_model_from_sysctl() -> str | None:
-    """Read `machdep.cpu.brand_string` via sysctl on macOS."""
-    try:
-        out = subprocess.check_output(
-            ["sysctl", "-n", "machdep.cpu.brand_string"],
-            text=True,
-            stderr=subprocess.DEVNULL,
-            timeout=2,
-        ).strip()
-        return out or None
-    except (OSError, subprocess.SubprocessError):
-        return None
 
 
 def _collect_os() -> dict:
@@ -296,6 +250,24 @@ def _require_psutil():
         )
         raise SystemExit(1) from exc
     return psutil
+
+
+def _require_cpuinfo():
+    """Import py-cpuinfo with an actionable error if missing.
+
+    Only called from `dashboard.py run`. `build` reads existing
+    run_env.json files and never invokes this.
+    """
+    try:
+        import cpuinfo  # noqa: WPS433
+    except ImportError as exc:
+        print(
+            "ERROR: py-cpuinfo is required for `dashboard.py run` (captures CPU model).\n"
+            "  pip install -r tools/comparison_dashboard/requirements.txt",
+            file=sys.stderr,
+        )
+        raise SystemExit(1) from exc
+    return cpuinfo
 
 
 def env_fingerprint(env: dict | None) -> dict | None:

--- a/tools/comparison_dashboard/dashboard.py
+++ b/tools/comparison_dashboard/dashboard.py
@@ -20,12 +20,13 @@ import argparse
 import fnmatch
 import json
 import os
+import platform
 import re
 import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 from pathlib import Path
 
@@ -139,6 +140,198 @@ def simplify_suite_yaml(suite: dict) -> dict:
         if key in suite:
             result[key] = suite[key]
     return result
+
+
+# ---------------------------------------------------------------------------
+# Run environment capture
+#
+# Per-suite run metadata captured at `dashboard.py run` time. Written as
+# <staging>/run_env.json, published as <data-dir>/suite/<slug>/run_env.json,
+# and consumed by `build` to (a) surface env info in the UI and (b) reject
+# comparisons across suites whose env fingerprints disagree.
+#
+# Fingerprint fields used for equality (build-time mismatch check):
+#   cpu.model, cpu.architecture, cpu.physical_cores,
+#   memory.total_gib_rounded, os.release
+# Times are captured/displayed but not part of equality.
+# ---------------------------------------------------------------------------
+RUN_ENV_SCHEMA_VERSION = 1
+
+
+def now_utc_iso() -> str:
+    """Return the current UTC time as an ISO 8601 string with a 'Z' suffix."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def collect_run_env(started_at: str, ended_at: str) -> dict:
+    """
+    Collect hardware/OS metadata for the current process. `started_at` and
+    `ended_at` are ISO 8601 UTC strings (see `now_utc_iso`) bracketing the
+    test run.
+    """
+    assert isinstance(started_at, str) and started_at, "started_at must be a non-empty ISO 8601 string"
+    assert isinstance(ended_at, str) and ended_at, "ended_at must be a non-empty ISO 8601 string"
+    return {
+        "schema_version": RUN_ENV_SCHEMA_VERSION,
+        "started_at": started_at,
+        "ended_at": ended_at,
+        "cpu": _collect_cpu(),
+        "os": _collect_os(),
+        "memory": _collect_memory(),
+    }
+
+
+def _collect_cpu() -> dict:
+    """CPU details: model, arch, physical/logical cores, max frequency."""
+    psutil = _require_psutil()
+    physical = psutil.cpu_count(logical=False)
+    logical = psutil.cpu_count(logical=True)
+    try:
+        freq = psutil.cpu_freq()
+        max_freq_mhz = float(freq.max) if freq and freq.max else None
+    except Exception:
+        max_freq_mhz = None
+    return {
+        "model": _cpu_model(),
+        "architecture": platform.machine() or "unknown",
+        "physical_cores": int(physical) if physical else None,
+        "logical_cores": int(logical) if logical else None,
+        "max_freq_mhz": max_freq_mhz,
+    }
+
+
+def _cpu_model() -> str:
+    """Best-effort cross-platform CPU model name."""
+    system = platform.system()
+    if system == "Linux":
+        model = _cpu_model_from_proc_cpuinfo()
+        if model:
+            return model
+    elif system == "Darwin":
+        model = _cpu_model_from_sysctl()
+        if model:
+            return model
+    # Windows and fallback
+    return platform.processor() or "unknown"
+
+
+def _cpu_model_from_proc_cpuinfo() -> str | None:
+    """Read the first 'model name' entry from /proc/cpuinfo."""
+    path = Path("/proc/cpuinfo")
+    if not path.exists():
+        return None
+    try:
+        for line in path.read_text().splitlines():
+            if line.startswith("model name"):
+                _, _, value = line.partition(":")
+                value = value.strip()
+                if value:
+                    return value
+    except OSError:
+        return None
+    return None
+
+
+def _cpu_model_from_sysctl() -> str | None:
+    """Read `machdep.cpu.brand_string` via sysctl on macOS."""
+    try:
+        out = subprocess.check_output(
+            ["sysctl", "-n", "machdep.cpu.brand_string"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+            timeout=2,
+        ).strip()
+        return out or None
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def _collect_os() -> dict:
+    """OS details: system name, kernel release/version, distro (Linux)."""
+    distro: dict | None = None
+    reader = getattr(platform, "freedesktop_os_release", None)
+    if callable(reader):
+        try:
+            info = reader()
+            distro = {
+                k: info[k]
+                for k in ("NAME", "VERSION", "VERSION_ID", "ID")
+                if k in info
+            }
+        except (OSError, AttributeError):
+            distro = None
+    return {
+        "system": platform.system() or "unknown",
+        "release": platform.release() or "unknown",
+        "version": platform.version() or "",
+        "distro": distro,
+    }
+
+
+def _collect_memory() -> dict:
+    """Total RAM in bytes plus a GiB-rounded bucket for fingerprinting."""
+    psutil = _require_psutil()
+    total = int(psutil.virtual_memory().total)
+    assert total > 0, "virtual_memory().total must be positive"
+    return {
+        "total_bytes": total,
+        "total_gib_rounded": int(round(total / (1024 ** 3))),
+    }
+
+
+def _require_psutil():
+    """Import psutil with an actionable error if missing.
+
+    The orchestrator already depends on psutil; `dashboard.py run` runs in
+    the same Python env, so the import is expected to succeed there. `build`
+    does not call this -- it only reads existing run_env.json files.
+    """
+    try:
+        import psutil  # noqa: WPS433 (local import is intentional)
+    except ImportError as exc:
+        print(
+            "ERROR: psutil is required for `dashboard.py run` (captures hardware info).\n"
+            "  pip install -r tools/comparison_dashboard/requirements.txt",
+            file=sys.stderr,
+        )
+        raise SystemExit(1) from exc
+    return psutil
+
+
+def env_fingerprint(env: dict | None) -> dict | None:
+    """Return the equality-check subset of an env dict, or None if `env` is None."""
+    if env is None:
+        return None
+    cpu = env.get("cpu") or {}
+    mem = env.get("memory") or {}
+    os_info = env.get("os") or {}
+    return {
+        "cpu_model": cpu.get("model"),
+        "architecture": cpu.get("architecture"),
+        "physical_cores": cpu.get("physical_cores"),
+        "total_gib_rounded": mem.get("total_gib_rounded"),
+        "os_release": os_info.get("release"),
+    }
+
+
+def env_fingerprint_str(fp: dict | None) -> str:
+    """Human-readable single-line summary used in CLI output and UI headers."""
+    if fp is None:
+        return "unknown environment"
+    parts = []
+    cpu = fp.get("cpu_model") or "unknown CPU"
+    arch = fp.get("architecture") or "?"
+    parts.append(f"{cpu} / {arch}")
+    cores = fp.get("physical_cores")
+    if cores is not None:
+        parts.append(f"{cores} cores")
+    gib = fp.get("total_gib_rounded")
+    if gib is not None:
+        parts.append(f"{gib} GiB")
+    release = fp.get("os_release")
+    if release:
+        parts.append(release)
+    return " / ".join(parts)
 
 
 # ===========================================================================
@@ -324,13 +517,25 @@ def run_single_suite(
         return True
 
     log_path = staging_dir / "orchestrator.log"
+    started_at = now_utc_iso()
     rc = run_orchestrator(config_path, log_path, tests=tests)
+    ended_at = now_utc_iso()
     if rc != 0:
         print(
             f"\nError: orchestrator exited with code {rc}\nFull log: {log_path}",
             file=sys.stderr,
         )
         return False
+
+    # Capture run-time environment for the dashboard. Written here (not in
+    # the orchestrator) because the orchestrator may also be invoked outside
+    # the dashboard, where this metadata is not desired.
+    env = collect_run_env(started_at, ended_at)
+    env_path = staging_dir / "run_env.json"
+    with open(env_path, "w") as f:
+        json.dump(env, f, indent=2)
+    print(f"  Captured run env: {env_path}")
+    print(f"  Environment:      {env_fingerprint_str(env_fingerprint(env))}")
 
     publish_results(staging_dir, suite, publish_dir)
     return True
@@ -457,6 +662,11 @@ def publish_results(staging_dir: Path, suite: dict, publish_dir: Path) -> None:
     with open(suite_dir / "suite.yaml", "w") as f:
         yaml.dump(simplified, f, default_flow_style=False, sort_keys=False)
     print(f"  Updated {suite_dir / 'suite.yaml'}")
+
+    env_src = staging_dir / "run_env.json"
+    if env_src.exists():
+        shutil.copy2(env_src, suite_dir / "run_env.json")
+        print(f"  Updated {suite_dir / 'run_env.json'}")
 
     staging_tests = staging_dir / "tests"
     if not staging_tests.exists():
@@ -604,6 +814,10 @@ def cmd_build(args) -> int:
 
     print("Building suite data...")
     suites = build_suites(parsed_suites, paths)
+    print()
+
+    print("Checking comparison env consistency...")
+    check_comparison_env_consistency(comparisons, suites, args.allow_env_mismatch)
     print()
 
     if suites:
@@ -774,6 +988,7 @@ def build_suites(
             suite = yaml.safe_load(f)
 
         slug = suite_dir.name
+        env = load_suite_env(suite_dir)
 
         tests = []
         for test_dir in sorted(suite_dir.iterdir()):
@@ -795,10 +1010,12 @@ def build_suites(
             "slug": slug,
             "description": suite.get("description", ""),
             "meta": suite.get("meta", {}),
+            "env": env,
             "tests": tests,
         }
 
-        print(f"  {slug}: {len(tests)} tests")
+        env_note = env_fingerprint_str(env_fingerprint(env)) if env else "no env recorded"
+        print(f"  {slug}: {len(tests)} tests [{env_note}]")
 
     for _, suite in parsed_suites:
         slug = suite.get("slug")
@@ -816,12 +1033,30 @@ def build_suites(
             "slug": slug,
             "description": suite.get("description", ""),
             "meta": suite.get("meta", {}),
+            "env": None,
             "tests": [],
         }
 
         print(f"  {slug}: 0 tests (no data yet)")
 
     return suites
+
+
+def load_suite_env(suite_dir: Path) -> dict | None:
+    """Load <suite_dir>/run_env.json if present; return None on absence or parse error."""
+    env_path = suite_dir / "run_env.json"
+    if not env_path.exists():
+        return None
+    try:
+        with open(env_path) as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"  WARNING: failed to read {env_path}: {exc}")
+        return None
+    if not isinstance(data, dict):
+        print(f"  WARNING: {env_path} is not a JSON object; ignoring")
+        return None
+    return data
 
 
 def load_comparisons(manifest: Manifest) -> list:
@@ -953,6 +1188,94 @@ def validate_manifest(
         print("ERROR: manifest validation failed:")
         for msg in errors:
             print(f"  - {msg}")
+        sys.exit(1)
+
+
+def check_comparison_env_consistency(
+    comparisons: list,
+    suites: dict,
+    allow_mismatch: bool,
+) -> None:
+    """
+    Reject (or warn about) comparisons that mix suites collected on different
+    hardware. Issue #2949: "never compare across different hardware."
+
+    For each comparison, gather the env fingerprint of every referenced suite
+    that has a `run_env.json`. If any two fingerprints disagree -- or any
+    referenced suite is missing env data -- the comparison is flagged.
+
+    With `allow_mismatch=False` (default), flagged comparisons cause
+    sys.exit(1). With `allow_mismatch=True`, the function instead attaches
+    `comparison["envMismatch"]` (a dict consumed by the frontend banner)
+    and the build proceeds.
+    """
+    errors: list[str] = []
+
+    for comp in comparisons:
+        slug = comp.get("slug", "?")
+        refs = comp.get("suites", [])
+        per_suite: list[tuple[str, dict | None]] = []
+        for ref in refs:
+            ref_slug = ref.get("slug")
+            if ref_slug is None:
+                continue
+            suite = suites.get(ref_slug)
+            env = suite.get("env") if suite else None
+            per_suite.append((ref_slug, env))
+
+        missing = [s for s, e in per_suite if e is None]
+        fingerprints = {
+            s: env_fingerprint(e) for s, e in per_suite if e is not None
+        }
+        unique_fps = {json.dumps(fp, sort_keys=True) for fp in fingerprints.values()}
+
+        is_mismatch = len(unique_fps) > 1
+        is_missing = bool(missing) and fingerprints  # mix of known + unknown
+
+        if not is_mismatch and not is_missing:
+            continue
+
+        reasons = []
+        if is_mismatch:
+            reasons.append("differing hardware fingerprints")
+        if is_missing:
+            reasons.append(f"missing run_env.json for: {', '.join(missing)}")
+        reason_str = "; ".join(reasons)
+
+        # Build a human-readable per-suite summary used in CLI output AND
+        # passed through to the frontend so the mismatch banner can list
+        # exactly which suites disagree.
+        summary = [
+            {
+                "slug": s,
+                "fingerprint": env_fingerprint(e),
+                "fingerprintStr": env_fingerprint_str(env_fingerprint(e))
+                if e else "no env recorded",
+            }
+            for s, e in per_suite
+        ]
+
+        if allow_mismatch:
+            comp["envMismatch"] = {"reason": reason_str, "suites": summary}
+            print(f"  WARNING: comparison '{slug}': {reason_str}")
+            for entry in summary:
+                print(f"    - {entry['slug']}: {entry['fingerprintStr']}")
+        else:
+            errors.append(f"comparison '{slug}': {reason_str}")
+            for entry in summary:
+                errors.append(f"    {entry['slug']}: {entry['fingerprintStr']}")
+
+    if errors:
+        print(
+            "ERROR: build refused -- comparisons reference suites with mismatched envs.",
+            file=sys.stderr,
+        )
+        print(
+            "Pass --allow-env-mismatch to render a warning banner and proceed anyway.",
+            file=sys.stderr,
+        )
+        for msg in errors:
+            print(f"  - {msg}", file=sys.stderr)
         sys.exit(1)
 
 
@@ -1271,6 +1594,15 @@ def build_parser() -> argparse.ArgumentParser:
             "landing page at <compare-dir>/index.html and per-comparison "
             "pages at <compare-dir>/<slug>/index.html, plus the copied "
             "shared/ static assets."
+        ),
+    )
+    p_build.add_argument(
+        "--allow-env-mismatch", action="store_true",
+        help=(
+            "Allow building comparisons whose referenced suites have "
+            "differing hardware/OS fingerprints (or are missing run_env.json). "
+            "Without this flag, such comparisons cause the build to fail. "
+            "When set, the affected comparison pages render a warning banner."
         ),
     )
     p_build.set_defaults(func=cmd_build)

--- a/tools/comparison_dashboard/requirements.txt
+++ b/tools/comparison_dashboard/requirements.txt
@@ -7,3 +7,4 @@
 pyyaml==6.0.3
 jinja2==3.1.6
 psutil==7.2.2
+py-cpuinfo==9.0.0

--- a/tools/comparison_dashboard/requirements.txt
+++ b/tools/comparison_dashboard/requirements.txt
@@ -6,3 +6,4 @@
 
 pyyaml==6.0.3
 jinja2==3.1.6
+psutil==7.2.2

--- a/tools/comparison_dashboard/shared/app.js
+++ b/tools/comparison_dashboard/shared/app.js
@@ -626,6 +626,7 @@ function renderComparisonPage(compSlug) {
   const filterState = getFilterState(compSlug, categories);
   const hasFilters = Object.keys(categories).length > 0;
   const filterHtml = hasFilters ? buildFilterHtml(categories, filterState) : "";
+  const envHeaderHtml = renderComparisonEnvHeader(suiteData, comparison);
 
   app.innerHTML = `
     <div class="scenario-header">
@@ -633,6 +634,7 @@ function renderComparisonPage(compSlug) {
       <h1>${escapeHtml(comparison.name || compSlug)}</h1>
       <div class="sub">${escapeHtml(comparison.description || "")}</div>
     </div>
+    ${envHeaderHtml}
     ${renderColorblindToggle()}
     ${filterHtml}
     <div id="comparison-chart"></div>
@@ -739,6 +741,8 @@ function renderComparisonDetail(suiteData, comparison, testNames, initialSuiteId
       if (files.length) filesHtml = `<div class="files-flex">${files.map((f) => `<div class="file-list-item" data-file="${escapeHtml(f)}">${escapeHtml(f)}</div>`).join("")}</div>`;
     }
 
+    const envHtml = ref ? renderEnvDetail(suiteData[ref.slug] ? suiteData[ref.slug].env : null) : "";
+
     const rm = selTest.match(/^(\d+)k$/);
     const lr = rm ? parseInt(rm[1]) * 1000 : null;
     const bpBadge = hasBackpressure(metrics, lr) ? '<div class="detail-backpressure-badge">\u26A0 Backpressure detected</div>' : "";
@@ -764,9 +768,9 @@ function renderComparisonDetail(suiteData, comparison, testNames, initialSuiteId
     }
 
     if (!test) {
-      target.innerHTML = `<div class="scenario-section"><div class="scenario-section-head"><div class="scenario-section-title">Test Details</div></div><div class="detail-controls"><div class="detail-pills">${pillsHtml}</div><select class="detail-test-select">${testOptsHtml}</select></div><div class="muted" style="padding:12px 0">No data available for this selection.</div></div>`;
+      target.innerHTML = `<div class="scenario-section"><div class="scenario-section-head"><div class="scenario-section-title">Test Details</div></div><div class="detail-controls"><div class="detail-pills">${pillsHtml}</div><select class="detail-test-select">${testOptsHtml}</select></div>${envHtml}<div class="muted" style="padding:12px 0">No data available for this selection.</div></div>`;
     } else {
-      target.innerHTML = `<div class="scenario-section"><div class="scenario-section-head"><div class="scenario-section-title">Test Details</div></div><div class="detail-controls"><div class="detail-pills">${pillsHtml}</div><select class="detail-test-select">${testOptsHtml}</select></div>${bpBadge}<div class="files-section"><div class="detail-pane-title">Files</div>${filesHtml}</div><div class="detail-pane-title" style="margin-top:16px">Metrics</div>${scalarsHtml}${chartsHtml || '<div class="muted">No metrics available.</div>'}</div>`;
+      target.innerHTML = `<div class="scenario-section"><div class="scenario-section-head"><div class="scenario-section-title">Test Details</div></div><div class="detail-controls"><div class="detail-pills">${pillsHtml}</div><select class="detail-test-select">${testOptsHtml}</select></div>${bpBadge}<div class="files-section"><div class="detail-pane-title">Files</div>${filesHtml}</div>${envHtml}<div class="detail-pane-title" style="margin-top:16px">Metrics</div>${scalarsHtml}${chartsHtml || '<div class="muted">No metrics available.</div>'}</div>`;
     }
 
     for (const pill of target.querySelectorAll(".detail-pill")) pill.onclick = () => { selSuite = Number(pill.dataset.suiteIdx); if (onSelectionChange) onSelectionChange(selSuite, selTest); render(); };
@@ -787,6 +791,89 @@ function renderComparisonDetail(suiteData, comparison, testNames, initialSuiteId
 
   render();
   return setSelection;
+}
+
+// ── Environment summary / detail ───────────────────────────────────────────
+
+function renderComparisonEnvHeader(suiteData, comparison) {
+  // If the build flagged a mismatch (only happens with --allow-env-mismatch),
+  // surface the warning prominently with a per-suite breakdown.
+  if (comparison.envMismatch) return renderEnvMismatchBanner(comparison.envMismatch);
+
+  // No mismatch: every suite that has env data agrees on its fingerprint.
+  // Show the fingerprint once. If no suite has env data, say so.
+  const refs = comparison.suites || [];
+  for (const ref of refs) {
+    const suite = suiteData[ref.slug];
+    const env = suite && suite.env;
+    if (env) return renderEnvSummary(env);
+  }
+  return '<div class="env-summary env-summary-unknown">Environment: unknown (no run_env.json recorded)</div>';
+}
+
+function renderEnvSummary(env) {
+  const line = envFingerprintLine(env);
+  const t = envTimesString(env);
+  return `<div class="env-summary"><span class="env-summary-label">Environment:</span> <span class="env-summary-value">${escapeHtml(line)}</span>${t ? `<div class="env-summary-times">${escapeHtml(t)}</div>` : ""}</div>`;
+}
+
+function renderEnvMismatchBanner(mm) {
+  const rows = (mm.suites || []).map((s) =>
+    `<li><span class="env-mismatch-slug">${escapeHtml(s.slug)}</span>: ${escapeHtml(s.fingerprintStr || "no env recorded")}</li>`
+  ).join("");
+  return `<div class="env-mismatch-banner" role="alert">
+    <div class="env-mismatch-title">&#9888;&#65039; Mismatched run environments</div>
+    <div class="env-mismatch-reason">${escapeHtml(mm.reason || "")}</div>
+    <ul class="env-mismatch-list">${rows}</ul>
+    <div class="env-mismatch-note">Comparisons across hardware are not apples-to-apples. Treat results with caution.</div>
+  </div>`;
+}
+
+function renderEnvDetail(env) {
+  if (!env) {
+    return '<div class="detail-pane-title" style="margin-top:16px">Environment</div><div class="muted" style="padding:4px 0">No environment data recorded for this run.</div>';
+  }
+  const cpu = env.cpu || {};
+  const os = env.os || {};
+  const mem = env.memory || {};
+  const rows = [
+    ["CPU", cpu.model || "unknown"],
+    ["Architecture", cpu.architecture || "unknown"],
+    ["Cores", `${cpu.physical_cores ?? "?"} physical / ${cpu.logical_cores ?? "?"} logical`],
+    ["RAM", mem.total_gib_rounded != null ? `${mem.total_gib_rounded} GiB` : "unknown"],
+    ["OS", `${os.system || "unknown"} ${os.release || ""}`.trim()],
+  ];
+  if (cpu.max_freq_mhz) rows.push(["Max CPU freq", `${cpu.max_freq_mhz.toFixed(0)} MHz`]);
+  if (os.distro && os.distro.NAME) {
+    const ver = os.distro.VERSION_ID || os.distro.VERSION || "";
+    rows.push(["Distro", `${os.distro.NAME} ${ver}`.trim()]);
+  }
+  if (env.started_at) rows.push(["Started", env.started_at]);
+  if (env.ended_at) rows.push(["Ended", env.ended_at]);
+
+  const body = rows.map(([k, v]) =>
+    `<div class="env-detail-row"><div class="env-detail-key">${escapeHtml(k)}</div><div class="env-detail-val">${escapeHtml(String(v))}</div></div>`
+  ).join("");
+  return `<div class="detail-pane-title" style="margin-top:16px">Environment</div><div class="env-detail">${body}</div>`;
+}
+
+function envFingerprintLine(env) {
+  if (!env) return "unknown environment";
+  const cpu = env.cpu || {};
+  const os = env.os || {};
+  const mem = env.memory || {};
+  const parts = [`${cpu.model || "unknown CPU"} / ${cpu.architecture || "?"}`];
+  if (cpu.physical_cores != null) parts.push(`${cpu.physical_cores} cores`);
+  if (mem.total_gib_rounded != null) parts.push(`${mem.total_gib_rounded} GiB`);
+  if (os.release) parts.push(String(os.release));
+  return parts.join(" / ");
+}
+
+function envTimesString(env) {
+  const s = env.started_at, e = env.ended_at;
+  if (!s && !e) return "";
+  if (s && e) return `Run: ${s} -> ${e}`;
+  return `Run: ${s || e}`;
 }
 
 // ── File viewer modal ──────────────────────────────────────────────────────

--- a/tools/comparison_dashboard/shared/app.js
+++ b/tools/comparison_dashboard/shared/app.js
@@ -327,10 +327,15 @@ function buildComparisonChartData(suiteData, comparison, testNames, selectedMetr
         missing.push(false);
       }
     }
+    // Fall back to a scalar color when no bars will be drawn (e.g. the
+    // comparison has zero published tests). Chart.js reads index 0 of
+    // backgroundColor for the legend swatch; an empty array yields black.
+    const bgColor = data.length ? data.map((_, i) => missing[i] ? pattern : color) : color;
+    const bdColor = data.length ? data.map((_, i) => missing[i] ? `${color}80` : color) : color;
     return {
       label: ref.short || ref.name, data, _hasBackpressure: bp, _missing: missing,
-      backgroundColor: data.map((_, i) => missing[i] ? pattern : color),
-      borderColor: data.map((_, i) => missing[i] ? `${color}80` : color),
+      backgroundColor: bgColor,
+      borderColor: bdColor,
       borderWidth: 1,
       borderRadius: 4, borderSkipped: "bottom",
     };
@@ -560,7 +565,6 @@ function renderComparisonSection(suiteData, comparison) {
   const categories = collectFilterCategories(suiteData, comparison);
   const filterState = getFilterState(slug, categories);
   const filtered = filterComparison(comparison, suiteData, filterState);
-  const testNames = collectTestNames(suiteData, filtered);
   const metrics = findAvailableMetrics(suiteData, filtered);
   if (!perComparisonMetrics.has(slug)) perComparisonMetrics.set(slug, metrics.includes("cpu_percentage_normalized_avg") ? "cpu_percentage_normalized_avg" : metrics[0] || "cpu_percentage_normalized_avg");
   const sel = perComparisonMetrics.get(slug);
@@ -592,7 +596,11 @@ function wireComparisonSection(suiteData, comparison) {
 
   function renderChart() {
     const filtered = filterComparison(comparison, suiteData, filterState);
-    const testNames = collectTestNames(suiteData, filtered);
+    // X-axis is the union of test names across the WHOLE comparison, not the
+    // filter-survivors. Keeps the chart stable when filters hide the only
+    // data-having suite -- remaining suites then render striped "missing"
+    // stubs in their proper colors instead of an empty black-legend chart.
+    const testNames = collectTestNames(suiteData, comparison);
     const sel = perComparisonMetrics.get(slug);
     if (activeCharts.has(slug)) { activeCharts.get(slug).destroy(); activeCharts.delete(slug); }
     const canvas = section.querySelector("canvas");
@@ -644,7 +652,11 @@ function renderComparisonPage(compSlug) {
 
   function renderAll() {
     const filtered = filterComparison(comparison, suiteData, filterState);
-    const testNames = collectTestNames(suiteData, filtered);
+    // X-axis is the union of test names across the WHOLE comparison, not the
+    // filter-survivors. Keeps the chart stable when filters hide the only
+    // data-having suite -- remaining suites then render striped "missing"
+    // stubs in their proper colors instead of an empty black-legend chart.
+    const testNames = collectTestNames(suiteData, comparison);
     if (detailSuiteIdx >= filtered.suites.length) detailSuiteIdx = 0;
     if (!testNames.includes(detailTestName)) detailTestName = testNames[0] || "";
 

--- a/tools/comparison_dashboard/shared/app.js
+++ b/tools/comparison_dashboard/shared/app.js
@@ -818,14 +818,16 @@ function renderEnvSummary(env) {
 }
 
 function renderEnvMismatchBanner(mm) {
-  const rows = (mm.suites || []).map((s) =>
-    `<li><span class="env-mismatch-slug">${escapeHtml(s.slug)}</span>: ${escapeHtml(s.fingerprintStr || "no env recorded")}</li>`
-  ).join("");
+  const ref = mm.reference || {};
+  const con = mm.conflict || {};
   return `<div class="env-mismatch-banner" role="alert">
     <div class="env-mismatch-title">&#9888;&#65039; Mismatched run environments</div>
-    <div class="env-mismatch-reason">${escapeHtml(mm.reason || "")}</div>
-    <ul class="env-mismatch-list">${rows}</ul>
-    <div class="env-mismatch-note">Comparisons across hardware are not apples-to-apples. Treat results with caution.</div>
+    <div class="env-mismatch-reason">This comparison mixes data collected on different hardware. Results are not apples-to-apples.</div>
+    <ul class="env-mismatch-list">
+      <li><span class="env-mismatch-slug">${escapeHtml(ref.slug || "?")}</span> (reference): ${escapeHtml(ref.fingerprintStr || "no env recorded")}</li>
+      <li><span class="env-mismatch-slug">${escapeHtml(con.slug || "?")}</span>: ${escapeHtml(con.fingerprintStr || "no env recorded")}</li>
+    </ul>
+    <div class="env-mismatch-note">Re-run the conflicting suite on the reference hardware, or omit it from the comparison.</div>
   </div>`;
 }
 
@@ -865,7 +867,12 @@ function envFingerprintLine(env) {
   const parts = [`${cpu.model || "unknown CPU"} / ${cpu.architecture || "?"}`];
   if (cpu.physical_cores != null) parts.push(`${cpu.physical_cores} cores`);
   if (mem.total_gib_rounded != null) parts.push(`${mem.total_gib_rounded} GiB`);
-  if (os.release) parts.push(String(os.release));
+  // OS portion: prefer "Ubuntu 24.04" over kernel release (kernel is
+  // captured but is not part of the comparison-invalidation fingerprint).
+  const distro = os.distro || {};
+  const distroLabel = [distro.NAME, distro.VERSION_ID || distro.VERSION].filter(Boolean).join(" ");
+  if (distroLabel) parts.push(distroLabel);
+  else if (os.system) parts.push(String(os.system));
   return parts.join(" / ");
 }
 

--- a/tools/comparison_dashboard/shared/app.js
+++ b/tools/comparison_dashboard/shared/app.js
@@ -813,8 +813,7 @@ function renderComparisonEnvHeader(suiteData, comparison) {
 
 function renderEnvSummary(env) {
   const line = envFingerprintLine(env);
-  const t = envTimesString(env);
-  return `<div class="env-summary"><span class="env-summary-label">Environment:</span> <span class="env-summary-value">${escapeHtml(line)}</span>${t ? `<div class="env-summary-times">${escapeHtml(t)}</div>` : ""}</div>`;
+  return `<div class="env-summary"><span class="env-summary-label">Environment:</span> <span class="env-summary-value">${escapeHtml(line)}</span></div>`;
 }
 
 function renderEnvMismatchBanner(mm) {
@@ -874,13 +873,6 @@ function envFingerprintLine(env) {
   if (distroLabel) parts.push(distroLabel);
   else if (os.system) parts.push(String(os.system));
   return parts.join(" / ");
-}
-
-function envTimesString(env) {
-  const s = env.started_at, e = env.ended_at;
-  if (!s && !e) return "";
-  if (s && e) return `Run: ${s} -> ${e}`;
-  return `Run: ${s || e}`;
 }
 
 // ── File viewer modal ──────────────────────────────────────────────────────

--- a/tools/comparison_dashboard/shared/styles.css
+++ b/tools/comparison_dashboard/shared/styles.css
@@ -1346,3 +1346,92 @@ a.scenario-section-title:hover {
   flex: 0 1 auto;
   text-align: center;
 }
+
+/* ── Environment summary (comparison header) ─────────────────────────────── */
+.env-summary {
+  margin: 12px 0 8px;
+  padding: 8px 12px;
+  background: #f1f5f9;
+  border-left: 3px solid #64748b;
+  border-radius: 4px;
+  font-size: 13px;
+  color: #0f172a;
+}
+.env-summary-label {
+  font-weight: 600;
+  color: #334155;
+  margin-right: 6px;
+}
+.env-summary-value {
+  font-family: "SF Mono", Menlo, monospace;
+  font-size: 12px;
+}
+.env-summary-times {
+  margin-top: 2px;
+  color: #64748b;
+  font-size: 11px;
+  font-family: "SF Mono", Menlo, monospace;
+}
+.env-summary-unknown {
+  background: #fef3c7;
+  border-left-color: #f59e0b;
+  color: #78350f;
+}
+
+/* ── Environment mismatch banner ─────────────────────────────────────────── */
+.env-mismatch-banner {
+  margin: 12px 0;
+  padding: 12px 14px;
+  background: #fee2e2;
+  border: 1px solid #fca5a5;
+  border-left: 4px solid #dc2626;
+  border-radius: 6px;
+  color: #7f1d1d;
+}
+.env-mismatch-title {
+  font-weight: 700;
+  font-size: 14px;
+  margin-bottom: 4px;
+}
+.env-mismatch-reason {
+  font-size: 12px;
+  margin-bottom: 8px;
+}
+.env-mismatch-list {
+  margin: 0 0 6px 0;
+  padding-left: 18px;
+  font-size: 12px;
+  font-family: "SF Mono", Menlo, monospace;
+}
+.env-mismatch-list li { margin-bottom: 2px; }
+.env-mismatch-slug { font-weight: 600; }
+.env-mismatch-note {
+  font-size: 11px;
+  color: #991b1b;
+  font-style: italic;
+}
+
+/* ── Environment detail pane (per-test) ──────────────────────────────────── */
+.env-detail {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 4px 12px;
+  margin-top: 4px;
+  padding: 8px 10px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 4px;
+  font-size: 12px;
+}
+.env-detail-row {
+  display: contents;
+}
+.env-detail-key {
+  color: #64748b;
+  font-weight: 600;
+}
+.env-detail-val {
+  color: #0f172a;
+  font-family: "SF Mono", Menlo, monospace;
+  word-break: break-word;
+}

--- a/tools/comparison_dashboard/shared/styles.css
+++ b/tools/comparison_dashboard/shared/styles.css
@@ -1366,12 +1366,6 @@ a.scenario-section-title:hover {
   font-family: "SF Mono", Menlo, monospace;
   font-size: 12px;
 }
-.env-summary-times {
-  margin-top: 2px;
-  color: #64748b;
-  font-size: 11px;
-  font-family: "SF Mono", Menlo, monospace;
-}
 .env-summary-unknown {
   background: #fef3c7;
   border-left-color: #f59e0b;


### PR DESCRIPTION
# Change Summary

This PR adds environment details like cpu architecture/model, available core counts/memory, os, and run start/end times.

We also validate at dashboard build time that the environment for all tests within a comparison was the same and fail the build if not. 

## What issue does this PR close?

* Closes #2949

## How are these changes tested?

<img width="2397" height="1960" alt="image" src="https://github.com/user-attachments/assets/df37ed3b-364d-4ee1-ab80-87a705bd43dd" />

## Are there any user-facing changes?

Yes, new information in the dashboard.