### PR TITLE
Move passthrough benchmarks from continuous to nightly CI

### DIFF
--- a/.github/workflows/pipeline-perf-test-continuous.yml
+++ b/.github/workflows/pipeline-perf-test-continuous.yml
@@ -68,29 +68,11 @@ jobs:
           cd tools/pipeline_perf_test
           python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/100klrps-docker.yaml
 
-      - name: Run passthrough performance test (OTLP)
-        if: ${{ !cancelled() }}
-        run: |
-          cd tools/pipeline_perf_test
-          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/passthrough.yaml
-
-      - name: Run passthrough performance test (OTAP)
-        if: ${{ !cancelled() }}
-        run: |
-          cd tools/pipeline_perf_test
-          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/passthrough-otap.yaml
-
       - name: Upload benchmark results for processing
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: benchmark-results-pipeline
           path: tools/pipeline_perf_test/results/integration/gh-actions-benchmark/*.json
-
-      - name: Upload benchmark results for processing (Passthrough)
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: benchmark-results-passthrough
-          path: tools/pipeline_perf_test/results/continuous_passthrough/gh-actions-benchmark/*.json
 
       - name: Add benchmark link to job summary
         run: |
@@ -115,20 +97,9 @@ jobs:
           merge-multiple: true
           path: results-pipeline
 
-      - name: Download benchmark artifacts (Passthrough)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          pattern: benchmark-results-passthrough*
-          merge-multiple: true
-          path: results-passthrough
-
       - name: Consolidate pipeline benchmark data
         run: |
           bash ./.github/workflows/scripts/consolidate-benchmarks.sh results-pipeline output-pipeline.json
-
-      - name: Consolidate passthrough benchmark data
-        run: |
-          bash ./.github/workflows/scripts/consolidate-benchmarks.sh results-passthrough output-passthrough.json
 
       - name: Update pipeline benchmark data and deploy to GitHub Pages
         uses: benchmark-action/github-action-benchmark@a60cea5bc7b49e15c1f58f411161f99e0df48372 # v1.22.0
@@ -142,20 +113,7 @@ jobs:
           auto-push: true
           save-data-file: true
 
-      - name: Update passthrough benchmark data and deploy to GitHub Pages
-        uses: benchmark-action/github-action-benchmark@a60cea5bc7b49e15c1f58f411161f99e0df48372 # v1.22.0
-        with:
-          tool: "customSmallerIsBetter"
-          output-file-path: output-passthrough.json
-          gh-pages-branch: benchmarks
-          max-items-in-chart: 100
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          benchmark-data-dir-path: "docs/benchmarks/continuous-passthrough"
-          auto-push: true
-          save-data-file: true
-
       - name: Add benchmark link to job summary
         run: |
           echo "### Benchmark Results" >> $GITHUB_STEP_SUMMARY
           echo "[View the pipeline benchmark results here](https://open-telemetry.github.io/otel-arrow/benchmarks/continuous/)" >> $GITHUB_STEP_SUMMARY
-          echo "[View the passthrough benchmark results here](https://open-telemetry.github.io/otel-arrow/benchmarks/continuous-passthrough/)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pipeline-perf-test-nightly.yml
+++ b/.github/workflows/pipeline-perf-test-nightly.yml
@@ -138,6 +138,18 @@ jobs:
           cd tools/pipeline_perf_test
           python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/saturation-max-throughput-otap.yaml
 
+      - name: Run passthrough performance test (OTLP)
+        if: ${{ !cancelled() }}
+        run: |
+          cd tools/pipeline_perf_test
+          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/passthrough.yaml
+
+      - name: Run passthrough performance test (OTAP)
+        if: ${{ !cancelled() }}
+        run: |
+          cd tools/pipeline_perf_test
+          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/passthrough-otap.yaml
+
       - name: Upload syslog results for processing
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -221,6 +233,13 @@ jobs:
         with:
           name: scaling-efficiency-nightly-results
           path: tools/pipeline_perf_test/results/scaling-efficiency.json
+
+      - name: Upload passthrough results for processing
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: passthrough-nightly-results
+          path: tools/pipeline_perf_test/results/continuous_passthrough/gh-actions-benchmark/*.json
 
       - name: Add benchmark link to job summary
         if: ${{ !cancelled() }}
@@ -324,6 +343,13 @@ jobs:
           merge-multiple: true
           path: scaling_efficiency_results
 
+      - name: Download passthrough artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: passthrough-nightly-results*
+          merge-multiple: true
+          path: passthrough_results
+
       - name: Consolidate syslog benchmark data
         if: ${{ !cancelled() }}
         run: |
@@ -373,6 +399,11 @@ jobs:
         if: ${{ !cancelled() }}
         run: |
           bash ./.github/workflows/scripts/consolidate-benchmarks.sh idle_state_results idle_state_output.json
+
+      - name: Consolidate passthrough benchmark data
+        if: ${{ !cancelled() }}
+        run: |
+          bash ./.github/workflows/scripts/consolidate-benchmarks.sh passthrough_results passthrough_output.json
 
       - name: Update benchmark data
         if: ${{ !cancelled() && hashFiles('syslog_output.json') != '' }}
@@ -527,6 +558,19 @@ jobs:
           max-items-in-chart: 100
           github-token: ${{ secrets.GITHUB_TOKEN }}
           benchmark-data-dir-path: "docs/benchmarks/nightly/scaling-efficiency"
+          auto-push: true
+          save-data-file: true
+
+      - name: Update passthrough benchmark data
+        if: ${{ !cancelled() && hashFiles('passthrough_output.json') != '' }}
+        uses: benchmark-action/github-action-benchmark@a60cea5bc7b49e15c1f58f411161f99e0df48372 # v1.22.0
+        with:
+          tool: "customSmallerIsBetter"
+          output-file-path: passthrough_output.json
+          gh-pages-branch: benchmarks
+          max-items-in-chart: 100
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          benchmark-data-dir-path: "docs/benchmarks/continuous-passthrough"
           auto-push: true
           save-data-file: true
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -83,7 +83,7 @@ protocol is significantly more efficient and requires more load to saturate.
 
 ##### 6b. Scaling Efficiency (Multi-Core)
 
-**URL:** <https://open-telemetry.github.io/otel-arrow/benchmarks/nightly/saturation/>
+**URL:** <https://open-telemetry.github.io/otel-arrow/benchmarks/nightly/scaling-efficiency/>
 
 Validates the shared-nothing, thread-per-core architecture by measuring how
 throughput scales as more CPU cores are added. Each test pushes load until the
@@ -103,19 +103,16 @@ Uses static 1KB log bodies with realistic entropy (512 unique bodies) -- unlike
 other tests which use `semantic_conventions` (~300 byte logs) -- to better
 exercise the serialization/compression/network path at saturation.
 
-Scaling efficiency ratios are tracked over time:
-<https://open-telemetry.github.io/otel-arrow/benchmarks/nightly/scaling-efficiency/>
-
 #### 7. Pass-through Mode
 
 **URL:** <https://open-telemetry.github.io/otel-arrow/benchmarks/continuous-passthrough/>
 
 Tests maximum throughput in pass-through mode where the engine forwards data
-without transformation. This scenario represents the minimum engine overhead for
-load balancing and routing use cases. Unlike the saturation tests which include
-an attribute processor, pass-through mode allows the engine to forward data
-without materializing the internal representation, achieving significantly
-higher throughput.
+without transformation (run nightly). This scenario represents the minimum
+engine overhead for load balancing and routing use cases. Unlike the saturation
+tests which include an attribute processor, pass-through mode allows the engine
+to forward data without materializing the internal representation, achieving
+significantly higher throughput.
 
 #### 8. Idle State
 


### PR DESCRIPTION
Moves the passthrough performance tests (OTLP and OTAP) from the per-commit continuous workflow to the nightly workflow to save bare-metal runner resources.

The passthrough tests measure single-core peak throughput for a no-op pipeline. While useful for regression detection, the nightly cadence is sufficient since the saturation/scaling tests already run nightly and cover similar ground.

Results continue publishing to the same `docs/benchmarks/continuous-passthrough` dashboard path on the benchmarks branch.