### PR TITLE
chore(deps): Isolate digest updates while keeping once a week pattern

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -84,10 +84,16 @@
       ]
     },
     {
-      // limit Go and Rust git/module digest-only updates to once a week
-      // these trickle in frequently, so consolidate them
-      "groupName": "go and rust digest updates",
-      "matchManagers": ["gomod", "cargo"],
+      // limit Go git/module digest-only updates to once a week
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["digest"],
+      "schedule": [
+        "before 8am on Monday"
+      ]
+    },
+    {
+      // limit Rust git/module digest-only updates to once a week
+      "matchManagers": ["cargo"],
       "matchUpdateTypes": ["digest"],
       "schedule": [
         "before 8am on Monday"


### PR DESCRIPTION
# Change Summary

It is taxing to isolate the breaking change from #3235.

In this specific case, it is the `geneva` dependency: https://github.com/open-telemetry/otel-arrow/actions/runs/27225496774/job/80391437570?pr=3235

```log
error[E0063]: missing field `obo_event_map` in initializer of `geneva_uploader::GenevaClientConfig`
   --> crates/contrib-nodes/src/exporters/geneva_exporter/mod.rs:301:29
    |
301 |         let client_config = GenevaClientConfig {
    |                             ^^^^^^^^^^^^^^^^^^ missing `obo_event_map`
```

#3140 attempted to limit the number of digest PRs we get, but grouping them all together probably isn't the right move.

Instead, still get digest updates from Go and Rust once a week, but treat each one as a separate PR. That way, we can easily merge non-breaking ones and immediately have visibility into which breaking ones.

## What issue does this PR close?

N/A

## How are these changes tested?

N/A

## Are there any user-facing changes?

N/A

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
