### PR TITLE
docs: improve logging macro guidance and event naming references

### DIFF
--- a/rust/otap-dataflow/crates/telemetry/README.md
+++ b/rust/otap-dataflow/crates/telemetry/README.md
@@ -61,7 +61,7 @@ There are internal macros defined in `otap_df_telemetry` with names
 `otel_info!`, `otel_warn!`, `otel_error!`, and `otel_debug!`. These
 macros all require a constant event-name string as the first argument;
 the event name must follow
-[OpenTelemetry Event naming conventions](../../../docs/telemetry/events-guide.md#event-naming)
+[OpenTelemetry Event naming conventions](../../docs/telemetry/events-guide.md#event-naming)
 (lowercase, dot-separated, stable, low-cardinality). The `target`
 (equivalent to OpenTelemetry `InstrumentationScope.name`) is
 automatically set to the crate name by these macros. Otherwise, they

--- a/rust/otap-dataflow/crates/telemetry/README.md
+++ b/rust/otap-dataflow/crates/telemetry/README.md
@@ -59,15 +59,24 @@ See the [telemetry-macros crate](../telemetry-macros) for details.
 
 There are internal macros defined in `otap_df_telemetry` with names
 `otel_info!`, `otel_warn!`, `otel_error!`, and `otel_debug!`. These
-macros all require a constant event-name string as the first argument,
-otherwise, they follow Tokio `tracing` syntax for key-value expressions.
+macros all require a constant event-name string as the first argument;
+the event name must follow
+[OpenTelemetry Event naming conventions](../../../docs/telemetry/events-guide.md#event-naming)
+(lowercase, dot-separated, stable, low-cardinality). The `target`
+(equivalent to OpenTelemetry `InstrumentationScope.name`) is
+automatically set to the crate name by these macros. Otherwise, they
+follow Tokio `tracing` syntax for key-value expressions.
 
 For example:
 
 ```rust
-use otap_df_telemetry::otel_error;
+use otap_df_telemetry::otel_info;
 
-otel_error!("bad configuration", error = ?err);
+otel_info!(
+    "syslog_cef_receiver.start",
+    protocol = "TCP",
+    listening_addr = tcp_config.listening_addr.to_string()
+);
 ```
 
 ## Internal telemetry collection

--- a/rust/otap-dataflow/docs/telemetry/events-guide.md
+++ b/rust/otap-dataflow/docs/telemetry/events-guide.md
@@ -50,7 +50,8 @@ All events MUST be emitted using the `otel_*` macros from the
   includes the file path and line number -- which is not durable and breaks
   filtering, alerting, and dashboards whenever code is moved or reformatted.
 - **Automatic `target`.** The wrappers set the tracing `target` field to the
-  crate name (`env!("CARGO_PKG_NAME")`) automatically. With raw `tracing`
+  crate name (`env!("CARGO_PKG_NAME")`) automatically. When exported via
+  OTLP, this becomes the `InstrumentationScope.name`. With raw `tracing`
   macros the default target is the module path, which is an internal
   implementation detail and can change without notice.
 
@@ -194,8 +195,9 @@ otel_info!("exporter.start",
 
 ## Event naming
 
-Event names MUST be low-cardinality and stable. Follow the semantic conventions
-guide for naming:
+Event names MUST be low-cardinality and stable. Follow the
+[semantic conventions guide](semantic-conventions-guide.md#event-naming) for
+naming:
 
 - Lowercase and dot-separated. It identifies a class of event, not an instance.
 - Keep the name stable and "type-like". Treat it as a schema identifier.


### PR DESCRIPTION
Improve the otel_* logging macro documentation to be accurate and consistent across docs.

- **telemetry README**: Document that event names must follow OTel Event naming conventions (with link to events guide). Note that target maps to InstrumentationScope.name and is auto-set to crate name. Replace the outdated example with a real call from the codebase.
- **events-guide**: Add that target becomes InstrumentationScope.name in OTLP export. Link the event naming section anchor to the semantic conventions guide.