### PR TITLE
feat: add 'drop' operator to OPL

### DIFF
--- a/rust/otap-dataflow/.chloggen/opl-drop-operator.yaml
+++ b/rust/otap-dataflow/.chloggen/opl-drop-operator.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: query-engine
+note: "Adds `drop` operator to OPL for unconditionally discarding telemetry data"
+issues: [3253]

--- a/rust/otap-dataflow/crates/query-engine-languages/docs/opl-user-guide/src/attr_operators.md
+++ b/rust/otap-dataflow/crates/query-engine-languages/docs/opl-user-guide/src/attr_operators.md
@@ -229,7 +229,15 @@ logs | apply instrumentation_scope.attributes {
 
 ### Supported operators
 
-The operators `where`, `set`, and `if` are supported inside `apply` blocks.
+The operators `where`, `drop`, `set`, and `if` are supported inside `apply`
+blocks. The `drop` operator inside `apply` clears all entries from the applied
+map:
+
+```text
+// remove all attributes
+logs | apply attributes { drop }
+```
+
 Operators like `rename` and `remove` are not supported inside `apply` -- they
 operate on the outer pipeline level by targeting specific attribute keys.
 Using an unsupported operator inside `apply` will produce an error.

--- a/rust/otap-dataflow/crates/query-engine-languages/docs/opl-user-guide/src/basic_operators.md
+++ b/rust/otap-dataflow/crates/query-engine-languages/docs/opl-user-guide/src/basic_operators.md
@@ -101,6 +101,26 @@ The `is` check works with any attribute scope:
 logs | where resource.attributes["service.version"] is String
 ```
 
+## Drop (`drop`)
+
+The `drop` operator unconditionally discards all telemetry data. It is
+equivalent to `where false`.
+
+```text
+// drop all logs
+logs | drop
+```
+
+This is most useful inside conditional branches to selectively discard records
+based on a condition:
+
+```text
+// drop debug logs, keep everything else
+logs | if (severity_number < 9) {
+    drop
+}
+```
+
 ## Assign (`set`)
 
 The `set` operator modifies or assigns a field value:

--- a/rust/otap-dataflow/crates/query-engine-languages/docs/opl-user-guide/src/flow_control.md
+++ b/rust/otap-dataflow/crates/query-engine-languages/docs/opl-user-guide/src/flow_control.md
@@ -64,7 +64,7 @@ skipped for that record.
 ### Operators inside branches
 
 The body of each branch can contain any operators chained with `|`, just like a
-top-level pipeline. This includes `where`, `set`, `rename`, `remove`,
+top-level pipeline. This includes `where`, `drop`, `set`, `rename`, `remove`,
 `route_to`, and even nested `if` blocks:
 
 ```text
@@ -92,6 +92,20 @@ if (severity_text == "ERROR") {
 In this example, ERROR logs from the payments service are kept and tagged.
 ERROR logs from other services are dropped. All non-ERROR logs pass through
 unchanged.
+
+The `drop` operator unconditionally discards all records in a branch. This is
+useful when you want to discard an entire category of records:
+
+```text
+logs |
+if (severity_number < 9) {
+    // discard debug and trace logs
+    drop
+}
+```
+
+In this example, logs with a severity number below 9 are discarded. All other
+logs pass through unchanged.
 
 ### Row ordering
 
@@ -127,6 +141,19 @@ The `is` check can also be used in `where` filters:
 ```text
 // process only logs, drop metrics and spans
 signals | where is Log
+```
+
+Alternatively, `drop` can be used inside `if` branches to discard specific
+signal types:
+
+```text
+// drop metrics and spans, keep only logs
+signals |
+if (is Metric) {
+    drop
+} else if (is Span) {
+    drop
+}
 ```
 
 ## Route Output (`route_to`)

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/opl.pest
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/opl.pest
@@ -218,6 +218,10 @@ where_operator_call = {
     "where" ~ expression
 }
 
+drop_operator_call = {
+    "drop"
+}
+
 route_to_operator_call = {
     "route_to" ~ string_literal
 }
@@ -232,6 +236,7 @@ operator_call = {
   | remove_map_keys_operator_call
   | if_else_operator_call
   | route_to_operator_call
+  | drop_operator_call
   | where_operator_call
   | apply_operator_call
 }

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser.rs
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser.rs
@@ -222,4 +222,47 @@ mod test {
             &gen_simple_equals_filter_expected("body", "example /* comment */")
         );
     }
+
+    #[test]
+    fn test_parse_drop() {
+        let result = OplParser::parse("logs | drop");
+        assert!(result.is_ok());
+
+        let pipeline = result.unwrap().pipeline;
+        let expressions = pipeline.get_expressions();
+        assert_eq!(expressions.len(), 1);
+
+        let expected =
+            DataExpression::Discard(DiscardDataExpression::new(QueryLocation::new_fake()));
+        pretty_assertions::assert_eq!(&expressions[0], &expected);
+    }
+
+    #[test]
+    fn test_parse_drop_in_if_else() {
+        let query = r#"
+            logs | if (severity_text == "DEBUG") {
+                drop
+            }
+        "#;
+        let result = OplParser::parse(query);
+        assert!(result.is_ok());
+
+        let pipeline = result.unwrap().pipeline;
+        let expressions = pipeline.get_expressions();
+        assert_eq!(expressions.len(), 1);
+
+        // The outer expression should be a Conditional containing a Discard in the branch
+        match &expressions[0] {
+            DataExpression::Conditional(cond) => {
+                let branches = cond.get_branches();
+                assert_eq!(branches.len(), 1);
+                let branch_exprs = branches[0].get_expressions();
+                assert_eq!(branch_exprs.len(), 1);
+                let expected =
+                    DataExpression::Discard(DiscardDataExpression::new(QueryLocation::new_fake()));
+                pretty_assertions::assert_eq!(&branch_exprs[0], &expected);
+            }
+            other => panic!("expected Conditional, got {other:?}"),
+        }
+    }
 }

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser/operator.rs
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser/operator.rs
@@ -40,6 +40,7 @@ pub(crate) fn parse_operator_call(
             Rule::rename_operator_call => parse_rename_operator_call(rule, pipeline_builder)?,
             Rule::route_to_operator_call => parse_route_to_operator_call(rule, pipeline_builder)?,
             Rule::set_operator_call => parse_set_operator_call(rule, pipeline_builder)?,
+            Rule::drop_operator_call => parse_drop_operator_call(rule, pipeline_builder)?,
             Rule::where_operator_call => parse_where_operator_call(rule, pipeline_builder)?,
             Rule::apply_operator_call => parse_apply_operator_call(rule, pipeline_builder)?,
             invalid_rule => {
@@ -423,6 +424,20 @@ pub(crate) fn parse_if_else_operator_call(
 
     pipeline_builder.push_data_expression(DataExpression::Conditional(conditional_expr));
 
+    Ok(())
+}
+
+/// Parses the `drop` operator, which unconditionally discards all data.
+///
+/// `drop` is equivalent to `where false` and produces a [`DiscardDataExpression`] with no
+/// predicate. The planner interprets a predicate-less discard as "reject all rows".
+pub(crate) fn parse_drop_operator_call(
+    operator_call_rule: Pair<'_, Rule>,
+    pipeline_builder: &mut dyn PipelineBuilder,
+) -> Result<(), ParserError> {
+    let query_location = to_query_location(&operator_call_rule);
+    let discard_expr = DiscardDataExpression::new(query_location);
+    pipeline_builder.push_data_expression(DataExpression::Discard(discard_expr));
     Ok(())
 }
 
@@ -1373,5 +1388,82 @@ mod tests {
             )],
         );
         assert_eq!(&functions[1], &expected1);
+    }
+
+    #[test]
+    fn test_parse_drop_operator_call() {
+        let query = "drop";
+        let mut state = ParserState::new_with_options(query, ParserOptions::default());
+        let parse_result = OplPestParser::parse(Rule::operator_call, query).unwrap();
+        assert_eq!(parse_result.len(), 1);
+        let rule = parse_result.into_iter().next().unwrap();
+        parse_operator_call(rule, &mut RootPipelineBuilder::new(&mut state)).unwrap();
+
+        let result = state.build().unwrap();
+        let expressions = result.get_expressions();
+        assert_eq!(expressions.len(), 1);
+        let expected =
+            DataExpression::Discard(DiscardDataExpression::new(QueryLocation::new_fake()));
+
+        assert_eq!(&expressions[0], &expected);
+    }
+
+    #[test]
+    fn test_parse_apply_drop_operator_call() {
+        let query = r#"apply attributes { drop }"#;
+
+        let mut state = ParserState::new_with_options(query, ParserOptions::default());
+        let parse_result = OplPestParser::parse(Rule::operator_call, query).unwrap();
+        assert_eq!(parse_result.len(), 1);
+        let rule = parse_result.into_iter().next().unwrap();
+        parse_operator_call(rule, &mut RootPipelineBuilder::new(&mut state)).unwrap();
+
+        let result = state.build().unwrap();
+        let expressions = result.get_expressions();
+        assert_eq!(expressions.len(), 1);
+
+        let expected =
+            DataExpression::Transform(TransformExpression::Set(SetTransformExpression::new(
+                QueryLocation::new_fake(),
+                ScalarExpression::InvokeFunction(InvokeFunctionScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    None,
+                    0,
+                    Vec::new(),
+                )),
+                MutableValueExpression::Source(SourceScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                        StaticScalarExpression::String(StringScalarExpression::new(
+                            QueryLocation::new_fake(),
+                            "attributes",
+                        )),
+                    )]),
+                )),
+            )));
+        assert_eq!(&expressions[0], &expected);
+
+        let functions = result.get_functions();
+        assert_eq!(functions.len(), 1);
+
+        let expected_fn = PipelineFunction::new_with_expressions(
+            QueryLocation::new_fake(),
+            vec![PipelineFunctionParameter::new(
+                QueryLocation::new_fake(),
+                PipelineFunctionParameterType::MutableValue(Some(ValueType::Map)),
+            )],
+            Some(ValueType::Map),
+            vec![PipelineFunctionExpression::Discard(
+                DiscardDataExpression::new(QueryLocation::new_fake()).with_target(
+                    MutableValueExpression::Argument(ArgumentScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        Some(ValueType::Map),
+                        0,
+                        ValueAccessor::new(),
+                    )),
+                ),
+            )],
+        );
+        assert_eq!(&functions[0], &expected_fn);
     }
 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
@@ -544,6 +544,32 @@ mod test {
         test_simple_filter::<OplParser, _>(|dt| format!("timestamp\"{dt}\"")).await
     }
 
+    /// Tests the `drop` operator, which unconditionally discards all data (equivalent to
+    /// `where false`).
+    #[tokio::test]
+    async fn test_drop_operator_opl_parser() {
+        let log_records = vec![
+            LogRecord::build()
+                .severity_text("ERROR")
+                .event_name("1")
+                .finish(),
+            LogRecord::build()
+                .severity_text("INFO")
+                .event_name("2")
+                .finish(),
+        ];
+
+        // `drop` should discard all records, same as `where false`
+        let result =
+            exec_logs_pipeline::<OplParser>("logs | drop", to_logs_data(log_records.clone())).await;
+        assert_eq!(result.resource_logs.len(), 0);
+
+        // verify equivalence: `where false` should produce the same result
+        let result_where_false =
+            exec_logs_pipeline::<OplParser>("logs | where false", to_logs_data(log_records)).await;
+        assert_eq!(result_where_false.resource_logs.len(), 0);
+    }
+
     async fn test_simple_attrs_filter<P: Parser>() {
         let otap_batch = to_otap_logs(vec![
             LogRecord::build()


### PR DESCRIPTION
# Change Summary

<!--
Replace with a brief summary of the change in this PR
-->

Add `drop` operator to OPL. Shortcut for `where false`.

## What issue does this PR close?

<!--
We highly recommend correlation of every PR to an issue
-->

* Closes #3253

## How are these changes tested?

unit tests

## Are there any user-facing changes?

 <!-- If yes, provide further info below -->

yes - this is now available in OPL programs in transform processor.

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
