### PR TITLE
feat(flow_metrics): Add kept/dropped flow metrics recorded per keep/drop decision node

### DIFF
--- a/rust/otap-dataflow/.chloggen/flow-kept-dropped-metrics.yaml
+++ b/rust/otap-dataflow/.chloggen/flow-kept-dropped-metrics.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: engine
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `signals.kept` / `signals.dropped` flow metrics recorded per keep/drop decision node
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [2859]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Flow metrics declared in the telemetry policy can now enable `signals_kept` and
+  `signals_dropped`. A processor that declares the keep/drop capability and lies
+  within such a flow records its kept/dropped counts, attributed per decision node
+  via the new `flow.node.decision` scope attribute (so a flow may contain multiple
+  decision nodes). `filter_processor` and `log_sampling_processor` are the first
+  consumers. Single-node flow ranges (`start == end`) are now supported.

--- a/rust/otap-dataflow/configs/fake-flow-metrics-demo.yaml
+++ b/rust/otap-dataflow/configs/fake-flow-metrics-demo.yaml
@@ -1,9 +1,10 @@
-# Demonstrates the distributed flow metrics feature.
+# Demonstrates the distributed flow metrics feature, including two keep/drop
+# decision nodes within a single flow range.
 #
-# Five attribute processors form a sequential processing chain, with a 1-in-3
-# log sampler in the middle so that produced < consumed:
+#   receiver -> attr1 -> sampler -> attr2 -> attr3 -> filter -> attr4 -> noop
 #
-#   flow metric "ingest_pipeline" - covers sampler through attr4 (full chain)
+#   flow metric "ingest_pipeline" - covers attr1 through attr4. Both decision
+#   nodes (sampler, filter) sit in the interior of the range.
 #
 # Flow metrics sum per-processor wall-clock compute time across each node in
 # the range. The engine arms an Instant send-marker before each `process()` call
@@ -17,13 +18,33 @@
 #   - compute.duration (MMSC histogram, nanoseconds)
 #   - signals.incoming   (MMSC, items observed at the start node)
 #   - signals.outgoing   (MMSC, items observed at the end node)
+#   - signals.kept       (MMSC, items a decision node chose to keep)
+#   - signals.dropped    (MMSC, items a decision node chose to drop)
 #
-# With the sampler in place, `signals.incoming` (at sampler) reflects the full
-# input volume while `signals.outgoing` (at attr4) reflects roughly 1/3 of it,
-# so the difference is directly visible.
+# With the sampler in place, `signals.incoming` (at attr1) reflects the full
+# input volume while `signals.outgoing` (at attr4) reflects what survives both
+# decision nodes, so the difference is directly visible.
+#
+# `signals.kept` / `signals.dropped` are recorded only by processors that
+# declare the keep/drop capability and lie within a flow range. This flow has
+# TWO such decision nodes, both interior to the range:
+#   - sampler (between attr1 and attr2): keeps ~1/3 of log records.
+#   - filter  (between attr3 and attr4): drops records matching its exclude rule.
+# Each decision node's counts carry a `flow.node.decision` attribute set to that
+# node's name ("sampler" / "filter"), so the two are not conflated. The flow's
+# incoming/outgoing/duration entity carries an empty `flow.node.decision` value.
+#
+# Aggregation across `flow.node.decision` differs by metric:
+#   - signals.dropped sums correctly (drops at different nodes are disjoint), so
+#     the total equals signals.incoming - signals.outgoing.
+#   - signals.kept does NOT sum: each node's kept count is relative to its own
+#     input and nested for nodes in series, so summing double-counts. The
+#     flow-wide kept count is just signals.outgoing; per-node kept is only
+#     meaningful on its own entity.
 #
 # Note: only non-overlapping flow metric ranges are supported. A message can
-# be inside at most one flow metric range at a time.
+# be inside at most one flow metric range at a time. Two flows may not share an
+# interior decision node.
 #
 # Query metrics while running:
 #   curl -s 'http://127.0.0.1:8080/api/v1/telemetry/metrics?format=json' \
@@ -46,11 +67,11 @@ groups:
             flow_metrics:
               - id: ingest_pipeline
                 bounds:
-                  start_node: sampler
+                  start_node: attr1
                   end_node: attr4
                 # metrics is optional
                 # if omitted, all supported metrics are recorded
-                metrics: [compute_duration, signals_incoming, signals_outgoing]
+                metrics: [compute_duration, signals_incoming, signals_outgoing, signals_kept, signals_dropped]
 
         nodes:
           receiver:
@@ -60,12 +81,16 @@ groups:
                 max_batch_size: 10
                 signals_per_second: 10
                 log_weight: 100
-              registry_path: https://github.com/open-telemetry/semantic-conventions.git[model]
+              # Synthetic data source emits deterministic log attributes
+              # (thread.id, thread.name) so the filter below drops a
+              # predictable fraction regardless of registry contents.
+              data_source: synthetic
 
-          # Drops ~2 of every 3 log records so that signals.outgoing
-          # at attr4 is visibly smaller than signals.incoming at sampler.
-          # Used as beginning of flow metric range to prove that signals.incoming
-          # is reported before start node's process() begins.
+          # Decision node #1 (interior of the flow range, between attr1 and
+          # attr2). Deterministically keeps
+          # ~1/3 of log records and drops the rest, independent of payload
+          # content. Records signals.kept / signals.dropped with
+          # flow.node.decision="sampler".
           sampler:
             type: processor:log_sampling
             config:
@@ -90,6 +115,25 @@ groups:
                   key: pipeline.stage2
                   value: "2"
 
+          # Decision node #2 (interior of the flow range, between attr3 and
+          # attr4). Drops log records whose
+          # thread.name matches the exclude rule. The ratio sampler upstream keeps
+          # a per-batch prefix, so the records reaching here cycle through the
+          # first few synthetic thread.name values (main, worker-1, worker-2,
+          # worker-3); excluding two of them drops roughly half of the survivors.
+          # Records signals.kept / signals.dropped with flow.node.decision="filter".
+          filter:
+            type: processor:filter
+            config:
+              logs:
+                exclude:
+                  match_type: strict
+                  record_attributes:
+                    - key: thread.name
+                      value: worker-1
+                    - key: thread.name
+                      value: worker-3
+
           attr3:
             type: processor:attribute
             config:
@@ -112,14 +156,16 @@ groups:
 
         connections:
           - from: receiver
-            to: sampler
-          - from: sampler
             to: attr1
           - from: attr1
+            to: sampler
+          - from: sampler
             to: attr2
           - from: attr2
             to: attr3
           - from: attr3
+            to: filter
+          - from: filter
             to: attr4
           - from: attr4
             to: noop

--- a/rust/otap-dataflow/crates/config/src/policy.rs
+++ b/rust/otap-dataflow/crates/config/src/policy.rs
@@ -329,6 +329,10 @@ pub enum FlowMetric {
     SignalsIncoming,
     /// Signal item count leaving the flow.
     SignalsOutgoing,
+    /// Signal item count a decision node chose to keep.
+    SignalsKept,
+    /// Signal item count a decision node chose to drop.
+    SignalsDropped,
 }
 
 impl TelemetryPolicy {
@@ -883,6 +887,8 @@ mod tests {
         assert!(flow.has(super::FlowMetric::ComputeDuration));
         assert!(flow.has(super::FlowMetric::SignalsIncoming));
         assert!(flow.has(super::FlowMetric::SignalsOutgoing));
+        assert!(flow.has(super::FlowMetric::SignalsKept));
+        assert!(flow.has(super::FlowMetric::SignalsDropped));
     }
 
     #[test]
@@ -898,6 +904,23 @@ mod tests {
         assert!(flow.has(super::FlowMetric::ComputeDuration));
         assert!(!flow.has(super::FlowMetric::SignalsIncoming));
         assert!(!flow.has(super::FlowMetric::SignalsOutgoing));
+        assert!(!flow.has(super::FlowMetric::SignalsKept));
+        assert!(!flow.has(super::FlowMetric::SignalsDropped));
+    }
+
+    #[test]
+    fn flow_metrics_kept_dropped_are_parsed() {
+        let yaml = r#"
+            flow_metrics:
+              - id: flow1
+                bounds: { start_node: a, end_node: b }
+                metrics: [signals_kept, signals_dropped]
+        "#;
+        let policy: super::TelemetryPolicy = serde_yaml::from_str(yaml).expect("parse");
+        let flow = &policy.flow_metrics[0];
+        assert!(flow.has(super::FlowMetric::SignalsKept));
+        assert!(flow.has(super::FlowMetric::SignalsDropped));
+        assert!(!flow.has(super::FlowMetric::ComputeDuration));
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
@@ -1218,6 +1218,7 @@ impl local::Processor<OtapPdata> for BatchProcessor {
     fn runtime_requirements(&self) -> ProcessorRuntimeRequirements {
         ProcessorRuntimeRequirements {
             local_wakeups: Some(self.local_wakeup_requirements()),
+            ..ProcessorRuntimeRequirements::none()
         }
     }
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
@@ -1801,6 +1801,7 @@ impl otap_df_engine::local::processor::Processor<OtapPdata> for DurableBuffer {
     fn runtime_requirements(&self) -> ProcessorRuntimeRequirements {
         ProcessorRuntimeRequirements {
             local_wakeups: Some(LocalWakeupRequirements::new(1)),
+            ..ProcessorRuntimeRequirements::none()
         }
     }
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/mod.rs
@@ -24,7 +24,7 @@ use otap_df_engine::local::processor as local;
 use otap_df_engine::message::Message;
 use otap_df_engine::node::NodeId;
 use otap_df_engine::process_duration::ComputeDuration;
-use otap_df_engine::processor::ProcessorWrapper;
+use otap_df_engine::processor::{ProcessorRuntimeRequirements, ProcessorWrapper};
 use otap_df_otap::{OTAP_PROCESSOR_FACTORIES, pdata::OtapPdata};
 use otap_df_pdata::TryIntoWithOptions;
 use otap_df_pdata::otap::OtapArrowRecords;
@@ -119,6 +119,13 @@ impl FilterProcessor {
 
 #[async_trait(?Send)]
 impl local::Processor<OtapPdata> for FilterProcessor {
+    fn runtime_requirements(&self) -> ProcessorRuntimeRequirements {
+        // The filter processor makes keep/drop decisions on signal items, so
+        // it records `signals.kept` / `signals.dropped` when it lies within a
+        // flow that enables them.
+        ProcessorRuntimeRequirements::none().with_keep_drop_decisions()
+    }
+
     async fn process(
         &mut self,
         msg: Message<OtapPdata>,
@@ -213,6 +220,15 @@ impl local::Processor<OtapPdata> for FilterProcessor {
                         self.metrics.span_signals_filtered.add(signals_filtered);
                     }
                 }
+
+                // Record keep/drop flow-metric decisions. These are no-ops
+                // unless this node is a decision node in a flow that enables
+                // `signals.kept` / `signals.dropped`. `signals_consumed` is the
+                // total input count and `signals_filtered` is the dropped count,
+                // so kept = consumed - filtered.
+                effect_handler.record_flow_signals_dropped(signals_filtered);
+                effect_handler
+                    .record_flow_signals_kept(signals_consumed.saturating_sub(signals_filtered));
 
                 effect_handler
                     .send_message_with_source_node(OtapPdata::new(

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/log_sampling_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/log_sampling_processor/mod.rs
@@ -31,7 +31,7 @@ use otap_df_engine::error::Error as EngineError;
 use otap_df_engine::local::processor as local;
 use otap_df_engine::message::Message;
 use otap_df_engine::node::NodeId;
-use otap_df_engine::processor::ProcessorWrapper;
+use otap_df_engine::processor::{ProcessorRuntimeRequirements, ProcessorWrapper};
 use otap_df_otap::OTAP_PROCESSOR_FACTORIES;
 use otap_df_otap::pdata::OtapPdata;
 use otap_df_pdata::OtapPayload;
@@ -154,6 +154,12 @@ impl LogSamplingProcessor {
         let dropped = total - kept;
         self.metrics.log_signals_dropped.add(dropped as u64);
 
+        // Record keep/drop flow-metric decisions. These are no-ops unless this
+        // node is a decision node in a flow that enables `signals.kept` /
+        // `signals.dropped`.
+        effect_handler.record_flow_signals_kept(kept as u64);
+        effect_handler.record_flow_signals_dropped(dropped as u64);
+
         let pdata = OtapPdata::new(context, OtapPayload::OtapArrowRecords(filtered));
         if kept == 0 {
             effect_handler.notify_ack(AckMsg::new(pdata)).await?;
@@ -167,6 +173,13 @@ impl LogSamplingProcessor {
 
 #[async_trait(?Send)]
 impl local::Processor<OtapPdata> for LogSamplingProcessor {
+    fn runtime_requirements(&self) -> ProcessorRuntimeRequirements {
+        // The log sampling processor makes keep/drop decisions on log records,
+        // so it records `signals.kept` / `signals.dropped` when it lies within
+        // a flow that enables them.
+        ProcessorRuntimeRequirements::none().with_keep_drop_decisions()
+    }
+
     async fn process(
         &mut self,
         msg: Message<OtapPdata>,

--- a/rust/otap-dataflow/crates/engine/src/flow_metrics.rs
+++ b/rust/otap-dataflow/crates/engine/src/flow_metrics.rs
@@ -55,6 +55,26 @@ pub struct FlowSignalsOutgoingMetrics {
     pub signals_outgoing: Mmsc,
 }
 
+/// Kept signal metric set emitted by a decision node within a flow range.
+#[metric_set(name = "flow")]
+#[derive(Debug, Default, Clone)]
+pub struct FlowSignalsKeptMetrics {
+    /// Number of signal items (log records, spans, or metric data points) a
+    /// decision node chose to keep.
+    #[metric(name = "signals.kept", unit = "{item}")]
+    pub signals_kept: Mmsc,
+}
+
+/// Dropped signal metric set emitted by a decision node within a flow range.
+#[metric_set(name = "flow")]
+#[derive(Debug, Default, Clone)]
+pub struct FlowSignalsDroppedMetrics {
+    /// Number of signal items (log records, spans, or metric data points) a
+    /// decision node chose to drop.
+    #[metric(name = "signals.dropped", unit = "{item}")]
+    pub signals_dropped: Mmsc,
+}
+
 /// Entity attributes that scope a flow metric set.
 #[attribute_set(name = "flow.attrs")]
 #[derive(Debug, Clone, Default, Hash)]
@@ -75,6 +95,22 @@ pub struct FlowAttributeSet {
     /// `flow` scope.
     #[attribute(key = "flow.purpose")]
     pub purpose: Cow<'static, str>,
+    /// Name of the decision node that recorded `signals.kept` / `signals.dropped`.
+    /// Always emitted as the `flow.node.decision` scope attribute; carries an
+    /// empty value for the flow's incoming/outgoing/duration entity (which is
+    /// not attributed to a specific decision node). Lets a single flow contain
+    /// multiple decision nodes without conflation.
+    ///
+    /// Aggregation across this attribute differs by metric. `signals.dropped`
+    /// sums correctly: drops at different decision nodes are disjoint (a dropped
+    /// item never reaches a later node), so the sum equals the flow's total
+    /// removed = `signals.incoming - signals.outgoing`. `signals.kept` does NOT
+    /// sum: each node's kept count is relative to its own input, and for nodes
+    /// in series those sets are nested subsets, so summing double-counts. The
+    /// flow-wide kept count is simply `signals.outgoing`; the per-node
+    /// `signals.kept` is only meaningful on its own entity.
+    #[attribute(key = "flow.node.decision")]
+    pub decision: Cow<'static, str>,
     /// Pipeline attributes.
     #[compose]
     pub pipeline_attrs: PipelineAttributeSet,
@@ -100,6 +136,29 @@ pub(crate) struct PipelineFlowMetricState {
     pub end_nodes: HashMap<usize, usize>,
     /// Mapping from node index → flow metric index where this node is the start node.
     pub start_nodes: HashMap<usize, usize>,
+    /// Decision-node candidates keyed by node index. A processor at one of
+    /// these indices that declares the keep/drop capability records
+    /// `signals.kept` / `signals.dropped` attributed to itself via
+    /// `flow.node.decision`. Populated only for flows that enable kept and/or
+    /// dropped metrics, for every processor node within the flow's active
+    /// range (start..=end).
+    pub decision_candidates: HashMap<usize, DecisionCandidate>,
+}
+
+/// A node that may record `signals.kept` / `signals.dropped` for a flow.
+///
+/// Carries the flow's base attribute set (with an empty `flow.node.decision`)
+/// so the runtime can register a per-node decision entity by filling in the
+/// deciding node's name, plus which of the two metrics the flow enables.
+#[derive(Clone)]
+pub(crate) struct DecisionCandidate {
+    /// Flow attribute set with an empty `decision` field; the runtime fills in
+    /// the deciding node's name before registering the per-node entity.
+    pub attrs: FlowAttributeSet,
+    /// Whether the flow enables `signals.kept`.
+    pub kept: bool,
+    /// Whether the flow enables `signals.dropped`.
+    pub dropped: bool,
 }
 
 /// Start-side measurements for a node that begins a flow_metric range.
@@ -124,6 +183,22 @@ pub(crate) struct EndFlowMetrics<Accumulator> {
     pub duration: Option<(MetricSet<FlowDurationMetrics>, Accumulator)>,
     /// Outgoing signal measurement, if enabled for this flow.
     pub signals_outgoing: Option<(MetricSet<FlowSignalsOutgoingMetrics>, Accumulator)>,
+}
+
+/// Decision-side measurements for a node that records keep/drop decisions
+/// within a flow_metric range.
+///
+/// Groups the metric sets and their accumulators so that they share the
+/// `Option` on `FlowMetricState` — non-decision nodes pay no allocation for
+/// either.
+#[derive(Clone)]
+pub(crate) struct DecisionFlowMetrics<Accumulator> {
+    /// Kept signal measurement, if enabled for this flow and this node is a
+    /// keep/drop decision node.
+    pub signals_kept: Option<(MetricSet<FlowSignalsKeptMetrics>, Accumulator)>,
+    /// Dropped signal measurement, if enabled for this flow and this node is a
+    /// keep/drop decision node.
+    pub signals_dropped: Option<(MetricSet<FlowSignalsDroppedMetrics>, Accumulator)>,
 }
 
 /// Per-`EffectHandler` flow_metric state.
@@ -155,6 +230,8 @@ pub(crate) struct FlowMetricState<Marker, Accumulator> {
     pub is_start: bool,
     /// Whether this node is a flow metric end node.
     pub is_end: bool,
+    /// Whether this node is a keep/drop decision node for some flow.
+    pub is_decision: bool,
     /// Whether any flow_metric is configured in this pipeline.
     /// When false, `begin_process_timing` and
     /// `take_elapsed_since_send_marker_ns` are no-ops.
@@ -165,6 +242,8 @@ pub(crate) struct FlowMetricState<Marker, Accumulator> {
     pub incoming: IncomingFlowMetrics<Accumulator>,
     /// End-side measurements.
     pub end: EndFlowMetrics<Accumulator>,
+    /// Decision-side measurements (kept/dropped).
+    pub decision: DecisionFlowMetrics<Accumulator>,
 }
 
 /// Concrete `FlowMetricState` for the local (`!Send`) `EffectHandler`.
@@ -181,6 +260,7 @@ impl Default for LocalFlowMetricState {
             last_send_marker: Rc::new(Cell::new(None)),
             is_start: false,
             is_end: false,
+            is_decision: false,
             active: false,
             incoming: IncomingFlowMetrics {
                 signals_incoming: None,
@@ -188,6 +268,10 @@ impl Default for LocalFlowMetricState {
             end: EndFlowMetrics {
                 duration: None,
                 signals_outgoing: None,
+            },
+            decision: DecisionFlowMetrics {
+                signals_kept: None,
+                signals_dropped: None,
             },
         }
     }
@@ -199,6 +283,7 @@ impl Default for SharedFlowMetricState {
             last_send_marker: Arc::new(Mutex::new(None)),
             is_start: false,
             is_end: false,
+            is_decision: false,
             active: false,
             incoming: IncomingFlowMetrics {
                 signals_incoming: None,
@@ -206,6 +291,10 @@ impl Default for SharedFlowMetricState {
             end: EndFlowMetrics {
                 duration: None,
                 signals_outgoing: None,
+            },
+            decision: DecisionFlowMetrics {
+                signals_kept: None,
+                signals_dropped: None,
             },
         }
     }
@@ -238,8 +327,10 @@ pub(crate) fn build_flow_metric_state(
     let mut signals_outgoing_metrics = Vec::new();
     let mut end_nodes: HashMap<usize, usize> = HashMap::new();
     let mut start_nodes: HashMap<usize, usize> = HashMap::new();
+    let mut decision_candidates: HashMap<usize, DecisionCandidate> = HashMap::new();
 
     let pipeline_attrs = pipeline_context.pipeline_attribute_set();
+    let adjacency = build_adjacency(pipeline_connections);
 
     // Collect resolved (start, end, name) triples for the graph-based
     // interleave check that runs after all flow metrics are registered.
@@ -286,10 +377,13 @@ pub(crate) fn build_flow_metric_state(
                 .purpose
                 .clone()
                 .map_or(Cow::Borrowed(""), Cow::Owned),
+            decision: Cow::Borrowed(""),
             pipeline_attrs: pipeline_attrs.clone(),
         };
 
-        let entity_key = pipeline_context.metrics_registry().register_entity(attrs);
+        let entity_key = pipeline_context
+            .metrics_registry()
+            .register_entity(attrs.clone());
         let signals_incoming_metric = flow_config.has(FlowMetric::SignalsIncoming).then(|| {
             pipeline_context
                 .metrics_registry()
@@ -306,6 +400,46 @@ pub(crate) fn build_flow_metric_state(
                 .register_metric_set_for_entity::<FlowSignalsOutgoingMetrics>(entity_key)
         });
 
+        // Register keep/drop decision candidates for every processor node
+        // within this flow's active range (inclusive of start and end). A
+        // processor at one of these indices that declares the keep/drop
+        // capability records `signals.kept` / `signals.dropped` attributed to
+        // itself. A decision node must belong to at most one flow — otherwise
+        // its single kept/dropped count could not be unambiguously attributed
+        // to one `flow.id`. The pairwise overlap check below only rejects
+        // shared start/end nodes, so we explicitly reject shared interior nodes
+        // here (e.g. fan-in/merge topologies where two ranges meet at a node).
+        let kept = flow_config.has(FlowMetric::SignalsKept);
+        let dropped = flow_config.has(FlowMetric::SignalsDropped);
+        if kept || dropped {
+            let (mut range_nodes, _) = active_range(start_idx, end_idx, &adjacency);
+            let _ = range_nodes.insert(start_idx);
+            let _ = range_nodes.insert(end_idx);
+            for node_idx in range_nodes {
+                if processor_indices.contains(&node_idx) {
+                    if let Some(existing) = decision_candidates.get(&node_idx) {
+                        return Err(invalid_flow_metric_config(format!(
+                            "flow metric `{}` shares keep/drop decision node `{}` with flow metric `{}`: a decision node may belong to at most one flow",
+                            flow_config.id,
+                            node_name_to_index
+                                .iter()
+                                .find(|&(_, &idx)| idx == node_idx)
+                                .map_or("<unknown>", |(name, _)| name.as_str()),
+                            existing.attrs.flow_id,
+                        )));
+                    }
+                    let _ = decision_candidates.insert(
+                        node_idx,
+                        DecisionCandidate {
+                            attrs: attrs.clone(),
+                            kept,
+                            dropped,
+                        },
+                    );
+                }
+            }
+        }
+
         let id = duration_metrics.len();
         signals_incoming_metrics.push(signals_incoming_metric);
         duration_metrics.push(duration_metric);
@@ -316,7 +450,6 @@ pub(crate) fn build_flow_metric_state(
     }
 
     if !resolved_ranges.is_empty() {
-        let adjacency = build_adjacency(pipeline_connections);
         validate_metric_ranges(&resolved_ranges, &adjacency)?;
     }
 
@@ -326,6 +459,7 @@ pub(crate) fn build_flow_metric_state(
         signals_outgoing_metrics,
         end_nodes,
         start_nodes,
+        decision_candidates,
     })
 }
 
@@ -445,6 +579,7 @@ impl PipelineFlowMetricState {
             signals_outgoing_metrics: Vec::new(),
             end_nodes: HashMap::new(),
             start_nodes: HashMap::new(),
+            decision_candidates: HashMap::new(),
         }
     }
 
@@ -455,6 +590,7 @@ impl PipelineFlowMetricState {
         self.signals_incoming_metrics.iter().any(Option::is_some)
             || self.duration_metrics.iter().any(Option::is_some)
             || self.signals_outgoing_metrics.iter().any(Option::is_some)
+            || !self.decision_candidates.is_empty()
     }
 }
 
@@ -484,6 +620,7 @@ mod tests {
             signals_outgoing_metrics: vec![Some(signals_outgoing_metric)],
             end_nodes: HashMap::from([(2, 0)]),
             start_nodes: HashMap::from([(0, 0)]),
+            decision_candidates: HashMap::new(),
         }
     }
 
@@ -673,6 +810,100 @@ mod tests {
         assert!(state.duration_metrics[0].is_some());
         assert!(state.signals_incoming_metrics[0].is_none());
         assert!(state.signals_outgoing_metrics[0].is_none());
+    }
+
+    #[test]
+    fn kept_dropped_registers_decision_candidates_for_range_processors() {
+        let (ctx, _) = test_pipeline_ctx();
+        let (names, procs) = test_maps(&["a", "b", "c"], &[]);
+        let edges = test_edges(&[("a", "b"), ("b", "c")], &names);
+        let mut flow = sw("decisions", "a", "c");
+        flow.metrics = Some(vec![FlowMetric::SignalsKept, FlowMetric::SignalsDropped]);
+        let policy = policy_with(vec![flow]);
+
+        let state = build_flow_metric_state(&policy, &names, &procs, &ctx, &edges)
+            .expect("kept/dropped config should build");
+
+        // Every processor node in the range a..=c is a decision candidate.
+        assert_eq!(state.decision_candidates.len(), 3);
+        for idx in [0usize, 1, 2] {
+            let candidate = state
+                .decision_candidates
+                .get(&idx)
+                .expect("each range node should be a candidate");
+            assert!(candidate.kept);
+            assert!(candidate.dropped);
+            assert!(candidate.attrs.decision.is_empty());
+        }
+        assert!(state.is_active());
+    }
+
+    #[test]
+    fn kept_only_registers_candidates_without_dropped() {
+        let (ctx, _) = test_pipeline_ctx();
+        let (names, procs) = test_maps(&["a", "b"], &[]);
+        let edges = test_edges(&[("a", "b")], &names);
+        let mut flow = sw("kept_only", "a", "b");
+        flow.metrics = Some(vec![FlowMetric::SignalsKept]);
+        let policy = policy_with(vec![flow]);
+
+        let state = build_flow_metric_state(&policy, &names, &procs, &ctx, &edges)
+            .expect("kept-only config should build");
+
+        let candidate = state.decision_candidates.get(&0).expect("candidate");
+        assert!(candidate.kept);
+        assert!(!candidate.dropped);
+    }
+
+    #[test]
+    fn no_kept_dropped_means_no_decision_candidates() {
+        let (ctx, _) = test_pipeline_ctx();
+        let (names, procs) = test_maps(&["a", "b"], &[]);
+        let edges = test_edges(&[("a", "b")], &names);
+        let mut flow = sw("duration_only", "a", "b");
+        flow.metrics = Some(vec![FlowMetric::ComputeDuration]);
+        let policy = policy_with(vec![flow]);
+
+        let state = build_flow_metric_state(&policy, &names, &procs, &ctx, &edges)
+            .expect("config should build");
+
+        assert!(state.decision_candidates.is_empty());
+    }
+
+    #[test]
+    fn single_node_flow_is_supported() {
+        let (ctx, _) = test_pipeline_ctx();
+        let (names, procs) = test_maps(&["solo"], &[]);
+        let mut flow = sw("single", "solo", "solo");
+        flow.metrics = Some(vec![FlowMetric::SignalsKept, FlowMetric::SignalsDropped]);
+        let policy = policy_with(vec![flow]);
+
+        let state = build_flow_metric_state(&policy, &names, &procs, &ctx, &[])
+            .expect("single-node flow should build");
+
+        assert_eq!(state.decision_candidates.len(), 1);
+        assert!(state.decision_candidates.contains_key(&0));
+    }
+
+    #[test]
+    fn shared_interior_decision_node_is_rejected() {
+        let (ctx, _) = test_pipeline_ctx();
+        // Fan-in/merge topology: two ranges meet at interior node `m`.
+        // a -> m -> b  and  c -> m -> d. Neither range contains the other's
+        // start node, so the interleave check passes — but both ranges include
+        // `m`, which would otherwise silently overwrite the decision candidate.
+        let (names, procs) = test_maps(&["a", "c", "m", "b", "d"], &[]);
+        let edges = test_edges(&[("a", "m"), ("c", "m"), ("m", "b"), ("m", "d")], &names);
+        let mut flow1 = sw("flow1", "a", "b");
+        flow1.metrics = Some(vec![FlowMetric::SignalsKept, FlowMetric::SignalsDropped]);
+        let mut flow2 = sw("flow2", "c", "d");
+        flow2.metrics = Some(vec![FlowMetric::SignalsKept, FlowMetric::SignalsDropped]);
+        let policy = policy_with(vec![flow1, flow2]);
+
+        let err = build_flow_metric_state(&policy, &names, &procs, &ctx, &edges)
+            .err()
+            .expect("shared interior decision node should be rejected");
+        assert_invalid_user_config(&err, "flow2");
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/engine/src/local/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/local/processor.rs
@@ -41,7 +41,8 @@ use crate::effect_handler::{
 };
 use crate::error::{Error, TypedError};
 use crate::flow_metrics::{
-    EndFlowMetrics, FlowDurationMetrics, FlowSignalsIncomingMetrics, FlowSignalsOutgoingMetrics,
+    DecisionFlowMetrics, EndFlowMetrics, FlowDurationMetrics, FlowSignalsDroppedMetrics,
+    FlowSignalsIncomingMetrics, FlowSignalsKeptMetrics, FlowSignalsOutgoingMetrics,
     IncomingFlowMetrics, LocalFlowMetricState, nanos_u64,
 };
 use crate::message::{Message, Sender};
@@ -230,10 +231,13 @@ impl<PData> EffectHandler<PData> {
         signals_incoming_metric: Option<MetricSet<FlowSignalsIncomingMetrics>>,
         duration_metric: Option<MetricSet<FlowDurationMetrics>>,
         signals_outgoing_metric: Option<MetricSet<FlowSignalsOutgoingMetrics>>,
+        signals_kept_metric: Option<MetricSet<FlowSignalsKeptMetrics>>,
+        signals_dropped_metric: Option<MetricSet<FlowSignalsDroppedMetrics>>,
         flow_metrics_active: bool,
     ) {
         self.flow.is_start = is_start;
         self.flow.is_end = is_end;
+        self.flow.is_decision = signals_kept_metric.is_some() || signals_dropped_metric.is_some();
         self.flow.active = flow_metrics_active;
         self.flow.incoming = IncomingFlowMetrics {
             signals_incoming: signals_incoming_metric
@@ -242,6 +246,11 @@ impl<PData> EffectHandler<PData> {
         self.flow.end = EndFlowMetrics {
             duration: duration_metric.map(|metrics| (metrics, Cell::new(Mmsc::default()))),
             signals_outgoing: signals_outgoing_metric
+                .map(|metrics| (metrics, Cell::new(Mmsc::default()))),
+        };
+        self.flow.decision = DecisionFlowMetrics {
+            signals_kept: signals_kept_metric.map(|metrics| (metrics, Cell::new(Mmsc::default()))),
+            signals_dropped: signals_dropped_metric
                 .map(|metrics| (metrics, Cell::new(Mmsc::default()))),
         };
     }
@@ -256,6 +265,12 @@ impl<PData> EffectHandler<PData> {
     #[must_use]
     pub fn is_flow_end(&self) -> bool {
         self.flow.is_end
+    }
+
+    /// Returns whether this node is a keep/drop decision node for some flow.
+    #[must_use]
+    pub fn is_flow_decision(&self) -> bool {
+        self.flow.is_decision
     }
 
     /// Record `total` nanoseconds into the local flow_metric accumulator.
@@ -293,6 +308,34 @@ impl<PData> EffectHandler<PData> {
         acc_cell.set(acc);
     }
 
+    /// Record the count of signal items this decision node chose to keep.
+    ///
+    /// No-op unless this node is wired as a keep/drop decision node for a flow
+    /// that enables `signals.kept`. The observation accumulates into a local
+    /// `Mmsc` drained on the next [`report_flow_metrics`] call.
+    pub fn record_flow_signals_kept(&self, signals: u64) {
+        let Some((_, acc_cell)) = self.flow.decision.signals_kept.as_ref() else {
+            return;
+        };
+        let mut acc = acc_cell.get();
+        acc.record(signals as f64);
+        acc_cell.set(acc);
+    }
+
+    /// Record the count of signal items this decision node chose to drop.
+    ///
+    /// No-op unless this node is wired as a keep/drop decision node for a flow
+    /// that enables `signals.dropped`. The observation accumulates into a local
+    /// `Mmsc` drained on the next [`report_flow_metrics`] call.
+    pub fn record_flow_signals_dropped(&self, signals: u64) {
+        let Some((_, acc_cell)) = self.flow.decision.signals_dropped.as_ref() else {
+            return;
+        };
+        let mut acc = acc_cell.get();
+        acc.record(signals as f64);
+        acc_cell.set(acc);
+    }
+
     /// Drain accumulated flow_metric observations into the MetricSet and
     /// report to the telemetry collector.
     ///
@@ -312,6 +355,16 @@ impl<PData> EffectHandler<PData> {
         if let Some((metrics, acc_cell)) = self.flow.end.signals_outgoing.as_mut() {
             let acc = acc_cell.replace(Mmsc::default());
             metrics.signals_outgoing.merge(acc);
+            let _ = self.core.metrics_reporter.report(metrics);
+        }
+        if let Some((metrics, acc_cell)) = self.flow.decision.signals_kept.as_mut() {
+            let acc = acc_cell.replace(Mmsc::default());
+            metrics.signals_kept.merge(acc);
+            let _ = self.core.metrics_reporter.report(metrics);
+        }
+        if let Some((metrics, acc_cell)) = self.flow.decision.signals_dropped.as_mut() {
+            let acc = acc_cell.replace(Mmsc::default());
+            metrics.signals_dropped.merge(acc);
             let _ = self.core.metrics_reporter.report(metrics);
         }
     }
@@ -1037,6 +1090,8 @@ mod tests {
             Some(start_metric_set),
             Some(duration_metric_set),
             Some(outgoing_metric_set),
+            None,
+            None,
             true,
         );
 
@@ -1128,7 +1183,7 @@ mod tests {
         let (_metrics_rx, metrics_reporter) = MetricsReporter::create_new_and_receiver(1);
         let mut eh =
             EffectHandler::<u64>::new(test_node("proc"), HashMap::new(), None, metrics_reporter);
-        eh.set_flow_roles(true, false, None, None, None, true);
+        eh.set_flow_roles(true, false, None, None, None, None, None, true);
         assert!(eh.flow.active);
 
         eh.begin_process_timing();
@@ -1155,7 +1210,7 @@ mod tests {
         let (_metrics_rx, metrics_reporter) = MetricsReporter::create_new_and_receiver(1);
         let mut eh =
             EffectHandler::<u64>::new(test_node("proc"), HashMap::new(), None, metrics_reporter);
-        eh.set_flow_roles(true, false, None, None, None, true);
+        eh.set_flow_roles(true, false, None, None, None, None, None, true);
         assert_eq!(eh.take_elapsed_since_send_marker_ns(), 0);
     }
 }

--- a/rust/otap-dataflow/crates/engine/src/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/processor.rs
@@ -21,7 +21,8 @@ use crate::effect_handler::SourceTagging;
 use crate::entity_context::NodeTelemetryGuard;
 use crate::error::{Error, ProcessorErrorKind};
 use crate::flow_metrics::{
-    FlowDurationMetrics, FlowSignalsIncomingMetrics, FlowSignalsOutgoingMetrics,
+    FlowDurationMetrics, FlowSignalsDroppedMetrics, FlowSignalsIncomingMetrics,
+    FlowSignalsKeptMetrics, FlowSignalsOutgoingMetrics,
 };
 use crate::local::message::{LocalReceiver, LocalSender};
 use crate::local::processor as local;
@@ -130,6 +131,10 @@ pub struct ProcessorRuntimeRequirements {
     /// Processor-local wakeup requirements, if the processor uses the local
     /// wakeup API.
     pub local_wakeups: Option<LocalWakeupRequirements>,
+    /// Whether this processor makes keep/drop decisions on signal items and
+    /// therefore records `signals.kept` / `signals.dropped` flow metrics when
+    /// it lies within a flow that enables them. Defaults to `false`.
+    pub makes_keep_drop_decisions: bool,
 }
 
 impl ProcessorRuntimeRequirements {
@@ -139,6 +144,7 @@ impl ProcessorRuntimeRequirements {
     pub const fn none() -> Self {
         Self {
             local_wakeups: None,
+            makes_keep_drop_decisions: false,
         }
     }
 
@@ -147,7 +153,16 @@ impl ProcessorRuntimeRequirements {
     pub const fn with_local_wakeups(live_slots: usize) -> Self {
         Self {
             local_wakeups: Some(LocalWakeupRequirements::new(live_slots)),
+            makes_keep_drop_decisions: false,
         }
+    }
+
+    /// Declare that this processor makes keep/drop decisions, enabling
+    /// `signals.kept` / `signals.dropped` flow-metric recording.
+    #[must_use]
+    pub const fn with_keep_drop_decisions(mut self) -> Self {
+        self.makes_keep_drop_decisions = true;
+        self
     }
 }
 
@@ -569,6 +584,8 @@ impl<PData> ProcessorWrapper<PData> {
             None,
             None,
             None,
+            None,
+            None,
             false,
         )
         .await
@@ -586,6 +603,8 @@ impl<PData> ProcessorWrapper<PData> {
         flow_signals_incoming_metric: Option<MetricSet<FlowSignalsIncomingMetrics>>,
         flow_duration_metric: Option<MetricSet<FlowDurationMetrics>>,
         flow_signals_outgoing_metric: Option<MetricSet<FlowSignalsOutgoingMetrics>>,
+        flow_signals_kept_metric: Option<MetricSet<FlowSignalsKeptMetrics>>,
+        flow_signals_dropped_metric: Option<MetricSet<FlowSignalsDroppedMetrics>>,
         flow_metrics_active: bool,
     ) -> Result<(), Error>
     where
@@ -617,6 +636,8 @@ impl<PData> ProcessorWrapper<PData> {
                     flow_signals_incoming_metric.clone(),
                     flow_duration_metric.clone(),
                     flow_signals_outgoing_metric.clone(),
+                    flow_signals_kept_metric.clone(),
+                    flow_signals_dropped_metric.clone(),
                     flow_metrics_active,
                 );
 
@@ -625,7 +646,8 @@ impl<PData> ProcessorWrapper<PData> {
                         match &mut msg {
                             Message::Control(NodeControlMsg::CollectTelemetry { .. })
                                 if effect_handler.is_flow_start()
-                                    || effect_handler.is_flow_end() =>
+                                    || effect_handler.is_flow_end()
+                                    || effect_handler.is_flow_decision() =>
                             {
                                 effect_handler.report_flow_metrics();
                             }
@@ -639,7 +661,10 @@ impl<PData> ProcessorWrapper<PData> {
                     processor.process(msg, &mut effect_handler).await?;
                 }
                 // Collect final metrics before exiting
-                if effect_handler.is_flow_start() || effect_handler.is_flow_end() {
+                if effect_handler.is_flow_start()
+                    || effect_handler.is_flow_end()
+                    || effect_handler.is_flow_decision()
+                {
                     effect_handler.report_flow_metrics();
                 }
                 processor
@@ -670,6 +695,8 @@ impl<PData> ProcessorWrapper<PData> {
                     flow_signals_incoming_metric.clone(),
                     flow_duration_metric.clone(),
                     flow_signals_outgoing_metric.clone(),
+                    flow_signals_kept_metric.clone(),
+                    flow_signals_dropped_metric.clone(),
                     flow_metrics_active,
                 );
 
@@ -678,7 +705,8 @@ impl<PData> ProcessorWrapper<PData> {
                         match &mut msg {
                             Message::Control(NodeControlMsg::CollectTelemetry { .. })
                                 if effect_handler.is_flow_start()
-                                    || effect_handler.is_flow_end() =>
+                                    || effect_handler.is_flow_end()
+                                    || effect_handler.is_flow_decision() =>
                             {
                                 effect_handler.report_flow_metrics();
                             }
@@ -692,7 +720,10 @@ impl<PData> ProcessorWrapper<PData> {
                     processor.process(msg, &mut effect_handler).await?;
                 }
                 // Collect final metrics before exiting
-                if effect_handler.is_flow_start() || effect_handler.is_flow_end() {
+                if effect_handler.is_flow_start()
+                    || effect_handler.is_flow_end()
+                    || effect_handler.is_flow_decision()
+                {
                     effect_handler.report_flow_metrics();
                 }
                 processor
@@ -860,8 +891,8 @@ mod tests {
         pipeline_completion_msg_channel, runtime_ctrl_msg_channel,
     };
     use crate::flow_metrics::{
-        FlowAttributeSet, FlowDurationMetrics, FlowSignalsIncomingMetrics,
-        FlowSignalsOutgoingMetrics,
+        FlowAttributeSet, FlowDurationMetrics, FlowSignalsDroppedMetrics,
+        FlowSignalsIncomingMetrics, FlowSignalsKeptMetrics, FlowSignalsOutgoingMetrics,
     };
     use crate::local::message::{LocalReceiver, LocalSender};
     use crate::local::processor as local;
@@ -1181,7 +1212,16 @@ mod tests {
             None,
             metrics_reporter,
         );
-        handler.set_flow_roles(true, false, Some(incoming_metric), None, None, true);
+        handler.set_flow_roles(
+            true,
+            false,
+            Some(incoming_metric),
+            None,
+            None,
+            None,
+            None,
+            true,
+        );
 
         handler.record_flow_signals_incoming(3);
         handler.record_flow_duration(10);
@@ -1224,6 +1264,8 @@ mod tests {
             None,
             Some(duration_metric),
             Some(outgoing_metric),
+            None,
+            None,
             true,
         );
 
@@ -1249,6 +1291,61 @@ mod tests {
         assert!(metrics_rx.try_recv().is_err());
     }
 
+    #[test]
+    fn flow_decision_node_reports_kept_and_dropped() {
+        let (pipeline_ctx, _) = crate::testing::test_pipeline_ctx();
+        let entity_key = pipeline_ctx
+            .metrics_registry()
+            .register_entity(FlowAttributeSet::default());
+        let kept_metric = pipeline_ctx
+            .metrics_registry()
+            .register_metric_set_for_entity::<FlowSignalsKeptMetrics>(entity_key);
+        let dropped_metric = pipeline_ctx
+            .metrics_registry()
+            .register_metric_set_for_entity::<FlowSignalsDroppedMetrics>(entity_key);
+        let (metrics_rx, metrics_reporter) =
+            otap_df_telemetry::reporter::MetricsReporter::create_new_and_receiver(4);
+        let mut handler = local::EffectHandler::<TestMsg>::new(
+            test_node("proc"),
+            std::collections::HashMap::new(),
+            None,
+            metrics_reporter,
+        );
+        // A decision node that is neither start nor end of the flow range.
+        handler.set_flow_roles(
+            false,
+            false,
+            None,
+            None,
+            None,
+            Some(kept_metric),
+            Some(dropped_metric),
+            true,
+        );
+        assert!(handler.is_flow_decision());
+
+        handler.record_flow_signals_kept(7);
+        handler.record_flow_signals_dropped(3);
+        // Recording incoming/outgoing here must be a no-op (not a start/end node).
+        handler.record_flow_signals_incoming(99);
+        handler.record_flow_signals_outgoing(99);
+        handler.report_flow_metrics();
+
+        let kept_snapshot = metrics_rx.try_recv().expect("kept metric should report");
+        let [MetricValue::Mmsc(kept)] = kept_snapshot.get_metrics() else {
+            panic!("expected kept metric");
+        };
+        assert_eq!(kept.count, 1);
+        assert!((kept.sum - 7.0).abs() < f64::EPSILON);
+        let dropped_snapshot = metrics_rx.try_recv().expect("dropped metric should report");
+        let [MetricValue::Mmsc(dropped)] = dropped_snapshot.get_metrics() else {
+            panic!("expected dropped metric");
+        };
+        assert_eq!(dropped.count, 1);
+        assert!((dropped.sum - 3.0).abs() < f64::EPSILON);
+        assert!(metrics_rx.try_recv().is_err());
+    }
+
     #[tokio::test]
     async fn flow_metric_auto_measures_process_without_timed() {
         let (pipeline_ctx, _) = crate::testing::test_pipeline_ctx();
@@ -1257,6 +1354,7 @@ mod tests {
             start_node: "auto_measure_processor".into(),
             end_node: "auto_measure_processor".into(),
             purpose: "".into(),
+            decision: "".into(),
             pipeline_attrs: pipeline_ctx.pipeline_attribute_set(),
         };
         let entity_key = pipeline_ctx.metrics_registry().register_entity(attrs);
@@ -1322,6 +1420,8 @@ mod tests {
                             Some(start_metric_set),
                             Some(duration_metric_set),
                             Some(outgoing_metric_set),
+                            None,
+                            None,
                             true,
                         )
                         .await

--- a/rust/otap-dataflow/crates/engine/src/runtime_pipeline.rs
+++ b/rust/otap-dataflow/crates/engine/src/runtime_pipeline.rs
@@ -18,8 +18,8 @@ use crate::control::{
 use crate::entity_context::{NodeTaskContext, NodeTelemetryHandle, instrument_with_node_context};
 use crate::error::{Error, TypedError};
 use crate::flow_metrics::{
-    FlowDurationMetrics, FlowSignalsIncomingMetrics, FlowSignalsOutgoingMetrics,
-    build_flow_metric_state,
+    FlowDurationMetrics, FlowSignalsDroppedMetrics, FlowSignalsIncomingMetrics,
+    FlowSignalsKeptMetrics, FlowSignalsOutgoingMetrics, build_flow_metric_state,
 };
 use crate::memory_limiter::MemoryPressureChanged;
 use crate::node::{Node, NodeDefs, NodeId, NodeType, NodeWithPDataReceiver, NodeWithPDataSender};
@@ -474,6 +474,36 @@ impl<PData: 'static + Debug + Clone + ReceivedAtNode + Unwindable + FlowMetricHo
                     .end_nodes
                     .get(&node_id.index)
                     .and_then(|&id| flow_metric_state.signals_outgoing_metrics[id].clone());
+            // Register per-node keep/drop decision metric sets when this
+            // processor declares the keep/drop capability and lies within a
+            // flow that enables kept/dropped. Each decision node gets its own
+            // entity tagged with `flow.node.decision` = this node's name.
+            let mut flow_signals_kept_metric: Option<MetricSet<FlowSignalsKeptMetrics>> = None;
+            let mut flow_signals_dropped_metric: Option<MetricSet<FlowSignalsDroppedMetrics>> =
+                None;
+            if processor.runtime_requirements().makes_keep_drop_decisions
+                && let Some(candidate) = flow_metric_state.decision_candidates.get(&node_id.index)
+            {
+                let mut attrs = candidate.attrs.clone();
+                attrs.decision = std::borrow::Cow::Owned(node_id.name.to_string());
+                let entity_key = pipeline_context.metrics_registry().register_entity(attrs);
+                if candidate.kept {
+                    flow_signals_kept_metric = Some(
+                        pipeline_context
+                            .metrics_registry()
+                            .register_metric_set_for_entity::<FlowSignalsKeptMetrics>(entity_key),
+                    );
+                }
+                if candidate.dropped {
+                    flow_signals_dropped_metric = Some(
+                        pipeline_context
+                            .metrics_registry()
+                            .register_metric_set_for_entity::<FlowSignalsDroppedMetrics>(
+                                entity_key,
+                            ),
+                    );
+                }
+            }
             let flow_active = flow_metric_state.is_active();
             let fut = async move {
                 let result = processor
@@ -488,6 +518,8 @@ impl<PData: 'static + Debug + Clone + ReceivedAtNode + Unwindable + FlowMetricHo
                         flow_signals_incoming_metric,
                         flow_duration_metric,
                         flow_signals_outgoing_metric,
+                        flow_signals_kept_metric,
+                        flow_signals_dropped_metric,
                         flow_active,
                     )
                     .await;

--- a/rust/otap-dataflow/crates/engine/src/shared/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/shared/processor.rs
@@ -40,7 +40,8 @@ use crate::effect_handler::{
 };
 use crate::error::{Error, TypedError};
 use crate::flow_metrics::{
-    EndFlowMetrics, FlowDurationMetrics, FlowSignalsIncomingMetrics, FlowSignalsOutgoingMetrics,
+    DecisionFlowMetrics, EndFlowMetrics, FlowDurationMetrics, FlowSignalsDroppedMetrics,
+    FlowSignalsIncomingMetrics, FlowSignalsKeptMetrics, FlowSignalsOutgoingMetrics,
     IncomingFlowMetrics, SharedFlowMetricState, nanos_u64,
 };
 use crate::message::Message;
@@ -202,10 +203,13 @@ impl<PData> EffectHandler<PData> {
         signals_incoming_metric: Option<MetricSet<FlowSignalsIncomingMetrics>>,
         duration_metric: Option<MetricSet<FlowDurationMetrics>>,
         signals_outgoing_metric: Option<MetricSet<FlowSignalsOutgoingMetrics>>,
+        signals_kept_metric: Option<MetricSet<FlowSignalsKeptMetrics>>,
+        signals_dropped_metric: Option<MetricSet<FlowSignalsDroppedMetrics>>,
         flow_metrics_active: bool,
     ) {
         self.flow.is_start = is_start;
         self.flow.is_end = is_end;
+        self.flow.is_decision = signals_kept_metric.is_some() || signals_dropped_metric.is_some();
         self.flow.active = flow_metrics_active;
         self.flow.incoming = IncomingFlowMetrics {
             signals_incoming: signals_incoming_metric
@@ -215,6 +219,12 @@ impl<PData> EffectHandler<PData> {
             duration: duration_metric
                 .map(|metrics| (metrics, Arc::new(Mutex::new(Mmsc::default())))),
             signals_outgoing: signals_outgoing_metric
+                .map(|metrics| (metrics, Arc::new(Mutex::new(Mmsc::default())))),
+        };
+        self.flow.decision = DecisionFlowMetrics {
+            signals_kept: signals_kept_metric
+                .map(|metrics| (metrics, Arc::new(Mutex::new(Mmsc::default())))),
+            signals_dropped: signals_dropped_metric
                 .map(|metrics| (metrics, Arc::new(Mutex::new(Mmsc::default())))),
         };
     }
@@ -229,6 +239,12 @@ impl<PData> EffectHandler<PData> {
     #[must_use]
     pub fn is_flow_end(&self) -> bool {
         self.flow.is_end
+    }
+
+    /// Returns whether this node is a keep/drop decision node for some flow.
+    #[must_use]
+    pub fn is_flow_decision(&self) -> bool {
+        self.flow.is_decision
     }
 
     /// Returns whether any flow_metric is configured in this pipeline.
@@ -305,6 +321,34 @@ impl<PData> EffectHandler<PData> {
         acc.record(signals as f64);
     }
 
+    /// Record the count of signal items this decision node chose to keep.
+    ///
+    /// No-op unless this node is wired as a keep/drop decision node for a flow
+    /// that enables `signals.kept`.
+    pub fn record_flow_signals_kept(&self, signals: u64) {
+        let Some((_, acc_mutex)) = self.flow.decision.signals_kept.as_ref() else {
+            return;
+        };
+        let mut acc = acc_mutex
+            .lock()
+            .expect("flow signals_kept accumulator poisoned");
+        acc.record(signals as f64);
+    }
+
+    /// Record the count of signal items this decision node chose to drop.
+    ///
+    /// No-op unless this node is wired as a keep/drop decision node for a flow
+    /// that enables `signals.dropped`.
+    pub fn record_flow_signals_dropped(&self, signals: u64) {
+        let Some((_, acc_mutex)) = self.flow.decision.signals_dropped.as_ref() else {
+            return;
+        };
+        let mut acc = acc_mutex
+            .lock()
+            .expect("flow signals_dropped accumulator poisoned");
+        acc.record(signals as f64);
+    }
+
     /// Drain accumulated flow_metric observations into the MetricSet and report.
     pub(crate) fn report_flow_metrics(&mut self) {
         if let Some((metrics, acc_mutex)) = self.flow.incoming.signals_incoming.as_mut() {
@@ -335,6 +379,26 @@ impl<PData> EffectHandler<PData> {
                 std::mem::take(&mut *guard)
             };
             metrics.signals_outgoing.merge(drained);
+            let _ = self.core.metrics_reporter.report(metrics);
+        }
+        if let Some((metrics, acc_mutex)) = self.flow.decision.signals_kept.as_mut() {
+            let drained = {
+                let mut guard = acc_mutex
+                    .lock()
+                    .expect("flow signals_kept accumulator poisoned");
+                std::mem::take(&mut *guard)
+            };
+            metrics.signals_kept.merge(drained);
+            let _ = self.core.metrics_reporter.report(metrics);
+        }
+        if let Some((metrics, acc_mutex)) = self.flow.decision.signals_dropped.as_mut() {
+            let drained = {
+                let mut guard = acc_mutex
+                    .lock()
+                    .expect("flow signals_dropped accumulator poisoned");
+                std::mem::take(&mut *guard)
+            };
+            metrics.signals_dropped.merge(drained);
             let _ = self.core.metrics_reporter.report(metrics);
         }
     }
@@ -688,7 +752,7 @@ mod tests {
         let (_metrics_rx, metrics_reporter) = MetricsReporter::create_new_and_receiver(1);
         let mut eh =
             EffectHandler::<u64>::new(test_node("proc"), HashMap::new(), None, metrics_reporter);
-        eh.set_flow_roles(true, false, None, None, None, true);
+        eh.set_flow_roles(true, false, None, None, None, None, None, true);
         assert!(eh.is_flow_start());
         assert!(eh.flow.active);
 
@@ -732,6 +796,8 @@ mod tests {
             Some(start_metric_set),
             Some(duration_metric_set),
             Some(outgoing_metric_set),
+            None,
+            None,
             true,
         );
         assert!(eh.is_flow_start());


### PR DESCRIPTION
# Change Summary

Adds two customer-facing flow metrics — `signals.kept` and `signals.dropped` — so operators can see, per flow, how many signal items each in-pipeline decision node keeps versus drops.

Unlike `signals.incoming` / `signals.outgoing` (recorded at the start/end of a flow range), kept/dropped are recorded by individual **decision-node processors** inside the range. A processor opts in via a capability flag; the engine registers a per-decision-node entity and the processor reports its counts each cycle. A new `flow.node.decision` scope attribute carries the deciding node's name, so a flow may contain multiple decision nodes without conflating their counts.

This is PR1 of the accept/reject telemetry effort (#2859). kept/dropped is scoped to **true decision-point processors only** — processors that can keep or drop whole signal items by a predicate (filter, sampler, and transform/KQL `where`), where `kept + dropped = incoming`. Processors that only route, fan out, buffer, or aggregate are intentionally excluded, since relocating, duplicating, or collapsing items is not a keep/drop decision. Receiver/exporter directional endpoints are a separate follow-up.

## Motivation

`incoming`/`outgoing` only show the net effect across a whole flow range. With multiple processors that each keep/drop data, operators couldn't attribute the loss to a specific node. `flow.node.decision` makes each decision node's contribution observable while the whole-flow aggregate remains available by summing across the attribute.

## What changed

- **Config**: added `SignalsKept` / `SignalsDropped` to the `FlowMetric` enum (`signals_kept` / `signals_dropped`, enabled by default when `metrics` is omitted).
- **Engine**: new `signals.kept` / `signals.dropped` metric sets and a `flow.node.decision` attribute; processors opt in via `ProcessorRuntimeRequirements::with_keep_drop_decisions()` and report through `EffectHandler::record_flow_signals_kept` / `record_flow_signals_dropped`. Supports single-node flow ranges and rejects flows that share an interior decision node.
- **Processors**: `filter_processor` and `log_sampling_processor` wired as the first consumers.
- **Demo config**: `fake-flow-metrics-demo.yaml` shows two interior decision nodes in one flow (`log_sampling` + `filter`) using the synthetic data source.
- **Changelog**: `.chloggen/flow-kept-dropped-metrics.yaml`.

## Design notes

- Capability is a simple bool on `ProcessorRuntimeRequirements`, not the extension capability/DI system.
- kept + dropped share one entity per decision node, keyed by `flow.node.decision`; the empty value belongs to the flow's incoming/outgoing/duration entity.
- No counting cost when disabled: `record_flow_signals_kept` / `_dropped` are cheap no-ops unless the node is a decision node in an enabled flow. The two wired consumers reuse counts they already compute for their own metrics, so this PR adds no extra per-batch work. Future consumers that need *new* counting (e.g. transform summing `num_items` across routed ports) should guard it with `EffectHandler::is_flow_decision()`.
- Aggregating across `flow.node.decision` only makes sense for `signals.dropped` (drops at different nodes are disjoint, summing to `incoming − outgoing`). `signals.kept` must **not** be summed across nodes — series nodes keep nested subsets, so the sum double-counts; the flow-wide kept count is just `signals.outgoing`, and per-node `signals.kept` is only meaningful on its own entity.
- Flow metrics remain aggregate (no `signal.type` dimension) in this PR. Per-signal breakdown is a tracked follow-up.

## Validation

Captured from `/api/v1/telemetry/metrics` with the demo config (flow range `attr1..attr4`, `sampler` and `filter` interior). The `sampler` keeps ~1/3 of log records (ratio 1-in-3); the `filter` then drops records whose `thread.name` matches its exclude rule. Each entity emits only some metrics; blank = not emitted by that entity:

| pipeline position (`flow.node.decision`) | `signals.incoming` | `signals.kept` | `signals.dropped` | `signals.outgoing` | `compute.duration` |
|---|---|---|---|---|---|
| flow start `""` | 340 | | | | |
| `sampler` | | 114 | 226 | | |
| `filter` | | 68 | 46 | | |
| flow end `""` | | | | 68 | 142,892,257 ns |

(The flow start/end rows are the same flow entity — `flow.node.decision = ""` — shown at both ends of the range for pipeline order. `compute.duration` is accumulated across the range and reported on that entity.)

Aggregation across `flow.node.decision`:

- **`dropped` sums** — drops are disjoint across nodes: `226 + 46 = 272 = incoming − outgoing (340 − 68)`.
- **`kept` does not sum** — series nodes keep nested subsets (the sampler produces 114 while the filter produces 68), so a sum double-counts the same items multiple times. Flow-wide kept is just `outgoing = 68`, not `114 + 68 = 182`.

## What issue does this PR close?

<!--
We highly recommend correlation of every PR to an issue
-->

* Progress towards #2859 

## How are these changes tested?

Unit tests, run of demo config

## Are there any user-facing changes?

Yes, operators can now get kept/dropped metrics from `flow`s.

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
