### PR TITLE
Skip continuous benchmark when only docs/non-rust files change

### DIFF
--- a/.github/workflows/pipeline-perf-test-continuous.yml
+++ b/.github/workflows/pipeline-perf-test-continuous.yml
@@ -9,6 +9,7 @@ on:
       - 'rust/**'
       - 'tools/pipeline_perf_test/**'
       - 'tools/comparison_dashboard/**'
+      - '.github/workflows/scripts/**'
       - '.github/workflows/pipeline-perf-test-continuous.yml'
   workflow_dispatch:
 

--- a/.github/workflows/pipeline-perf-test-continuous.yml
+++ b/.github/workflows/pipeline-perf-test-continuous.yml
@@ -5,6 +5,11 @@ permissions:
 on:
   push:
     branches: [main]
+    paths:
+      - 'rust/**'
+      - 'tools/pipeline_perf_test/**'
+      - 'tools/comparison_dashboard/**'
+      - '.github/workflows/pipeline-perf-test-continuous.yml'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Adds `paths` filter to the continuous pipeline performance test workflow so it only runs when relevant code is modified:

- `rust/**`
- `tools/pipeline_perf_test/**`
- `tools/comparison_dashboard/**`
- The workflow file itself

This avoids wasting expensive bare-metal runner time on commits that only touch markdown, Go code, or other unrelated files. `workflow_dispatch` still allows manual runs anytime.