### PR TITLE
feat(flow_metrics): Add purpose scope attribute to flow_metric config to enable differentiation of flows

### DIFF
--- a/rust/otap-dataflow/.chloggen/flow-metrics-purpose-scope-attribute.yaml
+++ b/rust/otap-dataflow/.chloggen/flow-metrics-purpose-scope-attribute.yaml
@@ -1,0 +1,19 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: engine
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add an optional `purpose` field to flow_metric config, emitted as the `flow.purpose` scope attribute so OTel View selectors can target distinct flavors of flow work.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [2859]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Omitting `purpose` preserves the existing single `flow` scope behavior (backward compatible).

--- a/rust/otap-dataflow/benchmarks/benches/self_tracing/main.rs
+++ b/rust/otap-dataflow/benchmarks/benches/self_tracing/main.rs
@@ -48,6 +48,7 @@ static BENCH_SCOPE_ATTRIBUTES_DESCRIPTOR: AttributesDescriptor = AttributesDescr
             brief: "CPU ID",
         },
     ],
+    scope_keys: &[],
 };
 
 /// Mock attribute set for benchmarking scope attributes.

--- a/rust/otap-dataflow/configs/flow-purpose-demo.yaml
+++ b/rust/otap-dataflow/configs/flow-purpose-demo.yaml
@@ -1,0 +1,192 @@
+# flow.purpose scope-attribute demo
+# =================================================================
+# Demonstrates the `flow.purpose` scope attribute: two DIFFERENT flows that
+# both emit under the single `flow` instrumentation scope, disambiguated by a
+# per-flow `purpose` so OpenTelemetry View selectors can target each one.
+#
+# This mirrors the PR use case of two distinct flavors of processor work:
+#
+#   1. SAMPLING  (purpose: log_sampler) - a 1-in-3 log sampler.
+#      Enables the volume metrics (signals_incoming / signals_outgoing) so you
+#      can see "how many records came in vs survived sampling", plus
+#      compute_duration so you can see "how long sampling takes".
+#
+#   2. ENRICH    (purpose: transform)   - an attribute-enrichment stage.
+#      Enables only compute_duration so you can see "how long enrichment takes"
+#      without volume noise.
+#
+# BOTH flows emit `compute.duration` on the SAME `flow` scope with the SAME
+# instrument name. This is exactly the collision this feature targets: before
+# this change a View keyed on `scope_name: flow` + `instrument_name:
+# compute.duration` would match BOTH flows and conflate their durations. Now
+# each flow stamps `flow.purpose` onto the instrumentation scope, so the Views
+# below select on `scope_attributes: { flow.purpose: ... }` to pull each flow's
+# `compute.duration` (and the sampling volume metrics) into distinct,
+# customer-facing Prometheus metrics.
+#
+# -----------------------------------------------------------------------------
+# Run it:
+#   cd rust/otap-dataflow
+#   .dev/run.sh flow-purpose-demo.yaml
+#
+# Inspect results (Prometheus pull endpoint on :9090):
+#   # All demo metrics:
+#   curl -s http://127.0.0.1:9090/metrics | grep -E 'sampling_|enrich_'
+#
+#   # Sampling flow: records in vs records emitted (expect emitted ~= in/3):
+#   curl -s http://127.0.0.1:9090/metrics | grep sampling_log_records
+#
+#   # Enrich flow: compute-duration histogram:
+#   curl -s http://127.0.0.1:9090/metrics | grep enrich_compute_duration
+#
+#   # Confirm flow.purpose rode along on the instrumentation scope
+#   # (OTel Prometheus exposes scope attributes via otel_scope_* labels):
+#   curl -s http://127.0.0.1:9090/metrics | grep otel_scope
+# -----------------------------------------------------------------------------
+
+version: otel_dataflow/v1
+
+engine:
+  telemetry:
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              type: prometheus
+              config:
+                host: "0.0.0.0"
+                port: 9090
+                path: "/metrics"
+      views:
+        # --- SAMPLING flow (flow.purpose = log_sampler) ----------------------
+        # Records entering the sampler (full input volume).
+        - selector:
+            scope_name: "flow"
+            scope_attributes:
+              flow.purpose: "log_sampler"
+            instrument_name: "signals.incoming"
+          stream:
+            name: "sampling.log_records.received"
+            description: "Log records entering the sampling flow"
+        # Records leaving the sampler (survivors, ~1/3 of received).
+        - selector:
+            scope_name: "flow"
+            scope_attributes:
+              flow.purpose: "log_sampler"
+            instrument_name: "signals.outgoing"
+          stream:
+            name: "sampling.log_records.emitted"
+            description: "Log records surviving the sampling flow"
+        # Sampler duration.
+        - selector:
+            scope_name: "flow"
+            scope_attributes:
+              flow.purpose: "log_sampler"
+            instrument_name: "compute.duration"
+          stream:
+            name: "sampling.compute.duration"
+            description: "Compute duration of the sampling flow"
+
+        # --- ENRICH flow (flow.purpose = transform) --------------------------
+        # Only the compute-duration latency of the enrichment stage.
+        - selector:
+            scope_name: "flow"
+            scope_attributes:
+              flow.purpose: "transform"
+            instrument_name: "compute.duration"
+          stream:
+            name: "enrich.compute.duration"
+            description: "Compute duration of the enrichment flow"
+    resource:
+      service.name: "flow-purpose-demo"
+
+groups:
+  default:
+    pipelines:
+      main:
+        policies:
+          channel_capacity:
+            control:
+              node: 100
+              pipeline: 100
+            pdata: 128
+          telemetry:
+            runtime_metrics: normal
+            flow_metrics:
+              # Flow 1: SAMPLING. Volume metrics plus compute_duration.
+              - id: sampling_ingest
+                purpose: log_sampler
+                bounds:
+                  start_node: sampler
+                  end_node: attr1
+                metrics: [compute_duration, signals_incoming, signals_outgoing]
+
+              # Flow 2: ENRICH. compute_duration only, no volume.
+              # Non-overlapping with the sampling range above.
+              - id: enrich_stage
+                purpose: transform
+                bounds:
+                  start_node: enrich1
+                  end_node: enrich2
+                metrics: [compute_duration]
+
+        nodes:
+          receiver:
+            type: receiver:traffic_generator
+            config:
+              traffic_config:
+                max_batch_size: 10
+                signals_per_second: 30
+                log_weight: 100
+              registry_path: https://github.com/open-telemetry/semantic-conventions.git[model]
+
+          # Sampling flow: keep 1 of every 3 log records.
+          sampler:
+            type: processor:log_sampling
+            config:
+              policy:
+                ratio:
+                  emit: 1
+                  out_of: 3
+
+          # End node of the sampling flow range.
+          attr1:
+            type: processor:attribute
+            config:
+              actions:
+                - action: insert
+                  key: pipeline.stage
+                  value: "sampled"
+
+          # Enrich flow: two attribute-enrichment nodes forming a 2-node range.
+          enrich1:
+            type: processor:attribute
+            config:
+              actions:
+                - action: insert
+                  key: enrich.tenant
+                  value: "demo-tenant"
+
+          enrich2:
+            type: processor:attribute
+            config:
+              actions:
+                - action: insert
+                  key: enrich.region
+                  value: "demo-region"
+
+          noop:
+            type: exporter:noop
+            config:
+
+        connections:
+          - from: receiver
+            to: sampler
+          - from: sampler
+            to: attr1
+          - from: attr1
+            to: enrich1
+          - from: enrich1
+            to: enrich2
+          - from: enrich2
+            to: noop

--- a/rust/otap-dataflow/configs/flow-purpose-demo.yaml
+++ b/rust/otap-dataflow/configs/flow-purpose-demo.yaml
@@ -39,9 +39,18 @@
 #   # Enrich flow: compute-duration histogram:
 #   curl -s http://127.0.0.1:9090/metrics | grep enrich_compute_duration
 #
-#   # Confirm flow.purpose rode along on the instrumentation scope
-#   # (OTel Prometheus exposes scope attributes via otel_scope_* labels):
-#   curl -s http://127.0.0.1:9090/metrics | grep otel_scope
+# Seeing `flow.purpose` itself:
+#   The Prometheus exporter does NOT render scope ATTRIBUTES. Every series only
+#   carries `otel_scope_name="flow"` (and the `otel_scope_info` gauge likewise
+#   exposes only name/version), so `flow.purpose` never appears in the Prometheus
+#   output. The proof that the scope attribute is applied is that the two flows'
+#   identically-named `compute.duration` instruments are routed to separate
+#   streams (`sampling_*` vs `enrich_*`) by the Views below.
+#
+#   To observe the `flow.purpose` scope attribute value directly, use the
+#   `console` periodic reader configured below: it writes full ScopeMetrics
+#   (including scope attributes) to stdout. Look for the `flow` scope entry that
+#   carries `flow.purpose` in the engine's stdout.
 # -----------------------------------------------------------------------------
 
 version: otel_dataflow/v1
@@ -57,6 +66,13 @@ engine:
                 host: "0.0.0.0"
                 port: 9090
                 path: "/metrics"
+        # Console reader: writes full ScopeMetrics (including scope attributes)
+        # to stdout, so the `flow.purpose` scope attribute is directly visible
+        # (the Prometheus exporter above does not render scope attributes).
+        - periodic:
+            interval: 6s
+            exporter:
+              type: console
       views:
         # --- SAMPLING flow (flow.purpose = log_sampler) ----------------------
         # Records entering the sampler (full input volume).

--- a/rust/otap-dataflow/crates/admin/src/telemetry.rs
+++ b/rust/otap-dataflow/crates/admin/src/telemetry.rs
@@ -2541,6 +2541,7 @@ mod tests {
                     brief: "Region",
                 },
             ],
+            scope_keys: &[],
         };
 
         #[derive(Debug)]
@@ -3480,6 +3481,7 @@ mod tests {
             r#type: AttributeValueType::String,
             brief: "HTTP method",
         }],
+        scope_keys: &[],
     };
 
     impl MetricSetHandler for E2eMetricSet {

--- a/rust/otap-dataflow/crates/config/src/policy.rs
+++ b/rust/otap-dataflow/crates/config/src/policy.rs
@@ -287,6 +287,15 @@ pub struct FlowMetricConfig {
     /// Metrics to enable. Omitted means all metrics are enabled.
     #[serde(default)]
     pub metrics: Option<Vec<FlowMetric>>,
+    /// Optional per-flow purpose differentiator, emitted as the `flow.purpose`
+    /// scope attribute on every metric this flow produces. Lets OTel View
+    /// selectors target distinct flavors of processor work (e.g. `filter`
+    /// flows that keep/drop records vs `transform` flows that enrich and
+    /// reshape them) even though all flows share the single `flow`
+    /// instrumentation scope. Omitted means no `flow.purpose` differentiation
+    /// (backward compatible).
+    #[serde(default)]
+    pub purpose: Option<String>,
 }
 
 impl FlowMetricConfig {
@@ -892,6 +901,29 @@ mod tests {
     }
 
     #[test]
+    fn flow_metrics_purpose_defaults_to_none() {
+        let yaml = r#"
+            flow_metrics:
+              - id: flow1
+                bounds: { start_node: a, end_node: b }
+        "#;
+        let policy: super::TelemetryPolicy = serde_yaml::from_str(yaml).expect("parse");
+        assert_eq!(policy.flow_metrics[0].purpose, None);
+    }
+
+    #[test]
+    fn flow_metrics_purpose_is_parsed() {
+        let yaml = r#"
+            flow_metrics:
+              - id: flow1
+                bounds: { start_node: a, end_node: b }
+                purpose: receiver
+        "#;
+        let policy: super::TelemetryPolicy = serde_yaml::from_str(yaml).expect("parse");
+        assert_eq!(policy.flow_metrics[0].purpose.as_deref(), Some("receiver"));
+    }
+
+    #[test]
     fn flow_metrics_rejects_empty_metrics() {
         let policies = Policies {
             telemetry: Some(super::TelemetryPolicy {
@@ -902,6 +934,7 @@ mod tests {
                         end_node: "b".to_string(),
                     },
                     metrics: Some(vec![]),
+                    purpose: None,
                 }],
                 ..super::TelemetryPolicy::default()
             }),
@@ -929,6 +962,7 @@ mod tests {
                         super::FlowMetric::ComputeDuration,
                         super::FlowMetric::ComputeDuration,
                     ]),
+                    purpose: None,
                 }],
                 ..super::TelemetryPolicy::default()
             }),

--- a/rust/otap-dataflow/crates/engine/src/attributes.rs
+++ b/rust/otap-dataflow/crates/engine/src/attributes.rs
@@ -190,6 +190,7 @@ static CUSTOM_ATTRIBUTES_DESCRIPTOR: AttributesDescriptor = AttributesDescriptor
         brief: "Custom user-defined attributes",
         r#type: AttributeValueType::Map,
     }],
+    scope_keys: &[],
 };
 
 impl CustomAttributeSet {

--- a/rust/otap-dataflow/crates/engine/src/flow_metrics.rs
+++ b/rust/otap-dataflow/crates/engine/src/flow_metrics.rs
@@ -69,10 +69,10 @@ pub struct FlowAttributeSet {
     #[attribute(key = "flow.node.end")]
     pub end_node: Cow<'static, str>,
     /// Optional per-flow purpose differentiator (e.g. `filter`, `transform`).
-    /// Empty when the flow declares no purpose. Lets OTel View selectors target
-    /// distinct flavors of processor work while all flows share the single
-    /// `flow` scope.
-    #[attribute(key = "flow.purpose")]
+    /// Empty when the flow declares no purpose. Emitted on the OpenTelemetry
+    /// instrumentation scope so View selectors can target distinct flavors of
+    /// processor work while all flows share the single `flow` scope.
+    #[attribute(key = "flow.purpose", scope)]
     pub purpose: Cow<'static, str>,
     /// Pipeline attributes.
     #[compose]
@@ -933,6 +933,19 @@ mod tests {
             "flow.purpose missing from FlowAttributeSet descriptor"
         );
 
+        // `flow.purpose` must be designated a scope-level attribute (it is
+        // emitted on the OpenTelemetry instrumentation scope, not on data
+        // points), while ordinary flow attributes remain data-point attributes.
+        assert!(
+            descriptor.scope_keys.contains(&"flow.purpose"),
+            "flow.purpose missing from descriptor scope_keys: {:?}",
+            descriptor.scope_keys
+        );
+        let attrs = FlowAttributeSet::default();
+        assert!(attrs.is_scope_attribute("flow.purpose"));
+        assert!(!attrs.is_scope_attribute("flow.id"));
+        assert!(!attrs.is_scope_attribute("flow.node.start"));
+
         // When set, the value is emitted under the `flow.purpose` key.
         let attrs = FlowAttributeSet {
             flow_id: "sampling".into(),
@@ -950,8 +963,9 @@ mod tests {
             "expected flow.purpose=filter in {set:?}"
         );
 
-        // When unset, the key is still present but carries an empty value
-        // (preserving the single `flow` scope behavior).
+        // When unset, the attribute-set layer still yields the key with an empty
+        // value; the metrics dispatcher omits empty scope attributes before
+        // emission, so the instrumentation scope keeps its prior shape.
         let unset = FlowAttributeSet::default();
         let unset_set: Vec<(&str, AttributeValue)> = unset
             .iter_attributes()

--- a/rust/otap-dataflow/crates/engine/src/flow_metrics.rs
+++ b/rust/otap-dataflow/crates/engine/src/flow_metrics.rs
@@ -68,6 +68,12 @@ pub struct FlowAttributeSet {
     /// Name of the processor node where the measurement ends.
     #[attribute(key = "flow.node.end")]
     pub end_node: Cow<'static, str>,
+    /// Optional per-flow purpose differentiator (e.g. `filter`, `transform`).
+    /// Empty when the flow declares no purpose. Lets OTel View selectors target
+    /// distinct flavors of processor work while all flows share the single
+    /// `flow` scope.
+    #[attribute(key = "flow.purpose")]
+    pub purpose: Cow<'static, str>,
     /// Pipeline attributes.
     #[compose]
     pub pipeline_attrs: PipelineAttributeSet,
@@ -275,6 +281,10 @@ pub(crate) fn build_flow_metric_state(
             flow_id: Cow::Owned(flow_config.id.clone()),
             start_node: Cow::Owned(flow_config.bounds.start_node.clone()),
             end_node: Cow::Owned(flow_config.bounds.end_node.clone()),
+            purpose: flow_config
+                .purpose
+                .clone()
+                .map_or(Cow::Borrowed(""), Cow::Owned),
             pipeline_attrs: pipeline_attrs.clone(),
         };
 
@@ -565,6 +575,7 @@ mod tests {
                 end_node: stop.to_string(),
             },
             metrics: None,
+            purpose: None,
         }
     }
 

--- a/rust/otap-dataflow/crates/engine/src/flow_metrics.rs
+++ b/rust/otap-dataflow/crates/engine/src/flow_metrics.rs
@@ -454,6 +454,7 @@ impl PipelineFlowMetricState {
 mod tests {
     use super::*;
     use crate::testing::test_pipeline_ctx;
+    use otap_df_telemetry::attributes::{AttributeSetHandler, AttributeValue};
 
     fn one_flow_metric_state() -> PipelineFlowMetricState {
         let (ctx, _) = test_pipeline_ctx();
@@ -920,5 +921,45 @@ mod tests {
         assert!(range.contains(&0));
         assert!(range.contains(&1));
         assert!(!range.contains(&5));
+    }
+
+    #[test]
+    fn flow_attribute_set_exposes_purpose_scope_attribute() {
+        // Descriptor must declare the `flow.purpose` key so View selectors can
+        // match on it as a scope attribute.
+        let descriptor = FlowAttributeSet::default().descriptor();
+        assert!(
+            descriptor.fields.iter().any(|f| f.key == "flow.purpose"),
+            "flow.purpose missing from FlowAttributeSet descriptor"
+        );
+
+        // When set, the value is emitted under the `flow.purpose` key.
+        let attrs = FlowAttributeSet {
+            flow_id: "sampling".into(),
+            start_node: "log_sampler".into(),
+            end_node: "log_sampler".into(),
+            purpose: "filter".into(),
+            ..FlowAttributeSet::default()
+        };
+        let set: Vec<(&str, AttributeValue)> = attrs
+            .iter_attributes()
+            .map(|(key, value)| (key, value.clone()))
+            .collect();
+        assert!(
+            set.contains(&("flow.purpose", AttributeValue::String("filter".to_string()))),
+            "expected flow.purpose=filter in {set:?}"
+        );
+
+        // When unset, the key is still present but carries an empty value
+        // (preserving the single `flow` scope behavior).
+        let unset = FlowAttributeSet::default();
+        let unset_set: Vec<(&str, AttributeValue)> = unset
+            .iter_attributes()
+            .map(|(key, value)| (key, value.clone()))
+            .collect();
+        assert!(
+            unset_set.contains(&("flow.purpose", AttributeValue::String(String::new()))),
+            "expected empty flow.purpose in {unset_set:?}"
+        );
     }
 }

--- a/rust/otap-dataflow/crates/engine/src/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/processor.rs
@@ -1256,6 +1256,7 @@ mod tests {
             flow_id: "auto_measure".into(),
             start_node: "auto_measure_processor".into(),
             end_node: "auto_measure_processor".into(),
+            purpose: "".into(),
             pipeline_attrs: pipeline_ctx.pipeline_attribute_set(),
         };
         let entity_key = pipeline_ctx.metrics_registry().register_entity(attrs);

--- a/rust/otap-dataflow/crates/telemetry-macros/src/lib.rs
+++ b/rust/otap-dataflow/crates/telemetry-macros/src/lib.rs
@@ -325,6 +325,8 @@ pub fn derive_metric_set_handler(input: TokenStream) -> TokenStream {
 ///   - `#[attributes(name = "my.attributes.name")]`
 ///     Field attributes:
 ///   - `#[attribute(key = "field.key")]` (optional, defaults to field name with dots)
+///   - `#[attribute(key = "field.key", scope)]` to emit the attribute on the
+///     OpenTelemetry instrumentation scope instead of on each data point
 ///   - `#[compose]` for fields that implement AttributeSetHandler
 #[proc_macro_derive(AttributeSetHandler, attributes(attributes, attribute, compose))]
 pub fn derive_attribute_set_handler(input: TokenStream) -> TokenStream {
@@ -413,6 +415,7 @@ pub fn derive_attribute_set_handler(input: TokenStream) -> TokenStream {
     let mut attr_field_descriptions = Vec::new();
     let mut attr_field_types: Vec<proc_macro2::TokenStream> = Vec::new();
     let mut attr_iter_values: Vec<proc_macro2::TokenStream> = Vec::new();
+    let mut attr_field_scope_keys: Vec<String> = Vec::new();
 
     let mut composed_field_idents = Vec::new();
 
@@ -478,6 +481,16 @@ pub fn derive_attribute_set_handler(input: TokenStream) -> TokenStream {
         }
         let derived_key = ident.to_string().replace('_', ".");
         let final_key = key_attr.unwrap_or(derived_key);
+
+        // Detect `#[attribute(..., scope)]` to mark this attribute as a
+        // scope-level (instrumentation-scope) attribute.
+        let is_scope_field = field
+            .attrs
+            .iter()
+            .any(parse_attribute_field_is_scope);
+        if is_scope_field {
+            attr_field_scope_keys.push(final_key.clone());
+        }
 
         // Determine attribute value type based on field type
         let (attr_type, iter_value) = match &field.ty {
@@ -555,6 +568,9 @@ pub fn derive_attribute_set_handler(input: TokenStream) -> TokenStream {
 
     let desc_ident = format_ident!("ATTRIBUTES_DESCRIPTOR");
 
+    // Local scope-attribute keys (from `#[attribute(key = "...", scope)]`).
+    let local_scope_keys = &attr_field_scope_keys;
+
     // Generate the descriptor and iterator implementation
     if composed_field_idents.is_empty() {
         // Simple case: no composition - keep the original approach
@@ -570,6 +586,7 @@ pub fn derive_attribute_set_handler(input: TokenStream) -> TokenStream {
                                 r#type: #attr_field_types
                             } ),*
                         ],
+                        scope_keys: &[ #( #local_scope_keys ),* ],
                     };
                     &#desc_ident
                 }
@@ -636,9 +653,17 @@ pub fn derive_attribute_set_handler(input: TokenStream) -> TokenStream {
                             // Leak the vector to get a 'static reference
                             let fields_slice: &'static [#field_path] = ::std::boxed::Box::leak(all_fields.into_boxed_slice());
 
+                            // Merge local scope keys with those of composed sets.
+                            let mut all_scope_keys: ::std::vec::Vec<&'static str> =
+                                ::std::vec![ #( #local_scope_keys ),* ];
+                            #( all_scope_keys.extend_from_slice(dummy.#composed_field_idents.descriptor().scope_keys); )*
+                            let scope_keys_slice: &'static [&'static str] =
+                                ::std::boxed::Box::leak(all_scope_keys.into_boxed_slice());
+
                             #desc_ident = Some(#descriptor_path {
                                 name: #attributes_name,
                                 fields: fields_slice,
+                                scope_keys: scope_keys_slice,
                             });
                         });
 
@@ -864,4 +889,24 @@ fn parse_attribute_field_attr(attr: &Attribute) -> Option<String> {
         Ok(())
     });
     out
+}
+
+/// Returns `true` when a field is marked as a scope-level attribute via
+/// `#[attribute(key = "...", scope)]`. Scope attributes are emitted on the
+/// OpenTelemetry instrumentation scope rather than as data-point attributes.
+fn parse_attribute_field_is_scope(attr: &Attribute) -> bool {
+    if !attr.path().is_ident("attribute") {
+        return false;
+    }
+    let mut is_scope = false;
+    let _ = attr.parse_nested_meta(|meta| {
+        if meta.path.is_ident("scope") {
+            is_scope = true;
+        } else if meta.path.is_ident("key") {
+            // Consume the `key = "..."` value so nested-meta parsing succeeds.
+            let _: LitStr = meta.value()?.parse()?;
+        }
+        Ok(())
+    });
+    is_scope
 }

--- a/rust/otap-dataflow/crates/telemetry-macros/src/lib.rs
+++ b/rust/otap-dataflow/crates/telemetry-macros/src/lib.rs
@@ -484,10 +484,7 @@ pub fn derive_attribute_set_handler(input: TokenStream) -> TokenStream {
 
         // Detect `#[attribute(..., scope)]` to mark this attribute as a
         // scope-level (instrumentation-scope) attribute.
-        let is_scope_field = field
-            .attrs
-            .iter()
-            .any(parse_attribute_field_is_scope);
+        let is_scope_field = field.attrs.iter().any(parse_attribute_field_is_scope);
         if is_scope_field {
             attr_field_scope_keys.push(final_key.clone());
         }

--- a/rust/otap-dataflow/crates/telemetry/src/attributes.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/attributes.rs
@@ -121,6 +121,18 @@ pub trait AttributeSetHandler {
         AttributeIterator::new(self.descriptor().fields, self.attribute_values())
     }
 
+    /// Returns `true` if the given attribute key should be emitted on the
+    /// OpenTelemetry instrumentation scope rather than as a data-point attribute.
+    ///
+    /// Backed by the static descriptor's `scope_keys`, which the
+    /// `#[derive(AttributeSetHandler)]` macro populates from fields marked
+    /// `#[attribute(key = "...", scope)]`. Because this reads the descriptor, it
+    /// keeps working through type-erased wrappers (e.g. `EntityAttributeSet`)
+    /// that carry the original `&'static` descriptor.
+    fn is_scope_attribute(&self, key: &str) -> bool {
+        self.descriptor().scope_keys.contains(&key)
+    }
+
     /// Returns the schema name for this attribute set (e.g., "pipeline.attrs").
     fn schema_name(&self) -> &'static str {
         self.descriptor().name
@@ -429,6 +441,7 @@ mod tests {
                 r#type: AttributeValueType::String,
                 brief: "Test attribute",
             }],
+            scope_keys: &[],
         };
 
         impl AttributeSetHandler for TestAttributeSet {

--- a/rust/otap-dataflow/crates/telemetry/src/collector.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/collector.rs
@@ -157,6 +157,7 @@ mod tests {
             r#type: AttributeValueType::String,
             brief: "Test attribute",
         }],
+        scope_keys: &[],
     };
 
     impl MetricSetHandler for MockMetricSet {

--- a/rust/otap-dataflow/crates/telemetry/src/descriptor.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/descriptor.rs
@@ -106,4 +106,10 @@ pub struct AttributesDescriptor {
     pub name: &'static str,
     /// Ordered attribute field metadata.
     pub fields: &'static [AttributeField],
+    /// Keys of attributes that must be emitted on the OpenTelemetry
+    /// instrumentation scope rather than as data-point attributes. Populated by
+    /// the `#[derive(AttributeSetHandler)]` macro from fields marked
+    /// `#[attribute(key = "...", scope)]` (composed sets contribute their own
+    /// scope keys). Empty when the set has no scope-level attributes.
+    pub scope_keys: &'static [&'static str],
 }

--- a/rust/otap-dataflow/crates/telemetry/src/entity.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/entity.rs
@@ -306,6 +306,7 @@ mod tests {
             r#type: AttributeValueType::String,
             brief: "Test attribute",
         }],
+        scope_keys: &[],
     };
 
     #[derive(Debug)]
@@ -360,6 +361,7 @@ mod tests {
                     brief: "beta",
                 },
             ],
+            scope_keys: &[],
         };
 
         static DESCRIPTOR_B: AttributesDescriptor = AttributesDescriptor {
@@ -376,6 +378,7 @@ mod tests {
                     brief: "alpha",
                 },
             ],
+            scope_keys: &[],
         };
 
         #[derive(Debug)]
@@ -462,5 +465,68 @@ mod tests {
         assert_eq!(registry.len(), 0);
         assert!(registry.get_shared(key).is_none());
         assert!(!registry.unregister(key));
+    }
+
+    // Regression: scope-attribute designation must survive type erasure through
+    // `EntityAttributeSet`. The registry stores attribute sets as
+    // `EntityAttributeSet` (descriptor + values), discarding the original
+    // concrete type. Because `is_scope_attribute` is backed by the static
+    // descriptor's `scope_keys`, the type-erased entity must still report which
+    // attributes belong on the instrumentation scope.
+    #[test]
+    fn test_scope_attribute_survives_type_erasure() {
+        static SCOPED_DESCRIPTOR: AttributesDescriptor = AttributesDescriptor {
+            name: "scoped_attrs",
+            fields: &[
+                AttributeField {
+                    key: "data.point.key",
+                    r#type: AttributeValueType::String,
+                    brief: "a data-point attribute",
+                },
+                AttributeField {
+                    key: "scope.key",
+                    r#type: AttributeValueType::String,
+                    brief: "a scope-level attribute",
+                },
+            ],
+            scope_keys: &["scope.key"],
+        };
+
+        #[derive(Debug)]
+        struct ScopedAttributeSet {
+            values: Vec<AttributeValue>,
+        }
+
+        impl AttributeSetHandler for ScopedAttributeSet {
+            fn descriptor(&self) -> &'static AttributesDescriptor {
+                &SCOPED_DESCRIPTOR
+            }
+
+            fn attribute_values(&self) -> &[AttributeValue] {
+                &self.values
+            }
+        }
+
+        let mut registry = EntityRegistry::default();
+        let key = registry
+            .register(ScopedAttributeSet {
+                values: vec![
+                    AttributeValue::String("dp".to_string()),
+                    AttributeValue::String("sc".to_string()),
+                ],
+            })
+            .key();
+
+        // `get` returns the type-erased `EntityAttributeSet`.
+        let erased = registry.get(key).expect("missing attributes");
+        assert!(
+            erased.is_scope_attribute("scope.key"),
+            "scope attribute should survive type erasure"
+        );
+        assert!(
+            !erased.is_scope_attribute("data.point.key"),
+            "data-point attribute must not be reported as scope-level"
+        );
+        assert!(!erased.is_scope_attribute("unknown.key"));
     }
 }

--- a/rust/otap-dataflow/crates/telemetry/src/entity.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/entity.rs
@@ -87,6 +87,15 @@ impl PartialEq for EntityAttributeSet {
             return false;
         }
 
+        // `scope_keys` is part of the semantic identity of an attribute set:
+        // two sets with identical fields/values but different scope designations
+        // must not be de-duplicated, otherwise a scope attribute could be emitted
+        // as a data-point attribute (or vice versa) after type erasure. Compare
+        // order-independently since the field order is not significant here.
+        if !scope_keys_equal(self.descriptor.scope_keys, other.descriptor.scope_keys) {
+            return false;
+        }
+
         self.sorted_indices
             .iter()
             .zip(other.sorted_indices.iter())
@@ -122,6 +131,16 @@ impl Hash for EntityAttributeSet {
             attribute_value_type_rank(field.r#type).hash(state);
             let value = &self.values[*idx];
             hash_attribute_value(value, state);
+        }
+
+        // Mirror the `PartialEq` treatment of `scope_keys` so the scope/data-point
+        // designation survives registry de-duplication. Hash in sorted order to
+        // stay consistent with the order-independent equality comparison.
+        let mut scope_keys: Vec<&'static str> = self.descriptor.scope_keys.to_vec();
+        scope_keys.sort_unstable();
+        scope_keys.len().hash(state);
+        for key in scope_keys {
+            key.hash(state);
         }
     }
 }
@@ -293,6 +312,18 @@ fn attribute_value_equal(left: &AttributeValue, right: &AttributeValue) -> bool 
     }
 }
 
+/// Compares two scope-key slices for set equality, ignoring ordering.
+fn scope_keys_equal(left: &[&'static str], right: &[&'static str]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    let mut left_sorted: Vec<&'static str> = left.to_vec();
+    let mut right_sorted: Vec<&'static str> = right.to_vec();
+    left_sorted.sort_unstable();
+    right_sorted.sort_unstable();
+    left_sorted == right_sorted
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -430,6 +461,88 @@ mod tests {
 
         assert_eq!(outcome1.key(), outcome2.key());
         assert_eq!(registry.len(), 1);
+    }
+
+    #[test]
+    fn test_scope_keys_prevent_dedup() {
+        // Two descriptors with identical fields and values, differing only in
+        // which key is designated as a scope-level attribute. They must NOT be
+        // de-duplicated, otherwise a scope attribute could be emitted as a
+        // data-point attribute (or vice versa) after type erasure.
+        static DESCRIPTOR_UNSCOPED: AttributesDescriptor = AttributesDescriptor {
+            name: "unscoped",
+            fields: &[AttributeField {
+                key: "alpha",
+                r#type: AttributeValueType::String,
+                brief: "alpha",
+            }],
+            scope_keys: &[],
+        };
+
+        static DESCRIPTOR_SCOPED: AttributesDescriptor = AttributesDescriptor {
+            name: "scoped",
+            fields: &[AttributeField {
+                key: "alpha",
+                r#type: AttributeValueType::String,
+                brief: "alpha",
+            }],
+            scope_keys: &["alpha"],
+        };
+
+        #[derive(Debug)]
+        struct Unscoped {
+            values: Vec<AttributeValue>,
+        }
+
+        #[derive(Debug)]
+        struct Scoped {
+            values: Vec<AttributeValue>,
+        }
+
+        impl AttributeSetHandler for Unscoped {
+            fn descriptor(&self) -> &'static AttributesDescriptor {
+                &DESCRIPTOR_UNSCOPED
+            }
+
+            fn attribute_values(&self) -> &[AttributeValue] {
+                &self.values
+            }
+        }
+
+        impl AttributeSetHandler for Scoped {
+            fn descriptor(&self) -> &'static AttributesDescriptor {
+                &DESCRIPTOR_SCOPED
+            }
+
+            fn attribute_values(&self) -> &[AttributeValue] {
+                &self.values
+            }
+        }
+
+        let mut registry = EntityRegistry::default();
+
+        let outcome1 = registry.register(Unscoped {
+            values: vec![AttributeValue::String("value".to_string())],
+        });
+        assert!(matches!(outcome1, RegisterOutcome::Created(_)));
+
+        let outcome2 = registry.register(Scoped {
+            values: vec![AttributeValue::String("value".to_string())],
+        });
+        assert!(matches!(outcome2, RegisterOutcome::Created(_)));
+
+        let key1 = outcome1.key();
+        let key2 = outcome2.key();
+        assert_ne!(key1, key2);
+        assert_eq!(registry.len(), 2);
+
+        // Registering the same scoped set again should reuse the scoped entry.
+        let outcome3 = registry.register(Scoped {
+            values: vec![AttributeValue::String("value".to_string())],
+        });
+        assert!(matches!(outcome3, RegisterOutcome::Existing(_)));
+        assert_eq!(key2, outcome3.key());
+        assert_eq!(registry.len(), 2);
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/telemetry/src/metrics.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/metrics.rs
@@ -604,6 +604,7 @@ mod tests {
             r#type: AttributeValueType::String,
             brief: "Test attribute",
         }],
+        scope_keys: &[],
     };
 
     impl MetricSetHandler for MockMetricSet {

--- a/rust/otap-dataflow/crates/telemetry/src/metrics/dispatcher.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/metrics/dispatcher.rs
@@ -5,7 +5,7 @@
 
 use std::sync::Arc;
 
-use opentelemetry::{global, metrics::Meter};
+use opentelemetry::{InstrumentationScope, global, metrics::Meter};
 use tokio::time::{MissedTickBehavior, interval};
 use tokio_util::sync::CancellationToken;
 
@@ -59,28 +59,62 @@ impl MetricsDispatcher {
     fn dispatch_metrics(&self) -> Result<(), Error> {
         self.metrics_handler
             .visit_metrics_and_reset(|descriptor, attributes, metrics_iter| {
-                let meter = global::meter(descriptor.name);
+                // Split the entity's attributes into instrumentation-scope
+                // attributes (those the attribute set marks `#[attribute(...,
+                // scope)]`, e.g. `flow.purpose`) and data-point attributes.
+                // Scope attributes are attached to the meter so View selectors
+                // keyed on scope attributes can match the emitted metrics.
+                let (scope_attributes, datapoint_attributes) =
+                    Self::partition_otel_attributes(attributes);
+
+                let meter = if scope_attributes.is_empty() {
+                    global::meter(descriptor.name)
+                } else {
+                    global::meter_with_scope(
+                        InstrumentationScope::builder(descriptor.name)
+                            .with_attributes(scope_attributes)
+                            .build(),
+                    )
+                };
 
                 // There is no support for metric level attributes currently. Attaching resource level attributes to every metric.
                 // TODO: Consider adding metric level attributes and not to add resource level attributes to every metric.
-                let otel_attributes = Self::to_opentelemetry_attributes(attributes);
-
                 for (field, value) in metrics_iter {
-                    self.add_opentelemetry_metric(field, value, &otel_attributes, &meter);
+                    self.add_opentelemetry_metric(field, value, &datapoint_attributes, &meter);
                 }
             });
 
         Ok(())
     }
 
-    fn to_opentelemetry_attributes(
+    /// Split an entity's attributes into `(scope, data_point)` OpenTelemetry
+    /// attributes in a single pass. An attribute is scope-level when the
+    /// attribute set declares it so via [`AttributeSetHandler::is_scope_attribute`]
+    /// (driven by `#[attribute(key = "...", scope)]`); everything else is a
+    /// data-point attribute.
+    ///
+    /// Scope attributes with an empty string value are omitted entirely (pushed
+    /// to neither bucket). Scope attributes participate in the OpenTelemetry
+    /// instrumentation-scope identity, so emitting an unset value (e.g. an
+    /// undeclared `flow.purpose`) would change the scope identity and export a
+    /// spurious empty attribute. Omitting them keeps the previous scope shape
+    /// for entities that do not configure the attribute.
+    fn partition_otel_attributes(
         attributes: &dyn AttributeSetHandler,
-    ) -> Vec<opentelemetry::KeyValue> {
-        let mut kvs = Vec::new();
+    ) -> (Vec<opentelemetry::KeyValue>, Vec<opentelemetry::KeyValue>) {
+        let mut scope = Vec::new();
+        let mut data_point = Vec::new();
         for (key, value) in attributes.iter_attributes() {
-            kvs.push(Self::to_opentelemetry_key_value(key, value));
+            if attributes.is_scope_attribute(key) {
+                if matches!(value, AttributeValue::String(s) if s.is_empty()) {
+                    continue;
+                }
+                scope.push(Self::to_opentelemetry_key_value(key, value));
+            } else {
+                data_point.push(Self::to_opentelemetry_key_value(key, value));
+            }
         }
-        kvs
+        (scope, data_point)
     }
 
     fn to_opentelemetry_key_value(key: &str, value: &AttributeValue) -> opentelemetry::KeyValue {
@@ -376,7 +410,7 @@ mod tests {
     }
 
     #[test]
-    fn test_to_opentelemetry_attributes() {
+    fn test_partition_otel_attributes() {
         struct MockAttributeSetHandler {
             values: Vec<AttributeValue>,
         }
@@ -408,6 +442,73 @@ mod tests {
                             r#type: AttributeValueType::Int,
                         },
                     ],
+                    scope_keys: &[],
+                }
+            }
+
+            fn attribute_values(&self) -> &[AttributeValue] {
+                &self.values
+            }
+
+            fn iter_attributes<'a>(&'a self) -> AttributeIterator<'a> {
+                AttributeIterator::new(self.descriptor().fields, self.attribute_values())
+            }
+
+            // Mark `key2` as a scope-level attribute to exercise partitioning.
+            fn is_scope_attribute(&self, key: &str) -> bool {
+                key == "key2"
+            }
+        }
+
+        let attributes = MockAttributeSetHandler::new();
+        let (scope_attributes, datapoint_attributes) =
+            MetricsDispatcher::partition_otel_attributes(&attributes);
+
+        // `key1` is a data-point attribute, `key2` is lifted onto the scope.
+        assert_eq!(datapoint_attributes.len(), 1);
+        assert!(
+            datapoint_attributes
+                .iter()
+                .any(|kv| kv.key.as_str() == "key1" && kv.value.as_str() == "value1")
+        );
+        assert!(
+            !datapoint_attributes
+                .iter()
+                .any(|kv| kv.key.as_str() == "key2")
+        );
+
+        assert_eq!(scope_attributes.len(), 1);
+        assert!(scope_attributes.iter().any(
+            |kv| kv.key.as_str() == "key2" && matches!(kv.value, opentelemetry::Value::I64(42))
+        ));
+    }
+
+    #[test]
+    fn test_partition_otel_attributes_omits_empty_scope_attribute() {
+        // A scope attribute with an empty string value must be omitted entirely
+        // so it does not alter the instrumentation-scope identity or export a
+        // spurious empty attribute (e.g. an unset `flow.purpose`).
+        struct MockAttributeSetHandler {
+            values: Vec<AttributeValue>,
+        }
+
+        impl AttributeSetHandler for MockAttributeSetHandler {
+            fn descriptor(&self) -> &'static AttributesDescriptor {
+                &AttributesDescriptor {
+                    name: "mock",
+                    fields: &[
+                        AttributeField {
+                            key: "data.key",
+                            brief: "a data-point attribute",
+                            r#type: AttributeValueType::String,
+                        },
+                        AttributeField {
+                            key: "scope.key",
+                            brief: "an unset scope attribute",
+                            r#type: AttributeValueType::String,
+                        },
+                    ],
+                    scope_keys: &["scope.key"],
                 }
             }
 
@@ -420,17 +521,25 @@ mod tests {
             }
         }
 
-        let attributes = MockAttributeSetHandler::new();
-        let otel_attributes = MetricsDispatcher::to_opentelemetry_attributes(&attributes);
-        assert_eq!(otel_attributes.len(), 2);
+        let attributes = MockAttributeSetHandler {
+            values: vec![
+                AttributeValue::String("present".to_string()),
+                AttributeValue::String(String::new()),
+            ],
+        };
+        let (scope_attributes, datapoint_attributes) =
+            MetricsDispatcher::partition_otel_attributes(&attributes);
+
+        // The empty scope attribute is dropped, leaving no scope attributes so
+        // the dispatcher falls back to the plain meter.
+        assert!(scope_attributes.is_empty());
+        // The non-empty data-point attribute is retained.
+        assert_eq!(datapoint_attributes.len(), 1);
         assert!(
-            otel_attributes
+            datapoint_attributes
                 .iter()
-                .any(|kv| kv.key.as_str() == "key1" && kv.value.as_str() == "value1")
+                .any(|kv| kv.key.as_str() == "data.key" && kv.value.as_str() == "present")
         );
-        assert!(otel_attributes.iter().any(
-            |kv| kv.key.as_str() == "key2" && matches!(kv.value, opentelemetry::Value::I64(42))
-        ));
     }
 
     #[test]
@@ -630,6 +739,7 @@ mod tests {
                 r#type: AttributeValueType::String,
                 brief: "service name",
             }],
+            scope_keys: &[],
         };
 
         #[derive(Debug)]
@@ -680,9 +790,10 @@ mod tests {
             MetricsDispatcher::new(registry.clone(), std::time::Duration::from_secs(1));
         registry.visit_metrics_and_reset(|descriptor, attributes, metrics_iter| {
             let meter = meter_provider.meter(descriptor.name);
-            let otel_attributes = MetricsDispatcher::to_opentelemetry_attributes(attributes);
+            let (_scope_attributes, datapoint_attributes) =
+                MetricsDispatcher::partition_otel_attributes(attributes);
             for (field, value) in metrics_iter {
-                dispatcher.add_opentelemetry_metric(field, value, &otel_attributes, &meter);
+                dispatcher.add_opentelemetry_metric(field, value, &datapoint_attributes, &meter);
             }
         });
 

--- a/rust/otap-dataflow/crates/telemetry/src/registry.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/registry.rs
@@ -278,6 +278,7 @@ mod tests {
             r#type: AttributeValueType::String,
             brief: "Test attribute",
         }],
+        scope_keys: &[],
     };
 
     impl MetricSetHandler for MockMetricSet {

--- a/rust/otap-dataflow/crates/telemetry/src/self_tracing/encoder.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/self_tracing/encoder.rs
@@ -674,6 +674,7 @@ mod tests {
                 brief: "CPU ID",
             },
         ],
+        scope_keys: &[],
     };
 
     /// Mock attribute set for testing scope attributes.
@@ -796,6 +797,7 @@ mod tests {
             r#type: AttributeValueType::Map,
             brief: "Custom user-defined attributes",
         }],
+        scope_keys: &[],
     };
 
     /// Mirrors engine::CustomAttributeSet: a single "custom" field of type Map.

--- a/rust/otap-dataflow/crates/telemetry/src/testing/mod.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/testing/mod.rs
@@ -10,6 +10,7 @@ use crate::descriptor::AttributesDescriptor;
 static EMPTY_ATTRIBUTES_DESCRIPTOR: AttributesDescriptor = AttributesDescriptor {
     name: "empty_metrics",
     fields: &[],
+    scope_keys: &[],
 };
 
 /// Empty attribute set for testing.


### PR DESCRIPTION
# Change Summary

(Attempt 2, see #3132 for context. Copilot identified real issue with that simpler implementation)

 ## Add `flow.purpose` scope attribute to flow metrics

 ### What

 Adds an optional `purpose` field to flow-metric configuration (`FlowMetricConfig` in `crates/config/src/policy.rs`). When set, it is emitted as the **`flow.purpose` instrumentation-scope attribute** on every metric the flow produces.

 To do this correctly, this PR adds a small, general mechanism for declaring that an attribute belongs on the OpenTelemetry **instrumentation scope** rather than on each data point:

 - A new `#[attribute(key = "...", scope)]` marker in `telemetry-macros`. The derive records these keys in a new `scope_keys` field on`AttributesDescriptor` (and merges them across `#[compose]`d attribute sets).
 - A descriptor-backed `AttributeSetHandler::is_scope_attribute(key)` helper, so the designation survives type erasure through `EntityAttributeSet`.
 - The metrics dispatcher (`crates/telemetry/src/metrics/dispatcher.rs`) now partitions an entity's attributes into `(scope, data_point)`. Scopeattributes are attached to the meter via `global::meter_with_scope(InstrumentationScope::builder(name).with_attributes(...))`; everything else stays on `counter.add` / `histogram.record` as before.
 - `flow.purpose` (in `FlowAttributeSet`, `crates/engine/src/flow_metrics.rs`) is marked `scope`.

 This is change **A** from #2859 ("per-flow scope"): the smallest, backward-compatible step that lets OTel View selectors distinguish flows thatshare the single `flow` instrumentation scope. It builds on #2755, which enabled `scope_attributes` for Metric View filtering.

 ### Why

 All flow metrics emit under one shared `flow` scope. OTel View selectors match on **scope name + scope attributes + instrument name**, so todaythey cannot target one flow's metrics without also matching every other flow's same-named instrument. As we start declaring flows for different*flavors* of work, their metrics collide in a single View.

 `flow.purpose` gives operators a per-flow differentiator that selectors can key on, **without introducing a new scope per flow**. Crucially,because View selectors match on `instrument.scope().attributes()`, the value must be emitted on the instrumentation scope — emitting it as adata-point attribute (an earlier iteration of this PR) would never match a `scope_attributes` selector.

 ### Backward compatibility

 Flows that do not configure a `purpose` are unchanged: an unset/empty `flow.purpose` is **omitted entirely** (the dispatcher drops empty scopeattributes), so the instrumentation-scope identity for existing flows stays exactly as before. No new attribute or label appears on existingmetrics.

 ### Example — two flows that need to be told apart

 A pipeline declares two flows over different processor stages. Both enable `compute_duration`, so without a differentiator a `compute.duration`View selector would match — and conflate — both:

 ```yaml
 policies:
   telemetry:
     flow_metrics:
       # A sampling stage: records not selected by the sampler are dropped.
       # Operator cares about all flow metrics (duration, incoming, and outgoing).
       - id: sampling
         bounds: { start_node: log_sampler, end_node: log_sampler }
         purpose: filter
         metrics: [compute_duration, signals_incoming, signals_outgoing]

       # A downstream enrichment/transform stage. Operator only cares about how
       # long the transforms takes.
       - id: enrich
         bounds: { start_node: transform_a, end_node: transform_b }
         purpose: transform
         metrics: [compute_duration]
 ```

 Both flows emit under scope `flow`. With `flow.purpose` on the scope, Views route each flow's instruments to distinct streams:

 ```yaml
 views:
   - selector: { scope_name: flow, scope_attributes: { flow.purpose: filter }, instrument_name: compute.duration }
     stream:   { name: sampler_duration }
   - selector: { scope_name: flow, scope_attributes: { flow.purpose: filter }, instrument_name: signals.incoming }
     stream:   { name: sampler_incoming_items }
   - selector: { scope_name: flow, scope_attributes: { flow.purpose: filter }, instrument_name: signals.outgoing }
     stream:   { name: sampled_records_kept }
   - selector: { scope_name: flow, scope_attributes: { flow.purpose: transform }, instrument_name: compute.duration }
     stream:   { name: enrich_duration }
 ```

 Without `flow.purpose`, a `scope_name: flow` + `instrument_name: compute.duration` selector would match **both** flows and report mixed durationdata.

 A runnable demonstration is included at `rust/otap-dataflow/configs/flow-purpose-demo.yaml`.

 ## What issue does this PR close?

 * Progress towards #2859

 ## How are these changes tested?

Unit tests

## Are there any user-facing changes?

Yes — operators can now specify a flow `purpose`, emitted as the `flow.purpose` scope attribute. Flows without a `purpose` are unaffected.

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).