### PR TITLE
engine: pass ExtensionContext to ExtensionFactory.create

### DIFF
--- a/rust/otap-dataflow/.chloggen/engine-extension-context-factory.yaml
+++ b/rust/otap-dataflow/.chloggen/engine-extension-context-factory.yaml
@@ -1,0 +1,24 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: engine
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Pass `&ExtensionContext` to `ExtensionFactory.create` so extensions can register custom metric sets and extension entities at construction time.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [3285]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  After PipelineContext was decoupled from extensions, factories had no way to
+  build a `MetricSet<T>` (no public constructor) or otherwise register telemetry
+  before the extension started. The new first argument re-opens that path with a
+  narrower, extension-scoped context. All in-tree factories and tests have been
+  updated.

--- a/rust/otap-dataflow/crates/engine/src/lib.rs
+++ b/rust/otap-dataflow/crates/engine/src/lib.rs
@@ -26,6 +26,7 @@ use crate::{
 };
 use async_trait::async_trait;
 pub use channel_metrics::RequestOutcome;
+use context::ExtensionContext;
 use context::NodeNameIndex;
 use context::PipelineContext;
 pub use linkme::distributed_slice;
@@ -257,6 +258,7 @@ pub struct ExtensionFactory {
     pub capabilities: Option<capability::ExtensionCapabilities>,
     /// A function that creates a new extension instance.
     pub create: fn(
+        ext_ctx: &ExtensionContext,
         name: otap_df_config::ExtensionId,
         ext_config: Arc<otap_df_config::extension::ExtensionUserConfig>,
         extension_config: &ExtensionConfig,
@@ -832,10 +834,15 @@ impl<PData: 'static + Clone + Debug> PipelineFactory<PData> {
                 ext_id.clone(),
                 channel_capacity_policy.control.node,
             );
-            let bundle = (factory.create)(ext_id.clone(), ext_user_config.clone(), &runtime_config)
-                .map_err(|e| Error::ConfigError(Box::new(e)))?;
-            let mut bundle = bundle;
             let ext_ctx = pipeline_ctx.extension_context();
+            let bundle = (factory.create)(
+                &ext_ctx,
+                ext_id.clone(),
+                ext_user_config.clone(),
+                &runtime_config,
+            )
+            .map_err(|e| Error::ConfigError(Box::new(e)))?;
+            let mut bundle = bundle;
             let entity_keys = bundle.wire_telemetry(
                 ext_id.clone(),
                 &ext_ctx,
@@ -2660,6 +2667,7 @@ mod test {
     #[test]
     fn test_extension_factory_named_factory() {
         fn dummy_create(
+            _: &ExtensionContext,
             _: otap_df_config::ExtensionId,
             _: Arc<otap_df_config::extension::ExtensionUserConfig>,
             _: &ExtensionConfig,
@@ -2699,6 +2707,7 @@ mod test {
     #[test]
     fn test_extension_factory_validate_config() {
         fn dummy_create(
+            _: &ExtensionContext,
             _: otap_df_config::ExtensionId,
             _: Arc<otap_df_config::extension::ExtensionUserConfig>,
             _: &ExtensionConfig,

--- a/rust/otap-dataflow/crates/engine/src/lib.rs
+++ b/rust/otap-dataflow/crates/engine/src/lib.rs
@@ -2736,4 +2736,67 @@ mod test {
         assert!((factory.validate_config)(&serde_json::Value::Null).is_ok());
         assert!((factory.validate_config)(&serde_json::json!({"key": "val"})).is_err());
     }
+
+    #[otap_df_telemetry_macros::metric_set(name = "test.extension.factory")]
+    #[derive(Debug, Default, Clone)]
+    struct FactoryTestMetrics {
+        #[metric(unit = "{tick}")]
+        ticks: otap_df_telemetry::instrument::Counter<u64>,
+    }
+
+    #[test]
+    fn test_extension_factory_create_receives_extension_context() {
+        use crate::extension::wrapper::ExtensionVariant;
+        use crate::testing::test_extension_ctx;
+        use otap_df_config::extension::{ExtensionUrn, ExtensionUserConfig};
+        use otap_df_telemetry::registry::EntityKey;
+        use std::cell::Cell;
+
+        thread_local! {
+            static REGISTERED_ENTITY: Cell<Option<EntityKey>> = const { Cell::new(None) };
+        }
+
+        fn entity_registering_create(
+            ext_ctx: &ExtensionContext,
+            name: otap_df_config::ExtensionId,
+            _: Arc<ExtensionUserConfig>,
+            _: &ExtensionConfig,
+        ) -> Result<ExtensionBundle, otap_df_config::error::Error> {
+            let entity = ext_ctx.register_extension_entity(name, ExtensionVariant::Local);
+            REGISTERED_ENTITY.with(|cell| cell.set(Some(entity)));
+            Err(otap_df_config::error::Error::InvalidUserConfig {
+                error: "no-op factory".into(),
+            })
+        }
+        fn dummy_validate(_: &serde_json::Value) -> Result<(), otap_df_config::error::Error> {
+            Ok(())
+        }
+
+        let factory = ExtensionFactory {
+            name: "urn:otel:extension:test_ext",
+            description: "test extension that registers an entity via ext_ctx",
+            documentation_url: "",
+            capabilities: None,
+            create: entity_registering_create,
+            validate_config: dummy_validate,
+        };
+
+        let (ctx, registry) = test_extension_ctx();
+        let entities_before = registry.entity_count();
+        let metrics_before = registry.metric_set_count();
+        let user_config = Arc::new(ExtensionUserConfig::with_type(ExtensionUrn::from(
+            "urn:otel:extension:test_ext",
+        )));
+        let ext_config = ExtensionConfig::with_control_channel_capacity("test_ext", 16);
+
+        let result = (factory.create)(&ctx, "test_ext".into(), user_config, &ext_config);
+        assert!(result.is_err());
+        assert_eq!(registry.entity_count(), entities_before + 1);
+
+        let entity_key = REGISTERED_ENTITY
+            .with(|cell| cell.take())
+            .expect("factory should have registered an entity via ext_ctx");
+        let _metrics = ctx.register_metric_set_for_entity::<FactoryTestMetrics>(entity_key);
+        assert_eq!(registry.metric_set_count(), metrics_before + 1);
+    }
 }

--- a/rust/otap-dataflow/crates/engine/tests/extension_e2e.rs
+++ b/rust/otap-dataflow/crates/engine/tests/extension_e2e.rs
@@ -37,7 +37,7 @@ use otap_df_engine::ExtensionFactory;
 use otap_df_engine::ReceiverFactory;
 use otap_df_engine::capability::registry::Capabilities;
 use otap_df_engine::config::{ExporterConfig, ExtensionConfig, ReceiverConfig};
-use otap_df_engine::context::{ControllerContext, PipelineContext};
+use otap_df_engine::context::{ControllerContext, ExtensionContext, PipelineContext};
 use otap_df_engine::control::{
     ExtensionControlMsg, RuntimeControlMsg, pipeline_completion_msg_channel,
     runtime_ctrl_msg_channel,
@@ -561,6 +561,7 @@ impl LocalNoOpStateless for NoOpStatelessImplLocal {
 // ─────────────────────────────────────────────────────────────────────
 
 fn passive_extension_create(
+    _ctx: &ExtensionContext,
     name: otap_df_config::ExtensionId,
     user_config: Arc<otap_df_config::extension::ExtensionUserConfig>,
     extension_config: &ExtensionConfig,
@@ -593,6 +594,7 @@ const PASSIVE_EXTENSION_FACTORY: ExtensionFactory = ExtensionFactory {
 // ─────────────────────────────────────────────────────────────────────
 
 fn dual_extension_create(
+    _ctx: &ExtensionContext,
     name: otap_df_config::ExtensionId,
     user_config: Arc<otap_df_config::extension::ExtensionUserConfig>,
     extension_config: &ExtensionConfig,
@@ -700,6 +702,7 @@ fn lookup_active_ext_probe(key: &str) -> ActiveExtProbe {
 }
 
 fn active_extension_create(
+    _ctx: &ExtensionContext,
     name: otap_df_config::ExtensionId,
     user_config: Arc<otap_df_config::extension::ExtensionUserConfig>,
     extension_config: &ExtensionConfig,
@@ -795,6 +798,7 @@ const ACTIVE_SHARED_COUNTER_EXTENSION_URN: &str =
     "urn:test:extension:active_shared_counter_extension";
 
 fn active_shared_counter_extension_create(
+    _ctx: &ExtensionContext,
     name: otap_df_config::ExtensionId,
     user_config: Arc<otap_df_config::extension::ExtensionUserConfig>,
     extension_config: &ExtensionConfig,
@@ -870,6 +874,7 @@ impl otap_df_engine::shared::extension::Extension for FailingExtImpl {
 }
 
 fn failing_extension_create(
+    _ctx: &ExtensionContext,
     name: otap_df_config::ExtensionId,
     user_config: Arc<otap_df_config::extension::ExtensionUserConfig>,
     extension_config: &ExtensionConfig,
@@ -930,6 +935,7 @@ impl otap_df_engine::shared::extension::Extension for ImmediateOkExtImpl {
 }
 
 fn immediate_ok_extension_create(
+    _ctx: &ExtensionContext,
     name: otap_df_config::ExtensionId,
     user_config: Arc<otap_df_config::extension::ExtensionUserConfig>,
     extension_config: &ExtensionConfig,
@@ -1031,6 +1037,7 @@ fn lookup_shutdown_recording_probe(key: &str) -> ShutdownRecordingProbe {
 }
 
 fn shutdown_recording_extension_create(
+    _ctx: &ExtensionContext,
     name: otap_df_config::ExtensionId,
     user_config: Arc<otap_df_config::extension::ExtensionUserConfig>,
     extension_config: &ExtensionConfig,
@@ -1122,6 +1129,7 @@ impl otap_df_engine::local::extension::Extension for ActiveLocalExtImpl {
 const DUAL_ACTIVE_EXTENSION_URN: &str = "urn:test:extension:dual_active_extension";
 
 fn dual_active_extension_create(
+    _ctx: &ExtensionContext,
     name: otap_df_config::ExtensionId,
     user_config: Arc<otap_df_config::extension::ExtensionUserConfig>,
     extension_config: &ExtensionConfig,
@@ -1235,6 +1243,7 @@ fn lookup_background_probe(key: &str) -> BackgroundProbe {
 }
 
 fn background_extension_create(
+    _ctx: &ExtensionContext,
     name: otap_df_config::ExtensionId,
     user_config: Arc<otap_df_config::extension::ExtensionUserConfig>,
     extension_config: &ExtensionConfig,
@@ -1354,6 +1363,7 @@ fn lookup_shared_counter_probe(key: &str) -> SharedCounterProbe {
 }
 
 fn shared_counter_extension_create(
+    _ctx: &ExtensionContext,
     name: otap_df_config::ExtensionId,
     user_config: Arc<otap_df_config::extension::ExtensionUserConfig>,
     extension_config: &ExtensionConfig,
@@ -1402,6 +1412,7 @@ const SHARED_COUNTER_SHARED_EXTENSION_URN: &str =
     "urn:test:extension:shared_counter_shared_extension";
 
 fn shared_counter_shared_extension_create(
+    _ctx: &ExtensionContext,
     name: otap_df_config::ExtensionId,
     user_config: Arc<otap_df_config::extension::ExtensionUserConfig>,
     extension_config: &ExtensionConfig,
@@ -1495,6 +1506,7 @@ fn lookup_constructed_probe(key: &str) -> ConstructedProbe {
 }
 
 fn constructed_extension_create(
+    _ctx: &ExtensionContext,
     name: otap_df_config::ExtensionId,
     user_config: Arc<otap_df_config::extension::ExtensionUserConfig>,
     extension_config: &ExtensionConfig,
@@ -1571,6 +1583,7 @@ impl LocalNoOpStateful for RcCounterImpl {
 const RC_COUNTER_EXTENSION_URN: &str = "urn:test:extension:rc_counter_extension";
 
 fn rc_counter_extension_create(
+    _ctx: &ExtensionContext,
     name: otap_df_config::ExtensionId,
     user_config: Arc<otap_df_config::extension::ExtensionUserConfig>,
     extension_config: &ExtensionConfig,


### PR DESCRIPTION
# Change Summary

Restores extension factories' access to telemetry-registration APIs by passing `&ExtensionContext` as the first argument to `ExtensionFactory.create`.

After `PipelineContext` was decoupled from extensions, factories had no way to register their own custom metric sets — `MetricSet<T>` has no public constructor, and `EffectHandler` (reached only inside `start()`) can only `report` a pre-built set, not create one. This change re-opens that path with a narrower, extension-scoped context.

## What issue does this PR close?

## How are these changes tested?

* `cargo check -p otap-df-engine --tests` — clean
* `cargo test -p otap-df-engine --test extension_e2e` → 28/28 pass
* `cargo test -p otap-df-engine --lib test_extension_factory` → 2/2 pass
* No new tests added; existing e2e factories exercise the new signature.

## Are there any user-facing changes?

Yes — `ExtensionFactory.create` signature changed. All in-tree factories and tests have been updated.

### Changelog

* [x] Added a `.chloggen/*.yaml` entry (`breaking`, component `engine`).
