### PR TITLE
chore(deps): bump geneva-uploader dependency

### DIFF
--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -254,7 +254,7 @@ tonic-prost-build = "0.14"
 tracepoint = { version = "0.5.0", features = ["user_events"] }
 tracepoint_decode = "0.5.0"
 urlencoding = "2"
-geneva-uploader = { git = "https://github.com/open-telemetry/opentelemetry-rust-contrib.git", rev = "47ece283fa10334cca14c2dd6311824c052c08e3" }
+geneva-uploader = { git = "https://github.com/open-telemetry/opentelemetry-rust-contrib.git", rev = "e263bdb5af68ddcba4af1645c32ce1d8443c8cbc" }
 
 [patch."https://github.com/open-telemetry/otel-arrow"]
 otap-df-pdata = { path = "crates/pdata" }

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/mod.rs
@@ -310,6 +310,7 @@ impl GenevaExporter {
             role_name: config.role_name.clone(),
             role_instance: config.role_instance.clone(),
             msi_resource,
+            obo_event_map: None,
         };
 
         // Initialize Geneva client


### PR DESCRIPTION
# Change Summary

- Bumps `geneva-uploader` to `e263bdb5af68ddcba4af1645c32ce1d8443c8cbc`                            
- Passes `obo_event_map: None` to `GenevaClientConfig` to preserve existing Geneva exporter        
  behavior with the updated API    

## What issue does this PR close?

* Closes None / chore

## How are these changes tested?

 - `cargo fmt --check` passed                                                                       
- `cargo check -p otap-df-contrib-nodes --features geneva-exporter
- 
## Are there any user-facing changes?

None.

### Changelog

* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
