### PR TITLE
fix(security): Refactor Go tidy workflows to avoid usage of pull_request_target

### DIFF
--- a/.github/workflows/tidy-commit.yml
+++ b/.github/workflows/tidy-commit.yml
@@ -35,8 +35,20 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_branch }}
-      - name: Apply patch and commit
+      - name: Verify HEAD matches workflow_run head_sha
+        id: verify
         if: steps.download.outcome == 'success'
+        run: |
+          expected="${{ github.event.workflow_run.head_sha }}"
+          actual="$(git rev-parse HEAD)"
+          if [ "$expected" != "$actual" ]; then
+            echo "PR branch advanced to $actual past the SHA the patch was generated for ($expected); skipping to avoid pushing stale changes."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Apply patch and commit
+        if: steps.download.outcome == 'success' && steps.verify.outputs.skip != 'true'
         run: |
           set -euo pipefail
 

--- a/.github/workflows/tidy-commit.yml
+++ b/.github/workflows/tidy-commit.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Check for patch
         if: steps.download.outcome == 'failure'
         run: |
-          echo "No tidy-patch artifact found — nothing to commit."
+          echo "No tidy-patch artifact found - nothing to commit."
           exit 0
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: steps.download.outcome == 'success'

--- a/.github/workflows/tidy-commit.yml
+++ b/.github/workflows/tidy-commit.yml
@@ -38,6 +38,8 @@ jobs:
       - name: Apply patch and commit
         if: steps.download.outcome == 'success'
         run: |
+          set -euo pipefail
+
           git apply changes.patch
 
           # Configure git for otelbot

--- a/.github/workflows/tidy-commit.yml
+++ b/.github/workflows/tidy-commit.yml
@@ -1,0 +1,49 @@
+name: "Commit Tidy Changes"
+permissions:
+  contents: read
+
+on:
+  workflow_run:
+    workflows: ["Tidy Renovate PRs"]
+    types: [completed]
+
+jobs:
+  commit:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      contains(fromJson('["renovate[bot]", "dependabot[bot]"]'), github.event.workflow_run.actor.login) &&
+      github.event.workflow_run.head_repository.fork == false
+    steps:
+      - name: Download patch
+        id: download
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        continue-on-error: true
+        with:
+          name: tidy-patch
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check for patch
+        if: steps.download.outcome == 'failure'
+        run: |
+          echo "No tidy-patch artifact found — nothing to commit."
+          exit 0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        if: steps.download.outcome == 'success'
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_branch }}
+      - name: Apply patch and commit
+        if: steps.download.outcome == 'success'
+        run: |
+          git apply changes.patch
+
+          # Configure git for otelbot
+          git config user.name otelbot
+          git config user.email 197425009+otelbot@users.noreply.github.com
+
+          git add .
+          git commit -m "make genotelarrowcol"
+          git push

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -12,6 +12,9 @@ jobs:
   tidy:
     runs-on: ubuntu-latest
     # This workflow is used to ensure Renovate and Dependabot PRs to Go code are 'tidy' and are reflected in the generated code produced by makefile command
+    # Note: fork PRs are blocked at the commit stage (tidy-commit.yml) via
+    # `workflow_run.head_repository.fork == false`. This run has no write
+    # permissions and no secrets, so executing PR code here is safe.
     if: ${{ contains(fromJson('["renovate[bot]", "dependabot[bot]"]'), github.actor) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -3,37 +3,40 @@ permissions:
   contents: read
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
     branches:
       - main
 
 jobs:
   tidy:
-    permissions:
-      contents: write
     runs-on: ubuntu-latest
     # This workflow is used to ensure Renovate and Dependabot PRs to Go code are 'tidy' and are reflected in the generated code produced by makefile command
-    if: ${{ contains(fromJson('["renovate[bot]", "dependabot[bot]"]'), github.actor) && github.event.pull_request.head.repo.fork == false }}
+    if: ${{ contains(fromJson('["renovate[bot]", "dependabot[bot]"]'), github.actor) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          ref: ${{ github.head_ref }}
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26.2"
       - name: make genotelarrowcol
         # This also runs 'go mod tidy' as part of its process
         run: make genotelarrowcol
-      - name: Commit changes
+      - name: Check for changes
+        id: changes
         run: |
-          # Configure git for otelbot
-          git config user.name otelbot
-          git config user.email 197425009+otelbot@users.noreply.github.com
-
-          if ! git diff --exit-code; then
-            git add .
-            git commit -m "make genotelarrowcol"
-            git push
+          if git diff --quiet; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi
+      - name: Create patch
+        if: steps.changes.outputs.has_changes == 'true'
+        run: git diff > changes.patch
+      - name: Upload patch
+        if: steps.changes.outputs.has_changes == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: tidy-patch
+          path: changes.patch


### PR DESCRIPTION
# Change Summary

### Problem

The `tidy.yml` workflow uses `pull_request_target` to run `make genotelarrowcol` and push the result back to Renovate/Dependabot PR branches.

`pull_request_target` runs in the context of the base branch, which means it has access to secrets and write permissions. The current workflow checks out the PR's head ref (`ref: ${{ github.head_ref }}`) and then executes code from it (`make genotelarrowcol`). If the actor/fork guards were ever bypassed — via a compromised bot account, misconfigured Renovate, or a GitHub bug — an attacker's code would run with full write access and secrets.

### Solution

Split the workflow into two:

1. **`tidy.yml`** — Triggered by `pull_request` (not `pull_request_target`). Runs `make genotelarrowcol` with **no write permissions and no secrets**. If changes are detected, uploads a `git diff` patch as an artifact.

2. **`tidy-commit.yml`** — Triggered by `workflow_run` on completion of the first workflow. Downloads the patch, applies it, and pushes. This workflow has write access but **never executes any code from the PR** — it only applies a static diff.

This ensures that code execution and write access never coexist in the same workflow run.

### Before

```
pull_request_target
  ✓ contents: write, secrets available
  ✓ checks out + executes PR code
  ✓ pushes to branch
```

### After

```
pull_request (tidy.yml)          →  workflow_run (tidy-commit.yml)
  ✗ no write, no secrets              ✓ contents: write
  ✓ executes PR code                  ✗ never executes PR code
  → uploads patch artifact             → applies patch, commits, pushes
```

## What issue does this PR close?

N/A

## How are these changes tested?

Unfortunately, need to test it on the next set of Go Renovate PRs

## Are there any user-facing changes?

No
