### PR TITLE
Fix gRPC DNS startup check proxy selection

### DIFF
--- a/rust/otap-dataflow/.chloggen/grpc-dns-proxy-selection.yaml
+++ b/rust/otap-dataflow/.chloggen/grpc-dns-proxy-selection.yaml
@@ -1,0 +1,19 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: otap
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix gRPC startup DNS checks to skip local DNS only when the target endpoint actually uses a configured proxy."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [3222]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/rust/otap-dataflow/crates/otap/src/otap_grpc/client_settings.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_grpc/client_settings.rs
@@ -257,10 +257,10 @@ impl GrpcClientSettings {
             }
         });
 
-        // If a proxy is configured and the endpoint is not bypassed, the proxy performs DNS
-        // resolution -- skip the local check.
+        // If the actual connection path will use a proxy for this endpoint, the proxy performs
+        // DNS resolution -- skip the local check.
         let proxy = self.effective_proxy_config();
-        if proxy.has_proxy() && !proxy.should_bypass(&host, port) {
+        if proxy.get_proxy_for_uri(&uri).is_some() {
             return Ok(());
         }
 
@@ -1192,6 +1192,25 @@ mod tests {
         };
         // Should succeed because the proxy handles resolution.
         settings.run_startup_check().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn startup_check_dns_not_skipped_when_proxy_does_not_apply_to_endpoint_scheme() {
+        let settings = GrpcClientSettings {
+            grpc_endpoint: "http://this.host.definitely.does.not.exist.invalid:4317".to_string(),
+            startup_check: StartupCheck::Dns,
+            proxy: Some(ProxyConfig {
+                https_proxy: Some("http://my-proxy:3128".into()),
+                ..Default::default()
+            }),
+            ..GrpcClientSettings::default()
+        };
+
+        let err = settings.run_startup_check().await.unwrap_err();
+        assert!(
+            matches!(err, GrpcEndpointError::DnsCheckFailed { .. }),
+            "expected DnsCheckFailed, got: {err}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Change Summary

Fixes the gRPC `startup_check: dns` path so it skips local DNS resolution only when the target endpoint would actually use a configured proxy.

Previously, the check skipped whenever any proxy was configured. That was too broad: for example, an `http://` endpoint does not use `HTTPS_PROXY`, so local DNS is still required unless `HTTP_PROXY` or `ALL_PROXY` applies.

  ## What issue does this PR close?

  * Part of #3222

  ## How are these changes tested?

  * `cargo test -p otap-df-otap startup_check_dns_not_skipped_when_proxy_does_not_apply_to_endpoint_scheme`
  * `cargo check -p otap-df-otap --features crypto-ring`
  * `python3 tools/sanitycheck.py`
  * `cargo xtask check`

  ## Are there any user-facing changes?

  Yes. `startup_check: dns` now matches the real proxy selection path and catches DNS failures when a configured proxy does not apply to the endpoint scheme.

  ### Changelog

  * [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).