### PR TITLE
Preserve raw ETW level in `etw.level` attribute

### DIFF
--- a/rust/otap-dataflow/.chloggen/etw-receiver-preserve-raw-level.yaml
+++ b/rust/otap-dataflow/.chloggen/etw-receiver-preserve-raw-level.yaml
@@ -8,7 +8,7 @@ change_type: enhancement
 component: pipeline
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Preserve the raw ETW level in the `etw.level` attribute so the SeverityNumber mapping remains reversible, aligning with the OpenTelemetry logs data model appendix ETW mapping
+note: Align the ETW receiver with the OpenTelemetry logs data model appendix ETW mapping - preserve the raw ETW level in the `etw.level` attribute so the SeverityNumber mapping stays reversible, and emit `SeverityText` using the standardized ETW level names (`LOG_ALWAYS`, `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `VERBOSE`)
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [2783]

--- a/rust/otap-dataflow/.chloggen/etw-receiver-preserve-raw-level.yaml
+++ b/rust/otap-dataflow/.chloggen/etw-receiver-preserve-raw-level.yaml
@@ -1,0 +1,19 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: pipeline
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Preserve the raw ETW level in the `etw.level` attribute so the SeverityNumber mapping remains reversible, aligning with the OpenTelemetry logs data model appendix ETW mapping
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [2783]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/rust/otap-dataflow/crates/contrib-nodes/src/receivers/etw_receiver/arrow_records_encoder.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/receivers/etw_receiver/arrow_records_encoder.rs
@@ -45,15 +45,22 @@ const fn etw_level_to_otel_severity(level: u8) -> i32 {
 ///
 /// Per the OpenTelemetry logs data model, `SeverityText` is the original
 /// string representation of the severity as it is known at the source, so this
-/// returns the ETW level name (e.g. `"Critical"`) rather than the OTel
+/// returns the ETW level name (e.g. `"CRITICAL"`) rather than the OTel
 /// severity short name (e.g. `"FATAL"`).
+///
+/// Level 0 (`LOG_ALWAYS`) is a filtering directive rather than a severity, but
+/// its source name is still recorded here even though `SeverityNumber` maps to
+/// UNSPECIFIED. Reserved (6-15) and provider-defined (16-255) levels have no
+/// name standardized across providers, so they return `None`. The names match
+/// the ETW mapping table in the OpenTelemetry logs data model appendix.
 const fn etw_level_to_severity_text(level: u8) -> Option<&'static str> {
     match level {
-        1 => Some("Critical"),
-        2 => Some("Error"),
-        3 => Some("Warning"),
-        4 => Some("Information"),
-        5 => Some("Verbose"),
+        0 => Some("LOG_ALWAYS"),
+        1 => Some("CRITICAL"),
+        2 => Some("ERROR"),
+        3 => Some("WARNING"),
+        4 => Some("INFO"),
+        5 => Some("VERBOSE"),
         _ => None,
     }
 }
@@ -167,16 +174,16 @@ impl EtwArrowRecordsBuilder {
         // field in the general case).  Decoded fields go into attributes.
         self.logs.body.append_null();
 
-        // Severity from ETW level
+        // Severity from ETW level. The severity number is only set for the
+        // mapped levels 1-5; UNSPECIFIED (0) levels leave it null. The
+        // `SeverityText` carries the original ETW level name as known at the
+        // source and is emitted even when the number is UNSPECIFIED (e.g.
+        // level 0 -> "LOG_ALWAYS"), per the OpenTelemetry logs data model.
         let severity = etw_level_to_otel_severity(event.level);
-        if severity > 0 {
-            self.logs.append_severity_number(Some(severity));
-            self.logs
-                .append_severity_text(etw_level_to_severity_text(event.level).map(str::as_bytes));
-        } else {
-            self.logs.append_severity_number(None);
-            self.logs.append_severity_text(None);
-        }
+        self.logs
+            .append_severity_number(if severity > 0 { Some(severity) } else { None });
+        self.logs
+            .append_severity_text(etw_level_to_severity_text(event.level).map(str::as_bytes));
 
         self.logs.append_id(Some(self.curr_log_id));
 
@@ -379,6 +386,22 @@ mod tests {
         assert_eq!(etw_level_to_otel_severity(5), 5); // DEBUG
         assert_eq!(etw_level_to_otel_severity(0), 0); // UNSPECIFIED
         assert_eq!(etw_level_to_otel_severity(255), 0); // Unknown
+    }
+
+    #[test]
+    fn severity_text_matches_data_model_mapping() {
+        // SeverityText carries the original ETW level name per the
+        // OpenTelemetry logs data model appendix ETW mapping table.
+        assert_eq!(etw_level_to_severity_text(0), Some("LOG_ALWAYS"));
+        assert_eq!(etw_level_to_severity_text(1), Some("CRITICAL"));
+        assert_eq!(etw_level_to_severity_text(2), Some("ERROR"));
+        assert_eq!(etw_level_to_severity_text(3), Some("WARNING"));
+        assert_eq!(etw_level_to_severity_text(4), Some("INFO"));
+        assert_eq!(etw_level_to_severity_text(5), Some("VERBOSE"));
+        // Reserved (6-15) and provider-defined (16-255) levels have no
+        // standardized name.
+        assert_eq!(etw_level_to_severity_text(6), None);
+        assert_eq!(etw_level_to_severity_text(200), None);
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/contrib-nodes/src/receivers/etw_receiver/arrow_records_encoder.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/receivers/etw_receiver/arrow_records_encoder.rs
@@ -188,6 +188,11 @@ impl EtwArrowRecordsBuilder {
 
         // Attributes: ETW header metadata
         self.append_attr("etw.event_id", AttrValue::Int(i64::from(event.event_id)));
+        // Preserve the raw ETW level so the severity mapping remains
+        // reversible (levels 0 and 6-255 map to UNSPECIFIED but the original
+        // value is retained here).  See the ETW mapping in the OpenTelemetry
+        // logs data model appendix.
+        self.append_attr("etw.level", AttrValue::Int(i64::from(event.level)));
         self.append_attr("etw.opcode", AttrValue::Int(i64::from(event.opcode)));
         self.append_attr("etw.version", AttrValue::Int(i64::from(event.version)));
         self.append_attr(
@@ -352,12 +357,12 @@ mod tests {
             .expect("attrs batch present");
 
         assert_eq!(logs_rb.num_rows(), 1);
-        // 7 header attrs (event_id, opcode, version, keywords, process_id,
-        // thread_id, provider_id) + 2 decoded fields = 9 rows.
+        // 8 header attrs (event_id, level, opcode, version, keywords,
+        // process_id, thread_id, provider_id) + 2 decoded fields = 10 rows.
         // (event_name is carried in the OTAP `event_name` log-record column,
         // not duplicated as an attribute; activity_id is all zeros so it's
         // omitted.)
-        assert_eq!(attrs_rb.num_rows(), 9);
+        assert_eq!(attrs_rb.num_rows(), 10);
     }
 
     #[test]
@@ -399,10 +404,10 @@ mod tests {
         let attrs_rb = batch
             .get(ArrowPayloadType::LogAttrs)
             .expect("attrs batch present");
-        // 7 header attributes (event_id, opcode, version, keywords,
+        // 8 header attributes (event_id, level, opcode, version, keywords,
         // process_id, thread_id, provider_id); event_name is carried in the
         // OTAP `event_name` log-record column; activity_id is zero → omitted
-        assert_eq!(attrs_rb.num_rows(), 7);
+        assert_eq!(attrs_rb.num_rows(), 8);
     }
 
     #[test]
@@ -419,7 +424,7 @@ mod tests {
         let attrs_rb = batch
             .get(ArrowPayloadType::LogAttrs)
             .expect("attrs batch present");
-        // 7 header attributes; the empty-named field is skipped
-        assert_eq!(attrs_rb.num_rows(), 7);
+        // 8 header attributes; the empty-named field is skipped
+        assert_eq!(attrs_rb.num_rows(), 8);
     }
 }

--- a/rust/otap-dataflow/crates/contrib-nodes/src/receivers/etw_receiver/arrow_records_encoder.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/receivers/etw_receiver/arrow_records_encoder.rs
@@ -53,6 +53,9 @@ const fn etw_level_to_otel_severity(level: u8) -> i32 {
 /// UNSPECIFIED. Reserved (6-15) and provider-defined (16-255) levels have no
 /// name standardized across providers, so they return `None`. The names match
 /// the ETW mapping table in the OpenTelemetry logs data model appendix.
+///
+/// See the Windows `EVENT_DESCRIPTOR` documentation for the level semantics:
+/// <https://learn.microsoft.com/en-us/windows/win32/api/evntprov/ns-evntprov-event_descriptor>
 const fn etw_level_to_severity_text(level: u8) -> Option<&'static str> {
     match level {
         0 => Some("LOG_ALWAYS"),
@@ -61,6 +64,9 @@ const fn etw_level_to_severity_text(level: u8) -> Option<&'static str> {
         3 => Some("WARNING"),
         4 => Some("INFO"),
         5 => Some("VERBOSE"),
+        // TODO: Manifest-based events can define their own levels in the
+        // 16-255 range. We will need to handle the mapping for those once
+        // manifest-based event support is implemented.
         _ => None,
     }
 }
@@ -174,14 +180,13 @@ impl EtwArrowRecordsBuilder {
         // field in the general case).  Decoded fields go into attributes.
         self.logs.body.append_null();
 
-        // Severity from ETW level. The severity number is only set for the
-        // mapped levels 1-5; UNSPECIFIED (0) levels leave it null. The
-        // `SeverityText` carries the original ETW level name as known at the
-        // source and is emitted even when the number is UNSPECIFIED (e.g.
-        // level 0 -> "LOG_ALWAYS"), per the OpenTelemetry logs data model.
+        // Severity from ETW level. The severity number is always emitted;
+        // unmapped levels resolve to UNSPECIFIED (0). The `SeverityText`
+        // carries the original ETW level name as known at the source and is
+        // emitted even when the number is UNSPECIFIED (e.g. level 0 ->
+        // "LOG_ALWAYS"), per the OpenTelemetry logs data model.
         let severity = etw_level_to_otel_severity(event.level);
-        self.logs
-            .append_severity_number(if severity > 0 { Some(severity) } else { None });
+        self.logs.append_severity_number(Some(severity));
         self.logs
             .append_severity_text(etw_level_to_severity_text(event.level).map(str::as_bytes));
 
@@ -406,11 +411,12 @@ mod tests {
 
     #[test]
     fn unspecified_severity_preserves_raw_level() {
-        use arrow::array::{DictionaryArray, Int64Array, StringArray};
+        use arrow::array::{Array, DictionaryArray, Int32Array, Int64Array, StringArray};
         use arrow::datatypes::{UInt8Type, UInt16Type};
 
         // An ETW level outside the documented 1-5 range (e.g. 200) maps to
-        // OTel UNSPECIFIED, so no severity number/text is emitted.
+        // OTel UNSPECIFIED, so the severity number is emitted as 0 and no
+        // severity text is emitted.
         assert_eq!(etw_level_to_otel_severity(200), 0);
         assert_eq!(etw_level_to_severity_text(200), None);
 
@@ -421,15 +427,28 @@ mod tests {
         builder.append(&event);
         let batch = builder.build().expect("build succeeds");
 
-        // The severity maps to UNSPECIFIED, so the logs batch carries no
-        // severity number (the column is either omitted or null).
+        // The severity maps to UNSPECIFIED, so the logs batch carries a
+        // severity number of 0.
         let logs_rb = batch
             .get(ArrowPayloadType::Logs)
             .expect("logs batch present");
         if let Some(severity) = logs_rb.column_by_name("severity_number") {
+            // The column may be dictionary-encoded, so cast to a plain Int32
+            // array before inspecting the value.
+            let severity = arrow::compute::cast(severity, &arrow::datatypes::DataType::Int32)
+                .expect("cast severity_number to i32");
+            let severity = severity
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .expect("severity_number is i32");
             assert!(
-                severity.is_null(0),
-                "UNSPECIFIED severity must not emit a severity number"
+                !severity.is_null(0),
+                "UNSPECIFIED severity must still emit a severity number"
+            );
+            assert_eq!(
+                severity.value(0),
+                0,
+                "UNSPECIFIED severity number must be 0"
             );
         }
 

--- a/rust/otap-dataflow/crates/contrib-nodes/src/receivers/etw_receiver/arrow_records_encoder.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/receivers/etw_receiver/arrow_records_encoder.rs
@@ -41,14 +41,19 @@ const fn etw_level_to_otel_severity(level: u8) -> i32 {
     }
 }
 
-/// Map an ETW level to the conventional OTel severity text.
+/// Map an ETW level to the `SeverityText`.
+///
+/// Per the OpenTelemetry logs data model, `SeverityText` is the original
+/// string representation of the severity as it is known at the source, so this
+/// returns the ETW level name (e.g. `"Critical"`) rather than the OTel
+/// severity short name (e.g. `"FATAL"`).
 const fn etw_level_to_severity_text(level: u8) -> Option<&'static str> {
     match level {
-        1 => Some("FATAL"),
-        2 => Some("ERROR"),
-        3 => Some("WARN"),
-        4 => Some("INFO"),
-        5 => Some("DEBUG"),
+        1 => Some("Critical"),
+        2 => Some("Error"),
+        3 => Some("Warning"),
+        4 => Some("Information"),
+        5 => Some("Verbose"),
         _ => None,
     }
 }
@@ -374,6 +379,82 @@ mod tests {
         assert_eq!(etw_level_to_otel_severity(5), 5); // DEBUG
         assert_eq!(etw_level_to_otel_severity(0), 0); // UNSPECIFIED
         assert_eq!(etw_level_to_otel_severity(255), 0); // Unknown
+    }
+
+    #[test]
+    fn unspecified_severity_preserves_raw_level() {
+        use arrow::array::{DictionaryArray, Int64Array, StringArray};
+        use arrow::datatypes::{UInt8Type, UInt16Type};
+
+        // An ETW level outside the documented 1-5 range (e.g. 200) maps to
+        // OTel UNSPECIFIED, so no severity number/text is emitted.
+        assert_eq!(etw_level_to_otel_severity(200), 0);
+        assert_eq!(etw_level_to_severity_text(200), None);
+
+        let mut event = test_event();
+        event.level = 200;
+
+        let mut builder = EtwArrowRecordsBuilder::new();
+        builder.append(&event);
+        let batch = builder.build().expect("build succeeds");
+
+        // The severity maps to UNSPECIFIED, so the logs batch carries no
+        // severity number (the column is either omitted or null).
+        let logs_rb = batch
+            .get(ArrowPayloadType::Logs)
+            .expect("logs batch present");
+        if let Some(severity) = logs_rb.column_by_name("severity_number") {
+            assert!(
+                severity.is_null(0),
+                "UNSPECIFIED severity must not emit a severity number"
+            );
+        }
+
+        // The raw ETW level is still recoverable from the `etw.level`
+        // attribute, even though the severity mapping discarded it.
+        let attrs_rb = batch
+            .get(ArrowPayloadType::LogAttrs)
+            .expect("attrs batch present");
+
+        let key_dict = attrs_rb
+            .column_by_name("key")
+            .expect("key column present")
+            .as_any()
+            .downcast_ref::<DictionaryArray<UInt8Type>>()
+            .expect("key is dictionary-encoded");
+        let key_values = key_dict
+            .values()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("key dictionary values are strings");
+
+        let int_dict = attrs_rb
+            .column_by_name("int")
+            .expect("int column present")
+            .as_any()
+            .downcast_ref::<DictionaryArray<UInt16Type>>()
+            .expect("int is dictionary-encoded");
+        let int_values = int_dict
+            .values()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("int dictionary values are i64");
+
+        let mut recovered_level = None;
+        for row in 0..attrs_rb.num_rows() {
+            let key = key_values.value(key_dict.key(row).expect("key index"));
+            if key == "etw.level" {
+                let int_idx = int_dict.key(row).expect("etw.level has an int value");
+                recovered_level = Some(int_values.value(int_idx));
+                break;
+            }
+        }
+
+        assert_eq!(
+            recovered_level,
+            Some(200),
+            "raw ETW level should be recoverable from the etw.level attribute"
+        );
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/contrib-nodes/src/receivers/etw_receiver/windows_e2e_tests.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/receivers/etw_receiver/windows_e2e_tests.rs
@@ -463,8 +463,8 @@ fn assert_log_record_common(records: &OtapArrowRecords, row: usize, event_name: 
 
     // severity: producer wrote `Informational` (== ETW level 4), which
     // the encoder maps to OTel INFO (severity_number 9). `SeverityText`
-    // carries the original ETW level name ("Information") as known at the
-    // source, per the OpenTelemetry logs data model.
+    // carries the original ETW level name ("INFO") as known at the
+    // source, per the OpenTelemetry logs data model ETW mapping.
     let severity_number = i32_column(logs_rb, consts::SEVERITY_NUMBER);
     assert_eq!(
         severity_number[row],
@@ -475,8 +475,8 @@ fn assert_log_record_common(records: &OtapArrowRecords, row: usize, event_name: 
     let severity_text = string_column(logs_rb, consts::SEVERITY_TEXT);
     assert_eq!(
         severity_text[row].as_deref(),
-        Some("Information"),
-        "severity_text at row {row}: expected Some(\"Information\"), got {:?}",
+        Some("INFO"),
+        "severity_text at row {row}: expected Some(\"INFO\"), got {:?}",
         severity_text[row]
     );
 

--- a/rust/otap-dataflow/crates/contrib-nodes/src/receivers/etw_receiver/windows_e2e_tests.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/receivers/etw_receiver/windows_e2e_tests.rs
@@ -462,7 +462,9 @@ fn assert_log_record_common(records: &OtapArrowRecords, row: usize, event_name: 
     );
 
     // severity: producer wrote `Informational` (== ETW level 4), which
-    // the encoder maps to OTel INFO (severity_number 9, text "INFO").
+    // the encoder maps to OTel INFO (severity_number 9). `SeverityText`
+    // carries the original ETW level name ("Information") as known at the
+    // source, per the OpenTelemetry logs data model.
     let severity_number = i32_column(logs_rb, consts::SEVERITY_NUMBER);
     assert_eq!(
         severity_number[row],
@@ -473,8 +475,8 @@ fn assert_log_record_common(records: &OtapArrowRecords, row: usize, event_name: 
     let severity_text = string_column(logs_rb, consts::SEVERITY_TEXT);
     assert_eq!(
         severity_text[row].as_deref(),
-        Some("INFO"),
-        "severity_text at row {row}: expected Some(\"INFO\"), got {:?}",
+        Some("Information"),
+        "severity_text at row {row}: expected Some(\"Information\"), got {:?}",
         severity_text[row]
     );
 


### PR DESCRIPTION
Preserve raw ETW level in `etw.level` attribute for reversible severity mapping

# Change Summary

<!--
Replace with a brief summary of the change in this PR
-->

## What issue does this PR close?

<!--
We highly recommend correlation of every PR to an issue
-->

* Closes #NNN

## How are these changes tested?

## Are there any user-facing changes?

 <!-- If yes, provide further info below -->

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
