### PR TITLE
chore: add traffic-generator log compression-ratio sanity tests

### DIFF
--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/compression_ratio_tests.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/compression_ratio_tests.rs
@@ -227,7 +227,7 @@ fn print_ratio(label: &str, raw: usize, compressed: usize, ratio: f64) {
     );
 }
 
-/// Print compression ratios for all four (source × strategy) combinations.
+/// Print compression ratios for all six (source × strategy) combinations.
 /// Numbers are informational — run with `--nocapture` to inspect them. The
 /// asserts enforce only loose, order-of-magnitude bounds:
 ///

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/compression_ratio_tests.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/compression_ratio_tests.rs
@@ -57,7 +57,7 @@
 #![cfg(test)]
 
 use super::semconv_signal::semconv_otlp_logs;
-use super::static_signal::static_otlp_logs_with_config;
+use super::synthetic_signal::static_otlp_logs_with_config;
 use prost::Message;
 use weaver_common::{result::WResult, vdir::VirtualDirectoryPath};
 use weaver_forge::registry::ResolvedRegistry;
@@ -161,8 +161,10 @@ fn measure(bytes: &[u8]) -> (usize, usize, f64) {
 
 /// Concatenate `NUM_BATCHES` independently-generated `static` batches.
 fn static_fresh_stream() -> Vec<u8> {
-    let mut concatenated = Vec::new();
-    for _ in 0..NUM_BATCHES {
+    let first = static_batch_bytes();
+    let mut concatenated = Vec::with_capacity(first.len() * NUM_BATCHES);
+    concatenated.extend_from_slice(&first);
+    for _ in 1..NUM_BATCHES {
         concatenated.extend_from_slice(&static_batch_bytes());
     }
     concatenated
@@ -171,8 +173,10 @@ fn static_fresh_stream() -> Vec<u8> {
 /// Concatenate `NUM_BATCHES` independently-generated `static` batches with
 /// trace context enabled.
 fn static_with_trace_ctx_fresh_stream() -> Vec<u8> {
-    let mut concatenated = Vec::new();
-    for _ in 0..NUM_BATCHES {
+    let first = static_with_trace_ctx_batch_bytes();
+    let mut concatenated = Vec::with_capacity(first.len() * NUM_BATCHES);
+    concatenated.extend_from_slice(&first);
+    for _ in 1..NUM_BATCHES {
         concatenated.extend_from_slice(&static_with_trace_ctx_batch_bytes());
     }
     concatenated
@@ -180,8 +184,10 @@ fn static_with_trace_ctx_fresh_stream() -> Vec<u8> {
 
 /// Concatenate `NUM_BATCHES` independently-generated `semconv` batches.
 fn semconv_fresh_stream(registry: &ResolvedRegistry) -> Vec<u8> {
-    let mut concatenated = Vec::new();
-    for _ in 0..NUM_BATCHES {
+    let first = semconv_batch_bytes(registry);
+    let mut concatenated = Vec::with_capacity(first.len() * NUM_BATCHES);
+    concatenated.extend_from_slice(&first);
+    for _ in 1..NUM_BATCHES {
         concatenated.extend_from_slice(&semconv_batch_bytes(registry));
     }
     concatenated
@@ -228,15 +234,6 @@ fn print_ratio(label: &str, raw: usize, compressed: usize, ratio: f64) {
 }
 
 /// Print compression ratios for all six (source × strategy) combinations.
-/// Numbers are informational — run with `--nocapture` to inspect them. The
-/// asserts enforce only loose, order-of-magnitude bounds:
-///
-/// - `fresh` ratios land within [`FRESH_RATIO_RANGE`].
-/// - `pre_generated` ratios stay above [`PRE_GENERATED_RATIO_FLOOR`] (i.e.
-///   replay remains trivially compressible, as expected when batches are
-///   byte-identical).
-/// - For each source, `pre_generated >= fresh` (replay can never compress
-///   worse than fresh batches).
 #[test]
 fn test_compression_ratios_across_source_and_strategy() {
     let registry = load_semconv_registry();
@@ -306,7 +303,7 @@ fn test_compression_ratios_across_source_and_strategy() {
         ("semconv/pre_generated", cp_ratio),
     ] {
         assert!(
-            ratio > PRE_GENERATED_RATIO_FLOOR,
+            ratio >= PRE_GENERATED_RATIO_FLOOR,
             "{label} compression ratio {ratio:.1}:1 is below expected floor \
              {PRE_GENERATED_RATIO_FLOOR}:1 (replayed identical batches should compress trivially)",
         );
@@ -322,5 +319,11 @@ fn test_compression_ratios_across_source_and_strategy() {
     assert!(
         cp_ratio >= cf_ratio,
         "semconv: pre_generated ratio {cp_ratio:.1}:1 should be >= fresh ratio {cf_ratio:.1}:1",
+    );
+    // Trace context adds 24 random bytes/record, so it should compress worse.
+    assert!(
+        sf_ratio > tf_ratio,
+        "static+tc/fresh ratio {tf_ratio:.1}:1 should be worse (lower) than \
+         static/fresh ratio {sf_ratio:.1}:1 (trace context adds incompressible entropy)",
     );
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/compression_ratio_tests.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/compression_ratio_tests.rs
@@ -1,0 +1,326 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Compression-ratio sanity tests covering the cartesian product of:
+//! - **Data source**: `static` (hard-coded varied payloads) vs `semantic_conventions`
+//!   (registry-driven payloads).
+//! - **Generation strategy**: `fresh` (new batch every iteration, simulating the
+//!   loadgen `fresh` strategy) vs `pre_generated` (one batch reused for every
+//!   iteration, simulating the loadgen `pre_generated` strategy).
+//!
+//! These tests are primarily **informational** — run with `--nocapture` to
+//! eyeball the bytes/record and compression ratios for each combination and
+//! sanity-check whether the loadgen output looks realistic. The asserts use
+//! deliberately wide bands so they don't flake on platform variance; their job
+//! is to catch order-of-magnitude regressions (e.g. `fresh` accidentally
+//! collapsing into `pre_generated`-style 300:1 compression), not exact numbers.
+//!
+//! ## Reference numbers (10 batches × 512 records, zstd level 3)
+//!
+//! Captured on macOS at the time of writing — your numbers should be within
+//! a few percent. Run with `--nocapture` to see live values.
+//!
+//! | Source     | Strategy        |       Raw | B/rec | Compressed | Ratio   |
+//! |------------|-----------------|-----------|-------|------------|---------|
+//! | Static     | `fresh`         | 1,856,370 | 362.6 |     45,480 |  40.8:1 |
+//! | Static     | `pre_generated` | 1,856,370 | 362.6 |     17,119 | 108.4:1 |
+//! | Static+TC  | `fresh`         | 1,999,730 | 390.6 |    187,532 |  10.7:1 |
+//! | Static+TC  | `pre_generated` | 1,999,730 | 390.6 |     32,277 |  62.0:1 |
+//! | Semconv    | `fresh`         | 1,843,320 | 360.0 |     71,596 |  25.7:1 |
+//! | Semconv    | `pre_generated` | 1,842,310 | 359.8 |     10,331 | 178.3:1 |
+//!
+//! Takeaways:
+//! - `pre_generated` collapses everything via cross-batch byte-identical replay.
+//! - At a comparable per-record size (~360 B/rec), `static + fresh` (~41:1) is
+//!   somewhat more compressible than `semconv + fresh` (~26:1). Counterintuitive
+//!   at first: static cycles values within a single fixed attribute schema,
+//!   so every record carries the same 4 attribute keys and zstd dictionary-
+//!   back-references them efficiently. Semconv cycles through ~30 different
+//!   event groups with different attribute key sets, which breaks that
+//!   structural repetition even though enum/single-example attribute values
+//!   within a group are constant. Neither perfectly models a real OTel
+//!   collector aggregating heterogeneous service traffic.
+//! - Adding `use_trace_context: true` to `static + fresh` drops the ratio ~4×
+//!   (41:1 → 11:1) because the 24 random bytes of trace+span ID per record are
+//!   essentially incompressible — this most closely matches the wire footprint
+//!   of OTel-instrumented application logs, where the SDK automatically attaches
+//!   the active span context to every emitted log. Logs ingested through
+//!   collector receivers (syslog, journald, filelog) typically lack trace
+//!   context and look more like the Static row.
+//!
+//! Run with:
+//! ```sh
+//! cargo test -p otap-df-core-nodes --features dev-tools \
+//!     -- receivers::traffic_generator::compression_ratio_tests --nocapture
+//! ```
+
+#![cfg(test)]
+
+use super::semconv_signal::semconv_otlp_logs;
+use super::static_signal::static_otlp_logs_with_config;
+use prost::Message;
+use weaver_common::{result::WResult, vdir::VirtualDirectoryPath};
+use weaver_forge::registry::ResolvedRegistry;
+use weaver_resolver::SchemaResolver;
+use weaver_semconv::registry_repo::RegistryRepo;
+
+/// OTel SDK default batch size for log/span/metric exporters.
+const BATCH_SIZE: usize = 512;
+
+/// Number of batches concatenated into a single zstd stream, approximating
+/// what a long-lived OTAP gRPC stream sees over time.
+const NUM_BATCHES: usize = 10;
+
+/// Generous window for `fresh` generation across both data sources.
+/// Observed values today: static ~41:1, semconv ~26:1, static+trace_context
+/// ~11:1 (random 16-byte trace_id + 8-byte span_id per record are
+/// essentially incompressible and drag the ratio way down). Bounds are wide
+/// on purpose — they exist to catch order-of-magnitude regressions only.
+const FRESH_RATIO_RANGE: std::ops::RangeInclusive<f64> = 3.0..=70.0;
+
+/// Floor for `pre_generated` replay across both data sources. Observed
+/// values today: static ~108:1, semconv ~178:1, static+trace_context ~62:1
+/// (per-batch random IDs become incompressible bulk inside the replayed
+/// batch). Anything noticeably below this suggests the generator has
+/// gained enough per-batch entropy that replay is no longer trivially
+/// compressible (which would be a notable behavior change worth
+/// re-examining this guard for).
+const PRE_GENERATED_RATIO_FLOOR: f64 = 50.0;
+
+/// Load the OpenTelemetry semantic-conventions registry for tests.
+///
+/// The registry source can be overridden via the `OTAP_SEMCONV_REGISTRY`
+/// env var (any `VirtualDirectoryPath`-parseable value, e.g. a local path).
+/// When unset, the upstream Git repo is used.
+fn load_semconv_registry() -> ResolvedRegistry {
+    let registry_path = std::env::var("OTAP_SEMCONV_REGISTRY")
+        .map(|path| {
+            path.parse::<VirtualDirectoryPath>()
+                .expect("valid OTAP_SEMCONV_REGISTRY")
+        })
+        .unwrap_or_else(|_| VirtualDirectoryPath::GitRepo {
+            url: "https://github.com/open-telemetry/semantic-conventions.git".to_owned(),
+            sub_folder: Some("model".to_owned()),
+            refspec: None,
+        });
+
+    let mut semconv_errors = Vec::new();
+    let registry_repo = RegistryRepo::try_new(None, &registry_path, &mut semconv_errors)
+        .expect("semantic convention registry");
+    let registry = match SchemaResolver::load_semconv_repository(registry_repo, false) {
+        WResult::Ok(registry) | WResult::OkWithNFEs(registry, _) => registry,
+        WResult::FatalErr(err) => panic!("failed to load semantic convention registry: {err}"),
+    };
+    let resolved_schema = match SchemaResolver::resolve(registry, true) {
+        WResult::Ok(schema) | WResult::OkWithNFEs(schema, _) => schema,
+        WResult::FatalErr(err) => {
+            panic!("failed to resolve semantic convention registry: {err}");
+        }
+    };
+
+    ResolvedRegistry::try_from_resolved_registry(
+        &resolved_schema.registry,
+        resolved_schema.catalog(),
+    )
+    .expect("resolved semantic convention registry")
+}
+
+/// Generate a `static` log batch with a per-record shape chosen so its
+/// byte/record footprint roughly matches semconv-generated logs (~360 B/rec):
+/// a small bounded body (which activates the body-pool entropy path —
+/// `MIN_BODY_POOL_SIZE` unique bodies in the pool — and is the realistic
+/// configuration for static-source loadgen) and 4 attributes, no trace
+/// context. Keeps the static vs semconv compression-ratio numbers
+/// apples-to-apples.
+fn static_batch_bytes() -> Vec<u8> {
+    static_otlp_logs_with_config(BATCH_SIZE, Some(150), Some(4), false, None).encode_to_vec()
+}
+
+/// Same as [`static_batch_bytes`] but with `use_trace_context: true`, which
+/// adds a fresh random 16-byte trace_id and 8-byte span_id per record. These
+/// 24 bytes/record of pure entropy are essentially incompressible and let us
+/// see how much compression drops once realistic correlation IDs are in the
+/// payload.
+fn static_with_trace_ctx_batch_bytes() -> Vec<u8> {
+    static_otlp_logs_with_config(BATCH_SIZE, Some(150), Some(4), true, None).encode_to_vec()
+}
+
+/// Generate a `semconv` log batch.
+fn semconv_batch_bytes(registry: &ResolvedRegistry) -> Vec<u8> {
+    semconv_otlp_logs(BATCH_SIZE, registry).encode_to_vec()
+}
+
+/// Compress `bytes` with zstd level 3 and return (raw_size, compressed_size, ratio).
+fn measure(bytes: &[u8]) -> (usize, usize, f64) {
+    let raw_size = bytes.len();
+    let compressed = zstd::bulk::compress(bytes, 3).expect("zstd compression failed");
+    let compressed_size = compressed.len();
+    let ratio = raw_size as f64 / compressed_size as f64;
+    (raw_size, compressed_size, ratio)
+}
+
+/// Concatenate `NUM_BATCHES` independently-generated `static` batches.
+fn static_fresh_stream() -> Vec<u8> {
+    let mut concatenated = Vec::new();
+    for _ in 0..NUM_BATCHES {
+        concatenated.extend_from_slice(&static_batch_bytes());
+    }
+    concatenated
+}
+
+/// Concatenate `NUM_BATCHES` independently-generated `static` batches with
+/// trace context enabled.
+fn static_with_trace_ctx_fresh_stream() -> Vec<u8> {
+    let mut concatenated = Vec::new();
+    for _ in 0..NUM_BATCHES {
+        concatenated.extend_from_slice(&static_with_trace_ctx_batch_bytes());
+    }
+    concatenated
+}
+
+/// Concatenate `NUM_BATCHES` independently-generated `semconv` batches.
+fn semconv_fresh_stream(registry: &ResolvedRegistry) -> Vec<u8> {
+    let mut concatenated = Vec::new();
+    for _ in 0..NUM_BATCHES {
+        concatenated.extend_from_slice(&semconv_batch_bytes(registry));
+    }
+    concatenated
+}
+
+/// Concatenate the **same** `static` batch `NUM_BATCHES` times.
+fn static_pregenerated_stream() -> Vec<u8> {
+    let batch = static_batch_bytes();
+    let mut concatenated = Vec::with_capacity(batch.len() * NUM_BATCHES);
+    for _ in 0..NUM_BATCHES {
+        concatenated.extend_from_slice(&batch);
+    }
+    concatenated
+}
+
+/// Concatenate the **same** `static`-with-trace-context batch `NUM_BATCHES`
+/// times. The trace/span IDs inside the single generated batch are random
+/// but identical across replays, so zstd can still back-reference them.
+fn static_with_trace_ctx_pregenerated_stream() -> Vec<u8> {
+    let batch = static_with_trace_ctx_batch_bytes();
+    let mut concatenated = Vec::with_capacity(batch.len() * NUM_BATCHES);
+    for _ in 0..NUM_BATCHES {
+        concatenated.extend_from_slice(&batch);
+    }
+    concatenated
+}
+
+/// Concatenate the **same** `semconv` batch `NUM_BATCHES` times.
+fn semconv_pregenerated_stream(registry: &ResolvedRegistry) -> Vec<u8> {
+    let batch = semconv_batch_bytes(registry);
+    let mut concatenated = Vec::with_capacity(batch.len() * NUM_BATCHES);
+    for _ in 0..NUM_BATCHES {
+        concatenated.extend_from_slice(&batch);
+    }
+    concatenated
+}
+
+fn print_ratio(label: &str, raw: usize, compressed: usize, ratio: f64) {
+    let total_records = BATCH_SIZE * NUM_BATCHES;
+    println!(
+        "{label}: raw={raw} bytes ({:.1} B/rec), compressed={compressed} bytes, ratio={ratio:.1}:1",
+        raw as f64 / total_records as f64
+    );
+}
+
+/// Print compression ratios for all four (source × strategy) combinations.
+/// Numbers are informational — run with `--nocapture` to inspect them. The
+/// asserts enforce only loose, order-of-magnitude bounds:
+///
+/// - `fresh` ratios land within [`FRESH_RATIO_RANGE`].
+/// - `pre_generated` ratios stay above [`PRE_GENERATED_RATIO_FLOOR`] (i.e.
+///   replay remains trivially compressible, as expected when batches are
+///   byte-identical).
+/// - For each source, `pre_generated >= fresh` (replay can never compress
+///   worse than fresh batches).
+#[test]
+fn test_compression_ratios_across_source_and_strategy() {
+    let registry = load_semconv_registry();
+
+    let (sf_raw, sf_comp, sf_ratio) = measure(&static_fresh_stream());
+    print_ratio(
+        &format!("Static  fresh         ({NUM_BATCHES}x{BATCH_SIZE})"),
+        sf_raw,
+        sf_comp,
+        sf_ratio,
+    );
+
+    let (sp_raw, sp_comp, sp_ratio) = measure(&static_pregenerated_stream());
+    print_ratio(
+        &format!("Static  pre_generated ({NUM_BATCHES}x{BATCH_SIZE})"),
+        sp_raw,
+        sp_comp,
+        sp_ratio,
+    );
+
+    let (tf_raw, tf_comp, tf_ratio) = measure(&static_with_trace_ctx_fresh_stream());
+    print_ratio(
+        &format!("Static+TC fresh       ({NUM_BATCHES}x{BATCH_SIZE})"),
+        tf_raw,
+        tf_comp,
+        tf_ratio,
+    );
+
+    let (tp_raw, tp_comp, tp_ratio) = measure(&static_with_trace_ctx_pregenerated_stream());
+    print_ratio(
+        &format!("Static+TC pre_generated ({NUM_BATCHES}x{BATCH_SIZE})"),
+        tp_raw,
+        tp_comp,
+        tp_ratio,
+    );
+
+    let (cf_raw, cf_comp, cf_ratio) = measure(&semconv_fresh_stream(&registry));
+    print_ratio(
+        &format!("Semconv fresh         ({NUM_BATCHES}x{BATCH_SIZE})"),
+        cf_raw,
+        cf_comp,
+        cf_ratio,
+    );
+
+    let (cp_raw, cp_comp, cp_ratio) = measure(&semconv_pregenerated_stream(&registry));
+    print_ratio(
+        &format!("Semconv pre_generated ({NUM_BATCHES}x{BATCH_SIZE})"),
+        cp_raw,
+        cp_comp,
+        cp_ratio,
+    );
+
+    for (label, ratio) in [
+        ("static/fresh", sf_ratio),
+        ("static+tc/fresh", tf_ratio),
+        ("semconv/fresh", cf_ratio),
+    ] {
+        assert!(
+            FRESH_RATIO_RANGE.contains(&ratio),
+            "{label} compression ratio {ratio:.1}:1 is outside expected range {:?}:1",
+            FRESH_RATIO_RANGE,
+        );
+    }
+    for (label, ratio) in [
+        ("static/pre_generated", sp_ratio),
+        ("static+tc/pre_generated", tp_ratio),
+        ("semconv/pre_generated", cp_ratio),
+    ] {
+        assert!(
+            ratio > PRE_GENERATED_RATIO_FLOOR,
+            "{label} compression ratio {ratio:.1}:1 is below expected floor \
+             {PRE_GENERATED_RATIO_FLOOR}:1 (replayed identical batches should compress trivially)",
+        );
+    }
+    assert!(
+        sp_ratio >= sf_ratio,
+        "static: pre_generated ratio {sp_ratio:.1}:1 should be >= fresh ratio {sf_ratio:.1}:1",
+    );
+    assert!(
+        tp_ratio >= tf_ratio,
+        "static+tc: pre_generated ratio {tp_ratio:.1}:1 should be >= fresh ratio {tf_ratio:.1}:1",
+    );
+    assert!(
+        cp_ratio >= cf_ratio,
+        "semconv: pre_generated ratio {cp_ratio:.1}:1 should be >= fresh ratio {cf_ratio:.1}:1",
+    );
+}

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/mod.rs
@@ -40,6 +40,9 @@ use tokio::time::{Duration, Interval, MissedTickBehavior, interval};
 use self::producer::{GenerateError, TrafficProducer};
 
 pub mod attributes;
+
+#[cfg(test)]
+mod compression_ratio_tests;
 /// allows the user to configure their traffic generator receiver
 pub mod config;
 /// provides synthetic data for generated signals

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/mod.rs
@@ -41,7 +41,7 @@ use self::producer::{GenerateError, TrafficProducer};
 
 pub mod attributes;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "dev-tools"))]
 mod compression_ratio_tests;
 /// allows the user to configure their traffic generator receiver
 pub mod config;

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/synthetic_signal.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/synthetic_signal.rs
@@ -1326,44 +1326,4 @@ mod tests {
         let records = &logs.resource_logs[0].scope_logs[0].log_records;
         assert!(records[0].attributes.is_empty());
     }
-
-    /// Verify that generated log batches are not trivially compressible.
-    ///
-    /// Generates 500 logs with ~1KB bodies, 6 attributes, and trace context
-    /// enabled, then checks the zstd compression ratio stays within a
-    /// realistic range. Before these changes all records were nearly identical
-    /// and compressed at ~57:1; with varied bodies, attribute values, severity
-    /// rotation, and random trace_id/span_id the ratio drops to ~19:1.
-    ///
-    /// The assert uses a generous 3:1–45:1 window to avoid flaky failures
-    /// across platforms while still catching regressions to the old
-    /// all-identical regime (>50:1).
-    ///
-    /// Run with:
-    /// ```sh
-    /// cargo test -p otap-df-core-nodes --features dev-tools -- test_compression_ratio --nocapture
-    /// ```
-    #[test]
-    fn test_compression_ratio_is_realistic() {
-        use prost::Message;
-
-        let logs = static_otlp_logs_with_config(500, Some(1024), Some(6), true, None);
-        let raw = logs.encode_to_vec();
-        let raw_size = raw.len();
-
-        let compressed = zstd::bulk::compress(&raw, 3).expect("zstd compression failed");
-        let compressed_size = compressed.len();
-
-        let ratio = raw_size as f64 / compressed_size as f64;
-
-        println!(
-            "Compression: raw={raw_size} bytes, compressed={compressed_size} bytes, ratio={ratio:.1}:1"
-        );
-
-        assert!(
-            (3.0..=45.0).contains(&ratio),
-            "compression ratio {ratio:.1}:1 is outside acceptable range (3:1 – 45:1); \
-             raw={raw_size} bytes, compressed={compressed_size} bytes"
-        );
-    }
 }


### PR DESCRIPTION
Adds an informational test that captures zstd compression ratios for log batches generated by the traffic generator, across the cartesian product of:

- **Data source**: `static` vs `semantic_conventions`
- **Generation strategy**: `fresh` vs `pre_generated`
- Plus a `static + fresh + use_trace_context` variant.

Each run encodes 10 batches × 512 records and reports raw / compressed sizes and ratios. Asserts are deliberately wide — the goal is to make it easy to eyeball whether loadgen output is realistic, and to catch order-of-magnitude regressions (e.g. a config inadvertently producing 300:1-compressible data).

Run with `--nocapture` to see the numbers:

```sh
cargo test -p otap-df-core-nodes --features dev-tools \
    -- receivers::traffic_generator::compression_ratio_tests --nocapture
```

The module doc-comment includes a reference table of expected values so reviewers don't need to run it themselves.

No production code changes — purely additive tests. The new file consolidates two earlier compression checks that previously lived inside `static_signal.rs` and `semconv_signal.rs`.

Requires network access (or `OTAP_SEMCONV_REGISTRY` pointing at a local checkout) because it loads the upstream semantic-conventions registry — same pattern as existing `host_metrics_receiver` dev-tools tests.
