### PR TITLE
Remove stale TODOs from OTLP Http Exporter that are already implemented

### DIFF
--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs
@@ -6,11 +6,9 @@
 //! This exporter sends telemetry data to an OTLP server using the HTTP Protocol.
 //!
 //! ToDo:
-//! - TLS/mTLS
 //! - Proxy settings
 //! - Compression (payloads and accepting compressed responses)
 //! - JSON encoding payloads (currently only proto is supported and it's not configurable)
-//! - Allow endpoint overrides for each signal type (similar to Go collector implementation)
 //! - Unit test metrics reporting
 
 use std::num::NonZeroUsize;


### PR DESCRIPTION
# Change Summary

The module-level `ToDo:` block at the top of `crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs` still listed two items that have since been implemented. This PR removes them so the list reflects only work that is actually outstanding.

## Removed entries and where they are implemented

### 1. `TLS/mTLS`

- Configured via `HttpClientSettings.tls: Option<TlsClientConfig>` in `crates/otap/src/otlp_http/client_settings.rs` (lines 51-53).
- Trust store (CA file/PEM, system roots), `insecure_skip_verify`, and the mTLS client identity (cert + key paired into a reqwest `Identity`) are wired into the `reqwest::ClientBuilder` at `crates/otap/src/otlp_http/client_settings.rs` (lines 85-188).
- Exporter validates and surfaces TLS-specific configuration errors at `crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs` (lines 139-175), e.g. unsupported `server_name_override`, ignored `insecure: true` when scheme is `https://`.
- Integration coverage in `crates/otap/tests/otlp_exporter_tls.rs`:
  - `otlp_exporter_connects_with_mtls`
  - `otlp_exporter_connects_with_tls_only`
  - `otlp_exporter_fails_partial_mtls`
  - `otlp_exporter_fails_with_invalid_ca_pem`
  - `otlp_exporter_allows_http_with_tls_config`
- Proxy + TLS combinations in `crates/otap/tests/otlp_exporter_proxy_tls.rs`.

### 2. `Allow endpoint overrides for each signal type (similar to Go collector implementation)`

- Per-signal override fields exist on the config struct: `traces_endpoint`, `metrics_endpoint`, `logs_endpoint` in `crates/core-nodes/src/exporters/otlp_http_exporter/config.rs` (lines 26-40).
- Resolved per-signal at construction time at `crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs` (lines 156-167 and 203-221), then dispatched per `SignalType` in the export path at lines 368-370 of the same file.

## Remaining ToDo items (unchanged)

- Proxy settings
- Compression (payloads and accepting compressed responses)
- JSON encoding payloads (only proto is supported, not configurable; see existing inline TODO at `crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs` line 670)
- Unit test metrics reporting

## What issue does this PR close?

* Closes #NNN

## How are these changes tested?

## Are there any user-facing changes?

 <!-- If yes, provide further info below -->
