### PR TITLE
[pdata] [query-engine] Expose LogsBodyBuilder::finish as pub

### DIFF
--- a/rust/otap-dataflow/crates/pdata/src/encode/record/logs.rs
+++ b/rust/otap-dataflow/crates/pdata/src/encode/record/logs.rs
@@ -443,7 +443,11 @@ impl LogsBodyBuilder {
         self.nulls.append_null();
     }
 
-    /// Finish this builder try to build the resulting `StructArray` for the log body
+    /// Finish this builder and try to build the resulting `StructArray` for the log body.
+    ///
+    /// Returns `None` when the body is entirely null. Otherwise, returns `Some(Err(_))`
+    /// if building the `StructArray` fails, or `Some(Ok(_))` with the resulting array
+    /// on success.
     pub fn finish(&mut self) -> Option<Result<StructArray, ArrowError>> {
         let len = self.nulls.len();
         let nulls = self.nulls.finish();

--- a/rust/otap-dataflow/crates/pdata/src/encode/record/logs.rs
+++ b/rust/otap-dataflow/crates/pdata/src/encode/record/logs.rs
@@ -444,7 +444,7 @@ impl LogsBodyBuilder {
     }
 
     /// Finish this builder try to build the resulting `StructArray` for the log body
-    fn finish(&mut self) -> Option<Result<StructArray, ArrowError>> {
+    pub fn finish(&mut self) -> Option<Result<StructArray, ArrowError>> {
         let len = self.nulls.len();
         let nulls = self.nulls.finish();
 


### PR DESCRIPTION
# Changes

* Expose `LogsBodyBuilder::finish` as `pub`

# Details

I would like to use `LogsBodyBuilder` in OTAP columnar query engine but `finish` is currently private. It seems the other `finish` methods in here are all `pub` so I'm hoping this is OK to change\expose.

/cc @albertlockett