### PR TITLE
chore: Bump arrow-rs from 58.1.0 to 58.3.0

### DIFF
--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -68,13 +68,13 @@ data_engine_parser_abstractions = { path = "../experimental/query_engine/parser-
 ahash = "0.8.11"
 arc-swap = "1.7"
 arrayvec = "0.7.6"
-arrow = { version = "58.1", features=["prettyprint"] }
-arrow-buffer = { version = "58.1" }
-arrow-ipc = { version = "58.1", features=["zstd"] }
-arrow-schema = { version = "58.1" }
-arrow-array = { version = "58.1" }
-arrow-cast = { version = "58.1" }
-arrow-select = { version = "58.1" }
+arrow = { version = "58.3", features=["prettyprint"] }
+arrow-buffer = { version = "58.3" }
+arrow-ipc = { version = "58.3", features=["zstd"] }
+arrow-schema = { version = "58.3" }
+arrow-array = { version = "58.3" }
+arrow-cast = { version = "58.3" }
+arrow-select = { version = "58.3" }
 async-stream = "0.3.6"
 async-trait = "0.1.88"
 async-unsync = "0.3.0"
@@ -143,7 +143,7 @@ opentelemetry-otlp = { version = "0.31.1", default-features = false, features = 
 opentelemetry-prometheus = { version = "0.31.0", default-features = false, features = ["internal-logs"] }
 parking_lot = "0.12.5"
 paste = "1"
-parquet = { version = "58.1", default-features = false, features = ["arrow", "async", "object_store"]}
+parquet = { version = "58.3", default-features = false, features = ["arrow", "async", "object_store"]}
 pest = "2.8"
 pest_derive = "2.8"
 portpicker = "0.1.1"


### PR DESCRIPTION
# Change Summary

Bump arrow-rs versions because I'm poking at arrow ipc costs and there is an optimization available that was introduced here: https://github.com/apache/arrow-rs/pull/9808/changes.

According to my profile we spend around 18% of ipc reader time initializing a zstd context that we don't use for compressionless cases and someone happened to fix it already.

<img width="3817" height="627" alt="image" src="https://github.com/user-attachments/assets/2688794d-d981-41bb-9b97-71f9f0ec235a" />

## How are these changes tested?

Existing tests will cover functionality. Same profile after showing no zstd anymore:

<img width="3820" height="787" alt="image" src="https://github.com/user-attachments/assets/6aea59f9-47f6-41c0-bc56-4e98b658c479" />

## Are there any user-facing changes?

No

### Changelog


* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
