### PR TITLE
chore(repo): Use proper git config for automation and small release format nits

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -34,10 +34,17 @@ jobs:
       - name: Create GitHub App token
         if: "!inputs.dry_run"
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: otelbot-token
+        id: app-token
         with:
           app-id: ${{ vars.OTELBOT_ARROW_APP_ID }}
           private-key: ${{ secrets.OTELBOT_ARROW_PRIVATE_KEY }}
+
+      - name: Get GitHub App User ID
+        if: "!inputs.dry_run"
+        id: get-user-id
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
 
       - name: Checkout (release preparation)
         if: "!inputs.dry_run"
@@ -46,7 +53,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
           ref: ${{ github.ref }}
-          token: ${{ steps.otelbot-token.outputs.token }}
+          token: ${{ steps.app-token.outputs.token }}
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: stable
@@ -198,8 +205,8 @@ jobs:
         if: "!inputs.dry_run"
         run: |
           # Configure git for otelbot
-          git config user.name otelbot
-          git config user.email 197425009+otelbot@users.noreply.github.com
+          git config user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
 
           # Use script to create branch and commit
           ./.github/workflows/scripts/create-release-branch.sh "${{ inputs.version }}" --push
@@ -208,7 +215,7 @@ jobs:
         if: "!inputs.dry_run"
         env:
           # not using secrets.GITHUB_TOKEN since pull requests from that token do not trigger workflows
-          GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           # Read combined changelog content for PR body
           CHANGELOG_CONTENT=$(cat /tmp/combined_release_content.txt)

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -34,10 +34,17 @@ jobs:
       - name: Create GitHub App token
         if: "!inputs.dry_run"
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: otelbot-token
+        id: app-token
         with:
           app-id: ${{ vars.OTELBOT_ARROW_APP_ID }}
           private-key: ${{ secrets.OTELBOT_ARROW_PRIVATE_KEY }}
+
+      - name: Get GitHub App User ID
+        if: "!inputs.dry_run"
+        id: get-user-id
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
 
       - name: Checkout (release push)
         if: "!inputs.dry_run"
@@ -46,7 +53,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
           ref: ${{ github.ref }}
-          token: ${{ steps.otelbot-token.outputs.token }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Validate inputs
         run: |
@@ -140,8 +147,8 @@ jobs:
             echo ""
             echo "This release includes the following Go modules:"
             echo ""
-            echo "- github.com/open-telemetry/otel-arrow/go@v${{ inputs.version }}"
-            echo "- github.com/open-telemetry/otel-arrow/collector/cmd/otelarrowcol@v${{ inputs.version }}"
+            echo "- \`github.com/open-telemetry/otel-arrow/go@v${{ inputs.version }}\`"
+            echo "- \`github.com/open-telemetry/otel-arrow/collector/cmd/otelarrowcol@v${{ inputs.version }}\`"
             echo ""
             echo "## What's Changed (Rust :crab:)"
             echo ""
@@ -153,9 +160,7 @@ jobs:
             echo ""
             echo "### Rust Workspace"
             echo ""
-            echo "The Rust workspace at \`rust/otap-dataflow/\` is tagged as"
-            echo "\`rust/otap-dataflow/v${{ inputs.version }}\`. Crates are not"
-            echo "published to crates.io yet; consume this release via git."
+            echo "The Rust workspace at \`rust/otap-dataflow/\` is tagged as \`rust/otap-dataflow/v${{ inputs.version }}\`. Crates are not published to crates.io yet; consume this release via git."
           } > /tmp/release_content.txt
 
       - name: Dry run - Show planned changes
@@ -211,8 +216,8 @@ jobs:
         if: "!inputs.dry_run"
         run: |
           # Configure git
-          git config user.name otelbot
-          git config user.email 197425009+otelbot@users.noreply.github.com
+          git config user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
 
           # Create main release tag
           git tag -a "v${{ inputs.version }}" -m "Release v${{ inputs.version }}"
@@ -246,7 +251,7 @@ jobs:
       - name: Create GitHub release
         if: "!inputs.dry_run"
         env:
-          GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           # Read combined changelog content into a variable
           RELEASE_CONTENT=$(cat /tmp/release_content.txt)

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -17,15 +17,20 @@ jobs:
     if: ${{ contains(fromJson('["renovate[bot]", "dependabot[bot]"]'), github.actor) && github.event.pull_request.head.repo.fork == false }}
     steps:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: otelbot-token
+        id: app-token
         with:
           app-id: ${{ vars.OTELBOT_ARROW_APP_ID }}
           private-key: ${{ secrets.OTELBOT_ARROW_PRIVATE_KEY }}
+      - name: Get GitHub App User ID
+        id: get-user-id
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
-          token: ${{ steps.otelbot-token.outputs.token }}
+          token: ${{ steps.app-token.outputs.token }}
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26.3"
@@ -34,9 +39,8 @@ jobs:
         run: make genotelarrowcol
       - name: Commit changes
         run: |
-          # Configure git for otelbot
-          git config user.name otelbot
-          git config user.email 197425009+otelbot@users.noreply.github.com
+          git config user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
 
           if ! git diff --exit-code; then
             git add .


### PR DESCRIPTION
# Change Summary

* Use proper git config settings to accurately reflect otel-arrow bot doing automation work (instead of a mixture as seen below). Following docs at https://github.com/open-telemetry/community/blob/main/assets.md#otelbot-sig-specific

<img width="754" height="66" alt="image" src="https://github.com/user-attachments/assets/418ad71e-3258-43ff-ab1d-7d8d310f3b77" />

* Minor formatting improvements to the Release draft template

## What issue does this PR close?

N/A

## How are these changes tested?

N/A

## Are there any user-facing changes?

N/A

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
