### PR TITLE
[Journald receiver] Implement journald ingestion

### DIFF
--- a/rust/otap-dataflow/.chloggen/journald-receiver-implementation.yaml
+++ b/rust/otap-dataflow/.chloggen/journald-receiver-implementation.yaml
@@ -1,0 +1,7 @@
+change_type: enhancement
+component: pipeline
+note: Implement journald receiver ingestion, encoding, and cursor checkpointing.
+issues: [2858]
+subtext: |
+  Adds the Linux sd-journal worker, OTAP log projection, downstream Ack/Nack
+  handling, durable cursor commits, and source metrics for the journald receiver.

--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -218,7 +218,7 @@ xxhash-rust = { version = "0.8", features = ["xxh3"] }
 zip = "=8.6.0"
 byte-unit = { version = "5.2.0", features = ["serde"] }
 cpu-time = "1.0.0"
-one_collect = { git = "https://github.com/microsoft/one-collect.git", rev = "f655a30aec1d15467501ae9f735defb2d6b86581" }
+one_collect = { git = "https://github.com/microsoft/one-collect.git", rev = "293b7d3b135f862bf3a128a98b2a9715c97f3994" }
 
 azure_core = {version = "1.0.0", default-features = false }
 azure_identity = {version = "1.0.0", default-features = false }

--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -218,7 +218,7 @@ xxhash-rust = { version = "0.8", features = ["xxh3"] }
 zip = "=8.6.0"
 byte-unit = { version = "5.2.0", features = ["serde"] }
 cpu-time = "1.0.0"
-one_collect = { git = "https://github.com/microsoft/one-collect.git", rev = "293b7d3b135f862bf3a128a98b2a9715c97f3994" }
+one_collect = { git = "https://github.com/microsoft/one-collect.git", rev = "f655a30aec1d15467501ae9f735defb2d6b86581" }
 
 azure_core = {version = "1.0.0", default-features = false }
 azure_identity = {version = "1.0.0", default-features = false }

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/README.md
@@ -126,6 +126,31 @@ config:
     on_nack: rewind
 ```
 
+## Configuration Options
+
+| Field | Type | Default | Description |
+| ----- | ---- | ------- | ----------- |
+| `source_id` | string | `system` | Stable source identifier used for checkpoint paths and telemetry labels. |
+| `journal.root_path` | path | `/` | Local or mounted host root used for `sd-journal` access. |
+| `journal.namespace` | string | unset | Named namespaces are rejected in v1. |
+| `units` | list | `[]` | Exact `_SYSTEMD_UNIT` matches. |
+| `identifiers` | list | `[]` | Exact `SYSLOG_IDENTIFIER` matches. |
+| `priorities` | list | unset | Exact journald `PRIORITY` values to include. When unset, no priority filter is installed. |
+| `max_priority` | enum | unset | Shorthand for all priorities up to the selected level. Mutually exclusive with `priorities`. |
+| `start_at` | enum | `end` | `end` reads new entries only when no checkpoint exists; `beginning` reads existing entries. |
+| `batch.max_records` | integer | `1024` | Maximum log records per emitted batch. |
+| `batch.max_flush_period` | duration | `200ms` | Maximum time to hold a partial batch. |
+| `extraction.max_entry_bytes` | byte size | `1MiB` | Maximum copied bytes per journal entry. |
+| `extraction.max_field_bytes` | byte size | `256KiB` | Maximum copied bytes per field value. |
+| `extraction.max_fields_per_entry` | integer | `256` | Maximum copied fields per journal entry. |
+| `extraction.large_field_policy` | enum | `drop_and_count` | Oversized fields are dropped and counted. |
+| `checkpoint.directory` | path | `${engine.state_dir}/journald` | Root directory for durable cursor checkpoints. |
+| `checkpoint.max_in_flight_batches` | integer | `1` | Must be `1` in v1. |
+| `checkpoint.on_nack` | enum | `rewind` | Either `rewind` or `fail`. |
+| `checkpoint.max_consecutive_failures` | integer | `5` | Consecutive checkpoint write failures before failing the source. |
+| `wait_timeout` | duration | `1s` | Bounds idle wait and shutdown responsiveness. |
+| `drain_timeout` | duration | `5s` | Drain deadline budget; must exceed `wait_timeout`. |
+
 ## Telemetry
 
 These tables list telemetry emitted directly by this node. Common engine

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/README.md
@@ -181,6 +181,10 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
   Startup fails clearly when journal files are present but unreadable.
 - Must run in a one-core source pipeline. Use `receiver:journald` followed by a
   topic exporter to fan out to multicore downstream processing.
+- Run one active journald receiver per host journal source
+  (`journal.root_path` + namespace) unless duplicate collection is intentional.
+  The receiver rejects duplicate journal sources inside one process, but v1 does
+  not coordinate ownership across separate collector processes.
 - Named journal namespaces are not supported in v1.
 - Kernel ring-buffer (`dmesg`) ingestion is not supported by this receiver.
 - `checkpoint.max_in_flight_batches` must be `1` in v1.
@@ -189,7 +193,9 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
 - Only one receiver in a process can target the same concrete journal source.
 - Duplicate journald fields are emitted as repeated same-key attributes in the
   first implementation. Array coalescing is planned as a follow-up.
-- Cross-process duplicate readers are not prevented in v1.
+- Cross-process source locking is not implemented in v1; run one owner for a
+  checkpoint identity (`source_id` and checkpoint directory) to avoid cursor
+  races.
 - NUMA pinning and placement are future work.
 
 ## Related Docs

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/README.md
@@ -185,6 +185,9 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
   (`journal.root_path` + namespace) unless duplicate collection is intentional.
   The receiver rejects duplicate journal sources inside one process, but v1 does
   not coordinate ownership across separate collector processes.
+  Filters such as units, identifiers, and priorities do not define separate
+  source ownership; two receivers with different filters but the same journal
+  root/namespace still conflict in the same process.
 - Named journal namespaces are not supported in v1.
 - Kernel ring-buffer (`dmesg`) ingestion is not supported by this receiver.
 - `checkpoint.max_in_flight_batches` must be `1` in v1.

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/README.md
@@ -10,25 +10,42 @@
 
 ## Overview
 
-Linux-only receiver for local `systemd-journald` entries. It targets structured
-journal records, uses journald source selection such as units, identifiers, and
-priorities, and is designed around journald cursors for checkpointed progress.
+Linux-only receiver for local `systemd-journald` entries backed by the
+`sd-journal` API. It reads structured journal records through runtime-loaded
+`libsystemd.so.0`, uses journald source selection such as units, identifiers,
+and priorities, and emits OTAP log records for downstream processing.
 
-The current implementation is the first receiver slice: it registers the
-factory, validates configuration, enforces a process-local source lease, and
-handles lifecycle, drain, shutdown, and telemetry control messages. The blocking
-`sd-journal` worker, batch handoff, ACK/NACK tracking, and checkpoint
-persistence are follow-up work.
+The receiver does not exec `journalctl` and does not read `.journal` files
+directly. It uses journald cursors for progress tracking and advances the
+durable checkpoint only after downstream Ack.
 
 ## Getting Started
 
 Start at the end of the default system journal:
 
 ```yaml
-type: receiver:journald
-config:
-  source_id: system
-  start_at: end
+groups:
+  host:
+    pipelines:
+      collect:
+        policies:
+          resources:
+            core_allocation:
+              type: core_count
+              count: 1
+        nodes:
+          journald:
+            type: receiver:journald
+            config:
+              source_id: system
+              start_at: end
+          publish:
+            type: exporter:topic
+            config:
+              topic: journald_logs
+        connections:
+          - from: journald
+            to: publish
 ```
 
 ## Configuration
@@ -62,6 +79,16 @@ config:
     max_records: 1024
     # Maximum time to hold a partial batch before flushing (default: 200ms).
     max_flush_period: 200ms
+
+  extraction:
+    # Maximum copied bytes per journal entry (default: 1MiB).
+    max_entry_bytes: 1MiB
+    # Maximum copied bytes per field value (default: 256KiB).
+    max_field_bytes: 256KiB
+    # Maximum copied fields per journal entry (default: 256).
+    max_fields_per_entry: 256
+    # Behavior for oversized fields: "drop_and_count" (default).
+    large_field_policy: drop_and_count
 
   checkpoint:
     # Root directory for cursor checkpoint files (default:
@@ -125,6 +152,7 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
 ## Limits
 
 - Linux only.
+- Requires `libsystemd.so.0` and permission to read the selected journal.
 - Must run in a one-core source pipeline. Use `receiver:journald` followed by a
   topic exporter to fan out to multicore downstream processing.
 - Named journal namespaces are not supported in v1.
@@ -133,9 +161,10 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
 - `wait_timeout` must be no more than `5s`, and `drain_timeout` must be greater
   than `wait_timeout`.
 - Only one receiver in a process can target the same concrete journal source.
-- The current implementation does not yet emit journal records; the blocking
-  `sd-journal` worker, batch handoff, ACK/NACK tracking, and checkpoint
-  persistence are follow-up work.
+- Duplicate journald fields are emitted as repeated same-key attributes in the
+  first implementation. Array coalescing is planned as a follow-up.
+- Cross-process duplicate readers are not prevented in v1.
+- NUMA pinning and placement are future work.
 
 ## Related Docs
 

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/README.md
@@ -178,6 +178,7 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
 
 - Linux only.
 - Requires `libsystemd.so.0` and permission to read the selected journal.
+- Many `unsafe` regions, everywhere Rust calls the C library.
   Startup fails clearly when journal files are present but fully unreadable;
   failing closed on partially readable journal trees is planned for production
   hardening.

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/README.md
@@ -178,7 +178,9 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
 
 - Linux only.
 - Requires `libsystemd.so.0` and permission to read the selected journal.
-  Startup fails clearly when journal files are present but unreadable.
+  Startup fails clearly when journal files are present but fully unreadable;
+  failing closed on partially readable journal trees is planned for production
+  hardening.
 - Must run in a one-core source pipeline. Use `receiver:journald` followed by a
   topic exporter to fan out to multicore downstream processing.
 - Run one active journald receiver per host journal source
@@ -196,6 +198,11 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
 - Only one receiver in a process can target the same concrete journal source.
 - Duplicate journald fields are emitted as repeated same-key attributes in the
   first implementation. Array coalescing is planned as a follow-up.
+- With `start_at: end`, a process crash before the first successful checkpoint
+  can skip entries already read from journald but not yet durably committed.
+- Extraction limits are per entry and per field. There is no aggregate batch
+  byte cap in v1, so tune `batch.max_records` and extraction limits for the
+  expected host log volume and memory budget.
 - Cross-process source locking is not implemented in v1; run one owner for a
   checkpoint identity (`source_id` and checkpoint directory) to avoid cursor
   races.

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/README.md
@@ -144,7 +144,7 @@ config:
 | `extraction.max_field_bytes` | byte size | `256KiB` | Maximum copied bytes per field value. |
 | `extraction.max_fields_per_entry` | integer | `256` | Maximum copied fields per journal entry. |
 | `extraction.large_field_policy` | enum | `drop_and_count` | Oversized fields are dropped and counted. |
-| `checkpoint.directory` | path | `${engine.state_dir}/journald` | Root directory for durable cursor checkpoints. |
+| `checkpoint.directory` | path | `${engine.state_dir}/journald` | Root directory for durable cursor checkpoints. `${engine.state_dir}` expands to `$OTAP_DF_STATE_DIR` or `.otap-state` when unset. |
 | `checkpoint.max_in_flight_batches` | integer | `1` | Must be `1` in v1. |
 | `checkpoint.on_nack` | enum | `rewind` | Either `rewind` or `fail`. |
 | `checkpoint.max_consecutive_failures` | integer | `5` | Consecutive checkpoint write failures before failing the source. |

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/README.md
@@ -62,7 +62,8 @@ config:
     root_path: /
     # namespace: default
 
-  # Exact source filters. Empty entries are rejected and duplicates are removed.
+  # Exact source filters. Empty lists install no filter for that field.
+  # Empty entries are rejected and duplicates are removed.
   units: []
   identifiers: []
 
@@ -133,8 +134,8 @@ config:
 | `source_id` | string | `system` | Stable source identifier used for checkpoint paths and telemetry labels. |
 | `journal.root_path` | path | `/` | Local or mounted host root used for `sd-journal` access. |
 | `journal.namespace` | string | unset | Named namespaces are rejected in v1. |
-| `units` | list | `[]` | Exact `_SYSTEMD_UNIT` matches. |
-| `identifiers` | list | `[]` | Exact `SYSLOG_IDENTIFIER` matches. |
+| `units` | list | `[]` | Exact `_SYSTEMD_UNIT` matches. An empty list installs no unit filter. |
+| `identifiers` | list | `[]` | Exact `SYSLOG_IDENTIFIER` matches. An empty list installs no identifier filter. |
 | `priorities` | list | unset | Exact journald `PRIORITY` values to include. When unset, no priority filter is installed. |
 | `max_priority` | enum | unset | Shorthand for all priorities up to the selected level. Mutually exclusive with `priorities`. |
 | `start_at` | enum | `end` | `end` reads new entries only when no checkpoint exists; `beginning` reads existing entries. |
@@ -147,7 +148,7 @@ config:
 | `checkpoint.directory` | path | `${engine.state_dir}/journald` | Root directory for durable cursor checkpoints. `${engine.state_dir}` expands to `$OTAP_DF_STATE_DIR` or `.otap-state` when unset. |
 | `checkpoint.max_in_flight_batches` | integer | `1` | Must be `1` in v1. |
 | `checkpoint.on_nack` | enum | `rewind` | Either `rewind` or `fail`. |
-| `checkpoint.max_consecutive_failures` | integer | `5` | Consecutive checkpoint write failures before failing the source. |
+| `checkpoint.max_consecutive_failures` | integer | `5` | Consecutive checkpoint write failures before failing the source. Must be greater than zero; unbounded retries are not supported in v1. |
 | `wait_timeout` | duration | `1s` | Bounds idle wait and shutdown responsiveness. |
 | `drain_timeout` | duration | `5s` | Drain deadline budget; must exceed `wait_timeout`. |
 
@@ -178,7 +179,6 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
 
 - Linux only.
 - Requires `libsystemd.so.0` and permission to read the selected journal.
-- Many `unsafe` regions, everywhere Rust calls the C library.
   Startup fails clearly when journal files are present but fully unreadable;
   failing closed on partially readable journal trees is planned for production
   hardening.

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/README.md
@@ -178,6 +178,7 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
 
 - Linux only.
 - Requires `libsystemd.so.0` and permission to read the selected journal.
+  Startup fails clearly when journal files are present but unreadable.
 - Must run in a one-core source pipeline. Use `receiver:journald` followed by a
   topic exporter to fan out to multicore downstream processing.
 - Named journal namespaces are not supported in v1.

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/arrow_records_encoder.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/arrow_records_encoder.rs
@@ -68,8 +68,8 @@ impl JournaldArrowRecordsBuilder {
     }
 
     pub(crate) fn append(&mut self, entry: &JournalEntry) {
-        self.logs
-            .append_time_unix_nano(entry.realtime_unix_nano as i64);
+        let time_unix_nano = i64::try_from(entry.realtime_unix_nano).unwrap_or(i64::MAX);
+        self.logs.append_time_unix_nano(time_unix_nano);
         self.logs.append_severity_number(
             entry
                 .priority()

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/arrow_records_encoder.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/arrow_records_encoder.rs
@@ -1,0 +1,210 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! OTAP log record construction for journald entries.
+
+use chrono::Utc;
+use otap_df_pdata::{
+    encode::Result,
+    encode::record::{
+        attributes::StrKeysAttributesRecordBatchBuilder, logs::LogsRecordBatchBuilder,
+    },
+    otap::{Logs, OtapArrowRecords},
+    proto::opentelemetry::arrow::v1::ArrowPayloadType,
+};
+
+use crate::receivers::journald_receiver::config::severity_number_from_priority;
+
+/// One field from a journald entry.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct JournalField {
+    pub(crate) name: String,
+    pub(crate) value: Vec<u8>,
+}
+
+/// A decoded journald entry ready for OTAP projection.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct JournalEntry {
+    pub(crate) cursor: String,
+    pub(crate) realtime_unix_nano: u64,
+    pub(crate) fields: Vec<JournalField>,
+}
+
+impl JournalEntry {
+    pub(crate) fn priority(&self) -> Option<u8> {
+        self.field("PRIORITY")
+            .and_then(|v| std::str::from_utf8(v).ok())
+            .and_then(|v| v.parse::<u8>().ok())
+    }
+
+    fn field(&self, key: &str) -> Option<&[u8]> {
+        self.fields
+            .iter()
+            .find(|field| field.name == key)
+            .map(|field| field.value.as_slice())
+    }
+}
+
+/// Builder for creating Arrow record batches from journald entries.
+pub(crate) struct JournaldArrowRecordsBuilder {
+    curr_log_id: u16,
+    logs: LogsRecordBatchBuilder,
+    log_attrs: StrKeysAttributesRecordBatchBuilder<u16>,
+}
+
+impl JournaldArrowRecordsBuilder {
+    pub(crate) fn new() -> Self {
+        Self {
+            curr_log_id: 0,
+            logs: LogsRecordBatchBuilder::new(),
+            log_attrs: StrKeysAttributesRecordBatchBuilder::<u16>::new(),
+        }
+    }
+
+    pub(crate) const fn len(&self) -> u16 {
+        self.curr_log_id
+    }
+
+    pub(crate) fn append(&mut self, entry: &JournalEntry) {
+        self.logs
+            .append_time_unix_nano(entry.realtime_unix_nano as i64);
+        self.logs.append_severity_number(
+            entry
+                .priority()
+                .and_then(severity_number_from_priority)
+                .map(i32::from),
+        );
+        self.logs.append_severity_text(None);
+
+        match entry.field("MESSAGE") {
+            Some(message) if std::str::from_utf8(message).is_ok() => {
+                self.logs.body.append_str(message);
+            }
+            Some(message) => {
+                self.logs.body.append_bytes(message);
+            }
+            None => self.logs.body.append_null(),
+        }
+
+        for field in &entry.fields {
+            if field.name == "MESSAGE" || field.name == "__CURSOR" {
+                continue;
+            }
+            self.log_attrs.append_parent_id(&self.curr_log_id);
+            self.log_attrs.append_key(&field.name);
+            if let Ok(value) = std::str::from_utf8(&field.value) {
+                self.log_attrs
+                    .any_values_builder
+                    .append_str(value.as_bytes());
+            } else {
+                self.log_attrs.any_values_builder.append_bytes(&field.value);
+            }
+        }
+
+        self.logs.append_id(Some(self.curr_log_id));
+        self.curr_log_id = self
+            .curr_log_id
+            .checked_add(1)
+            .expect("journald batch contains more than u16::MAX log records");
+    }
+
+    pub(crate) fn build(mut self) -> Result<OtapArrowRecords> {
+        let log_record_count = usize::from(self.curr_log_id);
+
+        self.logs.resource.append_id_n(0, log_record_count);
+        self.logs
+            .resource
+            .append_schema_url_n(None, log_record_count);
+        self.logs
+            .resource
+            .append_dropped_attributes_count_n(0, log_record_count);
+
+        self.logs.scope.append_id_n(0, log_record_count);
+        self.logs
+            .scope
+            .append_name_n(Some(b"otap-df-core-nodes/journald"), log_record_count);
+        self.logs
+            .scope
+            .append_version_n(Some(env!("CARGO_PKG_VERSION").as_bytes()), log_record_count);
+        self.logs
+            .scope
+            .append_dropped_attributes_count_n(0, log_record_count);
+
+        let observed_time = Utc::now().timestamp_nanos_opt().unwrap_or(0);
+        self.logs
+            .append_observed_time_unix_nano_n(observed_time, log_record_count);
+        self.logs.append_schema_url_n(None, log_record_count);
+        self.logs
+            .append_dropped_attributes_count_n(0, log_record_count);
+        self.logs.append_flags_n(None, log_record_count);
+        self.logs.append_trace_id_n(None, log_record_count)?;
+        self.logs.append_span_id_n(None, log_record_count)?;
+
+        let mut otap_batch = OtapArrowRecords::Logs(Logs::default());
+        otap_batch.set(ArrowPayloadType::Logs, self.logs.finish()?)?;
+
+        let log_attrs_rb = self.log_attrs.finish()?;
+        if log_attrs_rb.num_rows() > 0 {
+            otap_batch.set(ArrowPayloadType::LogAttrs, log_attrs_rb)?;
+        }
+        Ok(otap_batch)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use otap_df_pdata::{
+        otlp::{ProtoBuffer, ProtoBytesEncoder, logs::LogsProtoBytesEncoder},
+        proto::opentelemetry::{
+            collector::logs::v1::ExportLogsServiceRequest, common::v1::any_value::Value,
+        },
+    };
+    use prost::Message;
+
+    #[test]
+    fn projects_message_priority_time_and_attributes() {
+        let entry = JournalEntry {
+            cursor: "s=1".to_owned(),
+            realtime_unix_nano: 123,
+            fields: vec![
+                JournalField {
+                    name: "MESSAGE".to_owned(),
+                    value: b"hello".to_vec(),
+                },
+                JournalField {
+                    name: "PRIORITY".to_owned(),
+                    value: b"4".to_vec(),
+                },
+                JournalField {
+                    name: "_SYSTEMD_UNIT".to_owned(),
+                    value: b"sshd.service".to_vec(),
+                },
+            ],
+        };
+
+        let mut builder = JournaldArrowRecordsBuilder::new();
+        builder.append(&entry);
+        let mut records = builder.build().unwrap();
+        let mut encoder = LogsProtoBytesEncoder::new();
+        let mut buffer = ProtoBuffer::default();
+        encoder.encode(&mut records, &mut buffer).unwrap();
+        let req = ExportLogsServiceRequest::decode(buffer.as_ref()).unwrap();
+        let log = &req.resource_logs[0].scope_logs[0].log_records[0];
+        assert_eq!(log.time_unix_nano, 123);
+        assert_eq!(log.severity_number, 13);
+        assert!(matches!(
+            log.body.as_ref().and_then(|v| v.value.as_ref()),
+            Some(Value::StringValue(v)) if v == "hello"
+        ));
+        assert_eq!(log.attributes.len(), 2);
+        assert!(matches!(
+            log.attributes
+                .iter()
+                .find(|kv| kv.key == "PRIORITY")
+                .and_then(|kv| kv.value.as_ref())
+                .and_then(|v| v.value.as_ref()),
+            Some(Value::StringValue(v)) if v == "4"
+        ));
+    }
+}

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/arrow_records_encoder.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/arrow_records_encoder.rs
@@ -26,6 +26,7 @@ pub(crate) struct JournalField {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct JournalEntry {
     pub(crate) cursor: String,
+    pub(crate) message_body: Option<Vec<u8>>,
     pub(crate) realtime_unix_nano: u64,
     pub(crate) fields: Vec<JournalField>,
     pub(crate) dropped_fields: u64,
@@ -77,7 +78,7 @@ impl JournaldArrowRecordsBuilder {
         );
         self.logs.append_severity_text(None);
 
-        match entry.field("MESSAGE") {
+        match entry.message_body.as_deref() {
             Some(message) if std::str::from_utf8(message).is_ok() => {
                 self.logs.body.append_str(message);
             }
@@ -167,6 +168,7 @@ mod tests {
     fn projects_message_priority_time_and_attributes() {
         let entry = JournalEntry {
             cursor: "s=1".to_owned(),
+            message_body: Some(b"hello".to_vec()),
             realtime_unix_nano: 123,
             fields: vec![
                 JournalField {
@@ -215,6 +217,38 @@ mod tests {
                 .and_then(|kv| kv.value.as_ref())
                 .and_then(|v| v.value.as_ref()),
             Some(Value::StringValue(v)) if v == "4"
+        ));
+    }
+
+    #[test]
+    fn leaves_body_unset_when_first_message_was_dropped() {
+        let entry = JournalEntry {
+            cursor: "s=2".to_owned(),
+            message_body: None,
+            realtime_unix_nano: 456,
+            fields: vec![JournalField {
+                name: "MESSAGE".to_owned(),
+                value: b"surviving duplicate".to_vec(),
+            }],
+            dropped_fields: 1,
+        };
+
+        let mut builder = JournaldArrowRecordsBuilder::new();
+        builder.append(&entry);
+        let mut records = builder.build().unwrap();
+        let mut encoder = LogsProtoBytesEncoder::new();
+        let mut buffer = ProtoBuffer::default();
+        encoder.encode(&mut records, &mut buffer).unwrap();
+        let req = ExportLogsServiceRequest::decode(buffer.as_ref()).unwrap();
+        let log = &req.resource_logs[0].scope_logs[0].log_records[0];
+        assert!(log.body.is_none());
+        assert!(matches!(
+            log.attributes
+                .iter()
+                .find(|kv| kv.key == "MESSAGE")
+                .and_then(|kv| kv.value.as_ref())
+                .and_then(|v| v.value.as_ref()),
+            Some(Value::StringValue(v)) if v == "surviving duplicate"
         ));
     }
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/arrow_records_encoder.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/arrow_records_encoder.rs
@@ -28,6 +28,7 @@ pub(crate) struct JournalEntry {
     pub(crate) cursor: String,
     pub(crate) realtime_unix_nano: u64,
     pub(crate) fields: Vec<JournalField>,
+    pub(crate) dropped_fields: u64,
 }
 
 impl JournalEntry {
@@ -87,7 +88,7 @@ impl JournaldArrowRecordsBuilder {
         }
 
         for field in &entry.fields {
-            if field.name == "MESSAGE" || field.name == "__CURSOR" {
+            if field.name == "__CURSOR" {
                 continue;
             }
             self.log_attrs.append_parent_id(&self.curr_log_id);
@@ -181,6 +182,7 @@ mod tests {
                     value: b"sshd.service".to_vec(),
                 },
             ],
+            dropped_fields: 0,
         };
 
         let mut builder = JournaldArrowRecordsBuilder::new();
@@ -197,7 +199,15 @@ mod tests {
             log.body.as_ref().and_then(|v| v.value.as_ref()),
             Some(Value::StringValue(v)) if v == "hello"
         ));
-        assert_eq!(log.attributes.len(), 2);
+        assert_eq!(log.attributes.len(), 3);
+        assert!(matches!(
+            log.attributes
+                .iter()
+                .find(|kv| kv.key == "MESSAGE")
+                .and_then(|kv| kv.value.as_ref())
+                .and_then(|v| v.value.as_ref()),
+            Some(Value::StringValue(v)) if v == "hello"
+        ));
         assert!(matches!(
             log.attributes
                 .iter()

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/checkpoint.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/checkpoint.rs
@@ -123,6 +123,7 @@ pub(crate) fn write_cursor(path: &Path, cursor: &str) -> Result<(), CheckpointEr
     })?;
     let file = std::fs::OpenOptions::new()
         .read(true)
+        .write(true)
         .open(&tmp)
         .map_err(|source| CheckpointError::Reopen {
             path: tmp.clone(),

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/checkpoint.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/checkpoint.rs
@@ -1,0 +1,174 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Durable cursor checkpoint helpers for the journald receiver.
+
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+const ENVELOPE_VERSION: u8 = 1;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CursorEnvelope {
+    version: u8,
+    cursor: String,
+    checksum: String,
+}
+
+pub(crate) fn checkpoint_path(
+    root: &Path,
+    pipeline_group_id: &str,
+    pipeline_id: &str,
+    receiver_name: &str,
+    source_id: &str,
+) -> PathBuf {
+    let mut path = expand_state_dir(root);
+    path.push(sanitize_segment(pipeline_group_id));
+    path.push(sanitize_segment(pipeline_id));
+    path.push(sanitize_segment(receiver_name));
+    path.push(format!("{}.cursor", sanitize_segment(source_id)));
+    path
+}
+
+pub(crate) fn read_cursor(path: &Path) -> Result<Option<String>, String> {
+    let bytes = match std::fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => {
+            return Err(format!(
+                "failed to read checkpoint {}: {err}",
+                path.display()
+            ));
+        }
+    };
+    let envelope: CursorEnvelope = serde_json::from_slice(&bytes)
+        .map_err(|err| format!("failed to parse checkpoint {}: {err}", path.display()))?;
+    if envelope.version != ENVELOPE_VERSION {
+        return Err(format!(
+            "unsupported checkpoint version {} in {}",
+            envelope.version,
+            path.display()
+        ));
+    }
+    let expected = checksum(&envelope.cursor);
+    if envelope.checksum != expected {
+        return Err(format!(
+            "checkpoint checksum mismatch in {}",
+            path.display()
+        ));
+    }
+    Ok(Some(envelope.cursor))
+}
+
+pub(crate) fn write_cursor(path: &Path, cursor: &str) -> Result<(), String> {
+    let envelope = CursorEnvelope {
+        version: ENVELOPE_VERSION,
+        cursor: cursor.to_owned(),
+        checksum: checksum(cursor),
+    };
+    let bytes = serde_json::to_vec(&envelope)
+        .map_err(|err| format!("failed to encode checkpoint envelope: {err}"))?;
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("checkpoint path has no parent: {}", path.display()))?;
+    std::fs::create_dir_all(parent).map_err(|err| {
+        format!(
+            "failed to create checkpoint directory {}: {err}",
+            parent.display()
+        )
+    })?;
+    let tmp = path.with_extension("cursor.tmp");
+    std::fs::write(&tmp, bytes)
+        .map_err(|err| format!("failed to write checkpoint {}: {err}", tmp.display()))?;
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .open(&tmp)
+        .map_err(|err| format!("failed to reopen checkpoint {}: {err}", tmp.display()))?;
+    file.sync_all()
+        .map_err(|err| format!("failed to fsync checkpoint {}: {err}", tmp.display()))?;
+    std::fs::rename(&tmp, path).map_err(|err| {
+        format!(
+            "failed to install checkpoint {} -> {}: {err}",
+            tmp.display(),
+            path.display()
+        )
+    })?;
+    let dir = std::fs::OpenOptions::new()
+        .read(true)
+        .open(parent)
+        .map_err(|err| {
+            format!(
+                "failed to open checkpoint directory {} for fsync: {err}",
+                parent.display()
+            )
+        })?;
+    dir.sync_all().map_err(|err| {
+        format!(
+            "failed to fsync checkpoint directory {}: {err}",
+            parent.display()
+        )
+    })?;
+    Ok(())
+}
+
+fn checksum(cursor: &str) -> String {
+    blake3::hash(cursor.as_bytes()).to_hex().to_string()
+}
+
+fn expand_state_dir(root: &Path) -> PathBuf {
+    let text = root.to_string_lossy();
+    if let Some(rest) = text.strip_prefix("${engine.state_dir}") {
+        let base = std::env::var_os("OTAP_DF_STATE_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(".otap-state"));
+        return base.join(rest.trim_start_matches('/'));
+    }
+    root.to_path_buf()
+}
+
+fn sanitize_segment(value: &str) -> String {
+    value
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn writes_and_reads_cursor_envelope() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cursor");
+        write_cursor(&path, "abc").unwrap();
+        assert_eq!(read_cursor(&path).unwrap(), Some("abc".to_owned()));
+    }
+
+    #[test]
+    fn corrupt_checkpoint_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cursor");
+        std::fs::write(&path, br#"{"version":1,"cursor":"abc","checksum":"bad"}"#).unwrap();
+        assert!(read_cursor(&path).is_err());
+    }
+
+    #[test]
+    fn checkpoint_path_is_stable() {
+        let path = checkpoint_path(
+            Path::new("${engine.state_dir}/journald"),
+            "g",
+            "p",
+            "recv",
+            "system",
+        );
+        assert!(path.ends_with("journald/g/p/recv/system.cursor"));
+    }
+}

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/checkpoint.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/checkpoint.rs
@@ -78,6 +78,7 @@ pub(crate) fn write_cursor(path: &Path, cursor: &str) -> Result<(), String> {
             parent.display()
         )
     })?;
+    // Keep the temporary file beside the final checkpoint so rename is atomic.
     let tmp = path.with_extension("cursor.tmp");
     std::fs::write(&tmp, bytes)
         .map_err(|err| format!("failed to write checkpoint {}: {err}", tmp.display()))?;

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/checkpoint.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/checkpoint.rs
@@ -4,6 +4,7 @@
 //! Durable cursor checkpoint helpers for the journald receiver.
 
 use serde::{Deserialize, Serialize};
+use std::io;
 use std::path::{Path, PathBuf};
 
 const ENVELOPE_VERSION: u8 = 1;
@@ -14,6 +15,43 @@ struct CursorEnvelope {
     version: u8,
     cursor: String,
     checksum: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum CheckpointError {
+    #[error("failed to read checkpoint {path}: {source}")]
+    Read { path: PathBuf, source: io::Error },
+    #[error("failed to parse checkpoint {path}: {source}")]
+    Parse {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+    #[error("unsupported checkpoint version {version} in {path}")]
+    UnsupportedVersion { path: PathBuf, version: u8 },
+    #[error("checkpoint checksum mismatch in {path}")]
+    ChecksumMismatch { path: PathBuf },
+    #[error("failed to encode checkpoint envelope: {source}")]
+    Encode { source: serde_json::Error },
+    #[error("checkpoint path has no parent: {path}")]
+    NoParent { path: PathBuf },
+    #[error("failed to create checkpoint directory {path}: {source}")]
+    CreateDirectory { path: PathBuf, source: io::Error },
+    #[error("failed to write checkpoint {path}: {source}")]
+    Write { path: PathBuf, source: io::Error },
+    #[error("failed to reopen checkpoint {path}: {source}")]
+    Reopen { path: PathBuf, source: io::Error },
+    #[error("failed to fsync checkpoint {path}: {source}")]
+    FsyncFile { path: PathBuf, source: io::Error },
+    #[error("failed to install checkpoint {tmp} -> {path}: {source}")]
+    Rename {
+        tmp: PathBuf,
+        path: PathBuf,
+        source: io::Error,
+    },
+    #[error("failed to open checkpoint directory {path} for fsync: {source}")]
+    OpenDirectory { path: PathBuf, source: io::Error },
+    #[error("failed to fsync checkpoint directory {path}: {source}")]
+    FsyncDirectory { path: PathBuf, source: io::Error },
 }
 
 pub(crate) fn checkpoint_path(
@@ -31,85 +69,87 @@ pub(crate) fn checkpoint_path(
     path
 }
 
-pub(crate) fn read_cursor(path: &Path) -> Result<Option<String>, String> {
+pub(crate) fn read_cursor(path: &Path) -> Result<Option<String>, CheckpointError> {
     let bytes = match std::fs::read(path) {
         Ok(bytes) => bytes,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(err) => {
-            return Err(format!(
-                "failed to read checkpoint {}: {err}",
-                path.display()
-            ));
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => {
+            return Err(CheckpointError::Read {
+                path: path.to_path_buf(),
+                source,
+            });
         }
     };
-    let envelope: CursorEnvelope = serde_json::from_slice(&bytes)
-        .map_err(|err| format!("failed to parse checkpoint {}: {err}", path.display()))?;
+    let envelope: CursorEnvelope =
+        serde_json::from_slice(&bytes).map_err(|source| CheckpointError::Parse {
+            path: path.to_path_buf(),
+            source,
+        })?;
     if envelope.version != ENVELOPE_VERSION {
-        return Err(format!(
-            "unsupported checkpoint version {} in {}",
-            envelope.version,
-            path.display()
-        ));
+        return Err(CheckpointError::UnsupportedVersion {
+            path: path.to_path_buf(),
+            version: envelope.version,
+        });
     }
     let expected = checksum(&envelope.cursor);
     if envelope.checksum != expected {
-        return Err(format!(
-            "checkpoint checksum mismatch in {}",
-            path.display()
-        ));
+        return Err(CheckpointError::ChecksumMismatch {
+            path: path.to_path_buf(),
+        });
     }
     Ok(Some(envelope.cursor))
 }
 
-pub(crate) fn write_cursor(path: &Path, cursor: &str) -> Result<(), String> {
+pub(crate) fn write_cursor(path: &Path, cursor: &str) -> Result<(), CheckpointError> {
     let envelope = CursorEnvelope {
         version: ENVELOPE_VERSION,
         cursor: cursor.to_owned(),
         checksum: checksum(cursor),
     };
-    let bytes = serde_json::to_vec(&envelope)
-        .map_err(|err| format!("failed to encode checkpoint envelope: {err}"))?;
-    let parent = path
-        .parent()
-        .ok_or_else(|| format!("checkpoint path has no parent: {}", path.display()))?;
-    std::fs::create_dir_all(parent).map_err(|err| {
-        format!(
-            "failed to create checkpoint directory {}: {err}",
-            parent.display()
-        )
+    let bytes =
+        serde_json::to_vec(&envelope).map_err(|source| CheckpointError::Encode { source })?;
+    let parent = path.parent().ok_or_else(|| CheckpointError::NoParent {
+        path: path.to_path_buf(),
+    })?;
+    std::fs::create_dir_all(parent).map_err(|source| CheckpointError::CreateDirectory {
+        path: parent.to_path_buf(),
+        source,
     })?;
     // Keep the temporary file beside the final checkpoint so rename is atomic.
     let tmp = path.with_extension("cursor.tmp");
-    std::fs::write(&tmp, bytes)
-        .map_err(|err| format!("failed to write checkpoint {}: {err}", tmp.display()))?;
+    std::fs::write(&tmp, bytes).map_err(|source| CheckpointError::Write {
+        path: tmp.clone(),
+        source,
+    })?;
     let file = std::fs::OpenOptions::new()
         .read(true)
         .open(&tmp)
-        .map_err(|err| format!("failed to reopen checkpoint {}: {err}", tmp.display()))?;
+        .map_err(|source| CheckpointError::Reopen {
+            path: tmp.clone(),
+            source,
+        })?;
     file.sync_all()
-        .map_err(|err| format!("failed to fsync checkpoint {}: {err}", tmp.display()))?;
-    std::fs::rename(&tmp, path).map_err(|err| {
-        format!(
-            "failed to install checkpoint {} -> {}: {err}",
-            tmp.display(),
-            path.display()
-        )
+        .map_err(|source| CheckpointError::FsyncFile {
+            path: tmp.clone(),
+            source,
+        })?;
+    std::fs::rename(&tmp, path).map_err(|source| CheckpointError::Rename {
+        tmp: tmp.clone(),
+        path: path.to_path_buf(),
+        source,
     })?;
     let dir = std::fs::OpenOptions::new()
         .read(true)
         .open(parent)
-        .map_err(|err| {
-            format!(
-                "failed to open checkpoint directory {} for fsync: {err}",
-                parent.display()
-            )
+        .map_err(|source| CheckpointError::OpenDirectory {
+            path: parent.to_path_buf(),
+            source,
         })?;
-    dir.sync_all().map_err(|err| {
-        format!(
-            "failed to fsync checkpoint directory {}: {err}",
-            parent.display()
-        )
-    })?;
+    dir.sync_all()
+        .map_err(|source| CheckpointError::FsyncDirectory {
+            path: parent.to_path_buf(),
+            source,
+        })?;
     Ok(())
 }
 

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/checkpoint.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/checkpoint.rs
@@ -62,10 +62,10 @@ pub(crate) fn checkpoint_path(
     source_id: &str,
 ) -> PathBuf {
     let mut path = expand_state_dir(root);
-    path.push(sanitize_segment(pipeline_group_id));
-    path.push(sanitize_segment(pipeline_id));
-    path.push(sanitize_segment(receiver_name));
-    path.push(format!("{}.cursor", sanitize_segment(source_id)));
+    path.push(encode_path_segment(pipeline_group_id));
+    path.push(encode_path_segment(pipeline_id));
+    path.push(encode_path_segment(receiver_name));
+    path.push(format!("{}.cursor", encode_path_segment(source_id)));
     path
 }
 
@@ -179,17 +179,35 @@ fn expand_state_dir(root: &Path) -> PathBuf {
     root.to_path_buf()
 }
 
-fn sanitize_segment(value: &str) -> String {
-    value
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.') {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect()
+fn encode_path_segment(value: &str) -> String {
+    if value.is_empty() {
+        return "%".to_owned();
+    }
+
+    let encode_all = matches!(value, "." | "..");
+    let mut encoded = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        if !encode_all && is_checkpoint_path_safe_byte(byte) {
+            encoded.push(char::from(byte));
+        } else {
+            encoded.push('%');
+            encoded.push(char::from(hex_digit(byte >> 4)));
+            encoded.push(char::from(hex_digit(byte & 0x0f)));
+        }
+    }
+    encoded
+}
+
+fn is_checkpoint_path_safe_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.')
+}
+
+fn hex_digit(value: u8) -> u8 {
+    match value {
+        0..=9 => b'0' + value,
+        10..=15 => b'A' + (value - 10),
+        _ => unreachable!("nibble must be in range"),
+    }
 }
 
 #[cfg(test)]
@@ -222,5 +240,32 @@ mod tests {
             "system",
         );
         assert!(path.ends_with("journald/g/p/recv/system.cursor"));
+    }
+
+    #[test]
+    fn checkpoint_path_segments_are_collision_free_for_common_unsafe_chars() {
+        let root = Path::new("/state");
+        let slash_path = checkpoint_path(root, "a/b", "p", "recv", "system");
+        let underscore_path = checkpoint_path(root, "a_b", "p", "recv", "system");
+
+        assert_ne!(slash_path, underscore_path);
+        assert!(slash_path.ends_with("a%2Fb/p/recv/system.cursor"));
+        assert!(underscore_path.ends_with("a_b/p/recv/system.cursor"));
+    }
+
+    #[test]
+    fn checkpoint_path_segments_do_not_create_special_path_components() {
+        let path = checkpoint_path(Path::new("/state"), ".", "..", "recv/name", "system");
+        let components: Vec<_> = path
+            .strip_prefix("/state")
+            .unwrap()
+            .components()
+            .map(|component| component.as_os_str().to_string_lossy().into_owned())
+            .collect();
+
+        assert_eq!(
+            components,
+            ["%2E", "%2E%2E", "recv%2Fname", "system.cursor"]
+        );
     }
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/checkpoint.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/checkpoint.rs
@@ -138,6 +138,12 @@ pub(crate) fn write_cursor(path: &Path, cursor: &str) -> Result<(), CheckpointEr
         path: path.to_path_buf(),
         source,
     })?;
+    sync_parent_directory(parent)?;
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn sync_parent_directory(parent: &Path) -> Result<(), CheckpointError> {
     let dir = std::fs::OpenOptions::new()
         .read(true)
         .open(parent)
@@ -149,7 +155,11 @@ pub(crate) fn write_cursor(path: &Path, cursor: &str) -> Result<(), CheckpointEr
         .map_err(|source| CheckpointError::FsyncDirectory {
             path: parent.to_path_buf(),
             source,
-        })?;
+        })
+}
+
+#[cfg(not(target_os = "linux"))]
+fn sync_parent_directory(_parent: &Path) -> Result<(), CheckpointError> {
     Ok(())
 }
 

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/config.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/config.rs
@@ -342,6 +342,9 @@ impl TryFrom<Config> for RuntimeConfig {
         if batch.max_records == 0 {
             return Err(invalid("batch.max_records must be greater than zero"));
         }
+        if batch.max_records > u16::MAX as usize {
+            return Err(invalid("batch.max_records must be <= u16::MAX"));
+        }
         if batch.max_flush_period.is_zero() {
             return Err(invalid("batch.max_flush_period must be greater than zero"));
         }

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/config.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/config.rs
@@ -524,6 +524,8 @@ fn validate_journal(
         .as_os_str()
         .to_str()
         .expect("journal.root_path UTF-8 checked above");
+    // Validation runs on non-Linux CI too. Accept Unix-style host-root paths
+    // such as /host even when the host platform's Path::is_absolute disagrees.
     if !journal.root_path.is_absolute() && !root_path_text.starts_with('/') {
         return Err(invalid(&format!(
             "journal.root_path must be absolute: {}",

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/config.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/config.rs
@@ -289,7 +289,7 @@ pub struct Config {
     #[serde(default)]
     pub identifiers: Vec<String>,
 
-    /// Exact-match priority set. Defaults to all levels (0..=7) when omitted.
+    /// Exact-match priority set. When omitted, no `PRIORITY` match is added.
     #[serde(default)]
     pub priorities: Option<Vec<u8>>,
 
@@ -371,6 +371,8 @@ pub(crate) struct RuntimeConfig {
     pub(crate) identifiers: Vec<String>,
     /// Sorted, deduplicated set of accepted journald `PRIORITY` levels.
     pub(crate) priorities: Vec<u8>,
+    /// Whether to install a journald `PRIORITY` match group.
+    pub(crate) priority_filter_enabled: bool,
     /// Where to start when there is no committed cursor.
     pub(crate) start_at: StartAt,
     /// Field extraction safety limits.
@@ -409,6 +411,7 @@ impl TryFrom<Config> for RuntimeConfig {
         let lease_key = journal_source_lease_key(&journal);
         let units = dedup_non_empty(units, "units")?;
         let identifiers = dedup_non_empty(identifiers, "identifiers")?;
+        let priority_filter_enabled = priorities.is_some() || max_priority.is_some();
         let priorities = resolve_priorities(priorities, max_priority)?;
 
         if batch.max_records == 0 {
@@ -469,6 +472,7 @@ impl TryFrom<Config> for RuntimeConfig {
             units,
             identifiers,
             priorities,
+            priority_filter_enabled,
             start_at,
             extraction,
             batch,
@@ -680,6 +684,7 @@ mod tests {
             PathBuf::from(DEFAULT_JOURNAL_ROOT_PATH)
         );
         assert_eq!(runtime.priorities, (0..=7).collect::<Vec<u8>>());
+        assert!(!runtime.priority_filter_enabled);
         assert_eq!(runtime.start_at, StartAt::End);
         assert_eq!(runtime.batch.max_records, DEFAULT_BATCH_MAX_RECORDS);
         assert_eq!(runtime.extraction.max_entry_bytes, DEFAULT_MAX_ENTRY_BYTES);
@@ -851,6 +856,7 @@ mod tests {
         };
         let runtime = RuntimeConfig::try_from(cfg).expect("must validate");
         assert_eq!(runtime.priorities, vec![0, 1, 3]);
+        assert!(runtime.priority_filter_enabled);
     }
 
     #[test]
@@ -861,6 +867,18 @@ mod tests {
         };
         let runtime = RuntimeConfig::try_from(cfg).expect("must validate");
         assert_eq!(runtime.priorities, vec![0, 1, 2, 3, 4]);
+        assert!(runtime.priority_filter_enabled);
+    }
+
+    #[test]
+    fn explicit_full_priorities_still_enable_priority_filter() {
+        let cfg = Config {
+            priorities: Some(default_priorities()),
+            ..base()
+        };
+        let runtime = RuntimeConfig::try_from(cfg).expect("must validate");
+        assert_eq!(runtime.priorities, (0..=7).collect::<Vec<u8>>());
+        assert!(runtime.priority_filter_enabled);
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/config.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/config.rs
@@ -6,6 +6,8 @@
 //! See [`docs/journald-receiver.md`](../../../../../../docs/journald-receiver.md)
 //! for the design document this implementation follows.
 
+use serde::Deserializer;
+use serde::de::Error as DeError;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use std::path::{Component, Path, PathBuf};
@@ -32,6 +34,12 @@ const DEFAULT_MAX_IN_FLIGHT_BATCHES: usize = 1;
 const DEFAULT_MAX_CONSECUTIVE_FAILURES: u32 = 5;
 /// Default checkpoint root directory; the receiver appends a stable suffix.
 const DEFAULT_CHECKPOINT_DIR: &str = "${engine.state_dir}/journald";
+/// Default maximum copied bytes per journald entry.
+const DEFAULT_MAX_ENTRY_BYTES: u64 = 1024 * 1024;
+/// Default maximum copied bytes per journald field value.
+const DEFAULT_MAX_FIELD_BYTES: u64 = 256 * 1024;
+/// Default maximum copied fields per journald entry.
+const DEFAULT_MAX_FIELDS_PER_ENTRY: usize = 256;
 
 fn default_source_id() -> String {
     DEFAULT_SOURCE_ID.to_owned()
@@ -61,6 +69,15 @@ pub enum OnNack {
     Rewind,
     /// Fail the receiver source.
     Fail,
+}
+
+/// Behavior when an entry field exceeds configured extraction limits.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LargeFieldPolicy {
+    /// Drop oversized fields and count them in receiver self-telemetry.
+    #[default]
+    DropAndCount,
 }
 
 /// Shorthand for the maximum journald `PRIORITY` to accept.
@@ -204,6 +221,53 @@ impl Default for JournalConfig {
     }
 }
 
+/// Field extraction safety limits.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExtractionConfig {
+    /// Maximum copied bytes per journal entry.
+    #[serde(
+        default = "ExtractionConfig::default_max_entry_bytes",
+        deserialize_with = "deserialize_byte_size"
+    )]
+    pub max_entry_bytes: u64,
+    /// Maximum copied bytes per field value.
+    #[serde(
+        default = "ExtractionConfig::default_max_field_bytes",
+        deserialize_with = "deserialize_byte_size"
+    )]
+    pub max_field_bytes: u64,
+    /// Maximum copied fields per journal entry.
+    #[serde(default = "ExtractionConfig::default_max_fields_per_entry")]
+    pub max_fields_per_entry: usize,
+    /// Policy for fields that exceed extraction limits.
+    #[serde(default)]
+    pub large_field_policy: LargeFieldPolicy,
+}
+
+impl ExtractionConfig {
+    const fn default_max_entry_bytes() -> u64 {
+        DEFAULT_MAX_ENTRY_BYTES
+    }
+    const fn default_max_field_bytes() -> u64 {
+        DEFAULT_MAX_FIELD_BYTES
+    }
+    const fn default_max_fields_per_entry() -> usize {
+        DEFAULT_MAX_FIELDS_PER_ENTRY
+    }
+}
+
+impl Default for ExtractionConfig {
+    fn default() -> Self {
+        Self {
+            max_entry_bytes: Self::default_max_entry_bytes(),
+            max_field_bytes: Self::default_max_field_bytes(),
+            max_fields_per_entry: Self::default_max_fields_per_entry(),
+            large_field_policy: LargeFieldPolicy::default(),
+        }
+    }
+}
+
 /// User-facing journald receiver configuration.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -238,6 +302,10 @@ pub struct Config {
     /// Where to start when no checkpoint exists.
     #[serde(default)]
     pub start_at: StartAt,
+
+    /// Field extraction safety limits.
+    #[serde(default)]
+    pub extraction: ExtractionConfig,
 
     /// Batch shaping.
     #[serde(default)]
@@ -275,6 +343,7 @@ impl Default for Config {
             priorities: None,
             max_priority: None,
             start_at: StartAt::default(),
+            extraction: ExtractionConfig::default(),
             batch: BatchConfig::default(),
             checkpoint: CheckpointConfig::default(),
             wait_timeout: Self::default_wait_timeout(),
@@ -304,6 +373,8 @@ pub(crate) struct RuntimeConfig {
     pub(crate) priorities: Vec<u8>,
     /// Where to start when there is no committed cursor.
     pub(crate) start_at: StartAt,
+    /// Field extraction safety limits.
+    pub(crate) extraction: ExtractionConfig,
     /// Batch shaping.
     pub(crate) batch: BatchConfig,
     /// Checkpoint configuration.
@@ -326,6 +397,7 @@ impl TryFrom<Config> for RuntimeConfig {
             priorities,
             max_priority,
             start_at,
+            extraction,
             batch,
             checkpoint,
             wait_timeout,
@@ -344,6 +416,21 @@ impl TryFrom<Config> for RuntimeConfig {
         }
         if batch.max_records > u16::MAX as usize {
             return Err(invalid("batch.max_records must be <= u16::MAX"));
+        }
+        if extraction.max_entry_bytes == 0 {
+            return Err(invalid(
+                "extraction.max_entry_bytes must be greater than zero",
+            ));
+        }
+        if extraction.max_field_bytes == 0 {
+            return Err(invalid(
+                "extraction.max_field_bytes must be greater than zero",
+            ));
+        }
+        if extraction.max_fields_per_entry == 0 {
+            return Err(invalid(
+                "extraction.max_fields_per_entry must be greater than zero",
+            ));
         }
         if batch.max_flush_period.is_zero() {
             return Err(invalid("batch.max_flush_period must be greater than zero"));
@@ -383,12 +470,21 @@ impl TryFrom<Config> for RuntimeConfig {
             identifiers,
             priorities,
             start_at,
+            extraction,
             batch,
             checkpoint,
             wait_timeout,
             drain_timeout,
         })
     }
+}
+
+fn deserialize_byte_size<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    otap_df_config::byte_units::deserialize_u64(deserializer)?
+        .ok_or_else(|| DeError::custom("byte size must not be null"))
 }
 
 fn invalid(msg: &str) -> otap_df_config::error::Error {
@@ -584,6 +680,67 @@ mod tests {
         assert_eq!(runtime.priorities, (0..=7).collect::<Vec<u8>>());
         assert_eq!(runtime.start_at, StartAt::End);
         assert_eq!(runtime.batch.max_records, DEFAULT_BATCH_MAX_RECORDS);
+        assert_eq!(runtime.extraction.max_entry_bytes, DEFAULT_MAX_ENTRY_BYTES);
+        assert_eq!(runtime.extraction.max_field_bytes, DEFAULT_MAX_FIELD_BYTES);
+        assert_eq!(
+            runtime.extraction.max_fields_per_entry,
+            DEFAULT_MAX_FIELDS_PER_ENTRY
+        );
+        assert_eq!(
+            runtime.extraction.large_field_policy,
+            LargeFieldPolicy::DropAndCount
+        );
+    }
+
+    #[test]
+    fn accepts_extraction_limits_from_config() {
+        let cfg: Config = serde_json::from_value(serde_json::json!({
+            "extraction": {
+                "max_entry_bytes": "1 MiB",
+                "max_field_bytes": "16 KiB",
+                "max_fields_per_entry": 32,
+                "large_field_policy": "drop_and_count"
+            }
+        }))
+        .expect("extraction config should parse");
+        let runtime = RuntimeConfig::try_from(cfg).expect("must validate");
+        assert_eq!(runtime.extraction.max_entry_bytes, 1024 * 1024);
+        assert_eq!(runtime.extraction.max_field_bytes, 16 * 1024);
+        assert_eq!(runtime.extraction.max_fields_per_entry, 32);
+        assert_eq!(
+            runtime.extraction.large_field_policy,
+            LargeFieldPolicy::DropAndCount
+        );
+    }
+
+    #[test]
+    fn rejects_zero_extraction_limits() {
+        let cfg = Config {
+            extraction: ExtractionConfig {
+                max_entry_bytes: 0,
+                ..ExtractionConfig::default()
+            },
+            ..base()
+        };
+        assert!(RuntimeConfig::try_from(cfg).is_err());
+
+        let cfg = Config {
+            extraction: ExtractionConfig {
+                max_field_bytes: 0,
+                ..ExtractionConfig::default()
+            },
+            ..base()
+        };
+        assert!(RuntimeConfig::try_from(cfg).is_err());
+
+        let cfg = Config {
+            extraction: ExtractionConfig {
+                max_fields_per_entry: 0,
+                ..ExtractionConfig::default()
+            },
+            ..base()
+        };
+        assert!(RuntimeConfig::try_from(cfg).is_err());
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
@@ -163,7 +163,24 @@ mod imp {
             config: &RuntimeConfig,
             checkpoint: Option<&str>,
         ) -> Result<Self, JournalError> {
-            preflight_journal_access(&config.journal.root_path)?;
+            Self::open_inner(config, checkpoint, true)
+        }
+
+        pub(crate) fn open_for_rewind(
+            config: &RuntimeConfig,
+            checkpoint: Option<&str>,
+        ) -> Result<Self, JournalError> {
+            Self::open_inner(config, checkpoint, false)
+        }
+
+        fn open_inner(
+            config: &RuntimeConfig,
+            checkpoint: Option<&str>,
+            run_preflight: bool,
+        ) -> Result<Self, JournalError> {
+            if run_preflight {
+                preflight_journal_access(&config.journal.root_path)?;
+            }
             let lib = LibSystemd::load()?;
             let mut raw = std::ptr::null_mut();
             if config.journal.root_path == Path::new("/") {
@@ -466,12 +483,6 @@ mod imp {
             inspect_journal_path(&root_path.join(relative), 0, &mut summary);
         }
 
-        if root_path != Path::new("/") && summary.visible_directories == 0 {
-            return Err(JournalError::JournalDirectoriesMissing {
-                root_path: root_path.to_path_buf(),
-            });
-        }
-
         if (summary.journal_files > 0 || summary.unreadable_directories > 0)
             && summary.readable_files == 0
             && (summary.unreadable_files > 0 || summary.unreadable_directories > 0)
@@ -484,6 +495,11 @@ mod imp {
                 first_error: summary
                     .first_error
                     .unwrap_or_else(|| "permission denied".to_owned()),
+            });
+        }
+        if root_path != Path::new("/") && summary.visible_directories == 0 {
+            return Err(JournalError::JournalDirectoriesMissing {
+                root_path: root_path.to_path_buf(),
             });
         }
         Ok(())
@@ -573,6 +589,28 @@ mod imp {
     fn record_first_error(summary: &mut JournalAccessSummary, path: &Path, err: &std::io::Error) {
         if summary.first_error.is_none() {
             summary.first_error = Some(format!("{}: {err}", path.display()));
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use std::os::unix::fs::PermissionsExt;
+
+        #[test]
+        fn preflight_reports_access_when_journal_parent_is_not_traversable() {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let root = temp.path();
+            let log_dir = root.join("var/log");
+            std::fs::create_dir_all(log_dir.join("journal")).expect("journal dir");
+            std::fs::set_permissions(&log_dir, std::fs::Permissions::from_mode(0o000))
+                .expect("chmod log dir");
+
+            let result = preflight_journal_access(root);
+
+            std::fs::set_permissions(&log_dir, std::fs::Permissions::from_mode(0o755))
+                .expect("restore log dir permissions");
+            assert!(matches!(result, Err(JournalError::JournalAccess { .. })));
         }
     }
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
@@ -32,6 +32,7 @@ mod imp {
     type TestCursorFn = unsafe extern "C" fn(*mut SdJournal, *const c_char) -> c_int;
     type GetCursorFn = unsafe extern "C" fn(*mut SdJournal, *mut *mut c_char) -> c_int;
     type GetRealtimeUsecFn = unsafe extern "C" fn(*mut SdJournal, *mut u64) -> c_int;
+    type SetDataThresholdFn = unsafe extern "C" fn(*mut SdJournal, size_t) -> c_int;
     type RestartDataFn = unsafe extern "C" fn(*mut SdJournal);
     type EnumerateDataFn =
         unsafe extern "C" fn(*mut SdJournal, *mut *const c_void, *mut size_t) -> c_int;
@@ -52,6 +53,7 @@ mod imp {
         test_cursor: TestCursorFn,
         get_cursor: GetCursorFn,
         get_realtime_usec: GetRealtimeUsecFn,
+        set_data_threshold: SetDataThresholdFn,
         restart_data: RestartDataFn,
         enumerate_data: EnumerateDataFn,
         add_match: AddMatchFn,
@@ -102,6 +104,7 @@ mod imp {
                 test_cursor: sym!("sd_journal_test_cursor", TestCursorFn),
                 get_cursor: sym!("sd_journal_get_cursor", GetCursorFn),
                 get_realtime_usec: sym!("sd_journal_get_realtime_usec", GetRealtimeUsecFn),
+                set_data_threshold: sym!("sd_journal_set_data_threshold", SetDataThresholdFn),
                 restart_data: sym!("sd_journal_restart_data", RestartDataFn),
                 enumerate_data: sym!("sd_journal_enumerate_data", EnumerateDataFn),
                 add_match: sym!("sd_journal_add_match", AddMatchFn),
@@ -150,6 +153,10 @@ mod imp {
                 journal,
                 extraction: config.extraction.clone(),
             };
+            check(
+                unsafe { (reader.lib.set_data_threshold)(reader.journal.as_ptr(), 0) },
+                "sd_journal_set_data_threshold",
+            )?;
             reader.configure(config, checkpoint)?;
             Ok(reader)
         }

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
@@ -293,9 +293,11 @@ mod imp {
                 "sd_journal_get_cursor",
             )?;
             let cursor = unsafe { CStr::from_ptr(cursor_ptr) }
-                .to_string_lossy()
-                .into_owned();
+                .to_str()
+                .map(str::to_owned)
+                .map_err(|err| format!("sd_journal_get_cursor returned non-UTF-8 cursor: {err}"));
             unsafe { libc::free(cursor_ptr.cast()) };
+            let cursor = cursor?;
 
             let mut realtime_usec = 0u64;
             check(
@@ -337,9 +339,13 @@ mod imp {
                             }
                         }
                     }
-                    let name = std::str::from_utf8(&bytes[..eq])
-                        .map_err(|err| format!("journald field name is not UTF-8: {err}"))?
-                        .to_owned();
+                    let name = match std::str::from_utf8(&bytes[..eq]) {
+                        Ok(name) => name.to_owned(),
+                        Err(_) => {
+                            dropped_fields = dropped_fields.saturating_add(1);
+                            continue;
+                        }
+                    };
                     let value = bytes[eq + 1..].to_vec();
                     fields.push(JournalField { name, value });
                     copied_entry_bytes = copied_entry_bytes.saturating_add(field_len);

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
@@ -157,11 +157,7 @@ mod imp {
                     })?;
                 check(
                     unsafe {
-                        (lib.open_directory)(
-                            &mut raw,
-                            root_path.as_ptr(),
-                            SD_JOURNAL_LOCAL_ONLY | SD_JOURNAL_OS_ROOT,
-                        )
+                        (lib.open_directory)(&mut raw, root_path.as_ptr(), SD_JOURNAL_OS_ROOT)
                     },
                     "sd_journal_open_directory",
                 )?;
@@ -195,16 +191,18 @@ mod imp {
                 "SYSLOG_IDENTIFIER",
                 config.identifiers.iter().map(String::as_str),
             )?;
-            if has_match_group {
-                self.add_conjunction()?;
+            if config.priority_filter_enabled {
+                if has_match_group {
+                    self.add_conjunction()?;
+                }
+                let _ = self.add_match_group(
+                    "PRIORITY",
+                    config
+                        .priorities
+                        .iter()
+                        .map(|priority| priority.to_string()),
+                )?;
             }
-            let _ = self.add_match_group(
-                "PRIORITY",
-                config
-                    .priorities
-                    .iter()
-                    .map(|priority| priority.to_string()),
-            )?;
 
             if let Some(cursor) = checkpoint {
                 let c = CString::new(cursor).map_err(|_| JournalError::Nul {
@@ -342,6 +340,8 @@ mod imp {
             let mut copied_entry_bytes = 0u64;
             let mut copied_field_count = 0usize;
             let mut dropped_fields = 0u64;
+            let mut message_seen = false;
+            let mut message_body = None;
             loop {
                 let mut data: *const c_void = std::ptr::null();
                 let mut len: size_t = 0;
@@ -359,6 +359,12 @@ mod imp {
                 }
                 let bytes = unsafe { std::slice::from_raw_parts(data.cast::<u8>(), len) };
                 if let Some(eq) = bytes.iter().position(|b| *b == b'=') {
+                    let is_first_message = if !message_seen && &bytes[..eq] == b"MESSAGE" {
+                        message_seen = true;
+                        true
+                    } else {
+                        false
+                    };
                     let value_len = bytes.len().saturating_sub(eq + 1) as u64;
                     let field_len = bytes.len() as u64;
                     let would_exceed_entry = copied_entry_bytes.saturating_add(field_len)
@@ -382,6 +388,9 @@ mod imp {
                         }
                     };
                     let value = bytes[eq + 1..].to_vec();
+                    if is_first_message {
+                        message_body = Some(value.clone());
+                    }
                     fields.push(JournalField { name, value });
                     copied_entry_bytes = copied_entry_bytes.saturating_add(field_len);
                     copied_field_count = copied_field_count.saturating_add(1);
@@ -390,6 +399,7 @@ mod imp {
 
             Ok(JournalEntry {
                 cursor,
+                message_body,
                 realtime_unix_nano: realtime_usec.saturating_mul(1000),
                 fields,
                 dropped_fields,

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
@@ -114,7 +114,6 @@ mod imp {
     pub(crate) struct SdJournalReader {
         lib: &'static LibSystemd,
         journal: NonNull<SdJournal>,
-        wait_timeout: Duration,
         extraction: ExtractionConfig,
     }
 
@@ -149,12 +148,9 @@ mod imp {
             let mut reader = Self {
                 lib,
                 journal,
-                wait_timeout: config.wait_timeout,
                 extraction: config.extraction.clone(),
             };
-            if let Err(err) = reader.configure(config, checkpoint) {
-                return Err(err);
-            }
+            reader.configure(config, checkpoint)?;
             Ok(reader)
         }
 
@@ -265,10 +261,6 @@ mod imp {
                 },
                 "sd_journal_add_match",
             )
-        }
-
-        pub(crate) fn next_entry(&mut self) -> Result<Option<JournalEntry>, String> {
-            self.next_entry_with_wait_timeout(self.wait_timeout)
         }
 
         pub(crate) fn next_entry_with_wait_timeout(

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
@@ -516,6 +516,13 @@ mod imp {
             inspect_journal_path(&root_path.join(relative), 0, &mut summary);
         }
 
+        check_journal_access_summary(root_path, summary)
+    }
+
+    fn check_journal_access_summary(
+        root_path: &Path,
+        summary: JournalAccessSummary,
+    ) -> Result<(), JournalError> {
         if (summary.journal_files > 0 || summary.unreadable_directories > 0)
             && summary.readable_files == 0
             && (summary.unreadable_files > 0 || summary.unreadable_directories > 0)
@@ -530,7 +537,7 @@ mod imp {
                     .unwrap_or_else(|| "permission denied".to_owned()),
             });
         }
-        if root_path != Path::new("/") && summary.visible_directories == 0 {
+        if summary.visible_directories == 0 {
             return Err(JournalError::JournalDirectoriesMissing {
                 root_path: root_path.to_path_buf(),
             });
@@ -649,6 +656,17 @@ mod imp {
             std::fs::set_permissions(&log_dir, std::fs::Permissions::from_mode(0o755))
                 .expect("restore log dir permissions");
             assert!(matches!(result, Err(JournalError::JournalAccess { .. })));
+        }
+
+        #[test]
+        fn preflight_reports_missing_directories_for_default_root() {
+            let result =
+                check_journal_access_summary(Path::new("/"), JournalAccessSummary::default());
+
+            assert!(matches!(
+                result,
+                Err(JournalError::JournalDirectoriesMissing { .. })
+            ));
         }
     }
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
@@ -8,7 +8,9 @@ mod imp {
     #![allow(unsafe_code)]
 
     use crate::receivers::journald_receiver::arrow_records_encoder::{JournalEntry, JournalField};
-    use crate::receivers::journald_receiver::config::{RuntimeConfig, StartAt};
+    use crate::receivers::journald_receiver::config::{
+        ExtractionConfig, LargeFieldPolicy, RuntimeConfig, StartAt,
+    };
 
     use libc::{RTLD_NOW, c_char, c_int, c_void, size_t};
     use std::ffi::{CStr, CString};
@@ -25,10 +27,9 @@ mod imp {
     type NextFn = unsafe extern "C" fn(*mut SdJournal) -> c_int;
     type WaitFn = unsafe extern "C" fn(*mut SdJournal, u64) -> c_int;
     type SeekHeadFn = unsafe extern "C" fn(*mut SdJournal) -> c_int;
-    type SeekTailFn = unsafe extern "C" fn(*mut SdJournal) -> c_int;
+    type SeekRealtimeUsecFn = unsafe extern "C" fn(*mut SdJournal, u64) -> c_int;
     type SeekCursorFn = unsafe extern "C" fn(*mut SdJournal, *const c_char) -> c_int;
     type TestCursorFn = unsafe extern "C" fn(*mut SdJournal, *const c_char) -> c_int;
-    type PreviousFn = unsafe extern "C" fn(*mut SdJournal) -> c_int;
     type GetCursorFn = unsafe extern "C" fn(*mut SdJournal, *mut *mut c_char) -> c_int;
     type GetRealtimeUsecFn = unsafe extern "C" fn(*mut SdJournal, *mut u64) -> c_int;
     type RestartDataFn = unsafe extern "C" fn(*mut SdJournal);
@@ -46,10 +47,9 @@ mod imp {
         next: NextFn,
         wait: WaitFn,
         seek_head: SeekHeadFn,
-        seek_tail: SeekTailFn,
+        seek_realtime_usec: SeekRealtimeUsecFn,
         seek_cursor: SeekCursorFn,
         test_cursor: TestCursorFn,
-        previous: PreviousFn,
         get_cursor: GetCursorFn,
         get_realtime_usec: GetRealtimeUsecFn,
         restart_data: RestartDataFn,
@@ -97,10 +97,9 @@ mod imp {
                 next: sym!("sd_journal_next", NextFn),
                 wait: sym!("sd_journal_wait", WaitFn),
                 seek_head: sym!("sd_journal_seek_head", SeekHeadFn),
-                seek_tail: sym!("sd_journal_seek_tail", SeekTailFn),
+                seek_realtime_usec: sym!("sd_journal_seek_realtime_usec", SeekRealtimeUsecFn),
                 seek_cursor: sym!("sd_journal_seek_cursor", SeekCursorFn),
                 test_cursor: sym!("sd_journal_test_cursor", TestCursorFn),
-                previous: sym!("sd_journal_previous", PreviousFn),
                 get_cursor: sym!("sd_journal_get_cursor", GetCursorFn),
                 get_realtime_usec: sym!("sd_journal_get_realtime_usec", GetRealtimeUsecFn),
                 restart_data: sym!("sd_journal_restart_data", RestartDataFn),
@@ -116,6 +115,7 @@ mod imp {
         lib: &'static LibSystemd,
         journal: NonNull<SdJournal>,
         wait_timeout: Duration,
+        extraction: ExtractionConfig,
     }
 
     impl SdJournalReader {
@@ -150,9 +150,9 @@ mod imp {
                 lib,
                 journal,
                 wait_timeout: config.wait_timeout,
+                extraction: config.extraction.clone(),
             };
             if let Err(err) = reader.configure(config, checkpoint) {
-                unsafe { (reader.lib.close)(reader.journal.as_ptr()) };
                 return Err(err);
             }
             Ok(reader)
@@ -214,16 +214,15 @@ mod imp {
                     "sd_journal_seek_head",
                 ),
                 StartAt::End => {
+                    let now = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map_err(|_| "system clock is before Unix epoch".to_owned())?
+                        .as_micros()
+                        .min(u64::MAX as u128) as u64;
                     check(
-                        unsafe { (self.lib.seek_tail)(self.journal.as_ptr()) },
-                        "sd_journal_seek_tail",
-                    )?;
-                    let previous = unsafe { (self.lib.previous)(self.journal.as_ptr()) };
-                    if previous < 0 {
-                        Err(format!("sd_journal_previous failed with {previous}"))
-                    } else {
-                        Ok(())
-                    }
+                        unsafe { (self.lib.seek_realtime_usec)(self.journal.as_ptr(), now) },
+                        "sd_journal_seek_realtime_usec",
+                    )
                 }
             }
         }
@@ -269,6 +268,13 @@ mod imp {
         }
 
         pub(crate) fn next_entry(&mut self) -> Result<Option<JournalEntry>, String> {
+            self.next_entry_with_wait_timeout(self.wait_timeout)
+        }
+
+        pub(crate) fn next_entry_with_wait_timeout(
+            &mut self,
+            wait_timeout: Duration,
+        ) -> Result<Option<JournalEntry>, String> {
             loop {
                 let next = unsafe { (self.lib.next)(self.journal.as_ptr()) };
                 if next < 0 {
@@ -277,7 +283,7 @@ mod imp {
                 if next > 0 {
                     return self.current_entry().map(Some);
                 }
-                let timeout = self.wait_timeout.as_micros().min(u64::MAX as u128) as u64;
+                let timeout = duration_to_usec(wait_timeout);
                 let waited = unsafe { (self.lib.wait)(self.journal.as_ptr(), timeout) };
                 if waited < 0 {
                     return Err(format!("sd_journal_wait failed with {waited}"));
@@ -307,6 +313,9 @@ mod imp {
 
             unsafe { (self.lib.restart_data)(self.journal.as_ptr()) };
             let mut fields = Vec::new();
+            let mut copied_entry_bytes = 0u64;
+            let mut copied_field_count = 0usize;
+            let mut dropped_fields = 0u64;
             loop {
                 let mut data: *const c_void = std::ptr::null();
                 let mut len: size_t = 0;
@@ -321,9 +330,26 @@ mod imp {
                 }
                 let bytes = unsafe { std::slice::from_raw_parts(data.cast::<u8>(), len) };
                 if let Some(eq) = bytes.iter().position(|b| *b == b'=') {
+                    let value_len = bytes.len().saturating_sub(eq + 1) as u64;
+                    let field_len = bytes.len() as u64;
+                    let would_exceed_entry = copied_entry_bytes.saturating_add(field_len)
+                        > self.extraction.max_entry_bytes;
+                    let should_drop = value_len > self.extraction.max_field_bytes
+                        || copied_field_count >= self.extraction.max_fields_per_entry
+                        || would_exceed_entry;
+                    if should_drop {
+                        match self.extraction.large_field_policy {
+                            LargeFieldPolicy::DropAndCount => {
+                                dropped_fields = dropped_fields.saturating_add(1);
+                                continue;
+                            }
+                        }
+                    }
                     let name = String::from_utf8_lossy(&bytes[..eq]).into_owned();
                     let value = bytes[eq + 1..].to_vec();
                     fields.push(JournalField { name, value });
+                    copied_entry_bytes = copied_entry_bytes.saturating_add(field_len);
+                    copied_field_count = copied_field_count.saturating_add(1);
                 }
             }
 
@@ -331,8 +357,17 @@ mod imp {
                 cursor,
                 realtime_unix_nano: realtime_usec.saturating_mul(1000),
                 fields,
+                dropped_fields,
             })
         }
+    }
+
+    fn duration_to_usec(duration: Duration) -> u64 {
+        if duration.is_zero() {
+            return 0;
+        }
+        let usec = duration.as_micros().min(u64::MAX as u128) as u64;
+        usec.max(1)
     }
 
     impl Drop for SdJournalReader {

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
@@ -605,6 +605,11 @@ mod imp {
             std::fs::create_dir_all(log_dir.join("journal")).expect("journal dir");
             std::fs::set_permissions(&log_dir, std::fs::Permissions::from_mode(0o000))
                 .expect("chmod log dir");
+            if std::fs::metadata(log_dir.join("journal")).is_ok() {
+                std::fs::set_permissions(&log_dir, std::fs::Permissions::from_mode(0o755))
+                    .expect("restore log dir permissions");
+                return;
+            }
 
             let result = preflight_journal_access(root);
 

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
@@ -15,6 +15,7 @@ mod imp {
     use libc::{RTLD_NOW, c_char, c_int, c_void, size_t};
     use std::ffi::{CStr, CString};
     use std::ptr::NonNull;
+    use std::str::Utf8Error;
     use std::time::Duration;
 
     const SD_JOURNAL_LOCAL_ONLY: c_int = 1;
@@ -39,6 +40,24 @@ mod imp {
     type AddMatchFn = unsafe extern "C" fn(*mut SdJournal, *const c_void, size_t) -> c_int;
     type AddDisjunctionFn = unsafe extern "C" fn(*mut SdJournal) -> c_int;
     type AddConjunctionFn = unsafe extern "C" fn(*mut SdJournal) -> c_int;
+
+    #[derive(Debug, thiserror::Error, Clone)]
+    pub(crate) enum JournalError {
+        #[error("failed to load libsystemd.so.0")]
+        LoadLibSystemd,
+        #[error("missing libsystemd symbol {symbol}")]
+        MissingSymbol { symbol: &'static str },
+        #[error("{operation} failed with {rc}")]
+        SystemdCall { operation: &'static str, rc: c_int },
+        #[error("sd_journal_open returned null")]
+        OpenReturnedNull,
+        #[error("{field} contains NUL")]
+        Nul { field: &'static str },
+        #[error("checkpoint cursor is no longer present in journal")]
+        CheckpointCursorMissing,
+        #[error("sd_journal_get_cursor returned non-UTF-8 cursor: {source}")]
+        CursorUtf8 { source: Utf8Error },
+    }
 
     struct LibSystemd {
         _handle: NonNull<c_void>,
@@ -66,26 +85,25 @@ mod imp {
     unsafe impl Sync for LibSystemd {}
 
     impl LibSystemd {
-        fn load() -> Result<&'static Self, String> {
-            static LIB: std::sync::OnceLock<Result<LibSystemd, String>> =
+        fn load() -> Result<&'static Self, JournalError> {
+            static LIB: std::sync::OnceLock<Result<LibSystemd, JournalError>> =
                 std::sync::OnceLock::new();
             LIB.get_or_init(Self::load_inner)
                 .as_ref()
                 .map_err(Clone::clone)
         }
 
-        fn load_inner() -> Result<Self, String> {
+        fn load_inner() -> Result<Self, JournalError> {
             let name = CString::new("libsystemd.so.0").expect("static string");
             let handle = unsafe { libc::dlopen(name.as_ptr(), RTLD_NOW) };
-            let handle =
-                NonNull::new(handle).ok_or_else(|| "failed to load libsystemd.so.0".to_owned())?;
+            let handle = NonNull::new(handle).ok_or(JournalError::LoadLibSystemd)?;
 
             macro_rules! sym {
                 ($name:literal, $ty:ty) => {{
                     let cname = CString::new($name).expect("static string");
                     let ptr = unsafe { libc::dlsym(handle.as_ptr(), cname.as_ptr()) };
                     if ptr.is_null() {
-                        return Err(format!("missing libsystemd symbol {}", $name));
+                        return Err(JournalError::MissingSymbol { symbol: $name });
                     }
                     unsafe { std::mem::transmute::<*mut c_void, $ty>(ptr) }
                 }};
@@ -124,7 +142,7 @@ mod imp {
         pub(crate) fn open(
             config: &RuntimeConfig,
             checkpoint: Option<&str>,
-        ) -> Result<Self, String> {
+        ) -> Result<Self, JournalError> {
             let lib = LibSystemd::load()?;
             let mut raw = std::ptr::null_mut();
             if config.journal.root_path == std::path::Path::new("/") {
@@ -134,7 +152,9 @@ mod imp {
                 )?;
             } else {
                 let root_path = CString::new(config.journal.root_path.to_string_lossy().as_bytes())
-                    .map_err(|_| "journal.root_path contains NUL".to_owned())?;
+                    .map_err(|_| JournalError::Nul {
+                        field: "journal.root_path",
+                    })?;
                 check(
                     unsafe {
                         (lib.open_directory)(
@@ -146,8 +166,7 @@ mod imp {
                     "sd_journal_open_directory",
                 )?;
             }
-            let journal =
-                NonNull::new(raw).ok_or_else(|| "sd_journal_open returned null".to_owned())?;
+            let journal = NonNull::new(raw).ok_or(JournalError::OpenReturnedNull)?;
             let mut reader = Self {
                 lib,
                 journal,
@@ -165,7 +184,7 @@ mod imp {
             &mut self,
             config: &RuntimeConfig,
             checkpoint: Option<&str>,
-        ) -> Result<(), String> {
+        ) -> Result<(), JournalError> {
             let mut has_match_group = false;
             has_match_group |=
                 self.add_match_group("_SYSTEMD_UNIT", config.units.iter().map(String::as_str))?;
@@ -188,25 +207,32 @@ mod imp {
             )?;
 
             if let Some(cursor) = checkpoint {
-                let c = CString::new(cursor)
-                    .map_err(|_| "checkpoint cursor contains NUL".to_owned())?;
+                let c = CString::new(cursor).map_err(|_| JournalError::Nul {
+                    field: "checkpoint cursor",
+                })?;
                 check(
                     unsafe { (self.lib.seek_cursor)(self.journal.as_ptr(), c.as_ptr()) },
                     "sd_journal_seek_cursor",
                 )?;
                 let next = unsafe { (self.lib.next)(self.journal.as_ptr()) };
                 if next < 0 {
-                    return Err(format!("sd_journal_next failed with {next}"));
+                    return Err(JournalError::SystemdCall {
+                        operation: "sd_journal_next",
+                        rc: next,
+                    });
                 }
                 if next == 0 {
-                    return Err("checkpoint cursor is no longer present in journal".to_owned());
+                    return Err(JournalError::CheckpointCursorMissing);
                 }
                 let matches = unsafe { (self.lib.test_cursor)(self.journal.as_ptr(), c.as_ptr()) };
                 if matches < 0 {
-                    return Err(format!("sd_journal_test_cursor failed with {matches}"));
+                    return Err(JournalError::SystemdCall {
+                        operation: "sd_journal_test_cursor",
+                        rc: matches,
+                    });
                 }
                 if matches == 0 {
-                    return Err("checkpoint cursor is no longer present in journal".to_owned());
+                    return Err(JournalError::CheckpointCursorMissing);
                 }
                 return Ok(());
             }
@@ -223,7 +249,7 @@ mod imp {
             }
         }
 
-        fn add_match_group<I, V>(&mut self, field: &str, values: I) -> Result<bool, String>
+        fn add_match_group<I, V>(&mut self, field: &str, values: I) -> Result<bool, JournalError>
         where
             I: IntoIterator<Item = V>,
             V: AsRef<str>,
@@ -242,14 +268,14 @@ mod imp {
             Ok(added)
         }
 
-        fn add_conjunction(&mut self) -> Result<(), String> {
+        fn add_conjunction(&mut self) -> Result<(), JournalError> {
             check(
                 unsafe { (self.lib.add_conjunction)(self.journal.as_ptr()) },
                 "sd_journal_add_conjunction",
             )
         }
 
-        fn add_match(&mut self, field: &str, value: &str) -> Result<(), String> {
+        fn add_match(&mut self, field: &str, value: &str) -> Result<(), JournalError> {
             let matcher = format!("{field}={value}");
             check(
                 unsafe {
@@ -266,11 +292,14 @@ mod imp {
         pub(crate) fn next_entry_with_wait_timeout(
             &mut self,
             wait_timeout: Duration,
-        ) -> Result<Option<JournalEntry>, String> {
+        ) -> Result<Option<JournalEntry>, JournalError> {
             loop {
                 let next = unsafe { (self.lib.next)(self.journal.as_ptr()) };
                 if next < 0 {
-                    return Err(format!("sd_journal_next failed with {next}"));
+                    return Err(JournalError::SystemdCall {
+                        operation: "sd_journal_next",
+                        rc: next,
+                    });
                 }
                 if next > 0 {
                     return self.current_entry().map(Some);
@@ -278,7 +307,10 @@ mod imp {
                 let timeout = duration_to_usec(wait_timeout);
                 let waited = unsafe { (self.lib.wait)(self.journal.as_ptr(), timeout) };
                 if waited < 0 {
-                    return Err(format!("sd_journal_wait failed with {waited}"));
+                    return Err(JournalError::SystemdCall {
+                        operation: "sd_journal_wait",
+                        rc: waited,
+                    });
                 }
                 if waited == 0 {
                     return Ok(None);
@@ -286,7 +318,7 @@ mod imp {
             }
         }
 
-        fn current_entry(&mut self) -> Result<JournalEntry, String> {
+        fn current_entry(&mut self) -> Result<JournalEntry, JournalError> {
             let mut cursor_ptr: *mut c_char = std::ptr::null_mut();
             check(
                 unsafe { (self.lib.get_cursor)(self.journal.as_ptr(), &mut cursor_ptr) },
@@ -295,7 +327,7 @@ mod imp {
             let cursor = unsafe { CStr::from_ptr(cursor_ptr) }
                 .to_str()
                 .map(str::to_owned)
-                .map_err(|err| format!("sd_journal_get_cursor returned non-UTF-8 cursor: {err}"));
+                .map_err(|source| JournalError::CursorUtf8 { source });
             unsafe { libc::free(cursor_ptr.cast()) };
             let cursor = cursor?;
 
@@ -317,7 +349,10 @@ mod imp {
                     (self.lib.enumerate_data)(self.journal.as_ptr(), &mut data, &mut len)
                 };
                 if rc < 0 {
-                    return Err(format!("sd_journal_enumerate_data failed with {rc}"));
+                    return Err(JournalError::SystemdCall {
+                        operation: "sd_journal_enumerate_data",
+                        rc,
+                    });
                 }
                 if rc == 0 {
                     break;
@@ -376,9 +411,9 @@ mod imp {
         }
     }
 
-    fn check(rc: c_int, name: &str) -> Result<(), String> {
+    fn check(rc: c_int, operation: &'static str) -> Result<(), JournalError> {
         if rc < 0 {
-            Err(format!("{name} failed with {rc}"))
+            Err(JournalError::SystemdCall { operation, rc })
         } else {
             Ok(())
         }
@@ -386,4 +421,4 @@ mod imp {
 }
 
 #[cfg(target_os = "linux")]
-pub(crate) use imp::SdJournalReader;
+pub(crate) use imp::{JournalError, SdJournalReader};

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
@@ -389,10 +389,6 @@ mod imp {
                     (self.lib.enumerate_data)(self.journal.as_ptr(), &mut data, &mut len)
                 };
                 if rc < 0 {
-                    if rc == -libc::E2BIG {
-                        dropped_fields = dropped_fields.saturating_add(1);
-                        continue;
-                    }
                     return Err(JournalError::SystemdCall {
                         operation: "sd_journal_enumerate_data",
                         rc,

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
@@ -1,0 +1,354 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Linux `sd-journal` reader abstraction.
+
+#[cfg(target_os = "linux")]
+mod imp {
+    #![allow(unsafe_code)]
+
+    use crate::receivers::journald_receiver::arrow_records_encoder::{JournalEntry, JournalField};
+    use crate::receivers::journald_receiver::config::{RuntimeConfig, StartAt};
+
+    use libc::{RTLD_NOW, c_char, c_int, c_void, size_t};
+    use std::ffi::{CStr, CString};
+    use std::ptr::NonNull;
+    use std::time::Duration;
+
+    const SD_JOURNAL_LOCAL_ONLY: c_int = 1;
+    const SD_JOURNAL_OS_ROOT: c_int = 16;
+
+    type SdJournal = c_void;
+    type OpenFn = unsafe extern "C" fn(*mut *mut SdJournal, c_int) -> c_int;
+    type OpenDirectoryFn = unsafe extern "C" fn(*mut *mut SdJournal, *const c_char, c_int) -> c_int;
+    type CloseFn = unsafe extern "C" fn(*mut SdJournal);
+    type NextFn = unsafe extern "C" fn(*mut SdJournal) -> c_int;
+    type WaitFn = unsafe extern "C" fn(*mut SdJournal, u64) -> c_int;
+    type SeekHeadFn = unsafe extern "C" fn(*mut SdJournal) -> c_int;
+    type SeekTailFn = unsafe extern "C" fn(*mut SdJournal) -> c_int;
+    type SeekCursorFn = unsafe extern "C" fn(*mut SdJournal, *const c_char) -> c_int;
+    type TestCursorFn = unsafe extern "C" fn(*mut SdJournal, *const c_char) -> c_int;
+    type PreviousFn = unsafe extern "C" fn(*mut SdJournal) -> c_int;
+    type GetCursorFn = unsafe extern "C" fn(*mut SdJournal, *mut *mut c_char) -> c_int;
+    type GetRealtimeUsecFn = unsafe extern "C" fn(*mut SdJournal, *mut u64) -> c_int;
+    type RestartDataFn = unsafe extern "C" fn(*mut SdJournal);
+    type EnumerateDataFn =
+        unsafe extern "C" fn(*mut SdJournal, *mut *const c_void, *mut size_t) -> c_int;
+    type AddMatchFn = unsafe extern "C" fn(*mut SdJournal, *const c_void, size_t) -> c_int;
+    type AddDisjunctionFn = unsafe extern "C" fn(*mut SdJournal) -> c_int;
+    type AddConjunctionFn = unsafe extern "C" fn(*mut SdJournal) -> c_int;
+
+    struct LibSystemd {
+        _handle: NonNull<c_void>,
+        open: OpenFn,
+        open_directory: OpenDirectoryFn,
+        close: CloseFn,
+        next: NextFn,
+        wait: WaitFn,
+        seek_head: SeekHeadFn,
+        seek_tail: SeekTailFn,
+        seek_cursor: SeekCursorFn,
+        test_cursor: TestCursorFn,
+        previous: PreviousFn,
+        get_cursor: GetCursorFn,
+        get_realtime_usec: GetRealtimeUsecFn,
+        restart_data: RestartDataFn,
+        enumerate_data: EnumerateDataFn,
+        add_match: AddMatchFn,
+        add_disjunction: AddDisjunctionFn,
+        add_conjunction: AddConjunctionFn,
+    }
+
+    // Function pointers are immutable after load and libsystemd is process-global.
+    unsafe impl Send for LibSystemd {}
+    unsafe impl Sync for LibSystemd {}
+
+    impl LibSystemd {
+        fn load() -> Result<&'static Self, String> {
+            static LIB: std::sync::OnceLock<Result<LibSystemd, String>> =
+                std::sync::OnceLock::new();
+            LIB.get_or_init(Self::load_inner)
+                .as_ref()
+                .map_err(Clone::clone)
+        }
+
+        fn load_inner() -> Result<Self, String> {
+            let name = CString::new("libsystemd.so.0").expect("static string");
+            let handle = unsafe { libc::dlopen(name.as_ptr(), RTLD_NOW) };
+            let handle =
+                NonNull::new(handle).ok_or_else(|| "failed to load libsystemd.so.0".to_owned())?;
+
+            macro_rules! sym {
+                ($name:literal, $ty:ty) => {{
+                    let cname = CString::new($name).expect("static string");
+                    let ptr = unsafe { libc::dlsym(handle.as_ptr(), cname.as_ptr()) };
+                    if ptr.is_null() {
+                        return Err(format!("missing libsystemd symbol {}", $name));
+                    }
+                    unsafe { std::mem::transmute::<*mut c_void, $ty>(ptr) }
+                }};
+            }
+
+            Ok(Self {
+                _handle: handle,
+                open: sym!("sd_journal_open", OpenFn),
+                open_directory: sym!("sd_journal_open_directory", OpenDirectoryFn),
+                close: sym!("sd_journal_close", CloseFn),
+                next: sym!("sd_journal_next", NextFn),
+                wait: sym!("sd_journal_wait", WaitFn),
+                seek_head: sym!("sd_journal_seek_head", SeekHeadFn),
+                seek_tail: sym!("sd_journal_seek_tail", SeekTailFn),
+                seek_cursor: sym!("sd_journal_seek_cursor", SeekCursorFn),
+                test_cursor: sym!("sd_journal_test_cursor", TestCursorFn),
+                previous: sym!("sd_journal_previous", PreviousFn),
+                get_cursor: sym!("sd_journal_get_cursor", GetCursorFn),
+                get_realtime_usec: sym!("sd_journal_get_realtime_usec", GetRealtimeUsecFn),
+                restart_data: sym!("sd_journal_restart_data", RestartDataFn),
+                enumerate_data: sym!("sd_journal_enumerate_data", EnumerateDataFn),
+                add_match: sym!("sd_journal_add_match", AddMatchFn),
+                add_disjunction: sym!("sd_journal_add_disjunction", AddDisjunctionFn),
+                add_conjunction: sym!("sd_journal_add_conjunction", AddConjunctionFn),
+            })
+        }
+    }
+
+    pub(crate) struct SdJournalReader {
+        lib: &'static LibSystemd,
+        journal: NonNull<SdJournal>,
+        wait_timeout: Duration,
+    }
+
+    impl SdJournalReader {
+        pub(crate) fn open(
+            config: &RuntimeConfig,
+            checkpoint: Option<&str>,
+        ) -> Result<Self, String> {
+            let lib = LibSystemd::load()?;
+            let mut raw = std::ptr::null_mut();
+            if config.journal.root_path == std::path::Path::new("/") {
+                check(
+                    unsafe { (lib.open)(&mut raw, SD_JOURNAL_LOCAL_ONLY) },
+                    "sd_journal_open",
+                )?;
+            } else {
+                let root_path = CString::new(config.journal.root_path.to_string_lossy().as_bytes())
+                    .map_err(|_| "journal.root_path contains NUL".to_owned())?;
+                check(
+                    unsafe {
+                        (lib.open_directory)(
+                            &mut raw,
+                            root_path.as_ptr(),
+                            SD_JOURNAL_LOCAL_ONLY | SD_JOURNAL_OS_ROOT,
+                        )
+                    },
+                    "sd_journal_open_directory",
+                )?;
+            }
+            let journal =
+                NonNull::new(raw).ok_or_else(|| "sd_journal_open returned null".to_owned())?;
+            let mut reader = Self {
+                lib,
+                journal,
+                wait_timeout: config.wait_timeout,
+            };
+            if let Err(err) = reader.configure(config, checkpoint) {
+                unsafe { (reader.lib.close)(reader.journal.as_ptr()) };
+                return Err(err);
+            }
+            Ok(reader)
+        }
+
+        fn configure(
+            &mut self,
+            config: &RuntimeConfig,
+            checkpoint: Option<&str>,
+        ) -> Result<(), String> {
+            let mut has_match_group = false;
+            has_match_group |=
+                self.add_match_group("_SYSTEMD_UNIT", config.units.iter().map(String::as_str))?;
+            if has_match_group && !config.identifiers.is_empty() {
+                self.add_conjunction()?;
+            }
+            has_match_group |= self.add_match_group(
+                "SYSLOG_IDENTIFIER",
+                config.identifiers.iter().map(String::as_str),
+            )?;
+            if has_match_group {
+                self.add_conjunction()?;
+            }
+            let _ = self.add_match_group(
+                "PRIORITY",
+                config
+                    .priorities
+                    .iter()
+                    .map(|priority| priority.to_string()),
+            )?;
+
+            if let Some(cursor) = checkpoint {
+                let c = CString::new(cursor)
+                    .map_err(|_| "checkpoint cursor contains NUL".to_owned())?;
+                check(
+                    unsafe { (self.lib.seek_cursor)(self.journal.as_ptr(), c.as_ptr()) },
+                    "sd_journal_seek_cursor",
+                )?;
+                let next = unsafe { (self.lib.next)(self.journal.as_ptr()) };
+                if next < 0 {
+                    return Err(format!("sd_journal_next failed with {next}"));
+                }
+                if next == 0 {
+                    return Err("checkpoint cursor is no longer present in journal".to_owned());
+                }
+                let matches = unsafe { (self.lib.test_cursor)(self.journal.as_ptr(), c.as_ptr()) };
+                if matches < 0 {
+                    return Err(format!("sd_journal_test_cursor failed with {matches}"));
+                }
+                if matches == 0 {
+                    return Err("checkpoint cursor is no longer present in journal".to_owned());
+                }
+                return Ok(());
+            }
+
+            match config.start_at {
+                StartAt::Beginning => check(
+                    unsafe { (self.lib.seek_head)(self.journal.as_ptr()) },
+                    "sd_journal_seek_head",
+                ),
+                StartAt::End => {
+                    check(
+                        unsafe { (self.lib.seek_tail)(self.journal.as_ptr()) },
+                        "sd_journal_seek_tail",
+                    )?;
+                    let previous = unsafe { (self.lib.previous)(self.journal.as_ptr()) };
+                    if previous < 0 {
+                        Err(format!("sd_journal_previous failed with {previous}"))
+                    } else {
+                        Ok(())
+                    }
+                }
+            }
+        }
+
+        fn add_match_group<I, V>(&mut self, field: &str, values: I) -> Result<bool, String>
+        where
+            I: IntoIterator<Item = V>,
+            V: AsRef<str>,
+        {
+            let mut added = false;
+            for value in values {
+                if added {
+                    check(
+                        unsafe { (self.lib.add_disjunction)(self.journal.as_ptr()) },
+                        "sd_journal_add_disjunction",
+                    )?;
+                }
+                self.add_match(field, value.as_ref())?;
+                added = true;
+            }
+            Ok(added)
+        }
+
+        fn add_conjunction(&mut self) -> Result<(), String> {
+            check(
+                unsafe { (self.lib.add_conjunction)(self.journal.as_ptr()) },
+                "sd_journal_add_conjunction",
+            )
+        }
+
+        fn add_match(&mut self, field: &str, value: &str) -> Result<(), String> {
+            let matcher = format!("{field}={value}");
+            check(
+                unsafe {
+                    (self.lib.add_match)(
+                        self.journal.as_ptr(),
+                        matcher.as_ptr().cast(),
+                        matcher.len(),
+                    )
+                },
+                "sd_journal_add_match",
+            )
+        }
+
+        pub(crate) fn next_entry(&mut self) -> Result<Option<JournalEntry>, String> {
+            loop {
+                let next = unsafe { (self.lib.next)(self.journal.as_ptr()) };
+                if next < 0 {
+                    return Err(format!("sd_journal_next failed with {next}"));
+                }
+                if next > 0 {
+                    return self.current_entry().map(Some);
+                }
+                let timeout = self.wait_timeout.as_micros().min(u64::MAX as u128) as u64;
+                let waited = unsafe { (self.lib.wait)(self.journal.as_ptr(), timeout) };
+                if waited < 0 {
+                    return Err(format!("sd_journal_wait failed with {waited}"));
+                }
+                if waited == 0 {
+                    return Ok(None);
+                }
+            }
+        }
+
+        fn current_entry(&mut self) -> Result<JournalEntry, String> {
+            let mut cursor_ptr: *mut c_char = std::ptr::null_mut();
+            check(
+                unsafe { (self.lib.get_cursor)(self.journal.as_ptr(), &mut cursor_ptr) },
+                "sd_journal_get_cursor",
+            )?;
+            let cursor = unsafe { CStr::from_ptr(cursor_ptr) }
+                .to_string_lossy()
+                .into_owned();
+            unsafe { libc::free(cursor_ptr.cast()) };
+
+            let mut realtime_usec = 0u64;
+            check(
+                unsafe { (self.lib.get_realtime_usec)(self.journal.as_ptr(), &mut realtime_usec) },
+                "sd_journal_get_realtime_usec",
+            )?;
+
+            unsafe { (self.lib.restart_data)(self.journal.as_ptr()) };
+            let mut fields = Vec::new();
+            loop {
+                let mut data: *const c_void = std::ptr::null();
+                let mut len: size_t = 0;
+                let rc = unsafe {
+                    (self.lib.enumerate_data)(self.journal.as_ptr(), &mut data, &mut len)
+                };
+                if rc < 0 {
+                    return Err(format!("sd_journal_enumerate_data failed with {rc}"));
+                }
+                if rc == 0 {
+                    break;
+                }
+                let bytes = unsafe { std::slice::from_raw_parts(data.cast::<u8>(), len) };
+                if let Some(eq) = bytes.iter().position(|b| *b == b'=') {
+                    let name = String::from_utf8_lossy(&bytes[..eq]).into_owned();
+                    let value = bytes[eq + 1..].to_vec();
+                    fields.push(JournalField { name, value });
+                }
+            }
+
+            Ok(JournalEntry {
+                cursor,
+                realtime_unix_nano: realtime_usec.saturating_mul(1000),
+                fields,
+            })
+        }
+    }
+
+    impl Drop for SdJournalReader {
+        fn drop(&mut self) {
+            unsafe { (self.lib.close)(self.journal.as_ptr()) };
+        }
+    }
+
+    fn check(rc: c_int, name: &str) -> Result<(), String> {
+        if rc < 0 {
+            Err(format!("{name} failed with {rc}"))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) use imp::SdJournalReader;

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
@@ -14,6 +14,7 @@ mod imp {
 
     use libc::{RTLD_NOW, c_char, c_int, c_void, size_t};
     use std::ffi::{CStr, CString};
+    use std::path::{Path, PathBuf};
     use std::ptr::NonNull;
     use std::str::Utf8Error;
     use std::time::Duration;
@@ -57,6 +58,25 @@ mod imp {
         CheckpointCursorMissing,
         #[error("sd_journal_get_cursor returned non-UTF-8 cursor: {source}")]
         CursorUtf8 { source: Utf8Error },
+        #[error(
+            "selected journal root {root_path} is not readable \
+             (journal_files={journal_files}, unreadable_files={unreadable_files}, \
+             unreadable_directories={unreadable_directories}, first_error={first_error}); \
+             run as root or grant access to the systemd-journal group, and ensure container \
+             host-root mounts expose readable journal files"
+        )]
+        JournalAccess {
+            root_path: PathBuf,
+            journal_files: usize,
+            unreadable_files: usize,
+            unreadable_directories: usize,
+            first_error: String,
+        },
+        #[error(
+            "no systemd journal directories are visible under {root_path}; mount \
+             /run/log/journal or /var/log/journal below journal.root_path"
+        )]
+        JournalDirectoriesMissing { root_path: PathBuf },
     }
 
     struct LibSystemd {
@@ -143,9 +163,10 @@ mod imp {
             config: &RuntimeConfig,
             checkpoint: Option<&str>,
         ) -> Result<Self, JournalError> {
+            preflight_journal_access(&config.journal.root_path)?;
             let lib = LibSystemd::load()?;
             let mut raw = std::ptr::null_mut();
-            if config.journal.root_path == std::path::Path::new("/") {
+            if config.journal.root_path == Path::new("/") {
                 check(
                     unsafe { (lib.open)(&mut raw, SD_JOURNAL_LOCAL_ONLY) },
                     "sd_journal_open",
@@ -426,6 +447,132 @@ mod imp {
             Err(JournalError::SystemdCall { operation, rc })
         } else {
             Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct JournalAccessSummary {
+        journal_files: usize,
+        readable_files: usize,
+        visible_directories: usize,
+        unreadable_files: usize,
+        unreadable_directories: usize,
+        first_error: Option<String>,
+    }
+
+    fn preflight_journal_access(root_path: &Path) -> Result<(), JournalError> {
+        let mut summary = JournalAccessSummary::default();
+        for relative in ["run/log/journal", "var/log/journal"] {
+            inspect_journal_path(&root_path.join(relative), 0, &mut summary);
+        }
+
+        if root_path != Path::new("/") && summary.visible_directories == 0 {
+            return Err(JournalError::JournalDirectoriesMissing {
+                root_path: root_path.to_path_buf(),
+            });
+        }
+
+        if (summary.journal_files > 0 || summary.unreadable_directories > 0)
+            && summary.readable_files == 0
+            && (summary.unreadable_files > 0 || summary.unreadable_directories > 0)
+        {
+            return Err(JournalError::JournalAccess {
+                root_path: root_path.to_path_buf(),
+                journal_files: summary.journal_files,
+                unreadable_files: summary.unreadable_files,
+                unreadable_directories: summary.unreadable_directories,
+                first_error: summary
+                    .first_error
+                    .unwrap_or_else(|| "permission denied".to_owned()),
+            });
+        }
+        Ok(())
+    }
+
+    fn inspect_journal_path(path: &Path, depth: usize, summary: &mut JournalAccessSummary) {
+        const MAX_DEPTH: usize = 4;
+        if depth > MAX_DEPTH {
+            return;
+        }
+
+        let metadata = match std::fs::metadata(path) {
+            Ok(metadata) => metadata,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return,
+            Err(err) => {
+                if err.kind() == std::io::ErrorKind::PermissionDenied {
+                    summary.unreadable_directories =
+                        summary.unreadable_directories.saturating_add(1);
+                }
+                record_first_error(summary, path, &err);
+                return;
+            }
+        };
+
+        if metadata.is_file() {
+            inspect_journal_file(path, summary);
+            return;
+        }
+        if !metadata.is_dir() {
+            return;
+        }
+        summary.visible_directories = summary.visible_directories.saturating_add(1);
+
+        let entries = match std::fs::read_dir(path) {
+            Ok(entries) => entries,
+            Err(err) => {
+                if err.kind() == std::io::ErrorKind::PermissionDenied {
+                    summary.unreadable_directories =
+                        summary.unreadable_directories.saturating_add(1);
+                }
+                record_first_error(summary, path, &err);
+                return;
+            }
+        };
+
+        for entry in entries {
+            match entry {
+                Ok(entry) => inspect_journal_path(&entry.path(), depth + 1, summary),
+                Err(err) => {
+                    if err.kind() == std::io::ErrorKind::PermissionDenied {
+                        summary.unreadable_directories =
+                            summary.unreadable_directories.saturating_add(1);
+                    }
+                    if summary.first_error.is_none() {
+                        summary.first_error = Some(err.to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    fn inspect_journal_file(path: &Path, summary: &mut JournalAccessSummary) {
+        if !is_journal_file(path) {
+            return;
+        }
+        summary.journal_files = summary.journal_files.saturating_add(1);
+        match std::fs::File::open(path) {
+            Ok(_) => {
+                summary.readable_files = summary.readable_files.saturating_add(1);
+            }
+            Err(err) => {
+                if err.kind() == std::io::ErrorKind::PermissionDenied {
+                    summary.unreadable_files = summary.unreadable_files.saturating_add(1);
+                }
+                record_first_error(summary, path, &err);
+            }
+        }
+    }
+
+    fn is_journal_file(path: &Path) -> bool {
+        let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+            return false;
+        };
+        name.ends_with(".journal") || name.ends_with(".journal~")
+    }
+
+    fn record_first_error(summary: &mut JournalAccessSummary, path: &Path, err: &std::io::Error) {
+        if summary.first_error.is_none() {
+            summary.first_error = Some(format!("{}: {err}", path.display()));
         }
     }
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
@@ -221,6 +221,32 @@ mod imp {
             config: &RuntimeConfig,
             checkpoint: Option<&str>,
         ) -> Result<(), JournalError> {
+            if let Some(cursor) = checkpoint {
+                // Verify checkpoint existence against the unfiltered journal. If filters are
+                // applied first, a normal unit/identifier/priority config change can hide the
+                // checkpoint entry and make a valid cursor look stale. The verify step leaves the
+                // read head on the committed entry; after installing matches, the worker's first
+                // next() advances from that committed position to the first newly visible entry.
+                self.verify_checkpoint_cursor(cursor)?;
+                self.configure_matches(config)?;
+                return Ok(());
+            }
+
+            self.configure_matches(config)?;
+
+            match config.start_at {
+                StartAt::Beginning => check(
+                    unsafe { (self.lib.seek_head)(self.journal.as_ptr()) },
+                    "sd_journal_seek_head",
+                ),
+                StartAt::End => check(
+                    unsafe { (self.lib.seek_tail)(self.journal.as_ptr()) },
+                    "sd_journal_seek_tail",
+                ),
+            }
+        }
+
+        fn configure_matches(&mut self, config: &RuntimeConfig) -> Result<(), JournalError> {
             let mut has_match_group = false;
             has_match_group |=
                 self.add_match_group("_SYSTEMD_UNIT", config.units.iter().map(String::as_str))?;
@@ -243,48 +269,38 @@ mod imp {
                         .map(|priority| priority.to_string()),
                 )?;
             }
+            Ok(())
+        }
 
-            if let Some(cursor) = checkpoint {
-                let c = CString::new(cursor).map_err(|_| JournalError::Nul {
-                    field: "checkpoint cursor",
-                })?;
-                check(
-                    unsafe { (self.lib.seek_cursor)(self.journal.as_ptr(), c.as_ptr()) },
-                    "sd_journal_seek_cursor",
-                )?;
-                let next = unsafe { (self.lib.next)(self.journal.as_ptr()) };
-                if next < 0 {
-                    return Err(JournalError::SystemdCall {
-                        operation: "sd_journal_next",
-                        rc: next,
-                    });
-                }
-                if next == 0 {
-                    return Err(JournalError::CheckpointCursorMissing);
-                }
-                let matches = unsafe { (self.lib.test_cursor)(self.journal.as_ptr(), c.as_ptr()) };
-                if matches < 0 {
-                    return Err(JournalError::SystemdCall {
-                        operation: "sd_journal_test_cursor",
-                        rc: matches,
-                    });
-                }
-                if matches == 0 {
-                    return Err(JournalError::CheckpointCursorMissing);
-                }
-                return Ok(());
+        fn verify_checkpoint_cursor(&mut self, cursor: &str) -> Result<(), JournalError> {
+            let c = CString::new(cursor).map_err(|_| JournalError::Nul {
+                field: "checkpoint cursor",
+            })?;
+            check(
+                unsafe { (self.lib.seek_cursor)(self.journal.as_ptr(), c.as_ptr()) },
+                "sd_journal_seek_cursor",
+            )?;
+            let next = unsafe { (self.lib.next)(self.journal.as_ptr()) };
+            if next < 0 {
+                return Err(JournalError::SystemdCall {
+                    operation: "sd_journal_next",
+                    rc: next,
+                });
             }
-
-            match config.start_at {
-                StartAt::Beginning => check(
-                    unsafe { (self.lib.seek_head)(self.journal.as_ptr()) },
-                    "sd_journal_seek_head",
-                ),
-                StartAt::End => check(
-                    unsafe { (self.lib.seek_tail)(self.journal.as_ptr()) },
-                    "sd_journal_seek_tail",
-                ),
+            if next == 0 {
+                return Err(JournalError::CheckpointCursorMissing);
             }
+            let matches = unsafe { (self.lib.test_cursor)(self.journal.as_ptr(), c.as_ptr()) };
+            if matches < 0 {
+                return Err(JournalError::SystemdCall {
+                    operation: "sd_journal_test_cursor",
+                    rc: matches,
+                });
+            }
+            if matches == 0 {
+                return Err(JournalError::CheckpointCursorMissing);
+            }
+            Ok(())
         }
 
         fn add_match_group<I, V>(&mut self, field: &str, values: I) -> Result<bool, JournalError>

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
@@ -21,6 +21,7 @@ mod imp {
 
     const SD_JOURNAL_LOCAL_ONLY: c_int = 1;
     const SD_JOURNAL_OS_ROOT: c_int = 16;
+    const FIELD_NAME_THRESHOLD_HEADROOM_BYTES: u64 = 4096;
 
     type SdJournal = c_void;
     type OpenFn = unsafe extern "C" fn(*mut *mut SdJournal, c_int) -> c_int;
@@ -206,8 +207,9 @@ mod imp {
                 journal,
                 extraction: config.extraction.clone(),
             };
+            let data_threshold = extraction_data_threshold(&reader.extraction);
             check(
-                unsafe { (reader.lib.set_data_threshold)(reader.journal.as_ptr(), 0) },
+                unsafe { (reader.lib.set_data_threshold)(reader.journal.as_ptr(), data_threshold) },
                 "sd_journal_set_data_threshold",
             )?;
             reader.configure(config, checkpoint)?;
@@ -387,6 +389,10 @@ mod imp {
                     (self.lib.enumerate_data)(self.journal.as_ptr(), &mut data, &mut len)
                 };
                 if rc < 0 {
+                    if rc == -libc::E2BIG {
+                        dropped_fields = dropped_fields.saturating_add(1);
+                        continue;
+                    }
                     return Err(JournalError::SystemdCall {
                         operation: "sd_journal_enumerate_data",
                         rc,
@@ -405,9 +411,12 @@ mod imp {
                     };
                     let value_len = bytes.len().saturating_sub(eq + 1) as u64;
                     let field_len = bytes.len() as u64;
+                    let possibly_truncated =
+                        field_len >= extraction_data_threshold_u64(&self.extraction);
                     let would_exceed_entry = copied_entry_bytes.saturating_add(field_len)
                         > self.extraction.max_entry_bytes;
-                    let should_drop = value_len > self.extraction.max_field_bytes
+                    let should_drop = possibly_truncated
+                        || value_len > self.extraction.max_field_bytes
                         || copied_field_count >= self.extraction.max_fields_per_entry
                         || would_exceed_entry;
                     if should_drop {
@@ -451,6 +460,18 @@ mod imp {
         }
         let usec = duration.as_micros().min(u64::MAX as u128) as u64;
         usec.max(1)
+    }
+
+    fn extraction_data_threshold(extraction: &ExtractionConfig) -> size_t {
+        extraction_data_threshold_u64(extraction).min(size_t::MAX as u64) as size_t
+    }
+
+    fn extraction_data_threshold_u64(extraction: &ExtractionConfig) -> u64 {
+        extraction
+            .max_field_bytes
+            .saturating_add(FIELD_NAME_THRESHOLD_HEADROOM_BYTES)
+            .min(extraction.max_entry_bytes)
+            .max(1)
     }
 
     impl Drop for SdJournalReader {

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
@@ -27,7 +27,7 @@ mod imp {
     type NextFn = unsafe extern "C" fn(*mut SdJournal) -> c_int;
     type WaitFn = unsafe extern "C" fn(*mut SdJournal, u64) -> c_int;
     type SeekHeadFn = unsafe extern "C" fn(*mut SdJournal) -> c_int;
-    type SeekRealtimeUsecFn = unsafe extern "C" fn(*mut SdJournal, u64) -> c_int;
+    type SeekTailFn = unsafe extern "C" fn(*mut SdJournal) -> c_int;
     type SeekCursorFn = unsafe extern "C" fn(*mut SdJournal, *const c_char) -> c_int;
     type TestCursorFn = unsafe extern "C" fn(*mut SdJournal, *const c_char) -> c_int;
     type GetCursorFn = unsafe extern "C" fn(*mut SdJournal, *mut *mut c_char) -> c_int;
@@ -48,7 +48,7 @@ mod imp {
         next: NextFn,
         wait: WaitFn,
         seek_head: SeekHeadFn,
-        seek_realtime_usec: SeekRealtimeUsecFn,
+        seek_tail: SeekTailFn,
         seek_cursor: SeekCursorFn,
         test_cursor: TestCursorFn,
         get_cursor: GetCursorFn,
@@ -99,7 +99,7 @@ mod imp {
                 next: sym!("sd_journal_next", NextFn),
                 wait: sym!("sd_journal_wait", WaitFn),
                 seek_head: sym!("sd_journal_seek_head", SeekHeadFn),
-                seek_realtime_usec: sym!("sd_journal_seek_realtime_usec", SeekRealtimeUsecFn),
+                seek_tail: sym!("sd_journal_seek_tail", SeekTailFn),
                 seek_cursor: sym!("sd_journal_seek_cursor", SeekCursorFn),
                 test_cursor: sym!("sd_journal_test_cursor", TestCursorFn),
                 get_cursor: sym!("sd_journal_get_cursor", GetCursorFn),
@@ -216,17 +216,10 @@ mod imp {
                     unsafe { (self.lib.seek_head)(self.journal.as_ptr()) },
                     "sd_journal_seek_head",
                 ),
-                StartAt::End => {
-                    let now = std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .map_err(|_| "system clock is before Unix epoch".to_owned())?
-                        .as_micros()
-                        .min(u64::MAX as u128) as u64;
-                    check(
-                        unsafe { (self.lib.seek_realtime_usec)(self.journal.as_ptr(), now) },
-                        "sd_journal_seek_realtime_usec",
-                    )
-                }
+                StartAt::End => check(
+                    unsafe { (self.lib.seek_tail)(self.journal.as_ptr()) },
+                    "sd_journal_seek_tail",
+                ),
             }
         }
 
@@ -311,7 +304,7 @@ mod imp {
             )?;
 
             unsafe { (self.lib.restart_data)(self.journal.as_ptr()) };
-            let mut fields = Vec::new();
+            let mut fields = Vec::with_capacity(self.extraction.max_fields_per_entry.min(64));
             let mut copied_entry_bytes = 0u64;
             let mut copied_field_count = 0usize;
             let mut dropped_fields = 0u64;
@@ -344,7 +337,9 @@ mod imp {
                             }
                         }
                     }
-                    let name = String::from_utf8_lossy(&bytes[..eq]).into_owned();
+                    let name = std::str::from_utf8(&bytes[..eq])
+                        .map_err(|err| format!("journald field name is not UTF-8: {err}"))?
+                        .to_owned();
                     let value = bytes[eq + 1..].to_vec();
                     fields.push(JournalField { name, value });
                     copied_entry_bytes = copied_entry_bytes.saturating_add(field_len);

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/mod.rs
@@ -1146,6 +1146,7 @@ mod tests {
         }
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn rejects_unknown_config_field() {
         let json = serde_json::json!({

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/mod.rs
@@ -254,10 +254,29 @@ enum WorkerEvent {
     CommitResult {
         batch_id: u64,
         cursor: String,
-        result: Result<(), String>,
+        result: Result<(), checkpoint::CheckpointError>,
     },
-    Failed(String),
+    Failed(WorkerError),
     Stopped,
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Debug, thiserror::Error)]
+enum WorkerError {
+    #[error(transparent)]
+    Checkpoint(#[from] checkpoint::CheckpointError),
+    #[error(transparent)]
+    Journal(#[from] journal::JournalError),
+    #[error("failed to encode journald batch: {source}")]
+    Encode {
+        source: otap_df_pdata::encode::Error,
+    },
+    #[error("journald receiver event channel closed")]
+    EventChannelClosed,
+    #[error("journald worker received an unexpected command while handing off a batch")]
+    UnexpectedCommand,
+    #[error("journald cannot rewind before the first checkpoint is committed")]
+    RewindBeforeCheckpoint,
 }
 
 #[cfg(any(target_os = "linux", test))]
@@ -476,7 +495,7 @@ fn worker_loop_inner(
     checkpoint_path: PathBuf,
     event_tx: &tokio::sync::mpsc::Sender<WorkerEvent>,
     cmd_rx: &std::sync::mpsc::Receiver<WorkerCommand>,
-) -> Result<(), String> {
+) -> Result<(), WorkerError> {
     let mut committed_cursor = checkpoint::read_cursor(&checkpoint_path)?;
     let mut reader = journal::SdJournalReader::open(&config, committed_cursor.as_deref())?;
     let mut next_batch_id = 1u64;
@@ -556,10 +575,7 @@ fn worker_loop_inner(
                     let Some(cursor) = committed_cursor.as_deref() else {
                         // Defense-in-depth: with max_in_flight=1, a valid Nack rewind
                         // before the first commit is handled by the in-flight arm above.
-                        return Err(
-                            "journald cannot rewind before the first checkpoint is committed"
-                                .to_owned(),
-                        );
+                        return Err(WorkerError::RewindBeforeCheckpoint);
                     };
                     builder = arrow_records_encoder::JournaldArrowRecordsBuilder::new();
                     first_cursor.clear();
@@ -613,7 +629,7 @@ fn worker_loop_inner(
                 arrow_records_encoder::JournaldArrowRecordsBuilder::new(),
             )
             .build()
-            .map_err(|err| format!("failed to encode journald batch: {err}"))?;
+            .map_err(|source| WorkerError::Encode { source })?;
             let batch = WorkerBatch {
                 id: next_batch_id,
                 first_cursor: std::mem::take(&mut first_cursor),
@@ -642,14 +658,14 @@ fn send_batch_or_observe_shutdown(
     event_tx: &tokio::sync::mpsc::Sender<WorkerEvent>,
     cmd_rx: &std::sync::mpsc::Receiver<WorkerCommand>,
     batch: WorkerBatch,
-) -> Result<BatchHandoff, String> {
+) -> Result<BatchHandoff, WorkerError> {
     let mut event = WorkerEvent::Batch(batch);
     let mut drain_requested = false;
     loop {
         match event_tx.try_send(event) {
             Ok(()) => return Ok(BatchHandoff::Sent { drain_requested }),
             Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
-                return Err("journald receiver event channel closed".to_owned());
+                return Err(WorkerError::EventChannelClosed);
             }
             Err(tokio::sync::mpsc::error::TrySendError::Full(returned)) => {
                 event = returned;
@@ -662,10 +678,7 @@ fn send_batch_or_observe_shutdown(
                         return Ok(BatchHandoff::Shutdown);
                     }
                     Ok(WorkerCommand::Commit { .. } | WorkerCommand::Rewind) => {
-                        return Err(
-                            "journald worker received an unexpected command while handing off a batch"
-                                .to_owned(),
-                        );
+                        return Err(WorkerError::UnexpectedCommand);
                     }
                     Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
                 }
@@ -1001,7 +1014,7 @@ impl local::Receiver<OtapPdata> for JournaldReceiver {
                                         "journald_receiver.checkpoint_failed",
                                         source_id = config.source_id.as_str(),
                                         batch_id = batch_id,
-                                        error = err.as_str()
+                                        error = err.to_string()
                                     );
                                     if checkpoint_failures >= config.checkpoint.max_consecutive_failures {
                                         let _ =

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/mod.rs
@@ -3,11 +3,7 @@
 
 //! Journald receiver.
 //!
-//! This is the first incremental slice. It introduces the receiver factory,
-//! configuration types, process-local source lease, and a no-op
-//! receiver loop that honors lifecycle/drain/shutdown control messages.
-//! The blocking `sd-journal` worker, batch handoff, Ack/Nack tracking, and
-//! checkpoint persistence land in follow-up PRs as described in
+//! This module implements the Linux-only journald source described in
 //! [`docs/journald-receiver.md`](../../../../../../docs/journald-receiver.md).
 //!
 //! Most runtime code is Linux-only (`#[cfg(target_os = "linux")]`); on other
@@ -17,35 +13,54 @@
 #[cfg(target_os = "linux")]
 use async_trait::async_trait;
 use linkme::distributed_slice;
+#[cfg(target_os = "linux")]
+use otap_df_channel::error::SendError;
 use otap_df_config::node::NodeUserConfig;
 use otap_df_engine::ReceiverFactory;
 use otap_df_engine::config::ReceiverConfig;
 use otap_df_engine::context::PipelineContext;
 #[cfg(target_os = "linux")]
-use otap_df_engine::control::NodeControlMsg;
+use otap_df_engine::control::{CallData, Context8u8, NodeControlMsg};
 #[cfg(target_os = "linux")]
-use otap_df_engine::error::Error;
+use otap_df_engine::error::{Error, ReceiverErrorKind, TypedError};
 #[cfg(target_os = "linux")]
 use otap_df_engine::local::receiver as local;
 use otap_df_engine::node::NodeId;
 use otap_df_engine::receiver::ReceiverWrapper;
 #[cfg(target_os = "linux")]
 use otap_df_engine::terminal_state::TerminalState;
+#[cfg(target_os = "linux")]
+use otap_df_engine::{
+    Interests, MessageSourceLocalEffectHandlerExtension, ProducerEffectHandlerExtension,
+};
 use otap_df_otap::OTAP_RECEIVER_FACTORIES;
+#[cfg(target_os = "linux")]
+use otap_df_otap::pdata::Context;
 use otap_df_otap::pdata::OtapPdata;
+#[cfg(target_os = "linux")]
+use otap_df_pdata::OtapPayload;
 use otap_df_telemetry::instrument::Counter;
 use otap_df_telemetry::metrics::MetricSet;
 #[cfg(target_os = "linux")]
 use otap_df_telemetry::metrics::MetricSetSnapshot;
 #[cfg(target_os = "linux")]
-use otap_df_telemetry::otel_info;
+use otap_df_telemetry::{otel_info, otel_warn};
 use otap_df_telemetry_macros::metric_set;
 use serde_json::Value;
+#[cfg(target_os = "linux")]
+use std::collections::BTreeMap;
 use std::collections::HashSet;
+#[cfg(target_os = "linux")]
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::{LazyLock, Mutex};
+#[cfg(target_os = "linux")]
+use std::time::Instant as StdInstant;
 
+mod arrow_records_encoder;
+mod checkpoint;
 mod config;
+mod journal;
 
 use config::RuntimeConfig;
 pub use config::{
@@ -58,9 +73,8 @@ pub const JOURNALD_RECEIVER_URN: &str = "urn:otel:receiver:journald";
 
 /// Telemetry metrics for the journald receiver.
 ///
-/// The set is intentionally small in this first slice; richer counters
-/// (records emitted, cursor commits, batches held by backpressure, etc.) land
-/// alongside the worker thread that produces them.
+/// Tracks lifecycle transitions, downstream delivery, Ack/Nack handling, and
+/// durable cursor checkpoint progress.
 #[metric_set(name = "receiver.journald")]
 #[derive(Debug, Default, Clone)]
 pub struct JournaldReceiverMetrics {
@@ -73,12 +87,38 @@ pub struct JournaldReceiverMetrics {
     /// Number of clean shutdown transitions.
     #[metric(unit = "{shutdown}")]
     pub shutdowns: Counter<u64>,
+    /// Number of log batches emitted downstream.
+    #[metric(unit = "{batch}")]
+    pub batches_sent: Counter<u64>,
+    /// Number of log records emitted downstream.
+    #[metric(unit = "{record}")]
+    pub records_sent: Counter<u64>,
+    /// Number of downstream Acks observed.
+    #[metric(unit = "{ack}")]
+    pub acks: Counter<u64>,
+    /// Number of downstream Nacks observed.
+    #[metric(unit = "{nack}")]
+    pub nacks: Counter<u64>,
+    /// Number of durable cursor commits completed.
+    #[metric(unit = "{commit}")]
+    pub cursor_commits: Counter<u64>,
+    /// Number of durable cursor commit failures.
+    #[metric(unit = "{failure}")]
+    pub checkpoint_failures: Counter<u64>,
+    /// Number of source read failures reported by the worker.
+    #[metric(unit = "{failure}")]
+    pub source_failures: Counter<u64>,
+    /// Number of times the worker was asked to rewind after a Nack.
+    #[metric(unit = "{rewind}")]
+    pub rewinds: Counter<u64>,
 }
 
 /// Journald receiver instance.
 pub struct JournaldReceiver {
     #[allow(dead_code)]
     config: RuntimeConfig,
+    #[cfg(target_os = "linux")]
+    checkpoint_path: PathBuf,
     _lease: SourceLease,
     metrics: Option<MetricSet<JournaldReceiverMetrics>>,
 }
@@ -114,6 +154,13 @@ fn create_journald_receiver(
         });
     }
     let mut receiver = JournaldReceiver::from_config(&node_config.config)?;
+    receiver.checkpoint_path = checkpoint::checkpoint_path(
+        &receiver.config.checkpoint.directory,
+        pipeline.pipeline_group_id().as_ref(),
+        pipeline.pipeline_id().as_ref(),
+        receiver_config.name.as_ref(),
+        &receiver.config.source_id,
+    );
     receiver.metrics = Some(pipeline.register_metrics::<JournaldReceiverMetrics>());
     Ok(ReceiverWrapper::local(
         receiver,
@@ -151,7 +198,7 @@ fn unsupported_platform_error() -> otap_df_config::error::Error {
 
 impl JournaldReceiver {
     /// Builds a receiver from a JSON config value.
-    pub fn from_config(config: &Value) -> Result<Self, otap_df_config::error::Error> {
+    fn from_config(config: &Value) -> Result<Self, otap_df_config::error::Error> {
         let parsed: Config = serde_json::from_value(config.clone()).map_err(|e| {
             otap_df_config::error::Error::InvalidUserConfig {
                 error: e.to_string(),
@@ -161,11 +208,13 @@ impl JournaldReceiver {
     }
 
     /// Builds a receiver from an already-deserialized `Config`.
-    pub fn new(config: Config) -> Result<Self, otap_df_config::error::Error> {
+    fn new(config: Config) -> Result<Self, otap_df_config::error::Error> {
         let runtime = RuntimeConfig::try_from(config)?;
         let lease = SourceLease::acquire(&runtime.lease_key)?;
         Ok(Self {
             config: runtime,
+            #[cfg(target_os = "linux")]
+            checkpoint_path: PathBuf::new(),
             _lease: lease,
             metrics: None,
         })
@@ -185,6 +234,307 @@ fn terminal_state(
 }
 
 #[cfg(target_os = "linux")]
+struct WorkerBatch {
+    id: u64,
+    first_cursor: String,
+    last_cursor: String,
+    records: otap_df_pdata::otap::OtapArrowRecords,
+    record_count: usize,
+}
+
+#[cfg(target_os = "linux")]
+enum WorkerEvent {
+    Batch(WorkerBatch),
+    CommitResult {
+        batch_id: u64,
+        cursor: String,
+        result: Result<(), String>,
+    },
+    Failed(String),
+    Stopped,
+}
+
+#[cfg(target_os = "linux")]
+enum WorkerCommand {
+    Commit { batch_id: u64, cursor: String },
+    Rewind,
+    Shutdown,
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Clone)]
+struct PendingBatch {
+    last_cursor: String,
+    decision: PendingDecision,
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum PendingDecision {
+    Pending,
+    CommitSent,
+    RewindSent,
+}
+
+#[cfg(target_os = "linux")]
+struct WorkerHandle {
+    cmd_tx: std::sync::mpsc::SyncSender<WorkerCommand>,
+    join: std::thread::JoinHandle<()>,
+}
+
+#[cfg(target_os = "linux")]
+const WORKER_COMMAND_CHANNEL_CAPACITY: usize = 8;
+#[cfg(target_os = "linux")]
+const WORKER_EVENT_CONTROL_SLOTS: usize = 4;
+#[cfg(target_os = "linux")]
+const WORKER_COMMAND_RETRY_LIMIT: usize = 200;
+#[cfg(target_os = "linux")]
+const WORKER_COMMAND_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(10);
+
+#[cfg(target_os = "linux")]
+fn batch_id_from_call_data(call_data: &CallData) -> Option<u64> {
+    call_data.first().copied().map(u64::from)
+}
+
+#[cfg(target_os = "linux")]
+fn receiver_error(receiver: NodeId, error: impl Into<String>) -> Error {
+    Error::ReceiverError {
+        receiver,
+        kind: ReceiverErrorKind::Other,
+        error: error.into(),
+        source_detail: String::new(),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn terminal_error(
+    effect_handler: &local::EffectHandler<OtapPdata>,
+    error: impl Into<String>,
+) -> Error {
+    receiver_error(effect_handler.receiver_id(), error)
+}
+
+#[cfg(target_os = "linux")]
+async fn send_worker_command(
+    tx: &std::sync::mpsc::SyncSender<WorkerCommand>,
+    cmd: WorkerCommand,
+    effect_handler: &local::EffectHandler<OtapPdata>,
+) -> Result<(), Error> {
+    let mut cmd = Some(cmd);
+    for _ in 0..WORKER_COMMAND_RETRY_LIMIT {
+        match tx.try_send(cmd.take().expect("command must be present")) {
+            Ok(()) => return Ok(()),
+            Err(std::sync::mpsc::TrySendError::Full(returned)) => {
+                cmd = Some(returned);
+                tokio::time::sleep(WORKER_COMMAND_RETRY_DELAY).await;
+            }
+            Err(std::sync::mpsc::TrySendError::Disconnected(_)) => {
+                return Err(terminal_error(
+                    effect_handler,
+                    "journald worker command channel disconnected",
+                ));
+            }
+        }
+    }
+    Err(terminal_error(
+        effect_handler,
+        "journald worker command channel saturated",
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn spawn_worker(
+    config: RuntimeConfig,
+    checkpoint_path: PathBuf,
+    event_tx: tokio::sync::mpsc::Sender<WorkerEvent>,
+) -> Result<WorkerHandle, String> {
+    let (cmd_tx, cmd_rx) = std::sync::mpsc::sync_channel(WORKER_COMMAND_CHANNEL_CAPACITY);
+    let join = std::thread::Builder::new()
+        .name(format!("otap-journald-{}", config.source_id))
+        .spawn(move || worker_loop(config, checkpoint_path, event_tx, cmd_rx))
+        .map_err(|err| format!("failed to spawn journald worker thread: {err}"))?;
+    Ok(WorkerHandle { cmd_tx, join })
+}
+
+#[cfg(target_os = "linux")]
+async fn join_worker(
+    worker: WorkerHandle,
+    effect_handler: &local::EffectHandler<OtapPdata>,
+) -> Result<(), Error> {
+    let receiver_id = effect_handler.receiver_id();
+    drop(worker.cmd_tx);
+    tokio::task::spawn_blocking(move || worker.join.join())
+        .await
+        .map_err(|err| {
+            receiver_error(
+                receiver_id.clone(),
+                format!("journald worker join failed: {err}"),
+            )
+        })?
+        .map_err(|_| receiver_error(receiver_id, "journald worker thread panicked"))
+}
+
+#[cfg(target_os = "linux")]
+fn worker_loop(
+    config: RuntimeConfig,
+    checkpoint_path: PathBuf,
+    event_tx: tokio::sync::mpsc::Sender<WorkerEvent>,
+    cmd_rx: std::sync::mpsc::Receiver<WorkerCommand>,
+) {
+    let result = worker_loop_inner(config, checkpoint_path, &event_tx, &cmd_rx);
+    if let Err(err) = result {
+        let _ = event_tx.blocking_send(WorkerEvent::Failed(err));
+    }
+    let _ = event_tx.blocking_send(WorkerEvent::Stopped);
+}
+
+#[cfg(target_os = "linux")]
+fn worker_loop_inner(
+    config: RuntimeConfig,
+    checkpoint_path: PathBuf,
+    event_tx: &tokio::sync::mpsc::Sender<WorkerEvent>,
+    cmd_rx: &std::sync::mpsc::Receiver<WorkerCommand>,
+) -> Result<(), String> {
+    let mut committed_cursor = checkpoint::read_cursor(&checkpoint_path)?;
+    let mut reader = journal::SdJournalReader::open(&config, committed_cursor.as_deref())?;
+    let mut next_batch_id = 1u64;
+    let mut builder = arrow_records_encoder::JournaldArrowRecordsBuilder::new();
+    let mut first_cursor = String::new();
+    let mut last_cursor = String::new();
+    let mut first_record_at = StdInstant::now();
+    let mut in_flight = false;
+
+    loop {
+        if in_flight {
+            match cmd_rx.recv() {
+                Ok(WorkerCommand::Commit { batch_id, cursor }) => {
+                    let result = checkpoint::write_cursor(&checkpoint_path, &cursor);
+                    if result.is_ok() {
+                        committed_cursor = Some(cursor.clone());
+                        in_flight = false;
+                    }
+                    let _ = event_tx.blocking_send(WorkerEvent::CommitResult {
+                        batch_id,
+                        cursor,
+                        result,
+                    });
+                }
+                Ok(WorkerCommand::Rewind) => {
+                    if committed_cursor.is_none() {
+                        return Err(
+                            "journald cannot rewind before the first checkpoint is committed"
+                                .to_owned(),
+                        );
+                    }
+                    builder = arrow_records_encoder::JournaldArrowRecordsBuilder::new();
+                    first_cursor.clear();
+                    last_cursor.clear();
+                    reader = journal::SdJournalReader::open(&config, committed_cursor.as_deref())?;
+                    in_flight = false;
+                }
+                Ok(WorkerCommand::Shutdown) | Err(_) => return Ok(()),
+            }
+            continue;
+        }
+
+        while let Ok(cmd) = cmd_rx.try_recv() {
+            match cmd {
+                WorkerCommand::Commit { batch_id, cursor } => {
+                    let result = checkpoint::write_cursor(&checkpoint_path, &cursor);
+                    if result.is_ok() {
+                        committed_cursor = Some(cursor.clone());
+                    }
+                    let _ = event_tx.blocking_send(WorkerEvent::CommitResult {
+                        batch_id,
+                        cursor,
+                        result,
+                    });
+                }
+                WorkerCommand::Rewind => {
+                    if committed_cursor.is_none() {
+                        return Err(
+                            "journald cannot rewind before the first checkpoint is committed"
+                                .to_owned(),
+                        );
+                    }
+                    builder = arrow_records_encoder::JournaldArrowRecordsBuilder::new();
+                    first_cursor.clear();
+                    last_cursor.clear();
+                    reader = journal::SdJournalReader::open(&config, committed_cursor.as_deref())?;
+                }
+                WorkerCommand::Shutdown => return Ok(()),
+            }
+        }
+
+        if let Some(entry) = reader.next_entry()? {
+            if builder.len() == 0 {
+                first_cursor = entry.cursor.clone();
+                first_record_at = StdInstant::now();
+            }
+            last_cursor = entry.cursor.clone();
+            builder.append(&entry);
+        }
+
+        let should_flush = builder.len() as usize >= config.batch.max_records
+            || (builder.len() > 0 && first_record_at.elapsed() >= config.batch.max_flush_period);
+        if should_flush {
+            let record_count = usize::from(builder.len());
+            let records = std::mem::replace(
+                &mut builder,
+                arrow_records_encoder::JournaldArrowRecordsBuilder::new(),
+            )
+            .build()
+            .map_err(|err| format!("failed to encode journald batch: {err}"))?;
+            let batch = WorkerBatch {
+                id: next_batch_id,
+                first_cursor: std::mem::take(&mut first_cursor),
+                last_cursor: std::mem::take(&mut last_cursor),
+                records,
+                record_count,
+            };
+            next_batch_id = next_batch_id.saturating_add(1);
+            if !send_batch_or_observe_shutdown(event_tx, cmd_rx, batch)? {
+                return Ok(());
+            }
+            in_flight = true;
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn send_batch_or_observe_shutdown(
+    event_tx: &tokio::sync::mpsc::Sender<WorkerEvent>,
+    cmd_rx: &std::sync::mpsc::Receiver<WorkerCommand>,
+    batch: WorkerBatch,
+) -> Result<bool, String> {
+    let mut event = WorkerEvent::Batch(batch);
+    loop {
+        match event_tx.try_send(event) {
+            Ok(()) => return Ok(true),
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                return Err("journald receiver event channel closed".to_owned());
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Full(returned)) => {
+                event = returned;
+                match cmd_rx.recv_timeout(std::time::Duration::from_millis(50)) {
+                    Ok(WorkerCommand::Shutdown)
+                    | Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                        return Ok(false);
+                    }
+                    Ok(WorkerCommand::Commit { .. } | WorkerCommand::Rewind) => {
+                        return Err(
+                            "journald worker received an unexpected command while handing off a batch"
+                                .to_owned(),
+                        );
+                    }
+                    Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+                }
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
 #[async_trait(?Send)]
 impl local::Receiver<OtapPdata> for JournaldReceiver {
     async fn start(
@@ -194,6 +544,7 @@ impl local::Receiver<OtapPdata> for JournaldReceiver {
     ) -> Result<TerminalState, Error> {
         let JournaldReceiver {
             config,
+            checkpoint_path,
             _lease,
             mut metrics,
         } = *self;
@@ -213,42 +564,319 @@ impl local::Receiver<OtapPdata> for JournaldReceiver {
             .start_periodic_telemetry(std::time::Duration::from_secs(1))
             .await?;
 
-        // The blocking sd-journal worker, bounded handoff channel, and Ack
-        // tracker are introduced in a follow-up PR. Until then this loop only
-        // services control messages so the engine sees a well-behaved node
-        // that drains and shuts down on demand.
+        let (event_tx, mut event_rx) = tokio::sync::mpsc::channel::<WorkerEvent>(
+            config
+                .checkpoint
+                .max_in_flight_batches
+                .saturating_add(WORKER_EVENT_CONTROL_SLOTS),
+        );
+        let worker = spawn_worker(config.clone(), checkpoint_path, event_tx)
+            .map_err(|err| terminal_error(&effect_handler, err))?;
+        let mut pending: BTreeMap<u64, PendingBatch> = BTreeMap::new();
+        let mut checkpoint_failures = 0u32;
+        let max_in_flight = config.checkpoint.max_in_flight_batches;
+        let mut drain_deadline = None;
+
         loop {
-            match ctrl_msg_recv.recv().await {
-                Ok(NodeControlMsg::CollectTelemetry {
-                    mut metrics_reporter,
-                }) => {
-                    if let Some(metrics) = metrics.as_mut() {
-                        let _ = metrics_reporter.report(metrics);
+            tokio::select! {
+                biased;
+
+                _ = async {
+                    if let Some(deadline) = drain_deadline {
+                        tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)).await;
+                    } else {
+                        std::future::pending::<()>().await;
                     }
-                }
-                Ok(NodeControlMsg::DrainIngress { deadline, .. }) => {
-                    if let Some(metrics) = metrics.as_mut() {
-                        metrics.drains.add(1);
-                    }
-                    otel_info!(
-                        "journald_receiver.drain_ingress",
-                        source_id = config.source_id.as_str()
-                    );
+                }, if drain_deadline.is_some() => {
+                    let deadline = drain_deadline.expect("drain deadline must be set");
+                    let _ =
+                        send_worker_command(&worker.cmd_tx, WorkerCommand::Shutdown, &effect_handler).await;
+                    drop(event_rx);
+                    join_worker(worker, &effect_handler).await?;
                     effect_handler.notify_receiver_drained().await?;
                     return Ok(terminal_state(deadline, &metrics));
                 }
-                Ok(NodeControlMsg::Shutdown { deadline, .. }) => {
-                    if let Some(metrics) = metrics.as_mut() {
-                        metrics.shutdowns.add(1);
+
+                msg = ctrl_msg_recv.recv() => {
+                    match msg {
+                        Ok(NodeControlMsg::CollectTelemetry { mut metrics_reporter }) => {
+                            if let Some(metrics) = metrics.as_mut() {
+                                let _ = metrics_reporter.report(metrics);
+                            }
+                        }
+                        Ok(NodeControlMsg::Ack(ack)) => {
+                            let Some(batch_id) = batch_id_from_call_data(&ack.unwind.route.calldata) else {
+                                continue;
+                            };
+                            if let Some(pending_batch) = pending.get_mut(&batch_id) {
+                                if pending_batch.decision != PendingDecision::Pending {
+                                    continue;
+                                }
+                                pending_batch.decision = PendingDecision::CommitSent;
+                                if let Some(metrics) = metrics.as_mut() {
+                                    metrics.acks.add(1);
+                                }
+                                let cursor = pending_batch.last_cursor.clone();
+                                send_worker_command(
+                                    &worker.cmd_tx,
+                                    WorkerCommand::Commit {
+                                        batch_id,
+                                        cursor,
+                                    },
+                                    &effect_handler,
+                                )
+                                .await?;
+                            }
+                        }
+                        Ok(NodeControlMsg::Nack(nack)) => {
+                            let Some(batch_id) = batch_id_from_call_data(&nack.unwind.route.calldata) else {
+                                continue;
+                            };
+                            if let Some(pending_batch) = pending.get_mut(&batch_id) {
+                                if pending_batch.decision != PendingDecision::Pending {
+                                    continue;
+                                }
+                                if let Some(metrics) = metrics.as_mut() {
+                                    metrics.nacks.add(1);
+                                    metrics.rewinds.add(1);
+                                }
+                                match config.checkpoint.on_nack {
+                                    OnNack::Rewind => {
+                                        pending_batch.decision = PendingDecision::RewindSent;
+                                        pending.clear();
+                                        send_worker_command(&worker.cmd_tx, WorkerCommand::Rewind, &effect_handler).await?;
+                                    }
+                                    OnNack::Fail => {
+                                        let _ =
+                                            send_worker_command(&worker.cmd_tx, WorkerCommand::Shutdown, &effect_handler).await;
+                                        drop(event_rx);
+                                        join_worker(worker, &effect_handler).await?;
+                                        return Err(terminal_error(&effect_handler, "journald batch was Nacked"));
+                                    }
+                                }
+                            }
+                        }
+                        Ok(NodeControlMsg::DrainIngress { deadline, .. }) => {
+                            if let Some(metrics) = metrics.as_mut() {
+                                metrics.drains.add(1);
+                            }
+                            otel_info!(
+                                "journald_receiver.drain_ingress",
+                                source_id = config.source_id.as_str()
+                            );
+                            let local_deadline = StdInstant::now()
+                                .checked_add(config.drain_timeout)
+                                .unwrap_or(deadline);
+                            let deadline = deadline.min(local_deadline);
+                            if pending.is_empty() {
+                                let _ =
+                                    send_worker_command(&worker.cmd_tx, WorkerCommand::Shutdown, &effect_handler).await;
+                                drop(event_rx);
+                                join_worker(worker, &effect_handler).await?;
+                                effect_handler.notify_receiver_drained().await?;
+                                return Ok(terminal_state(deadline, &metrics));
+                            }
+                            drain_deadline = Some(deadline);
+                        }
+                        Ok(NodeControlMsg::Shutdown { deadline, .. }) => {
+                            if let Some(metrics) = metrics.as_mut() {
+                                metrics.shutdowns.add(1);
+                            }
+                            otel_info!(
+                                "journald_receiver.shutdown",
+                                source_id = config.source_id.as_str()
+                            );
+                            let _ =
+                                send_worker_command(&worker.cmd_tx, WorkerCommand::Shutdown, &effect_handler).await;
+                            drop(event_rx);
+                            join_worker(worker, &effect_handler).await?;
+                            return Ok(terminal_state(deadline, &metrics));
+                        }
+                        Ok(_) => {}
+                        Err(e) => return Err(Error::ChannelRecvError(e)),
                     }
-                    otel_info!(
-                        "journald_receiver.shutdown",
-                        source_id = config.source_id.as_str()
-                    );
-                    return Ok(terminal_state(deadline, &metrics));
                 }
-                Ok(_) => {}
-                Err(e) => return Err(Error::ChannelRecvError(e)),
+
+                event = event_rx.recv() => {
+                    match event {
+                        Some(WorkerEvent::Batch(batch)) => {
+                            if pending.len() >= max_in_flight {
+                                let _ =
+                                    send_worker_command(&worker.cmd_tx, WorkerCommand::Shutdown, &effect_handler).await;
+                                drop(event_rx);
+                                join_worker(worker, &effect_handler).await?;
+                                return Err(terminal_error(
+                                    &effect_handler,
+                                    "journald worker exceeded configured in-flight batch limit",
+                                ));
+                            }
+                            let mut pdata = OtapPdata::new(
+                                Context::default(),
+                                OtapPayload::OtapArrowRecords(batch.records),
+                            );
+                            let mut calldata = CallData::new();
+                            calldata.push(Context8u8::from(batch.id));
+                            effect_handler.subscribe_to(
+                                Interests::ACKS | Interests::NACKS,
+                                calldata,
+                                &mut pdata,
+                            );
+                            let record_count = batch.record_count;
+                            let batch_id = batch.id;
+                            let last_cursor = batch.last_cursor.clone();
+                            let send_result = match effect_handler.try_send_message_with_source_node(pdata) {
+                                Ok(()) => Ok(()),
+                                Err(TypedError::ChannelSendError(SendError::Full(pdata))) => {
+                                    let mut send = Box::pin(effect_handler.send_message_with_source_node(pdata));
+                                    loop {
+                                        let result = tokio::select! {
+                                            biased;
+
+                                            msg = ctrl_msg_recv.recv() => {
+                                                match msg {
+                                                    Ok(NodeControlMsg::CollectTelemetry { mut metrics_reporter }) => {
+                                                        if let Some(metrics) = metrics.as_mut() {
+                                                            let _ = metrics_reporter.report(metrics);
+                                                        }
+                                                        continue;
+                                                    }
+                                                    Ok(NodeControlMsg::DrainIngress { deadline, .. }) => {
+                                                        if let Some(metrics) = metrics.as_mut() {
+                                                            metrics.drains.add(1);
+                                                        }
+                                                        let local_deadline = StdInstant::now()
+                                                            .checked_add(config.drain_timeout)
+                                                            .unwrap_or(deadline);
+                                                        let deadline = deadline.min(local_deadline);
+                                                        let _ =
+                                                            send_worker_command(&worker.cmd_tx, WorkerCommand::Shutdown, &effect_handler).await;
+                                                        drop(event_rx);
+                                                        join_worker(worker, &effect_handler).await?;
+                                                        effect_handler.notify_receiver_drained().await?;
+                                                        return Ok(terminal_state(deadline, &metrics));
+                                                    }
+                                                    Ok(NodeControlMsg::Shutdown { deadline, .. }) => {
+                                                        if let Some(metrics) = metrics.as_mut() {
+                                                            metrics.shutdowns.add(1);
+                                                        }
+                                                        let _ =
+                                                            send_worker_command(&worker.cmd_tx, WorkerCommand::Shutdown, &effect_handler).await;
+                                                        drop(event_rx);
+                                                        join_worker(worker, &effect_handler).await?;
+                                                        return Ok(terminal_state(deadline, &metrics));
+                                                    }
+                                                    Ok(_) => {
+                                                        continue;
+                                                    }
+                                                    Err(e) => return Err(Error::ChannelRecvError(e)),
+                                                }
+                                            }
+
+                                            result = send.as_mut() => result,
+                                        };
+                                        break result;
+                                    }
+                                }
+                                Err(err) => Err(err),
+                            };
+                            match send_result {
+                                Ok(()) => {
+                                    let _ = pending.insert(
+                                        batch_id,
+                                        PendingBatch {
+                                            last_cursor,
+                                            decision: PendingDecision::Pending,
+                                        },
+                                    );
+                                    if let Some(metrics) = metrics.as_mut() {
+                                        metrics.batches_sent.add(1);
+                                        metrics.records_sent.add(record_count as u64);
+                                    }
+                                    otel_info!(
+                                        "journald_receiver.batch_sent",
+                                        source_id = config.source_id.as_str(),
+                                        batch_id = batch_id,
+                                        first_cursor = batch.first_cursor.as_str(),
+                                        last_cursor = batch.last_cursor.as_str(),
+                                        records = record_count
+                                    );
+                                }
+                                Err(TypedError::ChannelSendError(err)) => {
+                                    return Err(terminal_error(
+                                        &effect_handler,
+                                        format!("failed to send journald batch downstream: {err}"),
+                                    ));
+                                }
+                                Err(err) => {
+                                    return Err(terminal_error(
+                                        &effect_handler,
+                                        format!("failed to send journald batch downstream: {err}"),
+                                    ));
+                                }
+                            }
+                        }
+                        Some(WorkerEvent::CommitResult { batch_id, cursor, result }) => {
+                            match result {
+                                Ok(()) => {
+                                    let _ = pending.remove(&batch_id);
+                                    checkpoint_failures = 0;
+                                    if let Some(metrics) = metrics.as_mut() {
+                                        metrics.cursor_commits.add(1);
+                                    }
+                                    otel_info!(
+                                        "journald_receiver.cursor_committed",
+                                        source_id = config.source_id.as_str(),
+                                        batch_id = batch_id,
+                                        cursor = cursor.as_str()
+                                    );
+                                    if let Some(deadline) = drain_deadline && pending.is_empty() {
+                                        let _ =
+                                            send_worker_command(&worker.cmd_tx, WorkerCommand::Shutdown, &effect_handler).await;
+                                        drop(event_rx);
+                                        join_worker(worker, &effect_handler).await?;
+                                        effect_handler.notify_receiver_drained().await?;
+                                        return Ok(terminal_state(deadline, &metrics));
+                                    }
+                                }
+                                Err(err) => {
+                                    checkpoint_failures = checkpoint_failures.saturating_add(1);
+                                    if let Some(metrics) = metrics.as_mut() {
+                                        metrics.checkpoint_failures.add(1);
+                                    }
+                                    otel_warn!(
+                                        "journald_receiver.checkpoint_failed",
+                                        source_id = config.source_id.as_str(),
+                                        batch_id = batch_id,
+                                        error = err.as_str()
+                                    );
+                                    if checkpoint_failures >= config.checkpoint.max_consecutive_failures {
+                                        let _ =
+                                            send_worker_command(&worker.cmd_tx, WorkerCommand::Shutdown, &effect_handler).await;
+                                        drop(event_rx);
+                                        join_worker(worker, &effect_handler).await?;
+                                        return Err(terminal_error(
+                                            &effect_handler,
+                                            format!("journald checkpoint failed {checkpoint_failures} consecutive times: {err}"),
+                                        ));
+                                    }
+                                }
+                            }
+                        }
+                        Some(WorkerEvent::Failed(err)) => {
+                            if let Some(metrics) = metrics.as_mut() {
+                                metrics.source_failures.add(1);
+                            }
+                            drop(event_rx);
+                            join_worker(worker, &effect_handler).await?;
+                            return Err(terminal_error(&effect_handler, err));
+                        }
+                        Some(WorkerEvent::Stopped) | None => {
+                            drop(event_rx);
+                            join_worker(worker, &effect_handler).await?;
+                            return Err(terminal_error(&effect_handler, "journald worker stopped unexpectedly"));
+                        }
+                    }
+                }
             }
         }
     }
@@ -258,7 +886,8 @@ impl local::Receiver<OtapPdata> for JournaldReceiver {
 //
 // The receiver design (see `docs/journald-receiver.md`) requires that, within
 // a single process, no two journald receivers target the same concrete journal
-// source selection. Cross-process duplication is left to operators in v1.
+// source. The lease key is derived from journal root plus namespace; cross-
+// process duplication is left to operators in v1.
 
 static JOURNALD_LEASES: LazyLock<Mutex<HashSet<String>>> =
     LazyLock::new(|| Mutex::new(HashSet::new()));
@@ -314,7 +943,7 @@ mod tests {
 
     #[test]
     fn lease_blocks_duplicate_source_in_process() {
-        // Use a key not used elsewhere in tests to avoid races.
+        // Use a source key not used elsewhere in tests to avoid races.
         let key = "journald:/test-lease-duplicate:<default>";
         let lease1 = SourceLease::acquire(key).expect("first lease must succeed");
         let lease2 = SourceLease::acquire(key);
@@ -331,32 +960,5 @@ mod tests {
         let b = SourceLease::acquire("journald:/test-lease-b:<default>").expect("b");
         drop(a);
         drop(b);
-    }
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn factory_rejects_multi_core_pipeline() {
-        let registry = otap_df_telemetry::registry::TelemetryRegistryHandle::new();
-        let controller = otap_df_engine::context::ControllerContext::new(registry);
-        let pipeline =
-            controller.pipeline_context_with("test-group".into(), "test-pipeline".into(), 0, 2, 0);
-        let node_config = Arc::new(NodeUserConfig::new_receiver_config(JOURNALD_RECEIVER_URN));
-        let receiver_config = ReceiverConfig::new("journald");
-        let result = create_journald_receiver(
-            pipeline,
-            NodeId {
-                index: 0,
-                name: "journald".into(),
-            },
-            node_config,
-            &receiver_config,
-        );
-        match result {
-            Err(otap_df_config::error::Error::InvalidUserConfig { error }) => {
-                assert!(error.contains("one-core"));
-            }
-            Err(other) => panic!("unexpected error: {other:?}"),
-            Ok(_) => panic!("multi-core journald receiver must be rejected"),
-        }
     }
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/mod.rs
@@ -184,6 +184,7 @@ fn create_journald_receiver(
     Err(unsupported_platform_error())
 }
 
+#[cfg(target_os = "linux")]
 fn validate_journald_config(config: &Value) -> Result<(), otap_df_config::error::Error> {
     let parsed: Config = serde_json::from_value(config.clone()).map_err(|e| {
         otap_df_config::error::Error::InvalidUserConfig {
@@ -191,6 +192,11 @@ fn validate_journald_config(config: &Value) -> Result<(), otap_df_config::error:
         }
     })?;
     RuntimeConfig::try_from(parsed).map(|_| ())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn validate_journald_config(_config: &Value) -> Result<(), otap_df_config::error::Error> {
+    Err(unsupported_platform_error())
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -307,6 +313,7 @@ enum PendingDecision {
     Pending,
     CommitSent,
     RewindSent,
+    FailSent,
 }
 
 #[cfg(any(target_os = "linux", test))]
@@ -384,13 +391,16 @@ fn apply_pending_nack(
                 record_rewind: true,
             })
         }
-        OnNack::Fail => Some(PendingControlEffect {
-            command: None,
-            fail_nack: true,
-            record_ack: false,
-            record_nack: true,
-            record_rewind: false,
-        }),
+        OnNack::Fail => {
+            pending_batch.decision = PendingDecision::FailSent;
+            Some(PendingControlEffect {
+                command: None,
+                fail_nack: true,
+                record_ack: false,
+                record_nack: true,
+                record_rewind: false,
+            })
+        }
     }
 }
 
@@ -534,7 +544,7 @@ fn worker_loop_inner(
                         first_cursor.clear();
                         last_cursor.clear();
                         dropped_fields = 0;
-                        reader = journal::SdJournalReader::open(&config, Some(cursor))?;
+                        reader = journal::SdJournalReader::open_for_rewind(&config, Some(cursor))?;
                         in_flight = None;
                     } else if let Some(batch) = in_flight.clone() {
                         // No cursor has been committed yet. Re-opening from start_at=end
@@ -581,7 +591,7 @@ fn worker_loop_inner(
                     first_cursor.clear();
                     last_cursor.clear();
                     dropped_fields = 0;
-                    reader = journal::SdJournalReader::open(&config, Some(cursor))?;
+                    reader = journal::SdJournalReader::open_for_rewind(&config, Some(cursor))?;
                 }
                 WorkerCommand::Drain => {
                     draining = true;
@@ -1131,10 +1141,18 @@ mod tests {
         assert!(validate_journald_config(&json).is_err());
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn validates_default_config() {
         let json = serde_json::json!({});
         validate_journald_config(&json).expect("default config must validate");
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn rejects_config_validation_on_non_linux() {
+        let json = serde_json::json!({});
+        assert!(validate_journald_config(&json).is_err());
     }
 
     #[test]
@@ -1222,7 +1240,8 @@ mod tests {
         );
         assert_eq!(
             pending.get(&7).map(|batch| batch.decision),
-            Some(PendingDecision::Pending)
+            Some(PendingDecision::FailSent)
         );
+        assert!(apply_pending_nack(&mut pending, 7, OnNack::Fail).is_none());
     }
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/mod.rs
@@ -1190,6 +1190,36 @@ mod tests {
         drop(b);
     }
 
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn factory_rejects_multi_core_pipeline() {
+        let registry = otap_df_telemetry::registry::TelemetryRegistryHandle::new();
+        let controller = otap_df_engine::context::ControllerContext::new(registry);
+        let pipeline =
+            controller.pipeline_context_with("test-group".into(), "test-pipeline".into(), 0, 2, 0);
+        let node_config = Arc::new(NodeUserConfig::new_receiver_config(JOURNALD_RECEIVER_URN));
+        let receiver_config = ReceiverConfig::new("journald");
+
+        let result = create_journald_receiver(
+            pipeline,
+            NodeId {
+                index: 0,
+                name: "journald".into(),
+            },
+            node_config,
+            &receiver_config,
+        );
+
+        let Err(err) = result else {
+            panic!("journald receiver must reject multi-core source pipelines");
+        };
+
+        assert!(
+            err.to_string().contains("one-core source pipeline"),
+            "unexpected error: {err}"
+        );
+    }
+
     #[test]
     fn ack_marks_pending_batch_for_commit() {
         let mut pending = BTreeMap::from([(7, pending_batch("cursor-7"))]);

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/mod.rs
@@ -497,6 +497,9 @@ fn worker_loop_inner(
                         committed_cursor = Some(cursor.clone());
                         in_flight = None;
                     }
+                    // On failure, keep the batch in flight and report the result.
+                    // The async task owns retry counting and resends Commit until
+                    // the write succeeds or max_consecutive_failures is reached.
                     let _ = event_tx.blocking_send(WorkerEvent::CommitResult {
                         batch_id,
                         cursor,
@@ -551,6 +554,8 @@ fn worker_loop_inner(
                 }
                 WorkerCommand::Rewind => {
                     let Some(cursor) = committed_cursor.as_deref() else {
+                        // Defense-in-depth: with max_in_flight=1, a valid Nack rewind
+                        // before the first commit is handled by the in-flight arm above.
                         return Err(
                             "journald cannot rewind before the first checkpoint is committed"
                                 .to_owned(),
@@ -811,7 +816,13 @@ impl local::Receiver<OtapPdata> for JournaldReceiver {
                             return Ok(terminal_state(deadline, &metrics));
                         }
                         Ok(_) => {}
-                        Err(e) => return Err(Error::ChannelRecvError(e)),
+                        Err(e) => {
+                            let _ =
+                                send_worker_command(&worker.cmd_tx, WorkerCommand::Shutdown, &effect_handler).await;
+                            drop(event_rx);
+                            join_worker(worker, &effect_handler).await?;
+                            return Err(Error::ChannelRecvError(e));
+                        }
                     }
                 }
 
@@ -904,7 +915,13 @@ impl local::Receiver<OtapPdata> for JournaldReceiver {
                                                     Ok(_) => {
                                                         continue;
                                                     }
-                                                    Err(e) => return Err(Error::ChannelRecvError(e)),
+                                                    Err(e) => {
+                                                        let _ =
+                                                            send_worker_command(&worker.cmd_tx, WorkerCommand::Shutdown, &effect_handler).await;
+                                                        drop(event_rx);
+                                                        join_worker(worker, &effect_handler).await?;
+                                                        return Err(Error::ChannelRecvError(e));
+                                                    }
                                                 }
                                             }
 
@@ -974,11 +991,6 @@ impl local::Receiver<OtapPdata> for JournaldReceiver {
                                         batch_id = batch_id,
                                         cursor = cursor.as_str()
                                     );
-                                    if drain_deadline.is_some() {
-                                        if pending.is_empty() {
-                                            continue;
-                                        }
-                                    }
                                 }
                                 Err(err) => {
                                     checkpoint_failures = checkpoint_failures.saturating_add(1);

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/mod.rs
@@ -44,7 +44,7 @@ use otap_df_telemetry::metrics::MetricSet;
 #[cfg(target_os = "linux")]
 use otap_df_telemetry::metrics::MetricSetSnapshot;
 #[cfg(target_os = "linux")]
-use otap_df_telemetry::{otel_info, otel_warn};
+use otap_df_telemetry::{otel_debug, otel_info, otel_warn};
 use otap_df_telemetry_macros::metric_set;
 use serde_json::Value;
 #[cfg(any(target_os = "linux", test))]
@@ -977,7 +977,7 @@ impl local::Receiver<OtapPdata> for JournaldReceiver {
                                         )
                                         .await?;
                                     }
-                                    otel_info!(
+                                    otel_debug!(
                                         "journald_receiver.batch_sent",
                                         source_id = config.source_id.as_str(),
                                         batch_id = batch_id,
@@ -1008,7 +1008,7 @@ impl local::Receiver<OtapPdata> for JournaldReceiver {
                                     if let Some(metrics) = metrics.as_mut() {
                                         metrics.cursor_commits.add(1);
                                     }
-                                    otel_info!(
+                                    otel_debug!(
                                         "journald_receiver.cursor_committed",
                                         source_id = config.source_id.as_str(),
                                         batch_id = batch_id,

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/mod.rs
@@ -375,11 +375,6 @@ fn apply_pending_nack(
     }
 }
 
-#[cfg(any(target_os = "linux", test))]
-fn should_complete_drain_after_nack(effect: &PendingControlEffect, draining: bool) -> bool {
-    draining && matches!(effect.command, Some(WorkerCommand::Rewind))
-}
-
 #[cfg(target_os = "linux")]
 fn receiver_error(receiver: NodeId, error: impl Into<String>) -> Error {
     Error::ReceiverError {
@@ -766,28 +761,15 @@ impl local::Receiver<OtapPdata> for JournaldReceiver {
                             if let Some(effect) =
                                 apply_pending_nack(&mut pending, batch_id, config.checkpoint.on_nack)
                             {
-                                let complete_drain = should_complete_drain_after_nack(
-                                    &effect,
-                                    drain_deadline.is_some(),
-                                );
                                 if let Some(metrics) = metrics.as_mut() {
                                     if effect.record_nack {
                                         metrics.nacks.add(1);
                                     }
-                                    if effect.record_rewind && !complete_drain {
+                                    if effect.record_rewind {
                                         metrics.rewinds.add(1);
                                     }
                                 }
-                                if complete_drain {
-                                    let deadline =
-                                        drain_deadline.expect("drain deadline must be set");
-                                    let _ =
-                                        send_worker_command(&worker.cmd_tx, WorkerCommand::Shutdown, &effect_handler).await;
-                                    drop(event_rx);
-                                    join_worker(worker, &effect_handler).await?;
-                                    effect_handler.notify_receiver_drained().await?;
-                                    return Ok(terminal_state(deadline, &metrics));
-                                } else if let Some(command) = effect.command {
+                                if let Some(command) = effect.command {
                                     send_worker_command(&worker.cmd_tx, command, &effect_handler).await?;
                                 }
                                 if effect.fail_nack {
@@ -1189,17 +1171,6 @@ mod tests {
             }
         );
         assert!(pending.is_empty());
-    }
-
-    #[test]
-    fn nack_with_rewind_completes_active_drain_instead_of_rewinding() {
-        let mut pending = BTreeMap::from([(7, pending_batch("cursor-7"))]);
-
-        let effect =
-            apply_pending_nack(&mut pending, 7, OnNack::Rewind).expect("nack should apply");
-
-        assert!(should_complete_drain_after_nack(&effect, true));
-        assert!(!should_complete_drain_after_nack(&effect, false));
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/mod.rs
@@ -752,6 +752,14 @@ impl local::Receiver<OtapPdata> for JournaldReceiver {
                     }
                 }, if drain_deadline.is_some() => {
                     let deadline = drain_deadline.expect("drain deadline must be set");
+                    if !pending.is_empty() {
+                        otel_warn!(
+                            "journald_receiver.drain_timeout",
+                            source_id = config.source_id.as_str(),
+                            pending_batches = pending.len() as u64,
+                            message = "Drain deadline reached with batches still awaiting Ack/Nack; shutting down without advancing their checkpoints"
+                        );
+                    }
                     let _ =
                         send_worker_command(&worker.cmd_tx, WorkerCommand::Shutdown, &effect_handler).await;
                     drop(event_rx);
@@ -898,6 +906,12 @@ impl local::Receiver<OtapPdata> for JournaldReceiver {
                                                 }
                                             }, if drain_deadline.is_some() => {
                                                 let deadline = drain_deadline.expect("drain deadline must be set");
+                                                otel_warn!(
+                                                    "journald_receiver.drain_timeout",
+                                                    source_id = config.source_id.as_str(),
+                                                    batch_id = batch_id,
+                                                    message = "Drain deadline reached while blocked sending a batch downstream; shutting down without advancing the checkpoint"
+                                                );
                                                 let _ =
                                                     send_worker_command(&worker.cmd_tx, WorkerCommand::Shutdown, &effect_handler).await;
                                                 drop(event_rx);

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/mod.rs
@@ -47,7 +47,7 @@ use otap_df_telemetry::metrics::MetricSetSnapshot;
 use otap_df_telemetry::{otel_info, otel_warn};
 use otap_df_telemetry_macros::metric_set;
 use serde_json::Value;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", test))]
 use std::collections::BTreeMap;
 use std::collections::HashSet;
 #[cfg(target_os = "linux")]
@@ -65,7 +65,8 @@ mod journal;
 use config::RuntimeConfig;
 pub use config::{
     BatchConfig, CheckpointConfig, Config, DEFAULT_JOURNAL_ROOT_PATH, DEFAULT_SOURCE_ID,
-    JournalConfig, MaxPriority, OnNack, StartAt, severity_number_from_priority,
+    ExtractionConfig, JournalConfig, LargeFieldPolicy, MaxPriority, OnNack, StartAt,
+    severity_number_from_priority,
 };
 
 /// URN for the journald receiver.
@@ -108,6 +109,9 @@ pub struct JournaldReceiverMetrics {
     /// Number of source read failures reported by the worker.
     #[metric(unit = "{failure}")]
     pub source_failures: Counter<u64>,
+    /// Number of journald fields dropped by extraction safety limits.
+    #[metric(unit = "{field}")]
+    pub source_dropped_fields: Counter<u64>,
     /// Number of times the worker was asked to rewind after a Nack.
     #[metric(unit = "{rewind}")]
     pub rewinds: Counter<u64>,
@@ -234,12 +238,14 @@ fn terminal_state(
 }
 
 #[cfg(target_os = "linux")]
+#[derive(Clone)]
 struct WorkerBatch {
     id: u64,
     first_cursor: String,
     last_cursor: String,
     records: otap_df_pdata::otap::OtapArrowRecords,
     record_count: usize,
+    dropped_fields: u64,
 }
 
 #[cfg(target_os = "linux")]
@@ -254,26 +260,44 @@ enum WorkerEvent {
     Stopped,
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", test))]
+#[derive(Debug, Eq, PartialEq)]
 enum WorkerCommand {
     Commit { batch_id: u64, cursor: String },
     Rewind,
+    Drain,
     Shutdown,
 }
 
 #[cfg(target_os = "linux")]
-#[derive(Clone)]
+enum BatchHandoff {
+    Sent { drain_requested: bool },
+    Shutdown,
+}
+
+#[cfg(any(target_os = "linux", test))]
+#[derive(Clone, Debug)]
 struct PendingBatch {
     last_cursor: String,
     decision: PendingDecision,
 }
 
-#[cfg(target_os = "linux")]
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[cfg(any(target_os = "linux", test))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum PendingDecision {
     Pending,
     CommitSent,
     RewindSent,
+}
+
+#[cfg(any(target_os = "linux", test))]
+#[derive(Debug, Eq, PartialEq)]
+struct PendingControlEffect {
+    command: Option<WorkerCommand>,
+    fail_nack: bool,
+    record_ack: bool,
+    record_nack: bool,
+    record_rewind: bool,
 }
 
 #[cfg(target_os = "linux")]
@@ -294,6 +318,66 @@ const WORKER_COMMAND_RETRY_DELAY: std::time::Duration = std::time::Duration::fro
 #[cfg(target_os = "linux")]
 fn batch_id_from_call_data(call_data: &CallData) -> Option<u64> {
     call_data.first().copied().map(u64::from)
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn apply_pending_ack(
+    pending: &mut BTreeMap<u64, PendingBatch>,
+    batch_id: u64,
+) -> Option<PendingControlEffect> {
+    let pending_batch = pending.get_mut(&batch_id)?;
+    if pending_batch.decision != PendingDecision::Pending {
+        return None;
+    }
+    pending_batch.decision = PendingDecision::CommitSent;
+    Some(PendingControlEffect {
+        command: Some(WorkerCommand::Commit {
+            batch_id,
+            cursor: pending_batch.last_cursor.clone(),
+        }),
+        fail_nack: false,
+        record_ack: true,
+        record_nack: false,
+        record_rewind: false,
+    })
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn apply_pending_nack(
+    pending: &mut BTreeMap<u64, PendingBatch>,
+    batch_id: u64,
+    on_nack: OnNack,
+) -> Option<PendingControlEffect> {
+    let pending_batch = pending.get_mut(&batch_id)?;
+    if pending_batch.decision != PendingDecision::Pending {
+        return None;
+    }
+
+    match on_nack {
+        OnNack::Rewind => {
+            pending_batch.decision = PendingDecision::RewindSent;
+            pending.clear();
+            Some(PendingControlEffect {
+                command: Some(WorkerCommand::Rewind),
+                fail_nack: false,
+                record_ack: false,
+                record_nack: true,
+                record_rewind: true,
+            })
+        }
+        OnNack::Fail => Some(PendingControlEffect {
+            command: None,
+            fail_nack: true,
+            record_ack: false,
+            record_nack: true,
+            record_rewind: false,
+        }),
+    }
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn should_complete_drain_after_nack(effect: &PendingControlEffect, draining: bool) -> bool {
+    draining && matches!(effect.command, Some(WorkerCommand::Rewind))
 }
 
 #[cfg(target_os = "linux")]
@@ -348,6 +432,9 @@ fn spawn_worker(
     checkpoint_path: PathBuf,
     event_tx: tokio::sync::mpsc::Sender<WorkerEvent>,
 ) -> Result<WorkerHandle, String> {
+    // Keep blocking libsystemd reads and checkpoint fsyncs off the dfengine
+    // async runtime thread. As with host_metrics, a dedicated source worker
+    // caps the blocking surface at one OS thread for this receiver.
     let (cmd_tx, cmd_rx) = std::sync::mpsc::sync_channel(WORKER_COMMAND_CHANNEL_CAPACITY);
     let join = std::thread::Builder::new()
         .name(format!("otap-journald-{}", config.source_id))
@@ -401,36 +488,50 @@ fn worker_loop_inner(
     let mut builder = arrow_records_encoder::JournaldArrowRecordsBuilder::new();
     let mut first_cursor = String::new();
     let mut last_cursor = String::new();
+    let mut dropped_fields = 0u64;
     let mut first_record_at = StdInstant::now();
-    let mut in_flight = false;
+    let mut in_flight = None;
+    let mut draining = false;
 
     loop {
-        if in_flight {
+        if in_flight.is_some() {
             match cmd_rx.recv() {
                 Ok(WorkerCommand::Commit { batch_id, cursor }) => {
                     let result = checkpoint::write_cursor(&checkpoint_path, &cursor);
                     if result.is_ok() {
                         committed_cursor = Some(cursor.clone());
-                        in_flight = false;
+                        in_flight = None;
                     }
                     let _ = event_tx.blocking_send(WorkerEvent::CommitResult {
                         batch_id,
                         cursor,
                         result,
                     });
+                    if draining && in_flight.is_none() {
+                        return Ok(());
+                    }
                 }
                 Ok(WorkerCommand::Rewind) => {
-                    if committed_cursor.is_none() {
-                        return Err(
-                            "journald cannot rewind before the first checkpoint is committed"
-                                .to_owned(),
-                        );
+                    if let Some(cursor) = committed_cursor.as_deref() {
+                        builder = arrow_records_encoder::JournaldArrowRecordsBuilder::new();
+                        first_cursor.clear();
+                        last_cursor.clear();
+                        dropped_fields = 0;
+                        reader = journal::SdJournalReader::open(&config, Some(cursor))?;
+                        in_flight = None;
+                    } else if let Some(batch) = in_flight.clone() {
+                        // No cursor has been committed yet. Re-opening from start_at=end
+                        // would skip the uncheckpointed batch, so retry the retained batch.
+                        match send_batch_or_observe_shutdown(event_tx, cmd_rx, batch)? {
+                            BatchHandoff::Sent { drain_requested } => {
+                                draining |= drain_requested;
+                            }
+                            BatchHandoff::Shutdown => return Ok(()),
+                        }
                     }
-                    builder = arrow_records_encoder::JournaldArrowRecordsBuilder::new();
-                    first_cursor.clear();
-                    last_cursor.clear();
-                    reader = journal::SdJournalReader::open(&config, committed_cursor.as_deref())?;
-                    in_flight = false;
+                }
+                Ok(WorkerCommand::Drain) => {
+                    draining = true;
                 }
                 Ok(WorkerCommand::Shutdown) | Err(_) => return Ok(()),
             }
@@ -449,33 +550,61 @@ fn worker_loop_inner(
                         cursor,
                         result,
                     });
+                    if draining {
+                        return Ok(());
+                    }
                 }
                 WorkerCommand::Rewind => {
-                    if committed_cursor.is_none() {
+                    let Some(cursor) = committed_cursor.as_deref() else {
                         return Err(
                             "journald cannot rewind before the first checkpoint is committed"
                                 .to_owned(),
                         );
-                    }
+                    };
                     builder = arrow_records_encoder::JournaldArrowRecordsBuilder::new();
                     first_cursor.clear();
                     last_cursor.clear();
-                    reader = journal::SdJournalReader::open(&config, committed_cursor.as_deref())?;
+                    dropped_fields = 0;
+                    reader = journal::SdJournalReader::open(&config, Some(cursor))?;
+                }
+                WorkerCommand::Drain => {
+                    draining = true;
                 }
                 WorkerCommand::Shutdown => return Ok(()),
             }
         }
 
-        if let Some(entry) = reader.next_entry()? {
-            if builder.len() == 0 {
-                first_cursor = entry.cursor.clone();
-                first_record_at = StdInstant::now();
+        if draining && builder.len() == 0 {
+            return Ok(());
+        }
+
+        if !draining {
+            let read_timeout = if builder.len() == 0 {
+                Some(config.wait_timeout)
+            } else {
+                let elapsed = first_record_at.elapsed();
+                config
+                    .batch
+                    .max_flush_period
+                    .checked_sub(elapsed)
+                    .filter(|remaining| !remaining.is_zero())
+                    .map(|remaining| remaining.min(config.wait_timeout))
+            };
+            if let Some(timeout) = read_timeout {
+                if let Some(entry) = reader.next_entry_with_wait_timeout(timeout)? {
+                    if builder.len() == 0 {
+                        first_cursor = entry.cursor.clone();
+                        first_record_at = StdInstant::now();
+                    }
+                    last_cursor = entry.cursor.clone();
+                    dropped_fields = dropped_fields.saturating_add(entry.dropped_fields);
+                    builder.append(&entry);
+                }
             }
-            last_cursor = entry.cursor.clone();
-            builder.append(&entry);
         }
 
         let should_flush = builder.len() as usize >= config.batch.max_records
+            || (draining && builder.len() > 0)
             || (builder.len() > 0 && first_record_at.elapsed() >= config.batch.max_flush_period);
         if should_flush {
             let record_count = usize::from(builder.len());
@@ -491,12 +620,19 @@ fn worker_loop_inner(
                 last_cursor: std::mem::take(&mut last_cursor),
                 records,
                 record_count,
+                dropped_fields: std::mem::take(&mut dropped_fields),
             };
+            let retained_batch = batch.clone();
             next_batch_id = next_batch_id.saturating_add(1);
-            if !send_batch_or_observe_shutdown(event_tx, cmd_rx, batch)? {
-                return Ok(());
+            match send_batch_or_observe_shutdown(event_tx, cmd_rx, batch)? {
+                BatchHandoff::Sent { drain_requested } => {
+                    draining |= drain_requested;
+                }
+                BatchHandoff::Shutdown => {
+                    return Ok(());
+                }
             }
-            in_flight = true;
+            in_flight = Some(retained_batch);
         }
     }
 }
@@ -506,20 +642,24 @@ fn send_batch_or_observe_shutdown(
     event_tx: &tokio::sync::mpsc::Sender<WorkerEvent>,
     cmd_rx: &std::sync::mpsc::Receiver<WorkerCommand>,
     batch: WorkerBatch,
-) -> Result<bool, String> {
+) -> Result<BatchHandoff, String> {
     let mut event = WorkerEvent::Batch(batch);
+    let mut drain_requested = false;
     loop {
         match event_tx.try_send(event) {
-            Ok(()) => return Ok(true),
+            Ok(()) => return Ok(BatchHandoff::Sent { drain_requested }),
             Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
                 return Err("journald receiver event channel closed".to_owned());
             }
             Err(tokio::sync::mpsc::error::TrySendError::Full(returned)) => {
                 event = returned;
                 match cmd_rx.recv_timeout(std::time::Duration::from_millis(50)) {
+                    Ok(WorkerCommand::Drain) => {
+                        drain_requested = true;
+                    }
                     Ok(WorkerCommand::Shutdown)
                     | Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                        return Ok(false);
+                        return Ok(BatchHandoff::Shutdown);
                     }
                     Ok(WorkerCommand::Commit { .. } | WorkerCommand::Rewind) => {
                         return Err(
@@ -608,51 +748,54 @@ impl local::Receiver<OtapPdata> for JournaldReceiver {
                             let Some(batch_id) = batch_id_from_call_data(&ack.unwind.route.calldata) else {
                                 continue;
                             };
-                            if let Some(pending_batch) = pending.get_mut(&batch_id) {
-                                if pending_batch.decision != PendingDecision::Pending {
-                                    continue;
-                                }
-                                pending_batch.decision = PendingDecision::CommitSent;
+                            if let Some(effect) = apply_pending_ack(&mut pending, batch_id) {
                                 if let Some(metrics) = metrics.as_mut() {
-                                    metrics.acks.add(1);
+                                    if effect.record_ack {
+                                        metrics.acks.add(1);
+                                    }
                                 }
-                                let cursor = pending_batch.last_cursor.clone();
-                                send_worker_command(
-                                    &worker.cmd_tx,
-                                    WorkerCommand::Commit {
-                                        batch_id,
-                                        cursor,
-                                    },
-                                    &effect_handler,
-                                )
-                                .await?;
+                                if let Some(command) = effect.command {
+                                    send_worker_command(&worker.cmd_tx, command, &effect_handler).await?;
+                                }
                             }
                         }
                         Ok(NodeControlMsg::Nack(nack)) => {
                             let Some(batch_id) = batch_id_from_call_data(&nack.unwind.route.calldata) else {
                                 continue;
                             };
-                            if let Some(pending_batch) = pending.get_mut(&batch_id) {
-                                if pending_batch.decision != PendingDecision::Pending {
-                                    continue;
-                                }
+                            if let Some(effect) =
+                                apply_pending_nack(&mut pending, batch_id, config.checkpoint.on_nack)
+                            {
+                                let complete_drain = should_complete_drain_after_nack(
+                                    &effect,
+                                    drain_deadline.is_some(),
+                                );
                                 if let Some(metrics) = metrics.as_mut() {
-                                    metrics.nacks.add(1);
-                                    metrics.rewinds.add(1);
+                                    if effect.record_nack {
+                                        metrics.nacks.add(1);
+                                    }
+                                    if effect.record_rewind && !complete_drain {
+                                        metrics.rewinds.add(1);
+                                    }
                                 }
-                                match config.checkpoint.on_nack {
-                                    OnNack::Rewind => {
-                                        pending_batch.decision = PendingDecision::RewindSent;
-                                        pending.clear();
-                                        send_worker_command(&worker.cmd_tx, WorkerCommand::Rewind, &effect_handler).await?;
-                                    }
-                                    OnNack::Fail => {
-                                        let _ =
-                                            send_worker_command(&worker.cmd_tx, WorkerCommand::Shutdown, &effect_handler).await;
-                                        drop(event_rx);
-                                        join_worker(worker, &effect_handler).await?;
-                                        return Err(terminal_error(&effect_handler, "journald batch was Nacked"));
-                                    }
+                                if complete_drain {
+                                    let deadline =
+                                        drain_deadline.expect("drain deadline must be set");
+                                    let _ =
+                                        send_worker_command(&worker.cmd_tx, WorkerCommand::Shutdown, &effect_handler).await;
+                                    drop(event_rx);
+                                    join_worker(worker, &effect_handler).await?;
+                                    effect_handler.notify_receiver_drained().await?;
+                                    return Ok(terminal_state(deadline, &metrics));
+                                } else if let Some(command) = effect.command {
+                                    send_worker_command(&worker.cmd_tx, command, &effect_handler).await?;
+                                }
+                                if effect.fail_nack {
+                                    let _ =
+                                        send_worker_command(&worker.cmd_tx, WorkerCommand::Shutdown, &effect_handler).await;
+                                    drop(event_rx);
+                                    join_worker(worker, &effect_handler).await?;
+                                    return Err(terminal_error(&effect_handler, "journald batch was Nacked"));
                                 }
                             }
                         }
@@ -668,15 +811,8 @@ impl local::Receiver<OtapPdata> for JournaldReceiver {
                                 .checked_add(config.drain_timeout)
                                 .unwrap_or(deadline);
                             let deadline = deadline.min(local_deadline);
-                            if pending.is_empty() {
-                                let _ =
-                                    send_worker_command(&worker.cmd_tx, WorkerCommand::Shutdown, &effect_handler).await;
-                                drop(event_rx);
-                                join_worker(worker, &effect_handler).await?;
-                                effect_handler.notify_receiver_drained().await?;
-                                return Ok(terminal_state(deadline, &metrics));
-                            }
                             drain_deadline = Some(deadline);
+                            send_worker_command(&worker.cmd_tx, WorkerCommand::Drain, &effect_handler).await?;
                         }
                         Ok(NodeControlMsg::Shutdown { deadline, .. }) => {
                             if let Some(metrics) = metrics.as_mut() {
@@ -722,15 +858,37 @@ impl local::Receiver<OtapPdata> for JournaldReceiver {
                                 &mut pdata,
                             );
                             let record_count = batch.record_count;
+                            let dropped_fields = batch.dropped_fields;
                             let batch_id = batch.id;
                             let last_cursor = batch.last_cursor.clone();
+                            debug_assert_eq!(max_in_flight, 1);
+                            debug_assert!(pending.is_empty());
                             let send_result = match effect_handler.try_send_message_with_source_node(pdata) {
                                 Ok(()) => Ok(()),
                                 Err(TypedError::ChannelSendError(SendError::Full(pdata))) => {
                                     let mut send = Box::pin(effect_handler.send_message_with_source_node(pdata));
                                     loop {
+                                        // While the downstream send is blocked, this batch is not
+                                        // in `pending` yet. With v1's max_in_flight=1 invariant,
+                                        // no Ack/Nack can require receiver state changes here.
                                         let result = tokio::select! {
                                             biased;
+
+                                            _ = async {
+                                                if let Some(deadline) = drain_deadline {
+                                                    tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)).await;
+                                                } else {
+                                                    std::future::pending::<()>().await;
+                                                }
+                                            }, if drain_deadline.is_some() => {
+                                                let deadline = drain_deadline.expect("drain deadline must be set");
+                                                let _ =
+                                                    send_worker_command(&worker.cmd_tx, WorkerCommand::Shutdown, &effect_handler).await;
+                                                drop(event_rx);
+                                                join_worker(worker, &effect_handler).await?;
+                                                effect_handler.notify_receiver_drained().await?;
+                                                return Ok(terminal_state(deadline, &metrics));
+                                            }
 
                                             msg = ctrl_msg_recv.recv() => {
                                                 match msg {
@@ -748,12 +906,8 @@ impl local::Receiver<OtapPdata> for JournaldReceiver {
                                                             .checked_add(config.drain_timeout)
                                                             .unwrap_or(deadline);
                                                         let deadline = deadline.min(local_deadline);
-                                                        let _ =
-                                                            send_worker_command(&worker.cmd_tx, WorkerCommand::Shutdown, &effect_handler).await;
-                                                        drop(event_rx);
-                                                        join_worker(worker, &effect_handler).await?;
-                                                        effect_handler.notify_receiver_drained().await?;
-                                                        return Ok(terminal_state(deadline, &metrics));
+                                                        drain_deadline = Some(deadline);
+                                                        continue;
                                                     }
                                                     Ok(NodeControlMsg::Shutdown { deadline, .. }) => {
                                                         if let Some(metrics) = metrics.as_mut() {
@@ -791,6 +945,15 @@ impl local::Receiver<OtapPdata> for JournaldReceiver {
                                     if let Some(metrics) = metrics.as_mut() {
                                         metrics.batches_sent.add(1);
                                         metrics.records_sent.add(record_count as u64);
+                                        metrics.source_dropped_fields.add(dropped_fields);
+                                    }
+                                    if drain_deadline.is_some() {
+                                        send_worker_command(
+                                            &worker.cmd_tx,
+                                            WorkerCommand::Drain,
+                                            &effect_handler,
+                                        )
+                                        .await?;
                                     }
                                     otel_info!(
                                         "journald_receiver.batch_sent",
@@ -829,13 +992,10 @@ impl local::Receiver<OtapPdata> for JournaldReceiver {
                                         batch_id = batch_id,
                                         cursor = cursor.as_str()
                                     );
-                                    if let Some(deadline) = drain_deadline && pending.is_empty() {
-                                        let _ =
-                                            send_worker_command(&worker.cmd_tx, WorkerCommand::Shutdown, &effect_handler).await;
-                                        drop(event_rx);
-                                        join_worker(worker, &effect_handler).await?;
-                                        effect_handler.notify_receiver_drained().await?;
-                                        return Ok(terminal_state(deadline, &metrics));
+                                    if let Some(deadline) = drain_deadline {
+                                        if pending.is_empty() {
+                                            continue;
+                                        }
                                     }
                                 }
                                 Err(err) => {
@@ -859,6 +1019,15 @@ impl local::Receiver<OtapPdata> for JournaldReceiver {
                                             format!("journald checkpoint failed {checkpoint_failures} consecutive times: {err}"),
                                         ));
                                     }
+                                    send_worker_command(
+                                        &worker.cmd_tx,
+                                        WorkerCommand::Commit {
+                                            batch_id,
+                                            cursor,
+                                        },
+                                        &effect_handler,
+                                    )
+                                    .await?;
                                 }
                             }
                         }
@@ -873,6 +1042,12 @@ impl local::Receiver<OtapPdata> for JournaldReceiver {
                         Some(WorkerEvent::Stopped) | None => {
                             drop(event_rx);
                             join_worker(worker, &effect_handler).await?;
+                            if let Some(deadline) = drain_deadline {
+                                if pending.is_empty() {
+                                    effect_handler.notify_receiver_drained().await?;
+                                    return Ok(terminal_state(deadline, &metrics));
+                                }
+                            }
                             return Err(terminal_error(&effect_handler, "journald worker stopped unexpectedly"));
                         }
                     }
@@ -925,6 +1100,14 @@ impl Drop for SourceLease {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
+
+    fn pending_batch(cursor: &str) -> PendingBatch {
+        PendingBatch {
+            last_cursor: cursor.to_owned(),
+            decision: PendingDecision::Pending,
+        }
+    }
 
     #[test]
     fn rejects_unknown_config_field() {
@@ -960,5 +1143,84 @@ mod tests {
         let b = SourceLease::acquire("journald:/test-lease-b:<default>").expect("b");
         drop(a);
         drop(b);
+    }
+
+    #[test]
+    fn ack_marks_pending_batch_for_commit() {
+        let mut pending = BTreeMap::from([(7, pending_batch("cursor-7"))]);
+
+        let effect = apply_pending_ack(&mut pending, 7).expect("ack should apply");
+
+        assert_eq!(
+            effect,
+            PendingControlEffect {
+                command: Some(WorkerCommand::Commit {
+                    batch_id: 7,
+                    cursor: "cursor-7".to_owned(),
+                }),
+                fail_nack: false,
+                record_ack: true,
+                record_nack: false,
+                record_rewind: false,
+            }
+        );
+        assert_eq!(
+            pending.get(&7).map(|batch| batch.decision),
+            Some(PendingDecision::CommitSent)
+        );
+        assert!(apply_pending_ack(&mut pending, 7).is_none());
+    }
+
+    #[test]
+    fn nack_with_rewind_clears_pending_and_requests_rewind() {
+        let mut pending = BTreeMap::from([(7, pending_batch("cursor-7"))]);
+
+        let effect =
+            apply_pending_nack(&mut pending, 7, OnNack::Rewind).expect("nack should apply");
+
+        assert_eq!(
+            effect,
+            PendingControlEffect {
+                command: Some(WorkerCommand::Rewind),
+                fail_nack: false,
+                record_ack: false,
+                record_nack: true,
+                record_rewind: true,
+            }
+        );
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn nack_with_rewind_completes_active_drain_instead_of_rewinding() {
+        let mut pending = BTreeMap::from([(7, pending_batch("cursor-7"))]);
+
+        let effect =
+            apply_pending_nack(&mut pending, 7, OnNack::Rewind).expect("nack should apply");
+
+        assert!(should_complete_drain_after_nack(&effect, true));
+        assert!(!should_complete_drain_after_nack(&effect, false));
+    }
+
+    #[test]
+    fn nack_with_fail_requests_terminal_failure_without_rewind() {
+        let mut pending = BTreeMap::from([(7, pending_batch("cursor-7"))]);
+
+        let effect = apply_pending_nack(&mut pending, 7, OnNack::Fail).expect("nack should apply");
+
+        assert_eq!(
+            effect,
+            PendingControlEffect {
+                command: None,
+                fail_nack: true,
+                record_ack: false,
+                record_nack: true,
+                record_rewind: false,
+            }
+        );
+        assert_eq!(
+            pending.get(&7).map(|batch| batch.decision),
+            Some(PendingDecision::Pending)
+        );
     }
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/mod.rs
@@ -1042,9 +1042,15 @@ impl local::Receiver<OtapPdata> for JournaldReceiver {
                             if let Some(metrics) = metrics.as_mut() {
                                 metrics.source_failures.add(1);
                             }
+                            let error = err.to_string();
+                            otel_warn!(
+                                "journald_receiver.source_failed",
+                                source_id = config.source_id.as_str(),
+                                error = error.as_str()
+                            );
                             drop(event_rx);
                             join_worker(worker, &effect_handler).await?;
-                            return Err(terminal_error(&effect_handler, err.to_string()));
+                            return Err(terminal_error(&effect_handler, error));
                         }
                         Some(WorkerEvent::Stopped) | None => {
                             drop(event_rx);

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/mod.rs
@@ -992,7 +992,7 @@ impl local::Receiver<OtapPdata> for JournaldReceiver {
                                         batch_id = batch_id,
                                         cursor = cursor.as_str()
                                     );
-                                    if let Some(deadline) = drain_deadline {
+                                    if drain_deadline.is_some() {
                                         if pending.is_empty() {
                                             continue;
                                         }

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/mod.rs
@@ -1044,7 +1044,7 @@ impl local::Receiver<OtapPdata> for JournaldReceiver {
                             }
                             drop(event_rx);
                             join_worker(worker, &effect_handler).await?;
-                            return Err(terminal_error(&effect_handler, err));
+                            return Err(terminal_error(&effect_handler, err.to_string()));
                         }
                         Some(WorkerEvent::Stopped) | None => {
                             drop(event_rx);

--- a/rust/otap-dataflow/docs/journald-receiver.md
+++ b/rust/otap-dataflow/docs/journald-receiver.md
@@ -511,9 +511,10 @@ will become:
 CUSTOM=["value1", "value2"]
 ```
 
-Extraction has hard resource limits. `sd_journal_set_data_threshold` may be
-used as an optimization hint, but it is not treated as a safety boundary. The
-receiver enforces `max_field_bytes`, `max_entry_bytes`, and
+Extraction has hard resource limits. The receiver disables libsystemd's
+per-field data threshold with `sd_journal_set_data_threshold(0)` so
+`sd_journal_enumerate_data` can surface fields to the receiver's own extraction
+policy. The receiver enforces `max_field_bytes`, `max_entry_bytes`, and
 `max_fields_per_entry` while copying fields out of the journal handle. With the
 v1 `large_field_policy: drop_and_count`, any field value that exceeds the
 per-field limit, any field that would exceed the per-entry copied-byte budget,

--- a/rust/otap-dataflow/docs/journald-receiver.md
+++ b/rust/otap-dataflow/docs/journald-receiver.md
@@ -517,8 +517,7 @@ Attribute projection rules:
 - a single occurrence of a field becomes a scalar attribute
 - the first `MESSAGE` value becomes the OTAP body; all `MESSAGE` values are
   also preserved in a native journal attribute
-- binary values are preserved as OTAP bytes when supported; otherwise they are
-  base64 encoded with an explicit encoding marker
+- binary values are preserved as OTAP bytes
 - field values must not be lossy-decoded
 
 In the first implementation, duplicate field names are emitted as repeated

--- a/rust/otap-dataflow/docs/journald-receiver.md
+++ b/rust/otap-dataflow/docs/journald-receiver.md
@@ -84,7 +84,7 @@ not copy every behavior directly. The v1 classification is:
 | `journalctl` backend | Reject | Use `sd-journal` through runtime-loaded `libsystemd`; no `journalctl` fallback |
 | `start_at` | Preserve | Keep `start_at: beginning/end`, applied only when no checkpoint exists |
 | Cursor storage | Improve | Ack-driven durable cursor envelope keyed by stable `source_id` |
-| Priority default | Improve | Go defaults to `info`; v1 includes all priorities `0..=7` unless configured |
+| Priority default | Improve | Go defaults to `info`; v1 does not install a priority filter unless configured |
 | `units` | Preserve | Keep exact unit matches |
 | `matches` | Defer | V1 exposes common filters; arbitrary field matches can be added after the first implementation |
 | `grep` | Defer | Content filtering belongs in a processor unless a receiver-side need is proven |
@@ -393,7 +393,7 @@ journal:
 
 When `journal.root_path` is unset or `/`, the receiver opens the local journal
 view. When it is set to a host-root mount such as `/host`, `SdJournalSource`
-opens that root with `sd_journal_open_directory(..., SD_JOURNAL_OS_ROOT | ...)`
+opens that root with `sd_journal_open_directory(..., SD_JOURNAL_OS_ROOT)`.
 so journald resolves the usual journal locations below that root, such as
 `/host/run/log/journal` and `/host/var/log/journal`.
 
@@ -461,8 +461,11 @@ groups:
 ```
 
 `priorities` is an exact-match set. `max_priority` is shorthand expanded by the
-receiver into explicit `PRIORITY=N` matches. The default should include all
-levels `0..=7`; it should not silently drop debug entries.
+receiver into explicit `PRIORITY=N` matches. When neither field is configured,
+the receiver does not install a `PRIORITY` match, so entries without a
+`PRIORITY` field are not silently excluded. Explicit `priorities: [0, 1, 2, 3,
+4, 5, 6, 7]` remains a real filter and only matches entries that carry one of
+those `PRIORITY` values.
 
 Filter changes are not retroactive. If filters are widened after a checkpoint
 exists, the receiver resumes from the existing cursor and does not backfill

--- a/rust/otap-dataflow/docs/journald-receiver.md
+++ b/rust/otap-dataflow/docs/journald-receiver.md
@@ -515,14 +515,16 @@ will become:
 CUSTOM=["value1", "value2"]
 ```
 
-Extraction has hard resource limits. The receiver disables libsystemd's
-per-field data threshold with `sd_journal_set_data_threshold(0)` so
-`sd_journal_enumerate_data` can surface fields to the receiver's own extraction
-policy. The receiver enforces `max_field_bytes`, `max_entry_bytes`, and
-`max_fields_per_entry` while copying fields out of the journal handle. With the
-v1 `large_field_policy: drop_and_count`, any field value that exceeds the
-per-field limit, any field that would exceed the per-entry copied-byte budget,
-and any field beyond the per-entry field-count limit is omitted and counted.
+Extraction has hard resource limits. The receiver configures libsystemd's
+per-field data threshold from the extraction limits, with small headroom for the
+`FIELD_NAME=` prefix, so pathological journal fields are not materialized
+unboundedly before the receiver can apply its own copy limits. The receiver
+enforces `max_field_bytes`, `max_entry_bytes`, and `max_fields_per_entry` while
+copying fields out of the journal handle. With the v1
+`large_field_policy: drop_and_count`, any field value that exceeds the per-field
+limit, any field that would exceed the per-entry copied-byte budget, any field
+at the libsystemd threshold, and any field beyond the per-entry field-count
+limit is omitted and counted.
 If the first `MESSAGE` value is dropped, the body is unset; preserved
 `MESSAGE` values are still preserved as native journal attributes.
 

--- a/rust/otap-dataflow/docs/journald-receiver.md
+++ b/rust/otap-dataflow/docs/journald-receiver.md
@@ -393,7 +393,7 @@ journal:
 
 When `journal.root_path` is unset or `/`, the receiver opens the local journal
 view. When it is set to a host-root mount such as `/host`, `SdJournalSource`
-opens that root with `sd_journal_open_directory(..., SD_JOURNAL_OS_ROOT)`.
+opens that root with `sd_journal_open_directory(..., SD_JOURNAL_OS_ROOT)`
 so journald resolves the usual journal locations below that root, such as
 `/host/run/log/journal` and `/host/var/log/journal`.
 

--- a/rust/otap-dataflow/docs/journald-receiver.md
+++ b/rust/otap-dataflow/docs/journald-receiver.md
@@ -157,7 +157,9 @@ multicore pipeline:
 A process-local startup lease keyed by the concrete journal source selection
 (`journal.root_path` plus `journal.namespace`) prevents duplicate readers in
 the same process, even across different pipelines. Cross-process duplication is
-not prevented in v1.
+not prevented in v1. Filters such as units, syslog identifiers, and priorities
+do not define separate source ownership; two receivers with different filters
+but the same journal root/namespace still conflict in the same process.
 
 The intended v1 deployment model is one active owner per concrete host journal
 source. Running two collector processes against the same host journal may

--- a/rust/otap-dataflow/docs/journald-receiver.md
+++ b/rust/otap-dataflow/docs/journald-receiver.md
@@ -23,7 +23,7 @@ depend on the #2844 filelog assignment extension landing first.
 
 | Decision | Choice |
 | --- | --- |
-| Source API | `sd-journal` behind a small internal `JournalSource` boundary |
+| Source API | `sd-journal` through runtime-loaded `libsystemd` FFI |
 | Progress unit | Opaque journald cursor (`__CURSOR`) |
 | First implementation | Linux-only, default local system journal, single-instance source pipeline (one core) |
 | Delivery model | At-least-once from the last committed cursor |
@@ -39,12 +39,11 @@ receiver needs only a narrow `sd-journal` API surface and should keep
 native `pkg-config`/linker setup to normal builds. If `libsystemd.so.0` is not
 available when the receiver starts, startup fails with an explicit error.
 
-In v1, `SdJournalSource` is the only production `JournalSource`
-implementation. The boundary exists to keep the worker and Ack/checkpoint
-logic independent from the raw FFI wrapper and to allow deterministic
+A future `JournalSource` trait boundary can keep the worker and Ack/checkpoint
+logic independent from the raw FFI wrapper and allow deterministic
 `FakeJournalSource` tests. Its surface should stay narrow: open the source,
 seek after a cursor, read the next entry, wait for new entries, and close. It
-does not imply v1 support for `journalctl`, offline journal files, remote
+does not imply support for `journalctl`, offline journal files, remote
 journals, or multiple source backends.
 
 ## Journald vs Filelog
@@ -323,9 +322,11 @@ Checkpoint commit ownership is split deliberately:
 - in-memory `committed_cursor` advances only after the worker confirms the
   on-disk write succeeded
 
-If there is no committed cursor yet, `on_nack: rewind` fails closed instead of
-seeking to the live tail and silently skipping the Nacked batch. Operators can
-use `on_nack: fail` for the same terminal behavior explicitly.
+If there is no committed cursor yet, `on_nack: rewind` replays the retained
+un-Acked batch instead of reopening at the live tail and silently skipping it.
+This is equivalent to rewinding from a committed cursor once one exists: the
+batch replays until downstream Acks, drain or shutdown ends the receiver, or
+operators choose `on_nack: fail` for terminal failure behavior.
 
 ## Checkpoints
 
@@ -559,10 +560,10 @@ surfaces an error through the receiver/engine path.
 
 ## Receiver Self-Telemetry
 
-The first implementation emits receiver self-telemetry because journald access
-is operationally sensitive and failures can otherwise look like an idle source.
-Metric names should follow the repository's receiver metric conventions, but
-the v1 signal set includes:
+The receiver emits core self-telemetry because journald access is
+operationally sensitive and failures can otherwise look like an idle source.
+Metric names should follow the repository's receiver metric conventions. The
+broader intended signal set includes:
 
 | Signal | Type |
 | --- | --- |
@@ -632,8 +633,9 @@ Included in the first implementation:
 - dedicated blocking worker thread with bounded handoff channels
 - Ack-driven checkpoint advancement and Nack-aware rewind/fail behavior
 - raw journald field projection without semantic-convention normalization
-- receiver self-telemetry for reads, drops, batches, checkpoints, cursor
-  failures, permission warnings, worker restarts, and backpressure
+- receiver self-telemetry for lifecycle transitions, batches, Ack/Nack
+  handling, checkpoint commits/failures, source failures, field drops, and
+  rewinds
 
 Excluded from the first implementation:
 

--- a/rust/otap-dataflow/docs/journald-receiver.md
+++ b/rust/otap-dataflow/docs/journald-receiver.md
@@ -266,10 +266,12 @@ downstream backpressure, the async task races the blocked send against lifecycle
 control messages and the worker polls its command channel while holding a full
 handoff batch.
 
-During drain, a batch that has already been read from journald but is queued or
-currently being sent downstream is not abandoned. Drain first stops additional
-worker reads, then lets the current batch reach a terminal Ack/Commit,
-Nack/Rewind, or configured fail outcome before the receiver reports drained.
+During drain, the worker stops additional reads and attempts to let any batch
+that has already been read from journald reach a terminal Ack/Commit,
+Nack/Rewind, or configured fail outcome before the receiver reports drained. If
+the drain deadline expires first, the receiver shuts down without advancing the
+checkpoint for uncommitted work; those entries may replay on restart under the
+at-least-once delivery model.
 
 ## Ack and Checkpoint Model
 

--- a/rust/otap-dataflow/docs/journald-receiver.md
+++ b/rust/otap-dataflow/docs/journald-receiver.md
@@ -624,6 +624,11 @@ Deferred follow-ups include:
 - failing closed or warning clearly on partially readable journal trees
 - an initial durable resume anchor for `start_at: end` before the first
   checkpoint commit
+- configurable recovery for corrupt or unsupported checkpoint envelopes, such
+  as falling back to `start_at` and writing a fresh cursor when the operator
+  opts in
+- configurable recovery for stale or vacuumed cursors, such as accepting the
+  next available newer journal entry instead of failing closed
 - aggregate batch byte limits in addition to per-entry and per-field extraction
   limits
 - named systemd journal namespace support

--- a/rust/otap-dataflow/docs/journald-receiver.md
+++ b/rust/otap-dataflow/docs/journald-receiver.md
@@ -307,6 +307,14 @@ If the committed cursor is invalid, stale, or vacuumed, v1 fails closed and
 does not silently fall back to tail or head. The operator must remove the
 checkpoint or choose an explicit recovery action.
 
+Before the first successful checkpoint exists, `start_at: end` has no durable
+resume anchor. If the process crashes after entries are read from journald but
+before the first cursor commit succeeds, restart applies `start_at` again and
+may skip those uncommitted entries. While the process stays alive, a Nack before
+the first checkpoint replays the retained in-flight batch instead of reopening
+at the live tail. A production follow-up should add an initial durable anchor or
+document an operator policy for first-start loss tolerance.
+
 Each emitted batch carries:
 
 - `batch_id`
@@ -559,6 +567,7 @@ Initial severity mapping:
 | `libsystemd.so.0` load failure | startup failure; this receiver has no `journalctl` fallback |
 | `sd_journal_open` / permission failure | startup failure; not treated as an empty stream |
 | invalid `journal.root_path` / no visible journal directory | startup failure; operator must fix the mount or config |
+| partially readable journal tree | v1 may start if at least one journal file is readable; production hardening should fail closed or emit a mandatory warning/metric |
 | checkpoint missing | apply `start_at` |
 | checkpoint corrupt / unknown version | fail closed; operator must remove or migrate it |
 | cursor vacuumed / stale | fail closed; operator must remove the checkpoint or choose an explicit recovery action |
@@ -610,6 +619,11 @@ Deferred follow-ups include:
 - introducing a `JournalSource` trait and `FakeJournalSource` test boundary
 - expanding receiver self-telemetry for stale cursors, permission warnings,
   worker restarts, last-entry timestamp, and backpressure duration
+- failing closed or warning clearly on partially readable journal trees
+- an initial durable resume anchor for `start_at: end` before the first
+  checkpoint commit
+- aggregate batch byte limits in addition to per-entry and per-field extraction
+  limits
 - named systemd journal namespace support
 - arbitrary journald match expressions
 - NUMA-aware placement

--- a/rust/otap-dataflow/docs/journald-receiver.md
+++ b/rust/otap-dataflow/docs/journald-receiver.md
@@ -257,6 +257,11 @@ downstream backpressure, the async task races the blocked send against lifecycle
 control messages and the worker polls its command channel while holding a full
 handoff batch.
 
+During drain, a batch that has already been read from journald but is queued or
+currently being sent downstream is not abandoned. Drain first stops additional
+worker reads, then lets the current batch reach a terminal Ack/Commit,
+Nack/Rewind, or configured fail outcome before the receiver reports drained.
+
 ## Ack and Checkpoint Model
 
 The receiver advances its durable cursor only after a downstream Ack and never
@@ -283,7 +288,7 @@ seek_after_committed_cursor(cursor):
   seek_cursor(cursor)
   state = next()
   if state == no_entry:
-    wait_or_return_empty()
+    return invalid_or_stale_cursor
   if test_cursor(cursor):
     return next()
   return invalid_or_stale_cursor
@@ -473,7 +478,7 @@ processors.
 | `body` | `MESSAGE`, unset when missing |
 | `time_unix_nano` | `sd_journal_get_realtime_usec() * 1000` |
 | `severity_number` | derived from `PRIORITY` |
-| `attributes` | native journal fields, key names preserved, with duplicate and binary rules below |
+| `attributes` | native journal fields, key names preserved |
 | internal completion state | cursor from `sd_journal_get_cursor()`, plus range and batch id; not emitted as attributes |
 
 The receiver uses `sd_journal_get_data` and field enumeration for journal
@@ -485,13 +490,26 @@ the receiver must copy the required field names and values before calling
 Attribute projection rules:
 
 - a single occurrence of a field becomes a scalar attribute
-- repeated occurrences of the same field become an array attribute in journal
-  enumeration order
 - the first `MESSAGE` value becomes the OTAP body; all `MESSAGE` values are
-  also preserved in a native journal attribute using the duplicate-field rules
+  also preserved in a native journal attribute
 - binary values are preserved as OTAP bytes when supported; otherwise they are
   base64 encoded with an explicit encoding marker
 - field values must not be lossy-decoded
+
+In the first implementation, duplicate field names are emitted as repeated
+same-key attributes. A follow-up PR will coalesce repeated fields into array
+attributes while preserving journald enumeration order. For example:
+
+```text
+CUSTOM=value1
+CUSTOM=value2
+```
+
+will become:
+
+```text
+CUSTOM=["value1", "value2"]
+```
 
 Extraction has hard resource limits. `sd_journal_set_data_threshold` may be
 used as an optimization hint, but it is not treated as a safety boundary. The
@@ -501,7 +519,7 @@ v1 `large_field_policy: drop_and_count`, any field value that exceeds the
 per-field limit, any field that would exceed the per-entry copied-byte budget,
 and any field beyond the per-entry field-count limit is omitted and counted.
 If the first `MESSAGE` value is dropped, the body is unset; preserved
-`MESSAGE` values still follow the duplicate-field rules above.
+`MESSAGE` values are still preserved as native journal attributes.
 
 Initial severity mapping:
 
@@ -556,6 +574,28 @@ the v1 signal set includes:
 | last observed entry timestamp | gauge |
 | worker restarts | counter |
 | downstream backpressure duration | histogram or counter duration |
+
+## Phased Implementation Notes
+
+The first implementation intentionally focuses on the core receiver path:
+Linux `sd-journal` ingestion, bounded worker isolation, Ack-driven checkpoint
+advancement, durable cursor persistence, basic filtering, extraction limits,
+and raw journald field projection.
+
+Some design goals are deferred to follow-up PRs once the core receiver has
+landed and the worker/checkpoint behavior is validated in production-like
+environments.
+
+Deferred follow-ups include:
+
+- coalescing duplicate journald fields into array attributes
+- introducing a `JournalSource` trait and `FakeJournalSource` test boundary
+- expanding receiver self-telemetry for stale cursors, permission warnings,
+  worker restarts, last-entry timestamp, and backpressure duration
+- named systemd journal namespace support
+- arbitrary journald match expressions
+- NUMA-aware placement
+- cross-process source locking
 
 ## NUMA and Placement
 

--- a/rust/otap-dataflow/docs/journald-receiver.md
+++ b/rust/otap-dataflow/docs/journald-receiver.md
@@ -159,6 +159,14 @@ A process-local startup lease keyed by the concrete journal source selection
 the same process, even across different pipelines. Cross-process duplication is
 not prevented in v1.
 
+The intended v1 deployment model is one active owner per concrete host journal
+source. Running two collector processes against the same host journal may
+duplicate exported logs, and running two processes with the same checkpoint
+identity (`checkpoint.directory` plus pipeline/receiver identity plus
+`source_id`) may race cursor writes. Operators should use a single collector
+owner per host journal source unless duplicate collection is intentional.
+Cross-process file locking is a planned follow-up.
+
 Multiple journald receivers in the *same* engine are not useful in v1 because
 only the default systemd journal namespace is supported and the process-local
 lease rejects duplicate readers. With named-namespace support or a future
@@ -363,11 +371,12 @@ The final segment is the configured `source_id`; it is `system` for the
 default local journal. It is not the systemd journal namespace. There is no
 `instance_id` or `core_id` segment.
 
-A single cursor file must not be written by two processes concurrently. In
-v1, cross-process duplication is prevented operationally by running one engine
-per host against the default systemd journal namespace. The process-local lease covers
-in-process duplication. A future enhancement may add a file lock alongside the
-cursor file; that addition does not change the checkpoint key shape above.
+A single cursor file must not be written by two processes concurrently. In v1,
+cross-process duplication is prevented operationally by running one engine per
+host against the default systemd journal namespace. The process-local lease
+covers in-process duplication. A future enhancement may add a file lock
+alongside the cursor file; that addition does not change the checkpoint key
+shape above.
 
 The cursor file is a small versioned envelope (cursor string + version +
 checksum). Corrupt or unknown-version envelopes fail closed; see [Failure


### PR DESCRIPTION
  # Change Summary

Adds the Rust `receiver:journald` implementation for Linux `systemd-journald` ingestion.

This includes `sd-journal` based log reading, batching, OTAP Arrow log projection, Ack/Nack-driven checkpoint advancement, durable cursor checkpointing, extraction limits, receiver metrics, documentation, and changelog entry.

The README and design doc document current operational limits, including one active owner per host journal source/checkpoint identity, process-local duplicate protection only, deferred cross-process locking, and deferred production hardening for partial journal access, first-checkpoint anchoring, and aggregate batch byte limits.

  ## What issue does this PR close?

  * Closes #2858 

  ## How are these changes tested?

  * Added unit tests for config validation, checkpoint read/write, corrupt checkpoint handling, log projection, extraction limits, lease behavior, and Ack/Nack/drain state handling.
  * Ran targeted Rust checks locally:
    * `cargo check -p otap-df-core-nodes --features otap-df-otap/crypto-ring`
    * `cargo test -p otap-df-core-nodes --features otap-df-otap/crypto-ring journald_receiver`
    * `cargo clippy -p otap-df-core-nodes --features otap-df-otap/crypto-ring --all-targets -- -D warnings`
  * Ran markdown and sanity checks for docs/changelog updates.
  *   Manually validated on an Ubuntu VM using real `systemd-journald` input through the `df_engine` pipeline to local debug/noop output. Covered basic ingestion, unit filtering, stdout/stderr, metadata mapping, start positions, checkpoint restart behavior, checkpoint deletion behavior, invalid config, missing permissions smoke, lifecycle shutdown, and high volume smoke.

  ## Are there any user-facing changes?

  Yes. This adds a Linux-only `receiver:journald` component for reading logs from `systemd-journald`.

  ### Changelog

  * [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
