### PR TITLE
fix(comparison_dashboard): Fix landing page backpressure detection for a comparison

### DIFF
--- a/tools/comparison_dashboard/shared/app.js
+++ b/tools/comparison_dashboard/shared/app.js
@@ -257,6 +257,20 @@ function hasBackpressure(metricsArray, loadgenRate) {
   return false;
 }
 
+// Single source of truth for whether any test in a comparison currently
+// shows backpressure. Drives both the landing-page legend and the
+// per-comparison chart legend so they cannot disagree.
+function anyComparisonBackpressure(suiteData, comparison) {
+  const tests = comparison.tests || [];
+  return (comparison.suites || []).some((r) => {
+    const suiteTests = getSuiteTests(suiteData, r.slug);
+    return tests.some((ct) => {
+      const t = suiteTests.find((x) => x.name === ct.name);
+      return t && hasBackpressure(t.metrics, ct.loadgen_rate);
+    });
+  });
+}
+
 function buildComparisonChartData(suiteData, comparison, tests, selectedMetric) {
   const refs = comparison.suites || [];
   const origIdx = comparison._originalIndices || null;
@@ -732,7 +746,7 @@ function renderComparisonSection(suiteData, comparison) {
   const optsHtml = metrics.map((n) => `<option value="${escapeHtml(n)}" ${n === sel ? "selected" : ""}>${escapeHtml(metricTitle(n, suiteData, filtered))}</option>`).join("");
   const hasFilters = Object.keys(categories).length > 0;
   const filterHtml = hasFilters ? buildFilterHtml(categories, filterState) : "";
-  const anyBP = (filtered.suites || []).some((r) => getSuiteTests(suiteData, r.slug).some((t) => { const rm = t.name.match(/^(\d+)k$/); return hasBackpressure(t.metrics, rm ? parseInt(rm[1])*1000 : null); }));
+  const anyBP = anyComparisonBackpressure(suiteData, filtered);
   const bpHtml = anyBP ? '<div class="chart-backpressure-legend">\u26A0 Backpressure detected</div>' : "";
   const link = `${encodeURIComponent(slug)}/`;
   return `
@@ -765,16 +779,7 @@ function wireComparisonSection(suiteData, comparison) {
       activeCharts.set(slug, createBarChart(canvas, suiteData, filtered, tests, sel));
     }
     const bpEl = section.querySelector(".chart-backpressure-legend");
-    if (bpEl) {
-      const anyBP = (filtered.suites || []).some((r) => {
-        const suiteTests = getSuiteTests(suiteData, r.slug);
-        return tests.some((ct) => {
-          const t = suiteTests.find((x) => x.name === ct.name);
-          return t && hasBackpressure(t.metrics, ct.loadgen_rate);
-        });
-      });
-      bpEl.style.display = anyBP ? "" : "none";
-    }
+    if (bpEl) bpEl.style.display = anyComparisonBackpressure(suiteData, filtered) ? "" : "none";
   }
 
   const fc = section.querySelector(".chart-filters");
@@ -851,13 +856,7 @@ function renderComparisonChart(suiteData, comparison, tests, onBarClick) {
     if (ref && ct) onBarClick(datasetIndex, ct.name);
   } : null;
 
-  const anyBP = (comparison.suites || []).some((r) => {
-    const suiteTests = getSuiteTests(suiteData, r.slug);
-    return tests.some((ct) => {
-      const t = suiteTests.find((x) => x.name === ct.name);
-      return t && hasBackpressure(t.metrics, ct.loadgen_rate);
-    });
-  });
+  const anyBP = anyComparisonBackpressure(suiteData, comparison);
   const bpHtml = anyBP ? '<div class="chart-backpressure-legend">\u26A0 Backpressure detected</div>' : "";
 
   if (comparison.suites.length === 0) {

--- a/tools/comparison_dashboard/shared/app.js
+++ b/tools/comparison_dashboard/shared/app.js
@@ -257,9 +257,8 @@ function hasBackpressure(metricsArray, loadgenRate) {
   return false;
 }
 
-// Single source of truth for whether any test in a comparison currently
-// shows backpressure. Drives both the landing-page legend and the
-// per-comparison chart legend so they cannot disagree.
+// Determines whether any test in a comparison currently shows backpressure. 
+// Drives both the landing-page legend.
 function anyComparisonBackpressure(suiteData, comparison) {
   const tests = comparison.tests || [];
   return (comparison.suites || []).some((r) => {


### PR DESCRIPTION
# Change Summary

Pull out backpressure detection for a comparison to a helper - There was already a helper for backpressure detection for a test, but not for an entire comparison which determines when the warning sign is displayed in the legend.

## What issue does this PR close?

* Closes #3109

## How are these changes tested?

<img width="2333" height="712" alt="image" src="https://github.com/user-attachments/assets/03a1335d-3d13-4275-b08a-0f299ee703d5" />

## Are there any user-facing changes?

No