### PR TITLE
chore(repo): Post-process chloggen to remove trailing spaces for sanity…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,8 @@ CHLOGGEN_VERSION = v0.30.0
 CHLOGGEN = chloggen
 CHLOGGEN_GO_CONFIG = go/.chloggen/config.yaml
 CHLOGGEN_RUST_CONFIG = rust/otap-dataflow/.chloggen/config.yaml
+CHANGELOG_GO = go/CHANGELOG.md
+CHANGELOG_RUST = rust/otap-dataflow/CHANGELOG.md
 
 .PHONY: chlog-install
 chlog-install:
@@ -97,9 +99,9 @@ chlog-validate:
 
 .PHONY: chlog-preview
 chlog-preview:
-	@echo "=== go/CHANGELOG.md ==="
+	@echo "=== $(CHANGELOG_GO) ==="
 	$(CHLOGGEN) update --config $(CHLOGGEN_GO_CONFIG) --dry
-	@echo "=== rust/otap-dataflow/CHANGELOG.md ==="
+	@echo "=== $(CHANGELOG_RUST) ==="
 	$(CHLOGGEN) update --config $(CHLOGGEN_RUST_CONFIG) --dry
 
 # Render pending entries into the configured CHANGELOG files for VERSION
@@ -108,3 +110,9 @@ chlog-preview:
 chlog-update:
 	$(CHLOGGEN) update --config $(CHLOGGEN_GO_CONFIG) --version $(VERSION)
 	$(CHLOGGEN) update --config $(CHLOGGEN_RUST_CONFIG) --version $(VERSION)
+	# chloggen's indent function leaves trailing whitespace on blank sub-text
+	# lines and the template emits consecutive blank lines; fix both so the
+	# sanity check and markdownlint pass.
+	sed -i 's/[[:space:]]*$$//' $(CHANGELOG_GO) $(CHANGELOG_RUST)
+	cat -s $(CHANGELOG_GO) > $(CHANGELOG_GO).tmp && mv $(CHANGELOG_GO).tmp $(CHANGELOG_GO)
+	cat -s $(CHANGELOG_RUST) > $(CHANGELOG_RUST).tmp && mv $(CHANGELOG_RUST).tmp $(CHANGELOG_RUST)

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,7 @@ chlog-update:
 	# chloggen's indent function leaves trailing whitespace on blank sub-text
 	# lines and the template emits consecutive blank lines; fix both so the
 	# sanity check and markdownlint pass.
-	sed -i 's/[[:space:]]*$$//' $(CHANGELOG_GO) $(CHANGELOG_RUST)
-	cat -s $(CHANGELOG_GO) > $(CHANGELOG_GO).tmp && mv $(CHANGELOG_GO).tmp $(CHANGELOG_GO)
-	cat -s $(CHANGELOG_RUST) > $(CHANGELOG_RUST).tmp && mv $(CHANGELOG_RUST).tmp $(CHANGELOG_RUST)
+	for f in $(CHANGELOG_GO) $(CHANGELOG_RUST); do \
+		sed -i.bak 's/[[:space:]]*$$//' $$f && rm -f $$f.bak; \
+		cat -s $$f > $$f.tmp && mv $$f.tmp $$f; \
+	done


### PR DESCRIPTION
# Change Summary

Lint saga continues, resolving https://github.com/open-telemetry/otel-arrow/actions/runs/26839451005/job/79142216123?pr=3173

I've run both `markdownlint-cli2` and `sanitycheck.py` locally 5 times on the generated result, we _should_ be green now (famous last words).
