### PR TITLE
feat(traffic_generator): add cross-batch diversity to PreGenerated mode

### DIFF
--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/bench/bench.sh
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/bench/bench.sh
@@ -35,14 +35,14 @@ run_saturation() {
   cargo run --release -- --config "$sender_config" --num-cores 1 >/dev/null 2>&1 &
   local SENDER=$!; sleep $SETTLE
 
-  local sm=$(curl -s http://127.0.0.1:8080/metrics)
-  local em=$(curl -s http://127.0.0.1:8081/metrics)
-  local sender_cpu=$(echo "$sm" | awk '/^cpu_utilization\{set="pipeline/{print $2}')
-  local sut_cpu=$(echo "$em" | awk '/^cpu_utilization\{set="pipeline/{print $2}')
-  local logs1=$(echo "$sm" | awk '/^logs_produced\{/{print $2}')
+  local sm=$(curl -s http://127.0.0.1:8080/api/v1/telemetry/metrics)
+  local em=$(curl -s http://127.0.0.1:8081/api/v1/telemetry/metrics)
+  local sender_cpu=$(echo "$sm" | awk '/^cpu_utilization\{otel_scope_name="pipeline"/{print $2}')
+  local sut_cpu=$(echo "$em" | awk '/^cpu_utilization\{otel_scope_name="pipeline"/{print $2}')
+  local logs1=$(echo "$sm" | awk '/^logs_produced_total\{/{print $2}')
   sleep $SAMPLE
-  sm=$(curl -s http://127.0.0.1:8080/metrics)
-  local logs2=$(echo "$sm" | awk '/^logs_produced\{/{print $2}')
+  sm=$(curl -s http://127.0.0.1:8080/api/v1/telemetry/metrics)
+  local logs2=$(echo "$sm" | awk '/^logs_produced_total\{/{print $2}')
   local rps=$(( (${logs2:-0} - ${logs1:-0}) / SAMPLE ))
   local s_pct=$(echo "scale=1; ${sender_cpu:-0} * 100" | bc)
   local e_pct=$(echo "scale=1; ${sut_cpu:-0} * 100" | bc)

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/bench/sender-synthetic-fresh.yaml
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/bench/sender-synthetic-fresh.yaml
@@ -1,5 +1,7 @@
 version: otel_dataflow/v1
-engine: {}
+engine:
+  http_admin:
+    bind_address: "127.0.0.1:8080"
 groups:
   default:
     pipelines:

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/bench/sender-synthetic-pregen.yaml
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/bench/sender-synthetic-pregen.yaml
@@ -1,5 +1,7 @@
 version: otel_dataflow/v1
-engine: {}
+engine:
+  http_admin:
+    bind_address: "127.0.0.1:8080"
 groups:
   default:
     pipelines:

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/producer.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/producer.rs
@@ -523,6 +523,7 @@ impl SignalGenerator for SyntheticGenerator {
             self.num_log_attributes,
             self.use_trace_context,
             attrs,
+            self.idx,
         );
         let payload = OtlpProtoMessage::Logs(payload);
 

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/synthetic_signal.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/synthetic_signal.rs
@@ -582,7 +582,7 @@ pub fn static_otlp_logs(
     signal_count: usize,
     extra_attrs: Option<&HashMap<String, String>>,
 ) -> LogsData {
-    static_otlp_logs_with_config(signal_count, None, None, false, extra_attrs)
+    static_otlp_logs_with_config(signal_count, None, None, false, extra_attrs, 0)
 }
 
 /// Generates LogsData with configurable body size, attribute count, and
@@ -593,6 +593,8 @@ pub fn static_otlp_logs(
 /// - `num_log_attributes`: When `Some(n)`, generates `n` key-value string attributes.
 ///   When `None`, uses the default 2 attributes (thread.id, thread.name).
 /// - `extra_attrs`: Optional extra key-value pairs merged into the resource attributes.
+/// - `batch_index`: Shifts pool selection indices so consecutive batches produce
+///   distinct payloads (important for realistic compression in `PreGenerated` mode).
 #[must_use]
 pub fn static_otlp_logs_with_config(
     signal_count: usize,
@@ -600,12 +602,14 @@ pub fn static_otlp_logs_with_config(
     num_log_attributes: Option<usize>,
     use_trace_context: bool,
     extra_attrs: Option<&HashMap<String, String>>,
+    batch_index: usize,
 ) -> LogsData {
     let logs = static_logs(
         signal_count,
         log_body_size_bytes,
         num_log_attributes,
         use_trace_context,
+        batch_index,
     );
 
     let scopes = vec![ScopeLogs::new(
@@ -1083,20 +1087,28 @@ fn static_logs(
     log_body_size_bytes: Option<usize>,
     num_log_attributes: Option<usize>,
     use_trace_context: bool,
+    batch_index: usize,
 ) -> Vec<LogRecord> {
     let body_pool = build_body_pool(log_body_size_bytes);
+    // Use a prime stride to shift pool indices per batch, ensuring consecutive
+    // batches select different body/attribute combinations and produce distinct
+    // compressed payloads.
+    let body_offset = batch_index.wrapping_mul(37);
+    let attr_offset = batch_index.wrapping_mul(13);
 
     (0..signal_count)
         .map(|i| {
             let timestamp = current_time();
-            let (severity_number, severity_text) = match i % 20 {
+            let (severity_number, severity_text) = match (i + attr_offset) % 20 {
                 0..=15 => (SeverityNumber::Info, "INFO"),
                 16..=18 => (SeverityNumber::Warn, "WARN"),
                 _ => (SeverityNumber::Error, "ERROR"),
             };
 
-            let attributes =
-                build_log_attributes(num_log_attributes.unwrap_or(DEFAULT_LOG_ATTRIBUTE_COUNT), i);
+            let attributes = build_log_attributes(
+                num_log_attributes.unwrap_or(DEFAULT_LOG_ATTRIBUTE_COUNT),
+                i + attr_offset,
+            );
 
             let mut builder = LogRecord::build()
                 .time_unix_nano(timestamp)
@@ -1110,7 +1122,8 @@ fn static_logs(
             }
 
             if !body_pool.is_empty() {
-                builder = builder.body(AnyValue::new_string(&body_pool[i % body_pool.len()]));
+                let body_idx = (i + body_offset) % body_pool.len();
+                builder = builder.body(AnyValue::new_string(&body_pool[body_idx]));
             }
 
             builder.finish()
@@ -1267,7 +1280,7 @@ mod tests {
 
     #[test]
     fn test_static_logs_with_custom_body_size() {
-        let logs = static_otlp_logs_with_config(5, Some(1024), None, false, None);
+        let logs = static_otlp_logs_with_config(5, Some(1024), None, false, None, 0);
         let records = &logs.resource_logs[0].scope_logs[0].log_records;
         assert_eq!(records.len(), 5);
         if let Some(body) = &records[0].body {
@@ -1286,7 +1299,7 @@ mod tests {
 
     #[test]
     fn test_static_logs_with_custom_attributes() {
-        let logs = static_otlp_logs_with_config(3, None, Some(5), false, None);
+        let logs = static_otlp_logs_with_config(3, None, Some(5), false, None, 0);
         let records = &logs.resource_logs[0].scope_logs[0].log_records;
         assert_eq!(records.len(), 3);
         assert_eq!(records[0].attributes.len(), 5);
@@ -1304,7 +1317,7 @@ mod tests {
 
     #[test]
     fn test_static_logs_with_both_custom() {
-        let logs = static_otlp_logs_with_config(2, Some(512), Some(10), false, None);
+        let logs = static_otlp_logs_with_config(2, Some(512), Some(10), false, None, 0);
         let records = &logs.resource_logs[0].scope_logs[0].log_records;
         assert_eq!(records.len(), 2);
         assert_eq!(records[0].attributes.len(), 10);
@@ -1312,7 +1325,7 @@ mod tests {
 
     #[test]
     fn test_static_logs_zero_body_size() {
-        let logs = static_otlp_logs_with_config(1, Some(0), None, false, None);
+        let logs = static_otlp_logs_with_config(1, Some(0), None, false, None, 0);
         let records = &logs.resource_logs[0].scope_logs[0].log_records;
         assert!(
             records[0].body.is_none(),
@@ -1322,7 +1335,7 @@ mod tests {
 
     #[test]
     fn test_static_logs_zero_attributes() {
-        let logs = static_otlp_logs_with_config(1, None, Some(0), false, None);
+        let logs = static_otlp_logs_with_config(1, None, Some(0), false, None, 0);
         let records = &logs.resource_logs[0].scope_logs[0].log_records;
         assert!(records[0].attributes.is_empty());
     }
@@ -1347,7 +1360,7 @@ mod tests {
     fn test_compression_ratio_is_realistic() {
         use prost::Message;
 
-        let logs = static_otlp_logs_with_config(500, Some(1024), Some(6), true, None);
+        let logs = static_otlp_logs_with_config(500, Some(1024), Some(6), true, None, 0);
         let raw = logs.encode_to_vec();
         let raw_size = raw.len();
 
@@ -1365,5 +1378,40 @@ mod tests {
             "compression ratio {ratio:.1}:1 is outside acceptable range (3:1 – 45:1); \
              raw={raw_size} bytes, compressed={compressed_size} bytes"
         );
+    }
+
+    /// Verify that consecutive batches with different `batch_index` values
+    /// produce distinct encoded payloads, ensuring `PreGenerated` mode doesn't
+    /// replay identical data that would be trivially compressible across batches.
+    #[test]
+    fn test_pregenerated_batches_are_diverse() {
+        use prost::Message;
+
+        let batch_0 = static_otlp_logs_with_config(512, Some(1024), Some(6), false, None, 0);
+        let batch_1 = static_otlp_logs_with_config(512, Some(1024), Some(6), false, None, 1);
+        let batch_5 = static_otlp_logs_with_config(512, Some(1024), Some(6), false, None, 5);
+
+        let bytes_0 = batch_0.encode_to_vec();
+        let bytes_1 = batch_1.encode_to_vec();
+        let bytes_5 = batch_5.encode_to_vec();
+
+        // Batches must not be identical
+        assert_ne!(bytes_0, bytes_1, "batch 0 and 1 should differ");
+        assert_ne!(bytes_0, bytes_5, "batch 0 and 5 should differ");
+        assert_ne!(bytes_1, bytes_5, "batch 1 and 5 should differ");
+
+        // Each batch individually should have realistic compression
+        for (label, bytes) in [
+            ("batch_0", &bytes_0),
+            ("batch_1", &bytes_1),
+            ("batch_5", &bytes_5),
+        ] {
+            let compressed = zstd::bulk::compress(bytes, 3).expect("zstd failed");
+            let ratio = bytes.len() as f64 / compressed.len() as f64;
+            assert!(
+                (3.0..=45.0).contains(&ratio),
+                "{label}: compression ratio {ratio:.1}:1 is outside acceptable range"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds a `batch_index` parameter to the synthetic log generation path so that consecutive batches produced by `PreGenerated` mode are byte-level distinct. Previously all pre-generated batches were structurally identical (same pool indices), making them trivially compressible across batches on stateful streams.

### Problem

In `PreGenerated` mode, `static_logs(512, ...)` was called N times but always iterated `i` from 0..511 — every batch selected the same body pool entries, same attribute values, and same severity rotation. This produced identical protobuf payloads that compress unrealistically well, making saturation benchmarks measure transport efficiency rather than engine throughput.

### Solution

Pass a `batch_index` through to the generation function that shifts body and attribute pool selections using prime strides (37 for bodies, 13 for attributes). The `SyntheticGenerator` already tracks `self.idx` per batch — we now plumb it into the generation path.

This ensures:
- Each pre-generated batch selects different body/attribute combinations
- Per-batch compression ratios remain realistic (3:1–45:1 zstd at level 3)
- Cross-batch byte patterns are distinct, preventing stateful compressors from achieving unrealistic ratios

### Also fixes

- **bench.sh**: Updated metrics endpoint URL from `/metrics` to `/api/v1/telemetry/metrics` and metric name patterns to match current df_engine format
- **Sender bench configs**: Added `http_admin` section so the benchmark can scrape sender metrics

### Benchmark results (1 sender core → 1 SUT core, batch_size=512, 1KB bodies)

| Config | Logs/sec | Sender CPU | SUT CPU |
|--------|----------|-----------|---------|
| synthetic/pregen 1KB | 235,520 | 47.8% | 35.4% |
| synthetic/fresh 1KB | 188,416 | 54.0% | 31.9% |

PreGenerated is 25% faster than Fresh with equivalent per-batch entropy.

### Tests

- All existing tests pass
- New `test_pregenerated_batches_are_diverse` verifies cross-batch byte-level diversity and per-batch compression ratios

Relates to #2540