### PR TITLE
chore(clippy): Fix random clippy warning on channel.rs

### DIFF
--- a/rust/otap-dataflow/crates/control-channel/src/channel.rs
+++ b/rust/otap-dataflow/crates/control-channel/src/channel.rs
@@ -943,14 +943,6 @@ mod sender_waiters_tests {
     use std::sync::{Arc, Mutex};
     use std::task::{Wake, Waker};
 
-    struct NoopWake;
-
-    impl Wake for NoopWake {
-        fn wake(self: Arc<Self>) {}
-
-        fn wake_by_ref(self: &Arc<Self>) {}
-    }
-
     struct RecordingWake {
         id: usize,
         wake_log: Arc<Mutex<Vec<usize>>>,
@@ -973,7 +965,7 @@ mod sender_waiters_tests {
     }
 
     fn noop_waker() -> Waker {
-        Waker::from(Arc::new(NoopWake))
+        Waker::noop().clone()
     }
 
     #[test]


### PR DESCRIPTION
# Change Summary

Address clippy error seen in unrelated CI runs: https://github.com/open-telemetry/otel-arrow/actions/runs/26595755792/job/78366180074?pr=3123

> error: manual implementation of a no-op waker
   --> crates/control-channel/src/channel.rs:948:10
    |
948 |     impl Wake for NoopWake {
    |          ^^^^
    |
    = help: use `std::task::Waker::noop()` instead
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#manual_noop_waker
    = note: `-D clippy::manual-noop-waker` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::manual_noop_waker)]`

> error: could not compile `otap-df-control-channel` (lib test) due to 1 previous error
> warning: build failed, waiting for other jobs to finish...
> Error: Process completed with exit code 101.

## What issue does this PR close?

N/A

## How are these changes tested?

N/A

## Are there any user-facing changes?

No

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
