### PR TITLE
perf: keep network rate metrics in bytes/sec for dashboard formatting

### DIFF
--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/reports/report_logs.yaml
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/reports/report_logs.yaml
@@ -323,7 +323,7 @@ queries:
 
           UNION ALL
 
-          SELECT 'network_tx_mb_per_sec' AS name, 'MB/s' AS unit, average_rate / 1048576.0 AS value,
+          SELECT 'network_tx_bytes_rate_avg' AS name, 'bytes/sec' AS unit, average_rate AS value,
                 metadata_row."test.suite" || '/' || metadata_row."test.name" || ' - Network Utilization' AS extra
           FROM container_network_rates
           CROSS JOIN metadata_row
@@ -331,7 +331,7 @@ queries:
 
           UNION ALL
 
-          SELECT 'network_rx_mb_per_sec' AS name, 'MB/s' AS unit, average_rate / 1048576.0 AS value,
+          SELECT 'network_rx_bytes_rate_avg' AS name, 'bytes/sec' AS unit, average_rate AS value,
                 metadata_row."test.suite" || '/' || metadata_row."test.name" || ' - Network Utilization' AS extra
           FROM container_network_rates
           CROSS JOIN metadata_row

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/reports/report_metrics.yaml
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/reports/report_metrics.yaml
@@ -323,7 +323,7 @@ queries:
 
           UNION ALL
 
-          SELECT 'network_tx_mb_per_sec' AS name, 'MB/s' AS unit, average_rate / 1048576.0 AS value,
+          SELECT 'network_tx_bytes_rate_avg' AS name, 'bytes/sec' AS unit, average_rate AS value,
                 metadata_row."test.suite" || '/' || metadata_row."test.name" || ' - Network Utilization' AS extra
           FROM container_network_rates
           CROSS JOIN metadata_row
@@ -331,7 +331,7 @@ queries:
 
           UNION ALL
 
-          SELECT 'network_rx_mb_per_sec' AS name, 'MB/s' AS unit, average_rate / 1048576.0 AS value,
+          SELECT 'network_rx_bytes_rate_avg' AS name, 'bytes/sec' AS unit, average_rate AS value,
                 metadata_row."test.suite" || '/' || metadata_row."test.name" || ' - Network Utilization' AS extra
           FROM container_network_rates
           CROSS JOIN metadata_row

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/reports/report_traces.yaml
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/reports/report_traces.yaml
@@ -323,7 +323,7 @@ queries:
 
           UNION ALL
 
-          SELECT 'network_tx_mb_per_sec' AS name, 'MB/s' AS unit, average_rate / 1048576.0 AS value,
+          SELECT 'network_tx_bytes_rate_avg' AS name, 'bytes/sec' AS unit, average_rate AS value,
                 metadata_row."test.suite" || '/' || metadata_row."test.name" || ' - Network Utilization' AS extra
           FROM container_network_rates
           CROSS JOIN metadata_row
@@ -331,7 +331,7 @@ queries:
 
           UNION ALL
 
-          SELECT 'network_rx_mb_per_sec' AS name, 'MB/s' AS unit, average_rate / 1048576.0 AS value,
+          SELECT 'network_rx_bytes_rate_avg' AS name, 'bytes/sec' AS unit, average_rate AS value,
                 metadata_row."test.suite" || '/' || metadata_row."test.name" || ' - Network Utilization' AS extra
           FROM container_network_rates
           CROSS JOIN metadata_row

--- a/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_logs.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_logs.yaml
@@ -326,7 +326,7 @@ queries:
 
           UNION ALL
 
-          SELECT 'network_tx_mb_per_sec' AS name, 'MB/s' AS unit, average_rate / 1048576.0 AS value,
+          SELECT 'network_tx_bytes_rate_avg' AS name, 'bytes/sec' AS unit, average_rate AS value,
                 metadata_row."test.suite" || '/' || metadata_row."test.name" || ' - Network Utilization' AS extra
           FROM container_network_rates
           CROSS JOIN metadata_row
@@ -334,7 +334,7 @@ queries:
 
           UNION ALL
 
-          SELECT 'network_rx_mb_per_sec' AS name, 'MB/s' AS unit, average_rate / 1048576.0 AS value,
+          SELECT 'network_rx_bytes_rate_avg' AS name, 'bytes/sec' AS unit, average_rate AS value,
                 metadata_row."test.suite" || '/' || metadata_row."test.name" || ' - Network Utilization' AS extra
           FROM container_network_rates
           CROSS JOIN metadata_row

--- a/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_metrics.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_metrics.yaml
@@ -326,7 +326,7 @@ queries:
 
           UNION ALL
 
-          SELECT 'network_tx_mb_per_sec' AS name, 'MB/s' AS unit, average_rate / 1048576.0 AS value,
+          SELECT 'network_tx_bytes_rate_avg' AS name, 'bytes/sec' AS unit, average_rate AS value,
                 metadata_row."test.suite" || '/' || metadata_row."test.name" || ' - Network Utilization' AS extra
           FROM container_network_rates
           CROSS JOIN metadata_row
@@ -334,7 +334,7 @@ queries:
 
           UNION ALL
 
-          SELECT 'network_rx_mb_per_sec' AS name, 'MB/s' AS unit, average_rate / 1048576.0 AS value,
+          SELECT 'network_rx_bytes_rate_avg' AS name, 'bytes/sec' AS unit, average_rate AS value,
                 metadata_row."test.suite" || '/' || metadata_row."test.name" || ' - Network Utilization' AS extra
           FROM container_network_rates
           CROSS JOIN metadata_row

--- a/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_traces.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_traces.yaml
@@ -326,7 +326,7 @@ queries:
 
           UNION ALL
 
-          SELECT 'network_tx_mb_per_sec' AS name, 'MB/s' AS unit, average_rate / 1048576.0 AS value,
+          SELECT 'network_tx_bytes_rate_avg' AS name, 'bytes/sec' AS unit, average_rate AS value,
                 metadata_row."test.suite" || '/' || metadata_row."test.name" || ' - Network Utilization' AS extra
           FROM container_network_rates
           CROSS JOIN metadata_row
@@ -334,7 +334,7 @@ queries:
 
           UNION ALL
 
-          SELECT 'network_rx_mb_per_sec' AS name, 'MB/s' AS unit, average_rate / 1048576.0 AS value,
+          SELECT 'network_rx_bytes_rate_avg' AS name, 'bytes/sec' AS unit, average_rate AS value,
                 metadata_row."test.suite" || '/' || metadata_row."test.name" || ' - Network Utilization' AS extra
           FROM container_network_rates
           CROSS JOIN metadata_row


### PR DESCRIPTION
Follow-up to #2982 per [review suggestion](https://github.com/open-telemetry/otel-arrow/pull/2982#issuecomment-4464515872): keep report data in bytes/sec and let the dashboard handle rounding/reformatting into MiB/s or GiB/s as needed.