### PR TITLE
Trim no-batch baselines from nightly batch processor perf suite

### DIFF
--- a/tools/pipeline_perf_test/test_suites/integration/nightly/batch-processor-docker.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/nightly/batch-processor-docker.yaml
@@ -80,42 +80,12 @@ tests:
         metric_weight: 0
         trace_weight: 0
 
-  - name: Logs-OTAP-OTAP
-    from_template:
-      path: test_suites/integration/templates/test_steps/df-loadgen-steps-docker.yaml
-      variables:
-        result_dir: nightly_batch_processor
-        engine_config_template: test_suites/integration/templates/configs/engine/batch_processor/otap-otap.yaml
-        loadgen_exporter_type: otap
-        backend_receiver_type: otap
-        generation_strategy: fresh
-        observation_interval: 60
-        log_weight: 100
-        metric_weight: 0
-        trace_weight: 0
-
   - name: Logs-OTLP-BATCH-OTLP
     from_template:
       path: test_suites/integration/templates/test_steps/df-loadgen-steps-docker.yaml
       variables:
         result_dir: nightly_batch_processor
         engine_config_template: test_suites/integration/templates/configs/engine/batch_processor/otlp-batch-otlp.yaml
-        loadgen_exporter_type: otlp
-        backend_receiver_type: otlp
-        generation_strategy: fresh
-        observation_interval: 60
-        log_weight: 100
-        metric_weight: 0
-        trace_weight: 0
-        exporter_extra_config:
-          max_in_flight: 256
-
-  - name: Logs-OTLP-OTLP
-    from_template:
-      path: test_suites/integration/templates/test_steps/df-loadgen-steps-docker.yaml
-      variables:
-        result_dir: nightly_batch_processor
-        engine_config_template: test_suites/integration/templates/configs/engine/batch_processor/otlp-otlp.yaml
         loadgen_exporter_type: otlp
         backend_receiver_type: otlp
         generation_strategy: fresh
@@ -142,44 +112,12 @@ tests:
         trace_weight: 0
         report_config: ./test_suites/integration/configs/integration_report_metrics.yaml
 
-  - name: Metrics-OTAP-OTAP
-    from_template:
-      path: test_suites/integration/templates/test_steps/df-loadgen-steps-docker.yaml
-      variables:
-        result_dir: nightly_batch_processor
-        engine_config_template: test_suites/integration/templates/configs/engine/batch_processor/otap-otap.yaml
-        loadgen_exporter_type: otap
-        backend_receiver_type: otap
-        generation_strategy: fresh
-        observation_interval: 60
-        log_weight: 0
-        metric_weight: 100
-        trace_weight: 0
-        report_config: ./test_suites/integration/configs/integration_report_metrics.yaml
-
   - name: Metrics-OTLP-BATCH-OTLP
     from_template:
       path: test_suites/integration/templates/test_steps/df-loadgen-steps-docker.yaml
       variables:
         result_dir: nightly_batch_processor
         engine_config_template: test_suites/integration/templates/configs/engine/batch_processor/otlp-batch-otlp.yaml
-        loadgen_exporter_type: otlp
-        backend_receiver_type: otlp
-        generation_strategy: fresh
-        observation_interval: 60
-        log_weight: 0
-        metric_weight: 100
-        trace_weight: 0
-        report_config: ./test_suites/integration/configs/integration_report_metrics.yaml
-        exporter_extra_config:
-          max_in_flight: 256
-
-  - name: Metrics-OTLP-OTLP
-    from_template:
-      path: test_suites/integration/templates/test_steps/df-loadgen-steps-docker.yaml
-      variables:
-        result_dir: nightly_batch_processor
-        engine_config_template: test_suites/integration/templates/configs/engine/batch_processor/otlp-otlp.yaml
         loadgen_exporter_type: otlp
         backend_receiver_type: otlp
         generation_strategy: fresh
@@ -207,21 +145,6 @@ tests:
         trace_weight: 100
         report_config: ./test_suites/integration/configs/integration_report_traces.yaml
 
-  - name: Traces-OTAP-OTAP
-    from_template:
-      path: test_suites/integration/templates/test_steps/df-loadgen-steps-docker.yaml
-      variables:
-        result_dir: nightly_batch_processor
-        engine_config_template: test_suites/integration/templates/configs/engine/batch_processor/otap-otap.yaml
-        loadgen_exporter_type: otap
-        backend_receiver_type: otap
-        generation_strategy: fresh
-        observation_interval: 60
-        log_weight: 0
-        metric_weight: 0
-        trace_weight: 100
-        report_config: ./test_suites/integration/configs/integration_report_traces.yaml
-
   - name: Traces-OTLP-BATCH-OTLP
     from_template:
       path: test_suites/integration/templates/test_steps/df-loadgen-steps-docker.yaml
@@ -239,19 +162,3 @@ tests:
         exporter_extra_config:
           max_in_flight: 256
 
-  - name: Traces-OTLP-OTLP
-    from_template:
-      path: test_suites/integration/templates/test_steps/df-loadgen-steps-docker.yaml
-      variables:
-        result_dir: nightly_batch_processor
-        engine_config_template: test_suites/integration/templates/configs/engine/batch_processor/otlp-otlp.yaml
-        loadgen_exporter_type: otlp
-        backend_receiver_type: otlp
-        generation_strategy: fresh
-        observation_interval: 60
-        log_weight: 0
-        metric_weight: 0
-        trace_weight: 100
-        report_config: ./test_suites/integration/configs/integration_report_traces.yaml
-        exporter_extra_config:
-          max_in_flight: 256


### PR DESCRIPTION
## Motivation

The Nightly Batch Processor perf suite (`tools/pipeline_perf_test/test_suites/integration/nightly/batch-processor-docker.yaml`) currently runs 12 tests = 3 signals (logs/metrics/traces) × 4 pipeline configs (OTAP+batch, OTAP-no-batch, OTLP+batch, OTLP-no-batch). It takes ~24 min in nightly runs (e.g. [run 25835389073](https://github.com/open-telemetry/otel-arrow/actions/runs/25835389073/job/75909238633)).

The no-batch baseline variants (`otap-otap`, `otlp-otlp`) don't actually exercise the batch processor, and equivalent passthrough OTAP/OTLP coverage already exists in other nightly suites (`otelcol-docker.yaml`, `100klrps-batch-sizes-docker.yaml`).

## Change

Remove the 6 no-batch baseline tests from this suite, keeping only the 6 batch-enabled variants. Expected wall-time saving: roughly half (~12 min).

## Remaining tests

- Logs-OTAP-BATCH-OTAP, Logs-OTLP-BATCH-OTLP
- Metrics-OTAP-BATCH-OTAP, Metrics-OTLP-BATCH-OTLP
- Traces-OTAP-BATCH-OTAP, Traces-OTLP-BATCH-OTLP

All batch_processor regression coverage across (signal × transport) is preserved.