### PR TITLE
fix: logical expression evaluation correctness fixes

### DIFF
--- a/rust/otap-dataflow/.chloggen/3003-otap-query-engine-logical-expr-correctness-fixes.yaml
+++ b/rust/otap-dataflow/.chloggen/3003-otap-query-engine-logical-expr-correctness-fixes.yaml
@@ -1,4 +1,4 @@
 change_type: bug_fix
 component: query-engine
-note: Resolves handful fo correctness issues in the otap query-engine related to logical expression evaluation
+note: Resolves handful of correctness issues in the otap query-engine related to logical expression evaluation
 issues: [ 3003 ]

--- a/rust/otap-dataflow/.chloggen/3003-otap-query-engine-logical-expr-correctness-fixes.yaml
+++ b/rust/otap-dataflow/.chloggen/3003-otap-query-engine-logical-expr-correctness-fixes.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: query-engine
+note: Resolves handful fo correctness issues in the otap query-engine related to logical expression evaluation
+issues: [ 3003 ]

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
@@ -181,6 +181,7 @@ impl From<&ColumnAccessor> for DataScope {
 ///
 /// The dual-mode design allows chains of boolean operations to stay in ID bitmap space without
 /// materializing intermediate arrays.
+#[derive(Debug)]
 pub(crate) enum ScopedExpr {
     /// Leaf: evaluate an expression on a specific data scope (RecordBatch).
     ///
@@ -197,6 +198,12 @@ pub(crate) enum ScopedExpr {
     JoinAndEval {
         children: Vec<ScopedExpr>,
         eval: LeafEval,
+
+        /// Whether to default a child that evaluates to null to a null array when evaluating the
+        /// leaf expression. Normally, if some child evaluates to null, we propagate the null by
+        /// having this expr node evaluate to null as well. However, some expressions may have
+        /// special null handling semantics where they expect the null value to be passed.
+        default_null_children: bool,
     },
 
     /// Combine two boolean-producing children via IdMask bitmap intersection (AND).
@@ -291,6 +298,11 @@ pub(crate) enum LeafEval {
         /// treated as "passes" rather than "fails". This is set to true for `is_null()`
         /// expressions, where a missing field means the field IS null — which is a match.
         missing_data_passes: bool,
+
+        /// Whether to align the result of the expression to the root record batch. This adds
+        /// extra overhead, but sometimes it is necessary in cases where we can
+        /// TODO comment comment blah blah
+        align_to_root: bool,
     },
 
     /// A batch-level predicate that evaluates a property of the entire `OtapArrowRecords`
@@ -323,10 +335,12 @@ impl LeafEval {
             projection,
             projection_opts: ProjectionOptions {
                 downcast_dicts: requires_dict_downcast,
+                ..Default::default()
             },
             eval_anyval_as_struct: true,
             attr_key_case_sensitive: true,
             missing_data_passes: false,
+            align_to_root: false,
         })
     }
 
@@ -346,10 +360,12 @@ impl LeafEval {
             projection,
             projection_opts: ProjectionOptions {
                 downcast_dicts: requires_dict_downcast,
+                ..Default::default()
             },
             eval_anyval_as_struct,
             attr_key_case_sensitive,
             missing_data_passes,
+            align_to_root: false,
         })
     }
 }
@@ -526,12 +542,12 @@ mod test {
         // severity_number > 14
         let mut op = root_eval(col(consts::SEVERITY_NUMBER).gt(lit(14i32)));
 
-        let mask = op
+        let result = op
             .execute_as_id_mask(&otap, &session_ctx, &mut pool)
             .unwrap();
 
         // exactly one row (index 1) passes
-        match &mask {
+        match &result.mask {
             IdMask::Some(bitmap) => {
                 // the root batch should have id values [0, 1, 2]
                 // only id=1 (severity_number=17) passes
@@ -583,10 +599,10 @@ mod test {
         }
 
         // execute_as_id_mask: should return IdMask::All
-        let mask = op
+        let result = op
             .execute_as_id_mask(&otap, &session_ctx, &mut pool)
             .unwrap();
-        assert_eq!(mask, IdMask::All);
+        assert_eq!(result.mask, IdMask::All);
     }
 
     #[test]
@@ -604,10 +620,10 @@ mod test {
             other => panic!("expected false scalar, got {other:?}"),
         }
 
-        let mask = op
+        let result = op
             .execute_as_id_mask(&otap, &session_ctx, &mut pool)
             .unwrap();
-        assert_eq!(mask, IdMask::None);
+        assert_eq!(result.mask, IdMask::None);
     }
 
     #[test]
@@ -650,6 +666,7 @@ mod test {
 
         let mut op = ScopedExpr::JoinAndEval {
             children: vec![left_child, right_child],
+            default_null_children: false,
             eval: LeafEval::new_df_expr(
                 Expr::BinaryExpr(datafusion::logical_expr::BinaryExpr::new(
                     Box::new(col(arg_column_name(0))),
@@ -695,11 +712,11 @@ mod test {
         let mut op = ScopedExpr::BitmapAnd(Box::new(left), Box::new(right));
 
         // test execute_as_id_mask
-        let mask = op
+        let result = op
             .execute_as_id_mask(&otap, &session_ctx, &mut pool)
             .unwrap();
 
-        match &mask {
+        match &result.mask {
             IdMask::Some(bitmap) => {
                 assert!(bitmap.contains(0));
                 assert!(!bitmap.contains(1));
@@ -748,11 +765,11 @@ mod test {
 
         let mut op = ScopedExpr::BitmapOr(Box::new(left), Box::new(right));
 
-        let mask = op
+        let result = op
             .execute_as_id_mask(&otap, &session_ctx, &mut pool)
             .unwrap();
 
-        match &mask {
+        match &result.mask {
             IdMask::Some(bitmap) => {
                 assert!(bitmap.contains(0));
                 assert!(!bitmap.contains(1));
@@ -776,11 +793,11 @@ mod test {
         let inner = root_eval(col(consts::SEVERITY_TEXT).eq(lit("WARN")));
         let mut op = ScopedExpr::BitmapNot(Box::new(inner));
 
-        let mask = op
+        let result = op
             .execute_as_id_mask(&otap, &session_ctx, &mut pool)
             .unwrap();
 
-        match &mask {
+        match &result.mask {
             IdMask::NotSome(bitmap) => {
                 // NotSome means "everything except what's in the bitmap"
                 // The inner produced Some({0, 2}), so NOT is NotSome({0, 2})
@@ -836,11 +853,11 @@ mod test {
         let inner_and = ScopedExpr::BitmapAnd(Box::new(attr_namespace), Box::new(attr_line));
         let mut op = ScopedExpr::BitmapAnd(Box::new(inner_and), Box::new(severity));
 
-        let mask = op
+        let result = op
             .execute_as_id_mask(&otap, &session_ctx, &mut pool)
             .unwrap();
 
-        match &mask {
+        match &result.mask {
             IdMask::Some(bitmap) => {
                 assert!(bitmap.contains(0), "row 0 should match");
                 assert!(!bitmap.contains(1), "row 1 should not match");

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
@@ -199,11 +199,22 @@ pub(crate) enum ScopedExpr {
         children: Vec<ScopedExpr>,
         eval: LeafEval,
 
-        /// Whether to default a child that evaluates to null to a null array when evaluating the
-        /// leaf expression. Normally, if some child evaluates to null, we propagate the null by
-        /// having this expr node evaluate to null as well. However, some expressions may have
-        /// special null handling semantics where they expect the null value to be passed.
+        /// Whether to produce a null placeholder when some child evaluates to `None`, likely due
+        /// to some optional column used by an expression not being present.
+        ///
+        /// Ordinarily, we propagate what equates to a null value by having this expression node
+        /// also evaluate to `None`. However, some expressions may have special null handling
+        /// semantics where they expect the null value to be passed.
         default_null_children: bool,
+
+        /// Whether to force the children to be aligned to the root row order before joining the
+        /// results.
+        ///
+        /// When this is false, the expression evaluation will attempt to choose the most
+        /// appropriate join type to avoid reordering the child results if possible. Setting this
+        /// flag overrides the dynamic join choice and forces root alignment when combining the
+        /// child results.
+        align_children_to_root: bool,
     },
 
     /// Combine two boolean-producing children via IdMask bitmap intersection (AND).
@@ -298,11 +309,6 @@ pub(crate) enum LeafEval {
         /// treated as "passes" rather than "fails". This is set to true for `is_null()`
         /// expressions, where a missing field means the field IS null — which is a match.
         missing_data_passes: bool,
-
-        /// Whether to align the result of the expression to the root record batch. This adds
-        /// extra overhead, but sometimes it is necessary in cases where we can
-        /// TODO comment comment blah blah
-        align_to_root: bool,
     },
 
     /// A batch-level predicate that evaluates a property of the entire `OtapArrowRecords`
@@ -340,7 +346,6 @@ impl LeafEval {
             eval_anyval_as_struct: true,
             attr_key_case_sensitive: true,
             missing_data_passes: false,
-            align_to_root: false,
         })
     }
 
@@ -365,7 +370,6 @@ impl LeafEval {
             eval_anyval_as_struct,
             attr_key_case_sensitive,
             missing_data_passes,
-            align_to_root: false,
         })
     }
 }
@@ -667,6 +671,7 @@ mod test {
         let mut op = ScopedExpr::JoinAndEval {
             children: vec![left_child, right_child],
             default_null_children: false,
+            align_children_to_root: false,
             eval: LeafEval::new_df_expr(
                 Expr::BinaryExpr(datafusion::logical_expr::BinaryExpr::new(
                     Box::new(col(arg_column_name(0))),

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/bitmap.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/bitmap.rs
@@ -121,14 +121,12 @@ pub fn combine_scope(left: Option<DataScope>, right: Option<DataScope>) -> Optio
     // which point to different ID columns on the root record batch).
     #[cfg(debug_assertions)]
     {
-        match (&left, &right) {
-            (
-                Some(DataScope::Attribute(l_attr_id, _) | DataScope::AttributesAll(l_attr_id)),
-                Some(DataScope::Attribute(r_attr_id, _) | DataScope::AttributesAll(r_attr_id)),
-            ) => {
-                debug_assert!(l_attr_id == r_attr_id);
-            }
-            _ => {}
+        if let (
+            Some(DataScope::Attribute(l_attr_id, _) | DataScope::AttributesAll(l_attr_id)),
+            Some(DataScope::Attribute(r_attr_id, _) | DataScope::AttributesAll(r_attr_id)),
+        ) = (&left, &right)
+        {
+            debug_assert!(l_attr_id == r_attr_id);
         }
     }
 

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/bitmap.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/bitmap.rs
@@ -24,6 +24,11 @@ use crate::pipeline::id_mask::IdMask;
 use super::eval::{eval_datafusion_expr_value, invert_id_mask, join_and_eval_value};
 use super::{LeafEval, ScopedExpr, ScopedValue};
 
+pub struct ScopedIdMask {
+    pub scope: Option<DataScope>,
+    pub mask: IdMask,
+}
+
 impl ScopedExpr {
     /// Produce an `IdMask` (bitmap of IDs that matched).
     ///
@@ -35,46 +40,80 @@ impl ScopedExpr {
         otap_batch: &OtapArrowRecords,
         session_ctx: &SessionContext,
         pool: &mut IdBitmapPool,
-    ) -> Result<IdMask> {
+    ) -> Result<ScopedIdMask> {
         match self {
             Self::Eval { scope, eval } => {
                 execute_eval_as_id_mask(scope, eval, otap_batch, session_ctx, pool)
             }
-            Self::JoinAndEval { children, eval } => execute_join_and_eval_as_id_mask(
+            Self::JoinAndEval {
+                children,
+                eval,
+                default_null_children,
+            } => execute_join_and_eval_as_id_mask(
                 children.as_mut_slice(),
                 eval,
+                *default_null_children,
                 otap_batch,
                 session_ctx,
                 pool,
             ),
             Self::BitmapAnd(left, right) => {
-                let left_mask = left.execute_as_id_mask(otap_batch, session_ctx, pool)?;
+                let left_result = left.execute_as_id_mask(otap_batch, session_ctx, pool)?;
 
                 // short-circuit: if left is None, the AND result is None regardless of right
-                if left_mask == IdMask::None {
-                    return Ok(IdMask::None);
+                if left_result.mask == IdMask::None {
+                    return Ok(ScopedIdMask {
+                        mask: IdMask::None,
+                        scope: None,
+                    });
                 }
 
-                let right_mask = right.execute_as_id_mask(otap_batch, session_ctx, pool)?;
-                Ok(left_mask.combine_and(right_mask, pool))
+                let right_result = right.execute_as_id_mask(otap_batch, session_ctx, pool)?;
+                let scope = combine_scope(left_result.scope, right_result.scope);
+                Ok(ScopedIdMask {
+                    scope,
+                    mask: left_result.mask.combine_and(right_result.mask, pool),
+                })
             }
             Self::BitmapOr(left, right) => {
-                let left_mask = left.execute_as_id_mask(otap_batch, session_ctx, pool)?;
+                let left_result = left.execute_as_id_mask(otap_batch, session_ctx, pool)?;
 
                 // short-circuit: if left is All, the OR result is All regardless of right
-                if left_mask == IdMask::All {
-                    return Ok(IdMask::All);
+                if left_result.mask == IdMask::All {
+                    return Ok(ScopedIdMask {
+                        mask: IdMask::All,
+                        scope: None,
+                    });
                 }
 
-                let right_mask = right.execute_as_id_mask(otap_batch, session_ctx, pool)?;
-                Ok(left_mask.combine_or(right_mask, pool))
+                let right_result = right.execute_as_id_mask(otap_batch, session_ctx, pool)?;
+                let scope = combine_scope(left_result.scope, right_result.scope);
+                Ok(ScopedIdMask {
+                    scope,
+                    mask: left_result.mask.combine_or(right_result.mask, pool),
+                })
             }
             Self::BitmapNot(child) => {
-                let child_mask = child.execute_as_id_mask(otap_batch, session_ctx, pool)?;
-                Ok(invert_id_mask(child_mask))
+                let child_result = child.execute_as_id_mask(otap_batch, session_ctx, pool)?;
+                Ok(ScopedIdMask {
+                    mask: invert_id_mask(child_result.mask),
+                    scope: child_result.scope,
+                })
             }
         }
     }
+}
+
+pub fn combine_scope(left: Option<DataScope>, right: Option<DataScope>) -> Option<DataScope> {
+    if left.is_none() {
+        return right;
+    }
+
+    if right.is_none() {
+        return left;
+    }
+
+    left
 }
 
 /// Execute an `Eval` node as an IdMask.
@@ -84,43 +123,66 @@ fn execute_eval_as_id_mask(
     otap_batch: &OtapArrowRecords,
     session_ctx: &SessionContext,
     pool: &mut IdBitmapPool,
-) -> Result<IdMask> {
-    match eval {
+) -> Result<ScopedIdMask> {
+    let (mask, scope) = match eval {
         LeafEval::BatchPredicate(predicate) => {
-            if predicate.evaluate(otap_batch) {
-                Ok(IdMask::All)
+            let mask = if predicate.evaluate(otap_batch) {
+                IdMask::All
             } else {
-                Ok(IdMask::None)
-            }
+                IdMask::None
+            };
+            (mask, None)
         }
         LeafEval::DatafusionExpr { .. } => {
             // evaluate as value first, then convert to IdMask
             let value_result = eval_datafusion_expr_value(scope, eval, otap_batch, session_ctx)?;
 
             match value_result {
-                None => Ok(IdMask::None), // missing data, nothing matches
-                Some(sv) => scoped_value_to_id_mask(sv, otap_batch, pool),
+                None => (
+                    IdMask::None, // missing data, nothing matches
+                    None,
+                ),
+                Some(sv) => {
+                    let scope = sv.scope.clone();
+                    let mask = scoped_value_to_id_mask(sv, otap_batch, pool)?;
+                    (mask, Some(scope))
+                }
             }
         }
-    }
+    };
+
+    Ok(ScopedIdMask { scope, mask })
 }
 
 /// Execute a `JoinAndEval` node as an IdMask.
 fn execute_join_and_eval_as_id_mask(
     children: &mut [ScopedExpr],
     eval: &mut LeafEval,
+    default_null_children: bool,
     otap_batch: &OtapArrowRecords,
     session_ctx: &SessionContext,
     pool: &mut IdBitmapPool,
-) -> Result<IdMask> {
+) -> Result<ScopedIdMask> {
     // JoinAndEval always materializes values (the join requires actual arrays),
     // then converts the boolean result to an IdMask.
-    let value_result = join_and_eval_value(children, eval, otap_batch, session_ctx)?;
+    let value_result = join_and_eval_value(
+        children,
+        eval,
+        default_null_children,
+        otap_batch,
+        session_ctx,
+    )?;
 
-    match value_result {
-        None => Ok(IdMask::None),
-        Some(sv) => scoped_value_to_id_mask(sv, otap_batch, pool),
-    }
+    let (mask, scope) = match value_result {
+        None => (IdMask::None, None),
+        Some(sv) => {
+            let scope = sv.scope.clone();
+            let mask = scoped_value_to_id_mask(sv, otap_batch, pool)?;
+            (mask, Some(scope))
+        }
+    };
+
+    Ok(ScopedIdMask { scope, mask })
 }
 
 /// Convert a `ScopedValue` containing a boolean result into an `IdMask`.

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/bitmap.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/bitmap.rs
@@ -49,10 +49,12 @@ impl ScopedExpr {
                 children,
                 eval,
                 default_null_children,
+                align_children_to_root,
             } => execute_join_and_eval_as_id_mask(
                 children.as_mut_slice(),
                 eval,
                 *default_null_children,
+                *align_children_to_root,
                 otap_batch,
                 session_ctx,
                 pool,
@@ -159,6 +161,7 @@ fn execute_join_and_eval_as_id_mask(
     children: &mut [ScopedExpr],
     eval: &mut LeafEval,
     default_null_children: bool,
+    align_children_to_root: bool,
     otap_batch: &OtapArrowRecords,
     session_ctx: &SessionContext,
     pool: &mut IdBitmapPool,
@@ -169,6 +172,7 @@ fn execute_join_and_eval_as_id_mask(
         children,
         eval,
         default_null_children,
+        align_children_to_root,
         otap_batch,
         session_ctx,
     )?;

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/bitmap.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/bitmap.rs
@@ -115,6 +115,23 @@ pub fn combine_scope(left: Option<DataScope>, right: Option<DataScope>) -> Optio
         return left;
     }
 
+    // if left != right, we've got a planning error because we shouldn't be trying to combine
+    // ID bitmaps from different scopes. This would mean we're combining IdMasks for parent IDs
+    // that are associated with different ID columns (e.g. parent_ids from Root Attrs/Scope Attrs
+    // which point to different ID columns on the root record batch).
+    #[cfg(debug_assertions)]
+    {
+        match (&left, &right) {
+            (
+                Some(DataScope::Attribute(l_attr_id, _) | DataScope::AttributesAll(l_attr_id)),
+                Some(DataScope::Attribute(r_attr_id, _) | DataScope::AttributesAll(r_attr_id)),
+            ) => {
+                debug_assert!(l_attr_id == r_attr_id);
+            }
+            _ => {}
+        }
+    }
+
     left
 }
 

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
@@ -839,7 +839,7 @@ fn align_value_to_root(value: ScopedValue, otap_batch: &OtapArrowRecords) -> Res
     let left_input = JoinInput::new(
         ColumnarValue::Array(Arc::new(NullArray::new(root_batch.num_rows()))),
         Rc::new(DataScope::Root),
-        &root_batch,
+        root_batch,
     );
 
     let right_input = scoped_value_to_join_input(value, otap_batch)?;

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
@@ -63,7 +63,6 @@ impl ScopedExpr {
         otap_batch: &OtapArrowRecords,
         session_ctx: &SessionContext,
     ) -> Result<Option<ScopedValue>> {
-        println!("executing {self:?}");
         match self {
             Self::Eval { scope, eval } => {
                 eval_datafusion_expr_value(scope, eval, otap_batch, session_ctx)
@@ -72,10 +71,12 @@ impl ScopedExpr {
                 children,
                 eval,
                 default_null_children,
+                align_children_to_root,
             } => join_and_eval_value(
                 children.as_mut_slice(),
                 eval,
                 *default_null_children,
+                *align_children_to_root,
                 otap_batch,
                 session_ctx,
             ),
@@ -135,7 +136,6 @@ pub(super) fn eval_datafusion_expr_value(
             eval_anyval_as_struct,
             attr_key_case_sensitive,
             missing_data_passes,
-            align_to_root,
         } => {
             // resolve the source RecordBatch for this scope
             let source_rb = match scope {
@@ -218,17 +218,11 @@ pub(super) fn eval_datafusion_expr_value(
                 )?
             };
 
-            let mut result = ScopedValue::new(
+            let result = ScopedValue::new(
                 coerce_nulls_for_predicate(result_vals, *missing_data_passes),
                 scope.clone(),
                 &source_rb,
             );
-
-            if *align_to_root {
-                result = align_value_to_root(result, otap_batch)?;
-            }
-
-            // println!("result of eval = {:#?}", result);
 
             Ok(Some(result))
         }
@@ -253,6 +247,7 @@ pub(super) fn join_and_eval_value(
     children: &mut [ScopedExpr],
     eval: &mut LeafEval,
     default_null_children: bool,
+    align_children_to_root: bool,
     otap_batch: &OtapArrowRecords,
     session_ctx: &SessionContext,
 ) -> Result<Option<ScopedValue>> {
@@ -260,7 +255,13 @@ pub(super) fn join_and_eval_value(
     let mut child_results = Vec::with_capacity(children.len());
     for child in children.iter_mut() {
         let result = match child.execute_as_value(otap_batch, session_ctx)? {
-            Some(result) => result,
+            Some(mut result) => {
+                // align children to root if configured to do so
+                if align_children_to_root && matches!(result.values, ColumnarValue::Array(_)) {
+                    result = align_value_to_root(result, otap_batch)?;
+                }
+                result
+            }
             None => {
                 if default_null_children {
                     ScopedValue::new_scalar(ScalarValue::Null)
@@ -269,6 +270,7 @@ pub(super) fn join_and_eval_value(
                 }
             }
         };
+
         child_results.push(result)
     }
 
@@ -277,8 +279,6 @@ pub(super) fn join_and_eval_value(
         .into_iter()
         .map(|sv| scoped_value_to_join_input(sv, otap_batch))
         .collect::<Result<Vec<_>>>()?;
-
-    println!("join inputs = {join_inputs:?}");
 
     // perform the join
     // TODO in the future we should consolidate join strategy so multi-join is the only option.
@@ -297,7 +297,6 @@ pub(super) fn join_and_eval_value(
         eval_anyval_as_struct,
         attr_key_case_sensitive: _,
         missing_data_passes,
-        align_to_root,
     } = eval
     else {
         // TODO - technically we could evaluate the batch predicate w/out joining. It would be
@@ -340,15 +339,6 @@ pub(super) fn join_and_eval_value(
         DataScope::clone(&result_scope),
         &joined_rb,
     );
-
-    // println!("result before join = {:#?}", result);
-
-    if *align_to_root {
-        // println!("doing realignment");
-        result = align_value_to_root(result, otap_batch)?;
-    }
-
-    // println!("result of join = {:#?}", result);
 
     Ok(Some(result))
 }
@@ -849,7 +839,6 @@ fn maybe_downcast_dicts(batch: RecordBatch, opts: &ProjectionOptions) -> Result<
 }
 
 fn align_value_to_root(value: ScopedValue, otap_batch: &OtapArrowRecords) -> Result<ScopedValue> {
-    println!("in alignment value = {value:?}");
     let root_batch = match otap_batch.root_record_batch() {
         Some(rb) => rb,
         None => return Ok(value),

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
@@ -16,8 +16,8 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use arrow::array::{
-    Array, ArrayRef, AsArray, BooleanArray, BooleanBufferBuilder, RecordBatch, StringArray,
-    StructArray, UInt16Array,
+    Array, ArrayRef, AsArray, BooleanArray, BooleanBufferBuilder, NullArray, RecordBatch,
+    StringArray, StructArray, UInt16Array,
 };
 use arrow::buffer::BooleanBuffer;
 use arrow::compute::filter_record_batch;
@@ -36,9 +36,11 @@ use otap_df_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
 use otap_df_pdata::schema::consts;
 
 use crate::error::{Error, Result};
+use crate::pipeline::expr::bitmap::combine_scope;
 use crate::pipeline::expr::join::{JoinInput, join, multi_join};
 use crate::pipeline::expr::{
     DataScope, LeafEval, SCALAR_RECORD_BATCH_INPUT, ScopedExpr, ScopedValue, VALUE_COLUMN_NAME,
+    arg_column_name,
 };
 use crate::pipeline::id_mask::IdMask;
 use crate::pipeline::planner::AttributesIdentifier;
@@ -61,13 +63,22 @@ impl ScopedExpr {
         otap_batch: &OtapArrowRecords,
         session_ctx: &SessionContext,
     ) -> Result<Option<ScopedValue>> {
+        println!("executing {self:?}");
         match self {
             Self::Eval { scope, eval } => {
                 eval_datafusion_expr_value(scope, eval, otap_batch, session_ctx)
             }
-            Self::JoinAndEval { children, eval } => {
-                join_and_eval_value(children.as_mut_slice(), eval, otap_batch, session_ctx)
-            }
+            Self::JoinAndEval {
+                children,
+                eval,
+                default_null_children,
+            } => join_and_eval_value(
+                children.as_mut_slice(),
+                eval,
+                *default_null_children,
+                otap_batch,
+                session_ctx,
+            ),
             Self::BitmapAnd(left, right) => {
                 execute_bitmap_and_as_value(left, right, otap_batch, session_ctx)
             }
@@ -124,6 +135,7 @@ pub(super) fn eval_datafusion_expr_value(
             eval_anyval_as_struct,
             attr_key_case_sensitive,
             missing_data_passes,
+            align_to_root,
         } => {
             // resolve the source RecordBatch for this scope
             let source_rb = match scope {
@@ -184,6 +196,12 @@ pub(super) fn eval_datafusion_expr_value(
                 source_rb.as_ref().clone()
             };
 
+            println!("In eval - source RB:");
+            arrow::util::pretty::print_batches(&[source_rb.as_ref().clone()]).unwrap();
+
+            println!("In eval - projected RB:");
+            arrow::util::pretty::print_batches(&[projected_rb.clone()]).unwrap();
+
             // check for AnyValue struct columns that need resolution
             let any_value_indices = find_any_value_columns(projected_rb.schema_ref());
 
@@ -200,11 +218,19 @@ pub(super) fn eval_datafusion_expr_value(
                 )?
             };
 
-            Ok(Some(ScopedValue::new(
+            let mut result = ScopedValue::new(
                 coerce_nulls_for_predicate(result_vals, *missing_data_passes),
                 scope.clone(),
                 &source_rb,
-            )))
+            );
+
+            if *align_to_root {
+                result = align_value_to_root(result, otap_batch)?;
+            }
+
+            // println!("result of eval = {:#?}", result);
+
+            Ok(Some(result))
         }
 
         LeafEval::BatchPredicate(predicate) => {
@@ -226,30 +252,40 @@ pub(super) fn eval_datafusion_expr_value(
 pub(super) fn join_and_eval_value(
     children: &mut [ScopedExpr],
     eval: &mut LeafEval,
+    default_null_children: bool,
     otap_batch: &OtapArrowRecords,
     session_ctx: &SessionContext,
 ) -> Result<Option<ScopedValue>> {
     // evaluate all children
     let mut child_results = Vec::with_capacity(children.len());
     for child in children.iter_mut() {
-        match child.execute_as_value(otap_batch, session_ctx)? {
-            Some(result) => child_results.push(result),
-            None => return Ok(None), // if any child is absent, the whole expression is null
-        }
+        let result = match child.execute_as_value(otap_batch, session_ctx)? {
+            Some(result) => result,
+            None => {
+                if default_null_children {
+                    ScopedValue::new_scalar(ScalarValue::Null)
+                } else {
+                    return Ok(None); // if any child is absent, the whole expression is null
+                }
+            }
+        };
+        child_results.push(result)
     }
 
     // convert ScopedValues to JoinInputs for the join boundary
-    let eval_results: Vec<JoinInput> = child_results
+    let join_inputs: Vec<JoinInput> = child_results
         .into_iter()
         .map(|sv| scoped_value_to_join_input(sv, otap_batch))
         .collect::<Result<Vec<_>>>()?;
 
+    println!("join inputs = {join_inputs:?}");
+
     // perform the join
     // TODO in the future we should consolidate join strategy so multi-join is the only option.
-    let (joined_rb, result_scope) = if eval_results.len() == 2 {
-        join(&eval_results[0], &eval_results[1], otap_batch)?
+    let (joined_rb, result_scope) = if join_inputs.len() == 2 {
+        join(&join_inputs[0], &join_inputs[1], otap_batch)?
     } else {
-        multi_join(&eval_results, otap_batch)?
+        multi_join(&join_inputs, otap_batch)?
     };
 
     // evaluate the expression on the joined RecordBatch
@@ -261,6 +297,7 @@ pub(super) fn join_and_eval_value(
         eval_anyval_as_struct,
         attr_key_case_sensitive: _,
         missing_data_passes,
+        align_to_root,
     } = eval
     else {
         // TODO - technically we could evaluate the batch predicate w/out joining. It would be
@@ -277,6 +314,12 @@ pub(super) fn join_and_eval_value(
         None => return Ok(None),
     };
 
+    println!("In join - joined RB:");
+    arrow::util::pretty::print_batches(&[joined_rb.clone()]).unwrap();
+
+    println!("In join - projected RB:");
+    arrow::util::pretty::print_batches(&[projected_rb.clone()]).unwrap();
+
     // handle AnyValue columns
     let any_value_indices = find_any_value_columns(projected_rb.schema_ref());
     let result_vals = if any_value_indices.is_empty() || *eval_anyval_as_struct {
@@ -292,11 +335,22 @@ pub(super) fn join_and_eval_value(
         )?
     };
 
-    Ok(Some(ScopedValue::new(
+    let mut result = ScopedValue::new(
         coerce_nulls_for_predicate(result_vals, *missing_data_passes),
         DataScope::clone(&result_scope),
         &joined_rb,
-    )))
+    );
+
+    // println!("result before join = {:#?}", result);
+
+    if *align_to_root {
+        // println!("doing realignment");
+        result = align_value_to_root(result, otap_batch)?;
+    }
+
+    // println!("result of join = {:#?}", result);
+
+    Ok(Some(result))
 }
 
 fn coerce_nulls_for_predicate(
@@ -338,16 +392,17 @@ fn execute_bitmap_and_as_value(
     session_ctx: &SessionContext,
 ) -> Result<Option<ScopedValue>> {
     let mut pool = IdBitmapPool::new();
-    let left_mask = left.execute_as_id_mask(otap_batch, session_ctx, &mut pool)?;
+    let left_result = left.execute_as_id_mask(otap_batch, session_ctx, &mut pool)?;
 
     // short-circuit: if left is all-false, skip right
-    if left_mask == IdMask::None {
-        return materialize_id_mask_to_value(IdMask::None, otap_batch);
+    if left_result.mask == IdMask::None {
+        return materialize_id_mask_to_value(IdMask::None, None, otap_batch);
     }
 
-    let right_mask = right.execute_as_id_mask(otap_batch, session_ctx, &mut pool)?;
-    let combined = left_mask.combine_and(right_mask, &mut pool);
-    materialize_id_mask_to_value(combined, otap_batch)
+    let right_result = right.execute_as_id_mask(otap_batch, session_ctx, &mut pool)?;
+    let combined_scope = combine_scope(left_result.scope, right_result.scope);
+    let combined = left_result.mask.combine_and(right_result.mask, &mut pool);
+    materialize_id_mask_to_value(combined, combined_scope, otap_batch)
 }
 
 /// Execute a `BitmapOr` node as a value.
@@ -360,16 +415,17 @@ fn execute_bitmap_or_as_value(
     session_ctx: &SessionContext,
 ) -> Result<Option<ScopedValue>> {
     let mut pool = IdBitmapPool::new();
-    let left_mask = left.execute_as_id_mask(otap_batch, session_ctx, &mut pool)?;
+    let left_result = left.execute_as_id_mask(otap_batch, session_ctx, &mut pool)?;
 
     // short-circuit: if left is all-true, skip right
-    if left_mask == IdMask::All {
-        return materialize_id_mask_to_value(IdMask::All, otap_batch);
+    if left_result.mask == IdMask::All {
+        return materialize_id_mask_to_value(IdMask::All, None, otap_batch);
     }
 
-    let right_mask = right.execute_as_id_mask(otap_batch, session_ctx, &mut pool)?;
-    let combined = left_mask.combine_or(right_mask, &mut pool);
-    materialize_id_mask_to_value(combined, otap_batch)
+    let right_result = right.execute_as_id_mask(otap_batch, session_ctx, &mut pool)?;
+    let combined_scope = combine_scope(left_result.scope, right_result.scope);
+    let combined = left_result.mask.combine_or(right_result.mask, &mut pool);
+    materialize_id_mask_to_value(combined, combined_scope, otap_batch)
 }
 
 /// Execute a `BitmapNot` node as a value.
@@ -379,9 +435,9 @@ fn execute_bitmap_not_as_value(
     session_ctx: &SessionContext,
 ) -> Result<Option<ScopedValue>> {
     let mut pool = IdBitmapPool::new();
-    let child_mask = child.execute_as_id_mask(otap_batch, session_ctx, &mut pool)?;
-    let inverted = invert_id_mask(child_mask);
-    materialize_id_mask_to_value(inverted, otap_batch)
+    let child_result = child.execute_as_id_mask(otap_batch, session_ctx, &mut pool)?;
+    let inverted = invert_id_mask(child_result.mask);
+    materialize_id_mask_to_value(inverted, child_result.scope, otap_batch)
 }
 
 /// Evaluate a DataFusion expression on a RecordBatch.
@@ -410,7 +466,7 @@ fn evaluate_df_expr(
 
 /// Evaluate a DataFusion expression on a RecordBatch that has AnyValue struct columns,
 /// using the split-evaluate-stitch pattern where each value type is evaluated as a separate
-/// partition and the results are then stiched back together.
+/// partition and the results are then stitched back together.
 fn evaluate_with_anyval_partitions(
     logical_expr: &Expr,
     physical_expr: &mut Option<PhysicalExprRef>,
@@ -512,6 +568,8 @@ pub(super) fn invert_id_mask(mask: IdMask) -> IdMask {
 /// Materialize an `IdMask` to a root-aligned `BooleanArray` wrapped in a `ScopedValue`.
 fn materialize_id_mask_to_value(
     mask: IdMask,
+    // TODO could comment on the argument?
+    mask_scope: Option<DataScope>,
     otap_batch: &OtapArrowRecords,
 ) -> Result<Option<ScopedValue>> {
     let root_rb = match otap_batch.root_record_batch() {
@@ -525,9 +583,32 @@ fn materialize_id_mask_to_value(
         IdMask::All => BooleanArray::new(BooleanBuffer::new_set(num_rows), None),
         IdMask::None => BooleanArray::new(BooleanBuffer::new_unset(num_rows), None),
         IdMask::Some(_) | IdMask::NotSome(_) => {
-            let id_col = root_rb
-                .column_by_name(consts::ID)
-                .and_then(|c| c.as_any().downcast_ref::<UInt16Array>());
+            let id_col = match mask_scope {
+                Some(
+                    DataScope::Attribute(AttributesIdentifier::NonRoot(payload_type), _)
+                    | DataScope::AttributesAll(AttributesIdentifier::NonRoot(payload_type)),
+                ) => match payload_type {
+                    ArrowPayloadType::ResourceAttrs => {
+                        get_optional_array_from_struct_array_from_record_batch(
+                            root_rb,
+                            consts::RESOURCE,
+                            consts::ID,
+                        )?
+                    }
+                    ArrowPayloadType::ScopeAttrs => {
+                        get_optional_array_from_struct_array_from_record_batch(
+                            root_rb,
+                            consts::SCOPE,
+                            consts::ID,
+                        )?
+                    }
+                    _ => {
+                        todo!()
+                    }
+                },
+                _ => root_rb.column_by_name(consts::ID),
+            }
+            .and_then(|arr| arr.as_any().downcast_ref::<UInt16Array>());
 
             match id_col {
                 Some(id_col) => {
@@ -765,4 +846,36 @@ fn maybe_downcast_dicts(batch: RecordBatch, opts: &ProjectionOptions) -> Result<
         Arc::new(Schema::new(fields)),
         columns,
     )?)
+}
+
+fn align_value_to_root(value: ScopedValue, otap_batch: &OtapArrowRecords) -> Result<ScopedValue> {
+    println!("in alignment value = {value:?}");
+    let root_batch = match otap_batch.root_record_batch() {
+        Some(rb) => rb,
+        None => return Ok(value),
+    };
+
+    let left_input = JoinInput::new(
+        ColumnarValue::Array(Arc::new(NullArray::new(root_batch.num_rows()))),
+        Rc::new(DataScope::Root),
+        &root_batch,
+    );
+
+    let right_input = scoped_value_to_join_input(value, otap_batch)?;
+
+    // arg_column_name(0)
+
+    // TODO is this GUARANTEED to always be root?
+    // TODO using the join machinery is a hack here
+    let (result_rb, result_scope) = join(&left_input, &right_input, otap_batch)?;
+    let col = result_rb
+        .column_by_name(&arg_column_name(1))
+        .unwrap() // TODO uwnrap?
+        .clone();
+
+    Ok(ScopedValue::new(
+        ColumnarValue::Array(col),
+        result_scope.as_ref().clone(),
+        root_batch,
+    ))
 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
@@ -196,12 +196,6 @@ pub(super) fn eval_datafusion_expr_value(
                 source_rb.as_ref().clone()
             };
 
-            println!("In eval - source RB:");
-            arrow::util::pretty::print_batches(&[source_rb.as_ref().clone()]).unwrap();
-
-            println!("In eval - projected RB:");
-            arrow::util::pretty::print_batches(&[projected_rb.clone()]).unwrap();
-
             // check for AnyValue struct columns that need resolution
             let any_value_indices = find_any_value_columns(projected_rb.schema_ref());
 
@@ -256,7 +250,8 @@ pub(super) fn join_and_eval_value(
     for child in children.iter_mut() {
         let result = match child.execute_as_value(otap_batch, session_ctx)? {
             Some(mut result) => {
-                // align children to root if configured to do so
+                // maybe align children to root if configured. We skip alignment for scalar results
+                // because it's handled by the join below
                 if align_children_to_root && matches!(result.values, ColumnarValue::Array(_)) {
                     result = align_value_to_root(result, otap_batch)?;
                 }
@@ -313,12 +308,6 @@ pub(super) fn join_and_eval_value(
         None => return Ok(None),
     };
 
-    println!("In join - joined RB:");
-    arrow::util::pretty::print_batches(&[joined_rb.clone()]).unwrap();
-
-    println!("In join - projected RB:");
-    arrow::util::pretty::print_batches(&[projected_rb.clone()]).unwrap();
-
     // handle AnyValue columns
     let any_value_indices = find_any_value_columns(projected_rb.schema_ref());
     let result_vals = if any_value_indices.is_empty() || *eval_anyval_as_struct {
@@ -334,7 +323,7 @@ pub(super) fn join_and_eval_value(
         )?
     };
 
-    let mut result = ScopedValue::new(
+    let result = ScopedValue::new(
         coerce_nulls_for_predicate(result_vals, *missing_data_passes),
         DataScope::clone(&result_scope),
         &joined_rb,
@@ -556,9 +545,12 @@ pub(super) fn invert_id_mask(mask: IdMask) -> IdMask {
 }
 
 /// Materialize an `IdMask` to a root-aligned `BooleanArray` wrapped in a `ScopedValue`.
+///
+/// The `mask_scope`, if passed, parameter will be used to determine which ID column
+/// (`id`, `scope.id` or `resource.id`) will be checked for membership in the `mask`.
+/// When `mask_scope` is `None`, the `id` column will be used by default.
 fn materialize_id_mask_to_value(
     mask: IdMask,
-    // TODO could comment on the argument?
     mask_scope: Option<DataScope>,
     otap_batch: &OtapArrowRecords,
 ) -> Result<Option<ScopedValue>> {
@@ -852,15 +844,17 @@ fn align_value_to_root(value: ScopedValue, otap_batch: &OtapArrowRecords) -> Res
 
     let right_input = scoped_value_to_join_input(value, otap_batch)?;
 
-    // arg_column_name(0)
-
-    // TODO is this GUARANTEED to always be root?
-    // TODO using the join machinery is a hack here
     let (result_rb, result_scope) = join(&left_input, &right_input, otap_batch)?;
+    let result_col_name = arg_column_name(1);
     let col = result_rb
-        .column_by_name(&arg_column_name(1))
-        .unwrap() // TODO uwnrap?
+        .column_by_name(&result_col_name)
+        .ok_or_else(|| Error::ExecutionError {
+            // shouldn't happen - we expect the join to always produce the column with the
+            // correct name, but returning the error here is just being defensive
+            cause: format!("unexpected join result - expected column {result_col_name}"),
+        })?
         .clone();
+    debug_assert!(matches!(result_scope.as_ref(), DataScope::Root));
 
     Ok(ScopedValue::new(
         ColumnarValue::Array(col),

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
@@ -832,6 +832,11 @@ fn maybe_downcast_dicts(batch: RecordBatch, opts: &ProjectionOptions) -> Result<
     )?)
 }
 
+/// Converts the row order of the passed value to match the root record batch.
+///
+/// The value may have been computed from attributes, or a scalar, or some other expression
+/// will have the row order based on the computation input. This method realigns the rows so
+/// that they match the root batch by invoking join.
 fn align_value_to_root(value: ScopedValue, otap_batch: &OtapArrowRecords) -> Result<ScopedValue> {
     let root_batch = match otap_batch.root_record_batch() {
         Some(rb) => rb,

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
@@ -584,8 +584,10 @@ fn materialize_id_mask_to_value(
                             consts::ID,
                         )?
                     }
-                    _ => {
-                        todo!()
+                    other => {
+                        return Err(Error::ExecutionError {
+                            cause: format!("invalid payload type from IdMask scope: {other:?}"),
+                        });
                     }
                 },
                 _ => root_rb.column_by_name(consts::ID),

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/join.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/join.rs
@@ -1352,9 +1352,9 @@ impl AttributesAllSelectionVecJoin {
 impl JoinExec for AttributesAllSelectionVecJoin {
     fn rows_to_take(
         &self,
-        left: &JoinInput,
-        right: &JoinInput,
-        otap_batch: &OtapArrowRecords,
+        _left: &JoinInput,
+        _right: &JoinInput,
+        _otap_batch: &OtapArrowRecords,
     ) -> Result<Int32Array> {
         // Not implemented - should not need to compute rows to take. instead, just determine
         // alignment based on the ordering of the other side's matching IDs
@@ -1367,7 +1367,7 @@ impl JoinExec for AttributesAllSelectionVecJoin {
         &self,
         left: &JoinInput,
         right: &JoinInput,
-        otap_batch: &OtapArrowRecords,
+        _otap_batch: &OtapArrowRecords,
     ) -> Result<RecordBatch> {
         let vals = if self.all_attrs_left {
             &left.values

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/join.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/join.rs
@@ -1422,15 +1422,23 @@ impl JoinExec for AttributesAllSelectionVecJoin {
         };
 
         if vals.data_type() != DataType::Boolean {
-            // TODO - need to return an error here
-            todo!()
+            return Err(Error::ExecutionError {
+                cause: format!(
+                    "Invalid type from AttributesAll eval {:?}",
+                    vals.data_type()
+                ),
+            });
         }
 
         let selection_vec = match vals {
             ColumnarValue::Array(arr) => arr.as_boolean(),
             ColumnarValue::Scalar(_) => {
-                // TODO - refactor to return a bitmap here
-                todo!()
+                // In the future (if needed someday) we could handle by invoking scalar join
+                return Err(Error::ExecutionError {
+                    cause: "Invalid columnar value from AttributesAll eval. \
+                        expected Array got Scalar"
+                        .into(),
+                });
             }
         };
 
@@ -1458,8 +1466,10 @@ impl JoinExec for AttributesAllSelectionVecJoin {
             .as_ref();
         let attrs_side_id = match attrs_side_scope {
             DataScope::AttributesAll(attrs_id) => attrs_id,
-            _ => {
-                todo!();
+            other => {
+                return Err(Error::ExecutionError {
+                    cause: format!("Invalid scope value from AttributesAll join {other:?}"),
+                });
             }
         };
 

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/join.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/join.rs
@@ -1405,7 +1405,7 @@ impl JoinExec for AttributesAllSelectionVecJoin {
         // Not implemented - should not need to compute rows to take. instead, just determine
         // alignment based on the ordering of the other side's matching IDs
         Err(Error::ExecutionError {
-            cause: "rows_to_take not implemented for ScalarJoin".into(),
+            cause: "rows_to_take not implemented for AttributesAllSelectionVecJoin".into(),
         })
     }
 

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/join.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/join.rs
@@ -1310,9 +1310,46 @@ impl JoinExec for AttributeToDifferentAttributeReverseJoin {
     }
 }
 
-/// TODO comments
-/// TODO - add comments about how this only works when the non-attrs side is root
-/// TODO - need to implement this for when the attrs side is not root attrs (and test)
+/// This implementation aligns the result of a "fused" attribute evaluation with the data on
+/// the other side. The resulting data is always aligned with the join on the non-all-attrs side.
+///
+/// It expects the all-attrs side has returned a boolean, and this implementation produces a result
+/// from this boolean column in the order of the non-attrs batch, selecting a boolean value of
+/// "true" if some row in the attrs side has a "true", and "false" otherwise.
+///
+/// For example:
+/// ```text
+/// left side:
+/// parent_id | value
+/// ----------|------
+///    0      | true
+///    0      | false
+///    1      | true
+///    2      | false
+///    4      | true
+///
+/// right side:
+/// id  | val
+/// --- | ---
+///  0  | ... (val column of right side isn't factored into join)
+///  1  |
+///  2  |
+///  3  |
+///  4  |
+///
+/// result:
+/// id  | arg0  | arg1
+/// --- | ----- |----
+///  0  | true  | ... (the original val column)
+///  1  | true  |
+///  2  | false |
+///  3  | false |
+///  4  | true  |
+/// ```
+///
+/// Currently the only "other side" supported is the root record batch, since this is currently
+/// the only data that gets planned for the other side. Other implementations may be added in
+/// future as need arises.
 struct AttributesAllSelectionVecJoin {
     all_attrs_left: bool,
 }
@@ -1336,15 +1373,20 @@ impl AttributesAllSelectionVecJoin {
                     ArrowPayloadType::ResourceAttrs => input.resource_ids.as_ref(),
                     ArrowPayloadType::ScopeAttrs => input.scope_ids.as_ref(),
                     _ => {
-                        // invalid
-                        todo!()
+                        return Err(Error::ExecutionError {
+                            cause: format!("invalid attrs payload {payload:?}"),
+                        });
                     }
                 },
             };
             extract_u16_array(ids, consts::ID)
         } else {
             // not yet supported
-            todo!()
+            return Err(Error::NotYetSupportedError {
+                message:
+                    "joining result with scope AttributesAll to non-root scope not yet supported"
+                        .into(),
+            });
         }
     }
 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/join.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/join.rs
@@ -50,7 +50,6 @@ use otap_df_pdata::schema::consts;
 
 use crate::error::{Error, Result};
 use crate::pipeline::expr::{DataScope, arg_column_name};
-use crate::pipeline::id_mask::IdMask;
 use crate::pipeline::planner::AttributesIdentifier;
 
 /// Input to the join module, representing an evaluated expression result with its scope
@@ -147,7 +146,7 @@ pub fn join<'a>(
             DataScope::Root | DataScope::RootParent(_),
         ) => {
             let join_result = EqualScopeJoin::default().join(left, right, otap_batch)?;
-            return Ok((join_result, left.data_scope.clone()));
+            Ok((join_result, left.data_scope.clone()))
         }
         (_, DataScope::StaticScalar) => {
             let join_exec = ScalarJoin {
@@ -787,13 +786,18 @@ impl JoinExec for EqualScopeJoin {
     }
 }
 
+/// flips the left/right side of a two way join.
+///
+/// When we do a two-way join, the left-side gets column name "arg_0" and the right side
+/// gets column name "arg_1". This function simply switches the column names.
+///
+/// Safety note: it is expected that the record batch passed has both these columns.
 fn flip_left_right(record_batch: RecordBatch) -> RecordBatch {
     // join left to right, then switch the field names
     let (schema, columns, _) = record_batch.into_parts();
     let fields = schema.fields.clone();
     let (left_field_idx, left_field) = fields
         .find(&arg_column_name(0))
-        // TOOD unsure we can "expect" here since we've refactored this into a helper
         .expect("left column present");
     let (right_field_idx, right_field) = fields
         .find(&arg_column_name(1))
@@ -1382,11 +1386,11 @@ impl AttributesAllSelectionVecJoin {
             extract_u16_array(ids, consts::ID)
         } else {
             // not yet supported
-            return Err(Error::NotYetSupportedError {
+            Err(Error::NotYetSupportedError {
                 message:
                     "joining result with scope AttributesAll to non-root scope not yet supported"
                         .into(),
-            });
+            })
         }
     }
 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/join.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/join.rs
@@ -32,20 +32,25 @@
 use std::rc::Rc;
 use std::sync::Arc;
 
-use arrow::array::{Array, ArrayRef, Int32Array, RecordBatch, StructArray, UInt16Array};
-use arrow::compute::take;
-use arrow::datatypes::{DataType, Field, Fields, Schema};
+use arrow::array::{
+    Array, ArrayRef, AsArray, BooleanArray, Int32Array, RecordBatch, StructArray, UInt16Array,
+};
+use arrow::buffer::{BooleanBuffer, MutableBuffer};
+use arrow::compute::{filter, take};
+use arrow::datatypes::{DataType, Field, Fields, Schema, UInt16Type};
 use datafusion::logical_expr::ColumnarValue;
 use datafusion::scalar::ScalarValue;
 use otap_df_pdata::OtapArrowRecords;
 use otap_df_pdata::arrays::{
     get_optional_array_from_struct_array_from_record_batch, get_required_struct_array,
 };
+use otap_df_pdata::otap::filter::IdBitmap;
 use otap_df_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
 use otap_df_pdata::schema::consts;
 
 use crate::error::{Error, Result};
 use crate::pipeline::expr::{DataScope, arg_column_name};
+use crate::pipeline::id_mask::IdMask;
 use crate::pipeline::planner::AttributesIdentifier;
 
 /// Input to the join module, representing an evaluated expression result with its scope
@@ -137,6 +142,13 @@ pub fn join<'a>(
 
     // determine the join strategy from the source of the data
     match (left.data_scope.as_ref(), right.data_scope.as_ref()) {
+        (
+            DataScope::Root | DataScope::RootParent(_),
+            DataScope::Root | DataScope::RootParent(_),
+        ) => {
+            let join_result = EqualScopeJoin::default().join(left, right, otap_batch)?;
+            return Ok((join_result, left.data_scope.clone()));
+        }
         (_, DataScope::StaticScalar) => {
             let join_exec = ScalarJoin {
                 left_is_scalar: false,
@@ -151,6 +163,7 @@ pub fn join<'a>(
             let join_result = join_exec.join(left, right, otap_batch)?;
             Ok((join_result, right.data_scope.clone()))
         }
+
         (DataScope::Attribute(left_attrs_id, _), DataScope::Attribute(right_attrs_id, _)) => {
             if left_attrs_id == right_attrs_id {
                 let join_exec = AttributeToSameAttributeJoin::new();
@@ -186,6 +199,16 @@ pub fn join<'a>(
                     Ok((join_result, right.data_scope.clone()))
                 }
             }
+        }
+        (DataScope::Root | DataScope::RootParent(_), DataScope::AttributesAll(_)) => {
+            let join_exec = AttributesAllSelectionVecJoin::new(false);
+            let join_result = join_exec.join(left, right, otap_batch)?;
+            Ok((join_result, left.data_scope.clone()))
+        }
+        (DataScope::AttributesAll(_), DataScope::Root | DataScope::RootParent(_)) => {
+            let join_exec = AttributesAllSelectionVecJoin::new(true);
+            let join_result = join_exec.join(left, right, otap_batch)?;
+            Ok((join_result, right.data_scope.clone()))
         }
         (left, right) => {
             // Note: with expression trees created by our logical expression planner, we shouldn't
@@ -764,6 +787,28 @@ impl JoinExec for EqualScopeJoin {
     }
 }
 
+fn flip_left_right(record_batch: RecordBatch) -> RecordBatch {
+    // join left to right, then switch the field names
+    let (schema, columns, _) = record_batch.into_parts();
+    let fields = schema.fields.clone();
+    let (left_field_idx, left_field) = fields
+        .find(&arg_column_name(0))
+        // TOOD unsure we can "expect" here since we've refactored this into a helper
+        .expect("left column present");
+    let (right_field_idx, right_field) = fields
+        .find(&arg_column_name(1))
+        .expect("right_column present");
+
+    let left_field_name_fixed = left_field.as_ref().clone().with_name(arg_column_name(1));
+    let right_field_name_fixed = right_field.as_ref().clone().with_name(arg_column_name(0));
+
+    let mut fields = fields.to_vec();
+    fields[left_field_idx] = Arc::new(left_field_name_fixed);
+    fields[right_field_idx] = Arc::new(right_field_name_fixed);
+
+    RecordBatch::try_new(Arc::new(Schema::new(fields)), columns).expect("valid schema")
+}
+
 /// Broadcasts the scalar
 struct ScalarJoin {
     left_is_scalar: bool,
@@ -801,24 +846,8 @@ impl JoinExec for ScalarJoin {
         };
 
         if self.left_is_scalar {
-            // join left to right, then switch the field names
-            let (schema, columns, _) =
-                to_join_result(right, scalar_col.to_array(rows)?)?.into_parts();
-            let fields = schema.fields.clone();
-            let (left_field_idx, left_field) = fields
-                .find(&arg_column_name(0))
-                .expect("left column present");
-            let (right_field_idx, right_field) = fields
-                .find(&arg_column_name(1))
-                .expect("right_column present");
-
-            let left_field_name_fixed = left_field.as_ref().clone().with_name(arg_column_name(1));
-            let right_field_name_fixed = right_field.as_ref().clone().with_name(arg_column_name(0));
-
-            let mut fields = fields.to_vec();
-            fields[left_field_idx] = Arc::new(left_field_name_fixed);
-            fields[right_field_idx] = Arc::new(right_field_name_fixed);
-            Ok(RecordBatch::try_new(Arc::new(Schema::new(fields)), columns).expect("valid schema"))
+            let rb = to_join_result(right, scalar_col.to_array(rows)?)?;
+            Ok(flip_left_right(rb))
         } else {
             to_join_result(left, scalar_col.to_array(rows)?)
         }
@@ -1278,6 +1307,133 @@ impl JoinExec for AttributeToDifferentAttributeReverseJoin {
             Arc::new(Schema::new(fields)),
             columns,
         )?)
+    }
+}
+
+/// TODO comments
+/// TODO - add comments about how this only works when the non-attrs side is root
+/// TODO - need to implement this for when the attrs side is not root attrs (and test)
+struct AttributesAllSelectionVecJoin {
+    all_attrs_left: bool,
+}
+
+impl AttributesAllSelectionVecJoin {
+    fn new(all_attrs_left: bool) -> Self {
+        Self { all_attrs_left }
+    }
+
+    fn extract_probe_ids(
+        input: &JoinInput,
+        attrs_id: AttributesIdentifier,
+    ) -> Result<&UInt16Array> {
+        if matches!(
+            input.data_scope.as_ref(),
+            DataScope::Root | DataScope::RootParent(_)
+        ) {
+            let ids = match attrs_id {
+                AttributesIdentifier::Root => input.ids.as_ref(),
+                AttributesIdentifier::NonRoot(payload) => match payload {
+                    ArrowPayloadType::ResourceAttrs => input.resource_ids.as_ref(),
+                    ArrowPayloadType::ScopeAttrs => input.scope_ids.as_ref(),
+                    _ => {
+                        // invalid
+                        todo!()
+                    }
+                },
+            };
+            extract_u16_array(ids, consts::ID)
+        } else {
+            // not yet supported
+            todo!()
+        }
+    }
+}
+
+impl JoinExec for AttributesAllSelectionVecJoin {
+    fn rows_to_take(
+        &self,
+        left: &JoinInput,
+        right: &JoinInput,
+        otap_batch: &OtapArrowRecords,
+    ) -> Result<Int32Array> {
+        // Not implemented - should not need to compute rows to take. instead, just determine
+        // alignment based on the ordering of the other side's matching IDs
+        Err(Error::ExecutionError {
+            cause: "rows_to_take not implemented for ScalarJoin".into(),
+        })
+    }
+
+    fn join(
+        &self,
+        left: &JoinInput,
+        right: &JoinInput,
+        otap_batch: &OtapArrowRecords,
+    ) -> Result<RecordBatch> {
+        let vals = if self.all_attrs_left {
+            &left.values
+        } else {
+            &right.values
+        };
+
+        if vals.data_type() != DataType::Boolean {
+            // TODO - need to return an error here
+            todo!()
+        }
+
+        let selection_vec = match vals {
+            ColumnarValue::Array(arr) => arr.as_boolean(),
+            ColumnarValue::Scalar(_) => {
+                // TODO - refactor to return a bitmap here
+                todo!()
+            }
+        };
+
+        let parent_ids = extract_u16_array(
+            if self.all_attrs_left {
+                left.parent_ids.as_ref()
+            } else {
+                right.parent_ids.as_ref()
+            },
+            consts::PARENT_ID,
+        )?;
+
+        let selected_parent_ids = filter(parent_ids, selection_vec)?;
+        let mut selected_lookup = IdBitmap::new();
+        selected_lookup.populate(
+            selected_parent_ids
+                .as_primitive::<UInt16Type>()
+                .values()
+                .iter()
+                .map(|i| *i as u32),
+        );
+
+        let attrs_side_scope = if self.all_attrs_left { left } else { right }
+            .data_scope
+            .as_ref();
+        let attrs_side_id = match attrs_side_scope {
+            DataScope::AttributesAll(attrs_id) => attrs_id,
+            _ => {
+                todo!();
+            }
+        };
+
+        let id_col = Self::extract_probe_ids(
+            if self.all_attrs_left { right } else { left },
+            *attrs_side_id,
+        )?;
+        let bool_buf = MutableBuffer::collect_bool(id_col.len(), |index| {
+            let parent_id = id_col.values()[index];
+            selected_lookup.contains(parent_id as u32)
+        });
+        let aligned_selection_vec =
+            BooleanArray::new(BooleanBuffer::new(bool_buf.into(), 0, id_col.len()), None);
+
+        if self.all_attrs_left {
+            let rb = to_join_result(right, Arc::new(aligned_selection_vec))?;
+            Ok(flip_left_right(rb))
+        } else {
+            to_join_result(left, Arc::new(aligned_selection_vec))
+        }
     }
 }
 

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
@@ -44,11 +44,13 @@ use crate::consts::{
 };
 use crate::error::{Error, Result};
 use crate::pipeline::assign::leaf_requires_dict_downcast;
+use crate::pipeline::expr::join::is_one_to_many;
 use crate::pipeline::expr::types::{
     ExprLogicalType, coerce_arithmetic, nested_struct_field_type, root_field_type,
 };
 use crate::pipeline::expr::{DataScope, VALUE_COLUMN_NAME, arg_column_name};
 use crate::pipeline::expr::{LeafEval, RootParentStruct, ScopedExpr, SignalTypePredicate};
+use crate::pipeline::functions::compare::CompareFunc;
 use crate::pipeline::functions::expr_fn::contains;
 use crate::pipeline::functions::is_type::IsTypeFunc;
 #[cfg(feature = "sha1-hash")]
@@ -56,7 +58,8 @@ use crate::pipeline::functions::sha1_hash;
 use crate::pipeline::functions::{
     arity_range, fnv_hash, murmur3_hash, regexp_substr, substring, uuidv7, xxh3_hash, xxh128_hash,
 };
-use crate::pipeline::planner::ColumnAccessor;
+use crate::pipeline::planner::{AttributesIdentifier, ColumnAccessor};
+use crate::pipeline::project::{Projection, ProjectionOptions};
 
 /// Planner that converts AST expressions into `ScopedExpr` execution trees.
 pub(crate) struct ExprPlanner {
@@ -353,8 +356,8 @@ impl ExprPlanner {
                     requires_dict_downcast: false,
                 };
                 let combined_scope = try_combine_scopes(&left_planned, &right_planned);
-                let left = left_planned.expr;
-                let right = right_planned.expr;
+                let mut left = left_planned.expr;
+                let mut right = right_planned.expr;
                 if let Some(combined_scope) = combined_scope
                     && !matches!(combined_scope, DataScope::AttributesAll(_))
                 {
@@ -378,7 +381,36 @@ impl ExprPlanner {
                         eval: LeafEval::new_df_expr(left_expr.and(right_expr), downcast_dicts)?,
                     })
                 } else {
-                    Ok(ScopedExpr::BitmapAnd(Box::new(left), Box::new(right)))
+                    match (
+                        left.effective_value_scope().as_ref(),
+                        right.effective_value_scope().as_ref(),
+                    ) {
+                        (
+                            DataScope::AttributesAll(left_attrs_id),
+                            DataScope::AttributesAll(right_attrs_id),
+                        ) if left_attrs_id == right_attrs_id => {
+                            return Ok(ScopedExpr::BitmapAnd(Box::new(left), Box::new(right)));
+                        }
+                        (
+                            DataScope::AttributesAll(left_attrs_id),
+                            DataScope::AttributesAll(right_attrs_id),
+                        ) if left_attrs_id != right_attrs_id => {
+                            // TODO should we comment why we're doing this?
+                            // TODO would a custom join impl be faster?
+                            left.set_eval_align_to_root();
+                            right.set_eval_align_to_root();
+                        }
+                        _ => {}
+                    }
+
+                    Ok(ScopedExpr::JoinAndEval {
+                        children: vec![left, right],
+                        eval: LeafEval::new_df_expr(
+                            col(arg_column_name(0)).and(col(arg_column_name(1))),
+                            false,
+                        )?,
+                        default_null_children: false,
+                    })
                 }
             }
 
@@ -396,8 +428,9 @@ impl ExprPlanner {
                     requires_dict_downcast: false,
                 };
                 let combined_scope = try_combine_scopes(&left_planned, &right_planned);
-                let left = left_planned.expr;
-                let right = right_planned.expr;
+                let mut left = left_planned.expr;
+                let mut right = right_planned.expr;
+
                 if let Some(combined_scope) = combined_scope
                     && !matches!(combined_scope, DataScope::AttributesAll(_))
                 {
@@ -421,12 +454,88 @@ impl ExprPlanner {
                         eval: LeafEval::new_df_expr(left_expr.or(right_expr), downcast_dicts)?,
                     })
                 } else {
-                    Ok(ScopedExpr::BitmapOr(Box::new(left), Box::new(right)))
+                    match (
+                        left.effective_value_scope().as_ref(),
+                        right.effective_value_scope().as_ref(),
+                    ) {
+                        (
+                            DataScope::AttributesAll(left_attrs_id),
+                            DataScope::AttributesAll(right_attrs_id),
+                        ) if left_attrs_id == right_attrs_id => {
+                            return Ok(ScopedExpr::BitmapOr(Box::new(left), Box::new(right)));
+                        }
+                        (
+                            DataScope::AttributesAll(left_attrs_id),
+                            DataScope::AttributesAll(right_attrs_id),
+                        ) if left_attrs_id != right_attrs_id => {
+                            // TODO should we comment why we're doing this?
+                            // TODO would a custom join impl be faster?
+                            left.set_eval_align_to_root();
+                            right.set_eval_align_to_root();
+                        }
+                        _ => {}
+                    }
+
+                    Ok(ScopedExpr::JoinAndEval {
+                        children: vec![left, right],
+                        eval: LeafEval::new_df_expr(
+                            col(arg_column_name(0)).or(col(arg_column_name(1))),
+                            false,
+                        )?,
+                        default_null_children: false,
+                    })
+
+                    // let left_is_root_scope =
+                    //     matches!(left.effective_value_scope().as_ref(), DataScope::Root);
+                    // let right_is_root_scope =
+                    //     matches!(right.effective_value_scope().as_ref(), DataScope::Root);
+                    // let should_join = (left_is_root_scope && !left.is_bitmap_exec())
+                    //     || (right_is_root_scope && !right.is_bitmap_exec());
+                    // if should_join {
+                    //     Ok(ScopedExpr::JoinAndEval {
+                    //         children: vec![left, right],
+                    //         eval: LeafEval::new_df_expr(
+                    //             col(arg_column_name(0)).or(col(arg_column_name(1))),
+                    //             false,
+                    //         )?,
+                    //         default_null_children: false,
+                    //     })
+                    // } else {
+                    //     Ok(ScopedExpr::BitmapOr(Box::new(left), Box::new(right)))
+                    // }
                 }
             }
 
             LogicalExpression::Not(not_expr) => {
-                let inner = self.plan_logical(not_expr.get_inner_expression(), functions)?;
+                let inner_expr = not_expr.get_inner_expression();
+                // TODO comments
+                match inner_expr {
+                    LogicalExpression::GreaterThan(gt_expr) => {
+                        return self.plan_comparison(
+                            gt_expr.get_left(),
+                            Operator::LtEq,
+                            gt_expr.get_right(),
+                            true,
+                            functions,
+                        );
+                    }
+                    LogicalExpression::GreaterThanOrEqualTo(gte_expr) => {
+                        return self.plan_comparison(
+                            gte_expr.get_left(),
+                            Operator::Lt,
+                            gte_expr.get_right(),
+                            false,
+                            functions,
+                        );
+                    }
+                    _ => {}
+                }
+
+                let inner = self.plan_logical(inner_expr, functions)?;
+                let is_attrs_all_scope = matches!(
+                    inner.effective_value_scope().as_ref(),
+                    DataScope::AttributesAll(_)
+                );
                 Ok(match inner {
                     ScopedExpr::Eval { scope, eval } => match eval {
                         LeafEval::DatafusionExpr {
@@ -437,7 +546,8 @@ impl ExprPlanner {
                             eval_anyval_as_struct,
                             attr_key_case_sensitive,
                             missing_data_passes,
-                        } if scope == DataScope::Root => ScopedExpr::Eval {
+                            align_to_root,
+                        } if !is_attrs_all_scope => ScopedExpr::Eval {
                             scope,
                             eval: LeafEval::DatafusionExpr {
                                 logical_expr: not(logical_expr),
@@ -447,9 +557,44 @@ impl ExprPlanner {
                                 eval_anyval_as_struct,
                                 attr_key_case_sensitive,
                                 missing_data_passes: !missing_data_passes,
+                                align_to_root,
                             },
                         },
                         _ => ScopedExpr::BitmapNot(Box::new(ScopedExpr::Eval { scope, eval })),
+                    },
+                    ScopedExpr::JoinAndEval {
+                        children,
+                        eval,
+                        default_null_children,
+                    } if !is_attrs_all_scope => match eval {
+                        LeafEval::DatafusionExpr {
+                            logical_expr,
+                            physical_expr: _,
+                            projection,
+                            projection_opts,
+                            eval_anyval_as_struct,
+                            attr_key_case_sensitive,
+                            missing_data_passes,
+                            align_to_root,
+                        } => ScopedExpr::JoinAndEval {
+                            children,
+                            default_null_children,
+                            eval: LeafEval::DatafusionExpr {
+                                logical_expr: not(logical_expr),
+                                physical_expr: None,
+                                projection,
+                                projection_opts,
+                                eval_anyval_as_struct,
+                                attr_key_case_sensitive,
+                                missing_data_passes: !missing_data_passes,
+                                align_to_root,
+                            },
+                        },
+                        _ => ScopedExpr::BitmapNot(Box::new(ScopedExpr::JoinAndEval {
+                            children,
+                            eval,
+                            default_null_children,
+                        })),
                     },
                     _ => ScopedExpr::BitmapNot(Box::new(inner)),
                 })
@@ -894,8 +1039,7 @@ impl ExprPlanner {
         let left_is_null = is_null_literal(left_expr);
         let right_is_null = is_null_literal(right_expr);
 
-        // handle null comparisons specially — Arrow does not support binary comparisons
-        // with null values directly
+        // handle null comparisons specially
         if left_is_null || right_is_null {
             if operator != Operator::Eq {
                 // TODO in the future we may want to relax this and return static false here
@@ -924,6 +1068,7 @@ impl ExprPlanner {
 
         let mut left = self.plan_scalar(left_expr, functions)?;
         let mut right = self.plan_scalar(right_expr, functions)?;
+        let either_side_literal = is_literal_eval(&left) || is_literal_eval(&right);
 
         // Try fused attribute comparison optimization: when one side is an attribute
         // access and the other is a typed literal, skip the expensive key-filter +
@@ -963,7 +1108,108 @@ impl ExprPlanner {
         }
 
         let requires_dict_downcast = left.requires_dict_downcast || right.requires_dict_downcast;
-        self.build_binary_expr(left, operator, right, requires_dict_downcast)
+
+        // println!("left = {:?}", left.expr);
+        // println!("right = {:?}", right.expr);
+        let mut expr = self.build_binary_expr(left, operator, right, requires_dict_downcast)?;
+
+        if !either_side_literal {
+            // if we're here, it means both sides of the comparison are non-null literals. For
+            // these cases, we want to use a special comparison evaluation which handles:
+            // - when each side resolves to a different type (the normal DF binary expr evaluation
+            //   produces an error for this case)
+            // - when both sides are null we treat want to treat this as equal whereas datafusion
+            //   will produce a `null` which may get coerced into false by ScopedExpr.
+
+            expr = self.compare_using_udf(operator, expr);
+        }
+
+        Ok(expr)
+    }
+
+    /// Switches from using datafusion's BinaryExpr for comparison to a custom scalar UDF wrapping
+    /// [`compare`](crate::pipeline::filter::compare::compare)
+    // TODO shouldn't have to pass op
+    fn compare_using_udf(&self, op: Operator, expr: ScopedExpr) -> ScopedExpr {
+        fn transform_leaf(eval: LeafEval) -> LeafEval {
+            match eval {
+                LeafEval::DatafusionExpr {
+                    logical_expr: Expr::BinaryExpr(binary_expr),
+                    physical_expr,
+                    projection,
+                    projection_opts,
+                    eval_anyval_as_struct,
+                    attr_key_case_sensitive,
+                    missing_data_passes,
+                    align_to_root,
+                } => LeafEval::DatafusionExpr {
+                    logical_expr: CompareFunc::new_expr(
+                        *binary_expr.left,
+                        binary_expr.op,
+                        *binary_expr.right,
+                    ),
+                    physical_expr,
+                    projection,
+                    projection_opts: ProjectionOptions {
+                        // the comparison function here handles all null columns
+                        default_null_columns: true,
+                        ..projection_opts
+                    },
+                    eval_anyval_as_struct,
+                    attr_key_case_sensitive,
+                    missing_data_passes,
+                    align_to_root,
+                },
+                other => other,
+            }
+        }
+
+        // TODO - is this all kind of messy?
+        // TODO - we only need to do the pre-align if the op is Eq I'm pretty sure
+
+        fn set_align_to_root(eval: &mut LeafEval) {
+            match eval {
+                LeafEval::DatafusionExpr { align_to_root, .. } => *align_to_root = true,
+                _ => {}
+            }
+        }
+
+        match expr {
+            ScopedExpr::Eval { scope, eval } => {
+                let mut new_eval = transform_leaf(eval);
+                if op == Operator::Eq {
+                    set_align_to_root(&mut new_eval);
+                }
+                ScopedExpr::Eval {
+                    scope,
+                    eval: new_eval,
+                }
+            }
+            ScopedExpr::JoinAndEval {
+                mut children, eval, ..
+            } => {
+                if op == Operator::Eq {
+                    for child in &mut children {
+                        // TODO I'm not sure both these branches are covered by tests?
+                        match child {
+                            ScopedExpr::Eval { eval, .. } => {
+                                set_align_to_root(eval);
+                            }
+                            ScopedExpr::JoinAndEval { eval, .. } => {
+                                set_align_to_root(eval);
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                ScopedExpr::JoinAndEval {
+                    children,
+                    default_null_children: true,
+                    eval: transform_leaf(eval),
+                }
+            }
+            other => other,
+        }
     }
 
     /// Plan a null comparison: `<value_expr> == null`.
@@ -1198,6 +1444,7 @@ impl ExprPlanner {
         } else {
             Ok(ScopedExpr::JoinAndEval {
                 children: vec![haystack.expr, needle.expr],
+                default_null_children: false,
                 eval: LeafEval::new_df_expr(
                     contains(col(arg_column_name(0)), col(arg_column_name(1))),
                     true,
@@ -1562,6 +1809,7 @@ impl ExprPlanner {
         } else {
             Ok(ScopedExpr::JoinAndEval {
                 children: vec![left.expr, right.expr],
+                default_null_children: false,
                 eval: LeafEval::new_df_expr(
                     Expr::BinaryExpr(BinaryExpr::new(
                         Box::new(col(arg_column_name(0))),
@@ -1593,6 +1841,7 @@ impl ExprPlanner {
             }),
             FunctionArgScope::Join(children) => Ok(ScopedExpr::JoinAndEval {
                 children,
+                default_null_children: false,
                 eval: LeafEval::new_df_expr(expr, dict_downcast)?,
             }),
         }
@@ -1674,6 +1923,87 @@ impl ScopedExpr {
         }
     }
 
+    pub(crate) fn set_eval_align_to_root(&mut self) {
+        match self {
+            Self::Eval {
+                eval: LeafEval::DatafusionExpr { align_to_root, .. },
+                ..
+            } => *align_to_root = true,
+            _ => {}
+        }
+    }
+
+    /// returns the scope of the data that would be produced if this Expr was evaluated to
+    /// produce a scoped value
+    pub(crate) fn effective_value_scope(&self) -> Cow<'_, DataScope> {
+        match self {
+            Self::Eval { scope, eval } => match eval {
+                LeafEval::DatafusionExpr {
+                    align_to_root: true,
+                    ..
+                } => Cow::Owned(DataScope::Root),
+                _ => Cow::Borrowed(scope),
+            },
+            Self::JoinAndEval { children, .. } => {
+                // TODO comment on what's going on here ...
+                if children.is_empty() {
+                    // weird
+                    todo!()
+                }
+                let mut curr_scope = children[0].effective_value_scope();
+
+                for child in children.iter().skip(1) {
+                    let next_scope = child.effective_value_scope();
+                    curr_scope = match (curr_scope.as_ref(), next_scope.as_ref()) {
+                        (_, DataScope::StaticScalar | DataScope::AttributesAll(_)) => curr_scope,
+                        (DataScope::StaticScalar | DataScope::AttributesAll(_), _) => next_scope,
+                        (
+                            DataScope::Attribute(left_attrs_id, _),
+                            DataScope::Attribute(right_attrs_id, _),
+                        ) => {
+                            if left_attrs_id == right_attrs_id {
+                                curr_scope
+                            } else if is_one_to_many(&left_attrs_id, &right_attrs_id) {
+                                next_scope
+                            } else {
+                                curr_scope
+                            }
+                        }
+                        (
+                            DataScope::Root | DataScope::RootParent(_),
+                            DataScope::Attribute(_, _),
+                        ) => curr_scope,
+                        (
+                            DataScope::Attribute(attr_id, _),
+                            DataScope::Root | DataScope::RootParent(_),
+                        ) => match attr_id {
+                            AttributesIdentifier::Root => curr_scope,
+                            AttributesIdentifier::NonRoot(_) => next_scope,
+                        },
+
+                        // rest always have root alignment
+                        (DataScope::Root, DataScope::Root) => curr_scope,
+                        (DataScope::RootParent(_), DataScope::Root) => curr_scope,
+                        (DataScope::Root, DataScope::RootParent(_)) => curr_scope,
+                        (DataScope::RootParent(_), DataScope::RootParent(_)) => curr_scope,
+                    }
+                }
+
+                curr_scope
+            }
+            Self::BitmapAnd(_, _) | Self::BitmapOr(_, _) | Self::BitmapNot(_) => {
+                Cow::Owned(DataScope::Root)
+            }
+        }
+    }
+
+    fn is_bitmap_exec(&self) -> bool {
+        matches!(
+            self,
+            Self::BitmapAnd(_, _) | Self::BitmapOr(_, _) | Self::BitmapNot(_)
+        )
+    }
+
     /// Consume an `Eval(DatafusionExpr)` node and return its DataFusion logical expression.
     /// Returns `None` for non-`Eval` or `LeafEval::BatchPredicate` variants.
     pub(crate) fn into_df_eval_expr(self) -> Option<Expr> {
@@ -1696,6 +2026,20 @@ impl ScopedExpr {
             } => Some(logical_expr),
             _ => None,
         }
+    }
+}
+
+fn is_literal_eval(plan: &PlannedOp) -> bool {
+    match plan.expr {
+        ScopedExpr::Eval {
+            eval:
+                LeafEval::DatafusionExpr {
+                    logical_expr: Expr::Literal(_, _),
+                    ..
+                },
+            ..
+        } => true,
+        _ => false,
     }
 }
 
@@ -1868,7 +2212,7 @@ fn rewrite_attr_value_column(planned: &mut PlannedOp, field_name: &str) {
         let new_expr = col(field_name);
         *logical_expr = new_expr.clone();
         *physical_expr = None; // reset lazy physical expr
-        if let Ok(new_proj) = crate::pipeline::project::Projection::try_new(&new_expr) {
+        if let Ok(new_proj) = Projection::try_new(&new_expr) {
             *projection = new_proj;
         }
 
@@ -1965,7 +2309,7 @@ fn rewrite_body_expr(planned: &mut PlannedOp, field_name: &str) {
         *logical_expr = new_expr.clone();
         *physical_expr = None; // reset lazy physical expr
         *eval_anyval_as_struct = false;
-        if let Ok(new_proj) = crate::pipeline::project::Projection::try_new(&new_expr) {
+        if let Ok(new_proj) = Projection::try_new(&new_expr) {
             *projection = new_proj;
         }
 
@@ -2274,11 +2618,11 @@ mod test {
         let session_ctx = Pipeline::create_session_context();
         let mut pool = IdBitmapPool::new();
         let mut op = op;
-        let mask = op
+        let result = op
             .execute_as_id_mask(&otap, &session_ctx, &mut pool)
             .unwrap();
 
-        match &mask {
+        match &result.mask {
             IdMask::Some(bitmap) => {
                 assert!(bitmap.contains(0), "row 0 should pass");
                 assert!(!bitmap.contains(1), "row 1 (ERROR) should not pass");
@@ -2314,10 +2658,10 @@ mod test {
         let session_ctx = Pipeline::create_session_context();
         let mut pool = IdBitmapPool::new();
         let mut op = op;
-        let mask = op
+        let result = op
             .execute_as_id_mask(&otap, &session_ctx, &mut pool)
             .unwrap();
-        assert_eq!(mask, IdMask::All);
+        assert_eq!(result.mask, IdMask::All);
     }
 
     #[test]
@@ -2375,12 +2719,12 @@ mod test {
         let session_ctx = Pipeline::create_session_context();
         let mut pool = IdBitmapPool::new();
         let mut op = op;
-        let mask = op
+        let result = op
             .execute_as_id_mask(&otap, &session_ctx, &mut pool)
             .unwrap();
 
         // not(Some({0, 2})) = matches everything except 0 and 2 = matches 1
-        match &mask {
+        match &result.mask {
             IdMask::Some(bitmap) => {
                 assert!(!bitmap.contains(0), "0 in negated set");
                 assert!(bitmap.contains(1), "1 not in negated set");
@@ -2416,11 +2760,11 @@ mod test {
         let session_ctx = Pipeline::create_session_context();
         let mut pool = IdBitmapPool::new();
         let mut op = op;
-        let mask = op
+        let result = op
             .execute_as_id_mask(&otap, &session_ctx, &mut pool)
             .unwrap();
 
-        match &mask {
+        match &result.mask {
             IdMask::Some(bitmap) => {
                 assert!(bitmap.contains(0), "row 0 (x=a) should pass");
                 assert!(!bitmap.contains(1), "row 1 (x=b) should not pass");
@@ -2456,11 +2800,11 @@ mod test {
         let session_ctx = Pipeline::create_session_context();
         let mut pool = IdBitmapPool::new();
         let mut op = op;
-        let mask = op
+        let result = op
             .execute_as_id_mask(&otap, &session_ctx, &mut pool)
             .unwrap();
 
-        match &mask {
+        match &result.mask {
             IdMask::Some(bitmap) => {
                 assert!(bitmap.contains(0), "row 0 should pass");
                 assert!(!bitmap.contains(1), "row 1 should not pass");
@@ -2513,11 +2857,11 @@ mod test {
         let session_ctx = Pipeline::create_session_context();
         let mut pool = IdBitmapPool::new();
         let mut op = op;
-        let mask = op
+        let result = op
             .execute_as_id_mask(&otap, &session_ctx, &mut pool)
             .unwrap();
 
-        match &mask {
+        match &result.mask {
             IdMask::Some(bitmap) => {
                 assert!(bitmap.contains(0), "row 0 (count=10 > 7) should pass");
                 assert!(!bitmap.contains(1), "row 1 (count=5 < 7) should not pass");
@@ -2559,11 +2903,11 @@ mod test {
         let session_ctx = Pipeline::create_session_context();
         let mut pool = IdBitmapPool::new();
         let mut op = op;
-        let mask = op
+        let result = op
             .execute_as_id_mask(&otap, &session_ctx, &mut pool)
             .unwrap();
 
-        match &mask {
+        match &result.mask {
             IdMask::Some(bitmap) => {
                 assert!(bitmap.contains(0), "row 0 should pass");
                 assert!(!bitmap.contains(1), "row 1 should not pass");
@@ -2622,12 +2966,12 @@ mod test {
         let session_ctx = Pipeline::create_session_context();
         let mut pool = IdBitmapPool::new();
         let mut op = op;
-        let mask = op
+        let result = op
             .execute_as_id_mask(&otap, &session_ctx, &mut pool)
             .unwrap();
 
         // 10 + 2 = 12 > 5 -> should pass
-        match &mask {
+        match &result.mask {
             IdMask::Some(bitmap) => {
                 assert!(bitmap.contains(0), "row 0 should pass");
             }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
@@ -395,8 +395,8 @@ impl ExprPlanner {
                             // combine the bitmaps
                             return Ok(ScopedExpr::BitmapAnd(Box::new(left), Box::new(right)));
                         } else {
-                            // here we're "and"ing the results of filters on attributes, but they
-                            // the parent_id columns represent different IDs, so we can't "and" the
+                            // here we're "and"ing the results of filters on attributes, but the
+                            // parent_id columns represent different IDs, so we can't "and" the
                             // bitmaps. We set `align_children_to_root` because it's just the most
                             // performant way to line up the results of the filters on each side in
                             // join eval
@@ -465,13 +465,13 @@ impl ExprPlanner {
                         right.effective_value_scope()?.as_ref(),
                     ) {
                         if left_attrs_id == right_attrs_id {
-                            // most performant way to "and" the results of the children exprs
+                            // most performant way to "or" the results of the children exprs
                             // is to create a bitmap of the parent_ids passing each side then
                             // combine the bitmaps
                             return Ok(ScopedExpr::BitmapOr(Box::new(left), Box::new(right)));
                         } else {
-                            // here we're "or"ing the results of filters on attributes, but they
-                            // the parent_id columns represent different IDs, so we can't "and" the
+                            // here we're "or"ing the results of filters on attributes, but the
+                            // parent_id columns represent different IDs, so we can't "or" the
                             // bitmaps. We set `align_children_to_root` because it's just the most
                             // performant way to line up the results of the filters on each side in
                             // join eval
@@ -1097,7 +1097,7 @@ impl ExprPlanner {
 
         let mut expr = self.build_binary_expr(left, operator, right, requires_dict_downcast)?;
         if !either_side_literal {
-            // if we're here, it means both sides of the comparison are non-null literals. For
+            // if we're here, it means both sides of the comparison are not literals. For
             // these cases, we want to use a special comparison evaluation which handles:
             // - when each side resolves to a different type (the normal DF binary expr evaluation
             //   produces an error for this case)

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
@@ -1093,10 +1093,7 @@ impl ExprPlanner {
 
         let requires_dict_downcast = left.requires_dict_downcast || right.requires_dict_downcast;
 
-        // println!("left = {:?}", left.expr);
-        // println!("right = {:?}", right.expr);
         let mut expr = self.build_binary_expr(left, operator, right, requires_dict_downcast)?;
-
         if !either_side_literal {
             // if we're here, it means both sides of the comparison are non-null literals. For
             // these cases, we want to use a special comparison evaluation which handles:
@@ -1104,7 +1101,6 @@ impl ExprPlanner {
             //   produces an error for this case)
             // - when both sides are null we treat want to treat this as equal whereas datafusion
             //   will produce a `null` which may get coerced into false by ScopedExpr.
-
             expr = self.compare_using_udf(operator, expr);
         }
 

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
@@ -381,26 +381,27 @@ impl ExprPlanner {
                         eval: LeafEval::new_df_expr(left_expr.and(right_expr), downcast_dicts)?,
                     })
                 } else {
-                    match (
+                    let mut align_children_to_root = false;
+                    if let (
+                        DataScope::AttributesAll(left_attrs_id),
+                        DataScope::AttributesAll(right_attrs_id),
+                    ) = (
                         left.effective_value_scope().as_ref(),
                         right.effective_value_scope().as_ref(),
                     ) {
-                        (
-                            DataScope::AttributesAll(left_attrs_id),
-                            DataScope::AttributesAll(right_attrs_id),
-                        ) if left_attrs_id == right_attrs_id => {
+                        if left_attrs_id == right_attrs_id {
+                            // most performant way to "and" the results of the children exprs
+                            // is to create a bitmap of the parent_ids passing each side then
+                            // combine the bitmaps
                             return Ok(ScopedExpr::BitmapAnd(Box::new(left), Box::new(right)));
+                        } else {
+                            // here we're "and"ing the results of filters on attributes, but they
+                            // the parent_id columns represent different IDs, so we can't "and" the
+                            // bitmaps. We set `align_children_to_root` because it's just the most
+                            // performant way to line up the results of the filters on each side in
+                            // join eval
+                            align_children_to_root = true;
                         }
-                        (
-                            DataScope::AttributesAll(left_attrs_id),
-                            DataScope::AttributesAll(right_attrs_id),
-                        ) if left_attrs_id != right_attrs_id => {
-                            // TODO should we comment why we're doing this?
-                            // TODO would a custom join impl be faster?
-                            left.set_eval_align_to_root();
-                            right.set_eval_align_to_root();
-                        }
-                        _ => {}
                     }
 
                     Ok(ScopedExpr::JoinAndEval {
@@ -409,6 +410,7 @@ impl ExprPlanner {
                             col(arg_column_name(0)).and(col(arg_column_name(1))),
                             false,
                         )?,
+                        align_children_to_root,
                         default_null_children: false,
                     })
                 }
@@ -428,8 +430,8 @@ impl ExprPlanner {
                     requires_dict_downcast: false,
                 };
                 let combined_scope = try_combine_scopes(&left_planned, &right_planned);
-                let mut left = left_planned.expr;
-                let mut right = right_planned.expr;
+                let left = left_planned.expr;
+                let right = right_planned.expr;
 
                 if let Some(combined_scope) = combined_scope
                     && !matches!(combined_scope, DataScope::AttributesAll(_))
@@ -454,26 +456,27 @@ impl ExprPlanner {
                         eval: LeafEval::new_df_expr(left_expr.or(right_expr), downcast_dicts)?,
                     })
                 } else {
-                    match (
+                    let mut align_children_to_root = false;
+                    if let (
+                        DataScope::AttributesAll(left_attrs_id),
+                        DataScope::AttributesAll(right_attrs_id),
+                    ) = (
                         left.effective_value_scope().as_ref(),
                         right.effective_value_scope().as_ref(),
                     ) {
-                        (
-                            DataScope::AttributesAll(left_attrs_id),
-                            DataScope::AttributesAll(right_attrs_id),
-                        ) if left_attrs_id == right_attrs_id => {
+                        if left_attrs_id == right_attrs_id {
+                            // most performant way to "and" the results of the children exprs
+                            // is to create a bitmap of the parent_ids passing each side then
+                            // combine the bitmaps
                             return Ok(ScopedExpr::BitmapOr(Box::new(left), Box::new(right)));
+                        } else {
+                            // here we're "or"ing the results of filters on attributes, but they
+                            // the parent_id columns represent different IDs, so we can't "and" the
+                            // bitmaps. We set `align_children_to_root` because it's just the most
+                            // performant way to line up the results of the filters on each side in
+                            // join eval
+                            align_children_to_root = true;
                         }
-                        (
-                            DataScope::AttributesAll(left_attrs_id),
-                            DataScope::AttributesAll(right_attrs_id),
-                        ) if left_attrs_id != right_attrs_id => {
-                            // TODO should we comment why we're doing this?
-                            // TODO would a custom join impl be faster?
-                            left.set_eval_align_to_root();
-                            right.set_eval_align_to_root();
-                        }
-                        _ => {}
                     }
 
                     Ok(ScopedExpr::JoinAndEval {
@@ -482,27 +485,9 @@ impl ExprPlanner {
                             col(arg_column_name(0)).or(col(arg_column_name(1))),
                             false,
                         )?,
+                        align_children_to_root,
                         default_null_children: false,
                     })
-
-                    // let left_is_root_scope =
-                    //     matches!(left.effective_value_scope().as_ref(), DataScope::Root);
-                    // let right_is_root_scope =
-                    //     matches!(right.effective_value_scope().as_ref(), DataScope::Root);
-                    // let should_join = (left_is_root_scope && !left.is_bitmap_exec())
-                    //     || (right_is_root_scope && !right.is_bitmap_exec());
-                    // if should_join {
-                    //     Ok(ScopedExpr::JoinAndEval {
-                    //         children: vec![left, right],
-                    //         eval: LeafEval::new_df_expr(
-                    //             col(arg_column_name(0)).or(col(arg_column_name(1))),
-                    //             false,
-                    //         )?,
-                    //         default_null_children: false,
-                    //     })
-                    // } else {
-                    //     Ok(ScopedExpr::BitmapOr(Box::new(left), Box::new(right)))
-                    // }
                 }
             }
 
@@ -546,7 +531,6 @@ impl ExprPlanner {
                             eval_anyval_as_struct,
                             attr_key_case_sensitive,
                             missing_data_passes,
-                            align_to_root,
                         } if !is_attrs_all_scope => ScopedExpr::Eval {
                             scope,
                             eval: LeafEval::DatafusionExpr {
@@ -557,7 +541,6 @@ impl ExprPlanner {
                                 eval_anyval_as_struct,
                                 attr_key_case_sensitive,
                                 missing_data_passes: !missing_data_passes,
-                                align_to_root,
                             },
                         },
                         _ => ScopedExpr::BitmapNot(Box::new(ScopedExpr::Eval { scope, eval })),
@@ -566,6 +549,7 @@ impl ExprPlanner {
                         children,
                         eval,
                         default_null_children,
+                        align_children_to_root,
                     } if !is_attrs_all_scope => match eval {
                         LeafEval::DatafusionExpr {
                             logical_expr,
@@ -575,10 +559,10 @@ impl ExprPlanner {
                             eval_anyval_as_struct,
                             attr_key_case_sensitive,
                             missing_data_passes,
-                            align_to_root,
                         } => ScopedExpr::JoinAndEval {
                             children,
                             default_null_children,
+                            align_children_to_root,
                             eval: LeafEval::DatafusionExpr {
                                 logical_expr: not(logical_expr),
                                 physical_expr: None,
@@ -587,13 +571,13 @@ impl ExprPlanner {
                                 eval_anyval_as_struct,
                                 attr_key_case_sensitive,
                                 missing_data_passes: !missing_data_passes,
-                                align_to_root,
                             },
                         },
                         _ => ScopedExpr::BitmapNot(Box::new(ScopedExpr::JoinAndEval {
                             children,
                             eval,
                             default_null_children,
+                            align_children_to_root,
                         })),
                     },
                     _ => ScopedExpr::BitmapNot(Box::new(inner)),
@@ -1141,7 +1125,6 @@ impl ExprPlanner {
                     eval_anyval_as_struct,
                     attr_key_case_sensitive,
                     missing_data_passes,
-                    align_to_root,
                 } => LeafEval::DatafusionExpr {
                     logical_expr: CompareFunc::new_expr(
                         *binary_expr.left,
@@ -1158,56 +1141,22 @@ impl ExprPlanner {
                     eval_anyval_as_struct,
                     attr_key_case_sensitive,
                     missing_data_passes,
-                    align_to_root,
                 },
                 other => other,
             }
         }
 
-        // TODO - is this all kind of messy?
-        // TODO - we only need to do the pre-align if the op is Eq I'm pretty sure
-
-        fn set_align_to_root(eval: &mut LeafEval) {
-            match eval {
-                LeafEval::DatafusionExpr { align_to_root, .. } => *align_to_root = true,
-                _ => {}
-            }
-        }
-
         match expr {
-            ScopedExpr::Eval { scope, eval } => {
-                let mut new_eval = transform_leaf(eval);
-                if op == Operator::Eq {
-                    set_align_to_root(&mut new_eval);
-                }
-                ScopedExpr::Eval {
-                    scope,
-                    eval: new_eval,
-                }
-            }
-            ScopedExpr::JoinAndEval {
-                mut children, eval, ..
-            } => {
-                if op == Operator::Eq {
-                    for child in &mut children {
-                        // TODO I'm not sure both these branches are covered by tests?
-                        match child {
-                            ScopedExpr::Eval { eval, .. } => {
-                                set_align_to_root(eval);
-                            }
-                            ScopedExpr::JoinAndEval { eval, .. } => {
-                                set_align_to_root(eval);
-                            }
-                            _ => {}
-                        }
-                    }
-                }
-                ScopedExpr::JoinAndEval {
-                    children,
-                    default_null_children: true,
-                    eval: transform_leaf(eval),
-                }
-            }
+            ScopedExpr::Eval { scope, eval } => ScopedExpr::Eval {
+                scope,
+                eval: transform_leaf(eval),
+            },
+            ScopedExpr::JoinAndEval { children, eval, .. } => ScopedExpr::JoinAndEval {
+                children,
+                default_null_children: true,
+                align_children_to_root: op == Operator::Eq,
+                eval: transform_leaf(eval),
+            },
             other => other,
         }
     }
@@ -1445,6 +1394,7 @@ impl ExprPlanner {
             Ok(ScopedExpr::JoinAndEval {
                 children: vec![haystack.expr, needle.expr],
                 default_null_children: false,
+                align_children_to_root: false,
                 eval: LeafEval::new_df_expr(
                     contains(col(arg_column_name(0)), col(arg_column_name(1))),
                     true,
@@ -1810,6 +1760,7 @@ impl ExprPlanner {
             Ok(ScopedExpr::JoinAndEval {
                 children: vec![left.expr, right.expr],
                 default_null_children: false,
+                align_children_to_root: false,
                 eval: LeafEval::new_df_expr(
                     Expr::BinaryExpr(BinaryExpr::new(
                         Box::new(col(arg_column_name(0))),
@@ -1842,6 +1793,7 @@ impl ExprPlanner {
             FunctionArgScope::Join(children) => Ok(ScopedExpr::JoinAndEval {
                 children,
                 default_null_children: false,
+                align_children_to_root: false,
                 eval: LeafEval::new_df_expr(expr, dict_downcast)?,
             }),
         }
@@ -1923,33 +1875,28 @@ impl ScopedExpr {
         }
     }
 
-    pub(crate) fn set_eval_align_to_root(&mut self) {
-        match self {
-            Self::Eval {
-                eval: LeafEval::DatafusionExpr { align_to_root, .. },
-                ..
-            } => *align_to_root = true,
-            _ => {}
-        }
-    }
-
     /// returns the scope of the data that would be produced if this Expr was evaluated to
     /// produce a scoped value
     pub(crate) fn effective_value_scope(&self) -> Cow<'_, DataScope> {
         match self {
             Self::Eval { scope, eval } => match eval {
-                LeafEval::DatafusionExpr {
-                    align_to_root: true,
-                    ..
-                } => Cow::Owned(DataScope::Root),
                 _ => Cow::Borrowed(scope),
             },
-            Self::JoinAndEval { children, .. } => {
+            Self::JoinAndEval {
+                children,
+                align_children_to_root,
+                ..
+            } => {
                 // TODO comment on what's going on here ...
                 if children.is_empty() {
                     // weird
                     todo!()
                 }
+
+                if *align_children_to_root {
+                    return Cow::Owned(DataScope::Root);
+                }
+
                 let mut curr_scope = children[0].effective_value_scope();
 
                 for child in children.iter().skip(1) {
@@ -1995,13 +1942,6 @@ impl ScopedExpr {
                 Cow::Owned(DataScope::Root)
             }
         }
-    }
-
-    fn is_bitmap_exec(&self) -> bool {
-        matches!(
-            self,
-            Self::BitmapAnd(_, _) | Self::BitmapOr(_, _) | Self::BitmapNot(_)
-        )
     }
 
     /// Consume an `Eval(DatafusionExpr)` node and return its DataFusion logical expression.

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
@@ -1111,7 +1111,6 @@ impl ExprPlanner {
 
     /// Switches from using datafusion's BinaryExpr for comparison to a custom scalar UDF wrapping
     /// [`compare`](crate::pipeline::filter::compare::compare)
-    // TODO shouldn't have to pass op
     fn compare_using_udf(&self, op: Operator, expr: ScopedExpr) -> ScopedExpr {
         fn transform_leaf(eval: LeafEval) -> LeafEval {
             match eval {

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
@@ -502,7 +502,7 @@ impl ExprPlanner {
                             gt_expr.get_left(),
                             Operator::LtEq,
                             gt_expr.get_right(),
-                            true,
+                            false,
                             functions,
                         );
                     }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
@@ -356,8 +356,8 @@ impl ExprPlanner {
                     requires_dict_downcast: false,
                 };
                 let combined_scope = try_combine_scopes(&left_planned, &right_planned);
-                let mut left = left_planned.expr;
-                let mut right = right_planned.expr;
+                let left = left_planned.expr;
+                let right = right_planned.expr;
                 if let Some(combined_scope) = combined_scope
                     && !matches!(combined_scope, DataScope::AttributesAll(_))
                 {
@@ -386,8 +386,8 @@ impl ExprPlanner {
                         DataScope::AttributesAll(left_attrs_id),
                         DataScope::AttributesAll(right_attrs_id),
                     ) = (
-                        left.effective_value_scope().as_ref(),
-                        right.effective_value_scope().as_ref(),
+                        left.effective_value_scope()?.as_ref(),
+                        right.effective_value_scope()?.as_ref(),
                     ) {
                         if left_attrs_id == right_attrs_id {
                             // most performant way to "and" the results of the children exprs
@@ -461,8 +461,8 @@ impl ExprPlanner {
                         DataScope::AttributesAll(left_attrs_id),
                         DataScope::AttributesAll(right_attrs_id),
                     ) = (
-                        left.effective_value_scope().as_ref(),
-                        right.effective_value_scope().as_ref(),
+                        left.effective_value_scope()?.as_ref(),
+                        right.effective_value_scope()?.as_ref(),
                     ) {
                         if left_attrs_id == right_attrs_id {
                             // most performant way to "and" the results of the children exprs
@@ -493,7 +493,9 @@ impl ExprPlanner {
 
             LogicalExpression::Not(not_expr) => {
                 let inner_expr = not_expr.get_inner_expression();
-                // TODO comments
+
+                // The parser will plan Lt/LtEq as Not(GtEq)/Not(Gt) - we look for this pattern and
+                // simply plan comparison with the correct operator when its encountered
                 match inner_expr {
                     LogicalExpression::GreaterThan(gt_expr) => {
                         return self.plan_comparison(
@@ -518,7 +520,7 @@ impl ExprPlanner {
 
                 let inner = self.plan_logical(inner_expr, functions)?;
                 let is_attrs_all_scope = matches!(
-                    inner.effective_value_scope().as_ref(),
+                    inner.effective_value_scope()?.as_ref(),
                     DataScope::AttributesAll(_)
                 );
                 Ok(match inner {
@@ -1873,30 +1875,32 @@ impl ScopedExpr {
 
     /// returns the scope of the data that would be produced if this Expr was evaluated to
     /// produce a scoped value
-    pub(crate) fn effective_value_scope(&self) -> Cow<'_, DataScope> {
+    pub(crate) fn effective_value_scope(&self) -> Result<Cow<'_, DataScope>> {
         match self {
-            Self::Eval { scope, eval } => match eval {
-                _ => Cow::Borrowed(scope),
-            },
+            Self::Eval { scope, .. } => Ok(Cow::Borrowed(scope)),
             Self::JoinAndEval {
                 children,
                 align_children_to_root,
                 ..
             } => {
-                // TODO comment on what's going on here ...
                 if children.is_empty() {
-                    // weird
-                    todo!()
+                    return Err(Error::InvalidPipelineError {
+                        cause:
+                            "Error computing expr scope. invalid join eval passed with no children"
+                                .into(),
+                        query_location: None,
+                    });
                 }
 
                 if *align_children_to_root {
-                    return Cow::Owned(DataScope::Root);
+                    return Ok(Cow::Owned(DataScope::Root));
                 }
 
-                let mut curr_scope = children[0].effective_value_scope();
+                let mut curr_scope = children[0].effective_value_scope()?;
 
+                // compute the data scope of what will be produced when the children are join:
                 for child in children.iter().skip(1) {
-                    let next_scope = child.effective_value_scope();
+                    let next_scope = child.effective_value_scope()?;
                     curr_scope = match (curr_scope.as_ref(), next_scope.as_ref()) {
                         (_, DataScope::StaticScalar | DataScope::AttributesAll(_)) => curr_scope,
                         (DataScope::StaticScalar | DataScope::AttributesAll(_), _) => next_scope,
@@ -1906,7 +1910,7 @@ impl ScopedExpr {
                         ) => {
                             if left_attrs_id == right_attrs_id {
                                 curr_scope
-                            } else if is_one_to_many(&left_attrs_id, &right_attrs_id) {
+                            } else if is_one_to_many(left_attrs_id, right_attrs_id) {
                                 next_scope
                             } else {
                                 curr_scope
@@ -1932,10 +1936,10 @@ impl ScopedExpr {
                     }
                 }
 
-                curr_scope
+                Ok(curr_scope)
             }
             Self::BitmapAnd(_, _) | Self::BitmapOr(_, _) | Self::BitmapNot(_) => {
-                Cow::Owned(DataScope::Root)
+                Ok(Cow::Owned(DataScope::Root))
             }
         }
     }
@@ -1966,17 +1970,16 @@ impl ScopedExpr {
 }
 
 fn is_literal_eval(plan: &PlannedOp) -> bool {
-    match plan.expr {
+    matches!(
+        plan.expr,
         ScopedExpr::Eval {
-            eval:
-                LeafEval::DatafusionExpr {
-                    logical_expr: Expr::Literal(_, _),
-                    ..
-                },
+            eval: LeafEval::DatafusionExpr {
+                logical_expr: Expr::Literal(_, _),
+                ..
+            },
             ..
-        } => true,
-        _ => false,
-    }
+        }
+    )
 }
 
 /// Try to combine the scopes of two `PlannedOp`s. Returns `Some(scope)` if they're

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
@@ -3378,7 +3378,7 @@ mod test {
         assert_eq!(result.resource_logs[0].scope_logs.len(), 1);
         assert_eq!(
             &result.resource_logs[0].scope_logs[0].log_records,
-            &[log_record2.clone()]
+            std::slice::from_ref(&log_record2)
         );
 
         let result = exec_logs_pipeline::<OplParser>(
@@ -3389,7 +3389,7 @@ mod test {
         assert_eq!(result.resource_logs[0].scope_logs.len(), 1);
         assert_eq!(
             &result.resource_logs[0].scope_logs[0].log_records,
-            &[log_record1.clone()]
+            std::slice::from_ref(&log_record1)
         );
 
         let result = exec_logs_pipeline::<OplParser>(
@@ -3400,7 +3400,7 @@ mod test {
         assert_eq!(result.resource_logs[0].scope_logs.len(), 1);
         assert_eq!(
             &result.resource_logs[0].scope_logs[0].log_records,
-            &[log_record0.clone()]
+            std::slice::from_ref(&log_record0)
         );
 
         let result = exec_logs_pipeline::<OplParser>(
@@ -3411,7 +3411,7 @@ mod test {
         assert_eq!(result.resource_logs[0].scope_logs.len(), 1);
         assert_eq!(
             &result.resource_logs[0].scope_logs[0].log_records,
-            &[log_record0.clone()]
+            std::slice::from_ref(&log_record0)
         );
 
         let result = exec_logs_pipeline::<OplParser>(
@@ -3466,7 +3466,7 @@ mod test {
         assert_eq!(result.resource_logs[0].scope_logs.len(), 1);
         assert_eq!(
             &result.resource_logs[0].scope_logs[0].log_records,
-            &[log_record2.clone()]
+            std::slice::from_ref(&log_record2)
         );
 
         let result = exec_logs_pipeline::<OplParser>(
@@ -3477,11 +3477,11 @@ mod test {
         assert_eq!(result.resource_logs[0].scope_logs.len(), 2);
         assert_eq!(
             &result.resource_logs[0].scope_logs[0].log_records,
-            &[log_record0.clone()]
+            std::slice::from_ref(&log_record0)
         );
         assert_eq!(
             &result.resource_logs[0].scope_logs[1].log_records,
-            &[log_record2.clone()]
+            std::slice::from_ref(&log_record2)
         );
 
         let result = exec_logs_pipeline::<OplParser>(
@@ -3492,11 +3492,11 @@ mod test {
         assert_eq!(result.resource_logs[0].scope_logs.len(), 2);
         assert_eq!(
             &result.resource_logs[0].scope_logs[0].log_records,
-            &[log_record1.clone()],
+            std::slice::from_ref(&log_record1)
         );
         assert_eq!(
             &result.resource_logs[0].scope_logs[1].log_records,
-            &[log_record2.clone()]
+            std::slice::from_ref(&log_record2)
         );
 
         let result = exec_logs_pipeline::<OplParser>(
@@ -3533,7 +3533,7 @@ mod test {
         );
         assert_eq!(
             &result.resource_logs[0].scope_logs[1].log_records,
-            &[log_record2.clone()]
+            std::slice::from_ref(&log_record2)
         );
 
         let result = exec_logs_pipeline::<OplParser>(
@@ -3795,11 +3795,11 @@ mod test {
         .await;
         assert_eq!(
             &result.resource_logs[0].scope_logs[0].log_records,
-            &[log_record0.clone()]
+            std::slice::from_ref(&log_record0)
         );
         assert_eq!(
             &result.resource_logs[0].scope_logs[1].log_records,
-            &[log_record3.clone()]
+            std::slice::from_ref(&log_record3)
         );
 
         // compare column w/ nulls to all null struct column (where struct column is present)
@@ -3810,11 +3810,11 @@ mod test {
         .await;
         assert_eq!(
             &result.resource_logs[0].scope_logs[0].log_records,
-            &[log_record1.clone()]
+            std::slice::from_ref(&log_record1)
         );
         assert_eq!(
             &result.resource_logs[0].scope_logs[1].log_records,
-            &[log_record3.clone()]
+            std::slice::from_ref(&log_record3)
         );
 
         // compare column w/ nulls to all null struct column (where struct column is present)
@@ -3825,11 +3825,11 @@ mod test {
         .await;
         assert_eq!(
             &result.resource_logs[0].scope_logs[0].log_records,
-            &[log_record0.clone()]
+            std::slice::from_ref(&log_record0)
         );
         assert_eq!(
             &result.resource_logs[0].scope_logs[1].log_records,
-            &[log_record3.clone()]
+            std::slice::from_ref(&log_record3)
         );
 
         // compare column w/ nulls to all null struct column (where struct column is present)
@@ -3840,11 +3840,11 @@ mod test {
         .await;
         assert_eq!(
             &result.resource_logs[0].scope_logs[0].log_records,
-            &[log_record0.clone()]
+            std::slice::from_ref(&log_record0)
         );
         assert_eq!(
             &result.resource_logs[0].scope_logs[1].log_records,
-            &[log_record3.clone()]
+            std::slice::from_ref(&log_record3)
         );
 
         // compare column w/ nulls to all null struct column (where struct column is present)
@@ -4108,7 +4108,7 @@ mod test {
         );
         assert_eq!(
             &result.resource_logs[0].scope_logs[1].log_records,
-            &[log_record4.clone()]
+            std::slice::from_ref(&log_record4)
         );
 
         // compare column w/ nulls to all null struct column (where struct column is present)
@@ -4123,7 +4123,7 @@ mod test {
         );
         assert_eq!(
             &result.resource_logs[0].scope_logs[1].log_records,
-            &[log_record4.clone()]
+            std::slice::from_ref(&log_record4)
         );
 
         // compare column w/ nulls to all null struct column (where struct column is present)
@@ -4138,7 +4138,7 @@ mod test {
         );
         assert_eq!(
             &result.resource_logs[0].scope_logs[1].log_records,
-            &[log_record4.clone()]
+            std::slice::from_ref(&log_record4)
         );
 
         // compare column w/ nulls to all null struct column (where struct column is present)
@@ -4153,7 +4153,7 @@ mod test {
         );
         assert_eq!(
             &result.resource_logs[0].scope_logs[1].log_records,
-            &[log_record4.clone()]
+            std::slice::from_ref(&log_record4)
         );
 
         // compare column w/ nulls to all null struct column (where struct column is present)
@@ -4168,7 +4168,7 @@ mod test {
         .await;
         assert_eq!(
             &result.resource_logs[0].scope_logs[0].log_records,
-            &[log_record2.clone()]
+            std::slice::from_ref(&log_record2)
         );
         assert_eq!(
             &result.resource_logs[0].scope_logs[1].log_records,
@@ -4187,7 +4187,7 @@ mod test {
         assert_eq!(result.resource_logs.len(), 1);
         assert_eq!(
             &result.resource_logs[0].scope_logs[0].log_records,
-            &[log_record2.clone()]
+            std::slice::from_ref(&log_record2)
         );
     }
 

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
@@ -3339,7 +3339,7 @@ mod test {
     }
 
     /// Test to ensure that we correctly combine the results of filtering with predicates on
-    /// attributes that are kept in different OTAPr record batches
+    /// attributes that are kept in different OTAP record batches
     #[tokio::test]
     async fn test_attribute_and_attribute_different_record_batches() {
         let log_record0 = LogRecord::build()
@@ -3427,7 +3427,7 @@ mod test {
     }
 
     /// Test to ensure that we correctly combine the results of filtering with predicates on
-    /// attributes that are kept in different OTAPr record batches using or
+    /// attributes that are kept in different OTAP record batches using or
     #[tokio::test]
     async fn test_attribute_or_attribute_different_record_batches() {
         let log_record0 = LogRecord::build()

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
@@ -3718,7 +3718,6 @@ mod test {
         ];
         assert_eq!(result_log_records, expected);
 
-        // TODO comment about what this is testing
         let result = exec_logs_pipeline::<OplParser>(
             "logs | where  attributes[\"x\"] == attributes[\"y\"] and attributes[\"z\"] == null",
             to_logs_data(log_records.clone()),

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
@@ -3580,8 +3580,6 @@ mod test {
                 .finish(),
         ];
 
-        // TODO - we should validate that OTAP representation is missing the columns we expect are missing
-
         // compare col containing null w/ other column also containing nulls
         let result = exec_logs_pipeline::<OplParser>(
             "logs | where severity_text == event_name",
@@ -3603,7 +3601,6 @@ mod test {
         assert_eq!(result_log_records, expected);
 
         // compare col containing nulls w/ all null struct column
-        // TODO - we should have a different version of this test where the scope column isn't null
         let result = exec_logs_pipeline::<OplParser>(
             "logs | where severity_text == instrumentation_scope.version",
             to_logs_data(log_records.clone()),

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
@@ -392,7 +392,6 @@ mod test {
     use crate::pipeline::{Pipeline, PipelineOptions};
 
     use super::*;
-    use datafusion::functions::math::log;
     use otap_df_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
     use otap_df_pdata::schema::consts;
 

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
@@ -392,6 +392,7 @@ mod test {
     use crate::pipeline::{Pipeline, PipelineOptions};
 
     use super::*;
+    use datafusion::functions::math::log;
     use otap_df_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
     use otap_df_pdata::schema::consts;
 
@@ -3338,6 +3339,1013 @@ mod test {
         run_filter_attribute_is_not_null_no_attrs::<OplParser>("null").await;
     }
 
+    /// Test to ensure that we correctly combine the results of filtering with predicates on
+    /// attributes that are kept in different OTAPr record batches
+    #[tokio::test]
+    async fn test_attribute_and_attribute_different_record_batches() {
+        let log_record0 = LogRecord::build()
+            .attributes(vec![KeyValue::new("x", AnyValue::new_string("1"))])
+            .finish();
+        let log_record1 = LogRecord::build()
+            .attributes(vec![KeyValue::new("x", AnyValue::new_string("2"))])
+            .finish();
+        let log_record2 = LogRecord::build()
+            .attributes(vec![KeyValue::new("x", AnyValue::new_string("3"))])
+            .finish();
+
+        let logs_data = LogsData::new(vec![ResourceLogs::new(
+            Resource::default(),
+            vec![
+                ScopeLogs::new(
+                    InstrumentationScope::build()
+                        .attributes(vec![KeyValue::new("y", AnyValue::new_string("1"))])
+                        .finish(),
+                    vec![log_record0.clone(), log_record1.clone()],
+                ),
+                ScopeLogs::new(
+                    InstrumentationScope::build()
+                        .attributes(vec![KeyValue::new("y", AnyValue::new_string("2"))])
+                        .finish(),
+                    vec![log_record2.clone()],
+                ),
+            ],
+        )]);
+
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where attributes[\"x\"] == \"3\" and instrumentation_scope.attributes[\"y\"] == \"2\"",
+            logs_data.clone()
+        ).await;
+
+        assert_eq!(result.resource_logs[0].scope_logs.len(), 1);
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[log_record2.clone()]
+        );
+
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where attributes[\"x\"] == \"2\" and instrumentation_scope.attributes[\"y\"] == \"1\"",
+            logs_data.clone()
+        ).await;
+
+        assert_eq!(result.resource_logs[0].scope_logs.len(), 1);
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[log_record1.clone()]
+        );
+
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where attributes[\"x\"] == \"1\" and instrumentation_scope.attributes[\"y\"] == \"1\"",
+            logs_data.clone()
+        ).await;
+
+        assert_eq!(result.resource_logs[0].scope_logs.len(), 1);
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[log_record0.clone()]
+        );
+
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where attributes[\"x\"] == \"1\" and instrumentation_scope.attributes[\"y\"] != \"2\"",
+            logs_data.clone()
+        ).await;
+
+        assert_eq!(result.resource_logs[0].scope_logs.len(), 1);
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[log_record0.clone()]
+        );
+
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where attributes[\"x\"] != \"3\" and instrumentation_scope.attributes[\"y\"] != \"2\"",
+            logs_data.clone()
+        ).await;
+
+        assert_eq!(result.resource_logs[0].scope_logs.len(), 1);
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[log_record0.clone(), log_record1.clone()]
+        );
+    }
+
+    /// Test to ensure that we correctly combine the results of filtering with predicates on
+    /// attributes that are kept in different OTAPr record batches using or
+    #[tokio::test]
+    async fn test_attribute_or_attribute_different_record_batches() {
+        let log_record0 = LogRecord::build()
+            .attributes(vec![KeyValue::new("x", AnyValue::new_string("1"))])
+            .finish();
+        let log_record1 = LogRecord::build()
+            .attributes(vec![KeyValue::new("x", AnyValue::new_string("2"))])
+            .finish();
+        let log_record2 = LogRecord::build()
+            .attributes(vec![KeyValue::new("x", AnyValue::new_string("3"))])
+            .finish();
+
+        let logs_data = LogsData::new(vec![ResourceLogs::new(
+            Resource::default(),
+            vec![
+                ScopeLogs::new(
+                    InstrumentationScope::build()
+                        .attributes(vec![KeyValue::new("y", AnyValue::new_string("1"))])
+                        .finish(),
+                    vec![log_record0.clone(), log_record1.clone()],
+                ),
+                ScopeLogs::new(
+                    InstrumentationScope::build()
+                        .attributes(vec![KeyValue::new("y", AnyValue::new_string("2"))])
+                        .finish(),
+                    vec![log_record2.clone()],
+                ),
+            ],
+        )]);
+
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where attributes[\"x\"] == \"3\" or instrumentation_scope.attributes[\"y\"] == \"2\"",
+            logs_data.clone()
+        ).await;
+
+        assert_eq!(result.resource_logs[0].scope_logs.len(), 1);
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[log_record2.clone()]
+        );
+
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where attributes[\"x\"] == \"1\" or instrumentation_scope.attributes[\"y\"] == \"2\"",
+            logs_data.clone()
+        ).await;
+
+        assert_eq!(result.resource_logs[0].scope_logs.len(), 2);
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[log_record0.clone()]
+        );
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[1].log_records,
+            &[log_record2.clone()]
+        );
+
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where attributes[\"x\"] == \"2\" or instrumentation_scope.attributes[\"y\"] == \"2\"",
+            logs_data.clone()
+        ).await;
+
+        assert_eq!(result.resource_logs[0].scope_logs.len(), 2);
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[log_record1.clone()],
+        );
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[1].log_records,
+            &[log_record2.clone()]
+        );
+
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where attributes[\"x\"] == \"1\" or instrumentation_scope.attributes[\"y\"] == \"1\"",
+            logs_data.clone()
+        ).await;
+
+        assert_eq!(result.resource_logs[0].scope_logs.len(), 1);
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[log_record0.clone(), log_record1.clone()]
+        );
+
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where attributes[\"x\"] == \"1\" or instrumentation_scope.attributes[\"y\"] != \"2\"",
+            logs_data.clone()
+        ).await;
+
+        assert_eq!(result.resource_logs[0].scope_logs.len(), 1);
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[log_record0.clone(), log_record1.clone()]
+        );
+
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where attributes[\"x\"] != \"1\" or instrumentation_scope.attributes[\"y\"] != \"2\"",
+            logs_data.clone()
+        ).await;
+
+        assert_eq!(result.resource_logs[0].scope_logs.len(), 2);
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[log_record0.clone(), log_record1.clone()]
+        );
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[1].log_records,
+            &[log_record2.clone()]
+        );
+
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where attributes[\"x\"] != \"3\" or instrumentation_scope.attributes[\"y\"] != \"2\"",
+            logs_data.clone()
+        ).await;
+
+        assert_eq!(result.resource_logs[0].scope_logs.len(), 1);
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[log_record0.clone(), log_record1.clone()]
+        );
+    }
+
+    /// Tests the behaviour of evaluating a filter where one or both sides evaluate to null, but
+    /// the fact that we're comparing with null isn't known at compile time. This should use the
+    /// [`compare`](super::compare::compare) function which has proper null comparison semantics
+    #[tokio::test]
+    async fn test_filter_compare_null_eq_null_evaluated_at_runtime() {
+        let log_records = vec![
+            LogRecord::build()
+                .event_name("ERROR")
+                .severity_text("ERROR")
+                .attributes(vec![
+                    KeyValue::new("x", AnyValue::new_string("ERROR")),
+                    KeyValue::new("y", AnyValue::new_string("ERROR")),
+                ])
+                .finish(),
+            LogRecord::build().finish(),
+            LogRecord::build()
+                .event_name("ERROR")
+                .attributes(vec![
+                    KeyValue::new("x", AnyValue::new_string("ERROR")),
+                    KeyValue::new("z", AnyValue::new_string("test")),
+                ])
+                .finish(),
+            LogRecord::build()
+                .event_name("ERROR")
+                .severity_text("asdf")
+                .attributes(vec![
+                    KeyValue::new("x", AnyValue::new_string("ERROR")),
+                    KeyValue::new("y", AnyValue::new_string("b")),
+                ])
+                .finish(),
+        ];
+
+        // TODO - we should validate that OTAP representation is missing the columns we expect are missing
+
+        // compare col containing null w/ other column also containing nulls
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where severity_text == event_name",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        let result_log_records = &result.resource_logs[0].scope_logs[0].log_records;
+        let expected = &[log_records[0].clone(), log_records[1].clone()];
+        assert_eq!(result_log_records, expected);
+
+        // compare col w/ nulls to all null column
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where severity_text == trace_id",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        let result_log_records = &result.resource_logs[0].scope_logs[0].log_records;
+        let expected = &[log_records[1].clone(), log_records[2].clone()];
+        assert_eq!(result_log_records, expected);
+
+        // compare col containing nulls w/ all null struct column
+        // TODO - we should have a different version of this test where the scope column isn't null
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where severity_text == instrumentation_scope.version",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        let result_log_records = &result.resource_logs[0].scope_logs[0].log_records;
+        let expected = &[log_records[1].clone(), log_records[2].clone()];
+        assert_eq!(result_log_records, expected);
+
+        // two all null columns
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where trace_id == span_id",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        let result_log_records = &result.resource_logs[0].scope_logs[0].log_records;
+        let expected = &[
+            log_records[0].clone(),
+            log_records[1].clone(),
+            log_records[2].clone(),
+            log_records[3].clone(),
+        ];
+        assert_eq!(result_log_records, expected);
+
+        // compare col w/ nulls to all null column
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where severity_text == trace_id",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        let result_log_records = &result.resource_logs[0].scope_logs[0].log_records;
+        let expected = &[log_records[1].clone(), log_records[2].clone()];
+        assert_eq!(result_log_records, expected);
+
+        // compare col w/ nulls to attr which is sometimes null
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where severity_text == attributes[\"x\"]",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        let result_log_records = &result.resource_logs[0].scope_logs[0].log_records;
+        let expected = &[log_records[0].clone(), log_records[1].clone()];
+        assert_eq!(result_log_records, expected);
+
+        // same as above, but with left/right reversed
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where attributes[\"x\"] == severity_text",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        let result_log_records = &result.resource_logs[0].scope_logs[0].log_records;
+        let expected = &[log_records[0].clone(), log_records[1].clone()];
+        assert_eq!(result_log_records, expected);
+
+        // compare all null column to attr which is sometimes null
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where trace_id == attributes[\"x\"]",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        let result_log_records = &result.resource_logs[0].scope_logs[0].log_records;
+        let expected = &[log_records[1].clone()];
+        assert_eq!(result_log_records, expected);
+
+        // compare all null struct column to attr which is sometimes null
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where instrumentation_scope.name == attributes[\"x\"]",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        let result_log_records = &result.resource_logs[0].scope_logs[0].log_records;
+        let expected = &[log_records[1].clone()];
+        assert_eq!(result_log_records, expected);
+
+        // compare attributes which are sometimes null
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where  attributes[\"x\"] == attributes[\"y\"]",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        let result_log_records = &result.resource_logs[0].scope_logs[0].log_records;
+        let expected = &[log_records[0].clone(), log_records[1].clone()];
+        assert_eq!(result_log_records, expected);
+
+        // comparisons that get or'd w/ something that will be misaligned, and so we need to do
+        // a bitmap OR, except that the left side has a 'true' in a place where there is no ID
+        // because null == null evaluated to true.
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where  attributes[\"x\"] == attributes[\"y\"] or attributes[\"z\"] == \"test\"",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        let result_log_records = &result.resource_logs[0].scope_logs[0].log_records;
+        let expected = &[
+            log_records[0].clone(),
+            log_records[1].clone(),
+            log_records[2].clone(),
+        ];
+        assert_eq!(result_log_records, expected);
+
+        // same as case above but left/right of "or" reversed
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where  attributes[\"z\"] == \"test\" or attributes[\"x\"] == attributes[\"y\"]",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        let result_log_records = &result.resource_logs[0].scope_logs[0].log_records;
+        let expected = &[
+            log_records[0].clone(),
+            log_records[1].clone(),
+            log_records[2].clone(),
+        ];
+        assert_eq!(result_log_records, expected);
+
+        // TODO comment about what this is testing
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where  attributes[\"x\"] == attributes[\"y\"] and attributes[\"z\"] == null",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        let result_log_records = &result.resource_logs[0].scope_logs[0].log_records;
+        let expected = &[log_records[0].clone(), log_records[1].clone()];
+        assert_eq!(result_log_records, expected);
+
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where  attributes[\"z\"] == null and attributes[\"x\"] == attributes[\"y\"] ",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        let result_log_records = &result.resource_logs[0].scope_logs[0].log_records;
+        let expected = &[log_records[0].clone(), log_records[1].clone()];
+        assert_eq!(result_log_records, expected);
+    }
+
+    /// This is similar to the test above, but the nulls on either side of the comparison are
+    /// coming from either struct columns or non-root attributes (scope attrs).
+    #[tokio::test]
+    async fn test_filter_compare_null_eq_null_eval_at_runtime_with_parent_data() {
+        let log_record0 = LogRecord::build()
+            .severity_text("ERROR")
+            .attributes(vec![
+                KeyValue::new("x", AnyValue::new_string("hello")),
+                KeyValue::new("y", AnyValue::new_string("hello")),
+            ])
+            .event_name("hello")
+            .finish();
+        let log_record1 = LogRecord::build().finish();
+        let log_record2 = LogRecord::build()
+            .severity_text("ERROR")
+            .event_name("asdf")
+            .attributes(vec![KeyValue::new("x", AnyValue::new_string("asdf"))])
+            .finish();
+        let log_record3 = LogRecord::build().severity_text("ERROR").finish();
+        let log_record4 = LogRecord::build()
+            .severity_text("ERROR")
+            .event_name("hello")
+            .attributes(vec![
+                KeyValue::new("x", AnyValue::new_string("hello")),
+                KeyValue::new("y", AnyValue::new_string("hello")),
+            ])
+            .finish();
+
+        let logs_data = LogsData::new(vec![ResourceLogs::new(
+            Resource::default(),
+            vec![
+                ScopeLogs::new(
+                    InstrumentationScope::build()
+                        .name("hello")
+                        .attributes(vec![KeyValue::new("z", AnyValue::new_string("hello"))])
+                        .finish(),
+                    vec![
+                        log_record0.clone(),
+                        log_record1.clone(),
+                        log_record2.clone(),
+                    ],
+                ),
+                ScopeLogs::new(
+                    InstrumentationScope::build().finish(),
+                    vec![log_record3.clone(), log_record4.clone()],
+                ),
+            ],
+        )]);
+
+        // compare column w/ nulls to null struct column w/ nulls
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where event_name == instrumentation_scope.name",
+            logs_data.clone(),
+        )
+        .await;
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[log_record0.clone()]
+        );
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[1].log_records,
+            &[log_record3.clone()]
+        );
+
+        // compare column w/ nulls to all null struct column (where struct column is present)
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where event_name == instrumentation_scope.version",
+            logs_data.clone(),
+        )
+        .await;
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[log_record1.clone()]
+        );
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[1].log_records,
+            &[log_record3.clone()]
+        );
+
+        // compare column w/ nulls to all null struct column (where struct column is present)
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where event_name == instrumentation_scope.attributes[\"z\"]",
+            logs_data.clone(),
+        )
+        .await;
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[log_record0.clone()]
+        );
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[1].log_records,
+            &[log_record3.clone()]
+        );
+
+        // compare column w/ nulls to all null struct column (where struct column is present)
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where attributes[\"x\"] == instrumentation_scope.attributes[\"z\"]",
+            logs_data.clone(),
+        )
+        .await;
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[log_record0.clone()]
+        );
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[1].log_records,
+            &[log_record3.clone()]
+        );
+
+        // compare column w/ nulls to all null struct column (where struct column is present)
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | 
+                where 
+                    attributes[\"x\"] == attributes[\"y\"]
+                    or instrumentation_scope.attributes[\"z\"] == \"hello\"
+            ",
+            logs_data.clone(),
+        )
+        .await;
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[
+                log_record0.clone(),
+                log_record1.clone(),
+                log_record2.clone()
+            ]
+        );
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[1].log_records,
+            &[log_record3.clone(), log_record4.clone()]
+        );
+
+        // compare column w/ nulls to all null struct column (where struct column is present)
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | 
+                where 
+                    attributes[\"x\"] == attributes[\"y\"]
+                    and instrumentation_scope.attributes[\"w\"] == null
+            ",
+            logs_data.clone(),
+        )
+        .await;
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[log_record0.clone(), log_record1.clone()]
+        );
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[1].log_records,
+            &[log_record3.clone(), log_record4.clone()]
+        );
+    }
+
+    /// Basically the same as the test above testing null == null but all the predicates are
+    /// inverted
+    #[tokio::test]
+    async fn test_filter_compare_null_neq_null_evaluated_at_runtime() {
+        let log_records = vec![
+            LogRecord::build()
+                .event_name("ERROR")
+                .severity_text("ERROR")
+                .attributes(vec![
+                    KeyValue::new("x", AnyValue::new_string("ERROR")),
+                    KeyValue::new("y", AnyValue::new_string("ERROR")),
+                ])
+                .finish(),
+            LogRecord::build().finish(),
+            LogRecord::build()
+                .event_name("ERROR")
+                .attributes(vec![KeyValue::new("x", AnyValue::new_string("ERROR"))])
+                .finish(),
+            LogRecord::build()
+                .event_name("ERROR")
+                .severity_text("asdf")
+                .attributes(vec![
+                    KeyValue::new("x", AnyValue::new_string("ERROR")),
+                    KeyValue::new("y", AnyValue::new_string("b")),
+                ])
+                .finish(),
+        ];
+
+        // fields containing nulls
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where severity_text != event_name",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        let result_log_records = &result.resource_logs[0].scope_logs[0].log_records;
+        let expected = &[log_records[2].clone(), log_records[3].clone()];
+        assert_eq!(result_log_records, expected);
+
+        // compare col w/ nulls to all null column
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where severity_text != trace_id",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        let result_log_records = &result.resource_logs[0].scope_logs[0].log_records;
+        let expected = &[log_records[0].clone(), log_records[3].clone()];
+        assert_eq!(result_log_records, expected);
+
+        // compare col w/ nulls to all null struct column
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where severity_text != instrumentation_scope.version",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        let result_log_records = &result.resource_logs[0].scope_logs[0].log_records;
+        let expected = &[log_records[0].clone(), log_records[3].clone()];
+        assert_eq!(result_log_records, expected);
+
+        // two all null columns
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where trace_id != span_id",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        assert_eq!(result.resource_logs.len(), 0);
+
+        // compare col w/ nulls to all null column
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where severity_text != trace_id",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        let result_log_records = &result.resource_logs[0].scope_logs[0].log_records;
+        let expected = &[log_records[0].clone(), log_records[3].clone()];
+        assert_eq!(result_log_records, expected);
+
+        // compare col w/ nulls to attr which is sometimes null
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where severity_text != attributes[\"x\"]",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        let result_log_records = &result.resource_logs[0].scope_logs[0].log_records;
+        let expected = &[log_records[2].clone(), log_records[3].clone()];
+        assert_eq!(result_log_records, expected);
+
+        // same as above, but with left/right reversed
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where attributes[\"x\"] != severity_text",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        let result_log_records = &result.resource_logs[0].scope_logs[0].log_records;
+        let expected = &[log_records[2].clone(), log_records[3].clone()];
+        assert_eq!(result_log_records, expected);
+
+        // compare all null column to attr which is sometimes null
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where trace_id != attributes[\"x\"]",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        let result_log_records = &result.resource_logs[0].scope_logs[0].log_records;
+        let expected = &[
+            log_records[0].clone(),
+            log_records[2].clone(),
+            log_records[3].clone(),
+        ];
+        assert_eq!(result_log_records, expected);
+
+        // compare all null struct column to attr which is sometimes null
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where instrumentation_scope.version != attributes[\"x\"]",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        let result_log_records = &result.resource_logs[0].scope_logs[0].log_records;
+        let expected = &[
+            log_records[0].clone(),
+            log_records[2].clone(),
+            log_records[3].clone(),
+        ];
+        assert_eq!(result_log_records, expected);
+
+        // compare attributes which are sometimes null
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where  attributes[\"x\"] != attributes[\"y\"]",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        let result_log_records = &result.resource_logs[0].scope_logs[0].log_records;
+        let expected = &[log_records[2].clone(), log_records[3].clone()];
+        assert_eq!(result_log_records, expected);
+
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where  attributes[\"x\"] != attributes[\"y\"] or attributes[\"x\"] == null",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        let result_log_records = &result.resource_logs[0].scope_logs[0].log_records;
+        let expected = &[
+            log_records[1].clone(),
+            log_records[2].clone(),
+            log_records[3].clone(),
+        ];
+        assert_eq!(result_log_records, expected);
+
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where  attributes[\"x\"] != null and attributes[\"x\"] != attributes[\"y\"] ",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        let result_log_records = &result.resource_logs[0].scope_logs[0].log_records;
+        let expected = &[log_records[2].clone(), log_records[3].clone()];
+        assert_eq!(result_log_records, expected);
+    }
+
+    /// This is similar to the test above, testing null == null w/ struct columns except
+    /// all the predicates are inverted
+    #[tokio::test]
+    async fn test_filter_compare_null_neq_null_eval_at_runtime_with_parent_data() {
+        let log_record0 = LogRecord::build()
+            .severity_text("ERROR")
+            .attributes(vec![
+                KeyValue::new("x", AnyValue::new_string("hello")),
+                KeyValue::new("y", AnyValue::new_string("hello")),
+            ])
+            .event_name("hello")
+            .finish();
+        let log_record1 = LogRecord::build().finish();
+        let log_record2 = LogRecord::build()
+            .severity_text("ERROR")
+            .event_name("asdf")
+            .attributes(vec![KeyValue::new("x", AnyValue::new_string("asdf"))])
+            .finish();
+        let log_record3 = LogRecord::build().severity_text("ERROR").finish();
+        let log_record4 = LogRecord::build()
+            .severity_text("ERROR")
+            .event_name("hello")
+            .attributes(vec![
+                KeyValue::new("x", AnyValue::new_string("hello")),
+                KeyValue::new("y", AnyValue::new_string("hello")),
+            ])
+            .finish();
+
+        let logs_data = LogsData::new(vec![ResourceLogs::new(
+            Resource::default(),
+            vec![
+                ScopeLogs::new(
+                    InstrumentationScope::build()
+                        .name("hello")
+                        .attributes(vec![KeyValue::new("z", AnyValue::new_string("hello"))])
+                        .finish(),
+                    vec![
+                        log_record0.clone(),
+                        log_record1.clone(),
+                        log_record2.clone(),
+                    ],
+                ),
+                ScopeLogs::new(
+                    InstrumentationScope::build().finish(),
+                    vec![log_record3.clone(), log_record4.clone()],
+                ),
+            ],
+        )]);
+
+        // compare column w/ nulls to null struct column w/ nulls
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where event_name != instrumentation_scope.name",
+            logs_data.clone(),
+        )
+        .await;
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[log_record1.clone(), log_record2.clone()]
+        );
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[1].log_records,
+            &[log_record4.clone()]
+        );
+
+        // compare column w/ nulls to all null struct column (where struct column is present)
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where event_name != instrumentation_scope.version",
+            logs_data.clone(),
+        )
+        .await;
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[log_record0.clone(), log_record2.clone()]
+        );
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[1].log_records,
+            &[log_record4.clone()]
+        );
+
+        // compare column w/ nulls to all null struct column (where struct column is present)
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where event_name != instrumentation_scope.attributes[\"z\"]",
+            logs_data.clone(),
+        )
+        .await;
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[log_record1.clone(), log_record2.clone()]
+        );
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[1].log_records,
+            &[log_record4.clone()]
+        );
+
+        // compare column w/ nulls to all null struct column (where struct column is present)
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where attributes[\"x\"] != instrumentation_scope.attributes[\"z\"]",
+            logs_data.clone(),
+        )
+        .await;
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[log_record1.clone(), log_record2.clone()]
+        );
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[1].log_records,
+            &[log_record4.clone()]
+        );
+
+        // compare column w/ nulls to all null struct column (where struct column is present)
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | 
+                where 
+                    attributes[\"x\"] != attributes[\"y\"]
+                    or instrumentation_scope.attributes[\"z\"] != \"hello\"
+            ",
+            logs_data.clone(),
+        )
+        .await;
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[log_record2.clone()]
+        );
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[1].log_records,
+            &[log_record3.clone(), log_record4.clone()]
+        );
+        // compare column w/ nulls to all null struct column (where struct column is present)
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | 
+                where 
+                    attributes[\"x\"] != attributes[\"y\"]
+                    and instrumentation_scope.attributes[\"z\"] != null
+            ",
+            logs_data.clone(),
+        )
+        .await;
+        assert_eq!(result.resource_logs.len(), 1);
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[log_record2.clone()]
+        );
+    }
+
+    /// This is similar to the two tests above, except for operations other than equals/not equals
+    /// there is no case where `null <op> null` is true. E.g. x > y is always false if either side
+    /// is null
+    #[tokio::test]
+    async fn test_filter_numeric_compare_null_with_null_evaluated_at_runtime() {
+        let log_records = vec![
+            LogRecord::build()
+                .severity_number(5)
+                .attributes(vec![
+                    KeyValue::new("x", AnyValue::new_int(2)),
+                    KeyValue::new("y", AnyValue::new_int(5)),
+                ])
+                .finish(),
+            LogRecord::build().finish(),
+            LogRecord::build()
+                .attributes(vec![
+                    KeyValue::new("x", AnyValue::new_int(5)),
+                    KeyValue::new("y", AnyValue::new_int(5)),
+                ])
+                .finish(),
+            LogRecord::build()
+                .severity_number(1)
+                .attributes(vec![KeyValue::new("x", AnyValue::new_int(2))])
+                .finish(),
+        ];
+
+        // compare field containing nulls with attributes which are sometimes null
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where severity_number > attributes[\"x\"]",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        let result_log_records = &result.resource_logs[0].scope_logs[0].log_records;
+        let expected = &[log_records[0].clone()];
+        assert_eq!(result_log_records, expected);
+
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where severity_number >= attributes[\"y\"]",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        let result_log_records = &result.resource_logs[0].scope_logs[0].log_records;
+        let expected = &[log_records[0].clone()];
+        assert_eq!(result_log_records, expected);
+
+        // same as case above, but the left/right are switched
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where attributes[\"x\"] < severity_number",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        let result_log_records = &result.resource_logs[0].scope_logs[0].log_records;
+        let expected = &[log_records[0].clone()];
+        assert_eq!(result_log_records, expected);
+
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where attributes[\"y\"] <= severity_number",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        let result_log_records = &result.resource_logs[0].scope_logs[0].log_records;
+        let expected = &[log_records[0].clone()];
+        assert_eq!(result_log_records, expected);
+
+        // compare field containing nulls with field that is all null (hence not present)
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where severity_number > dropped_attributes_count",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        assert!(result.resource_logs.is_empty());
+
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where severity_number < dropped_attributes_count",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        assert!(result.resource_logs.is_empty());
+
+        // attribute compared with sometimes null attribute:
+
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where attributes[\"x\"] < attributes[\"y\"]",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        let result_log_records = &result.resource_logs[0].scope_logs[0].log_records;
+        let expected = &[log_records[0].clone()];
+        assert_eq!(result_log_records, expected);
+
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where attributes[\"y\"] <= attributes[\"x\"]",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        let result_log_records = &result.resource_logs[0].scope_logs[0].log_records;
+        let expected = &[log_records[2].clone()];
+        assert_eq!(result_log_records, expected);
+
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where attributes[\"x\"] > attributes[\"y\"]",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        assert!(result.resource_logs.is_empty());
+
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where attributes[\"x\"] >= attributes[\"y\"]",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        let result_log_records = &result.resource_logs[0].scope_logs[0].log_records;
+        let expected = &[log_records[2].clone()];
+        assert_eq!(result_log_records, expected);
+    }
+
+    #[tokio::test]
+    async fn test_filter_by_attributes_where_some_log_has_no_id() {
+        let log_records = vec![
+            LogRecord::build()
+                .event_name("ERROR")
+                .severity_text("ERROR")
+                .attributes(vec![
+                    KeyValue::new("x", AnyValue::new_string("ERROR")),
+                    KeyValue::new("y", AnyValue::new_string("ERROR")),
+                ])
+                .finish(),
+            // no attributes, so no ID
+            LogRecord::build().finish(),
+            LogRecord::build()
+                .event_name("ERROR")
+                .attributes(vec![KeyValue::new("x", AnyValue::new_string("ERROR"))])
+                .finish(),
+            LogRecord::build()
+                .event_name("ERROR")
+                .severity_text("asdf")
+                .attributes(vec![
+                    KeyValue::new("x", AnyValue::new_string("b")),
+                    KeyValue::new("y", AnyValue::new_string("b")),
+                ])
+                .finish(),
+        ];
+
+        // fields containing nulls
+        let result = exec_logs_pipeline::<OplParser>(
+            "logs | where not(attributes[\"x\"] == substring(\"ERROR\", 0, 5))",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        let result_log_records = &result.resource_logs[0].scope_logs[0].log_records;
+        let expected = &[log_records[1].clone(), log_records[3].clone()];
+        assert_eq!(result_log_records, expected);
+    }
+
     async fn test_optional_attrs_existence_changes<P: Parser>() {
         // what happens if some optional attributes are present one batch, then not present in the
         // next, then present in the next, etc.
@@ -4700,5 +5708,47 @@ mod test {
         let result =
             exec_logs_pipeline::<OplParser>(query, to_logs_data(log_records.clone())).await;
         assert_eq!(result.resource_logs.len(), 0, "expected empty result");
+    }
+
+    #[tokio::test]
+    async fn test_filter_by_type_before_predicate_requiring_type() {
+        let log_records = vec![
+            LogRecord::build()
+                .severity_text("DEBUG")
+                .attributes(vec![KeyValue::new("x", AnyValue::new_string("hi"))])
+                .finish(),
+            LogRecord::build()
+                .severity_text("INFO")
+                .attributes(vec![KeyValue::new("x", AnyValue::new_string("HELLO"))])
+                .finish(),
+            LogRecord::build()
+                .severity_text("INFO")
+                .attributes(vec![KeyValue::new("x", AnyValue::new_string("goodbye"))])
+                .finish(),
+            LogRecord::build()
+                .severity_text("INFO")
+                .attributes(vec![KeyValue::new("x", AnyValue::new_bool(false))])
+                .finish(),
+        ];
+
+        let query = "logs | where attributes[\"x\"] is String and matches(lower_case(attributes[\"x\"]), r\"h.*\")";
+        let result =
+            exec_logs_pipeline::<OplParser>(query, to_logs_data(log_records.clone())).await;
+
+        let expected = vec![log_records[0].clone(), log_records[1].clone()];
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &expected
+        );
+
+        let query = "logs | where attributes[\"x\"] is String and contains(lower_case(attributes[\"x\"]), \"h\")";
+        let result =
+            exec_logs_pipeline::<OplParser>(query, to_logs_data(log_records.clone())).await;
+
+        let expected = vec![log_records[0].clone(), log_records[1].clone()];
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &expected
+        );
     }
 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/functions.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/functions.rs
@@ -12,6 +12,7 @@ use datafusion::functions::{export_functions, make_udf_function};
 use datafusion::logical_expr::{self as datafusion_expr, TypeSignature};
 use datafusion::logical_expr_common::signature::Arity;
 
+pub(crate) mod compare;
 mod contains;
 mod fnv;
 pub(crate) mod is_type;

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/compare.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/compare.rs
@@ -1,0 +1,78 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::any::Any;
+use std::sync::Arc;
+
+use arrow::datatypes::DataType;
+use datafusion::common::exec_err;
+use datafusion::error::{DataFusionError, Result};
+use datafusion::logical_expr::expr::ScalarFunction;
+use datafusion::logical_expr::{
+    ColumnarValue, Documentation, Expr, Operator, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl,
+    Signature, Volatility,
+};
+
+use crate::pipeline::filter::compare::compare;
+
+/// Scalar UDF for invoking [`compare`].
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct CompareFunc {
+    operator: Operator,
+    signature: Signature,
+}
+
+impl CompareFunc {
+    pub fn new(operator: Operator) -> Self {
+        Self {
+            operator,
+            signature: Signature::any(2, Volatility::Immutable),
+        }
+    }
+
+    /// return an [`Expr`] that invokes this function on the given args
+    pub fn new_expr(left: Expr, operator: Operator, right: Expr) -> Expr {
+        Expr::ScalarFunction(ScalarFunction::new_udf(
+            Arc::new(ScalarUDF::new_from_shared_impl(Arc::new(CompareFunc::new(
+                operator,
+            )))),
+            vec![left, right],
+        ))
+    }
+}
+
+impl ScalarUDFImpl for CompareFunc {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "compare"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Boolean)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        if args.args.len() != 2 {
+            return exec_err!(
+                "invalid number of args. received {} expected 2",
+                args.args.len()
+            );
+        }
+
+        let result = compare(&args.args[0], self.operator, &args.args[1])
+            .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+
+        Ok(ColumnarValue::Array(Arc::new(result)))
+    }
+
+    fn documentation(&self) -> Option<&Documentation> {
+        None
+    }
+}

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/planner.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/planner.rs
@@ -668,7 +668,7 @@ impl PipelinePlanner {
                         }
                     }
                 },
-                ScopedExpr::JoinAndEval { children, eval } => {
+                ScopedExpr::JoinAndEval { children, eval, .. } => {
                     let children_ref = children
                         .iter()
                         .any(|child| source_references_col_or_key(child, referenced));

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/project.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/project.rs
@@ -5,7 +5,7 @@
 
 use std::sync::Arc;
 
-use arrow::array::{Array, ArrayRef, RecordBatch, RecordBatchOptions, StructArray};
+use arrow::array::{Array, ArrayRef, NullArray, RecordBatch, RecordBatchOptions, StructArray};
 use arrow::compute::cast;
 use arrow::datatypes::{DataType, Field, Schema};
 use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion, TreeNodeVisitor};
@@ -24,6 +24,14 @@ pub struct ProjectionOptions {
     /// Whether or not to downcast dictionary arrays to the native type. Some types of expressions,
     /// arithmetic operations for example, do not work on dictionary encoded columns.
     pub downcast_dicts: bool,
+
+    /// Whether to create null placeholders when some column does not exist. A column not being
+    /// present means it is optional in the OTAP model, or it represents the value of an attribute
+    /// that is not present. Ordinarily, when any column is not present the projection return
+    /// `None` and lets the caller handle it, however this option can be used in cases where the
+    /// caller is feeding the resulting projected batch into an expression that has some specific
+    /// handling for null columns
+    pub default_null_columns: bool,
 }
 
 /// Projection helper that can project a RecordBatch to only the columns needed by an expression
@@ -59,10 +67,11 @@ impl Projection {
         record_batch: &RecordBatch,
         options: &ProjectionOptions,
     ) -> Result<Option<RecordBatch>> {
-        let (mut fields, mut columns) = match self.project_columns(record_batch) {
-            Some(projection) => projection,
-            None => return Ok(None),
-        };
+        let (mut fields, mut columns) =
+            match self.project_columns(record_batch, options.default_null_columns) {
+                Some(projection) => projection,
+                None => return Ok(None),
+            };
 
         if options.downcast_dicts {
             Self::try_downcast_dicts(&mut fields, &mut columns)?;
@@ -84,6 +93,7 @@ impl Projection {
     fn project_columns(
         &self,
         record_batch: &RecordBatch,
+        default_nulls: bool,
     ) -> Option<(Vec<Arc<Field>>, Vec<ArrayRef>)> {
         let original_schema = record_batch.schema_ref();
 
@@ -95,24 +105,62 @@ impl Projection {
         for projected_col in &self.schema {
             match projected_col {
                 ProjectedSchemaColumn::Root(desired_col_name) => {
-                    let index = original_schema.index_of(desired_col_name).ok()?;
-                    let column = record_batch.column(index).clone();
-                    let field = original_schema.fields[index].clone();
+                    let (column, field) =
+                        if let Some(index) = original_schema.index_of(desired_col_name).ok() {
+                            // original column
+                            Some((
+                                record_batch.column(index).clone(),
+                                original_schema.fields[index].clone(),
+                            ))
+                        } else if default_nulls {
+                            // default nulls
+                            Some((
+                                Arc::new(NullArray::new(record_batch.num_rows())) as ArrayRef,
+                                Arc::new(Field::new(desired_col_name, DataType::Null, true)),
+                            ))
+                        } else {
+                            // column could not be projected
+                            None
+                        }?;
                     columns.push(column);
-                    fields.push(field)
+                    fields.push(field);
                 }
                 ProjectedSchemaColumn::Struct(desired_struct_name, desired_struct_fields) => {
-                    let struct_index = original_schema.index_of(desired_struct_name).ok()?;
-                    let column = record_batch.column(struct_index);
-                    let col_as_struct = column.as_any().downcast_ref::<StructArray>()?;
+                    let struct_index = original_schema.index_of(desired_struct_name).ok();
+                    if struct_index.is_none() && !default_nulls {
+                        return None;
+                    }
+
+                    let struct_col = struct_index.and_then(|i| {
+                        record_batch
+                            .column(i)
+                            .as_any()
+                            .downcast_ref::<StructArray>()
+                    });
 
                     let mut struct_fields = Vec::new();
                     let mut struct_field_defs = Vec::new();
 
                     for field_name in desired_struct_fields {
-                        let (field_index, field) = col_as_struct.fields().find(field_name)?;
-                        struct_fields.push(col_as_struct.column(field_index).clone());
-                        struct_field_defs.push(field.clone());
+                        let (struct_field, field_def) = struct_col
+                            .and_then(|struct_col| struct_col.fields().find(field_name))
+                            .map(|(field_index, field)| {
+                                (
+                                    struct_col.expect("not none").column(field_index).clone(),
+                                    field.clone(),
+                                )
+                            })
+                            .or(if default_nulls {
+                                Some((
+                                    Arc::new(NullArray::new(record_batch.num_rows())) as ArrayRef,
+                                    Arc::new(Field::new(field_name, DataType::Null, true)),
+                                ))
+                            } else {
+                                None
+                            })?;
+
+                        struct_fields.push(struct_field);
+                        struct_field_defs.push(field_def)
                     }
 
                     // safety: `try_new` will return an error here if the types of arrays we pass
@@ -122,14 +170,22 @@ impl Projection {
                     let projected_struct_arr = StructArray::try_new(
                         struct_field_defs.into(),
                         struct_fields,
-                        col_as_struct.nulls().cloned(),
+                        struct_col.map(|arr| arr.nulls().cloned()).unwrap_or(None),
                     )
                     .expect("can init StructArray");
 
-                    let projected_field = original_schema.fields[struct_index]
-                        .as_ref()
-                        .clone()
-                        .with_data_type(projected_struct_arr.data_type().clone());
+                    let projected_field = if let Some(struct_index) = struct_index {
+                        original_schema.fields[struct_index]
+                            .as_ref()
+                            .clone()
+                            .with_data_type(projected_struct_arr.data_type().clone())
+                    } else {
+                        Field::new(
+                            desired_struct_name,
+                            projected_struct_arr.data_type().clone(),
+                            true,
+                        )
+                    };
                     fields.push(Arc::new(projected_field));
                     columns.push(Arc::new(projected_struct_arr));
                 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/project.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/project.rs
@@ -106,7 +106,7 @@ impl Projection {
             match projected_col {
                 ProjectedSchemaColumn::Root(desired_col_name) => {
                     let (column, field) =
-                        if let Some(index) = original_schema.index_of(desired_col_name).ok() {
+                        if let Ok(index) = original_schema.index_of(desired_col_name) {
                             // original column
                             Some((
                                 record_batch.column(index).clone(),


### PR DESCRIPTION

# Change Summary

<!--
Replace with a brief summary of the change in this PR
-->

in #3059, we added a unified expression evaluation which bridges the gap between evaluating logical expressions and other types of expressions. With the code that was added, a new host of expressions are now supported. However, there were some subtle correctness issues that needed addressing.

**non-root attribute filters were not selecting the correct rows**

When we evaluate and expression like `attributes["x"] == "y"`, we produce an intermediate `IdMask` with the in the parent_ids from the attributes record batch that matched this predicate. We then select rows in the root record batch having values in the `id` column contained in this bitmap.

However, the `IdMask` does not contain any information about which attribute record batch it applies to, which was a problem when the expression is actually something like `resource.attributes["x"] == "y"`. In this case, we'd need to actually select rows from the root batch whose values from the _`resource.id`_ column were contained in this `IdMask`.

Now, the result of this expression returns a new type called `ScopedIdMask` both the id mask, and additional information about which `id` column to use when selecting rows from the parent record batch.

**"and"/"or"-ing attribute predicates from different record batches**

When evaluating expressions like this:
```
attributes["x"] == "y" or resource.attributes["x"] == "y"
```
We were producing intermediate `IdMask` bitmaps of the parent_id columns from the attrs / resource attrs record batches where key == "x" and the str column == "y". To evaluate the "or", we'd then "or" these bitmaps together. 

This obviously is not correct because attr's parent_id column is associated with the "id" column on the root batch, whereas resource attr's parent_id column is associated with the "resource.id" column, and these columns may (usually will) have different values for each row.

We change the planner to make it intelligent enough to recognize that these expressions do not produce bitmaps that can be 'or'd together. Instead it now does aligns the results of both sides of the "or" to the root record batch and then "or"s the selection vec from either side. This is basically what the old filter code did before we made changes in #3059.

**comparisons involving nulls:**

The comparison rules spelled out in the [OPL Spec](https://github.com/open-telemetry/otel-arrow/blob/7c096f6671b91bd03ced8669fabfa063d5beaca4/rust/otap-dataflow/docs/opl/OPLSpec.tex#L670-L676) and the [OTTL Comparison rules](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/LANGUAGE.md#comparison-rules) whic state that `null == null` evaluates to `true`, `null != <something not null>` also evaluates to `true`.

We were not handling this correctly in the following cases:
- one or both sides of the comparison were a missing column / a non-existent attribute
- when the root record has no attributes, and an expression like `attributes["x"] == attributes["y"]` evaluates to `null == null` (true)

To fix: in the planner when one side of the comparison is not a static literal (e.g., when we don't know wether it may evaluate to null at runtime), we plan to do the comparison using a new UDF containing the correct comparison logic that was added in https://github.com/open-telemetry/otel-arrow/pull/2758. To ensure this actually gets invoked (and a missing column/attr doesn't propagate null to the result before invoking the function), we add flags to the "eval" variants of `ScopedExpr` telling it to use null placeholder columns for missing data and then evaluate the datafusion expressions despite the missing data.

Also, when we were joining the result of something like `attributes["x"] == attributes["y"]`, we'd create a selection that was aligned with the rows from the attributes record batch on one side of the comparison Then we'd consider any parent_ids in the positions where this selection vec was true to have passed the predicate. This is incorrect for the case where the record had no attributes, because both sides are null and hence this should also pass the predicate since `null == null` is `true`. For this reason, the planner now also forces the alignment of both sides to the root record batch before evaluating the equals check, to ensure we get a proper selection vector value in the case where the ID column on the root batch is null.

Similarly, when we evaluated an expression like `attributes["x"] != event_name`, and this evaluated to something like `null != "<not null>"` -> `true`, what we were actually doing was evaluating `not(attributes["x"] == event_name)`. `not` operations were being evaluated as a `BitmapNot`, which means this would evaluate by creating a bitmap of the ID column from the result of `attributes["x"] == event_name`, inverting the bitmap, and then using it to select rows from IDs not in the inverted bitmap. This is wasteful, but also wouldn't evaluate correctly in the case where the  root record had no attributes, because the ID would be null meaning the inverted bitmap didn't contain it. Now when planning `not` expressions, we only use `BitmapNot` when it will actrually return correct results.


## What issue does this PR close?

<!--
We highly recommend correlation of every PR to an issue
-->

* Related to #3003

## How are these changes tested?

Unit

## Are there any user-facing changes?

 <!-- If yes, provide further info below -->
 
 No

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
