### PR TITLE
chore(repo): Reduce stale PR time to 14+7days

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,9 +1,9 @@
-name: 'Mark stale issues and pull requests'
+name: "Mark stale issues and pull requests"
 
 on:
   schedule:
     # Run daily at 1:30 UTC
-    - cron: '30 1 * * *'
+    - cron: "30 1 * * *"
   workflow_dispatch:
 
 permissions:
@@ -24,19 +24,20 @@ jobs:
             This issue has been marked as stale due to lack of recent activity.
             It will be closed in 30 days if no further activity occurs.
             If this issue is still relevant, please comment or remove the stale label.
-          stale-issue-label: 'stale'
+          stale-issue-label: "stale"
           days-before-issue-stale: 180
           days-before-issue-close: 30
-          exempt-issue-labels: 'do-not-stale'
+          exempt-issue-labels: "do-not-stale"
           # Pull request settings
           stale-pr-message: >
             This pull request has been marked as stale due to lack of recent activity.
-            It will be closed in 30 days if no further activity occurs.
+            It will be closed in 7 days if no further activity occurs.
             If this PR is still relevant, please comment or push new commits to keep it active.
-          stale-pr-label: 'stale'
-          days-before-pr-stale: 14
-          days-before-pr-close: 30
-          exempt-pr-labels: 'do-not-stale'
+            If your PR was closed, you can reopen it to continue working on it.
+          stale-pr-label: "stale"
+          days-before-pr-stale: 7
+          days-before-pr-close: 7
+          exempt-pr-labels: "do-not-stale"
           # General settings
           operations-per-run: 100
           remove-stale-when-updated: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -30,12 +30,13 @@ jobs:
           exempt-issue-labels: "do-not-stale"
           # Pull request settings
           stale-pr-message: >
-            This pull request has been marked as stale due to lack of recent activity.
-            It will be closed in 7 days if no further activity occurs.
-            If this PR is still relevant, please comment or push new commits to keep it active.
-            If your PR was closed, you can reopen it to continue working on it.
+            Thank you for your contribution! This PR has been automatically marked as stale because it has not had activity in the last 14 days. This may be due to a delay in review on our side or awaiting a response from you; either is fine, and we appreciate your patience.
+
+            It will be closed in 7 days if no further activity occurs. Pushing a new commit, updating from main branch, or commenting will remove the stale label and keep the PR open.
+          close-pr-message: >
+            This PR has been closed due to inactivity. Thank you again for the contribution; please feel free to reopen this PR (or open a new one) if you'd like to continue the work.
           stale-pr-label: "stale"
-          days-before-pr-stale: 7
+          days-before-pr-stale: 14
           days-before-pr-close: 7
           exempt-pr-labels: "do-not-stale"
           # General settings


### PR DESCRIPTION
# Change Summary

Follow-up from general agreement in SIG meeting to help keep PR list shorter

## What issue does this PR close?

N/A

## How are these changes tested?

N/A

## Are there any user-facing changes?

N/A

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
