### PR TITLE
chore: fix go changelog CI failing

### DIFF
--- a/go/.chloggen/config.yaml
+++ b/go/.chloggen/config.yaml
@@ -23,6 +23,7 @@ default_change_logs:
 # not literal directory paths.
 components:
   - all
+  - collector/cmd/otelarrowcol
   - pkg/arrow
   - pkg/otel/arrow
   - pkg/otel/otlp


### PR DESCRIPTION
# Change Summary

<!--
Replace with a brief summary of the change in this PR
-->

Fixes CI failing since https://github.com/open-telemetry/otel-arrow/pull/3194

https://github.com/open-telemetry/otel-arrow/actions/runs/27019015377/job/79741568871?pr=3193

## What issue does this PR close?

<!--
We highly recommend correlation of every PR to an issue
-->

* Closes #NNN

## How are these changes tested?

## Are there any user-facing changes?

 <!-- If yes, provide further info below -->

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
