### PR TITLE
chore(dependencies): Reduce frequency of Go/Rust digest dependency updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -75,6 +75,16 @@
       ]
     },
     {
+      // limit Go and Rust git/module digest-only updates to once a week
+      // these trickle in frequently, so consolidate them
+      "groupName": "go and rust digest updates",
+      "matchManagers": ["gomod", "cargo"],
+      "matchUpdateTypes": ["digest"],
+      "schedule": [
+        "before 8am on Monday"
+      ]
+    },
+    {
       // keep pip-compile source + lock updates together in one PR stream
       "groupName": "pipeline perf python dependencies",
       "matchManagers": ["pip-compile"],


### PR DESCRIPTION
# Change Summary

In the past few week alone, we've had 9 PRs updating various Go and Rust digest references, sometimes on every commit to the upstream repo. Examples:
- https://github.com/open-telemetry/otel-arrow/pull/3092
- https://github.com/open-telemetry/otel-arrow/pull/3091
- https://github.com/open-telemetry/otel-arrow/pull/3099
- https://github.com/open-telemetry/otel-arrow/pull/3136

This creates some churn in the repo, want to limit each dependency to only spawn once a week.

(Note: if a dependency upgrade is needed immediately, can always override the schedule by hitting checkbox for relevant update on #417)

## What issue does this PR close?

N/A

## How are these changes tested?

Renovate config passes validation

## Are there any user-facing changes?

No

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
