### PR TITLE
perf: add egress_bytes_per_log metric to benchmark reports

### DIFF
--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/reports/report_logs.yaml
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/reports/report_logs.yaml
@@ -323,7 +323,7 @@ queries:
 
           UNION ALL
 
-          SELECT 'network_tx_bytes_rate_avg' AS name, 'bytes/sec' AS unit, average_rate AS value,
+          SELECT 'network_tx_mb_per_sec' AS name, 'MB/s' AS unit, average_rate / 1048576.0 AS value,
                 metadata_row."test.suite" || '/' || metadata_row."test.name" || ' - Network Utilization' AS extra
           FROM container_network_rates
           CROSS JOIN metadata_row
@@ -331,11 +331,26 @@ queries:
 
           UNION ALL
 
-          SELECT 'network_rx_bytes_rate_avg' AS name, 'bytes/sec' AS unit, average_rate AS value,
+          SELECT 'network_rx_mb_per_sec' AS name, 'MB/s' AS unit, average_rate / 1048576.0 AS value,
                 metadata_row."test.suite" || '/' || metadata_row."test.name" || ' - Network Utilization' AS extra
           FROM container_network_rates
           CROSS JOIN metadata_row
-          WHERE metric_name = 'container.network.rx' AND component_name IN ('df-engine', 'go-collector');
+          WHERE metric_name = 'container.network.rx' AND component_name IN ('df-engine', 'go-collector')
+
+          UNION ALL
+
+          SELECT 'egress_bytes_per_log' AS name, 'bytes/log' AS unit,
+                CASE WHEN ltr.logs_per_second > 0
+                  THEN cnr.average_rate / ltr.logs_per_second
+                  ELSE NULL
+                END AS value,
+                metadata_row."test.suite" || '/' || metadata_row."test.name" || ' - Egress Bytes Per Log' AS extra
+          FROM container_network_rates cnr
+          CROSS JOIN log_throughput_rates ltr
+          CROSS JOIN metadata_row
+          WHERE cnr.metric_name = 'container.network.tx'
+            AND cnr.component_name IN ('df-engine', 'go-collector')
+            AND ltr.metric_name = 'logs';
 
   - name: Dashboard time-series data
     sql: |

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/reports/report_metrics.yaml
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/reports/report_metrics.yaml
@@ -323,7 +323,7 @@ queries:
 
           UNION ALL
 
-          SELECT 'network_tx_bytes_rate_avg' AS name, 'bytes/sec' AS unit, average_rate AS value,
+          SELECT 'network_tx_mb_per_sec' AS name, 'MB/s' AS unit, average_rate / 1048576.0 AS value,
                 metadata_row."test.suite" || '/' || metadata_row."test.name" || ' - Network Utilization' AS extra
           FROM container_network_rates
           CROSS JOIN metadata_row
@@ -331,7 +331,7 @@ queries:
 
           UNION ALL
 
-          SELECT 'network_rx_bytes_rate_avg' AS name, 'bytes/sec' AS unit, average_rate AS value,
+          SELECT 'network_rx_mb_per_sec' AS name, 'MB/s' AS unit, average_rate / 1048576.0 AS value,
                 metadata_row."test.suite" || '/' || metadata_row."test.name" || ' - Network Utilization' AS extra
           FROM container_network_rates
           CROSS JOIN metadata_row

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/reports/report_traces.yaml
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/reports/report_traces.yaml
@@ -323,7 +323,7 @@ queries:
 
           UNION ALL
 
-          SELECT 'network_tx_bytes_rate_avg' AS name, 'bytes/sec' AS unit, average_rate AS value,
+          SELECT 'network_tx_mb_per_sec' AS name, 'MB/s' AS unit, average_rate / 1048576.0 AS value,
                 metadata_row."test.suite" || '/' || metadata_row."test.name" || ' - Network Utilization' AS extra
           FROM container_network_rates
           CROSS JOIN metadata_row
@@ -331,7 +331,7 @@ queries:
 
           UNION ALL
 
-          SELECT 'network_rx_bytes_rate_avg' AS name, 'bytes/sec' AS unit, average_rate AS value,
+          SELECT 'network_rx_mb_per_sec' AS name, 'MB/s' AS unit, average_rate / 1048576.0 AS value,
                 metadata_row."test.suite" || '/' || metadata_row."test.name" || ' - Network Utilization' AS extra
           FROM container_network_rates
           CROSS JOIN metadata_row

--- a/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_logs.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_logs.yaml
@@ -326,7 +326,7 @@ queries:
 
           UNION ALL
 
-          SELECT 'network_tx_bytes_rate_avg' AS name, 'bytes/sec' AS unit, average_rate AS value,
+          SELECT 'network_tx_mb_per_sec' AS name, 'MB/s' AS unit, average_rate / 1048576.0 AS value,
                 metadata_row."test.suite" || '/' || metadata_row."test.name" || ' - Network Utilization' AS extra
           FROM container_network_rates
           CROSS JOIN metadata_row
@@ -334,11 +334,26 @@ queries:
 
           UNION ALL
 
-          SELECT 'network_rx_bytes_rate_avg' AS name, 'bytes/sec' AS unit, average_rate AS value,
+          SELECT 'network_rx_mb_per_sec' AS name, 'MB/s' AS unit, average_rate / 1048576.0 AS value,
                 metadata_row."test.suite" || '/' || metadata_row."test.name" || ' - Network Utilization' AS extra
           FROM container_network_rates
           CROSS JOIN metadata_row
-          WHERE metric_name = 'container.network.rx' AND component_name IN ('go-collector', 'df-engine');
+          WHERE metric_name = 'container.network.rx' AND component_name IN ('go-collector', 'df-engine')
+
+          UNION ALL
+
+          SELECT 'egress_bytes_per_log' AS name, 'bytes/log' AS unit,
+                CASE WHEN ltr.logs_per_second > 0
+                  THEN cnr.average_rate / ltr.logs_per_second
+                  ELSE NULL
+                END AS value,
+                metadata_row."test.suite" || '/' || metadata_row."test.name" || ' - Egress Bytes Per Log' AS extra
+          FROM container_network_rates cnr
+          CROSS JOIN log_throughput_rates ltr
+          CROSS JOIN metadata_row
+          WHERE cnr.metric_name = 'container.network.tx'
+            AND cnr.component_name IN ('go-collector', 'df-engine')
+            AND ltr.metric_name = 'logs';
 
 result_tables:
   - name: metadata_filtered

--- a/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_metrics.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_metrics.yaml
@@ -326,7 +326,7 @@ queries:
 
           UNION ALL
 
-          SELECT 'network_tx_bytes_rate_avg' AS name, 'bytes/sec' AS unit, average_rate AS value,
+          SELECT 'network_tx_mb_per_sec' AS name, 'MB/s' AS unit, average_rate / 1048576.0 AS value,
                 metadata_row."test.suite" || '/' || metadata_row."test.name" || ' - Network Utilization' AS extra
           FROM container_network_rates
           CROSS JOIN metadata_row
@@ -334,7 +334,7 @@ queries:
 
           UNION ALL
 
-          SELECT 'network_rx_bytes_rate_avg' AS name, 'bytes/sec' AS unit, average_rate AS value,
+          SELECT 'network_rx_mb_per_sec' AS name, 'MB/s' AS unit, average_rate / 1048576.0 AS value,
                 metadata_row."test.suite" || '/' || metadata_row."test.name" || ' - Network Utilization' AS extra
           FROM container_network_rates
           CROSS JOIN metadata_row

--- a/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_traces.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_traces.yaml
@@ -326,7 +326,7 @@ queries:
 
           UNION ALL
 
-          SELECT 'network_tx_bytes_rate_avg' AS name, 'bytes/sec' AS unit, average_rate AS value,
+          SELECT 'network_tx_mb_per_sec' AS name, 'MB/s' AS unit, average_rate / 1048576.0 AS value,
                 metadata_row."test.suite" || '/' || metadata_row."test.name" || ' - Network Utilization' AS extra
           FROM container_network_rates
           CROSS JOIN metadata_row
@@ -334,7 +334,7 @@ queries:
 
           UNION ALL
 
-          SELECT 'network_rx_bytes_rate_avg' AS name, 'bytes/sec' AS unit, average_rate AS value,
+          SELECT 'network_rx_mb_per_sec' AS name, 'MB/s' AS unit, average_rate / 1048576.0 AS value,
                 metadata_row."test.suite" || '/' || metadata_row."test.name" || ' - Network Utilization' AS extra
           FROM container_network_rates
           CROSS JOIN metadata_row


### PR DESCRIPTION
## Summary

Two changes to benchmark report metrics:

### 1. Add `egress_bytes_per_log` metric
Adds a derived metric (bytes/log) computed as `network_tx_bytes_rate / logs_received_rate`. This makes it easy to assess whether compression ratios in tests are realistic.

For a ~150 byte log record, realistic values should be ~35-50 bytes/log. Values like ~27 bytes/log indicate unrealistic compression from low-entropy test data (e.g., replayed identical payloads).

### 2. Switch network metrics from bytes/sec to MB/s
Replaces `network_tx_bytes_rate_avg` and `network_rx_bytes_rate_avg` (bytes/sec) with `network_tx_mb_per_sec` and `network_rx_mb_per_sec` (MB/s) for readability. Raw bytes/sec values like 2,689,390 are hard to interpret at a glance; 2.56 MB/s is immediately meaningful.

### Files changed
- `integration/configs/integration_report_logs.yaml`
- `integration/configs/integration_report_metrics.yaml`
- `integration/configs/integration_report_traces.yaml`
- `comparison_dashboard/reports/report_logs.yaml`
- `comparison_dashboard/reports/report_metrics.yaml`
- `comparison_dashboard/reports/report_traces.yaml`

Relates to #2540