### PR TITLE
Add value formatting to benchmark dashboards for bytes/sec display

### DIFF
--- a/docs/benchmarks/continuous-idle-state/index.html
+++ b/docs/benchmarks/continuous-idle-state/index.html
@@ -214,6 +214,24 @@
     "#97dbfc", "#006174", "#00b6b6", "#854200", "#f3c8ad", "#410472",
   ];
 
+
+  function formatValue(value, unit) {
+    const v = Number(value);
+    if (!Number.isFinite(v)) return '-';
+    if (unit === 'bytes/sec' || unit === 'bytes/s') {
+      if (Math.abs(v) >= 1e9) return (v / 1e9).toFixed(1) + ' GB/s';
+      if (Math.abs(v) >= 1e6) return (v / 1e6).toFixed(1) + ' MB/s';
+      if (Math.abs(v) >= 1e3) return (v / 1e3).toFixed(1) + ' KB/s';
+      return Math.round(v) + ' B/s';
+    }
+    if (unit === 'bytes/log' || unit === 'bytes/span' || unit === 'bytes/metric') {
+      if (Math.abs(v) >= 1e6) return (v / 1e6).toFixed(1) + ' MB/' + unit.split('/')[1];
+      if (Math.abs(v) >= 1e3) return (v / 1e3).toFixed(1) + ' KB/' + unit.split('/')[1];
+      return Math.round(v) + ' B/' + unit.split('/')[1];
+    }
+    return v % 1 === 0 ? String(v) + ' ' + unit : v.toFixed(2) + ' ' + unit;
+  }
+
   function init() {
     function collectBenchesPerTestCase(entries) {
       const byGroup = new Map();
@@ -360,7 +378,13 @@
               display: true,
               labelString: results?.[0]?.dataset.find(d => d !== null)?.bench.unit ?? '',
             },
-            ticks: { beginAtZero: true },
+            ticks: {
+              beginAtZero: true,
+              callback: function(value) {
+                const unit = this.chart.options.scales.yAxes[0].scaleLabel.labelString || '';
+                return formatValue(value, unit);
+              }
+            },
           }]
         },
         tooltips: {
@@ -377,8 +401,7 @@
               if (!data) return `${results[datasetIndex].name}: N/A`;
               const { name, dataset } = results[datasetIndex];
               const { range, unit } = data.bench;
-              let label = `${name}: ${value}`;
-              label += unit;
+              let label = `${name}: ${formatValue(value, unit)}`;
               if (range) label += ` (${range})`;
               return label;
             },

--- a/docs/benchmarks/continuous-passthrough/index.html
+++ b/docs/benchmarks/continuous-passthrough/index.html
@@ -214,6 +214,24 @@
     "#97dbfc", "#006174", "#00b6b6", "#854200", "#f3c8ad", "#410472",
   ];
 
+
+  function formatValue(value, unit) {
+    const v = Number(value);
+    if (!Number.isFinite(v)) return '-';
+    if (unit === 'bytes/sec' || unit === 'bytes/s') {
+      if (Math.abs(v) >= 1e9) return (v / 1e9).toFixed(1) + ' GB/s';
+      if (Math.abs(v) >= 1e6) return (v / 1e6).toFixed(1) + ' MB/s';
+      if (Math.abs(v) >= 1e3) return (v / 1e3).toFixed(1) + ' KB/s';
+      return Math.round(v) + ' B/s';
+    }
+    if (unit === 'bytes/log' || unit === 'bytes/span' || unit === 'bytes/metric') {
+      if (Math.abs(v) >= 1e6) return (v / 1e6).toFixed(1) + ' MB/' + unit.split('/')[1];
+      if (Math.abs(v) >= 1e3) return (v / 1e3).toFixed(1) + ' KB/' + unit.split('/')[1];
+      return Math.round(v) + ' B/' + unit.split('/')[1];
+    }
+    return v % 1 === 0 ? String(v) + ' ' + unit : v.toFixed(2) + ' ' + unit;
+  }
+
   function init() {
     function collectBenchesPerTestCase(entries) {
       const byGroup = new Map();
@@ -360,7 +378,13 @@
               display: true,
               labelString: results?.[0]?.dataset.find(d => d !== null)?.bench.unit ?? '',
             },
-            ticks: { beginAtZero: true },
+            ticks: {
+              beginAtZero: true,
+              callback: function(value) {
+                const unit = this.chart.options.scales.yAxes[0].scaleLabel.labelString || '';
+                return formatValue(value, unit);
+              }
+            },
           }]
         },
         tooltips: {
@@ -377,8 +401,7 @@
               if (!data) return `${results[datasetIndex].name}: N/A`;
               const { name, dataset } = results[datasetIndex];
               const { range, unit } = data.bench;
-              let label = `${name}: ${value}`;
-              label += unit;
+              let label = `${name}: ${formatValue(value, unit)}`;
               if (range) label += ` (${range})`;
               return label;
             },

--- a/docs/benchmarks/continuous-saturation/index.html
+++ b/docs/benchmarks/continuous-saturation/index.html
@@ -214,6 +214,24 @@
     "#97dbfc", "#006174", "#00b6b6", "#854200", "#f3c8ad", "#410472",
   ];
 
+
+  function formatValue(value, unit) {
+    const v = Number(value);
+    if (!Number.isFinite(v)) return '-';
+    if (unit === 'bytes/sec' || unit === 'bytes/s') {
+      if (Math.abs(v) >= 1e9) return (v / 1e9).toFixed(1) + ' GB/s';
+      if (Math.abs(v) >= 1e6) return (v / 1e6).toFixed(1) + ' MB/s';
+      if (Math.abs(v) >= 1e3) return (v / 1e3).toFixed(1) + ' KB/s';
+      return Math.round(v) + ' B/s';
+    }
+    if (unit === 'bytes/log' || unit === 'bytes/span' || unit === 'bytes/metric') {
+      if (Math.abs(v) >= 1e6) return (v / 1e6).toFixed(1) + ' MB/' + unit.split('/')[1];
+      if (Math.abs(v) >= 1e3) return (v / 1e3).toFixed(1) + ' KB/' + unit.split('/')[1];
+      return Math.round(v) + ' B/' + unit.split('/')[1];
+    }
+    return v % 1 === 0 ? String(v) + ' ' + unit : v.toFixed(2) + ' ' + unit;
+  }
+
   function init() {
     function collectBenchesPerTestCase(entries) {
       const byGroup = new Map();
@@ -360,7 +378,13 @@
               display: true,
               labelString: results?.[0]?.dataset.find(d => d !== null)?.bench.unit ?? '',
             },
-            ticks: { beginAtZero: true },
+            ticks: {
+              beginAtZero: true,
+              callback: function(value) {
+                const unit = this.chart.options.scales.yAxes[0].scaleLabel.labelString || '';
+                return formatValue(value, unit);
+              }
+            },
           }]
         },
         tooltips: {
@@ -377,8 +401,7 @@
               if (!data) return `${results[datasetIndex].name}: N/A`;
               const { name, dataset } = results[datasetIndex];
               const { range, unit } = data.bench;
-              let label = `${name}: ${value}`;
-              label += unit;
+              let label = `${name}: ${formatValue(value, unit)}`;
               if (range) label += ` (${range})`;
               return label;
             },

--- a/docs/benchmarks/continuous-scaling-efficiency/index.html
+++ b/docs/benchmarks/continuous-scaling-efficiency/index.html
@@ -214,6 +214,24 @@
     "#97dbfc", "#006174", "#00b6b6", "#854200", "#f3c8ad", "#410472",
   ];
 
+
+  function formatValue(value, unit) {
+    const v = Number(value);
+    if (!Number.isFinite(v)) return '-';
+    if (unit === 'bytes/sec' || unit === 'bytes/s') {
+      if (Math.abs(v) >= 1e9) return (v / 1e9).toFixed(1) + ' GB/s';
+      if (Math.abs(v) >= 1e6) return (v / 1e6).toFixed(1) + ' MB/s';
+      if (Math.abs(v) >= 1e3) return (v / 1e3).toFixed(1) + ' KB/s';
+      return Math.round(v) + ' B/s';
+    }
+    if (unit === 'bytes/log' || unit === 'bytes/span' || unit === 'bytes/metric') {
+      if (Math.abs(v) >= 1e6) return (v / 1e6).toFixed(1) + ' MB/' + unit.split('/')[1];
+      if (Math.abs(v) >= 1e3) return (v / 1e3).toFixed(1) + ' KB/' + unit.split('/')[1];
+      return Math.round(v) + ' B/' + unit.split('/')[1];
+    }
+    return v % 1 === 0 ? String(v) + ' ' + unit : v.toFixed(2) + ' ' + unit;
+  }
+
   function init() {
     function collectBenchesPerTestCase(entries) {
       const byGroup = new Map();
@@ -360,7 +378,13 @@
               display: true,
               labelString: results?.[0]?.dataset.find(d => d !== null)?.bench.unit ?? '',
             },
-            ticks: { beginAtZero: true },
+            ticks: {
+              beginAtZero: true,
+              callback: function(value) {
+                const unit = this.chart.options.scales.yAxes[0].scaleLabel.labelString || '';
+                return formatValue(value, unit);
+              }
+            },
           }]
         },
         tooltips: {
@@ -377,8 +401,7 @@
               if (!data) return `${results[datasetIndex].name}: N/A`;
               const { name, dataset } = results[datasetIndex];
               const { range, unit } = data.bench;
-              let label = `${name}: ${value}`;
-              label += unit;
+              let label = `${name}: ${formatValue(value, unit)}`;
               if (range) label += ` (${range})`;
               return label;
             },

--- a/docs/benchmarks/continuous/index.html
+++ b/docs/benchmarks/continuous/index.html
@@ -214,6 +214,24 @@
     "#97dbfc", "#006174", "#00b6b6", "#854200", "#f3c8ad", "#410472",
   ];
 
+
+  function formatValue(value, unit) {
+    const v = Number(value);
+    if (!Number.isFinite(v)) return '-';
+    if (unit === 'bytes/sec' || unit === 'bytes/s') {
+      if (Math.abs(v) >= 1e9) return (v / 1e9).toFixed(1) + ' GB/s';
+      if (Math.abs(v) >= 1e6) return (v / 1e6).toFixed(1) + ' MB/s';
+      if (Math.abs(v) >= 1e3) return (v / 1e3).toFixed(1) + ' KB/s';
+      return Math.round(v) + ' B/s';
+    }
+    if (unit === 'bytes/log' || unit === 'bytes/span' || unit === 'bytes/metric') {
+      if (Math.abs(v) >= 1e6) return (v / 1e6).toFixed(1) + ' MB/' + unit.split('/')[1];
+      if (Math.abs(v) >= 1e3) return (v / 1e3).toFixed(1) + ' KB/' + unit.split('/')[1];
+      return Math.round(v) + ' B/' + unit.split('/')[1];
+    }
+    return v % 1 === 0 ? String(v) + ' ' + unit : v.toFixed(2) + ' ' + unit;
+  }
+
   function init() {
     function collectBenchesPerTestCase(entries) {
       const byGroup = new Map();
@@ -360,7 +378,13 @@
               display: true,
               labelString: results?.[0]?.dataset.find(d => d !== null)?.bench.unit ?? '',
             },
-            ticks: { beginAtZero: true },
+            ticks: {
+              beginAtZero: true,
+              callback: function(value) {
+                const unit = this.chart.options.scales.yAxes[0].scaleLabel.labelString || '';
+                return formatValue(value, unit);
+              }
+            },
           }]
         },
         tooltips: {
@@ -377,8 +401,7 @@
               if (!data) return `${results[datasetIndex].name}: N/A`;
               const { name, dataset } = results[datasetIndex];
               const { range, unit } = data.bench;
-              let label = `${name}: ${value}`;
-              label += unit;
+              let label = `${name}: ${formatValue(value, unit)}`;
               if (range) label += ` (${range})`;
               return label;
             },

--- a/docs/benchmarks/nightly/backpressure/index.html
+++ b/docs/benchmarks/nightly/backpressure/index.html
@@ -232,6 +232,24 @@
     "#97dbfc", "#006174", "#00b6b6", "#854200", "#f3c8ad", "#410472",
   ];
 
+
+  function formatValue(value, unit) {
+    const v = Number(value);
+    if (!Number.isFinite(v)) return '-';
+    if (unit === 'bytes/sec' || unit === 'bytes/s') {
+      if (Math.abs(v) >= 1e9) return (v / 1e9).toFixed(1) + ' GB/s';
+      if (Math.abs(v) >= 1e6) return (v / 1e6).toFixed(1) + ' MB/s';
+      if (Math.abs(v) >= 1e3) return (v / 1e3).toFixed(1) + ' KB/s';
+      return Math.round(v) + ' B/s';
+    }
+    if (unit === 'bytes/log' || unit === 'bytes/span' || unit === 'bytes/metric') {
+      if (Math.abs(v) >= 1e6) return (v / 1e6).toFixed(1) + ' MB/' + unit.split('/')[1];
+      if (Math.abs(v) >= 1e3) return (v / 1e3).toFixed(1) + ' KB/' + unit.split('/')[1];
+      return Math.round(v) + ' B/' + unit.split('/')[1];
+    }
+    return v % 1 === 0 ? String(v) + ' ' + unit : v.toFixed(2) + ' ' + unit;
+  }
+
   function init() {
     function collectBenchesPerTestCase(entries) {
       const byGroup = new Map();
@@ -392,7 +410,13 @@
               display: true,
               labelString: results?.[0]?.dataset.find(d => d !== null)?.bench.unit ?? '',
             },
-            ticks: { beginAtZero: true },
+            ticks: {
+              beginAtZero: true,
+              callback: function(value) {
+                const unit = this.chart.options.scales.yAxes[0].scaleLabel.labelString || '';
+                return formatValue(value, unit);
+              }
+            },
           }]
         },
         tooltips: {
@@ -409,8 +433,7 @@
               if (!data) return `${results[datasetIndex].name}: N/A`;
               const { name, dataset } = results[datasetIndex];
               const { range, unit } = data.bench;
-              let label = `${name}: ${value}`;
-              label += unit;
+              let label = `${name}: ${formatValue(value, unit)}`;
               if (range) label += ` (${range})`;
               return label;
             },

--- a/docs/benchmarks/nightly/batch-processor/index.html
+++ b/docs/benchmarks/nightly/batch-processor/index.html
@@ -386,6 +386,24 @@
     }
   }
 
+
+  function formatValue(value, unit) {
+    const v = Number(value);
+    if (!Number.isFinite(v)) return '-';
+    if (unit === 'bytes/sec' || unit === 'bytes/s') {
+      if (Math.abs(v) >= 1e9) return (v / 1e9).toFixed(1) + ' GB/s';
+      if (Math.abs(v) >= 1e6) return (v / 1e6).toFixed(1) + ' MB/s';
+      if (Math.abs(v) >= 1e3) return (v / 1e3).toFixed(1) + ' KB/s';
+      return Math.round(v) + ' B/s';
+    }
+    if (unit === 'bytes/log' || unit === 'bytes/span' || unit === 'bytes/metric') {
+      if (Math.abs(v) >= 1e6) return (v / 1e6).toFixed(1) + ' MB/' + unit.split('/')[1];
+      if (Math.abs(v) >= 1e3) return (v / 1e3).toFixed(1) + ' KB/' + unit.split('/')[1];
+      return Math.round(v) + ' B/' + unit.split('/')[1];
+    }
+    return v % 1 === 0 ? String(v) + ' ' + unit : v.toFixed(2) + ' ' + unit;
+  }
+
   function init() {
     function collectBenchesPerTestCase(entries) {
       const byGroup = new Map();
@@ -551,7 +569,13 @@
               display: true,
               labelString: results?.[0]?.dataset.find(d => d !== null)?.bench.unit ?? '',
             },
-            ticks: { beginAtZero: true },
+            ticks: {
+              beginAtZero: true,
+              callback: function(value) {
+                const unit = this.chart.options.scales.yAxes[0].scaleLabel.labelString || '';
+                return formatValue(value, unit);
+              }
+            },
           }]
         },
         tooltips: {

--- a/docs/benchmarks/nightly/filter/index.html
+++ b/docs/benchmarks/nightly/filter/index.html
@@ -232,6 +232,24 @@
     "#97dbfc", "#006174", "#00b6b6", "#854200", "#f3c8ad", "#410472",
   ];
 
+
+  function formatValue(value, unit) {
+    const v = Number(value);
+    if (!Number.isFinite(v)) return '-';
+    if (unit === 'bytes/sec' || unit === 'bytes/s') {
+      if (Math.abs(v) >= 1e9) return (v / 1e9).toFixed(1) + ' GB/s';
+      if (Math.abs(v) >= 1e6) return (v / 1e6).toFixed(1) + ' MB/s';
+      if (Math.abs(v) >= 1e3) return (v / 1e3).toFixed(1) + ' KB/s';
+      return Math.round(v) + ' B/s';
+    }
+    if (unit === 'bytes/log' || unit === 'bytes/span' || unit === 'bytes/metric') {
+      if (Math.abs(v) >= 1e6) return (v / 1e6).toFixed(1) + ' MB/' + unit.split('/')[1];
+      if (Math.abs(v) >= 1e3) return (v / 1e3).toFixed(1) + ' KB/' + unit.split('/')[1];
+      return Math.round(v) + ' B/' + unit.split('/')[1];
+    }
+    return v % 1 === 0 ? String(v) + ' ' + unit : v.toFixed(2) + ' ' + unit;
+  }
+
   function init() {
     function collectBenchesPerTestCase(entries) {
       const byGroup = new Map();
@@ -392,7 +410,13 @@
               display: true,
               labelString: results?.[0]?.dataset.find(d => d !== null)?.bench.unit ?? '',
             },
-            ticks: { beginAtZero: true },
+            ticks: {
+              beginAtZero: true,
+              callback: function(value) {
+                const unit = this.chart.options.scales.yAxes[0].scaleLabel.labelString || '';
+                return formatValue(value, unit);
+              }
+            },
           }]
         },
         tooltips: {
@@ -409,8 +433,7 @@
               if (!data) return `${results[datasetIndex].name}: N/A`;
               const { name, dataset } = results[datasetIndex];
               const { range, unit } = data.bench;
-              let label = `${name}: ${value}`;
-              label += unit;
+              let label = `${name}: ${formatValue(value, unit)}`;
               if (range) label += ` (${range})`;
               return label;
             },

--- a/docs/benchmarks/nightly/saturation/index.html
+++ b/docs/benchmarks/nightly/saturation/index.html
@@ -222,6 +222,24 @@
     "#97dbfc", "#006174", "#00b6b6", "#854200", "#f3c8ad", "#410472",
   ];
 
+
+  function formatValue(value, unit) {
+    const v = Number(value);
+    if (!Number.isFinite(v)) return '-';
+    if (unit === 'bytes/sec' || unit === 'bytes/s') {
+      if (Math.abs(v) >= 1e9) return (v / 1e9).toFixed(1) + ' GB/s';
+      if (Math.abs(v) >= 1e6) return (v / 1e6).toFixed(1) + ' MB/s';
+      if (Math.abs(v) >= 1e3) return (v / 1e3).toFixed(1) + ' KB/s';
+      return Math.round(v) + ' B/s';
+    }
+    if (unit === 'bytes/log' || unit === 'bytes/span' || unit === 'bytes/metric') {
+      if (Math.abs(v) >= 1e6) return (v / 1e6).toFixed(1) + ' MB/' + unit.split('/')[1];
+      if (Math.abs(v) >= 1e3) return (v / 1e3).toFixed(1) + ' KB/' + unit.split('/')[1];
+      return Math.round(v) + ' B/' + unit.split('/')[1];
+    }
+    return v % 1 === 0 ? String(v) + ' ' + unit : v.toFixed(2) + ' ' + unit;
+  }
+
   function init() {
     function collectBenchesPerTestCase(entries) {
       const byGroup = new Map();
@@ -382,7 +400,13 @@
               display: true,
               labelString: results?.[0]?.dataset.find(d => d !== null)?.bench.unit ?? '',
             },
-            ticks: { beginAtZero: true },
+            ticks: {
+              beginAtZero: true,
+              callback: function(value) {
+                const unit = this.chart.options.scales.yAxes[0].scaleLabel.labelString || '';
+                return formatValue(value, unit);
+              }
+            },
           }]
         },
         tooltips: {
@@ -399,8 +423,7 @@
               if (!data) return `${results[datasetIndex].name}: N/A`;
               const { name, dataset } = results[datasetIndex];
               const { range, unit } = data.bench;
-              let label = `${name}: ${value}`;
-              label += unit;
+              let label = `${name}: ${formatValue(value, unit)}`;
               if (range) label += ` (${range})`;
               return label;
             },

--- a/docs/benchmarks/nightly/scaling-efficiency/index.html
+++ b/docs/benchmarks/nightly/scaling-efficiency/index.html
@@ -222,6 +222,24 @@
     "#97dbfc", "#006174", "#00b6b6", "#854200", "#f3c8ad", "#410472",
   ];
 
+
+  function formatValue(value, unit) {
+    const v = Number(value);
+    if (!Number.isFinite(v)) return '-';
+    if (unit === 'bytes/sec' || unit === 'bytes/s') {
+      if (Math.abs(v) >= 1e9) return (v / 1e9).toFixed(1) + ' GB/s';
+      if (Math.abs(v) >= 1e6) return (v / 1e6).toFixed(1) + ' MB/s';
+      if (Math.abs(v) >= 1e3) return (v / 1e3).toFixed(1) + ' KB/s';
+      return Math.round(v) + ' B/s';
+    }
+    if (unit === 'bytes/log' || unit === 'bytes/span' || unit === 'bytes/metric') {
+      if (Math.abs(v) >= 1e6) return (v / 1e6).toFixed(1) + ' MB/' + unit.split('/')[1];
+      if (Math.abs(v) >= 1e3) return (v / 1e3).toFixed(1) + ' KB/' + unit.split('/')[1];
+      return Math.round(v) + ' B/' + unit.split('/')[1];
+    }
+    return v % 1 === 0 ? String(v) + ' ' + unit : v.toFixed(2) + ' ' + unit;
+  }
+
   function init() {
     function collectBenchesPerTestCase(entries) {
       const byGroup = new Map();
@@ -382,7 +400,13 @@
               display: true,
               labelString: results?.[0]?.dataset.find(d => d !== null)?.bench.unit ?? '',
             },
-            ticks: { beginAtZero: true },
+            ticks: {
+              beginAtZero: true,
+              callback: function(value) {
+                const unit = this.chart.options.scales.yAxes[0].scaleLabel.labelString || '';
+                return formatValue(value, unit);
+              }
+            },
           }]
         },
         tooltips: {
@@ -399,8 +423,7 @@
               if (!data) return `${results[datasetIndex].name}: N/A`;
               const { name, dataset } = results[datasetIndex];
               const { range, unit } = data.bench;
-              let label = `${name}: ${value}`;
-              label += unit;
+              let label = `${name}: ${formatValue(value, unit)}`;
               if (range) label += ` (${range})`;
               return label;
             },

--- a/docs/benchmarks/nightly/standardload-batch-size/index.html
+++ b/docs/benchmarks/nightly/standardload-batch-size/index.html
@@ -222,6 +222,24 @@
     "#97dbfc", "#006174", "#00b6b6", "#854200", "#f3c8ad", "#410472",
   ];
 
+
+  function formatValue(value, unit) {
+    const v = Number(value);
+    if (!Number.isFinite(v)) return '-';
+    if (unit === 'bytes/sec' || unit === 'bytes/s') {
+      if (Math.abs(v) >= 1e9) return (v / 1e9).toFixed(1) + ' GB/s';
+      if (Math.abs(v) >= 1e6) return (v / 1e6).toFixed(1) + ' MB/s';
+      if (Math.abs(v) >= 1e3) return (v / 1e3).toFixed(1) + ' KB/s';
+      return Math.round(v) + ' B/s';
+    }
+    if (unit === 'bytes/log' || unit === 'bytes/span' || unit === 'bytes/metric') {
+      if (Math.abs(v) >= 1e6) return (v / 1e6).toFixed(1) + ' MB/' + unit.split('/')[1];
+      if (Math.abs(v) >= 1e3) return (v / 1e3).toFixed(1) + ' KB/' + unit.split('/')[1];
+      return Math.round(v) + ' B/' + unit.split('/')[1];
+    }
+    return v % 1 === 0 ? String(v) + ' ' + unit : v.toFixed(2) + ' ' + unit;
+  }
+
   function init() {
     function collectBenchesPerTestCase(entries) {
       const byGroup = new Map();
@@ -382,7 +400,13 @@
               display: true,
               labelString: results?.[0]?.dataset.find(d => d !== null)?.bench.unit ?? '',
             },
-            ticks: { beginAtZero: true },
+            ticks: {
+              beginAtZero: true,
+              callback: function(value) {
+                const unit = this.chart.options.scales.yAxes[0].scaleLabel.labelString || '';
+                return formatValue(value, unit);
+              }
+            },
           }]
         },
         tooltips: {
@@ -399,8 +423,7 @@
               if (!data) return `${results[datasetIndex].name}: N/A`;
               const { name, dataset } = results[datasetIndex];
               const { range, unit } = data.bench;
-              let label = `${name}: ${value}`;
-              label += unit;
+              let label = `${name}: ${formatValue(value, unit)}`;
               if (range) label += ` (${range})`;
               return label;
             },

--- a/docs/benchmarks/nightly/syslog-tcp-otelcol/index.html
+++ b/docs/benchmarks/nightly/syslog-tcp-otelcol/index.html
@@ -235,6 +235,24 @@
     "#97dbfc", "#006174", "#00b6b6", "#854200", "#f3c8ad", "#410472",
   ];
 
+
+  function formatValue(value, unit) {
+    const v = Number(value);
+    if (!Number.isFinite(v)) return '-';
+    if (unit === 'bytes/sec' || unit === 'bytes/s') {
+      if (Math.abs(v) >= 1e9) return (v / 1e9).toFixed(1) + ' GB/s';
+      if (Math.abs(v) >= 1e6) return (v / 1e6).toFixed(1) + ' MB/s';
+      if (Math.abs(v) >= 1e3) return (v / 1e3).toFixed(1) + ' KB/s';
+      return Math.round(v) + ' B/s';
+    }
+    if (unit === 'bytes/log' || unit === 'bytes/span' || unit === 'bytes/metric') {
+      if (Math.abs(v) >= 1e6) return (v / 1e6).toFixed(1) + ' MB/' + unit.split('/')[1];
+      if (Math.abs(v) >= 1e3) return (v / 1e3).toFixed(1) + ' KB/' + unit.split('/')[1];
+      return Math.round(v) + ' B/' + unit.split('/')[1];
+    }
+    return v % 1 === 0 ? String(v) + ' ' + unit : v.toFixed(2) + ' ' + unit;
+  }
+
   function init() {
     function collectBenchesPerTestCase(entries) {
       const byGroup = new Map();
@@ -395,7 +413,13 @@
               display: true,
               labelString: results?.[0]?.dataset.find(d => d !== null)?.bench.unit ?? '',
             },
-            ticks: { beginAtZero: true },
+            ticks: {
+              beginAtZero: true,
+              callback: function(value) {
+                const unit = this.chart.options.scales.yAxes[0].scaleLabel.labelString || '';
+                return formatValue(value, unit);
+              }
+            },
           }]
         },
         tooltips: {
@@ -412,8 +436,7 @@
               if (!data) return `${results[datasetIndex].name}: N/A`;
               const { name, dataset } = results[datasetIndex];
               const { range, unit } = data.bench;
-              let label = `${name}: ${value}`;
-              label += unit;
+              let label = `${name}: ${formatValue(value, unit)}`;
               if (range) label += ` (${range})`;
               return label;
             },

--- a/docs/benchmarks/nightly/syslog-tcp/index.html
+++ b/docs/benchmarks/nightly/syslog-tcp/index.html
@@ -222,6 +222,24 @@
     "#97dbfc", "#006174", "#00b6b6", "#854200", "#f3c8ad", "#410472",
   ];
 
+
+  function formatValue(value, unit) {
+    const v = Number(value);
+    if (!Number.isFinite(v)) return '-';
+    if (unit === 'bytes/sec' || unit === 'bytes/s') {
+      if (Math.abs(v) >= 1e9) return (v / 1e9).toFixed(1) + ' GB/s';
+      if (Math.abs(v) >= 1e6) return (v / 1e6).toFixed(1) + ' MB/s';
+      if (Math.abs(v) >= 1e3) return (v / 1e3).toFixed(1) + ' KB/s';
+      return Math.round(v) + ' B/s';
+    }
+    if (unit === 'bytes/log' || unit === 'bytes/span' || unit === 'bytes/metric') {
+      if (Math.abs(v) >= 1e6) return (v / 1e6).toFixed(1) + ' MB/' + unit.split('/')[1];
+      if (Math.abs(v) >= 1e3) return (v / 1e3).toFixed(1) + ' KB/' + unit.split('/')[1];
+      return Math.round(v) + ' B/' + unit.split('/')[1];
+    }
+    return v % 1 === 0 ? String(v) + ' ' + unit : v.toFixed(2) + ' ' + unit;
+  }
+
   function init() {
     function collectBenchesPerTestCase(entries) {
       const byGroup = new Map();
@@ -382,7 +400,13 @@
               display: true,
               labelString: results?.[0]?.dataset.find(d => d !== null)?.bench.unit ?? '',
             },
-            ticks: { beginAtZero: true },
+            ticks: {
+              beginAtZero: true,
+              callback: function(value) {
+                const unit = this.chart.options.scales.yAxes[0].scaleLabel.labelString || '';
+                return formatValue(value, unit);
+              }
+            },
           }]
         },
         tooltips: {
@@ -399,8 +423,7 @@
               if (!data) return `${results[datasetIndex].name}: N/A`;
               const { name, dataset } = results[datasetIndex];
               const { range, unit } = data.bench;
-              let label = `${name}: ${value}`;
-              label += unit;
+              let label = `${name}: ${formatValue(value, unit)}`;
               if (range) label += ` (${range})`;
               return label;
             },

--- a/docs/benchmarks/nightly/syslog/index.html
+++ b/docs/benchmarks/nightly/syslog/index.html
@@ -244,6 +244,24 @@
     "#97dbfc", "#006174", "#00b6b6", "#854200", "#f3c8ad", "#410472",
   ];
 
+
+  function formatValue(value, unit) {
+    const v = Number(value);
+    if (!Number.isFinite(v)) return '-';
+    if (unit === 'bytes/sec' || unit === 'bytes/s') {
+      if (Math.abs(v) >= 1e9) return (v / 1e9).toFixed(1) + ' GB/s';
+      if (Math.abs(v) >= 1e6) return (v / 1e6).toFixed(1) + ' MB/s';
+      if (Math.abs(v) >= 1e3) return (v / 1e3).toFixed(1) + ' KB/s';
+      return Math.round(v) + ' B/s';
+    }
+    if (unit === 'bytes/log' || unit === 'bytes/span' || unit === 'bytes/metric') {
+      if (Math.abs(v) >= 1e6) return (v / 1e6).toFixed(1) + ' MB/' + unit.split('/')[1];
+      if (Math.abs(v) >= 1e3) return (v / 1e3).toFixed(1) + ' KB/' + unit.split('/')[1];
+      return Math.round(v) + ' B/' + unit.split('/')[1];
+    }
+    return v % 1 === 0 ? String(v) + ' ' + unit : v.toFixed(2) + ' ' + unit;
+  }
+
   function init() {
     function collectBenchesPerTestCase(entries) {
       const byGroup = new Map();
@@ -404,7 +422,13 @@
               display: true,
               labelString: results?.[0]?.dataset.find(d => d !== null)?.bench.unit ?? '',
             },
-            ticks: { beginAtZero: true },
+            ticks: {
+              beginAtZero: true,
+              callback: function(value) {
+                const unit = this.chart.options.scales.yAxes[0].scaleLabel.labelString || '';
+                return formatValue(value, unit);
+              }
+            },
           }]
         },
         tooltips: {
@@ -421,8 +445,7 @@
               if (!data) return `${results[datasetIndex].name}: N/A`;
               const { name, dataset } = results[datasetIndex];
               const { range, unit } = data.bench;
-              let label = `${name}: ${value}`;
-              label += unit;
+              let label = `${name}: ${formatValue(value, unit)}`;
               if (range) label += ` (${range})`;
               return label;
             },


### PR DESCRIPTION
Follow-up to #2982 and #3035. Adds a `formatValue` helper to the nightly and continuous benchmark dashboards so that raw `bytes/sec` values are displayed as human-readable KB/s, MB/s, or GB/s in both y-axis labels and tooltips.

This enables the report queries to emit raw bytes/sec (as reverted in #3035) while the dashboard handles presentation formatting.