### PR TITLE
telemetry: encode event_name as bare name; emit crate via InstrumentationScope.name

### DIFF
--- a/rust/otap-dataflow/crates/telemetry/src/self_tracing/encoder.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/self_tracing/encoder.rs
@@ -81,13 +81,17 @@ impl<'buf, B: BoundedBuf> DirectLogRecordEncoder<'buf, B> {
 }
 
 /// Encode the event name from callsite metadata.
-/// Format: "target::name (file:line)" or "target::name" if no file/line.
+///
+/// Emits the bare `callsite.name()` (the first argument to `otel_info!` /
+/// `otel_warn!` / …). The crate name (`callsite.target()`) is **not**
+/// prefixed here; it is conveyed separately through
+/// `InstrumentationScope.name` by [`encode_export_logs_request`] so that
+/// `event.name` on the wire matches the value declared in the
+/// `rust/otap-dataflow/semconv/` registry and validated by
+/// `weaver registry live-check`.
 fn encode_event_name<B: BoundedBuf>(buf: &mut B, callsite: SavedCallsite) -> EncodeResult {
     buf.encode_len_delimited(LOG_RECORD_EVENT_NAME, |buf| {
-        buf.try_extend(callsite.target().as_bytes())?;
-        buf.try_extend(b"::")?;
-        buf.try_extend(callsite.name().as_bytes())?;
-        Ok(())
+        buf.try_extend(callsite.name().as_bytes())
     })
 }
 
@@ -607,6 +611,13 @@ pub fn encode_export_logs_request(
         buf.encode_len_delimited(RESOURCE_LOGS_SCOPE_LOGS, |buf| {
             // ScopeLogs.scope (field 1, InstrumentationScope message)
             buf.encode_len_delimited(SCOPE_LOG_SCOPE, |buf| {
+                // InstrumentationScope.name (field 1, string) — the crate
+                // that emitted the event (i.e. the tracing target,
+                // `env!("CARGO_PKG_NAME")` at the call site). Pairing
+                // scope.name with the bare `event.name` encoded below
+                // keeps `event.name` aligned with the
+                // `rust/otap-dataflow/semconv/` registry.
+                buf.encode_string(INSTRUMENTATION_SCOPE_NAME, event.record.callsite().target())?;
                 for entity_key in event.record.context.iter() {
                     let scope_bytes = scope_cache.get_or_encode(*entity_key);
                     buf.extend_from_slice(&scope_bytes)?;
@@ -725,11 +736,14 @@ mod tests {
         encode_export_logs_request(&mut buf, &log_event, &resource_bytes, &mut scope_cache);
 
         let decoded = ExportLogsServiceRequest::decode(buf.into_bytes().as_ref()).unwrap();
-        let event_name = &decoded
-            .resource_logs
+        let scope_logs = &decoded.resource_logs.first().unwrap().scope_logs;
+        let scope = scope_logs
             .first()
             .unwrap()
-            .scope_logs
+            .scope
+            .as_ref()
+            .expect("scope present");
+        let event_name = &scope_logs
             .first()
             .unwrap()
             .log_records
@@ -737,13 +751,17 @@ mod tests {
             .unwrap()
             .event_name;
 
-        // Test for the event name prefix to avoid a hard-coded line number.
-        assert!(event_name.starts_with("otap-df-telemetry::test.scope.encoding"));
+        // event_name is the bare semconv identifier; the emitting crate
+        // is conveyed via InstrumentationScope.name. See
+        // encode_event_name + encode_export_logs_request.
+        assert_eq!(event_name, "test.scope.encoding");
+        assert_eq!(scope.name, "otap-df-telemetry");
 
         let expected = ExportLogsServiceRequest::new([ResourceLogs::new(
             Resource::build().finish(),
             [ScopeLogs::new(
                 InstrumentationScope::build()
+                    .name("otap-df-telemetry")
                     .attributes([
                         KeyValue::new("pipeline.name", AnyValue::new_string("my-pipeline")),
                         KeyValue::new("cpu.id", AnyValue::new_int(3)),
@@ -757,10 +775,14 @@ mod tests {
             )],
         )]);
 
-        // Inspect the printed format. Entity name is appended.
+        // Inspect the printed format. Console output still uses the
+        // `target::name` style for human readability; only OTLP changes.
         assert_eq!(
             format_log_record_to_string(None, &log_event.record),
-            format!("INFO  {event_name} entity={:?}\n", entity_key),
+            format!(
+                "INFO  otap-df-telemetry::{event_name} entity={:?}\n",
+                entity_key
+            ),
         );
         assert_eq!(expected, decoded);
     }
@@ -829,14 +851,20 @@ mod tests {
         encode_export_logs_request(&mut buf, &log_event, &resource_bytes, &mut scope_cache);
 
         let decoded = ExportLogsServiceRequest::decode(buf.into_bytes().as_ref()).unwrap();
+        let scope = decoded.resource_logs[0].scope_logs[0]
+            .scope
+            .as_ref()
+            .expect("scope present");
         let event_name = &decoded.resource_logs[0].scope_logs[0].log_records[0].event_name;
-        assert!(event_name.starts_with("otap-df-telemetry::test.map.encoding"));
+        assert_eq!(event_name, "test.map.encoding");
+        assert_eq!(scope.name, "otap-df-telemetry");
 
         // BTreeMap iterates in sorted key order: "priority" before "region".
         let expected = ExportLogsServiceRequest::new([ResourceLogs::new(
             Resource::build().finish(),
             [ScopeLogs::new(
                 InstrumentationScope::build()
+                    .name("otap-df-telemetry")
                     .attributes([KeyValue::new(
                         "custom",
                         AnyValue::new_kvlist(vec![

--- a/rust/otap-dataflow/crates/telemetry/src/self_tracing/formatter.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/self_tracing/formatter.rs
@@ -846,9 +846,12 @@ mod tests {
         assert_eq!(decoded.time_unix_nano, 1_705_321_845_678_000_000);
         assert_eq!(decoded.severity_number, 9); // INFO
         assert!(decoded.severity_text.is_empty()); // Not coded
-        // OTLP `event_name` is the bare callsite name; the module path
-        // (`callsite.target()`) is conveyed through
-        // `InstrumentationScope.name` by `encode_export_logs_request`.
+        // `DirectLogRecordEncoder` only writes the `LogRecord` message;
+        // `event_name` here is the bare callsite name. The owning
+        // `InstrumentationScope` (which carries `callsite.target()` as
+        // its `name`) is written by `encode_export_logs_request` and is
+        // covered by `encode_export_logs_request_with_scope_attributes`
+        // in encoder.rs.
         assert_eq!(decoded.event_name, "test_event");
     }
 

--- a/rust/otap-dataflow/crates/telemetry/src/self_tracing/formatter.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/self_tracing/formatter.rs
@@ -753,12 +753,14 @@ mod tests {
         let attrs_text = format_attrs(&expected_attrs);
         let expected_suffix = format!(": {}{}", expected_body, attrs_text);
 
-        // Verify event_name has correct prefix. Note: file:line are not always available, not tested.
-        let expected_prefix = "otap_df_telemetry::self_tracing::formatter::tests::event";
+        // Verify event_name has correct shape. Note: tracing
+        // autogenerates names of the form `event <file>:<line>` for
+        // unannotated macro calls; we just check it starts with
+        // `event`. The crate/module path appears in
+        // InstrumentationScope.name (verified separately below).
         assert!(
-            decoded.event_name.starts_with(expected_prefix),
-            "event_name should start with '{}', got: {}",
-            expected_prefix,
+            decoded.event_name.starts_with("event"),
+            "event_name should start with 'event', got: {}",
             decoded.event_name
         );
 
@@ -844,7 +846,10 @@ mod tests {
         assert_eq!(decoded.time_unix_nano, 1_705_321_845_678_000_000);
         assert_eq!(decoded.severity_number, 9); // INFO
         assert!(decoded.severity_text.is_empty()); // Not coded
-        assert_eq!(decoded.event_name, "test_module::submodule::test_event");
+        // OTLP `event_name` is the bare callsite name; the module path
+        // (`callsite.target()`) is conveyed through
+        // `InstrumentationScope.name` by `encode_export_logs_request`.
+        assert_eq!(decoded.event_name, "test_event");
     }
 
     #[test]


### PR DESCRIPTION
Align df_engine's OTLP log output with the OpenTelemetry logs data model: emit the crate name via `InstrumentationScope.name` instead of prepending it to `LogRecord.event_name`. Stands on its own merit irrespective of the parallel weaver live-check work (#3047, will rebase once this lands).

## Today

`encode_event_name` writes `LogRecord.event_name` as `"<target>::<name>"` (e.g. `otap-df-otap::tls.handshake.failed`). `InstrumentationScope.name` is left empty. This conflates two distinct OTel concepts: the emitting library identity (scope) and the stable event identifier (event.name).

## With this change

```
InstrumentationScope.name  = "otap-df-otap"           (new: was empty)
LogRecord.event_name       = "tls.handshake.failed"   (was "otap-df-otap::tls.handshake.failed")
```

Matches the OTel logs spec: `instrumentation_scope.name` identifies the emitting library; `event.name` is a stable, library-independent identifier.

## Out of scope, left unchanged

- The console formatter still renders `target::name` for stdout/stderr -- humans tailing logs see the same string as before. Only OTLP-on-the-wire is affected.
- `InstrumentationScope.version` is still empty (could later be populated from `env!("CARGO_PKG_VERSION")`).
- The admin/log_tap path already separated `target` and `event_name` (`crates/admin/src/telemetry.rs:214-215`); no change needed there. This PR brings the OTLP exporter in line with what admin already does.