### PR TITLE
feat: add num_connections config to OTLP gRPC exporter

### DIFF
--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/mod.rs
@@ -44,6 +44,7 @@ use otap_df_telemetry::instrument::Counter;
 use otap_df_telemetry::metrics::MetricSet;
 use otap_df_telemetry::{otel_debug, otel_info, otel_warn};
 use serde::Deserialize;
+use std::collections::VecDeque;
 use std::future::Future;
 use std::sync::Arc;
 use tonic::codec::CompressionEncoding;
@@ -63,10 +64,19 @@ pub struct Config {
     /// Maximum number of concurrent in-flight export RPCs.
     #[serde(default = "default_max_in_flight")]
     pub max_in_flight: usize,
+    /// Number of separate gRPC channels (TCP connections) to open to the
+    /// endpoint. Multiple connections improve load distribution when the
+    /// receiver uses `SO_REUSEPORT` across cores. Defaults to 1.
+    #[serde(default = "default_num_connections")]
+    pub num_connections: usize,
 }
 
 pub(crate) const fn default_max_in_flight() -> usize {
     5
+}
+
+pub(crate) const fn default_num_connections() -> usize {
+    1
 }
 
 /// Exporter that sends OTLP data via gRPC
@@ -132,20 +142,31 @@ impl Exporter<OtapPdata> for OTLPExporter {
 
         let exporter_id = effect_handler.exporter_id();
 
-        let channel = self
-            .config
-            .grpc
-            .connect_channel_lazy(None)
-            .await
-            .map_err(|e| {
-                let source_detail = format_error_sources(&e);
-                Error::ExporterError {
-                    exporter: exporter_id.clone(),
-                    kind: ExporterErrorKind::Connect,
-                    error: format!("grpc channel error {e}"),
-                    source_detail,
-                }
-            })?;
+        let num_connections = self.config.num_connections.max(1);
+        let mut channels = Vec::with_capacity(num_connections);
+        for _ in 0..num_connections {
+            let channel = self
+                .config
+                .grpc
+                .connect_channel_lazy(None)
+                .await
+                .map_err(|e| {
+                    let source_detail = format_error_sources(&e);
+                    Error::ExporterError {
+                        exporter: exporter_id.clone(),
+                        kind: ExporterErrorKind::Connect,
+                        error: format!("grpc channel error {e}"),
+                        source_detail,
+                    }
+                })?;
+            channels.push(channel);
+        }
+
+        otel_info!(
+            "otlp.exporter.grpc.channels",
+            num_connections = num_connections,
+            endpoint = self.config.grpc.grpc_endpoint.as_str()
+        );
 
         let compression = self.config.grpc.compression_encoding();
         let max_in_flight = self.config.max_in_flight.max(1);
@@ -159,7 +180,7 @@ impl Exporter<OtapPdata> for OTLPExporter {
         let mut metrics_proto_buffer = ProtoBuffer::with_capacity(8 * 1024);
         let mut traces_proto_buffer = ProtoBuffer::with_capacity(8 * 1024);
 
-        let mut grpc_clients = GrpcClientPool::new(max_in_flight, channel, compression);
+        let mut grpc_clients = GrpcClientPool::new(max_in_flight, channels, compression);
         grpc_clients.prepopulate_clients();
 
         let mut inflight_exports = InFlightExports::new();
@@ -741,78 +762,88 @@ where
 }
 
 /// Keeps a small stash of gRPC clients so each export can reuse an existing connection.
+/// When multiple channels are configured, clients are distributed across them in
+/// round-robin order so that exports spread evenly across TCP connections.
 struct GrpcClientPool {
-    base_channel: Channel,
+    channels: Vec<Channel>,
     compression: Option<CompressionEncoding>,
-    logs: Vec<LogsServiceClient<Channel>>,
-    metrics: Vec<MetricsServiceClient<Channel>>,
-    traces: Vec<TraceServiceClient<Channel>>,
+    logs: VecDeque<LogsServiceClient<Channel>>,
+    metrics: VecDeque<MetricsServiceClient<Channel>>,
+    traces: VecDeque<TraceServiceClient<Channel>>,
 }
 
 impl GrpcClientPool {
     fn new(
         max_in_flight: usize,
-        base_channel: Channel,
+        channels: Vec<Channel>,
         compression: Option<CompressionEncoding>,
     ) -> Self {
+        // Pool must hold at least one client per channel so every TCP connection
+        // gets exercised, even when max_in_flight is smaller than the channel count.
+        let pool_size = max_in_flight.max(channels.len());
         Self {
-            base_channel,
+            channels,
             compression,
-            logs: Vec::with_capacity(max_in_flight),
-            metrics: Vec::with_capacity(max_in_flight),
-            traces: Vec::with_capacity(max_in_flight),
+            logs: VecDeque::with_capacity(pool_size),
+            metrics: VecDeque::with_capacity(pool_size),
+            traces: VecDeque::with_capacity(pool_size),
         }
     }
 
-    /// Eagerly build up to `max_in_flight` clients per signal to avoid first-call setup.
+    /// Eagerly build up to `max_in_flight` clients per signal, distributing them
+    /// round-robin across the available channels.
     fn prepopulate_clients(&mut self) {
         let logs_cap = self.logs.capacity();
-        for _ in 0..logs_cap {
-            self.logs.push(self.make_logs_client());
+        for i in 0..logs_cap {
+            let channel = self.channels[i % self.channels.len()].clone();
+            self.logs.push_back(self.make_logs_client_with(channel));
         }
 
         let metrics_cap = self.metrics.capacity();
-        for _ in 0..metrics_cap {
-            self.metrics.push(self.make_metrics_client());
+        for i in 0..metrics_cap {
+            let channel = self.channels[i % self.channels.len()].clone();
+            self.metrics
+                .push_back(self.make_metrics_client_with(channel));
         }
 
         let traces_cap = self.traces.capacity();
-        for _ in 0..traces_cap {
-            self.traces.push(self.make_traces_client());
+        for i in 0..traces_cap {
+            let channel = self.channels[i % self.channels.len()].clone();
+            self.traces.push_back(self.make_traces_client_with(channel));
         }
     }
 
     #[inline(always)]
     fn take_logs(&mut self) -> LogsServiceClient<Channel> {
         self.logs
-            .pop()
+            .pop_front()
             .expect("client pool underflow: take_logs called with empty pool")
     }
 
     #[inline(always)]
     fn take_metrics(&mut self) -> MetricsServiceClient<Channel> {
         self.metrics
-            .pop()
+            .pop_front()
             .expect("client pool underflow: take_metrics called with empty pool")
     }
 
     #[inline(always)]
     fn take_traces(&mut self) -> TraceServiceClient<Channel> {
         self.traces
-            .pop()
+            .pop_front()
             .expect("client pool underflow: take_traces called with empty pool")
     }
 
     fn release(&mut self, client: SignalClient) {
         match client {
-            SignalClient::Logs(client) => self.logs.push(client),
-            SignalClient::Metrics(client) => self.metrics.push(client),
-            SignalClient::Traces(client) => self.traces.push(client),
+            SignalClient::Logs(client) => self.logs.push_back(client),
+            SignalClient::Metrics(client) => self.metrics.push_back(client),
+            SignalClient::Traces(client) => self.traces.push_back(client),
         }
     }
 
-    fn make_logs_client(&self) -> LogsServiceClient<Channel> {
-        let mut client = LogsServiceClient::new(self.base_channel.clone());
+    fn make_logs_client_with(&self, channel: Channel) -> LogsServiceClient<Channel> {
+        let mut client = LogsServiceClient::new(channel);
         if let Some(encoding) = self.compression {
             client = client.send_compressed(encoding);
             client = client.accept_compressed(encoding);
@@ -820,8 +851,8 @@ impl GrpcClientPool {
         client
     }
 
-    fn make_metrics_client(&self) -> MetricsServiceClient<Channel> {
-        let mut client = MetricsServiceClient::new(self.base_channel.clone());
+    fn make_metrics_client_with(&self, channel: Channel) -> MetricsServiceClient<Channel> {
+        let mut client = MetricsServiceClient::new(channel);
         if let Some(encoding) = self.compression {
             client = client.send_compressed(encoding);
             client = client.accept_compressed(encoding);
@@ -829,8 +860,8 @@ impl GrpcClientPool {
         client
     }
 
-    fn make_traces_client(&self) -> TraceServiceClient<Channel> {
-        let mut client = TraceServiceClient::new(self.base_channel.clone());
+    fn make_traces_client_with(&self, channel: Channel) -> TraceServiceClient<Channel> {
+        let mut client = TraceServiceClient::new(channel);
         if let Some(encoding) = self.compression {
             client = client.send_compressed(encoding);
             client = client.accept_compressed(encoding);
@@ -1107,6 +1138,7 @@ mod tests {
                         ..Default::default()
                     },
                     max_in_flight: 32,
+                    num_connections: default_num_connections(),
                 },
                 pdata_metrics: pipeline_ctx.register_metrics::<ExporterPDataMetrics>(),
             },
@@ -1176,6 +1208,7 @@ mod tests {
                         ..Default::default()
                     },
                     max_in_flight: 32,
+                    num_connections: default_num_connections(),
                 },
                 pdata_metrics: pipeline_ctx.register_metrics::<ExporterPDataMetrics>(),
             },

--- a/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-cores-template.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-cores-template.yaml.j2
@@ -78,3 +78,4 @@ tests:
         observation_interval: 60
         signals_per_second: null # Using null means loadgen don't self-cap the rate.
         max_batch_size: {{max_batch_size}}
+        num_connections: {{num_cores * 4}}

--- a/tools/pipeline_perf_test/test_suites/integration/templates/configs/loadgen/config.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/integration/templates/configs/loadgen/config.yaml.j2
@@ -44,6 +44,9 @@ groups:
               {%- if exporter_type in ["otap", "otlp"] %}
               grpc_endpoint: "http://{{ engine_host }}:{{ exporter_port }}"
               compression_method: {{ compression }}
+              {%- if num_connections is defined %}
+              num_connections: {{ num_connections }}
+              {%- endif %}
               {%- if exporter_extra_config is defined %}
               {%- for k, v in exporter_extra_config.items() %}
               {{ k }}: {{ v }}

--- a/tools/pipeline_perf_test/test_suites/integration/templates/test_steps/df-loadgen-steps-docker.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/templates/test_steps/df-loadgen-steps-docker.yaml
@@ -79,6 +79,7 @@ steps:
                 # compression_method: zstd           # Default is 'zstd' for otap, 'gzip' for otlp
                 engine_hostname: df-engine
                 loadgen_exporter_type: '{{loadgen_exporter_type}}'
+                {% if num_connections is defined %}num_connections: {{num_connections}}{% endif %}
                 {% if exporter_extra_config is defined %}exporter_extra_config: {{exporter_extra_config}}{% endif %}
 
         post:


### PR DESCRIPTION
## Summary

Add a `num_connections` configuration option to the OTLP gRPC exporter that controls how many independent TCP connections (tonic Channels) are created per pipeline.

Fixes https://github.com/open-telemetry/otel-arrow/issues/1323

## Problem

When the receiver uses `SO_REUSEPORT` across multiple cores, the kernel distributes **new TCP connections** (not individual RPCs) across listener sockets. With the previous behavior of 1 gRPC channel per pipeline, this caused severe core imbalance — e.g., with 2 engine cores: one core at 60% and another at 94%.

## Solution

- Added `num_connections` config field (default: 1) to the OTLP gRPC exporter
- When `num_connections > 1`, creates N independent tonic Channels, each establishing its own TCP connection
- Rewrote `GrpcClientPool` to use a FIFO `VecDeque` for round-robin distribution of gRPC clients across channels
- Pool is sized to `max(max_in_flight, num_connections)` ensuring every channel gets at least one client
- Updated saturation test templates to set `num_connections = num_cores * 4`

## Results

With `num_connections` set appropriately:
- Core imbalance fixed: 60%/94% → 99%/99%
- 2-core throughput improved from 0.90× to 1.36× of 1-core baseline

| Config | logs/sec | Scaling | Core balance |
|--------|----------|---------|--------------|
| 1-core, 1 conn (old) | 164,727 | baseline | N/A |
| 2-core, 1 conn (old) | 148,685 | 0.90× | 60%/94% |
| 1-core, 4 conns (new) | 177,461 | baseline | 99.6% |
| 2-core, 8 conns (new) | 241,964 | 1.36× | 95.4% avg, balanced |