### PR TITLE
task(comparison_dashboard): Update the banner

### DIFF
--- a/tools/comparison_dashboard/dashboard.py
+++ b/tools/comparison_dashboard/dashboard.py
@@ -59,6 +59,11 @@ ALLOWED_EXTENSIONS = {".toml", ".yaml", ".yml", ".json", ".txt"}
 # File extensions to publish from staging to the data dir after a run
 PUBLISH_CONFIG_EXTENSIONS = {".yaml", ".yml", ".toml"}
 
+# Banner text pinned to each page
+BANNER_TEXT = "The Dataflow Engine and these benchmarks are a work in progress. Do you have feedback?"
+BANNER_LINK_TEXT = "Tell us here!"
+ISSUE_URL = "https://github.com/open-telemetry/otel-arrow/issues"
+
 # ---------------------------------------------------------------------------
 # Manifest
 # ---------------------------------------------------------------------------
@@ -1503,7 +1508,7 @@ def generate_index_html(comparisons: list, suites: dict, paths: BuildPaths, mani
         '<body>',
         '  <div class="wip-banner" role="alert">',
         '    <span class="wip-icon" aria-hidden="true">&#9888;&#65039;</span>',
-        '    <span class="wip-text">All benchmarks are WIP and not final. Inaccuracies may exist.</span>',
+        f'   <span class="wip-text">{BANNER_TEXT} <a class="wip-link" href="{ISSUE_URL}" target="_blank" rel="noopener">{BANNER_LINK_TEXT}</a></span>',
         '    <span class="wip-icon" aria-hidden="true">&#9888;&#65039;</span>',
         '  </div>',
         '  <div class="wrap">',
@@ -1590,7 +1595,7 @@ def generate_compare_stubs(comparisons: list, suites: dict, paths: BuildPaths, m
             '<body>',
             '  <div class="wip-banner" role="alert">',
             '    <span class="wip-icon" aria-hidden="true">&#9888;&#65039;</span>',
-            '    <span class="wip-text">All benchmarks are WIP and not final. Inaccuracies may exist.</span>',
+            f'   <span class="wip-text">{BANNER_TEXT} <a class="wip-link" href="{ISSUE_URL}" target="_blank" rel="noopener">{BANNER_LINK_TEXT}</a></span>',
             '    <span class="wip-icon" aria-hidden="true">&#9888;&#65039;</span>',
             '  </div>',
             '  <div class="wrap">',

--- a/tools/comparison_dashboard/shared/styles.css
+++ b/tools/comparison_dashboard/shared/styles.css
@@ -1346,6 +1346,13 @@ a.scenario-section-title:hover {
   flex: 0 1 auto;
   text-align: center;
 }
+.wip-banner .wip-link {
+  color: #78350f;
+  text-decoration: underline;
+}
+.wip-banner .wip-link:hover {
+  color: #92400e;
+}
 
 /* ── Environment summary (comparison header) ─────────────────────────────── */
 .env-summary {


### PR DESCRIPTION
# Change Summary

Rather than remove, I thought we might want to update the banner with some new text and a link to file issues for feedback.

I know the name "Dataflow Engine" is up for some debate, though we already use this name elsewhere in the site.

Open to suggestions on all fronts including just removing the banner!

## What issue does this PR close?

* Closes #3019

## How are these changes tested?

<img width="2435" height="817" alt="image" src="https://github.com/user-attachments/assets/b3cb0454-37b5-4afd-81f0-7dc6acac0136" />

## Are there any user-facing changes?

Yes - Banner update.