### PR TITLE
NUMA-aware core assignments for saturation tests

### DIFF
--- a/.github/workflows/pipeline-perf-on-label.yaml
+++ b/.github/workflows/pipeline-perf-on-label.yaml
@@ -6,6 +6,7 @@ name: Pipeline Perf Dedicated
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     branches:
       - main
 
@@ -93,6 +94,17 @@ jobs:
         run: |
           cd tools/pipeline_perf_test
           python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/100klrps-docker.yaml
+
+      - name: Run saturation/scaling performance test suite
+        if: ${{ !cancelled() }}
+        run: |
+          cd tools/pipeline_perf_test
+          ./scripts/run-saturation-tests.sh --output-json results/scaling-efficiency.json \
+            | tee saturation-scaling-report.txt
+          echo "### Saturation/Scaling Test Analysis" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          sed -n '/^=.*SCALING ANALYSIS/,/^=\{10,\}$/p' saturation-scaling-report.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Post-run disk usage diagnostics
         if: always()

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/static_signal.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/static_signal.rs
@@ -1017,28 +1017,49 @@ const DEFAULT_BODY_TEMPLATES: &[&str] = &[
     "Batch export succeeded protocol=otlp/grpc destination=collector.prod:4317 spans=0 metrics=0 logs=500 bytes=612394 duration_ms=89 compression=zstd retries=0 stream=arrow",
 ];
 
+/// Minimum number of bodies in the pool when `log_body_size_bytes` is set.
+/// This ensures enough variety within a single batch (default batch_size=512)
+/// to produce realistic compression ratios.
+const MIN_BODY_POOL_SIZE: usize = 512;
+
 /// Build a pool of body strings for log generation.
 ///
-/// When `size_bytes` is specified, each template from [`DEFAULT_BODY_TEMPLATES`]
-/// is repeated to fill the target size, then truncated to exactly `size_bytes`.
+/// When `size_bytes` is specified, generates a pool of at least
+/// [`MIN_BODY_POOL_SIZE`] unique bodies. Each body is built by cycling through
+/// *different* templates from [`DEFAULT_BODY_TEMPLATES`] (starting at a
+/// different offset per entry) and prepending a deterministic unique prefix
+/// (`seq=N`) so that no two pool entries are identical. This produces
+/// realistic entropy that avoids inflating compression ratios.
+///
 /// When `None`, the templates are used as-is.
 fn build_body_pool(size_bytes: Option<usize>) -> Vec<String> {
     match size_bytes {
         Some(0) => Vec::new(),
-        Some(n) => DEFAULT_BODY_TEMPLATES
-            .iter()
-            .map(|template| {
-                let mut body = String::with_capacity(n);
-                while body.len() < n {
-                    if !body.is_empty() {
-                        body.push(' ');
+        Some(n) => {
+            let pool_size = MIN_BODY_POOL_SIZE.max(DEFAULT_BODY_TEMPLATES.len());
+            (0..pool_size)
+                .map(|pool_idx| {
+                    let mut body = String::with_capacity(n);
+                    // Deterministic unique prefix so no two bodies are identical.
+                    let prefix = format!("seq={pool_idx:04} ");
+                    body.push_str(&prefix);
+                    // Fill by cycling through different templates starting at
+                    // a unique offset.
+                    let mut tmpl_idx = pool_idx;
+                    while body.len() < n {
+                        if body.len() > prefix.len() {
+                            body.push(' ');
+                        }
+                        body.push_str(
+                            DEFAULT_BODY_TEMPLATES[tmpl_idx % DEFAULT_BODY_TEMPLATES.len()],
+                        );
+                        tmpl_idx += 1;
                     }
-                    body.push_str(template);
-                }
-                body.truncate(n);
-                body
-            })
-            .collect(),
+                    body.truncate(n);
+                    body
+                })
+                .collect()
+        }
         None => DEFAULT_BODY_TEMPLATES
             .iter()
             .map(|s| s.to_string())

--- a/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-16cores.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-16cores.yaml
@@ -1,11 +1,14 @@
 # Saturation test with 16 core df_engine
+# NUMA-aware layout: SUT on NUMA node 0, loadgen+backend on NUMA node 1.
+# Loadgen uses 32 physical cores (32-63) + 16 HT siblings (96-111).
+# Backend uses 16 HT siblings (112-127).
 from_template:
   path: test_suites/integration/continuous/saturation-cores-template.yaml.j2
   variables:
     num_cores: 16
     engine_core_range: "0-15"
     loadgen_cores: 48
-    loadgen_core_range: "16-63"
+    loadgen_core_range: "32-63,96-111"
     backend_cores: 16
-    backend_core_range: "64-79"
+    backend_core_range: "112-127"
     max_batch_size: 512

--- a/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-1core.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-1core.yaml
@@ -1,11 +1,13 @@
 # Saturation test with 1 core df_engine
+# NUMA-aware layout: SUT on NUMA node 0, loadgen+backend on NUMA node 1
+# to avoid L3 cache contention and HT sibling sharing.
 from_template:
   path: test_suites/integration/continuous/saturation-cores-template.yaml.j2
   variables:
     num_cores: 1
     engine_core_range: "0-0"
     loadgen_cores: 3
-    loadgen_core_range: "1-3"
+    loadgen_core_range: "32-34"
     backend_cores: 1
-    backend_core_range: "4-4"
+    backend_core_range: "35-35"
     max_batch_size: 512

--- a/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-2cores.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-2cores.yaml
@@ -1,11 +1,12 @@
 # Saturation test with 2 core df_engine
+# NUMA-aware layout: SUT on NUMA node 0, loadgen+backend on NUMA node 1
 from_template:
   path: test_suites/integration/continuous/saturation-cores-template.yaml.j2
   variables:
     num_cores: 2
     engine_core_range: "0-1"
     loadgen_cores: 6
-    loadgen_core_range: "2-7"
+    loadgen_core_range: "32-37"
     backend_cores: 2
-    backend_core_range: "8-9"
+    backend_core_range: "38-39"
     max_batch_size: 512

--- a/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-4cores.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-4cores.yaml
@@ -1,11 +1,12 @@
 # Saturation test with 4 core df_engine
+# NUMA-aware layout: SUT on NUMA node 0, loadgen+backend on NUMA node 1
 from_template:
   path: test_suites/integration/continuous/saturation-cores-template.yaml.j2
   variables:
     num_cores: 4
     engine_core_range: "0-3"
     loadgen_cores: 12
-    loadgen_core_range: "4-15"
+    loadgen_core_range: "32-43"
     backend_cores: 4
-    backend_core_range: "16-19"
+    backend_core_range: "44-47"
     max_batch_size: 512

--- a/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-8cores.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-8cores.yaml
@@ -1,11 +1,12 @@
 # Saturation test with 8 core df_engine
+# NUMA-aware layout: SUT on NUMA node 0, loadgen+backend on NUMA node 1
 from_template:
   path: test_suites/integration/continuous/saturation-cores-template.yaml.j2
   variables:
     num_cores: 8
     engine_core_range: "0-7"
     loadgen_cores: 24
-    loadgen_core_range: "8-31"
+    loadgen_core_range: "32-55"
     backend_cores: 8
-    backend_core_range: "32-39"
+    backend_core_range: "56-63"
     max_batch_size: 512

--- a/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-cores-template.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-cores-template.yaml.j2
@@ -78,4 +78,6 @@ tests:
         observation_interval: 60
         signals_per_second: null # Using null means loadgen don't self-cap the rate.
         max_batch_size: {{max_batch_size}}
+        data_source: static
+        log_body_size_bytes: 1024
         num_connections: {{num_cores * 4}}

--- a/tools/pipeline_perf_test/test_suites/integration/templates/configs/loadgen/config.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/integration/templates/configs/loadgen/config.yaml.j2
@@ -16,7 +16,7 @@ groups:
           receiver:
             type: "urn:otel:receiver:traffic_generator"
             config:
-              data_source: semantic_conventions
+              data_source: {{ data_source | default("semantic_conventions") }}
               generation_strategy: {{ generation_strategy | default("pre_generated") }}
               traffic_config:
                 max_batch_size: {{ max_batch_size | default(1000) }}
@@ -24,6 +24,7 @@ groups:
                 metric_weight: {{ metric_weight | default(0) }}
                 trace_weight: {{ trace_weight | default(0) }}
                 log_weight: {{ log_weight | default(100) }}
+                {% if log_body_size_bytes is defined %}log_body_size_bytes: {{ log_body_size_bytes }}{% endif %}
 
 {%- set exporter_type = loadgen_exporter_type | default("otap") %}
 {%- set engine_host = engine_hostname | default("localhost") %}

--- a/tools/pipeline_perf_test/test_suites/integration/templates/test_steps/df-loadgen-steps-docker.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/templates/test_steps/df-loadgen-steps-docker.yaml
@@ -79,6 +79,8 @@ steps:
                 # compression_method: zstd           # Default is 'zstd' for otap, 'gzip' for otlp
                 engine_hostname: df-engine
                 loadgen_exporter_type: '{{loadgen_exporter_type}}'
+                data_source: {{data_source | default("semantic_conventions")}}
+                {% if log_body_size_bytes is defined %}log_body_size_bytes: {{log_body_size_bytes}}{% endif %}
                 {% if num_connections is defined %}num_connections: {{num_connections}}{% endif %}
                 {% if exporter_extra_config is defined %}exporter_extra_config: {{exporter_extra_config}}{% endif %}
 


### PR DESCRIPTION
## Summary

Improves the accuracy and consistency of the saturation/scaling test suite by eliminating hardware-level interference (NUMA cross-socket traffic, HT sibling contention) and making the workload more realistic.

## Problem

The saturation tests measure CPU scaling efficiency by running the SUT at 1/2/4/8/16 cores and checking for linear throughput growth. On our 2-socket NUMA CI box (Intel Xeon 8358, 128 logical CPUs), results were unreliable:

- **16-core showed ~48% efficiency** — far below expected for a shared-nothing architecture
- **High run-to-run variance** made results hard to interpret

Root causes identified:
1. **HT sibling contention** — SUT (cores 0-15) and backend (cores 64-79) were placed on hyperthreaded siblings of the same physical cores, causing L1/L2 thrashing
2. **Cross-NUMA traffic** — components spanning both NUMA nodes incurred 2x memory latency (node distance: 10 local vs 20 remote)
3. **Unrealistic workload** — semantic_conventions data source with ~300-byte logs and low entropy bodies gave artificially good compression, not representative of real pipelines

## Changes

### 1. NUMA-aware core pinning

Pin SUT exclusively to NUMA node 0 physical cores (0-15), loadgen and backend to NUMA node 1 (32-63, 96-127). This ensures:
- No HT sibling sharing between components
- All memory accesses are NUMA-local within each component
- SUT gets dedicated L3 cache (no pollution from loadgen/backend)

### 2. Static 1KB log bodies (saturation tests only)

Switch from `semantic_conventions` (~300 bytes) to `static` data source with `log_body_size_bytes: 1024`. Larger payloads better exercise the serialization/compression/network path that dominates real workloads. Only affects saturation tests — all other tests continue using `semantic_conventions`.

### 3. Body pool entropy (512 unique bodies)

Generate 512 unique log bodies with sequence-prefixed cycling templates instead of repeating the same ~50 bodies. This gives a realistic ~3:1 compression ratio rather than artificially high compression from duplicate data.

### 4. Saturation tests in label-triggered workflow

Add saturation suite to `pipeline-perf-on-label.yaml` so scaling can be validated on PRs via the `pipelineperf` label without waiting for nightly runs. Also adds `labeled` event type to trigger on label addition.

## Results (3 consecutive CI runs on bare metal)

| Cores | Before | Run 0 | Run 1 | Run 2 |
|-------|--------|-------|-------|-------|
| 2 | 97% | 96% | 116%* | 99% |
| 4 | 87% | 99.6% | 102% | 100% |
| 8 | 82% | 100% | 95% | 91% |
| 16 | 48% | 80% | 68% | 91% |
| **Avg** | **79%** | **94%** | **96%** | **96%** |
| **Speedup** | **7.7x** | **12.8x** | **11.0x** | **14.6x** |

*\* >100% is measurement noise (super-linear artifact from cache warming effects)*

Verdict changed from 🟠 ACCEPTABLE to ✅ EXCELLENT across all runs.

16-core variance (68-91%) is due to loadgen CPU saturation — with 48 loadgen cores at 100%, small throughput fluctuations swing the efficiency metric. This is a measurement limitation, not a SUT issue.

## Files changed

- `saturation-{1,2,4,8,16}cores.yaml` — NUMA-aware core ranges
- `saturation-cores-template.yaml.j2` — `data_source: static`, `log_body_size_bytes: 1024`
- `configs/loadgen/config.yaml.j2` — template variables for data_source and log_body_size_bytes
- `df-loadgen-steps-docker.yaml` — pass through new template variables
- `static_signal.rs` — body pool entropy (512 unique bodies with cycling templates)
- `pipeline-perf-on-label.yaml` — saturation step + labeled trigger