### PR TITLE
fix(perf): update df_engine mount path to /home/nonroot in syslog-tcp-otelcol nightly suite

### DIFF
--- a/tools/pipeline_perf_test/test_suites/integration/nightly/syslog-tcp-otelcol-docker.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/nightly/syslog-tcp-otelcol-docker.yaml
@@ -52,7 +52,7 @@ components:
         ports:
           - "8087:8080"
         volumes:
-          - 'test_suites/integration/configs/backend/config.rendered.yaml:/home/dataflow/config.yaml:ro'
+          - 'test_suites/integration/configs/backend/config.rendered.yaml:/home/nonroot/config.yaml:ro'
         command:
           - "--config"
           - "./config.yaml"


### PR DESCRIPTION
The nightly Pipeline Performance Tests run [26069747923](https://github.com/open-telemetry/otel-arrow/actions/runs/26069747923/job/76648381259) failed in the "Run syslog TCP performance test otelcol log suite" step because the backend (`df_engine`) container never became ready (readiness check timed out after 10 attempts).

Root cause: PR #2919 switched the `df_engine` image from musl/alpine to glibc/distroless, changing the in-container home directory from `/home/dataflow` to `/home/nonroot`, and updated the volume mount path in all then-existing nightly docker yamls. The `syslog-tcp-otelcol-docker.yaml` suite (added concurrently in #2962) was missed, so it was still mounting the backend config at `/home/dataflow/config.yaml` — a path that doesn't exist in the new image — causing the backend container to fail to start.

This one-line change brings it in line with the other nightly suites.