### PR TITLE
Experiment: Split-NUMA 8-core OTAP saturation test

### DIFF
--- a/.github/workflows/pipeline-perf-on-label.yaml
+++ b/.github/workflows/pipeline-perf-on-label.yaml
@@ -90,20 +90,23 @@ jobs:
           python -m pip install --user --require-hashes -r tools/pipeline_perf_test/orchestrator/requirements.lock.txt
           python -m pip install --user --require-hashes -r tools/pipeline_perf_test/load_generator/requirements.lock.txt
 
-      - name: Run OTAP 8-core split-NUMA experiment
+      - name: Run OTLP saturation/scaling tests (fixed 64 connections)
         run: |
           cd tools/pipeline_perf_test
-          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/saturation-otap-8cores.yaml
+          for config in test_suites/integration/continuous/saturation-{1core,2cores,4cores,8cores,16cores}.yaml; do
+            echo "=== Running: $config ==="
+            python orchestrator/run_orchestrator.py --config "$config" || true
+          done
 
-      - name: Analyze OTAP scaling results
+      - name: Analyze OTLP scaling results
         if: ${{ !cancelled() }}
         run: |
           cd tools/pipeline_perf_test
           python ../../.github/workflows/scripts/analyze-saturation-scaling.py results \
-            | tee otap-scaling-report.txt
-          echo "### OTAP 8-Core Split-NUMA Experiment" >> $GITHUB_STEP_SUMMARY
+            | tee scaling-report.txt
+          echo "### OTLP Scaling (fixed 64 connections)" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          cat otap-scaling-report.txt >> $GITHUB_STEP_SUMMARY
+          cat scaling-report.txt >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Post-run disk usage diagnostics

--- a/.github/workflows/pipeline-perf-on-label.yaml
+++ b/.github/workflows/pipeline-perf-on-label.yaml
@@ -93,7 +93,7 @@ jobs:
       - name: Run OTLP saturation/scaling tests (fixed 64 connections)
         run: |
           cd tools/pipeline_perf_test
-          for config in test_suites/integration/continuous/saturation-{1core,2cores,4cores,8cores,16cores}.yaml; do
+          for config in test_suites/integration/continuous/saturation-{2cores,4cores}.yaml; do
             echo "=== Running: $config ==="
             python orchestrator/run_orchestrator.py --config "$config" || true
           done

--- a/.github/workflows/pipeline-perf-on-label.yaml
+++ b/.github/workflows/pipeline-perf-on-label.yaml
@@ -90,45 +90,24 @@ jobs:
           python -m pip install --user --require-hashes -r tools/pipeline_perf_test/orchestrator/requirements.lock.txt
           python -m pip install --user --require-hashes -r tools/pipeline_perf_test/load_generator/requirements.lock.txt
 
-      - name: Run pipeline performance test suite
+      - name: Run OTAP saturation/scaling tests
         run: |
           cd tools/pipeline_perf_test
-          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/100klrps-docker.yaml
+          for config in test_suites/integration/continuous/saturation-otap-*.yaml; do
+            echo "=== Running: $config ==="
+            python orchestrator/run_orchestrator.py --config "$config" || true
+          done
 
-      - name: Run saturation/scaling performance test suite
+      - name: Analyze OTAP scaling results
         if: ${{ !cancelled() }}
         run: |
           cd tools/pipeline_perf_test
-          ./scripts/run-saturation-tests.sh --output-json results/scaling-efficiency.json \
-            | tee saturation-scaling-report.txt
-          echo "### Saturation/Scaling Test Analysis" >> $GITHUB_STEP_SUMMARY
+          python ../../.github/workflows/scripts/analyze-saturation-scaling.py results \
+            | tee otap-scaling-report.txt
+          echo "### OTAP Saturation/Scaling Test Analysis" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          sed -n '/^=.*SCALING ANALYSIS/,/^=\{10,\}$/p' saturation-scaling-report.txt >> $GITHUB_STEP_SUMMARY
+          cat otap-scaling-report.txt >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-
-      - name: Run single-core saturation max throughput test (OTLP)
-        if: ${{ !cancelled() }}
-        run: |
-          cd tools/pipeline_perf_test
-          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/saturation-max-throughput.yaml
-
-      - name: Run single-core saturation max throughput test (OTAP)
-        if: ${{ !cancelled() }}
-        run: |
-          cd tools/pipeline_perf_test
-          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/saturation-max-throughput-otap.yaml
-
-      - name: Run passthrough performance test (OTLP)
-        if: ${{ !cancelled() }}
-        run: |
-          cd tools/pipeline_perf_test
-          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/passthrough.yaml
-
-      - name: Run passthrough performance test (OTAP)
-        if: ${{ !cancelled() }}
-        run: |
-          cd tools/pipeline_perf_test
-          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/passthrough-otap.yaml
 
       - name: Post-run disk usage diagnostics
         if: always()

--- a/.github/workflows/pipeline-perf-on-label.yaml
+++ b/.github/workflows/pipeline-perf-on-label.yaml
@@ -90,24 +90,45 @@ jobs:
           python -m pip install --user --require-hashes -r tools/pipeline_perf_test/orchestrator/requirements.lock.txt
           python -m pip install --user --require-hashes -r tools/pipeline_perf_test/load_generator/requirements.lock.txt
 
-      - name: Run OTAP saturation/scaling tests
+      - name: Run pipeline performance test suite
         run: |
           cd tools/pipeline_perf_test
-          for config in test_suites/integration/continuous/saturation-otap-*.yaml; do
-            echo "=== Running: $config ==="
-            python orchestrator/run_orchestrator.py --config "$config" || true
-          done
+          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/100klrps-docker.yaml
 
-      - name: Analyze OTAP scaling results
+      - name: Run saturation/scaling performance test suite
         if: ${{ !cancelled() }}
         run: |
           cd tools/pipeline_perf_test
-          python ../../.github/workflows/scripts/analyze-saturation-scaling.py results \
-            | tee otap-scaling-report.txt
-          echo "### OTAP Saturation/Scaling Test Analysis" >> $GITHUB_STEP_SUMMARY
+          ./scripts/run-saturation-tests.sh --output-json results/scaling-efficiency.json \
+            | tee saturation-scaling-report.txt
+          echo "### Saturation/Scaling Test Analysis" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          cat otap-scaling-report.txt >> $GITHUB_STEP_SUMMARY
+          sed -n '/^=.*SCALING ANALYSIS/,/^=\{10,\}$/p' saturation-scaling-report.txt >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Run single-core saturation max throughput test (OTLP)
+        if: ${{ !cancelled() }}
+        run: |
+          cd tools/pipeline_perf_test
+          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/saturation-max-throughput.yaml
+
+      - name: Run single-core saturation max throughput test (OTAP)
+        if: ${{ !cancelled() }}
+        run: |
+          cd tools/pipeline_perf_test
+          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/saturation-max-throughput-otap.yaml
+
+      - name: Run passthrough performance test (OTLP)
+        if: ${{ !cancelled() }}
+        run: |
+          cd tools/pipeline_perf_test
+          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/passthrough.yaml
+
+      - name: Run passthrough performance test (OTAP)
+        if: ${{ !cancelled() }}
+        run: |
+          cd tools/pipeline_perf_test
+          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/passthrough-otap.yaml
 
       - name: Post-run disk usage diagnostics
         if: always()

--- a/.github/workflows/pipeline-perf-on-label.yaml
+++ b/.github/workflows/pipeline-perf-on-label.yaml
@@ -90,45 +90,21 @@ jobs:
           python -m pip install --user --require-hashes -r tools/pipeline_perf_test/orchestrator/requirements.lock.txt
           python -m pip install --user --require-hashes -r tools/pipeline_perf_test/load_generator/requirements.lock.txt
 
-      - name: Run pipeline performance test suite
+      - name: Run OTAP 8-core split-NUMA experiment
         run: |
           cd tools/pipeline_perf_test
-          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/100klrps-docker.yaml
+          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/saturation-otap-8cores.yaml
 
-      - name: Run saturation/scaling performance test suite
+      - name: Analyze OTAP scaling results
         if: ${{ !cancelled() }}
         run: |
           cd tools/pipeline_perf_test
-          ./scripts/run-saturation-tests.sh --output-json results/scaling-efficiency.json \
-            | tee saturation-scaling-report.txt
-          echo "### Saturation/Scaling Test Analysis" >> $GITHUB_STEP_SUMMARY
+          python ../../.github/workflows/scripts/analyze-saturation-scaling.py results \
+            | tee otap-scaling-report.txt
+          echo "### OTAP 8-Core Split-NUMA Experiment" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          sed -n '/^=.*SCALING ANALYSIS/,/^=\{10,\}$/p' saturation-scaling-report.txt >> $GITHUB_STEP_SUMMARY
+          cat otap-scaling-report.txt >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-
-      - name: Run single-core saturation max throughput test (OTLP)
-        if: ${{ !cancelled() }}
-        run: |
-          cd tools/pipeline_perf_test
-          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/saturation-max-throughput.yaml
-
-      - name: Run single-core saturation max throughput test (OTAP)
-        if: ${{ !cancelled() }}
-        run: |
-          cd tools/pipeline_perf_test
-          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/saturation-max-throughput-otap.yaml
-
-      - name: Run passthrough performance test (OTLP)
-        if: ${{ !cancelled() }}
-        run: |
-          cd tools/pipeline_perf_test
-          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/passthrough.yaml
-
-      - name: Run passthrough performance test (OTAP)
-        if: ${{ !cancelled() }}
-        run: |
-          cd tools/pipeline_perf_test
-          python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/passthrough-otap.yaml
 
       - name: Post-run disk usage diagnostics
         if: always()

--- a/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-cores-template.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-cores-template.yaml.j2
@@ -80,4 +80,4 @@ tests:
         max_batch_size: {{max_batch_size}}
         data_source: synthetic
         log_body_size_bytes: 1024
-        num_connections: {{num_cores * 4}}
+        num_connections: 64

--- a/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-otap-8cores.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-otap-8cores.yaml
@@ -1,13 +1,13 @@
 # OTAP saturation test with 8 core df_engine
-# NUMA-aware layout: SUT on NUMA node 0 (physical 0-7), loadgen uses all remaining cores except 4 for backend.
-# Loadgen: NUMA1 phys(32-63) + NUMA1 HT(96-127) + NUMA0 phys(8-31) + NUMA0 HT(68-95) = 104 cores
-# Backend: NUMA0 HT(64-67) = 4 cores (only uses ~3.4 in practice)
+# NUMA-aware layout: SUT on NUMA node 0 (physical 0-7), loadgen on entire NUMA node 1,
+# backend on NUMA0 HT cores (not siblings of SUT cores 0-7).
+# Note: 64 LG cores is the max without cross-NUMA contention. SUT reaches ~91% (loadgen-limited).
 from_template:
   path: test_suites/integration/continuous/saturation-otap-cores-template.yaml.j2
   variables:
     num_cores: 8
     engine_core_range: "0-7"
-    loadgen_cores: 104
-    loadgen_core_range: "32-63,96-127,8-31,68-95"
-    backend_cores: 4
-    backend_core_range: "64-67"
+    loadgen_cores: 64
+    loadgen_core_range: "32-63,96-127"
+    backend_cores: 16
+    backend_core_range: "64-79"

--- a/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-otap-8cores.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-otap-8cores.yaml
@@ -1,14 +1,13 @@
 # OTAP saturation test with 8 core df_engine
-# Split-NUMA layout: SUT split 4+4 across both NUMA nodes.
-# SUT HT siblings (64-67, 96-99) left completely unoccupied.
-# Loadgen gets remaining cores = 108 total.
-# Backend on non-sibling HT cores (68-69, 100-101).
+# NUMA-aware layout: SUT on NUMA node 0 (physical 0-7), loadgen on entire NUMA node 1,
+# backend on NUMA0 HT cores (not siblings of SUT cores 0-7).
+# Note: 64 LG cores is the max without cross-NUMA contention. SUT reaches ~91% (loadgen-limited).
 from_template:
   path: test_suites/integration/continuous/saturation-otap-cores-template.yaml.j2
   variables:
     num_cores: 8
-    engine_core_range: "0-3,32-35"
-    loadgen_cores: 108
-    loadgen_core_range: "4-31,70-95,36-63,102-127"
-    backend_cores: 4
-    backend_core_range: "68-69,100-101"
+    engine_core_range: "0-7"
+    loadgen_cores: 64
+    loadgen_core_range: "32-63,96-127"
+    backend_cores: 16
+    backend_core_range: "64-79"

--- a/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-otap-8cores.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-otap-8cores.yaml
@@ -1,12 +1,13 @@
 # OTAP saturation test with 8 core df_engine
-# NUMA-aware layout: SUT on NUMA node 0 (physical 0-7), loadgen+backend spread across remaining cores.
-# Uses all NUMA1 physical+HT for loadgen, and NUMA0 HT siblings (not used by SUT) for extra loadgen+backend.
+# NUMA-aware layout: SUT on NUMA node 0 (physical 0-7), loadgen uses all remaining cores except 4 for backend.
+# Loadgen: NUMA1 phys(32-63) + NUMA1 HT(96-127) + NUMA0 phys(8-31) + NUMA0 HT(68-95) = 104 cores
+# Backend: NUMA0 HT(64-67) = 4 cores (only uses ~3.4 in practice)
 from_template:
   path: test_suites/integration/continuous/saturation-otap-cores-template.yaml.j2
   variables:
     num_cores: 8
     engine_core_range: "0-7"
-    loadgen_cores: 64
-    loadgen_core_range: "32-63,96-127"
-    backend_cores: 16
-    backend_core_range: "64-79"
+    loadgen_cores: 104
+    loadgen_core_range: "32-63,96-127,8-31,68-95"
+    backend_cores: 4
+    backend_core_range: "64-67"

--- a/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-otap-8cores.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-otap-8cores.yaml
@@ -1,13 +1,13 @@
 # OTAP saturation test with 8 core df_engine
-# NUMA-aware layout: SUT on NUMA node 0 (physical 0-7), loadgen on entire NUMA node 1,
-# backend on NUMA0 HT cores (not siblings of SUT cores 0-7).
-# Note: 64 LG cores is the max without cross-NUMA contention. SUT reaches ~91% (loadgen-limited).
+# Split-NUMA layout: SUT split 4+4 across both NUMA nodes.
+# Loadgen gets remaining 58 cores per NUMA node = 116 total.
+# Backend gets 2 HT cores per NUMA node = 4 total.
 from_template:
   path: test_suites/integration/continuous/saturation-otap-cores-template.yaml.j2
   variables:
     num_cores: 8
-    engine_core_range: "0-7"
-    loadgen_cores: 64
-    loadgen_core_range: "32-63,96-127"
-    backend_cores: 16
-    backend_core_range: "64-79"
+    engine_core_range: "0-3,32-35"
+    loadgen_cores: 116
+    loadgen_core_range: "4-31,66-95,36-63,98-127"
+    backend_cores: 4
+    backend_core_range: "64-65,96-97"

--- a/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-otap-8cores.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-otap-8cores.yaml
@@ -1,13 +1,14 @@
 # OTAP saturation test with 8 core df_engine
 # Split-NUMA layout: SUT split 4+4 across both NUMA nodes.
-# Loadgen gets remaining 58 cores per NUMA node = 116 total.
-# Backend gets 2 HT cores per NUMA node = 4 total.
+# SUT HT siblings (64-67, 96-99) left completely unoccupied.
+# Loadgen gets remaining cores = 108 total.
+# Backend on non-sibling HT cores (68-69, 100-101).
 from_template:
   path: test_suites/integration/continuous/saturation-otap-cores-template.yaml.j2
   variables:
     num_cores: 8
     engine_core_range: "0-3,32-35"
-    loadgen_cores: 116
-    loadgen_core_range: "4-31,66-95,36-63,98-127"
+    loadgen_cores: 108
+    loadgen_core_range: "4-31,70-95,36-63,102-127"
     backend_cores: 4
-    backend_core_range: "64-65,96-97"
+    backend_core_range: "68-69,100-101"

--- a/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-otap-8cores.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-otap-8cores.yaml
@@ -1,7 +1,6 @@
 # OTAP saturation test with 8 core df_engine
-# NUMA-aware layout: SUT on NUMA node 0 (physical 0-7), loadgen on entire NUMA node 1,
-# backend on NUMA0 HT cores (not siblings of SUT cores 0-7).
-# Note: 64 LG cores is the max without cross-NUMA contention. SUT reaches ~91% (loadgen-limited).
+# NUMA-aware layout: SUT on NUMA node 0 (physical 0-7), loadgen+backend spread across remaining cores.
+# Uses all NUMA1 physical+HT for loadgen, and NUMA0 HT siblings (not used by SUT) for extra loadgen+backend.
 from_template:
   path: test_suites/integration/continuous/saturation-otap-cores-template.yaml.j2
   variables:


### PR DESCRIPTION
## Experiment: Split-NUMA layout for 8-core OTAP saturation

Testing Laurent's suggestion: split SUT across both NUMA nodes (4 cores each) to free up more loadgen cores.

### Run 1: Split-NUMA with HT sibling contention ❌

**Layout:** SUT 0-3,32-35 | LG 4-31,66-95,36-63,98-127 (116) | BE 64-65,96-97 (4)

**Problem:** Loadgen cores 66-67 and 98-99 are HT siblings of SUT cores 2-3 and 34-35.

**Result:** 7.81M logs/sec, 95% CPU — 4 of 8 SUT cores shared physical core with busy loadgen.

### Run 2 & 3: Split-NUMA with HT siblings unoccupied ⚠️

**Layout:**
| Component | NUMA0 | NUMA1 | Total |
|-----------|-------|-------|-------|
| SUT | 0-3 (4 phys) | 32-35 (4 phys) | 8 |
| Empty (SUT siblings) | 64-67 | 96-99 | 8 |
| Backend | 68-69 | 100-101 | 4 |
| Loadgen | 4-31, 70-95 (54) | 36-63, 102-127 (54) | 108 |

| Run | Throughput | SUT CPU | LG CPU |
|-----|-----------|---------|--------|
| 2 | 11.4M | 93% | 108/108 |
| 3 | 8.55M | 78% | 108/108 |

Results are both worse than baseline AND highly variable (25% swing between runs). The cross-NUMA SUT introduces non-deterministic behavior.

### Baseline (SUT all on NUMA0, LG on separate NUMA1)

**14.1M logs/sec**, 92% SUT CPU, 64/64 LG cores — consistent across 3 runs (±2%)

### Conclusion (Split-NUMA)

Splitting SUT across NUMA nodes is conclusively worse:
1. **Lower throughput** — 8.5-11.4M vs 14.1M baseline (20-40% degradation)
2. **Highly variable** — 25% swing between identical runs (vs ±2% on baseline)
3. **L3 cache sharing** between LG and SUT on same node degrades per-core throughput even without HT contention

The single-NUMA layout with SUT isolated on NUMA0 and loadgen on NUMA1 remains optimal.

---

## Experiment: OTLP fixed num_connections=64

Testing Laurent's suggestion to fix connections at 64 across all core counts (was `num_cores * 4`, i.e., 4/8/16/32/64 for 1/2/4/8/16 cores). Goal: isolate core count as the only variable.

### Full run (1-16 cores, fixed 64 connections)

| Cores | Throughput | SUT CPU | Old (variable conn) |
|-------|-----------|---------|---------------------|
| 1 | 112K | 81% | 145K / 100% |
| 2 | 236K | 86% | 226-264K / 81-90% |
| 4 | 493K | 91% | 499-559K / 89-98% |
| 8 | 812K | 85% | 843-910K / 85% |
| 16 | 1.93M | 95% | 1.92M / 94% |

**1-core regressed** — 64 connections on 1 core adds too much overhead (100% → 81% CPU, 145K → 112K).

### Consistency check (2/4-core only, 2 runs)

| Cores | Run 1 | Run 2 | Variance |
|-------|-------|-------|----------|
| 2 | 225K / 83% | 234K / 87% | ~4% |
| 4 | 467K / 87% | 454K / 85% | ~3% |

### Conclusion (fixed connections)

- **More consistent** — variance improved to 3-4% (was 11-15% with variable connections)
- **But lower throughput** — SUT never reaches 100% CPU (stuck at 83-91%)
- Too many connections on fewer cores adds per-connection overhead without benefit
- The original `num_cores * 4` formula is better for peak throughput but less predictable

## Temporary
Label workflow modified for experiments. Will not merge.
