### PR TITLE
task(comparison_dashboard): Update OTC sending queue default settings

### DIFF
--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/otelcol/otap-otap.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/otelcol/otap-otap.yaml.j2
@@ -13,6 +13,12 @@ exporters:
     arrow:
       payload_compression: {{ payload_compression | default("none") }}
       disabled: false
+    sending_queue:
+      enabled: {{ sending_queue_enabled | default(true) }}
+      wait_for_result: {{ wait_for_result | default(true) }}
+      block_on_overflow: {{ block_on_overflow | default(true) }}
+      sizer: {{ sending_queue_sizer | default("requests") }}
+      queue_size: {{ sending_queue_size | default(100) }}
 
 service:
   telemetry:

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/otelcol/otlp-attr-insert.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/otelcol/otlp-attr-insert.yaml.j2
@@ -17,6 +17,12 @@ exporters:
     compression: {{ compression_method | default("none") }}
     tls:
       insecure: true
+    sending_queue:
+      enabled: {{ sending_queue_enabled | default(true) }}
+      wait_for_result: {{ wait_for_result | default(true) }}
+      block_on_overflow: {{ block_on_overflow | default(true) }}
+      sizer: {{ sending_queue_sizer | default("requests") }}
+      queue_size: {{ sending_queue_size | default(100) }}
 
 service:
   telemetry:

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/otelcol/otlp-attr-rename.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/otelcol/otlp-attr-rename.yaml.j2
@@ -19,6 +19,12 @@ exporters:
     compression: {{ compression_method | default("none") }}
     tls:
       insecure: true
+    sending_queue:
+      enabled: {{ sending_queue_enabled | default(true) }}
+      wait_for_result: {{ wait_for_result | default(true) }}
+      block_on_overflow: {{ block_on_overflow | default(true) }}
+      sizer: {{ sending_queue_sizer | default("requests") }}
+      queue_size: {{ sending_queue_size | default(100) }}
 
 service:
   telemetry:

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/otelcol/otlp-otlp.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/otelcol/otlp-otlp.yaml.j2
@@ -12,10 +12,10 @@ exporters:
       insecure: true
     sending_queue:
       enabled: {{ sending_queue_enabled | default(true) }}
-      wait_for_result: {{ wait_for_result | default(false) }}
-      block_on_overflow: {{ block_on_overflow | default(false) }}
+      wait_for_result: {{ wait_for_result | default(true) }}
+      block_on_overflow: {{ block_on_overflow | default(true) }}
       sizer: {{ sending_queue_sizer | default("requests") }}
-      queue_size: {{ sending_queue_size | default(1000) }}
+      queue_size: {{ sending_queue_size | default(100) }}
 
 service:
   telemetry:

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/otelcol/otlp-otlp.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/otelcol/otlp-otlp.yaml.j2
@@ -10,6 +10,12 @@ exporters:
     compression: {{ compression_method | default("none") }}
     tls:
       insecure: true
+    sending_queue:
+      enabled: {{ sending_queue_enabled | default(true) }}
+      wait_for_result: {{ wait_for_result | default(false) }}
+      block_on_overflow: {{ block_on_overflow | default(false) }}
+      sizer: {{ sending_queue_sizer | default("requests") }}
+      queue_size: {{ sending_queue_size | default(1000) }}
 
 service:
   telemetry:

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/otelcol/otlp-transform-insert.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/otelcol/otlp-transform-insert.yaml.j2
@@ -18,6 +18,12 @@ exporters:
     compression: {{ compression_method | default("none") }}
     tls:
       insecure: true
+    sending_queue:
+      enabled: {{ sending_queue_enabled | default(true) }}
+      wait_for_result: {{ wait_for_result | default(true) }}
+      block_on_overflow: {{ block_on_overflow | default(true) }}
+      sizer: {{ sending_queue_sizer | default("requests") }}
+      queue_size: {{ sending_queue_size | default(100) }}
 
 service:
   telemetry:

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/otelcol/otlp-transform-rename-replace.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/otelcol/otlp-transform-rename-replace.yaml.j2
@@ -18,6 +18,12 @@ exporters:
     compression: {{ compression_method | default("none") }}
     tls:
       insecure: true
+    sending_queue:
+      enabled: {{ sending_queue_enabled | default(true) }}
+      wait_for_result: {{ wait_for_result | default(true) }}
+      block_on_overflow: {{ block_on_overflow | default(true) }}
+      sizer: {{ sending_queue_sizer | default("requests") }}
+      queue_size: {{ sending_queue_size | default(100) }}
 
 service:
   telemetry:

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/otelcol/otlp-transform-rename.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/otelcol/otlp-transform-rename.yaml.j2
@@ -19,6 +19,12 @@ exporters:
     compression: {{ compression_method | default("none") }}
     tls:
       insecure: true
+    sending_queue:
+      enabled: {{ sending_queue_enabled | default(true) }}
+      wait_for_result: {{ wait_for_result | default(true) }}
+      block_on_overflow: {{ block_on_overflow | default(true) }}
+      sizer: {{ sending_queue_sizer | default("requests") }}
+      queue_size: {{ sending_queue_size | default(100) }}
 
 service:
   telemetry:

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/otelcol/otlphttp-otlphttp.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/templates/otelcol/otlphttp-otlphttp.yaml.j2
@@ -9,6 +9,12 @@ exporters:
     endpoint: 'http://{{backend_hostname}}:1235'
     tls:
       insecure: true
+    sending_queue:
+      enabled: {{ sending_queue_enabled | default(true) }}
+      wait_for_result: {{ wait_for_result | default(true) }}
+      block_on_overflow: {{ block_on_overflow | default(true) }}
+      sizer: {{ sending_queue_sizer | default("requests") }}
+      queue_size: {{ sending_queue_size | default(100) }}
 
 service:
   telemetry:


### PR DESCRIPTION
# Change Summary

Updates sending queue settings for OTC to make for a fairer comparison.

## What issue does this PR close?

* Closes #3088

## How are these changes tested?

Initial results show a possible slight improvement which is interesting.

  | Suite    | Rate | Mode      | Produced | Received | Drop %  | CPU avg % | RAM max (MiB) |
  |----------|------|-----------|---------:|---------:|--------:|----------:|--------------:|
  | otlp     | 200k | queue-cfg | 202,290  | 197,103  |    2.56 |      26.9 |            54 |
  | otlp     | 200k | baseline  | 201,901  | 198,794  |    2.56 |      26.9 |            60 |
  | otap     | 200k | queue-cfg | 197,579  | 198,706  |   -0.05 |      95.8 |           148 |
  | otap     | 200k | baseline  | 187,793  | 177,178  |    7.11 |     100.2 |           137 |
  | otlphttp | 200k | queue-cfg | 203,055  | 198,945  |    2.56 |      64.0 |            68 |
  | otlphttp | 200k | baseline  | 207,940  | 196,510  |    5.00 |      76.1 |            80 |

## Are there any user-facing changes?

No.