### PR TITLE
feat(otap): preserve OtapPdata::peer_addr across merging processors

### DIFF
--- a/rust/otap-dataflow/.chloggen/preserve-peer-address-merging-processors.yaml
+++ b/rust/otap-dataflow/.chloggen/preserve-peer-address-merging-processors.yaml
@@ -1,0 +1,26 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: pipeline
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Preserve `OtapPdata::peer_addr` across merging processors (`batch_processor`, `temporal_reaggregation_processor`) by merging contributing inputs' peer addresses via the new `Context::merge_peer_addr` helper.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [3228]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Adds `Context::merge_peer_addr`, which returns `Some(addr)` only when every
+  contributing input observed the same peer address and `None` otherwise.
+  `batch_processor` and `temporal_reaggregation_processor` — the two processors
+  that rebuild `OtapPdata` with a fresh `Context` when merging multiple inputs
+  — now apply this helper so single-peer streams retain the receiver-observed
+  peer address end-to-end, while multi-peer merges keep `peer_addr` as `None`
+  to avoid misattribution.

--- a/rust/otap-dataflow/.chloggen/preserve-peer-address-merging-processors.yaml
+++ b/rust/otap-dataflow/.chloggen/preserve-peer-address-merging-processors.yaml
@@ -19,7 +19,7 @@ issues: [3228]
 subtext: |
   Adds `Context::merge_peer_addr`, which returns `Some(addr)` only when every
   contributing input observed the same peer address and `None` otherwise.
-  `batch_processor` and `temporal_reaggregation_processor` — the two processors
+  `batch_processor` and `temporal_reaggregation_processor` - the two processors
   that rebuild `OtapPdata` with a fresh `Context` when merging multiple inputs
   — now apply this helper so single-peer streams retain the receiver-observed
   peer address end-to-end, while multi-peer merges keep `peer_addr` as `None`

--- a/rust/otap-dataflow/.chloggen/preserve-peer-address-merging-processors.yaml
+++ b/rust/otap-dataflow/.chloggen/preserve-peer-address-merging-processors.yaml
@@ -21,6 +21,6 @@ subtext: |
   contributing input observed the same peer address and `None` otherwise.
   `batch_processor` and `temporal_reaggregation_processor` - the two processors
   that rebuild `OtapPdata` with a fresh `Context` when merging multiple inputs
-  — now apply this helper so single-peer streams retain the receiver-observed
+  - now apply this helper so single-peer streams retain the receiver-observed
   peer address end-to-end, while multi-peer merges keep `peer_addr` as `None`
   to avoid misattribution.

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
@@ -48,7 +48,7 @@ use otap_df_engine::{
 };
 use otap_df_otap::OTAP_PROCESSOR_FACTORIES;
 use otap_df_otap::accessory::slots::{Key as SlotKey, State as SlotState};
-use otap_df_otap::pdata::{Context, OtapPdata};
+use otap_df_otap::pdata::{Context, OtapPdata, PeerAddrMerger};
 use otap_df_pdata::TryIntoWithOptions;
 use otap_df_pdata::{
     OtapArrowRecords, OtapPayload, OtapPayloadHelpers, OtlpProtoBytes, error::Error as PDataError,
@@ -1439,7 +1439,16 @@ where
         let remaining = output_batches.pop().expect("has last");
         let last_input = from_inputs.context.last().expect("has last");
         let last_weight = sizer.batch_size(&remaining).expect("known size");
-        let new_part = BatchPortion::new(last_input.inkey, last_input.peer_addr, last_weight);
+        // The retained partial output may aggregate records from multiple
+        // input requests, but the existing context bookkeeping only tracks
+        // input portions, not which inputs contributed to which output
+        // batch. Reusing `last_input.peer_addr` here would be wrong when
+        // inputs from multiple peers fed the final output batch: it would
+        // misattribute the retained portion (and any future merge that
+        // consumes it) to one arbitrary contributor. Conservatively drop
+        // the address — merge_peer_addr will then propagate `None`, the
+        // safe default.
+        let new_part = BatchPortion::new(last_input.inkey, None, last_weight);
 
         from_inputs.weight -= last_weight;
 
@@ -1461,8 +1470,9 @@ where
         let mut out = Vec::new();
         // Track every contributing portion's peer_addr, even ones that do not
         // route ack/nack, so the merged output `peer_addr` is correct when
-        // some (or all) inputs had no subscribers.
-        let mut peers: Vec<Option<SocketAddr>> = Vec::new();
+        // some (or all) inputs had no subscribers. Folded incrementally to
+        // avoid allocating a `Vec` on every flush.
+        let mut peer_merger = PeerAddrMerger::new();
 
         while weight > 0 && contexts.pos < contexts.inputs.len() {
             let bp = contexts.inputs.get_mut(contexts.pos).expect("valid");
@@ -1471,7 +1481,7 @@ where
             bp.weight -= take;
             weight -= take;
             let peer_addr = bp.peer_addr;
-            peers.push(peer_addr);
+            peer_merger.push(peer_addr);
 
             if bp.weight == 0 {
                 contexts.pos += 1;
@@ -1486,7 +1496,7 @@ where
             }
         }
 
-        let merged_peer = Context::merge_peer_addr(peers);
+        let merged_peer = peer_merger.finish();
         let routed = (!out.is_empty()).then_some(out);
         (routed, merged_peer)
     }

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
@@ -1439,16 +1439,24 @@ where
         let remaining = output_batches.pop().expect("has last");
         let last_input = from_inputs.context.last().expect("has last");
         let last_weight = sizer.batch_size(&remaining).expect("known size");
-        // The retained partial output may aggregate records from multiple
-        // input requests, but the existing context bookkeeping only tracks
-        // input portions, not which inputs contributed to which output
-        // batch. Reusing `last_input.peer_addr` here would be wrong when
-        // inputs from multiple peers fed the final output batch: it would
-        // misattribute the retained portion (and any future merge that
-        // consumes it) to one arbitrary contributor. Conservatively drop
-        // the address — merge_peer_addr will then propagate `None`, the
-        // safe default.
-        let new_part = BatchPortion::new(last_input.inkey, None, last_weight);
+        // Compute the retained portion's peer_addr from the input portions
+        // that actually contributed to this output batch. Inputs are emitted
+        // in order, so the contributing portions are the tail of
+        // `from_inputs.context` covering the last `last_weight` units.
+        // Walking from the back and folding each contributor's peer_addr
+        // through PeerAddrMerger yields the correct merge: single-peer
+        // remainders keep the address, mixed-peer or peerless remainders
+        // settle on `None`.
+        let mut peer_merger = PeerAddrMerger::new();
+        let mut covered = 0usize;
+        for bp in from_inputs.context.iter().rev() {
+            peer_merger.push(bp.peer_addr);
+            covered = covered.saturating_add(bp.weight);
+            if covered >= last_weight {
+                break;
+            }
+        }
+        let new_part = BatchPortion::new(last_input.inkey, peer_merger.finish(), last_weight);
 
         from_inputs.weight -= last_weight;
 
@@ -3574,6 +3582,207 @@ mod tests {
                         "any peerless contributor must drop peer_addr on the merged batch"
                     );
                 }
+            })
+            .validate(|_| async {});
+    }
+
+    /// Build a `LogsData` containing exactly `count` log records, with
+    /// unique time_unix_nano values derived from `base_id` for ordering
+    /// assertions. Used by the retained-partial tests below.
+    fn logs_with_n_records(base_id: usize, count: usize) -> LogsData {
+        let base_time = 1_000_000_000 + (base_id * 1000) as u64;
+        LogsData {
+            resource_logs: vec![ResourceLogs {
+                scope_logs: vec![ScopeLogs {
+                    log_records: (0..count)
+                        .map(|i| LogRecord {
+                            time_unix_nano: base_time + i as u64,
+                            ..Default::default()
+                        })
+                        .collect(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        }
+    }
+
+    /// take_remaining retained-partial path, single contributing input.
+    ///
+    /// Scenario: one 8-item input from peer A → `make_batches` splits into
+    /// `[5, 3]`. The 3-item tail is below `min_size=4` and is re-buffered
+    /// via `take_remaining`. A follow-up 2-item input from peer A then
+    /// triggers a 5-item size flush whose contents come from the retained
+    /// portion (peer A) + the new input (peer A).
+    ///
+    /// Guarantee: the second flush's batch carries `peer_addr = A` — the
+    /// retained portion correctly remembered its single contributor's peer.
+    #[test]
+    fn test_take_remaining_preserves_peer_addr_single_input() {
+        let (_telemetry_registry, _metrics_reporter, phase) = setup_test_runtime(json!({
+            "otap": {
+                "min_size": 4,
+                "max_size": 5,
+                "sizer": "items",
+            },
+            "max_batch_duration": "10s"
+        }));
+
+        phase
+            .run_test(move |mut ctx| async move {
+                let peer: SocketAddr = "10.0.0.1:5000".parse().unwrap();
+
+                // 8-item input from peer A → batches [5, 3]; the 3-item
+                // tail is retained because 3 < min_size=4.
+                let big = encode_logs_otap_batch(&logs_with_n_records(0, 8)).expect("encode logs");
+                ctx.process(Message::PData(
+                    OtapPdata::new_default(big.into()).with_peer_addr(peer),
+                ))
+                .await
+                .expect("process big input");
+
+                let first = ctx.drain_pdata().await;
+                assert_eq!(first.len(), 1, "first flush should emit one batch");
+                assert_eq!(
+                    first[0].peer_addr(),
+                    Some(peer),
+                    "single-peer first batch must preserve peer_addr"
+                );
+
+                // 2-item follow-up from peer A: retained(3, A) + new(2, A) = 5 → flush.
+                let extra =
+                    encode_logs_otap_batch(&logs_with_n_records(1, 2)).expect("encode logs");
+                ctx.process(Message::PData(
+                    OtapPdata::new_default(extra.into()).with_peer_addr(peer),
+                ))
+                .await
+                .expect("process follow-up input");
+
+                let second = ctx.drain_pdata().await;
+                assert_eq!(second.len(), 1, "second flush should emit one batch");
+                assert_eq!(
+                    second[0].peer_addr(),
+                    Some(peer),
+                    "single-input retained partial must preserve peer_addr on the next merge"
+                );
+            })
+            .validate(|_| async {});
+    }
+
+    /// take_remaining retained-partial path, multiple contributing inputs
+    /// that all share one peer.
+    ///
+    /// Scenario: three inputs of sizes [3, 3, 2] all from peer A
+    /// (total 8 items) → `make_batches` splits into `[5, 3]`. The 3-item
+    /// tail spans inputs #2 and #3 — both peer A. A follow-up 2-item input
+    /// from peer A triggers a second size flush over the retained portion.
+    ///
+    /// Guarantee: the second flush's batch carries `peer_addr = A`, even
+    /// though the retained portion spans more than one input — because all
+    /// contributors agreed.
+    #[test]
+    fn test_take_remaining_preserves_peer_addr_multi_input_same_peer() {
+        let (_telemetry_registry, _metrics_reporter, phase) = setup_test_runtime(json!({
+            "otap": {
+                "min_size": 4,
+                "max_size": 5,
+                "sizer": "items",
+            },
+            "max_batch_duration": "10s"
+        }));
+
+        phase
+            .run_test(move |mut ctx| async move {
+                let peer: SocketAddr = "10.0.0.1:5000".parse().unwrap();
+
+                for (idx, count) in [(0, 3usize), (1, 3), (2, 2)] {
+                    let rec = encode_logs_otap_batch(&logs_with_n_records(idx, count))
+                        .expect("encode logs");
+                    ctx.process(Message::PData(
+                        OtapPdata::new_default(rec.into()).with_peer_addr(peer),
+                    ))
+                    .await
+                    .expect("process input");
+                }
+
+                let first = ctx.drain_pdata().await;
+                assert_eq!(first.len(), 1, "first flush should emit one batch");
+                assert_eq!(first[0].peer_addr(), Some(peer));
+
+                let extra =
+                    encode_logs_otap_batch(&logs_with_n_records(3, 2)).expect("encode logs");
+                ctx.process(Message::PData(
+                    OtapPdata::new_default(extra.into()).with_peer_addr(peer),
+                ))
+                .await
+                .expect("process follow-up input");
+
+                let second = ctx.drain_pdata().await;
+                assert_eq!(second.len(), 1, "second flush should emit one batch");
+                assert_eq!(
+                    second[0].peer_addr(),
+                    Some(peer),
+                    "multi-input retained partial with one shared peer must preserve it"
+                );
+            })
+            .validate(|_| async {});
+    }
+
+    /// take_remaining retained-partial path, multiple contributing inputs
+    /// from distinct peers.
+    ///
+    /// Scenario: inputs of sizes [3, 3, 2] from peers [A, A, B]
+    /// (total 8 items) → `make_batches` splits into `[5, 3]`. The 3-item
+    /// tail spans inputs #2 (peer A) and #3 (peer B) — mixed peers. A
+    /// follow-up 2-item input from peer A triggers a second size flush.
+    ///
+    /// Guarantee: the second flush's batch carries `peer_addr = None` —
+    /// the retained portion correctly recorded the mixed-peer merge as
+    /// `None` rather than misattributing to one arbitrary contributor.
+    #[test]
+    fn test_take_remaining_drops_peer_addr_multi_input_different_peers() {
+        let (_telemetry_registry, _metrics_reporter, phase) = setup_test_runtime(json!({
+            "otap": {
+                "min_size": 4,
+                "max_size": 5,
+                "sizer": "items",
+            },
+            "max_batch_duration": "10s"
+        }));
+
+        phase
+            .run_test(move |mut ctx| async move {
+                let peer_a: SocketAddr = "10.0.0.1:5000".parse().unwrap();
+                let peer_b: SocketAddr = "10.0.0.2:5000".parse().unwrap();
+
+                for (idx, count, peer) in [(0usize, 3usize, peer_a), (1, 3, peer_a), (2, 2, peer_b)]
+                {
+                    let rec = encode_logs_otap_batch(&logs_with_n_records(idx, count))
+                        .expect("encode logs");
+                    ctx.process(Message::PData(
+                        OtapPdata::new_default(rec.into()).with_peer_addr(peer),
+                    ))
+                    .await
+                    .expect("process input");
+                }
+
+                let _first = ctx.drain_pdata().await;
+
+                let extra =
+                    encode_logs_otap_batch(&logs_with_n_records(3, 2)).expect("encode logs");
+                ctx.process(Message::PData(
+                    OtapPdata::new_default(extra.into()).with_peer_addr(peer_a),
+                ))
+                .await
+                .expect("process follow-up input");
+
+                let second = ctx.drain_pdata().await;
+                assert_eq!(second.len(), 1, "second flush should emit one batch");
+                assert_eq!(
+                    second[0].peer_addr(),
+                    None,
+                    "retained partial spanning distinct peers must not be attributed to one"
+                );
             })
             .validate(|_| async {});
     }

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
@@ -59,6 +59,7 @@ use otap_df_telemetry::metrics::MetricSet;
 use otap_df_telemetry_macros::metric_set;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::net::SocketAddr;
 use std::num::NonZeroU64;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
@@ -411,6 +412,11 @@ struct BatchContext {
 struct BatchPortion {
     /// The number of these matches Signalbuffer.inbound[inkey]
     inkey: Option<SlotKey>,
+    /// Peer address observed by the receiving socket for the input that this
+    /// portion came from. Retained on every portion (whether or not the input
+    /// requested ack/nack) so that a merged output batch's `peer_addr` can be
+    /// computed even when the contributing inputs had no subscribers.
+    peer_addr: Option<SocketAddr>,
     /// Weight of this portion in the active sizer's unit.
     weight: usize,
 }
@@ -845,6 +851,12 @@ where
             return Ok(());
         }
 
+        // Capture the receiver-observed peer address before `ctx` may be
+        // moved into BatchContext below. The portion retains it so the
+        // flush path can merge peer_addr across contributing inputs even
+        // when none of them subscribed to ack/nack.
+        let peer_addr = ctx.peer_addr();
+
         // If there are subscribers, calculate an inbound slot key.
         let inkey = if ctx.has_subscribers() {
             let slot = self
@@ -883,7 +895,7 @@ where
 
         self.buffer
             .inputs
-            .accept(payload, BatchPortion::new(inkey, weight));
+            .accept(payload, BatchPortion::new(inkey, peer_addr, weight));
 
         let pending_size = self.buffer.inputs.size_by(self.fmtcfg.sizer)?;
 
@@ -1060,7 +1072,16 @@ where
 
             // If any inputs in this batch require notification, get an
             // outbound slot and subscribe.
-            if let Some(ctxs) = self.buffer.drain_context(weight, &mut input_context) {
+            let (routed_ctxs, merged_peer) =
+                self.buffer.drain_context(weight, &mut input_context);
+            // Forward the receiver-observed peer address only when every
+            // input merged into this output batch came from the same peer
+            // (see Context::merge_peer_addr). Mixed-peer batches leave
+            // peer_addr as None to avoid misattribution.
+            if let Some(addr) = merged_peer {
+                pdata.set_peer_addr(addr);
+            }
+            if let Some(ctxs) = routed_ctxs {
                 match self.buffer.outbound.allocate_with_data(ctxs) {
                     Err(ctxs) => {
                         for bp in ctxs {
@@ -1325,8 +1346,12 @@ where
 }
 
 impl BatchPortion {
-    const fn new(inkey: Option<SlotKey>, weight: usize) -> Self {
-        Self { inkey, weight }
+    const fn new(inkey: Option<SlotKey>, peer_addr: Option<SocketAddr>, weight: usize) -> Self {
+        Self {
+            inkey,
+            peer_addr,
+            weight,
+        }
     }
 }
 
@@ -1415,7 +1440,7 @@ where
         let remaining = output_batches.pop().expect("has last");
         let last_input = from_inputs.context.last().expect("has last");
         let last_weight = sizer.batch_size(&remaining).expect("known size");
-        let new_part = BatchPortion::new(last_input.inkey, last_weight);
+        let new_part = BatchPortion::new(last_input.inkey, last_input.peer_addr, last_weight);
 
         from_inputs.weight -= last_weight;
 
@@ -1433,8 +1458,12 @@ where
         &mut self,
         mut weight: usize,
         contexts: &mut MultiContext,
-    ) -> Option<Vec<BatchPortion>> {
+    ) -> (Option<Vec<BatchPortion>>, Option<SocketAddr>) {
         let mut out = Vec::new();
+        // Track every contributing portion's peer_addr, even ones that do not
+        // route ack/nack, so the merged output `peer_addr` is correct when
+        // some (or all) inputs had no subscribers.
+        let mut peers: Vec<Option<SocketAddr>> = Vec::new();
 
         while weight > 0 && contexts.pos < contexts.inputs.len() {
             let bp = contexts.inputs.get_mut(contexts.pos).expect("valid");
@@ -1442,6 +1471,8 @@ where
             let take = bp.weight.min(weight);
             bp.weight -= take;
             weight -= take;
+            let peer_addr = bp.peer_addr;
+            peers.push(peer_addr);
 
             if bp.weight == 0 {
                 contexts.pos += 1;
@@ -1452,11 +1483,13 @@ where
             {
                 batch.outbound += 1;
 
-                out.push(BatchPortion::new(Some(inkey), take));
+                out.push(BatchPortion::new(Some(inkey), peer_addr, take));
             }
         }
 
-        (!out.is_empty()).then_some(out)
+        let merged_peer = Context::merge_peer_addr(peers);
+        let routed = (!out.is_empty()).then_some(out);
+        (routed, merged_peer)
     }
 
     /// Handles a response, returning an Ack or Nack conditionally when
@@ -3402,6 +3435,136 @@ mod tests {
                 }
 
                 assert_eq!(nack_count, 1);
+            })
+            .validate(|_| async {});
+    }
+
+    /// Scenario: every input merged into one output batch carries the same
+    /// `peer_addr`. Guarantee: the flushed batch's `peer_addr` equals that
+    /// common address (single-peer batches keep working as if no merge
+    /// happened).
+    #[test]
+    fn test_flush_peer_addr_preserved_when_single_peer() {
+        let (_telemetry_registry, _metrics_reporter, phase) = setup_test_runtime(json!({
+            "otap": {
+                "min_size": 4,
+                "max_size": 5,
+                "sizer": "items",
+            },
+            "max_batch_duration": "1s"
+        }));
+
+        phase
+            .run_test(move |mut ctx| async move {
+                let peer: SocketAddr = "10.0.0.1:5000".parse().unwrap();
+                let mut datagen = DataGenerator::new(1);
+
+                // Send enough inputs to size-trigger one output batch.
+                for _ in 0..2 {
+                    let rec = encode_logs_otap_batch(&datagen.generate_logs())
+                        .expect("encode logs");
+                    let pdata = OtapPdata::new_default(rec.into()).with_peer_addr(peer);
+                    ctx.process(Message::PData(pdata))
+                        .await
+                        .expect("process input");
+                }
+
+                let outputs = ctx.drain_pdata().await;
+                assert!(!outputs.is_empty(), "size flush should produce a batch");
+                for out in outputs {
+                    assert_eq!(
+                        out.peer_addr(),
+                        Some(peer),
+                        "single-peer batch must preserve peer_addr"
+                    );
+                }
+            })
+            .validate(|_| async {});
+    }
+
+    /// Scenario: inputs merged into one output batch came from distinct
+    /// peers. Guarantee: the flushed batch's `peer_addr` is `None` (no
+    /// silent misattribution to one arbitrary contributor).
+    #[test]
+    fn test_flush_peer_addr_dropped_when_mixed_peers() {
+        let (_telemetry_registry, _metrics_reporter, phase) = setup_test_runtime(json!({
+            "otap": {
+                "min_size": 4,
+                "max_size": 5,
+                "sizer": "items",
+            },
+            "max_batch_duration": "1s"
+        }));
+
+        phase
+            .run_test(move |mut ctx| async move {
+                let peer_a: SocketAddr = "10.0.0.1:5000".parse().unwrap();
+                let peer_b: SocketAddr = "10.0.0.2:5000".parse().unwrap();
+                let mut datagen = DataGenerator::new(1);
+
+                for peer in [peer_a, peer_b] {
+                    let rec = encode_logs_otap_batch(&datagen.generate_logs())
+                        .expect("encode logs");
+                    let pdata = OtapPdata::new_default(rec.into()).with_peer_addr(peer);
+                    ctx.process(Message::PData(pdata))
+                        .await
+                        .expect("process input");
+                }
+
+                let outputs = ctx.drain_pdata().await;
+                assert!(!outputs.is_empty(), "size flush should produce a batch");
+                for out in outputs {
+                    assert_eq!(
+                        out.peer_addr(),
+                        None,
+                        "mixed-peer batch must not be attributed to one peer"
+                    );
+                }
+            })
+            .validate(|_| async {});
+    }
+
+    /// Scenario: at least one input has no peer_addr (e.g. came from a
+    /// sourceless receiver). Guarantee: the flushed batch's `peer_addr`
+    /// is `None`.
+    #[test]
+    fn test_flush_peer_addr_dropped_when_any_input_peerless() {
+        let (_telemetry_registry, _metrics_reporter, phase) = setup_test_runtime(json!({
+            "otap": {
+                "min_size": 4,
+                "max_size": 5,
+                "sizer": "items",
+            },
+            "max_batch_duration": "1s"
+        }));
+
+        phase
+            .run_test(move |mut ctx| async move {
+                let peer: SocketAddr = "10.0.0.1:5000".parse().unwrap();
+                let mut datagen = DataGenerator::new(1);
+
+                // First input has a peer, second does not.
+                let rec1 = encode_logs_otap_batch(&datagen.generate_logs()).expect("encode logs");
+                ctx.process(Message::PData(
+                    OtapPdata::new_default(rec1.into()).with_peer_addr(peer),
+                ))
+                .await
+                .expect("process input");
+
+                let rec2 = encode_logs_otap_batch(&datagen.generate_logs()).expect("encode logs");
+                ctx.process(Message::PData(OtapPdata::new_default(rec2.into())))
+                    .await
+                    .expect("process input");
+
+                let outputs = ctx.drain_pdata().await;
+                assert!(!outputs.is_empty(), "size flush should produce a batch");
+                for out in outputs {
+                    assert_eq!(
+                        out.peer_addr(),
+                        None,
+                        "any peerless contributor must drop peer_addr on the merged batch"
+                    );
+                }
             })
             .validate(|_| async {});
     }

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
@@ -1072,8 +1072,7 @@ where
 
             // If any inputs in this batch require notification, get an
             // outbound slot and subscribe.
-            let (routed_ctxs, merged_peer) =
-                self.buffer.drain_context(weight, &mut input_context);
+            let (routed_ctxs, merged_peer) = self.buffer.drain_context(weight, &mut input_context);
             // Forward the receiver-observed peer address only when every
             // input merged into this output batch came from the same peer
             // (see Context::merge_peer_addr). Mixed-peer batches leave
@@ -3461,8 +3460,8 @@ mod tests {
 
                 // Send enough inputs to size-trigger one output batch.
                 for _ in 0..2 {
-                    let rec = encode_logs_otap_batch(&datagen.generate_logs())
-                        .expect("encode logs");
+                    let rec =
+                        encode_logs_otap_batch(&datagen.generate_logs()).expect("encode logs");
                     let pdata = OtapPdata::new_default(rec.into()).with_peer_addr(peer);
                     ctx.process(Message::PData(pdata))
                         .await
@@ -3503,8 +3502,8 @@ mod tests {
                 let mut datagen = DataGenerator::new(1);
 
                 for peer in [peer_a, peer_b] {
-                    let rec = encode_logs_otap_batch(&datagen.generate_logs())
-                        .expect("encode logs");
+                    let rec =
+                        encode_logs_otap_batch(&datagen.generate_logs()).expect("encode logs");
                     let pdata = OtapPdata::new_default(rec.into()).with_peer_addr(peer);
                     ctx.process(Message::PData(pdata))
                         .await

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/mod.rs
@@ -6,7 +6,6 @@
 //! This processor decreases telemetry volume by reaggregating metrics collected
 //! at a higher frequency into a lower one.
 
-use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -33,7 +32,7 @@ use otap_df_engine::processor::{ProcessorRuntimeRequirements, ProcessorWrapper};
 use otap_df_engine::{ConsumerEffectHandlerExtension, Interests};
 use otap_df_otap::OTAP_PROCESSOR_FACTORIES;
 use otap_df_otap::accessory::slots::{Key as SlotKey, State as SlotState};
-use otap_df_otap::pdata::{Context, OtapPdata};
+use otap_df_otap::pdata::{Context, OtapPdata, PeerAddrMerger};
 use otap_df_pdata::otap::OtapArrowRecords;
 use otap_df_pdata::views::otap::OtapMetricsView;
 use otap_df_pdata::views::otlp::bytes::metrics::RawMetricsData;
@@ -241,12 +240,12 @@ pub struct TemporalReaggregationProcessor {
     /// flushed.
     pending_flush: Vec<CallData>,
 
-    /// Receiver-observed peer addresses of every input whose data contributed
-    /// to [Self::builder]. Tracked independently of subscriber state so that
-    /// flushes from no-subscriber inputs can also forward `peer_addr` (via
-    /// [`Context::merge_peer_addr`]) when all contributing inputs agreed.
-    /// Drained on every flush alongside the builder.
-    aggregated_peer_addrs: Vec<Option<SocketAddr>>,
+    /// Running merge of the receiver-observed peer addresses of every input
+    /// whose data contributed to [Self::builder]. Tracked independently of
+    /// subscriber state so that flushes from no-subscriber inputs can also
+    /// forward `peer_addr` when all contributing inputs agreed. Reset on
+    /// every flush alongside the builder.
+    aggregated_peer: PeerAddrMerger,
 
     /// A map of all passthrough and aggregated batches sent by this processor.
     /// The CallData returned to this processor in ack/nack messages can be
@@ -361,7 +360,7 @@ impl TemporalReaggregationProcessor {
             inbound_batches: SlotState::new(config.inbound_request_limit.get()),
             pending_flush: Vec::new(),
             outbound_batches: SlotState::new(config.outbound_request_limit.get()),
-            aggregated_peer_addrs: Vec::new(),
+            aggregated_peer: PeerAddrMerger::new(),
         })
     }
 
@@ -647,7 +646,7 @@ impl TemporalReaggregationProcessor {
                     // The aggregated portion of this input has been folded into
                     // the in-progress builder; remember its peer_addr so the
                     // next flush can compute the merged output peer_addr.
-                    self.aggregated_peer_addrs.push(pdata.peer_addr());
+                    self.aggregated_peer.push(pdata.peer_addr());
                     // Pass data through if there are no subscribers — but we
                     // still need a wakeup to flush the aggregated portion.
                     let (inbound_ctx, _) = pdata.into_parts();
@@ -705,7 +704,7 @@ impl TemporalReaggregationProcessor {
                 AggregationResult::AllAggregated => {
                     // The full input was folded into the in-progress builder;
                     // remember its peer_addr for the next flush.
-                    self.aggregated_peer_addrs.push(pdata.peer_addr());
+                    self.aggregated_peer.push(pdata.peer_addr());
                     // Nothing to passthrough and no subscribers so we don't
                     // care about ack/nack — but we still need a wakeup to
                     // flush the aggregated data.
@@ -760,10 +759,10 @@ impl TemporalReaggregationProcessor {
         checkpoint: Option<Checkpoint>,
     ) -> Result<(), Error> {
         let records = self.builder.finish(checkpoint);
-        // Compute the merged peer_addr from every input that contributed to
-        // this aggregate before clear_state drains the accumulator. Returns
-        // None when contributing inputs disagreed or any were peerless.
-        let merged_peer = Context::merge_peer_addr(std::mem::take(&mut self.aggregated_peer_addrs));
+        // Snapshot the merged peer_addr from every input that contributed to
+        // this aggregate before clear_state resets the running merger.
+        // Returns None when contributing inputs disagreed or any were peerless.
+        let merged_peer = self.aggregated_peer.finish();
         self.clear_state();
         // Whenever we flush we cancel the current wakeup if any. Wakeups are
         // scheduled whenever we start aggregating a new batch
@@ -1356,7 +1355,7 @@ impl TemporalReaggregationProcessor {
     fn clear_state(&mut self) {
         self.identities.clear();
         self.builder.clear();
-        self.aggregated_peer_addrs.clear();
+        self.aggregated_peer = PeerAddrMerger::new();
     }
 }
 
@@ -1424,6 +1423,7 @@ mod tests {
     use super::testing::*;
     use super::*;
     use std::future::Future;
+    use std::net::SocketAddr;
 
     use otap_df_engine::testing::processor::TestContext;
     use otap_df_pdata::otap::OtapBatchStore;

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/mod.rs
@@ -6,6 +6,7 @@
 //! This processor decreases telemetry volume by reaggregating metrics collected
 //! at a higher frequency into a lower one.
 
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -240,6 +241,13 @@ pub struct TemporalReaggregationProcessor {
     /// flushed.
     pending_flush: Vec<CallData>,
 
+    /// Receiver-observed peer addresses of every input whose data contributed
+    /// to [Self::builder]. Tracked independently of subscriber state so that
+    /// flushes from no-subscriber inputs can also forward `peer_addr` (via
+    /// [`Context::merge_peer_addr`]) when all contributing inputs agreed.
+    /// Drained on every flush alongside the builder.
+    aggregated_peer_addrs: Vec<Option<SocketAddr>>,
+
     /// A map of all passthrough and aggregated batches sent by this processor.
     /// The CallData returned to this processor in ack/nack messages can be
     /// casted to a [SlotKey] and points into this map.
@@ -353,6 +361,7 @@ impl TemporalReaggregationProcessor {
             inbound_batches: SlotState::new(config.inbound_request_limit.get()),
             pending_flush: Vec::new(),
             outbound_batches: SlotState::new(config.outbound_request_limit.get()),
+            aggregated_peer_addrs: Vec::new(),
         })
     }
 
@@ -635,6 +644,10 @@ impl TemporalReaggregationProcessor {
                     Ok(effect_handler.send_message_with_source_node(pdata).await?)
                 }
                 AggregationResult::SomeAggregations(records) => {
+                    // The aggregated portion of this input has been folded into
+                    // the in-progress builder; remember its peer_addr so the
+                    // next flush can compute the merged output peer_addr.
+                    self.aggregated_peer_addrs.push(pdata.peer_addr());
                     // Pass data through if there are no subscribers — but we
                     // still need a wakeup to flush the aggregated portion.
                     let (inbound_ctx, _) = pdata.into_parts();
@@ -648,6 +661,10 @@ impl TemporalReaggregationProcessor {
                             .await?;
                         return Ok(());
                     }
+
+                    // The partial-passthrough output represents exactly one
+                    // input, so forward its peer_addr unconditionally.
+                    let passthrough_peer = inbound_ctx.peer_addr();
 
                     // One ref for the passthrough, we will bump the ack count again
                     // when we actually flush the batch.
@@ -671,6 +688,9 @@ impl TemporalReaggregationProcessor {
                     let context = Context::with_capacity(1);
                     let mut pt_pdata =
                         OtapPdata::new(context, OtapPayload::OtapArrowRecords(records));
+                    if let Some(addr) = passthrough_peer {
+                        pt_pdata.set_peer_addr(addr);
+                    }
 
                     effect_handler.subscribe_to(
                         Interests::ACKS | Interests::NACKS,
@@ -683,6 +703,9 @@ impl TemporalReaggregationProcessor {
                         .await?)
                 }
                 AggregationResult::AllAggregated => {
+                    // The full input was folded into the in-progress builder;
+                    // remember its peer_addr for the next flush.
+                    self.aggregated_peer_addrs.push(pdata.peer_addr());
                     // Nothing to passthrough and no subscribers so we don't
                     // care about ack/nack — but we still need a wakeup to
                     // flush the aggregated data.
@@ -737,6 +760,11 @@ impl TemporalReaggregationProcessor {
         checkpoint: Option<Checkpoint>,
     ) -> Result<(), Error> {
         let records = self.builder.finish(checkpoint);
+        // Compute the merged peer_addr from every input that contributed to
+        // this aggregate before clear_state drains the accumulator. Returns
+        // None when contributing inputs disagreed or any were peerless.
+        let merged_peer =
+            Context::merge_peer_addr(std::mem::take(&mut self.aggregated_peer_addrs));
         self.clear_state();
         // Whenever we flush we cancel the current wakeup if any. Wakeups are
         // scheduled whenever we start aggregating a new batch
@@ -751,7 +779,10 @@ impl TemporalReaggregationProcessor {
         // Nobody was subscribed to anything here
         if pending_flush_calldata.is_empty() {
             let context = Context::default();
-            let pdata = OtapPdata::new(context, OtapPayload::OtapArrowRecords(records));
+            let mut pdata = OtapPdata::new(context, OtapPayload::OtapArrowRecords(records));
+            if let Some(addr) = merged_peer {
+                pdata.set_peer_addr(addr);
+            }
             effect_handler.send_message_with_source_node(pdata).await?;
             return Ok(());
         }
@@ -776,6 +807,9 @@ impl TemporalReaggregationProcessor {
         let outbound_calldata: CallData = outbound_key.into();
         let outbound_ctx = Context::with_capacity(1);
         let mut pdata = OtapPdata::new(outbound_ctx, OtapPayload::OtapArrowRecords(records));
+        if let Some(addr) = merged_peer {
+            pdata.set_peer_addr(addr);
+        }
         effect_handler.subscribe_to(
             Interests::ACKS | Interests::NACKS,
             outbound_calldata,
@@ -1323,6 +1357,7 @@ impl TemporalReaggregationProcessor {
     fn clear_state(&mut self) {
         self.identities.clear();
         self.builder.clear();
+        self.aggregated_peer_addrs.clear();
     }
 }
 
@@ -3537,5 +3572,98 @@ mod tests {
             );
             assert!(ctx.drain_pdata().await.is_empty());
         });
+    }
+
+    /// AllAggregated flush path: all contributing inputs share one peer.
+    /// Guarantee: the flushed aggregate's `peer_addr` equals that peer.
+    #[test]
+    fn test_flush_peer_addr_preserved_when_single_peer() {
+        let peer: SocketAddr = "10.0.0.1:5000".parse().unwrap();
+        let config = json!({});
+        let actions = vec![
+            Action::SendPdataWithPeer {
+                interests: Interests::empty(),
+                payload: make_otap_payload_from_metrics(make_n_gauge_metrics(1)),
+                peer_addr: peer,
+            },
+            Action::SendPdataWithPeer {
+                interests: Interests::empty(),
+                payload: make_otap_payload_from_metrics(make_n_gauge_metrics_with_offset(1, 1)),
+                peer_addr: peer,
+            },
+            Action::FireWakeup,
+            Action::DrainPdata {
+                actions: vec![PdataAction::AssertCustom(Box::new(move |out| {
+                    assert_eq!(
+                        out.peer_addr(),
+                        Some(peer),
+                        "single-peer aggregate must preserve peer_addr"
+                    );
+                }))],
+            },
+        ];
+        run_test(config, actions);
+    }
+
+    /// AllAggregated flush path: contributing inputs came from distinct peers.
+    /// Guarantee: the flushed aggregate's `peer_addr` is `None`.
+    #[test]
+    fn test_flush_peer_addr_dropped_when_mixed_peers() {
+        let peer_a: SocketAddr = "10.0.0.1:5000".parse().unwrap();
+        let peer_b: SocketAddr = "10.0.0.2:5000".parse().unwrap();
+        let config = json!({});
+        let actions = vec![
+            Action::SendPdataWithPeer {
+                interests: Interests::empty(),
+                payload: make_otap_payload_from_metrics(make_n_gauge_metrics(1)),
+                peer_addr: peer_a,
+            },
+            Action::SendPdataWithPeer {
+                interests: Interests::empty(),
+                payload: make_otap_payload_from_metrics(make_n_gauge_metrics_with_offset(1, 1)),
+                peer_addr: peer_b,
+            },
+            Action::FireWakeup,
+            Action::DrainPdata {
+                actions: vec![PdataAction::AssertCustom(Box::new(|out| {
+                    assert_eq!(
+                        out.peer_addr(),
+                        None,
+                        "mixed-peer aggregate must not be attributed to one peer"
+                    );
+                }))],
+            },
+        ];
+        run_test(config, actions);
+    }
+
+    /// Partial-passthrough subscriber path: forwards the single input's
+    /// peer address directly to the passthrough output.
+    #[test]
+    fn test_passthrough_subscriber_forwards_peer_addr() {
+        let peer: SocketAddr = "10.0.0.1:5000".parse().unwrap();
+        let config = json!({});
+        let actions = vec![
+            Action::SendPdataWithPeer {
+                interests: Interests::ACKS | Interests::NACKS,
+                payload: make_mixed_metrics_payload(),
+                peer_addr: peer,
+            },
+            // First drained output is the partial passthrough.
+            Action::DrainPdata {
+                actions: vec![
+                    PdataAction::AssertSubscribers(true),
+                    PdataAction::AssertCustom(Box::new(move |out| {
+                        assert_eq!(
+                            out.peer_addr(),
+                            Some(peer),
+                            "single-input passthrough must forward peer_addr"
+                        );
+                    })),
+                    PdataAction::Ack,
+                ],
+            },
+        ];
+        run_test(config, actions);
     }
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/mod.rs
@@ -763,8 +763,7 @@ impl TemporalReaggregationProcessor {
         // Compute the merged peer_addr from every input that contributed to
         // this aggregate before clear_state drains the accumulator. Returns
         // None when contributing inputs disagreed or any were peerless.
-        let merged_peer =
-            Context::merge_peer_addr(std::mem::take(&mut self.aggregated_peer_addrs));
+        let merged_peer = Context::merge_peer_addr(std::mem::take(&mut self.aggregated_peer_addrs));
         self.clear_state();
         // Whenever we flush we cancel the current wakeup if any. Wakeups are
         // scheduled whenever we start aggregating a new batch

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/testing.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/testing.rs
@@ -4,6 +4,7 @@
 //! Declarative test framework for temporal reaggregation processor ack/nack
 //! scenarios.
 
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use otap_df_config::SignalType;
@@ -49,6 +50,14 @@ pub(super) enum Action {
     SendPdata {
         interests: Interests,
         payload: OtapPayload,
+    },
+
+    /// Send pdata with optional ack/nack subscriber interest and an attached
+    /// peer socket address — mirrors what receivers do at request acceptance.
+    SendPdataWithPeer {
+        interests: Interests,
+        payload: OtapPayload,
+        peer_addr: SocketAddr,
     },
 
     /// Send a message to the processor
@@ -116,6 +125,24 @@ pub(super) fn run_test(config: serde_json::Value, actions: Vec<Action>) {
                 match action {
                     Action::SendPdata { interests, payload } => {
                         let mut pdata = OtapPdata::new_default(payload);
+                        if !interests.is_empty() {
+                            pdata = pdata.test_subscribe_to(
+                                interests,
+                                TestCallData::new_with(input_idx, 0).into(),
+                                1,
+                            );
+                        }
+                        ctx.process(Message::PData(pdata))
+                            .await
+                            .expect("process pdata");
+                        input_idx += 1;
+                    }
+                    Action::SendPdataWithPeer {
+                        interests,
+                        payload,
+                        peer_addr,
+                    } => {
+                        let mut pdata = OtapPdata::new_default(payload).with_peer_addr(peer_addr);
                         if !interests.is_empty() {
                             pdata = pdata.test_subscribe_to(
                                 interests,

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -343,14 +343,11 @@ impl Context {
     where
         I: IntoIterator<Item = Option<SocketAddr>>,
     {
-        let mut iter = inputs.into_iter();
-        let first = iter.next()??;
-        for next in iter {
-            if next? != first {
-                return None;
-            }
+        let mut merger = PeerAddrMerger::new();
+        for next in inputs {
+            merger.push(next);
         }
-        Some(first)
+        merger.finish()
     }
 
     /// Get the source node for this context.
@@ -375,6 +372,63 @@ impl Context {
 }
 
 // Frame is defined in otap_df_engine::control (imported above).
+
+/// Incremental builder applying the same merge rule as
+/// [`Context::merge_peer_addr`] without allocating a `Vec` of intermediate
+/// peer addresses.
+///
+/// Use when contributing inputs are observed one-at-a-time as part of an
+/// existing pass over the input list (e.g. a processor's flush loop). Push
+/// each input's `peer_addr` exactly once with [`PeerAddrMerger::push`], then
+/// call [`PeerAddrMerger::finish`] to obtain the merged result.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PeerAddrMerger {
+    candidate: Option<SocketAddr>,
+    started: bool,
+    poisoned: bool,
+}
+
+impl PeerAddrMerger {
+    /// Create an empty merger. `finish` on an unused merger returns `None`.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            candidate: None,
+            started: false,
+            poisoned: false,
+        }
+    }
+
+    /// Fold one contributing input's `peer_addr` into the running merge.
+    pub fn push(&mut self, peer_addr: Option<SocketAddr>) {
+        if self.poisoned {
+            return;
+        }
+        match peer_addr {
+            None => {
+                self.poisoned = true;
+                self.candidate = None;
+            }
+            Some(addr) if !self.started => {
+                self.started = true;
+                self.candidate = Some(addr);
+            }
+            Some(addr) => {
+                if self.candidate != Some(addr) {
+                    self.poisoned = true;
+                    self.candidate = None;
+                }
+            }
+        }
+    }
+
+    /// Return the merged peer address, or `None` if no inputs were pushed or
+    /// the merge was poisoned by a peerless or distinct contributor.
+    #[must_use]
+    pub const fn finish(self) -> Option<SocketAddr> {
+        self.candidate
+    }
+}
 
 impl otap_df_engine::Unwindable for OtapPdata {
     fn has_frames(&self) -> bool {
@@ -2415,5 +2469,47 @@ mod test {
 
         // Distinct Somes → None (refuse to misattribute).
         assert_eq!(Context::merge_peer_addr([Some(a), Some(b)]), None);
+    }
+
+    #[test]
+    fn peer_addr_merger_matches_merge_peer_addr() {
+        let a: SocketAddr = "10.0.0.1:1".parse().unwrap();
+        let b: SocketAddr = "10.0.0.2:2".parse().unwrap();
+
+        // Empty.
+        let m = PeerAddrMerger::new();
+        assert_eq!(m.finish(), None);
+
+        // Single Some.
+        let mut m = PeerAddrMerger::new();
+        m.push(Some(a));
+        assert_eq!(m.finish(), Some(a));
+
+        // All identical.
+        let mut m = PeerAddrMerger::new();
+        m.push(Some(a));
+        m.push(Some(a));
+        m.push(Some(a));
+        assert_eq!(m.finish(), Some(a));
+
+        // Any None poisons subsequent pushes.
+        let mut m = PeerAddrMerger::new();
+        m.push(Some(a));
+        m.push(None);
+        m.push(Some(a));
+        assert_eq!(m.finish(), None);
+
+        // Distinct Somes.
+        let mut m = PeerAddrMerger::new();
+        m.push(Some(a));
+        m.push(Some(b));
+        assert_eq!(m.finish(), None);
+
+        // After conflict, further identical pushes do not "heal" the result.
+        let mut m = PeerAddrMerger::new();
+        m.push(Some(a));
+        m.push(Some(b));
+        m.push(Some(a));
+        assert_eq!(m.finish(), None);
     }
 }

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -2403,7 +2403,10 @@ mod test {
         assert_eq!(Context::merge_peer_addr([Some(a)]), Some(a));
 
         // All identical → that address.
-        assert_eq!(Context::merge_peer_addr([Some(a), Some(a), Some(a)]), Some(a));
+        assert_eq!(
+            Context::merge_peer_addr([Some(a), Some(a), Some(a)]),
+            Some(a)
+        );
 
         // Any None → None.
         assert_eq!(Context::merge_peer_addr([Some(a), None]), None);

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -381,52 +381,48 @@ impl Context {
 /// existing pass over the input list (e.g. a processor's flush loop). Push
 /// each input's `peer_addr` exactly once with [`PeerAddrMerger::push`], then
 /// call [`PeerAddrMerger::finish`] to obtain the merged result.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct PeerAddrMerger {
-    candidate: Option<SocketAddr>,
-    started: bool,
-    poisoned: bool,
+///
+/// Modeled as an enum so illegal states (e.g. a peer address present
+/// alongside a poisoned flag) cannot be constructed.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum PeerAddrMerger {
+    /// No inputs pushed yet.
+    #[default]
+    Empty,
+    /// Every input pushed so far agreed on this address.
+    Single(SocketAddr),
+    /// At least one input was peerless or distinct from a prior agreed
+    /// address. The merge stays in this state regardless of later pushes.
+    Poisoned,
 }
 
 impl PeerAddrMerger {
     /// Create an empty merger. `finish` on an unused merger returns `None`.
     #[must_use]
     pub const fn new() -> Self {
-        Self {
-            candidate: None,
-            started: false,
-            poisoned: false,
-        }
+        Self::Empty
     }
 
     /// Fold one contributing input's `peer_addr` into the running merge.
     pub fn push(&mut self, peer_addr: Option<SocketAddr>) {
-        if self.poisoned {
-            return;
-        }
-        match peer_addr {
-            None => {
-                self.poisoned = true;
-                self.candidate = None;
-            }
-            Some(addr) if !self.started => {
-                self.started = true;
-                self.candidate = Some(addr);
-            }
-            Some(addr) => {
-                if self.candidate != Some(addr) {
-                    self.poisoned = true;
-                    self.candidate = None;
-                }
-            }
-        }
+        *self = match (*self, peer_addr) {
+            (Self::Empty, None) => Self::Poisoned,
+            (Self::Empty, Some(addr)) => Self::Single(addr),
+            (Self::Single(_), None) => Self::Poisoned,
+            (Self::Single(existing), Some(addr)) if existing == addr => Self::Single(existing),
+            (Self::Single(_), Some(_)) => Self::Poisoned,
+            (Self::Poisoned, _) => Self::Poisoned,
+        };
     }
 
     /// Return the merged peer address, or `None` if no inputs were pushed or
     /// the merge was poisoned by a peerless or distinct contributor.
     #[must_use]
     pub const fn finish(self) -> Option<SocketAddr> {
-        self.candidate
+        match self {
+            Self::Single(addr) => Some(addr),
+            Self::Empty | Self::Poisoned => None,
+        }
     }
 }
 

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -332,6 +332,27 @@ impl Context {
         self.peer_addr = Some(addr);
     }
 
+    /// Merge peer addresses from a set of contributing inputs.
+    ///
+    /// Returns `Some(addr)` only when every contributing input observed the
+    /// same peer address. Returns `None` if any input was peerless or if
+    /// distinct peers contributed — merging processors must use this to
+    /// avoid attributing a multi-peer output to one arbitrary contributor.
+    #[must_use]
+    pub fn merge_peer_addr<I>(inputs: I) -> Option<SocketAddr>
+    where
+        I: IntoIterator<Item = Option<SocketAddr>>,
+    {
+        let mut iter = inputs.into_iter();
+        let first = iter.next()??;
+        for next in iter {
+            if next? != first {
+                return None;
+            }
+        }
+        Some(first)
+    }
+
     /// Get the source node for this context.
     #[must_use]
     pub fn source_node(&self) -> Option<usize> {
@@ -2368,5 +2389,28 @@ mod test {
             Some(addr),
             "peer_addr must survive transport-boundary clone"
         );
+    }
+
+    #[test]
+    fn merge_peer_addr_rules() {
+        let a: SocketAddr = "10.0.0.1:1".parse().unwrap();
+        let b: SocketAddr = "10.0.0.2:2".parse().unwrap();
+
+        // Empty input → None.
+        assert_eq!(Context::merge_peer_addr(std::iter::empty()), None);
+
+        // Single Some → that address.
+        assert_eq!(Context::merge_peer_addr([Some(a)]), Some(a));
+
+        // All identical → that address.
+        assert_eq!(Context::merge_peer_addr([Some(a), Some(a), Some(a)]), Some(a));
+
+        // Any None → None.
+        assert_eq!(Context::merge_peer_addr([Some(a), None]), None);
+        assert_eq!(Context::merge_peer_addr([None, Some(a)]), None);
+        assert_eq!(Context::merge_peer_addr([None, None]), None);
+
+        // Distinct Somes → None (refuse to misattribute).
+        assert_eq!(Context::merge_peer_addr([Some(a), Some(b)]), None);
     }
 }


### PR DESCRIPTION
# Change Summary

Preserve `OtapPdata::peer_addr` across the two processors that previously
dropped it when merging multiple inputs into one output batch
(`batch_processor` and `temporal_reaggregation_processor`).

Single-peer streams now retain the receiver-observed peer address end-to-end.
Multi-peer merges intentionally keep `peer_addr` as `None` to avoid attributing
a merged batch to one arbitrary contributor.

## What issue does this PR close?

- Closes #3228

## How are these changes tested?

- Unit test for the merge rule (empty / single / all-equal / any-`None` /
  distinct contributors).
- Three end-to-end tests per processor covering: single peer preserved,
  mixed peers dropped, peerless contributor drops. For
  `temporal_reaggregation_processor` an additional test covers the
  partial-passthrough subscriber path.

## Are there any user-facing changes?

Yes. Processors that consult `OtapPdata::peer_addr()` now observe the correct 
peer address downstream of `batch_processor` and `temporal_reaggregation_processor` 
for single-peer streams instead of always seeing `None`.

### Changelog

- [x] Added `rust/otap-dataflow/.chloggen/preserve-peer-address-merging-processors.yaml`.