### PR TITLE
task(comparison_dashboard): Don't reset the focused metric when filters are changed

### DIFF
--- a/tools/comparison_dashboard/comparisons/dfe_logs_baselines.yaml
+++ b/tools/comparison_dashboard/comparisons/dfe_logs_baselines.yaml
@@ -2,6 +2,10 @@ slug: dfe_logs_baselines
 name: Dataflow Engine Logs
 description: Baseline DFE logs runs across OTAP, OTLP, and OTLP/HTTP with none, gzip, and zstd compression.
 
+chart:
+  metrics:
+    default: cpu_percentage_normalized_avg
+
 tests:
   - name: 100k
     loadgen_rate: 100000

--- a/tools/comparison_dashboard/comparisons/dfe_metrics_baselines.yaml
+++ b/tools/comparison_dashboard/comparisons/dfe_metrics_baselines.yaml
@@ -2,6 +2,10 @@ slug: dfe_metrics_baselines
 name: Dataflow Engine Metrics
 description: Baseline DFE metrics runs across OTAP, OTLP, and OTLP/HTTP with none, gzip, and zstd compression.
 
+chart:
+  metrics:
+    default: cpu_percentage_normalized_avg
+
 tests:
   - name: 100k
     loadgen_rate: 100000

--- a/tools/comparison_dashboard/comparisons/dfe_traces_baselines.yaml
+++ b/tools/comparison_dashboard/comparisons/dfe_traces_baselines.yaml
@@ -2,6 +2,10 @@ slug: dfe_traces_baselines
 name: Dataflow Engine Traces
 description: Baseline DFE traces runs across OTAP, OTLP, and OTLP/HTTP with none, gzip, and zstd compression.
 
+chart:
+  metrics:
+    default: cpu_percentage_normalized_avg
+
 tests:
   - name: 100k
     loadgen_rate: 100000

--- a/tools/comparison_dashboard/dashboard.py
+++ b/tools/comparison_dashboard/dashboard.py
@@ -1211,31 +1211,52 @@ def validate_manifest(
 
     known_metric_names = {m["name"] for m in manifest.metrics}
     for comp in comparisons:
-        comp_metrics = comp.get("metrics")
-        if comp_metrics is None:
+        chart = comp.get("chart")
+        if chart is None:
             continue
-        if not isinstance(comp_metrics, dict):
+        if not isinstance(chart, dict):
             errors.append(
-                f"comparison '{comp.get('slug')}' 'metrics' must be a mapping (source: {comp.get('_source')})"
+                f"comparison '{comp.get('slug')}' 'chart' must be a mapping (source: {comp.get('_source')})"
             )
             continue
-        chart_list = comp_metrics.get("chart")
-        if chart_list is None:
+        chart_metrics = chart.get("metrics")
+        if chart_metrics is None:
             continue
-        if not isinstance(chart_list, list) or not chart_list:
+        if not isinstance(chart_metrics, dict):
             errors.append(
-                f"comparison '{comp.get('slug')}' 'metrics.chart' must be a non-empty list (source: {comp.get('_source')})"
+                f"comparison '{comp.get('slug')}' 'chart.metrics' must be a mapping (source: {comp.get('_source')})"
             )
             continue
-        for j, name in enumerate(chart_list):
-            if not isinstance(name, str) or not name:
+        allowed = chart_metrics.get("allowed")
+        if allowed is not None:
+            if not isinstance(allowed, list) or not allowed:
                 errors.append(
-                    f"comparison '{comp.get('slug')}' metrics.chart[{j}] must be a non-empty string (source: {comp.get('_source')})"
+                    f"comparison '{comp.get('slug')}' 'chart.metrics.allowed' must be a non-empty list (source: {comp.get('_source')})"
                 )
-                continue
-            if name not in known_metric_names:
+            else:
+                for j, name in enumerate(allowed):
+                    if not isinstance(name, str) or not name:
+                        errors.append(
+                            f"comparison '{comp.get('slug')}' chart.metrics.allowed[{j}] must be a non-empty string (source: {comp.get('_source')})"
+                        )
+                        continue
+                    if name not in known_metric_names:
+                        errors.append(
+                            f"comparison '{comp.get('slug')}' chart.metrics.allowed references unknown metric '{name}' (source: {comp.get('_source')})"
+                        )
+        default = chart_metrics.get("default")
+        if default is not None:
+            if not isinstance(default, str) or not default:
                 errors.append(
-                    f"comparison '{comp.get('slug')}' metrics.chart references unknown metric '{name}' (source: {comp.get('_source')})"
+                    f"comparison '{comp.get('slug')}' 'chart.metrics.default' must be a non-empty string (source: {comp.get('_source')})"
+                )
+            elif default not in known_metric_names:
+                errors.append(
+                    f"comparison '{comp.get('slug')}' chart.metrics.default references unknown metric '{default}' (source: {comp.get('_source')})"
+                )
+            elif isinstance(allowed, list) and allowed and default not in allowed:
+                errors.append(
+                    f"comparison '{comp.get('slug')}' chart.metrics.default '{default}' is not in chart.metrics.allowed (source: {comp.get('_source')})"
                 )
 
     for comp in comparisons:

--- a/tools/comparison_dashboard/shared/app.js
+++ b/tools/comparison_dashboard/shared/app.js
@@ -455,15 +455,28 @@ function metricTitle(name, suiteData, comparison) {
   return unit ? `${label} (${unit})` : label;
 }
 
+function chartMetricsConfig(comparison) {
+  return (comparison.chart && comparison.chart.metrics) || {};
+}
+
 function findAvailableMetrics(suiteData, comparison) {
-  const chartList = comparison.metrics && comparison.metrics.chart;
-  const candidates = chartList && chartList.length
-    ? chartList
+  const allowed = chartMetricsConfig(comparison).allowed;
+  const candidates = allowed && allowed.length
+    ? allowed
     : Object.keys(window.METRICS_META || {});
   return candidates.filter((mn) =>
     (comparison.suites || []).some((ref) =>
       getSuiteTests(suiteData, ref.slug).some((t) =>
         t.metrics && t.metrics.some((m) => m.name === mn && m.value != null))));
+}
+
+// Resolve the default metric for a comparison: prefer the configured
+// chart.metrics.default if it is available; otherwise fall back to the
+// first available metric.
+function defaultMetric(comparison, availableMetrics) {
+  const configured = chartMetricsConfig(comparison).default;
+  if (configured && availableMetrics.includes(configured)) return configured;
+  return availableMetrics[0] || null;
 }
 
 // ── Syntax highlighting ────────────────────────────────────────────────────
@@ -543,7 +556,7 @@ function renderComparisonSection(suiteData, comparison) {
   const filterState = getFilterState(slug, categories);
   const filtered = filterComparison(comparison, suiteData, filterState);
   const metrics = findAvailableMetrics(suiteData, filtered);
-  if (!perComparisonMetrics.has(slug)) perComparisonMetrics.set(slug, metrics.includes("cpu_percentage_normalized_avg") ? "cpu_percentage_normalized_avg" : metrics[0] || "cpu_percentage_normalized_avg");
+  if (!perComparisonMetrics.has(slug)) perComparisonMetrics.set(slug, defaultMetric(comparison, metrics));
   const sel = perComparisonMetrics.get(slug);
   const optsHtml = metrics.map((n) => `<option value="${escapeHtml(n)}" ${n === sel ? "selected" : ""}>${escapeHtml(metricLabel(n))}</option>`).join("");
   const hasFilters = Object.keys(categories).length > 0;
@@ -652,9 +665,7 @@ function renderComparisonChart(suiteData, comparison, tests, onBarClick) {
   const metrics = findAvailableMetrics(suiteData, comparison);
   const compSlug = window.COMPARISON_SLUG;
   const prev = perComparisonMetrics.get(compSlug);
-  let sel = prev && metrics.includes(prev)
-    ? prev
-    : (metrics.includes("cpu_percentage_normalized_avg") ? "cpu_percentage_normalized_avg" : metrics[0] || "cpu_percentage_normalized_avg");
+  let sel = prev && metrics.includes(prev) ? prev : defaultMetric(comparison, metrics);
   perComparisonMetrics.set(compSlug, sel);
   const optsHtml = metrics.map((n) => `<option value="${escapeHtml(n)}" ${n === sel ? "selected" : ""}>${escapeHtml(metricLabel(n))}</option>`).join("");
 

--- a/tools/comparison_dashboard/shared/app.js
+++ b/tools/comparison_dashboard/shared/app.js
@@ -650,7 +650,12 @@ function renderComparisonChart(suiteData, comparison, tests, onBarClick) {
   const target = document.getElementById("comparison-chart");
   if (!target) return;
   const metrics = findAvailableMetrics(suiteData, comparison);
-  let sel = metrics.includes("cpu_percentage_normalized_avg") ? "cpu_percentage_normalized_avg" : metrics[0] || "cpu_percentage_normalized_avg";
+  const compSlug = window.COMPARISON_SLUG;
+  const prev = perComparisonMetrics.get(compSlug);
+  let sel = prev && metrics.includes(prev)
+    ? prev
+    : (metrics.includes("cpu_percentage_normalized_avg") ? "cpu_percentage_normalized_avg" : metrics[0] || "cpu_percentage_normalized_avg");
+  perComparisonMetrics.set(compSlug, sel);
   const optsHtml = metrics.map((n) => `<option value="${escapeHtml(n)}" ${n === sel ? "selected" : ""}>${escapeHtml(metricLabel(n))}</option>`).join("");
 
   const onClick = onBarClick ? (event, elements) => {
@@ -690,6 +695,7 @@ function renderComparisonChart(suiteData, comparison, tests, onBarClick) {
   const ms = document.getElementById("metric-select");
   if (ms) ms.onchange = () => {
     sel = ms.value;
+    perComparisonMetrics.set(compSlug, sel);
     updateBarChartData(chart, suiteData, comparison, tests, sel);
     const t = target.querySelector(".scenario-section-title");
     if (t) t.textContent = metricTitle(sel, suiteData, comparison);


### PR DESCRIPTION
# Change Summary

Fix the dashboard so that the focused metric is not updated when filters are changed.

Also made a couple tweaks to the comparison definition to be able to set the default metric.

## What issue does this PR close?

* Closes #3017

## How are these changes tested?

By hand

## Are there any user-facing changes?

Yes, slightly new behavior.