### PR TITLE
fix(observability): Emit resource/entity metric attributes at proper OpenTelemetry layer

### DIFF
--- a/rust/otap-dataflow/.chloggen/resource-scope-datapoint-attributes.yaml
+++ b/rust/otap-dataflow/.chloggen/resource-scope-datapoint-attributes.yaml
@@ -1,0 +1,22 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: observability
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Self-telemetry attributes are now split across the correct OpenTelemetry layers instead of all being emitted as data-point attributes
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [3161]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Process/host identity (`host.id`, `container.id`, `service.instance.id`) moves
+  to the Resource layer (SDK `Resource` / Prometheus `target_info`); entity
+  identity moves to the instrumentation scope (`otel_scope_*` labels). Resource
+  attributes are no longer per-metric labels (query `target_info`), and entity
+  attributes are now `otel_scope_`-prefixed on the admin Prometheus output.

--- a/rust/otap-dataflow/.chloggen/resource-scope-datapoint-attributes.yaml
+++ b/rust/otap-dataflow/.chloggen/resource-scope-datapoint-attributes.yaml
@@ -6,7 +6,7 @@ change_type: breaking
 component: observability
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Self-telemetry attributes are now split across the correct OpenTelemetry layers instead of all being emitted as data-point attributes
+note: Self-telemetry metric attributes are now split across the correct OpenTelemetry layers instead of all being emitted as data-point attributes
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [3161]
@@ -15,8 +15,10 @@ issues: [3161]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  Process/host identity (`host.id`, `container.id`, `service.instance.id`) moves
-  to the Resource layer (SDK `Resource` / Prometheus `target_info`); entity
-  identity moves to the instrumentation scope (`otel_scope_*` labels). Resource
-  attributes are no longer per-metric labels (query `target_info`), and entity
-  attributes are now `otel_scope_`-prefixed on the admin Prometheus output.
+  Metric entity identity moves to the instrumentation scope (`otel_scope_*`
+  labels); logs already emitted entity identity on scope. Process/host identity
+  (`host.id`, `container.id`, `service.instance.id`) is now applied
+  consistently to the Resource layer for both metrics and logs (SDK `Resource`
+  / Prometheus `target_info`). Resource attributes are no longer per-metric
+  labels (query `target_info`), and metric entity attributes are now
+  `otel_scope_`-prefixed on the admin Prometheus output.

--- a/rust/otap-dataflow/crates/admin/src/telemetry.rs
+++ b/rust/otap-dataflow/crates/admin/src/telemetry.rs
@@ -1784,7 +1784,10 @@ where
         let final_key = if prefix.is_empty() {
             sanitized
         } else {
-            format!("{prefix}{sanitized}")
+            let mut key = String::with_capacity(prefix.len() + sanitized.len());
+            key.push_str(prefix);
+            key.push_str(&sanitized);
+            key
         };
         // Skip keys that collide with separately-emitted scope/reserved
         // labels. Comparison is on the final label key after prefixing.

--- a/rust/otap-dataflow/crates/admin/src/telemetry.rs
+++ b/rust/otap-dataflow/crates/admin/src/telemetry.rs
@@ -938,8 +938,9 @@ pub(crate) fn render_target_info(
         resource_attributes
             .iter()
             .map(|(k, v)| (k.as_str(), v.to_string_value())),
+        "",
         // No reserved keys: `target_info` is a separate metric line and
-        // does not carry `otel_scope_*` labels, so no collision is possible.
+        // resource attributes remain unprefixed.
         &[],
     );
     let mut labels = String::new();
@@ -985,15 +986,17 @@ fn agg_prometheus_text(
                 escape_prom_label_value(&g.name)
             );
         }
-        // Merge values for keys that collide after sanitization (per
-        // OTel→Prometheus spec). Emission order is unspecified — Prometheus
-        // treats labels as an unordered set. Drop attribute keys that
-        // sanitize to the reserved `otel_scope_*` names already emitted
-        // above to avoid duplicate-label rejection by Prometheus.
+        // Scope attributes become `otel_scope_<key>` labels. Merge values
+        // for keys that collide after sanitization (per OTel→Prometheus
+        // spec). Emission order is unspecified — Prometheus treats labels as
+        // an unordered set. Drop attribute keys whose prefixed labels collide
+        // with reserved `otel_scope_*` names already emitted above to avoid
+        // duplicate-label rejection by Prometheus.
         let merged = sanitize_and_merge_label_pairs(
             g.attributes
                 .iter()
                 .map(|(k, v)| (k.as_str(), v.to_string_value())),
+            "otel_scope_",
             RESERVED_SCOPE_LABEL_KEYS,
         );
         for (k, v) in &merged {
@@ -1288,14 +1291,16 @@ fn format_prometheus_text(
                 escape_prom_label_value(descriptor.name)
             );
         }
-        // Merge values for keys that collide after sanitization (per
-        // OTel→Prometheus spec). Emission order is unspecified. Drop
-        // attribute keys that sanitize to the reserved `otel_scope_*`
-        // names already emitted above.
+        // Scope attributes become `otel_scope_<key>` labels. Merge values
+        // for keys that collide after sanitization (per OTel→Prometheus
+        // spec). Emission order is unspecified. Drop attribute keys whose
+        // prefixed labels collide with reserved `otel_scope_*` names already
+        // emitted above.
         let merged = sanitize_and_merge_label_pairs(
             attributes
                 .iter_attributes()
                 .map(|(k, v)| (k, v.to_string_value())),
+            "otel_scope_",
             RESERVED_SCOPE_LABEL_KEYS,
         );
         for (key, value) in &merged {
@@ -1744,19 +1749,22 @@ fn escape_prom_help(s: &str) -> String {
 /// regardless of caller iteration order (e.g. `HashMap::iter`, which has
 /// no defined order).
 ///
-/// `reserved_keys` lists already-emitted labels (post-sanitization) that
-/// must not appear in the merged map. Per the spec, the scope-derived
-/// `otel_scope_name` / `otel_scope_version` labels are emitted separately
-/// from per-metric attributes; if a metric attribute key sanitizes to one
-/// of those reserved names, the conflicting attribute is dropped (Prometheus
-/// rejects duplicate label names on a single sample). Pass `&[]` when no
-/// reservation applies (e.g. when rendering `target_info` from resource
-/// attributes).
+/// `prefix` is prepended after sanitization: use `otel_scope_` for scope
+/// attributes and `""` for `target_info` resource attributes, which must remain
+/// unprefixed.
+///
+/// `reserved_keys` lists already-emitted labels (after sanitization and
+/// prefixing) that must not appear in the merged map. Per the spec, scope
+/// identity labels are emitted separately from per-metric attributes; if a
+/// metric attribute's final prefixed key collides with one of those reserved
+/// names, the conflicting attribute is dropped (Prometheus rejects duplicate
+/// label names on a single sample). Pass `&[]` when no reservation applies.
 ///
 /// Iteration order over the returned map is not specified — Prometheus
 /// treats labels as an unordered set.
 fn sanitize_and_merge_label_pairs<'a, I>(
     attrs: I,
+    prefix: &str,
     reserved_keys: &[&str],
 ) -> HashMap<String, String>
 where
@@ -1773,14 +1781,18 @@ where
     let mut merged: HashMap<String, String> = HashMap::with_capacity(entries.len());
     for (key, value) in entries {
         let sanitized = sanitize_prom_label_key(key);
+        let final_key = if prefix.is_empty() {
+            sanitized
+        } else {
+            format!("{prefix}{sanitized}")
+        };
         // Skip keys that collide with separately-emitted scope/reserved
-        // labels. Comparison is on the sanitized form to catch inputs like
-        // `otel.scope.name` that map to the reserved name.
-        if reserved_keys.contains(&sanitized.as_str()) {
+        // labels. Comparison is on the final label key after prefixing.
+        if reserved_keys.contains(&final_key.as_str()) {
             continue;
         }
         let _ = merged
-            .entry(sanitized)
+            .entry(final_key)
             .and_modify(|existing| {
                 existing.push(';');
                 existing.push_str(&value);
@@ -1791,15 +1803,14 @@ where
 }
 
 /// Reserved Prometheus label keys for OTel scope identity. These are emitted
-/// separately from per-metric attributes; per-metric attributes whose keys
-/// sanitize to one of these names are dropped to avoid duplicate-label
-/// scrape errors.
-///
-/// `otel_scope_version` is intentionally omitted: the current
-/// `MetricsDescriptor` does not carry a version, so we never emit
-/// `otel_scope_version` ourselves and a user attribute with that name is
-/// not a collision. Add it here when version emission is implemented.
-const RESERVED_SCOPE_LABEL_KEYS: &[&str] = &["otel_scope_name"];
+/// separately from per-metric attributes; per the spec, scope attributes whose
+/// prefixed keys collide with these reserved identity labels are dropped to
+/// avoid duplicate-label scrape errors.
+const RESERVED_SCOPE_LABEL_KEYS: &[&str] = &[
+    "otel_scope_name",
+    "otel_scope_version",
+    "otel_scope_schema_url",
+];
 
 // ---------------------------------------------------------------------------
 // WebSocket live log stream  (/api/v1/telemetry/logs/stream)
@@ -3304,6 +3315,7 @@ mod tests {
                 ("http.method", "GET".to_string()),
                 ("http_method", "POST".to_string()),
             ],
+            "",
             &[],
         );
         // Keys are merged into a single sanitized entry.
@@ -3344,7 +3356,7 @@ mod tests {
             ],
         ];
         for input in cases {
-            let merged = sanitize_and_merge_label_pairs(input, &[]);
+            let merged = sanitize_and_merge_label_pairs(input, "", &[]);
             assert_eq!(merged.len(), 1);
             assert_eq!(
                 merged.get("service_name").map(String::as_str),
@@ -3359,7 +3371,8 @@ mod tests {
         let _ = hm.insert("service.name", "dot".to_string());
         let _ = hm.insert("service_name", "underscore".to_string());
         let _ = hm.insert("service-name", "dash".to_string());
-        let merged = sanitize_and_merge_label_pairs(hm.iter().map(|(k, v)| (*k, v.clone())), &[]);
+        let merged =
+            sanitize_and_merge_label_pairs(hm.iter().map(|(k, v)| (*k, v.clone())), "", &[]);
         assert_eq!(
             merged.get("service_name").map(String::as_str),
             Some("dash;dot;underscore")
@@ -3370,6 +3383,7 @@ mod tests {
     fn test_sanitize_and_merge_label_pairs_distinct_keys_unchanged() {
         let merged = sanitize_and_merge_label_pairs(
             vec![("a", "1".to_string()), ("b", "2".to_string())],
+            "",
             &[],
         );
         assert_eq!(merged.len(), 2);
@@ -3379,24 +3393,29 @@ mod tests {
 
     #[test]
     fn test_sanitize_and_merge_label_pairs_drops_reserved_keys() {
-        // Per OTel→Prometheus spec: `otel_scope_name` is emitted separately
-        // from per-metric attributes. If a metric attribute key sanitizes to
-        // that reserved name (e.g. raw key `otel.scope.name`), the
-        // conflicting attribute is dropped to avoid Prometheus duplicate-
-        // label rejection. (`otel_scope_version` is not currently emitted,
-        // so user attributes with that name are not reserved.)
+        // Per OTel→Prometheus spec: scope attributes are prefixed with
+        // `otel_scope_`, and prefixed labels that collide with reserved scope
+        // identity labels are dropped to avoid Prometheus duplicate-label
+        // rejection.
         let merged = sanitize_and_merge_label_pairs(
             vec![
-                ("otel.scope.name", "user_value".to_string()),
-                ("otel_scope_name", "literal_collision".to_string()),
-                ("http_method", "GET".to_string()),
+                ("name", "user_value".to_string()),
+                ("version", "1.0.0".to_string()),
+                ("schema.url", "https://example.test/schema".to_string()),
+                ("node.kind", "processor".to_string()),
             ],
+            "otel_scope_",
             RESERVED_SCOPE_LABEL_KEYS,
         );
         // Only the non-reserved key survives.
         assert_eq!(merged.len(), 1);
-        assert_eq!(merged.get("http_method").map(String::as_str), Some("GET"));
+        assert_eq!(
+            merged.get("otel_scope_node_kind").map(String::as_str),
+            Some("processor")
+        );
         assert!(!merged.contains_key("otel_scope_name"));
+        assert!(!merged.contains_key("otel_scope_version"));
+        assert!(!merged.contains_key("otel_scope_schema_url"));
     }
 
     /// Returns true if `output` contains a line of the shape
@@ -3635,7 +3654,7 @@ mod tests {
         );
         assert!(
             output.contains(
-                "http_requests_total{otel_scope_name=\"http_server\",http_method=\"GET\"} 42 1000\n"
+                "http_requests_total{otel_scope_name=\"http_server\",otel_scope_http_method=\"GET\"} 42 1000\n"
             ),
             "counter should have otel_scope_name and (omitted-when-empty) otel_scope_version labels. Output:\n{output}"
         );
@@ -3659,7 +3678,7 @@ mod tests {
             "TYPE should be counter"
         );
         assert!(
-            output.contains("http_request_duration_seconds_total{otel_scope_name=\"http_server\",http_method=\"GET\"} 1.25 1000\n"),
+            output.contains("http_request_duration_seconds_total{otel_scope_name=\"http_server\",otel_scope_http_method=\"GET\"} 1.25 1000\n"),
             "should have correct value with labels. Output:\n{output}"
         );
 
@@ -3677,7 +3696,7 @@ mod tests {
             "TYPE should be gauge"
         );
         assert!(
-            output.contains("memory_usage_bytes{otel_scope_name=\"http_server\",http_method=\"GET\"} 1024 1000\n"),
+            output.contains("memory_usage_bytes{otel_scope_name=\"http_server\",otel_scope_http_method=\"GET\"} 1024 1000\n"),
             "gauge should have correct value. Output:\n{output}"
         );
 

--- a/rust/otap-dataflow/crates/controller/src/lib.rs
+++ b/rust/otap-dataflow/crates/controller/src/lib.rs
@@ -50,6 +50,7 @@ use otap_df_config::engine::{
     SYSTEM_OBSERVABILITY_PIPELINE_ID, SYSTEM_PIPELINE_GROUP_ID,
 };
 use otap_df_config::node::{NodeKind, NodeUserConfig};
+use otap_df_config::pipeline::telemetry::AttributeValue;
 use otap_df_config::policy::MemoryLimiterMode;
 use otap_df_config::policy::{
     ChannelCapacityPolicy, CoreAllocation, CoreAllocationStrategy, TelemetryPolicy,
@@ -1163,9 +1164,32 @@ impl<
     {
         let num_pipeline_groups = engine_config.groups.len();
         let resolved_config = engine_config.resolve();
-        let (engine, pipelines, observability_pipeline) = resolved_config.into_parts();
+        let (mut engine, pipelines, observability_pipeline) = resolved_config.into_parts();
         let num_pipelines = pipelines.len();
         let admin_settings = engine.http_admin.clone().unwrap_or_default();
+
+        // Create the shared telemetry registry first - it is used by both the
+        // observed state store and the internal telemetry system, and by the
+        // controller context below.
+        let telemetry_registry = TelemetryRegistryHandle::new();
+        let controller_ctx = ControllerContext::new(telemetry_registry.clone());
+
+        // Inject auto-detected process/host resource attributes (host.id,
+        // container.id, service.instance.id) into the telemetry resource map so
+        // they surface on the OTel Resource / Prometheus target_info. Explicit
+        // config-provided keys take precedence over auto-detected values.
+        for (key, value) in controller_ctx.resource_attributes() {
+            let _ = engine
+                .telemetry
+                .resource
+                .entry(key)
+                .or_insert_with(|| AttributeValue::String(value));
+        }
+
+        // Snapshot the resolved resource map (config + auto-detected) for the admin
+        // endpoint's target_info, mirroring what the SDK Resource receives.
+        let admin_resource = engine.telemetry.resource.clone();
+
         // Initialize metrics system and observed event store.
         // ToDo A hierarchical metrics system will be implemented to better support hardware with multiple NUMA nodes.
         let telemetry_config = &engine.telemetry;
@@ -1178,7 +1202,6 @@ impl<
 
         // Create the shared telemetry registry first - it will be used by both
         // the observed state store and the internal telemetry system.
-        let telemetry_registry = TelemetryRegistryHandle::new();
         let log_tap_handle = telemetry_config
             .logs
             .tap
@@ -1223,7 +1246,6 @@ impl<
 
         let metrics_dispatcher = telemetry_system.dispatcher();
         let metrics_reporter = telemetry_system.reporter();
-        let controller_ctx = ControllerContext::new(telemetry_system.registry());
         let memory_pressure_state = controller_ctx.memory_pressure_state();
         let (memory_pressure_tx, _memory_pressure_rx) =
             tokio::sync::watch::channel(MemoryPressureChanged::initial());
@@ -1552,7 +1574,7 @@ impl<
                     telemetry_registry,
                     memory_pressure_state,
                     log_tap_handle,
-                    engine_config.engine.telemetry.resource.clone(),
+                    admin_resource,
                     cancellation_token,
                 )
             },

--- a/rust/otap-dataflow/crates/engine/src/attributes.rs
+++ b/rust/otap-dataflow/crates/engine/src/attributes.rs
@@ -44,21 +44,6 @@ pub fn config_map_to_telemetry(
         .collect()
 }
 
-/// Resource attributes (host id, process instance id, container id, ...).
-#[attribute_set(name = "resource.attrs")]
-#[derive(Debug, Clone, Default, Hash)]
-pub struct ResourceAttributeSet {
-    /// Unique process instance identifier (base32-encoded UUID v7).
-    #[attribute]
-    pub process_instance_id: Cow<'static, str>,
-    /// Host identifier, when available (e.g. hostname).
-    #[attribute]
-    pub host_id: Cow<'static, str>,
-    /// Container identifier, when available (e.g. Docker or containerd container ID).
-    #[attribute]
-    pub container_id: Cow<'static, str>,
-}
-
 /// Engine attributes (core id, numa node id, ...).
 #[attribute_set(name = "controller.attrs")]
 #[derive(Debug, Clone, Default, Hash)]
@@ -67,13 +52,30 @@ pub struct EngineAttributeSet {
     #[attribute]
     pub core_id: usize,
 
-    /// Resource attributes.
-    #[compose]
-    pub resource_attrs: ResourceAttributeSet,
-
     /// NUMA node identifier.
     #[attribute]
     pub numa_node_id: usize,
+}
+
+static ENGINE_ENTITY_DESCRIPTOR: AttributesDescriptor = AttributesDescriptor {
+    name: "engine",
+    fields: &[],
+};
+
+/// Empty attribute set for the engine-global entity. Process/host identity
+/// now lives on the OTel Resource layer, so engine-wide metrics carry no
+/// scope attributes.
+#[derive(Debug, Clone, Default, Hash)]
+pub struct EngineEntityAttributeSet;
+
+impl AttributeSetHandler for EngineEntityAttributeSet {
+    fn descriptor(&self) -> &'static AttributesDescriptor {
+        &ENGINE_ENTITY_DESCRIPTOR
+    }
+
+    fn attribute_values(&self) -> &[AttributeValue] {
+        &[]
+    }
 }
 
 /// Pipeline attributes.

--- a/rust/otap-dataflow/crates/engine/src/context.rs
+++ b/rust/otap-dataflow/crates/engine/src/context.rs
@@ -4,9 +4,9 @@
 //! Context providing general information on the current controller and the current pipeline.
 
 use crate::attributes::{
-    ChannelAttributeSet, CustomAttributeSet, EngineAttributeSet, NodeAttributeSet,
-    NodeWithCustomAttributeSet, NodeWithCustomTopicAttributeSet, NodeWithTopicAttributeSet,
-    PipelineAttributeSet, config_map_to_telemetry,
+    ChannelAttributeSet, CustomAttributeSet, EngineAttributeSet, EngineEntityAttributeSet,
+    NodeAttributeSet, NodeWithCustomAttributeSet, NodeWithCustomTopicAttributeSet,
+    NodeWithTopicAttributeSet, PipelineAttributeSet, config_map_to_telemetry,
 };
 use crate::entity_context::{current_node_telemetry_handle, node_entity_key};
 use crate::memory_limiter::MemoryPressureState;
@@ -98,8 +98,11 @@ static CONTAINER_ID: LazyLock<Cow<'static, str>> =
 #[derive(Clone, Debug)]
 pub struct ControllerContext {
     telemetry_registry_handle: TelemetryRegistryHandle,
+    /// Unique process instance identifier (base32-encoded UUID v7).
     process_instance_id: Cow<'static, str>,
+    /// Host identifier, when available (e.g. hostname).
     host_id: Cow<'static, str>,
+    /// Container identifier, when available (e.g. Docker or containerd container ID).
     container_id: Cow<'static, str>,
     numa_node_id: usize,
     memory_pressure_state: MemoryPressureState,
@@ -204,20 +207,35 @@ impl ControllerContext {
         )
     }
 
-    /// Registers the engine-level entity for engine-wide metrics.
+    /// Registers the engine-level entity for engine-wide metrics with no scope attributes.
     ///
     /// Returns the [`EntityKey`] to pass to
     /// [`EngineMetricsMonitor::new`](crate::engine_metrics::EngineMetricsMonitor::new).
     #[must_use]
     pub fn register_engine_entity(&self) -> EntityKey {
-        use crate::attributes::ResourceAttributeSet;
-
         self.telemetry_registry_handle
-            .register_entity(ResourceAttributeSet {
-                process_instance_id: self.process_instance_id.clone(),
-                host_id: self.host_id.clone(),
-                container_id: self.container_id.clone(),
-            })
+            .register_entity(EngineEntityAttributeSet)
+    }
+
+    /// Returns the auto-detected process/host resource attributes mapped to
+    /// OpenTelemetry semantic-convention keys. Empty values are omitted.
+    /// Keys: `host.id`, `container.id`, `service.instance.id`.
+    #[must_use]
+    pub fn resource_attributes(&self) -> Vec<(String, String)> {
+        let mut out = Vec::new();
+        if !self.host_id.is_empty() {
+            out.push(("host.id".to_string(), self.host_id.to_string()));
+        }
+        if !self.container_id.is_empty() {
+            out.push(("container.id".to_string(), self.container_id.to_string()));
+        }
+        if !self.process_instance_id.is_empty() {
+            out.push((
+                "service.instance.id".to_string(),
+                self.process_instance_id.to_string(),
+            ));
+        }
+        out
     }
 
     /// Returns a handle to the telemetry registry.
@@ -471,14 +489,7 @@ impl PipelineContext {
     }
 
     fn engine_attribute_set(&self) -> EngineAttributeSet {
-        use crate::attributes::ResourceAttributeSet;
-
         EngineAttributeSet {
-            resource_attrs: ResourceAttributeSet {
-                process_instance_id: self.controller_context.process_instance_id.clone(),
-                host_id: self.controller_context.host_id.clone(),
-                container_id: self.controller_context.container_id.clone(),
-            },
             core_id: self.pipeline_context_params.core_id,
             numa_node_id: self.controller_context.numa_node_id,
         }

--- a/rust/otap-dataflow/crates/engine/src/context.rs
+++ b/rust/otap-dataflow/crates/engine/src/context.rs
@@ -162,6 +162,28 @@ impl ControllerContext {
         }
     }
 
+    /// Creates a `ControllerContext` with explicit auto-detected identity values.
+    ///
+    /// Test-only: the production [`new`](Self::new) constructor derives these
+    /// from the host environment, which is unsuitable for asserting the
+    /// semantic-convention mapping in [`resource_attributes`](Self::resource_attributes).
+    #[cfg(test)]
+    fn new_with_identity(
+        telemetry_registry_handle: TelemetryRegistryHandle,
+        process_instance_id: impl Into<Cow<'static, str>>,
+        host_id: impl Into<Cow<'static, str>>,
+        container_id: impl Into<Cow<'static, str>>,
+    ) -> Self {
+        Self {
+            telemetry_registry_handle,
+            process_instance_id: process_instance_id.into(),
+            host_id: host_id.into(),
+            container_id: container_id.into(),
+            numa_node_id: 0,
+            memory_pressure_state: MemoryPressureState::default(),
+        }
+    }
+
     /// Returns a new pipeline context with the given identifiers and the current controller context
     /// as the parent context.
     #[must_use]
@@ -604,5 +626,48 @@ impl PipelineContext {
             node_names: self.node_names.clone(),
             topic_set: self.topic_set.clone(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resource_attributes_maps_semconv_keys() {
+        let ctx = ControllerContext::new_with_identity(
+            TelemetryRegistryHandle::new(),
+            "proc-123",
+            "machine-abc",
+            "container-xyz",
+        );
+
+        // All three identities present: emitted in a stable order under their
+        // OpenTelemetry semantic-convention keys.
+        assert_eq!(
+            ctx.resource_attributes(),
+            vec![
+                ("host.id".to_string(), "machine-abc".to_string()),
+                ("container.id".to_string(), "container-xyz".to_string()),
+                ("service.instance.id".to_string(), "proc-123".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn resource_attributes_omits_empty_values() {
+        // Empty host/container should be skipped entirely (no empty-valued
+        // attributes), leaving only the populated service.instance.id.
+        let ctx = ControllerContext::new_with_identity(
+            TelemetryRegistryHandle::new(),
+            "proc-123",
+            "",
+            "",
+        );
+
+        assert_eq!(
+            ctx.resource_attributes(),
+            vec![("service.instance.id".to_string(), "proc-123".to_string())]
+        );
     }
 }

--- a/rust/otap-dataflow/crates/telemetry/src/metrics/dispatcher.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/metrics/dispatcher.rs
@@ -5,7 +5,7 @@
 
 use std::sync::Arc;
 
-use opentelemetry::{global, metrics::Meter};
+use opentelemetry::{InstrumentationScope, global, metrics::Meter};
 use tokio::time::{MissedTickBehavior, interval};
 use tokio_util::sync::CancellationToken;
 
@@ -59,14 +59,21 @@ impl MetricsDispatcher {
     fn dispatch_metrics(&self) -> Result<(), Error> {
         self.metrics_handler
             .visit_metrics_and_reset(|descriptor, attributes, metrics_iter| {
-                let meter = global::meter(descriptor.name);
+                let scope_attributes = Self::to_opentelemetry_attributes(attributes);
+                let meter = if scope_attributes.is_empty() {
+                    global::meter(descriptor.name)
+                } else {
+                    global::meter_with_scope(
+                        InstrumentationScope::builder(descriptor.name)
+                            .with_attributes(scope_attributes)
+                            .build(),
+                    )
+                };
 
-                // There is no support for metric level attributes currently. Attaching resource level attributes to every metric.
-                // TODO: Consider adding metric level attributes and not to add resource level attributes to every metric.
-                let otel_attributes = Self::to_opentelemetry_attributes(attributes);
-
+                // Entity attributes live on the instrumentation scope so OTel Views can
+                // target them via scope_attributes selectors; data points carry none.
                 for (field, value) in metrics_iter {
-                    self.add_opentelemetry_metric(field, value, &otel_attributes, &meter);
+                    self.add_opentelemetry_metric(field, value, &[], &meter);
                 }
             });
 

--- a/rust/otap-dataflow/crates/telemetry/src/metrics/dispatcher.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/metrics/dispatcher.rs
@@ -5,7 +5,7 @@
 
 use std::sync::Arc;
 
-use opentelemetry::{InstrumentationScope, global, metrics::Meter};
+use opentelemetry::{InstrumentationScope, global, metrics::Meter, metrics::MeterProvider};
 use tokio::time::{MissedTickBehavior, interval};
 use tokio_util::sync::CancellationToken;
 
@@ -57,13 +57,22 @@ impl MetricsDispatcher {
     }
 
     fn dispatch_metrics(&self) -> Result<(), Error> {
+        self.dispatch_metrics_to(&*global::meter_provider())
+    }
+
+    /// Dispatches the accumulated metrics through `meter_provider`.
+    ///
+    /// Production callers pass the global meter provider; tests can inject a
+    /// dedicated [`MeterProvider`] (e.g. backed by an in-memory exporter) to
+    /// observe the emitted instrumentation scopes and data points.
+    fn dispatch_metrics_to(&self, meter_provider: &dyn MeterProvider) -> Result<(), Error> {
         self.metrics_handler
             .visit_metrics_and_reset(|descriptor, attributes, metrics_iter| {
                 let scope_attributes = Self::to_opentelemetry_attributes(attributes);
                 let meter = if scope_attributes.is_empty() {
-                    global::meter(descriptor.name)
+                    meter_provider.meter(descriptor.name)
                 } else {
-                    global::meter_with_scope(
+                    meter_provider.meter_with_scope(
                         InstrumentationScope::builder(descriptor.name)
                             .with_attributes(scope_attributes)
                             .build(),
@@ -326,10 +335,160 @@ mod tests {
 
     use super::*;
     use crate::descriptor::MetricValueType;
+    use crate::instrument::Mmsc;
+    use crate::metrics::{MetricSetHandler, MetricsDescriptor};
     use crate::{
         attributes::AttributeIterator,
         descriptor::{AttributeField, AttributeValueType, AttributesDescriptor},
     };
+    use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData, ResourceMetrics};
+    use opentelemetry_sdk::metrics::{InMemoryMetricExporter, SdkMeterProvider};
+
+    // --- End-to-end scope-attribute dispatch tests -----------------------------
+    //
+    // These drive the real `dispatch_metrics_to` code path against a dedicated
+    // in-memory meter provider (no global state, parallel-safe) and assert the
+    // key behavior of the resource/scope reorganization: entity attributes are
+    // attached to the *instrumentation scope*, never duplicated onto data points.
+
+    static SCOPE_ATTR_METRICS_DESCRIPTOR: MetricsDescriptor = MetricsDescriptor {
+        name: "scope_attr_dispatch_test",
+        metrics: &[MetricsField {
+            name: "requests",
+            unit: "{request}",
+            brief: "request count",
+            instrument: Instrument::Counter,
+            temporality: Some(Temporality::Delta),
+            value_type: MetricValueType::U64,
+        }],
+    };
+
+    #[derive(Debug, Default)]
+    struct CounterMetricSet {
+        requests: crate::instrument::Counter<u64>,
+    }
+
+    impl MetricSetHandler for CounterMetricSet {
+        fn descriptor(&self) -> &'static MetricsDescriptor {
+            &SCOPE_ATTR_METRICS_DESCRIPTOR
+        }
+        fn snapshot_values(&self) -> Vec<MetricValue> {
+            vec![MetricValue::from(self.requests.get())]
+        }
+        fn clear_values(&mut self) {
+            self.requests.reset();
+        }
+        fn needs_flush(&self) -> bool {
+            !MetricValue::from(self.requests.get()).is_zero()
+        }
+    }
+
+    // Carries a single `service` attribute -> exercises the scope-attribute branch.
+    static WITH_ATTRS_DESCRIPTOR: AttributesDescriptor = AttributesDescriptor {
+        name: "scope_attrs_present",
+        fields: &[AttributeField {
+            key: "service",
+            r#type: AttributeValueType::String,
+            brief: "service name",
+        }],
+    };
+
+    // Carries no attributes -> exercises the bare-scope branch.
+    static NO_ATTRS_DESCRIPTOR: AttributesDescriptor = AttributesDescriptor {
+        name: "scope_attrs_absent",
+        fields: &[],
+    };
+
+    #[derive(Debug)]
+    struct ScopeAttrs {
+        descriptor: &'static AttributesDescriptor,
+        values: Vec<AttributeValue>,
+    }
+
+    impl AttributeSetHandler for ScopeAttrs {
+        fn descriptor(&self) -> &'static AttributesDescriptor {
+            self.descriptor
+        }
+        fn attribute_values(&self) -> &[AttributeValue] {
+            &self.values
+        }
+        fn iter_attributes<'a>(&'a self) -> AttributeIterator<'a> {
+            AttributeIterator::new(self.descriptor.fields, &self.values)
+        }
+    }
+
+    /// Dispatches the dispatcher's accumulated metrics through a dedicated
+    /// in-memory meter provider and returns the exported resource metrics.
+    ///
+    /// Shared harness for the end-to-end dispatch tests: it drives the real
+    /// `dispatch_metrics_to` code path with no global state (parallel-safe).
+    fn dispatch_to_in_memory(dispatcher: &MetricsDispatcher) -> Vec<ResourceMetrics> {
+        let exporter = InMemoryMetricExporter::default();
+        let meter_provider = SdkMeterProvider::builder()
+            .with_periodic_exporter(exporter.clone())
+            .build();
+
+        dispatcher
+            .dispatch_metrics_to(&meter_provider)
+            .expect("dispatch_metrics_to failed");
+
+        meter_provider.force_flush().expect("force_flush failed");
+
+        exporter
+            .get_finished_metrics()
+            .expect("get_finished_metrics failed")
+    }
+
+    /// Registers a counter metric set with `attrs`, records `count` increments,
+    /// dispatches through the shared in-memory harness, and returns
+    /// `(scope attributes, data-point attributes, summed value)` for the
+    /// exported `requests` counter. Asserts exactly one data point was emitted.
+    fn dispatch_and_collect(
+        attrs: ScopeAttrs,
+        count: u64,
+    ) -> (
+        Vec<opentelemetry::KeyValue>,
+        Vec<opentelemetry::KeyValue>,
+        u64,
+    ) {
+        let registry = TelemetryRegistryHandle::new();
+        let mut metric_set = registry.register_metric_set::<CounterMetricSet>(attrs);
+        metric_set.requests.add(count);
+
+        let snapshot = metric_set.snapshot();
+        registry.accumulate_metric_set_snapshot(snapshot.key, &snapshot.metrics);
+
+        let dispatcher =
+            MetricsDispatcher::new(registry.clone(), std::time::Duration::from_secs(1));
+        let finished = dispatch_to_in_memory(&dispatcher);
+
+        let mut result = None;
+        for rm in &finished {
+            for sm in rm.scope_metrics() {
+                for metric in sm.metrics() {
+                    if metric.name() == "requests" {
+                        let scope_attrs = sm.scope().attributes().cloned().collect::<Vec<_>>();
+                        let AggregatedMetrics::U64(MetricData::Sum(sum)) = metric.data() else {
+                            panic!("expected a u64 Sum for the requests counter");
+                        };
+                        let data_points: Vec<_> = sum.data_points().collect();
+                        assert_eq!(
+                            data_points.len(),
+                            1,
+                            "expected exactly one data point, found {}",
+                            data_points.len()
+                        );
+                        let dp = data_points[0];
+                        let dp_attrs = dp.attributes().cloned().collect::<Vec<_>>();
+                        assert!(result.is_none(), "requests metric exported more than once");
+                        result = Some((scope_attrs, dp_attrs, dp.value()));
+                    }
+                }
+            }
+        }
+
+        result.expect("requests metric not exported")
+    }
 
     #[test]
     fn test_to_opentelemetry_key_value() {
@@ -587,15 +746,6 @@ mod tests {
     /// record_synthetic_histogram → OTel SDK histogram export.
     #[test]
     fn test_mmsc_exported_as_histogram_with_no_buckets() {
-        use opentelemetry::metrics::MeterProvider as _;
-        use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
-        use opentelemetry_sdk::metrics::{InMemoryMetricExporter, SdkMeterProvider};
-
-        use crate::attributes::AttributeIterator;
-        use crate::descriptor::{AttributeField, AttributeValueType, AttributesDescriptor};
-        use crate::instrument::Mmsc;
-        use crate::metrics::{MetricSetHandler, MetricsDescriptor};
-
         // --- Mock metric set with a single MMSC field --------------------------
 
         static MMSC_METRICS_DESCRIPTOR: MetricsDescriptor = MetricsDescriptor {
@@ -630,43 +780,11 @@ mod tests {
             }
         }
 
-        static MOCK_ATTRS_DESCRIPTOR: AttributesDescriptor = AttributesDescriptor {
-            name: "test_attrs",
-            fields: &[AttributeField {
-                key: "service",
-                r#type: AttributeValueType::String,
-                brief: "service name",
-            }],
-        };
-
-        #[derive(Debug)]
-        struct MockAttrs {
-            values: Vec<AttributeValue>,
-        }
-
-        impl AttributeSetHandler for MockAttrs {
-            fn descriptor(&self) -> &'static AttributesDescriptor {
-                &MOCK_ATTRS_DESCRIPTOR
-            }
-            fn attribute_values(&self) -> &[AttributeValue] {
-                &self.values
-            }
-            fn iter_attributes<'a>(&'a self) -> AttributeIterator<'a> {
-                AttributeIterator::new(self.descriptor().fields, &self.values)
-            }
-        }
-
-        // --- Set up OTel SDK with in-memory exporter ---------------------------
-
-        let exporter = InMemoryMetricExporter::default();
-        let meter_provider = SdkMeterProvider::builder()
-            .with_periodic_exporter(exporter.clone())
-            .build();
-
         // --- Register, record, accumulate, dispatch ----------------------------
 
         let registry = TelemetryRegistryHandle::new();
-        let mut metric_set = registry.register_metric_set::<MmscMetricSet>(MockAttrs {
+        let mut metric_set = registry.register_metric_set::<MmscMetricSet>(ScopeAttrs {
+            descriptor: &WITH_ATTRS_DESCRIPTOR,
             values: vec![AttributeValue::String("my-svc".into())],
         });
 
@@ -681,26 +799,12 @@ mod tests {
         let snapshot = metric_set.snapshot();
         registry.accumulate_metric_set_snapshot(snapshot.key, &snapshot.metrics);
 
-        // Dispatch: walk the registry and push to OTel SDK (via a
-        // provider-specific meter instead of the global one).
+        // Dispatch through the real code path via the shared in-memory harness.
         let dispatcher =
             MetricsDispatcher::new(registry.clone(), std::time::Duration::from_secs(1));
-        registry.visit_metrics_and_reset(|descriptor, attributes, metrics_iter| {
-            let meter = meter_provider.meter(descriptor.name);
-            let otel_attributes = MetricsDispatcher::to_opentelemetry_attributes(attributes);
-            for (field, value) in metrics_iter {
-                dispatcher.add_opentelemetry_metric(field, value, &otel_attributes, &meter);
-            }
-        });
-
-        // Flush to trigger export.
-        meter_provider.force_flush().expect("force_flush failed");
+        let finished = dispatch_to_in_memory(&dispatcher);
 
         // --- Assert on the exported histogram ----------------------------------
-
-        let finished = exporter
-            .get_finished_metrics()
-            .expect("get_finished_metrics failed");
 
         let mut found = false;
         for rm in &finished {
@@ -733,5 +837,46 @@ mod tests {
             found,
             "histogram metric 'latency' not found in exported data"
         );
+    }
+
+    #[test]
+    fn test_dispatch_metrics_puts_entity_attributes_on_scope() {
+        let attrs = ScopeAttrs {
+            descriptor: &WITH_ATTRS_DESCRIPTOR,
+            values: vec![AttributeValue::String("my-svc".into())],
+        };
+
+        let (scope_attrs, dp_attrs, value) = dispatch_and_collect(attrs, 3);
+
+        // The recorded value must survive the dispatch unchanged.
+        assert_eq!(value, 3, "exported counter value mismatch");
+
+        // Entity attributes must live on the instrumentation scope...
+        assert_eq!(scope_attrs.len(), 1, "expected exactly one scope attribute");
+        assert_eq!(scope_attrs[0].key.as_str(), "service");
+        assert_eq!(scope_attrs[0].value.as_str(), "my-svc");
+
+        // ...and must NOT be duplicated onto the data points.
+        assert!(
+            dp_attrs.is_empty(),
+            "data points must not carry entity attributes, found: {dp_attrs:?}"
+        );
+    }
+
+    #[test]
+    fn test_dispatch_metrics_without_attributes_uses_bare_scope() {
+        let attrs = ScopeAttrs {
+            descriptor: &NO_ATTRS_DESCRIPTOR,
+            values: vec![],
+        };
+
+        let (scope_attrs, dp_attrs, value) = dispatch_and_collect(attrs, 5);
+
+        assert_eq!(value, 5, "exported counter value mismatch");
+        assert!(
+            scope_attrs.is_empty(),
+            "scope must have no attributes when the entity has none, found: {scope_attrs:?}"
+        );
+        assert!(dp_attrs.is_empty(), "data points must carry no attributes");
     }
 }

--- a/rust/otap-dataflow/docs/telemetry/attributes-guide.md
+++ b/rust/otap-dataflow/docs/telemetry/attributes-guide.md
@@ -89,6 +89,40 @@ Do not duplicate information:
   signal-specific attribute.
 - Prefer a single canonical key.
 
+### How the layers are rendered
+
+The self-telemetry pipeline emits each category on its correct OpenTelemetry
+layer for **every exported signal** — both metrics and logs (see issue #3161).
+The mapping is signal-independent:
+
+| Category | OTLP export (metrics + logs) | Admin Prometheus endpoint (metrics only) |
+| --- | --- | --- |
+| Resource | `Resource` on `ResourceMetrics` / `ResourceLogs` | `target_info{...}` gauge labels |
+| Entity | `InstrumentationScope.attributes` on scope metrics / scope logs | `otel_scope_<key>` labels on each series |
+| Signal-specific | Data-point attributes (metrics) / log-record attributes (logs) | Inline (unprefixed) data-point labels |
+
+Notes:
+
+- The engine auto-detects and injects process/host resource attributes
+  (`host.id`, `container.id`, `service.instance.id`) into the configured
+  `engine.telemetry.resource` map. Config-provided keys take precedence over
+  auto-detected values, and empty values are omitted.
+- The **same** resolved resource map feeds every consumer: the SDK metrics
+  `Resource`, the pre-encoded OTLP log `Resource` bytes
+  (`ResourceLogs.resource`), and the admin `target_info` gauge — so resource
+  identity is consistent across metrics, logs, and the admin endpoint.
+- Entity identity is resolved from the telemetry registry once per entity and
+  attached as `InstrumentationScope.attributes` for both metrics and logs
+  (logs carry entity keys via their `LogContext`). On the admin Prometheus
+  endpoint the same entity attributes are rendered as `otel_scope_*` labels per
+  the OpenTelemetry-to-Prometheus specification; the reserved keys
+  `otel_scope_name`, `otel_scope_version`, and `otel_scope_schema_url` are not
+  overridden.
+- Engine-global signals (e.g. the `memory_rss` metric) carry no scope
+  attributes; their identity comes entirely from the Resource layer.
+- Today, no self-telemetry attributes are emitted on the signal-specific
+  (data-point / log-record) layer.
+
 ### Core rule
 
 Attributes attached to core system metrics MUST have bounded cardinality.

--- a/rust/otap-dataflow/docs/telemetry/attributes-guide.md
+++ b/rust/otap-dataflow/docs/telemetry/attributes-guide.md
@@ -92,7 +92,7 @@ Do not duplicate information:
 ### How the layers are rendered
 
 The self-telemetry pipeline emits each category on its correct OpenTelemetry
-layer for **every exported signal** — both metrics and logs (see issue #3161).
+layer for **every exported signal** - both metrics and logs (see issue #3161).
 The mapping is signal-independent:
 
 | Category | OTLP export (metrics + logs) | Admin Prometheus endpoint (metrics only) |
@@ -109,7 +109,7 @@ Notes:
   auto-detected values, and empty values are omitted.
 - The **same** resolved resource map feeds every consumer: the SDK metrics
   `Resource`, the pre-encoded OTLP log `Resource` bytes
-  (`ResourceLogs.resource`), and the admin `target_info` gauge — so resource
+  (`ResourceLogs.resource`), and the admin `target_info` gauge - so resource
   identity is consistent across metrics, logs, and the admin endpoint.
 - Entity identity is resolved from the telemetry registry once per entity and
   attached as `InstrumentationScope.attributes` for both metrics and logs

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/reports/report_logs.yaml
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/reports/report_logs.yaml
@@ -88,7 +88,7 @@ queries:
         metrics_filtered AS (
             SELECT *,
             "metric_attributes.component_name" AS component_name,
-            COALESCE("metric_attributes.core_id", 'N/A') AS core_id,
+            COALESCE("metric_attributes.otel_scope_core_id", 'N/A') AS core_id,
             FROM metrics
             WHERE metric_name IN (
               'logs_produced',

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/reports/report_metrics.yaml
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/reports/report_metrics.yaml
@@ -88,7 +88,7 @@ queries:
         metrics_filtered AS (
             SELECT *,
             "metric_attributes.component_name" AS component_name,
-            COALESCE("metric_attributes.core_id", 'N/A') AS core_id,
+            COALESCE("metric_attributes.otel_scope_core_id", 'N/A') AS core_id,
             FROM metrics
             WHERE metric_name IN (
               'metrics_produced',

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/reports/report_traces.yaml
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/reports/report_traces.yaml
@@ -88,7 +88,7 @@ queries:
         metrics_filtered AS (
             SELECT *,
             "metric_attributes.component_name" AS component_name,
-            COALESCE("metric_attributes.core_id", 'N/A') AS core_id,
+            COALESCE("metric_attributes.otel_scope_core_id", 'N/A') AS core_id,
             FROM metrics
             WHERE metric_name IN (
               'spans_produced',

--- a/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_logs.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_logs.yaml
@@ -91,7 +91,7 @@ queries:
         metrics_filtered AS (
             SELECT *,
             "metric_attributes.component_name" AS component_name,
-            COALESCE("metric_attributes.core_id", 'N/A') AS core_id,
+            COALESCE("metric_attributes.otel_scope_core_id", 'N/A') AS core_id,
             FROM metrics
             WHERE metric_name IN (
               'logs_produced',

--- a/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_metrics.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_metrics.yaml
@@ -91,7 +91,7 @@ queries:
         metrics_filtered AS (
             SELECT *,
             "metric_attributes.component_name" AS component_name,
-            COALESCE("metric_attributes.core_id", 'N/A') AS core_id,
+            COALESCE("metric_attributes.otel_scope_core_id", 'N/A') AS core_id,
             FROM metrics
             WHERE metric_name IN (
               'metrics_produced',

--- a/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_traces.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_traces.yaml
@@ -91,7 +91,7 @@ queries:
         metrics_filtered AS (
             SELECT *,
             "metric_attributes.component_name" AS component_name,
-            COALESCE("metric_attributes.core_id", 'N/A') AS core_id,
+            COALESCE("metric_attributes.otel_scope_core_id", 'N/A') AS core_id,
             FROM metrics
             WHERE metric_name IN (
               'spans_produced',


### PR DESCRIPTION
# Change Summary

### Problem
 All self-telemetry attributes were emitted as **data-point attributes**, regardless of whether theydescribed the process/host (Resource), the in-process entity (Scope), or the individual measurement (Datapoint). This produced high-cardinality per-series labels, prevented `target_info`-based joins,and did not follow the OpenTelemetry data model.

### Change
 Each attribute is now emitted on its correct OpenTelemetry layer, for **both metrics and logs**:
 | Category | Source | OTLP export (metrics + logs) | Admin Prometheus |
 | --- | --- | --- | --- |
 | **Resource** | process/host identity: `host.id`, `container.id`, `service.instance.id`(auto-detected) + config `engine.telemetry.resource` | `Resource` on `ResourceMetrics` /`ResourceLogs` | `target_info{...}` gauge |
 | **Scope** | entity identity: pipeline/node/channel/flow + `core.id`, `numa.node.id`,`deployment.generation` | `InstrumentationScope.attributes` | `otel_scope_*` labels |
 | **Datapoint** | none today | data-point / log-record attributes | inline labels |

 Key points:
 - Process/host resource attributes are auto-detected and injected into the resolved `engine.telemetry.resource` map; **config-provided keys take precedence**, empty values are omitted.
 - The **same** resolved resource map feeds the SDK metrics `Resource`, the OTLP log `Resource` bytes, and the admin `target_info` gauge — so resource identity is consistent across metrics, logs, and theadmin endpoint.
 - Entity attributes are rendered as `otel_scope_*` labels per the OTel→Prometheus spec; reserved keys (`otel_scope_name`/`version`/`schema_url`) are never overridden.
 - Engine-global metrics carry **no** scope attributes — identity comes entirely from the Resource layer.

### Validation

Running the same test pipeline described in #3161, we see the following from Prometheus:

```log
target_info{host_id="<computer name>",service_instance_id="AGPIRRISSR6UDHSZJSAHIKJV3U",service_name="resource-demo",deployment_environment_name="dev-proof"} 1
cpu_utilization{otel_scope_name="pipeline",otel_scope_pipeline_group_id="demo",otel_scope_core_id="0",otel_scope_pipeline_id="main",otel_scope_deployment_generation="0",otel_scope_numa_node_id="0"}0.00135 
```

The Console OTLP exporter shows similar results:

```log
Resource
     ->  service.instance.id=String(Owned("AGPIRRISSR6UDHSZJSAHIKJV3U"))
     ->  deployment.environment.name=String(Owned("dev-proof"))
     ->  service.name=String(Owned("resource-demo"))
     ->  host.id=String(Owned("<computer name>"))
...
Instrumentation Scope #0
     Name         : channel.sender
     Scope Attributes:
          ->  channel.id: gen:control
          ->  node.id: gen
          ->  node.urn: urn:otel:receiver:traffic_generator
          ->  node.type: receiver
          ->  pipeline.id: main
          ->  pipeline.group.id: demo
          ->  deployment.generation: 0
          ->  core.id: 0
          ->  numa.node.id: 0
 Metric #0
     Name         : send.count
     ...
     DataPoint #0
         Value        : 1
         Attributes   :          # <- empty: datapoint layer carries nothing
```

## What issue does this PR close?

* Closes #3161

## How are these changes tested?

Local pipeline runs and unit tests

## Are there any user-facing changes?

**Yes, this is a breaking change for any downstream consumers of otap-dataflow via Prometheus or OTLP metric exporter**

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
