### PR TITLE
chore: update codecov action to v7

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -39,7 +39,7 @@ jobs:
       # the repo, update `codecov.notify.after_n_builds` in
       # .github/codecov.yaml so codecov waits for the new total.
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -84,7 +84,7 @@ jobs:
       # .github/codecov.yaml so codecov waits for the new total.
       - name: Upload to codecov.io
         if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -608,7 +608,7 @@ jobs:
       # the repo, update `codecov.notify.after_n_builds` in
       # .github/codecov.yaml so codecov waits for the new total.
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:


### PR DESCRIPTION
 ## Change Summary

  Updates `codecov/codecov-action` from v6.0.1 to v7.0.0 in the Go and Rust CI workflows.

Bump to Codecov v7 (released Jun 7th) to address the recent GPG/keybase migration issue that cause coverage upload steps to [fail](https://github.com/open-telemetry/otel-arrow/actions/runs/27088889435/job/79948607419?pr=3233) while verifying the downloaded Codecov CLI signature.

  ## What issue does this PR close?

  None.

  ## How are these changes tested?

  - Ran `python3 tools/sanitycheck.py`
  - Ran `git diff --check`

  ## Are there any user-facing changes?

  No. This is a CI maintenance chore.
