### PR TITLE
feat(perf): add syslog TCP perf test through OTel Collector

### DIFF
--- a/.github/workflows/pipeline-perf-test-nightly.yml
+++ b/.github/workflows/pipeline-perf-test-nightly.yml
@@ -88,6 +88,12 @@ jobs:
           cd tools/pipeline_perf_test
           python orchestrator/run_orchestrator.py --config test_suites/integration/nightly/otelcol-docker.yaml
 
+      - name: Run syslog TCP performance test otelcol log suite
+        if: ${{ !cancelled() }}
+        run: |
+          cd tools/pipeline_perf_test
+          python orchestrator/run_orchestrator.py --config test_suites/integration/nightly/syslog-tcp-otelcol-docker.yaml
+
       - name: Run batch processor performance test log suite
         if: ${{ !cancelled() }}
         run: |
@@ -155,6 +161,13 @@ jobs:
         with:
           name: filter-otelcol-results
           path: tools/pipeline_perf_test/results/otelcol_filter/gh-actions-benchmark/*.json
+
+      - name: Upload otelcol syslog TCP results for processing
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: syslog-tcp-otelcol-results
+          path: tools/pipeline_perf_test/results/nightly_syslog_tcp_otelcol/gh-actions-benchmark/*.json
 
       - name: Upload saturation results for processing
         if: ${{ !cancelled() }}
@@ -237,6 +250,13 @@ jobs:
           merge-multiple: true
           path: filter_otelcol_results
 
+      - name: Download otelcol syslog TCP artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: syslog-tcp-otelcol-results*
+          merge-multiple: true
+          path: syslog_tcp_otelcol_results
+
       - name: Download saturation artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -285,6 +305,11 @@ jobs:
         if: ${{ !cancelled() }}
         run: |
           bash ./.github/workflows/scripts/consolidate-benchmarks.sh filter_otelcol_results filter_otelcol_output.json
+
+      - name: Consolidate otelcol syslog TCP benchmark data
+        if: ${{ !cancelled() }}
+        run: |
+          bash ./.github/workflows/scripts/consolidate-benchmarks.sh syslog_tcp_otelcol_results syslog_tcp_otelcol_output.json
 
       - name: Consolidate saturation benchmark data
         if: ${{ !cancelled() }}
@@ -379,6 +404,19 @@ jobs:
           max-items-in-chart: 100
           github-token: ${{ secrets.GITHUB_TOKEN }}
           benchmark-data-dir-path: "docs/benchmarks/nightly/filter"
+          auto-push: true
+          save-data-file: true
+
+      - name: Update syslog TCP otelcol benchmark data
+        if: ${{ !cancelled() && hashFiles('syslog_tcp_otelcol_output.json') != '' }}
+        uses: benchmark-action/github-action-benchmark@a60cea5bc7b49e15c1f58f411161f99e0df48372 # v1.22.0
+        with:
+          tool: "customSmallerIsBetter"
+          output-file-path: syslog_tcp_otelcol_output.json
+          gh-pages-branch: benchmarks
+          max-items-in-chart: 100
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          benchmark-data-dir-path: "docs/benchmarks/nightly/syslog-tcp-otelcol"
           auto-push: true
           save-data-file: true
 

--- a/collector/cmd/otelarrowcol/components.go
+++ b/collector/cmd/otelarrowcol/components.go
@@ -23,6 +23,7 @@ import (
 	otelarrowreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver"
 	otlpjsonfilereceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver"
 	otlpreceiver "go.opentelemetry.io/collector/receiver/otlpreceiver"
+	syslogreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver"
 )
 
 type aliasProvider interface{ DeprecatedAlias() component.Type }
@@ -63,6 +64,7 @@ func components() (otelcol.Factories, error) {
 		otelarrowreceiver.NewFactory(),
 		otlpjsonfilereceiver.NewFactory(),
 		otlpreceiver.NewFactory(),
+		syslogreceiver.NewFactory(),
 	)
 	if err != nil {
 		return otelcol.Factories{}, err
@@ -71,6 +73,7 @@ func components() (otelcol.Factories, error) {
 		otelarrowreceiver.NewFactory().Type(): "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver v0.149.0",
 		otlpjsonfilereceiver.NewFactory().Type(): "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver v0.149.0",
 		otlpreceiver.NewFactory().Type(): "go.opentelemetry.io/collector/receiver/otlpreceiver v0.149.0",
+		syslogreceiver.NewFactory().Type(): "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver v0.149.0",
 	})
 
 	factories.Exporters, err = otelcol.MakeFactoryMap[exporter.Factory](

--- a/collector/cmd/otelarrowcol/go.mod
+++ b/collector/cmd/otelarrowcol/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.149.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver v0.149.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver v0.149.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver v0.149.0
 	go.opentelemetry.io/collector/component v1.55.0
 	go.opentelemetry.io/collector/confmap v1.55.0
 	go.opentelemetry.io/collector/confmap/provider/envprovider v1.55.0
@@ -76,6 +77,7 @@ require (
 	github.com/iancoleman/strcase v0.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jonboulle/clockwork v0.5.0 // indirect
+	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kamstrup/intmap v0.5.2 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect

--- a/collector/cmd/otelarrowcol/go.sum
+++ b/collector/cmd/otelarrowcol/go.sum
@@ -108,6 +108,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
+github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
+github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kamstrup/intmap v0.5.2 h1:qnwBm1mh4XAnW9W9Ue9tZtTff8pS6+s6iKF6JRIV2Dk=
@@ -194,6 +196,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowrece
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver v0.149.0/go.mod h1:W7hks+NivHSHNnSyQOXgRxLqkmEqW1L7wGgnetb0eI8=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver v0.149.0 h1:eFYBAKpTwS4TgWAX9uY+O2jWlGi3bvWVLlV2xQrjyq8=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver v0.149.0/go.mod h1:jGZvC8NhIjt5Nnz0dfxTQ6ypkEUryZ3L8AGv5Fs9ux8=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver v0.149.0 h1:F9MdIJEN9Nwln2Mq5g1JhTlvN5vi7ICY5T82tjddea0=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver v0.149.0/go.mod h1:mAkPDoBcIDglZqFL9I7tWtZkvUWwQnvIo3vNiiDZtHk=
 github.com/pierrec/lz4/v4 v4.1.26 h1:GrpZw1gZttORinvzBdXPUXATeqlJjqUG/D87TKMnhjY=
 github.com/pierrec/lz4/v4 v4.1.26/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/collector/otelarrowcol-build.yaml
+++ b/collector/otelarrowcol-build.yaml
@@ -44,6 +44,8 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver v0.149.0
   # OTLP receiver is included for the OTLP/HTTP Receiver, test and validation.
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.149.0
+  # Syslog receiver is included for syslog performance testing.
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver v0.149.0
 processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.149.0
 

--- a/tools/pipeline_perf_test/test_suites/integration/nightly/syslog-tcp-otelcol-docker.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/nightly/syslog-tcp-otelcol-docker.yaml
@@ -1,0 +1,91 @@
+name: Nightly - Syslog TCP (OTel Collector)
+components:
+  load-generator:
+    deployment:
+      docker:
+        image: load_generator:latest
+        network: testbed
+        command: ["--serve"]
+        environment:
+          - SYSLOG_SERVER=go-collector
+          - SYSLOG_PORT=4317
+        ports:
+          - "5001:5001"
+        build:
+          context: ./load_generator
+    execution:
+      pipeline_perf_loadgen:
+        threads: 1
+        target_rate: 5000
+        batch_size: 100
+        load_type: syslog
+    monitoring:
+      docker_component:
+        allocated_cores: 1
+      prometheus:
+        endpoint: http://localhost:5001/metrics
+  go-collector:
+    deployment:
+      docker:
+        image: otelarrowcol:latest
+        network: testbed
+        ports:
+          - "8086:8086"
+        volumes:
+          - './test_suites/integration/configs/otelcol/config.rendered.yaml:/tmp/config.yaml:ro'
+        environment:
+          - GOMAXPROCS=1
+        command:
+          - "--config"
+          - "/tmp/config.yaml"
+        cpuset: "3-3"
+    monitoring:
+      docker_component:
+        allocated_cores: 1  # Matches cpuset: 3-3
+      prometheus:
+        endpoint: http://localhost:8086/metrics
+  backend-service:
+    deployment:
+      docker:
+        image: df_engine:latest
+        network: testbed
+        ports:
+          - "8087:8080"
+        volumes:
+          - 'test_suites/integration/configs/backend/config.rendered.yaml:/home/dataflow/config.yaml:ro'
+        command:
+          - "--config"
+          - "./config.yaml"
+          - "--core-id-range"
+          - "1-1"
+          - "--http-admin-bind"
+          - "0.0.0.0:8080"
+    monitoring:
+      docker_component:
+        allocated_cores: 1  # Matches core-id-range: 1-1
+      prometheus:
+        endpoint: http://localhost:8087/api/v1/telemetry/metrics?format=prometheus&reset=false
+
+tests:
+  - name: SYSLOG-TCP-OTLP (Go Collector)
+    from_template:
+      path: test_suites/integration/templates/test_steps/python-loadgen-steps-docker-otel.yaml
+      variables:
+        result_dir: "nightly_syslog_tcp_otelcol"
+        collector_config_template: test_suites/integration/templates/configs/otelcol/syslog-tcp-otlp.yaml
+        backend_receiver_type: otlp
+        syslog_transport: tcp
+        syslog_message: 'NOT-CEF:0|Security|threatmanager|1.0|100|worm stopped|10|src=192.168.1.10 dst=10.0.0.25 spt=443 dpt=8080 proto=TCP act=blocked cs1Label=MalwareType cs1=Worm cs2Label=DetectionMethod cs2=Heuristic cs3Label=Severity cs3=High requestMethod=POST'
+        syslog_rate: 0
+        observation_interval: 60
+  - name: SYSLOG-TCP-OTAP (Go Collector)
+    from_template:
+      path: test_suites/integration/templates/test_steps/python-loadgen-steps-docker-otel.yaml
+      variables:
+        result_dir: "nightly_syslog_tcp_otelcol"
+        collector_config_template: test_suites/integration/templates/configs/otelcol/syslog-tcp-otap.yaml
+        backend_receiver_type: otap
+        syslog_transport: tcp
+        syslog_message: 'NOT-CEF:0|Security|threatmanager|1.0|100|worm stopped|10|src=192.168.1.10 dst=10.0.0.25 spt=443 dpt=8080 proto=TCP act=blocked cs1Label=MalwareType cs1=Worm cs2Label=DetectionMethod cs2=Heuristic cs3Label=Severity cs3=High requestMethod=POST'
+        syslog_rate: 0
+        observation_interval: 60

--- a/tools/pipeline_perf_test/test_suites/integration/templates/configs/otelcol/syslog-tcp-otap.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/templates/configs/otelcol/syslog-tcp-otap.yaml
@@ -1,0 +1,28 @@
+receivers:
+  syslog:
+    tcp:
+      listen_address: "0.0.0.0:4317"
+    protocol: rfc3164
+
+exporters:
+  otelarrow:
+    endpoint: '{{backend_hostname}}:1235'
+    compression: none
+    arrow:
+      payload_compression: zstd
+    tls:
+      insecure: true
+
+service:
+  telemetry:
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: '0.0.0.0'
+                port: 8086
+  pipelines:
+    logs:
+      receivers: [syslog]
+      exporters: [otelarrow]

--- a/tools/pipeline_perf_test/test_suites/integration/templates/configs/otelcol/syslog-tcp-otlp.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/templates/configs/otelcol/syslog-tcp-otlp.yaml
@@ -1,0 +1,27 @@
+receivers:
+  syslog:
+    tcp:
+      listen_address: "0.0.0.0:4317"
+    protocol: rfc3164
+
+exporters:
+  otlp:
+    endpoint: '{{backend_hostname}}:1235'
+    tls:
+      insecure: true
+    sending_queue:
+      enabled: false
+
+service:
+  telemetry:
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: '0.0.0.0'
+                port: 8086
+  pipelines:
+    logs:
+      receivers: [syslog]
+      exporters: [otlp]

--- a/tools/pipeline_perf_test/test_suites/integration/templates/test_steps/python-loadgen-steps-docker-otel.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/templates/test_steps/python-loadgen-steps-docker-otel.yaml
@@ -1,0 +1,149 @@
+steps:
+  - name: Configure syslog generator with test params
+    action:
+      update_component_strategy:
+        target: load-generator
+        execution:
+          pipeline_perf_loadgen:
+            threads: {{syslog_threads | default(1)}}
+            target_rate: {{syslog_rate | default(5000)}}
+            batch_size:  {{syslog_batch_size | default(100)}}
+            load_type: syslog
+            syslog_transport: '{{syslog_transport | default("tcp")}}'
+            message_body:  '{{syslog_message | default(None)}}'
+  - name: Deploy Backend Engine
+    action:
+      component_action:
+        phase: deploy
+        target: backend-service
+    hooks:
+      run:
+        pre:
+          # Render the engine config into the suite config directory
+          - render_template:
+              template_path: './test_suites/integration/templates/configs/backend/config.yaml.j2'
+              output_path: ./test_suites/integration/configs/backend/config.rendered.yaml
+              variables:
+                backend_receiver_type: '{{backend_receiver_type}}'
+        post:
+          # Wait for the telemetry endpoint to be active (TODO: switch to healthcheck endpoint when available).
+          - ready_check_http:
+              url: http://localhost:8087/api/v1/telemetry/metrics?reset=false
+              method: GET
+              expected_status_code: 200
+  - name: Deploy Go Collector
+    action:
+      component_action:
+        phase: deploy
+        target: go-collector
+    hooks:
+      run:
+        pre:
+          # Render the collector config into the suite config directory
+          - render_template:
+              template_path: '{{collector_config_template}}'
+              output_path: ./test_suites/integration/configs/otelcol/config.rendered.yaml
+              variables:
+                backend_hostname: backend-service
+        post:
+          # Wait for the telemetry endpoint to be active (TODO: switch to healthcheck endpoint when available).
+          - ready_check_http:
+              url: http://localhost:8086/metrics
+              method: GET
+              expected_status_code: 200
+  - name: Deploy Load Generator
+    action:
+      component_action:
+        phase: deploy
+        target: load-generator
+    hooks:
+      run:
+        post:
+          # Wait for the telemetry endpoint to be active (TODO: switch to healthcheck endpoint when available).
+          - ready_check_http:
+              url: http://localhost:5001/metrics
+              method: GET
+              expected_status_code: 200
+  - name: Monitor All
+    action:
+      multi_component_action:
+        phase: start_monitoring
+        targets:
+          - backend-service
+          - load-generator
+          - go-collector
+  - name: Start Load
+    action:
+      component_action:
+        phase: start
+        target: load-generator
+  - name: Wait for data
+    action:
+      wait:
+        delay_seconds: {{wait_for_data_interval | default(5)}}
+  # This is the main observation window, marked by custom events at start/stop
+  - name: Observe Load
+    action:
+      wait:
+        delay_seconds: {{observation_interval | default(20)}}
+    hooks:
+      run:
+        pre:
+          - record_event:
+              name: observation_start
+        post:
+          - record_event:
+              name: observation_stop
+  # Stop the load generator from sending traffic.
+  - name: Stop Load
+    action:
+      component_action:
+        phase: stop
+        target: load-generator
+  # Wait for all items in-flight to transit and ensure metrics are updated.
+  - name: Wait For Drain and Reset
+    action:
+      wait:
+        delay_seconds: 3
+  # Stop monitoring all components.
+  - name: Stop Monitoring All
+    action:
+      multi_component_action:
+        phase: stop_monitoring
+        targets:
+          - backend-service
+          - load-generator
+          - go-collector
+  # Stop all running components.
+  - name: Destroy All
+    action:
+      multi_component_action:
+        phase: destroy
+        targets:
+          - load-generator
+          - go-collector
+          - backend-service
+  # Run the report
+  - name: Run Report
+    action:
+      wait:
+        delay_seconds: 0
+    hooks:
+      run:
+        post:
+          # Print all Docker container logs
+          - print_container_logs: {}
+          - sql_report:
+              name: Otelcol Syslog Report - Logs
+              report_config_file: ./test_suites/integration/configs/integration_report_logs.yaml
+              output:
+                - format:
+                    template: {}
+                  destination:
+                    console: {}
+                - format:
+                    template:
+                      path: ./test_suites/integration/templates/reports/gh-action-sqlreport.j2
+                  destination:
+                    file:
+                      directory: results/{{result_dir | default('integration')}}/gh-actions-benchmark


### PR DESCRIPTION
Add syslog TCP perf test suite routing traffic through the Go OTel Collector with syslog receiver, for comparison against the existing df-engine syslog path.