### PR TITLE
Set cache-bin: false on Swatinem/rust-cache to fix broken cargo on macos-latest

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -115,6 +115,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: ./rust/${{ matrix.folder }}
+          cache-bin: false
       - name: Free disk space (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -208,6 +209,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: ./rust/otap-dataflow
+          cache-bin: false
       - name: Run user_events Linux smoke test when supported
         env:
           OTAP_DF_RUN_USEREVENTS_E2E: "1"
@@ -325,6 +327,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: ./rust/${{ matrix.folder }}
+          cache-bin: false
       - name: cargo clippy ${{ matrix.folder }}
         run: |
           cargo clippy --all-targets --all-features --workspace -- -D warnings
@@ -485,6 +488,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: ./rust/${{ matrix.folder }}
+          cache-bin: false
       - name: Free disk space (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -593,6 +597,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: ./rust/otap-dataflow
+          cache-bin: false
       - name: Free disk space
         run: |
           sudo rm -rf /usr/lib/jvm /usr/share/dotnet /usr/share/swift /usr/local/.ghcup
@@ -659,6 +664,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: ./rust/${{ matrix.folder }}
+          cache-bin: false
       - name: Install OpenSSL (Windows)
         if: runner.os == 'Windows'
         # Required for the crypto-openssl feature (rustls-openssl -> openssl-sys).
@@ -691,6 +697,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: ./rust/otap-dataflow
+          cache-bin: false
       - name: Run host metrics semconv drift check
         env:
           OTAP_HOST_METRICS_SEMCONV_REGISTRY: ${{ github.workspace }}/semantic-conventions/model


### PR DESCRIPTION
## Problem

CI `clippy (*, macos-latest)` (and other macOS rust steps) started failing today across many PRs with:

```
error: error: unexpected argument 'clippy' found
Usage: rustup-init[EXE] [OPTIONS]
```

## Root cause

GitHub rolled out a new macos-latest runner image today ([actions/runner-images#14037](https://github.com/actions/runner-images/pull/14037)) that changed how the `rustc`/`cargo` rustup proxy binaries are set up. Combined with [Swatinem/rust-cache#325](https://github.com/Swatinem/rust-cache/pull/325) (which made `cache-bin: true` the default in v2.8+), the cached `$CARGO_HOME/bin/` from previous runs gets restored over the freshly-installed proxies, leaving `cargo` dispatching to `rustup-init` behavior instead of the real cargo.

Tracked upstream: [Swatinem/rust-cache#341](https://github.com/Swatinem/rust-cache/issues/341).

## Fix

Set `cache-bin: false` on all 7 `Swatinem/rust-cache` invocations in `.github/workflows/rust-ci.yml`. This is the workaround confirmed by the upstream issue reporter. We don't `cargo install` any binaries that need caching, so this loses no useful caching.