### PR TITLE
chore: update jemalloc to 0.7

### DIFF
--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -116,9 +116,9 @@ local-sync = "0.1.1"
 miette = { version="7.6.0", features = ["fancy"] }
 mimalloc = { version = "0.1.48", features = ["extended", "v3", "debug"] }
 libmimalloc-sys = { version = "0.1.44", features = ["extended", "v3"] }
-tikv-jemallocator = { version = "0.6.1" }
-tikv-jemalloc-ctl = { version = "0.6.1", features = ["stats"] }
-tikv-jemalloc-sys = "0.6.1"
+tikv-jemallocator = { version = "0.7.0" }
+tikv-jemalloc-ctl = { version = "0.7.0", features = ["stats"] }
+tikv-jemalloc-sys = "0.7.0"
 memchr = "2.8.0"
 memmap2 = "0.9"
 memory-stats = "1"


### PR DESCRIPTION
# Change Summary

<!--
Replace with a brief summary of the change in this PR
-->

update jemalloc to 0.7

fixes/sueprsedes https://github.com/open-telemetry/otel-arrow/pull/3238

## What issue does this PR close?

<!--
We highly recommend correlation of every PR to an issue
-->

* Closes #NNN

## How are these changes tested?

## Are there any user-facing changes?

 <!-- If yes, provide further info below -->

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
