### PR TITLE
feat(observability): Add a general mechanism for defining instrumentation-scope metric attributes

### DIFF
--- a/rust/otap-dataflow/.chloggen/scope-attribute-plumbing.yaml
+++ b/rust/otap-dataflow/.chloggen/scope-attribute-plumbing.yaml
@@ -1,0 +1,19 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: observability
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add a mechanism to declare attributes as OpenTelemetry instrumentation-scope attributes via `#[attribute(key = "...", scope)]`, so the metrics dispatcher emits them on the meter scope rather than on each data point.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [2859]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/rust/otap-dataflow/.chloggen/scope-attribute-plumbing.yaml
+++ b/rust/otap-dataflow/.chloggen/scope-attribute-plumbing.yaml
@@ -8,7 +8,7 @@ change_type: enhancement
 component: observability
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add a mechanism to declare attributes as OpenTelemetry instrumentation-scope attributes via `#[attribute(key = "...", scope)]`, so the metrics dispatcher emits them on the meter scope rather than on each data point.
+note: Add a mechanism to declare attributes as OpenTelemetry instrumentation-scope attributes via `#[attribute_set(name = "...", scope)]`, so the metrics dispatcher emits them on the meter scope rather than on each data point.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [2859]

--- a/rust/otap-dataflow/benchmarks/benches/self_tracing/main.rs
+++ b/rust/otap-dataflow/benchmarks/benches/self_tracing/main.rs
@@ -48,6 +48,7 @@ static BENCH_SCOPE_ATTRIBUTES_DESCRIPTOR: AttributesDescriptor = AttributesDescr
             brief: "CPU ID",
         },
     ],
+    scope_keys: &[],
 };
 
 /// Mock attribute set for benchmarking scope attributes.

--- a/rust/otap-dataflow/crates/admin/src/telemetry.rs
+++ b/rust/otap-dataflow/crates/admin/src/telemetry.rs
@@ -2541,6 +2541,7 @@ mod tests {
                     brief: "Region",
                 },
             ],
+            scope_keys: &[],
         };
 
         #[derive(Debug)]
@@ -3480,6 +3481,7 @@ mod tests {
             r#type: AttributeValueType::String,
             brief: "HTTP method",
         }],
+        scope_keys: &[],
     };
 
     impl MetricSetHandler for E2eMetricSet {

--- a/rust/otap-dataflow/crates/engine/src/attributes.rs
+++ b/rust/otap-dataflow/crates/engine/src/attributes.rs
@@ -190,6 +190,7 @@ static CUSTOM_ATTRIBUTES_DESCRIPTOR: AttributesDescriptor = AttributesDescriptor
         brief: "Custom user-defined attributes",
         r#type: AttributeValueType::Map,
     }],
+    scope_keys: &[],
 };
 
 impl CustomAttributeSet {

--- a/rust/otap-dataflow/crates/engine/src/attributes.rs
+++ b/rust/otap-dataflow/crates/engine/src/attributes.rs
@@ -245,3 +245,90 @@ pub struct ChannelAttributeSet {
     #[attribute(key = "channel.impl")]
     pub channel_impl: Cow<'static, str>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A dedicated scope-level attribute set: every key it declares is emitted
+    /// on the OpenTelemetry instrumentation scope.
+    #[attribute_set(name = "test.scope.attrs", scope)]
+    #[derive(Debug, Clone, Default, Hash)]
+    struct ScopeOnlyAttributeSet {
+        #[attribute(key = "test.purpose")]
+        purpose: Cow<'static, str>,
+        #[attribute(key = "test.flavor")]
+        flavor: Cow<'static, str>,
+    }
+
+    /// A regular (data-point) attribute set that composes the scope set.
+    #[attribute_set(name = "test.mixed.attrs")]
+    #[derive(Debug, Clone, Default, Hash)]
+    struct MixedAttributeSet {
+        #[attribute(key = "test.id")]
+        id: Cow<'static, str>,
+        #[compose]
+        scope: ScopeOnlyAttributeSet,
+    }
+
+    #[test]
+    fn scope_set_marks_all_its_keys() {
+        let set = ScopeOnlyAttributeSet::default();
+        let scope_keys = set.descriptor().scope_keys;
+        assert_eq!(scope_keys.len(), 2);
+        assert!(scope_keys.contains(&"test.purpose"));
+        assert!(scope_keys.contains(&"test.flavor"));
+        assert!(set.is_scope_attribute("test.purpose"));
+        assert!(set.is_scope_attribute("test.flavor"));
+    }
+
+    #[test]
+    fn composing_set_inherits_only_scope_keys() {
+        let set = MixedAttributeSet::default();
+        let scope_keys = set.descriptor().scope_keys;
+
+        // The composed scope set's keys are scope-level.
+        assert_eq!(scope_keys.len(), 2);
+        assert!(scope_keys.contains(&"test.purpose"));
+        assert!(scope_keys.contains(&"test.flavor"));
+
+        // The composing set's own field is a data-point attribute, not a scope key.
+        assert!(!scope_keys.contains(&"test.id"));
+        assert!(set.is_scope_attribute("test.purpose"));
+        assert!(!set.is_scope_attribute("test.id"));
+    }
+
+    /// A non-scope set composed into a `scope`-marked parent: the parent's own
+    /// keys are scope-level, but the composed child's keys are governed by the
+    /// child's (absent) marker and remain data-point attributes.
+    #[attribute_set(name = "test.data.attrs")]
+    #[derive(Debug, Clone, Default, Hash)]
+    struct DataOnlyAttributeSet {
+        #[attribute(key = "test.detail")]
+        detail: Cow<'static, str>,
+    }
+
+    #[attribute_set(name = "test.scope.parent.attrs", scope)]
+    #[derive(Debug, Clone, Default, Hash)]
+    struct ScopeParentAttributeSet {
+        #[attribute(key = "test.region")]
+        region: Cow<'static, str>,
+        #[compose]
+        data: DataOnlyAttributeSet,
+    }
+
+    #[test]
+    fn scope_marked_parent_does_not_promote_composed_child() {
+        let set = ScopeParentAttributeSet::default();
+        let scope_keys = set.descriptor().scope_keys;
+
+        // Parent's own key is scope-level.
+        assert!(scope_keys.contains(&"test.region"));
+        assert!(set.is_scope_attribute("test.region"));
+
+        // Composed non-scope child's key stays a data-point attribute.
+        assert!(!scope_keys.contains(&"test.detail"));
+        assert!(!set.is_scope_attribute("test.detail"));
+        assert_eq!(scope_keys.len(), 1);
+    }
+}

--- a/rust/otap-dataflow/crates/telemetry-macros/src/lib.rs
+++ b/rust/otap-dataflow/crates/telemetry-macros/src/lib.rs
@@ -325,6 +325,8 @@ pub fn derive_metric_set_handler(input: TokenStream) -> TokenStream {
 ///   - `#[attributes(name = "my.attributes.name")]`
 ///     Field attributes:
 ///   - `#[attribute(key = "field.key")]` (optional, defaults to field name with dots)
+///   - `#[attribute(key = "field.key", scope)]` to emit the attribute on the
+///     OpenTelemetry instrumentation scope instead of on each data point
 ///   - `#[compose]` for fields that implement AttributeSetHandler
 #[proc_macro_derive(AttributeSetHandler, attributes(attributes, attribute, compose))]
 pub fn derive_attribute_set_handler(input: TokenStream) -> TokenStream {
@@ -413,6 +415,7 @@ pub fn derive_attribute_set_handler(input: TokenStream) -> TokenStream {
     let mut attr_field_descriptions = Vec::new();
     let mut attr_field_types: Vec<proc_macro2::TokenStream> = Vec::new();
     let mut attr_iter_values: Vec<proc_macro2::TokenStream> = Vec::new();
+    let mut attr_field_scope_keys: Vec<String> = Vec::new();
 
     let mut composed_field_idents = Vec::new();
 
@@ -478,6 +481,13 @@ pub fn derive_attribute_set_handler(input: TokenStream) -> TokenStream {
         }
         let derived_key = ident.to_string().replace('_', ".");
         let final_key = key_attr.unwrap_or(derived_key);
+
+        // Detect `#[attribute(..., scope)]` to mark this attribute as a
+        // scope-level (instrumentation-scope) attribute.
+        let is_scope_field = field.attrs.iter().any(parse_attribute_field_is_scope);
+        if is_scope_field {
+            attr_field_scope_keys.push(final_key.clone());
+        }
 
         // Determine attribute value type based on field type
         let (attr_type, iter_value) = match &field.ty {
@@ -555,6 +565,9 @@ pub fn derive_attribute_set_handler(input: TokenStream) -> TokenStream {
 
     let desc_ident = format_ident!("ATTRIBUTES_DESCRIPTOR");
 
+    // Local scope-attribute keys (from `#[attribute(key = "...", scope)]`).
+    let local_scope_keys = &attr_field_scope_keys;
+
     // Generate the descriptor and iterator implementation
     if composed_field_idents.is_empty() {
         // Simple case: no composition - keep the original approach
@@ -570,6 +583,7 @@ pub fn derive_attribute_set_handler(input: TokenStream) -> TokenStream {
                                 r#type: #attr_field_types
                             } ),*
                         ],
+                        scope_keys: &[ #( #local_scope_keys ),* ],
                     };
                     &#desc_ident
                 }
@@ -636,9 +650,17 @@ pub fn derive_attribute_set_handler(input: TokenStream) -> TokenStream {
                             // Leak the vector to get a 'static reference
                             let fields_slice: &'static [#field_path] = ::std::boxed::Box::leak(all_fields.into_boxed_slice());
 
+                            // Merge local scope keys with those of composed sets.
+                            let mut all_scope_keys: ::std::vec::Vec<&'static str> =
+                                ::std::vec![ #( #local_scope_keys ),* ];
+                            #( all_scope_keys.extend_from_slice(dummy.#composed_field_idents.descriptor().scope_keys); )*
+                            let scope_keys_slice: &'static [&'static str] =
+                                ::std::boxed::Box::leak(all_scope_keys.into_boxed_slice());
+
                             #desc_ident = Some(#descriptor_path {
                                 name: #attributes_name,
                                 fields: fields_slice,
+                                scope_keys: scope_keys_slice,
                             });
                         });
 
@@ -864,4 +886,24 @@ fn parse_attribute_field_attr(attr: &Attribute) -> Option<String> {
         Ok(())
     });
     out
+}
+
+/// Returns `true` when a field is marked as a scope-level attribute via
+/// `#[attribute(key = "...", scope)]`. Scope attributes are emitted on the
+/// OpenTelemetry instrumentation scope rather than as data-point attributes.
+fn parse_attribute_field_is_scope(attr: &Attribute) -> bool {
+    if !attr.path().is_ident("attribute") {
+        return false;
+    }
+    let mut is_scope = false;
+    let _ = attr.parse_nested_meta(|meta| {
+        if meta.path.is_ident("scope") {
+            is_scope = true;
+        } else if meta.path.is_ident("key") {
+            // Consume the `key = "..."` value so nested-meta parsing succeeds.
+            let _: LitStr = meta.value()?.parse()?;
+        }
+        Ok(())
+    });
+    is_scope
 }

--- a/rust/otap-dataflow/crates/telemetry-macros/src/lib.rs
+++ b/rust/otap-dataflow/crates/telemetry-macros/src/lib.rs
@@ -323,10 +323,20 @@ pub fn derive_metric_set_handler(input: TokenStream) -> TokenStream {
 ///
 /// Container attribute:
 ///   - `#[attributes(name = "my.attributes.name")]`
+///   - `#[attributes(name = "my.attributes.name", scope)]` marks every
+///     attribute the set itself declares as an OpenTelemetry
+///     instrumentation-scope attribute (emitted on the scope rather than on
+///     each data point). Composed sets are governed by their own marker, not
+///     the parent's: a non-scope set keeps its own keys as data-point
+///     attributes even when composed into a `scope`-marked parent. Usually a
+///     small dedicated scope set is `#[compose]`d into a parent.
+///     Reach for `scope` when a value must be targetable by OpenTelemetry View
+///     selectors; in the engine it offers no perf/cardinality benefit over a
+///     data-point attribute, and moving an attribute between scope and
+///     data-point is a breaking change. See
+///     `docs/telemetry/attributes-guide.md` ("Scope vs. data-point attributes").
 ///     Field attributes:
 ///   - `#[attribute(key = "field.key")]` (optional, defaults to field name with dots)
-///   - `#[attribute(key = "field.key", scope)]` to emit the attribute on the
-///     OpenTelemetry instrumentation scope instead of on each data point
 ///   - `#[compose]` for fields that implement AttributeSetHandler
 #[proc_macro_derive(AttributeSetHandler, attributes(attributes, attribute, compose))]
 pub fn derive_attribute_set_handler(input: TokenStream) -> TokenStream {
@@ -337,10 +347,14 @@ pub fn derive_attribute_set_handler(input: TokenStream) -> TokenStream {
     let generics = input.generics.clone();
 
     let mut attributes_name: Option<String> = None;
+    let mut attributes_is_scope = false;
 
     for attr in &input.attrs {
         if let Some(name) = parse_attributes_name_attr(attr) {
             attributes_name = Some(name);
+        }
+        if parse_attributes_is_scope(attr) {
+            attributes_is_scope = true;
         }
     }
     let attributes_name = match attributes_name {
@@ -415,7 +429,6 @@ pub fn derive_attribute_set_handler(input: TokenStream) -> TokenStream {
     let mut attr_field_descriptions = Vec::new();
     let mut attr_field_types: Vec<proc_macro2::TokenStream> = Vec::new();
     let mut attr_iter_values: Vec<proc_macro2::TokenStream> = Vec::new();
-    let mut attr_field_scope_keys: Vec<String> = Vec::new();
 
     let mut composed_field_idents = Vec::new();
 
@@ -481,13 +494,6 @@ pub fn derive_attribute_set_handler(input: TokenStream) -> TokenStream {
         }
         let derived_key = ident.to_string().replace('_', ".");
         let final_key = key_attr.unwrap_or(derived_key);
-
-        // Detect `#[attribute(..., scope)]` to mark this attribute as a
-        // scope-level (instrumentation-scope) attribute.
-        let is_scope_field = field.attrs.iter().any(parse_attribute_field_is_scope);
-        if is_scope_field {
-            attr_field_scope_keys.push(final_key.clone());
-        }
 
         // Determine attribute value type based on field type
         let (attr_type, iter_value) = match &field.ty {
@@ -565,8 +571,15 @@ pub fn derive_attribute_set_handler(input: TokenStream) -> TokenStream {
 
     let desc_ident = format_ident!("ATTRIBUTES_DESCRIPTOR");
 
-    // Local scope-attribute keys (from `#[attribute(key = "...", scope)]`).
-    let local_scope_keys = &attr_field_scope_keys;
+    // When the set is marked `#[attribute_set(..., scope)]`, every attribute it
+    // declares is a scope-level attribute; otherwise it contributes none of its
+    // own (composed sets still contribute their own scope keys below).
+    let local_scope_keys: Vec<String> = if attributes_is_scope {
+        attr_field_keys.clone()
+    } else {
+        Vec::new()
+    };
+    let local_scope_keys = &local_scope_keys;
 
     // Generate the descriptor and iterator implementation
     if composed_field_idents.is_empty() {
@@ -650,10 +663,15 @@ pub fn derive_attribute_set_handler(input: TokenStream) -> TokenStream {
                             // Leak the vector to get a 'static reference
                             let fields_slice: &'static [#field_path] = ::std::boxed::Box::leak(all_fields.into_boxed_slice());
 
-                            // Merge local scope keys with those of composed sets.
+                            // Merge local scope keys with those of composed sets,
+                            // de-duplicating so a key shared across a parent and
+                            // a composed child (or composed twice) yields a
+                            // canonical scope-key set.
                             let mut all_scope_keys: ::std::vec::Vec<&'static str> =
                                 ::std::vec![ #( #local_scope_keys ),* ];
                             #( all_scope_keys.extend_from_slice(dummy.#composed_field_idents.descriptor().scope_keys); )*
+                            all_scope_keys.sort_unstable();
+                            all_scope_keys.dedup();
                             let scope_keys_slice: &'static [&'static str] =
                                 ::std::boxed::Box::leak(all_scope_keys.into_boxed_slice());
 
@@ -772,19 +790,30 @@ pub fn metric_set(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// Usage:
 ///   #[otap_df_telemetry_macros::attribute_set(name = "my.attributes")]
 ///   pub struct MyAttributes { #[attribute(key = "custom.key")] field: String, ... }
+///
+/// Add the `scope` flag to declare that every attribute in the set is emitted
+/// on the OpenTelemetry instrumentation scope rather than as a data-point
+/// attribute (typically a small set `#[compose]`d into a parent):
+///   #[otap_df_telemetry_macros::attribute_set(name = "my.scope.attrs", scope)]
 #[proc_macro_attribute]
 pub fn attribute_set(attr: TokenStream, item: TokenStream) -> TokenStream {
     // Parse name argument
     let args = proc_macro2::TokenStream::from(attr);
     let mut name_val: Option<String> = None;
+    let mut scope_val = false;
     if let Err(err) = syn::parse::Parser::parse2(
         |input: syn::parse::ParseStream<'_>| -> syn::Result<()> {
             while !input.is_empty() {
                 let ident: syn::Ident = input.parse()?;
-                let _: syn::Token![=] = input.parse()?;
-                let lit: LitStr = input.parse()?;
-                if ident == "name" {
-                    name_val = Some(lit.value());
+                if ident == "scope" {
+                    // Bare flag: the whole set is scope-level.
+                    scope_val = true;
+                } else {
+                    let _: syn::Token![=] = input.parse()?;
+                    let lit: LitStr = input.parse()?;
+                    if ident == "name" {
+                        name_val = Some(lit.value());
+                    }
                 }
                 if input.peek(syn::Token![,]) {
                     let _: syn::Token![,] = input.parse()?;
@@ -817,8 +846,14 @@ pub fn attribute_set(attr: TokenStream, item: TokenStream) -> TokenStream {
         parse_quote!(#[derive(otap_df_telemetry_macros::AttributeSetHandler)]);
     s.attrs.push(derive_attr);
 
-    // Add container descriptor attribute consumed by the derive
-    let attributes_attr: Attribute = parse_quote!(#[attributes(name = #attributes_name)]);
+    // Add container descriptor attribute consumed by the derive. Forward the
+    // set-level `scope` designation so the derive can mark every key as a
+    // scope attribute.
+    let attributes_attr: Attribute = if scope_val {
+        parse_quote!(#[attributes(name = #attributes_name, scope)])
+    } else {
+        parse_quote!(#[attributes(name = #attributes_name)])
+    };
     s.attrs.push(attributes_attr);
 
     quote!( #s ).into()
@@ -867,10 +902,33 @@ fn parse_attributes_name_attr(attr: &Attribute) -> Option<String> {
         if meta.path.is_ident("name") {
             let s: LitStr = meta.value()?.parse()?;
             out = Some(s.value());
+        } else if meta.path.is_ident("scope") {
+            // Bare flag handled by `parse_attributes_is_scope`; nothing to consume.
         }
         Ok(())
     });
     out
+}
+
+/// Returns `true` when an `#[attributes(name = "...", scope)]` container marks
+/// the whole set as scope-level. Every attribute the set declares is then
+/// emitted on the OpenTelemetry instrumentation scope rather than as a
+/// data-point attribute.
+fn parse_attributes_is_scope(attr: &Attribute) -> bool {
+    if !attr.path().is_ident("attributes") {
+        return false;
+    }
+    let mut is_scope = false;
+    let _ = attr.parse_nested_meta(|meta| {
+        if meta.path.is_ident("scope") {
+            is_scope = true;
+        } else if meta.path.is_ident("name") {
+            // Consume the `name = "..."` value so nested-meta parsing succeeds.
+            let _: LitStr = meta.value()?.parse()?;
+        }
+        Ok(())
+    });
+    is_scope
 }
 
 fn parse_attribute_field_attr(attr: &Attribute) -> Option<String> {
@@ -886,24 +944,4 @@ fn parse_attribute_field_attr(attr: &Attribute) -> Option<String> {
         Ok(())
     });
     out
-}
-
-/// Returns `true` when a field is marked as a scope-level attribute via
-/// `#[attribute(key = "...", scope)]`. Scope attributes are emitted on the
-/// OpenTelemetry instrumentation scope rather than as data-point attributes.
-fn parse_attribute_field_is_scope(attr: &Attribute) -> bool {
-    if !attr.path().is_ident("attribute") {
-        return false;
-    }
-    let mut is_scope = false;
-    let _ = attr.parse_nested_meta(|meta| {
-        if meta.path.is_ident("scope") {
-            is_scope = true;
-        } else if meta.path.is_ident("key") {
-            // Consume the `key = "..."` value so nested-meta parsing succeeds.
-            let _: LitStr = meta.value()?.parse()?;
-        }
-        Ok(())
-    });
-    is_scope
 }

--- a/rust/otap-dataflow/crates/telemetry/src/attributes.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/attributes.rs
@@ -125,10 +125,10 @@ pub trait AttributeSetHandler {
     /// OpenTelemetry instrumentation scope rather than as a data-point attribute.
     ///
     /// Backed by the static descriptor's `scope_keys`, which the
-    /// `#[derive(AttributeSetHandler)]` macro populates from fields marked
-    /// `#[attribute(key = "...", scope)]`. Because this reads the descriptor, it
-    /// keeps working through type-erased wrappers (e.g. `EntityAttributeSet`)
-    /// that carry the original `&'static` descriptor.
+    /// `#[derive(AttributeSetHandler)]` macro populates from attribute sets
+    /// marked `#[attribute_set(name = "...", scope)]`. Because this reads the
+    /// descriptor, it keeps working through type-erased wrappers (e.g.
+    /// `EntityAttributeSet`) that carry the original `&'static` descriptor.
     fn is_scope_attribute(&self, key: &str) -> bool {
         self.descriptor().scope_keys.contains(&key)
     }

--- a/rust/otap-dataflow/crates/telemetry/src/attributes.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/attributes.rs
@@ -121,6 +121,18 @@ pub trait AttributeSetHandler {
         AttributeIterator::new(self.descriptor().fields, self.attribute_values())
     }
 
+    /// Returns `true` if the given attribute key should be emitted on the
+    /// OpenTelemetry instrumentation scope rather than as a data-point attribute.
+    ///
+    /// Backed by the static descriptor's `scope_keys`, which the
+    /// `#[derive(AttributeSetHandler)]` macro populates from fields marked
+    /// `#[attribute(key = "...", scope)]`. Because this reads the descriptor, it
+    /// keeps working through type-erased wrappers (e.g. `EntityAttributeSet`)
+    /// that carry the original `&'static` descriptor.
+    fn is_scope_attribute(&self, key: &str) -> bool {
+        self.descriptor().scope_keys.contains(&key)
+    }
+
     /// Returns the schema name for this attribute set (e.g., "pipeline.attrs").
     fn schema_name(&self) -> &'static str {
         self.descriptor().name
@@ -429,6 +441,7 @@ mod tests {
                 r#type: AttributeValueType::String,
                 brief: "Test attribute",
             }],
+            scope_keys: &[],
         };
 
         impl AttributeSetHandler for TestAttributeSet {

--- a/rust/otap-dataflow/crates/telemetry/src/collector.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/collector.rs
@@ -157,6 +157,7 @@ mod tests {
             r#type: AttributeValueType::String,
             brief: "Test attribute",
         }],
+        scope_keys: &[],
     };
 
     impl MetricSetHandler for MockMetricSet {

--- a/rust/otap-dataflow/crates/telemetry/src/descriptor.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/descriptor.rs
@@ -108,8 +108,8 @@ pub struct AttributesDescriptor {
     pub fields: &'static [AttributeField],
     /// Keys of attributes that must be emitted on the OpenTelemetry
     /// instrumentation scope rather than as data-point attributes. Populated by
-    /// the `#[derive(AttributeSetHandler)]` macro from fields marked
-    /// `#[attribute(key = "...", scope)]` (composed sets contribute their own
-    /// scope keys). Empty when the set has no scope-level attributes.
+    /// the `#[derive(AttributeSetHandler)]` macro from attribute sets marked
+    /// `#[attribute_set(name = "...", scope)]` (composed sets contribute their
+    /// own scope keys). Empty when the set has no scope-level attributes.
     pub scope_keys: &'static [&'static str],
 }

--- a/rust/otap-dataflow/crates/telemetry/src/descriptor.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/descriptor.rs
@@ -106,4 +106,10 @@ pub struct AttributesDescriptor {
     pub name: &'static str,
     /// Ordered attribute field metadata.
     pub fields: &'static [AttributeField],
+    /// Keys of attributes that must be emitted on the OpenTelemetry
+    /// instrumentation scope rather than as data-point attributes. Populated by
+    /// the `#[derive(AttributeSetHandler)]` macro from fields marked
+    /// `#[attribute(key = "...", scope)]` (composed sets contribute their own
+    /// scope keys). Empty when the set has no scope-level attributes.
+    pub scope_keys: &'static [&'static str],
 }

--- a/rust/otap-dataflow/crates/telemetry/src/entity.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/entity.rs
@@ -136,11 +136,20 @@ impl Hash for EntityAttributeSet {
         // Mirror the `PartialEq` treatment of `scope_keys` so the scope/data-point
         // designation survives registry de-duplication. Hash in sorted order to
         // stay consistent with the order-independent equality comparison.
-        let mut scope_keys: Vec<&'static str> = self.descriptor.scope_keys.to_vec();
-        scope_keys.sort_unstable();
+        let scope_keys = self.descriptor.scope_keys;
         scope_keys.len().hash(state);
-        for key in scope_keys {
-            key.hash(state);
+        match scope_keys.len() {
+            // Fast paths: empty and single-element sets need no allocation or
+            // sorting (ordering is irrelevant), which matters on registry lookups.
+            0 => {}
+            1 => scope_keys[0].hash(state),
+            _ => {
+                let mut sorted: Vec<&'static str> = scope_keys.to_vec();
+                sorted.sort_unstable();
+                for key in sorted {
+                    key.hash(state);
+                }
+            }
         }
     }
 }
@@ -316,6 +325,15 @@ fn attribute_value_equal(left: &AttributeValue, right: &AttributeValue) -> bool 
 fn scope_keys_equal(left: &[&'static str], right: &[&'static str]) -> bool {
     if left.len() != right.len() {
         return false;
+    }
+    // Fast paths for the common cases on the registry hot path: identical
+    // slices (e.g. the same `&'static` descriptor), empty, and single-element
+    // sets need no allocation or sorting.
+    if std::ptr::eq(left, right) || left.is_empty() {
+        return true;
+    }
+    if left.len() == 1 {
+        return left[0] == right[0];
     }
     let mut left_sorted: Vec<&'static str> = left.to_vec();
     let mut right_sorted: Vec<&'static str> = right.to_vec();

--- a/rust/otap-dataflow/crates/telemetry/src/entity.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/entity.rs
@@ -87,6 +87,15 @@ impl PartialEq for EntityAttributeSet {
             return false;
         }
 
+        // `scope_keys` is part of the semantic identity of an attribute set:
+        // two sets with identical fields/values but different scope designations
+        // must not be de-duplicated, otherwise a scope attribute could be emitted
+        // as a data-point attribute (or vice versa) after type erasure. Compare
+        // order-independently since the field order is not significant here.
+        if !scope_keys_equal(self.descriptor.scope_keys, other.descriptor.scope_keys) {
+            return false;
+        }
+
         self.sorted_indices
             .iter()
             .zip(other.sorted_indices.iter())
@@ -122,6 +131,16 @@ impl Hash for EntityAttributeSet {
             attribute_value_type_rank(field.r#type).hash(state);
             let value = &self.values[*idx];
             hash_attribute_value(value, state);
+        }
+
+        // Mirror the `PartialEq` treatment of `scope_keys` so the scope/data-point
+        // designation survives registry de-duplication. Hash in sorted order to
+        // stay consistent with the order-independent equality comparison.
+        let mut scope_keys: Vec<&'static str> = self.descriptor.scope_keys.to_vec();
+        scope_keys.sort_unstable();
+        scope_keys.len().hash(state);
+        for key in scope_keys {
+            key.hash(state);
         }
     }
 }
@@ -293,6 +312,18 @@ fn attribute_value_equal(left: &AttributeValue, right: &AttributeValue) -> bool 
     }
 }
 
+/// Compares two scope-key slices for set equality, ignoring ordering.
+fn scope_keys_equal(left: &[&'static str], right: &[&'static str]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    let mut left_sorted: Vec<&'static str> = left.to_vec();
+    let mut right_sorted: Vec<&'static str> = right.to_vec();
+    left_sorted.sort_unstable();
+    right_sorted.sort_unstable();
+    left_sorted == right_sorted
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -306,6 +337,7 @@ mod tests {
             r#type: AttributeValueType::String,
             brief: "Test attribute",
         }],
+        scope_keys: &[],
     };
 
     #[derive(Debug)]
@@ -360,6 +392,7 @@ mod tests {
                     brief: "beta",
                 },
             ],
+            scope_keys: &[],
         };
 
         static DESCRIPTOR_B: AttributesDescriptor = AttributesDescriptor {
@@ -376,6 +409,7 @@ mod tests {
                     brief: "alpha",
                 },
             ],
+            scope_keys: &[],
         };
 
         #[derive(Debug)]
@@ -430,6 +464,88 @@ mod tests {
     }
 
     #[test]
+    fn test_scope_keys_prevent_dedup() {
+        // Two descriptors with identical fields and values, differing only in
+        // which key is designated as a scope-level attribute. They must NOT be
+        // de-duplicated, otherwise a scope attribute could be emitted as a
+        // data-point attribute (or vice versa) after type erasure.
+        static DESCRIPTOR_UNSCOPED: AttributesDescriptor = AttributesDescriptor {
+            name: "unscoped",
+            fields: &[AttributeField {
+                key: "alpha",
+                r#type: AttributeValueType::String,
+                brief: "alpha",
+            }],
+            scope_keys: &[],
+        };
+
+        static DESCRIPTOR_SCOPED: AttributesDescriptor = AttributesDescriptor {
+            name: "scoped",
+            fields: &[AttributeField {
+                key: "alpha",
+                r#type: AttributeValueType::String,
+                brief: "alpha",
+            }],
+            scope_keys: &["alpha"],
+        };
+
+        #[derive(Debug)]
+        struct Unscoped {
+            values: Vec<AttributeValue>,
+        }
+
+        #[derive(Debug)]
+        struct Scoped {
+            values: Vec<AttributeValue>,
+        }
+
+        impl AttributeSetHandler for Unscoped {
+            fn descriptor(&self) -> &'static AttributesDescriptor {
+                &DESCRIPTOR_UNSCOPED
+            }
+
+            fn attribute_values(&self) -> &[AttributeValue] {
+                &self.values
+            }
+        }
+
+        impl AttributeSetHandler for Scoped {
+            fn descriptor(&self) -> &'static AttributesDescriptor {
+                &DESCRIPTOR_SCOPED
+            }
+
+            fn attribute_values(&self) -> &[AttributeValue] {
+                &self.values
+            }
+        }
+
+        let mut registry = EntityRegistry::default();
+
+        let outcome1 = registry.register(Unscoped {
+            values: vec![AttributeValue::String("value".to_string())],
+        });
+        assert!(matches!(outcome1, RegisterOutcome::Created(_)));
+
+        let outcome2 = registry.register(Scoped {
+            values: vec![AttributeValue::String("value".to_string())],
+        });
+        assert!(matches!(outcome2, RegisterOutcome::Created(_)));
+
+        let key1 = outcome1.key();
+        let key2 = outcome2.key();
+        assert_ne!(key1, key2);
+        assert_eq!(registry.len(), 2);
+
+        // Registering the same scoped set again should reuse the scoped entry.
+        let outcome3 = registry.register(Scoped {
+            values: vec![AttributeValue::String("value".to_string())],
+        });
+        assert!(matches!(outcome3, RegisterOutcome::Existing(_)));
+        assert_eq!(key2, outcome3.key());
+        assert_eq!(registry.len(), 2);
+    }
+
+    #[test]
     fn test_get_attributes() {
         let mut registry = EntityRegistry::default();
 
@@ -462,5 +578,68 @@ mod tests {
         assert_eq!(registry.len(), 0);
         assert!(registry.get_shared(key).is_none());
         assert!(!registry.unregister(key));
+    }
+
+    // Regression: scope-attribute designation must survive type erasure through
+    // `EntityAttributeSet`. The registry stores attribute sets as
+    // `EntityAttributeSet` (descriptor + values), discarding the original
+    // concrete type. Because `is_scope_attribute` is backed by the static
+    // descriptor's `scope_keys`, the type-erased entity must still report which
+    // attributes belong on the instrumentation scope.
+    #[test]
+    fn test_scope_attribute_survives_type_erasure() {
+        static SCOPED_DESCRIPTOR: AttributesDescriptor = AttributesDescriptor {
+            name: "scoped_attrs",
+            fields: &[
+                AttributeField {
+                    key: "data.point.key",
+                    r#type: AttributeValueType::String,
+                    brief: "a data-point attribute",
+                },
+                AttributeField {
+                    key: "scope.key",
+                    r#type: AttributeValueType::String,
+                    brief: "a scope-level attribute",
+                },
+            ],
+            scope_keys: &["scope.key"],
+        };
+
+        #[derive(Debug)]
+        struct ScopedAttributeSet {
+            values: Vec<AttributeValue>,
+        }
+
+        impl AttributeSetHandler for ScopedAttributeSet {
+            fn descriptor(&self) -> &'static AttributesDescriptor {
+                &SCOPED_DESCRIPTOR
+            }
+
+            fn attribute_values(&self) -> &[AttributeValue] {
+                &self.values
+            }
+        }
+
+        let mut registry = EntityRegistry::default();
+        let key = registry
+            .register(ScopedAttributeSet {
+                values: vec![
+                    AttributeValue::String("dp".to_string()),
+                    AttributeValue::String("sc".to_string()),
+                ],
+            })
+            .key();
+
+        // `get` returns the type-erased `EntityAttributeSet`.
+        let erased = registry.get(key).expect("missing attributes");
+        assert!(
+            erased.is_scope_attribute("scope.key"),
+            "scope attribute should survive type erasure"
+        );
+        assert!(
+            !erased.is_scope_attribute("data.point.key"),
+            "data-point attribute must not be reported as scope-level"
+        );
+        assert!(!erased.is_scope_attribute("unknown.key"));
     }
 }

--- a/rust/otap-dataflow/crates/telemetry/src/metrics.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/metrics.rs
@@ -604,6 +604,7 @@ mod tests {
             r#type: AttributeValueType::String,
             brief: "Test attribute",
         }],
+        scope_keys: &[],
     };
 
     impl MetricSetHandler for MockMetricSet {

--- a/rust/otap-dataflow/crates/telemetry/src/metrics/dispatcher.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/metrics/dispatcher.rs
@@ -60,8 +60,9 @@ impl MetricsDispatcher {
         self.metrics_handler
             .visit_metrics_and_reset(|descriptor, attributes, metrics_iter| {
                 // Split the entity's attributes into instrumentation-scope
-                // attributes (those the attribute set marks `#[attribute(...,
-                // scope)]`) and data-point attributes.
+                // attributes (those declared by a set marked
+                // `#[attribute_set(name = "...", scope)]`) and data-point
+                // attributes.
                 // Scope attributes are attached to the meter so View selectors
                 // keyed on scope attributes can match the emitted metrics.
                 let (scope_attributes, datapoint_attributes) =
@@ -90,7 +91,7 @@ impl MetricsDispatcher {
     /// Split an entity's attributes into `(scope, data_point)` OpenTelemetry
     /// attributes in a single pass. An attribute is scope-level when the
     /// attribute set declares it so via [`AttributeSetHandler::is_scope_attribute`]
-    /// (driven by `#[attribute(key = "...", scope)]`); everything else is a
+    /// (driven by `#[attribute_set(name = "...", scope)]`); everything else is a
     /// data-point attribute.
     ///
     /// Scope attributes with an empty string value are omitted entirely (pushed
@@ -102,10 +103,27 @@ impl MetricsDispatcher {
     fn partition_otel_attributes(
         attributes: &dyn AttributeSetHandler,
     ) -> (Vec<opentelemetry::KeyValue>, Vec<opentelemetry::KeyValue>) {
+        let field_count = attributes.descriptor().fields.len();
+
+        // Fast path: no scope attributes declared (the common, behavior-preserving
+        // case). Every attribute is a data-point attribute, so skip the per-key
+        // `is_scope_attribute` checks and the scope bucket allocation.
+        if attributes.descriptor().scope_keys.is_empty() {
+            let mut data_point = Vec::with_capacity(field_count);
+            for (key, value) in attributes.iter_attributes() {
+                data_point.push(Self::to_opentelemetry_key_value(key, value));
+            }
+            return (Vec::new(), data_point);
+        }
+
         let mut scope = Vec::new();
-        let mut data_point = Vec::new();
+        let mut data_point = Vec::with_capacity(field_count);
         for (key, value) in attributes.iter_attributes() {
             if attributes.is_scope_attribute(key) {
+                // Scope attributes are expected to be string-typed; an empty
+                // string is treated as "unset" and dropped so it does not
+                // perturb the instrumentation-scope identity. Non-string types
+                // are not special-cased here.
                 if matches!(value, AttributeValue::String(s) if s.is_empty()) {
                     continue;
                 }
@@ -442,7 +460,7 @@ mod tests {
                             r#type: AttributeValueType::Int,
                         },
                     ],
-                    scope_keys: &[],
+                    scope_keys: &["key2"],
                 }
             }
 

--- a/rust/otap-dataflow/crates/telemetry/src/metrics/dispatcher.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/metrics/dispatcher.rs
@@ -5,7 +5,7 @@
 
 use std::sync::Arc;
 
-use opentelemetry::{global, metrics::Meter};
+use opentelemetry::{InstrumentationScope, global, metrics::Meter};
 use tokio::time::{MissedTickBehavior, interval};
 use tokio_util::sync::CancellationToken;
 
@@ -59,28 +59,62 @@ impl MetricsDispatcher {
     fn dispatch_metrics(&self) -> Result<(), Error> {
         self.metrics_handler
             .visit_metrics_and_reset(|descriptor, attributes, metrics_iter| {
-                let meter = global::meter(descriptor.name);
+                // Split the entity's attributes into instrumentation-scope
+                // attributes (those the attribute set marks `#[attribute(...,
+                // scope)]`) and data-point attributes.
+                // Scope attributes are attached to the meter so View selectors
+                // keyed on scope attributes can match the emitted metrics.
+                let (scope_attributes, datapoint_attributes) =
+                    Self::partition_otel_attributes(attributes);
+
+                let meter = if scope_attributes.is_empty() {
+                    global::meter(descriptor.name)
+                } else {
+                    global::meter_with_scope(
+                        InstrumentationScope::builder(descriptor.name)
+                            .with_attributes(scope_attributes)
+                            .build(),
+                    )
+                };
 
                 // There is no support for metric level attributes currently. Attaching resource level attributes to every metric.
                 // TODO: Consider adding metric level attributes and not to add resource level attributes to every metric.
-                let otel_attributes = Self::to_opentelemetry_attributes(attributes);
-
                 for (field, value) in metrics_iter {
-                    self.add_opentelemetry_metric(field, value, &otel_attributes, &meter);
+                    self.add_opentelemetry_metric(field, value, &datapoint_attributes, &meter);
                 }
             });
 
         Ok(())
     }
 
-    fn to_opentelemetry_attributes(
+    /// Split an entity's attributes into `(scope, data_point)` OpenTelemetry
+    /// attributes in a single pass. An attribute is scope-level when the
+    /// attribute set declares it so via [`AttributeSetHandler::is_scope_attribute`]
+    /// (driven by `#[attribute(key = "...", scope)]`); everything else is a
+    /// data-point attribute.
+    ///
+    /// Scope attributes with an empty string value are omitted entirely (pushed
+    /// to neither bucket). Scope attributes participate in the OpenTelemetry
+    /// instrumentation-scope identity, so emitting an unset value would change
+    /// the scope identity and export a spurious empty attribute. Omitting them
+    /// keeps the previous scope shape for entities that do not configure the
+    /// attribute.
+    fn partition_otel_attributes(
         attributes: &dyn AttributeSetHandler,
-    ) -> Vec<opentelemetry::KeyValue> {
-        let mut kvs = Vec::new();
+    ) -> (Vec<opentelemetry::KeyValue>, Vec<opentelemetry::KeyValue>) {
+        let mut scope = Vec::new();
+        let mut data_point = Vec::new();
         for (key, value) in attributes.iter_attributes() {
-            kvs.push(Self::to_opentelemetry_key_value(key, value));
+            if attributes.is_scope_attribute(key) {
+                if matches!(value, AttributeValue::String(s) if s.is_empty()) {
+                    continue;
+                }
+                scope.push(Self::to_opentelemetry_key_value(key, value));
+            } else {
+                data_point.push(Self::to_opentelemetry_key_value(key, value));
+            }
         }
-        kvs
+        (scope, data_point)
     }
 
     fn to_opentelemetry_key_value(key: &str, value: &AttributeValue) -> opentelemetry::KeyValue {
@@ -376,7 +410,7 @@ mod tests {
     }
 
     #[test]
-    fn test_to_opentelemetry_attributes() {
+    fn test_partition_otel_attributes() {
         struct MockAttributeSetHandler {
             values: Vec<AttributeValue>,
         }
@@ -408,6 +442,73 @@ mod tests {
                             r#type: AttributeValueType::Int,
                         },
                     ],
+                    scope_keys: &[],
+                }
+            }
+
+            fn attribute_values(&self) -> &[AttributeValue] {
+                &self.values
+            }
+
+            fn iter_attributes<'a>(&'a self) -> AttributeIterator<'a> {
+                AttributeIterator::new(self.descriptor().fields, self.attribute_values())
+            }
+
+            // Mark `key2` as a scope-level attribute to exercise partitioning.
+            fn is_scope_attribute(&self, key: &str) -> bool {
+                key == "key2"
+            }
+        }
+
+        let attributes = MockAttributeSetHandler::new();
+        let (scope_attributes, datapoint_attributes) =
+            MetricsDispatcher::partition_otel_attributes(&attributes);
+
+        // `key1` is a data-point attribute, `key2` is lifted onto the scope.
+        assert_eq!(datapoint_attributes.len(), 1);
+        assert!(
+            datapoint_attributes
+                .iter()
+                .any(|kv| kv.key.as_str() == "key1" && kv.value.as_str() == "value1")
+        );
+        assert!(
+            !datapoint_attributes
+                .iter()
+                .any(|kv| kv.key.as_str() == "key2")
+        );
+
+        assert_eq!(scope_attributes.len(), 1);
+        assert!(scope_attributes.iter().any(
+            |kv| kv.key.as_str() == "key2" && matches!(kv.value, opentelemetry::Value::I64(42))
+        ));
+    }
+
+    #[test]
+    fn test_partition_otel_attributes_omits_empty_scope_attribute() {
+        // A scope attribute with an empty string value must be omitted entirely
+        // so it does not alter the instrumentation-scope identity or export a
+        // spurious empty attribute (e.g. an unset scope attribute).
+        struct MockAttributeSetHandler {
+            values: Vec<AttributeValue>,
+        }
+
+        impl AttributeSetHandler for MockAttributeSetHandler {
+            fn descriptor(&self) -> &'static AttributesDescriptor {
+                &AttributesDescriptor {
+                    name: "mock",
+                    fields: &[
+                        AttributeField {
+                            key: "data.key",
+                            brief: "a data-point attribute",
+                            r#type: AttributeValueType::String,
+                        },
+                        AttributeField {
+                            key: "scope.key",
+                            brief: "an unset scope attribute",
+                            r#type: AttributeValueType::String,
+                        },
+                    ],
+                    scope_keys: &["scope.key"],
                 }
             }
 
@@ -420,17 +521,25 @@ mod tests {
             }
         }
 
-        let attributes = MockAttributeSetHandler::new();
-        let otel_attributes = MetricsDispatcher::to_opentelemetry_attributes(&attributes);
-        assert_eq!(otel_attributes.len(), 2);
+        let attributes = MockAttributeSetHandler {
+            values: vec![
+                AttributeValue::String("present".to_string()),
+                AttributeValue::String(String::new()),
+            ],
+        };
+        let (scope_attributes, datapoint_attributes) =
+            MetricsDispatcher::partition_otel_attributes(&attributes);
+
+        // The empty scope attribute is dropped, leaving no scope attributes so
+        // the dispatcher falls back to the plain meter.
+        assert!(scope_attributes.is_empty());
+        // The non-empty data-point attribute is retained.
+        assert_eq!(datapoint_attributes.len(), 1);
         assert!(
-            otel_attributes
+            datapoint_attributes
                 .iter()
-                .any(|kv| kv.key.as_str() == "key1" && kv.value.as_str() == "value1")
+                .any(|kv| kv.key.as_str() == "data.key" && kv.value.as_str() == "present")
         );
-        assert!(otel_attributes.iter().any(
-            |kv| kv.key.as_str() == "key2" && matches!(kv.value, opentelemetry::Value::I64(42))
-        ));
     }
 
     #[test]
@@ -630,6 +739,7 @@ mod tests {
                 r#type: AttributeValueType::String,
                 brief: "service name",
             }],
+            scope_keys: &[],
         };
 
         #[derive(Debug)]
@@ -680,9 +790,10 @@ mod tests {
             MetricsDispatcher::new(registry.clone(), std::time::Duration::from_secs(1));
         registry.visit_metrics_and_reset(|descriptor, attributes, metrics_iter| {
             let meter = meter_provider.meter(descriptor.name);
-            let otel_attributes = MetricsDispatcher::to_opentelemetry_attributes(attributes);
+            let (_scope_attributes, datapoint_attributes) =
+                MetricsDispatcher::partition_otel_attributes(attributes);
             for (field, value) in metrics_iter {
-                dispatcher.add_opentelemetry_metric(field, value, &otel_attributes, &meter);
+                dispatcher.add_opentelemetry_metric(field, value, &datapoint_attributes, &meter);
             }
         });
 

--- a/rust/otap-dataflow/crates/telemetry/src/registry.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/registry.rs
@@ -278,6 +278,7 @@ mod tests {
             r#type: AttributeValueType::String,
             brief: "Test attribute",
         }],
+        scope_keys: &[],
     };
 
     impl MetricSetHandler for MockMetricSet {

--- a/rust/otap-dataflow/crates/telemetry/src/self_tracing/encoder.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/self_tracing/encoder.rs
@@ -674,6 +674,7 @@ mod tests {
                 brief: "CPU ID",
             },
         ],
+        scope_keys: &[],
     };
 
     /// Mock attribute set for testing scope attributes.
@@ -796,6 +797,7 @@ mod tests {
             r#type: AttributeValueType::Map,
             brief: "Custom user-defined attributes",
         }],
+        scope_keys: &[],
     };
 
     /// Mirrors engine::CustomAttributeSet: a single "custom" field of type Map.

--- a/rust/otap-dataflow/crates/telemetry/src/testing/mod.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/testing/mod.rs
@@ -10,6 +10,7 @@ use crate::descriptor::AttributesDescriptor;
 static EMPTY_ATTRIBUTES_DESCRIPTOR: AttributesDescriptor = AttributesDescriptor {
     name: "empty_metrics",
     fields: &[],
+    scope_keys: &[],
 };
 
 /// Empty attribute set for testing.

--- a/rust/otap-dataflow/docs/telemetry/attributes-guide.md
+++ b/rust/otap-dataflow/docs/telemetry/attributes-guide.md
@@ -2,8 +2,8 @@
 
 Status: Draft
 
-This document consolidates project decisions and guidance on attributes:
-naming, placement, cardinality, normalization, and lifecycle.
+This document consolidates project decisions and guidance on attributes: naming,
+placement, cardinality, normalization, and lifecycle.
 
 It complements:
 
@@ -88,6 +88,27 @@ Do not duplicate information:
 - If a value is already present as an entity attribute, do not repeat it as a
   signal-specific attribute.
 - Prefer a single canonical key.
+
+### Scope vs. data-point attributes
+
+The `#[attribute_set(name = "...", scope)]` marker emits an attribute set on the
+OpenTelemetry **instrumentation scope** instead of on each data point. Use it
+deliberately:
+
+- **Why to choose scope.** A primary motivation is **OpenTelemetry View-based
+  selection**: View selectors match on scope name + scope attributes +
+  instrument name, so a value must be on the scope for a `scope_attributes`
+  selector to target it (e.g. `flow.purpose` distinguishing flows that share the
+  single `flow` scope). If you do not have a concrete reason to put the value on
+  the scope, keep it as a data-point attribute.
+- **Bound the value space.** Scope attributes participate in the
+  instrumentation-scope identity, so each distinct value yields a distinct
+  scope/meter. Only use bounded, known-at-creation values; never an unbounded or
+  high-cardinality value.
+- **Moving an attribute between scope and data-point is a breaking change.** It
+  changes where the value appears in the OTLP export, so any downstream View,
+  query, or dashboard keyed on it breaks. Treat such a move under
+  [stability-compatibility-guide.md](stability-compatibility-guide.md).
 
 ### Core rule
 


### PR DESCRIPTION
# Change Summary

## Add a general mechanism for instrumentation-scope attributes

 Plumbing-only half of a two-part split (from #3144); a follow-up PR wires it into `flow_metrics`.

 ### What

- New **set-level** `#[attribute_set(name = "...", scope)]` marker in `telemetry-macros`. Marking a set `scope`designates **every attribute that set directly declares** as an instrumentation-scope attribute. The derive records thosekeys in a new `scope_keys` field on `AttributesDescriptor` (merged, sorted, and de-duplicated across `#[compose]`d sets).Composed children are governed by their own marker, not the parent's.
 - `AttributeSetHandler::is_scope_attribute(key)`, descriptor-backed so it survives type erasure through `&dynAttributeSetHandler` and `EntityAttributeSet`.
 - The metrics dispatcher partitions attributes into `(scope, data_point)`. Scope attributes attach to the meter via`meter_with_scope(...)`; the rest stay on `counter.add` / `histogram.record`. Empty-string scope values are omitted sothey don't perturb scope identity.
 - `EntityAttributeSet` equality/hash now include `scope_keys` (compared order-independently), so sets differing only inscope designation aren't merged during registry de-dup.

 No set is marked `scope` yet, so this is behavior-preserving. Other file changes are mechanical (`scope_keys: &[]`).

 ### Why

 OTel View selectors match on scope name + scope attributes + instrument name (see https://github.com/open-telemetry/otel-arrow/pull/2755). This lets chosen attributes be emitted on the scope rather than per data point. Split out from the `flow.purpose` work so the reusable mechanism is reviewable on its own.

### Example

```rust
```rust
 /// Scope-level attributes, lifted onto the OpenTelemetry instrumentation
 /// scope instead of each data point. The set-level `scope` flag marks every
 /// field it declares as a scope attribute.
 #[attribute_set(name = "node.scope", scope)]
 #[derive(Debug, Clone, Default, Hash)]
 pub struct NodeScopeAttributes {
     /// Scope attribute: bounded, known at node creation. OTel View selectors
     /// keyed on `scope_attributes` can match it (e.g. all `exporter` nodes).
     /// Omitted entirely when empty.
     #[attribute(key = "node.kind")]
     pub kind: Cow<'static, str>, // "receiver" | "processor" | "exporter"
 }

 /// A pipeline node's metric attributes. `node.name` stays a data-point
 /// attribute; the composed scope set contributes `node.kind` on the scope.
 #[attribute_set(name = "node.attrs")]
 #[derive(Debug, Clone, Default, Hash)]
 pub struct NodeAttributeSet {
     /// A regular data-point attribute (emitted on each measurement).
     #[attribute(key = "node.name")]
     pub name: Cow<'static, str>,

     #[compose]
     pub scope: NodeScopeAttributes,
 }
```

What the derive produces from this — a descriptor whose `scope_keys` captures the composed scope set's keys:

```rust
// Generated (illustrative):
 AttributesDescriptor {
     name: "node.attrs",
     fields: &[
         AttributeField { key: "node.name", r#type: AttributeValueType::String, /* ... */ },
         AttributeField { key: "node.kind", r#type: AttributeValueType::String, /* ... */ },
     ],
     scope_keys: &["node.kind"], // <-- drives is_scope_attribute(...)
 };
```

## What issue does this PR close?

* Progress towards #2859 

## How are these changes tested?

Unit tests

## Are there any user-facing changes?

Developers may now emit scope-level metric attributes

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
