### PR TITLE
chore(repo): Turn on Renovate vulnerability reporting

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,6 +8,19 @@
     // keep pip-compile refreshes aligned with CI/runtime interpreter
     "python": "==3.14"
   },
+  // Cross-reference dependencies against the OSV database (https://osv.dev)
+  // and surface resolved CVE/GHSA/RUSTSEC advisories in PR bodies.
+  "osvVulnerabilityAlerts": true,
+  // Config applied only to vulnerability-motivated fix PRs. This path
+  // activates once osvVulnerabilityAlerts (above) and/or GitHub Dependabot
+  // alerts are in effect.
+  "vulnerabilityAlerts": {
+    "addLabels": ["area:security"],
+  },
+  // List unresolved CVEs (from osv.dev) on the Dependency Dashboard issue.
+  // The dashboard itself is already enabled via the config:recommended
+  // preset (which extends :dependencyDashboard).
+  "dependencyDashboardOSVVulnerabilitySummary": "unresolved",
   "extends": [
     "config:recommended",
     "docker:pinDigests",


### PR DESCRIPTION
# Change Summary

Enable https://docs.renovatebot.com/configuration-options/#osvvulnerabilityalerts and https://docs.renovatebot.com/configuration-options/#dependencydashboardosvvulnerabilitysummary

This should:
1. Make Renovate embed CVE information when applicable in dependency update PRs
   - I intend to use this information in Changelog automation to detail resolved CVEs in each release
2. Make Renovate automatically document unresolved CVEs at https://github.com/open-telemetry/otel-arrow/issues/417

## What issue does this PR close?

N/A

## How are these changes tested?

N/A

## Are there any user-facing changes?

N/A

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
