### PR TITLE
chore(ci): broaden PR size labeler ignore list for lock/sum files

### DIFF
--- a/.github/workflows/pr-size-label.yml
+++ b/.github/workflows/pr-size-label.yml
@@ -47,9 +47,10 @@ jobs:
             [CONTRIBUTING.md](https://github.com/open-telemetry/otel-arrow/blob/main/CONTRIBUTING.md#keep-pull-requests-small-and-incremental)
             for guidelines on keeping PRs small.
           files_to_ignore: |
-            "go.sum"
+            "*.sum"
             "Cargo.lock"
             "*.lock"
+            "*.lock.txt"
             "*.pb.go"
             "*.pb.gw.go"
             "**/testdata/**"


### PR DESCRIPTION
Follow-up to #2989.

Two adjustments based on PRs opened after that merge:

- `"go.sum"` → `"*.sum"`. The labeler uses bash glob matching (not minimatch), so `"go.sum"` only matched a root-level file and missed `go/go.sum` and `collector/cmd/otelarrowcol/go.sum`. This was also flagged by @ThomsonTan in the original PR review.
- Added `"*.lock.txt"` to catch `requirements.lock.txt` (used under `tools/pipeline_perf_test/`). Without this, renovate/dependabot PRs that touch only lockfiles get inflated labels — e.g. #3312 was labeled `size/M` even though the only non-generated change is 2 lines in `requirements.txt`.

No changelog entry — workflow-only chore.