### PR TITLE
chore(labels): Don't add release label on every PR with changelog entry

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -29,7 +29,6 @@ ci-repo:
 release:
   - changed-files:
       - any-glob-to-any-file:
-          - "**/.chloggen/**"
           - "**/CHANGELOG.md"
           - "RELEASING.md"
           - ".github/workflows/prepare-release.yml"


### PR DESCRIPTION
# Change Summary

Small fix for an issue observed on #3058

`release` shouldn't be labeled when a changelog entry is added, that would be a large percentage of PRs.

## What issue does this PR close?

N/A

## How are these changes tested?

N/A

## Are there any user-facing changes?

No

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
