### PR TITLE
fix(otap): Transform processor config error on leading whitespace

### DIFF
--- a/rust/otap-dataflow/.chloggen/transform-processor-trim-leading-whitespace.yaml
+++ b/rust/otap-dataflow/.chloggen/transform-processor-trim-leading-whitespace.yaml
@@ -1,0 +1,19 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: pipeline
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Transform processor no longer returns a config error when the query has leading whitespace.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [3209]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
@@ -97,6 +97,7 @@ impl TryFrom<&PipelineExpression> for SignalScope {
         // TODO the logic here wouldn't be safe for languages other than Kql. We might want to have
         //  the pipeline expression be able to return name of the source
         let query = pipeline_expr.get_query_slice(pipeline_expr.get_query_location());
+        let query = query.trim_start();
         Ok(if query.starts_with("logs") {
             Self::Signal(SignalType::Logs)
         } else if query.starts_with("traces") {
@@ -1133,6 +1134,26 @@ mod test {
                 assert_eq!(metrics.num_rows(), 1);
             })
             .validate(|_ctx| async move {})
+    }
+
+    #[test]
+    fn test_signal_scope_leading_whitespace() {
+        // Regression test for https://github.com/open-telemetry/otel-arrow/issues/3209:
+        // leading whitespace (including newlines) must not break signal-type detection.
+        let runtime = TestRuntime::<OtapPdata>::new();
+        for query in [
+            "  logs | where name == \"foo\"",
+            "\n\ttraces | where name == \"foo\"",
+            "  metrics | where name == \"foo\"",
+            " \n signals | where name == \"foo\"",
+        ] {
+            let _processor = try_create_with_kql_query(query, &runtime)
+                .expect("created processor despite leading whitespace");
+        }
+
+        // also exercise the OPL path, which shares SignalScope::try_from
+        let _opl = try_create_with_opl_query("  logs | where name == \"foo\"", &runtime)
+            .expect("created OPL processor despite leading whitespace");
     }
 
     /// test helper function to set a pdata sender on the processor wrapper for the named output port


### PR DESCRIPTION
# Change Summary

In `SignalScope::try_from` (`rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs`), the query slice is now trimmed of leading whitespace before the keyword checks.

## What issue does this PR close?

<!--
We highly recommend correlation of every PR to an issue
-->

* Closes #3209 

## How are these changes tested?

Added test and passed locally.

## Are there any user-facing changes?

 <!-- If yes, provide further info below -->

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
