### PR TITLE
Tighten flow_metrics attribute naming to follow repo conventions

### DIFF
--- a/rust/otap-dataflow/configs/fake-flow-metrics-demo.yaml
+++ b/rust/otap-dataflow/configs/fake-flow-metrics-demo.yaml
@@ -44,13 +44,13 @@ groups:
           telemetry:
             runtime_metrics: normal
             flow_metrics:
-              - name: ingest_pipeline
+              - id: ingest_pipeline
                 bounds:
                   start_node: sampler
                   end_node: attr4
                 # metrics is optional
                 # if omitted, all supported metrics are recorded
-                metrics: [ compute_duration, signals_incoming, signals_outgoing ]
+                metrics: [compute_duration, signals_incoming, signals_outgoing]
 
         nodes:
           receiver:

--- a/rust/otap-dataflow/crates/config/src/policy.rs
+++ b/rust/otap-dataflow/crates/config/src/policy.rs
@@ -280,8 +280,8 @@ pub struct TelemetryPolicy {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct FlowMetricConfig {
-    /// User-facing name for this flow metric, used as a metric attribute.
-    pub name: String,
+    /// User-facing identifier for this flow metric, used as a metric attribute.
+    pub id: String,
     /// Processor node bounds for this flow metric.
     pub bounds: FlowBounds,
     /// Metrics to enable. Omitted means all metrics are enabled.
@@ -865,7 +865,7 @@ mod tests {
     fn flow_metrics_omitted_metrics_enable_all() {
         let yaml = r#"
             flow_metrics:
-              - name: flow1
+              - id: flow1
                 bounds: { start_node: a, end_node: b }
         "#;
         let policy: super::TelemetryPolicy = serde_yaml::from_str(yaml).expect("parse");
@@ -880,7 +880,7 @@ mod tests {
     fn flow_metrics_explicit_subset_is_honored() {
         let yaml = r#"
             flow_metrics:
-              - name: flow1
+              - id: flow1
                 bounds: { start_node: a, end_node: b }
                 metrics: [compute_duration]
         "#;
@@ -896,7 +896,7 @@ mod tests {
         let policies = Policies {
             telemetry: Some(super::TelemetryPolicy {
                 flow_metrics: vec![super::FlowMetricConfig {
-                    name: "flow1".to_string(),
+                    id: "flow1".to_string(),
                     bounds: super::FlowBounds {
                         start_node: "a".to_string(),
                         end_node: "b".to_string(),
@@ -920,7 +920,7 @@ mod tests {
         let policies = Policies {
             telemetry: Some(super::TelemetryPolicy {
                 flow_metrics: vec![super::FlowMetricConfig {
-                    name: "flow1".to_string(),
+                    id: "flow1".to_string(),
                     bounds: super::FlowBounds {
                         start_node: "a".to_string(),
                         end_node: "b".to_string(),

--- a/rust/otap-dataflow/crates/engine/src/flow_metrics.rs
+++ b/rust/otap-dataflow/crates/engine/src/flow_metrics.rs
@@ -59,14 +59,14 @@ pub struct FlowSignalsOutgoingMetrics {
 #[attribute_set(name = "flow.attrs")]
 #[derive(Debug, Clone, Default, Hash)]
 pub struct FlowAttributeSet {
-    /// User-given flow name.
-    #[attribute(key = "flow.name")]
-    pub flow_name: Cow<'static, str>,
+    /// User-given flow identifier.
+    #[attribute(key = "flow.id")]
+    pub flow_id: Cow<'static, str>,
     /// Name of the processor node where the measurement begins.
-    #[attribute(key = "flow.start_node")]
+    #[attribute(key = "flow.node.start")]
     pub start_node: Cow<'static, str>,
     /// Name of the processor node where the measurement ends.
-    #[attribute(key = "flow.end_node")]
+    #[attribute(key = "flow.node.end")]
     pub end_node: Cow<'static, str>,
     /// Pipeline attributes.
     #[compose]
@@ -249,14 +249,14 @@ pub(crate) fn build_flow_metric_state(
         let (Some(start_idx), Some(end_idx)) = (start_idx, end_idx) else {
             return Err(invalid_flow_metric_config(format!(
                 "flow metric `{}` references unknown node(s): start=`{}`, end=`{}`",
-                flow_config.name, flow_config.bounds.start_node, flow_config.bounds.end_node
+                flow_config.id, flow_config.bounds.start_node, flow_config.bounds.end_node
             )));
         };
 
         if !processor_indices.contains(&start_idx) || !processor_indices.contains(&end_idx) {
             return Err(invalid_flow_metric_config(format!(
                 "flow metric `{}` start/end nodes must be processors: start=`{}`, end=`{}`",
-                flow_config.name, flow_config.bounds.start_node, flow_config.bounds.end_node
+                flow_config.id, flow_config.bounds.start_node, flow_config.bounds.end_node
             )));
         }
 
@@ -267,12 +267,12 @@ pub(crate) fn build_flow_metric_state(
         {
             return Err(invalid_flow_metric_config(format!(
                 "flow metric `{}` overlaps with another flow metric (non-overlapping ranges only): start=`{}`, end=`{}`",
-                flow_config.name, flow_config.bounds.start_node, flow_config.bounds.end_node
+                flow_config.id, flow_config.bounds.start_node, flow_config.bounds.end_node
             )));
         }
 
         let attrs = FlowAttributeSet {
-            flow_name: Cow::Owned(flow_config.name.clone()),
+            flow_id: Cow::Owned(flow_config.id.clone()),
             start_node: Cow::Owned(flow_config.bounds.start_node.clone()),
             end_node: Cow::Owned(flow_config.bounds.end_node.clone()),
             pipeline_attrs: pipeline_attrs.clone(),
@@ -301,7 +301,7 @@ pub(crate) fn build_flow_metric_state(
         signals_outgoing_metrics.push(signals_outgoing_metric);
         let _ = end_nodes.insert(end_idx, id);
         let _ = start_nodes.insert(start_idx, id);
-        resolved_ranges.push((start_idx, end_idx, flow_config.name.clone()));
+        resolved_ranges.push((start_idx, end_idx, flow_config.id.clone()));
     }
 
     // Validate that flow_metric ranges don't interleave with each other.
@@ -559,7 +559,7 @@ mod tests {
 
     fn sw(name: &str, start: &str, stop: &str) -> FlowMetricConfig {
         FlowMetricConfig {
-            name: name.to_string(),
+            id: name.to_string(),
             bounds: FlowBounds {
                 start_node: start.to_string(),
                 end_node: stop.to_string(),

--- a/rust/otap-dataflow/crates/engine/src/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/processor.rs
@@ -1253,7 +1253,7 @@ mod tests {
     async fn flow_metric_auto_measures_process_without_timed() {
         let (pipeline_ctx, _) = crate::testing::test_pipeline_ctx();
         let attrs = FlowAttributeSet {
-            flow_name: "auto_measure".into(),
+            flow_id: "auto_measure".into(),
             start_node: "auto_measure_processor".into(),
             end_node: "auto_measure_processor".into(),
             pipeline_attrs: pipeline_ctx.pipeline_attribute_set(),


### PR DESCRIPTION
# Change Summary

Observed a few deviations from common practices in the repo in the `flow` implementation. This PR updates the standard metric attributes attached to all flow metrics:
- `flow.name` -> `flow.id` (to be more in line with `node.id`)
- `flow.start_node` -> `flow.node.start` (attribute labels normally use dot notation)
- `flow.end_node` -> `flow.node.end` (same)

In addition, updated the user-facing yaml contract from `name` -> `id` to match the attribute set.

Another motivation for this is an offline conversation with @jmacd in which he described flows as `virtual nodes`. That is the main motivation for changing `name` to `id`, to bring it in closer parity with node telemetry.

## What issue does this PR close?

N/A, minor fix not tracked in an issue

## How are these changes tested?

Tests

## Are there any user-facing changes?

This is a one-time breaking change in the config declaration of flows, which should be low-impact since it is such a new capability.
