### PR TITLE
Feature/durable buffer metrics fresh

### DIFF
--- a/rust/otap-dataflow/.chloggen/arrow-encoder-durable-buffer-metrics.yaml
+++ b/rust/otap-dataflow/.chloggen/arrow-encoder-durable-buffer-metrics.yaml
@@ -1,0 +1,31 @@
+# Use this template to create a new changelog entry.
+# Save this file to the `.chloggen/` directory in the repository root.
+# Example: `.chloggen/my-feature.yaml`
+
+# (Required) - Type of change. Allowed values are:
+#   breaking: A change that breaks backwards compatibility.
+#   deprecation: A change that deprecates a feature or component.
+#   new_component: A change that introduces a new component.
+#   enhancement: A change that introduces a new feature or enhancement.
+#   bug_fix: A change that fixes a bug.
+change_type: enhancement
+
+# (Required) - The component(s) affected by this change.
+# See the `config.yaml` file in this directory for a list of allowed components.
+component: pipeline
+
+# (Required) - A brief note explaining the change.
+# Example: "Add support for OTLP 1.0"
+note: Enhance durable_buffer observability with storage utilization and per-signal data loss metrics.
+
+# (Required) - Issue number(s) addressed by this change.
+# Example: [123, 456]
+issues: [3117]
+
+# (Optional) - User(s) who contributed to this change.
+# Omit if this change was authored by one of the project's core maintainers.
+# Note that this only applies to the top-level CHANGELOG, since we use
+# GitHub's auto-generated changelog for releases.
+# Example: [user1, user2]
+# subtext: "Thanks to @user1 and @user2 for this contribution!"
+subtext:

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/bundle_adapter.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/bundle_adapter.rs
@@ -82,7 +82,7 @@ const fn to_slot_id(_signal_type: SignalType, payload_type: ArrowPayloadType) ->
 }
 
 /// Convert signal type to OTLP slot ID (for opaque binary storage)
-const fn to_otlp_slot_id(signal_type: SignalType) -> SlotId {
+pub(crate) const fn to_otlp_slot_id(signal_type: SignalType) -> SlotId {
     SlotId::new(match signal_type {
         SignalType::Logs => otlp_slots::OTLP_LOGS,
         SignalType::Traces => otlp_slots::OTLP_TRACES,
@@ -1007,7 +1007,7 @@ mod tests {
         // HashMap iteration order is not guaranteed, but all slots should be from same signal
         #[rustfmt::skip]
         let records = OtapArrowRecords::Traces(traces!(
-            (Spans, 
+            (Spans,
                 ("id", UInt16, vec![0u16, 1])),
             (SpanEvents,
                 ("id", UInt32, vec![0u32, 1]),

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
@@ -304,6 +304,35 @@ pub struct DurableBufferMetrics {
     /// Data may still be recoverable via WAL replay on restart.
     #[metric(unit = "{error}")]
     pub flush_failures: Counter<u64>,
+
+    // ─── Appended metrics (Do not shift index) ──────────────────────────────
+    /// Current storage utilization ratio (0.0 to 1.0).
+    #[metric(unit = "{1}")]
+    pub storage_utilization: Gauge<f64>,
+
+    /// Total log records lost due to force-dropped segments (DropOldest policy).
+    #[metric(unit = "{log_record}")]
+    pub dropped_log_records: ObserveCounter<u64>,
+
+    /// Total spans lost due to force-dropped segments (DropOldest policy).
+    #[metric(unit = "{span}")]
+    pub dropped_spans: ObserveCounter<u64>,
+
+    /// Total metric data points lost due to force-dropped segments (DropOldest policy).
+    #[metric(unit = "{data_point}")]
+    pub dropped_metric_datapoints: ObserveCounter<u64>,
+
+    /// Total log records lost due to expired segments (max_age retention).
+    #[metric(unit = "{log_record}")]
+    pub expired_log_records: ObserveCounter<u64>,
+
+    /// Total spans lost due to expired segments (max_age retention).
+    #[metric(unit = "{span}")]
+    pub expired_spans: ObserveCounter<u64>,
+
+    /// Total metric data points lost due to expired segments (max_age retention).
+    #[metric(unit = "{data_point}")]
+    pub expired_metric_datapoints: ObserveCounter<u64>,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -420,7 +449,7 @@ struct CachedSegmentMetrics {
 ///
 /// # Segment Metrics Cache
 ///
-/// To avoid per-tick allocations in `recompute_queued_counters`, this struct
+/// To avoid per-tick allocations in `recompute_metrics`, this struct
 /// maintains a `segment_cache` that maps finalized segment sequences to their
 /// pre-computed per-bundle signal classification.  Because segments are
 /// **immutable** after finalization, the cache entry for a given segment
@@ -729,7 +758,7 @@ impl DurableBuffer {
                 Ok((engine, subscriber_id)) => {
                     // Seed queued gauges immediately so they reflect
                     // persisted state before the first telemetry tick.
-                    self.recompute_queued_counters(&engine, &subscriber_id);
+                    self.recompute_metrics(&engine, &subscriber_id);
 
                     self.engine_state = EngineState::Ready {
                         engine,
@@ -777,7 +806,7 @@ impl DurableBuffer {
     /// 3. `open_segment_metrics` — engine open-segment lock (brief snapshot).
     ///
     /// After snapshots are taken, all iteration is lock-free.
-    fn recompute_queued_counters(&mut self, engine: &QuiverEngine, subscriber_id: &SubscriberId) {
+    fn recompute_metrics(&mut self, engine: &QuiverEngine, subscriber_id: &SubscriberId) {
         self.segment_cache_generation = self.segment_cache_generation.wrapping_add(1);
         let current_generation = self.segment_cache_generation;
 
@@ -867,11 +896,15 @@ impl DurableBuffer {
                 }
             };
 
+            let mut seg_logs = 0;
+            let mut seg_metrics = 0;
+            let mut seg_spans = 0;
+
             // Fast path: no bundles resolved → use precomputed totals.
             if progress.resolved_count() == 0 {
-                logs += summary.total_logs;
-                metrics += summary.total_metrics;
-                spans += summary.total_spans;
+                seg_logs = summary.total_logs;
+                seg_metrics = summary.total_metrics;
+                seg_spans = summary.total_spans;
             } else {
                 // Slow path: iterate per-bundle, skipping resolved.
                 for (idx, &(item_count, signal)) in summary.bundles.iter().enumerate() {
@@ -887,14 +920,18 @@ impl DurableBuffer {
 
                     if !progress.is_resolved(BundleIndex::new(bundle_idx)) {
                         match signal {
-                            Some(SignalType::Logs) => logs += item_count,
-                            Some(SignalType::Metrics) => metrics += item_count,
-                            Some(SignalType::Traces) => spans += item_count,
+                            Some(SignalType::Logs) => seg_logs += item_count,
+                            Some(SignalType::Metrics) => seg_metrics += item_count,
+                            Some(SignalType::Traces) => seg_spans += item_count,
                             None => {}
                         }
                     }
                 }
             }
+
+            logs += seg_logs;
+            metrics += seg_metrics;
+            spans += seg_spans;
         }
 
         // Step 3: add items from the open (accumulating) segment.
@@ -921,6 +958,58 @@ impl DurableBuffer {
         // Step 4: evict cache entries for segments no longer tracked.
         self.segment_cache
             .retain(|seq, _| progress_snapshot.contains_key(&SegmentSeq::new(*seq)));
+
+        self.metrics
+            .dropped_segments
+            .observe(engine.force_dropped_segments());
+        self.metrics
+            .dropped_bundles
+            .observe(engine.force_dropped_bundles());
+        self.metrics
+            .dropped_items
+            .observe(engine.force_dropped_items());
+        self.metrics
+            .expired_bundles
+            .observe(engine.expired_bundles());
+        self.metrics.expired_items.observe(engine.expired_items());
+
+        // Update dropped and expired metrics by iterating the engine's per-slot snapshots
+        // and aggregating by signal type via signal_type_from_slot_id(). This handles all
+        // slot ranges (Arrow 10-45 and OTLP 60-62) without hardcoding any slot IDs here.
+        let mut dropped_logs = 0u64;
+        let mut dropped_metrics = 0u64;
+        let mut dropped_spans = 0u64;
+        for (slot, count) in engine.force_dropped_items_per_slot_snapshot() {
+            match signal_type_from_slot_id(slot) {
+                Some(SignalType::Logs) => dropped_logs += count,
+                Some(SignalType::Metrics) => dropped_metrics += count,
+                Some(SignalType::Traces) => dropped_spans += count,
+                None => {}
+            }
+        }
+        self.metrics.dropped_log_records.observe(dropped_logs);
+        self.metrics
+            .dropped_metric_datapoints
+            .observe(dropped_metrics);
+        self.metrics.dropped_spans.observe(dropped_spans);
+
+        let mut expired_logs = 0u64;
+        let mut expired_metrics = 0u64;
+        let mut expired_spans = 0u64;
+        for (slot, count) in engine.expired_items_per_slot_snapshot() {
+            match signal_type_from_slot_id(slot) {
+                Some(SignalType::Logs) => expired_logs += count,
+                Some(SignalType::Metrics) => expired_metrics += count,
+                Some(SignalType::Traces) => expired_spans += count,
+                None => {}
+            }
+        }
+        self.metrics.expired_log_records.observe(expired_logs);
+        self.metrics
+            .expired_metric_datapoints
+            .observe(expired_metrics);
+        self.metrics.expired_spans.observe(expired_spans);
+
         self.metadata_load_warned_segments
             .retain(|seq| progress_snapshot.contains_key(&SegmentSeq::new(*seq)));
         self.enforce_segment_cache_bound();
@@ -1871,6 +1960,14 @@ impl otap_df_engine::local::processor::Processor<OtapPdata> for DurableBuffer {
                     {
                         self.metrics.storage_bytes_used.set(used);
                         self.metrics.storage_bytes_cap.set(cap);
+
+                        let utilization = if cap > 0 {
+                            used as f64 / cap as f64
+                        } else {
+                            0.0
+                        };
+                        self.metrics.storage_utilization.set(utilization);
+
                         self.metrics.dropped_segments.observe(dropped_segs);
                         self.metrics.dropped_bundles.observe(dropped_buns);
                         self.metrics.dropped_items.observe(dropped_items);
@@ -1881,7 +1978,7 @@ impl otap_df_engine::local::processor::Processor<OtapPdata> for DurableBuffer {
                         // registry. This is the single source of truth for
                         // these gauges, correctly accounting for ACKs,
                         // force-drops, and expiry.
-                        self.recompute_queued_counters(&engine, &subscriber_id);
+                        self.recompute_metrics(&engine, &subscriber_id);
                     }
 
                     metrics_reporter
@@ -1954,6 +2051,100 @@ pub static DURABLE_BUFFER_FACTORY: ProcessorFactory<OtapPdata> = ProcessorFactor
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arrow::array::Int32Array;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use otap_df_engine::context::ControllerContext;
+    use otap_df_telemetry::registry::TelemetryRegistryHandle;
+    use otap_df_telemetry::reporter::MetricsReporter;
+    use quiver::record_bundle::{
+        BundleDescriptor, PayloadRef, RecordBundle, SchemaFingerprint, SlotDescriptor, SlotId,
+    };
+    use std::sync::Arc;
+    use std::time::{Duration, SystemTime};
+
+    struct SimpleBundle {
+        descriptor: BundleDescriptor,
+        batch: RecordBatch,
+        fingerprint: SchemaFingerprint,
+        slot_id: SlotId,
+        item_count: u64,
+    }
+
+    impl RecordBundle for SimpleBundle {
+        fn descriptor(&self) -> &BundleDescriptor {
+            &self.descriptor
+        }
+
+        fn ingestion_time(&self) -> SystemTime {
+            SystemTime::now()
+        }
+
+        fn payload(&self, slot: SlotId) -> Option<PayloadRef<'_>> {
+            if slot == self.slot_id {
+                Some(PayloadRef {
+                    schema_fingerprint: self.fingerprint,
+                    batch: &self.batch,
+                })
+            } else {
+                None
+            }
+        }
+
+        fn item_count(&self) -> u64 {
+            self.item_count
+        }
+    }
+
+    async fn setup_test_processor(
+        max_age: Option<Duration>,
+    ) -> (
+        DurableBuffer,
+        Arc<QuiverEngine>,
+        SubscriberId,
+        tempfile::TempDir,
+    ) {
+        let registry = TelemetryRegistryHandle::default();
+        let controller_ctx = ControllerContext::new(registry);
+        let pipeline_ctx =
+            controller_ctx.pipeline_context_with("test".into(), "test".into(), 0, 1, 0);
+
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let config = DurableBufferConfig {
+            path: temp_dir.path().to_path_buf(),
+            retention_size_cap: byte_unit::Byte::from_u64(256 * 1024 * 1024),
+            max_age,
+            size_cap_policy: SizeCapPolicy::Backpressure,
+            poll_interval: Duration::from_millis(100),
+            otlp_handling: OtlpHandling::PassThrough,
+            max_segment_open_duration: Duration::from_secs(60),
+            initial_retry_interval: Duration::from_secs(1),
+            max_retry_interval: Duration::from_secs(30),
+            retry_multiplier: 2.0,
+            max_in_flight: 1000,
+        };
+
+        let processor = DurableBuffer::new(config, &pipeline_ctx).unwrap();
+        let (engine, subscriber_id) = processor.init_engine().await.unwrap();
+        (processor, engine, subscriber_id, temp_dir)
+    }
+
+    fn make_simple_bundle(slot_id: SlotId, item_count: u64) -> SimpleBundle {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from(vec![1]))],
+        )
+        .expect("valid batch");
+
+        SimpleBundle {
+            descriptor: BundleDescriptor::new(vec![SlotDescriptor::new(slot_id, "test")]),
+            batch,
+            fingerprint: [0x11u8; 32],
+            slot_id,
+            item_count,
+        }
+    }
 
     // Metric field indices matching `DurableBufferMetrics` declaration order.
     // New metrics MUST be appended to the struct so these never shift.
@@ -1964,7 +2155,7 @@ mod tests {
     const IDX_QUEUED_LOG_RECORDS: usize = 27;
     const IDX_QUEUED_METRIC_POINTS: usize = 28;
     const IDX_QUEUED_SPANS: usize = 29;
-    const EXPECTED_METRIC_COUNT: usize = 31;
+    const EXPECTED_METRIC_COUNT: usize = 38;
 
     #[test]
     fn test_bundle_ref_encoding_roundtrip() {
@@ -2637,102 +2828,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_open_segment_included_in_queued_gauge() {
-        use std::sync::Arc;
-        use std::time::SystemTime;
+        let (mut processor, engine, subscriber_id, _temp_dir) = setup_test_processor(None).await;
 
-        use arrow::array::{Int32Array, StringArray};
-        use arrow::datatypes::{DataType, Field, Schema};
-        use arrow::record_batch::RecordBatch;
-        use otap_df_engine::context::ControllerContext;
-        use otap_df_telemetry::registry::TelemetryRegistryHandle;
-        use otap_df_telemetry::reporter::MetricsReporter;
-        use quiver::record_bundle::{
-            BundleDescriptor, PayloadRef, RecordBundle, SchemaFingerprint, SlotDescriptor, SlotId,
-        };
-
-        struct SimpleBundle {
-            descriptor: BundleDescriptor,
-            batch: RecordBatch,
-            fingerprint: SchemaFingerprint,
-            slot_id: SlotId,
-            item_count: u64,
-        }
-
-        impl RecordBundle for SimpleBundle {
-            fn descriptor(&self) -> &BundleDescriptor {
-                &self.descriptor
-            }
-
-            fn ingestion_time(&self) -> SystemTime {
-                SystemTime::now()
-            }
-
-            fn payload(&self, slot: SlotId) -> Option<PayloadRef<'_>> {
-                if slot == self.slot_id {
-                    Some(PayloadRef {
-                        schema_fingerprint: self.fingerprint,
-                        batch: &self.batch,
-                    })
-                } else {
-                    None
-                }
-            }
-
-            fn item_count(&self) -> u64 {
-                self.item_count
-            }
-        }
-
-        let registry = TelemetryRegistryHandle::default();
-        let controller_ctx = ControllerContext::new(registry);
-        let pipeline_ctx =
-            controller_ctx.pipeline_context_with("test".into(), "test".into(), 0, 1, 0);
-
-        let temp_dir = tempfile::tempdir().expect("tempdir");
-        let config = DurableBufferConfig {
-            path: temp_dir.path().to_path_buf(),
-            retention_size_cap: byte_unit::Byte::from_u64(256 * 1024 * 1024),
-            max_age: None,
-            size_cap_policy: SizeCapPolicy::Backpressure,
-            poll_interval: Duration::from_millis(100),
-            otlp_handling: OtlpHandling::PassThrough,
-            max_segment_open_duration: Duration::from_secs(60),
-            initial_retry_interval: Duration::from_secs(1),
-            max_retry_interval: Duration::from_secs(30),
-            retry_multiplier: 2.0,
-            max_in_flight: 1000,
-        };
-
-        let mut processor = DurableBuffer::new(config, &pipeline_ctx).unwrap();
-        let (engine, subscriber_id) = processor.init_engine().await.unwrap();
-
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("id", DataType::Int32, false),
-            Field::new("name", DataType::Utf8, true),
-        ]));
-        let batch = RecordBatch::try_new(
-            Arc::clone(&schema),
-            vec![
-                Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5])),
-                Arc::new(StringArray::from(vec![
-                    Some("a"),
-                    Some("b"),
-                    Some("c"),
-                    Some("d"),
-                    Some("e"),
-                ])),
-            ],
-        )
-        .expect("valid batch");
-
-        let slot_id = SlotId::new(30); // Logs slot
-        let bundle = SimpleBundle {
-            descriptor: BundleDescriptor::new(vec![SlotDescriptor::new(slot_id, "Logs")]),
-            batch,
-            fingerprint: [0x11u8; 32],
-            slot_id,
-            item_count: 5,
-        };
+        let slot_id = SlotId::new(30);
+        let bundle = make_simple_bundle(slot_id, 5);
 
         engine.ingest(&bundle).await.unwrap();
 
@@ -2752,7 +2851,7 @@ mod tests {
             "open segment bundle should have the logs slot"
         );
 
-        processor.recompute_queued_counters(&engine, &subscriber_id);
+        processor.recompute_metrics(&engine, &subscriber_id);
 
         let (metrics_rx, mut reporter) = MetricsReporter::create_new_and_receiver(1);
         reporter.report(&mut processor.metrics).unwrap();
@@ -2841,5 +2940,325 @@ mod tests {
         );
         assert!(processor.segment_cache.contains_key(&20));
         assert!(processor.segment_cache.contains_key(&30));
+    }
+
+    #[test]
+    fn test_storage_utilization_reporting() {
+        use otap_df_config::node::NodeUserConfig;
+        use otap_df_engine::config::ProcessorConfig;
+        use otap_df_engine::context::ControllerContext;
+        use otap_df_engine::message::Message;
+        use otap_df_engine::testing::processor::TestRuntime;
+        use otap_df_engine::testing::test_node;
+        use otap_df_pdata::encode::encode_logs_otap_batch;
+        use otap_df_pdata::testing::fixtures::DataGenerator;
+        use otap_df_telemetry::reporter::MetricsReporter;
+        use serde_json::json;
+
+        let rt = TestRuntime::new();
+        let controller = ControllerContext::new(rt.metrics_registry());
+        let pipeline_ctx = controller.pipeline_context_with("grp".into(), "pipe".into(), 0, 1, 0);
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+
+        let mut node_config = NodeUserConfig::new_processor_config(DURABLE_BUFFER_URN);
+        node_config.config = json!({
+            "path": temp_dir.path(),
+            "retention_size_cap": "256 MiB",
+            "poll_interval": "100ms",
+            "max_segment_open_duration": "1s",
+            "initial_retry_interval": "100ms",
+            "max_retry_interval": "100ms",
+            "retry_multiplier": 2.0,
+            "max_in_flight": 1000
+        });
+
+        let processor = create_durable_buffer(
+            pipeline_ctx,
+            test_node("durable-buffer-utilization-test"),
+            Arc::new(node_config),
+            &ProcessorConfig::new("durable-buffer-utilization-test"),
+            &otap_df_engine::capability::registry::Capabilities::empty(),
+        )
+        .expect("create durable buffer");
+
+        rt.set_processor(processor)
+            .run_test(move |mut ctx| async move {
+                // Ingest some logs to write data to disk (so used bytes > 0)
+                let mut datagen = DataGenerator::new(1);
+                let input = datagen.generate_logs();
+                let rec = encode_logs_otap_batch(&input).expect("encode logs");
+                ctx.process(Message::PData(OtapPdata::new_default(rec.into())))
+                    .await
+                    .expect("process input");
+
+                // Trigger flush to finalize the open segment and write it to disk
+                ctx.process(Message::Control(NodeControlMsg::TimerTick {}))
+                    .await
+                    .expect("process timer tick");
+
+                // Trigger metrics collection
+                let (metrics_rx, reporter) = MetricsReporter::create_new_and_receiver(1);
+                ctx.process(Message::Control(NodeControlMsg::CollectTelemetry {
+                    metrics_reporter: reporter,
+                }))
+                .await
+                .expect("collect telemetry");
+
+                let snap = metrics_rx.try_recv().unwrap();
+                let metrics = snap.get_metrics();
+
+                const IDX_STORAGE_UTILIZATION: usize = 31;
+                const IDX_STORAGE_BYTES_USED: usize = 15;
+                const IDX_STORAGE_BYTES_CAP: usize = 16;
+
+                let used = metrics[IDX_STORAGE_BYTES_USED].to_u64_lossy();
+                let cap = metrics[IDX_STORAGE_BYTES_CAP].to_u64_lossy();
+                let reported_utilization = metrics[IDX_STORAGE_UTILIZATION].to_f64();
+
+                assert!(used > 0, "used bytes should be greater than 0");
+                assert_eq!(cap, 256 * 1024 * 1024, "cap bytes should be 256 MiB");
+                assert_eq!(
+                    reported_utilization,
+                    used as f64 / cap as f64,
+                    "reported utilization should match used / cap"
+                );
+            })
+            .validate(|_| async {});
+    }
+
+    #[tokio::test]
+    async fn test_per_signal_dropped_expired_metrics() {
+        let (mut processor, engine, subscriber_id, _temp_dir) =
+            setup_test_processor(Some(Duration::from_millis(5))).await;
+
+        let slot_id = SlotId::new(30);
+        let bundle = make_simple_bundle(slot_id, 5);
+
+        // 1. Ingest and flush a segment
+        engine.ingest(&bundle).await.unwrap();
+        engine.flush().await.unwrap();
+
+        // 2. Force drop the oldest pending segment
+        let dropped = engine.force_drop_oldest_pending_segments();
+        assert_eq!(dropped, 1, "should have dropped 1 segment");
+
+        // Recompute metrics so processor reads the engine drop counts
+        processor.recompute_metrics(&engine, &subscriber_id);
+
+        let (metrics_rx, mut reporter) = MetricsReporter::create_new_and_receiver(1);
+        reporter.report(&mut processor.metrics).unwrap();
+        let snap = metrics_rx.try_recv().unwrap();
+        let metrics = snap.get_metrics();
+
+        const IDX_DROPPED_LOG_RECORDS: usize = 32;
+        assert_eq!(
+            metrics[IDX_DROPPED_LOG_RECORDS].to_u64_lossy(),
+            5,
+            "dropped_log_records should show 5 items dropped"
+        );
+
+        // 3. Test expiry metrics
+        // Ingest and flush another segment
+        let bundle2 = make_simple_bundle(slot_id, 3);
+        engine.ingest(&bundle2).await.unwrap();
+        engine.flush().await.unwrap();
+
+        // Wait for it to exceed max_age (5ms)
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        // Clean up expired segments
+        let expired = engine.cleanup_expired_segments().unwrap();
+        assert_eq!(expired, 1, "should have expired 1 segment");
+
+        // Recompute metrics so processor reads the engine expiry counts
+        processor.recompute_metrics(&engine, &subscriber_id);
+
+        reporter.report(&mut processor.metrics).unwrap();
+        let snap2 = metrics_rx.try_recv().unwrap();
+        let metrics2 = snap2.get_metrics();
+
+        const IDX_EXPIRED_LOG_RECORDS: usize = 35;
+        assert_eq!(
+            metrics2[IDX_EXPIRED_LOG_RECORDS].to_u64_lossy(),
+            3,
+            "expired_log_records should show 3 items expired"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dropped_metrics_item_count() {
+        let (mut processor, engine, subscriber_id, _temp_dir) = setup_test_processor(None).await;
+
+        // Metrics slot (11: Arrow metric data point slot)
+        let slot_id = SlotId::new(11);
+        let bundle = make_simple_bundle(slot_id, 42);
+
+        engine.ingest(&bundle).await.unwrap();
+        engine.flush().await.unwrap();
+
+        let dropped = engine.force_drop_oldest_pending_segments();
+        assert_eq!(dropped, 1);
+
+        processor.recompute_metrics(&engine, &subscriber_id);
+
+        let (metrics_rx, mut reporter) = MetricsReporter::create_new_and_receiver(1);
+        reporter.report(&mut processor.metrics).unwrap();
+        let snap = metrics_rx.try_recv().unwrap();
+        let metrics = snap.get_metrics();
+
+        const IDX_DROPPED_METRIC_DATAPOINTS: usize = 34;
+        assert_eq!(metrics[IDX_DROPPED_METRIC_DATAPOINTS].to_u64_lossy(), 42);
+        const IDX_DROPPED_ITEMS: usize = 19;
+        assert_eq!(metrics[IDX_DROPPED_ITEMS].to_u64_lossy(), 42);
+    }
+
+    #[tokio::test]
+    async fn test_dropped_spans_item_count() {
+        let (mut processor, engine, subscriber_id, _temp_dir) = setup_test_processor(None).await;
+
+        // Arrow spans slot (40)
+        let slot_id = SlotId::new(40);
+        let bundle = make_simple_bundle(slot_id, 55);
+
+        engine.ingest(&bundle).await.unwrap();
+        engine.flush().await.unwrap();
+
+        let dropped = engine.force_drop_oldest_pending_segments();
+        assert_eq!(dropped, 1);
+
+        processor.recompute_metrics(&engine, &subscriber_id);
+
+        let (metrics_rx, mut reporter) = MetricsReporter::create_new_and_receiver(1);
+        reporter.report(&mut processor.metrics).unwrap();
+        let snap = metrics_rx.try_recv().unwrap();
+        let metrics = snap.get_metrics();
+
+        const IDX_DROPPED_SPANS: usize = 33;
+        assert_eq!(metrics[IDX_DROPPED_SPANS].to_u64_lossy(), 55);
+        const IDX_DROPPED_ITEMS: usize = 19;
+        assert_eq!(metrics[IDX_DROPPED_ITEMS].to_u64_lossy(), 55);
+    }
+
+    #[tokio::test]
+    async fn test_dropped_otlp_passthrough_item_count() {
+        let (mut processor, engine, subscriber_id, _temp_dir) = setup_test_processor(None).await;
+
+        // OTLP Logs slot (60)
+        let slot_id = SlotId::new(60);
+        let bundle = make_simple_bundle(slot_id, 99); // represents 99 logical records in the OTLP payload
+
+        engine.ingest(&bundle).await.unwrap();
+        engine.flush().await.unwrap();
+
+        let dropped = engine.force_drop_oldest_pending_segments();
+        assert_eq!(dropped, 1);
+
+        processor.recompute_metrics(&engine, &subscriber_id);
+
+        let (metrics_rx, mut reporter) = MetricsReporter::create_new_and_receiver(1);
+        reporter.report(&mut processor.metrics).unwrap();
+        let snap = metrics_rx.try_recv().unwrap();
+        let metrics = snap.get_metrics();
+
+        const IDX_DROPPED_LOG_RECORDS: usize = 32;
+        // Verify we tracked the logical item count (99) rather than the batch row count (1)
+        assert_eq!(metrics[IDX_DROPPED_LOG_RECORDS].to_u64_lossy(), 99);
+        const IDX_DROPPED_ITEMS: usize = 19;
+        assert_eq!(metrics[IDX_DROPPED_ITEMS].to_u64_lossy(), 99);
+    }
+
+    #[tokio::test]
+    async fn test_reconciliation() {
+        let (mut processor, engine, subscriber_id, _temp_dir) =
+            setup_test_processor(Some(Duration::from_millis(5))).await;
+
+        // 1. Ingest logs, traces, metrics bundles to be dropped
+        let b_logs = make_simple_bundle(SlotId::new(30), 10);
+        let b_traces = make_simple_bundle(SlotId::new(40), 20);
+        let b_metrics = make_simple_bundle(SlotId::new(11), 30);
+
+        engine.ingest(&b_logs).await.unwrap();
+        engine.flush().await.unwrap();
+        engine.ingest(&b_traces).await.unwrap();
+        engine.flush().await.unwrap();
+        engine.ingest(&b_metrics).await.unwrap();
+        engine.flush().await.unwrap();
+
+        // Drop all 3 segments
+        let mut dropped = 0;
+        loop {
+            let n = engine.force_drop_oldest_pending_segments();
+            if n == 0 {
+                break;
+            }
+            dropped += n;
+        }
+        assert_eq!(dropped, 3);
+
+        // 2. Ingest logs, traces, metrics bundles to be expired
+        let b_logs_exp = make_simple_bundle(SlotId::new(30), 5);
+        let b_traces_exp = make_simple_bundle(SlotId::new(40), 15);
+        let b_metrics_exp = make_simple_bundle(SlotId::new(11), 25);
+
+        engine.ingest(&b_logs_exp).await.unwrap();
+        engine.flush().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        engine.ingest(&b_traces_exp).await.unwrap();
+        engine.flush().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        engine.ingest(&b_metrics_exp).await.unwrap();
+        engine.flush().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        // Wait for segments to expire
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        let expired = engine.cleanup_expired_segments().unwrap();
+        assert_eq!(expired, 3);
+
+        processor.recompute_metrics(&engine, &subscriber_id);
+
+        let (metrics_rx, mut reporter) = MetricsReporter::create_new_and_receiver(1);
+        reporter.report(&mut processor.metrics).unwrap();
+        let snap = metrics_rx.try_recv().unwrap();
+        let metrics = snap.get_metrics();
+
+        const IDX_DROPPED_ITEMS: usize = 19;
+        const IDX_EXPIRED_ITEMS: usize = 21;
+        const IDX_DROPPED_LOG_RECORDS: usize = 32;
+        const IDX_DROPPED_SPANS: usize = 33;
+        const IDX_DROPPED_METRIC_DATAPOINTS: usize = 34;
+        const IDX_EXPIRED_LOG_RECORDS: usize = 35;
+        const IDX_EXPIRED_SPANS: usize = 36;
+        const IDX_EXPIRED_METRIC_DATAPOINTS: usize = 37;
+
+        let dropped_logs = metrics[IDX_DROPPED_LOG_RECORDS].to_u64_lossy();
+        let dropped_spans = metrics[IDX_DROPPED_SPANS].to_u64_lossy();
+        let dropped_metrics = metrics[IDX_DROPPED_METRIC_DATAPOINTS].to_u64_lossy();
+        let dropped_items = metrics[IDX_DROPPED_ITEMS].to_u64_lossy();
+
+        let expired_logs = metrics[IDX_EXPIRED_LOG_RECORDS].to_u64_lossy();
+        let expired_spans = metrics[IDX_EXPIRED_SPANS].to_u64_lossy();
+        let expired_metrics = metrics[IDX_EXPIRED_METRIC_DATAPOINTS].to_u64_lossy();
+        let expired_items = metrics[IDX_EXPIRED_ITEMS].to_u64_lossy();
+
+        // Assert dropped reconciliation
+        assert_eq!(dropped_logs, 10);
+        assert_eq!(dropped_spans, 20);
+        assert_eq!(dropped_metrics, 30);
+        assert_eq!(
+            dropped_logs + dropped_spans + dropped_metrics,
+            dropped_items
+        );
+
+        // Assert expired reconciliation
+        assert_eq!(expired_logs, 5);
+        assert_eq!(expired_spans, 15);
+        assert_eq!(expired_metrics, 25);
+        assert_eq!(
+            expired_logs + expired_spans + expired_metrics,
+            expired_items
+        );
     }
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
@@ -504,6 +504,16 @@ pub struct DurableBuffer {
     /// Prevents warning spam when `bundle_metadata` repeatedly fails for the
     /// same segment across telemetry ticks.
     metadata_load_warned_segments: HashSet<u64>,
+
+    /// Cumulative logged items dropped via DropOldest policy.
+    total_dropped_logs: u64,
+    total_dropped_metrics: u64,
+    total_dropped_spans: u64,
+
+    /// Cumulative logged items dropped via MaxAge policy.
+    total_expired_logs: u64,
+    total_expired_metrics: u64,
+    total_expired_spans: u64,
 }
 
 impl DurableBuffer {
@@ -569,6 +579,12 @@ impl DurableBuffer {
             segment_cache: HashMap::new(),
             segment_cache_generation: 0,
             metadata_load_warned_segments: HashSet::new(),
+            total_dropped_logs: 0,
+            total_dropped_metrics: 0,
+            total_dropped_spans: 0,
+            total_expired_logs: 0,
+            total_expired_metrics: 0,
+            total_expired_spans: 0,
         })
     }
 
@@ -973,42 +989,38 @@ impl DurableBuffer {
             .observe(engine.expired_bundles());
         self.metrics.expired_items.observe(engine.expired_items());
 
-        // Update dropped and expired metrics by iterating the engine's per-slot snapshots
+        // Update dropped and expired metrics by draining the engine's pending bundles
         // and aggregating by signal type via signal_type_from_slot_id(). This handles all
         // slot ranges (Arrow 10-45 and OTLP 60-62) without hardcoding any slot IDs here.
-        let mut dropped_logs = 0u64;
-        let mut dropped_metrics = 0u64;
-        let mut dropped_spans = 0u64;
-        for (slot, count) in engine.force_dropped_items_per_slot_snapshot() {
-            match signal_type_from_slot_id(slot) {
-                Some(SignalType::Logs) => dropped_logs += count,
-                Some(SignalType::Metrics) => dropped_metrics += count,
-                Some(SignalType::Traces) => dropped_spans += count,
+        for (slot_ids, count) in engine.drain_dropped_bundles_pending() {
+            let sig = slot_ids.iter().copied().find_map(signal_type_from_slot_id);
+            match sig {
+                Some(SignalType::Logs) => self.total_dropped_logs += count,
+                Some(SignalType::Metrics) => self.total_dropped_metrics += count,
+                Some(SignalType::Traces) => self.total_dropped_spans += count,
                 None => {}
             }
         }
-        self.metrics.dropped_log_records.observe(dropped_logs);
+        self.metrics.dropped_log_records.observe(self.total_dropped_logs);
         self.metrics
             .dropped_metric_datapoints
-            .observe(dropped_metrics);
-        self.metrics.dropped_spans.observe(dropped_spans);
+            .observe(self.total_dropped_metrics);
+        self.metrics.dropped_spans.observe(self.total_dropped_spans);
 
-        let mut expired_logs = 0u64;
-        let mut expired_metrics = 0u64;
-        let mut expired_spans = 0u64;
-        for (slot, count) in engine.expired_items_per_slot_snapshot() {
-            match signal_type_from_slot_id(slot) {
-                Some(SignalType::Logs) => expired_logs += count,
-                Some(SignalType::Metrics) => expired_metrics += count,
-                Some(SignalType::Traces) => expired_spans += count,
+        for (slot_ids, count) in engine.drain_expired_bundles_pending() {
+            let sig = slot_ids.iter().copied().find_map(signal_type_from_slot_id);
+            match sig {
+                Some(SignalType::Logs) => self.total_expired_logs += count,
+                Some(SignalType::Metrics) => self.total_expired_metrics += count,
+                Some(SignalType::Traces) => self.total_expired_spans += count,
                 None => {}
             }
         }
-        self.metrics.expired_log_records.observe(expired_logs);
+        self.metrics.expired_log_records.observe(self.total_expired_logs);
         self.metrics
             .expired_metric_datapoints
-            .observe(expired_metrics);
-        self.metrics.expired_spans.observe(expired_spans);
+            .observe(self.total_expired_metrics);
+        self.metrics.expired_spans.observe(self.total_expired_spans);
 
         self.metadata_load_warned_segments
             .retain(|seq| progress_snapshot.contains_key(&SegmentSeq::new(*seq)));

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
@@ -1001,7 +1001,9 @@ impl DurableBuffer {
                 None => {}
             }
         }
-        self.metrics.dropped_log_records.observe(self.total_dropped_logs);
+        self.metrics
+            .dropped_log_records
+            .observe(self.total_dropped_logs);
         self.metrics
             .dropped_metric_datapoints
             .observe(self.total_dropped_metrics);
@@ -1016,7 +1018,9 @@ impl DurableBuffer {
                 None => {}
             }
         }
-        self.metrics.expired_log_records.observe(self.total_expired_logs);
+        self.metrics
+            .expired_log_records
+            .observe(self.total_expired_logs);
         self.metrics
             .expired_metric_datapoints
             .observe(self.total_expired_metrics);
@@ -1974,7 +1978,7 @@ impl otap_df_engine::local::processor::Processor<OtapPdata> for DurableBuffer {
                         self.metrics.storage_bytes_cap.set(cap);
 
                         let utilization = if cap > 0 {
-                            used as f64 / cap as f64
+                            (used.min(cap) as f64) / (cap as f64)
                         } else {
                             0.0
                         };

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
@@ -2079,7 +2079,7 @@ mod tests {
         descriptor: BundleDescriptor,
         batch: RecordBatch,
         fingerprint: SchemaFingerprint,
-        slot_id: SlotId,
+        primary_slot: SlotId,
         item_count: u64,
     }
 
@@ -2093,7 +2093,7 @@ mod tests {
         }
 
         fn payload(&self, slot: SlotId) -> Option<PayloadRef<'_>> {
-            if slot == self.slot_id {
+            if slot == self.primary_slot {
                 Some(PayloadRef {
                     schema_fingerprint: self.fingerprint,
                     batch: &self.batch,
@@ -2141,7 +2141,7 @@ mod tests {
         (processor, engine, subscriber_id, temp_dir)
     }
 
-    fn make_simple_bundle(slot_id: SlotId, item_count: u64) -> SimpleBundle {
+    fn make_simple_bundle(primary_slot: SlotId, item_count: u64) -> SimpleBundle {
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
         let batch = RecordBatch::try_new(
             Arc::clone(&schema),
@@ -2149,11 +2149,19 @@ mod tests {
         )
         .expect("valid batch");
 
+        // Include shared slots (ResourceAttrs=1, ScopeAttrs=2) alongside the
+        // primary signal slot, mirroring real OTAP bundles. This ensures
+        // find_map(signal_type_from_slot_id) skips shared slots and correctly
+        // classifies by the signal-specific slot.
         SimpleBundle {
-            descriptor: BundleDescriptor::new(vec![SlotDescriptor::new(slot_id, "test")]),
+            descriptor: BundleDescriptor::new(vec![
+                SlotDescriptor::new(SlotId::new(1), "resource_attrs"),
+                SlotDescriptor::new(SlotId::new(2), "scope_attrs"),
+                SlotDescriptor::new(primary_slot, "test"),
+            ]),
             batch,
             fingerprint: [0x11u8; 32],
-            slot_id,
+            primary_slot,
             item_count,
         }
     }

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/telemetry.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/telemetry.md
@@ -62,6 +62,35 @@ The effective instrument name is `otap.processor.durable_buffer.<field_name>`.
 | `otap.processor.durable_buffer.expired_bundles` | `{bundle}` | ObserveCounter | Cumulative bundles lost due to `max_age` segment expiry. Non-zero values indicate data aged out before delivery. | `crates/otap/src/durable_buffer_processor/mod.rs` |
 | `otap.processor.durable_buffer.expired_items` | `{item}` | ObserveCounter | Cumulative individual items lost due to `max_age` segment expiry. Non-zero values indicate data aged out before delivery. | `crates/otap/src/durable_buffer_processor/mod.rs` |
 
+### Flush Failures
+
+| Metric name | Unit | Instrument | Description | Produced in file |
+| --- | --- | --- | --- | --- |
+| `otap.processor.durable_buffer.flush_failures` | `{error}` | Counter | Cumulative segment finalization (flush) failures. Non-zero values indicate data at risk — check logs for root cause. Data may still be recoverable via WAL replay on restart. | `crates/otap/src/durable_buffer_processor/mod.rs` |
+
+### Storage Utilization
+
+| Metric name | Unit | Instrument | Description | Produced in file |
+| --- | --- | --- | --- | --- |
+| `otap.processor.durable_buffer.storage_utilization` | `{1}` | Gauge | Current storage utilization ratio (`storage_bytes_used / storage_bytes_cap`), in the range `[0.0, 1.0]`. Updated on each `CollectTelemetry` tick. | `crates/otap/src/durable_buffer_processor/mod.rs` |
+
+### Per-Signal Dropped Items (DropOldest policy)
+
+| Metric name | Unit | Instrument | Description | Produced in file |
+| --- | --- | --- | --- | --- |
+| `otap.processor.durable_buffer.dropped_log_records` | `{log_record}` | ObserveCounter | Cumulative log records lost due to force-dropped segments (`DropOldest`). Aggregated across all Arrow and OTLP log slots. | `crates/otap/src/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.dropped_spans` | `{span}` | ObserveCounter | Cumulative spans lost due to force-dropped segments (`DropOldest`). Aggregated across all Arrow and OTLP trace slots. | `crates/otap/src/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.dropped_metric_datapoints` | `{data_point}` | ObserveCounter | Cumulative metric data points lost due to force-dropped segments (`DropOldest`). Aggregated across all Arrow and OTLP metric slots (slots 11–14 for Arrow, slot 62 for OTLP). | `crates/otap/src/durable_buffer_processor/mod.rs` |
+
+### Per-Signal Expired Items (max_age policy)
+
+| Metric name | Unit | Instrument | Description | Produced in file |
+| --- | --- | --- | --- | --- |
+| `otap.processor.durable_buffer.expired_log_records` | `{log_record}` | ObserveCounter | Cumulative log records lost due to `max_age` segment expiry. Aggregated across all Arrow and OTLP log slots. | `crates/otap/src/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.expired_spans` | `{span}` | ObserveCounter | Cumulative spans lost due to `max_age` segment expiry. Aggregated across all Arrow and OTLP trace slots. | `crates/otap/src/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.expired_metric_datapoints` | `{data_point}` | ObserveCounter | Cumulative metric data points lost due to `max_age` segment expiry. Aggregated across all Arrow and OTLP metric slots. | `crates/otap/src/durable_buffer_processor/mod.rs` |
+
+
 ### In-flight and Retry
 
 | Metric name | Unit | Instrument | Description | Produced in file |

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/telemetry.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/telemetry.md
@@ -66,7 +66,7 @@ The effective instrument name is `otap.processor.durable_buffer.<field_name>`.
 
 | Metric name | Unit | Instrument | Description | Produced in file |
 | --- | --- | --- | --- | --- |
-| `otap.processor.durable_buffer.flush_failures` | `{error}` | Counter | Cumulative segment finalization (flush) failures. Non-zero values indicate data at risk — check logs for root cause. Data may still be recoverable via WAL replay on restart. | `crates/otap/src/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.flush_failures` | `{error}` | Counter | Cumulative segment finalization (flush) failures. Non-zero values indicate data at risk - check logs for root cause. Data may still be recoverable via WAL replay on restart. | `crates/otap/src/durable_buffer_processor/mod.rs` |
 
 ### Storage Utilization
 
@@ -80,7 +80,7 @@ The effective instrument name is `otap.processor.durable_buffer.<field_name>`.
 | --- | --- | --- | --- | --- |
 | `otap.processor.durable_buffer.dropped_log_records` | `{log_record}` | ObserveCounter | Cumulative log records lost due to force-dropped segments (`DropOldest`). Aggregated across all Arrow and OTLP log slots. | `crates/otap/src/durable_buffer_processor/mod.rs` |
 | `otap.processor.durable_buffer.dropped_spans` | `{span}` | ObserveCounter | Cumulative spans lost due to force-dropped segments (`DropOldest`). Aggregated across all Arrow and OTLP trace slots. | `crates/otap/src/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.dropped_metric_datapoints` | `{data_point}` | ObserveCounter | Cumulative metric data points lost due to force-dropped segments (`DropOldest`). Aggregated across all Arrow and OTLP metric slots (slots 11–14 for Arrow, slot 62 for OTLP). | `crates/otap/src/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.dropped_metric_datapoints` | `{data_point}` | ObserveCounter | Cumulative metric data points lost due to force-dropped segments (`DropOldest`). Aggregated across all Arrow and OTLP metric slots (slots 11-14 for Arrow, slot 62 for OTLP). | `crates/otap/src/durable_buffer_processor/mod.rs` |
 
 ### Per-Signal Expired Items (max_age policy)
 
@@ -89,7 +89,6 @@ The effective instrument name is `otap.processor.durable_buffer.<field_name>`.
 | `otap.processor.durable_buffer.expired_log_records` | `{log_record}` | ObserveCounter | Cumulative log records lost due to `max_age` segment expiry. Aggregated across all Arrow and OTLP log slots. | `crates/otap/src/durable_buffer_processor/mod.rs` |
 | `otap.processor.durable_buffer.expired_spans` | `{span}` | ObserveCounter | Cumulative spans lost due to `max_age` segment expiry. Aggregated across all Arrow and OTLP trace slots. | `crates/otap/src/durable_buffer_processor/mod.rs` |
 | `otap.processor.durable_buffer.expired_metric_datapoints` | `{data_point}` | ObserveCounter | Cumulative metric data points lost due to `max_age` segment expiry. Aggregated across all Arrow and OTLP metric slots. | `crates/otap/src/durable_buffer_processor/mod.rs` |
-
 
 ### In-flight and Retry
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/telemetry.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/telemetry.md
@@ -7,110 +7,112 @@ events emitted via `otel_*` log macros.
 
 ## Metrics
 
-All metrics are emitted under the metric-set name `otap.processor.durable_buffer`.
+All metrics are emitted under the metric-set name
+`otap.processor.durable_buffer`.
 The effective instrument name is `otap.processor.durable_buffer.<field_name>`.
 
 ### ACK / NACK Tracking
 
 | Metric name | Unit | Instrument | Description | Produced in file |
 | --- | --- | --- | --- | --- |
-| `otap.processor.durable_buffer.bundles_acked` | `{bundle}` | Counter | Number of bundles acknowledged by downstream. | `crates/otap/src/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.bundles_nacked_deferred` | `{bundle}` | Counter | Number of bundles deferred for retry after a transient downstream failure. | `crates/otap/src/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.bundles_nacked_permanent` | `{bundle}` | Counter | Number of bundles permanently rejected by downstream (not retried). Non-zero values may indicate malformed data. | `crates/otap/src/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.bundles_acked` | `{bundle}` | Counter | Number of bundles acknowledged by downstream. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.bundles_nacked_deferred` | `{bundle}` | Counter | Number of bundles deferred for retry after a transient downstream failure. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.bundles_nacked_permanent` | `{bundle}` | Counter | Number of bundles permanently rejected by downstream (not retried). Non-zero values may indicate malformed data. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
 
 ### Rejected Item Counts (per signal type)
 
 | Metric name | Unit | Instrument | Description | Produced in file |
 | --- | --- | --- | --- | --- |
-| `otap.processor.durable_buffer.rejected_log_records` | `{log_record}` | Counter | Number of log records in permanently rejected bundles. | `crates/otap/src/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.rejected_metric_points` | `{data_point}` | Counter | Number of metric data points in permanently rejected bundles. | `crates/otap/src/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.rejected_spans` | `{span}` | Counter | Number of spans in permanently rejected bundles. | `crates/otap/src/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.rejected_log_records` | `{log_record}` | Counter | Number of log records in permanently rejected bundles. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.rejected_metric_points` | `{data_point}` | Counter | Number of metric data points in permanently rejected bundles. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.rejected_spans` | `{span}` | Counter | Number of spans in permanently rejected bundles. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
 
 ### Consumed Item Counts (per signal type)
 
 | Metric name | Unit | Instrument | Description | Produced in file |
 | --- | --- | --- | --- | --- |
-| `otap.processor.durable_buffer.consumed_log_records` | `{log_record}` | Counter | Number of log records ingested to durable storage. For OTLP bytes, counted via a protobuf wire-format scan without full deserialization. | `crates/otap/src/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.consumed_metric_points` | `{data_point}` | Counter | Number of metric data points ingested to durable storage. Same counting method as above. | `crates/otap/src/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.consumed_spans` | `{span}` | Counter | Number of spans ingested to durable storage. Same counting method as above. | `crates/otap/src/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.consumed_log_records` | `{log_record}` | Counter | Number of log records ingested to durable storage. For OTLP bytes, counted via a protobuf wire-format scan without full deserialization. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.consumed_metric_points` | `{data_point}` | Counter | Number of metric data points ingested to durable storage. Same counting method as above. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.consumed_spans` | `{span}` | Counter | Number of spans ingested to durable storage. Same counting method as above. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
 
 ### Produced Item Counts (per signal type)
 
 | Metric name | Unit | Instrument | Description | Produced in file |
 | --- | --- | --- | --- | --- |
-| `otap.processor.durable_buffer.produced_log_records` | `{log_record}` | Counter | Number of log records sent downstream. | `crates/otap/src/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.produced_metric_points` | `{data_point}` | Counter | Number of metric data points sent downstream. | `crates/otap/src/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.produced_spans` | `{span}` | Counter | Number of spans sent downstream. | `crates/otap/src/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.produced_log_records` | `{log_record}` | Counter | Number of log records sent downstream. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.produced_metric_points` | `{data_point}` | Counter | Number of metric data points sent downstream. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.produced_spans` | `{span}` | Counter | Number of spans sent downstream. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
 
 ### Error and Backpressure
 
 | Metric name | Unit | Instrument | Description | Produced in file |
 | --- | --- | --- | --- | --- |
-| `otap.processor.durable_buffer.ingest_errors` | `{error}` | Counter | Number of ingest errors (excludes storage-backpressure rejections). | `crates/otap/src/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.ingest_backpressure` | `{rejection}` | Counter | Number of ingest rejections because the storage soft cap was exceeded. | `crates/otap/src/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.read_errors` | `{error}` | Counter | Number of read errors (poll or bundle-conversion failures). | `crates/otap/src/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.ingest_errors` | `{error}` | Counter | Number of ingest errors (excludes storage-backpressure rejections). | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.ingest_backpressure` | `{rejection}` | Counter | Number of ingest rejections because the storage soft cap was exceeded. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.read_errors` | `{error}` | Counter | Number of read errors (poll or bundle-conversion failures). | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
 
 ### Storage
 
 | Metric name | Unit | Instrument | Description | Produced in file |
 | --- | --- | --- | --- | --- |
-| `otap.processor.durable_buffer.storage_bytes_used` | `By` | Gauge | Current bytes used by persistent storage (durable storage + segments). Updated on each `CollectTelemetry` tick. | `crates/otap/src/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.storage_bytes_cap` | `By` | Gauge | Configured per-core storage capacity cap. Updated on each `CollectTelemetry` tick. | `crates/otap/src/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.dropped_segments` | `{segment}` | ObserveCounter | Cumulative segments force-dropped due to `DropOldest` retention policy. Non-zero values indicate data loss. | `crates/otap/src/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.dropped_bundles` | `{bundle}` | ObserveCounter | Cumulative bundles lost due to force-dropped segments. Non-zero values indicate data loss. | `crates/otap/src/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.dropped_items` | `{item}` | ObserveCounter | Cumulative individual items (log records, data points, spans) lost due to force-dropped segments. Non-zero values indicate data loss. | `crates/otap/src/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.expired_bundles` | `{bundle}` | ObserveCounter | Cumulative bundles lost due to `max_age` segment expiry. Non-zero values indicate data aged out before delivery. | `crates/otap/src/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.expired_items` | `{item}` | ObserveCounter | Cumulative individual items lost due to `max_age` segment expiry. Non-zero values indicate data aged out before delivery. | `crates/otap/src/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.storage_bytes_used` | `By` | Gauge | Current bytes used by persistent storage (durable storage + segments). Updated on each `CollectTelemetry` tick. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.storage_bytes_cap` | `By` | Gauge | Configured per-core storage capacity cap. Updated on each `CollectTelemetry` tick. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.dropped_segments` | `{segment}` | ObserveCounter | Cumulative segments force-dropped due to `DropOldest` retention policy. Non-zero values indicate data loss. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.dropped_bundles` | `{bundle}` | ObserveCounter | Cumulative bundles lost due to force-dropped segments. Non-zero values indicate data loss. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.dropped_items` | `{item}` | ObserveCounter | Cumulative individual items (log records, data points, spans) lost due to force-dropped segments. Non-zero values indicate data loss. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.expired_bundles` | `{bundle}` | ObserveCounter | Cumulative bundles lost due to `max_age` segment expiry. Non-zero values indicate data aged out before delivery. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.expired_items` | `{item}` | ObserveCounter | Cumulative individual items lost due to `max_age` segment expiry. Non-zero values indicate data aged out before delivery. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
 
 ### Flush Failures
 
 | Metric name | Unit | Instrument | Description | Produced in file |
 | --- | --- | --- | --- | --- |
-| `otap.processor.durable_buffer.flush_failures` | `{error}` | Counter | Cumulative segment finalization (flush) failures. Non-zero values indicate data at risk - check logs for root cause. Data may still be recoverable via WAL replay on restart. | `crates/otap/src/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.flush_failures` | `{error}` | Counter | Cumulative segment finalization (flush) failures. Non-zero values indicate data at risk - check logs for root cause. Data may still be recoverable via WAL replay on restart. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
 
 ### Storage Utilization
 
 | Metric name | Unit | Instrument | Description | Produced in file |
 | --- | --- | --- | --- | --- |
-| `otap.processor.durable_buffer.storage_utilization` | `{1}` | Gauge | Current storage utilization ratio (`storage_bytes_used / storage_bytes_cap`), in the range `[0.0, 1.0]`. Updated on each `CollectTelemetry` tick. | `crates/otap/src/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.storage_utilization` | `{1}` | Gauge | Current storage utilization ratio (`storage_bytes_used / storage_bytes_cap`), in the range `[0.0, 1.0]`. Updated on each `CollectTelemetry` tick. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
 
 ### Per-Signal Dropped Items (DropOldest policy)
 
 | Metric name | Unit | Instrument | Description | Produced in file |
 | --- | --- | --- | --- | --- |
-| `otap.processor.durable_buffer.dropped_log_records` | `{log_record}` | ObserveCounter | Cumulative log records lost due to force-dropped segments (`DropOldest`). Aggregated across all Arrow and OTLP log slots. | `crates/otap/src/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.dropped_spans` | `{span}` | ObserveCounter | Cumulative spans lost due to force-dropped segments (`DropOldest`). Aggregated across all Arrow and OTLP trace slots. | `crates/otap/src/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.dropped_metric_datapoints` | `{data_point}` | ObserveCounter | Cumulative metric data points lost due to force-dropped segments (`DropOldest`). Aggregated across all Arrow and OTLP metric slots (slots 11-14 for Arrow, slot 62 for OTLP). | `crates/otap/src/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.dropped_log_records` | `{log_record}` | ObserveCounter | Cumulative log records lost due to force-dropped segments (`DropOldest`). Aggregated across all Arrow and OTLP log slots. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.dropped_spans` | `{span}` | ObserveCounter | Cumulative spans lost due to force-dropped segments (`DropOldest`). Aggregated across all Arrow and OTLP trace slots. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.dropped_metric_datapoints` | `{data_point}` | ObserveCounter | Cumulative metric data points lost due to force-dropped segments (`DropOldest`). Aggregated across all Arrow and OTLP metric slots (slots 11-14 for Arrow, slot 62 for OTLP). | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
 
 ### Per-Signal Expired Items (max_age policy)
 
 | Metric name | Unit | Instrument | Description | Produced in file |
 | --- | --- | --- | --- | --- |
-| `otap.processor.durable_buffer.expired_log_records` | `{log_record}` | ObserveCounter | Cumulative log records lost due to `max_age` segment expiry. Aggregated across all Arrow and OTLP log slots. | `crates/otap/src/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.expired_spans` | `{span}` | ObserveCounter | Cumulative spans lost due to `max_age` segment expiry. Aggregated across all Arrow and OTLP trace slots. | `crates/otap/src/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.expired_metric_datapoints` | `{data_point}` | ObserveCounter | Cumulative metric data points lost due to `max_age` segment expiry. Aggregated across all Arrow and OTLP metric slots. | `crates/otap/src/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.expired_log_records` | `{log_record}` | ObserveCounter | Cumulative log records lost due to `max_age` segment expiry. Aggregated across all Arrow and OTLP log slots. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.expired_spans` | `{span}` | ObserveCounter | Cumulative spans lost due to `max_age` segment expiry. Aggregated across all Arrow and OTLP trace slots. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.expired_metric_datapoints` | `{data_point}` | ObserveCounter | Cumulative metric data points lost due to `max_age` segment expiry. Aggregated across all Arrow and OTLP metric slots. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
 
 ### In-flight and Retry
 
 | Metric name | Unit | Instrument | Description | Produced in file |
 | --- | --- | --- | --- | --- |
-| `otap.processor.durable_buffer.in_flight` | `{bundle}` | Gauge | Current number of bundles sent downstream but not yet ACKed/NACKed. | `crates/otap/src/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.retries_scheduled` | `{retry}` | Counter | Cumulative number of retry attempts scheduled after a transient NACK. | `crates/otap/src/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.requeued_log_records` | `{log_record}` | Counter | Cumulative log records in bundles requeued for retry after NACK. | `crates/otap/src/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.requeued_metric_points` | `{data_point}` | Counter | Cumulative metric data points in bundles requeued for retry after NACK. | `crates/otap/src/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.requeued_spans` | `{span}` | Counter | Cumulative spans in bundles requeued for retry after NACK. | `crates/otap/src/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.in_flight` | `{bundle}` | Gauge | Current number of bundles sent downstream but not yet ACKed/NACKed. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.retries_scheduled` | `{retry}` | Counter | Cumulative number of retry attempts scheduled after a transient NACK. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.requeued_log_records` | `{log_record}` | Counter | Cumulative log records in bundles requeued for retry after NACK. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.requeued_metric_points` | `{data_point}` | Counter | Cumulative metric data points in bundles requeued for retry after NACK. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.requeued_spans` | `{span}` | Counter | Cumulative spans in bundles requeued for retry after NACK. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
 
 ### Queued Item Gauges (ingested but not yet ACKed)
 
 | Metric name | Unit | Instrument | Description | Produced in file |
 | --- | --- | --- | --- | --- |
-| `otap.processor.durable_buffer.queued_log_records` | `{log_record}` | Gauge | Current log records queued in durable storage/segments awaiting downstream ACK. Seeded from existing segments on restart. | `crates/otap/src/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.queued_metric_points` | `{data_point}` | Gauge | Current metric data points queued in durable storage/segments awaiting downstream ACK. Seeded from existing segments on restart. | `crates/otap/src/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.queued_spans` | `{span}` | Gauge | Current spans queued in durable storage/segments awaiting downstream ACK. Seeded from existing segments on restart. | `crates/otap/src/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.queued_log_records` | `{log_record}` | Gauge | Current log records queued in durable storage/segments awaiting downstream ACK. Seeded from existing segments on restart. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.queued_metric_points` | `{data_point}` | Gauge | Current metric data points queued in durable storage/segments awaiting downstream ACK. Seeded from existing segments on restart. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
+| `otap.processor.durable_buffer.queued_spans` | `{span}` | Gauge | Current spans queued in durable storage/segments awaiting downstream ACK. Seeded from existing segments on restart. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
 
 ## Logs
 
-All events are emitted from `crates/otap/src/durable_buffer_processor/mod.rs`.
+All events are emitted from
+`crates/core-nodes/src/processors/durable_buffer_processor/mod.rs`.
 
 ### Engine Lifecycle
 
@@ -205,24 +207,24 @@ When adding or changing telemetry in this module:
 
 1. **Metrics**
      - If you add a field to `DurableBufferMetrics` in
-         `crates/otap/src/durable_buffer_processor/mod.rs`, add/update the
-         corresponding row in the **Metrics** table.
+       `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs`,
+       add/update the corresponding row in the **Metrics** table.
      - The effective emitted name is
-         `otap.processor.durable_buffer.<field_name>` (or the `name` override
-         in the `#[metric(...)]` attribute if present).
+       `otap.processor.durable_buffer.<field_name>` (or the `name` override
+       in the `#[metric(...)]` attribute if present).
      - Note the instrument type (`Counter`, `Gauge`, or `ObserveCounter`) in
-         the **Instrument** column.
+       the **Instrument** column.
 
 2. **Logs**
-     - If you add `otel_info!`, `otel_warn!`, `otel_error!`, `otel_debug!`, or
-         `otel_trace!` calls in this module, add/update a row in the appropriate
-         subsection of the **Logs** table.
+     - If you add `otel_info!`, `otel_warn!`, `otel_error!`, `otel_debug!`,
+       or `otel_trace!` calls in this module, add/update a row in the
+       appropriate subsection of the **Logs** table.
      - Keep event names exact (first macro argument), include the log level,
-         and describe the condition that triggers the event.
+       and describe the condition that triggers the event.
 
 3. **Review checklist (quick)**
      - Search for new metric fields: `#[metric(` in
-         `crates/otap/src/durable_buffer_processor/mod.rs`.
+       `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs`.
      - Search for new log events: `otel_(trace|debug|info|warn|error)!(` in
-         `crates/otap/src/durable_buffer_processor/**`.
+       `crates/otap/src/durable_buffer_processor/**`.
      - Confirm this document still matches current source files.

--- a/rust/otap-dataflow/crates/otap/tests/durable_buffer_processor_tests.rs
+++ b/rust/otap-dataflow/crates/otap/tests/durable_buffer_processor_tests.rs
@@ -365,7 +365,6 @@ const IDX_QUEUED_LOG_RECORDS: usize = 27;
 const IDX_QUEUED_METRIC_POINTS: usize = 28;
 const IDX_QUEUED_SPANS: usize = 29;
 const IDX_FLUSH_FAILURES: usize = 30;
-// ─── Appended metrics (Do not shift index above) ─────────────────────────────
 
 const DURABLE_BUFFER_METRIC_COUNT: usize = 38;
 

--- a/rust/otap-dataflow/crates/otap/tests/durable_buffer_processor_tests.rs
+++ b/rust/otap-dataflow/crates/otap/tests/durable_buffer_processor_tests.rs
@@ -366,20 +366,6 @@ const IDX_QUEUED_METRIC_POINTS: usize = 28;
 const IDX_QUEUED_SPANS: usize = 29;
 const IDX_FLUSH_FAILURES: usize = 30;
 // ─── Appended metrics (Do not shift index above) ─────────────────────────────
-#[allow(dead_code)]
-const IDX_STORAGE_UTILIZATION: usize = 31;
-#[allow(dead_code)]
-const IDX_DROPPED_LOG_RECORDS: usize = 32;
-#[allow(dead_code)]
-const IDX_DROPPED_SPANS: usize = 33;
-#[allow(dead_code)]
-const IDX_DROPPED_METRIC_DATAPOINTS: usize = 34;
-#[allow(dead_code)]
-const IDX_EXPIRED_LOG_RECORDS: usize = 35;
-#[allow(dead_code)]
-const IDX_EXPIRED_SPANS: usize = 36;
-#[allow(dead_code)]
-const IDX_EXPIRED_METRIC_DATAPOINTS: usize = 37;
 
 const DURABLE_BUFFER_METRIC_COUNT: usize = 38;
 

--- a/rust/otap-dataflow/crates/otap/tests/durable_buffer_processor_tests.rs
+++ b/rust/otap-dataflow/crates/otap/tests/durable_buffer_processor_tests.rs
@@ -365,8 +365,23 @@ const IDX_QUEUED_LOG_RECORDS: usize = 27;
 const IDX_QUEUED_METRIC_POINTS: usize = 28;
 const IDX_QUEUED_SPANS: usize = 29;
 const IDX_FLUSH_FAILURES: usize = 30;
+// ─── Appended metrics (Do not shift index above) ─────────────────────────────
+#[allow(dead_code)]
+const IDX_STORAGE_UTILIZATION: usize = 31;
+#[allow(dead_code)]
+const IDX_DROPPED_LOG_RECORDS: usize = 32;
+#[allow(dead_code)]
+const IDX_DROPPED_SPANS: usize = 33;
+#[allow(dead_code)]
+const IDX_DROPPED_METRIC_DATAPOINTS: usize = 34;
+#[allow(dead_code)]
+const IDX_EXPIRED_LOG_RECORDS: usize = 35;
+#[allow(dead_code)]
+const IDX_EXPIRED_SPANS: usize = 36;
+#[allow(dead_code)]
+const IDX_EXPIRED_METRIC_DATAPOINTS: usize = 37;
 
-const DURABLE_BUFFER_METRIC_COUNT: usize = 31;
+const DURABLE_BUFFER_METRIC_COUNT: usize = 38;
 
 /// Collected metrics from a pipeline run, aggregated across all telemetry snapshots.
 #[derive(Debug, Default)]

--- a/rust/otap-dataflow/crates/quiver/src/engine.rs
+++ b/rust/otap-dataflow/crates/quiver/src/engine.rs
@@ -1369,12 +1369,23 @@ impl QuiverEngine {
                 bundles_dropped += bundles as u64;
                 items_dropped += items;
             }
-            if let Ok(metadata) = self.segment_store.bundle_metadata(*seq) {
-                let mut map = self.dropped_items_by_shape.write();
-                for bundle in metadata {
-                    let mut key = bundle.slot_ids;
-                    key.sort_unstable();
-                    *map.entry(key).or_insert(0) += bundle.item_count;
+            match self.segment_store.bundle_metadata(*seq) {
+                Ok(metadata) => {
+                    let mut map = self.dropped_items_by_shape.write();
+                    for bundle in metadata {
+                        let mut key = bundle.slot_ids;
+                        key.sort_unstable();
+                        *map.entry(key).or_insert(0) += bundle.item_count;
+                    }
+                }
+                Err(e) => {
+                    otel_warn!(
+                        "quiver.segment.drop_metadata_failed",
+                        segment = seq.raw(),
+                        error = %e,
+                        error_type = "io",
+                        reason = "force_drop"
+                    );
                 }
             }
             if let Err(e) = self.segment_store.delete_segment(*seq) {
@@ -1446,12 +1457,23 @@ impl QuiverEngine {
                 bundles_expired += bundles as u64;
                 items_expired += items;
             }
-            if let Ok(metadata) = self.segment_store.bundle_metadata(*seq) {
-                let mut map = self.expired_items_by_shape.write();
-                for bundle in metadata {
-                    let mut key = bundle.slot_ids;
-                    key.sort_unstable();
-                    *map.entry(key).or_insert(0) += bundle.item_count;
+            match self.segment_store.bundle_metadata(*seq) {
+                Ok(metadata) => {
+                    let mut map = self.expired_items_by_shape.write();
+                    for bundle in metadata {
+                        let mut key = bundle.slot_ids;
+                        key.sort_unstable();
+                        *map.entry(key).or_insert(0) += bundle.item_count;
+                    }
+                }
+                Err(e) => {
+                    otel_warn!(
+                        "quiver.segment.drop_metadata_failed",
+                        segment = seq.raw(),
+                        error = %e,
+                        error_type = "io",
+                        reason = "expired"
+                    );
                 }
             }
 

--- a/rust/otap-dataflow/crates/quiver/src/engine.rs
+++ b/rust/otap-dataflow/crates/quiver/src/engine.rs
@@ -18,7 +18,6 @@
 //! 4. **WAL Consumer Cursor**: After segment finalization, the WAL cursor is
 //!    advanced to allow cleanup of consumed entries.
 
-use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -109,14 +108,14 @@ pub struct QuiverEngine {
     force_dropped_bundles: AtomicU64,
     /// Count of individual data items lost due to force-dropped segments.
     force_dropped_items: AtomicU64,
-    /// Per-slot count of individual data items lost due to force-dropped segments.
-    force_dropped_items_per_slot: RwLock<HashMap<crate::record_bundle::SlotId, u64>>,
+    /// Pending bundles from force-dropped segments, for per-signal tracking.
+    dropped_bundles_pending: RwLock<Vec<(Vec<crate::record_bundle::SlotId>, u64)>>,
     /// Count of bundles lost due to expired segments (max_age retention).
     expired_bundles: AtomicU64,
     /// Count of individual data items lost due to expired segments.
     expired_items: AtomicU64,
-    /// Per-slot count of individual data items lost due to expired segments.
-    expired_items_per_slot: RwLock<HashMap<crate::record_bundle::SlotId, u64>>,
+    /// Pending bundles from expired segments, for per-signal tracking.
+    expired_bundles_pending: RwLock<Vec<(Vec<crate::record_bundle::SlotId>, u64)>>,
     /// Segment store for finalized segment files.
     segment_store: Arc<SegmentStore>,
     /// Subscriber registry for tracking consumption progress.
@@ -404,10 +403,10 @@ impl QuiverEngine {
             force_dropped_segments: AtomicU64::new(0),
             force_dropped_bundles: AtomicU64::new(0),
             force_dropped_items: AtomicU64::new(0),
-            force_dropped_items_per_slot: RwLock::new(HashMap::new()),
+            dropped_bundles_pending: RwLock::new(Vec::new()),
             expired_bundles: AtomicU64::new(0),
             expired_items: AtomicU64::new(0),
-            expired_items_per_slot: RwLock::new(HashMap::new()),
+            expired_bundles_pending: RwLock::new(Vec::new()),
             segment_store,
             registry: registry.clone(),
             budget: budget.clone(),
@@ -505,15 +504,10 @@ impl QuiverEngine {
         self.force_dropped_items.load(Ordering::Relaxed)
     }
 
-    /// Returns the number of individual data items lost due to force-dropped segments for a specific slot.
-    ///
-    /// This metric provides granular visibility into data loss by signal type.
-    pub fn force_dropped_items_for_slot(&self, slot: crate::record_bundle::SlotId) -> u64 {
-        self.force_dropped_items_per_slot
-            .read()
-            .get(&slot)
-            .copied()
-            .unwrap_or(0)
+    /// Drains and returns pending bundles from force-dropped segments.
+    pub fn drain_dropped_bundles_pending(&self) -> Vec<(Vec<crate::record_bundle::SlotId>, u64)> {
+        let mut pending = self.dropped_bundles_pending.write();
+        std::mem::take(&mut *pending)
     }
 
     /// Returns the total number of bundles lost due to expired segments.
@@ -536,34 +530,10 @@ impl QuiverEngine {
         self.expired_items.load(Ordering::Relaxed)
     }
 
-    /// Returns the number of individual data items lost due to expired segments for a specific slot.
-    ///
-    /// This metric provides granular visibility into data loss by signal type.
-    pub fn expired_items_for_slot(&self, slot: crate::record_bundle::SlotId) -> u64 {
-        self.expired_items_per_slot
-            .read()
-            .get(&slot)
-            .copied()
-            .unwrap_or(0)
-    }
-
-    /// Returns a snapshot of the per-slot force-dropped item counts.
-    ///
-    /// The returned map contains every slot that has recorded at least one
-    /// dropped item since engine startup. Callers can iterate the map and
-    /// translate slot IDs to signal types without coupling this layer to
-    /// OTel semantics.
-    pub fn force_dropped_items_per_slot_snapshot(
-        &self,
-    ) -> HashMap<crate::record_bundle::SlotId, u64> {
-        self.force_dropped_items_per_slot.read().clone()
-    }
-
-    /// Returns a snapshot of the per-slot expired item counts.
-    ///
-    /// See [`Self::force_dropped_items_per_slot_snapshot`] for usage notes.
-    pub fn expired_items_per_slot_snapshot(&self) -> HashMap<crate::record_bundle::SlotId, u64> {
-        self.expired_items_per_slot.read().clone()
+    /// Drains and returns pending bundles from expired segments.
+    pub fn drain_expired_bundles_pending(&self) -> Vec<(Vec<crate::record_bundle::SlotId>, u64)> {
+        let mut pending = self.expired_bundles_pending.write();
+        std::mem::take(&mut *pending)
     }
 
     /// Returns a snapshot of the open segment's bundle summaries.
@@ -1390,8 +1360,6 @@ impl QuiverEngine {
         let mut deleted = 0;
         let mut bundles_dropped: u64 = 0;
         let mut items_dropped: u64 = 0;
-        let mut items_dropped_per_slot: HashMap<crate::record_bundle::SlotId, u64> = HashMap::new();
-
         for seq in &to_drop {
             // Count bundles and items before deleting (single lock acquisition)
             if let Ok((bundles, items)) = self.segment_store.segment_drop_counts(*seq) {
@@ -1399,10 +1367,9 @@ impl QuiverEngine {
                 items_dropped += items;
             }
             if let Ok(metadata) = self.segment_store.bundle_metadata(*seq) {
+                let mut pending = self.dropped_bundles_pending.write();
                 for bundle in metadata {
-                    if let Some(&slot) = bundle.slot_ids.first() {
-                        *items_dropped_per_slot.entry(slot).or_insert(0) += bundle.item_count;
-                    }
+                    pending.push((bundle.slot_ids, bundle.item_count));
                 }
             }
             if let Err(e) = self.segment_store.delete_segment(*seq) {
@@ -1427,13 +1394,6 @@ impl QuiverEngine {
         let _ = self
             .force_dropped_items
             .fetch_add(items_dropped, Ordering::Relaxed);
-
-        if !items_dropped_per_slot.is_empty() {
-            let mut global_map = self.force_dropped_items_per_slot.write();
-            for (slot, count) in items_dropped_per_slot {
-                *global_map.entry(slot).or_insert(0) += count;
-            }
-        }
 
         // Clean up registry internal state
         if let Some(&max_dropped) = to_drop.iter().max() {
@@ -1475,8 +1435,6 @@ impl QuiverEngine {
         let mut deleted = 0;
         let mut bundles_expired: u64 = 0;
         let mut items_expired: u64 = 0;
-        let mut items_expired_per_slot: HashMap<crate::record_bundle::SlotId, u64> = HashMap::new();
-
         for seq in &expired_segments {
             // Count bundles and items before deleting (single lock acquisition)
             if let Ok((bundles, items)) = self.segment_store.segment_drop_counts(*seq) {
@@ -1484,10 +1442,9 @@ impl QuiverEngine {
                 items_expired += items;
             }
             if let Ok(metadata) = self.segment_store.bundle_metadata(*seq) {
+                let mut pending = self.expired_bundles_pending.write();
                 for bundle in metadata {
-                    if let Some(&slot) = bundle.slot_ids.first() {
-                        *items_expired_per_slot.entry(slot).or_insert(0) += bundle.item_count;
-                    }
+                    pending.push((bundle.slot_ids, bundle.item_count));
                 }
             }
 
@@ -1525,12 +1482,6 @@ impl QuiverEngine {
             let _ = self
                 .expired_items
                 .fetch_add(items_expired, Ordering::Relaxed);
-        }
-        if !items_expired_per_slot.is_empty() {
-            let mut global_map = self.expired_items_per_slot.write();
-            for (slot, count) in items_expired_per_slot {
-                *global_map.entry(slot).or_insert(0) += count;
-            }
         }
 
         Ok(deleted)

--- a/rust/otap-dataflow/crates/quiver/src/engine.rs
+++ b/rust/otap-dataflow/crates/quiver/src/engine.rs
@@ -18,6 +18,7 @@
 //! 4. **WAL Consumer Cursor**: After segment finalization, the WAL cursor is
 //!    advanced to allow cleanup of consumed entries.
 
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -108,14 +109,16 @@ pub struct QuiverEngine {
     force_dropped_bundles: AtomicU64,
     /// Count of individual data items lost due to force-dropped segments.
     force_dropped_items: AtomicU64,
-    /// Pending bundles from force-dropped segments, for per-signal tracking.
-    dropped_bundles_pending: RwLock<Vec<(Vec<crate::record_bundle::SlotId>, u64)>>,
+    /// Pending dropped bundles grouped by slot shape, for per-signal tracking.
+    /// Keyed by sorted slot_ids to bound memory by unique bundle shapes.
+    dropped_items_by_shape: RwLock<HashMap<Vec<crate::record_bundle::SlotId>, u64>>,
     /// Count of bundles lost due to expired segments (max_age retention).
     expired_bundles: AtomicU64,
     /// Count of individual data items lost due to expired segments.
     expired_items: AtomicU64,
-    /// Pending bundles from expired segments, for per-signal tracking.
-    expired_bundles_pending: RwLock<Vec<(Vec<crate::record_bundle::SlotId>, u64)>>,
+    /// Pending expired bundles grouped by slot shape, for per-signal tracking.
+    /// Keyed by sorted slot_ids to bound memory by unique bundle shapes.
+    expired_items_by_shape: RwLock<HashMap<Vec<crate::record_bundle::SlotId>, u64>>,
     /// Segment store for finalized segment files.
     segment_store: Arc<SegmentStore>,
     /// Subscriber registry for tracking consumption progress.
@@ -403,10 +406,10 @@ impl QuiverEngine {
             force_dropped_segments: AtomicU64::new(0),
             force_dropped_bundles: AtomicU64::new(0),
             force_dropped_items: AtomicU64::new(0),
-            dropped_bundles_pending: RwLock::new(Vec::new()),
+            dropped_items_by_shape: RwLock::new(HashMap::new()),
             expired_bundles: AtomicU64::new(0),
             expired_items: AtomicU64::new(0),
-            expired_bundles_pending: RwLock::new(Vec::new()),
+            expired_items_by_shape: RwLock::new(HashMap::new()),
             segment_store,
             registry: registry.clone(),
             budget: budget.clone(),
@@ -504,10 +507,10 @@ impl QuiverEngine {
         self.force_dropped_items.load(Ordering::Relaxed)
     }
 
-    /// Drains and returns pending bundles from force-dropped segments.
+    /// Drains and returns pending dropped bundles (grouped by slot shape) for per-signal classification.
     pub fn drain_dropped_bundles_pending(&self) -> Vec<(Vec<crate::record_bundle::SlotId>, u64)> {
-        let mut pending = self.dropped_bundles_pending.write();
-        std::mem::take(&mut *pending)
+        let map = std::mem::take(&mut *self.dropped_items_by_shape.write());
+        map.into_iter().collect()
     }
 
     /// Returns the total number of bundles lost due to expired segments.
@@ -530,10 +533,10 @@ impl QuiverEngine {
         self.expired_items.load(Ordering::Relaxed)
     }
 
-    /// Drains and returns pending bundles from expired segments.
+    /// Drains and returns pending expired bundles (grouped by slot shape) for per-signal classification.
     pub fn drain_expired_bundles_pending(&self) -> Vec<(Vec<crate::record_bundle::SlotId>, u64)> {
-        let mut pending = self.expired_bundles_pending.write();
-        std::mem::take(&mut *pending)
+        let map = std::mem::take(&mut *self.expired_items_by_shape.write());
+        map.into_iter().collect()
     }
 
     /// Returns a snapshot of the open segment's bundle summaries.
@@ -1367,9 +1370,11 @@ impl QuiverEngine {
                 items_dropped += items;
             }
             if let Ok(metadata) = self.segment_store.bundle_metadata(*seq) {
-                let mut pending = self.dropped_bundles_pending.write();
+                let mut map = self.dropped_items_by_shape.write();
                 for bundle in metadata {
-                    pending.push((bundle.slot_ids, bundle.item_count));
+                    let mut key = bundle.slot_ids;
+                    key.sort_unstable();
+                    *map.entry(key).or_insert(0) += bundle.item_count;
                 }
             }
             if let Err(e) = self.segment_store.delete_segment(*seq) {
@@ -1442,9 +1447,11 @@ impl QuiverEngine {
                 items_expired += items;
             }
             if let Ok(metadata) = self.segment_store.bundle_metadata(*seq) {
-                let mut pending = self.expired_bundles_pending.write();
+                let mut map = self.expired_items_by_shape.write();
                 for bundle in metadata {
-                    pending.push((bundle.slot_ids, bundle.item_count));
+                    let mut key = bundle.slot_ids;
+                    key.sort_unstable();
+                    *map.entry(key).or_insert(0) += bundle.item_count;
                 }
             }
 

--- a/rust/otap-dataflow/crates/quiver/src/engine.rs
+++ b/rust/otap-dataflow/crates/quiver/src/engine.rs
@@ -18,13 +18,14 @@
 //! 4. **WAL Consumer Cursor**: After segment finalization, the WAL cursor is
 //!    advanced to allow cleanup of consumed entries.
 
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use parking_lot::Mutex;
+use parking_lot::{Mutex, RwLock};
 use tokio::sync::Mutex as TokioMutex;
 
 use crate::config::{DurabilityMode, QuiverConfig, RetentionPolicy};
@@ -108,10 +109,14 @@ pub struct QuiverEngine {
     force_dropped_bundles: AtomicU64,
     /// Count of individual data items lost due to force-dropped segments.
     force_dropped_items: AtomicU64,
+    /// Per-slot count of individual data items lost due to force-dropped segments.
+    force_dropped_items_per_slot: RwLock<HashMap<crate::record_bundle::SlotId, u64>>,
     /// Count of bundles lost due to expired segments (max_age retention).
     expired_bundles: AtomicU64,
     /// Count of individual data items lost due to expired segments.
     expired_items: AtomicU64,
+    /// Per-slot count of individual data items lost due to expired segments.
+    expired_items_per_slot: RwLock<HashMap<crate::record_bundle::SlotId, u64>>,
     /// Segment store for finalized segment files.
     segment_store: Arc<SegmentStore>,
     /// Subscriber registry for tracking consumption progress.
@@ -399,8 +404,10 @@ impl QuiverEngine {
             force_dropped_segments: AtomicU64::new(0),
             force_dropped_bundles: AtomicU64::new(0),
             force_dropped_items: AtomicU64::new(0),
+            force_dropped_items_per_slot: RwLock::new(HashMap::new()),
             expired_bundles: AtomicU64::new(0),
             expired_items: AtomicU64::new(0),
+            expired_items_per_slot: RwLock::new(HashMap::new()),
             segment_store,
             registry: registry.clone(),
             budget: budget.clone(),
@@ -498,6 +505,17 @@ impl QuiverEngine {
         self.force_dropped_items.load(Ordering::Relaxed)
     }
 
+    /// Returns the number of individual data items lost due to force-dropped segments for a specific slot.
+    ///
+    /// This metric provides granular visibility into data loss by signal type.
+    pub fn force_dropped_items_for_slot(&self, slot: crate::record_bundle::SlotId) -> u64 {
+        self.force_dropped_items_per_slot
+            .read()
+            .get(&slot)
+            .copied()
+            .unwrap_or(0)
+    }
+
     /// Returns the total number of bundles lost due to expired segments.
     ///
     /// This counter tracks data loss from segments deleted because they
@@ -516,6 +534,36 @@ impl QuiverEngine {
     /// losses that occurred *during the current engine lifetime* only.
     pub fn expired_items(&self) -> u64 {
         self.expired_items.load(Ordering::Relaxed)
+    }
+
+    /// Returns the number of individual data items lost due to expired segments for a specific slot.
+    ///
+    /// This metric provides granular visibility into data loss by signal type.
+    pub fn expired_items_for_slot(&self, slot: crate::record_bundle::SlotId) -> u64 {
+        self.expired_items_per_slot
+            .read()
+            .get(&slot)
+            .copied()
+            .unwrap_or(0)
+    }
+
+    /// Returns a snapshot of the per-slot force-dropped item counts.
+    ///
+    /// The returned map contains every slot that has recorded at least one
+    /// dropped item since engine startup. Callers can iterate the map and
+    /// translate slot IDs to signal types without coupling this layer to
+    /// OTel semantics.
+    pub fn force_dropped_items_per_slot_snapshot(
+        &self,
+    ) -> HashMap<crate::record_bundle::SlotId, u64> {
+        self.force_dropped_items_per_slot.read().clone()
+    }
+
+    /// Returns a snapshot of the per-slot expired item counts.
+    ///
+    /// See [`Self::force_dropped_items_per_slot_snapshot`] for usage notes.
+    pub fn expired_items_per_slot_snapshot(&self) -> HashMap<crate::record_bundle::SlotId, u64> {
+        self.expired_items_per_slot.read().clone()
     }
 
     /// Returns a snapshot of the open segment's bundle summaries.
@@ -1342,11 +1390,20 @@ impl QuiverEngine {
         let mut deleted = 0;
         let mut bundles_dropped: u64 = 0;
         let mut items_dropped: u64 = 0;
+        let mut items_dropped_per_slot: HashMap<crate::record_bundle::SlotId, u64> = HashMap::new();
+
         for seq in &to_drop {
             // Count bundles and items before deleting (single lock acquisition)
             if let Ok((bundles, items)) = self.segment_store.segment_drop_counts(*seq) {
                 bundles_dropped += bundles as u64;
                 items_dropped += items;
+            }
+            if let Ok(metadata) = self.segment_store.bundle_metadata(*seq) {
+                for bundle in metadata {
+                    if let Some(&slot) = bundle.slot_ids.first() {
+                        *items_dropped_per_slot.entry(slot).or_insert(0) += bundle.item_count;
+                    }
+                }
             }
             if let Err(e) = self.segment_store.delete_segment(*seq) {
                 otel_warn!("quiver.segment.drop", segment = seq.raw(), error = %e, error_type = "io", reason = "force_drop");
@@ -1370,6 +1427,13 @@ impl QuiverEngine {
         let _ = self
             .force_dropped_items
             .fetch_add(items_dropped, Ordering::Relaxed);
+
+        if !items_dropped_per_slot.is_empty() {
+            let mut global_map = self.force_dropped_items_per_slot.write();
+            for (slot, count) in items_dropped_per_slot {
+                *global_map.entry(slot).or_insert(0) += count;
+            }
+        }
 
         // Clean up registry internal state
         if let Some(&max_dropped) = to_drop.iter().max() {
@@ -1411,12 +1475,20 @@ impl QuiverEngine {
         let mut deleted = 0;
         let mut bundles_expired: u64 = 0;
         let mut items_expired: u64 = 0;
+        let mut items_expired_per_slot: HashMap<crate::record_bundle::SlotId, u64> = HashMap::new();
 
         for seq in &expired_segments {
             // Count bundles and items before deleting (single lock acquisition)
             if let Ok((bundles, items)) = self.segment_store.segment_drop_counts(*seq) {
                 bundles_expired += bundles as u64;
                 items_expired += items;
+            }
+            if let Ok(metadata) = self.segment_store.bundle_metadata(*seq) {
+                for bundle in metadata {
+                    if let Some(&slot) = bundle.slot_ids.first() {
+                        *items_expired_per_slot.entry(slot).or_insert(0) += bundle.item_count;
+                    }
+                }
             }
 
             if let Err(e) = self.segment_store.delete_segment(*seq) {
@@ -1453,6 +1525,12 @@ impl QuiverEngine {
             let _ = self
                 .expired_items
                 .fetch_add(items_expired, Ordering::Relaxed);
+        }
+        if !items_expired_per_slot.is_empty() {
+            let mut global_map = self.expired_items_per_slot.write();
+            for (slot, count) in items_expired_per_slot {
+                *global_map.entry(slot).or_insert(0) += count;
+            }
         }
 
         Ok(deleted)

--- a/rust/otap-dataflow/crates/quiver/src/subscriber/registry.rs
+++ b/rust/otap-dataflow/crates/quiver/src/subscriber/registry.rs
@@ -103,8 +103,7 @@ pub trait SegmentProvider: Send + Sync {
     /// Quiver needing to understand signal semantics.
     fn bundle_metadata(&self, segment_seq: SegmentSeq) -> Result<Vec<BundleMetadata>>;
 
-    /// Returns the bundle and total item counts for a segment in a single
-    /// lock acquisition.
+    /// Returns the bundle and total item counts for a segment in a single lock acquisition.
     fn segment_drop_counts(&self, segment_seq: SegmentSeq) -> Result<(u32, u64)>;
 
     /// Reads a bundle from a segment.
@@ -1114,10 +1113,8 @@ mod tests {
 
         fn segment_drop_counts(&self, segment_seq: SegmentSeq) -> Result<(u32, u64)> {
             let info = self.get_info(segment_seq)?;
-            Ok((
-                info.bundle_count,
-                info.bundle_count as u64 * info.items_per_bundle,
-            ))
+            let total_items = info.bundle_count as u64 * info.items_per_bundle;
+            Ok((info.bundle_count, total_items))
         }
 
         fn read_bundle(&self, bundle_ref: BundleRef) -> Result<ReconstructedBundle> {


### PR DESCRIPTION
Closes #3117

How are these changes tested?
Verified locally with the following commands:
cargo fmt --all -- --check        ✓ no formatting issues
cargo clippy -p otap-df-core-nodes --tests --features otap-df-otap/crypto-ring   ✓ no warnings or errors
cargo test -p otap-df-core-nodes --features otap-df-otap/crypto-ring              ✓ 723 passed, 0 failed
Key tests passing:

test_storage_utilization_reporting — ok
test_per_signal_dropped_expired_metrics — ok


Are there any user-facing changes?
Yes. The following new metrics are now emitted by durable_buffer_processor:

storage_utilization — storage used/cap ratio (0.0–1.0)
dropped_log_records — log records lost via DropOldest policy
dropped_spans — spans lost via DropOldest policy
dropped_metric_datapoints — metric datapoints lost via DropOldest policy
expired_log_records — log records lost via MaxAge policy
expired_spans — spans lost via MaxAge policy
expired_metric_datapoints — metric datapoints lost via MaxAge policy

Existing dropped_items and expired_items metrics are preserved for backward compatibility.

Changelog

 Added a .chloggen/*.yaml entry, OR this PR is a chore (indicated in title).