### PR TITLE
feat(otap): propagate receiver-observed peer address on OtapPdata

### DIFF
--- a/rust/otap-dataflow/.chloggen/propagate-peer-address-on-otap-pdata.yaml
+++ b/rust/otap-dataflow/.chloggen/propagate-peer-address-on-otap-pdata.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: otap
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Propagate the receiver-observed peer socket address on `OtapPdata` so processors can read request-scoped transport facts via `OtapPdata::peer_addr()`.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [3220]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Adds an optional `Option<SocketAddr>` peer-address slot to the `Context`
+  carried by every `OtapPdata`, populated by the OTLP gRPC, OTLP HTTP, OTAP
+  gRPC, and syslog/CEF TCP receivers from the accepting socket. Receivers
+  without a real socket (file-based, journald, UDS) leave it `None`. The
+  value is preserved across transport boundaries by `clone_without_context`
+  and is exposed via `OtapPdata::peer_addr()` so processors that care
+  (notably the k8sattributes processor's `pod_association: connection` and
+  `passthrough` modes) can opt in to reading it.

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs
@@ -461,9 +461,6 @@ impl local::Receiver<OtapPdata> for SyslogCefReceiver {
                                             Box::new(BufReader::new(socket))
                                         };
 
-                                        // Suppress unused variable warning when TLS is disabled
-                                        let _ = peer_addr;
-
                                         let mut line_bytes = Vec::with_capacity(INITIAL_MSG_BUFFER_CAPACITY);
 
                                         let mut arrow_records_builder = ArrowRecordsBuilder::new();
@@ -479,7 +476,7 @@ impl local::Receiver<OtapPdata> for SyslogCefReceiver {
                                                     match arrow_records_builder.build() {
                                                         Ok(arrow_records) => {
                                                             let res = effect_handler.try_send_message_with_source_node(
-                                                                OtapPdata::new_todo_context(arrow_records.into())
+                                                                OtapPdata::new_todo_context(arrow_records.into()).with_peer_addr(peer_addr)
                                                             );
                                                             let mut m = metrics.borrow_mut();
                                                             match &res {
@@ -563,7 +560,7 @@ impl local::Receiver<OtapPdata> for SyslogCefReceiver {
                                                                 let items = u64::from(arrow_records_builder.len());
                                                                 match arrow_records_builder.build() {
                                                                     Ok(arrow_records) => {
-                                                                        let res = effect_handler.send_message_with_source_node(OtapPdata::new_todo_context(arrow_records.into())).await;
+                                                                        let res = effect_handler.send_message_with_source_node(OtapPdata::new_todo_context(arrow_records.into()).with_peer_addr(peer_addr)).await;
 
                                                                         {
                                                                             let mut m = metrics.borrow_mut();
@@ -654,7 +651,7 @@ impl local::Receiver<OtapPdata> for SyslogCefReceiver {
                                                                         // Reset the timer since we already built an arrow record batch due to size constraint
                                                                         interval.reset();
 
-                                                                        let res = effect_handler.send_message_with_source_node(OtapPdata::new_todo_context(arrow_records.into())).await;
+                                                                        let res = effect_handler.send_message_with_source_node(OtapPdata::new_todo_context(arrow_records.into()).with_peer_addr(peer_addr)).await;
                                                                         {
                                                                             let mut m = metrics.borrow_mut();
                                                                             match &res {
@@ -678,7 +675,7 @@ impl local::Receiver<OtapPdata> for SyslogCefReceiver {
                                                                 let items = u64::from(arrow_records_builder.len());
                                                                 match arrow_records_builder.build() {
                                                                     Ok(arrow_records) => {
-                                                                        let res = effect_handler.send_message_with_source_node(OtapPdata::new_todo_context(arrow_records.into())).await;
+                                                                        let res = effect_handler.send_message_with_source_node(OtapPdata::new_todo_context(arrow_records.into()).with_peer_addr(peer_addr)).await;
 
                                                                         {
                                                                             let mut m = metrics.borrow_mut();
@@ -713,7 +710,7 @@ impl local::Receiver<OtapPdata> for SyslogCefReceiver {
                                                                 // Reset the builder for the next batch
                                                                 arrow_records_builder = ArrowRecordsBuilder::new();
 
-                                                                let res = effect_handler.send_message_with_source_node(OtapPdata::new_todo_context(arrow_records.into())).await;
+                                                                let res = effect_handler.send_message_with_source_node(OtapPdata::new_todo_context(arrow_records.into()).with_peer_addr(peer_addr)).await;
                                                                 {
                                                                     let mut m = metrics.borrow_mut();
                                                                     match &res {

--- a/rust/otap-dataflow/crates/otap/src/otap_grpc.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_grpc.rs
@@ -28,11 +28,13 @@ use otap_df_pdata::{
     },
 };
 use otap_df_telemetry::{otel_error, otel_warn};
+use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
 use tokio::sync::oneshot;
 use tokio_stream::Stream;
 use tokio_stream::wrappers::ReceiverStream;
+use tonic::transport::server::{TcpConnectInfo, TlsConnectInfo};
 use tonic::{Request, Response, Status, Streaming};
 
 pub mod client_settings;
@@ -174,6 +176,7 @@ impl ArrowLogsService for ArrowLogsServiceImpl {
         // Provide client a stream to listen to
         let output = ReceiverStream::new(rx);
 
+        let peer_addr = extract_peer_addr(&request);
         spawn_stream_handler::<Logs, _>(
             request.into_inner(),
             OtapArrowRecords::Logs,
@@ -181,6 +184,7 @@ impl ArrowLogsService for ArrowLogsServiceImpl {
             self.state.clone(),
             self.settings.clone(),
             tx,
+            peer_addr,
         );
 
         Ok(Response::new(Box::pin(output) as Self::ArrowLogsStream))
@@ -200,6 +204,7 @@ impl ArrowMetricsService for ArrowMetricsServiceImpl {
         // Provide client a stream to listen to
         let output = ReceiverStream::new(rx);
 
+        let peer_addr = extract_peer_addr(&request);
         spawn_stream_handler::<Metrics, _>(
             request.into_inner(),
             OtapArrowRecords::Metrics,
@@ -207,6 +212,7 @@ impl ArrowMetricsService for ArrowMetricsServiceImpl {
             self.state.clone(),
             self.settings.clone(),
             tx,
+            peer_addr,
         );
 
         Ok(Response::new(Box::pin(output) as Self::ArrowMetricsStream))
@@ -226,6 +232,7 @@ impl ArrowTracesService for ArrowTracesServiceImpl {
         // create a stream to output result to
         let output = ReceiverStream::new(rx);
 
+        let peer_addr = extract_peer_addr(&request);
         spawn_stream_handler::<Traces, _>(
             request.into_inner(),
             OtapArrowRecords::Traces,
@@ -233,10 +240,24 @@ impl ArrowTracesService for ArrowTracesServiceImpl {
             self.state.clone(),
             self.settings.clone(),
             tx,
+            peer_addr,
         );
 
         Ok(Response::new(Box::pin(output) as Self::ArrowTracesStream))
     }
+}
+
+/// Extracts the peer socket address from a tonic request's connection info
+/// extensions. Returns `None` for connections without TCP-backed transport
+/// (e.g. UDS) or when tonic was unable to record the remote address.
+fn extract_peer_addr<T>(request: &Request<T>) -> Option<SocketAddr> {
+    let exts = request.extensions();
+    exts.get::<TcpConnectInfo>()
+        .and_then(|info| info.remote_addr())
+        .or_else(|| {
+            exts.get::<TlsConnectInfo<TcpConnectInfo>>()
+                .and_then(|info| info.get_ref().remote_addr())
+        })
 }
 
 type PendingResponseFuture = BoxFuture<'static, PendingResponse>;
@@ -254,6 +275,7 @@ fn spawn_stream_handler<T, F>(
     state: Option<SharedState>,
     settings: Settings,
     tx: tokio::sync::mpsc::Sender<Result<BatchStatus, Status>>,
+    peer_addr: Option<SocketAddr>,
 ) where
     T: OtapBatchStore + Send + 'static,
     F: Fn(T) -> OtapArrowRecords + Copy + Send + 'static,
@@ -266,6 +288,7 @@ fn spawn_stream_handler<T, F>(
             state,
             settings,
             tx,
+            peer_addr,
         )
         .await;
     });
@@ -278,6 +301,7 @@ async fn handle_stream<T, F>(
     state: Option<SharedState>,
     settings: Settings,
     tx: tokio::sync::mpsc::Sender<Result<BatchStatus, Status>>,
+    peer_addr: Option<SocketAddr>,
 ) where
     T: OtapBatchStore + Send + 'static,
     F: Fn(T) -> OtapArrowRecords + Copy + Send + 'static,
@@ -335,6 +359,7 @@ async fn handle_stream<T, F>(
                     &settings.admission_state,
                     settings.receiver_rejection_metrics.as_deref(),
                     &tx,
+                    peer_addr,
                 )
                 .await {
                     Ok(Some(response)) => pending.push(response),
@@ -405,6 +430,7 @@ async fn accept_data<T: OtapBatchStore, F>(
     admission_state: &SharedReceiverAdmissionState,
     rejection_metrics: Option<&dyn ReceiverRejectionMetrics>,
     tx: &tokio::sync::mpsc::Sender<Result<BatchStatus, Status>>,
+    peer_addr: Option<SocketAddr>,
 ) -> Result<Option<PendingResponseFuture>, ()>
 where
     F: Fn(T) -> OtapArrowRecords,
@@ -443,6 +469,9 @@ where
     let otap_batch_as_otap_arrow_records = otap_batch(batch);
     let mut otap_pdata =
         OtapPdata::new(Context::default(), otap_batch_as_otap_arrow_records.into());
+    if let Some(addr) = peer_addr {
+        otap_pdata.set_peer_addr(addr);
+    }
 
     let cancel_rx = if let Some(state) = state {
         // Try to allocate a slot (under the mutex) for calldata.

--- a/rust/otap-dataflow/crates/otap/src/otap_grpc.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_grpc.rs
@@ -34,7 +34,6 @@ use std::sync::Arc;
 use tokio::sync::oneshot;
 use tokio_stream::Stream;
 use tokio_stream::wrappers::ReceiverStream;
-use tonic::transport::server::{TcpConnectInfo, TlsConnectInfo};
 use tonic::{Request, Response, Status, Streaming};
 
 pub mod client_settings;
@@ -45,6 +44,7 @@ pub mod proxy;
 pub mod server_settings;
 
 use crate::memory_pressure_layer::{ReceiverRejectionMetrics, grpc_memory_pressure_status};
+use crate::otap_grpc::common::peer_addr_from_extensions;
 use crate::otap_grpc::otlp::server::SharedState;
 pub use client_settings::GrpcClientSettings;
 pub use server_settings::GrpcServerSettings;
@@ -176,7 +176,7 @@ impl ArrowLogsService for ArrowLogsServiceImpl {
         // Provide client a stream to listen to
         let output = ReceiverStream::new(rx);
 
-        let peer_addr = extract_peer_addr(&request);
+        let peer_addr = peer_addr_from_extensions(request.extensions());
         spawn_stream_handler::<Logs, _>(
             request.into_inner(),
             OtapArrowRecords::Logs,
@@ -204,7 +204,7 @@ impl ArrowMetricsService for ArrowMetricsServiceImpl {
         // Provide client a stream to listen to
         let output = ReceiverStream::new(rx);
 
-        let peer_addr = extract_peer_addr(&request);
+        let peer_addr = peer_addr_from_extensions(request.extensions());
         spawn_stream_handler::<Metrics, _>(
             request.into_inner(),
             OtapArrowRecords::Metrics,
@@ -232,7 +232,7 @@ impl ArrowTracesService for ArrowTracesServiceImpl {
         // create a stream to output result to
         let output = ReceiverStream::new(rx);
 
-        let peer_addr = extract_peer_addr(&request);
+        let peer_addr = peer_addr_from_extensions(request.extensions());
         spawn_stream_handler::<Traces, _>(
             request.into_inner(),
             OtapArrowRecords::Traces,
@@ -245,19 +245,6 @@ impl ArrowTracesService for ArrowTracesServiceImpl {
 
         Ok(Response::new(Box::pin(output) as Self::ArrowTracesStream))
     }
-}
-
-/// Extracts the peer socket address from a tonic request's connection info
-/// extensions. Returns `None` for connections without TCP-backed transport
-/// (e.g. UDS) or when tonic was unable to record the remote address.
-fn extract_peer_addr<T>(request: &Request<T>) -> Option<SocketAddr> {
-    let exts = request.extensions();
-    exts.get::<TcpConnectInfo>()
-        .and_then(|info| info.remote_addr())
-        .or_else(|| {
-            exts.get::<TlsConnectInfo<TcpConnectInfo>>()
-                .and_then(|info| info.get_ref().remote_addr())
-        })
 }
 
 type PendingResponseFuture = BoxFuture<'static, PendingResponse>;

--- a/rust/otap-dataflow/crates/otap/src/otap_grpc/common.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_grpc/common.rs
@@ -13,9 +13,28 @@
 use crate::otap_grpc::otlp::server_new::{AckSlot, RouteResponse};
 use crate::otap_grpc::server_settings::GrpcServerSettings;
 use crate::pdata::OtapPdata;
+use http::Extensions;
 use otap_df_config::SignalType;
 use otap_df_engine::control::{AckMsg, NackMsg};
+use std::net::SocketAddr;
 use tonic::transport::Server;
+use tonic::transport::server::{TcpConnectInfo, TlsConnectInfo};
+
+/// Extracts the peer socket address from a tonic request's connection-info
+/// extensions. Returns `None` for connections without TCP-backed transport
+/// (e.g. UDS) or when tonic was unable to record the remote address. TLS
+/// connections wrap `TcpConnectInfo` inside `TlsConnectInfo`.
+#[must_use]
+pub fn peer_addr_from_extensions(extensions: &Extensions) -> Option<SocketAddr> {
+    extensions
+        .get::<TcpConnectInfo>()
+        .and_then(|info| info.remote_addr())
+        .or_else(|| {
+            extensions
+                .get::<TlsConnectInfo<TcpConnectInfo>>()
+                .and_then(|info| info.get_ref().remote_addr())
+        })
+}
 
 /// Aggregates the per-signal ACK subscription maps that let us route responses back to callers.
 #[derive(Clone, Default)]

--- a/rust/otap-dataflow/crates/otap/src/otap_grpc/otlp/server_new.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_grpc/otlp/server_new.rs
@@ -43,6 +43,7 @@ use tonic::Status;
 use tonic::body::Body;
 use tonic::codec::{Codec, DecodeBuf, Decoder, EnabledCompressionEncodings, EncodeBuf, Encoder};
 use tonic::server::{Grpc, NamedService, UnaryService};
+use tonic::transport::server::{TcpConnectInfo, TlsConnectInfo};
 
 /// Tracks outstanding request subscriptions for a single signal so ACK/NACK responses can be routed
 /// back to the waiting caller. When `wait_for_result` is disabled the receiver skips creating this
@@ -366,7 +367,22 @@ impl UnaryService<OtapPdata> for OtapBatchService {
     type Future = BoxFuture<'static, Result<tonic::Response<Self::Response>, Status>>;
 
     fn call(&mut self, request: tonic::Request<OtapPdata>) -> Self::Future {
-        let (metadata, _extensions, mut otap_batch) = request.into_parts();
+        let (metadata, extensions, mut otap_batch) = request.into_parts();
+
+        // Propagate the receiver-observed peer address so downstream processors
+        // (e.g. k8sattributes) can correlate telemetry with the originating
+        // socket. TLS connections wrap `TcpConnectInfo` inside `TlsConnectInfo`.
+        if let Some(addr) = extensions
+            .get::<TcpConnectInfo>()
+            .and_then(|info| info.remote_addr())
+            .or_else(|| {
+                extensions
+                    .get::<TlsConnectInfo<TcpConnectInfo>>()
+                    .and_then(|info| info.get_ref().remote_addr())
+            })
+        {
+            otap_batch.set_peer_addr(addr);
+        }
 
         let effect_handler = self
             .effect_handler

--- a/rust/otap-dataflow/crates/otap/src/otap_grpc/otlp/server_new.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_grpc/otlp/server_new.rs
@@ -43,7 +43,8 @@ use tonic::Status;
 use tonic::body::Body;
 use tonic::codec::{Codec, DecodeBuf, Decoder, EnabledCompressionEncodings, EncodeBuf, Encoder};
 use tonic::server::{Grpc, NamedService, UnaryService};
-use tonic::transport::server::{TcpConnectInfo, TlsConnectInfo};
+
+use crate::otap_grpc::common::peer_addr_from_extensions;
 
 /// Tracks outstanding request subscriptions for a single signal so ACK/NACK responses can be routed
 /// back to the waiting caller. When `wait_for_result` is disabled the receiver skips creating this
@@ -370,17 +371,8 @@ impl UnaryService<OtapPdata> for OtapBatchService {
         let (metadata, extensions, mut otap_batch) = request.into_parts();
 
         // Propagate the receiver-observed peer address so downstream processors
-        // (e.g. k8sattributes) can correlate telemetry with the originating
-        // socket. TLS connections wrap `TcpConnectInfo` inside `TlsConnectInfo`.
-        if let Some(addr) = extensions
-            .get::<TcpConnectInfo>()
-            .and_then(|info| info.remote_addr())
-            .or_else(|| {
-                extensions
-                    .get::<TlsConnectInfo<TcpConnectInfo>>()
-                    .and_then(|info| info.get_ref().remote_addr())
-            })
-        {
+        // (e.g. k8sattributes) can correlate telemetry with the originating socket.
+        if let Some(addr) = peer_addr_from_extensions(&extensions) {
             otap_batch.set_peer_addr(addr);
         }
 

--- a/rust/otap-dataflow/crates/otap/src/otlp_http.rs
+++ b/rust/otap-dataflow/crates/otap/src/otlp_http.rs
@@ -515,6 +515,10 @@ struct HttpHandler {
     global_semaphore: Option<Arc<Semaphore>>,
     /// Protocol-local semaphore enforcing HTTP's `max_concurrent_requests`.
     local_semaphore: Arc<Semaphore>,
+    /// Peer address observed at TCP accept time for this connection, attached
+    /// to every `OtapPdata` produced from the connection so downstream
+    /// processors can read it via `OtapPdata::peer_addr()`.
+    peer_addr: SocketAddr,
 }
 
 impl HttpHandler {
@@ -700,6 +704,7 @@ impl HttpHandler {
             };
 
             let mut pdata = OtapPdata::new(context, payload.into());
+            pdata.set_peer_addr(self.peer_addr);
 
             // Capture transport headers from HTTP headers when a capture policy is configured.
             if let Some(policy) = self.effect_handler.capture_policy() {
@@ -888,6 +893,7 @@ pub async fn serve(
                     admission_state: admission_state.clone(),
                     global_semaphore: global_semaphore.clone(),
                     local_semaphore: local_semaphore.clone(),
+                    peer_addr,
                 };
 
                 if let Some(acceptor) = maybe_tls_acceptor.clone() {

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -13,6 +13,7 @@
 //! encountered issues (Nack) downstream, optionally preserving the payload for retry or logging.
 //! This functionality is exposed through various traits implemented by effect handlers.
 
+use std::net::SocketAddr;
 use std::num::NonZeroU64;
 
 use async_trait::async_trait;
@@ -32,11 +33,16 @@ use crate::transport_headers::TransportHeaders;
 
 /// Context for OTAP requests.
 ///
-/// Carries two independent concerns:
+/// Carries three independent concerns:
 /// - **Routing stack**: Ack/Nack routing frames used by the pipeline engine
 ///   for result notification. Reset at transport boundaries (topic hops).
 /// - **Transport headers**: Protocol-neutral request-scoped metadata captured
 ///   from inbound transport headers. Preserved across transport boundaries.
+/// - **Peer address**: Optional socket address observed by the receiving
+///   socket at request acceptance time. Populated by receivers that have a
+///   real socket (OTLP gRPC/HTTP, OTAP gRPC, syslog/CEF) and left `None` by
+///   sourceless receivers (file-based, journald). Preserved across transport
+///   boundaries.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Context {
     stack: Vec<Frame>,
@@ -45,6 +51,9 @@ pub struct Context {
     /// `None` when no headers have been captured (the common case, zero
     /// additional allocation).
     transport_headers: Option<TransportHeaders>,
+    /// Peer address observed by the receiving socket at request acceptance
+    /// time. `None` for receivers without a real socket.
+    peer_addr: Option<SocketAddr>,
     /// Active flow_metric accumulator (nanoseconds).
     ///
     /// `Some(ns)` when a message is inside a flow_metric range (between
@@ -64,6 +73,7 @@ impl Context {
         Self {
             stack: Vec::with_capacity(capacity),
             transport_headers: None,
+            peer_addr: None,
             flow_compute_ns: None,
         }
     }
@@ -311,6 +321,17 @@ impl Context {
         self.transport_headers = Some(headers);
     }
 
+    /// Returns the peer address observed by the receiving socket, if any.
+    #[must_use]
+    pub fn peer_addr(&self) -> Option<SocketAddr> {
+        self.peer_addr
+    }
+
+    /// Set the peer address for this context.
+    pub fn set_peer_addr(&mut self, addr: SocketAddr) {
+        self.peer_addr = Some(addr);
+    }
+
     /// Get the source node for this context.
     #[must_use]
     pub fn source_node(&self) -> Option<usize> {
@@ -480,15 +501,16 @@ impl OtapPdata {
     /// pipelines) where in-process Ack/Nack routing state must not leak across
     /// boundaries.
     ///
-    /// Transport headers are **preserved** because they represent
-    /// request-scoped metadata (tenant ID, auth, trace context) that should
-    /// survive cross-pipeline hops.
+    /// Transport headers and peer address are **preserved** because they
+    /// represent request-scoped metadata (tenant ID, auth, trace context,
+    /// originating peer) that should survive cross-pipeline hops.
     #[must_use]
     pub fn clone_without_context(&self) -> Self {
         Self {
             context: Context {
                 stack: Vec::new(),
                 transport_headers: self.context.transport_headers.clone(),
+                peer_addr: self.context.peer_addr,
                 flow_compute_ns: None,
             },
             payload: self.payload.clone(),
@@ -620,6 +642,29 @@ impl OtapPdata {
     #[must_use]
     pub fn with_transport_headers(mut self, headers: TransportHeaders) -> Self {
         self.context.set_transport_headers(headers);
+        self
+    }
+
+    /// Returns the peer address observed by the receiving socket, if any.
+    ///
+    /// Receivers backed by a real socket (OTLP gRPC/HTTP, OTAP gRPC,
+    /// syslog/CEF) populate this at request acceptance time. Receivers
+    /// without a socket (file-based, journald) leave it `None`. Processors
+    /// and exporters that do not consult the peer address pay nothing.
+    #[must_use]
+    pub fn peer_addr(&self) -> Option<SocketAddr> {
+        self.context.peer_addr()
+    }
+
+    /// Set the peer address on this pdata's context.
+    pub fn set_peer_addr(&mut self, addr: SocketAddr) {
+        self.context.set_peer_addr(addr);
+    }
+
+    /// Builder-style method to attach a peer address.
+    #[must_use]
+    pub fn with_peer_addr(mut self, addr: SocketAddr) -> Self {
+        self.context.set_peer_addr(addr);
         self
     }
 }
@@ -2296,5 +2341,32 @@ mod test {
 
         let cloned = pdata.clone_without_context();
         assert!(!cloned.has_active_flow_metric());
+    }
+
+    #[test]
+    fn peer_addr_default_is_none_and_round_trips() {
+        let pdata = create_test_pdata();
+        assert!(pdata.peer_addr().is_none());
+
+        let addr: SocketAddr = "10.0.0.1:5005".parse().unwrap();
+        let pdata = create_test_pdata().with_peer_addr(addr);
+        assert_eq!(pdata.peer_addr(), Some(addr));
+
+        let mut pdata = create_test_pdata();
+        pdata.set_peer_addr(addr);
+        assert_eq!(pdata.peer_addr(), Some(addr));
+    }
+
+    #[test]
+    fn peer_addr_survives_clone_without_context() {
+        let addr: SocketAddr = "[2001:db8::1]:9999".parse().unwrap();
+        let pdata = create_test_pdata().with_peer_addr(addr);
+
+        let cloned = pdata.clone_without_context();
+        assert_eq!(
+            cloned.peer_addr(),
+            Some(addr),
+            "peer_addr must survive transport-boundary clone"
+        );
     }
 }


### PR DESCRIPTION
# Change Summary

Propagate the receiver-observed peer socket address end-to-end on
`OtapPdata` so downstream processors can read request-scoped transport
facts about the originating connection.

An optional `Option<SocketAddr>` peer-address slot is added to the
`Context` carried by every `OtapPdata`. It is populated by receivers
backed by a real socket — OTLP gRPC, OTLP HTTP, OTAP gRPC, and the
syslog/CEF TCP path — from the accepting socket at request acceptance
time. Receivers without a socket (file-based, journald, UDS, UDP) leave
it `None`. The value is preserved across transport boundaries by
`clone_without_context` and is exposed via `OtapPdata::peer_addr()`,
giving processors an opt-in accessor that costs nothing when unused.

This unblocks the OTAP k8sattributes processor's
`pod_association: connection` and `passthrough` modes, both of which
require the originating peer IP.

## What issue does this PR close?

* Closes #3220

## How are these changes tested?

* New unit tests in `crates/otap/src/pdata.rs` cover the default-`None`
  state, builder and setter round-trips for `peer_addr`, and that the
  field survives `clone_without_context()` (the transport-boundary
  clone).
* The existing OTLP/OTAP gRPC and HTTP receiver tests continue to
  exercise the receive paths; `peer_addr` is opportunistic metadata
  that defaults to `None` for any caller that does not set it, so
  existing assertions are unaffected.
* Verified with `cargo check -p otap-df-otap --all-features`.

## Are there any user-facing changes?

Yes. `OtapPdata` gains a public accessor (`peer_addr`) plus
`set_peer_addr` and `with_peer_addr` helpers. No existing API is
removed or changed; processors and exporters that do not consult the
field pay nothing.

### Changelog

* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
