### PR TITLE
Add support for Bytes type in OPL type-checking expressions

### DIFF
--- a/rust/experimental/query_engine/expressions/src/primitives/value_type.rs
+++ b/rust/experimental/query_engine/expressions/src/primitives/value_type.rs
@@ -4,6 +4,7 @@
 // representations for stringified value types:
 const VALUE_TYPE_AS_STR_ARRAY: &str = "Array";
 const VALUE_TYPE_AS_STR_BOOLEAN: &str = "Boolean";
+const VALUE_TYPE_AS_STR_BYTES: &str = "Bytes";
 const VALUE_TYPE_AS_STR_DATETIME: &str = "DateTime";
 const VALUE_TYPE_AS_STR_DOUBLE: &str = "Double";
 const VALUE_TYPE_AS_STR_INTEGER: &str = "Integer";
@@ -17,22 +18,24 @@ const VALUE_TYPE_AS_STR_TIMESPAN: &str = "TimeSpan";
 pub enum ValueType {
     Array = 0,
     Boolean = 1,
-    DateTime = 2,
-    Double = 3,
-    Integer = 4,
-    Map = 5,
-    Null = 6,
-    Regex = 7,
-    String = 8,
-    TimeSpan = 9,
+    Bytes = 2,
+    DateTime = 3,
+    Double = 4,
+    Integer = 5,
+    Map = 6,
+    Null = 7,
+    Regex = 8,
+    String = 9,
+    TimeSpan = 10,
 }
 
 impl ValueType {
     pub fn get_value_types() -> impl Iterator<Item = ValueType> {
         // Note: Order here must match the enum definition
-        static VARIANTS: [ValueType; 10] = [
+        static VARIANTS: [ValueType; 11] = [
             ValueType::Array,
             ValueType::Boolean,
+            ValueType::Bytes,
             ValueType::DateTime,
             ValueType::Double,
             ValueType::Integer,
@@ -60,6 +63,7 @@ impl ValueType {
         Some(match s {
             VALUE_TYPE_AS_STR_ARRAY => ValueType::Array,
             VALUE_TYPE_AS_STR_BOOLEAN => ValueType::Boolean,
+            VALUE_TYPE_AS_STR_BYTES => ValueType::Bytes,
             VALUE_TYPE_AS_STR_DATETIME => ValueType::DateTime,
             VALUE_TYPE_AS_STR_DOUBLE => ValueType::Double,
             VALUE_TYPE_AS_STR_INTEGER => ValueType::Integer,
@@ -78,6 +82,7 @@ impl From<ValueType> for &str {
         match value {
             ValueType::Array => VALUE_TYPE_AS_STR_ARRAY,
             ValueType::Boolean => VALUE_TYPE_AS_STR_BOOLEAN,
+            ValueType::Bytes => VALUE_TYPE_AS_STR_BYTES,
             ValueType::DateTime => VALUE_TYPE_AS_STR_DATETIME,
             ValueType::Double => VALUE_TYPE_AS_STR_DOUBLE,
             ValueType::Integer => VALUE_TYPE_AS_STR_INTEGER,

--- a/rust/experimental/query_engine/kql-parser/src/scalar_expression.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_expression.rs
@@ -312,6 +312,7 @@ pub(crate) fn parse_scalar_unary_expression(
                         let item = match value_type {
                             ValueType::Array => ("Array", "array"),
                             ValueType::Boolean => ("Boolean", "bool"),
+                            ValueType::Bytes => ("Bytes", "bytes"),
                             ValueType::DateTime => ("DateTime", "datetime"),
                             ValueType::Double => ("Double", "real"),
                             ValueType::Integer => ("Integer", "long"),

--- a/rust/otap-dataflow/.chloggen/opl-bytes-type-check.yaml
+++ b/rust/otap-dataflow/.chloggen/opl-bytes-type-check.yaml
@@ -1,0 +1,19 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: query-engine
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add `Bytes` type keyword support for OPL type-checking expressions (e.g. `attributes[\"x\"] is Bytes`)."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [3223]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/rust/otap-dataflow/crates/query-engine-languages/docs/opl-user-guide/src/types.md
+++ b/rust/otap-dataflow/crates/query-engine-languages/docs/opl-user-guide/src/types.md
@@ -136,6 +136,7 @@ The following type names are available for `is` checks:
 | `Integer` | 64-bit signed integer |
 | `Double` | Double-precision floating point |
 | `Boolean` | `true` or `false` |
+| `Bytes` | Binary data |
 | `Array` | Array of values |
 | `Map` | Key-value map |
 | `Null` | Null / empty value |
@@ -144,8 +145,6 @@ The following type names are available for `is` checks:
 currently no support for indexing into them or using their contents in
 expressions. This means you can test whether an attribute is an `Array` or
 `Map`, but you cannot access individual elements within them.
-
-A type for binary data (bytes) is not yet supported, but will be added soon.
 
 Type checks are commonly used to guard function calls that only accept
 specific types:

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
@@ -1668,6 +1668,7 @@ impl ExprPlanner {
 
                 let expected_type = match value_type {
                     ValueType::Boolean => ExprLogicalType::Boolean,
+                    ValueType::Bytes => ExprLogicalType::Binary,
                     ValueType::DateTime => ExprLogicalType::TimestampNanosecond,
                     ValueType::Double => ExprLogicalType::Float64,
                     ValueType::Integer => ExprLogicalType::AnyInt,

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
@@ -5709,6 +5709,56 @@ mod test {
     }
 
     #[tokio::test]
+    async fn test_filter_by_attr_bytes_type() {
+        let log_records = vec![
+            LogRecord::build()
+                .attributes([
+                    KeyValue::new("attr_bytes", AnyValue::new_bytes(b"hello")),
+                    KeyValue::new("mixed_types", AnyValue::new_bytes(b"world")),
+                ])
+                .finish(),
+            LogRecord::build()
+                .attributes([
+                    KeyValue::new("attr_bytes", AnyValue::new_bytes(b"hello")),
+                    KeyValue::new("mixed_types", AnyValue::new_string("text")),
+                ])
+                .finish(),
+        ];
+
+        // all rows match when all have a Bytes attribute
+        let query = r#"logs | where attributes["attr_bytes"] is Bytes"#;
+        let result =
+            exec_logs_pipeline::<OplParser>(query, to_logs_data(log_records.clone())).await;
+        let expected = vec![log_records[0].clone(), log_records[1].clone()];
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &expected
+        );
+
+        // inverted: no rows
+        let query = r#"logs | where not(attributes["attr_bytes"] is Bytes)"#;
+        let result =
+            exec_logs_pipeline::<OplParser>(query, to_logs_data(log_records.clone())).await;
+        assert_eq!(result.resource_logs.len(), 0, "expected empty result");
+
+        // Bytes attribute is not matched by String
+        let query = r#"logs | where attributes["attr_bytes"] is String"#;
+        let result =
+            exec_logs_pipeline::<OplParser>(query, to_logs_data(log_records.clone())).await;
+        assert_eq!(result.resource_logs.len(), 0, "expected empty result");
+
+        // only the row whose mixed_types is Bytes is selected
+        let query = r#"logs | where attributes["mixed_types"] is Bytes"#;
+        let result =
+            exec_logs_pipeline::<OplParser>(query, to_logs_data(log_records.clone())).await;
+        let expected = vec![log_records[0].clone()];
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &expected
+        );
+    }
+
+    #[tokio::test]
     async fn test_filter_by_known_type() {
         let log_records = vec![
             LogRecord::build().severity_text("DEBUG").finish(),


### PR DESCRIPTION
# Change Summary

Add `Bytes` as a supported type keyword for OPL type-checking expressions. Users can now write `attributes["x"] is Bytes` to filter records where an attribute holds binary data.

## What issue does this PR close?

* Closes #3223

## How are these changes tested?

Added an integration test `test_filter_by_attr_bytes_type` in `filter.rs` covering:
* Basic match — `is Bytes` selects rows with a bytes attribute
* Negation — `not(... is Bytes)` returns no results
* No false positive — `is String` does not match a bytes attribute
* Mixed types — only the row whose attribute is `Bytes` is selected

## Are there any user-facing changes?

Yes. The `Bytes` type keyword is now available in OPL `is` type-check expressions:
```text
logs | where attributes["trace.id"] is Bytes
```
The OPL user guide (`types.md`) has been updated to list `Bytes` in the value type table and the "not yet supported" note has been removed.

### Changelog

* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
