### PR TITLE
feat(flow_metrics): Add purpose field to flow_metric config to enable differentiation of flows

### DIFF
--- a/rust/otap-dataflow/.chloggen/flow-metrics-purpose-scope-attribute.yaml
+++ b/rust/otap-dataflow/.chloggen/flow-metrics-purpose-scope-attribute.yaml
@@ -1,0 +1,19 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: engine
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add an optional `purpose` field to flow_metric config, emitted as the `flow.purpose` scope attribute so OTel View selectors can target distinct flavors of flow work.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [2859]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Omitting `purpose` preserves the existing single `flow` scope behavior (backward compatible).

--- a/rust/otap-dataflow/.chloggen/flow-metrics-purpose-scope-attribute.yaml
+++ b/rust/otap-dataflow/.chloggen/flow-metrics-purpose-scope-attribute.yaml
@@ -16,4 +16,4 @@ issues: [2859]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: Omitting `purpose` preserves the existing single `flow` scope behavior (backward compatible).
+subtext: The `flow.purpose` attribute is always emitted on flow metrics; when `purpose` is omitted it carries an empty value, so existing single-`flow`-scope selectors keep matching.

--- a/rust/otap-dataflow/crates/config/src/policy.rs
+++ b/rust/otap-dataflow/crates/config/src/policy.rs
@@ -287,6 +287,15 @@ pub struct FlowMetricConfig {
     /// Metrics to enable. Omitted means all metrics are enabled.
     #[serde(default)]
     pub metrics: Option<Vec<FlowMetric>>,
+    /// Optional per-flow purpose differentiator, emitted as the `flow.purpose`
+    /// scope attribute on every metric this flow produces. Lets OTel View
+    /// selectors target distinct flavors of processor work (e.g. `filter`
+    /// flows that keep/drop records vs `transform` flows that enrich and
+    /// reshape them) even though all flows share the single `flow`
+    /// instrumentation scope. Omitted means no `flow.purpose` differentiation
+    /// (backward compatible).
+    #[serde(default)]
+    pub purpose: Option<String>,
 }
 
 impl FlowMetricConfig {
@@ -892,6 +901,29 @@ mod tests {
     }
 
     #[test]
+    fn flow_metrics_purpose_defaults_to_none() {
+        let yaml = r#"
+            flow_metrics:
+              - id: flow1
+                bounds: { start_node: a, end_node: b }
+        "#;
+        let policy: super::TelemetryPolicy = serde_yaml::from_str(yaml).expect("parse");
+        assert_eq!(policy.flow_metrics[0].purpose, None);
+    }
+
+    #[test]
+    fn flow_metrics_purpose_is_parsed() {
+        let yaml = r#"
+            flow_metrics:
+              - id: flow1
+                bounds: { start_node: a, end_node: b }
+                purpose: receiver
+        "#;
+        let policy: super::TelemetryPolicy = serde_yaml::from_str(yaml).expect("parse");
+        assert_eq!(policy.flow_metrics[0].purpose.as_deref(), Some("receiver"));
+    }
+
+    #[test]
     fn flow_metrics_rejects_empty_metrics() {
         let policies = Policies {
             telemetry: Some(super::TelemetryPolicy {
@@ -902,6 +934,7 @@ mod tests {
                         end_node: "b".to_string(),
                     },
                     metrics: Some(vec![]),
+                    purpose: None,
                 }],
                 ..super::TelemetryPolicy::default()
             }),
@@ -929,6 +962,7 @@ mod tests {
                         super::FlowMetric::ComputeDuration,
                         super::FlowMetric::ComputeDuration,
                     ]),
+                    purpose: None,
                 }],
                 ..super::TelemetryPolicy::default()
             }),

--- a/rust/otap-dataflow/crates/config/src/policy.rs
+++ b/rust/otap-dataflow/crates/config/src/policy.rs
@@ -292,8 +292,8 @@ pub struct FlowMetricConfig {
     /// selectors target distinct flavors of processor work (e.g. `filter`
     /// flows that keep/drop records vs `transform` flows that enrich and
     /// reshape them) even though all flows share the single `flow`
-    /// instrumentation scope. Omitted means no `flow.purpose` differentiation
-    /// (backward compatible).
+    /// instrumentation scope. When omitted, `flow.purpose` is still emitted
+    /// but carries an empty value (no purpose differentiation).
     #[serde(default)]
     pub purpose: Option<String>,
 }

--- a/rust/otap-dataflow/crates/engine/src/flow_metrics.rs
+++ b/rust/otap-dataflow/crates/engine/src/flow_metrics.rs
@@ -68,8 +68,9 @@ pub struct FlowAttributeSet {
     /// Name of the processor node where the measurement ends.
     #[attribute(key = "flow.node.end")]
     pub end_node: Cow<'static, str>,
-    /// Optional per-flow purpose differentiator (e.g. `filter`, `transform`).
-    /// Empty when the flow declares no purpose. Lets OTel View selectors target
+    /// Per-flow purpose differentiator (e.g. `filter`, `transform`). Always
+    /// emitted as the `flow.purpose` scope attribute; carries an empty value
+    /// when the flow declares no purpose. Lets OTel View selectors target
     /// distinct flavors of processor work while all flows share the single
     /// `flow` scope.
     #[attribute(key = "flow.purpose")]
@@ -1052,8 +1053,7 @@ mod tests {
             "expected flow.purpose=filter in {set:?}"
         );
 
-        // When unset, the key is still present but carries an empty value
-        // (preserving the single `flow` scope behavior).
+        // When unset, the key is still present but carries an empty value.
         let unset = FlowAttributeSet::default();
         let unset_set: Vec<(&str, AttributeValue)> = unset
             .iter_attributes()

--- a/rust/otap-dataflow/crates/engine/src/flow_metrics.rs
+++ b/rust/otap-dataflow/crates/engine/src/flow_metrics.rs
@@ -68,6 +68,12 @@ pub struct FlowAttributeSet {
     /// Name of the processor node where the measurement ends.
     #[attribute(key = "flow.node.end")]
     pub end_node: Cow<'static, str>,
+    /// Optional per-flow purpose differentiator (e.g. `filter`, `transform`).
+    /// Empty when the flow declares no purpose. Lets OTel View selectors target
+    /// distinct flavors of processor work while all flows share the single
+    /// `flow` scope.
+    #[attribute(key = "flow.purpose")]
+    pub purpose: Cow<'static, str>,
     /// Pipeline attributes.
     #[compose]
     pub pipeline_attrs: PipelineAttributeSet,
@@ -275,6 +281,10 @@ pub(crate) fn build_flow_metric_state(
             flow_id: Cow::Owned(flow_config.id.clone()),
             start_node: Cow::Owned(flow_config.bounds.start_node.clone()),
             end_node: Cow::Owned(flow_config.bounds.end_node.clone()),
+            purpose: flow_config
+                .purpose
+                .clone()
+                .map_or(Cow::Borrowed(""), Cow::Owned),
             pipeline_attrs: pipeline_attrs.clone(),
         };
 
@@ -451,6 +461,7 @@ impl PipelineFlowMetricState {
 mod tests {
     use super::*;
     use crate::testing::test_pipeline_ctx;
+    use otap_df_telemetry::attributes::{AttributeSetHandler, AttributeValue};
 
     fn one_flow_metric_state() -> PipelineFlowMetricState {
         let (ctx, _) = test_pipeline_ctx();
@@ -572,6 +583,7 @@ mod tests {
                 end_node: stop.to_string(),
             },
             metrics: None,
+            purpose: None,
         }
     }
 
@@ -1011,5 +1023,45 @@ mod tests {
             .expect("diamond-reachable flow metric should build");
 
         assert_eq!(state.duration_metrics.len(), 1);
+    }
+
+    #[test]
+    fn flow_attribute_set_exposes_purpose_scope_attribute() {
+        // Descriptor must declare the `flow.purpose` key so View selectors can
+        // match on it as a scope attribute.
+        let descriptor = FlowAttributeSet::default().descriptor();
+        assert!(
+            descriptor.fields.iter().any(|f| f.key == "flow.purpose"),
+            "flow.purpose missing from FlowAttributeSet descriptor"
+        );
+
+        // When set, the value is emitted under the `flow.purpose` key.
+        let attrs = FlowAttributeSet {
+            flow_id: "sampling".into(),
+            start_node: "log_sampler".into(),
+            end_node: "log_sampler".into(),
+            purpose: "filter".into(),
+            ..FlowAttributeSet::default()
+        };
+        let set: Vec<(&str, AttributeValue)> = attrs
+            .iter_attributes()
+            .map(|(key, value)| (key, value.clone()))
+            .collect();
+        assert!(
+            set.contains(&("flow.purpose", AttributeValue::String("filter".to_string()))),
+            "expected flow.purpose=filter in {set:?}"
+        );
+
+        // When unset, the key is still present but carries an empty value
+        // (preserving the single `flow` scope behavior).
+        let unset = FlowAttributeSet::default();
+        let unset_set: Vec<(&str, AttributeValue)> = unset
+            .iter_attributes()
+            .map(|(key, value)| (key, value.clone()))
+            .collect();
+        assert!(
+            unset_set.contains(&("flow.purpose", AttributeValue::String(String::new()))),
+            "expected empty flow.purpose in {unset_set:?}"
+        );
     }
 }

--- a/rust/otap-dataflow/crates/engine/src/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/processor.rs
@@ -1256,6 +1256,7 @@ mod tests {
             flow_id: "auto_measure".into(),
             start_node: "auto_measure_processor".into(),
             end_node: "auto_measure_processor".into(),
+            purpose: "".into(),
             pipeline_attrs: pipeline_ctx.pipeline_attribute_set(),
         };
         let entity_key = pipeline_ctx.metrics_registry().register_entity(attrs);


### PR DESCRIPTION
# Change Summary

> Note: This is iteration 3 of this change, see first two attempts at #3132 and #3144. This change is a lot simpler now after the work completed in #3161 / #3176.

## Add `flow.purpose` scope attribute to flow metrics
 
 ### What
 
 Adds an optional `purpose` field to flow-metric configuration (`FlowMetricConfig` in `crates/config/src/policy.rs`). When set, it is emitted as the **`flow.purpose` scope attribute** on every metric the flow produces (`FlowAttributeSet` in `crates/engine/src/flow_metrics.rs`).
 
 This is change **A** from #2859 ("per-flow scope"): the smallest, backward-compatible step that lets OTel View selectors distinguish flows that share the single `flow` instrumentation scope.

 It also relates to the code change made in #2755 to enable `scope_attributes` for Metric view filtering.
 
 ### Why
 
 All flow metrics emit under one shared `flow` scope. OTel View selectors match on scope name + scope attributes + instrument name, so today they cannot target one flow's metrics without also matching every other flow's same-named instrument. As we start declaring flows for different *flavors* of work, their metrics collide in a single View.
 
 `flow.purpose` gives operators a per-flow differentiator that selectors can key on, without introducing a new scope per flow.
 
 ### Example — two flows that need to be told apart
 
 A pipeline declares two flows over different processor stages, each enabling only the metrics relevant to its purpose:
 
 ```yaml
 policies:
   telemetry:
     flow_metrics:
       # A sampling stage: records not selected by the sampler are dropped.
       # Operator cares about all flow metrics (duration, incoming, and outgoing).
       - id: sampling
         bounds: { start_node: log_sampler, end_node: log_sampler }
         purpose: filter
         metrics: [compute_duration, signals_incoming, signals_outgoing]
 
       # A downstream enrichment/transform stage: Operator only cares about how long
       # the transform takes, not item counts.
       - id: enrich
         bounds: { start_node: transform_a, end_node: transform_b }
         purpose: transform
         metrics: [compute_duration]
 ```
 
 Both flows emit under scope `flow`. With `flow.purpose`, Views can route each flow's instruments to distinct streams instead of conflating them:
 
 ```yaml
 views:
   - selector: { scope_name: flow, scope_attributes: { flow.purpose: filter }, instrument_name: compute.duration }
     stream:   { name: sampler_duration }
   - selector: { scope_name: flow, scope_attributes: { flow.purpose: filter }, instrument_name: signals.incoming }
     stream:   { name: sampler_incoming_items }
   - selector: { scope_name: flow, scope_attributes: { flow.purpose: filter }, instrument_name: signals.outgoing }
     stream:   { name: sampled_records_kept }
   - selector: { scope_name: flow, scope_attributes: { flow.purpose: transform }, instrument_name: compute.duration }
     stream:   { name: enrich_duration }
 ```
 
 Without `flow.purpose`, a `scope_name: flow` + `instrument_name: compute.duration` selector would match **both** flows (any flow emitting that instrument) and report mixed duration data for both flows.

## What issue does this PR close?

* Progress towards #2859

## How are these changes tested?

Unit tests and local engine runs

## Are there any user-facing changes?

Yes, operators can now specify a flow `purpose`.

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
