### PR TITLE
feat(azure_monitor_exporter): Add in_flight_log_records metric

### DIFF
--- a/rust/otap-dataflow/.chloggen/azure-monitor-in-flight-log-records.yaml
+++ b/rust/otap-dataflow/.chloggen/azure-monitor-in-flight-log-records.yaml
@@ -19,5 +19,4 @@ issues: [3304]
 subtext: |
   The gauge reports the number of log records currently in-flight at the
   exporter (enqueued export requests awaiting completion, including records
-  being retried). A sustained non-zero value indicates the destination is
-  unreachable or slow and data is backing up at the exporter.
+  being retried).

--- a/rust/otap-dataflow/.chloggen/azure-monitor-in-flight-log-records.yaml
+++ b/rust/otap-dataflow/.chloggen/azure-monitor-in-flight-log-records.yaml
@@ -1,0 +1,23 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: pipeline
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `exporter.azure_monitor.in_flight_log_records` gauge to the Azure Monitor exporter for retry-backpressure visibility.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [3304]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The gauge reports the number of log records currently in-flight at the
+  exporter (enqueued export requests awaiting completion, including records
+  being retried). A sustained non-zero value indicates the destination is
+  unreachable or slow and data is backing up at the exporter.

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs
@@ -106,6 +106,7 @@ impl AzureMonitorExporter {
     fn sync_gauges(&self) {
         let mut m = self.metrics.borrow_mut();
         m.set_in_flight_exports(self.in_flight_exports.len() as u64);
+        m.set_in_flight_log_records(self.in_flight_exports.queued_rows());
         m.set_batch_to_msg_count(self.state.batch_to_msg.len() as u64);
         m.set_msg_to_batch_count(self.state.msg_to_batch.len() as u64);
         m.set_msg_to_data_count(self.state.msg_to_data.len() as u64);

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/in_flight_exports.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/in_flight_exports.rs
@@ -21,8 +21,11 @@ pub struct InFlightExports {
     futures: FuturesUnordered<LocalBoxFuture<'static, CompletedExport>>,
     limit: usize,
     /// Running total of log records (rows) across all in-flight exports.
-    /// Incremented when an export is enqueued and decremented when it
-    /// completes (success or failure), so it cannot drift from the futures set.
+    ///
+    /// Maintained by [`InFlightExports::push_export`] (which increments by the
+    /// enqueued `row_count`) and the completion paths ([`next_completion`],
+    /// [`push`], and [`drain`], which decrement by the completed export's
+    /// `row_count`).
     queued_rows: u64,
 }
 
@@ -62,7 +65,7 @@ impl InFlightExports {
 
     /// Push a future. If at capacity, waits for one completion and returns it.
     #[inline]
-    pub async fn push(
+    async fn push(
         &mut self,
         fut: LocalBoxFuture<'static, CompletedExport>,
     ) -> Option<CompletedExport> {

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/in_flight_exports.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/in_flight_exports.rs
@@ -95,7 +95,7 @@ impl InFlightExports {
     }
 
     /// Create a boxed export future.
-    pub fn make_export_future(
+    fn make_export_future(
         mut client: LogsIngestionClient,
         batch_id: u64,
         row_count: u64,

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/in_flight_exports.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/in_flight_exports.rs
@@ -20,6 +20,10 @@ pub struct CompletedExport {
 pub struct InFlightExports {
     futures: FuturesUnordered<LocalBoxFuture<'static, CompletedExport>>,
     limit: usize,
+    /// Running total of log records (rows) across all in-flight exports.
+    /// Incremented when an export is enqueued and decremented when it
+    /// completes (success or failure), so it cannot drift from the futures set.
+    queued_rows: u64,
 }
 
 impl InFlightExports {
@@ -27,6 +31,7 @@ impl InFlightExports {
         Self {
             futures: FuturesUnordered::new(),
             limit,
+            queued_rows: 0,
         }
     }
 
@@ -35,13 +40,23 @@ impl InFlightExports {
         self.futures.len()
     }
 
+    /// Current number of log records (rows) across all in-flight exports.
+    #[inline]
+    pub fn queued_rows(&self) -> u64 {
+        self.queued_rows
+    }
+
     #[inline]
     pub async fn next_completion(&mut self) -> Option<CompletedExport> {
         if self.futures.is_empty() {
             // Stay pending forever when empty - prevents busy loop
             std::future::pending().await
         } else {
-            self.futures.next().await
+            let completed = self.futures.next().await;
+            if let Some(ref c) = completed {
+                self.queued_rows = self.queued_rows.saturating_sub(c.row_count);
+            }
+            completed
         }
     }
 
@@ -56,6 +71,9 @@ impl InFlightExports {
         } else {
             None
         };
+        if let Some(ref c) = completed {
+            self.queued_rows = self.queued_rows.saturating_sub(c.row_count);
+        }
         self.futures.push(fut);
         completed
     }
@@ -69,6 +87,7 @@ impl InFlightExports {
         body: Bytes,
     ) -> Option<CompletedExport> {
         let fut = Self::make_export_future(client, batch_id, row_count, body);
+        self.queued_rows = self.queued_rows.saturating_add(row_count);
         self.push(fut).await
     }
 
@@ -94,6 +113,7 @@ impl InFlightExports {
     pub async fn drain(&mut self) -> Vec<CompletedExport> {
         let mut out = Vec::with_capacity(self.futures.len());
         while let Some(completed) = self.futures.next().await {
+            self.queued_rows = self.queued_rows.saturating_sub(completed.row_count);
             out.push(completed);
         }
         out
@@ -140,15 +160,25 @@ mod tests {
         )
     }
 
-    /// Create a future that completes immediately with a success result.
-    /// Used to fill the InFlightExports to test backpressure without waiting for real network calls.
-    fn mock_completed_export_future(batch_id: u64) -> LocalBoxFuture<'static, CompletedExport> {
+    /// Create a future that completes immediately with the given `row_count`
+    /// and result. Used to fill the InFlightExports and exercise backpressure
+    /// and in-flight record accounting without waiting for real network calls.
+    fn mock_completed_export_future(
+        batch_id: u64,
+        row_count: u64,
+        success: bool,
+    ) -> LocalBoxFuture<'static, CompletedExport> {
         Box::pin(async move {
+            let result = if success {
+                Ok(StdDuration::from_millis(1))
+            } else {
+                Err(Error::LogEntryTooLarge)
+            };
             CompletedExport {
                 batch_id,
                 client: create_test_client(),
-                result: Ok(StdDuration::from_millis(1)),
-                row_count: 1,
+                result,
+                row_count,
             }
         })
     }
@@ -255,7 +285,9 @@ mod tests {
         // 1. Fill the capacity with a dummy future that completes immediately
         // We use a dummy future because if we used push_export, it would create a real
         // export future that might retry and take a long time to fail/complete.
-        let _ = exports.push(mock_completed_export_future(100)).await;
+        let _ = exports
+            .push(mock_completed_export_future(100, 1, true))
+            .await;
         assert_eq!(exports.len(), 1);
 
         // 2. Now call push_export. Since we are at limit (1), it must wait for a completion.
@@ -272,6 +304,44 @@ mod tests {
 
         // The new export should be in the queue
         assert_eq!(exports.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_push_export_increments_queued_rows() {
+        let mut exports = InFlightExports::new(5);
+
+        // Under the limit, push_export does not block and increments the
+        // in-flight record tally by the enqueued row count. The real export
+        // future stays pending.
+        let _ = exports
+            .push_export(create_test_client(), 1, 100, Bytes::from("data"))
+            .await;
+        assert_eq!(exports.queued_rows(), 100);
+
+        let _ = exports
+            .push_export(create_test_client(), 2, 50, Bytes::from("data"))
+            .await;
+        assert_eq!(exports.queued_rows(), 150);
+    }
+
+    #[tokio::test]
+    async fn test_push_export_backpressure_decrements_queued_rows() {
+        let mut exports = InFlightExports::new(1);
+        exports.queued_rows = 10;
+        // Fill capacity with a completing future worth 10 records.
+        let _ = exports
+            .push(mock_completed_export_future(1, 10, true))
+            .await;
+        assert_eq!(exports.len(), 1);
+
+        // At capacity, push_export(+25) pops the completed future (-10) before
+        // adding the new one: 10 + 25 - 10 = 25.
+        let completed = exports
+            .push_export(create_test_client(), 2, 25, Bytes::from("data"))
+            .await;
+        assert!(completed.is_some());
+        assert_eq!(completed.unwrap().row_count, 10);
+        assert_eq!(exports.queued_rows(), 25);
     }
 
     // ==================== drain Tests ====================
@@ -291,9 +361,9 @@ mod tests {
         let mut exports = InFlightExports::new(5);
 
         // Push 3 dummy completed futures
-        let _ = exports.push(mock_completed_export_future(1)).await;
-        let _ = exports.push(mock_completed_export_future(2)).await;
-        let _ = exports.push(mock_completed_export_future(3)).await;
+        let _ = exports.push(mock_completed_export_future(1, 1, true)).await;
+        let _ = exports.push(mock_completed_export_future(2, 1, true)).await;
+        let _ = exports.push(mock_completed_export_future(3, 1, true)).await;
 
         assert_eq!(exports.len(), 3);
 
@@ -306,6 +376,22 @@ mod tests {
         assert!(ids.contains(&1));
         assert!(ids.contains(&2));
         assert!(ids.contains(&3));
+    }
+
+    #[tokio::test]
+    async fn test_drain_resets_queued_rows_to_zero() {
+        let mut exports = InFlightExports::new(5);
+        exports.queued_rows = 60;
+        let _ = exports
+            .push(mock_completed_export_future(1, 20, true))
+            .await;
+        let _ = exports
+            .push(mock_completed_export_future(2, 40, false))
+            .await;
+
+        let drained = exports.drain().await;
+        assert_eq!(drained.len(), 2);
+        assert_eq!(exports.queued_rows(), 0);
     }
 
     // ==================== next_completion Tests ====================
@@ -327,13 +413,52 @@ mod tests {
     async fn test_next_completion_returns_completed() {
         let mut exports = InFlightExports::new(5);
 
-        let _ = exports.push(mock_completed_export_future(42)).await;
+        let _ = exports
+            .push(mock_completed_export_future(42, 1, true))
+            .await;
 
         let result = exports.next_completion().await;
 
         assert!(result.is_some());
         assert_eq!(result.unwrap().batch_id, 42);
         assert_eq!(exports.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_next_completion_decrements_queued_rows() {
+        let mut exports = InFlightExports::new(5);
+        // Simulate in-flight exports totaling 100 records.
+        exports.queued_rows = 100;
+        let _ = exports
+            .push(mock_completed_export_future(1, 30, true))
+            .await;
+
+        let completed = exports.next_completion().await.unwrap();
+        assert_eq!(completed.row_count, 30);
+        assert_eq!(exports.queued_rows(), 70);
+    }
+
+    #[tokio::test]
+    async fn test_next_completion_failure_decrements_queued_rows() {
+        let mut exports = InFlightExports::new(5);
+        exports.queued_rows = 40;
+        let _ = exports
+            .push(mock_completed_export_future(1, 40, false))
+            .await;
+
+        let completed = exports.next_completion().await.unwrap();
+        assert!(completed.result.is_err());
+        assert_eq!(exports.queued_rows(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_next_completion_queued_rows_saturates_on_underflow() {
+        let mut exports = InFlightExports::new(5);
+        // queued_rows is 0 but a completion reports 5 records; saturating_sub
+        // must keep it at 0 rather than wrapping around.
+        let _ = exports.push(mock_completed_export_future(1, 5, true)).await;
+        let _ = exports.next_completion().await.unwrap();
+        assert_eq!(exports.queued_rows(), 0);
     }
 
     // ==================== Capacity/Backpressure Tests ====================
@@ -387,5 +512,11 @@ mod tests {
         let exports = InFlightExports::new(1000);
         assert_eq!(exports.limit, 1000);
         assert_eq!(exports.len(), 0);
+    }
+
+    #[test]
+    fn test_new_queued_rows_starts_at_zero() {
+        let exports = InFlightExports::new(5);
+        assert_eq!(exports.queued_rows(), 0);
     }
 }

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/metrics.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/metrics.rs
@@ -80,6 +80,10 @@ pub struct AzureMonitorExporterMetrics {
     /// Current number of in-flight export requests.
     #[metric(unit = "{export}")]
     pub in_flight_exports: Gauge<u64>,
+    /// Current number of log records in-flight at the exporter (enqueued export
+    /// requests awaiting completion, including records being retried).
+    #[metric(unit = "{log}")]
+    pub in_flight_log_records: Gauge<u64>,
     /// Current number of batch-to-message mappings (leak detector).
     #[metric(unit = "{entry}")]
     pub batch_to_msg_count: Gauge<u64>,
@@ -220,6 +224,13 @@ impl AzureMonitorExporterMetricsTracker {
         self.metrics.in_flight_exports.get()
     }
 
+    /// Get the current in-flight log records gauge value.
+    #[inline]
+    #[must_use]
+    pub fn in_flight_log_records(&self) -> u64 {
+        self.metrics.in_flight_log_records.get()
+    }
+
     /// Get the current batch_to_msg map size.
     #[inline]
     #[must_use]
@@ -315,6 +326,12 @@ impl AzureMonitorExporterMetricsTracker {
     #[inline]
     pub fn set_in_flight_exports(&mut self, count: u64) {
         self.metrics.in_flight_exports.set(count);
+    }
+
+    /// Set the current number of in-flight log records.
+    #[inline]
+    pub fn set_in_flight_log_records(&mut self, count: u64) {
+        self.metrics.in_flight_log_records.set(count);
     }
 
     /// Set the current batch_to_msg map size.
@@ -496,6 +513,21 @@ mod tests {
         stats.add_network_error();
         stats.add_network_error();
         assert_eq!(stats.metrics().laclient_network_errors.get(), 3);
+    }
+
+    #[test]
+    fn test_in_flight_log_records_gauge() {
+        let mut stats = new_test_tracker();
+
+        assert_eq!(stats.in_flight_log_records(), 0);
+
+        stats.set_in_flight_log_records(250);
+        assert_eq!(stats.in_flight_log_records(), 250);
+        assert_eq!(stats.metrics().in_flight_log_records.get(), 250);
+
+        // Gauge tracks the latest point-in-time value.
+        stats.set_in_flight_log_records(0);
+        assert_eq!(stats.in_flight_log_records(), 0);
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/telemetry.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/telemetry.md
@@ -26,6 +26,7 @@ by the crate and log events emitted via `otel_*` log macros.
 | `exporter.azure_monitor.batch_size` | Compressed batch size in bytes (min/max/sum/count). | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs` |
 | `exporter.azure_monitor.batch_uncompressed_size` | Uncompressed batch size in bytes (min/max/sum/count). | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
 | `exporter.azure_monitor.in_flight_exports` | Current number of in-flight export requests. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
+| `exporter.azure_monitor.in_flight_log_records` | Current number of log records in-flight at the exporter (enqueued export requests awaiting completion, including records being retried). A sustained non-zero value indicates the destination is unreachable or slow and data is backing up. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
 | `exporter.azure_monitor.batch_to_msg_count` | Current number of batch-to-message mappings. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
 | `exporter.azure_monitor.msg_to_batch_count` | Current number of message-to-batch mappings. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
 | `exporter.azure_monitor.msg_to_data_count` | Current number of message-to-data mappings. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/telemetry.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/telemetry.md
@@ -26,7 +26,7 @@ by the crate and log events emitted via `otel_*` log macros.
 | `exporter.azure_monitor.batch_size` | Compressed batch size in bytes (min/max/sum/count). | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs` |
 | `exporter.azure_monitor.batch_uncompressed_size` | Uncompressed batch size in bytes (min/max/sum/count). | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
 | `exporter.azure_monitor.in_flight_exports` | Current number of in-flight export requests. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
-| `exporter.azure_monitor.in_flight_log_records` | Current number of log records in-flight at the exporter (enqueued export requests awaiting completion, including records being retried). A sustained non-zero value indicates the destination is unreachable or slow and data is backing up. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
+| `exporter.azure_monitor.in_flight_log_records` | Current number of log records in-flight at the exporter (enqueued export requests awaiting completion, including records being retried). | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
 | `exporter.azure_monitor.batch_to_msg_count` | Current number of batch-to-message mappings. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
 | `exporter.azure_monitor.msg_to_batch_count` | Current number of message-to-batch mappings. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
 | `exporter.azure_monitor.msg_to_data_count` | Current number of message-to-data mappings. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |


### PR DESCRIPTION
# Change Summary

Add `in_flight_log_records` metric to `azure_monitor_exporter` to match existing `in_flight_exports`.

## What issue does this PR close?

No active issue, small gap

## How are these changes tested?

Unit tests

## Are there any user-facing changes?

Additional metric coming from `azure_monitor_exporter`

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
