### PR TITLE
[Attributes Processor] Add attribute `hash` action.

### DIFF
--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -213,6 +213,7 @@ weaver_resolved_schema = { git = "https://github.com/open-telemetry/weaver.git",
 weaver_resolver = { git = "https://github.com/open-telemetry/weaver.git", rev = "37c645a5ebc9e0d2a68f9228205f1d7d6a32ccbc"}
 weaver_semconv = { git = "https://github.com/open-telemetry/weaver.git", rev = "37c645a5ebc9e0d2a68f9228205f1d7d6a32ccbc"}
 sha1 = { version = "0.11" }
+sha2 = "0.10.9"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 zip = "=8.6.0"
 byte-unit = { version = "5.2.0", features = ["serde"] }

--- a/rust/otap-dataflow/benchmarks/benches/attribute_transform/main.rs
+++ b/rust/otap-dataflow/benchmarks/benches/attribute_transform/main.rs
@@ -114,6 +114,7 @@ fn bench_transform_attributes(c: &mut Criterion) {
         delete: None,
         update: None,
         upsert: None,
+        hash: None,
     };
 
     let single_replace_single_delete = AttributesTransform {
@@ -125,6 +126,7 @@ fn bench_transform_attributes(c: &mut Criterion) {
         delete: Some(DeleteTransform::new(BTreeSet::from_iter(["attr15".into()]))),
         update: None,
         upsert: None,
+        hash: None,
     };
 
     let no_replace_single_delete = AttributesTransform {
@@ -133,6 +135,7 @@ fn bench_transform_attributes(c: &mut Criterion) {
         delete: Some(DeleteTransform::new(BTreeSet::from_iter(["attr15".into()]))),
         update: None,
         upsert: None,
+        hash: None,
     };
 
     let attr3_replace_no_delete = AttributesTransform {
@@ -144,6 +147,7 @@ fn bench_transform_attributes(c: &mut Criterion) {
         delete: None,
         update: None,
         upsert: None,
+        hash: None,
     };
 
     let no_replace_attr9_delete = AttributesTransform {
@@ -152,6 +156,7 @@ fn bench_transform_attributes(c: &mut Criterion) {
         delete: Some(DeleteTransform::new(BTreeSet::from_iter(["attr9".into()]))),
         update: None,
         upsert: None,
+        hash: None,
     };
 
     let attr3_replace_attr9_delete = AttributesTransform {
@@ -163,6 +168,7 @@ fn bench_transform_attributes(c: &mut Criterion) {
         delete: Some(DeleteTransform::new(BTreeSet::from_iter(["attr9".into()]))),
         update: None,
         upsert: None,
+        hash: None,
     };
 
     // IDs aren't used during delete/rename, so we just pass empty IDs

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/attributes_processor/metrics.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/attributes_processor/metrics.rs
@@ -33,6 +33,9 @@ pub struct AttributesProcessorMetrics {
     /// Total number of attribute entries actually updated.
     #[metric(unit = "{attr}")]
     pub updated_entries: Counter<u64>,
+    /// Total number of attribute entries actually hashed.
+    #[metric(unit = "{attr}")]
+    pub hashed_entries: Counter<u64>,
 
     /// Number of times transforms were applied to signal-level payloads.
     #[metric(unit = "{apply}")]

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/attributes_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/attributes_processor/mod.rs
@@ -49,7 +49,7 @@ use otap_df_engine::message::Message;
 use otap_df_engine::node::NodeId;
 use otap_df_engine::process_duration::ComputeDuration;
 use otap_df_engine::processor::ProcessorWrapper;
-use otap_df_otap::{OTAP_PROCESSOR_FACTORIES, pdata::OtapPdata};
+use otap_df_otap::{OTAP_PROCESSOR_FACTORIES, opaque_string::OpaqueString, pdata::OtapPdata};
 use otap_df_pdata::TryIntoWithOptions;
 use otap_df_pdata::otap::transform::apply_attribute_transform;
 use otap_df_pdata::otap::{
@@ -127,58 +127,17 @@ pub enum Action {
         algorithm: HashAlgorithm,
         /// Salt prepended to the attribute bytes before hashing.
         ///
-        /// Stored as a [`RedactedString`] so that derived `Debug` output does not leak the salt
+        /// Stored as an [`OpaqueString`] so that derived `Debug` output does not leak the salt
         /// into logs, panics, or diagnostic dumps. The salt is still round-trippable via
         /// `Serialize`/`Deserialize`, so configuration reload and persistence are unaffected.
         #[serde(default)]
-        salt: RedactedString,
+        salt: OpaqueString,
     },
 
     /// Other actions are accepted for forward-compatibility but ignored.
     /// These variants allow deserialization of Go-style configs without effect.
     #[serde(other)]
     Unsupported,
-}
-
-/// A wrapper around `String` whose `Debug` representation redacts the inner value.
-///
-/// Use this for configuration fields that hold secrets (salts, tokens, ...). `Serialize` and
-/// `Deserialize` are transparent: the value round-trips through JSON/YAML as a plain string,
-/// but any code that formats the wrapper with `{:?}` will see `RedactedString(<redacted>)` rather
-/// than the secret. `Display` is intentionally not implemented so accidental `{}` formatting is
-/// rejected at compile time.
-#[derive(Clone, Default, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct RedactedString(String);
-
-impl RedactedString {
-    /// Wraps a `String` so it is redacted in `Debug` output.
-    #[must_use]
-    pub fn new(value: String) -> Self {
-        Self(value)
-    }
-
-    /// Returns the underlying string, consuming the wrapper.
-    #[must_use]
-    pub fn into_inner(self) -> String {
-        self.0
-    }
-
-    /// Returns a borrowed reference to the underlying string.
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl std::fmt::Debug for RedactedString {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.0.is_empty() {
-            f.write_str("RedactedString(\"\")")
-        } else {
-            f.write_str("RedactedString(<redacted>)")
-        }
-    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -415,7 +374,7 @@ impl AttributesProcessor {
         &self,
         records: &mut OtapArrowRecords,
         signal: SignalType,
-    ) -> Result<(u64, u64, u64, u64, u64), EngineError> {
+    ) -> Result<(u64, u64, u64, u64, u64, u64), EngineError> {
         let mut deleted_total: u64 = 0;
         let mut renamed_total: u64 = 0;
         let mut inserted_total: u64 = 0;
@@ -898,7 +857,7 @@ mod tests {
 
         let debug = format!("{action:?}");
         assert!(!debug.contains("pepper"));
-        assert!(debug.contains("<redacted>"));
+        assert!(debug.contains("***"));
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/attributes_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/attributes_processor/mod.rs
@@ -13,9 +13,10 @@
 //! - `insert`: Inserts a new attribute (only if the key doesn't already exist).
 //! - `upsert`: Inserts a new attribute, or updates the value if the key already exists.
 //! - `update`: Updates an existing attribute only if the key already exists.
+//! - `hash`: Replaces existing scalar attribute values with lowercase hex SHA-256 hashes.
 //!
 //! Unsupported actions are ignored if present in the config:
-//! `hash`, `extract`, `convert`.
+//! `extract`, `convert`.
 //! We may add support for them later.
 //!
 //! Example configuration (YAML):
@@ -54,8 +55,8 @@ use otap_df_pdata::otap::transform::apply_attribute_transform;
 use otap_df_pdata::otap::{
     OtapArrowRecords,
     transform::{
-        AttributesTransform, DeleteTransform, InsertTransform, LiteralValue, RenameTransform,
-        UpdateTransform, UpsertTransform,
+        AttributesTransform, DeleteTransform, HashSpec, HashTransform, InsertTransform,
+        LiteralValue, RenameTransform, UpdateTransform, UpsertTransform,
     },
 };
 use otap_df_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
@@ -113,17 +114,91 @@ pub enum Action {
         value: LiteralValue,
     },
 
+    /// Hash an existing scalar attribute value using SHA-256.
+    ///
+    /// The replacement value is a lowercase hex string. The hash input is `salt || value`, where
+    /// scalar values are encoded as UTF-8 for strings, raw bytes for byte arrays, a single `0` or
+    /// `1` byte for booleans, and little-endian bytes for `i64` and `f64` values.
+    Hash {
+        /// The attribute key to hash.
+        key: String,
+        /// The hashing algorithm to use. Defaults to `sha256`.
+        #[serde(default = "default_hash_algorithm")]
+        algorithm: HashAlgorithm,
+        /// Salt prepended to the attribute bytes before hashing.
+        ///
+        /// Stored as a [`RedactedString`] so that derived `Debug` output does not leak the salt
+        /// into logs, panics, or diagnostic dumps. The salt is still round-trippable via
+        /// `Serialize`/`Deserialize`, so configuration reload and persistence are unaffected.
+        #[serde(default)]
+        salt: RedactedString,
+    },
+
     /// Other actions are accepted for forward-compatibility but ignored.
     /// These variants allow deserialization of Go-style configs without effect.
     #[serde(other)]
     Unsupported,
 }
 
+/// A wrapper around `String` whose `Debug` representation redacts the inner value.
+///
+/// Use this for configuration fields that hold secrets (salts, tokens, ...). `Serialize` and
+/// `Deserialize` are transparent: the value round-trips through JSON/YAML as a plain string,
+/// but any code that formats the wrapper with `{:?}` will see `RedactedString(<redacted>)` rather
+/// than the secret. `Display` is intentionally not implemented so accidental `{}` formatting is
+/// rejected at compile time.
+#[derive(Clone, Default, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct RedactedString(String);
+
+impl RedactedString {
+    /// Wraps a `String` so it is redacted in `Debug` output.
+    #[must_use]
+    pub fn new(value: String) -> Self {
+        Self(value)
+    }
+
+    /// Returns the underlying string, consuming the wrapper.
+    #[must_use]
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+
+    /// Returns a borrowed reference to the underlying string.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for RedactedString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.0.is_empty() {
+            f.write_str("RedactedString(\"\")")
+        } else {
+            f.write_str("RedactedString(<redacted>)")
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+/// Supported hash algorithms for the `hash` action.
+pub enum HashAlgorithm {
+    /// SHA-256.
+    Sha256,
+}
+
+const fn default_hash_algorithm() -> HashAlgorithm {
+    HashAlgorithm::Sha256
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 /// Configuration for the AttributesProcessor.
 ///
 /// Accepts configuration in the same format as the OpenTelemetry Collector's attributes processor.
-/// Supported actions: rename (deviation), delete, insert, upsert, update. Others are ignored.
+/// Supported actions: rename (deviation), delete, insert, upsert, update, hash.
+/// Others are ignored.
 ///
 /// You can control which attribute domains are transformed via `apply_to`.
 /// Valid values: "signal" (default), "resource", "scope".
@@ -182,6 +257,7 @@ impl AttributesProcessor {
         let mut inserts = BTreeMap::new();
         let mut upserts = BTreeMap::new();
         let mut updates = BTreeMap::new();
+        let mut hashes = BTreeMap::new();
 
         for action in config.actions {
             match action {
@@ -203,6 +279,15 @@ impl AttributesProcessor {
                 Action::Update { key, value } => {
                     let _ = updates.insert(key, value);
                 }
+                Action::Hash {
+                    key,
+                    algorithm,
+                    salt,
+                } => match algorithm {
+                    HashAlgorithm::Sha256 => {
+                        let _ = hashes.insert(key, HashSpec::sha256(salt.into_inner()));
+                    }
+                },
                 // Unsupported actions are ignored for now
                 Action::Unsupported => {}
             }
@@ -248,6 +333,11 @@ impl AttributesProcessor {
             } else {
                 Some(UpdateTransform::new(updates))
             },
+            hash: if hashes.is_empty() {
+                None
+            } else {
+                Some(HashTransform::new(hashes))
+            },
         };
 
         transform
@@ -273,6 +363,7 @@ impl AttributesProcessor {
             && self.transform.insert.is_none()
             && self.transform.upsert.is_none()
             && self.transform.update.is_none()
+            && self.transform.hash.is_none()
     }
 
     #[inline]
@@ -330,6 +421,7 @@ impl AttributesProcessor {
         let mut inserted_total: u64 = 0;
         let mut upserted_total: u64 = 0;
         let mut updated_total: u64 = 0;
+        let mut hashed_total: u64 = 0;
 
         if !self.is_noop() {
             let payloads = self.attrs_payloads(signal);
@@ -342,6 +434,7 @@ impl AttributesProcessor {
                 inserted_total += stats.inserted_entries;
                 upserted_total += stats.upserted_entries;
                 updated_total += stats.updated_entries;
+                hashed_total += stats.hashed_entries;
             }
         }
 
@@ -351,6 +444,7 @@ impl AttributesProcessor {
             inserted_total,
             upserted_total,
             updated_total,
+            hashed_total,
         ))
     }
 }
@@ -409,6 +503,7 @@ impl local::Processor<OtapPdata> for AttributesProcessor {
                         inserted_total,
                         upserted_total,
                         updated_total,
+                        hashed_total,
                     )) => {
                         if deleted_total > 0 {
                             self.metrics.deleted_entries.add(deleted_total);
@@ -424,6 +519,9 @@ impl local::Processor<OtapPdata> for AttributesProcessor {
                         }
                         if updated_total > 0 {
                             self.metrics.updated_entries.add(updated_total);
+                        }
+                        if hashed_total > 0 {
+                            self.metrics.hashed_entries.add(hashed_total);
                         }
                     }
                     Err(e) => {
@@ -656,7 +754,8 @@ mod tests {
             "actions": [
                 {"action": "rename", "source_key": "a", "destination_key": "b"},
                 {"action": "delete", "key": "x"},
-                {"action": "update", "key": "secret", "value": "[REDACTED]"}
+                {"action": "update", "key": "secret", "value": "[REDACTED]"},
+                {"action": "hash", "key": "account.id", "algorithm": "sha256", "salt": "pepper"}
             ]
         });
         let telemetry_registry_handle = TelemetryRegistryHandle::new();
@@ -667,6 +766,7 @@ mod tests {
         assert!(parsed.transform.rename.is_some());
         assert!(parsed.transform.delete.is_some());
         assert!(parsed.transform.update.is_some());
+        assert!(parsed.transform.hash.is_some());
         // default apply_to should include Signal
         assert!(parsed.has_signal_domain);
         // and not necessarily Resource/Scope unless specified
@@ -767,6 +867,172 @@ mod tests {
                     log_attrs.iter().any(|kv| kv.key == "keep"
                         && kv.value == Some(AnyValue::new_string("unchanged")))
                 );
+            })
+            .validate(|_| async move {});
+    }
+
+    #[test]
+    fn test_config_rejects_unsupported_hash_algorithm() {
+        let cfg = json!({
+            "actions": [
+                {"action": "hash", "key": "secret", "algorithm": "sha512"}
+            ]
+        });
+        let telemetry_registry_handle = TelemetryRegistryHandle::new();
+        let controller_ctx = ControllerContext::new(telemetry_registry_handle);
+        let pipeline_ctx =
+            controller_ctx.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+
+        assert!(AttributesProcessor::from_config(pipeline_ctx, &cfg).is_err());
+    }
+
+    #[test]
+    fn test_hash_action_debug_redacts_salt() {
+        let action: Action = serde_json::from_value(json!({
+            "action": "hash",
+            "key": "secret",
+            "algorithm": "sha256",
+            "salt": "pepper"
+        }))
+        .expect("parse action");
+
+        let debug = format!("{action:?}");
+        assert!(!debug.contains("pepper"));
+        assert!(debug.contains("<redacted>"));
+    }
+
+    #[test]
+    fn test_hash_updates_existing_scalar_signal_attributes_only() {
+        let input = build_logs_with_attrs(
+            vec![KeyValue::new(
+                "str_attr",
+                AnyValue::new_string("resource-value"),
+            )],
+            vec![],
+            vec![
+                KeyValue::new("str_attr", AnyValue::new_string("alice@example.com")),
+                KeyValue::new("bytes_attr", AnyValue::new_bytes(b"abc")),
+                KeyValue::new("int_attr", AnyValue::new_int(514)),
+                KeyValue::new("double_attr", AnyValue::new_double(3.5)),
+                KeyValue::new("bool_attr", AnyValue::new_bool(true)),
+                KeyValue::new(
+                    "map_attr",
+                    AnyValue::new_kvlist(vec![KeyValue::new("nested", AnyValue::new_bool(true))]),
+                ),
+                KeyValue::new(
+                    "array_attr",
+                    AnyValue::new_array(vec![AnyValue::new_string("one")]),
+                ),
+                KeyValue::new("keep", AnyValue::new_string("unchanged")),
+            ],
+        );
+
+        let cfg = json!({
+            "actions": [
+                {"action": "hash", "key": "str_attr", "algorithm": "sha256", "salt": "pepper"},
+                {"action": "hash", "key": "bytes_attr", "algorithm": "sha256", "salt": "pepper"},
+                {"action": "hash", "key": "int_attr", "algorithm": "sha256", "salt": "pepper"},
+                {"action": "hash", "key": "double_attr", "algorithm": "sha256", "salt": "pepper"},
+                {"action": "hash", "key": "bool_attr", "algorithm": "sha256", "salt": "pepper"},
+                {"action": "hash", "key": "map_attr", "algorithm": "sha256", "salt": "pepper"},
+                {"action": "hash", "key": "array_attr", "algorithm": "sha256", "salt": "pepper"},
+                {"action": "hash", "key": "missing", "algorithm": "sha256", "salt": "pepper"}
+            ]
+        });
+
+        let telemetry_registry_handle = TelemetryRegistryHandle::new();
+        let controller_ctx = ControllerContext::new(telemetry_registry_handle);
+        let pipeline_ctx =
+            controller_ctx.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+
+        let node = test_node("attributes-processor-hash-test");
+        let rt: TestRuntime<OtapPdata> = TestRuntime::new();
+        let mut node_config = NodeUserConfig::new_processor_config(ATTRIBUTES_PROCESSOR_URN);
+        node_config.config = cfg;
+        let proc =
+            create_attributes_processor(pipeline_ctx, node, Arc::new(node_config), rt.config())
+                .expect("create processor");
+        let phase = rt.set_processor(proc);
+
+        phase
+            .run_test(|mut ctx| async move {
+                let mut bytes = BytesMut::new();
+                input.encode(&mut bytes).expect("encode");
+                let bytes = bytes.freeze();
+                let pdata_in =
+                    OtapPdata::new_default(OtlpProtoBytes::ExportLogsRequest(bytes).into());
+                ctx.process(Message::PData(pdata_in))
+                    .await
+                    .expect("process");
+
+                let out = ctx.drain_pdata().await;
+                let first = out.into_iter().next().expect("one output").payload();
+
+                let otlp_bytes: OtlpProtoBytes =
+                    first.try_into_with_default().expect("convert to otlp");
+                let bytes = match otlp_bytes {
+                    OtlpProtoBytes::ExportLogsRequest(b) => b,
+                    _ => panic!("unexpected otlp variant"),
+                };
+                let decoded = ExportLogsServiceRequest::decode(bytes.as_ref()).expect("decode");
+
+                let res_attrs = &decoded.resource_logs[0]
+                    .resource
+                    .as_ref()
+                    .unwrap()
+                    .attributes;
+                assert_eq!(
+                    res_attrs
+                        .iter()
+                        .find(|kv| kv.key == "str_attr")
+                        .and_then(|kv| kv.value.as_ref()),
+                    Some(&AnyValue::new_string("resource-value"))
+                );
+
+                let log_attrs = &decoded.resource_logs[0].scope_logs[0].log_records[0].attributes;
+                for (key, expected) in [
+                    (
+                        "str_attr",
+                        "8b8d9adc4875c0dca816e3e17b7ac87b45e40945b731fa02e3b42bf101589e21",
+                    ),
+                    (
+                        "bytes_attr",
+                        "fadf7b97406e1eaa259a82e26e6839e564c37c256876e060e17838c86b7275ef",
+                    ),
+                    (
+                        "int_attr",
+                        "13ddda943275484b13d00c410ab1ee38dafb4b468904979f561aa7a5c8d11699",
+                    ),
+                    (
+                        "double_attr",
+                        "3b25069b0582c48a0c401bb1f4fb6250de982cad1335473df46ca790ce41535e",
+                    ),
+                    (
+                        "bool_attr",
+                        "1c57981a8c749477991aa9772cd04531bb532f5c4965a69c498f044453a2d57a",
+                    ),
+                ] {
+                    assert_eq!(
+                        log_attrs
+                            .iter()
+                            .find(|kv| kv.key == key)
+                            .and_then(|kv| kv.value.as_ref()),
+                        Some(&AnyValue::new_string(expected))
+                    );
+                }
+                assert!(!log_attrs.iter().any(|kv| kv.key == "missing"));
+                assert!(
+                    log_attrs.iter().any(|kv| kv.key == "keep"
+                        && kv.value == Some(AnyValue::new_string("unchanged")))
+                );
+                assert!(log_attrs.iter().any(|kv| kv.key == "map_attr"
+                    && kv.value
+                        == Some(AnyValue::new_kvlist(vec![KeyValue::new(
+                            "nested",
+                            AnyValue::new_bool(true)
+                        )]))));
+                assert!(log_attrs.iter().any(|kv| kv.key == "array_attr"
+                    && kv.value == Some(AnyValue::new_array(vec![AnyValue::new_string("one")]))));
             })
             .validate(|_| async move {});
     }

--- a/rust/otap-dataflow/crates/otap/src/cloud_auth.rs
+++ b/rust/otap-dataflow/crates/otap/src/cloud_auth.rs
@@ -8,6 +8,3 @@ pub mod azure;
 /// AWS auth utilities
 #[cfg(feature = "aws")]
 pub mod aws;
-
-/// Redacted string type for sensitive values.
-pub mod opaque_string;

--- a/rust/otap-dataflow/crates/otap/src/cloud_auth/aws.rs
+++ b/rust/otap-dataflow/crates/otap/src/cloud_auth/aws.rs
@@ -4,7 +4,7 @@
 use object_store::aws::{AmazonS3Builder, AmazonS3ConfigKey};
 use serde::{Deserialize, Serialize};
 
-use crate::cloud_auth::opaque_string::OpaqueString;
+use crate::opaque_string::OpaqueString;
 
 /// AWS authentication methods. This can be leveraged in component
 /// configuration objects for a consistent way to specify AWS auth information.

--- a/rust/otap-dataflow/crates/otap/src/lib.rs
+++ b/rust/otap-dataflow/crates/otap/src/lib.rs
@@ -51,6 +51,9 @@ pub mod otlp_http;
 /// Cloud specific auth utilities
 pub mod cloud_auth;
 
+/// Redacted string type for sensitive values.
+pub mod opaque_string;
+
 /// Object storage utilities including integrations for different cloud
 /// providers
 pub mod object_store;

--- a/rust/otap-dataflow/crates/otap/src/opaque_string.rs
+++ b/rust/otap-dataflow/crates/otap/src/opaque_string.rs
@@ -7,9 +7,17 @@ use std::ops::Deref;
 use serde::{Deserialize, Serialize};
 
 /// A string wrapper that redacts its value in Debug/Display output.
-#[derive(Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(transparent)]
 pub struct OpaqueString(String);
+
+impl OpaqueString {
+    /// Returns the underlying string, consuming the wrapper.
+    #[must_use]
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
 
 impl Deref for OpaqueString {
     type Target = str;

--- a/rust/otap-dataflow/crates/pdata/Cargo.toml
+++ b/rust/otap-dataflow/crates/pdata/Cargo.toml
@@ -32,6 +32,7 @@ simdutf8 = { workspace = true }
 serde = { workspace = true }
 serde_cbor = { workspace = true }
 replace_with = { workspace = true }
+sha2 = { workspace = true }
 smallvec = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/rust/otap-dataflow/crates/pdata/src/otap/transform.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/transform.rs
@@ -26,7 +26,9 @@ use datafusion::scalar::ScalarValue;
 use sha2::{Digest, Sha256};
 
 use crate::OtapArrowRecords;
-use crate::arrays::{NullableArrayAccessor, StringArrayAccessor, get_required_array, get_u8_array};
+use crate::arrays::{
+    ByteArrayAccessor, NullableArrayAccessor, StringArrayAccessor, get_required_array, get_u8_array,
+};
 use crate::error::{Error, Result};
 use crate::otap::filter::IdBitmap;
 use crate::otap::transform::transport_optimize::remove_transport_optimized_encodings;
@@ -3833,28 +3835,31 @@ fn is_hashable_scalar_value(attr_arrays: &AnyValueArrays<'_>, row: usize) -> boo
         AttributeValueType::Str => attr_arrays
             .attr_str
             .as_ref()
-            .and_then(|col| col.str_at(row))
-            .is_some(),
+            .map(|col| col.is_valid(row))
+            .unwrap_or_default(),
         AttributeValueType::Bool => attr_arrays
             .attr_bool
             .as_ref()
-            .and_then(|col| col.value_at(row))
-            .is_some(),
+            .map(|col| col.is_valid(row))
+            .unwrap_or_default(),
         AttributeValueType::Int => attr_arrays
             .attr_int
             .as_ref()
-            .and_then(|col| col.value_at(row))
-            .is_some(),
+            .map(|col| col.is_valid(row))
+            .unwrap_or_default(),
         AttributeValueType::Double => attr_arrays
             .attr_double
             .as_ref()
-            .and_then(|col| col.value_at(row))
-            .is_some(),
+            .map(|col| col.is_valid(row))
+            .unwrap_or_default(),
         AttributeValueType::Bytes => attr_arrays
             .attr_bytes
             .as_ref()
-            .and_then(|col| col.slice_at(row))
-            .is_some(),
+            .map(|col| match col {
+                ByteArrayAccessor::Binary(col) => col.is_valid(row),
+                ByteArrayAccessor::FixedSizeBinary(col) => col.is_valid(row),
+            })
+            .unwrap_or_default(),
         AttributeValueType::Empty | AttributeValueType::Map | AttributeValueType::Slice => false,
     }
 }

--- a/rust/otap-dataflow/crates/pdata/src/otap/transform.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/transform.rs
@@ -8,9 +8,9 @@ use std::ops::{AddAssign, Deref, Range};
 use std::sync::Arc;
 
 use arrow::array::{
-    Array, ArrayRef, ArrowNativeTypeOp, ArrowPrimitiveType, BooleanArray, DictionaryArray,
-    MutableArrayData, PrimitiveArray, PrimitiveBuilder, RecordBatch, StringArray, StructArray,
-    UInt16Array, UInt32Array, make_array,
+    Array, ArrayRef, ArrowNativeTypeOp, ArrowPrimitiveType, BooleanArray, BooleanBufferBuilder,
+    DictionaryArray, MutableArrayData, PrimitiveArray, PrimitiveBuilder, RecordBatch, StringArray,
+    StringBuilder, StructArray, UInt16Array, UInt32Array, make_array,
 };
 use arrow::buffer::{BooleanBuffer, Buffer, MutableBuffer, OffsetBuffer, ScalarBuffer};
 use arrow::compute::kernels::cmp::{eq, gt_eq, lt};
@@ -23,6 +23,7 @@ use arrow::row::{RowConverter, SortField};
 use arrow::util::bit_iterator::{BitIndexIterator, BitSliceIterator};
 use datafusion::logical_expr::ColumnarValue;
 use datafusion::scalar::ScalarValue;
+use sha2::{Digest, Sha256};
 
 use crate::OtapArrowRecords;
 use crate::arrays::{NullableArrayAccessor, StringArrayAccessor, get_required_array, get_u8_array};
@@ -768,6 +769,41 @@ impl UpdateTransform {
     }
 }
 
+pub struct HashSpec {
+    pub(super) salt: Vec<u8>,
+}
+
+impl HashSpec {
+    /// Create a SHA-256 hash spec.
+    ///
+    /// The hash input is `salt || value`, where scalar values are encoded as UTF-8 for strings,
+    /// raw bytes for byte arrays, a single `0` or `1` byte for booleans, and little-endian bytes
+    /// for `i64` and `f64` values.
+    #[must_use]
+    pub fn sha256(salt: String) -> Self {
+        Self {
+            salt: salt.into_bytes(),
+        }
+    }
+}
+
+/// A hash transform updates existing scalar attribute values with lowercase hex SHA-256 hashes.
+pub struct HashTransform {
+    pub(super) entries: BTreeMap<String, HashSpec>,
+}
+
+impl HashTransform {
+    #[must_use]
+    pub fn new(entries: BTreeMap<String, HashSpec>) -> Self {
+        Self { entries }
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
 pub struct RenameTransform {
     pub(super) map: BTreeMap<String, String>,
     pub(super) target_bytes: Vec<Vec<u8>>,
@@ -827,6 +863,8 @@ pub struct AttributesTransform {
 
     // rows that will be updated only when the key already exists
     pub update: Option<UpdateTransform>,
+    // rows that will be hashed if the key already exists and the value is scalar
+    pub hash: Option<HashTransform>,
 }
 
 impl AttributesTransform {
@@ -862,6 +900,13 @@ impl AttributesTransform {
     #[must_use]
     pub fn with_update(mut self, update: UpdateTransform) -> Self {
         self.update = Some(update);
+        self
+    }
+
+    /// Set the hash transform
+    #[must_use]
+    pub fn with_hash(mut self, hash: HashTransform) -> Self {
+        self.hash = Some(hash);
         self
     }
 
@@ -948,6 +993,16 @@ impl AttributesTransform {
             }
         }
 
+        if let Some(hash) = &self.hash {
+            for key in hash.entries.keys() {
+                if !all_keys.insert(key) {
+                    return Err(Error::InvalidAttributeTransform {
+                        reason: format!("Duplicate key in hash: {key}"),
+                    });
+                }
+            }
+        }
+
         Ok(())
     }
 }
@@ -978,6 +1033,8 @@ pub struct TransformStats {
     pub upserted_entries: u64,
     /// Exact number of attribute entries updated by update rules
     pub updated_entries: u64,
+    /// Exact number of attribute entries updated by hash rules
+    pub hashed_entries: u64,
 }
 
 /// Applies the supplied transformation to the OTAP batch, transforming the attributes specified by
@@ -1301,6 +1358,13 @@ pub fn transform_attributes_impl(
     let has_insert = transform.insert.as_ref().is_some_and(|i| !i.is_empty());
     let has_upsert = transform.upsert.as_ref().is_some_and(|u| !u.is_empty());
     let has_update = transform.update.as_ref().is_some_and(|u| !u.is_empty());
+    // Hashing rewrites scalar value columns. Two rows of different scalar types whose hash inputs
+    // collide (e.g. Bool(true) and Bytes([1]) both feed [1] into the hasher) become identical
+    // (type, key, value) tuples after hashing. If the parent_id column is still delta-encoded
+    // from the original (pre-hash) layout, downstream materialization will treat the second row
+    // as a delta neighbour and decode a wrong parent id. Force eager materialization so the
+    // parent_id column is plain-encoded before we mutate the values.
+    let has_hash = transform.hash.as_ref().is_some_and(|h| !h.is_empty());
 
     let schema = attrs_record_batch.schema();
     let key_column = get_required_array(attrs_record_batch, consts::ATTRIBUTE_KEY)?;
@@ -1320,15 +1384,15 @@ pub fn transform_attributes_impl(
     }
 
     // Check whether to eagerly materialize the parent_id column, which is needed if insert,
-    // upsert, or update is present. Insert/upsert need the full list of parents before any
-    // deletes, and update can change value equality in a way that invalidates
+    // upsert, update, or hash is present. Insert/upsert need the full list of parents before any
+    // deletes, and update/hash can change value equality in a way that invalidates
     // transport-optimized parent_id encoding.
     //
     // At the same time, set flag to check if the batch already has the transport optimized
     // encoding. This is used later to determine if we need to lazily materialize the parent_id
     // column because the transformation would break some sequences of encoded IDs.
     let has_renames = transform.rename.as_ref().is_some_and(|r| !r.map.is_empty());
-    let early_materialize_needed = (has_insert || has_upsert || has_update)
+    let early_materialize_needed = (has_insert || has_upsert || has_update || has_hash)
         && schema.column_with_name(consts::PARENT_ID).is_some();
     let (attrs_record_batch_cow, is_transport_optimized) = if early_materialize_needed {
         let rb = materialize_parent_id_for_attributes_auto(attrs_record_batch)?;
@@ -1417,6 +1481,7 @@ pub fn transform_attributes_impl(
                 inserted_entries: 0,
                 upserted_entries: 0,
                 updated_entries: 0,
+                hashed_entries: 0,
             };
             let new_keys = Arc::new(keys_transform_result.new_keys);
 
@@ -1493,6 +1558,7 @@ pub fn transform_attributes_impl(
                             inserted_entries: 0,
                             upserted_entries: 0,
                             updated_entries: 0,
+                            hashed_entries: 0,
                         },
                     )
                 }
@@ -1519,6 +1585,7 @@ pub fn transform_attributes_impl(
                             inserted_entries: 0,
                             upserted_entries: 0,
                             updated_entries: 0,
+                            hashed_entries: 0,
                         },
                     )
                 }
@@ -1606,13 +1673,17 @@ pub fn transform_attributes_impl(
     let update_transform = transform.update.as_ref();
     let needs_update = update_transform.map(|u| !u.is_empty()).unwrap_or_default();
 
-    if needs_insert || needs_upsert || needs_update {
+    let hash_transform = transform.hash.as_ref();
+    let needs_hash = hash_transform.map(|h| !h.is_empty()).unwrap_or_default();
+
+    if needs_insert || needs_upsert || needs_update || needs_hash {
         let parent_ids_col = get_required_array(attrs_record_batch, consts::PARENT_ID)?;
         rb = if parent_ids_col.data_type() == &DataType::UInt16 {
             apply_inserts_upserts_and_updates::<UInt16Type>(
                 insert_transform,
                 upsert_transform,
                 update_transform,
+                hash_transform,
                 id_column,
                 rb,
                 &mut stats,
@@ -1622,6 +1693,7 @@ pub fn transform_attributes_impl(
                 insert_transform,
                 upsert_transform,
                 update_transform,
+                hash_transform,
                 id_column,
                 rb,
                 &mut stats,
@@ -3546,6 +3618,7 @@ fn apply_inserts_upserts_and_updates<T: ArrowPrimitiveType>(
     insert_transform: Option<&InsertTransform>,
     upsert_transform: Option<&UpsertTransform>,
     update_transform: Option<&UpdateTransform>,
+    hash_transform: Option<&HashTransform>,
     id_column: &ArrayRef,
     attrs_record_batch: RecordBatch,
     stats: &mut TransformStats,
@@ -3562,7 +3635,12 @@ fn apply_inserts_upserts_and_updates<T: ArrowPrimitiveType>(
         .as_ref()
         .map(|u| u.entries.len())
         .unwrap_or(0);
-    let mut attr_upsert_args = Vec::with_capacity(num_inserts + num_upserts + num_updates);
+    let num_hashes = hash_transform
+        .as_ref()
+        .map(|h| h.entries.len())
+        .unwrap_or(0);
+    let mut attr_upsert_args =
+        Vec::with_capacity(num_inserts + num_upserts + num_updates + num_hashes);
 
     let mut parent_id_set = IdBitmap::new();
     populate_parent_id_set(&mut parent_id_set, id_column)?;
@@ -3670,7 +3748,219 @@ fn apply_inserts_upserts_and_updates<T: ArrowPrimitiveType>(
         }
     }
 
+    if let Some(hashes) = hash_transform {
+        let any_value_arrays = AnyValueArrays::try_from(&attrs_record_batch)?;
+        for (attrs_key, hash_spec) in &hashes.entries {
+            let existing_key_mask =
+                eq(&key_column, &StringArray::new_scalar(attrs_key)).map_err(|_| {
+                    Error::UnsupportedStringColumnType {
+                        data_type: key_column.data_type().clone(),
+                    }
+                })?;
+            let hashable_key_mask = hashable_scalar_key_mask(&existing_key_mask, &any_value_arrays);
+            let existing_parent_ids = filter(&parent_ids_col, &hashable_key_mask)
+                .map_err(|e| Error::ColumnLengthMismatch { source: e })?;
+            // TODO: avoid materializing parent IDs for update-only transforms once
+            // upsert_attributes can derive update counts without this scratch Vec.
+            let mut parent_ids = Vec::with_capacity(existing_parent_ids.len());
+            populate_parent_id_vec::<T>(&mut parent_ids, &existing_parent_ids)?;
+            if parent_ids.is_empty() {
+                continue;
+            }
+
+            let mut salted_hasher = Sha256::new();
+            salted_hasher.update(&hash_spec.salt);
+            let mut hashed_values =
+                StringBuilder::with_capacity(parent_ids.len(), parent_ids.len() * 64);
+            for row in BitIndexIterator::new(
+                hashable_key_mask.values().inner().as_slice(),
+                hashable_key_mask.offset(),
+                hashable_key_mask.len(),
+            ) {
+                append_hashed_scalar_value(
+                    &mut hashed_values,
+                    &any_value_arrays,
+                    row,
+                    &salted_hasher,
+                )?;
+            }
+
+            let hashed_values = Arc::new(hashed_values.finish()) as ArrayRef;
+            stats.hashed_entries += parent_ids.len() as u64;
+
+            attr_upsert_args.push(AttributeUpsert {
+                attrs_key,
+                existing_key_mask: hashable_key_mask,
+                new_values: ColumnarValue::Array(hashed_values),
+                upsert_parent_ids: PrimitiveArray::<T>::from_iter_values(parent_ids),
+            })
+        }
+    }
+
     upsert_attributes::upsert_attributes::<T>(&attrs_record_batch, &attr_upsert_args)
+}
+
+fn hashable_scalar_key_mask(
+    existing_key_mask: &BooleanArray,
+    attr_arrays: &AnyValueArrays<'_>,
+) -> BooleanArray {
+    let mut mask = BooleanBufferBuilder::new(existing_key_mask.len());
+    let mut next_row = 0;
+
+    for row in BitIndexIterator::new(
+        existing_key_mask.values().inner().as_slice(),
+        existing_key_mask.offset(),
+        existing_key_mask.len(),
+    ) {
+        mask.append_n(row - next_row, false);
+        mask.append(existing_key_mask.is_valid(row) && is_hashable_scalar_value(attr_arrays, row));
+        next_row = row + 1;
+    }
+    mask.append_n(existing_key_mask.len() - next_row, false);
+
+    BooleanArray::new(mask.finish(), None)
+}
+
+fn is_hashable_scalar_value(attr_arrays: &AnyValueArrays<'_>, row: usize) -> bool {
+    let Some(value_type) = attr_arrays.attr_type.value_at(row) else {
+        return false;
+    };
+    let Ok(value_type) = AttributeValueType::try_from(value_type) else {
+        return false;
+    };
+
+    match value_type {
+        AttributeValueType::Str => attr_arrays
+            .attr_str
+            .as_ref()
+            .and_then(|col| col.str_at(row))
+            .is_some(),
+        AttributeValueType::Bool => attr_arrays
+            .attr_bool
+            .as_ref()
+            .and_then(|col| col.value_at(row))
+            .is_some(),
+        AttributeValueType::Int => attr_arrays
+            .attr_int
+            .as_ref()
+            .and_then(|col| col.value_at(row))
+            .is_some(),
+        AttributeValueType::Double => attr_arrays
+            .attr_double
+            .as_ref()
+            .and_then(|col| col.value_at(row))
+            .is_some(),
+        AttributeValueType::Bytes => attr_arrays
+            .attr_bytes
+            .as_ref()
+            .and_then(|col| col.slice_at(row))
+            .is_some(),
+        AttributeValueType::Empty | AttributeValueType::Map | AttributeValueType::Slice => false,
+    }
+}
+
+fn append_hashed_scalar_value(
+    builder: &mut StringBuilder,
+    attr_arrays: &AnyValueArrays<'_>,
+    row: usize,
+    salted_hasher: &Sha256,
+) -> Result<()> {
+    let Some(value_type) = attr_arrays.attr_type.value_at(row) else {
+        builder.append_null();
+        return Ok(());
+    };
+    let Ok(value_type) = AttributeValueType::try_from(value_type) else {
+        builder.append_null();
+        return Ok(());
+    };
+
+    let mut hasher = salted_hasher.clone();
+    match value_type {
+        AttributeValueType::Str => {
+            if let Some(value) = attr_arrays
+                .attr_str
+                .as_ref()
+                .and_then(|col| col.str_at(row))
+            {
+                hasher.update(value.as_bytes());
+            } else {
+                builder.append_null();
+                return Ok(());
+            }
+        }
+        AttributeValueType::Bool => {
+            if let Some(value) = attr_arrays
+                .attr_bool
+                .as_ref()
+                .and_then(|col| col.value_at(row))
+            {
+                hasher.update([u8::from(value)]);
+            } else {
+                builder.append_null();
+                return Ok(());
+            }
+        }
+        AttributeValueType::Int => {
+            if let Some(value) = attr_arrays
+                .attr_int
+                .as_ref()
+                .and_then(|col| col.value_at(row))
+            {
+                hasher.update(value.to_le_bytes());
+            } else {
+                builder.append_null();
+                return Ok(());
+            }
+        }
+        AttributeValueType::Double => {
+            if let Some(value) = attr_arrays
+                .attr_double
+                .as_ref()
+                .and_then(|col| col.value_at(row))
+            {
+                hasher.update(value.to_le_bytes());
+            } else {
+                builder.append_null();
+                return Ok(());
+            }
+        }
+        AttributeValueType::Bytes => {
+            if let Some(value) = attr_arrays
+                .attr_bytes
+                .as_ref()
+                .and_then(|col| col.slice_at(row))
+            {
+                hasher.update(value);
+            } else {
+                builder.append_null();
+                return Ok(());
+            }
+        }
+        AttributeValueType::Empty | AttributeValueType::Map | AttributeValueType::Slice => {
+            builder.append_null();
+            return Ok(());
+        }
+    }
+
+    let digest = hasher.finalize();
+    append_sha256_hex_lower(builder, digest.as_ref());
+    Ok(())
+}
+
+fn append_sha256_hex_lower(builder: &mut StringBuilder, bytes: &[u8]) {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    debug_assert_eq!(bytes.len(), 32);
+
+    let mut out = [0_u8; 64];
+    for (index, byte) in bytes.iter().enumerate() {
+        let output_index = index * 2;
+        out[output_index] = HEX[(byte >> 4) as usize];
+        out[output_index + 1] = HEX[(byte & 0x0f) as usize];
+    }
+
+    // Hex digits are always valid UTF-8.
+    let hex = std::str::from_utf8(&out).expect("hex digest is valid utf-8");
+    builder.append_value(hex);
 }
 
 /// push the values from the array into the vec. Returns an error if the passed array
@@ -4698,6 +4988,7 @@ mod test {
                     ]))),
                     upsert: None,
                     update: None,
+                    hash: None,
                 },
                 (vec!["a", "b", "c", "d", "e"], vec!["1", "1", "3", "4", "5"]),
                 (vec!["a", "B", "c", "e"], vec!["1", "1", "3", "5"]),
@@ -4713,6 +5004,7 @@ mod test {
                     delete: None,
                     upsert: None,
                     update: None,
+                    hash: None,
                 },
                 (vec!["a", "b", "a", "d", "a"], vec!["1", "1", "3", "4", "5"]),
                 (vec!["A", "b", "A", "d", "A"], vec!["1", "1", "3", "4", "5"]),
@@ -4728,6 +5020,7 @@ mod test {
                     delete: None,
                     upsert: None,
                     update: None,
+                    hash: None,
                 },
                 (vec!["a", "b", "a", "d", "a"], vec!["1", "1", "3", "4", "5"]),
                 (
@@ -4746,6 +5039,7 @@ mod test {
                     delete: None,
                     upsert: None,
                     update: None,
+                    hash: None,
                 },
                 (
                     vec!["aaa", "b", "aaa", "d", "aaa"],
@@ -4764,6 +5058,7 @@ mod test {
                     delete: None,
                     upsert: None,
                     update: None,
+                    hash: None,
                 },
                 (
                     vec!["a", "b", "a", "a", "b", "a", "a"],
@@ -4785,6 +5080,7 @@ mod test {
                     delete: None,
                     upsert: None,
                     update: None,
+                    hash: None,
                 },
                 (
                     vec!["a", "a", "b", "c", "dd", "dd", "e"],
@@ -4806,6 +5102,7 @@ mod test {
                     delete: None,
                     upsert: None,
                     update: None,
+                    hash: None,
                 },
                 (
                     vec!["a", "a", "b", "dd", "e", "a", "dd"],
@@ -4824,6 +5121,7 @@ mod test {
                     delete: Some(DeleteTransform::new(BTreeSet::from_iter(vec!["a".into()]))),
                     upsert: None,
                     update: None,
+                    hash: None,
                 },
                 (vec!["a", "b", "a", "d", "a"], vec!["1", "1", "3", "4", "5"]),
                 (vec!["b", "d"], vec!["1", "4"]),
@@ -4836,6 +5134,7 @@ mod test {
                     delete: Some(DeleteTransform::new(BTreeSet::from_iter(vec!["a".into()]))),
                     upsert: None,
                     update: None,
+                    hash: None,
                 },
                 (
                     vec!["a", "a", "a", "b", "a", "a", "b", "b", "a", "a"],
@@ -4854,6 +5153,7 @@ mod test {
                     ]))),
                     upsert: None,
                     update: None,
+                    hash: None,
                 },
                 (
                     vec!["a", "a", "a", "b", "a", "a", "b", "c", "a", "a"],
@@ -4872,6 +5172,7 @@ mod test {
                     delete: Some(DeleteTransform::new(BTreeSet::from_iter(vec!["b".into()]))),
                     upsert: None,
                     update: None,
+                    hash: None,
                 },
                 (vec!["_", "a", "a", "b", "c"], vec!["1", "2", "3", "4", "5"]),
                 (vec!["_", "AAA", "AAA", "c"], vec!["1", "2", "3", "5"]),
@@ -4884,6 +5185,7 @@ mod test {
                     delete: Some(DeleteTransform::new(BTreeSet::from_iter(vec!["b".into()]))),
                     upsert: None,
                     update: None,
+                    hash: None,
                 },
                 (vec!["a", "a", "b", "c"], vec!["1", "2", "3", "4"]),
                 (vec!["a", "a", "c"], vec!["1", "2", "4"]),
@@ -4899,6 +5201,7 @@ mod test {
                     delete: Some(DeleteTransform::new(BTreeSet::from_iter(vec![]))),
                     upsert: None,
                     update: None,
+                    hash: None,
                 },
                 (vec!["a", "a", "b", "c"], vec!["1", "2", "3", "4"]),
                 (vec!["AAAA", "AAAA", "b", "c"], vec!["1", "2", "3", "4"]),
@@ -5113,6 +5416,7 @@ mod test {
                     delete: Some(DeleteTransform::new(BTreeSet::from_iter(vec!["k3".into()]))),
                     upsert: None,
                     update: None,
+                    hash: None,
                 },
             )
             .unwrap();
@@ -5237,6 +5541,349 @@ mod test {
     }
 
     #[test]
+    fn test_transform_attrs_hashes_scalar_values_only() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(consts::PARENT_ID, DataType::UInt16, false).with_plain_encoding(),
+            Field::new(consts::ATTRIBUTE_TYPE, DataType::UInt8, false),
+            Field::new(consts::ATTRIBUTE_KEY, DataType::Utf8, false),
+            Field::new(consts::ATTRIBUTE_STR, DataType::Utf8, true),
+            Field::new(consts::ATTRIBUTE_INT, DataType::Int64, true),
+            Field::new(consts::ATTRIBUTE_DOUBLE, DataType::Float64, true),
+            Field::new(consts::ATTRIBUTE_BOOL, DataType::Boolean, true),
+            Field::new(consts::ATTRIBUTE_BYTES, DataType::Binary, true),
+            Field::new(consts::ATTRIBUTE_SER, DataType::Binary, true),
+        ]));
+
+        let keys = [
+            "str_attr",
+            "bytes_attr",
+            "int_attr",
+            "double_attr",
+            "bool_attr",
+            "map_attr",
+            "array_attr",
+            "null_str_attr",
+        ];
+        let input = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(UInt16Array::from_iter_values(0..keys.len() as u16)),
+                Arc::new(UInt8Array::from_iter_values([
+                    AttributeValueType::Str as u8,
+                    AttributeValueType::Bytes as u8,
+                    AttributeValueType::Int as u8,
+                    AttributeValueType::Double as u8,
+                    AttributeValueType::Bool as u8,
+                    AttributeValueType::Map as u8,
+                    AttributeValueType::Slice as u8,
+                    AttributeValueType::Str as u8,
+                ])),
+                Arc::new(StringArray::from_iter_values(keys)),
+                Arc::new(StringArray::from_iter([
+                    Some("alice@example.com"),
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                ])),
+                Arc::new(Int64Array::from_iter([
+                    None,
+                    None,
+                    Some(514),
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                ])),
+                Arc::new(Float64Array::from_iter([
+                    None,
+                    None,
+                    None,
+                    Some(3.5),
+                    None,
+                    None,
+                    None,
+                    None,
+                ])),
+                Arc::new(BooleanArray::from_iter([
+                    None,
+                    None,
+                    None,
+                    None,
+                    Some(true),
+                    None,
+                    None,
+                    None,
+                ])),
+                Arc::new(BinaryArray::from_iter([
+                    None,
+                    Some(b"abc".as_slice()),
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                ])),
+                Arc::new(BinaryArray::from_iter([
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    Some(b"map".as_slice()),
+                    Some(b"slice".as_slice()),
+                    None,
+                ])),
+            ],
+        )
+        .unwrap();
+
+        let transform = AttributesTransform::default().with_hash(HashTransform::new(
+            keys.into_iter()
+                .map(|key| (key.into(), HashSpec::sha256("pepper".into())))
+                .collect(),
+        ));
+
+        let (result, stats) = transform_attributes_with_stats(
+            &input,
+            &(Arc::new(UInt16Array::new_null(1)) as ArrayRef),
+            &transform,
+        )
+        .unwrap();
+
+        assert_eq!(stats.hashed_entries, 5);
+
+        let result_parent_ids = get_u16_array(&result, consts::PARENT_ID).unwrap();
+        assert_eq!(
+            result_parent_ids,
+            &UInt16Array::from_iter_values(0..keys.len() as u16)
+        );
+
+        let result_types = get_u8_array(&result, consts::ATTRIBUTE_TYPE).unwrap();
+        assert_eq!(
+            result_types,
+            &UInt8Array::from_iter_values([
+                AttributeValueType::Str as u8,
+                AttributeValueType::Str as u8,
+                AttributeValueType::Str as u8,
+                AttributeValueType::Str as u8,
+                AttributeValueType::Str as u8,
+                AttributeValueType::Map as u8,
+                AttributeValueType::Slice as u8,
+                AttributeValueType::Str as u8,
+            ])
+        );
+
+        let result_keys = result
+            .column_by_name(consts::ATTRIBUTE_KEY)
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(result_keys, &StringArray::from_iter_values(keys));
+
+        let result_values =
+            StringArrayAccessor::try_new(result.column_by_name(consts::ATTRIBUTE_STR).unwrap())
+                .unwrap();
+        for (row, expected) in [
+            (
+                0,
+                Some("8b8d9adc4875c0dca816e3e17b7ac87b45e40945b731fa02e3b42bf101589e21"),
+            ),
+            (
+                1,
+                Some("fadf7b97406e1eaa259a82e26e6839e564c37c256876e060e17838c86b7275ef"),
+            ),
+            (
+                2,
+                Some("13ddda943275484b13d00c410ab1ee38dafb4b468904979f561aa7a5c8d11699"),
+            ),
+            (
+                3,
+                Some("3b25069b0582c48a0c401bb1f4fb6250de982cad1335473df46ca790ce41535e"),
+            ),
+            (
+                4,
+                Some("1c57981a8c749477991aa9772cd04531bb532f5c4965a69c498f044453a2d57a"),
+            ),
+            (5, None),
+            (6, None),
+            (7, None),
+        ] {
+            assert_eq!(result_values.str_at(row), expected);
+        }
+
+        assert!(result.column_by_name(consts::ATTRIBUTE_INT).is_none());
+        assert!(result.column_by_name(consts::ATTRIBUTE_DOUBLE).is_none());
+        assert!(result.column_by_name(consts::ATTRIBUTE_BOOL).is_none());
+        assert!(result.column_by_name(consts::ATTRIBUTE_BYTES).is_none());
+
+        let result_ser = result
+            .column_by_name(consts::ATTRIBUTE_SER)
+            .unwrap()
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .unwrap();
+        assert!(result_ser.is_null(0));
+        assert!(result_ser.is_null(4));
+        assert_eq!(result_ser.value(5), b"map");
+        assert_eq!(result_ser.value(6), b"slice");
+        assert!(result_ser.is_null(7));
+    }
+
+    /// Regression for the cross-type hash collision case: two rows that share the same key but
+    /// have different scalar types whose hash inputs are byte-for-byte identical (e.g.
+    /// `Bool(true)` encodes to `[1]` and `Bytes([1])` is also `[1]`) become identical
+    /// `(type, key, value)` tuples after hashing. If the parent_id column is still delta-encoded
+    /// from the original (pre-hash) layout, downstream materialization would treat the second
+    /// row as a delta neighbour and decode a wrong parent id, silently mis-attributing the
+    /// hashed attribute to the wrong log record.
+    ///
+    /// This test exercises the full OTAP transport-optimized round-trip. The middle log does
+    /// not have a `secret` attribute, so the two colliding `secret` rows have parent IDs 0 and
+    /// 2. Without eager materialization the second row would be wrongly delta-decoded to parent
+    /// ID 1 and assigned to the middle log.
+    #[test]
+    fn test_hash_materializes_transport_optimized_parent_ids_on_cross_type_collision() {
+        let input = vec![
+            LogRecord::build()
+                .event_name("event 1")
+                .attributes(vec![KeyValue::new("secret", AnyValue::new_bool(true))])
+                .finish(),
+            LogRecord::build()
+                .event_name("event 2")
+                .attributes(vec![KeyValue::new("other", AnyValue::new_string("keep"))])
+                .finish(),
+            LogRecord::build()
+                .event_name("event 3")
+                .attributes(vec![KeyValue::new("secret", AnyValue::new_bytes([1u8]))])
+                .finish(),
+        ];
+        let mut otap_batch = otlp_to_otap(&OtlpProtoMessage::Logs(to_logs_data(input)));
+        otap_batch.encode_transport_optimized().unwrap();
+
+        let _ = apply_attribute_transform(
+            &mut otap_batch,
+            ArrowPayloadType::LogAttrs,
+            &AttributesTransform::default().with_hash(HashTransform::new(
+                [("secret".into(), HashSpec::sha256("pepper".into()))].into(),
+            )),
+            false,
+        )
+        .unwrap();
+
+        let as_otlp = otap_to_otlp(&otap_batch);
+        let OtlpProtoMessage::Logs(logs_data) = as_otlp else {
+            panic!("invalid decode result {:?}", as_otlp)
+        };
+
+        let logs = &logs_data.resource_logs[0].scope_logs[0].log_records;
+        assert_eq!(logs.len(), 3);
+
+        // sha256("pepper" || [0x01]): identical for Bool(true) and Bytes([1]) under the
+        // current byte-encoding contract.
+        let expected_hash = "1c57981a8c749477991aa9772cd04531bb532f5c4965a69c498f044453a2d57a";
+        assert_eq!(
+            logs[0].attributes,
+            vec![KeyValue::new("secret", AnyValue::new_string(expected_hash))]
+        );
+        assert_eq!(
+            logs[1].attributes,
+            vec![KeyValue::new("other", AnyValue::new_string("keep"))]
+        );
+        assert_eq!(
+            logs[2].attributes,
+            vec![KeyValue::new("secret", AnyValue::new_string(expected_hash))]
+        );
+    }
+
+    #[test]
+    fn test_rename_hash_collisions_use_materialized_parent_ids() {
+        let input_schema = Arc::new(Schema::new(vec![
+            // Absence of encoding metadata means parent_id is transport optimized.
+            Field::new(consts::PARENT_ID, DataType::UInt16, false),
+            Field::new(consts::ATTRIBUTE_TYPE, DataType::UInt8, false),
+            Field::new(consts::ATTRIBUTE_KEY, DataType::Utf8, false),
+            Field::new(consts::ATTRIBUTE_STR, DataType::Utf8, true),
+        ]));
+        let expected_schema = Arc::new(Schema::new(vec![
+            Field::new(consts::PARENT_ID, DataType::UInt16, false).with_plain_encoding(),
+            Field::new(consts::ATTRIBUTE_TYPE, DataType::UInt8, false),
+            Field::new(consts::ATTRIBUTE_KEY, DataType::Utf8, false),
+            Field::new(
+                consts::ATTRIBUTE_STR,
+                DataType::Dictionary(Box::new(DataType::UInt16), Box::new(DataType::Utf8)),
+                true,
+            ),
+        ]));
+
+        let input = RecordBatch::try_new(
+            input_schema,
+            vec![
+                // Actual parent IDs after materialization are [1, 1, 2, 3]. Row 2 is
+                // delta-encoded because it has the same type/key/value as row 1.
+                Arc::new(UInt16Array::from_iter_values(vec![1, 1, 1, 3])),
+                Arc::new(UInt8Array::from_iter_values(std::iter::repeat_n(
+                    AttributeValueType::Str as u8,
+                    4,
+                ))),
+                Arc::new(StringArray::from_iter_values(vec!["a", "b", "b", "secret"])),
+                Arc::new(StringArray::from_iter_values(vec![
+                    "x",
+                    "y",
+                    "y",
+                    "top-secret",
+                ])),
+            ],
+        )
+        .unwrap();
+
+        let expected_hash = "96469852e535505423bdbb05c1b6cb6813daf6933cef6b23ba05de570a0f7879";
+        let expected = RecordBatch::try_new(
+            expected_schema,
+            vec![
+                Arc::new(UInt16Array::from_iter_values(vec![1, 2, 3])),
+                Arc::new(UInt8Array::from_iter_values(std::iter::repeat_n(
+                    AttributeValueType::Str as u8,
+                    3,
+                ))),
+                Arc::new(StringArray::from_iter_values(vec!["b", "b", "secret"])),
+                Arc::new(DictionaryArray::new(
+                    UInt16Array::from_iter_values([0, 1, 2]),
+                    Arc::new(StringArray::from_iter_values(["x", "y", expected_hash])),
+                )),
+            ],
+        )
+        .unwrap();
+
+        let result = transform_attributes(
+            &input,
+            &(Arc::new(UInt16Array::from_iter_values([1, 2, 3])) as ArrayRef),
+            &AttributesTransform {
+                insert: None,
+                rename: Some(RenameTransform::new(BTreeMap::from_iter([(
+                    "a".into(),
+                    "b".into(),
+                )]))),
+                delete: None,
+                upsert: None,
+                hash: Some(HashTransform::new(BTreeMap::from_iter([(
+                    "secret".into(),
+                    HashSpec::sha256("pepper".into()),
+                )]))),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
     fn test_transform_attrs_keys_dict_encoded() {
         let test_cases: Vec<(
             AttributesTransform,
@@ -5259,6 +5906,7 @@ mod test {
                     delete: Some(DeleteTransform::new(BTreeSet::from_iter(["b".into()]))),
                     upsert: None,
                     update: None,
+                    hash: None,
                 },
                 (
                     // keys column - dict keys
@@ -5303,6 +5951,7 @@ mod test {
                     delete: Some(DeleteTransform::new(BTreeSet::from_iter(["b".into()]))),
                     upsert: None,
                     update: None,
+                    hash: None,
                 },
                 (
                     // keys column - dict keys
@@ -5453,6 +6102,7 @@ mod test {
                 delete: Some(DeleteTransform::new(BTreeSet::from_iter(["b".into()]))),
                 upsert: None,
                 update: None,
+                hash: None,
             },
         )
         .unwrap();
@@ -5508,6 +6158,7 @@ mod test {
                 delete: Some(DeleteTransform::new(["a".into()].into_iter().collect())),
                 upsert: None,
                 update: None,
+                hash: None,
             },
         )
         .unwrap();
@@ -5552,6 +6203,7 @@ mod test {
                 delete: Some(DeleteTransform::new(["a".into()].into_iter().collect())),
                 upsert: None,
                 update: None,
+                hash: None,
             },
         )
         .unwrap();
@@ -5639,6 +6291,7 @@ mod test {
                 delete: Some(DeleteTransform::new(BTreeSet::from_iter(["b".into()]))),
                 upsert: None,
                 update: None,
+                hash: None,
             },
         )
         .unwrap();
@@ -5721,6 +6374,7 @@ mod test {
                 delete: Some(DeleteTransform::new(BTreeSet::from_iter(["b".into()]))),
                 upsert: None,
                 update: None,
+                hash: None,
             },
         )
         .unwrap();
@@ -5785,6 +6439,7 @@ mod test {
                 delete: Some(DeleteTransform::new(BTreeSet::from_iter(["b".into()]))),
                 upsert: None,
                 update: None,
+                hash: None,
             },
         )
         .unwrap();
@@ -5854,6 +6509,7 @@ mod test {
                 delete: Some(DeleteTransform::new(BTreeSet::from_iter(["b".into()]))),
                 upsert: None,
                 update: None,
+                hash: None,
             },
         )
         .unwrap();
@@ -5928,6 +6584,7 @@ mod test {
                 ]))),
                 upsert: None,
                 update: None,
+                hash: None,
             },
         )
         .unwrap();
@@ -6013,6 +6670,7 @@ mod test {
                 ]))),
                 upsert: None,
                 update: None,
+                hash: None,
             },
         )
         .unwrap();
@@ -6647,6 +7305,7 @@ mod test {
                 delete: None,
                 upsert: None,
                 update: None,
+                hash: None,
             },
             AttributesTransform {
                 insert: None,
@@ -6657,6 +7316,7 @@ mod test {
                 delete: None,
                 upsert: None,
                 update: None,
+                hash: None,
             },
             AttributesTransform {
                 insert: None,
@@ -6667,6 +7327,7 @@ mod test {
                 delete: Some(DeleteTransform::new(BTreeSet::from_iter(vec!["b".into()]))),
                 upsert: None,
                 update: None,
+                hash: None,
             },
             AttributesTransform {
                 insert: None,
@@ -6677,6 +7338,7 @@ mod test {
                 delete: Some(DeleteTransform::new(BTreeSet::from_iter(vec!["a".into()]))),
                 upsert: None,
                 update: None,
+                hash: None,
             },
         ];
 
@@ -6733,6 +7395,7 @@ mod test {
             )]))),
             upsert: None,
             update: None,
+            hash: None,
         };
 
         let (with_stats, stats) = transform_attributes_with_stats(
@@ -6795,6 +7458,7 @@ mod test {
             )]))),
             upsert: None,
             update: None,
+            hash: None,
         };
 
         let (with_stats, stats) = transform_attributes_with_stats(
@@ -7991,6 +8655,7 @@ mod insert_tests {
             )]))),
             upsert: None,
             update: None,
+            hash: None,
         };
 
         let ids: ArrayRef = Arc::new(UInt16Array::from_iter_values([0, 1]));
@@ -8067,6 +8732,7 @@ mod insert_tests {
             )]))),
             upsert: None,
             update: None,
+            hash: None,
         };
 
         let ids: ArrayRef = Arc::new(UInt16Array::from_iter_values([0, 1]));
@@ -8132,6 +8798,7 @@ mod insert_tests {
             )]))),
             upsert: None,
             update: None,
+            hash: None,
         };
 
         let ids: ArrayRef = Arc::new(UInt16Array::from_iter([Some(0), None, Some(1), None]));
@@ -8210,6 +8877,7 @@ mod insert_tests {
                 )]))),
                 upsert: None,
                 update: None,
+                hash: None,
             };
 
             let ids: ArrayRef = Arc::new(UInt32Array::from_iter_values([0, 1]));
@@ -8282,6 +8950,7 @@ mod insert_tests {
             )]))),
             upsert: None,
             update: None,
+            hash: None,
         };
 
         let ids: ArrayRef = Arc::new(UInt16Array::from_iter_values([0]));
@@ -8336,6 +9005,7 @@ mod insert_tests {
             )]))),
             upsert: None,
             update: None,
+            hash: None,
         };
 
         let ids: ArrayRef = Arc::new(UInt16Array::from_iter_values([0]));
@@ -8402,6 +9072,7 @@ mod insert_tests {
             ]))),
             upsert: None,
             update: None,
+            hash: None,
         };
 
         let ids: ArrayRef = Arc::new(UInt16Array::from_iter_values([0, 1]));
@@ -8455,6 +9126,7 @@ mod insert_tests {
             )]))),
             upsert: None,
             update: None,
+            hash: None,
         };
 
         let ids: ArrayRef = Arc::new(UInt16Array::from_iter_values([0]));
@@ -8514,6 +9186,7 @@ mod insert_tests {
             )]))),
             upsert: None,
             update: None,
+            hash: None,
         };
 
         let ids: ArrayRef = Arc::new(UInt16Array::from_iter_values([0]));
@@ -8570,6 +9243,7 @@ mod insert_tests {
             )]))),
             upsert: None,
             update: None,
+            hash: None,
         };
 
         let ids: ArrayRef = Arc::new(UInt16Array::from_iter_values([0]));
@@ -8628,6 +9302,7 @@ mod insert_tests {
             ]))),
             upsert: None,
             update: None,
+            hash: None,
         };
 
         let ids: ArrayRef = Arc::new(UInt16Array::from_iter_values([0]));
@@ -8680,6 +9355,7 @@ mod insert_tests {
             )]))),
             upsert: None,
             update: None,
+            hash: None,
         };
 
         let ids: ArrayRef = Arc::new(UInt16Array::from_iter_values([0]));
@@ -8732,6 +9408,7 @@ mod insert_tests {
             )]))),
             upsert: None,
             update: None,
+            hash: None,
         };
 
         let ids: ArrayRef = Arc::new(UInt16Array::from_iter_values([0]));
@@ -8788,6 +9465,7 @@ mod insert_tests {
             ]))),
             upsert: None,
             update: None,
+            hash: None,
         };
 
         let ids: ArrayRef = Arc::new(UInt16Array::from_iter_values([0]));
@@ -8819,6 +9497,7 @@ mod insert_tests {
             )]))),
             upsert: None,
             update: None,
+            hash: None,
         };
 
         let ids: ArrayRef = Arc::new(UInt16Array::from_iter_values([]));
@@ -8850,6 +9529,7 @@ mod insert_tests {
             )]))),
             upsert: None,
             update: None,
+            hash: None,
         };
 
         let ids: ArrayRef = Arc::new(UInt16Array::from_iter_values([0, 1]));
@@ -8925,6 +9605,7 @@ mod insert_tests {
             ]))),
             upsert: None,
             update: None,
+            hash: None,
         };
 
         let ids: ArrayRef = Arc::new(UInt16Array::from_iter_values([0, 1, 2]));
@@ -8971,6 +9652,7 @@ mod insert_tests {
             )]))),
             upsert: None,
             update: None,
+            hash: None,
         };
 
         let ids: ArrayRef = Arc::new(UInt32Array::from_iter_values([0, 1]));
@@ -9018,6 +9700,7 @@ mod insert_tests {
             )]))),
             upsert: None,
             update: None,
+            hash: None,
         };
 
         let ids: ArrayRef = Arc::new(UInt32Array::from_iter_values([0]));
@@ -9080,6 +9763,7 @@ mod upsert_tests {
                 LiteralValue::Str("new_val".into()),
             )]))),
             update: None,
+            hash: None,
         };
 
         let ids: ArrayRef = Arc::new(UInt16Array::from_iter_values([0]));
@@ -9135,6 +9819,7 @@ mod upsert_tests {
                 LiteralValue::Str("updated_value".into()),
             )]))),
             update: None,
+            hash: None,
         };
 
         let ids: ArrayRef = Arc::new(UInt16Array::from_iter_values([0]));
@@ -9201,6 +9886,7 @@ mod upsert_tests {
                 ("c".into(), LiteralValue::Str("new_c".into())),
             ]))),
             update: None,
+            hash: None,
         };
 
         let ids: ArrayRef = Arc::new(UInt16Array::from_iter_values([0, 1]));
@@ -9264,6 +9950,7 @@ mod upsert_tests {
                 LiteralValue::Str("prod".into()),
             )]))),
             update: None,
+            hash: None,
         };
 
         let ids: ArrayRef = Arc::new(UInt16Array::from_iter_values([0, 1]));
@@ -9329,6 +10016,7 @@ mod upsert_tests {
                 LiteralValue::Str("prod".into()),
             )]))),
             update: None,
+            hash: None,
         };
 
         let ids: ArrayRef = Arc::new(UInt16Array::from_iter([Some(0), None, Some(1), None]));
@@ -9407,6 +10095,7 @@ mod upsert_tests {
                     LiteralValue::Str("prod".into()),
                 )]))),
                 update: None,
+                hash: None,
             };
 
             let ids: ArrayRef = Arc::new(UInt32Array::from_iter_values([0, 1]));
@@ -9480,6 +10169,7 @@ mod upsert_tests {
                 LiteralValue::Int(100),
             )]))),
             update: None,
+            hash: None,
         };
 
         let ids: ArrayRef = Arc::new(UInt16Array::from_iter_values([0]));
@@ -9532,6 +10222,7 @@ mod upsert_tests {
                 LiteralValue::Double(2.5),
             )]))),
             update: None,
+            hash: None,
         };
 
         let ids: ArrayRef = Arc::new(UInt16Array::from_iter_values([0]));
@@ -9582,6 +10273,7 @@ mod upsert_tests {
                 LiteralValue::Bool(true),
             )]))),
             update: None,
+            hash: None,
         };
 
         let ids: ArrayRef = Arc::new(UInt16Array::from_iter_values([0]));
@@ -9637,6 +10329,7 @@ mod upsert_tests {
                 LiteralValue::Str("updated".into()),
             )]))),
             update: None,
+            hash: None,
         };
 
         let ids: ArrayRef = Arc::new(UInt16Array::from_iter_values([0]));
@@ -9707,6 +10400,7 @@ mod upsert_tests {
                 LiteralValue::Str("nval".into()),
             )]))),
             update: None,
+            hash: None,
         };
 
         let ids: ArrayRef = Arc::new(UInt16Array::from_iter_values([0]));
@@ -9765,6 +10459,7 @@ mod upsert_tests {
                 LiteralValue::Str("updated".into()),
             )]))),
             update: None,
+            hash: None,
         };
 
         let ids: ArrayRef = Arc::new(UInt16Array::from_iter_values([0, 1]));
@@ -9807,6 +10502,7 @@ mod upsert_tests {
                 LiteralValue::Str("val".into()),
             )]))),
             update: None,
+            hash: None,
         };
 
         let ids: ArrayRef = Arc::new(UInt16Array::from_iter_values([]));
@@ -9838,6 +10534,7 @@ mod upsert_tests {
                 LiteralValue::Str("val".into()),
             )]))),
             update: None,
+            hash: None,
         };
 
         let ids: ArrayRef = Arc::new(UInt16Array::from_iter_values([0, 1]));
@@ -9912,6 +10609,7 @@ mod upsert_tests {
                 LiteralValue::Str("updated".into()),
             )]))),
             update: None,
+            hash: None,
         };
 
         let ids: ArrayRef = Arc::new(UInt16Array::from_iter_values([0]));
@@ -9987,6 +10685,7 @@ mod upsert_tests {
                 LiteralValue::Str("2".into()),
             )]))),
             update: None,
+            hash: None,
         };
 
         let ids: ArrayRef = Arc::new(UInt16Array::from_iter_values([0, 1, 2]));
@@ -10108,6 +10807,7 @@ mod upsert_tests {
                 delete: Some(DeleteTransform::new(BTreeSet::from_iter(["c".into()]))),
                 upsert: None,
                 update: None,
+                hash: None,
             },
         )
         .unwrap();
@@ -10164,6 +10864,7 @@ mod upsert_tests {
                 delete: Some(DeleteTransform::new(BTreeSet::from_iter(["c".into()]))),
                 upsert: None,
                 update: None,
+                hash: None,
             },
         )
         .unwrap();
@@ -10260,6 +10961,7 @@ mod upsert_tests {
                 delete: Some(DeleteTransform::new(BTreeSet::from_iter(["c".into()]))),
                 upsert: None,
                 update: None,
+                hash: None,
             },
         )
         .unwrap();

--- a/rust/otap-dataflow/crates/pdata/src/otap/transform.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/transform.rs
@@ -4970,6 +4970,7 @@ mod test {
                     "other".into(),
                     LiteralValue::Str("updated".into()),
                 )]))),
+                hash: None,
             },
         )
         .unwrap();
@@ -5877,6 +5878,7 @@ mod test {
                 )]))),
                 delete: None,
                 upsert: None,
+                update: None,
                 hash: Some(HashTransform::new(BTreeMap::from_iter([(
                     "secret".into(),
                     HashSpec::sha256("pepper".into()),


### PR DESCRIPTION
# Change Summary

Adds support for the attributes processor `hash` action.

`hash` replaces existing scalar attribute values with lowercase hex SHA-256 hashes computed as `sha256(salt || value)`. It supports all scalar attribute types and leaves non-scalar or null value unchanged.

The implementation keeps hashing in the existing attribute mutation path, documents the byte encoding used for scalar values, redacts salts from debug output, and materializes transport-optimized attribute batches before rewriting values.

* Closes #3055 

## How are these changes tested?

  - `cargo +1.95 fmt --all`
  - `cargo +1.95 check -p otap-df-pdata`

## Are there any user-facing changes?

Yes. Users can configure a new attributes processor `hash` action to replace existing scalar attribute values with lowercase hex SHA-256 hashes. Non-scalar and null values are left unchanged.

```yaml
processors:
  attributes/hash:
    actions:
      - action: hash
        key: user.email
        algorithm: sha256
        salt: "${env:ATTRIBUTE_HASH_SALT}"
```