### PR TITLE
chore(deps): exclude time 0.3.48 to unbreak CI

### DIFF
--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -229,7 +229,7 @@ flate2 = "1.1.5"
 # TLS remains enabled through rustls-no-provider, with the provider installed at startup via crypto-* features.
 reqwest = { version = "0.13.1", default-features = false, features = ["rustls-no-provider", "json", "query", "http2", "stream", "charset", "system-proxy"] }
 
-time = "0.3.47"
+time = ">=0.3.47, <0.3.48"
 wiremock = "0.6.5"
 anyhow = "1.0.98"
 crossterm = "0.29"


### PR DESCRIPTION
## What

Narrow the workspace `time` constraint in `rust/otap-dataflow/Cargo.toml` from `"0.3.47"` to `">=0.3.47, <0.3.48"`.

## Why

The `time` crate `0.3.48` (published 2026-06-12) adds a `From<HourBase>` impl reachable through an associated type that conflicts with the blanket `impl<'a, T> From<T> for Cell<'a> where T: Into<Text<'a>>` in `ratatui-widgets` (pulled in transitively via `crossterm`/`ratatui`), producing:

```
error[E0119]: conflicting implementations of trait `From<format_description::parse::format_item::HourBase>`
  for type `<format_description::parse::format_item::HourBase as format_description::parse::format_item::ModifierValue>::Type`
   --> ratatui-widgets-0.3.0/src/table/cell.rs:162:1
```

This repo does not check in a `Cargo.lock` for the `rust/otap-dataflow` workspace, so every fresh CI build started failing the moment the resolver picked up the new version.

Keeping the lower bound `>=0.3.47` preserves the `RUSTSEC-2026-0009` fix. The upper bound can be relaxed once `time` ships a fix (0.3.49+) or `ratatui-widgets` works around the conflict.

## Verification

Local repro (forcing `time = 0.3.48` via `cargo update -p time --precise 0.3.48`) reproduces the `E0119` errors during `cargo check --workspace --all-features`. With the constraint applied, `cargo update -p time` keeps `time 0.3.47` and the workspace check no longer reports any `time`-related errors.

## Related

Mirrors the fix applied in open-telemetry/opentelemetry-rust-contrib#648 for the same upstream `time` 0.3.48 breakage.