### PR TITLE
task(comparison_dashboard): Add benchmarks for attribute and transform processor operations

### DIFF
--- a/tools/comparison_dashboard/comparisons/dfe_logs_transform_attr_processor_insert.yaml
+++ b/tools/comparison_dashboard/comparisons/dfe_logs_transform_attr_processor_insert.yaml
@@ -32,21 +32,21 @@ suites:
   # DFE OTAP
   - name: DFE OTAP Attr Insert (Logs)
     slug: dfe_logs_otap_none_attr_insert
-    short: DFE/OTAP/Attr
+    short: OTAP/Attr
   - name: DFE OTAP Transform Insert (Logs)
     slug: dfe_logs_otap_none_transform_insert
-    short: DFE/OTAP/Transform
+    short: OTAP/Transform
   - name: DFE OTAP Baseline (Logs)
     slug: dfe_logs_otap_none_baseline
-    short: DFE/OTAP/Baseline
+    short: OTAP/Baseline
 
   # DFE OTLP
   - name: DFE OTLP Attr Insert (Logs)
     slug: dfe_logs_otlp_none_attr_insert
-    short: DFE/OTLP/Attr
+    short: OTLP/Attr
   - name: DFE OTLP Transform Insert (Logs)
     slug: dfe_logs_otlp_none_transform_insert
-    short: DFE/OTLP/Transform
+    short: OTLP/Transform
   - name: DFE OTLP Baseline (Logs)
     slug: dfe_logs_otlp_none_baseline
-    short: DFE/OTLP/Baseline
+    short: OTLP/Baseline

--- a/tools/comparison_dashboard/comparisons/dfe_logs_transform_attr_processor_insert.yaml
+++ b/tools/comparison_dashboard/comparisons/dfe_logs_transform_attr_processor_insert.yaml
@@ -1,0 +1,52 @@
+slug: dfe_logs_transform_attr_processor_insert
+name: DFE Logs Attribute Rename (Processor Comparison)
+description: >
+  Renaming the semantic-convention attribute exception.type to exception.kind on
+  logs in the Dataflow Engine, comparing the attributes processor vs the transform
+  processor (OPL) across the OTAP and OTLP protocols.
+
+chart:
+  axes:
+    x:
+      title: Generated Load (logs/sec)
+      description: Rate at which the load generator is configured to produce logs e.g. "100k" == "100,000 logs/sec".
+
+tests:
+  - name: 100k
+    loadgen_rate: 100000
+  - name: 200k
+    loadgen_rate: 200000
+  - name: 300k
+    loadgen_rate: 300000
+  - name: 400k
+    loadgen_rate: 400000
+  - name: 600k
+    loadgen_rate: 600000
+  - name: 800k
+    loadgen_rate: 800000
+  - name: 1000k
+    loadgen_rate: 1000000
+    label: 1M
+
+suites:
+  # DFE OTAP
+  - name: DFE OTAP Attr Insert (Logs)
+    slug: dfe_logs_otap_none_attr_insert
+    short: DFE/OTAP/Attr
+  - name: DFE OTAP Transform Insert (Logs)
+    slug: dfe_logs_otap_none_transform_insert
+    short: DFE/OTAP/Transform
+  - name: DFE OTAP Baseline (Logs)
+    slug: dfe_logs_otap_none_baseline
+    short: DFE/OTAP/Baseline
+
+  # DFE OTLP
+  - name: DFE OTLP Attr Insert (Logs)
+    slug: dfe_logs_otlp_none_attr_insert
+    short: DFE/OTLP/Attr
+  - name: DFE OTLP Transform Insert (Logs)
+    slug: dfe_logs_otlp_none_transform_insert
+    short: DFE/OTLP/Transform
+  - name: DFE OTLP Baseline (Logs)
+    slug: dfe_logs_otlp_none_baseline
+    short: DFE/OTLP/Baseline

--- a/tools/comparison_dashboard/comparisons/dfe_logs_transform_attr_processor_insert.yaml
+++ b/tools/comparison_dashboard/comparisons/dfe_logs_transform_attr_processor_insert.yaml
@@ -1,5 +1,5 @@
 slug: dfe_logs_transform_attr_processor_insert
-name: DFE Logs Attribute Rename (Processor Comparison)
+name: Dataflow Engine Attribute Insert
 description: >
   Renaming the semantic-convention attribute exception.type to exception.kind on
   logs in the Dataflow Engine, comparing the attributes processor vs the transform

--- a/tools/comparison_dashboard/comparisons/dfe_logs_transform_attr_processor_insert.yaml
+++ b/tools/comparison_dashboard/comparisons/dfe_logs_transform_attr_processor_insert.yaml
@@ -1,8 +1,8 @@
 slug: dfe_logs_transform_attr_processor_insert
 name: Dataflow Engine Attribute Insert
 description: >
-  Renaming the semantic-convention attribute exception.type to exception.kind on
-  logs in the Dataflow Engine, comparing the attributes processor vs the transform
+  Inserting an attribute "processing.engine" with a static value "benchmark" on
+  logs in the Dataflow Engine. Comparing the attributes processor vs the transform
   processor (OPL) across the OTAP and OTLP protocols.
 
 chart:

--- a/tools/comparison_dashboard/comparisons/dfe_logs_transform_attr_processor_rename.yaml
+++ b/tools/comparison_dashboard/comparisons/dfe_logs_transform_attr_processor_rename.yaml
@@ -1,10 +1,9 @@
-slug: processing_logs_rename
+slug: dfe_logs_transform_attr_processor_rename
 name: DFE Logs Attribute Rename (Processor Comparison)
 description: >
   Renaming the semantic-convention attribute exception.type to exception.kind on
   logs in the Dataflow Engine, comparing the attributes processor vs the transform
-  processor (OPL) across the OTAP and OTLP protocols. No-processing baselines
-  included for overhead reference.
+  processor (OPL) across the OTAP and OTLP protocols.
 
 chart:
   axes:

--- a/tools/comparison_dashboard/comparisons/dfe_logs_transform_attr_processor_rename.yaml
+++ b/tools/comparison_dashboard/comparisons/dfe_logs_transform_attr_processor_rename.yaml
@@ -1,5 +1,5 @@
 slug: dfe_logs_transform_attr_processor_rename
-name: DFE Logs Attribute Rename (Processor Comparison)
+name: Dataflow Engine Attribute Rename
 description: >
   Renaming the semantic-convention attribute exception.type to exception.kind on
   logs in the Dataflow Engine, comparing the attributes processor vs the transform

--- a/tools/comparison_dashboard/comparisons/dfe_logs_transform_attr_processor_rename.yaml
+++ b/tools/comparison_dashboard/comparisons/dfe_logs_transform_attr_processor_rename.yaml
@@ -32,21 +32,21 @@ suites:
   # DFE OTAP
   - name: DFE OTAP Attr Rename (Logs)
     slug: dfe_logs_otap_none_attr_rename
-    short: DFE/OTAP/Attr
+    short: OTAP/Attr
   - name: DFE OTAP Transform Rename (Logs)
     slug: dfe_logs_otap_none_transform_rename
-    short: DFE/OTAP/Transform
+    short: OTAP/Transform
   - name: DFE OTAP Baseline (Logs)
     slug: dfe_logs_otap_none_baseline
-    short: DFE/OTAP/Baseline
+    short: OTAP/Baseline
 
   # DFE OTLP
   - name: DFE OTLP Attr Rename (Logs)
     slug: dfe_logs_otlp_none_attr_rename
-    short: DFE/OTLP/Attr
+    short: OTLP/Attr
   - name: DFE OTLP Transform Rename (Logs)
     slug: dfe_logs_otlp_none_transform_rename
-    short: DFE/OTLP/Transform
+    short: OTLP/Transform
   - name: DFE OTLP Baseline (Logs)
     slug: dfe_logs_otlp_none_baseline
-    short: DFE/OTLP/Baseline
+    short: OTLP/Baseline

--- a/tools/comparison_dashboard/comparisons/processing_logs_rename.yaml
+++ b/tools/comparison_dashboard/comparisons/processing_logs_rename.yaml
@@ -1,0 +1,53 @@
+slug: processing_logs_rename
+name: DFE Logs Attribute Rename (Processor Comparison)
+description: >
+  Renaming the semantic-convention attribute exception.type to exception.kind on
+  logs in the Dataflow Engine, comparing the attributes processor vs the transform
+  processor (OPL) across the OTAP and OTLP protocols. No-processing baselines
+  included for overhead reference.
+
+chart:
+  axes:
+    x:
+      title: Generated Load (logs/sec)
+      description: Rate at which the load generator is configured to produce logs e.g. "100k" == "100,000 logs/sec".
+
+tests:
+  - name: 100k
+    loadgen_rate: 100000
+  - name: 200k
+    loadgen_rate: 200000
+  - name: 300k
+    loadgen_rate: 300000
+  - name: 400k
+    loadgen_rate: 400000
+  - name: 600k
+    loadgen_rate: 600000
+  - name: 800k
+    loadgen_rate: 800000
+  - name: 1000k
+    loadgen_rate: 1000000
+    label: 1M
+
+suites:
+  # DFE OTAP
+  - name: DFE OTAP Attr Rename (Logs)
+    slug: dfe_logs_otap_none_attr_rename
+    short: DFE/OTAP/Attr
+  - name: DFE OTAP Transform Rename (Logs)
+    slug: dfe_logs_otap_none_transform_rename
+    short: DFE/OTAP/Transform
+  - name: DFE OTAP Baseline (Logs)
+    slug: dfe_logs_otap_none_baseline
+    short: DFE/OTAP/Baseline
+
+  # DFE OTLP
+  - name: DFE OTLP Attr Rename (Logs)
+    slug: dfe_logs_otlp_none_attr_rename
+    short: DFE/OTLP/Attr
+  - name: DFE OTLP Transform Rename (Logs)
+    slug: dfe_logs_otlp_none_transform_rename
+    short: DFE/OTLP/Transform
+  - name: DFE OTLP Baseline (Logs)
+    slug: dfe_logs_otlp_none_baseline
+    short: DFE/OTLP/Baseline

--- a/tools/comparison_dashboard/manifest.yaml
+++ b/tools/comparison_dashboard/manifest.yaml
@@ -131,4 +131,5 @@ comparisons:
   - comparisons/dfe_logs_baselines.yaml
   - comparisons/dfe_metrics_baselines.yaml
   - comparisons/dfe_traces_baselines.yaml
-  - comparisons/processing_logs_rename.yaml
+  - comparisons/dfe_logs_transform_attr_processor_rename.yaml
+  - comparisons/dfe_logs_transform_attr_processor_insert.yaml

--- a/tools/comparison_dashboard/manifest.yaml
+++ b/tools/comparison_dashboard/manifest.yaml
@@ -109,6 +109,21 @@ suites:
   - suites/otc/otc-traces-otlp-gzip-baseline.yaml
   - suites/otc/otc-traces-otlp-zstd-baseline.yaml
   - suites/otc/otc-traces-otlphttp-none-baseline.yaml
+  # Lightweight processing suites (logs): attribute insert + rename, via the
+  # attributes processor vs the transform processor (OPL for DFE, OTTL for OTC).
+  - suites/dfe/dfe-logs-otap-none-attr-insert.yaml
+  - suites/dfe/dfe-logs-otlp-none-attr-insert.yaml
+  - suites/dfe/dfe-logs-otap-none-transform-insert.yaml
+  - suites/dfe/dfe-logs-otlp-none-transform-insert.yaml
+  - suites/dfe/dfe-logs-otap-none-attr-rename.yaml
+  - suites/dfe/dfe-logs-otlp-none-attr-rename.yaml
+  - suites/dfe/dfe-logs-otap-none-transform-rename.yaml
+  - suites/dfe/dfe-logs-otlp-none-transform-rename.yaml
+  - suites/otc/otc-logs-otlp-none-attr-insert.yaml
+  - suites/otc/otc-logs-otlp-none-transform-insert.yaml
+  - suites/otc/otc-logs-otlp-none-attr-rename.yaml
+  - suites/otc/otc-logs-otlp-none-transform-rename.yaml
+  - suites/otc/otc-logs-otlp-none-transform-rename-replace.yaml
 
 # Comparison definitions, listed by path. Each entry must point at an
 # existing YAML file with `slug` and `suites` (a list of suite refs).
@@ -116,3 +131,4 @@ comparisons:
   - comparisons/dfe_logs_baselines.yaml
   - comparisons/dfe_metrics_baselines.yaml
   - comparisons/dfe_traces_baselines.yaml
+  - comparisons/processing_logs_rename.yaml

--- a/tools/comparison_dashboard/manifest.yaml
+++ b/tools/comparison_dashboard/manifest.yaml
@@ -109,8 +109,6 @@ suites:
   - suites/otc/otc-traces-otlp-gzip-baseline.yaml
   - suites/otc/otc-traces-otlp-zstd-baseline.yaml
   - suites/otc/otc-traces-otlphttp-none-baseline.yaml
-  # Lightweight processing suites (logs): attribute insert + rename, via the
-  # attributes processor vs the transform processor (OPL for DFE, OTTL for OTC).
   - suites/dfe/dfe-logs-otap-none-attr-insert.yaml
   - suites/dfe/dfe-logs-otlp-none-attr-insert.yaml
   - suites/dfe/dfe-logs-otap-none-transform-insert.yaml

--- a/tools/comparison_dashboard/suites/dfe/dfe-logs-otap-none-attr-insert.yaml
+++ b/tools/comparison_dashboard/suites/dfe/dfe-logs-otap-none-attr-insert.yaml
@@ -1,0 +1,21 @@
+name: DFE OTAP Attr Insert (Logs)
+slug: dfe_logs_otap_none_attr_insert
+description: Dataflow Engine OTAP logs, attributes processor inserting processing.engine=benchmark
+orchestrator_template: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/orchestrator/dfe-single-core-multi-rate.yaml
+
+meta:
+  binary: dfe
+  protocols: [otap]
+  signals: [logs]
+  compression: none
+
+variables:
+  report: ../pipeline_perf_test/test_suites/comparison_dashboard/reports/report_logs.yaml
+  engine_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/engine/otap-attr-insert.yaml.j2
+  loadgen_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/loadgen/otap.yaml.j2
+  backend_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/backend/otap.yaml.j2
+  protocol: otap
+  signal: logs
+  loadgen_max_batch_size: 1000
+  compression_method: none
+  wait_for_result: true

--- a/tools/comparison_dashboard/suites/dfe/dfe-logs-otap-none-attr-rename.yaml
+++ b/tools/comparison_dashboard/suites/dfe/dfe-logs-otap-none-attr-rename.yaml
@@ -1,0 +1,21 @@
+name: DFE OTAP Attr Rename (Logs)
+slug: dfe_logs_otap_none_attr_rename
+description: Dataflow Engine OTAP logs, attributes processor renaming exception.type to exception.kind
+orchestrator_template: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/orchestrator/dfe-single-core-multi-rate.yaml
+
+meta:
+  binary: dfe
+  protocols: [otap]
+  signals: [logs]
+  compression: none
+
+variables:
+  report: ../pipeline_perf_test/test_suites/comparison_dashboard/reports/report_logs.yaml
+  engine_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/engine/otap-attr-rename.yaml.j2
+  loadgen_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/loadgen/otap.yaml.j2
+  backend_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/backend/otap.yaml.j2
+  protocol: otap
+  signal: logs
+  loadgen_max_batch_size: 1000
+  compression_method: none
+  wait_for_result: true

--- a/tools/comparison_dashboard/suites/dfe/dfe-logs-otap-none-transform-insert.yaml
+++ b/tools/comparison_dashboard/suites/dfe/dfe-logs-otap-none-transform-insert.yaml
@@ -1,0 +1,21 @@
+name: DFE OTAP Transform Insert (Logs)
+slug: dfe_logs_otap_none_transform_insert
+description: Dataflow Engine OTAP logs, transform processor (OPL) inserting processing.engine=benchmark
+orchestrator_template: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/orchestrator/dfe-single-core-multi-rate.yaml
+
+meta:
+  binary: dfe
+  protocols: [otap]
+  signals: [logs]
+  compression: none
+
+variables:
+  report: ../pipeline_perf_test/test_suites/comparison_dashboard/reports/report_logs.yaml
+  engine_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/engine/otap-transform-insert.yaml.j2
+  loadgen_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/loadgen/otap.yaml.j2
+  backend_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/backend/otap.yaml.j2
+  protocol: otap
+  signal: logs
+  loadgen_max_batch_size: 1000
+  compression_method: none
+  wait_for_result: true

--- a/tools/comparison_dashboard/suites/dfe/dfe-logs-otap-none-transform-rename.yaml
+++ b/tools/comparison_dashboard/suites/dfe/dfe-logs-otap-none-transform-rename.yaml
@@ -1,0 +1,21 @@
+name: DFE OTAP Transform Rename (Logs)
+slug: dfe_logs_otap_none_transform_rename
+description: Dataflow Engine OTAP logs, transform processor (OPL) renaming exception.type to exception.kind
+orchestrator_template: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/orchestrator/dfe-single-core-multi-rate.yaml
+
+meta:
+  binary: dfe
+  protocols: [otap]
+  signals: [logs]
+  compression: none
+
+variables:
+  report: ../pipeline_perf_test/test_suites/comparison_dashboard/reports/report_logs.yaml
+  engine_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/engine/otap-transform-rename.yaml.j2
+  loadgen_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/loadgen/otap.yaml.j2
+  backend_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/backend/otap.yaml.j2
+  protocol: otap
+  signal: logs
+  loadgen_max_batch_size: 1000
+  compression_method: none
+  wait_for_result: true

--- a/tools/comparison_dashboard/suites/dfe/dfe-logs-otlp-none-attr-insert.yaml
+++ b/tools/comparison_dashboard/suites/dfe/dfe-logs-otlp-none-attr-insert.yaml
@@ -1,0 +1,21 @@
+name: DFE OTLP Attr Insert (Logs)
+slug: dfe_logs_otlp_none_attr_insert
+description: Dataflow Engine OTLP logs, attributes processor inserting processing.engine=benchmark
+orchestrator_template: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/orchestrator/dfe-single-core-multi-rate.yaml
+
+meta:
+  binary: dfe
+  protocols: [otlp]
+  signals: [logs]
+  compression: none
+
+variables:
+  report: ../pipeline_perf_test/test_suites/comparison_dashboard/reports/report_logs.yaml
+  engine_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/engine/otlp-attr-insert.yaml.j2
+  loadgen_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/loadgen/otlp.yaml.j2
+  backend_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/backend/otlp.yaml.j2
+  protocol: otlp
+  signal: logs
+  loadgen_max_batch_size: 1000
+  compression_method: none
+  wait_for_result: true

--- a/tools/comparison_dashboard/suites/dfe/dfe-logs-otlp-none-attr-rename.yaml
+++ b/tools/comparison_dashboard/suites/dfe/dfe-logs-otlp-none-attr-rename.yaml
@@ -1,0 +1,21 @@
+name: DFE OTLP Attr Rename (Logs)
+slug: dfe_logs_otlp_none_attr_rename
+description: Dataflow Engine OTLP logs, attributes processor renaming exception.type to exception.kind
+orchestrator_template: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/orchestrator/dfe-single-core-multi-rate.yaml
+
+meta:
+  binary: dfe
+  protocols: [otlp]
+  signals: [logs]
+  compression: none
+
+variables:
+  report: ../pipeline_perf_test/test_suites/comparison_dashboard/reports/report_logs.yaml
+  engine_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/engine/otlp-attr-rename.yaml.j2
+  loadgen_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/loadgen/otlp.yaml.j2
+  backend_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/backend/otlp.yaml.j2
+  protocol: otlp
+  signal: logs
+  loadgen_max_batch_size: 1000
+  compression_method: none
+  wait_for_result: true

--- a/tools/comparison_dashboard/suites/dfe/dfe-logs-otlp-none-transform-insert.yaml
+++ b/tools/comparison_dashboard/suites/dfe/dfe-logs-otlp-none-transform-insert.yaml
@@ -1,0 +1,21 @@
+name: DFE OTLP Transform Insert (Logs)
+slug: dfe_logs_otlp_none_transform_insert
+description: Dataflow Engine OTLP logs, transform processor (OPL) inserting processing.engine=benchmark
+orchestrator_template: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/orchestrator/dfe-single-core-multi-rate.yaml
+
+meta:
+  binary: dfe
+  protocols: [otlp]
+  signals: [logs]
+  compression: none
+
+variables:
+  report: ../pipeline_perf_test/test_suites/comparison_dashboard/reports/report_logs.yaml
+  engine_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/engine/otlp-transform-insert.yaml.j2
+  loadgen_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/loadgen/otlp.yaml.j2
+  backend_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/backend/otlp.yaml.j2
+  protocol: otlp
+  signal: logs
+  loadgen_max_batch_size: 1000
+  compression_method: none
+  wait_for_result: true

--- a/tools/comparison_dashboard/suites/dfe/dfe-logs-otlp-none-transform-rename.yaml
+++ b/tools/comparison_dashboard/suites/dfe/dfe-logs-otlp-none-transform-rename.yaml
@@ -1,0 +1,21 @@
+name: DFE OTLP Transform Rename (Logs)
+slug: dfe_logs_otlp_none_transform_rename
+description: Dataflow Engine OTLP logs, transform processor (OPL) renaming exception.type to exception.kind
+orchestrator_template: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/orchestrator/dfe-single-core-multi-rate.yaml
+
+meta:
+  binary: dfe
+  protocols: [otlp]
+  signals: [logs]
+  compression: none
+
+variables:
+  report: ../pipeline_perf_test/test_suites/comparison_dashboard/reports/report_logs.yaml
+  engine_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/engine/otlp-transform-rename.yaml.j2
+  loadgen_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/loadgen/otlp.yaml.j2
+  backend_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/backend/otlp.yaml.j2
+  protocol: otlp
+  signal: logs
+  loadgen_max_batch_size: 1000
+  compression_method: none
+  wait_for_result: true

--- a/tools/comparison_dashboard/suites/otc/otc-logs-otlp-none-attr-insert.yaml
+++ b/tools/comparison_dashboard/suites/otc/otc-logs-otlp-none-attr-insert.yaml
@@ -1,0 +1,21 @@
+name: OTC OTLP Attr Insert (Logs)
+slug: otc_logs_otlp_none_attr_insert
+description: OpenTelemetry Collector OTLP logs, attributes processor inserting processing.engine=benchmark
+orchestrator_template: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/orchestrator/otc-single-core-multi-rate.yaml
+
+meta:
+  binary: otc
+  protocols: [otlp]
+  signals: [logs]
+  compression: none
+
+variables:
+  report: ../pipeline_perf_test/test_suites/comparison_dashboard/reports/report_logs.yaml
+  collector_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/otelcol/otlp-attr-insert.yaml.j2
+  loadgen_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/loadgen/otlp.yaml.j2
+  backend_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/backend/otlp.yaml.j2
+  protocol: otlp
+  signal: logs
+  loadgen_max_batch_size: 1000
+  compression_method: none
+  otelcol_gomaxprocs: 1

--- a/tools/comparison_dashboard/suites/otc/otc-logs-otlp-none-attr-rename.yaml
+++ b/tools/comparison_dashboard/suites/otc/otc-logs-otlp-none-attr-rename.yaml
@@ -1,0 +1,21 @@
+name: OTC OTLP Attr Rename (Logs)
+slug: otc_logs_otlp_none_attr_rename
+description: OpenTelemetry Collector OTLP logs, attributes processor renaming exception.type to exception.kind (from_attribute + delete)
+orchestrator_template: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/orchestrator/otc-single-core-multi-rate.yaml
+
+meta:
+  binary: otc
+  protocols: [otlp]
+  signals: [logs]
+  compression: none
+
+variables:
+  report: ../pipeline_perf_test/test_suites/comparison_dashboard/reports/report_logs.yaml
+  collector_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/otelcol/otlp-attr-rename.yaml.j2
+  loadgen_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/loadgen/otlp.yaml.j2
+  backend_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/backend/otlp.yaml.j2
+  protocol: otlp
+  signal: logs
+  loadgen_max_batch_size: 1000
+  compression_method: none
+  otelcol_gomaxprocs: 1

--- a/tools/comparison_dashboard/suites/otc/otc-logs-otlp-none-transform-insert.yaml
+++ b/tools/comparison_dashboard/suites/otc/otc-logs-otlp-none-transform-insert.yaml
@@ -1,0 +1,21 @@
+name: OTC OTLP Transform Insert (Logs)
+slug: otc_logs_otlp_none_transform_insert
+description: OpenTelemetry Collector OTLP logs, transform processor (OTTL) inserting processing.engine=benchmark
+orchestrator_template: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/orchestrator/otc-single-core-multi-rate.yaml
+
+meta:
+  binary: otc
+  protocols: [otlp]
+  signals: [logs]
+  compression: none
+
+variables:
+  report: ../pipeline_perf_test/test_suites/comparison_dashboard/reports/report_logs.yaml
+  collector_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/otelcol/otlp-transform-insert.yaml.j2
+  loadgen_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/loadgen/otlp.yaml.j2
+  backend_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/backend/otlp.yaml.j2
+  protocol: otlp
+  signal: logs
+  loadgen_max_batch_size: 1000
+  compression_method: none
+  otelcol_gomaxprocs: 1

--- a/tools/comparison_dashboard/suites/otc/otc-logs-otlp-none-transform-rename-replace.yaml
+++ b/tools/comparison_dashboard/suites/otc/otc-logs-otlp-none-transform-rename-replace.yaml
@@ -1,0 +1,21 @@
+name: OTC OTLP Transform Rename Replace (Logs)
+slug: otc_logs_otlp_none_transform_rename_replace
+description: OpenTelemetry Collector OTLP logs, transform processor (OTTL) renaming exception.type to exception.kind via replace_all_patterns on attribute keys
+orchestrator_template: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/orchestrator/otc-single-core-multi-rate.yaml
+
+meta:
+  binary: otc
+  protocols: [otlp]
+  signals: [logs]
+  compression: none
+
+variables:
+  report: ../pipeline_perf_test/test_suites/comparison_dashboard/reports/report_logs.yaml
+  collector_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/otelcol/otlp-transform-rename-replace.yaml.j2
+  loadgen_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/loadgen/otlp.yaml.j2
+  backend_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/backend/otlp.yaml.j2
+  protocol: otlp
+  signal: logs
+  loadgen_max_batch_size: 1000
+  compression_method: none
+  otelcol_gomaxprocs: 1

--- a/tools/comparison_dashboard/suites/otc/otc-logs-otlp-none-transform-rename.yaml
+++ b/tools/comparison_dashboard/suites/otc/otc-logs-otlp-none-transform-rename.yaml
@@ -1,0 +1,21 @@
+name: OTC OTLP Transform Rename (Logs)
+slug: otc_logs_otlp_none_transform_rename
+description: OpenTelemetry Collector OTLP logs, transform processor (OTTL) renaming exception.type to exception.kind (set + delete_key)
+orchestrator_template: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/orchestrator/otc-single-core-multi-rate.yaml
+
+meta:
+  binary: otc
+  protocols: [otlp]
+  signals: [logs]
+  compression: none
+
+variables:
+  report: ../pipeline_perf_test/test_suites/comparison_dashboard/reports/report_logs.yaml
+  collector_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/otelcol/otlp-transform-rename.yaml.j2
+  loadgen_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/loadgen/otlp.yaml.j2
+  backend_config: ../pipeline_perf_test/test_suites/comparison_dashboard/templates/backend/otlp.yaml.j2
+  protocol: otlp
+  signal: logs
+  loadgen_max_batch_size: 1000
+  compression_method: none
+  otelcol_gomaxprocs: 1

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/engine/otap-attr-insert.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/engine/otap-attr-insert.yaml.j2
@@ -1,0 +1,49 @@
+version: otel_dataflow/v1
+policies:
+  channel_capacity:
+    control:
+      node: 100
+      pipeline: 100
+    pdata: 100
+  resources:
+    core_allocation:
+      type: core_set
+      set:
+        - start: {{core_start}}
+          end: {{core_end}}
+engine:
+  telemetry:
+    logs:
+      level: info
+groups:
+  default:
+    pipelines:
+      main:
+        nodes:
+          receiver:
+            type: urn:otel:receiver:otap
+            config:
+              listening_addr: 0.0.0.0:4317
+              response_stream_channel_size: 100
+              max_concurrent_requests_per_stream: 64
+              wait_for_result: {% if wait_for_result | default(false) %}true{% else %}false{% endif %}
+              compression_method: {% if compression_method == "none" %}null{% else %}{{compression_method}}{% endif %}
+          processor:
+            type: urn:otel:processor:attribute
+            config:
+              actions:
+                - action: "insert"
+                  key: "processing.engine"
+                  value: "benchmark"
+          exporter:
+            type: urn:otel:exporter:otap
+            config:
+              grpc_endpoint: http://{{backend_hostname}}:1235
+              compression_method: {{ compression_method | default("none") }}
+              arrow:
+                payload_compression: {{ payload_compression | default("none") }}
+        connections:
+          - from: receiver
+            to: processor
+          - from: processor
+            to: exporter

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/engine/otap-attr-rename.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/engine/otap-attr-rename.yaml.j2
@@ -1,0 +1,49 @@
+version: otel_dataflow/v1
+policies:
+  channel_capacity:
+    control:
+      node: 100
+      pipeline: 100
+    pdata: 100
+  resources:
+    core_allocation:
+      type: core_set
+      set:
+        - start: {{core_start}}
+          end: {{core_end}}
+engine:
+  telemetry:
+    logs:
+      level: info
+groups:
+  default:
+    pipelines:
+      main:
+        nodes:
+          receiver:
+            type: urn:otel:receiver:otap
+            config:
+              listening_addr: 0.0.0.0:4317
+              response_stream_channel_size: 100
+              max_concurrent_requests_per_stream: 64
+              wait_for_result: {% if wait_for_result | default(false) %}true{% else %}false{% endif %}
+              compression_method: {% if compression_method == "none" %}null{% else %}{{compression_method}}{% endif %}
+          processor:
+            type: urn:otel:processor:attribute
+            config:
+              actions:
+                - action: "rename"
+                  source_key: "exception.type"
+                  destination_key: "exception.kind"
+          exporter:
+            type: urn:otel:exporter:otap
+            config:
+              grpc_endpoint: http://{{backend_hostname}}:1235
+              compression_method: {{ compression_method | default("none") }}
+              arrow:
+                payload_compression: {{ payload_compression | default("none") }}
+        connections:
+          - from: receiver
+            to: processor
+          - from: processor
+            to: exporter

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/engine/otap-transform-insert.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/engine/otap-transform-insert.yaml.j2
@@ -1,0 +1,46 @@
+version: otel_dataflow/v1
+policies:
+  channel_capacity:
+    control:
+      node: 100
+      pipeline: 100
+    pdata: 100
+  resources:
+    core_allocation:
+      type: core_set
+      set:
+        - start: {{core_start}}
+          end: {{core_end}}
+engine:
+  telemetry:
+    logs:
+      level: info
+groups:
+  default:
+    pipelines:
+      main:
+        nodes:
+          receiver:
+            type: urn:otel:receiver:otap
+            config:
+              listening_addr: 0.0.0.0:4317
+              response_stream_channel_size: 100
+              max_concurrent_requests_per_stream: 64
+              wait_for_result: {% if wait_for_result | default(false) %}true{% else %}false{% endif %}
+              compression_method: {% if compression_method == "none" %}null{% else %}{{compression_method}}{% endif %}
+          processor:
+            type: urn:otel:processor:transform
+            config:
+              opl_query: 'logs | set attributes["processing.engine"] = "benchmark"'
+          exporter:
+            type: urn:otel:exporter:otap
+            config:
+              grpc_endpoint: http://{{backend_hostname}}:1235
+              compression_method: {{ compression_method | default("none") }}
+              arrow:
+                payload_compression: {{ payload_compression | default("none") }}
+        connections:
+          - from: receiver
+            to: processor
+          - from: processor
+            to: exporter

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/engine/otap-transform-rename.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/engine/otap-transform-rename.yaml.j2
@@ -1,0 +1,46 @@
+version: otel_dataflow/v1
+policies:
+  channel_capacity:
+    control:
+      node: 100
+      pipeline: 100
+    pdata: 100
+  resources:
+    core_allocation:
+      type: core_set
+      set:
+        - start: {{core_start}}
+          end: {{core_end}}
+engine:
+  telemetry:
+    logs:
+      level: info
+groups:
+  default:
+    pipelines:
+      main:
+        nodes:
+          receiver:
+            type: urn:otel:receiver:otap
+            config:
+              listening_addr: 0.0.0.0:4317
+              response_stream_channel_size: 100
+              max_concurrent_requests_per_stream: 64
+              wait_for_result: {% if wait_for_result | default(false) %}true{% else %}false{% endif %}
+              compression_method: {% if compression_method == "none" %}null{% else %}{{compression_method}}{% endif %}
+          processor:
+            type: urn:otel:processor:transform
+            config:
+              opl_query: 'logs | rename attributes["exception.kind"] = attributes["exception.type"]'
+          exporter:
+            type: urn:otel:exporter:otap
+            config:
+              grpc_endpoint: http://{{backend_hostname}}:1235
+              compression_method: {{ compression_method | default("none") }}
+              arrow:
+                payload_compression: {{ payload_compression | default("none") }}
+        connections:
+          - from: receiver
+            to: processor
+          - from: processor
+            to: exporter

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/engine/otlp-attr-insert.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/engine/otlp-attr-insert.yaml.j2
@@ -1,0 +1,46 @@
+version: otel_dataflow/v1
+policies:
+  channel_capacity:
+    control:
+      node: 100
+      pipeline: 100
+    pdata: 100
+  resources:
+    core_allocation:
+      type: core_set
+      set:
+        - start: {{core_start}}
+          end: {{core_end}}
+engine:
+  telemetry:
+    logs:
+      level: info
+groups:
+  default:
+    pipelines:
+      main:
+        nodes:
+          receiver:
+            type: urn:otel:receiver:otlp
+            config:
+              protocols:
+                grpc:
+                  listening_addr: 0.0.0.0:4317
+                  wait_for_result: {% if wait_for_result | default(false) %}true{% else %}false{% endif %}
+          processor:
+            type: urn:otel:processor:attribute
+            config:
+              actions:
+                - action: "insert"
+                  key: "processing.engine"
+                  value: "benchmark"
+          exporter:
+            type: urn:otel:exporter:otlp_grpc
+            config:
+              grpc_endpoint: http://{{backend_hostname}}:1235
+              compression_method: {% if compression_method == "none" %}null{% else %}{{compression_method}}{% endif %}
+        connections:
+          - from: receiver
+            to: processor
+          - from: processor
+            to: exporter

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/engine/otlp-attr-rename.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/engine/otlp-attr-rename.yaml.j2
@@ -1,0 +1,46 @@
+version: otel_dataflow/v1
+policies:
+  channel_capacity:
+    control:
+      node: 100
+      pipeline: 100
+    pdata: 100
+  resources:
+    core_allocation:
+      type: core_set
+      set:
+        - start: {{core_start}}
+          end: {{core_end}}
+engine:
+  telemetry:
+    logs:
+      level: info
+groups:
+  default:
+    pipelines:
+      main:
+        nodes:
+          receiver:
+            type: urn:otel:receiver:otlp
+            config:
+              protocols:
+                grpc:
+                  listening_addr: 0.0.0.0:4317
+                  wait_for_result: {% if wait_for_result | default(false) %}true{% else %}false{% endif %}
+          processor:
+            type: urn:otel:processor:attribute
+            config:
+              actions:
+                - action: "rename"
+                  source_key: "exception.type"
+                  destination_key: "exception.kind"
+          exporter:
+            type: urn:otel:exporter:otlp_grpc
+            config:
+              grpc_endpoint: http://{{backend_hostname}}:1235
+              compression_method: {% if compression_method == "none" %}null{% else %}{{compression_method}}{% endif %}
+        connections:
+          - from: receiver
+            to: processor
+          - from: processor
+            to: exporter

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/engine/otlp-transform-insert.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/engine/otlp-transform-insert.yaml.j2
@@ -1,0 +1,43 @@
+version: otel_dataflow/v1
+policies:
+  channel_capacity:
+    control:
+      node: 100
+      pipeline: 100
+    pdata: 100
+  resources:
+    core_allocation:
+      type: core_set
+      set:
+        - start: {{core_start}}
+          end: {{core_end}}
+engine:
+  telemetry:
+    logs:
+      level: info
+groups:
+  default:
+    pipelines:
+      main:
+        nodes:
+          receiver:
+            type: urn:otel:receiver:otlp
+            config:
+              protocols:
+                grpc:
+                  listening_addr: 0.0.0.0:4317
+                  wait_for_result: {% if wait_for_result | default(false) %}true{% else %}false{% endif %}
+          processor:
+            type: urn:otel:processor:transform
+            config:
+              opl_query: 'logs | set attributes["processing.engine"] = "benchmark"'
+          exporter:
+            type: urn:otel:exporter:otlp_grpc
+            config:
+              grpc_endpoint: http://{{backend_hostname}}:1235
+              compression_method: {% if compression_method == "none" %}null{% else %}{{compression_method}}{% endif %}
+        connections:
+          - from: receiver
+            to: processor
+          - from: processor
+            to: exporter

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/engine/otlp-transform-rename.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/engine/otlp-transform-rename.yaml.j2
@@ -1,0 +1,43 @@
+version: otel_dataflow/v1
+policies:
+  channel_capacity:
+    control:
+      node: 100
+      pipeline: 100
+    pdata: 100
+  resources:
+    core_allocation:
+      type: core_set
+      set:
+        - start: {{core_start}}
+          end: {{core_end}}
+engine:
+  telemetry:
+    logs:
+      level: info
+groups:
+  default:
+    pipelines:
+      main:
+        nodes:
+          receiver:
+            type: urn:otel:receiver:otlp
+            config:
+              protocols:
+                grpc:
+                  listening_addr: 0.0.0.0:4317
+                  wait_for_result: {% if wait_for_result | default(false) %}true{% else %}false{% endif %}
+          processor:
+            type: urn:otel:processor:transform
+            config:
+              opl_query: 'logs | rename attributes["exception.kind"] = attributes["exception.type"]'
+          exporter:
+            type: urn:otel:exporter:otlp_grpc
+            config:
+              grpc_endpoint: http://{{backend_hostname}}:1235
+              compression_method: {% if compression_method == "none" %}null{% else %}{{compression_method}}{% endif %}
+        connections:
+          - from: receiver
+            to: processor
+          - from: processor
+            to: exporter

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/otelcol/otlp-attr-insert.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/otelcol/otlp-attr-insert.yaml.j2
@@ -1,0 +1,40 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  attributes:
+    actions:
+      - key: processing.engine
+        value: benchmark
+        action: insert
+
+exporters:
+  otlp:
+    endpoint: '{{backend_hostname}}:1235'
+    compression: {{ compression_method | default("none") }}
+    tls:
+      insecure: true
+
+service:
+  telemetry:
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: '0.0.0.0'
+                port: 8086
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [attributes]
+      exporters: [otlp]
+    metrics:
+      receivers: [otlp]
+      exporters: [otlp]
+    traces:
+      receivers: [otlp]
+      exporters: [otlp]

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/otelcol/otlp-attr-rename.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/otelcol/otlp-attr-rename.yaml.j2
@@ -1,0 +1,42 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  attributes:
+    actions:
+      - key: exception.kind
+        from_attribute: exception.type
+        action: insert
+      - key: exception.type
+        action: delete
+
+exporters:
+  otlp:
+    endpoint: '{{backend_hostname}}:1235'
+    compression: {{ compression_method | default("none") }}
+    tls:
+      insecure: true
+
+service:
+  telemetry:
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: '0.0.0.0'
+                port: 8086
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [attributes]
+      exporters: [otlp]
+    metrics:
+      receivers: [otlp]
+      exporters: [otlp]
+    traces:
+      receivers: [otlp]
+      exporters: [otlp]

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/otelcol/otlp-transform-insert.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/otelcol/otlp-transform-insert.yaml.j2
@@ -1,0 +1,41 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  transform:
+    error_mode: ignore
+    log_statements:
+      - context: log
+        statements:
+          - set(attributes["processing.engine"], "benchmark")
+
+exporters:
+  otlp:
+    endpoint: '{{backend_hostname}}:1235'
+    compression: {{ compression_method | default("none") }}
+    tls:
+      insecure: true
+
+service:
+  telemetry:
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: '0.0.0.0'
+                port: 8086
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [transform]
+      exporters: [otlp]
+    metrics:
+      receivers: [otlp]
+      exporters: [otlp]
+    traces:
+      receivers: [otlp]
+      exporters: [otlp]

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/otelcol/otlp-transform-rename-replace.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/otelcol/otlp-transform-rename-replace.yaml.j2
@@ -1,0 +1,41 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  transform:
+    error_mode: ignore
+    log_statements:
+      - context: log
+        statements:
+          - replace_all_patterns(attributes, "key", "exception\\.type", "exception.kind")
+
+exporters:
+  otlp:
+    endpoint: '{{backend_hostname}}:1235'
+    compression: {{ compression_method | default("none") }}
+    tls:
+      insecure: true
+
+service:
+  telemetry:
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: '0.0.0.0'
+                port: 8086
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [transform]
+      exporters: [otlp]
+    metrics:
+      receivers: [otlp]
+      exporters: [otlp]
+    traces:
+      receivers: [otlp]
+      exporters: [otlp]

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/otelcol/otlp-transform-rename.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/otelcol/otlp-transform-rename.yaml.j2
@@ -1,0 +1,42 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  transform:
+    error_mode: ignore
+    log_statements:
+      - context: log
+        statements:
+          - set(attributes["exception.kind"], attributes["exception.type"])
+          - delete_key(attributes, "exception.type")
+
+exporters:
+  otlp:
+    endpoint: '{{backend_hostname}}:1235'
+    compression: {{ compression_method | default("none") }}
+    tls:
+      insecure: true
+
+service:
+  telemetry:
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: '0.0.0.0'
+                port: 8086
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [transform]
+      exporters: [otlp]
+    metrics:
+      receivers: [otlp]
+      exporters: [otlp]
+    traces:
+      receivers: [otlp]
+      exporters: [otlp]


### PR DESCRIPTION
# Change Summary

This PR adds suites for both the DFE and OTC testing attribute and transform processor operations for both engines.

This also adds a comparison of attribute vs transform processor for two different operations (insert and rename) for DFE only.

## What issue does this PR close?

* Closes #3079

## How are these changes tested?

<img width="2357" height="906" alt="image" src="https://github.com/user-attachments/assets/efa69a78-5b20-4ccc-bce2-fccf03551ba6" />

<img width="2316" height="845" alt="image" src="https://github.com/user-attachments/assets/17a390e8-fce5-4e8b-af48-bbb12640b03d" />

## Are there any user-facing changes?

Yes, comparison for _DFE only_