### PR TITLE
chore(repo): Use new repo-scoped otelbot token for write automation workflows

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -34,10 +34,10 @@ jobs:
       - name: Create GitHub App token
         if: "!inputs.dry_run"
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: app-token
+        id: otelbot-token
         with:
-          app-id: ${{ vars.OTELBOT_APP_ID }}
-          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+          app-id: ${{ vars.OTELBOT_ARROW_APP_ID }}
+          private-key: ${{ secrets.OTELBOT_ARROW_PRIVATE_KEY }}
 
       - name: Checkout (release preparation)
         if: "!inputs.dry_run"
@@ -46,7 +46,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
           ref: ${{ github.ref }}
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.otelbot-token.outputs.token }}
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: stable
@@ -208,7 +208,7 @@ jobs:
         if: "!inputs.dry_run"
         env:
           # not using secrets.GITHUB_TOKEN since pull requests from that token do not trigger workflows
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
         run: |
           # Read combined changelog content for PR body
           CHANGELOG_CONTENT=$(cat /tmp/combined_release_content.txt)

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release version to tag and publish (e.g., 0.40.0)'
+        description: "Release version to tag and publish (e.g., 0.40.0)"
         required: true
         type: string
       dry_run:
-        description: 'Dry run mode (just show what would happen)'
+        description: "Dry run mode (just show what would happen)"
         required: true
         type: boolean
         default: true
@@ -32,21 +32,21 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Create GitHub App token
-        if: '!inputs.dry_run'
+        if: "!inputs.dry_run"
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: app-token
+        id: otelbot-token
         with:
-          app-id: ${{ vars.OTELBOT_APP_ID }}
-          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+          app-id: ${{ vars.OTELBOT_ARROW_APP_ID }}
+          private-key: ${{ secrets.OTELBOT_ARROW_PRIVATE_KEY }}
 
       - name: Checkout (release push)
-        if: '!inputs.dry_run'
+        if: "!inputs.dry_run"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           fetch-tags: true
           ref: ${{ github.ref }}
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.otelbot-token.outputs.token }}
 
       - name: Validate inputs
         run: |
@@ -208,7 +208,7 @@ jobs:
           EOF
 
       - name: Create git tags
-        if: '!inputs.dry_run'
+        if: "!inputs.dry_run"
         run: |
           # Configure git
           git config user.name otelbot
@@ -229,7 +229,7 @@ jobs:
           git tag --list "*v${{ inputs.version }}"
 
       - name: Push git tags
-        if: '!inputs.dry_run'
+        if: "!inputs.dry_run"
         run: |
           # Push all tags for this version
           git push origin "v${{ inputs.version }}"
@@ -244,9 +244,9 @@ jobs:
           echo "- rust/otap-dataflow/v${{ inputs.version }}"
 
       - name: Create GitHub release
-        if: '!inputs.dry_run'
+        if: "!inputs.dry_run"
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
         run: |
           # Read combined changelog content into a variable
           RELEASE_CONTENT=$(cat /tmp/release_content.txt)

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -16,10 +16,16 @@ jobs:
     # This workflow is used to ensure Renovate and Dependabot PRs to Go code are 'tidy' and are reflected in the generated code produced by makefile command
     if: ${{ contains(fromJson('["renovate[bot]", "dependabot[bot]"]'), github.actor) && github.event.pull_request.head.repo.fork == false }}
     steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: otelbot-token
+        with:
+          app-id: ${{ vars.OTELBOT_ARROW_APP_ID }}
+          private-key: ${{ secrets.OTELBOT_ARROW_PRIVATE_KEY }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
+          token: ${{ steps.otelbot-token.outputs.token }}
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26.3"


### PR DESCRIPTION
# Change Summary

Context: https://github.com/open-telemetry/community/issues/3489

## What issue does this PR close?

<!--
We highly recommend correlation of every PR to an issue
-->

* Closes #1469

## How are these changes tested?

N/A

## Are there any user-facing changes?

No

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
