### PR TITLE
task(comparison_dashboard): Add tooltips and axis labels to chart

### DIFF
--- a/tools/comparison_dashboard/comparisons/dfe_logs_baselines.yaml
+++ b/tools/comparison_dashboard/comparisons/dfe_logs_baselines.yaml
@@ -3,8 +3,10 @@ name: Dataflow Engine Logs
 description: Baseline DFE logs runs across OTAP, OTLP, and OTLP/HTTP with none, gzip, and zstd compression.
 
 chart:
-  metrics:
-    default: cpu_percentage_normalized_avg
+  axes:
+    x:
+      title: Generated Load (logs/sec)
+      description: Rate at which the load generator is configured to submit logs e.g. "100k" == "100,000 logs/sec".
 
 tests:
   - name: 100k

--- a/tools/comparison_dashboard/comparisons/dfe_logs_baselines.yaml
+++ b/tools/comparison_dashboard/comparisons/dfe_logs_baselines.yaml
@@ -6,7 +6,7 @@ chart:
   axes:
     x:
       title: Generated Load (logs/sec)
-      description: Rate at which the load generator is configured to submit logs e.g. "100k" == "100,000 logs/sec".
+      description: Rate at which the load generator is configured to produce logs e.g. "100k" == "100,000 logs/sec".
 
 tests:
   - name: 100k

--- a/tools/comparison_dashboard/comparisons/dfe_metrics_baselines.yaml
+++ b/tools/comparison_dashboard/comparisons/dfe_metrics_baselines.yaml
@@ -3,8 +3,10 @@ name: Dataflow Engine Metrics
 description: Baseline DFE metrics runs across OTAP, OTLP, and OTLP/HTTP with none, gzip, and zstd compression.
 
 chart:
-  metrics:
-    default: cpu_percentage_normalized_avg
+  axes:
+    x:
+      title: Generated Load (datapoints/sec)
+      description: Rate at which the load generator is configured to submit metric datapoints e.g. "100k" == "100,000 datapoints/sec".
 
 tests:
   - name: 100k

--- a/tools/comparison_dashboard/comparisons/dfe_traces_baselines.yaml
+++ b/tools/comparison_dashboard/comparisons/dfe_traces_baselines.yaml
@@ -3,8 +3,10 @@ name: Dataflow Engine Traces
 description: Baseline DFE traces runs across OTAP, OTLP, and OTLP/HTTP with none, gzip, and zstd compression.
 
 chart:
-  metrics:
-    default: cpu_percentage_normalized_avg
+  axes:
+    x:
+      title: Generated Load (spans/sec)
+      description: Rate at which the load generator is configured to submit spans e.g. "100k" == "100,000 spans/sec".
 
 tests:
   - name: 100k

--- a/tools/comparison_dashboard/dashboard.py
+++ b/tools/comparison_dashboard/dashboard.py
@@ -1260,6 +1260,20 @@ def validate_manifest(
                 )
 
     for comp in comparisons:
+        chart = comp.get("chart")
+        if chart is None:
+            continue
+        src = comp.get("_source", "?")
+        slug = comp.get("slug")
+        if not isinstance(chart, dict):
+            errors.append(f"comparison '{slug}' 'chart' must be a mapping (source: {src})")
+            continue
+        axes = chart.get("axes")
+        if axes is None:
+            continue
+        _validate_chart_axes(slug, src, axes, errors)
+
+    for comp in comparisons:
         comp_slug = comp.get("slug")
         src = comp.get("_source", "?")
         tests = comp.get("tests")
@@ -1305,6 +1319,48 @@ def validate_manifest(
         for msg in errors:
             print(f"  - {msg}")
         sys.exit(1)
+
+
+def _validate_chart_axes(slug: str, src: str, axes: object, errors: list) -> None:
+    """
+    Validate a comparison's `chart.axes` block.
+
+    Schema: { x?: AxisCfg, y?: AxisCfg } where AxisCfg = { title?: str, description?: str }.
+    Empty strings are permitted (treated as "not set" by the renderer).
+    Unknown keys are rejected to catch typos early.
+    """
+    if not isinstance(axes, dict):
+        errors.append(f"comparison '{slug}' 'chart.axes' must be a mapping (source: {src})")
+        return
+    allowed_axes = {"x"}
+    for ax_key in axes.keys():
+        if ax_key not in allowed_axes:
+            errors.append(
+                f"comparison '{slug}' chart.axes has unknown key '{ax_key}' (allowed: {sorted(allowed_axes)}) (source: {src})"
+            )
+    allowed_axis_fields = {"title", "description"}
+    for ax_key in allowed_axes:
+        ax_cfg = axes.get(ax_key)
+        if ax_cfg is None:
+            continue
+        if not isinstance(ax_cfg, dict):
+            errors.append(
+                f"comparison '{slug}' chart.axes.{ax_key} must be a mapping (source: {src})"
+            )
+            continue
+        for field in ax_cfg.keys():
+            if field not in allowed_axis_fields:
+                errors.append(
+                    f"comparison '{slug}' chart.axes.{ax_key} has unknown field '{field}' (allowed: {sorted(allowed_axis_fields)}) (source: {src})"
+                )
+        for field in allowed_axis_fields:
+            if field not in ax_cfg:
+                continue
+            val = ax_cfg[field]
+            if not isinstance(val, str):
+                errors.append(
+                    f"comparison '{slug}' chart.axes.{ax_key}.{field} must be a string (source: {src})"
+                )
 
 
 def check_comparison_env_consistency(

--- a/tools/comparison_dashboard/dashboard.py
+++ b/tools/comparison_dashboard/dashboard.py
@@ -1214,64 +1214,54 @@ def validate_manifest(
         chart = comp.get("chart")
         if chart is None:
             continue
-        if not isinstance(chart, dict):
-            errors.append(
-                f"comparison '{comp.get('slug')}' 'chart' must be a mapping (source: {comp.get('_source')})"
-            )
-            continue
-        chart_metrics = chart.get("metrics")
-        if chart_metrics is None:
-            continue
-        if not isinstance(chart_metrics, dict):
-            errors.append(
-                f"comparison '{comp.get('slug')}' 'chart.metrics' must be a mapping (source: {comp.get('_source')})"
-            )
-            continue
-        allowed = chart_metrics.get("allowed")
-        if allowed is not None:
-            if not isinstance(allowed, list) or not allowed:
-                errors.append(
-                    f"comparison '{comp.get('slug')}' 'chart.metrics.allowed' must be a non-empty list (source: {comp.get('_source')})"
-                )
-            else:
-                for j, name in enumerate(allowed):
-                    if not isinstance(name, str) or not name:
-                        errors.append(
-                            f"comparison '{comp.get('slug')}' chart.metrics.allowed[{j}] must be a non-empty string (source: {comp.get('_source')})"
-                        )
-                        continue
-                    if name not in known_metric_names:
-                        errors.append(
-                            f"comparison '{comp.get('slug')}' chart.metrics.allowed references unknown metric '{name}' (source: {comp.get('_source')})"
-                        )
-        default = chart_metrics.get("default")
-        if default is not None:
-            if not isinstance(default, str) or not default:
-                errors.append(
-                    f"comparison '{comp.get('slug')}' 'chart.metrics.default' must be a non-empty string (source: {comp.get('_source')})"
-                )
-            elif default not in known_metric_names:
-                errors.append(
-                    f"comparison '{comp.get('slug')}' chart.metrics.default references unknown metric '{default}' (source: {comp.get('_source')})"
-                )
-            elif isinstance(allowed, list) and allowed and default not in allowed:
-                errors.append(
-                    f"comparison '{comp.get('slug')}' chart.metrics.default '{default}' is not in chart.metrics.allowed (source: {comp.get('_source')})"
-                )
-
-    for comp in comparisons:
-        chart = comp.get("chart")
-        if chart is None:
-            continue
-        src = comp.get("_source", "?")
         slug = comp.get("slug")
+        src = comp.get("_source", "?")
         if not isinstance(chart, dict):
             errors.append(f"comparison '{slug}' 'chart' must be a mapping (source: {src})")
             continue
+
+        chart_metrics = chart.get("metrics")
+        if chart_metrics is not None:
+            if not isinstance(chart_metrics, dict):
+                errors.append(
+                    f"comparison '{slug}' 'chart.metrics' must be a mapping (source: {src})"
+                )
+            else:
+                allowed = chart_metrics.get("allowed")
+                if allowed is not None:
+                    if not isinstance(allowed, list) or not allowed:
+                        errors.append(
+                            f"comparison '{slug}' 'chart.metrics.allowed' must be a non-empty list (source: {src})"
+                        )
+                    else:
+                        for j, name in enumerate(allowed):
+                            if not isinstance(name, str) or not name:
+                                errors.append(
+                                    f"comparison '{slug}' chart.metrics.allowed[{j}] must be a non-empty string (source: {src})"
+                                )
+                                continue
+                            if name not in known_metric_names:
+                                errors.append(
+                                    f"comparison '{slug}' chart.metrics.allowed references unknown metric '{name}' (source: {src})"
+                                )
+                default = chart_metrics.get("default")
+                if default is not None:
+                    if not isinstance(default, str) or not default:
+                        errors.append(
+                            f"comparison '{slug}' 'chart.metrics.default' must be a non-empty string (source: {src})"
+                        )
+                    elif default not in known_metric_names:
+                        errors.append(
+                            f"comparison '{slug}' chart.metrics.default references unknown metric '{default}' (source: {src})"
+                        )
+                    elif isinstance(allowed, list) and allowed and default not in allowed:
+                        errors.append(
+                            f"comparison '{slug}' chart.metrics.default '{default}' is not in chart.metrics.allowed (source: {src})"
+                        )
+
         axes = chart.get("axes")
-        if axes is None:
-            continue
-        _validate_chart_axes(slug, src, axes, errors)
+        if axes is not None:
+            _validate_chart_axes(slug, src, axes, errors)
 
     for comp in comparisons:
         comp_slug = comp.get("slug")
@@ -1325,7 +1315,9 @@ def _validate_chart_axes(slug: str, src: str, axes: object, errors: list) -> Non
     """
     Validate a comparison's `chart.axes` block.
 
-    Schema: { x?: AxisCfg, y?: AxisCfg } where AxisCfg = { title?: str, description?: str }.
+    Schema: { x?: AxisCfg } where AxisCfg = { title?: str, description?: str }.
+    Only the x-axis is exposed for configuration today; the y-axis is left
+    unlabeled because the chart's title dropdown already names the metric.
     Empty strings are permitted (treated as "not set" by the renderer).
     Unknown keys are rejected to catch typos early.
     """

--- a/tools/comparison_dashboard/shared/app.js
+++ b/tools/comparison_dashboard/shared/app.js
@@ -349,9 +349,9 @@ function createBarChart(canvas, suiteData, comparison, tests, selectedMetric, on
   return chart;
 }
 
-// Resolve x/y axis titles for a chart. Both come exclusively from
-// chart.axes.x.title; the y-axis is left unlabeled because the metric
-// (with unit) is already shown in the chart's title dropdown.
+// Only the x-axis title is configurable; the y-axis is left unlabeled
+// because the metric (with unit) is already shown in the chart's title
+// dropdown.
 function resolveXAxisTitle(comparison) {
   const axes = chartAxesConfig(comparison);
   return (axes.x && axes.x.title) ? axes.x.title : null;
@@ -367,17 +367,25 @@ function sizeChartContainer(chart, canvas, baseHeight = 220) {
   chart.resize();
 }
 
-// Wire mousemove on the chart canvas so hovering over an axis title or an
-// individual tick label reveals a floating tooltip. Axis title hover shows
-// the configured chart.axes.{x,y}.description. Tick label hover shows a
-// per-tick string (currently derived from each test's loadgen_rate). No-op
-// when there is nothing to show.
+// Wire mousemove on the chart canvas so hovering over the x-axis title or
+// an individual tick label reveals a floating tooltip. Axis title hover
+// shows chart.axes.x.description. Tick label hover shows a per-tick string
+// (currently derived from each test's loadgen_rate). No-op when there is
+// nothing to show.
+//
+// Charts are destroyed and recreated on the same <canvas> when filters or
+// metrics change — detach any previously-attached handlers before adding
+// new ones so listeners don't accumulate on the reused canvas element.
 function attachAxisHoverTooltips(chart, canvas, comparison, tests) {
+  detachAxisHoverTooltips(canvas);
   const axes = chartAxesConfig(comparison);
   const xDesc = axes.x && typeof axes.x.description === "string" && axes.x.description.trim() ? axes.x.description : null;
   const tickTexts = (tests || []).map(tickHoverText);
   const hasTickHovers = tickTexts.some(Boolean);
   if (!xDesc && !hasTickHovers) return;
+  // Text width for the x-axis title is static for the chart's lifetime;
+  // measure it once instead of recomputing in xTitleBox on every mousemove.
+  const xTitleWidth = xDesc ? measureXAxisTitleWidth(chart, canvas) : 0;
   const PAD = 4;
   const onMove = (ev) => {
     const sx = chart.scales && chart.scales.x;
@@ -386,10 +394,8 @@ function attachAxisHoverTooltips(chart, canvas, comparison, tests) {
     const px = ev.clientX - rect.left;
     const py = ev.clientY - rect.top;
 
-    // 1) X-axis title: a box sized to the rendered text, centered along
-    //    the x scale's bottom strip.
     if (xDesc) {
-      const box = xTitleBox(sx, canvas);
+      const box = xTitleBoxFromWidth(sx, xTitleWidth);
       if (box && px >= box.left - PAD && px <= box.right + PAD
               && py >= box.top - PAD && py <= box.bottom + PAD) {
         showAxisHoverTooltip(ev.clientX, ev.clientY, xDesc);
@@ -397,12 +403,9 @@ function attachAxisHoverTooltips(chart, canvas, comparison, tests) {
       }
     }
 
-    // 2) Per-tick x label hover.
     if (hasTickHovers) {
       const xLabelH = tickFontSize(sx) + 4;
-      const xLabelTop = sx.top;
-      const xLabelBot = sx.top + xLabelH;
-      if (py >= xLabelTop - PAD && py <= xLabelBot + PAD
+      if (py >= sx.top - PAD && py <= sx.top + xLabelH + PAD
           && px >= sx.left - PAD && px <= sx.right + PAD) {
         const i = nearestTickIndex(sx, px);
         const text = i >= 0 ? tickTexts[i] : null;
@@ -414,6 +417,15 @@ function attachAxisHoverTooltips(chart, canvas, comparison, tests) {
   };
   canvas.addEventListener("mousemove", onMove);
   canvas.addEventListener("mouseleave", hideAxisHoverTooltip);
+  canvas._axisHoverHandlers = { onMove, onLeave: hideAxisHoverTooltip };
+}
+
+function detachAxisHoverTooltips(canvas) {
+  const h = canvas._axisHoverHandlers;
+  if (!h) return;
+  canvas.removeEventListener("mousemove", h.onMove);
+  canvas.removeEventListener("mouseleave", h.onLeave);
+  canvas._axisHoverHandlers = null;
 }
 
 function tickHoverText(test) {
@@ -429,21 +441,29 @@ function tickFontSize(scale) {
   return (scale.options && scale.options.ticks && scale.options.ticks.font && scale.options.ticks.font.size) || 12;
 }
 
-// Bounding box for the x-axis title text, in canvas-relative pixels. Title
-// is rendered centered horizontally at the bottom of the scale.
-function xTitleBox(scale, canvas) {
-  const t = scale.options && scale.options.title;
-  if (!t || !t.display || !t.text) return null;
+function measureXAxisTitleWidth(chart, canvas) {
+  const sx = chart.scales && chart.scales.x;
+  const t = sx && sx.options && sx.options.title;
+  if (!t || !t.display || !t.text) return 0;
   const fs = (t.font && t.font.size) || 12;
   const weight = (t.font && t.font.weight) || "normal";
-  const textW = measureCanvasText(canvas, t.text, fs, weight);
+  return measureCanvasText(canvas, t.text, fs, weight);
+}
+
+// Bounding box for the x-axis title text, in canvas-relative pixels. Title
+// is rendered centered horizontally at the bottom of the scale. Width is
+// precomputed (see measureXAxisTitleWidth) so this is cheap to call per
+// mousemove.
+function xTitleBoxFromWidth(scale, textW) {
+  const t = scale.options && scale.options.title;
+  if (!t || !t.display || !t.text || !textW) return null;
+  const fs = (t.font && t.font.size) || 12;
   const centerX = (scale.left + scale.right) / 2;
-  const bottom = scale.bottom;
   return {
     left: centerX - textW / 2,
     right: centerX + textW / 2,
-    top: bottom - fs - 2,
-    bottom: bottom,
+    top: scale.bottom - fs - 2,
+    bottom: scale.bottom,
   };
 }
 
@@ -490,7 +510,7 @@ function showAxisHoverTooltip(clientX, clientY, text) {
 }
 
 function hideAxisHoverTooltip() {
-  if (axisHoverTooltipEl) axisHoverTooltipEl.hidden = true;
+  if (axisHoverTooltipEl && !axisHoverTooltipEl.hidden) axisHoverTooltipEl.hidden = true;
 }
 
 function updateBarChartData(chart, suiteData, comparison, tests, selectedMetric) {

--- a/tools/comparison_dashboard/shared/app.js
+++ b/tools/comparison_dashboard/shared/app.js
@@ -306,13 +306,24 @@ function buildComparisonChartData(suiteData, comparison, tests, selectedMetric) 
   return { labels: tests.map((t) => t.label), datasets };
 }
 
-function chartOptions(onClick) {
+function axisTitleConfig(text) {
+  if (!text) return { display: false };
+  return {
+    display: true,
+    text,
+    color: "#475569",
+    font: { size: 12, weight: "600" },
+  };
+}
+
+function chartOptions(onClick, xTitle) {
   return {
     responsive: true, maintainAspectRatio: false, animation: false,
     layout: { padding: { top: 24 } },
     datasets: { bar: { categoryPercentage: 0.85, barPercentage: 0.9 } },
     scales: {
-      x: { grid: { display: false }, border: { display: false }, ticks: { font: { size: 12, weight: "600" }, color: "#64748b" } },
+      x: { grid: { display: false }, border: { display: false }, ticks: { font: { size: 12, weight: "600" }, color: "#64748b" },
+        title: axisTitleConfig(xTitle) },
       y: { beginAtZero: true, border: { display: true, color: "#cbd5e1" },
         ticks: { maxTicksLimit: 5, color: "#94a3b8", font: { size: 10 }, callback: (v) => formatMetricValue(v, "") },
         grid: { color: "#e2e8f0" } },
@@ -331,15 +342,155 @@ function chartOptions(onClick) {
 }
 
 function createBarChart(canvas, suiteData, comparison, tests, selectedMetric, onClick) {
-  const chart = new Chart(canvas, { type: "bar", data: buildComparisonChartData(suiteData, comparison, tests, selectedMetric), options: chartOptions(onClick), plugins: [barValueLabelsPlugin] });
+  const xTitle = resolveXAxisTitle(comparison);
+  const chart = new Chart(canvas, { type: "bar", data: buildComparisonChartData(suiteData, comparison, tests, selectedMetric), options: chartOptions(onClick, xTitle), plugins: [barValueLabelsPlugin] });
   sizeChartContainer(chart, canvas);
+  attachAxisHoverTooltips(chart, canvas, comparison, tests);
   return chart;
+}
+
+// Resolve x/y axis titles for a chart. Both come exclusively from
+// chart.axes.x.title; the y-axis is left unlabeled because the metric
+// (with unit) is already shown in the chart's title dropdown.
+function resolveXAxisTitle(comparison) {
+  const axes = chartAxesConfig(comparison);
+  return (axes.x && axes.x.title) ? axes.x.title : null;
+}
+
+function chartAxesConfig(comparison) {
+  return (comparison && comparison.chart && comparison.chart.axes) || {};
 }
 
 function sizeChartContainer(chart, canvas, baseHeight = 220) {
   const legendHeight = chart.legend?.height || 0;
   canvas.parentElement.style.height = `${baseHeight + legendHeight}px`;
   chart.resize();
+}
+
+// Wire mousemove on the chart canvas so hovering over an axis title or an
+// individual tick label reveals a floating tooltip. Axis title hover shows
+// the configured chart.axes.{x,y}.description. Tick label hover shows a
+// per-tick string (currently derived from each test's loadgen_rate). No-op
+// when there is nothing to show.
+function attachAxisHoverTooltips(chart, canvas, comparison, tests) {
+  const axes = chartAxesConfig(comparison);
+  const xDesc = axes.x && typeof axes.x.description === "string" && axes.x.description.trim() ? axes.x.description : null;
+  const tickTexts = (tests || []).map(tickHoverText);
+  const hasTickHovers = tickTexts.some(Boolean);
+  if (!xDesc && !hasTickHovers) return;
+  const PAD = 4;
+  const onMove = (ev) => {
+    const sx = chart.scales && chart.scales.x;
+    if (!sx) { hideAxisHoverTooltip(); return; }
+    const rect = canvas.getBoundingClientRect();
+    const px = ev.clientX - rect.left;
+    const py = ev.clientY - rect.top;
+
+    // 1) X-axis title: a box sized to the rendered text, centered along
+    //    the x scale's bottom strip.
+    if (xDesc) {
+      const box = xTitleBox(sx, canvas);
+      if (box && px >= box.left - PAD && px <= box.right + PAD
+              && py >= box.top - PAD && py <= box.bottom + PAD) {
+        showAxisHoverTooltip(ev.clientX, ev.clientY, xDesc);
+        return;
+      }
+    }
+
+    // 2) Per-tick x label hover.
+    if (hasTickHovers) {
+      const xLabelH = tickFontSize(sx) + 4;
+      const xLabelTop = sx.top;
+      const xLabelBot = sx.top + xLabelH;
+      if (py >= xLabelTop - PAD && py <= xLabelBot + PAD
+          && px >= sx.left - PAD && px <= sx.right + PAD) {
+        const i = nearestTickIndex(sx, px);
+        const text = i >= 0 ? tickTexts[i] : null;
+        if (text) { showAxisHoverTooltip(ev.clientX, ev.clientY, text); return; }
+      }
+    }
+
+    hideAxisHoverTooltip();
+  };
+  canvas.addEventListener("mousemove", onMove);
+  canvas.addEventListener("mouseleave", hideAxisHoverTooltip);
+}
+
+function tickHoverText(test) {
+  if (!test) return null;
+  if (typeof test.description === "string" && test.description.trim()) return test.description;
+  if (typeof test.loadgen_rate === "number" && Number.isFinite(test.loadgen_rate)) {
+    return `${test.loadgen_rate.toLocaleString()}/sec`;
+  }
+  return null;
+}
+
+function tickFontSize(scale) {
+  return (scale.options && scale.options.ticks && scale.options.ticks.font && scale.options.ticks.font.size) || 12;
+}
+
+// Bounding box for the x-axis title text, in canvas-relative pixels. Title
+// is rendered centered horizontally at the bottom of the scale.
+function xTitleBox(scale, canvas) {
+  const t = scale.options && scale.options.title;
+  if (!t || !t.display || !t.text) return null;
+  const fs = (t.font && t.font.size) || 12;
+  const weight = (t.font && t.font.weight) || "normal";
+  const textW = measureCanvasText(canvas, t.text, fs, weight);
+  const centerX = (scale.left + scale.right) / 2;
+  const bottom = scale.bottom;
+  return {
+    left: centerX - textW / 2,
+    right: centerX + textW / 2,
+    top: bottom - fs - 2,
+    bottom: bottom,
+  };
+}
+
+function measureCanvasText(canvas, text, fontSize, fontWeight) {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return text.length * fontSize * 0.6;
+  ctx.save();
+  ctx.font = `${fontWeight} ${fontSize}px "SF Pro Text", "Segoe UI", system-ui, sans-serif`;
+  const w = ctx.measureText(text).width;
+  ctx.restore();
+  return w;
+}
+
+function nearestTickIndex(scale, px) {
+  const n = (scale.ticks || []).length;
+  if (!n) return -1;
+  let best = -1, bestDist = Infinity;
+  for (let i = 0; i < n; i++) {
+    const tx = scale.getPixelForTick ? scale.getPixelForTick(i) : scale.getPixelForValue(i);
+    const d = Math.abs(px - tx);
+    if (d < bestDist) { bestDist = d; best = i; }
+  }
+  // Cap: only count a hit when within half the inter-tick spacing.
+  const halfSpan = n > 1 ? Math.abs(scale.getPixelForTick(1) - scale.getPixelForTick(0)) / 2 : (scale.right - scale.left) / 2;
+  return bestDist <= halfSpan ? best : -1;
+}
+
+let axisHoverTooltipEl = null;
+function showAxisHoverTooltip(clientX, clientY, text) {
+  if (!axisHoverTooltipEl) {
+    axisHoverTooltipEl = document.createElement("div");
+    axisHoverTooltipEl.className = "axis-hover-tooltip";
+    axisHoverTooltipEl.hidden = true;
+    document.body.appendChild(axisHoverTooltipEl);
+  }
+  axisHoverTooltipEl.textContent = text;
+  axisHoverTooltipEl.hidden = false;
+  // Offset from cursor; keep within viewport on the right edge.
+  const pad = 12;
+  const x = Math.min(clientX + pad, window.innerWidth - axisHoverTooltipEl.offsetWidth - pad);
+  const y = Math.min(clientY + pad, window.innerHeight - axisHoverTooltipEl.offsetHeight - pad);
+  axisHoverTooltipEl.style.left = `${x}px`;
+  axisHoverTooltipEl.style.top = `${y}px`;
+}
+
+function hideAxisHoverTooltip() {
+  if (axisHoverTooltipEl) axisHoverTooltipEl.hidden = true;
 }
 
 function updateBarChartData(chart, suiteData, comparison, tests, selectedMetric) {
@@ -558,7 +709,7 @@ function renderComparisonSection(suiteData, comparison) {
   const metrics = findAvailableMetrics(suiteData, filtered);
   if (!perComparisonMetrics.has(slug)) perComparisonMetrics.set(slug, defaultMetric(comparison, metrics));
   const sel = perComparisonMetrics.get(slug);
-  const optsHtml = metrics.map((n) => `<option value="${escapeHtml(n)}" ${n === sel ? "selected" : ""}>${escapeHtml(metricLabel(n))}</option>`).join("");
+  const optsHtml = metrics.map((n) => `<option value="${escapeHtml(n)}" ${n === sel ? "selected" : ""}>${escapeHtml(metricTitle(n, suiteData, filtered))}</option>`).join("");
   const hasFilters = Object.keys(categories).length > 0;
   const filterHtml = hasFilters ? buildFilterHtml(categories, filterState) : "";
   const anyBP = (filtered.suites || []).some((r) => getSuiteTests(suiteData, r.slug).some((t) => { const rm = t.name.match(/^(\d+)k$/); return hasBackpressure(t.metrics, rm ? parseInt(rm[1])*1000 : null); }));
@@ -663,11 +814,8 @@ function renderComparisonChart(suiteData, comparison, tests, onBarClick) {
   const target = document.getElementById("comparison-chart");
   if (!target) return;
   const metrics = findAvailableMetrics(suiteData, comparison);
-  const compSlug = window.COMPARISON_SLUG;
-  const prev = perComparisonMetrics.get(compSlug);
-  let sel = prev && metrics.includes(prev) ? prev : defaultMetric(comparison, metrics);
-  perComparisonMetrics.set(compSlug, sel);
-  const optsHtml = metrics.map((n) => `<option value="${escapeHtml(n)}" ${n === sel ? "selected" : ""}>${escapeHtml(metricLabel(n))}</option>`).join("");
+  let sel = metrics.includes("cpu_percentage_normalized_avg") ? "cpu_percentage_normalized_avg" : metrics[0] || "cpu_percentage_normalized_avg";
+  const optsHtml = metrics.map((n) => `<option value="${escapeHtml(n)}" ${n === sel ? "selected" : ""}>${escapeHtml(metricTitle(n, suiteData, comparison))}</option>`).join("");
 
   const onClick = onBarClick ? (event, elements) => {
     if (!elements.length) return;

--- a/tools/comparison_dashboard/shared/app.js
+++ b/tools/comparison_dashboard/shared/app.js
@@ -814,7 +814,13 @@ function renderComparisonChart(suiteData, comparison, tests, onBarClick) {
   const target = document.getElementById("comparison-chart");
   if (!target) return;
   const metrics = findAvailableMetrics(suiteData, comparison);
-  let sel = metrics.includes("cpu_percentage_normalized_avg") ? "cpu_percentage_normalized_avg" : metrics[0] || "cpu_percentage_normalized_avg";
+  // Preserve the user's selection across re-renders (e.g. filter changes).
+  // Fall back to the comparison's configured default, then the first
+  // available metric.
+  const compSlug = window.COMPARISON_SLUG;
+  const prev = perComparisonMetrics.get(compSlug);
+  let sel = prev && metrics.includes(prev) ? prev : defaultMetric(comparison, metrics);
+  perComparisonMetrics.set(compSlug, sel);
   const optsHtml = metrics.map((n) => `<option value="${escapeHtml(n)}" ${n === sel ? "selected" : ""}>${escapeHtml(metricTitle(n, suiteData, comparison))}</option>`).join("");
 
   const onClick = onBarClick ? (event, elements) => {

--- a/tools/comparison_dashboard/shared/styles.css
+++ b/tools/comparison_dashboard/shared/styles.css
@@ -1429,3 +1429,21 @@ a.scenario-section-title:hover {
   font-family: "SF Mono", Menlo, monospace;
   word-break: break-word;
 }
+
+/* Floating tooltip shown when hovering an x/y axis tick band on a bar chart. */
+.axis-hover-tooltip {
+  position: fixed;
+  pointer-events: none;
+  z-index: 1000;
+  background: rgba(15, 23, 42, 0.9);
+  color: #fff;
+  padding: 6px 10px;
+  border-radius: 4px;
+  font-size: 12px;
+  line-height: 1.3;
+  max-width: 280px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+}
+.axis-hover-tooltip[hidden] {
+  display: none;
+}


### PR DESCRIPTION
# Change Summary

Trying to clean up the readability of the chart a little bit added:

- An x axis label with a tooltip
- Added tooltips to the x axis test labels

## What issue does this PR close?

* Closes #3018

## How are these changes tested?

Before:

<img width="2310" height="625" alt="image" src="https://github.com/user-attachments/assets/b9ace2d0-75ac-48f0-a3a8-16e9eac40e66" />

After:

<img width="2313" height="628" alt="image" src="https://github.com/user-attachments/assets/2b03dbba-a153-4c4e-a7c6-ccedc452829e" />

<img width="2315" height="622" alt="image" src="https://github.com/user-attachments/assets/35fa2b4e-e3b7-4c9e-b56f-af44014ace0c" />


## Are there any user-facing changes?

Yes - Tooltips