### PR TITLE
OPL/OTAP Query-engine fork implementation

### DIFF
--- a/rust/experimental/query_engine/engine-recordset/src/engine.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/engine.rs
@@ -308,11 +308,11 @@ fn process_record<'a, TRecord: Record + 'static>(
                     }
                 }
             }
-            DataExpression::Conditional(c) => {
+            DataExpression::Branch(b) => {
                 execution_context.add_diagnostic_if_enabled(
                     RecordSetEngineDiagnosticLevel::Error,
-                    c,
-                    || "Conditional Expression not yet supported in record set engine".into(),
+                    b,
+                    || "Branch Expression not yet supported in record set engine".into(),
                 );
                 break;
             }

--- a/rust/experimental/query_engine/engine-recordset/src/scalars/scalar_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/scalars/scalar_expressions.rs
@@ -417,10 +417,10 @@ where
 
                     for e in expressions {
                         match e {
-                            PipelineFunctionExpression::Conditional(c) => {
+                            PipelineFunctionExpression::Branch(b) => {
                                 return Err(ExpressionError::NotSupported(
-                                    c.get_query_location().clone(),
-                                    format!("{} not supported in pipeline function", c.get_name()),
+                                    b.get_query_location().clone(),
+                                    format!("{} not supported in pipeline function", b.get_name()),
                                 ));
                             }
                             PipelineFunctionExpression::Discard(d) => {

--- a/rust/experimental/query_engine/expressions/src/data_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/data_expressions.rs
@@ -240,70 +240,60 @@ impl Expression for BranchDataExpression {
     }
 
     fn get_name(&self) -> &'static str {
-        "ConditionalExpression"
+        "BranchDataExpression"
     }
 
     fn fmt_with_indent(&self, f: &mut std::fmt::Formatter<'_>, indent: &str) -> std::fmt::Result {
-        /* TODO logic needs reworking
-        writeln!(f, "Conditional:")?;
+        writeln!(f, "Branch:")?;
+        writeln!(
+            f,
+            "{indent}├── BranchesConsumeRecords: {}",
+            self.branches_consume_records
+        )?;
+
         if self.branches.is_empty() {
-            writeln!(f, "{indent}├── Branches: []")?;
+            writeln!(f, "{indent}└── Branches: []")?;
         } else {
-            writeln!(f, "{indent}├── Branches:")?;
+            writeln!(f, "{indent}└── Branches:")?;
             let last_idx = self.branches.len() - 1;
             for (i, branch) in self.branches.iter().enumerate() {
-                writeln!(f, "{indent}│   ├── Condition:")?;
-                write!(f, "{indent}│   │   └── ")?;
-                branch
-                    .condition
-                    .fmt_with_indent(f, &format!("{indent}│   │       "))?;
-                if i == last_idx {
-                    writeln!(f, "{indent}│   └── Expressions:")?;
-                    let last_idx = branch.expressions.len() - 1;
-                    for (i, expr) in branch.expressions.iter().enumerate() {
-                        if i == last_idx {
-                            write!(f, "{indent}│       └── ")?;
-                            expr.fmt_with_indent(f, &format!("{indent}│           "))?;
-                        } else {
-                            write!(f, "{indent}│       ├── ")?;
-                            expr.fmt_with_indent(f, &format!("{indent}│       │   "))?;
-                        }
-                    }
+                if let Some(condition) = &branch.condition {
+                    writeln!(f, "{indent}    ├── Condition:")?;
+                    write!(f, "{indent}    │   └── ")?;
+                    condition.fmt_with_indent(f, &format!("{indent}    │       "))?;
                 } else {
-                    writeln!(f, "{indent}│   ├── Expressions:")?;
-                    let last_idx = branch.expressions.len() - 1;
-                    for (i, expr) in branch.expressions.iter().enumerate() {
-                        if i == last_idx {
-                            write!(f, "{indent}│   │   └── ")?;
-                            expr.fmt_with_indent(f, &format!("{indent}│   │       "))?;
-                        } else {
-                            write!(f, "{indent}│   │   ├── ")?;
-                            expr.fmt_with_indent(f, &format!("{indent}│   │   │   "))?;
-                        }
-                    }
+                    writeln!(f, "{indent}    ├── Condition: None")?;
                 }
-            }
-        }
 
-        if let Some(default_branch) = self.default_branch.as_ref() {
-            writeln!(f, "{indent}└── Default Branch:")?;
-            let last_idx = default_branch.len() - 1;
-            for (i, expr) in default_branch.iter().enumerate() {
                 if i == last_idx {
-                    write!(f, "{indent}    └── ")?;
-                    expr.fmt_with_indent(f, &format!("{indent}        "))?
+                    writeln!(f, "{indent}    └── Expressions:")?;
+                    let last_idx = branch.expressions.len() - 1;
+                    for (i, expr) in branch.expressions.iter().enumerate() {
+                        if i == last_idx {
+                            write!(f, "{indent}        └── ")?;
+                            expr.fmt_with_indent(f, &format!("{indent}            "))?;
+                        } else {
+                            write!(f, "{indent}        ├── ")?;
+                            expr.fmt_with_indent(f, &format!("{indent}        │   "))?;
+                        }
+                    }
                 } else {
-                    write!(f, "{indent}    ├── ")?;
-                    expr.fmt_with_indent(f, &format!("{indent}    │   "))?;
+                    writeln!(f, "{indent}    ├── Expressions:")?;
+                    let last_idx = branch.expressions.len() - 1;
+                    for (i, expr) in branch.expressions.iter().enumerate() {
+                        if i == last_idx {
+                            write!(f, "{indent}    │   └── ")?;
+                            expr.fmt_with_indent(f, &format!("{indent}    │       "))?;
+                        } else {
+                            write!(f, "{indent}    │   ├── ")?;
+                            expr.fmt_with_indent(f, &format!("{indent}    │   │   "))?;
+                        }
+                    }
                 }
             }
-        } else {
-            writeln!(f, "{indent}└── Default Branch: None")?;
         }
 
         Ok(())
-        */
-        todo!()
     }
 }
 
@@ -805,6 +795,10 @@ mod test {
                     )),
                 ))],
             ));
+
+        // println!("{}", )
+        let output = format!("{}", DisplayWrapper(&expr, ""));
+        println!("{}", output);
 
         let constants = Vec::new();
         let functions = Vec::new();

--- a/rust/experimental/query_engine/expressions/src/data_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/data_expressions.rs
@@ -14,8 +14,8 @@ pub enum DataExpression {
     /// Transform data expression.
     Transform(TransformExpression),
 
-    /// Conditional data expression.
-    Conditional(ConditionalDataExpression),
+    /// Branch data expression.
+    Branch(BranchDataExpression),
 
     /// Output data expression.
     Output(OutputDataExpression),
@@ -30,7 +30,7 @@ impl DataExpression {
             DataExpression::Discard(d) => d.try_fold(scope),
             DataExpression::Summary(s) => s.try_fold(scope),
             DataExpression::Transform(t) => t.try_fold(scope),
-            DataExpression::Conditional(c) => c.try_fold(scope),
+            DataExpression::Branch(b) => b.try_fold(scope),
             DataExpression::Output(o) => o.try_fold(scope),
         }
     }
@@ -42,7 +42,7 @@ impl Expression for DataExpression {
             DataExpression::Discard(d) => d.get_query_location(),
             DataExpression::Summary(s) => s.get_query_location(),
             DataExpression::Transform(t) => t.get_query_location(),
-            DataExpression::Conditional(c) => c.get_query_location(),
+            DataExpression::Branch(b) => b.get_query_location(),
             DataExpression::Output(o) => o.get_query_location(),
         }
     }
@@ -52,7 +52,7 @@ impl Expression for DataExpression {
             DataExpression::Discard(_) => "DataExpression(Discard)",
             DataExpression::Summary(_) => "DataExpression(Summary)",
             DataExpression::Transform(_) => "DataExpression(Transform)",
-            DataExpression::Conditional(_) => "DataExpression(Conditional)",
+            DataExpression::Branch(_) => "DataExpression(Conditional)",
             DataExpression::Output(_) => "DataExpression(Output)",
         }
     }
@@ -62,7 +62,7 @@ impl Expression for DataExpression {
             DataExpression::Discard(d) => d.fmt_with_indent(f, indent),
             DataExpression::Summary(s) => s.fmt_with_indent(f, indent),
             DataExpression::Transform(t) => t.fmt_with_indent(f, indent),
-            DataExpression::Conditional(c) => c.fmt_with_indent(f, indent),
+            DataExpression::Branch(b) => b.fmt_with_indent(f, indent),
             DataExpression::Output(o) => o.fmt_with_indent(f, indent),
         }
     }
@@ -161,27 +161,31 @@ impl Expression for DiscardDataExpression {
 /// forms a "branch". The "default branch" defines how to optionally handle data that matches no
 /// other branch's condition.
 #[derive(Clone, Debug, PartialEq)]
-pub struct ConditionalDataExpression {
+pub struct BranchDataExpression {
     query_location: QueryLocation,
 
+    /// Whether each branch consumes the records, or receive a copy
+    branches_consume_records: bool,
+
     /// Branches which will conditionally process
-    branches: Vec<ConditionalDataExpressionBranch>,
+    branches: Vec<DataExpressionBranch>,
 
     /// If `Some`, data that does not match the condition in any of the other branches
     /// will be handled by this branch
     default_branch: Option<Vec<DataExpression>>,
 }
 
-impl ConditionalDataExpression {
-    pub fn new(query_location: QueryLocation) -> Self {
+impl BranchDataExpression {
+    pub fn new(query_location: QueryLocation, branches_consume_records: bool) -> Self {
         Self {
             query_location,
+            branches_consume_records,
             branches: Vec::new(),
             default_branch: None,
         }
     }
 
-    pub fn with_branch(mut self, branch: ConditionalDataExpressionBranch) -> Self {
+    pub fn with_branch(mut self, branch: DataExpressionBranch) -> Self {
         self.branches.push(branch);
         self
     }
@@ -191,12 +195,16 @@ impl ConditionalDataExpression {
         self
     }
 
-    pub fn get_branches(&self) -> &[ConditionalDataExpressionBranch] {
+    pub fn get_branches(&self) -> &[DataExpressionBranch] {
         &self.branches
     }
 
     pub fn get_default_branch(&self) -> Option<&[DataExpression]> {
         self.default_branch.as_deref()
+    }
+
+    pub fn branches_consume_records(&self) -> bool {
+        self.branches_consume_records
     }
 
     /// The try_fold implementation for this type of expression will recursively call the relevant
@@ -210,7 +218,10 @@ impl ConditionalDataExpression {
         while i < self.branches.len() {
             let static_logical_expr = {
                 let branch = &mut self.branches[i];
-                branch.condition.try_resolve_static(scope)?
+                match &mut branch.condition {
+                    Some(c) => c.try_resolve_static(scope)?,
+                    None => None,
+                }
             };
 
             if let Some(static_logical_expr) = static_logical_expr {
@@ -248,7 +259,7 @@ impl ConditionalDataExpression {
     }
 }
 
-impl Expression for ConditionalDataExpression {
+impl Expression for BranchDataExpression {
     fn get_query_location(&self) -> &QueryLocation {
         &self.query_location
     }
@@ -258,6 +269,7 @@ impl Expression for ConditionalDataExpression {
     }
 
     fn fmt_with_indent(&self, f: &mut std::fmt::Formatter<'_>, indent: &str) -> std::fmt::Result {
+        /* TODO logic needs reworking
         writeln!(f, "Conditional:")?;
         if self.branches.is_empty() {
             writeln!(f, "{indent}├── Branches: []")?;
@@ -315,24 +327,26 @@ impl Expression for ConditionalDataExpression {
         }
 
         Ok(())
+        */
+        todo!()
     }
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct ConditionalDataExpressionBranch {
+pub struct DataExpressionBranch {
     query_location: QueryLocation,
 
     /// The condition that data must match to be handled by this branch
-    condition: LogicalExpression,
+    condition: Option<LogicalExpression>,
 
     /// The expressions to apply to the data handled by this branch
     expressions: Vec<DataExpression>,
 }
 
-impl ConditionalDataExpressionBranch {
+impl DataExpressionBranch {
     pub fn new(
         query_location: QueryLocation,
-        condition: LogicalExpression,
+        condition: Option<LogicalExpression>,
         expressions: Vec<DataExpression>,
     ) -> Self {
         Self {
@@ -342,8 +356,8 @@ impl ConditionalDataExpressionBranch {
         }
     }
 
-    pub fn get_condition(&self) -> &LogicalExpression {
-        &self.condition
+    pub fn get_condition(&self) -> Option<&LogicalExpression> {
+        self.condition.as_ref()
     }
 
     pub fn get_expressions(&self) -> &[DataExpression] {
@@ -437,10 +451,10 @@ mod test {
 
     #[test]
     fn test_fold_conditional_expr_removes_everything_after_all_true_condition() {
-        let mut expr = ConditionalDataExpression::new(QueryLocation::new_fake())
-            .with_branch(ConditionalDataExpressionBranch::new(
+        let mut expr = BranchDataExpression::new(QueryLocation::new_fake(), true)
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
-                LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                Some(LogicalExpression::EqualTo(EqualToLogicalExpression::new(
                     QueryLocation::new_fake(),
                     ScalarExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -455,7 +469,7 @@ mod test {
                         BooleanScalarExpression::new(QueryLocation::new_fake(), true),
                     )),
                     false,
-                )),
+                ))),
                 vec![DataExpression::Discard(
                     // this should get folded into a static false
                     DiscardDataExpression::new(QueryLocation::new_fake()).with_predicate(
@@ -472,10 +486,10 @@ mod test {
                     ),
                 )],
             ))
-            .with_branch(ConditionalDataExpressionBranch::new(
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
                 // this should also get folded to static true, meaning this branch will get the rest of the rows
-                LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                Some(LogicalExpression::EqualTo(EqualToLogicalExpression::new(
                     QueryLocation::new_fake(),
                     ScalarExpression::Static(StaticScalarExpression::String(
                         StringScalarExpression::new(QueryLocation::new_fake(), "a"),
@@ -484,7 +498,7 @@ mod test {
                         StringScalarExpression::new(QueryLocation::new_fake(), "a"),
                     )),
                     false,
-                )),
+                ))),
                 vec![DataExpression::Output(OutputDataExpression::new(
                     QueryLocation::new_fake(),
                     OutputExpression::NamedSink(StringScalarExpression::new(
@@ -494,9 +508,9 @@ mod test {
                 ))],
             ))
             // this should get removed
-            .with_branch(ConditionalDataExpressionBranch::new(
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
-                LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                Some(LogicalExpression::EqualTo(EqualToLogicalExpression::new(
                     QueryLocation::new_fake(),
                     ScalarExpression::Static(StaticScalarExpression::String(
                         StringScalarExpression::new(QueryLocation::new_fake(), "b"),
@@ -505,7 +519,7 @@ mod test {
                         StringScalarExpression::new(QueryLocation::new_fake(), "a"),
                     )),
                     false,
-                )),
+                ))),
                 vec![DataExpression::Output(OutputDataExpression::new(
                     QueryLocation::new_fake(),
                     OutputExpression::NamedSink(StringScalarExpression::new(
@@ -528,10 +542,10 @@ mod test {
         let scope = PipelineResolutionScope::new_for_test(&constants, &functions);
         expr.try_fold(&scope).unwrap();
 
-        let expected = ConditionalDataExpression::new(QueryLocation::new_fake())
-            .with_branch(ConditionalDataExpressionBranch::new(
+        let expected = BranchDataExpression::new(QueryLocation::new_fake(), true)
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
-                LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                Some(LogicalExpression::EqualTo(EqualToLogicalExpression::new(
                     QueryLocation::new_fake(),
                     ScalarExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -546,7 +560,7 @@ mod test {
                         BooleanScalarExpression::new(QueryLocation::new_fake(), true),
                     )),
                     false,
-                )),
+                ))),
                 vec![DataExpression::Discard(
                     DiscardDataExpression::new(QueryLocation::new_fake()).with_predicate(
                         LogicalExpression::Scalar(ScalarExpression::Static(
@@ -558,14 +572,14 @@ mod test {
                     ),
                 )],
             ))
-            .with_branch(ConditionalDataExpressionBranch::new(
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
-                LogicalExpression::Scalar(ScalarExpression::Static(
+                Some(LogicalExpression::Scalar(ScalarExpression::Static(
                     StaticScalarExpression::Boolean(BooleanScalarExpression::new(
                         QueryLocation::new_fake(),
                         true,
                     )),
-                )),
+                ))),
                 vec![DataExpression::Output(OutputDataExpression::new(
                     QueryLocation::new_fake(),
                     OutputExpression::NamedSink(StringScalarExpression::new(
@@ -582,10 +596,10 @@ mod test {
     fn test_fold_conditional_expr_removes_everything_all_true_condition_is_last() {
         // test to ensure we don't go out of bounds when trying to remove branches following
         // the branch chose condition always evaluates to always true
-        let mut expr = ConditionalDataExpression::new(QueryLocation::new_fake())
-            .with_branch(ConditionalDataExpressionBranch::new(
+        let mut expr = BranchDataExpression::new(QueryLocation::new_fake(), true)
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
-                LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                Some(LogicalExpression::EqualTo(EqualToLogicalExpression::new(
                     QueryLocation::new_fake(),
                     ScalarExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -600,7 +614,7 @@ mod test {
                         BooleanScalarExpression::new(QueryLocation::new_fake(), true),
                     )),
                     false,
-                )),
+                ))),
                 vec![DataExpression::Discard(
                     // this should get folded into a static false
                     DiscardDataExpression::new(QueryLocation::new_fake()).with_predicate(
@@ -617,10 +631,10 @@ mod test {
                     ),
                 )],
             ))
-            .with_branch(ConditionalDataExpressionBranch::new(
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
                 // this should also get folded to static true, meaning this branch will get the rest of the rows
-                LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                Some(LogicalExpression::EqualTo(EqualToLogicalExpression::new(
                     QueryLocation::new_fake(),
                     ScalarExpression::Static(StaticScalarExpression::String(
                         StringScalarExpression::new(QueryLocation::new_fake(), "a"),
@@ -629,7 +643,7 @@ mod test {
                         StringScalarExpression::new(QueryLocation::new_fake(), "a"),
                     )),
                     false,
-                )),
+                ))),
                 vec![DataExpression::Output(OutputDataExpression::new(
                     QueryLocation::new_fake(),
                     OutputExpression::NamedSink(StringScalarExpression::new(
@@ -652,10 +666,10 @@ mod test {
         let scope = PipelineResolutionScope::new_for_test(&constants, &functions);
         expr.try_fold(&scope).unwrap();
 
-        let expected = ConditionalDataExpression::new(QueryLocation::new_fake())
-            .with_branch(ConditionalDataExpressionBranch::new(
+        let expected = BranchDataExpression::new(QueryLocation::new_fake(), true)
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
-                LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                Some(LogicalExpression::EqualTo(EqualToLogicalExpression::new(
                     QueryLocation::new_fake(),
                     ScalarExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -670,7 +684,7 @@ mod test {
                         BooleanScalarExpression::new(QueryLocation::new_fake(), true),
                     )),
                     false,
-                )),
+                ))),
                 vec![DataExpression::Discard(
                     DiscardDataExpression::new(QueryLocation::new_fake()).with_predicate(
                         LogicalExpression::Scalar(ScalarExpression::Static(
@@ -682,14 +696,14 @@ mod test {
                     ),
                 )],
             ))
-            .with_branch(ConditionalDataExpressionBranch::new(
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
-                LogicalExpression::Scalar(ScalarExpression::Static(
+                Some(LogicalExpression::Scalar(ScalarExpression::Static(
                     StaticScalarExpression::Boolean(BooleanScalarExpression::new(
                         QueryLocation::new_fake(),
                         true,
                     )),
-                )),
+                ))),
                 vec![DataExpression::Output(OutputDataExpression::new(
                     QueryLocation::new_fake(),
                     OutputExpression::NamedSink(StringScalarExpression::new(
@@ -704,10 +718,10 @@ mod test {
 
     #[test]
     fn test_fold_conditional_expr_removes_branch_for_all_false_condition() {
-        let mut expr = ConditionalDataExpression::new(QueryLocation::new_fake())
-            .with_branch(ConditionalDataExpressionBranch::new(
+        let mut expr = BranchDataExpression::new(QueryLocation::new_fake(), true)
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
-                LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                Some(LogicalExpression::EqualTo(EqualToLogicalExpression::new(
                     QueryLocation::new_fake(),
                     ScalarExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -722,7 +736,7 @@ mod test {
                         BooleanScalarExpression::new(QueryLocation::new_fake(), true),
                     )),
                     false,
-                )),
+                ))),
                 vec![DataExpression::Discard(
                     // this should get folded into a static false
                     DiscardDataExpression::new(QueryLocation::new_fake()).with_predicate(
@@ -739,10 +753,10 @@ mod test {
                     ),
                 )],
             ))
-            .with_branch(ConditionalDataExpressionBranch::new(
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
                 // this will evaluate to all false, which means this branch should get removed
-                LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                Some(LogicalExpression::EqualTo(EqualToLogicalExpression::new(
                     QueryLocation::new_fake(),
                     ScalarExpression::Static(StaticScalarExpression::String(
                         StringScalarExpression::new(QueryLocation::new_fake(), "a"),
@@ -751,7 +765,7 @@ mod test {
                         StringScalarExpression::new(QueryLocation::new_fake(), "b"),
                     )),
                     false,
-                )),
+                ))),
                 vec![DataExpression::Output(OutputDataExpression::new(
                     QueryLocation::new_fake(),
                     OutputExpression::NamedSink(StringScalarExpression::new(
@@ -761,9 +775,9 @@ mod test {
                 ))],
             ))
             // this should be kept
-            .with_branch(ConditionalDataExpressionBranch::new(
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
-                LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                Some(LogicalExpression::EqualTo(EqualToLogicalExpression::new(
                     QueryLocation::new_fake(),
                     ScalarExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -778,7 +792,7 @@ mod test {
                         BooleanScalarExpression::new(QueryLocation::new_fake(), true),
                     )),
                     false,
-                )),
+                ))),
                 vec![DataExpression::Discard(
                     // this should get folded into a static false as well
                     DiscardDataExpression::new(QueryLocation::new_fake()).with_predicate(
@@ -809,10 +823,10 @@ mod test {
         let scope = PipelineResolutionScope::new_for_test(&constants, &functions);
         expr.try_fold(&scope).unwrap();
 
-        let expected = ConditionalDataExpression::new(QueryLocation::new_fake())
-            .with_branch(ConditionalDataExpressionBranch::new(
+        let expected = BranchDataExpression::new(QueryLocation::new_fake(), true)
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
-                LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                Some(LogicalExpression::EqualTo(EqualToLogicalExpression::new(
                     QueryLocation::new_fake(),
                     ScalarExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -827,7 +841,7 @@ mod test {
                         BooleanScalarExpression::new(QueryLocation::new_fake(), true),
                     )),
                     false,
-                )),
+                ))),
                 vec![DataExpression::Discard(
                     DiscardDataExpression::new(QueryLocation::new_fake()).with_predicate(
                         LogicalExpression::Scalar(ScalarExpression::Static(
@@ -839,9 +853,9 @@ mod test {
                     ),
                 )],
             ))
-            .with_branch(ConditionalDataExpressionBranch::new(
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
-                LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                Some(LogicalExpression::EqualTo(EqualToLogicalExpression::new(
                     QueryLocation::new_fake(),
                     ScalarExpression::Source(SourceScalarExpression::new(
                         QueryLocation::new_fake(),
@@ -856,7 +870,7 @@ mod test {
                         BooleanScalarExpression::new(QueryLocation::new_fake(), true),
                     )),
                     false,
-                )),
+                ))),
                 vec![DataExpression::Discard(
                     DiscardDataExpression::new(QueryLocation::new_fake()).with_predicate(
                         LogicalExpression::Scalar(ScalarExpression::Static(

--- a/rust/experimental/query_engine/expressions/src/data_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/data_expressions.rs
@@ -169,10 +169,6 @@ pub struct BranchDataExpression {
 
     /// Branches which will conditionally process
     branches: Vec<DataExpressionBranch>,
-
-    /// If `Some`, data that does not match the condition in any of the other branches
-    /// will be handled by this branch
-    default_branch: Option<Vec<DataExpression>>,
 }
 
 impl BranchDataExpression {
@@ -181,7 +177,6 @@ impl BranchDataExpression {
             query_location,
             branches_consume_records,
             branches: Vec::new(),
-            default_branch: None,
         }
     }
 
@@ -190,17 +185,8 @@ impl BranchDataExpression {
         self
     }
 
-    pub fn with_default_branch(mut self, expressions: Vec<DataExpression>) -> Self {
-        self.default_branch = Some(expressions);
-        self
-    }
-
     pub fn get_branches(&self) -> &[DataExpressionBranch] {
         &self.branches
-    }
-
-    pub fn get_default_branch(&self) -> Option<&[DataExpression]> {
-        self.default_branch.as_deref()
     }
 
     pub fn branches_consume_records(&self) -> bool {
@@ -229,10 +215,6 @@ impl BranchDataExpression {
                     // here everything will pass the filter. That means we can drop the test of the
                     // branches because all remaining rows will be evaluated by this branch
                     _ = self.branches.split_off(i + 1);
-
-                    // drop the default branch - no need to keep it as there will be now rows for
-                    // for it to evaluate
-                    self.default_branch = None;
                 } else {
                     // here nothing will pass the filter, so we can basically discard this branch
                     self.branches.remove(i);
@@ -246,13 +228,6 @@ impl BranchDataExpression {
             }
 
             i += 1;
-        }
-
-        if let Some(default_branch) = self.default_branch.as_mut() {
-            // optimize the expressions inside the branch
-            for expression in default_branch {
-                expression.try_fold(scope)?;
-            }
         }
 
         Ok(())
@@ -527,15 +502,20 @@ mod test {
                         "out2",
                     )),
                 ))],
+                // this should also get removed
             ))
             // this should also get removed
-            .with_default_branch(vec![DataExpression::Output(OutputDataExpression::new(
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
-                OutputExpression::NamedSink(StringScalarExpression::new(
+                None,
+                vec![DataExpression::Output(OutputDataExpression::new(
                     QueryLocation::new_fake(),
-                    "out2",
-                )),
-            ))]);
+                    OutputExpression::NamedSink(StringScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        "out2",
+                    )),
+                ))],
+            ));
 
         let constants = Vec::new();
         let functions = Vec::new();
@@ -653,13 +633,17 @@ mod test {
                 ))],
             ))
             // this should also get removed
-            .with_default_branch(vec![DataExpression::Output(OutputDataExpression::new(
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
-                OutputExpression::NamedSink(StringScalarExpression::new(
+                None,
+                vec![DataExpression::Output(OutputDataExpression::new(
                     QueryLocation::new_fake(),
-                    "out2",
-                )),
-            ))]);
+                    OutputExpression::NamedSink(StringScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        "out2",
+                    )),
+                ))],
+            ));
 
         let constants = Vec::new();
         let functions = Vec::new();
@@ -809,14 +793,18 @@ mod test {
                     ),
                 )],
             ))
-            // this should be kept
-            .with_default_branch(vec![DataExpression::Output(OutputDataExpression::new(
+            // this should also be kept
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
-                OutputExpression::NamedSink(StringScalarExpression::new(
+                None,
+                vec![DataExpression::Output(OutputDataExpression::new(
                     QueryLocation::new_fake(),
-                    "out2",
-                )),
-            ))]);
+                    OutputExpression::NamedSink(StringScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        "out2",
+                    )),
+                ))],
+            ));
 
         let constants = Vec::new();
         let functions = Vec::new();
@@ -883,13 +871,17 @@ mod test {
                 )],
             ))
             // this should be kept because
-            .with_default_branch(vec![DataExpression::Output(OutputDataExpression::new(
+            .with_branch(DataExpressionBranch::new(
                 QueryLocation::new_fake(),
-                OutputExpression::NamedSink(StringScalarExpression::new(
+                None,
+                vec![DataExpression::Output(OutputDataExpression::new(
                     QueryLocation::new_fake(),
-                    "out2",
-                )),
-            ))]);
+                    OutputExpression::NamedSink(StringScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        "out2",
+                    )),
+                ))],
+            ));
 
         assert_eq!(expr, expected);
     }

--- a/rust/experimental/query_engine/expressions/src/data_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/data_expressions.rs
@@ -52,7 +52,7 @@ impl Expression for DataExpression {
             DataExpression::Discard(_) => "DataExpression(Discard)",
             DataExpression::Summary(_) => "DataExpression(Summary)",
             DataExpression::Transform(_) => "DataExpression(Transform)",
-            DataExpression::Branch(_) => "DataExpression(Conditional)",
+            DataExpression::Branch(_) => "DataExpression(Branch)",
             DataExpression::Output(_) => "DataExpression(Output)",
         }
     }
@@ -154,10 +154,10 @@ impl Expression for DiscardDataExpression {
     }
 }
 
-/// Conditional data expression.
+/// Branch data expression.
 ///
 /// This is used to define a data operation where some nested [`DataExpression`]s are applied to
-/// a subset of data which matches a predicate condition. Each combination of condition/expressions
+/// a subset of data which may matches a predicate condition. Each combination of condition/expressions
 /// forms a "branch". The "default branch" defines how to optionally handle data that matches no
 /// other branch's condition.
 #[derive(Clone, Debug, PartialEq)]
@@ -167,7 +167,7 @@ pub struct BranchDataExpression {
     /// Whether each branch consumes the records, or receive a copy
     branches_consume_records: bool,
 
-    /// Branches which will conditionally process
+    /// Branches which will process the records
     branches: Vec<DataExpressionBranch>,
 }
 
@@ -269,27 +269,35 @@ impl Expression for BranchDataExpression {
                 }
 
                 if i == last_idx {
-                    writeln!(f, "{indent}    └── Expressions:")?;
-                    let last_idx = branch.expressions.len() - 1;
-                    for (i, expr) in branch.expressions.iter().enumerate() {
-                        if i == last_idx {
-                            write!(f, "{indent}        └── ")?;
-                            expr.fmt_with_indent(f, &format!("{indent}            "))?;
-                        } else {
-                            write!(f, "{indent}        ├── ")?;
-                            expr.fmt_with_indent(f, &format!("{indent}        │   "))?;
+                    if branch.expressions.is_empty() {
+                        writeln!(f, "{indent}    └── Expressions: []")?;
+                    } else {
+                        writeln!(f, "{indent}    └── Expressions:")?;
+                        let last_idx = branch.expressions.len() - 1;
+                        for (i, expr) in branch.expressions.iter().enumerate() {
+                            if i == last_idx {
+                                write!(f, "{indent}        └── ")?;
+                                expr.fmt_with_indent(f, &format!("{indent}            "))?;
+                            } else {
+                                write!(f, "{indent}        ├── ")?;
+                                expr.fmt_with_indent(f, &format!("{indent}        │   "))?;
+                            }
                         }
                     }
                 } else {
-                    writeln!(f, "{indent}    ├── Expressions:")?;
-                    let last_idx = branch.expressions.len() - 1;
-                    for (i, expr) in branch.expressions.iter().enumerate() {
-                        if i == last_idx {
-                            write!(f, "{indent}    │   └── ")?;
-                            expr.fmt_with_indent(f, &format!("{indent}    │       "))?;
-                        } else {
-                            write!(f, "{indent}    │   ├── ")?;
-                            expr.fmt_with_indent(f, &format!("{indent}    │   │   "))?;
+                    if branch.expressions.is_empty() {
+                        writeln!(f, "{indent}    ├── Expressions: []")?;
+                    } else {
+                        writeln!(f, "{indent}    ├── Expressions:")?;
+                        let last_idx = branch.expressions.len() - 1;
+                        for (i, expr) in branch.expressions.iter().enumerate() {
+                            if i == last_idx {
+                                write!(f, "{indent}    │   └── ")?;
+                                expr.fmt_with_indent(f, &format!("{indent}    │       "))?;
+                            } else {
+                                write!(f, "{indent}    │   ├── ")?;
+                                expr.fmt_with_indent(f, &format!("{indent}    │   │   "))?;
+                            }
                         }
                     }
                 }

--- a/rust/experimental/query_engine/expressions/src/data_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/data_expressions.rs
@@ -205,8 +205,11 @@ impl BranchDataExpression {
             let static_logical_expr = {
                 let branch = &mut self.branches[i];
                 match &mut branch.condition {
-                    Some(c) => c.try_resolve_static(scope)?,
-                    None => None,
+                    // note: we only do the "remove branch if can fold to static" optimization
+                    // below if the branch consumes the records -- otherwise all branches must be
+                    // kept because each branch must evaluate because each receives a copy
+                    Some(c) if self.branches_consume_records => c.try_resolve_static(scope)?,
+                    _ => None,
                 }
             };
 

--- a/rust/experimental/query_engine/expressions/src/data_expressions.rs
+++ b/rust/experimental/query_engine/expressions/src/data_expressions.rs
@@ -796,10 +796,6 @@ mod test {
                 ))],
             ));
 
-        // println!("{}", )
-        let output = format!("{}", DisplayWrapper(&expr, ""));
-        println!("{}", output);
-
         let constants = Vec::new();
         let functions = Vec::new();
         let scope = PipelineResolutionScope::new_for_test(&constants, &functions);

--- a/rust/experimental/query_engine/expressions/src/pipeline_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/pipeline_expression.rs
@@ -385,7 +385,7 @@ impl AsRef<PipelineExpression> for PipelineExpressionBuilder {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum PipelineFunctionExpression {
-    Conditional(ConditionalDataExpression),
+    Branch(BranchDataExpression),
     Discard(DiscardDataExpression),
     Transform(TransformExpression),
     Return(ScalarExpression),
@@ -397,7 +397,7 @@ impl PipelineFunctionExpression {
         scope: &PipelineResolutionScope,
     ) -> Result<(), ExpressionError> {
         match self {
-            Self::Conditional(c) => c.try_fold(scope),
+            Self::Branch(c) => c.try_fold(scope),
             Self::Discard(d) => d.try_fold(scope),
             Self::Transform(t) => t.try_fold(scope),
             Self::Return(_r) => Ok(()), // no need to fold return
@@ -412,8 +412,8 @@ impl PipelineFunctionExpression {
         indent: &str,
     ) -> std::fmt::Result {
         match self {
-            PipelineFunctionExpression::Conditional(c) => {
-                write!(f, "Conditional: ")?;
+            PipelineFunctionExpression::Branch(c) => {
+                write!(f, "Branch: ")?;
                 c.fmt_with_indent(f, format!("{indent}           ").as_str())
             }
             PipelineFunctionExpression::Discard(d) => {

--- a/rust/otap-dataflow/.chloggen/opl-query-engine-fork.yaml
+++ b/rust/otap-dataflow/.chloggen/opl-query-engine-fork.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: query-engine
+note: Add `fork` operator call to OPL language and support in query-engine
+issues: [3188]

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
@@ -1509,7 +1509,7 @@ mod test {
                     .unwrap();
                 assert_eq!(default_out, OtapArrowRecords::Logs(Logs::default()));
 
-                // assert on what came out of hte error out port
+                // assert on what came out of the error out port
                 let mut routed = Vec::new();
                 while let Ok(msg) = error_port.try_recv() {
                     routed.push(msg);

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
@@ -585,7 +585,7 @@ mod test {
             },
         },
         schema::consts,
-        testing::round_trip::{otap_to_otlp, otlp_to_otap, to_otap_logs},
+        testing::round_trip::{otap_to_otlp, otlp_to_otap, to_logs_data, to_otap_logs},
     };
 
     use otap_df_otap::{
@@ -1456,6 +1456,110 @@ mod test {
                     }
                     _ => panic!("unexpected payload type"),
                 }
+            })
+            .validate(|_ctx| async move {})
+    }
+
+    #[test]
+    fn test_fork_with_route_to() {
+        let runtime = TestRuntime::<OtapPdata>::new();
+        let query = r#"logs |
+        fork {
+            where severity_text == "ERROR" |
+            route_to "errors_only_port"
+        }
+        {
+            set attributes["x"] = "foo" |
+            route_to "decorated_everything"
+        }
+        "#;
+
+        let mut processor = try_create_with_opl_query(query, &runtime).unwrap();
+        let error_port = set_pdata_sender("errors_only_port", &mut processor);
+        let everything_port = set_pdata_sender("decorated_everything", &mut processor);
+
+        runtime
+            .set_processor(processor)
+            .run_test(|mut ctx| async move {
+                let log_records = vec![
+                    LogRecord::build()
+                        .severity_text("ERROR")
+                        .event_name("event1")
+                        .finish(),
+                    LogRecord::build()
+                        .severity_text("WARN")
+                        .event_name("event1")
+                        .finish(),
+                ];
+                let pdata = OtapPdata::new_default(
+                    otlp_to_otap(&OtlpProtoMessage::Logs(to_logs_data(log_records))).into(),
+                );
+
+                ctx.process(Message::PData(pdata))
+                    .await
+                    .expect("no process error");
+
+                let mut out = ctx.drain_pdata().await.into_iter().collect::<Vec<_>>();
+                assert_eq!(out.len(), 1);
+                let default_out: OtapArrowRecords = out
+                    .pop()
+                    .unwrap()
+                    .payload()
+                    .try_into_with_default()
+                    .unwrap();
+                assert_eq!(default_out, OtapArrowRecords::Logs(Logs::default()));
+
+                // assert on what came out of hte error out port
+                let mut routed = Vec::new();
+                while let Ok(msg) = error_port.try_recv() {
+                    routed.push(msg);
+                }
+                assert_eq!(routed.len(), 1);
+                let (_, r) = routed.pop().unwrap().into_parts();
+                let OtlpProtoMessage::Logs(logs_data) =
+                    otap_to_otlp(&r.try_into_with_default().unwrap())
+                else {
+                    panic!("unexpected signal type from result")
+                };
+                assert_eq!(logs_data.resource_logs.len(), 1);
+                assert_eq!(logs_data.resource_logs[0].scope_logs.len(), 1);
+                assert_eq!(
+                    &logs_data.resource_logs[0].scope_logs[0].log_records,
+                    &[LogRecord::build()
+                        .severity_text("ERROR")
+                        .event_name("event1")
+                        .finish()]
+                );
+
+                // assert on what came out of the everything out port
+                let mut routed = Vec::new();
+                while let Ok(msg) = everything_port.try_recv() {
+                    routed.push(msg);
+                }
+                assert_eq!(routed.len(), 1);
+                let (_, r) = routed.pop().unwrap().into_parts();
+                let OtlpProtoMessage::Logs(logs_data) =
+                    otap_to_otlp(&r.try_into_with_default().unwrap())
+                else {
+                    panic!("unexpected signal type from result")
+                };
+                assert_eq!(logs_data.resource_logs.len(), 1);
+                assert_eq!(logs_data.resource_logs[0].scope_logs.len(), 1);
+                assert_eq!(
+                    &logs_data.resource_logs[0].scope_logs[0].log_records,
+                    &[
+                        LogRecord::build()
+                            .severity_text("ERROR")
+                            .event_name("event1")
+                            .attributes(vec![KeyValue::new("x", AnyValue::new_string("foo"))])
+                            .finish(),
+                        LogRecord::build()
+                            .severity_text("WARN")
+                            .event_name("event1")
+                            .attributes(vec![KeyValue::new("x", AnyValue::new_string("foo"))])
+                            .finish(),
+                    ]
+                );
             })
             .validate(|_ctx| async move {})
     }

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/opl.pest
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/opl.pest
@@ -202,6 +202,14 @@ rename_target = {
     identifier_expression ~ ("." ~ identifier_expression)*
 }
 
+fork_operator_call = {
+    "fork" ~ fork_branch+
+}
+
+fork_branch = {
+    "{" ~ pipeline_stage ~ ("|" ~ pipeline_stage)* ~ "}"
+}
+
 rename_operator_call = {
     "rename" ~ rename_target ~ rename_pair ~ ("," ~ rename_pair)*
 }
@@ -235,6 +243,7 @@ operator_call = {
   | rename_operator_call
   | remove_map_keys_operator_call
   | if_else_operator_call
+  | fork_operator_call
   | route_to_operator_call
   | drop_operator_call
   | where_operator_call

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser.rs
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser.rs
@@ -253,8 +253,8 @@ mod test {
 
         // The outer expression should be a Conditional containing a Discard in the branch
         match &expressions[0] {
-            DataExpression::Conditional(cond) => {
-                let branches = cond.get_branches();
+            DataExpression::Branch(branch_expr) => {
+                let branches = branch_expr.get_branches();
                 assert_eq!(branches.len(), 1);
                 let branch_exprs = branches[0].get_expressions();
                 assert_eq!(branch_exprs.len(), 1);

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser/operator.rs
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser/operator.rs
@@ -4,15 +4,14 @@
 use std::hash::{DefaultHasher, Hash, Hasher};
 
 use data_engine_expressions::{
-    ArgumentScalarExpression, ConditionalDataExpression, ConditionalDataExpressionBranch,
-    DataExpression, DiscardDataExpression, Expression, InvokeFunctionScalarExpression,
-    LogicalExpression, MapKeyRenameSelector, MapSelectionExpression, MapSelector,
-    MutableValueExpression, NotLogicalExpression, OutputDataExpression, OutputExpression,
-    PipelineFunction, PipelineFunctionExpression, PipelineFunctionParameter,
-    PipelineFunctionParameterType, QueryLocation, ReduceMapTransformExpression,
-    RenameMapKeysTransformExpression, ScalarExpression, SetTransformExpression,
-    SourceScalarExpression, StaticScalarExpression, StringScalarExpression, TransformExpression,
-    ValueAccessor, ValueType,
+    ArgumentScalarExpression, BranchDataExpression, DataExpression, DataExpressionBranch,
+    DiscardDataExpression, Expression, InvokeFunctionScalarExpression, LogicalExpression,
+    MapKeyRenameSelector, MapSelectionExpression, MapSelector, MutableValueExpression,
+    NotLogicalExpression, OutputDataExpression, OutputExpression, PipelineFunction,
+    PipelineFunctionExpression, PipelineFunctionParameter, PipelineFunctionParameterType,
+    QueryLocation, ReduceMapTransformExpression, RenameMapKeysTransformExpression,
+    ScalarExpression, SetTransformExpression, SourceScalarExpression, StaticScalarExpression,
+    StringScalarExpression, TransformExpression, ValueAccessor, ValueType,
 };
 use data_engine_parser_abstractions::{
     ParserError, parse_standard_string_literal, to_query_location,
@@ -309,7 +308,7 @@ pub(crate) fn parse_if_else_operator_call(
     mut pipeline_builder: &mut dyn PipelineBuilder,
 ) -> Result<(), ParserError> {
     let query_location = to_query_location(&operator_call_rule);
-    let mut conditional_expr = ConditionalDataExpression::new(query_location);
+    let mut branch_expr = BranchDataExpression::new(query_location, true);
 
     // keep track of the location of the current branch (to fill in query location)
     let mut branch_location_start = 0;
@@ -379,12 +378,11 @@ pub(crate) fn parse_if_else_operator_call(
                     )
                 })?;
 
-                conditional_expr =
-                    conditional_expr.with_branch(ConditionalDataExpressionBranch::new(
-                        query_location,
-                        condition,
-                        curr_branch_data_exprs,
-                    ));
+                branch_expr = branch_expr.with_branch(DataExpressionBranch::new(
+                    query_location,
+                    Some(condition),
+                    curr_branch_data_exprs,
+                ));
             }
 
             // parse the data expressions for the else branch
@@ -411,18 +409,18 @@ pub(crate) fn parse_if_else_operator_call(
                 }
                 let (else_branch_data_exprs, parent) = else_branch_exprs.into_parts();
                 pipeline_builder = parent;
-                conditional_expr = conditional_expr.with_default_branch(else_branch_data_exprs);
+                branch_expr = branch_expr.with_default_branch(else_branch_data_exprs);
             }
             _ => {
                 return Err(ParserError::SyntaxError(
-                    conditional_expr.get_query_location().clone(),
+                    branch_expr.get_query_location().clone(),
                     format!("invalid rule found in if_else_expression {rule}"),
                 ));
             }
         }
     }
 
-    pipeline_builder.push_data_expression(DataExpression::Conditional(conditional_expr));
+    pipeline_builder.push_data_expression(DataExpression::Branch(branch_expr));
 
     Ok(())
 }
@@ -527,7 +525,7 @@ pub(crate) fn parse_apply_operator_call(
                     ValueAccessor::new(),
                 )),
             )),
-            DataExpression::Conditional(c) => PipelineFunctionExpression::Conditional(c),
+            DataExpression::Branch(b) => PipelineFunctionExpression::Branch(b),
             DataExpression::Transform(t) => PipelineFunctionExpression::Transform(t),
             other => {
                 return Err(ParserError::SyntaxNotSupported(
@@ -575,15 +573,15 @@ pub(crate) fn parse_apply_operator_call(
 #[cfg(test)]
 mod tests {
     use data_engine_expressions::{
-        ArgumentScalarExpression, ConditionalDataExpression, ConditionalDataExpressionBranch,
-        DataExpression, DiscardDataExpression, EqualToLogicalExpression,
-        InvokeFunctionScalarExpression, LogicalExpression, MapKeyRenameSelector,
-        MapSelectionExpression, MapSelector, MutableValueExpression, NotLogicalExpression,
-        OutputDataExpression, OutputExpression, PipelineFunction, PipelineFunctionExpression,
-        PipelineFunctionParameter, PipelineFunctionParameterType, QueryLocation,
-        ReduceMapTransformExpression, RenameMapKeysTransformExpression, ScalarExpression,
-        SetTransformExpression, SourceScalarExpression, StaticScalarExpression,
-        StringScalarExpression, TransformExpression, ValueAccessor, ValueType,
+        ArgumentScalarExpression, BranchDataExpression, DataExpression, DataExpressionBranch,
+        DiscardDataExpression, EqualToLogicalExpression, InvokeFunctionScalarExpression,
+        LogicalExpression, MapKeyRenameSelector, MapSelectionExpression, MapSelector,
+        MutableValueExpression, NotLogicalExpression, OutputDataExpression, OutputExpression,
+        PipelineFunction, PipelineFunctionExpression, PipelineFunctionParameter,
+        PipelineFunctionParameterType, QueryLocation, ReduceMapTransformExpression,
+        RenameMapKeysTransformExpression, ScalarExpression, SetTransformExpression,
+        SourceScalarExpression, StaticScalarExpression, StringScalarExpression,
+        TransformExpression, ValueAccessor, ValueType,
     };
     use data_engine_parser_abstractions::{Parser, ParserOptions, ParserState};
     use pest::Parser as _;
@@ -766,24 +764,24 @@ mod tests {
         let expressions = pipeline.get_expressions();
         assert_eq!(expressions.len(), 1);
 
-        let expected = DataExpression::Conditional(
-            ConditionalDataExpression::new(QueryLocation::new_fake())
-                .with_branch(ConditionalDataExpressionBranch::new(
+        let expected = DataExpression::Branch(
+            BranchDataExpression::new(QueryLocation::new_fake(), true)
+                .with_branch(DataExpressionBranch::new(
                     QueryLocation::new_fake(),
-                    equals_logical_expr("severity_text", "ERROR"),
+                    Some(equals_logical_expr("severity_text", "ERROR")),
                     vec![
                         assign_attribute_expression("important", "very"),
                         assign_attribute_expression("triggers_alarm", "true"),
                     ],
                 ))
-                .with_branch(ConditionalDataExpressionBranch::new(
+                .with_branch(DataExpressionBranch::new(
                     QueryLocation::new_fake(),
-                    equals_logical_expr("severity_text", "WARN"),
+                    Some(equals_logical_expr("severity_text", "WARN")),
                     vec![assign_attribute_expression("important", "somewhat")],
                 ))
-                .with_branch(ConditionalDataExpressionBranch::new(
+                .with_branch(DataExpressionBranch::new(
                     QueryLocation::new_fake(),
-                    equals_logical_expr("severity_text", "INFO"),
+                    Some(equals_logical_expr("severity_text", "INFO")),
                     vec![assign_attribute_expression("important", "rarely")],
                 ))
                 .with_default_branch(vec![assign_attribute_expression("important", "no")]),
@@ -808,19 +806,19 @@ mod tests {
         let expressions = pipeline.get_expressions();
         assert_eq!(expressions.len(), 1);
 
-        let expected = DataExpression::Conditional(
-            ConditionalDataExpression::new(QueryLocation::new_fake())
-                .with_branch(ConditionalDataExpressionBranch::new(
+        let expected = DataExpression::Branch(
+            BranchDataExpression::new(QueryLocation::new_fake(), true)
+                .with_branch(DataExpressionBranch::new(
                     QueryLocation::new_fake(),
-                    equals_logical_expr("severity_text", "ERROR"),
+                    Some(equals_logical_expr("severity_text", "ERROR")),
                     vec![
                         assign_attribute_expression("important", "very"),
                         assign_attribute_expression("triggers_alarm", "true"),
                     ],
                 ))
-                .with_branch(ConditionalDataExpressionBranch::new(
+                .with_branch(DataExpressionBranch::new(
                     QueryLocation::new_fake(),
-                    equals_logical_expr("severity_text", "WARN"),
+                    Some(equals_logical_expr("severity_text", "WARN")),
                     vec![assign_attribute_expression("important", "somewhat")],
                 )),
         );
@@ -844,11 +842,11 @@ mod tests {
         let expressions = pipeline.get_expressions();
         assert_eq!(expressions.len(), 1);
 
-        let expected = DataExpression::Conditional(
-            ConditionalDataExpression::new(QueryLocation::new_fake())
-                .with_branch(ConditionalDataExpressionBranch::new(
+        let expected = DataExpression::Branch(
+            BranchDataExpression::new(QueryLocation::new_fake(), true)
+                .with_branch(DataExpressionBranch::new(
                     QueryLocation::new_fake(),
-                    equals_logical_expr("severity_text", "ERROR"),
+                    Some(equals_logical_expr("severity_text", "ERROR")),
                     vec![
                         assign_attribute_expression("important", "very"),
                         assign_attribute_expression("triggers_alarm", "true"),
@@ -874,11 +872,11 @@ mod tests {
         let expressions = pipeline.get_expressions();
         assert_eq!(expressions.len(), 1);
 
-        let expected = DataExpression::Conditional(
-            ConditionalDataExpression::new(QueryLocation::new_fake()).with_branch(
-                ConditionalDataExpressionBranch::new(
+        let expected = DataExpression::Branch(
+            BranchDataExpression::new(QueryLocation::new_fake(), true).with_branch(
+                DataExpressionBranch::new(
                     QueryLocation::new_fake(),
-                    equals_logical_expr("severity_text", "ERROR"),
+                    Some(equals_logical_expr("severity_text", "ERROR")),
                     vec![assign_attribute_expression("triggers_alarm", "true")],
                 ),
             ),
@@ -1242,11 +1240,11 @@ mod tests {
         let expressions = result.get_expressions();
         assert_eq!(expressions.len(), 1);
 
-        let expected = DataExpression::Conditional(
-            ConditionalDataExpression::new(QueryLocation::new_fake())
-                .with_branch(ConditionalDataExpressionBranch::new(
+        let expected = DataExpression::Branch(
+            BranchDataExpression::new(QueryLocation::new_fake(), true)
+                .with_branch(DataExpressionBranch::new(
                     QueryLocation::new_fake(),
-                    LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                    Some(LogicalExpression::EqualTo(EqualToLogicalExpression::new(
                         QueryLocation::new_fake(),
                         ScalarExpression::Source(SourceScalarExpression::new(
                             QueryLocation::new_fake(),
@@ -1261,7 +1259,7 @@ mod tests {
                             StringScalarExpression::new(QueryLocation::new_fake(), "ERROR"),
                         )),
                         false,
-                    )),
+                    ))),
                     vec![DataExpression::Transform(TransformExpression::Set(
                         SetTransformExpression::new(
                             QueryLocation::new_fake(),

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser/operator.rs
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser/operator.rs
@@ -936,6 +936,46 @@ mod tests {
     }
 
     #[test]
+    pub fn test_fork_operator_call() {
+        let query = r#"
+               logs | 
+               fork
+               {
+                   extend attributes["triggers_alarm"] = "true"
+               }
+               {
+                   extend attributes["is_duplicate"] = "true"
+               }
+               {
+                   extend attributes["is_duplicate_again"] = "true"
+               }
+           "#;
+        let result = OplParser::parse(query);
+        assert!(result.is_ok());
+
+        let pipeline = result.unwrap().pipeline;
+        let expressions = pipeline.get_expressions();
+        assert_eq!(expressions.len(), 1);
+
+        let expected = DataExpression::Fork(
+            ForkDataExpression::new(QueryLocation::new_fake())
+                .with_branch(ForkDataExpressionBranch::new(
+                    QueryLocation::new_fake(),
+                    vec![assign_attribute_expression("triggers_alarm", "true")],
+                ))
+                .with_branch(ForkDataExpressionBranch::new(
+                    QueryLocation::new_fake(),
+                    vec![assign_attribute_expression("is_duplicate", "true")],
+                ))
+                .with_branch(ForkDataExpressionBranch::new(
+                    QueryLocation::new_fake(),
+                    vec![assign_attribute_expression("is_duplicate_again", "true")],
+                )),
+        );
+        assert_eq!(expressions[0], expected);
+    }
+
+    #[test]
     pub fn test_remove_map_keys_operator_call() {
         let query = r#"remove
             attributes["x"],

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser/operator.rs
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser/operator.rs
@@ -392,7 +392,7 @@ pub(crate) fn parse_if_else_operator_call(
                     // under normal invocation of this function this shouldn't happen as this
                     // missing expression should be caught by the parser
                     ParserError::SyntaxError(
-                        else_query_location,
+                        else_query_location.clone(),
                         "expected else_expression to contain one inner if_else_branch_expression"
                             .to_string(),
                     )
@@ -409,7 +409,11 @@ pub(crate) fn parse_if_else_operator_call(
                 }
                 let (else_branch_data_exprs, parent) = else_branch_exprs.into_parts();
                 pipeline_builder = parent;
-                branch_expr = branch_expr.with_default_branch(else_branch_data_exprs);
+                branch_expr = branch_expr.with_branch(DataExpressionBranch::new(
+                    else_query_location,
+                    None,
+                    else_branch_data_exprs,
+                ));
             }
             _ => {
                 return Err(ParserError::SyntaxError(
@@ -784,7 +788,11 @@ mod tests {
                     Some(equals_logical_expr("severity_text", "INFO")),
                     vec![assign_attribute_expression("important", "rarely")],
                 ))
-                .with_default_branch(vec![assign_attribute_expression("important", "no")]),
+                .with_branch(DataExpressionBranch::new(
+                    QueryLocation::new_fake(),
+                    None,
+                    vec![assign_attribute_expression("important", "no")],
+                )),
         );
         assert_eq!(expressions[0], expected);
     }
@@ -852,7 +860,11 @@ mod tests {
                         assign_attribute_expression("triggers_alarm", "true"),
                     ],
                 ))
-                .with_default_branch(vec![assign_attribute_expression("important", "no")]),
+                .with_branch(DataExpressionBranch::new(
+                    QueryLocation::new_fake(),
+                    None,
+                    vec![assign_attribute_expression("important", "no")],
+                )),
         );
         assert_eq!(expressions[0], expected);
     }
@@ -1281,26 +1293,30 @@ mod tests {
                         ),
                     ))],
                 ))
-                .with_default_branch(vec![DataExpression::Transform(TransformExpression::Set(
-                    SetTransformExpression::new(
-                        QueryLocation::new_fake(),
-                        ScalarExpression::InvokeFunction(InvokeFunctionScalarExpression::new(
+                .with_branch(DataExpressionBranch::new(
+                    QueryLocation::new_fake(),
+                    None,
+                    vec![DataExpression::Transform(TransformExpression::Set(
+                        SetTransformExpression::new(
                             QueryLocation::new_fake(),
-                            None,
-                            1,
-                            Vec::new(),
-                        )),
-                        MutableValueExpression::Source(SourceScalarExpression::new(
-                            QueryLocation::new_fake(),
-                            ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
-                                StaticScalarExpression::String(StringScalarExpression::new(
-                                    QueryLocation::new_fake(),
-                                    "attributes",
-                                )),
-                            )]),
-                        )),
-                    ),
-                ))]),
+                            ScalarExpression::InvokeFunction(InvokeFunctionScalarExpression::new(
+                                QueryLocation::new_fake(),
+                                None,
+                                1,
+                                Vec::new(),
+                            )),
+                            MutableValueExpression::Source(SourceScalarExpression::new(
+                                QueryLocation::new_fake(),
+                                ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                                    StaticScalarExpression::String(StringScalarExpression::new(
+                                        QueryLocation::new_fake(),
+                                        "attributes",
+                                    )),
+                                )]),
+                            )),
+                        ),
+                    ))],
+                )),
         );
         assert_eq!(&expressions[0], &expected);
 

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser/operator.rs
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser/operator.rs
@@ -32,6 +32,7 @@ pub(crate) fn parse_operator_call(
 ) -> Result<(), ParserError> {
     for rule in rule.into_inner() {
         match rule.as_rule() {
+            Rule::fork_operator_call => parse_fork_operator_call(rule, pipeline_builder)?,
             Rule::if_else_operator_call => parse_if_else_operator_call(rule, pipeline_builder)?,
             Rule::remove_map_keys_operator_call => {
                 parse_remove_map_keys_operator_call(rule, pipeline_builder)?
@@ -299,6 +300,44 @@ pub(crate) fn parse_set_operator_call(
             }
         }
     }
+
+    Ok(())
+}
+
+pub(crate) fn parse_fork_operator_call(
+    operator_call_rule: Pair<'_, Rule>,
+    mut pipeline_builder: &mut dyn PipelineBuilder,
+) -> Result<(), ParserError> {
+    let query_location = to_query_location(&operator_call_rule);
+    let mut fork_expr = ForkDataExpression::new(query_location);
+
+    for rule in operator_call_rule.into_inner() {
+        match rule.as_rule() {
+            Rule::fork_branch => {
+                let branch_query_location = to_query_location(&rule);
+                let mut next_branch = InnerPipelineBuilder::new(pipeline_builder);
+                for rule in rule.into_inner() {
+                    parse_pipeline_stage(rule, &mut next_branch)?;
+                }
+
+                let (curr_branch_data_exprs, parent) = next_branch.into_parts();
+                pipeline_builder = parent;
+
+                fork_expr = fork_expr.with_branch(ForkDataExpressionBranch::new(
+                    branch_query_location,
+                    curr_branch_data_exprs,
+                ));
+            }
+            _ => {
+                return Err(ParserError::SyntaxError(
+                    fork_expr.get_query_location().clone(),
+                    format!("invalid rule found in fork operator call {rule}"),
+                ));
+            }
+        }
+    }
+
+    pipeline_builder.push_data_expression(DataExpression::Fork(fork_expr));
 
     Ok(())
 }

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser/operator.rs
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser/operator.rs
@@ -309,7 +309,7 @@ pub(crate) fn parse_fork_operator_call(
     mut pipeline_builder: &mut dyn PipelineBuilder,
 ) -> Result<(), ParserError> {
     let query_location = to_query_location(&operator_call_rule);
-    let mut fork_expr = ForkDataExpression::new(query_location);
+    let mut fork_expr = BranchDataExpression::new(query_location, false);
 
     for rule in operator_call_rule.into_inner() {
         match rule.as_rule() {
@@ -323,8 +323,9 @@ pub(crate) fn parse_fork_operator_call(
                 let (curr_branch_data_exprs, parent) = next_branch.into_parts();
                 pipeline_builder = parent;
 
-                fork_expr = fork_expr.with_branch(ForkDataExpressionBranch::new(
+                fork_expr = fork_expr.with_branch(DataExpressionBranch::new(
                     branch_query_location,
+                    None,
                     curr_branch_data_exprs,
                 ));
             }
@@ -337,7 +338,7 @@ pub(crate) fn parse_fork_operator_call(
         }
     }
 
-    pipeline_builder.push_data_expression(DataExpression::Fork(fork_expr));
+    pipeline_builder.push_data_expression(DataExpression::Branch(fork_expr));
 
     Ok(())
 }
@@ -957,18 +958,21 @@ mod tests {
         let expressions = pipeline.get_expressions();
         assert_eq!(expressions.len(), 1);
 
-        let expected = DataExpression::Fork(
-            ForkDataExpression::new(QueryLocation::new_fake())
-                .with_branch(ForkDataExpressionBranch::new(
+        let expected = DataExpression::Branch(
+            BranchDataExpression::new(QueryLocation::new_fake(), false)
+                .with_branch(DataExpressionBranch::new(
                     QueryLocation::new_fake(),
+                    None,
                     vec![assign_attribute_expression("triggers_alarm", "true")],
                 ))
-                .with_branch(ForkDataExpressionBranch::new(
+                .with_branch(DataExpressionBranch::new(
                     QueryLocation::new_fake(),
+                    None,
                     vec![assign_attribute_expression("is_duplicate", "true")],
                 ))
-                .with_branch(ForkDataExpressionBranch::new(
+                .with_branch(DataExpressionBranch::new(
                     QueryLocation::new_fake(),
+                    None,
                     vec![assign_attribute_expression("is_duplicate_again", "true")],
                 )),
         );

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline.rs
@@ -27,9 +27,11 @@ use crate::table::RecordBatchPartitionStream;
 mod apply_attrs;
 mod assign;
 mod attributes;
+mod concat;
 mod conditional;
 mod expr;
 mod filter;
+mod fork;
 mod functions;
 pub(crate) mod id_mask;
 mod planner;
@@ -64,7 +66,7 @@ pub trait PipelineStage {
         session_context: &SessionContext,
         config_options: &ConfigOptions,
         task_context: Arc<TaskContext>,
-        exec_options: &mut ExecutionState,
+        exec_state: &mut ExecutionState,
     ) -> Result<OtapArrowRecords>;
 
     /// Execute this stage of the pipeline on a [`RecordBatch`] containing a set of attributes.

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/concat.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/concat.rs
@@ -1,0 +1,123 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Module contains utilities for concatenating OTAP batches.
+//!
+//! This is used by pipeline stages that split/duplicate the batch, evaluate nested pipelines
+//! on it, and concatenate the results to produce an output.
+
+use arrow::array::RecordBatch;
+use otap_df_pdata::OtapArrowRecords;
+use otap_df_pdata::otap::raw_batch_store::{
+    LOGS_TYPE_MASK, METRICS_TYPE_MASK, POSITION_LOOKUP, RawBatchStore, TRACES_TYPE_MASK,
+};
+use otap_df_pdata::otap::transform::concatenate::concatenate;
+use otap_df_pdata::otap::transform::reindex::reindex;
+use otap_df_pdata::otap::{Logs, Metrics, OtapBatchStore, Traces};
+use otap_df_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
+
+use crate::error::{Error, Result};
+
+pub(crate) fn concat_generic<T, const TYPE_MASK: u64, const COUNT: usize>(
+    branch_results: &mut Vec<OtapArrowRecords>,
+) -> Result<OtapArrowRecords>
+where
+    T: OtapBatchStore<BatchArray = [Option<RecordBatch>; COUNT]>
+        + TryFrom<RawBatchStore<TYPE_MASK, COUNT>, Error = otap_df_pdata::error::Error>
+        + TryFrom<OtapArrowRecords, Error = otap_df_pdata::error::Error>,
+    OtapArrowRecords: From<T>,
+{
+    let mut batches = Vec::new();
+    for branch_result in branch_results.drain(..) {
+        let batch_store: T = branch_result.try_into()?;
+        batches.push(batch_store.into_batches())
+    }
+
+    let concatenated_batches = concatenate(&mut batches)?;
+    let raw_store = RawBatchStore::<TYPE_MASK, COUNT>::from_batches(concatenated_batches);
+    let result_store = T::try_from(raw_store)?;
+
+    Ok(OtapArrowRecords::from(result_store))
+}
+
+pub(crate) fn concatenate_logs(
+    branch_results: &mut Vec<OtapArrowRecords>,
+) -> Result<OtapArrowRecords> {
+    concat_generic::<Logs, { LOGS_TYPE_MASK }, { Logs::COUNT }>(branch_results)
+}
+
+pub(crate) fn concatenate_metrics(
+    branch_results: &mut Vec<OtapArrowRecords>,
+) -> Result<OtapArrowRecords> {
+    concat_generic::<Metrics, { METRICS_TYPE_MASK }, { Metrics::COUNT }>(branch_results)
+}
+
+pub(crate) fn concatenate_traces(
+    branch_results: &mut Vec<OtapArrowRecords>,
+) -> Result<OtapArrowRecords> {
+    concat_generic::<Traces, { TRACES_TYPE_MASK }, { Traces::COUNT }>(branch_results)
+}
+
+pub(crate) fn concatenate_attrs_record_batches(
+    branch_results: &mut Vec<RecordBatch>,
+) -> Result<RecordBatch> {
+    // to call schema aware `concatenate` on just the attributes record batch, we stick it in
+    // a Logs OTAP batch and treat it as log attributes. This is a bit of a hack until we have
+    // a better top-level interface for calling concatenate.
+
+    let mut otap_batches = branch_results
+        .drain(..)
+        .map(|attrs_record_batch| {
+            let mut logs_record_batches = Logs::default();
+            logs_record_batches.set(ArrowPayloadType::LogAttrs, attrs_record_batch)?;
+            Ok(OtapArrowRecords::from(logs_record_batches))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let concatenated_logs = concatenate_logs(&mut otap_batches)?;
+    let mut concatenated_logs_batches = Logs::try_from(concatenated_logs)?.into_batches();
+    let concatenated_attrs_batch = concatenated_logs_batches
+        [POSITION_LOOKUP[ArrowPayloadType::LogAttrs as usize]]
+        .take()
+        .ok_or_else(|| Error::ExecutionError {
+            cause: "expected concatenate to produce non 'None' batch".into(),
+        })?;
+
+    Ok(concatenated_attrs_batch)
+}
+
+pub(crate) fn reindex_generic<T, const TYPE_MASK: u64, const COUNT: usize>(
+    branch_results: &mut Vec<OtapArrowRecords>,
+) -> Result<()>
+where
+    T: OtapBatchStore<BatchArray = [Option<RecordBatch>; COUNT]>
+        + TryFrom<RawBatchStore<TYPE_MASK, COUNT>, Error = otap_df_pdata::error::Error>
+        + TryFrom<OtapArrowRecords, Error = otap_df_pdata::error::Error>,
+    OtapArrowRecords: From<T>,
+{
+    let mut batches = Vec::new();
+    for branch_result in branch_results.drain(..) {
+        let batch_store: T = branch_result.try_into()?;
+        batches.push(batch_store.into_batches())
+    }
+
+    reindex(&mut batches)?;
+    for batch in batches {
+        let raw_store = RawBatchStore::<TYPE_MASK, COUNT>::from_batches(batch);
+        let result_store = T::try_from(raw_store)?;
+        branch_results.push(OtapArrowRecords::from(result_store))
+    }
+
+    Ok(())
+}
+
+pub(crate) fn reindex_logs(branch_results: &mut Vec<OtapArrowRecords>) -> Result<()> {
+    reindex_generic::<Logs, { LOGS_TYPE_MASK }, { Logs::COUNT }>(branch_results)
+}
+
+pub(crate) fn reindex_metrics(branch_results: &mut Vec<OtapArrowRecords>) -> Result<()> {
+    reindex_generic::<Metrics, { METRICS_TYPE_MASK }, { Metrics::COUNT }>(branch_results)
+}
+
+pub(crate) fn reindex_traces(branch_results: &mut Vec<OtapArrowRecords>) -> Result<()> {
+    reindex_generic::<Traces, { TRACES_TYPE_MASK }, { Traces::COUNT }>(branch_results)
+}

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/conditional.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/conditional.rs
@@ -14,16 +14,13 @@ use datafusion::config::ConfigOptions;
 use datafusion::execution::TaskContext;
 use datafusion::prelude::SessionContext;
 use otap_df_pdata::OtapArrowRecords;
-use otap_df_pdata::otap::raw_batch_store::{
-    LOGS_TYPE_MASK, METRICS_TYPE_MASK, POSITION_LOOKUP, RawBatchStore, TRACES_TYPE_MASK,
-};
-use otap_df_pdata::otap::transform::concatenate::concatenate;
-use otap_df_pdata::otap::{Logs, Metrics, OtapBatchStore, Traces};
-use otap_df_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
 
 use otap_df_pdata::otap::filter::{IdBitmapPool, filter_otap_batch};
 
-use crate::error::{Error, Result};
+use crate::error::Result;
+use crate::pipeline::concat::{
+    concatenate_attrs_record_batches, concatenate_logs, concatenate_metrics, concatenate_traces,
+};
 use crate::pipeline::expr::{DataScope, ScopedExpr};
 use crate::pipeline::filter::{align_selection_to_root, scoped_value_to_boolean_array};
 use crate::pipeline::state::ExecutionState;
@@ -71,64 +68,6 @@ impl ConditionalPipelineStage {
     }
 }
 
-fn concat_generic<T, const TYPE_MASK: u64, const COUNT: usize>(
-    branch_results: &mut Vec<OtapArrowRecords>,
-) -> Result<OtapArrowRecords>
-where
-    T: OtapBatchStore<BatchArray = [Option<RecordBatch>; COUNT]>
-        + TryFrom<RawBatchStore<TYPE_MASK, COUNT>, Error = otap_df_pdata::error::Error>
-        + TryFrom<OtapArrowRecords, Error = otap_df_pdata::error::Error>,
-    OtapArrowRecords: From<T>,
-{
-    let mut batches = Vec::new();
-    for branch_result in branch_results.drain(..) {
-        let batch_store: T = branch_result.try_into()?;
-        batches.push(batch_store.into_batches())
-    }
-
-    let concatenated_batches = concatenate(&mut batches)?;
-    let raw_store = RawBatchStore::<TYPE_MASK, COUNT>::from_batches(concatenated_batches);
-    let result_store = T::try_from(raw_store)?;
-
-    Ok(OtapArrowRecords::from(result_store))
-}
-
-fn concatenate_logs(branch_results: &mut Vec<OtapArrowRecords>) -> Result<OtapArrowRecords> {
-    concat_generic::<Logs, { LOGS_TYPE_MASK }, { Logs::COUNT }>(branch_results)
-}
-
-fn concatenate_metrics(branch_results: &mut Vec<OtapArrowRecords>) -> Result<OtapArrowRecords> {
-    concat_generic::<Metrics, { METRICS_TYPE_MASK }, { Metrics::COUNT }>(branch_results)
-}
-
-fn concatenate_traces(branch_results: &mut Vec<OtapArrowRecords>) -> Result<OtapArrowRecords> {
-    concat_generic::<Traces, { TRACES_TYPE_MASK }, { Traces::COUNT }>(branch_results)
-}
-
-fn concatenate_attrs_record_batches(branch_results: &mut Vec<RecordBatch>) -> Result<RecordBatch> {
-    // to call schema aware `concatenate` on just the attributes record batch, we stick it in
-    // a Logs OTAP batch and treat it as log attributes. This is a bit of a hack until we have
-    // a better top-level interface for calling concatenate.
-
-    let mut otap_batches = branch_results
-        .drain(..)
-        .map(|attrs_record_batch| {
-            let mut logs_record_batches = Logs::default();
-            logs_record_batches.set(ArrowPayloadType::LogAttrs, attrs_record_batch)?;
-            Ok(OtapArrowRecords::from(logs_record_batches))
-        })
-        .collect::<Result<Vec<_>>>()?;
-    let concatenated_logs = concatenate_logs(&mut otap_batches)?;
-    let mut concatenated_logs_batches = Logs::try_from(concatenated_logs)?.into_batches();
-    let concatenated_attrs_batch = concatenated_logs_batches
-        [POSITION_LOOKUP[ArrowPayloadType::LogAttrs as usize]]
-        .take()
-        .ok_or_else(|| Error::ExecutionError {
-            cause: "expected concatenate to produce non 'None' batch".into(),
-        })?;
-
-    Ok(concatenated_attrs_batch)
-}
 /// A branch within a conditional pipeline stage
 pub struct ConditionalPipelineStageBranch {
     /// This condition will be evaluated to determine for which rows to execute the pipeline
@@ -409,7 +348,9 @@ mod test {
     use arrow::array::UInt16Array;
     use data_engine_parser_abstractions::Parser;
     use otap_df_pdata::{
+        otap::Logs,
         proto::opentelemetry::{
+            arrow::v1::ArrowPayloadType,
             metrics::v1::Metric,
             trace::v1::{Status, span::SpanKind},
         },

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/fork.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/fork.rs
@@ -35,7 +35,6 @@ pub struct ForkPipelineStage {
     /// Scratch space for storing temporary batch results before concatenating results.
     branch_results: Vec<OtapArrowRecords>,
 }
-}
 
 impl ForkPipelineStage {
     pub fn new(branches: Vec<ForkPipelineStageBranch>) -> Self {

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/fork.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/fork.rs
@@ -29,12 +29,12 @@ use crate::{
 /// to duplicate the telemetry, process it, and send it to different destinations using an operator
 /// such as "route_to".
 pub struct ForkPipelineStage {
-    /// Branches that wil process a copy of each telemetry batch
+    /// Branches that will process a copy of each telemetry batch
     branches: Vec<ForkPipelineStageBranch>,
 
     /// Scratch space for storing temporary batch results before concatenating results.
-    /// T
     branch_results: Vec<OtapArrowRecords>,
+}
 }
 
 impl ForkPipelineStage {

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/fork.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/fork.rs
@@ -3,7 +3,6 @@
 
 use std::sync::Arc;
 
-use arrow::array::RecordBatch;
 use async_trait::async_trait;
 use datafusion::{
     config::ConfigOptions,

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/fork.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/fork.rs
@@ -9,7 +9,10 @@ use datafusion::{
     config::ConfigOptions,
     execution::{TaskContext, context::SessionContext},
 };
-use otap_df_pdata::{OtapArrowRecords, OtapPayloadHelpers};
+use otap_df_pdata::{
+    OtapArrowRecords, OtapPayloadHelpers,
+    otap::{Logs, Metrics, Traces},
+};
 
 use crate::pipeline::{BoxedPipelineStage, PipelineStage, state::ExecutionState};
 use crate::{
@@ -66,6 +69,8 @@ impl PipelineStage for ForkPipelineStage {
         task_context: Arc<TaskContext>,
         exec_state: &mut ExecutionState,
     ) -> Result<OtapArrowRecords> {
+        self.branch_results.clear();
+
         for branch in &mut self.branches {
             let mut branch_batch = otap_batch.clone();
             for stage in &mut branch.pipeline_stages {
@@ -85,19 +90,32 @@ impl PipelineStage for ForkPipelineStage {
             }
         }
 
-        match otap_batch {
-            OtapArrowRecords::Logs(_) => {
-                reindex_logs(&mut self.branch_results)?;
-                concatenate_logs(&mut self.branch_results)
-            }
-            OtapArrowRecords::Metrics(_) => {
-                reindex_metrics(&mut self.branch_results)?;
-                concatenate_metrics(&mut self.branch_results)
-            }
-            OtapArrowRecords::Traces(_) => {
-                reindex_traces(&mut self.branch_results)?;
-                concatenate_traces(&mut self.branch_results)
-            }
+        match self.branch_results.len() {
+            // no branch returned any results, return empty OTAP batch:
+            0 => Ok(match otap_batch {
+                OtapArrowRecords::Logs(_) => OtapArrowRecords::Logs(Logs::default()),
+                OtapArrowRecords::Metrics(_) => OtapArrowRecords::Metrics(Metrics::default()),
+                OtapArrowRecords::Traces(_) => OtapArrowRecords::Traces(Traces::default()),
+            }),
+
+            // only one branch returned a non-empty result, simply return this
+            1 => Ok(self.branch_results.pop().expect("one record")),
+
+            // concatenate batches together, adjusting IDs to avoid ID duplicates:
+            _ => match otap_batch {
+                OtapArrowRecords::Logs(_) => {
+                    reindex_logs(&mut self.branch_results)?;
+                    concatenate_logs(&mut self.branch_results)
+                }
+                OtapArrowRecords::Metrics(_) => {
+                    reindex_metrics(&mut self.branch_results)?;
+                    concatenate_metrics(&mut self.branch_results)
+                }
+                OtapArrowRecords::Traces(_) => {
+                    reindex_traces(&mut self.branch_results)?;
+                    concatenate_traces(&mut self.branch_results)
+                }
+            },
         }
     }
 
@@ -120,12 +138,14 @@ impl PipelineStage for ForkPipelineStage {
 #[cfg(test)]
 mod test {
 
-    use otap_df_pdata::{
-        proto::opentelemetry::logs::v1::LogRecord, testing::round_trip::to_logs_data,
-    };
+    use otap_df_pdata::proto::opentelemetry::common::v1::{AnyValue, KeyValue};
+    use otap_df_pdata::proto::opentelemetry::logs::v1::LogRecord;
+    use otap_df_pdata::proto::opentelemetry::metrics::v1::Metric;
+    use otap_df_pdata::proto::opentelemetry::trace::v1::{Span, Status};
+    use otap_df_pdata::testing::round_trip::{to_logs_data, to_metrics_data, to_traces_data};
     use otap_df_query_engine_languages::opl::parser::OplParser;
 
-    use crate::pipeline::test::exec_logs_pipeline;
+    use crate::pipeline::test::{exec_logs_pipeline, exec_metrics_pipeline, exec_traces_pipeline};
 
     #[tokio::test]
     async fn test_simple_fork() {
@@ -143,6 +163,142 @@ mod test {
         )
         .await;
 
-        println!("{result:#?}")
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[LogRecord::build()
+                .body(AnyValue::new_string("hello"))
+                .attributes(vec![KeyValue::new("x", AnyValue::new_string("hello"))])
+                .finish()]
+        );
+        assert_eq!(
+            &result.resource_logs[1].scope_logs[0].log_records,
+            &[LogRecord::build()
+                .body(AnyValue::new_string("world"))
+                .attributes(vec![KeyValue::new("x", AnyValue::new_string("world"))])
+                .finish()]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fork_only_one_branch_has_rows() {
+        let log_records = vec![LogRecord::build().severity_number(5).finish()];
+        let result = exec_logs_pipeline::<OplParser>(
+            r#"logs |
+            fork
+            {
+                where severity_number < 5 | set body = "branch1"
+            }
+            {
+                where severity_number == 5 | set body = "branch2"
+            }"#,
+            to_logs_data(log_records),
+        )
+        .await;
+
+        assert_eq!(result.resource_logs.len(), 1);
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[LogRecord::build()
+                .severity_number(5)
+                .body(AnyValue::new_string("branch2"))
+                .finish()]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fork_no_branch_returns_results() {
+        let log_records = vec![LogRecord::build().severity_number(5).finish()];
+        let result = exec_logs_pipeline::<OplParser>(
+            r#"logs |
+            fork
+            {
+                where severity_number < 5 | set body = "branch1"
+            }
+            {
+                where severity_number > 5 | set body = "branch2"
+            }"#,
+            to_logs_data(log_records),
+        )
+        .await;
+
+        assert_eq!(result.resource_logs.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_fork_metrics() {
+        let metrics = vec![Metric::build().name("my_metric").finish()];
+        let result = exec_metrics_pipeline::<OplParser>(
+            r#"metrics |
+            fork
+            {
+                set description = "my metric"
+            }
+            {
+                set description = "some metric"
+            }"#,
+            to_metrics_data(metrics),
+        )
+        .await;
+
+        assert_eq!(
+            &result.resource_metrics[0].scope_metrics[0].metrics,
+            &[Metric::build()
+                .name("my_metric")
+                .description("my metric")
+                .finish()]
+        );
+
+        assert_eq!(
+            &result.resource_metrics[0].scope_metrics[1].metrics,
+            &[Metric::build()
+                .name("my_metric")
+                .description("some metric")
+                .finish()]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fork_spans() {
+        let spans = vec![
+            Span::build()
+                .trace_id(vec![0; 16])
+                .span_id(vec![0; 8])
+                .status(Status::default())
+                .finish(),
+        ];
+        let result = exec_traces_pipeline::<OplParser>(
+            r#"
+            traces |
+            fork
+            {
+                set name = "my_span"
+            }
+            {
+                set attributes["x"] = "hello"
+            }
+        "#,
+            to_traces_data(spans),
+        )
+        .await;
+
+        assert_eq!(
+            &result.resource_spans[0].scope_spans[0].spans,
+            &[Span::build()
+                .name("my_span")
+                .trace_id(vec![0; 16])
+                .span_id(vec![0; 8])
+                .status(Status::default())
+                .finish()]
+        );
+
+        assert_eq!(
+            &result.resource_spans[1].scope_spans[0].spans,
+            &[Span::build()
+                .attributes(vec![KeyValue::new("x", AnyValue::new_string("hello"))])
+                .trace_id(vec![0; 16])
+                .span_id(vec![0; 8])
+                .status(Status::default())
+                .finish()]
+        );
     }
 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/fork.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/fork.rs
@@ -118,21 +118,6 @@ impl PipelineStage for ForkPipelineStage {
             },
         }
     }
-
-    fn supports_exec_on_attributes(&self) -> bool {
-        true
-    }
-
-    async fn execute_on_attributes(
-        &mut self,
-        attrs_record_batch: RecordBatch,
-        session_ctx: &SessionContext,
-        config_options: &ConfigOptions,
-        task_context: Arc<TaskContext>,
-        exec_options: &mut ExecutionState,
-    ) -> Result<RecordBatch> {
-        todo!()
-    }
 }
 
 #[cfg(test)]

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/fork.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/fork.rs
@@ -1,0 +1,148 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use arrow::array::RecordBatch;
+use async_trait::async_trait;
+use datafusion::{
+    config::ConfigOptions,
+    execution::{TaskContext, context::SessionContext},
+};
+use otap_df_pdata::{OtapArrowRecords, OtapPayloadHelpers};
+
+use crate::pipeline::{BoxedPipelineStage, PipelineStage, state::ExecutionState};
+use crate::{
+    error::Result,
+    pipeline::concat::{
+        concatenate_logs, concatenate_metrics, concatenate_traces, reindex_logs, reindex_metrics,
+        reindex_traces,
+    },
+};
+
+/// This [`PipelineStage`] implementation duplicates each batch of telemetry and processes it on
+/// each nested branch. The results are then unioned back together to produce the output.
+///
+/// This may produce duplicate telemetry records, however the nominal use case for fork is really
+/// to duplicate the telemetry, process it, and send it to different destinations using an operator
+/// such as "route_to".
+pub struct ForkPipelineStage {
+    /// Branches that wil process a copy of each telemetry batch
+    branches: Vec<ForkPipelineStageBranch>,
+
+    /// Scratch space for storing temporary batch results before concatenating results.
+    /// T
+    branch_results: Vec<OtapArrowRecords>,
+}
+
+impl ForkPipelineStage {
+    pub fn new(branches: Vec<ForkPipelineStageBranch>) -> Self {
+        Self {
+            branches,
+            branch_results: Vec::new(),
+        }
+    }
+}
+
+/// Branch that will process a copy of each telemetry batch
+pub struct ForkPipelineStageBranch {
+    /// The stages that will be executed in this branch
+    pipeline_stages: Vec<BoxedPipelineStage>,
+}
+
+impl ForkPipelineStageBranch {
+    pub fn new(pipeline_stages: Vec<BoxedPipelineStage>) -> Self {
+        Self { pipeline_stages }
+    }
+}
+
+#[async_trait(?Send)]
+impl PipelineStage for ForkPipelineStage {
+    async fn execute(
+        &mut self,
+        otap_batch: OtapArrowRecords,
+        session_ctx: &SessionContext,
+        config_options: &ConfigOptions,
+        task_context: Arc<TaskContext>,
+        exec_state: &mut ExecutionState,
+    ) -> Result<OtapArrowRecords> {
+        for branch in &mut self.branches {
+            let mut branch_batch = otap_batch.clone();
+            for stage in &mut branch.pipeline_stages {
+                branch_batch = stage
+                    .execute(
+                        branch_batch,
+                        session_ctx,
+                        config_options,
+                        Arc::clone(&task_context),
+                        exec_state,
+                    )
+                    .await?;
+            }
+
+            if !branch_batch.is_empty() {
+                self.branch_results.push(branch_batch);
+            }
+        }
+
+        match otap_batch {
+            OtapArrowRecords::Logs(_) => {
+                reindex_logs(&mut self.branch_results)?;
+                concatenate_logs(&mut self.branch_results)
+            }
+            OtapArrowRecords::Metrics(_) => {
+                reindex_metrics(&mut self.branch_results)?;
+                concatenate_metrics(&mut self.branch_results)
+            }
+            OtapArrowRecords::Traces(_) => {
+                reindex_traces(&mut self.branch_results)?;
+                concatenate_traces(&mut self.branch_results)
+            }
+        }
+    }
+
+    fn supports_exec_on_attributes(&self) -> bool {
+        true
+    }
+
+    async fn execute_on_attributes(
+        &mut self,
+        attrs_record_batch: RecordBatch,
+        session_ctx: &SessionContext,
+        config_options: &ConfigOptions,
+        task_context: Arc<TaskContext>,
+        exec_options: &mut ExecutionState,
+    ) -> Result<RecordBatch> {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use otap_df_pdata::{
+        proto::opentelemetry::logs::v1::LogRecord, testing::round_trip::to_logs_data,
+    };
+    use otap_df_query_engine_languages::opl::parser::OplParser;
+
+    use crate::pipeline::test::exec_logs_pipeline;
+
+    #[tokio::test]
+    async fn test_simple_fork() {
+        let log_records = vec![LogRecord::build().finish()];
+        let result = exec_logs_pipeline::<OplParser>(
+            r#"logs |
+            fork
+            {
+                set body="hello", attributes["x"] = "hello"
+            }
+            {
+                set body="world", attributes["x"] = "world"
+            }"#,
+            to_logs_data(log_records),
+        )
+        .await;
+
+        println!("{result:#?}")
+    }
+}

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/planner.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/planner.rs
@@ -246,7 +246,7 @@ impl PipelinePlanner {
                     // that some branch consumes all records, leaving none for the subsequent
                     // branches, which is non-sensible. Hence, we plan this into a the
                     // "conditional" pipeline stage, while treating non-terminal branch as invalid
-                    // if a condition is missing.
+                    // when a condition is missing and it's not the final branch.
 
                     let expr_planner = if self.plan_for_attributes {
                         ExprPlanner::for_attributes(self.filter_attribute_keys_case_sensitive)
@@ -256,15 +256,9 @@ impl PipelinePlanner {
                         )
                     };
 
+                    let mut default_branch = None;
                     let mut pipeline_branches = vec![];
-                    for branch in branch_expr.get_branches() {
-                        let predicate = match branch.get_condition() {
-                            Some(condition) => expr_planner.plan_logical(condition, functions)?,
-                            None => {
-                                todo!("return invalid")
-                            }
-                        };
-
+                    for (i, branch) in branch_expr.get_branches().iter().enumerate() {
                         let pipeline_stages = self.plan_data_exprs(
                             branch.get_expressions(),
                             functions,
@@ -272,18 +266,24 @@ impl PipelinePlanner {
                             otap_batch,
                         )?;
 
-                        pipeline_branches.push(ConditionalPipelineStageBranch::new(
-                            predicate,
-                            pipeline_stages,
-                        ));
+                        match branch.get_condition() {
+                            Some(condition) => {
+                                let predicate = expr_planner.plan_logical(condition, functions)?;
+                                pipeline_branches.push(ConditionalPipelineStageBranch::new(
+                                    predicate,
+                                    pipeline_stages,
+                                ))
+                            }
+                            None => {
+                                let is_final_branch = i == branch_expr.get_branches().len() - 1;
+                                if !is_final_branch {
+                                    todo!("return invalid")
+                                } else {
+                                    default_branch = Some(pipeline_stages)
+                                }
+                            }
+                        };
                     }
-
-                    let default_branch = branch_expr
-                        .get_default_branch()
-                        .map(|data_exprs| {
-                            self.plan_data_exprs(data_exprs, functions, session_ctx, otap_batch)
-                        })
-                        .transpose()?;
 
                     let pipeline_stage =
                         ConditionalPipelineStage::new(pipeline_branches, default_branch);

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/planner.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/planner.rs
@@ -240,7 +240,26 @@ impl PipelinePlanner {
 
             DataExpression::Branch(branch_expr) => {
                 if !branch_expr.branches_consume_records() {
-                    todo!()
+                    // when branches get a copy of the record, we consider this to be a "fork"
+                    let mut branches = Vec::with_capacity(branch_expr.get_branches().len());
+                    for branch in branch_expr.get_branches() {
+                        if branch.get_condition().is_some() {
+                            // forking with filter not yet supported. This should be composed by
+                            // caller into a fork containing either a conditional data or a filter
+                            return Err(Error::NotYetSupportedError { 
+                                message:  "copying data branch expression with condition not yet supported".into()
+                            })
+                        }
+
+                        let pipeline_stages = self.plan_data_exprs(
+                            branch.get_expressions(),
+                            functions,
+                            session_ctx,
+                            otap_batch,
+                        )?;
+                        branches.push(ForkPipelineStageBranch::new(pipeline_stages));
+                    }
+                    Ok(vec![Box::new(ForkPipelineStage::new(branches))])
                 } else {
                     // If branches consume the records, we assume that each branch, except for
                     // the last, must have a condition. If this were not the case, it would mean
@@ -278,7 +297,11 @@ impl PipelinePlanner {
                             None => {
                                 let is_final_branch = i == branch_expr.get_branches().len() - 1;
                                 if !is_final_branch {
-                                    todo!("return invalid")
+                                    return Err(Error::InvalidPipelineError { 
+                                        cause: "default branch found in non consuming Branch data expression 
+                                            found in invalid location".into(), 
+                                        query_location: Some(branch_expr.get_query_location().clone())
+                                    })
                                 } else {
                                     default_branch = Some(pipeline_stages)
                                 }
@@ -290,21 +313,6 @@ impl PipelinePlanner {
                         ConditionalPipelineStage::new(pipeline_branches, default_branch);
                     Ok(vec![Box::new(pipeline_stage)])
                 }
-            }
-
-            DataExpression::Fork(fork_expr) => {
-                let mut branches = Vec::with_capacity(fork_expr.get_branches().len());
-                for branch in fork_expr.get_branches() {
-                    let pipeline_stages = self.plan_data_exprs(
-                        branch.get_expressions(),
-                        functions,
-                        session_ctx,
-                        otap_batch,
-                    )?;
-                    branches.push(ForkPipelineStageBranch::new(pipeline_stages));
-                }
-
-                Ok(vec![Box::new(ForkPipelineStage::new(branches))])
             }
 
             DataExpression::Output(output_expr) => match output_expr.get_output() {

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/planner.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/planner.rs
@@ -246,9 +246,9 @@ impl PipelinePlanner {
                         if branch.get_condition().is_some() {
                             // forking with filter not yet supported. This should be composed by
                             // caller into a fork containing either a conditional data or a filter
-                            return Err(Error::NotYetSupportedError { 
+                            return Err(Error::NotYetSupportedError {
                                 message:  "copying data branch expression with condition not yet supported".into()
-                            })
+                            });
                         }
 
                         let pipeline_stages = self.plan_data_exprs(
@@ -297,11 +297,11 @@ impl PipelinePlanner {
                             None => {
                                 let is_final_branch = i == branch_expr.get_branches().len() - 1;
                                 if !is_final_branch {
-                                    return Err(Error::InvalidPipelineError { 
+                                    return Err(Error::InvalidPipelineError {
                                         cause: "default branch found in non consuming Branch data expression 
                                             found in invalid location".into(), 
                                         query_location: Some(branch_expr.get_query_location().clone())
-                                    })
+                                    });
                                 } else {
                                     default_branch = Some(pipeline_stages)
                                 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/planner.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/planner.rs
@@ -298,9 +298,8 @@ impl PipelinePlanner {
                                 let is_final_branch = i == branch_expr.get_branches().len() - 1;
                                 if !is_final_branch {
                                     return Err(Error::InvalidPipelineError {
-                                        cause: "default branch found in non consuming Branch data expression 
-                                            found in invalid location".into(), 
-                                        query_location: Some(branch_expr.get_query_location().clone())
+                                        cause: "default branch found in consuming Branch data expression in invalid location".into(),
+                                         query_location: Some(branch_expr.get_query_location().clone()),
                                     });
                                 } else {
                                     default_branch = Some(pipeline_stages)

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/planner.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/planner.rs
@@ -237,42 +237,58 @@ impl PipelinePlanner {
                 }),
             },
 
-            DataExpression::Conditional(conditional_expr) => {
-                let expr_planner = if self.plan_for_attributes {
-                    ExprPlanner::for_attributes(self.filter_attribute_keys_case_sensitive)
+            DataExpression::Branch(branch_expr) => {
+                if !branch_expr.branches_consume_records() {
+                    todo!()
                 } else {
-                    ExprPlanner::with_attr_key_case_sensitive(
-                        self.filter_attribute_keys_case_sensitive,
-                    )
-                };
+                    // If branches consume the records, we assume that each branch, except for
+                    // the last, must have a condition. If this were not the case, it would mean
+                    // that some branch consumes all records, leaving none for the subsequent
+                    // branches, which is non-sensible. Hence, we plan this into a the
+                    // "conditional" pipeline stage, while treating non-terminal branch as invalid
+                    // if a condition is missing.
 
-                let mut pipeline_branches = vec![];
-                for branch in conditional_expr.get_branches() {
-                    let predicate = expr_planner.plan_logical(branch.get_condition(), functions)?;
+                    let expr_planner = if self.plan_for_attributes {
+                        ExprPlanner::for_attributes(self.filter_attribute_keys_case_sensitive)
+                    } else {
+                        ExprPlanner::with_attr_key_case_sensitive(
+                            self.filter_attribute_keys_case_sensitive,
+                        )
+                    };
 
-                    let pipeline_stages = self.plan_data_exprs(
-                        branch.get_expressions(),
-                        functions,
-                        session_ctx,
-                        otap_batch,
-                    )?;
+                    let mut pipeline_branches = vec![];
+                    for branch in branch_expr.get_branches() {
+                        let predicate = match branch.get_condition() {
+                            Some(condition) => expr_planner.plan_logical(condition, functions)?,
+                            None => {
+                                todo!("return invalid")
+                            }
+                        };
 
-                    pipeline_branches.push(ConditionalPipelineStageBranch::new(
-                        predicate,
-                        pipeline_stages,
-                    ));
+                        let pipeline_stages = self.plan_data_exprs(
+                            branch.get_expressions(),
+                            functions,
+                            session_ctx,
+                            otap_batch,
+                        )?;
+
+                        pipeline_branches.push(ConditionalPipelineStageBranch::new(
+                            predicate,
+                            pipeline_stages,
+                        ));
+                    }
+
+                    let default_branch = branch_expr
+                        .get_default_branch()
+                        .map(|data_exprs| {
+                            self.plan_data_exprs(data_exprs, functions, session_ctx, otap_batch)
+                        })
+                        .transpose()?;
+
+                    let pipeline_stage =
+                        ConditionalPipelineStage::new(pipeline_branches, default_branch);
+                    Ok(vec![Box::new(pipeline_stage)])
                 }
-
-                let default_branch = conditional_expr
-                    .get_default_branch()
-                    .map(|data_exprs| {
-                        self.plan_data_exprs(data_exprs, functions, session_ctx, otap_batch)
-                    })
-                    .transpose()?;
-
-                let pipeline_stage =
-                    ConditionalPipelineStage::new(pipeline_branches, default_branch);
-                Ok(vec![Box::new(pipeline_stage)])
             }
 
             DataExpression::Output(output_expr) => match output_expr.get_output() {
@@ -740,8 +756,8 @@ impl PipelinePlanner {
                     let mut inner_pipeline_data_exprs = Vec::with_capacity(function_exprs.len());
                     for func_expr in function_exprs {
                         let data_expr = match func_expr {
-                            PipelineFunctionExpression::Conditional(c) => {
-                                DataExpression::Conditional(c.clone())
+                            PipelineFunctionExpression::Branch(c) => {
+                                DataExpression::Branch(c.clone())
                             }
                             PipelineFunctionExpression::Discard(d) => {
                                 DataExpression::Discard(d.clone())

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/planner.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/planner.rs
@@ -30,6 +30,7 @@ use crate::pipeline::conditional::{ConditionalPipelineStage, ConditionalPipeline
 use crate::pipeline::expr::planner::ExprPlanner;
 use crate::pipeline::expr::{DataScope, ScopedExpr};
 use crate::pipeline::filter::FilterPipelineStage;
+use crate::pipeline::fork::{ForkPipelineStage, ForkPipelineStageBranch};
 use crate::pipeline::routing::RouteToPipelineStage;
 use crate::pipeline::{BoxedPipelineStage, PipelineStage};
 
@@ -291,15 +292,29 @@ impl PipelinePlanner {
                 }
             }
 
+            DataExpression::Fork(fork_expr) => {
+                let mut branches = Vec::with_capacity(fork_expr.get_branches().len());
+                for branch in fork_expr.get_branches() {
+                    let pipeline_stages = self.plan_data_exprs(
+                        branch.get_expressions(),
+                        functions,
+                        session_ctx,
+                        otap_batch,
+                    )?;
+                    branches.push(ForkPipelineStageBranch::new(pipeline_stages));
+                }
+
+                Ok(vec![Box::new(ForkPipelineStage::new(branches))])
+            }
+
             DataExpression::Output(output_expr) => match output_expr.get_output() {
                 OutputExpression::NamedSink(name) => {
                     Ok(vec![Box::new(RouteToPipelineStage::new(name.get_value()))])
                 }
             },
 
-            // TODO support other DataExpressions
-            other => Err(Error::NotYetSupportedError {
-                message: format!("data expression not yet supported {}", other.get_name()),
+            DataExpression::Summary(_) => Err(Error::NotYetSupportedError {
+                message: format!("data expression not yet supported {}", data_expr.get_name()),
             }),
         }
     }


### PR DESCRIPTION

# Change Summary

<!--
Replace with a brief summary of the change in this PR
-->
(See linked issue for more details about what the overall feature is trying to achieve).

In a nutshell - we want to add a fork operator to OPL which duplicates the telemetry batch and sends it down multiple pipelines:
```
logs |
fork
  { 
      // all error logs for app1 namespace get sent to "app1_on_call" destination
      where resource.attributes["k8s.namespace.name"] == "app1" and severity_number >= 17 | 
      route_to "app1_on_call"
  }
  {
      // send all logs to "destination x" after decorating them with customer ID
      set attribute["dest_x_customer_id"] = "cust_id_2134" |
      route_to "destination_x_out_port"
  }
```


**AST Changes:**

This PR changes the `Conditional` variant of `DataExpression` to a more generic `Branch` implementation. This `Branch` implementation contains a flag for whether the branches contained within it consume the records that are passed into them, otherwise receive a copy (see previously closed PR for more discussion on AST design https://github.com/open-telemetry/otel-arrow/pull/3189)

Because data selected by a branch is no longer always conditional, the branch `condition` field now becomes an `Option`. What was formerly the "default branch" (e.g. branch with no condition), can now be removed as this just becomes a regular branch with `condition: None`.

**OPL Parser Changes**

1. Adapts the parsing of `if/else` to the new AST `DataExpression::Branch`
2. Adds parsing handing for OPL `fork` operator call

**Query-Engine Changes**

1. Planner for `Branch` data expression now plans either fork or conditional pipeline stage
2. Adds a pipeline stage for `fork` operator call

## What issue does this PR close?

<!--
We highly recommend correlation of every PR to an issue
-->

* Closes #3188

## How are these changes tested?

Unit

## Are there any user-facing changes?

Yes - OPL programs used in transform processor now can use a `fork` operator

 <!-- If yes, provide further info below -->

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
