### PR TITLE
Adjust 'rename' syntax in OPL

### DIFF
--- a/rust/otap-dataflow/.chloggen/opl-rename-syntax.yaml
+++ b/rust/otap-dataflow/.chloggen/opl-rename-syntax.yaml
@@ -1,0 +1,4 @@
+change_type: breaking
+component: query-engine
+note: "OPL `rename` syntax changed from `rename attributes[\"new\"] = attributes[\"old\"]` to `rename attributes \"old\" as \"new\"`. The `project-rename` alias has been removed from OPL."
+issues: [3224]

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/opl.pest
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/opl.pest
@@ -194,8 +194,16 @@ assignment_expression = {
     (attribute_selection_expression | index_expression | identifier_expression) ~ "=" ~ expression
 }
 
+rename_pair = {
+    string_literal ~ "as" ~ string_literal
+}
+
+rename_target = {
+    attribute_selection_expression | identifier_expression
+}
+
 rename_operator_call = {
-    ("rename" | "project-rename") ~ assignment_expression ~ ("," ~ assignment_expression)*
+    "rename" ~ rename_target ~ rename_pair ~ ("," ~ rename_pair)*
 }
 
 remove_map_keys_operator_call = {

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/opl.pest
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/opl.pest
@@ -199,8 +199,7 @@ rename_pair = {
 }
 
 rename_target = {
-    attribute_selection_expression
-  | identifier_expression
+    identifier_expression ~ ("." ~ identifier_expression)*
 }
 
 rename_operator_call = {

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/opl.pest
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/opl.pest
@@ -199,7 +199,8 @@ rename_pair = {
 }
 
 rename_target = {
-    attribute_selection_expression | identifier_expression
+    attribute_selection_expression
+  | identifier_expression
 }
 
 rename_operator_call = {

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser/operator.rs
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser/operator.rs
@@ -205,7 +205,6 @@ pub(crate) fn parse_rename_operator_call(
             }
         };
 
-        // Build full paths: target_selectors + key
         let mut source_selectors = target_selectors.clone();
         source_selectors.push(ScalarExpression::Static(StaticScalarExpression::String(
             source_key,
@@ -248,7 +247,10 @@ fn parse_rename_target(rule: Pair<'_, Rule>) -> Result<Vec<ScalarExpression>, Pa
         match inner_rule.as_rule() {
             Rule::identifier_expression => {
                 selectors.push(ScalarExpression::Static(StaticScalarExpression::String(
-                    StringScalarExpression::new(to_query_location(&inner_rule), inner_rule.as_str()),
+                    StringScalarExpression::new(
+                        to_query_location(&inner_rule),
+                        inner_rule.as_str(),
+                    ),
                 )));
             }
             invalid_rule => {

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser/operator.rs
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser/operator.rs
@@ -158,7 +158,7 @@ pub(crate) fn parse_rename_operator_call(
         ParserError::SyntaxError(query_location.clone(), "expected rename target".to_string())
     })?;
 
-    let target_selectors = parse_rename_target(target_rule, pipeline_builder)?;
+    let target_selectors = parse_rename_target(target_rule)?;
 
     // Parse each rename pair ("old_key" as "new_key")
     let mut keys = Vec::with_capacity(inner_rules.len());
@@ -239,42 +239,36 @@ pub(crate) fn parse_rename_operator_call(
 /// For example:
 /// - `attributes` -> `["attributes"]`
 /// - `resource.attributes` -> `["resource", "attributes"]`
-fn parse_rename_target(
-    rule: Pair<'_, Rule>,
-    pipeline_builder: &dyn PipelineBuilder,
-) -> Result<Vec<ScalarExpression>, ParserError> {
+fn parse_rename_target(rule: Pair<'_, Rule>) -> Result<Vec<ScalarExpression>, ParserError> {
     let query_location = to_query_location(&rule);
-    let inner_rule = rule.into_inner().next().ok_or_else(|| {
-        ParserError::SyntaxError(
-            query_location.clone(),
-            "expected rename target content".to_string(),
-        )
-    })?;
+    let inner_rules = rule.into_inner();
+    let mut selectors = Vec::with_capacity(inner_rules.len());
 
-    match inner_rule.as_rule() {
-        Rule::identifier_expression => Ok(vec![ScalarExpression::Static(
-            StaticScalarExpression::String(StringScalarExpression::new(
-                to_query_location(&inner_rule),
-                inner_rule.as_str(),
-            )),
-        )]),
-        Rule::attribute_selection_expression => {
-            match parse_attribute_selection_expression(inner_rule, pipeline_builder)?.into() {
-                ScalarExpression::Source(source_expr) => {
-                    Ok(source_expr.into_value_accessor().into_selectors())
-                }
-                other => Err(ParserError::SyntaxNotSupported(
+    for inner_rule in inner_rules {
+        match inner_rule.as_rule() {
+            Rule::identifier_expression => {
+                selectors.push(ScalarExpression::Static(StaticScalarExpression::String(
+                    StringScalarExpression::new(to_query_location(&inner_rule), inner_rule.as_str()),
+                )));
+            }
+            invalid_rule => {
+                return Err(invalid_child_rule_error(
                     query_location,
-                    format!("expected source expression for rename target, found {other:?}"),
-                )),
+                    Rule::rename_target,
+                    invalid_rule,
+                ));
             }
         }
-        invalid_rule => Err(invalid_child_rule_error(
-            query_location,
-            Rule::rename_target,
-            invalid_rule,
-        )),
     }
+
+    if selectors.is_empty() {
+        return Err(ParserError::SyntaxError(
+            query_location,
+            "expected rename target content".to_string(),
+        ));
+    }
+
+    Ok(selectors)
 }
 
 pub(crate) fn parse_set_operator_call(

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser/operator.rs
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser/operator.rs
@@ -11,7 +11,8 @@ use data_engine_expressions::{
     PipelineFunction, PipelineFunctionExpression, PipelineFunctionParameter,
     PipelineFunctionParameterType, QueryLocation, ReduceMapTransformExpression,
     RenameMapKeysTransformExpression, ScalarExpression, SetTransformExpression,
-    SourceScalarExpression, StaticScalarExpression, TransformExpression, ValueAccessor, ValueType,
+    SourceScalarExpression, StaticScalarExpression, StringScalarExpression, TransformExpression,
+    ValueAccessor, ValueType,
 };
 use data_engine_parser_abstractions::{
     ParserError, parse_standard_string_literal, to_query_location,
@@ -150,25 +151,74 @@ pub(crate) fn parse_rename_operator_call(
     pipeline_builder: &mut dyn PipelineBuilder,
 ) -> Result<(), ParserError> {
     let query_location = to_query_location(&rule);
-    let inner_rules = rule.into_inner();
-    let mut keys = Vec::with_capacity(inner_rules.len());
+    let mut inner_rules = rule.into_inner();
 
-    for rule in inner_rules {
-        let (dest, source) = parse_assignment_expression(rule, pipeline_builder)?;
-        match source {
-            ScalarExpression::Source(source) => keys.push(MapKeyRenameSelector::new(
-                source.into_value_accessor(),
-                dest.into_value_accessor(),
-            )),
+    // Parse the rename target (e.g. `attributes`, `resource.attributes`)
+    let target_rule = inner_rules.next().ok_or_else(|| {
+        ParserError::SyntaxError(query_location.clone(), "expected rename target".to_string())
+    })?;
+
+    let target_selectors = parse_rename_target(target_rule, pipeline_builder)?;
+
+    // Parse each rename pair ("old_key" as "new_key")
+    let mut keys = Vec::with_capacity(inner_rules.len());
+    for pair_rule in inner_rules {
+        if pair_rule.as_rule() != Rule::rename_pair {
+            return Err(ParserError::SyntaxError(
+                to_query_location(&pair_rule),
+                format!("expected rename pair, found {:?}", pair_rule.as_rule()),
+            ));
+        }
+
+        let pair_location = to_query_location(&pair_rule);
+        let mut pair_inner = pair_rule.into_inner();
+
+        let source_key_rule = pair_inner.next().ok_or_else(|| {
+            ParserError::SyntaxError(
+                pair_location.clone(),
+                "expected source key in rename pair".to_string(),
+            )
+        })?;
+        let dest_key_rule = pair_inner.next().ok_or_else(|| {
+            ParserError::SyntaxError(
+                pair_location.clone(),
+                "expected destination key in rename pair".to_string(),
+            )
+        })?;
+
+        let source_key = match parse_standard_string_literal(source_key_rule) {
+            StaticScalarExpression::String(s) => s,
             other => {
-                return Err(ParserError::SyntaxNotSupported(
-                    query_location,
-                    format!(
-                        "rename operator only supports assignment from source. Found {other:?}"
-                    ),
+                return Err(ParserError::SyntaxError(
+                    pair_location,
+                    format!("expected string literal for source key, found {other:?}"),
                 ));
             }
-        }
+        };
+        let dest_key = match parse_standard_string_literal(dest_key_rule) {
+            StaticScalarExpression::String(s) => s,
+            other => {
+                return Err(ParserError::SyntaxError(
+                    pair_location,
+                    format!("expected string literal for destination key, found {other:?}"),
+                ));
+            }
+        };
+
+        // Build full paths: target_selectors + key
+        let mut source_selectors = target_selectors.clone();
+        source_selectors.push(ScalarExpression::Static(StaticScalarExpression::String(
+            source_key,
+        )));
+        let mut dest_selectors = target_selectors.clone();
+        dest_selectors.push(ScalarExpression::Static(StaticScalarExpression::String(
+            dest_key,
+        )));
+
+        keys.push(MapKeyRenameSelector::new(
+            ValueAccessor::new_with_selectors(source_selectors),
+            ValueAccessor::new_with_selectors(dest_selectors),
+        ));
     }
 
     let transform_expr = TransformExpression::RenameMapKeys(RenameMapKeysTransformExpression::new(
@@ -182,6 +232,49 @@ pub(crate) fn parse_rename_operator_call(
     pipeline_builder.push_data_expression(DataExpression::Transform(transform_expr));
 
     Ok(())
+}
+
+/// Parses the rename target rule into a list of selectors representing the attribute path.
+///
+/// For example:
+/// - `attributes` -> `["attributes"]`
+/// - `resource.attributes` -> `["resource", "attributes"]`
+fn parse_rename_target(
+    rule: Pair<'_, Rule>,
+    pipeline_builder: &dyn PipelineBuilder,
+) -> Result<Vec<ScalarExpression>, ParserError> {
+    let query_location = to_query_location(&rule);
+    let inner_rule = rule.into_inner().next().ok_or_else(|| {
+        ParserError::SyntaxError(
+            query_location.clone(),
+            "expected rename target content".to_string(),
+        )
+    })?;
+
+    match inner_rule.as_rule() {
+        Rule::identifier_expression => Ok(vec![ScalarExpression::Static(
+            StaticScalarExpression::String(StringScalarExpression::new(
+                to_query_location(&inner_rule),
+                inner_rule.as_str(),
+            )),
+        )]),
+        Rule::attribute_selection_expression => {
+            match parse_attribute_selection_expression(inner_rule, pipeline_builder)?.into() {
+                ScalarExpression::Source(source_expr) => {
+                    Ok(source_expr.into_value_accessor().into_selectors())
+                }
+                other => Err(ParserError::SyntaxNotSupported(
+                    query_location,
+                    format!("expected source expression for rename target, found {other:?}"),
+                )),
+            }
+        }
+        invalid_rule => Err(invalid_child_rule_error(
+            query_location,
+            Rule::rename_target,
+            invalid_rule,
+        )),
+    }
 }
 
 pub(crate) fn parse_set_operator_call(
@@ -841,9 +934,7 @@ mod tests {
 
     #[test]
     fn test_parse_rename_operator_call() {
-        let query = r#"rename
-                attributes["x"] = attributes["y"],
-                resource.attributes["x2"] = resource.attributes["y2"]"#;
+        let query = r#"rename attributes "y" as "x", "y2" as "x2""#;
         let mut state = ParserState::new(query);
         let parse_result = OplPestParser::parse(Rule::operator_call, query).unwrap();
         assert_eq!(parse_result.len(), 1);
@@ -888,9 +979,6 @@ mod tests {
                     MapKeyRenameSelector::new(
                         ValueAccessor::new_with_selectors(vec![
                             ScalarExpression::Static(StaticScalarExpression::String(
-                                StringScalarExpression::new(QueryLocation::new_fake(), "resource"),
-                            )),
-                            ScalarExpression::Static(StaticScalarExpression::String(
                                 StringScalarExpression::new(
                                     QueryLocation::new_fake(),
                                     "attributes",
@@ -901,9 +989,6 @@ mod tests {
                             )),
                         ]),
                         ValueAccessor::new_with_selectors(vec![
-                            ScalarExpression::Static(StaticScalarExpression::String(
-                                StringScalarExpression::new(QueryLocation::new_fake(), "resource"),
-                            )),
                             ScalarExpression::Static(StaticScalarExpression::String(
                                 StringScalarExpression::new(
                                     QueryLocation::new_fake(),
@@ -916,6 +1001,55 @@ mod tests {
                         ]),
                     ),
                 ],
+            ),
+        ));
+
+        assert_eq!(&expressions[0], &expected);
+    }
+
+    #[test]
+    fn test_parse_rename_operator_call_resource_attrs() {
+        let query = r#"rename resource.attributes "y" as "x""#;
+        let mut state = ParserState::new(query);
+        let parse_result = OplPestParser::parse(Rule::operator_call, query).unwrap();
+        assert_eq!(parse_result.len(), 1);
+        let rule = parse_result.into_iter().next().unwrap();
+        parse_operator_call(rule, &mut RootPipelineBuilder::new(&mut state)).unwrap();
+        let result = state.build().unwrap();
+        let expressions = result.get_expressions();
+        assert_eq!(expressions.len(), 1);
+
+        let expected = DataExpression::Transform(TransformExpression::RenameMapKeys(
+            RenameMapKeysTransformExpression::new(
+                QueryLocation::new_fake(),
+                MutableValueExpression::Source(SourceScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    ValueAccessor::new(),
+                )),
+                vec![MapKeyRenameSelector::new(
+                    ValueAccessor::new_with_selectors(vec![
+                        ScalarExpression::Static(StaticScalarExpression::String(
+                            StringScalarExpression::new(QueryLocation::new_fake(), "resource"),
+                        )),
+                        ScalarExpression::Static(StaticScalarExpression::String(
+                            StringScalarExpression::new(QueryLocation::new_fake(), "attributes"),
+                        )),
+                        ScalarExpression::Static(StaticScalarExpression::String(
+                            StringScalarExpression::new(QueryLocation::new_fake(), "y"),
+                        )),
+                    ]),
+                    ValueAccessor::new_with_selectors(vec![
+                        ScalarExpression::Static(StaticScalarExpression::String(
+                            StringScalarExpression::new(QueryLocation::new_fake(), "resource"),
+                        )),
+                        ScalarExpression::Static(StaticScalarExpression::String(
+                            StringScalarExpression::new(QueryLocation::new_fake(), "attributes"),
+                        )),
+                        ScalarExpression::Static(StaticScalarExpression::String(
+                            StringScalarExpression::new(QueryLocation::new_fake(), "x"),
+                        )),
+                    ]),
+                )],
             ),
         ));
 

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/apply_attrs.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/apply_attrs.rs
@@ -334,7 +334,7 @@ mod test {
     fn test_pipeline_stages_that_dont_support_attribute_exec_is_planning_error() {
         let query = r#"
             logs | apply attributes {
-                project-rename attributes["x"] = attributes["y"]
+                rename attributes "y" as "x"
             }"#;
         let pipeline_expr = OplParser::parse(query).unwrap().pipeline;
         let planner = PipelinePlanner::new();

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/attributes.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/attributes.rs
@@ -106,8 +106,10 @@ mod test {
         )])
     }
 
-    async fn test_rename_single_attributes<P: Parser>() {
-        let result = exec_logs_pipeline::<P>(
+    // KQL rename tests use KQL's `project-rename` syntax (assignment-based)
+    #[tokio::test]
+    async fn test_rename_single_attributes_kql_parser() {
+        let result = exec_logs_pipeline::<KqlParser>(
             "logs | project-rename attributes[\"y\"] = attributes[\"x\"]",
             generate_logs_test_data(),
         )
@@ -124,8 +126,7 @@ mod test {
             ]
         );
 
-        // test renaming resource attributes:
-        let result = exec_logs_pipeline::<P>(
+        let result = exec_logs_pipeline::<KqlParser>(
             "logs | project-rename resource.attributes[\"yr1\"] = resource.attributes[\"xr1\"]",
             generate_logs_test_data(),
         )
@@ -142,8 +143,7 @@ mod test {
             ]
         );
 
-        // test renaming scope attributes:
-        let result = exec_logs_pipeline::<P>(
+        let result = exec_logs_pipeline::<KqlParser>(
             "logs | project-rename instrumentation_scope.attributes[\"ys1\"] = instrumentation_scope.attributes[\"xs1\"]",
             generate_logs_test_data(),
         )
@@ -161,19 +161,67 @@ mod test {
         );
     }
 
-    #[tokio::test]
-    async fn test_rename_single_attributes_kql_parser() {
-        test_rename_single_attributes::<KqlParser>().await;
-    }
-
+    // OPL rename tests use the new `rename <target> "old" as "new"` syntax
     #[tokio::test]
     async fn test_rename_single_attributes_opl_parser() {
-        test_rename_single_attributes::<OplParser>().await;
+        let result = exec_logs_pipeline::<OplParser>(
+            r#"logs | rename attributes "x" as "y""#,
+            generate_logs_test_data(),
+        )
+        .await;
+        assert_eq!(
+            result.resource_logs[0].scope_logs[0].log_records,
+            vec![
+                LogRecord::build()
+                    .attributes(vec![KeyValue::new("y", AnyValue::new_string("a"))])
+                    .finish(),
+                LogRecord::build()
+                    .attributes(vec![KeyValue::new("x2", AnyValue::new_string("b"))])
+                    .finish(),
+            ]
+        );
+
+        // test renaming resource attributes:
+        let result = exec_logs_pipeline::<OplParser>(
+            r#"logs | rename resource.attributes "xr1" as "yr1""#,
+            generate_logs_test_data(),
+        )
+        .await;
+        assert_eq!(
+            result.resource_logs[0]
+                .resource
+                .as_ref()
+                .unwrap()
+                .attributes,
+            &[
+                KeyValue::new("yr1", AnyValue::new_string("a")),
+                KeyValue::new("xr2", AnyValue::new_string("a")),
+            ]
+        );
+
+        // test renaming scope attributes:
+        let result = exec_logs_pipeline::<OplParser>(
+            r#"logs | rename instrumentation_scope.attributes "xs1" as "ys1""#,
+            generate_logs_test_data(),
+        )
+        .await;
+        assert_eq!(
+            result.resource_logs[0].scope_logs[0]
+                .scope
+                .as_ref()
+                .unwrap()
+                .attributes,
+            &[
+                KeyValue::new("ys1", AnyValue::new_string("a")),
+                KeyValue::new("xs2", AnyValue::new_string("a")),
+            ]
+        );
     }
 
-    async fn test_rename_multiple_attributes<P: Parser>() {
+    #[tokio::test]
+    async fn test_rename_multiple_attributes_kql_parser() {
         // test renaming multiple attributes from same batch
-        let result = exec_logs_pipeline::<P>(
+        let result = exec_logs_pipeline::<KqlParser>(
             "logs |
                 project-rename
                     attributes[\"y\"] = attributes[\"x\"],
@@ -195,7 +243,7 @@ mod test {
         );
 
         // test renaming multiple attributes from many batches
-        let result = exec_logs_pipeline::<P>(
+        let result = exec_logs_pipeline::<KqlParser>(
             "logs |
                 project-rename
                     attributes[\"y\"] = attributes[\"x\"],
@@ -243,18 +291,77 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_rename_multiple_attributes_kql_parser() {
-        test_rename_multiple_attributes::<KqlParser>().await;
+    async fn test_rename_multiple_attributes_opl_parser() {
+        // test renaming multiple attributes from same batch
+        let result = exec_logs_pipeline::<OplParser>(
+            r#"logs | rename attributes "x" as "y", "x2" as "y2""#,
+            generate_logs_test_data(),
+        )
+        .await;
+
+        assert_eq!(
+            result.resource_logs[0].scope_logs[0].log_records,
+            vec![
+                LogRecord::build()
+                    .attributes(vec![KeyValue::new("y", AnyValue::new_string("a"))])
+                    .finish(),
+                LogRecord::build()
+                    .attributes(vec![KeyValue::new("y2", AnyValue::new_string("b"))])
+                    .finish(),
+            ]
+        );
+
+        // test renaming multiple attributes from many batches using chained rename calls
+        let result = exec_logs_pipeline::<OplParser>(
+            r#"logs
+                | rename attributes "x" as "y"
+                | rename resource.attributes "xr1" as "yr1"
+                | rename instrumentation_scope.attributes "xs1" as "ys1""#,
+            generate_logs_test_data(),
+        )
+        .await;
+
+        assert_eq!(
+            result.resource_logs[0].scope_logs[0].log_records,
+            vec![
+                LogRecord::build()
+                    .attributes(vec![KeyValue::new("y", AnyValue::new_string("a"))])
+                    .finish(),
+                LogRecord::build()
+                    .attributes(vec![KeyValue::new("x2", AnyValue::new_string("b"))])
+                    .finish(),
+            ]
+        );
+
+        assert_eq!(
+            result.resource_logs[0]
+                .resource
+                .as_ref()
+                .unwrap()
+                .attributes,
+            &[
+                KeyValue::new("yr1", AnyValue::new_string("a")),
+                KeyValue::new("xr2", AnyValue::new_string("a")),
+            ]
+        );
+
+        assert_eq!(
+            result.resource_logs[0].scope_logs[0]
+                .scope
+                .as_ref()
+                .unwrap()
+                .attributes,
+            &[
+                KeyValue::new("ys1", AnyValue::new_string("a")),
+                KeyValue::new("xs2", AnyValue::new_string("a")),
+            ]
+        );
     }
 
     #[tokio::test]
-    async fn test_rename_multiple_attributes_opl_parser() {
-        test_rename_multiple_attributes::<OplParser>().await;
-    }
-
-    async fn test_rename_when_no_attrs_batch_present<P: Parser>() {
+    async fn test_rename_when_no_attrs_batch_present_kql_parser() {
         let input = vec![LogRecord::build().event_name("test").finish()];
-        let result = exec_logs_pipeline::<P>(
+        let result = exec_logs_pipeline::<KqlParser>(
             "logs |
                 project-rename
                     attributes[\"y\"] = attributes[\"x\"],
@@ -267,23 +374,26 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_rename_when_no_attrs_batch_present_kql_parser() {
-        test_rename_when_no_attrs_batch_present::<KqlParser>().await;
+    async fn test_rename_when_no_attrs_batch_present_opl_parser() {
+        let input = vec![LogRecord::build().event_name("test").finish()];
+        let result = exec_logs_pipeline::<OplParser>(
+            r#"logs | rename attributes "x" as "y", "x2" as "y2""#,
+            to_logs_data(input.clone()),
+        )
+        .await;
+
+        assert_eq!(result.resource_logs[0].scope_logs[0].log_records, input);
     }
 
     #[tokio::test]
-    async fn test_rename_when_no_attrs_batch_present_opl_parser() {
-        test_rename_when_no_attrs_batch_present::<OplParser>().await;
-    }
-
-    async fn test_invalid_renames_are_errors<P: Parser>() {
+    async fn test_invalid_renames_are_errors_kql_parser() {
         let invalid_renames = [
             "logs | project-rename attributes[\"y\"] = attributes[\"y\"]",
             "logs | project-rename attributes[\"y\"] = attributes[\"x\"], attributes[\"y\"] = attributes[\"z\"]",
         ];
 
         for query in invalid_renames {
-            let mut pipeline = Pipeline::new(P::parse(query).unwrap().pipeline);
+            let mut pipeline = Pipeline::new(KqlParser::parse(query).unwrap().pipeline);
             let result = pipeline
                 .execute(OtapArrowRecords::Logs(Logs::default()))
                 .await;
@@ -296,13 +406,23 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_invalid_renames_are_errors_kql_parser() {
-        test_invalid_renames_are_errors::<KqlParser>().await;
-    }
-
-    #[tokio::test]
     async fn test_invalid_renames_are_errors_opl_parser() {
-        test_invalid_renames_are_errors::<OplParser>().await;
+        let invalid_renames = [
+            r#"logs | rename attributes "y" as "y""#,
+            r#"logs | rename attributes "x" as "y", "z" as "y""#,
+        ];
+
+        for query in invalid_renames {
+            let mut pipeline = Pipeline::new(OplParser::parse(query).unwrap().pipeline);
+            let result = pipeline
+                .execute(OtapArrowRecords::Logs(Logs::default()))
+                .await;
+            let err = result.unwrap_err();
+            assert!(
+                err.to_string()
+                    .contains("Invalid attribute transform: Duplicate key in rename target")
+            )
+        }
     }
 
     async fn test_delete_attributes<P: Parser>() {

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/conditional.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/conditional.rs
@@ -447,7 +447,7 @@ mod test {
         let result = exec_logs_pipeline::<OplParser>(
             r#"
             logs | if (severity_text == "ERROR") {
-                project-rename attributes["y"] = attributes["x"]
+                rename attributes "x" as "y"
             }"#,
             to_logs_data(log_records),
         )
@@ -485,7 +485,7 @@ mod test {
         let result = exec_logs_pipeline::<OplParser>(
             r#"
             logs | if (matches(severity_text, ".*E.*")) {
-                project-rename attributes["y"] = attributes["x"]
+                rename attributes "x" as "y"
             }"#,
             to_logs_data(log_records),
         )
@@ -520,9 +520,9 @@ mod test {
         let result = exec_logs_pipeline::<OplParser>(
             r#"
             logs | if (severity_text == "ERROR") {
-                project-rename attributes["y"] = attributes["x"]
+                rename attributes "x" as "y"
             } else {
-                project-rename attributes["z"] = attributes["x"]
+                rename attributes "x" as "z"
             }"#,
             to_logs_data(log_records),
         )
@@ -567,9 +567,9 @@ mod test {
 
         let query = r#"logs |
             if (severity_text == "ERROR") {
-                project-rename attributes["y"] = attributes["x"]
+                rename attributes "x" as "y"
             } else if (event_name == "test") {
-                project-rename attributes["z"] = attributes["x"]
+                rename attributes "x" as "z"
             } else {
                 project-away attributes["x"]
             }
@@ -618,11 +618,11 @@ mod test {
         ];
         let query = r#"logs |
             if (severity_text == "INFO") {
-                project-rename attributes["y"] = attributes["x"]
+                rename attributes "x" as "y"
             } else if (severity_text == "ERROR") {
-                project-rename attributes["z"] = attributes["x"]
+                rename attributes "x" as "z"
             } else if (severity_text == "WARN") {
-                project-rename attributes["a"] = attributes["x"]
+                rename attributes "x" as "a"
             } else {
                 project-away attributes["x"]
             }
@@ -652,9 +652,9 @@ mod test {
         let pipeline_expr = OplParser::parse(
             r#"logs |
             if (severity_text == "ERROR") {
-                project-rename attributes["y"] = attributes["x"]
+                rename attributes "x" as "y"
             } else if (event_name == "test") {
-                project-rename attributes["z"] = attributes["x"]
+                rename attributes "x" as "z"
             } else {
                 project-away attributes["x"]
             }

--- a/rust/otap-dataflow/crates/validation/src/lib.rs
+++ b/rust/otap-dataflow/crates/validation/src/lib.rs
@@ -655,7 +655,7 @@ mod tests {
     /// Tests the transform processor OPL `rename` operation. Renames the
     /// `thread.id` attribute to `new_thread_id`. The old key must be absent
     /// and the new key must be present on every log record.
-    /// Query: `logs | rename attributes["new_thread_id"] = attributes["thread.id"]`
+    /// Query: `logs | rename attributes "thread.id" as "new_thread_id"`
     #[test]
     fn validation_transform_opl_rename_attribute() {
         Scenario::new()

--- a/rust/otap-dataflow/crates/validation/validation_pipelines/transform-opl-rename-attribute-processor.yaml
+++ b/rust/otap-dataflow/crates/validation/validation_pipelines/transform-opl-rename-attribute-processor.yaml
@@ -8,7 +8,7 @@ nodes:
   transform:
     type: "urn:otel:processor:transform"
     config:
-      opl_query: 'logs | rename attributes["new_thread_id"] = attributes["thread.id"]'
+      opl_query: 'logs | rename attributes "thread.id" as "new_thread_id"'
   exporter:
     type: "urn:otel:exporter:otap"
     config:


### PR DESCRIPTION
# Change Summary

<!--
Replace with a brief summary of the change in this PR
-->

Updates the syntax used for renaming attributes in OPL:

- Old syntax: `logs | rename attributes["new_key"] = attributes["old_key"]`
- New syntax: `logs | rename attributes "old_key" as "new_key"`

See the linked issue for more info about the motivation.

Changes:
- changes to OPL parser for new syntax (parses to same AST) & update test
- update test cases in query-engine to use new syntax

## What issue does this PR close?

<!--
We highly recommend correlation of every PR to an issue
-->

* Closes #3224 

## How are these changes tested?

Unit tests

## Are there any user-facing changes?

Yes - the syntax is user-facing via OPL via the transform processor

 <!-- If yes, provide further info below -->

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
