### PR TITLE
feat(comparison_dashboard): Specify metrics metadata via manifest

### DIFF
--- a/tools/comparison_dashboard/dashboard.py
+++ b/tools/comparison_dashboard/dashboard.py
@@ -70,6 +70,7 @@ class Manifest:
     comparison_files: list[Path]  # absolute paths to comparison YAMLs
     variables: dict               # template variables passed to Jinja at top level
     meta: dict                    # allowed values per meta key (key -> [values])
+    metrics: list                 # ordered list of {name, label} for dashboard metrics
 
 def load_manifest(manifest_path: Path) -> Manifest:
     """Load and validate the manifest file. Resolves all listed paths."""
@@ -88,7 +89,7 @@ def load_manifest(manifest_path: Path) -> Manifest:
         print(f"ERROR: manifest must be a mapping at top level: {manifest_path}")
         sys.exit(1)
 
-    for key in ("suites", "comparisons", "variables", "meta"):
+    for key in ("suites", "comparisons", "variables", "meta", "metrics"):
         if key not in data:
             print(f"ERROR: manifest missing required key '{key}': {manifest_path}")
             sys.exit(1)
@@ -107,6 +108,30 @@ def load_manifest(manifest_path: Path) -> Manifest:
             print(f"ERROR: manifest meta.{key} must be a list of allowed values: {manifest_path}")
             sys.exit(1)
 
+    metrics_raw = data["metrics"]
+    if not isinstance(metrics_raw, list) or not metrics_raw:
+        print(f"ERROR: manifest 'metrics' must be a non-empty list: {manifest_path}")
+        sys.exit(1)
+    metrics: list = []
+    seen_metric_names: set[str] = set()
+    for i, m in enumerate(metrics_raw):
+        if not isinstance(m, dict):
+            print(f"ERROR: manifest metrics[{i}] must be a mapping: {manifest_path}")
+            sys.exit(1)
+        name = m.get("name")
+        label = m.get("label")
+        if not isinstance(name, str) or not name:
+            print(f"ERROR: manifest metrics[{i}] missing non-empty 'name': {manifest_path}")
+            sys.exit(1)
+        if not isinstance(label, str) or not label:
+            print(f"ERROR: manifest metrics[{i}] missing non-empty 'label': {manifest_path}")
+            sys.exit(1)
+        if name in seen_metric_names:
+            print(f"ERROR: duplicate manifest metric name '{name}': {manifest_path}")
+            sys.exit(1)
+        seen_metric_names.add(name)
+        metrics.append({"name": name, "label": label})
+
     base = manifest_path.parent
     suite_files = [_resolve_listed_path(base, p, "suite") for p in data["suites"]]
     comparison_files = [_resolve_listed_path(base, p, "comparison") for p in data["comparisons"]]
@@ -118,6 +143,7 @@ def load_manifest(manifest_path: Path) -> Manifest:
         comparison_files=comparison_files,
         variables=variables,
         meta=meta,
+        metrics=metrics,
     )
 
 
@@ -830,11 +856,11 @@ def cmd_build(args) -> int:
     print()
 
     print("Generating index.html...")
-    generate_index_html(comparisons, suites, paths)
+    generate_index_html(comparisons, suites, paths, manifest)
     print()
 
     print("Generating comparison stubs...")
-    generate_compare_stubs(comparisons, suites, paths)
+    generate_compare_stubs(comparisons, suites, paths, manifest)
     print()
 
     print("Build complete.")
@@ -1183,6 +1209,35 @@ def validate_manifest(
                     f"'{ref_slug}' (source: {comp.get('_source')})"
                 )
 
+    known_metric_names = {m["name"] for m in manifest.metrics}
+    for comp in comparisons:
+        comp_metrics = comp.get("metrics")
+        if comp_metrics is None:
+            continue
+        if not isinstance(comp_metrics, dict):
+            errors.append(
+                f"comparison '{comp.get('slug')}' 'metrics' must be a mapping (source: {comp.get('_source')})"
+            )
+            continue
+        chart_list = comp_metrics.get("chart")
+        if chart_list is None:
+            continue
+        if not isinstance(chart_list, list) or not chart_list:
+            errors.append(
+                f"comparison '{comp.get('slug')}' 'metrics.chart' must be a non-empty list (source: {comp.get('_source')})"
+            )
+            continue
+        for j, name in enumerate(chart_list):
+            if not isinstance(name, str) or not name:
+                errors.append(
+                    f"comparison '{comp.get('slug')}' metrics.chart[{j}] must be a non-empty string (source: {comp.get('_source')})"
+                )
+                continue
+            if name not in known_metric_names:
+                errors.append(
+                    f"comparison '{comp.get('slug')}' metrics.chart references unknown metric '{name}' (source: {comp.get('_source')})"
+                )
+
     for comp in comparisons:
         comp_slug = comp.get("slug")
         src = comp.get("_source", "?")
@@ -1345,7 +1400,7 @@ def _url_relpath(target: Path, start: Path) -> str:
     return Path(os.path.relpath(target, start)).as_posix()
 
 
-def generate_index_html(comparisons: list, suites: dict, paths: BuildPaths) -> None:
+def generate_index_html(comparisons: list, suites: dict, paths: BuildPaths, manifest: Manifest) -> None:
     """Generate <compare_dir>/index.html with comparison sections."""
     shared_rel = _url_relpath(paths.shared_dst, paths.compare_dir)
     data_rel = _url_relpath(paths.data_dir, paths.compare_dir)
@@ -1364,6 +1419,8 @@ def generate_index_html(comparisons: list, suites: dict, paths: BuildPaths) -> N
 
     comparisons_public = [_strip_internal(c) for c in comparisons]
     comparisons_json = json.dumps(comparisons_public, indent=2)
+    metrics_meta = {m["name"]: {"label": m["label"]} for m in manifest.metrics}
+    metrics_meta_json = json.dumps(metrics_meta)
 
     lines = [
         '<!DOCTYPE html>',
@@ -1400,6 +1457,7 @@ def generate_index_html(comparisons: list, suites: dict, paths: BuildPaths) -> N
         '  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.js"></script>',
         data_script_tags,
         f'  <script>window.DATA_PATH = "{data_rel}/suite";</script>',
+        f'  <script>window.METRICS_META = {metrics_meta_json};</script>',
         f'  <script>window.COMPARISONS = {comparisons_json};</script>',
         f'  <script type="module" src="{shared_rel}/app.js"></script>',
         '</body>',
@@ -1417,13 +1475,15 @@ def _strip_internal(comp: dict) -> dict:
     return {k: v for k, v in comp.items() if not (isinstance(k, str) and k.startswith("_"))}
 
 
-def generate_compare_stubs(comparisons: list, suites: dict, paths: BuildPaths) -> None:
+def generate_compare_stubs(comparisons: list, suites: dict, paths: BuildPaths, manifest: Manifest) -> None:
     """Generate <compare_dir>/<slug>/index.html stub pages."""
     # Per-comparison pages are all siblings under compare_dir, so the
     # relpaths to shared/ and data/ are identical for every slug.
     sample_stub = paths.compare_page_dir("_")
     shared_rel = _url_relpath(paths.shared_dst, sample_stub)
     data_rel = _url_relpath(paths.data_dir, sample_stub)
+    metrics_meta = {m["name"]: {"label": m["label"]} for m in manifest.metrics}
+    metrics_meta_json = json.dumps(metrics_meta)
 
     for comp in comparisons:
         comp_slug = comp["slug"]
@@ -1480,6 +1540,7 @@ def generate_compare_stubs(comparisons: list, suites: dict, paths: BuildPaths) -
             '',
             '  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.js"></script>',
             f'  <script>window.DATA_PATH = "{data_rel}/suite";</script>',
+            f'  <script>window.METRICS_META = {metrics_meta_json};</script>',
             f'  <script>window.COMPARISON_SLUG = "{comp_slug}";</script>',
             suite_scripts,
             f'  <script>window.COMPARISON = {comp_json};</script>',

--- a/tools/comparison_dashboard/manifest.yaml
+++ b/tools/comparison_dashboard/manifest.yaml
@@ -25,6 +25,39 @@ meta:
   signals: [logs, metrics, traces]
   compression: [none, gzip, zstd]
 
+# Display registry for dashboard metrics. Names must match the `name` field on
+# per-test metric records in published suite data; units come from those
+# records (manifest declares label only).
+metrics:
+  - name: cpu_percentage_normalized_avg
+    label: CPU Average
+  - name: cpu_percentage_normalized_max
+    label: CPU Max
+  - name: ram_mib_avg
+    label: Memory Average
+  - name: ram_mib_max
+    label: Memory Max
+  - name: network_tx_bytes_rate_avg
+    label: Network TX Rate
+  - name: network_rx_bytes_rate_avg
+    label: Network RX Rate
+  - name: dropped_logs_percentage
+    label: Dropped Logs
+  - name: logs_delivery_deviation_percentage
+    label: Logs Delivery Deviation
+  - name: logs_produced_rate
+    label: Offered Load Rate
+  - name: loadgen_logs_sent_rate
+    label: Loadgen Sent Rate
+  - name: logs_received_rate
+    label: Collector Received Rate
+  - name: collector_logs_sent_rate
+    label: Collector Sent Rate
+  - name: backend_logs_received_rate
+    label: Backend Received Rate
+  - name: test_duration
+    label: Test Duration
+
 # Suite definitions, listed by path. Each entry must point at an existing
 # YAML file with at least `name`, `slug`, `variables`, and `orchestrator_template`.
 suites:

--- a/tools/comparison_dashboard/shared/app.js
+++ b/tools/comparison_dashboard/shared/app.js
@@ -25,61 +25,9 @@ if (!DATA_PATH) {
 }
 
 // ── Metric display config ──────────────────────────────────────────────────
-
-const METRIC_LABELS = {
-  cpu_percentage_normalized_avg: "CPU Average",
-  cpu_percentage_normalized_max: "CPU Max",
-  ram_mib_avg: "Memory Average",
-  ram_mib_max: "Memory Max",
-  network_tx_bytes_rate_avg: "Network TX Rate",
-  network_rx_bytes_rate_avg: "Network RX Rate",
-  dropped_logs_percentage: "Dropped Logs",
-  dropped_metrics_percentage: "Dropped Metrics",
-  dropped_spans_percentage: "Dropped Spans",
-  logs_delivery_deviation_percentage: "Logs Delivery Deviation",
-  logs_produced_rate: "Offered Load Rate",
-  metrics_produced_rate: "Offered Load Rate",
-  spans_produced_rate: "Offered Load Rate",
-  loadgen_logs_sent_rate: "Loadgen Sent Rate",
-  logs_received_rate: "Collector Received Rate",
-  metrics_received_rate: "Collector Received Rate",
-  spans_received_rate: "Collector Received Rate",
-  collector_logs_sent_rate: "Collector Sent Rate",
-  backend_logs_received_rate: "Backend Received Rate",
-  test_duration: "Test Duration",
-};
-
-const METRIC_UNITS = {
-  cpu_percentage_normalized_avg: "%",
-  cpu_percentage_normalized_max: "%",
-  ram_mib_avg: "MiB",
-  ram_mib_max: "MiB",
-  network_tx_bytes_rate_avg: "bytes/sec",
-  network_rx_bytes_rate_avg: "bytes/sec",
-  dropped_logs_percentage: "%",
-  dropped_metrics_percentage: "%",
-  dropped_spans_percentage: "%",
-  logs_delivery_deviation_percentage: "%",
-  logs_produced_rate: "logs/sec",
-  metrics_produced_rate: "metrics/sec",
-  spans_produced_rate: "spans/sec",
-  loadgen_logs_sent_rate: "logs/sec",
-  logs_received_rate: "logs/sec",
-  metrics_received_rate: "metrics/sec",
-  spans_received_rate: "spans/sec",
-  collector_logs_sent_rate: "logs/sec",
-  backend_logs_received_rate: "logs/sec",
-  test_duration: "seconds",
-};
-
-const DASHBOARD_METRICS = [
-  "cpu_percentage_normalized_avg",
-  "cpu_percentage_normalized_max",
-  "ram_mib_avg",
-  "ram_mib_max",
-  "network_tx_bytes_rate_avg",
-  "network_rx_bytes_rate_avg",
-];
+// Display labels come from window.METRICS_META (emitted by dashboard.py from
+// manifest.yaml). Units come from each per-test metric record's `unit` field
+// in the published JSON.
 
 const AUTO_COLORS = [
   "#f97316", "#3b82f6", "#22c55e", "#a855f7",
@@ -422,10 +370,8 @@ const TIMESERIES_METRICS = [
 ];
 
 const SCALAR_ONLY_METRICS = [
-  { name: "dropped_logs_percentage", label: "Dropped Logs", unit: "%" },
-  { name: "dropped_metrics_percentage", label: "Dropped Metrics", unit: "%" },
-  { name: "dropped_spans_percentage", label: "Dropped Spans", unit: "%" },
-  { name: "test_duration", label: "Test Duration", unit: "seconds" },
+  { name: "dropped_logs_percentage" },
+  { name: "test_duration" },
 ];
 
 function tmTitle(tm) { return tm.unit ? `${tm.label} (${tm.unit})` : tm.label; }
@@ -485,17 +431,34 @@ function formatBytes(v) {
 }
 
 function metricLabel(name) {
-  return METRIC_LABELS[name] || name.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+  const meta = (window.METRICS_META || {})[name];
+  if (meta && meta.label) return meta.label;
+  return name.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
-function metricTitle(name) {
+function lookupMetricUnit(suiteData, comparison, name) {
+  for (const ref of comparison.suites || []) {
+    for (const t of getSuiteTests(suiteData, ref.slug)) {
+      if (!t.metrics) continue;
+      const m = t.metrics.find((x) => x.name === name);
+      if (m && m.unit) return m.unit;
+    }
+  }
+  return null;
+}
+
+function metricTitle(name, suiteData, comparison) {
   const label = metricLabel(name);
-  const unit = METRIC_UNITS[name];
+  const unit = suiteData && comparison ? lookupMetricUnit(suiteData, comparison, name) : null;
   return unit ? `${label} (${unit})` : label;
 }
 
 function findAvailableMetrics(suiteData, comparison) {
-  return DASHBOARD_METRICS.filter((mn) =>
+  const chartList = comparison.metrics && comparison.metrics.chart;
+  const candidates = chartList && chartList.length
+    ? chartList
+    : Object.keys(window.METRICS_META || {});
+  return candidates.filter((mn) =>
     (comparison.suites || []).some((ref) =>
       getSuiteTests(suiteData, ref.slug).some((t) =>
         t.metrics && t.metrics.some((m) => m.name === mn && m.value != null))));
@@ -713,7 +676,7 @@ function renderComparisonChart(suiteData, comparison, tests, onBarClick) {
   target.innerHTML = `
     <div class="scenario-section">
       <div class="scenario-section-head">
-        <div class="scenario-section-title">${escapeHtml(metricTitle(sel))}</div>
+        <div class="scenario-section-title">${escapeHtml(metricTitle(sel, suiteData, comparison))}</div>
         <select id="metric-select" class="scenario-metric-select">${optsHtml}</select>
       </div>
       <div class="chart-container"><canvas></canvas></div>
@@ -727,7 +690,7 @@ function renderComparisonChart(suiteData, comparison, tests, onBarClick) {
     sel = ms.value;
     updateBarChartData(chart, suiteData, comparison, tests, sel);
     const t = target.querySelector(".scenario-section-title");
-    if (t) t.textContent = metricTitle(sel);
+    if (t) t.textContent = metricTitle(sel, suiteData, comparison);
   };
 }
 
@@ -778,8 +741,8 @@ function renderComparisonDetail(suiteData, comparison, tests, initialSuiteIdx, i
 
     let scalarsHtml = "";
     if (test && metrics.length) {
-      const cards = SCALAR_ONLY_METRICS.map((sm) => { const m = getAgg(sm.name); if (!m) return ""; const bad = /^dropped_(logs|metrics|spans)_percentage$/.test(sm.name) && m.value > DATA_LOSS_THRESHOLD;
-        return `<div class="metric-scalar-card${bad ? " backpressure" : ""}"><div class="metric-scalar-name">${escapeHtml(sm.label)}</div><div class="metric-scalar-value">${formatMetricValue(m.value, m.unit || sm.unit)}</div></div>`; }).filter(Boolean).join("");
+      const cards = SCALAR_ONLY_METRICS.map((sm) => { const m = getAgg(sm.name); if (!m) return ""; const bad = sm.name === "dropped_logs_percentage" && m.value > DATA_LOSS_THRESHOLD;
+        return `<div class="metric-scalar-card${bad ? " backpressure" : ""}"><div class="metric-scalar-name">${escapeHtml(metricLabel(sm.name))}</div><div class="metric-scalar-value">${formatMetricValue(m.value, m.unit)}</div></div>`; }).filter(Boolean).join("");
       if (cards) scalarsHtml = `<div class="metric-scalars">${cards}</div>`;
     }
 


### PR DESCRIPTION
# Change Summary

This PR makes the dashboard a little more generic by also pulling out test metric related parameters to the manifest.

Waiting on #3008 for a rebase.

## What issue does this PR close?

* Closes #3007

## How are these changes tested?

<img width="2320" height="864" alt="image" src="https://github.com/user-attachments/assets/d276c080-0db4-4676-ab10-791becf423f0" />

## Are there any user-facing changes?

No.