### PR TITLE
feat: added comment support in OPL

### DIFF
--- a/rust/otap-dataflow/.chloggen/opl-comments.yaml
+++ b/rust/otap-dataflow/.chloggen/opl-comments.yaml
@@ -1,19 +1,4 @@
-# Use this changelog template to create an entry for release notes.
-
-# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
 change_type: enhancement
-
-# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
-# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
 component: query-engine
-
-# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Adds support for comments in OPL programs
-
-# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: []
-
-# (Optional) One or more lines of additional information to render under the primary note.
-# These lines will be padded with 2 spaces and then inserted directly into the document.
-# Use pipe (|) for multiline entries.
-subtext:

--- a/rust/otap-dataflow/.chloggen/opl-comments.yaml
+++ b/rust/otap-dataflow/.chloggen/opl-comments.yaml
@@ -1,4 +1,4 @@
 change_type: enhancement
 component: query-engine
 note: Adds support for comments in OPL programs
-issues: []
+issues: [3151]

--- a/rust/otap-dataflow/.chloggen/opl-comments.yaml
+++ b/rust/otap-dataflow/.chloggen/opl-comments.yaml
@@ -1,0 +1,19 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: query-engine
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds support for comments in OPL programs
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/opl.pest
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/opl.pest
@@ -1,7 +1,7 @@
 // Grammar for Observability Programming Language (OPL)
 
 WHITESPACE = _{ " " | NEWLINE | "\t" }
-COMMENT    = _{ ("/*" ~ (!"*/" ~ ANY)* ~ "*/") | ("//" ~ (!"\n" ~ ANY)*) }
+COMMENT    = _{ ("/*" ~ (!"*/" ~ ANY)* ~ "*/") | ("//" ~ (!NEWLINE ~ ANY)*) }
 
 ident = @{ ("_" | ASCII_ALPHA) ~ ("_" | ASCII_ALPHANUMERIC)* }
 

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/opl.pest
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/opl.pest
@@ -1,10 +1,9 @@
 // Grammar for Observability Programming Language (OPL)
 
 WHITESPACE = _{ " " | NEWLINE | "\t" }
-COMMENT = _{ ("/*" ~ (!"*/" ~ ANY)* ~ "*/") | ("//" ~ (!"\n" ~ ANY)*) }
+COMMENT    = _{ ("/*" ~ (!"*/" ~ ANY)* ~ "*/") | ("//" ~ (!"\n" ~ ANY)*) }
 
 ident = @{ ("_" | ASCII_ALPHA) ~ ("_" | ASCII_ALPHANUMERIC)* }
-
 
 double_quote_string_char = _{
     !("\"" | "\\") ~ ANY

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/opl.pest
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/opl.pest
@@ -1,6 +1,5 @@
 // Grammar for Observability Programming Language (OPL)
 
-
 WHITESPACE = _{ " " | NEWLINE | "\t" }
 COMMENT = _{ ("/*" ~ (!"*/" ~ ANY)* ~ "*/") | ("//" ~ (!"\n" ~ ANY)*) }
 

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/opl.pest
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/opl.pest
@@ -1,8 +1,11 @@
 // Grammar for Observability Programming Language (OPL)
 
+
 WHITESPACE = _{ " " | NEWLINE | "\t" }
+COMMENT = _{ ("/*" ~ (!"*/" ~ ANY)* ~ "*/") | ("//" ~ (!"\n" ~ ANY)*) }
 
 ident = @{ ("_" | ASCII_ALPHA) ~ ("_" | ASCII_ALPHANUMERIC)* }
+
 
 double_quote_string_char = _{
     !("\"" | "\\") ~ ANY

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/opl.pest
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/opl.pest
@@ -16,7 +16,7 @@ single_quote_string_char = _{
   | "\\" ~ ("u" ~ ASCII_HEX_DIGIT{4})
 }
 
-string_literal = {
+string_literal = ${
     ("\"" ~ double_quote_string_char* ~ "\"")
   | ("'" ~ single_quote_string_char* ~ "'")
 }

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser.rs
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser.rs
@@ -143,6 +143,7 @@ mod test {
             // many inline comments
             "
             // inline comment
+            // adjacent line inline comment
             logs | 
             // yet another inline comment before operator
             where severity_text == \"ERROR\"  // comment end of line
@@ -166,6 +167,32 @@ mod test {
             ",
         ];
 
+        fn gen_simple_equals_filter_expected(source: &str, str: &str) -> DataExpression {
+            DataExpression::Discard(
+                DiscardDataExpression::new(QueryLocation::new_fake()).with_predicate(
+                    LogicalExpression::Not(NotLogicalExpression::new(
+                        QueryLocation::new_fake(),
+                        LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                            QueryLocation::new_fake(),
+                            ScalarExpression::Source(SourceScalarExpression::new(
+                                QueryLocation::new_fake(),
+                                ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                                    StaticScalarExpression::String(StringScalarExpression::new(
+                                        QueryLocation::new_fake(),
+                                        source,
+                                    )),
+                                )]),
+                            )),
+                            ScalarExpression::Static(StaticScalarExpression::String(
+                                StringScalarExpression::new(QueryLocation::new_fake(), str),
+                            )),
+                            false,
+                        )),
+                    )),
+                ),
+            )
+        }
+
         for program in programs {
             let result = OplParser::parse(program).unwrap();
 
@@ -174,32 +201,25 @@ mod test {
             assert_eq!(data_exprs.len(), 1);
             pretty_assertions::assert_eq!(
                 &data_exprs[0],
-                &DataExpression::Discard(
-                    DiscardDataExpression::new(QueryLocation::new_fake()).with_predicate(
-                        LogicalExpression::Not(NotLogicalExpression::new(
-                            QueryLocation::new_fake(),
-                            LogicalExpression::EqualTo(EqualToLogicalExpression::new(
-                                QueryLocation::new_fake(),
-                                ScalarExpression::Source(SourceScalarExpression::new(
-                                    QueryLocation::new_fake(),
-                                    ValueAccessor::new_with_selectors(vec![
-                                        ScalarExpression::Static(StaticScalarExpression::String(
-                                            StringScalarExpression::new(
-                                                QueryLocation::new_fake(),
-                                                "severity_text",
-                                            )
-                                        ))
-                                    ]),
-                                )),
-                                ScalarExpression::Static(StaticScalarExpression::String(
-                                    StringScalarExpression::new(QueryLocation::new_fake(), "ERROR"),
-                                )),
-                                false,
-                            )),
-                        )),
-                    ),
-                )
+                &gen_simple_equals_filter_expected("severity_text", "ERROR")
             );
         }
+
+        // test that we support the comment characters inside the text
+        let result = OplParser::parse("logs | where body == \"http://example.com\"").unwrap();
+        let data_exprs = result.pipeline.get_expressions();
+        assert_eq!(data_exprs.len(), 1);
+        pretty_assertions::assert_eq!(
+            &data_exprs[0],
+            &gen_simple_equals_filter_expected("body", "http://example.com")
+        );
+
+        let result = OplParser::parse("logs | where body == \"example /* comment */\"").unwrap();
+        let data_exprs = result.pipeline.get_expressions();
+        assert_eq!(data_exprs.len(), 1);
+        pretty_assertions::assert_eq!(
+            &data_exprs[0],
+            &gen_simple_equals_filter_expected("body", "example /* comment */")
+        );
     }
 }

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser.rs
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser.rs
@@ -101,6 +101,11 @@ pub(crate) fn invalid_child_rule_error(
 
 #[cfg(test)]
 mod test {
+    use data_engine_expressions::{
+        DataExpression, DiscardDataExpression, EqualToLogicalExpression, LogicalExpression,
+        NotLogicalExpression, QueryLocation, ScalarExpression, SourceScalarExpression,
+        StaticScalarExpression, StringScalarExpression, ValueAccessor,
+    };
     use data_engine_parser_abstractions::Parser;
 
     use super::OplParser;
@@ -125,5 +130,76 @@ mod test {
                 .to_string()
                 .contains("supplied in query is not supported")
         );
+    }
+
+    #[test]
+    fn test_parse_comments() {
+        let programs = [
+            // simple with inline comment
+            "
+            // inline comment
+            logs | where severity_text == \"ERROR\"
+            ",
+            // many inline comments
+            "
+            // inline comment
+            logs | 
+            // yet another inline comment before operator
+            where severity_text == \"ERROR\"  // comment end of line
+            // comment End of program
+            ",
+            // simple block comment
+            "
+            /*
+              block comment
+            */
+            logs | where severity_text == \"ERROR\"
+            ",
+            // many block comments
+            "
+            /* start of program comment */
+            logs /* end of line comment */ 
+            /* start of line comment */ | where severity_text /* another */ == \"ERROR\" /* hello */
+            /* 
+            end of program comment 
+            */
+            ",
+        ];
+
+        for program in programs {
+            let result = OplParser::parse(program).unwrap();
+
+            // expect we've only parsed the one expression, despite the comments
+            let data_exprs = result.pipeline.get_expressions();
+            assert_eq!(data_exprs.len(), 1);
+            pretty_assertions::assert_eq!(
+                &data_exprs[0],
+                &DataExpression::Discard(
+                    DiscardDataExpression::new(QueryLocation::new_fake()).with_predicate(
+                        LogicalExpression::Not(NotLogicalExpression::new(
+                            QueryLocation::new_fake(),
+                            LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                                QueryLocation::new_fake(),
+                                ScalarExpression::Source(SourceScalarExpression::new(
+                                    QueryLocation::new_fake(),
+                                    ValueAccessor::new_with_selectors(vec![
+                                        ScalarExpression::Static(StaticScalarExpression::String(
+                                            StringScalarExpression::new(
+                                                QueryLocation::new_fake(),
+                                                "severity_text",
+                                            )
+                                        ),)
+                                    ]),
+                                )),
+                                ScalarExpression::Static(StaticScalarExpression::String(
+                                    StringScalarExpression::new(QueryLocation::new_fake(), "ERROR"),
+                                )),
+                                false,
+                            )),
+                        )),
+                    ),
+                )
+            );
+        }
     }
 }

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser.rs
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser.rs
@@ -188,7 +188,7 @@ mod test {
                                                 QueryLocation::new_fake(),
                                                 "severity_text",
                                             )
-                                        ),)
+                                        ))
                                     ]),
                                 )),
                                 ScalarExpression::Static(StaticScalarExpression::String(


### PR DESCRIPTION
# Change Summary

<!--
Replace with a brief summary of the change in this PR
-->

Adds support for comments in OPL programs. Both inline comments (`//`) and block comments (`/* ... */`) are supported

## What issue does this PR close?

<!--
We highly recommend correlation of every PR to an issue
-->

* Closes https://github.com/open-telemetry/otel-arrow/issues/3151

## How are these changes tested?

Unit

## Are there any user-facing changes?

Yes - this comment syntax is now available for OPL programs written in the transform processor config.

 <!-- If yes, provide further info below -->

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
