### PR TITLE
Add `Fork` data expression to query-engine expressions AST 

### DIFF
--- a/rust/experimental/query_engine/engine-recordset/src/engine.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/engine.rs
@@ -308,11 +308,11 @@ fn process_record<'a, TRecord: Record + 'static>(
                     }
                 }
             }
-            DataExpression::Conditional(c) => {
+            DataExpression::Branch(b) => {
                 execution_context.add_diagnostic_if_enabled(
                     RecordSetEngineDiagnosticLevel::Error,
-                    c,
-                    || "Conditional Expression not yet supported in record set engine".into(),
+                    b,
+                    || "Branch Expression not yet supported in record set engine".into(),
                 );
                 break;
             }

--- a/rust/experimental/query_engine/engine-recordset/src/scalars/scalar_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/scalars/scalar_expressions.rs
@@ -417,10 +417,10 @@ where
 
                     for e in expressions {
                         match e {
-                            PipelineFunctionExpression::Conditional(c) => {
+                            PipelineFunctionExpression::Branch(b) => {
                                 return Err(ExpressionError::NotSupported(
-                                    c.get_query_location().clone(),
-                                    format!("{} not supported in pipeline function", c.get_name()),
+                                    b.get_query_location().clone(),
+                                    format!("{} not supported in pipeline function", b.get_name()),
                                 ));
                             }
                             PipelineFunctionExpression::Discard(d) => {

--- a/rust/experimental/query_engine/expressions/src/data_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/data_expressions.rs
@@ -14,8 +14,8 @@ pub enum DataExpression {
     /// Transform data expression.
     Transform(TransformExpression),
 
-    /// Conditional data expression.
-    Conditional(ConditionalDataExpression),
+    /// Branch data expression.
+    Branch(BranchDataExpression),
 
     /// Output data expression.
     Output(OutputDataExpression),
@@ -30,7 +30,7 @@ impl DataExpression {
             DataExpression::Discard(d) => d.try_fold(scope),
             DataExpression::Summary(s) => s.try_fold(scope),
             DataExpression::Transform(t) => t.try_fold(scope),
-            DataExpression::Conditional(c) => c.try_fold(scope),
+            DataExpression::Branch(b) => b.try_fold(scope),
             DataExpression::Output(o) => o.try_fold(scope),
         }
     }
@@ -42,7 +42,7 @@ impl Expression for DataExpression {
             DataExpression::Discard(d) => d.get_query_location(),
             DataExpression::Summary(s) => s.get_query_location(),
             DataExpression::Transform(t) => t.get_query_location(),
-            DataExpression::Conditional(c) => c.get_query_location(),
+            DataExpression::Branch(b) => b.get_query_location(),
             DataExpression::Output(o) => o.get_query_location(),
         }
     }
@@ -52,7 +52,7 @@ impl Expression for DataExpression {
             DataExpression::Discard(_) => "DataExpression(Discard)",
             DataExpression::Summary(_) => "DataExpression(Summary)",
             DataExpression::Transform(_) => "DataExpression(Transform)",
-            DataExpression::Conditional(_) => "DataExpression(Conditional)",
+            DataExpression::Branch(_) => "DataExpression(Conditional)",
             DataExpression::Output(_) => "DataExpression(Output)",
         }
     }
@@ -62,7 +62,7 @@ impl Expression for DataExpression {
             DataExpression::Discard(d) => d.fmt_with_indent(f, indent),
             DataExpression::Summary(s) => s.fmt_with_indent(f, indent),
             DataExpression::Transform(t) => t.fmt_with_indent(f, indent),
-            DataExpression::Conditional(c) => c.fmt_with_indent(f, indent),
+            DataExpression::Branch(b) => b.fmt_with_indent(f, indent),
             DataExpression::Output(o) => o.fmt_with_indent(f, indent),
         }
     }
@@ -161,27 +161,31 @@ impl Expression for DiscardDataExpression {
 /// forms a "branch". The "default branch" defines how to optionally handle data that matches no
 /// other branch's condition.
 #[derive(Clone, Debug, PartialEq)]
-pub struct ConditionalDataExpression {
+pub struct BranchDataExpression {
     query_location: QueryLocation,
 
+    /// Whether each branch consumes the records, or receive a copy
+    branches_consume_records: bool,
+
     /// Branches which will conditionally process
-    branches: Vec<ConditionalDataExpressionBranch>,
+    branches: Vec<DataExpressionBranch>,
 
     /// If `Some`, data that does not match the condition in any of the other branches
     /// will be handled by this branch
     default_branch: Option<Vec<DataExpression>>,
 }
 
-impl ConditionalDataExpression {
-    pub fn new(query_location: QueryLocation) -> Self {
+impl BranchDataExpression {
+    pub fn new(query_location: QueryLocation, branches_consume_records: bool) -> Self {
         Self {
             query_location,
+            branches_consume_records,
             branches: Vec::new(),
             default_branch: None,
         }
     }
 
-    pub fn with_branch(mut self, branch: ConditionalDataExpressionBranch) -> Self {
+    pub fn with_branch(mut self, branch: DataExpressionBranch) -> Self {
         self.branches.push(branch);
         self
     }
@@ -191,12 +195,16 @@ impl ConditionalDataExpression {
         self
     }
 
-    pub fn get_branches(&self) -> &[ConditionalDataExpressionBranch] {
+    pub fn get_branches(&self) -> &[DataExpressionBranch] {
         &self.branches
     }
 
     pub fn get_default_branch(&self) -> Option<&[DataExpression]> {
         self.default_branch.as_deref()
+    }
+
+    pub fn branches_consume_records(&self) -> bool {
+        self.branches_consume_records
     }
 
     /// The try_fold implementation for this type of expression will recursively call the relevant
@@ -210,7 +218,10 @@ impl ConditionalDataExpression {
         while i < self.branches.len() {
             let static_logical_expr = {
                 let branch = &mut self.branches[i];
-                branch.condition.try_resolve_static(scope)?
+                match &mut branch.condition {
+                    Some(c) => c.try_resolve_static(scope)?,
+                    None => None,
+                }
             };
 
             if let Some(static_logical_expr) = static_logical_expr {
@@ -248,7 +259,7 @@ impl ConditionalDataExpression {
     }
 }
 
-impl Expression for ConditionalDataExpression {
+impl Expression for BranchDataExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
     }
@@ -258,6 +269,7 @@ impl Expression for ConditionalDataExpression {
     }
 
     fn fmt_with_indent(&self, f: &mut std::fmt::Formatter<'_>, indent: &str) -> std::fmt::Result {
+        /* TODO logic needs reworking
         writeln!(f, "Conditional:")?;
         if self.branches.is_empty() {
             writeln!(f, "{indent}├── Branches: []")?;
@@ -315,24 +327,26 @@ impl Expression for ConditionalDataExpression {
         }
 
         Ok(())
+        */
+        todo!()
     }
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct ConditionalDataExpressionBranch {
+pub struct DataExpressionBranch {
     query_location: QueryLocation,
 
     /// The condition that data must match to be handled by this branch
-    condition: LogicalExpression,
+    condition: Option<LogicalExpression>,
 
     /// The expressions to apply to the data handled by this branch
     expressions: Vec<DataExpression>,
 }
 
-impl ConditionalDataExpressionBranch {
+impl DataExpressionBranch {
     pub fn new(
         query_location: QueryLocation,
-        condition: LogicalExpression,
+        condition: Option<LogicalExpression>,
         expressions: Vec<DataExpression>,
     ) -> Self {
         Self {
@@ -342,8 +356,8 @@ impl ConditionalDataExpressionBranch {
         }
     }
 
-    pub fn get_condition(&self) -> &LogicalExpression {
-        &self.condition
+    pub fn get_condition(&self) -> Option<&LogicalExpression> {
+        self.condition.as_ref()
     }
 
     pub fn get_expressions(&self) -> &[DataExpression] {
@@ -437,10 +451,10 @@ mod test {
 
     #[test]
     fn test_fold_conditional_expr_removes_everything_after_all_true_condition() {
-        let mut expr = ConditionalDataExpression::new(QueryLocation::new_fake())
-            .with_branch(ConditionalDataExpressionBranch::new(
+        let mut expr = BranchDataExpression::new(QueryLocation::new_fake(), true)
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
-                LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                Some(LogicalExpression::EqualTo(EqualToLogicalExpression::new(
                     QueryLocation::new_fake(),
                     ScalarExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -455,7 +469,7 @@ mod test {
                         BooleanScalarExpression::new(QueryLocation::new_fake(), true),
                     )),
                     false,
-                )),
+                ))),
                 vec![DataExpression::Discard(
                     // this should get folded into a static false
                     DiscardDataExpression::new(QueryLocation::new_fake()).with_predicate(
@@ -472,10 +486,10 @@ mod test {
                     ),
                 )],
             ))
-            .with_branch(ConditionalDataExpressionBranch::new(
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
                 // this should also get folded to static true, meaning this branch will get the rest of the rows
-                LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                Some(LogicalExpression::EqualTo(EqualToLogicalExpression::new(
                     QueryLocation::new_fake(),
                     ScalarExpression::Static(StaticScalarExpression::String(
                         StringScalarExpression::new(QueryLocation::new_fake(), "a"),
@@ -484,7 +498,7 @@ mod test {
                         StringScalarExpression::new(QueryLocation::new_fake(), "a"),
                     )),
                     false,
-                )),
+                ))),
                 vec![DataExpression::Output(OutputDataExpression::new(
                     QueryLocation::new_fake(),
                     OutputExpression::NamedSink(StringScalarExpression::new(
@@ -494,9 +508,9 @@ mod test {
                 ))],
             ))
             // this should get removed
-            .with_branch(ConditionalDataExpressionBranch::new(
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
-                LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                Some(LogicalExpression::EqualTo(EqualToLogicalExpression::new(
                     QueryLocation::new_fake(),
                     ScalarExpression::Static(StaticScalarExpression::String(
                         StringScalarExpression::new(QueryLocation::new_fake(), "b"),
@@ -505,7 +519,7 @@ mod test {
                         StringScalarExpression::new(QueryLocation::new_fake(), "a"),
                     )),
                     false,
-                )),
+                ))),
                 vec![DataExpression::Output(OutputDataExpression::new(
                     QueryLocation::new_fake(),
                     OutputExpression::NamedSink(StringScalarExpression::new(
@@ -528,10 +542,10 @@ mod test {
         let scope = PipelineResolutionScope::new_for_test(&constants, &functions);
         expr.try_fold(&scope).unwrap();
 
-        let expected = ConditionalDataExpression::new(QueryLocation::new_fake())
-            .with_branch(ConditionalDataExpressionBranch::new(
+        let expected = BranchDataExpression::new(QueryLocation::new_fake(), true)
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
-                LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                Some(LogicalExpression::EqualTo(EqualToLogicalExpression::new(
                     QueryLocation::new_fake(),
                     ScalarExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -546,7 +560,7 @@ mod test {
                         BooleanScalarExpression::new(QueryLocation::new_fake(), true),
                     )),
                     false,
-                )),
+                ))),
                 vec![DataExpression::Discard(
                     DiscardDataExpression::new(QueryLocation::new_fake()).with_predicate(
                         LogicalExpression::Scalar(ScalarExpression::Static(
@@ -558,14 +572,14 @@ mod test {
                     ),
                 )],
             ))
-            .with_branch(ConditionalDataExpressionBranch::new(
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
-                LogicalExpression::Scalar(ScalarExpression::Static(
+                Some(LogicalExpression::Scalar(ScalarExpression::Static(
                     StaticScalarExpression::Boolean(BooleanScalarExpression::new(
                         QueryLocation::new_fake(),
                         true,
                     )),
-                )),
+                ))),
                 vec![DataExpression::Output(OutputDataExpression::new(
                     QueryLocation::new_fake(),
                     OutputExpression::NamedSink(StringScalarExpression::new(
@@ -582,10 +596,10 @@ mod test {
     fn test_fold_conditional_expr_removes_everything_all_true_condition_is_last() {
         // test to ensure we don't go out of bounds when trying to remove branches following
         // the branch chose condition always evaluates to always true
-        let mut expr = ConditionalDataExpression::new(QueryLocation::new_fake())
-            .with_branch(ConditionalDataExpressionBranch::new(
+        let mut expr = BranchDataExpression::new(QueryLocation::new_fake(), true)
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
-                LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                Some(LogicalExpression::EqualTo(EqualToLogicalExpression::new(
                     QueryLocation::new_fake(),
                     ScalarExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -600,7 +614,7 @@ mod test {
                         BooleanScalarExpression::new(QueryLocation::new_fake(), true),
                     )),
                     false,
-                )),
+                ))),
                 vec![DataExpression::Discard(
                     // this should get folded into a static false
                     DiscardDataExpression::new(QueryLocation::new_fake()).with_predicate(
@@ -617,10 +631,10 @@ mod test {
                     ),
                 )],
             ))
-            .with_branch(ConditionalDataExpressionBranch::new(
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
                 // this should also get folded to static true, meaning this branch will get the rest of the rows
-                LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                Some(LogicalExpression::EqualTo(EqualToLogicalExpression::new(
                     QueryLocation::new_fake(),
                     ScalarExpression::Static(StaticScalarExpression::String(
                         StringScalarExpression::new(QueryLocation::new_fake(), "a"),
@@ -629,7 +643,7 @@ mod test {
                         StringScalarExpression::new(QueryLocation::new_fake(), "a"),
                     )),
                     false,
-                )),
+                ))),
                 vec![DataExpression::Output(OutputDataExpression::new(
                     QueryLocation::new_fake(),
                     OutputExpression::NamedSink(StringScalarExpression::new(
@@ -652,10 +666,10 @@ mod test {
         let scope = PipelineResolutionScope::new_for_test(&constants, &functions);
         expr.try_fold(&scope).unwrap();
 
-        let expected = ConditionalDataExpression::new(QueryLocation::new_fake())
-            .with_branch(ConditionalDataExpressionBranch::new(
+        let expected = BranchDataExpression::new(QueryLocation::new_fake(), true)
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
-                LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                Some(LogicalExpression::EqualTo(EqualToLogicalExpression::new(
                     QueryLocation::new_fake(),
                     ScalarExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -670,7 +684,7 @@ mod test {
                         BooleanScalarExpression::new(QueryLocation::new_fake(), true),
                     )),
                     false,
-                )),
+                ))),
                 vec![DataExpression::Discard(
                     DiscardDataExpression::new(QueryLocation::new_fake()).with_predicate(
                         LogicalExpression::Scalar(ScalarExpression::Static(
@@ -682,14 +696,14 @@ mod test {
                     ),
                 )],
             ))
-            .with_branch(ConditionalDataExpressionBranch::new(
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
-                LogicalExpression::Scalar(ScalarExpression::Static(
+                Some(LogicalExpression::Scalar(ScalarExpression::Static(
                     StaticScalarExpression::Boolean(BooleanScalarExpression::new(
                         QueryLocation::new_fake(),
                         true,
                     )),
-                )),
+                ))),
                 vec![DataExpression::Output(OutputDataExpression::new(
                     QueryLocation::new_fake(),
                     OutputExpression::NamedSink(StringScalarExpression::new(
@@ -704,10 +718,10 @@ mod test {
 
     #[test]
     fn test_fold_conditional_expr_removes_branch_for_all_false_condition() {
-        let mut expr = ConditionalDataExpression::new(QueryLocation::new_fake())
-            .with_branch(ConditionalDataExpressionBranch::new(
+        let mut expr = BranchDataExpression::new(QueryLocation::new_fake(), true)
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
-                LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                Some(LogicalExpression::EqualTo(EqualToLogicalExpression::new(
                     QueryLocation::new_fake(),
                     ScalarExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -722,7 +736,7 @@ mod test {
                         BooleanScalarExpression::new(QueryLocation::new_fake(), true),
                     )),
                     false,
-                )),
+                ))),
                 vec![DataExpression::Discard(
                     // this should get folded into a static false
                     DiscardDataExpression::new(QueryLocation::new_fake()).with_predicate(
@@ -739,10 +753,10 @@ mod test {
                     ),
                 )],
             ))
-            .with_branch(ConditionalDataExpressionBranch::new(
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
                 // this will evaluate to all false, which means this branch should get removed
-                LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                Some(LogicalExpression::EqualTo(EqualToLogicalExpression::new(
                     QueryLocation::new_fake(),
                     ScalarExpression::Static(StaticScalarExpression::String(
                         StringScalarExpression::new(QueryLocation::new_fake(), "a"),
@@ -751,7 +765,7 @@ mod test {
                         StringScalarExpression::new(QueryLocation::new_fake(), "b"),
                     )),
                     false,
-                )),
+                ))),
                 vec![DataExpression::Output(OutputDataExpression::new(
                     QueryLocation::new_fake(),
                     OutputExpression::NamedSink(StringScalarExpression::new(
@@ -761,9 +775,9 @@ mod test {
                 ))],
             ))
             // this should be kept
-            .with_branch(ConditionalDataExpressionBranch::new(
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
-                LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                Some(LogicalExpression::EqualTo(EqualToLogicalExpression::new(
                     QueryLocation::new_fake(),
                     ScalarExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -778,7 +792,7 @@ mod test {
                         BooleanScalarExpression::new(QueryLocation::new_fake(), true),
                     )),
                     false,
-                )),
+                ))),
                 vec![DataExpression::Discard(
                     // this should get folded into a static false as well
                     DiscardDataExpression::new(QueryLocation::new_fake()).with_predicate(
@@ -809,10 +823,10 @@ mod test {
         let scope = PipelineResolutionScope::new_for_test(&constants, &functions);
         expr.try_fold(&scope).unwrap();
 
-        let expected = ConditionalDataExpression::new(QueryLocation::new_fake())
-            .with_branch(ConditionalDataExpressionBranch::new(
+        let expected = BranchDataExpression::new(QueryLocation::new_fake(), true)
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
-                LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                Some(LogicalExpression::EqualTo(EqualToLogicalExpression::new(
                     QueryLocation::new_fake(),
                     ScalarExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -827,7 +841,7 @@ mod test {
                         BooleanScalarExpression::new(QueryLocation::new_fake(), true),
                     )),
                     false,
-                )),
+                ))),
                 vec![DataExpression::Discard(
                     DiscardDataExpression::new(QueryLocation::new_fake()).with_predicate(
                         LogicalExpression::Scalar(ScalarExpression::Static(
@@ -839,9 +853,9 @@ mod test {
                     ),
                 )],
             ))
-            .with_branch(ConditionalDataExpressionBranch::new(
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
-                LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                Some(LogicalExpression::EqualTo(EqualToLogicalExpression::new(
                     QueryLocation::new_fake(),
                     ScalarExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -856,7 +870,7 @@ mod test {
                         BooleanScalarExpression::new(QueryLocation::new_fake(), true),
                     )),
                     false,
-                )),
+                ))),
                 vec![DataExpression::Discard(
                     DiscardDataExpression::new(QueryLocation::new_fake()).with_predicate(
                         LogicalExpression::Scalar(ScalarExpression::Static(

--- a/rust/experimental/query_engine/expressions/src/data_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/data_expressions.rs
@@ -169,10 +169,6 @@ pub struct BranchDataExpression {
 
     /// Branches which will conditionally process
     branches: Vec<DataExpressionBranch>,
-
-    /// If `Some`, data that does not match the condition in any of the other branches
-    /// will be handled by this branch
-    default_branch: Option<Vec<DataExpression>>,
 }
 
 impl BranchDataExpression {
@@ -181,7 +177,6 @@ impl BranchDataExpression {
             query_location,
             branches_consume_records,
             branches: Vec::new(),
-            default_branch: None,
         }
     }
 
@@ -190,17 +185,8 @@ impl BranchDataExpression {
         self
     }
 
-    pub fn with_default_branch(mut self, expressions: Vec<DataExpression>) -> Self {
-        self.default_branch = Some(expressions);
-        self
-    }
-
     pub fn get_branches(&self) -> &[DataExpressionBranch] {
         &self.branches
-    }
-
-    pub fn get_default_branch(&self) -> Option<&[DataExpression]> {
-        self.default_branch.as_deref()
     }
 
     pub fn branches_consume_records(&self) -> bool {
@@ -229,10 +215,6 @@ impl BranchDataExpression {
                     // here everything will pass the filter. That means we can drop the test of the
                     // branches because all remaining rows will be evaluated by this branch
                     _ = self.branches.split_off(i + 1);
-
-                    // drop the default branch - no need to keep it as there will be now rows for
-                    // for it to evaluate
-                    self.default_branch = None;
                 } else {
                     // here nothing will pass the filter, so we can basically discard this branch
                     self.branches.remove(i);
@@ -246,13 +228,6 @@ impl BranchDataExpression {
             }
 
             i += 1;
-        }
-
-        if let Some(default_branch) = self.default_branch.as_mut() {
-            // optimize the expressions inside the branch
-            for expression in default_branch {
-                expression.try_fold(scope)?;
-            }
         }
 
         Ok(())
@@ -527,15 +502,20 @@ mod test {
                         "out2",
                     )),
                 ))],
+                // this should also get removed
             ))
             // this should also get removed
-            .with_default_branch(vec![DataExpression::Output(OutputDataExpression::new(
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
-                OutputExpression::NamedSink(StringScalarExpression::new(
+                None,
+                vec![DataExpression::Output(OutputDataExpression::new(
                     QueryLocation::new_fake(),
-                    "out2",
-                )),
-            ))]);
+                    OutputExpression::NamedSink(StringScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        "out2",
+                    )),
+                ))],
+            ));
 
         let constants = Vec::new();
         let functions = Vec::new();
@@ -653,13 +633,17 @@ mod test {
                 ))],
             ))
             // this should also get removed
-            .with_default_branch(vec![DataExpression::Output(OutputDataExpression::new(
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
-                OutputExpression::NamedSink(StringScalarExpression::new(
+                None,
+                vec![DataExpression::Output(OutputDataExpression::new(
                     QueryLocation::new_fake(),
-                    "out2",
-                )),
-            ))]);
+                    OutputExpression::NamedSink(StringScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        "out2",
+                    )),
+                ))],
+            ));
 
         let constants = Vec::new();
         let functions = Vec::new();
@@ -809,14 +793,18 @@ mod test {
                     ),
                 )],
             ))
-            // this should be kept
-            .with_default_branch(vec![DataExpression::Output(OutputDataExpression::new(
+            // this should also be kept
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
-                OutputExpression::NamedSink(StringScalarExpression::new(
+                None,
+                vec![DataExpression::Output(OutputDataExpression::new(
                     QueryLocation::new_fake(),
-                    "out2",
-                )),
-            ))]);
+                    OutputExpression::NamedSink(StringScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        "out2",
+                    )),
+                ))],
+            ));
 
         let constants = Vec::new();
         let functions = Vec::new();
@@ -883,13 +871,17 @@ mod test {
                 )],
             ))
             // this should be kept because
-            .with_default_branch(vec![DataExpression::Output(OutputDataExpression::new(
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
-                OutputExpression::NamedSink(StringScalarExpression::new(
+                None,
+                vec![DataExpression::Output(OutputDataExpression::new(
                     QueryLocation::new_fake(),
-                    "out2",
-                )),
-            ))]);
+                    OutputExpression::NamedSink(StringScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        "out2",
+                    )),
+                ))],
+            ));
 
         assert_eq!(expr, expected);
     }

--- a/rust/experimental/query_engine/expressions/src/pipeline_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/pipeline_expression.rs
@@ -385,7 +385,7 @@ impl AsRef<PipelineExpression> for PipelineExpressionBuilder {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum PipelineFunctionExpression {
-    Conditional(ConditionalDataExpression),
+    Branch(BranchDataExpression),
     Discard(DiscardDataExpression),
     Transform(TransformExpression),
     Return(ScalarExpression),
@@ -397,7 +397,7 @@ impl PipelineFunctionExpression {
         scope: &PipelineResolutionScope,
     ) -> Result<(), ExpressionError> {
         match self {
-            Self::Conditional(c) => c.try_fold(scope),
+            Self::Branch(c) => c.try_fold(scope),
             Self::Discard(d) => d.try_fold(scope),
             Self::Transform(t) => t.try_fold(scope),
             Self::Return(_r) => Ok(()), // no need to fold return
@@ -412,8 +412,8 @@ impl PipelineFunctionExpression {
         indent: &str,
     ) -> std::fmt::Result {
         match self {
-            PipelineFunctionExpression::Conditional(c) => {
-                write!(f, "Conditional: ")?;
+            PipelineFunctionExpression::Branch(c) => {
+                write!(f, "Branch: ")?;
                 c.fmt_with_indent(f, format!("{indent}           ").as_str())
             }
             PipelineFunctionExpression::Discard(d) => {

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser/operator.rs
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser/operator.rs
@@ -4,14 +4,14 @@
 use std::hash::{DefaultHasher, Hash, Hasher};
 
 use data_engine_expressions::{
-    ArgumentScalarExpression, ConditionalDataExpression, ConditionalDataExpressionBranch,
-    DataExpression, DiscardDataExpression, Expression, InvokeFunctionScalarExpression,
-    LogicalExpression, MapKeyRenameSelector, MapSelectionExpression, MapSelector,
-    MutableValueExpression, NotLogicalExpression, OutputDataExpression, OutputExpression,
-    PipelineFunction, PipelineFunctionExpression, PipelineFunctionParameter,
-    PipelineFunctionParameterType, QueryLocation, ReduceMapTransformExpression,
-    RenameMapKeysTransformExpression, ScalarExpression, SetTransformExpression,
-    SourceScalarExpression, StaticScalarExpression, TransformExpression, ValueAccessor, ValueType,
+    ArgumentScalarExpression, BranchDataExpression, DataExpression, DataExpressionBranch,
+    DiscardDataExpression, Expression, InvokeFunctionScalarExpression, LogicalExpression,
+    MapKeyRenameSelector, MapSelectionExpression, MapSelector, MutableValueExpression,
+    NotLogicalExpression, OutputDataExpression, OutputExpression, PipelineFunction,
+    PipelineFunctionExpression, PipelineFunctionParameter, PipelineFunctionParameterType,
+    QueryLocation, ReduceMapTransformExpression, RenameMapKeysTransformExpression,
+    ScalarExpression, SetTransformExpression, SourceScalarExpression, StaticScalarExpression,
+    TransformExpression, ValueAccessor, ValueType,
 };
 use data_engine_parser_abstractions::{
     ParserError, parse_standard_string_literal, to_query_location,
@@ -219,7 +219,7 @@ pub(crate) fn parse_if_else_operator_call(
     mut pipeline_builder: &mut dyn PipelineBuilder,
 ) -> Result<(), ParserError> {
     let query_location = to_query_location(&operator_call_rule);
-    let mut conditional_expr = ConditionalDataExpression::new(query_location);
+    let mut branch_expr = BranchDataExpression::new(query_location, true);
 
     // keep track of the location of the current branch (to fill in query location)
     let mut branch_location_start = 0;
@@ -289,12 +289,11 @@ pub(crate) fn parse_if_else_operator_call(
                     )
                 })?;
 
-                conditional_expr =
-                    conditional_expr.with_branch(ConditionalDataExpressionBranch::new(
-                        query_location,
-                        condition,
-                        curr_branch_data_exprs,
-                    ));
+                branch_expr = branch_expr.with_branch(DataExpressionBranch::new(
+                    query_location,
+                    Some(condition),
+                    curr_branch_data_exprs,
+                ));
             }
 
             // parse the data expressions for the else branch
@@ -321,18 +320,18 @@ pub(crate) fn parse_if_else_operator_call(
                 }
                 let (else_branch_data_exprs, parent) = else_branch_exprs.into_parts();
                 pipeline_builder = parent;
-                conditional_expr = conditional_expr.with_default_branch(else_branch_data_exprs);
+                branch_expr = branch_expr.with_default_branch(else_branch_data_exprs);
             }
             _ => {
                 return Err(ParserError::SyntaxError(
-                    conditional_expr.get_query_location().clone(),
+                    branch_expr.get_query_location().clone(),
                     format!("invalid rule found in if_else_expression {rule}"),
                 ));
             }
         }
     }
 
-    pipeline_builder.push_data_expression(DataExpression::Conditional(conditional_expr));
+    pipeline_builder.push_data_expression(DataExpression::Branch(branch_expr));
 
     Ok(())
 }
@@ -423,7 +422,7 @@ pub(crate) fn parse_apply_operator_call(
                     ValueAccessor::new(),
                 )),
             )),
-            DataExpression::Conditional(c) => PipelineFunctionExpression::Conditional(c),
+            DataExpression::Branch(b) => PipelineFunctionExpression::Branch(b),
             DataExpression::Transform(t) => PipelineFunctionExpression::Transform(t),
             other => {
                 return Err(ParserError::SyntaxNotSupported(
@@ -471,15 +470,15 @@ pub(crate) fn parse_apply_operator_call(
 #[cfg(test)]
 mod tests {
     use data_engine_expressions::{
-        ArgumentScalarExpression, ConditionalDataExpression, ConditionalDataExpressionBranch,
-        DataExpression, DiscardDataExpression, EqualToLogicalExpression,
-        InvokeFunctionScalarExpression, LogicalExpression, MapKeyRenameSelector,
-        MapSelectionExpression, MapSelector, MutableValueExpression, NotLogicalExpression,
-        OutputDataExpression, OutputExpression, PipelineFunction, PipelineFunctionExpression,
-        PipelineFunctionParameter, PipelineFunctionParameterType, QueryLocation,
-        ReduceMapTransformExpression, RenameMapKeysTransformExpression, ScalarExpression,
-        SetTransformExpression, SourceScalarExpression, StaticScalarExpression,
-        StringScalarExpression, TransformExpression, ValueAccessor, ValueType,
+        ArgumentScalarExpression, BranchDataExpression, DataExpression, DataExpressionBranch,
+        DiscardDataExpression, EqualToLogicalExpression, InvokeFunctionScalarExpression,
+        LogicalExpression, MapKeyRenameSelector, MapSelectionExpression, MapSelector,
+        MutableValueExpression, NotLogicalExpression, OutputDataExpression, OutputExpression,
+        PipelineFunction, PipelineFunctionExpression, PipelineFunctionParameter,
+        PipelineFunctionParameterType, QueryLocation, ReduceMapTransformExpression,
+        RenameMapKeysTransformExpression, ScalarExpression, SetTransformExpression,
+        SourceScalarExpression, StaticScalarExpression, StringScalarExpression,
+        TransformExpression, ValueAccessor, ValueType,
     };
     use data_engine_parser_abstractions::{Parser, ParserOptions, ParserState};
     use pest::Parser as _;
@@ -662,24 +661,24 @@ mod tests {
         let expressions = pipeline.get_expressions();
         assert_eq!(expressions.len(), 1);
 
-        let expected = DataExpression::Conditional(
-            ConditionalDataExpression::new(QueryLocation::new_fake())
-                .with_branch(ConditionalDataExpressionBranch::new(
+        let expected = DataExpression::Branch(
+            BranchDataExpression::new(QueryLocation::new_fake(), true)
+                .with_branch(DataExpressionBranch::new(
                     QueryLocation::new_fake(),
-                    equals_logical_expr("severity_text", "ERROR"),
+                    Some(equals_logical_expr("severity_text", "ERROR")),
                     vec![
                         assign_attribute_expression("important", "very"),
                         assign_attribute_expression("triggers_alarm", "true"),
                     ],
                 ))
-                .with_branch(ConditionalDataExpressionBranch::new(
+                .with_branch(DataExpressionBranch::new(
                     QueryLocation::new_fake(),
-                    equals_logical_expr("severity_text", "WARN"),
+                    Some(equals_logical_expr("severity_text", "WARN")),
                     vec![assign_attribute_expression("important", "somewhat")],
                 ))
-                .with_branch(ConditionalDataExpressionBranch::new(
+                .with_branch(DataExpressionBranch::new(
                     QueryLocation::new_fake(),
-                    equals_logical_expr("severity_text", "INFO"),
+                    Some(equals_logical_expr("severity_text", "INFO")),
                     vec![assign_attribute_expression("important", "rarely")],
                 ))
                 .with_default_branch(vec![assign_attribute_expression("important", "no")]),
@@ -704,19 +703,19 @@ mod tests {
         let expressions = pipeline.get_expressions();
         assert_eq!(expressions.len(), 1);
 
-        let expected = DataExpression::Conditional(
-            ConditionalDataExpression::new(QueryLocation::new_fake())
-                .with_branch(ConditionalDataExpressionBranch::new(
+        let expected = DataExpression::Branch(
+            BranchDataExpression::new(QueryLocation::new_fake(), true)
+                .with_branch(DataExpressionBranch::new(
                     QueryLocation::new_fake(),
-                    equals_logical_expr("severity_text", "ERROR"),
+                    Some(equals_logical_expr("severity_text", "ERROR")),
                     vec![
                         assign_attribute_expression("important", "very"),
                         assign_attribute_expression("triggers_alarm", "true"),
                     ],
                 ))
-                .with_branch(ConditionalDataExpressionBranch::new(
+                .with_branch(DataExpressionBranch::new(
                     QueryLocation::new_fake(),
-                    equals_logical_expr("severity_text", "WARN"),
+                    Some(equals_logical_expr("severity_text", "WARN")),
                     vec![assign_attribute_expression("important", "somewhat")],
                 )),
         );
@@ -740,11 +739,11 @@ mod tests {
         let expressions = pipeline.get_expressions();
         assert_eq!(expressions.len(), 1);
 
-        let expected = DataExpression::Conditional(
-            ConditionalDataExpression::new(QueryLocation::new_fake())
-                .with_branch(ConditionalDataExpressionBranch::new(
+        let expected = DataExpression::Branch(
+            BranchDataExpression::new(QueryLocation::new_fake(), true)
+                .with_branch(DataExpressionBranch::new(
                     QueryLocation::new_fake(),
-                    equals_logical_expr("severity_text", "ERROR"),
+                    Some(equals_logical_expr("severity_text", "ERROR")),
                     vec![
                         assign_attribute_expression("important", "very"),
                         assign_attribute_expression("triggers_alarm", "true"),
@@ -770,11 +769,11 @@ mod tests {
         let expressions = pipeline.get_expressions();
         assert_eq!(expressions.len(), 1);
 
-        let expected = DataExpression::Conditional(
-            ConditionalDataExpression::new(QueryLocation::new_fake()).with_branch(
-                ConditionalDataExpressionBranch::new(
+        let expected = DataExpression::Branch(
+            BranchDataExpression::new(QueryLocation::new_fake(), true).with_branch(
+                DataExpressionBranch::new(
                     QueryLocation::new_fake(),
-                    equals_logical_expr("severity_text", "ERROR"),
+                    Some(equals_logical_expr("severity_text", "ERROR")),
                     vec![assign_attribute_expression("triggers_alarm", "true")],
                 ),
             ),
@@ -1097,11 +1096,11 @@ mod tests {
         let expressions = result.get_expressions();
         assert_eq!(expressions.len(), 1);
 
-        let expected = DataExpression::Conditional(
-            ConditionalDataExpression::new(QueryLocation::new_fake())
-                .with_branch(ConditionalDataExpressionBranch::new(
+        let expected = DataExpression::Branch(
+            BranchDataExpression::new(QueryLocation::new_fake(), true)
+                .with_branch(DataExpressionBranch::new(
                     QueryLocation::new_fake(),
-                    LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                    Some(LogicalExpression::EqualTo(EqualToLogicalExpression::new(
                         QueryLocation::new_fake(),
                         ScalarExpression::Source(SourceScalarExpression::new(
                             QueryLocation::new_fake(),
@@ -1116,7 +1115,7 @@ mod tests {
                             StringScalarExpression::new(QueryLocation::new_fake(), "ERROR"),
                         )),
                         false,
-                    )),
+                    ))),
                     vec![DataExpression::Transform(TransformExpression::Set(
                         SetTransformExpression::new(
                             QueryLocation::new_fake(),

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser/operator.rs
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser/operator.rs
@@ -303,7 +303,7 @@ pub(crate) fn parse_if_else_operator_call(
                     // under normal invocation of this function this shouldn't happen as this
                     // missing expression should be caught by the parser
                     ParserError::SyntaxError(
-                        else_query_location,
+                        else_query_location.clone(),
                         "expected else_expression to contain one inner if_else_branch_expression"
                             .to_string(),
                     )
@@ -320,7 +320,11 @@ pub(crate) fn parse_if_else_operator_call(
                 }
                 let (else_branch_data_exprs, parent) = else_branch_exprs.into_parts();
                 pipeline_builder = parent;
-                branch_expr = branch_expr.with_default_branch(else_branch_data_exprs);
+                branch_expr = branch_expr.with_branch(DataExpressionBranch::new(
+                    else_query_location,
+                    None,
+                    else_branch_data_exprs,
+                ));
             }
             _ => {
                 return Err(ParserError::SyntaxError(
@@ -681,7 +685,11 @@ mod tests {
                     Some(equals_logical_expr("severity_text", "INFO")),
                     vec![assign_attribute_expression("important", "rarely")],
                 ))
-                .with_default_branch(vec![assign_attribute_expression("important", "no")]),
+                .with_branch(DataExpressionBranch::new(
+                    QueryLocation::new_fake(),
+                    None,
+                    vec![assign_attribute_expression("important", "no")],
+                )),
         );
         assert_eq!(expressions[0], expected);
     }
@@ -749,7 +757,11 @@ mod tests {
                         assign_attribute_expression("triggers_alarm", "true"),
                     ],
                 ))
-                .with_default_branch(vec![assign_attribute_expression("important", "no")]),
+                .with_branch(DataExpressionBranch::new(
+                    QueryLocation::new_fake(),
+                    None,
+                    vec![assign_attribute_expression("important", "no")],
+                )),
         );
         assert_eq!(expressions[0], expected);
     }
@@ -1137,26 +1149,30 @@ mod tests {
                         ),
                     ))],
                 ))
-                .with_default_branch(vec![DataExpression::Transform(TransformExpression::Set(
-                    SetTransformExpression::new(
-                        QueryLocation::new_fake(),
-                        ScalarExpression::InvokeFunction(InvokeFunctionScalarExpression::new(
+                .with_branch(DataExpressionBranch::new(
+                    QueryLocation::new_fake(),
+                    None,
+                    vec![DataExpression::Transform(TransformExpression::Set(
+                        SetTransformExpression::new(
                             QueryLocation::new_fake(),
-                            None,
-                            1,
-                            Vec::new(),
-                        )),
-                        MutableValueExpression::Source(SourceScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
-                                StaticScalarExpression::String(StringScalarExpression::new(
-                                    QueryLocation::new_fake(),
-                                    "attributes",
-                                )),
-                            )]),
-                        )),
-                    ),
-                ))]),
+                            ScalarExpression::InvokeFunction(InvokeFunctionScalarExpression::new(
+                                QueryLocation::new_fake(),
+                                None,
+                                1,
+                                Vec::new(),
+                            )),
+                            MutableValueExpression::Source(SourceScalarExpression::new(
+                                QueryLocation::new_fake(),
+                                ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                                    StaticScalarExpression::String(StringScalarExpression::new(
+                                        QueryLocation::new_fake(),
+                                        "attributes",
+                                    )),
+                                )]),
+                            )),
+                        ),
+                    ))],
+                )),
         );
         assert_eq!(&expressions[0], &expected);
 

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/planner.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/planner.rs
@@ -246,7 +246,7 @@ impl PipelinePlanner {
                     // that some branch consumes all records, leaving none for the subsequent
                     // branches, which is non-sensible. Hence, we plan this into a the
                     // "conditional" pipeline stage, while treating non-terminal branch as invalid
-                    // if a condition is missing.
+                    // when a condition is missing and it's not the final branch.
 
                     let expr_planner = if self.plan_for_attributes {
                         ExprPlanner::for_attributes(self.filter_attribute_keys_case_sensitive)
@@ -256,15 +256,9 @@ impl PipelinePlanner {
                         )
                     };
 
+                    let mut default_branch = None;
                     let mut pipeline_branches = vec![];
-                    for branch in branch_expr.get_branches() {
-                        let predicate = match branch.get_condition() {
-                            Some(condition) => expr_planner.plan_logical(condition, functions)?,
-                            None => {
-                                todo!("return invalid")
-                            }
-                        };
-
+                    for (i, branch) in branch_expr.get_branches().iter().enumerate() {
                         let pipeline_stages = self.plan_data_exprs(
                             branch.get_expressions(),
                             functions,
@@ -272,18 +266,24 @@ impl PipelinePlanner {
                             otap_batch,
                         )?;
 
-                        pipeline_branches.push(ConditionalPipelineStageBranch::new(
-                            predicate,
-                            pipeline_stages,
-                        ));
+                        match branch.get_condition() {
+                            Some(condition) => {
+                                let predicate = expr_planner.plan_logical(condition, functions)?;
+                                pipeline_branches.push(ConditionalPipelineStageBranch::new(
+                                    predicate,
+                                    pipeline_stages,
+                                ))
+                            }
+                            None => {
+                                let is_final_branch = i == branch_expr.get_branches().len() - 1;
+                                if !is_final_branch {
+                                    todo!("return invalid")
+                                } else {
+                                    default_branch = Some(pipeline_stages)
+                                }
+                            }
+                        };
                     }
-
-                    let default_branch = branch_expr
-                        .get_default_branch()
-                        .map(|data_exprs| {
-                            self.plan_data_exprs(data_exprs, functions, session_ctx, otap_batch)
-                        })
-                        .transpose()?;
 
                     let pipeline_stage =
                         ConditionalPipelineStage::new(pipeline_branches, default_branch);

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/planner.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/planner.rs
@@ -237,42 +237,58 @@ impl PipelinePlanner {
                 }),
             },
 
-            DataExpression::Conditional(conditional_expr) => {
-                let expr_planner = if self.plan_for_attributes {
-                    ExprPlanner::for_attributes(self.filter_attribute_keys_case_sensitive)
+            DataExpression::Branch(branch_expr) => {
+                if !branch_expr.branches_consume_records() {
+                    todo!()
                 } else {
-                    ExprPlanner::with_attr_key_case_sensitive(
-                        self.filter_attribute_keys_case_sensitive,
-                    )
-                };
+                    // If branches consume the records, we assume that each branch, except for
+                    // the last, must have a condition. If this were not the case, it would mean
+                    // that some branch consumes all records, leaving none for the subsequent
+                    // branches, which is non-sensible. Hence, we plan this into a the
+                    // "conditional" pipeline stage, while treating non-terminal branch as invalid
+                    // if a condition is missing.
 
-                let mut pipeline_branches = vec![];
-                for branch in conditional_expr.get_branches() {
-                    let predicate = expr_planner.plan_logical(branch.get_condition(), functions)?;
+                    let expr_planner = if self.plan_for_attributes {
+                        ExprPlanner::for_attributes(self.filter_attribute_keys_case_sensitive)
+                    } else {
+                        ExprPlanner::with_attr_key_case_sensitive(
+                            self.filter_attribute_keys_case_sensitive,
+                        )
+                    };
 
-                    let pipeline_stages = self.plan_data_exprs(
-                        branch.get_expressions(),
-                        functions,
-                        session_ctx,
-                        otap_batch,
-                    )?;
+                    let mut pipeline_branches = vec![];
+                    for branch in branch_expr.get_branches() {
+                        let predicate = match branch.get_condition() {
+                            Some(condition) => expr_planner.plan_logical(condition, functions)?,
+                            None => {
+                                todo!("return invalid")
+                            }
+                        };
 
-                    pipeline_branches.push(ConditionalPipelineStageBranch::new(
-                        predicate,
-                        pipeline_stages,
-                    ));
+                        let pipeline_stages = self.plan_data_exprs(
+                            branch.get_expressions(),
+                            functions,
+                            session_ctx,
+                            otap_batch,
+                        )?;
+
+                        pipeline_branches.push(ConditionalPipelineStageBranch::new(
+                            predicate,
+                            pipeline_stages,
+                        ));
+                    }
+
+                    let default_branch = branch_expr
+                        .get_default_branch()
+                        .map(|data_exprs| {
+                            self.plan_data_exprs(data_exprs, functions, session_ctx, otap_batch)
+                        })
+                        .transpose()?;
+
+                    let pipeline_stage =
+                        ConditionalPipelineStage::new(pipeline_branches, default_branch);
+                    Ok(vec![Box::new(pipeline_stage)])
                 }
-
-                let default_branch = conditional_expr
-                    .get_default_branch()
-                    .map(|data_exprs| {
-                        self.plan_data_exprs(data_exprs, functions, session_ctx, otap_batch)
-                    })
-                    .transpose()?;
-
-                let pipeline_stage =
-                    ConditionalPipelineStage::new(pipeline_branches, default_branch);
-                Ok(vec![Box::new(pipeline_stage)])
             }
 
             DataExpression::Output(output_expr) => match output_expr.get_output() {
@@ -740,8 +756,8 @@ impl PipelinePlanner {
                     let mut inner_pipeline_data_exprs = Vec::with_capacity(function_exprs.len());
                     for func_expr in function_exprs {
                         let data_expr = match func_expr {
-                            PipelineFunctionExpression::Conditional(c) => {
-                                DataExpression::Conditional(c.clone())
+                            PipelineFunctionExpression::Branch(c) => {
+                                DataExpression::Branch(c.clone())
                             }
                             PipelineFunctionExpression::Discard(d) => {
                                 DataExpression::Discard(d.clone())


### PR DESCRIPTION
# Change Summary

<!--
Replace with a brief summary of the change in this PR
-->

(See linked issue for more details about what the overall feature is trying to achieve).

In a nutshell - we want to add a `fork` operator to OPL which duplicates the telemetry batch and sends it down multiple pipelines:
```
logs |
fork
  { 
      // all error logs for app1 namespace get sent to "app1_on_call" destination
      where resource.attributes["k8s.namespace.name"] == "app1" and severity_number >= 17 | 
      route_to "app1_on_call"
  }
  {
      // send all logs to "destination x" after decorating them with customer ID
      set attribute["dest_x_customer_id"] = "cust_id_2134" |
      route_to "destination_x_out_port"
  }
```

This PR adds to the expression AST what we would need to support this kind of operation.

## What issue does this PR close?

<!--
We highly recommend correlation of every PR to an issue
-->

* Relates to  #3188

## How are these changes tested?

Unit tests for formatting.. The other code changes are jus structural (adding new types).

## Are there any user-facing changes?

No

 <!-- If yes, provide further info below -->

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
