### PR TITLE
NUMA-aware passthrough test with OTAP variant

### DIFF
--- a/.github/workflows/pipeline-perf-test-continuous.yml
+++ b/.github/workflows/pipeline-perf-test-continuous.yml
@@ -68,10 +68,17 @@ jobs:
           cd tools/pipeline_perf_test
           python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/100klrps-docker.yaml
 
-      - name: Run passthrough performance test
+      - name: Run passthrough performance test (OTLP)
+        if: ${{ !cancelled() }}
         run: |
           cd tools/pipeline_perf_test
           python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/passthrough.yaml
+
+      - name: Run passthrough performance test (OTAP)
+        if: ${{ !cancelled() }}
+        run: |
+          cd tools/pipeline_perf_test
+          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/passthrough-otap.yaml
 
       - name: Upload benchmark results for processing
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/tools/pipeline_perf_test/test_suites/integration/continuous/passthrough-otap.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/continuous/passthrough-otap.yaml
@@ -1,6 +1,7 @@
-# Passthrough test (no processor in middle)
+# Passthrough test OTAP variant (no processor in middle)
 # NUMA-aware layout: SUT on NUMA node 0, loadgen+backend on NUMA node 1
-name: Continuous - Passthrough
+# Uses more loadgen/backend cores than OTLP variant since OTAP is much faster.
+name: Continuous - Passthrough OTAP
 components:
   load-generator:
     deployment:
@@ -15,12 +16,12 @@ components:
           - "--config"
           - "./config.yaml"
           - "--core-id-range"
-          - "32-35"
+          - "32-39"
           - "--http-admin-bind"
           - "0.0.0.0:8080"
     monitoring:
       docker_component:
-        allocated_cores: 4
+        allocated_cores: 8
       prometheus:
         endpoint: http://localhost:8085/api/v1/telemetry/metrics?format=prometheus&reset=false
   df-engine:
@@ -57,25 +58,24 @@ components:
           - "--config"
           - "./config.yaml"
           - "--core-id-range"
-          - "36-37"
+          - "40-43"
           - "--http-admin-bind"
           - "0.0.0.0:8080"
     monitoring:
       docker_component:
-        allocated_cores: 2
+        allocated_cores: 4
       prometheus:
         endpoint: http://localhost:8087/api/v1/telemetry/metrics?format=prometheus&reset=false
 
 tests:
-  - name: OTLP-OTLP
+  - name: OTAP-OTAP
     from_template:
       path: test_suites/integration/templates/test_steps/df-loadgen-steps-docker.yaml
       variables:
         result_dir: continuous_passthrough
-        engine_config_template: test_suites/integration/templates/configs/engine/passthrough/otlp-otlp.yaml
-        loadgen_exporter_type: otlp
-        backend_receiver_type: otlp
+        engine_config_template: test_suites/integration/templates/configs/engine/passthrough/otap-otap.yaml
+        loadgen_exporter_type: otap
+        backend_receiver_type: otap
         observation_interval: 60
         signals_per_second: null
         max_batch_size: 1000
-        num_connections: 4

--- a/tools/pipeline_perf_test/test_suites/integration/templates/configs/engine/passthrough/otap-otap.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/templates/configs/engine/passthrough/otap-otap.yaml
@@ -1,0 +1,33 @@
+version: otel_dataflow/v1
+policies:
+  channel_capacity:
+    control:
+      node: 100
+      pipeline: 100
+    pdata: 100
+engine:
+  telemetry:
+    logs:
+      level: info
+groups:
+  default:
+    pipelines:
+      main:
+        nodes:
+          receiver:
+            type: urn:otel:receiver:otap
+            config:
+              listening_addr: 0.0.0.0:4317
+              response_stream_channel_size: 100
+              compression_method: zstd
+              wait_for_result: true
+          exporter:
+            type: urn:otel:exporter:otap
+            config:
+              grpc_endpoint: http://{{backend_hostname}}:1235
+              compression_method: zstd
+              arrow:
+                payload_compression: none
+        connections:
+        - from: receiver
+          to: exporter


### PR DESCRIPTION
## Summary

Fix passthrough benchmark test with NUMA-aware CPU pinning and add OTAP-OTAP variant.

## Changes

1. **NUMA-aware passthrough (OTLP)**: Pin SUT to core 0, loadgen to cores 32-35, backend to cores 36-37 (cross-NUMA). Increase batch size 512→1000 and add num_connections: 4.
2. **New OTAP passthrough test**: Add `passthrough-otap.yaml` with OTAP receiver/exporter engine config. Uses 8 loadgen cores (32-39) and 4 backend cores (40-43) to saturate single-core SUT.
3. **Add OTAP to continuous workflow**: Both passthrough variants run in the continuous CI pipeline.

## Results (CI validated, run 26076764277)

| Test | Throughput | CPU | Notes |
|------|-----------|-----|-------|
| Passthrough OTLP (before, no NUMA) | 263K logs/sec | ~70% | Loadgen bottleneck |
| Passthrough OTLP (after, NUMA-aware) | **607K logs/sec** | 100% | Fully saturated |
| Passthrough OTAP (NUMA-aware) | **2.64M logs/sec** | 100% | Fully saturated |
| With ATTR processor - OTLP (PR #3023) | 360K logs/sec | 100% | Deser/reser overhead |
| With ATTR processor - OTAP (PR #3023) | 2.58M logs/sec | 100% | In-place processing |

### Key Observations

- **NUMA fix alone gives 2.3x improvement** for OTLP passthrough (263K → 607K)
- **OTAP is 4.3x faster than OTLP** in passthrough mode
- **ATTR processor overhead**: ~41% for OTLP (607K → 360K, due to deserialization/reserialization), <2% for OTAP (2.64M → 2.58M, in-place processing)
- Both tests now properly saturate a single core

## Related

- Closes part of performance benchmarking improvements
- PR #3023 adds saturation-max-throughput tests (with ATTR processor)
