### PR TITLE
Add single-core saturation benchmark (semantic_conventions payload)

### DIFF
--- a/.github/workflows/pipeline-perf-on-label.yaml
+++ b/.github/workflows/pipeline-perf-on-label.yaml
@@ -90,27 +90,21 @@ jobs:
           python -m pip install --user --require-hashes -r tools/pipeline_perf_test/orchestrator/requirements.lock.txt
           python -m pip install --user --require-hashes -r tools/pipeline_perf_test/load_generator/requirements.lock.txt
 
-      # - name: Run pipeline performance test suite
-      #   run: |
-      #     cd tools/pipeline_perf_test
-      #     python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/100klrps-docker.yaml
+      - name: Run pipeline performance test suite
+        run: |
+          cd tools/pipeline_perf_test
+          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/100klrps-docker.yaml
 
-      - name: Run single-core saturation test (OTAP)
+      - name: Run saturation/scaling performance test suite
         if: ${{ !cancelled() }}
         run: |
           cd tools/pipeline_perf_test
-          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/saturation-max-throughput-otap.yaml
-
-      # - name: Run saturation/scaling performance test suite
-      #   if: ${{ !cancelled() }}
-      #   run: |
-      #     cd tools/pipeline_perf_test
-      #     ./scripts/run-saturation-tests.sh --output-json results/scaling-efficiency.json \
-      #       | tee saturation-scaling-report.txt
-      #     echo "### Saturation/Scaling Test Analysis" >> $GITHUB_STEP_SUMMARY
-      #     echo '```' >> $GITHUB_STEP_SUMMARY
-      #     sed -n '/^=.*SCALING ANALYSIS/,/^=\{10,\}$/p' saturation-scaling-report.txt >> $GITHUB_STEP_SUMMARY
-      #     echo '```' >> $GITHUB_STEP_SUMMARY
+          ./scripts/run-saturation-tests.sh --output-json results/scaling-efficiency.json \
+            | tee saturation-scaling-report.txt
+          echo "### Saturation/Scaling Test Analysis" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          sed -n '/^=.*SCALING ANALYSIS/,/^=\{10,\}$/p' saturation-scaling-report.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Post-run disk usage diagnostics
         if: always()

--- a/.github/workflows/pipeline-perf-on-label.yaml
+++ b/.github/workflows/pipeline-perf-on-label.yaml
@@ -95,11 +95,11 @@ jobs:
       #     cd tools/pipeline_perf_test
       #     python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/100klrps-docker.yaml
 
-      - name: Run single-core saturation test
+      - name: Run single-core saturation test (OTAP)
         if: ${{ !cancelled() }}
         run: |
           cd tools/pipeline_perf_test
-          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/saturation-max-throughput.yaml
+          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/saturation-max-throughput-otap.yaml
 
       # - name: Run saturation/scaling performance test suite
       #   if: ${{ !cancelled() }}

--- a/.github/workflows/pipeline-perf-on-label.yaml
+++ b/.github/workflows/pipeline-perf-on-label.yaml
@@ -90,21 +90,27 @@ jobs:
           python -m pip install --user --require-hashes -r tools/pipeline_perf_test/orchestrator/requirements.lock.txt
           python -m pip install --user --require-hashes -r tools/pipeline_perf_test/load_generator/requirements.lock.txt
 
-      - name: Run pipeline performance test suite
-        run: |
-          cd tools/pipeline_perf_test
-          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/100klrps-docker.yaml
+      # - name: Run pipeline performance test suite
+      #   run: |
+      #     cd tools/pipeline_perf_test
+      #     python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/100klrps-docker.yaml
 
-      - name: Run saturation/scaling performance test suite
+      - name: Run single-core saturation test
         if: ${{ !cancelled() }}
         run: |
           cd tools/pipeline_perf_test
-          ./scripts/run-saturation-tests.sh --output-json results/scaling-efficiency.json \
-            | tee saturation-scaling-report.txt
-          echo "### Saturation/Scaling Test Analysis" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          sed -n '/^=.*SCALING ANALYSIS/,/^=\{10,\}$/p' saturation-scaling-report.txt >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/saturation-max-throughput.yaml
+
+      # - name: Run saturation/scaling performance test suite
+      #   if: ${{ !cancelled() }}
+      #   run: |
+      #     cd tools/pipeline_perf_test
+      #     ./scripts/run-saturation-tests.sh --output-json results/scaling-efficiency.json \
+      #       | tee saturation-scaling-report.txt
+      #     echo "### Saturation/Scaling Test Analysis" >> $GITHUB_STEP_SUMMARY
+      #     echo '```' >> $GITHUB_STEP_SUMMARY
+      #     sed -n '/^=.*SCALING ANALYSIS/,/^=\{10,\}$/p' saturation-scaling-report.txt >> $GITHUB_STEP_SUMMARY
+      #     echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Post-run disk usage diagnostics
         if: always()

--- a/.github/workflows/pipeline-perf-test-nightly.yml
+++ b/.github/workflows/pipeline-perf-test-nightly.yml
@@ -126,6 +126,18 @@ jobs:
           sed -n '/^=.*SCALING ANALYSIS/,/^=\{10,\}$/p' saturation-scaling-report.txt >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
 
+      - name: Run single-core saturation max throughput test (OTLP)
+        if: ${{ !cancelled() }}
+        run: |
+          cd tools/pipeline_perf_test
+          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/saturation-max-throughput.yaml
+
+      - name: Run single-core saturation max throughput test (OTAP)
+        if: ${{ !cancelled() }}
+        run: |
+          cd tools/pipeline_perf_test
+          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/saturation-max-throughput-otap.yaml
+
       - name: Upload syslog results for processing
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -71,6 +71,8 @@ the impact of batch size on CPU, memory, and network efficiency.
 
 ##### 6a. Max Throughput (Single Core)
 
+**URL:** <https://open-telemetry.github.io/otel-arrow/benchmarks/nightly/saturation/>
+
 Measures the absolute maximum throughput a single core can sustain, for both
 OTLP and OTAP protocols. Uses `semantic_conventions` (~300 byte logs) -- the
 same payload as all other benchmarks -- for direct comparability. Loadgen is

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -69,6 +69,18 @@ the impact of batch size on CPU, memory, and network efficiency.
 
 #### 6. Saturation and Scaling
 
+##### 6a. Max Throughput (Single Core)
+
+Measures the absolute maximum throughput a single core can sustain, for both
+OTLP and OTAP protocols. Uses `semantic_conventions` (~300 byte logs) -- the
+same payload as all other benchmarks -- for direct comparability. Loadgen is
+unleashed (no rate cap) with enough cores to fully saturate the single SUT core.
+
+OTAP uses 8 loadgen + 4 backend cores (vs 4+2 for OTLP) because the Arrow
+protocol is significantly more efficient and requires more load to saturate.
+
+##### 6b. Scaling Efficiency (Multi-Core)
+
 **URL:** <https://open-telemetry.github.io/otel-arrow/benchmarks/nightly/saturation/>
 
 Validates the shared-nothing, thread-per-core architecture by measuring how

--- a/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-max-throughput-otap.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-max-throughput-otap.yaml
@@ -83,4 +83,3 @@ tests:
         observation_interval: 60
         signals_per_second: null
         max_batch_size: 1000
-        num_connections: 4

--- a/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-max-throughput-otap.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-max-throughput-otap.yaml
@@ -5,7 +5,7 @@
 #
 # NUMA-aware layout: SUT on NUMA node 0, loadgen+backend on NUMA node 1
 # Layout: SUT=1 core, Backend=4 cores, Loadgen=8 cores (13 total)
-# OTAP is ~5x faster than OTLP, so needs more loadgen/backend to saturate.
+# OTAP is significantly faster than OTLP, so needs more loadgen/backend to saturate.
 name: Continuous - Saturation - Max Throughput OTAP
 components:
   load-generator:
@@ -77,7 +77,7 @@ tests:
     from_template:
       path: test_suites/integration/templates/test_steps/df-loadgen-steps-docker.yaml
       variables:
-        result_dir: "continuous_saturation_max_throughput"
+        result_dir: "continuous_saturation_max_throughput_otap"
         engine_config_template: test_suites/integration/templates/configs/engine/backpressure/otap-attr-otap.yaml
         loadgen_exporter_type: otap
         backend_receiver_type: otap

--- a/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-max-throughput-otap.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-max-throughput-otap.yaml
@@ -4,7 +4,8 @@
 # to fully saturate the single SUT core.
 #
 # NUMA-aware layout: SUT on NUMA node 0, loadgen+backend on NUMA node 1
-# Layout: SUT=1 core, Backend=2 cores, Loadgen=4 cores (7 total)
+# Layout: SUT=1 core, Backend=4 cores, Loadgen=8 cores (13 total)
+# OTAP is ~5x faster than OTLP, so needs more loadgen/backend to saturate.
 name: Continuous - Saturation - Max Throughput OTAP
 components:
   load-generator:
@@ -20,12 +21,12 @@ components:
           - "--config"
           - "./config.yaml"
           - "--core-id-range"
-          - "32-35"
+          - "32-39"
           - "--http-admin-bind"
           - "0.0.0.0:8080"
     monitoring:
       docker_component:
-        allocated_cores: 4
+        allocated_cores: 8
       prometheus:
         endpoint: http://localhost:8085/api/v1/telemetry/metrics?format=prometheus&reset=false
   df-engine:
@@ -62,12 +63,12 @@ components:
           - "--config"
           - "./config.yaml"
           - "--core-id-range"
-          - "36-37"
+          - "40-43"
           - "--http-admin-bind"
           - "0.0.0.0:8080"
     monitoring:
       docker_component:
-        allocated_cores: 2
+        allocated_cores: 4
       prometheus:
         endpoint: http://localhost:8087/api/v1/telemetry/metrics?format=prometheus&reset=false
 

--- a/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-max-throughput-otap.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-max-throughput-otap.yaml
@@ -1,11 +1,11 @@
-# Single-core saturation test: measures maximum throughput per core
+# Single-core saturation test (OTAP variant): measures maximum throughput per core
 # Uses semantic_conventions (~300 byte logs) -- same payload as other benchmarks
 # for direct comparability. Loadgen is unleashed (no rate cap) with enough cores
 # to fully saturate the single SUT core.
 #
 # NUMA-aware layout: SUT on NUMA node 0, loadgen+backend on NUMA node 1
 # Layout: SUT=1 core, Backend=2 cores, Loadgen=4 cores (7 total)
-name: Continuous - Saturation - Max Throughput
+name: Continuous - Saturation - Max Throughput OTAP
 components:
   load-generator:
     deployment:
@@ -72,14 +72,14 @@ components:
         endpoint: http://localhost:8087/api/v1/telemetry/metrics?format=prometheus&reset=false
 
 tests:
-  - name: OTLP-ATTR-OTLP
+  - name: OTAP-ATTR-OTAP
     from_template:
       path: test_suites/integration/templates/test_steps/df-loadgen-steps-docker.yaml
       variables:
         result_dir: "continuous_saturation_max_throughput"
-        engine_config_template: test_suites/integration/templates/configs/engine/backpressure/otlp-attr-otlp.yaml
-        loadgen_exporter_type: otlp
-        backend_receiver_type: otlp
+        engine_config_template: test_suites/integration/templates/configs/engine/backpressure/otap-attr-otap.yaml
+        loadgen_exporter_type: otelarrow
+        backend_receiver_type: otelarrow
         observation_interval: 60
         signals_per_second: null
         max_batch_size: 1000

--- a/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-max-throughput-otap.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-max-throughput-otap.yaml
@@ -78,8 +78,8 @@ tests:
       variables:
         result_dir: "continuous_saturation_max_throughput"
         engine_config_template: test_suites/integration/templates/configs/engine/backpressure/otap-attr-otap.yaml
-        loadgen_exporter_type: otelarrow
-        backend_receiver_type: otelarrow
+        loadgen_exporter_type: otap
+        backend_receiver_type: otap
         observation_interval: 60
         signals_per_second: null
         max_batch_size: 1000

--- a/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-max-throughput.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-max-throughput.yaml
@@ -84,3 +84,15 @@ tests:
         signals_per_second: null
         max_batch_size: 1000
         num_connections: 4
+  - name: OTAP-ATTR-OTAP
+    from_template:
+      path: test_suites/integration/templates/test_steps/df-loadgen-steps-docker.yaml
+      variables:
+        result_dir: "continuous_saturation_max_throughput"
+        engine_config_template: test_suites/integration/templates/configs/engine/backpressure/otap-attr-otap.yaml
+        loadgen_exporter_type: otelarrow
+        backend_receiver_type: otelarrow
+        observation_interval: 60
+        signals_per_second: null
+        max_batch_size: 1000
+        num_connections: 4

--- a/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-max-throughput.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-max-throughput.yaml
@@ -76,7 +76,7 @@ tests:
     from_template:
       path: test_suites/integration/templates/test_steps/df-loadgen-steps-docker.yaml
       variables:
-        result_dir: "continuous_saturation_max_throughput"
+        result_dir: "continuous_saturation_max_throughput_otlp"
         engine_config_template: test_suites/integration/templates/configs/engine/backpressure/otlp-attr-otlp.yaml
         loadgen_exporter_type: otlp
         backend_receiver_type: otlp

--- a/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-max-throughput.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-max-throughput.yaml
@@ -1,0 +1,86 @@
+# Single-core saturation test: measures maximum throughput per core
+# Uses semantic_conventions (~300 byte logs) -- same payload as other benchmarks
+# for direct comparability. Loadgen is unleashed (no rate cap) with enough cores
+# to fully saturate the single SUT core.
+#
+# NUMA-aware layout: SUT on NUMA node 0, loadgen+backend on NUMA node 1
+# Layout: SUT=1 core, Backend=2 cores, Loadgen=4 cores (7 total)
+name: Continuous - Saturation - Max Throughput
+components:
+  load-generator:
+    deployment:
+      docker:
+        image: df_engine:latest
+        network: testbed
+        ports:
+          - "8085:8080"
+        volumes:
+          - 'test_suites/integration/configs/loadgen/config.rendered.yaml:/home/nonroot/config.yaml:ro'
+        command:
+          - "--config"
+          - "./config.yaml"
+          - "--core-id-range"
+          - "32-35"
+          - "--http-admin-bind"
+          - "0.0.0.0:8080"
+    monitoring:
+      docker_component:
+        allocated_cores: 4
+      prometheus:
+        endpoint: http://localhost:8085/api/v1/telemetry/metrics?format=prometheus&reset=false
+  df-engine:
+    deployment:
+      docker:
+        image: df_engine:latest
+        network: testbed
+        ports:
+          - "8086:8080"
+        volumes:
+          - 'test_suites/integration/configs/engine/config.rendered.yaml:/home/nonroot/config.yaml:ro'
+        command:
+          - "--config"
+          - "./config.yaml"
+          - "--core-id-range"
+          - "0-0"
+          - "--http-admin-bind"
+          - "0.0.0.0:8080"
+    monitoring:
+      docker_component:
+        allocated_cores: 1
+      prometheus:
+        endpoint: http://localhost:8086/api/v1/telemetry/metrics?format=prometheus&reset=false
+  backend-service:
+    deployment:
+      docker:
+        image: df_engine:latest
+        network: testbed
+        ports:
+          - "8087:8080"
+        volumes:
+          - 'test_suites/integration/configs/backend/config.rendered.yaml:/home/nonroot/config.yaml:ro'
+        command:
+          - "--config"
+          - "./config.yaml"
+          - "--core-id-range"
+          - "36-37"
+          - "--http-admin-bind"
+          - "0.0.0.0:8080"
+    monitoring:
+      docker_component:
+        allocated_cores: 2
+      prometheus:
+        endpoint: http://localhost:8087/api/v1/telemetry/metrics?format=prometheus&reset=false
+
+tests:
+  - name: OTLP-ATTR-OTLP
+    from_template:
+      path: test_suites/integration/templates/test_steps/df-loadgen-steps-docker.yaml
+      variables:
+        result_dir: "continuous_saturation_max_throughput"
+        engine_config_template: test_suites/integration/templates/configs/engine/backpressure/otlp-attr-otlp.yaml
+        loadgen_exporter_type: otlp
+        backend_receiver_type: otlp
+        observation_interval: 60
+        signals_per_second: null
+        max_batch_size: 1000
+        num_connections: 4


### PR DESCRIPTION
## Summary

Adds single-core saturation tests that measure maximum throughput per core using the same payload as all other benchmarks (`semantic_conventions`, ~300 byte logs). Tests both OTLP and OTAP protocols as separate test configs.

### Results (single core, fully saturated)

| Protocol | Max Throughput | CPU (avg) | RAM (avg) |
|----------|---------------|-----------|-----------|
| **OTLP-ATTR-OTLP** | **360K logs/sec** | 100% | 23 MiB |
| **OTAP-ATTR-OTAP** | **2.58M logs/sec** | 100% | 48 MiB |

OTAP is **7.2x faster** than OTLP on a single core using the Arrow protocol.

### Test configs

**OTLP (`saturation-max-throughput.yaml`):**
- SUT: 1 core (core 0, NUMA0)
- Loadgen: 4 cores (cores 32-35, NUMA1), unleashed
- Backend: 2 cores (cores 36-37, NUMA1)
- `num_connections: 4`

**OTAP (`saturation-max-throughput-otap.yaml`):**
- SUT: 1 core (core 0, NUMA0)
- Loadgen: 8 cores (cores 32-39, NUMA1), unleashed
- Backend: 4 cores (cores 40-43, NUMA1)
- OTAP needs more loadgen/backend cores because the Arrow protocol is ~7x more efficient

Both use NUMA-aware pinning: SUT on NUMA node 0, loadgen+backend on NUMA node 1 to avoid L3 cache contention.

### Changes
- New: `saturation-max-throughput.yaml` (OTLP single-core saturation)
- New: `saturation-max-throughput-otap.yaml` (OTAP single-core saturation)
- Modified: `pipeline-perf-test-nightly.yml` -- added both tests to nightly runs
- Modified: `docs/benchmarks.md` -- added section 6a (Max Throughput) and renamed existing section to 6b (Scaling Efficiency)
- `pipeline-perf-on-label.yaml` -- no changes (reverted validation-only modifications)

Closes: #3022