### PR TITLE
[otap-dataflow] Fix coalesce drops records missing the first attribute

### DIFF
--- a/rust/otap-dataflow/.chloggen/opl-coalesce-outer-join.yaml
+++ b/rust/otap-dataflow/.chloggen/opl-coalesce-outer-join.yaml
@@ -1,0 +1,19 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: query-engine
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix `coalesce` to preserve spans missing the first attribute by using an outer join when aligning attribute batches.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [3078]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
@@ -7208,6 +7208,71 @@ mod test {
         test_update_attr_coalesce_function_call::<KqlParser>().await
     }
 
+    /// `coalesce` must use an outer join so spans entirely missing the first attribute
+    /// (no key present, not even an explicit null) are not dropped.
+    async fn test_update_attr_coalesce_missing_attributes<P: Parser>() {
+        let logs_data = to_logs_data(vec![
+            // log 0: has attr1 — coalesce picks attr1
+            LogRecord::build()
+                .attributes(vec![
+                    KeyValue::new("attr1", AnyValue::new_string("X")),
+                    KeyValue::new("attr2", AnyValue::new_string("Y")),
+                ])
+                .finish(),
+            // log 1: attr1 absent entirely (no key), only attr2 — coalesce must pick attr2
+            LogRecord::build()
+                .attributes(vec![KeyValue::new("attr2", AnyValue::new_string("Z"))])
+                .finish(),
+            // log 2: both absent — coalesce falls through to the literal "foo"
+            LogRecord::build().attributes(vec![]).finish(),
+        ]);
+
+        let query = r#"logs | extend attributes["attr3"] = coalesce(attributes["attr1"], attributes["attr2"], "foo")"#;
+        let pipeline_expr = P::parse_with_options(query, default_parser_options())
+            .unwrap()
+            .pipeline;
+        let mut pipeline = Pipeline::new(pipeline_expr);
+
+        let input = otlp_to_otap(&OtlpProtoMessage::Logs(logs_data));
+        let result = pipeline.execute(input).await.unwrap();
+        let OtlpProtoMessage::Logs(result_logs_data) = otap_to_otlp(&result) else {
+            panic!("invalid signal type");
+        };
+
+        let records = &result_logs_data.resource_logs[0].scope_logs[0].log_records;
+        assert_eq!(records.len(), 3, "no logs should be dropped");
+
+        assert_eq!(
+            records[0].attributes,
+            vec![
+                KeyValue::new("attr1", AnyValue::new_string("X")),
+                KeyValue::new("attr2", AnyValue::new_string("Y")),
+                KeyValue::new("attr3", AnyValue::new_string("X")),
+            ]
+        );
+        assert_eq!(
+            records[1].attributes,
+            vec![
+                KeyValue::new("attr2", AnyValue::new_string("Z")),
+                KeyValue::new("attr3", AnyValue::new_string("Z")),
+            ]
+        );
+        assert_eq!(
+            records[2].attributes,
+            vec![KeyValue::new("attr3", AnyValue::new_string("foo"))]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_attr_coalesce_missing_attributes_opl_parser() {
+        test_update_attr_coalesce_missing_attributes::<OplParser>().await
+    }
+
+    #[tokio::test]
+    async fn test_update_attr_coalesce_missing_attributes_kql_parser() {
+        test_update_attr_coalesce_missing_attributes::<KqlParser>().await
+    }
+
     async fn test_update_attr_to_lower_case_function_call<P: Parser>() {
         let logs_data = to_logs_data(vec![
             LogRecord::build()

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
@@ -670,8 +670,17 @@ impl ExprPlanner {
             }
         };
 
+        let mut expr = self.build_eval_or_join(case_expr, args_scope, data_scope, true)?;
+        if let ScopedExpr::JoinAndEval {
+            ref mut align_children_to_root,
+            ..
+        } = expr
+        {
+            *align_children_to_root = true;
+        }
+
         Ok(PlannedOp {
-            expr: self.build_eval_or_join(case_expr, args_scope, data_scope, true)?,
+            expr,
             // Like `concat`, mixed attribute columns (often dictionary-encoded) and literals need
             // dictionary downcasting before CASE can build a single array.
             expr_type: ExprLogicalType::AnyValue,


### PR DESCRIPTION
# Change Summary

Fix `coalesce` to use an outer join when aligning attribute batches by setting `align_children_to_root = true` on the `JoinAndEval` node in `plan_coalesce_expr`, so records missing the first attribute are no longer dropped. The `align_children_to_root` field was introduced in #3127.

## What issue does this PR close?

- Closes #3078

## How are these changes tested?

Added `test_update_attr_coalesce_missing_attributes` (OPL + KQL variants) that runs `coalesce` on records where the first attribute is entirely absent. This test fails on main and passes after the fix.

## Are there any user-facing changes?

Yes, `coalesce(attributes["x"], attributes["y"], ...)` now correctly returns the first non-null value across all records, even when a record is entirely missing an earlier attribute key.

### Changelog

* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
