### PR TITLE
Add OTAP-ATTR-OTAP saturation scaling tests (1,2,4,8 cores)

### DIFF
--- a/.github/workflows/pipeline-perf-on-label.yaml
+++ b/.github/workflows/pipeline-perf-on-label.yaml
@@ -90,45 +90,24 @@ jobs:
           python -m pip install --user --require-hashes -r tools/pipeline_perf_test/orchestrator/requirements.lock.txt
           python -m pip install --user --require-hashes -r tools/pipeline_perf_test/load_generator/requirements.lock.txt
 
-      - name: Run pipeline performance test suite
+      - name: Run OTAP saturation/scaling tests
         run: |
           cd tools/pipeline_perf_test
-          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/100klrps-docker.yaml
+          for config in test_suites/integration/continuous/saturation-otap-*.yaml; do
+            echo "=== Running: $config ==="
+            python orchestrator/run_orchestrator.py --config "$config" || true
+          done
 
-      - name: Run saturation/scaling performance test suite
+      - name: Analyze OTAP scaling results
         if: ${{ !cancelled() }}
         run: |
           cd tools/pipeline_perf_test
-          ./scripts/run-saturation-tests.sh --output-json results/scaling-efficiency.json \
-            | tee saturation-scaling-report.txt
-          echo "### Saturation/Scaling Test Analysis" >> $GITHUB_STEP_SUMMARY
+          python ../../.github/workflows/scripts/analyze-saturation-scaling.py results \
+            | tee otap-scaling-report.txt
+          echo "### OTAP Saturation/Scaling Test Analysis" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          sed -n '/^=.*SCALING ANALYSIS/,/^=\{10,\}$/p' saturation-scaling-report.txt >> $GITHUB_STEP_SUMMARY
+          cat otap-scaling-report.txt >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-
-      - name: Run single-core saturation max throughput test (OTLP)
-        if: ${{ !cancelled() }}
-        run: |
-          cd tools/pipeline_perf_test
-          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/saturation-max-throughput.yaml
-
-      - name: Run single-core saturation max throughput test (OTAP)
-        if: ${{ !cancelled() }}
-        run: |
-          cd tools/pipeline_perf_test
-          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/saturation-max-throughput-otap.yaml
-
-      - name: Run passthrough performance test (OTLP)
-        if: ${{ !cancelled() }}
-        run: |
-          cd tools/pipeline_perf_test
-          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/passthrough.yaml
-
-      - name: Run passthrough performance test (OTAP)
-        if: ${{ !cancelled() }}
-        run: |
-          cd tools/pipeline_perf_test
-          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/passthrough-otap.yaml
 
       - name: Post-run disk usage diagnostics
         if: always()

--- a/.github/workflows/pipeline-perf-on-label.yaml
+++ b/.github/workflows/pipeline-perf-on-label.yaml
@@ -90,24 +90,45 @@ jobs:
           python -m pip install --user --require-hashes -r tools/pipeline_perf_test/orchestrator/requirements.lock.txt
           python -m pip install --user --require-hashes -r tools/pipeline_perf_test/load_generator/requirements.lock.txt
 
-      - name: Run OTAP saturation/scaling tests
+      - name: Run pipeline performance test suite
         run: |
           cd tools/pipeline_perf_test
-          for config in test_suites/integration/continuous/saturation-otap-*.yaml; do
-            echo "=== Running: $config ==="
-            python orchestrator/run_orchestrator.py --config "$config" || true
-          done
+          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/100klrps-docker.yaml
 
-      - name: Analyze OTAP scaling results
+      - name: Run saturation/scaling performance test suite
         if: ${{ !cancelled() }}
         run: |
           cd tools/pipeline_perf_test
-          python ../../.github/workflows/scripts/analyze-saturation-scaling.py results \
-            | tee otap-scaling-report.txt
-          echo "### OTAP Saturation/Scaling Test Analysis" >> $GITHUB_STEP_SUMMARY
+          ./scripts/run-saturation-tests.sh --output-json results/scaling-efficiency.json \
+            | tee saturation-scaling-report.txt
+          echo "### Saturation/Scaling Test Analysis" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          cat otap-scaling-report.txt >> $GITHUB_STEP_SUMMARY
+          sed -n '/^=.*SCALING ANALYSIS/,/^=\{10,\}$/p' saturation-scaling-report.txt >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Run single-core saturation max throughput test (OTLP)
+        if: ${{ !cancelled() }}
+        run: |
+          cd tools/pipeline_perf_test
+          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/saturation-max-throughput.yaml
+
+      - name: Run single-core saturation max throughput test (OTAP)
+        if: ${{ !cancelled() }}
+        run: |
+          cd tools/pipeline_perf_test
+          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/saturation-max-throughput-otap.yaml
+
+      - name: Run passthrough performance test (OTLP)
+        if: ${{ !cancelled() }}
+        run: |
+          cd tools/pipeline_perf_test
+          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/passthrough.yaml
+
+      - name: Run passthrough performance test (OTAP)
+        if: ${{ !cancelled() }}
+        run: |
+          cd tools/pipeline_perf_test
+          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/passthrough-otap.yaml
 
       - name: Post-run disk usage diagnostics
         if: always()

--- a/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-otap-1core.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-otap-1core.yaml
@@ -1,0 +1,11 @@
+# OTAP saturation test with 1 core df_engine
+# NUMA-aware layout: SUT on NUMA node 0, loadgen+backend on NUMA node 1
+from_template:
+  path: test_suites/integration/continuous/saturation-otap-cores-template.yaml.j2
+  variables:
+    num_cores: 1
+    engine_core_range: "0-0"
+    loadgen_cores: 10
+    loadgen_core_range: "32-41"
+    backend_cores: 2
+    backend_core_range: "42-43"

--- a/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-otap-2cores.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-otap-2cores.yaml
@@ -1,0 +1,11 @@
+# OTAP saturation test with 2 core df_engine
+# NUMA-aware layout: SUT on NUMA node 0, loadgen+backend on NUMA node 1
+from_template:
+  path: test_suites/integration/continuous/saturation-otap-cores-template.yaml.j2
+  variables:
+    num_cores: 2
+    engine_core_range: "0-1"
+    loadgen_cores: 20
+    loadgen_core_range: "32-51"
+    backend_cores: 4
+    backend_core_range: "52-55"

--- a/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-otap-4cores.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-otap-4cores.yaml
@@ -1,0 +1,13 @@
+# OTAP saturation test with 4 core df_engine
+# NUMA-aware layout: SUT on NUMA node 0, loadgen+backend on NUMA node 1
+# Uses physical (32-63) + HT (96-127) cores on NUMA node 1 to provide
+# enough loadgen/backend capacity for OTAP's high throughput.
+from_template:
+  path: test_suites/integration/continuous/saturation-otap-cores-template.yaml.j2
+  variables:
+    num_cores: 4
+    engine_core_range: "0-3"
+    loadgen_cores: 56
+    loadgen_core_range: "32-63,96-119"
+    backend_cores: 8
+    backend_core_range: "120-127"

--- a/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-otap-8cores.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-otap-8cores.yaml
@@ -1,13 +1,13 @@
 # OTAP saturation test with 8 core df_engine
-# NUMA-aware layout: SUT on NUMA node 0 (physical 0-7), loadgen uses all remaining cores except 4 for backend.
-# Loadgen: NUMA1 phys(32-63) + NUMA1 HT(96-127) + NUMA0 phys(8-31) + NUMA0 HT(68-95) = 104 cores
-# Backend: NUMA0 HT(64-67) = 4 cores (only uses ~3.4 in practice)
+# NUMA-aware layout: SUT on NUMA node 0 (physical 0-7), loadgen on entire NUMA node 1,
+# backend on NUMA0 HT cores (not siblings of SUT cores 0-7).
+# Note: 64 LG cores is the max without cross-NUMA contention. SUT reaches ~91% (loadgen-limited).
 from_template:
   path: test_suites/integration/continuous/saturation-otap-cores-template.yaml.j2
   variables:
     num_cores: 8
     engine_core_range: "0-7"
-    loadgen_cores: 104
-    loadgen_core_range: "32-63,96-127,8-31,68-95"
-    backend_cores: 4
-    backend_core_range: "64-67"
+    loadgen_cores: 64
+    loadgen_core_range: "32-63,96-127"
+    backend_cores: 16
+    backend_core_range: "64-79"

--- a/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-otap-8cores.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-otap-8cores.yaml
@@ -1,12 +1,13 @@
 # OTAP saturation test with 8 core df_engine
-# NUMA-aware layout: SUT on NUMA node 0 (physical 0-7), loadgen+backend spread across remaining cores.
-# Uses all NUMA1 physical+HT for loadgen, and NUMA0 HT siblings (not used by SUT) for extra loadgen+backend.
+# NUMA-aware layout: SUT on NUMA node 0 (physical 0-7), loadgen uses all remaining cores except 4 for backend.
+# Loadgen: NUMA1 phys(32-63) + NUMA1 HT(96-127) + NUMA0 phys(8-31) + NUMA0 HT(68-95) = 104 cores
+# Backend: NUMA0 HT(64-67) = 4 cores (only uses ~3.4 in practice)
 from_template:
   path: test_suites/integration/continuous/saturation-otap-cores-template.yaml.j2
   variables:
     num_cores: 8
     engine_core_range: "0-7"
-    loadgen_cores: 64
-    loadgen_core_range: "32-63,96-127"
-    backend_cores: 16
-    backend_core_range: "64-79"
+    loadgen_cores: 104
+    loadgen_core_range: "32-63,96-127,8-31,68-95"
+    backend_cores: 4
+    backend_core_range: "64-67"

--- a/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-otap-8cores.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-otap-8cores.yaml
@@ -1,0 +1,12 @@
+# OTAP saturation test with 8 core df_engine
+# NUMA-aware layout: SUT on NUMA node 0 (physical 0-7), loadgen+backend spread across remaining cores.
+# Uses all NUMA1 physical+HT for loadgen, and NUMA0 HT siblings (not used by SUT) for extra loadgen+backend.
+from_template:
+  path: test_suites/integration/continuous/saturation-otap-cores-template.yaml.j2
+  variables:
+    num_cores: 8
+    engine_core_range: "0-7"
+    loadgen_cores: 64
+    loadgen_core_range: "32-63,96-127"
+    backend_cores: 16
+    backend_core_range: "64-79"

--- a/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-otap-cores-template.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-otap-cores-template.yaml.j2
@@ -1,0 +1,83 @@
+# Template for OTAP core scaling saturation tests
+# This template is instantiated by the saturation-otap-*cores.yaml wrapper files
+# OTAP is significantly faster than OTLP, so loadgen/backend ratios are higher.
+name: Continuous - Saturation OTAP - {{num_cores}} Core(s)
+components:
+  load-generator:
+    deployment:
+      docker:
+        image: df_engine:latest
+        network: testbed
+        ports:
+          - "8085:8080"
+        volumes:
+          - 'test_suites/integration/configs/loadgen/config.rendered.yaml:/home/nonroot/config.yaml:ro'
+        command:
+          - "--config"
+          - "./config.yaml"
+          - "--core-id-range"
+          - "{{loadgen_core_range}}"
+          - "--http-admin-bind"
+          - "0.0.0.0:8080"
+    monitoring:
+      docker_component:
+        allocated_cores: {{loadgen_cores}}
+      prometheus:
+        endpoint: http://localhost:8085/api/v1/telemetry/metrics?format=prometheus&reset=false
+  df-engine:
+    deployment:
+      docker:
+        image: df_engine:latest
+        network: testbed
+        ports:
+          - "8086:8080"
+        volumes:
+          - 'test_suites/integration/configs/engine/config.rendered.yaml:/home/nonroot/config.yaml:ro'
+        command:
+          - "--config"
+          - "./config.yaml"
+          - "--core-id-range"
+          - "{{engine_core_range}}"
+          - "--http-admin-bind"
+          - "0.0.0.0:8080"
+    monitoring:
+      docker_component:
+        allocated_cores: {{num_cores}}  # The cores we're testing
+      prometheus:
+        endpoint: http://localhost:8086/api/v1/telemetry/metrics?format=prometheus&reset=false
+  backend-service:
+    deployment:
+      docker:
+        image: df_engine:latest
+        network: testbed
+        ports:
+          - "8087:8080"
+        volumes:
+          - 'test_suites/integration/configs/backend/config.rendered.yaml:/home/nonroot/config.yaml:ro'
+        command:
+          - "--config"
+          - "./config.yaml"
+          - "--core-id-range"
+          - "{{backend_core_range}}"
+          - "--http-admin-bind"
+          - "0.0.0.0:8080"
+    monitoring:
+      docker_component:
+        allocated_cores: {{backend_cores}}
+      prometheus:
+        endpoint: http://localhost:8087/api/v1/telemetry/metrics?format=prometheus&reset=false
+
+tests:
+  - name: OTAP-ATTR-OTAP
+    from_template:
+      path: test_suites/integration/templates/test_steps/df-loadgen-steps-docker.yaml
+      variables:
+        result_dir: "continuous_saturation_{{num_cores}}core_otap"
+        engine_config_template: test_suites/integration/templates/configs/engine/backpressure/otap-attr-otap.yaml
+        loadgen_exporter_type: otap
+        backend_receiver_type: otap
+        observation_interval: 60
+        signals_per_second: null
+        max_batch_size: 512
+        data_source: synthetic
+        log_body_size_bytes: 1024


### PR DESCRIPTION
## Summary

Add OTAP saturation/scaling tests to measure OTAP throughput scaling across core counts, matching the existing OTLP scaling tests.

**Config:** OTAP receiver → attribute rename processor → OTAP exporter, zstd compression, batch size 512, 1KB synthetic logs.

**Core layouts (NUMA-aware):**
| Cores | SUT | Loadgen | Backend |
|-------|-----|---------|---------|
| 1 | 0 (1) | 32-41 (10) | 42-43 (2) |
| 2 | 0-1 (2) | 32-51 (20) | 52-55 (4) |
| 4 | 0-3 (4) | 32-63,96-119 (56) | 120-127 (8) |
| 8 | 0-7 (8) | 32-63,96-127 (64) | 64-79 (16) |

## Results (3 runs, highly consistent ±2%)

| Cores | Throughput | SUT CPU | LG CPU (allocated) | BE CPU (allocated) | Scaling |
|-------|-----------|---------|-------|-------|---------|
| 1 | **2.47M** logs/sec | 100% | 10.0/10 ✅ | 0.63/2 | 100% |
| 2 | **4.82M** logs/sec | 100% | 20.0/20 ✅ | 0.71/4 | 97% |
| 4 | **9.04M** logs/sec | 100% ✅ | 56.0/56 ✅ | 2.35/8 | 92% |
| 8 | **14.1M** logs/sec | 92% ⚠️ | 64.0/64 ⚠️ | 2.87/16 | 72% |

### Analysis
- **1-4 cores: fully saturated** — near-linear scaling (92-100%)
- **8 cores: loadgen bottleneck** — used all 64 allocated cores, SUT only at 92%. True throughput is higher.
- **Backend is never the bottleneck** — peaks at ~3 cores out of 16 allocated
- **Per-core throughput: ~2.4-2.5M logs/sec** (vs OTLP ~120K — **~20x faster**)

### 8-core loadgen limitation

The 8-core SUT cannot be fully saturated due to a NUMA topology constraint:
- **CI machine:** 2-socket Intel Xeon 8358, 2 NUMA nodes × 64 logical cores (32 physical + 32 HT)
- **SUT on NUMA0** (cores 0-7), **Loadgen on NUMA1** (cores 32-63, 96-127 = 64 cores)
- Placing loadgen on the same NUMA node as SUT causes significant throughput reduction (tested: 14M → 8.7M)
- 64 cores is the maximum loadgen allocation without cross-NUMA contention
- Each loadgen core produces ~220K logs/sec → 64 × 220K ≈ 14M, insufficient for 8 × 2.5M = 20M theoretical max

### Comparison with OTLP scaling (same test)
| Cores | OTLP | OTAP | Speedup |
|-------|------|------|---------|
| 1 | 121K | 2.47M | 20.4x |
| 2 | 264K | 4.82M | 18.3x |
| 4 | 567K | 9.04M | 15.9x |
| 8 | 1.03M | 14.1M | 13.7x |