### PR TITLE
perf: switch 100kLRPS benchmarks to realistic entropy data source

### DIFF
--- a/tools/pipeline_perf_test/test_suites/integration/continuous/100klrps-docker.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/continuous/100klrps-docker.yaml
@@ -82,6 +82,9 @@ tests:
         loadgen_exporter_type: otlp
         backend_receiver_type: otlp
         max_batch_size: 1000
+        data_source: static
+        generation_strategy: fresh
+        use_trace_context: true
   - name: OTLP-ATTR-OTAP
     from_template:
       path: test_suites/integration/templates/test_steps/df-loadgen-steps-docker.yaml
@@ -90,6 +93,9 @@ tests:
         loadgen_exporter_type: otlp
         backend_receiver_type: otap
         max_batch_size: 1000
+        data_source: static
+        generation_strategy: fresh
+        use_trace_context: true
   - name: OTAP-ATTR-OTAP
     from_template:
       path: test_suites/integration/templates/test_steps/df-loadgen-steps-docker.yaml
@@ -98,6 +104,9 @@ tests:
         loadgen_exporter_type: otap
         backend_receiver_type: otap
         max_batch_size: 1000
+        data_source: static
+        generation_strategy: fresh
+        use_trace_context: true
   - name: OTAP-ATTR-OTLP
     from_template:
       path: test_suites/integration/templates/test_steps/df-loadgen-steps-docker.yaml
@@ -106,6 +115,9 @@ tests:
         loadgen_exporter_type: otap
         backend_receiver_type: otlp
         max_batch_size: 1000
+        data_source: static
+        generation_strategy: fresh
+        use_trace_context: true
   - name: OTLP-BATCH-OTLP
     from_template:
       path: test_suites/integration/templates/test_steps/df-loadgen-steps-docker.yaml
@@ -114,6 +126,9 @@ tests:
         loadgen_exporter_type: otlp
         backend_receiver_type: otlp
         max_batch_size: 1000
+        data_source: static
+        generation_strategy: fresh
+        use_trace_context: true
         exporter_extra_config:
           max_in_flight: 256
   - name: OTAP-BATCH-OTAP
@@ -124,3 +139,6 @@ tests:
         loadgen_exporter_type: otap
         backend_receiver_type: otap
         max_batch_size: 1000
+        data_source: static
+        generation_strategy: fresh
+        use_trace_context: true

--- a/tools/pipeline_perf_test/test_suites/integration/templates/configs/loadgen/config.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/integration/templates/configs/loadgen/config.yaml.j2
@@ -16,7 +16,7 @@ groups:
           receiver:
             type: "urn:otel:receiver:traffic_generator"
             config:
-              data_source: semantic_conventions
+              data_source: {{ data_source | default("semantic_conventions") }}
               generation_strategy: {{ generation_strategy | default("pre_generated") }}
               traffic_config:
                 max_batch_size: {{ max_batch_size | default(1000) }}
@@ -24,6 +24,9 @@ groups:
                 metric_weight: {{ metric_weight | default(0) }}
                 trace_weight: {{ trace_weight | default(0) }}
                 log_weight: {{ log_weight | default(100) }}
+                {%- if use_trace_context is defined and use_trace_context %}
+                use_trace_context: true
+                {%- endif %}
 
 {%- set exporter_type = loadgen_exporter_type | default("otap") %}
 {%- set engine_host = engine_hostname | default("localhost") %}

--- a/tools/pipeline_perf_test/test_suites/integration/templates/test_steps/df-loadgen-steps-docker.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/templates/test_steps/df-loadgen-steps-docker.yaml
@@ -67,7 +67,9 @@ steps:
                 # ----- Receiver traffic config -----
                 max_batch_size: {{max_batch_size | default(1000)}}
                 signals_per_second: {% if signals_per_second is none %}null{% else %}{{signals_per_second | default(100000)}}{% endif %}
+                data_source: {{data_source | default("semantic_conventions")}}
                 generation_strategy: {{generation_strategy | default("pre_generated")}}
+                {% if use_trace_context is defined %}use_trace_context: {{use_trace_context}}{% endif %}
                 metric_weight: {{metric_weight | default(0)}}
                 trace_weight: {{trace_weight | default(0)}}
                 log_weight: {{log_weight | default(100)}}


### PR DESCRIPTION
## Summary

Switches the rate-limited (100kLRPS) continuous benchmark tests from `semantic_conventions + pre_generated` to `static + fresh + use_trace_context: true`.

### Problem

The `semantic_conventions` data source with `pre_generated` strategy replays identical payloads every batch, resulting in unrealistically high compression ratios. OTAP egress was as low as 6-9 bytes/log, and OTLP ~27 bytes/log — making network utilization benchmarks misleading.

### Solution

The `static` data source with `fresh` generation provides:
- **50 diverse log body templates** (~150 bytes each) with realistic content
- **Unique trace_id/span_id per record** via `use_trace_context: true`
- **Fresh timestamps and varied attribute values** per batch

The uncompressed protobuf size per log record is approximately **250 bytes**. See #2987 for a planned metric to expose this directly.

### Before/After comparison (CI dedicated machine)

| Test | | CPU% | egress bytes/log | TX MB/s | Drop% |
|------|---|------|-----------------|---------|-------|
| **OTLP-ATTR-OTLP** | Before | 65.3 | 27.4 | 2.61 | 0% |
| | **After** | **65.1** | **49.9** | **4.52** | **0%** |
| **OTLP-ATTR-OTAP** | Before | 64.5 | 8.9 | 0.81 | 5% |
| | **After** | **64.4** | **37.3** | **3.38** | **0%** |
| **OTAP-ATTR-OTAP** | Before | 49.4 | 9.2 | 0.79 | 5.3% |
| | **After** | **51.3** | **37.4** | **3.39** | **0%** |
| **OTAP-ATTR-OTLP** | Before | 64.9 | 28.9 | 2.48 | 5.3% |
| | **After** | **64.9** | **57.9** | **5.24** | **0%** |
| **OTLP-BATCH-OTLP** | Before | 64.6 | 27.7 | 2.51 | 5% |
| | **After** | **64.9** | **49.9** | **4.52** | **0%** |
| **OTAP-BATCH-OTAP** | Before | 37.9 | 6.4 | 0.58 | 0.05% |
| | **After** | **38.2** | **34.9** | **3.16** | **0.05%** |

Key observations:
- **CPU is unchanged** — the engine handles the higher-entropy data at the same cost
- **Compression ratios are now realistic**: ~5:1 for OTLP (250→50), ~7:1 for OTAP (250→37)
- **OTAP columnar compression advantage over OTLP becomes measurable**: 35-37 vs 50-58 bytes/log = ~30% less wire usage, which was invisible with the old low-entropy data
- Saturation tests are not changed (they need `pre_generated` to avoid loadgen bottleneck)

Relates to #2540