### PR TITLE
OTAP exporter: support static request headers natively

### DIFF
--- a/rust/otap-dataflow/.chloggen/otap-exporter-static-headers.yaml
+++ b/rust/otap-dataflow/.chloggen/otap-exporter-static-headers.yaml
@@ -1,0 +1,26 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: pipeline
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: >-
+  OTAP exporter now supports static request `headers` natively: configured
+  headers are attached once as the initial metadata of each Arrow
+  log/metric/trace stream. The previous config-load rejection is removed.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [3314]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: >-
+  Headers are sent once per stream establishment, not per `BatchArrowRecords`,
+  so the per-message hot path remains allocation-free. Header validation
+  (ASCII-only, no gRPC-reserved metadata) is shared with the OTLP/gRPC exporter
+  via `GrpcClientSettings`.

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/README.md
@@ -138,7 +138,7 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
   `GrpcClientSettings` (ASCII-only, no gRPC-reserved metadata).
   - Because the metadata is bound when a stream opens, a changed `headers` value
     (e.g. a rotated `authorization` or tenant header) only takes effect on the
-    next stream open/reconnect — unlike the OTLP/gRPC exporter, which rebuilds
+    next stream open/reconnect, unlike the OTLP/gRPC exporter, which rebuilds
     metadata per unary request. Existing long-lived streams keep using the value
     they were opened with until they are re-established.
 - Compression values are limited to the variants supported by the shared OTAP

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/README.md
@@ -136,6 +136,11 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
   allocation-free; the one-time cost is a single metadata clone per stream
   establishment. Header names/values are validated at config load via the shared
   `GrpcClientSettings` (ASCII-only, no gRPC-reserved metadata).
+  - Because the metadata is bound when a stream opens, a changed `headers` value
+    (e.g. a rotated `authorization` or tenant header) only takes effect on the
+    next stream open/reconnect — unlike the OTLP/gRPC exporter, which rebuilds
+    metadata per unary request. Existing long-lived streams keep using the value
+    they were opened with until they are re-established.
 - Compression values are limited to the variants supported by the shared OTAP
   transport layer.
 - End-to-end delivery depends on downstream OTAP stream responses.

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/README.md
@@ -136,11 +136,11 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
   allocation-free; the one-time cost is a single metadata clone per stream
   establishment. Header names/values are validated at config load via the shared
   `GrpcClientSettings` (ASCII-only, no gRPC-reserved metadata).
-  - Because the metadata is bound when a stream opens, a changed `headers` value
-    (e.g. a rotated `authorization` or tenant header) only takes effect on the
-    next stream open/reconnect, unlike the OTLP/gRPC exporter, which rebuilds
-    metadata per unary request. Existing long-lived streams keep using the value
-    they were opened with until they are re-established.
+  - Because the metadata template is built once at exporter startup, a changed
+    `headers` value (e.g. a rotated `authorization` or tenant header) only takes
+    effect when the exporter is restarted/reconfigured and not on stream
+    reconnects, which reuse the template captured at startup. This differs from
+    the OTLP/gRPC exporter, which rebuilds metadata per unary request.
 - Compression values are limited to the variants supported by the shared OTAP
   transport layer.
 - End-to-end delivery depends on downstream OTAP stream responses.

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/README.md
@@ -53,6 +53,12 @@ config:
   # Number of streams opened for each signal type (default: 1).
   streams_per_signal: 1
 
+  # Optional static gRPC request headers (metadata) attached once as the
+  # initial metadata of each Arrow stream (e.g. auth or tenant routing).
+  headers:
+    authorization: "Basic dXNlcjpwYXNz"
+    x-scope-orgid: "tenant-1"
+
   # Optional RPC timeout.
   timeout: 30s
 ```
@@ -124,11 +130,12 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
 ## Limits
 
 - `stream_queue_capacity` and `streams_per_signal` must be greater than zero.
-- Static request `headers` are not supported yet: the OTAP exporter shares
-  `GrpcClientSettings` with the OTLP/gRPC exporter, but does not attach static
-  metadata to its Arrow streams, so a non-empty `headers` map is rejected at
-  config validation rather than silently dropped. Use `exporter:otlp_grpc` or
-  `exporter:otlp_http` to send static headers.
+- Static request `headers` are attached once, as the initial metadata of each
+  Arrow stream when it is opened (or re-opened after a reconnect). They are not
+  re-sent per `BatchArrowRecords`, so the per-message hot path stays
+  allocation-free; the one-time cost is a single metadata clone per stream
+  establishment. Header names/values are validated at config load via the shared
+  `GrpcClientSettings` (ASCII-only, no gRPC-reserved metadata).
 - Compression values are limited to the variants supported by the shared OTAP
   transport layer.
 - End-to-end delivery depends on downstream OTAP stream responses.

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/mod.rs
@@ -25,7 +25,6 @@ use otap_df_engine::node::NodeId;
 use otap_df_engine::terminal_state::TerminalState;
 use otap_df_otap::OTAP_EXPORTER_FACTORIES;
 use otap_df_otap::metrics::ExporterPDataMetrics;
-use otap_df_otap::otap_grpc::client_settings::build_static_metadata;
 use otap_df_otap::pdata::OtapPdata;
 use otap_df_pdata::Producer;
 use otap_df_pdata::TryIntoWithOptions;
@@ -479,7 +478,7 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
         // shared across all stream workers via `Arc`; each stream attaches a
         // clone as its initial metadata when it opens (see `stream_arrow_batches`),
         // so the per-`BatchArrowRecords` send path is never touched.
-        let static_metadata = build_static_metadata(&self.config.grpc.headers).map(Arc::new);
+        let static_metadata = self.config.grpc.build_static_metadata().map(Arc::new);
 
         // Operational breadcrumb: confirm which static header KEYS were loaded
         // (never the values, which may be credentials). Lets an operator verify
@@ -2693,7 +2692,7 @@ mod tests {
         let cap_logs = captured_tx.clone();
         let cap_metrics = captured_tx.clone();
         let cap_traces = captured_tx;
-        _ = tokio_rt.spawn(async move {
+        let server_handle = tokio_rt.spawn(async move {
             let tcp_listener = TcpListener::bind(listening_addr).await.unwrap();
             let _ = ready_sender.send(());
             let tcp_stream = TcpListenerStream::new(tcp_listener);
@@ -2790,6 +2789,11 @@ mod tests {
             });
 
         _ = shutdown_sender.send("Shutdown");
+        // Await the server task so teardown is deterministic and no background
+        // task is left pending at runtime drop.
+        tokio_rt
+            .block_on(server_handle)
+            .expect("server task should shut down cleanly");
     }
 
     /// Backwards compatibility: with no `headers` configured, the exporter must
@@ -2809,7 +2813,7 @@ mod tests {
         let listening_addr: SocketAddr = format!("{grpc_addr}:{grpc_port}").parse().unwrap();
         let tokio_rt = Runtime::new().unwrap();
 
-        _ = tokio_rt.spawn(async move {
+        let server_handle = tokio_rt.spawn(async move {
             let tcp_listener = TcpListener::bind(listening_addr).await.unwrap();
             let _ = ready_sender.send(());
             let tcp_stream = TcpListenerStream::new(tcp_listener);
@@ -2877,6 +2881,11 @@ mod tests {
             });
 
         _ = shutdown_sender.send("Shutdown");
+        // Await the server task so teardown is deterministic and no background
+        // task is left pending at runtime drop.
+        tokio_rt
+            .block_on(server_handle)
+            .expect("server task should shut down cleanly");
     }
 
     /// Reliability: the configured static headers must be applied to the request
@@ -2908,8 +2917,11 @@ mod tests {
 
         let mut headers = std::collections::HashMap::new();
         let _ = headers.insert(HDR_AUTH.to_string(), HDR_AUTH_VAL.to_string());
-        let static_metadata =
-            otap_df_otap::otap_grpc::client_settings::build_static_metadata(&headers).map(Arc::new);
+        let settings = otap_df_otap::otap_grpc::client_settings::GrpcClientSettings {
+            headers,
+            ..Default::default()
+        };
+        let static_metadata = settings.build_static_metadata().map(Arc::new);
         assert!(
             static_metadata.is_some(),
             "test setup should produce metadata"

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/mod.rs
@@ -25,6 +25,7 @@ use otap_df_engine::node::NodeId;
 use otap_df_engine::terminal_state::TerminalState;
 use otap_df_otap::OTAP_EXPORTER_FACTORIES;
 use otap_df_otap::metrics::ExporterPDataMetrics;
+use otap_df_otap::otap_grpc::client_settings::build_static_metadata;
 use otap_df_otap::pdata::OtapPdata;
 use otap_df_pdata::Producer;
 use otap_df_pdata::TryIntoWithOptions;
@@ -38,7 +39,7 @@ use otap_df_pdata::proto::opentelemetry::arrow::v1::{
 };
 use otap_df_telemetry::instrument::{Gauge, Mmsc};
 use otap_df_telemetry::metrics::MetricSet;
-use otap_df_telemetry::{otel_error, otel_info, otel_warn};
+use otap_df_telemetry::{otel_debug, otel_error, otel_info, otel_warn};
 use otap_df_telemetry_macros::metric_set;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -46,6 +47,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::task::JoinHandle;
+use tonic::metadata::MetadataMap;
 use tonic::transport::Channel;
 use tonic::{IntoStreamingRequest, Response, Status, Streaming};
 
@@ -191,28 +193,7 @@ fn validate_config(config: &Value) -> Result<(), otap_df_config::error::Error> {
         .map_err(|e| otap_df_config::error::Error::InvalidUserConfig {
             error: e.to_string(),
         })?;
-    reject_unsupported_headers(&cfg)?;
     Ok(())
-}
-
-/// Rejects static `headers` configured on the OTAP exporter.
-///
-/// [`GrpcClientSettings`] is shared with the OTLP/gRPC exporter, which applies
-/// static `headers` as per-request metadata. The OTAP exporter sends data over
-/// long-lived Arrow streams and does not attach that metadata yet, so accepting
-/// `headers` here would silently drop them (e.g. an `authorization` credential
-/// that never reaches the backend). Fail loudly until OTAP-native support lands.
-fn reject_unsupported_headers(cfg: &Config) -> Result<(), otap_df_config::error::Error> {
-    if cfg.grpc.headers.is_empty() {
-        return Ok(());
-    }
-    Err(otap_df_config::error::Error::InvalidUserConfig {
-        error: "the OTAP exporter (urn:otel:exporter:otap) does not support static \
-                `headers` yet; they would be silently dropped from the OTAP/Arrow \
-                stream. Configure `headers` on exporter:otlp_grpc or \
-                exporter:otlp_http instead, or remove the field"
-            .to_string(),
-    })
 }
 
 impl OTAPExporter {
@@ -240,7 +221,18 @@ impl OTAPExporter {
             }
         })?;
 
-        reject_unsupported_headers(&config)?;
+        // Defense-in-depth: validate the shared gRPC settings (including the
+        // ASCII/reserved/duplicate `headers` checks) here too, not only in the
+        // factory `validate_config` hook. This guarantees that any construction
+        // path — including direct/programmatic `from_config` callers — rejects
+        // invalid or gRPC-reserved headers up front, so `start()` can never
+        // build stream metadata from an unvalidated config.
+        config
+            .grpc
+            .validate()
+            .map_err(|e| otap_df_config::error::Error::InvalidUserConfig {
+                error: e.to_string(),
+            })?;
 
         Ok(OTAPExporter::new(pipeline_ctx, config))
     }
@@ -481,6 +473,37 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
         )
         .then(|| arrow_ipc::CompressionType::ZSTD);
 
+        // Build the static request-header metadata template ONCE, outside any
+        // hot path. `None` when no `headers` are configured, which keeps the
+        // stream-open path allocation-free for the common case. The template is
+        // shared across all stream workers via `Arc`; each stream attaches a
+        // clone as its initial metadata when it opens (see `stream_arrow_batches`),
+        // so the per-`BatchArrowRecords` send path is never touched.
+        let static_metadata = build_static_metadata(&self.config.grpc.headers).map(Arc::new);
+
+        // Operational breadcrumb: confirm which static header KEYS were loaded
+        // (never the values, which may be credentials). Lets an operator verify
+        // an auth/tenant header was actually picked up from config when
+        // diagnosing a backend auth/routing failure.
+        if static_metadata.is_some() {
+            let mut header_keys: Vec<&str> = self
+                .config
+                .grpc
+                .headers
+                .keys()
+                .map(String::as_str)
+                .collect();
+            header_keys.sort_unstable();
+            let header_count = header_keys.len();
+            let header_names = header_keys.join(",");
+            otel_debug!(
+                "otap_exporter.static_headers",
+                count = header_count,
+                header_names = header_names.as_str(),
+                message = "Attaching static headers to OTAP streams"
+            );
+        }
+
         // Tonic clients are cheap to clone because they share the underlying
         // Channel. Each clone below is used by exactly one worker, which lets
         // the workers drive separate streaming RPCs concurrently.
@@ -492,6 +515,7 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
             streams_per_signal,
             pdata_metrics_tx.clone(),
             shutdown_rx.clone(),
+            static_metadata.clone(),
         );
         let (metrics_senders, metrics_handles) = spawn_stream_workers(
             arrow_metrics_client,
@@ -501,6 +525,7 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
             streams_per_signal,
             pdata_metrics_tx.clone(),
             shutdown_rx.clone(),
+            static_metadata.clone(),
         );
         let (traces_senders, traces_handles) = spawn_stream_workers(
             arrow_traces_client,
@@ -510,6 +535,7 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
             streams_per_signal,
             pdata_metrics_tx.clone(),
             shutdown_rx.clone(),
+            static_metadata.clone(),
         );
 
         // Loop until a Shutdown event is received.
@@ -625,6 +651,7 @@ fn spawn_stream_workers<T>(
     streams_per_signal: usize,
     pdata_metrics_tx: Sender<PDataMetricsUpdate>,
     shutdown_rx: tokio::sync::watch::Receiver<bool>,
+    static_metadata: Option<Arc<MetadataMap>>,
 ) -> (Vec<Sender<StreamBatch>>, Vec<JoinHandle<()>>)
 where
     T: StreamingArrowService + Clone + 'static,
@@ -645,6 +672,7 @@ where
             receiver,
             pdata_metrics_tx.clone(),
             shutdown_rx.clone(),
+            static_metadata.clone(),
         )));
     }
 
@@ -722,6 +750,7 @@ async fn stream_arrow_batches<T: StreamingArrowService>(
     otap_batches_rx: Receiver<(OtapPdata, OtapArrowRecords)>,
     pdata_metrics_tx: Sender<PDataMetricsUpdate>,
     mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
+    static_metadata: Option<Arc<MetadataMap>>,
 ) {
     let otap_batches_rx = Arc::new(tokio::sync::Mutex::new(otap_batches_rx));
     let mut shutdown = false;
@@ -766,6 +795,25 @@ async fn stream_arrow_batches<T: StreamingArrowService>(
                     pdata_metrics_tx.clone(),
                     correlation_tx.clone(),
                 );
+
+                // Attach the configured static `headers` as the stream's initial
+                // request metadata. gRPC sends these once when the stream opens,
+                // so the cost (one `MetadataMap` clone) is paid per stream
+                // (re)connect, never per `BatchArrowRecords` — the per-message
+                // hot path in `create_req_stream` is untouched. When no headers
+                // are configured this is a cheap `Option` check with no clone.
+                //
+                // The assignment REPLACES the request's metadata map. That is
+                // correct here because `into_streaming_request()` yields a fresh
+                // `Request` with empty user metadata and tonic injects transport
+                // metadata (content-type, grpc-*, user-agent) below this layer.
+                // If a future change starts seeding request metadata before this
+                // point, switch to merging into `metadata_mut()` instead.
+                let mut req_stream = req_stream.into_streaming_request();
+                if let Some(static_metadata) = &static_metadata {
+                    *req_stream.metadata_mut() = (**static_metadata).clone();
+                }
+
                 match client.handle_req_stream(req_stream).await {
                     Ok(res) => {
                         // reset the reconnect timeout backoff
@@ -1434,35 +1482,76 @@ mod tests {
     }
 
     #[test]
-    fn test_from_config_rejects_headers() {
+    fn test_from_config_accepts_headers() {
         let telemetry_registry_handle = TelemetryRegistryHandle::new();
         let controller_ctx = ControllerContext::new(telemetry_registry_handle);
         let pipeline_ctx =
             controller_ctx.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
 
-        // `GrpcClientSettings` is shared with the OTLP/gRPC exporter, but the OTAP
-        // exporter does not apply static headers to its Arrow streams yet. They must
-        // be rejected loudly rather than silently dropped.
+        // The OTAP exporter applies static `headers` as initial stream metadata,
+        // so a valid non-empty map must now be accepted (it was previously
+        // rejected before native support landed).
         let json_config = json!({
             "grpc_endpoint": "http://localhost:4317",
-            "headers": { "authorization": "Basic dXNlcjpwYXNz" }
+            "headers": { "authorization": "Basic dXNlcjpwYXNz", "x-scope-orgid": "tenant-1" }
         });
-        let err = match OTAPExporter::from_config(pipeline_ctx, &json_config) {
-            Ok(_) => panic!("headers on the OTAP exporter should be rejected"),
-            Err(err) => err,
-        };
-        assert!(format!("{err}").contains("does not support static `headers`"));
+        let exporter = OTAPExporter::from_config(pipeline_ctx, &json_config)
+            .expect("valid headers should be accepted");
+        assert_eq!(exporter.config.grpc.headers.len(), 2);
+        assert_eq!(
+            exporter
+                .config
+                .grpc
+                .headers
+                .get("authorization")
+                .map(String::as_str),
+            Some("Basic dXNlcjpwYXNz")
+        );
     }
 
     #[test]
-    fn test_validate_config_rejects_headers() {
+    fn test_validate_config_accepts_headers() {
         let json_config = json!({
             "grpc_endpoint": "http://localhost:4317",
             "headers": { "x-tenant": "acme" }
         });
+        super::validate_config(&json_config).expect("valid headers should pass validation");
+    }
+
+    #[test]
+    fn test_validate_config_rejects_reserved_headers() {
+        // Header validation is delegated to `GrpcClientSettings::validate()`, which
+        // rejects gRPC-reserved metadata (here, the `grpc-` prefix) so a bad header
+        // is still caught loudly at config load rather than silently mangled.
+        let json_config = json!({
+            "grpc_endpoint": "http://localhost:4317",
+            "headers": { "grpc-timeout": "1S" }
+        });
         let err = super::validate_config(&json_config)
-            .expect_err("headers on the OTAP exporter should fail validation");
-        assert!(format!("{err}").contains("does not support static `headers`"));
+            .expect_err("reserved gRPC metadata must fail validation");
+        assert!(format!("{err}").contains("reserved by the gRPC protocol"));
+    }
+
+    #[test]
+    fn test_from_config_rejects_invalid_headers() {
+        let telemetry_registry_handle = TelemetryRegistryHandle::new();
+        let controller_ctx = ControllerContext::new(telemetry_registry_handle);
+        let pipeline_ctx =
+            controller_ctx.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+
+        // `from_config` validates the shared gRPC settings itself (defense in
+        // depth), so a reserved gRPC header is rejected at construction time and
+        // not only via the factory `validate_config` hook.
+        let json_config = json!({
+            "grpc_endpoint": "http://localhost:4317",
+            "headers": { "grpc-timeout": "1S" }
+        });
+        // `OTAPExporter` is not `Debug`, so match rather than `expect_err`.
+        let err = match OTAPExporter::from_config(pipeline_ctx, &json_config) {
+            Ok(_) => panic!("reserved gRPC metadata must be rejected by from_config"),
+            Err(err) => err,
+        };
+        assert!(format!("{err}").contains("reserved by the gRPC protocol"));
     }
 
     #[test]
@@ -1832,6 +1921,7 @@ mod tests {
             batches_rx,
             metrics_tx,
             shutdown_rx,
+            None,
         )
         .await;
 
@@ -1891,6 +1981,7 @@ mod tests {
             batches_rx,
             metrics_tx,
             shutdown_rx,
+            None,
         ));
 
         for attempt in 0..4 {
@@ -2451,5 +2542,406 @@ mod tests {
         tokio_rt
             .block_on(server_handle)
             .expect("server shutdown success");
+    }
+
+    /// Capture from a stream-open request: (signal label, value of the
+    /// `authorization` header, value of the tenant header), each `None` when
+    /// the header was absent from the initial stream metadata.
+    type CapturedHeaders = (&'static str, Option<String>, Option<String>);
+
+    const HDR_AUTH: &str = "authorization";
+    const HDR_AUTH_VAL: &str = "Basic dXNlcjpwYXNz";
+    const HDR_TENANT: &str = "x-scope-orgid";
+    const HDR_TENANT_VAL: &str = "tenant-1";
+
+    type BatchStatusStream =
+        std::pin::Pin<Box<dyn tokio_stream::Stream<Item = Result<BatchStatus, Status>> + Send>>;
+
+    /// Reads the configured static headers from a stream-open request's initial
+    /// metadata (before the body is consumed), labeled by signal type.
+    fn capture_configured(
+        request: &tonic::Request<Streaming<BatchArrowRecords>>,
+        signal: &'static str,
+    ) -> CapturedHeaders {
+        let get = |name: &str| {
+            request
+                .metadata()
+                .get(name)
+                .and_then(|value| value.to_str().ok())
+                .map(str::to_string)
+        };
+        (signal, get(HDR_AUTH), get(HDR_TENANT))
+    }
+
+    /// Spawns a responder that ACKs every received batch so the exporter's
+    /// stream completes cleanly, and returns the response stream.
+    fn ack_all_batches(mut input_stream: Streaming<BatchArrowRecords>) -> BatchStatusStream {
+        let (tx, rx) = tokio::sync::mpsc::channel(8);
+        _ = tokio::spawn(async move {
+            while let Ok(Some(batch)) = input_stream.message().await {
+                let _ = tx
+                    .send(Ok(BatchStatus {
+                        batch_id: batch.batch_id,
+                        status_code: StatusCode::Ok as i32,
+                        status_message: "ok".into(),
+                    }))
+                    .await;
+            }
+        });
+        Box::pin(tokio_stream::wrappers::ReceiverStream::new(rx))
+    }
+
+    /// Per-signal mocks that record the initial stream-open metadata and ACK.
+    struct CapturingLogsMock {
+        captured: tokio::sync::mpsc::Sender<CapturedHeaders>,
+    }
+    struct CapturingMetricsMock {
+        captured: tokio::sync::mpsc::Sender<CapturedHeaders>,
+    }
+    struct CapturingTracesMock {
+        captured: tokio::sync::mpsc::Sender<CapturedHeaders>,
+    }
+
+    #[tonic::async_trait]
+    impl otap_df_pdata::proto::opentelemetry::arrow::v1::arrow_logs_service_server::ArrowLogsService
+        for CapturingLogsMock
+    {
+        type ArrowLogsStream = BatchStatusStream;
+        async fn arrow_logs(
+            &self,
+            request: tonic::Request<Streaming<BatchArrowRecords>>,
+        ) -> Result<Response<Self::ArrowLogsStream>, Status> {
+            let _ = self.captured.try_send(capture_configured(&request, "logs"));
+            Ok(Response::new(ack_all_batches(request.into_inner())))
+        }
+    }
+
+    #[tonic::async_trait]
+    impl otap_df_pdata::proto::opentelemetry::arrow::v1::arrow_metrics_service_server::ArrowMetricsService
+        for CapturingMetricsMock
+    {
+        type ArrowMetricsStream = BatchStatusStream;
+        async fn arrow_metrics(
+            &self,
+            request: tonic::Request<Streaming<BatchArrowRecords>>,
+        ) -> Result<Response<Self::ArrowMetricsStream>, Status> {
+            let _ = self.captured.try_send(capture_configured(&request, "metrics"));
+            Ok(Response::new(ack_all_batches(request.into_inner())))
+        }
+    }
+
+    #[tonic::async_trait]
+    impl otap_df_pdata::proto::opentelemetry::arrow::v1::arrow_traces_service_server::ArrowTracesService
+        for CapturingTracesMock
+    {
+        type ArrowTracesStream = BatchStatusStream;
+        async fn arrow_traces(
+            &self,
+            request: tonic::Request<Streaming<BatchArrowRecords>>,
+        ) -> Result<Response<Self::ArrowTracesStream>, Status> {
+            let _ = self.captured.try_send(capture_configured(&request, "traces"));
+            Ok(Response::new(ack_all_batches(request.into_inner())))
+        }
+    }
+
+    /// Mock `StreamingArrowService` that records the request's static-header
+    /// metadata on every stream open, then fails (without consuming the request
+    /// stream) so the worker reconnects and opens another stream. Used to prove
+    /// the headers are re-applied on each (re)open, not just the first.
+    struct MockRecordMetadata {
+        recorded: Arc<std::sync::Mutex<Vec<Option<String>>>>,
+        header_name: String,
+    }
+
+    #[async_trait::async_trait]
+    impl super::StreamingArrowService for MockRecordMetadata {
+        async fn handle_req_stream(
+            &mut self,
+            req_stream: impl IntoStreamingRequest<Message = BatchArrowRecords> + Send,
+        ) -> Result<Response<Streaming<BatchStatus>>, Status> {
+            let request = req_stream.into_streaming_request();
+            let value = request
+                .metadata()
+                .get(self.header_name.as_str())
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_string);
+            self.recorded.lock().unwrap().push(value);
+            // Fail without consuming the request stream so the queued batch is
+            // not drained into this stream; the worker then reconnects and opens
+            // a fresh stream for the next batch.
+            Err(Status::unavailable("mock records metadata then fails"))
+        }
+    }
+
+    /// End-to-end: configured static `headers` must be attached as initial
+    /// metadata on the outbound Arrow log, metric, AND trace streams (issue
+    /// #3314 acceptance criteria), and multiple headers must all be present.
+    #[test]
+    fn test_otap_exporter_sends_static_headers() {
+        let test_runtime = TestRuntime::new();
+        let (captured_tx, mut captured_rx) = tokio::sync::mpsc::channel::<CapturedHeaders>(8);
+        let collected: Arc<std::sync::Mutex<Vec<CapturedHeaders>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+        let (shutdown_sender, shutdown_signal) = tokio::sync::oneshot::channel();
+        let (ready_sender, ready_receiver) = tokio::sync::oneshot::channel();
+        let grpc_addr = "127.0.0.1";
+        let grpc_port = portpicker::pick_unused_port().expect("No free ports");
+        let grpc_endpoint = format!("http://{grpc_addr}:{grpc_port}");
+        let listening_addr: SocketAddr = format!("{grpc_addr}:{grpc_port}").parse().unwrap();
+        let tokio_rt = Runtime::new().unwrap();
+
+        let cap_logs = captured_tx.clone();
+        let cap_metrics = captured_tx.clone();
+        let cap_traces = captured_tx;
+        _ = tokio_rt.spawn(async move {
+            let tcp_listener = TcpListener::bind(listening_addr).await.unwrap();
+            let _ = ready_sender.send(());
+            let tcp_stream = TcpListenerStream::new(tcp_listener);
+            Server::builder()
+                .add_service(ArrowLogsServiceServer::new(CapturingLogsMock {
+                    captured: cap_logs,
+                }))
+                .add_service(ArrowMetricsServiceServer::new(CapturingMetricsMock {
+                    captured: cap_metrics,
+                }))
+                .add_service(ArrowTracesServiceServer::new(CapturingTracesMock {
+                    captured: cap_traces,
+                }))
+                .serve_with_incoming_shutdown(tcp_stream, async {
+                    let _ = shutdown_signal.await;
+                })
+                .await
+                .expect("Test gRPC server has failed");
+        });
+
+        tokio_rt
+            .block_on(ready_receiver)
+            .expect("Server failed to start");
+
+        let node_config = Arc::new(NodeUserConfig::new_exporter_config(OTAP_EXPORTER_URN));
+        let config = json!({
+            "grpc_endpoint": grpc_endpoint,
+            "compression_method": "none",
+            "headers": { HDR_AUTH: HDR_AUTH_VAL, HDR_TENANT: HDR_TENANT_VAL },
+        });
+        let controller_ctx = ControllerContext::new(test_runtime.metrics_registry());
+        let pipeline_ctx =
+            controller_ctx.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+        let exporter = ExporterWrapper::local(
+            OTAPExporter::from_config(pipeline_ctx, &config).expect("Config should be valid"),
+            test_node(test_runtime.config().name.clone()),
+            node_config,
+            test_runtime.config(),
+        );
+
+        let collected_scenario = collected.clone();
+        test_runtime
+            .set_exporter(exporter)
+            .run_test(move |ctx| async move {
+                // One batch per signal opens one stream per signal.
+                for (batch_id, payload) in [
+                    (METRIC_BATCH_ID, ArrowPayloadType::UnivariateMetrics),
+                    (LOG_BATCH_ID, ArrowPayloadType::Logs),
+                    (TRACE_BATCH_ID, ArrowPayloadType::Spans),
+                ] {
+                    let msg = create_otap_batch(batch_id, payload);
+                    ctx.send_pdata(OtapPdata::new_default(msg.into()))
+                        .await
+                        .expect("Failed to send pdata");
+                }
+
+                // Deterministically wait for all three stream-open captures (no
+                // fixed sleep), then shut down. Always shut down so a missing
+                // capture surfaces as a validation failure rather than a hang.
+                for _ in 0..3 {
+                    if let Ok(Some(capture)) =
+                        timeout(Duration::from_secs(5), captured_rx.recv()).await
+                    {
+                        collected_scenario.lock().unwrap().push(capture);
+                    }
+                }
+
+                ctx.send_shutdown(
+                    Instant::now().add(Duration::from_millis(200)),
+                    "test complete",
+                )
+                .await
+                .expect("Failed to send Shutdown");
+            })
+            .run_validation(move |_, exporter_result| async move {
+                exporter_result.expect("exporter should shut down cleanly");
+                let captures = collected.lock().unwrap();
+                for signal in ["logs", "metrics", "traces"] {
+                    let entry = captures
+                        .iter()
+                        .find(|(s, _, _)| *s == signal)
+                        .unwrap_or_else(|| panic!("no stream-open capture for {signal} stream"));
+                    assert_eq!(
+                        entry.1.as_deref(),
+                        Some(HDR_AUTH_VAL),
+                        "authorization header missing on {signal} stream"
+                    );
+                    assert_eq!(
+                        entry.2.as_deref(),
+                        Some(HDR_TENANT_VAL),
+                        "tenant header missing on {signal} stream"
+                    );
+                }
+            });
+
+        _ = shutdown_sender.send("Shutdown");
+    }
+
+    /// Backwards compatibility: with no `headers` configured, the exporter must
+    /// open streams with NO static metadata (the zero-alloc fast path), not send
+    /// empty or stray header values.
+    #[test]
+    fn test_otap_exporter_without_headers_sends_no_metadata() {
+        let test_runtime = TestRuntime::new();
+        let (captured_tx, mut captured_rx) = tokio::sync::mpsc::channel::<CapturedHeaders>(4);
+        let collected: Arc<std::sync::Mutex<Vec<CapturedHeaders>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+        let (shutdown_sender, shutdown_signal) = tokio::sync::oneshot::channel();
+        let (ready_sender, ready_receiver) = tokio::sync::oneshot::channel();
+        let grpc_addr = "127.0.0.1";
+        let grpc_port = portpicker::pick_unused_port().expect("No free ports");
+        let grpc_endpoint = format!("http://{grpc_addr}:{grpc_port}");
+        let listening_addr: SocketAddr = format!("{grpc_addr}:{grpc_port}").parse().unwrap();
+        let tokio_rt = Runtime::new().unwrap();
+
+        _ = tokio_rt.spawn(async move {
+            let tcp_listener = TcpListener::bind(listening_addr).await.unwrap();
+            let _ = ready_sender.send(());
+            let tcp_stream = TcpListenerStream::new(tcp_listener);
+            Server::builder()
+                .add_service(ArrowLogsServiceServer::new(CapturingLogsMock {
+                    captured: captured_tx,
+                }))
+                .serve_with_incoming_shutdown(tcp_stream, async {
+                    let _ = shutdown_signal.await;
+                })
+                .await
+                .expect("Test gRPC server has failed");
+        });
+
+        tokio_rt
+            .block_on(ready_receiver)
+            .expect("Server failed to start");
+
+        let node_config = Arc::new(NodeUserConfig::new_exporter_config(OTAP_EXPORTER_URN));
+        // No `headers` key at all.
+        let config = json!({
+            "grpc_endpoint": grpc_endpoint,
+            "compression_method": "none",
+        });
+        let controller_ctx = ControllerContext::new(test_runtime.metrics_registry());
+        let pipeline_ctx =
+            controller_ctx.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+        let exporter = ExporterWrapper::local(
+            OTAPExporter::from_config(pipeline_ctx, &config).expect("Config should be valid"),
+            test_node(test_runtime.config().name.clone()),
+            node_config,
+            test_runtime.config(),
+        );
+
+        let collected_scenario = collected.clone();
+        test_runtime
+            .set_exporter(exporter)
+            .run_test(move |ctx| async move {
+                let msg = create_otap_batch(LOG_BATCH_ID, ArrowPayloadType::Logs);
+                ctx.send_pdata(OtapPdata::new_default(msg.into()))
+                    .await
+                    .expect("Failed to send log message");
+
+                if let Ok(Some(capture)) = timeout(Duration::from_secs(5), captured_rx.recv()).await
+                {
+                    collected_scenario.lock().unwrap().push(capture);
+                }
+
+                ctx.send_shutdown(
+                    Instant::now().add(Duration::from_millis(200)),
+                    "test complete",
+                )
+                .await
+                .expect("Failed to send Shutdown");
+            })
+            .run_validation(move |_, exporter_result| async move {
+                exporter_result.expect("exporter should shut down cleanly");
+                let captures = collected.lock().unwrap();
+                let entry = captures
+                    .iter()
+                    .find(|(s, _, _)| *s == "logs")
+                    .expect("logs stream should have opened");
+                assert_eq!(entry.1, None, "no authorization header should be sent");
+                assert_eq!(entry.2, None, "no tenant header should be sent");
+            });
+
+        _ = shutdown_sender.send("Shutdown");
+    }
+
+    /// Reliability: the configured static headers must be applied to the request
+    /// metadata on EVERY stream (re)open, not just the first. Drives
+    /// `stream_arrow_batches` directly with a mock that records the metadata of
+    /// each open and fails (forcing a reconnect), so two batches yield two opens
+    /// — both of which must carry the header. This unit-level test is fully
+    /// deterministic (no gRPC server / network timing).
+    #[tokio::test]
+    async fn test_stream_arrow_batches_applies_headers_on_every_open() {
+        use super::stream_arrow_batches;
+
+        let (batches_tx, batches_rx) = tokio::sync::mpsc::channel(4);
+        let (metrics_tx, _metrics_rx) = tokio::sync::mpsc::channel(16);
+        let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+
+        // Two batches => two stream opens (the mock fails each without consuming
+        // the request stream, so neither drains the other's queued batch).
+        for _ in 0..2 {
+            let msg = create_otap_batch(LOG_BATCH_ID, ArrowPayloadType::Logs);
+            let pdata = OtapPdata::new_default(msg.into());
+            let payload = pdata.clone();
+            batches_tx
+                .send((pdata, payload.payload().try_into_with_default().unwrap()))
+                .await
+                .unwrap();
+        }
+        drop(batches_tx);
+
+        let mut headers = std::collections::HashMap::new();
+        let _ = headers.insert(HDR_AUTH.to_string(), HDR_AUTH_VAL.to_string());
+        let static_metadata =
+            otap_df_otap::otap_grpc::client_settings::build_static_metadata(&headers).map(Arc::new);
+        assert!(
+            static_metadata.is_some(),
+            "test setup should produce metadata"
+        );
+
+        let recorded = Arc::new(std::sync::Mutex::new(Vec::<Option<String>>::new()));
+        stream_arrow_batches(
+            MockRecordMetadata {
+                recorded: recorded.clone(),
+                header_name: HDR_AUTH.to_string(),
+            },
+            SignalType::Logs,
+            None,
+            batches_rx,
+            metrics_tx,
+            shutdown_rx,
+            static_metadata,
+        )
+        .await;
+
+        let recorded = recorded.lock().unwrap();
+        assert_eq!(
+            recorded.len(),
+            2,
+            "each of the two stream opens must apply the static headers"
+        );
+        for (i, value) in recorded.iter().enumerate() {
+            assert_eq!(
+                value.as_deref(),
+                Some(HDR_AUTH_VAL),
+                "authorization header missing on stream open #{i} (must be re-applied per open)"
+            );
+        }
     }
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/mod.rs
@@ -42,6 +42,7 @@ use otap_df_telemetry::{otel_debug, otel_error, otel_info, otel_warn};
 use otap_df_telemetry_macros::metric_set;
 use serde_json::Value;
 use std::collections::HashMap;
+use std::rc::Rc;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc::{Receiver, Sender};
@@ -223,7 +224,7 @@ impl OTAPExporter {
         // Defense-in-depth: validate the shared gRPC settings (including the
         // ASCII/reserved/duplicate `headers` checks) here too, not only in the
         // factory `validate_config` hook. This guarantees that any construction
-        // path — including direct/programmatic `from_config` callers — rejects
+        // path (including direct/programmatic `from_config` callers) rejects
         // invalid or gRPC-reserved headers up front, so `start()` can never
         // build stream metadata from an unvalidated config.
         config
@@ -475,10 +476,11 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
         // Build the static request-header metadata template ONCE, outside any
         // hot path. `None` when no `headers` are configured, which keeps the
         // stream-open path allocation-free for the common case. The template is
-        // shared across all stream workers via `Arc`; each stream attaches a
-        // clone as its initial metadata when it opens (see `stream_arrow_batches`),
+        // shared across all stream workers via `Rc` (the workers run on the same
+        // thread-local set, so no atomic refcount is needed); each stream attaches
+        // a clone as its initial metadata when it opens (see `stream_arrow_batches`),
         // so the per-`BatchArrowRecords` send path is never touched.
-        let static_metadata = self.config.grpc.build_static_metadata().map(Arc::new);
+        let static_metadata = self.config.grpc.build_static_metadata().map(Rc::new);
 
         // Operational breadcrumb: confirm which static header KEYS were loaded
         // (never the values, which may be credentials). Lets an operator verify
@@ -650,7 +652,7 @@ fn spawn_stream_workers<T>(
     streams_per_signal: usize,
     pdata_metrics_tx: Sender<PDataMetricsUpdate>,
     shutdown_rx: tokio::sync::watch::Receiver<bool>,
-    static_metadata: Option<Arc<MetadataMap>>,
+    static_metadata: Option<Rc<MetadataMap>>,
 ) -> (Vec<Sender<StreamBatch>>, Vec<JoinHandle<()>>)
 where
     T: StreamingArrowService + Clone + 'static,
@@ -749,7 +751,7 @@ async fn stream_arrow_batches<T: StreamingArrowService>(
     otap_batches_rx: Receiver<(OtapPdata, OtapArrowRecords)>,
     pdata_metrics_tx: Sender<PDataMetricsUpdate>,
     mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
-    static_metadata: Option<Arc<MetadataMap>>,
+    static_metadata: Option<Rc<MetadataMap>>,
 ) {
     let otap_batches_rx = Arc::new(tokio::sync::Mutex::new(otap_batches_rx));
     let mut shutdown = false;
@@ -798,7 +800,7 @@ async fn stream_arrow_batches<T: StreamingArrowService>(
                 // Attach the configured static `headers` as the stream's initial
                 // request metadata. gRPC sends these once when the stream opens,
                 // so the cost (one `MetadataMap` clone) is paid per stream
-                // (re)connect, never per `BatchArrowRecords` — the per-message
+                // (re)connect, never per `BatchArrowRecords`; the per-message
                 // hot path in `create_req_stream` is untouched. When no headers
                 // are configured this is a cheap `Option` check with no clone.
                 //
@@ -1170,6 +1172,7 @@ mod tests {
     use serde_json::json;
     use std::net::SocketAddr;
     use std::ops::Add;
+    use std::rc::Rc;
     use std::sync::Arc;
     use std::time::Instant;
     use tokio::net::TcpListener;
@@ -1506,6 +1509,15 @@ mod tests {
                 .map(String::as_str),
             Some("Basic dXNlcjpwYXNz")
         );
+        assert_eq!(
+            exporter
+                .config
+                .grpc
+                .headers
+                .get("x-scope-orgid")
+                .map(String::as_str),
+            Some("tenant-1")
+        );
     }
 
     #[test]
@@ -1532,25 +1544,30 @@ mod tests {
     }
 
     #[test]
-    fn test_from_config_rejects_invalid_headers() {
+    fn test_from_config_rejects_invalid_header_value() {
         let telemetry_registry_handle = TelemetryRegistryHandle::new();
         let controller_ctx = ControllerContext::new(telemetry_registry_handle);
         let pipeline_ctx =
             controller_ctx.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
 
         // `from_config` validates the shared gRPC settings itself (defense in
-        // depth), so a reserved gRPC header is rejected at construction time and
-        // not only via the factory `validate_config` hook.
+        // depth), so a header whose value is not valid gRPC metadata is rejected
+        // at construction time, not only via the factory `validate_config` hook.
+        // Reserved-name rejection is covered separately by
+        // `test_validate_config_rejects_reserved_headers`. The value here carries a
+        // control character (a newline): high-byte bytes are accepted as obs-text,
+        // so a non-visible control byte is the value class actually rejected. It is
+        // written as an escape so this source file stays ASCII-only.
         let json_config = json!({
             "grpc_endpoint": "http://localhost:4317",
-            "headers": { "grpc-timeout": "1S" }
+            "headers": { "x-tenant": "bad\nvalue" }
         });
         // `OTAPExporter` is not `Debug`, so match rather than `expect_err`.
         let err = match OTAPExporter::from_config(pipeline_ctx, &json_config) {
-            Ok(_) => panic!("reserved gRPC metadata must be rejected by from_config"),
+            Ok(_) => panic!("invalid metadata value must be rejected by from_config"),
             Err(err) => err,
         };
-        assert!(format!("{err}").contains("reserved by the gRPC protocol"));
+        assert!(format!("{err}").contains("must be visible ASCII"));
     }
 
     #[test]
@@ -1885,7 +1902,7 @@ mod tests {
         ) -> Result<Response<Streaming<BatchStatus>>, Status> {
             use tokio_stream::StreamExt;
             let mut stream = Box::pin(req_stream.into_streaming_request().into_inner());
-            // Consume the first batch — this polls create_req_stream, which
+            // Consume the first batch; this polls create_req_stream, which
             // sends the corresponding OtapPdata to correlation_tx.
             let _ = stream.next().await;
             Err(Status::unavailable("mock failure after consume"))
@@ -1973,29 +1990,38 @@ mod tests {
                 .unwrap();
         }
 
-        let handle = tokio::spawn(stream_arrow_batches(
-            MockAlwaysFail,
-            SignalType::Logs,
-            None,
-            batches_rx,
-            metrics_tx,
-            shutdown_rx,
-            None,
-        ));
+        // Production drives `stream_arrow_batches` via `spawn_local` (the exporter
+        // runs on a thread-local set), so the worker future is `!Send`. Mirror that
+        // here with a `LocalSet` rather than `tokio::spawn`, which would require
+        // `Send` and does not reflect how the exporter actually runs.
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async move {
+                let handle = tokio::task::spawn_local(stream_arrow_batches(
+                    MockAlwaysFail,
+                    SignalType::Logs,
+                    None,
+                    batches_rx,
+                    metrics_tx,
+                    shutdown_rx,
+                    None,
+                ));
 
-        for attempt in 0..4 {
-            let update = metrics_rx.recv().await.expect("metrics channel closed");
-            assert!(
-                matches!(update, PDataMetricsUpdate::IncFailed(SignalType::Logs, ..)),
-                "expected IncFailed update for failed stream attempt #{attempt}"
-            );
-        }
+                for attempt in 0..4 {
+                    let update = metrics_rx.recv().await.expect("metrics channel closed");
+                    assert!(
+                        matches!(update, PDataMetricsUpdate::IncFailed(SignalType::Logs, ..)),
+                        "expected IncFailed update for failed stream attempt #{attempt}"
+                    );
+                }
 
-        _ = shutdown_tx.send_replace(true);
-        timeout(Duration::from_millis(40), handle)
-            .await
-            .expect("shutdown should interrupt reconnect backoff promptly")
-            .unwrap();
+                _ = shutdown_tx.send_replace(true);
+                timeout(Duration::from_millis(40), handle)
+                    .await
+                    .expect("shutdown should interrupt reconnect backoff promptly")
+                    .unwrap();
+            })
+            .await;
     }
 
     /// gRPC service mock that returns statuses out of request order.
@@ -2891,8 +2917,8 @@ mod tests {
     /// Reliability: the configured static headers must be applied to the request
     /// metadata on EVERY stream (re)open, not just the first. Drives
     /// `stream_arrow_batches` directly with a mock that records the metadata of
-    /// each open and fails (forcing a reconnect), so two batches yield two opens
-    /// — both of which must carry the header. This unit-level test is fully
+    /// each open and fails (forcing a reconnect), so two batches yield two opens,
+    /// both of which must carry the header. This unit-level test is fully
     /// deterministic (no gRPC server / network timing).
     #[tokio::test]
     async fn test_stream_arrow_batches_applies_headers_on_every_open() {
@@ -2921,7 +2947,7 @@ mod tests {
             headers,
             ..Default::default()
         };
-        let static_metadata = settings.build_static_metadata().map(Arc::new);
+        let static_metadata = settings.build_static_metadata().map(Rc::new);
         assert!(
             static_metadata.is_some(),
             "test setup should produce metadata"

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/mod.rs
@@ -29,7 +29,7 @@ use otap_df_engine::node::NodeId;
 use otap_df_engine::terminal_state::TerminalState;
 use otap_df_otap::OTAP_EXPORTER_FACTORIES;
 use otap_df_otap::metrics::ExporterPDataMetrics;
-use otap_df_otap::otap_grpc::client_settings::GrpcClientSettings;
+use otap_df_otap::otap_grpc::client_settings::{GrpcClientSettings, build_static_metadata};
 use otap_df_otap::otap_grpc::otlp::client::{
     LogsServiceClient, MetricsServiceClient, TraceServiceClient,
 };
@@ -44,7 +44,7 @@ use otap_df_telemetry::instrument::Counter;
 use otap_df_telemetry::metrics::MetricSet;
 use otap_df_telemetry::{otel_debug, otel_info, otel_warn};
 use serde::Deserialize;
-use std::collections::{HashMap, VecDeque};
+use std::collections::VecDeque;
 use std::future::Future;
 use std::sync::Arc;
 use tonic::codec::CompressionEncoding;
@@ -206,7 +206,7 @@ impl Exporter<OtapPdata> for OTLPExporter {
         // Pre-build the static gRPC metadata template ONCE, outside the hot loop.
         // Returns `None` when no static headers are configured, which preserves
         // the zero-allocation fast path in `build_grpc_metadata`.
-        let static_metadata = build_static_grpc_metadata(&self.config.grpc.headers);
+        let static_metadata = build_static_metadata(&self.config.grpc.headers);
 
         // reuse the encoder and the buffer across pdatas
         let mut logs_proto_encoder = LogsProtoBytesEncoder::new();
@@ -638,45 +638,6 @@ async fn finalize_completed_export(
     client
 }
 
-/// Pre-builds the static gRPC metadata template from configured headers.
-///
-/// Built once at exporter startup (outside the per-message hot path). Returns
-/// `None` when no static headers are configured so `build_grpc_metadata` keeps
-/// its zero-allocation fast path. Header names/values are validated at config
-/// load time; any that somehow fail to parse here are skipped with a debug log.
-fn build_static_grpc_metadata(headers: &HashMap<String, String>) -> Option<MetadataMap> {
-    if headers.is_empty() {
-        return None;
-    }
-
-    let mut metadata = MetadataMap::with_capacity(headers.len());
-    for (name, value) in headers {
-        let Ok(key) = name.parse::<MetadataKey<tonic::metadata::Ascii>>() else {
-            otel_debug!(
-                "otlp.exporter.grpc.header_skip",
-                reason = "invalid ascii metadata key",
-                header_name = name.as_str()
-            );
-            continue;
-        };
-        let Ok(val) = MetadataValue::try_from(value.as_str()) else {
-            otel_debug!(
-                "otlp.exporter.grpc.header_skip",
-                reason = "invalid ascii metadata value",
-                header_name = name.as_str()
-            );
-            continue;
-        };
-        let _ = metadata.insert(key, val);
-    }
-
-    if metadata.is_empty() {
-        None
-    } else {
-        Some(metadata)
-    }
-}
-
 /// Builds the per-request gRPC metadata by merging the pre-built static
 /// `static_metadata` template with any headers propagated from the incoming
 /// transport context.
@@ -1001,6 +962,7 @@ mod tests {
     use super::*;
 
     use otap_df_config::node::NodeUserConfig;
+    use std::collections::HashMap;
 
     use otap_df_config::transport_headers::{TransportHeader, TransportHeaders};
     use otap_df_config::transport_headers_policy::PropagationSelectorType;
@@ -1967,33 +1929,6 @@ mod tests {
     }
 
     #[test]
-    fn test_build_static_grpc_metadata_empty_returns_none() {
-        let headers: HashMap<String, String> = HashMap::new();
-        assert!(
-            build_static_grpc_metadata(&headers).is_none(),
-            "no configured headers must yield None to preserve the hot-path fast path"
-        );
-    }
-
-    #[test]
-    fn test_build_static_grpc_metadata_builds_map() {
-        let mut headers = HashMap::new();
-        _ = headers.insert("authorization".to_string(), "Basic abc123".to_string());
-        _ = headers.insert("x-scope-orgid".to_string(), "tenant-1".to_string());
-
-        let metadata = build_static_grpc_metadata(&headers).expect("should build metadata");
-        assert_eq!(metadata.len(), 2);
-        assert_eq!(
-            metadata.get("authorization").unwrap().to_str().unwrap(),
-            "Basic abc123"
-        );
-        assert_eq!(
-            metadata.get("x-scope-orgid").unwrap().to_str().unwrap(),
-            "tenant-1"
-        );
-    }
-
-    #[test]
     fn test_build_grpc_metadata_static_only() {
         // No propagation policy, but static headers are configured: the static
         // template alone must be applied to the request.
@@ -2003,7 +1938,7 @@ mod tests {
         let mut headers = HashMap::new();
         _ = headers.insert("authorization".to_string(), "Basic abc123".to_string());
         let static_metadata =
-            build_static_grpc_metadata(&headers).expect("static metadata should be present");
+            build_static_metadata(&headers).expect("static metadata should be present");
 
         let metadata = build_grpc_metadata(&handler, &context, Some(&static_metadata))
             .expect("should produce metadata from static headers alone");
@@ -2029,7 +1964,7 @@ mod tests {
         let mut static_headers = HashMap::new();
         _ = static_headers.insert("authorization".to_string(), "Basic abc123".to_string());
         let static_metadata =
-            build_static_grpc_metadata(&static_headers).expect("static metadata should be present");
+            build_static_metadata(&static_headers).expect("static metadata should be present");
 
         let metadata = build_grpc_metadata(&handler, &context, Some(&static_metadata))
             .expect("should merge static and propagated headers");
@@ -2063,7 +1998,7 @@ mod tests {
         let mut static_headers = HashMap::new();
         _ = static_headers.insert("authorization".to_string(), "Basic static".to_string());
         let static_metadata =
-            build_static_grpc_metadata(&static_headers).expect("static metadata should be present");
+            build_static_metadata(&static_headers).expect("static metadata should be present");
 
         let metadata = build_grpc_metadata(&handler, &context, Some(&static_metadata))
             .expect("should produce metadata");

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/mod.rs
@@ -29,7 +29,7 @@ use otap_df_engine::node::NodeId;
 use otap_df_engine::terminal_state::TerminalState;
 use otap_df_otap::OTAP_EXPORTER_FACTORIES;
 use otap_df_otap::metrics::ExporterPDataMetrics;
-use otap_df_otap::otap_grpc::client_settings::{GrpcClientSettings, build_static_metadata};
+use otap_df_otap::otap_grpc::client_settings::GrpcClientSettings;
 use otap_df_otap::otap_grpc::otlp::client::{
     LogsServiceClient, MetricsServiceClient, TraceServiceClient,
 };
@@ -206,7 +206,7 @@ impl Exporter<OtapPdata> for OTLPExporter {
         // Pre-build the static gRPC metadata template ONCE, outside the hot loop.
         // Returns `None` when no static headers are configured, which preserves
         // the zero-allocation fast path in `build_grpc_metadata`.
-        let static_metadata = build_static_metadata(&self.config.grpc.headers);
+        let static_metadata = self.config.grpc.build_static_metadata();
 
         // reuse the encoder and the buffer across pdatas
         let mut logs_proto_encoder = LogsProtoBytesEncoder::new();
@@ -1937,8 +1937,12 @@ mod tests {
 
         let mut headers = HashMap::new();
         _ = headers.insert("authorization".to_string(), "Basic abc123".to_string());
-        let static_metadata =
-            build_static_metadata(&headers).expect("static metadata should be present");
+        let static_metadata = GrpcClientSettings {
+            headers,
+            ..Default::default()
+        }
+        .build_static_metadata()
+        .expect("static metadata should be present");
 
         let metadata = build_grpc_metadata(&handler, &context, Some(&static_metadata))
             .expect("should produce metadata from static headers alone");
@@ -1963,8 +1967,12 @@ mod tests {
 
         let mut static_headers = HashMap::new();
         _ = static_headers.insert("authorization".to_string(), "Basic abc123".to_string());
-        let static_metadata =
-            build_static_metadata(&static_headers).expect("static metadata should be present");
+        let static_metadata = GrpcClientSettings {
+            headers: static_headers,
+            ..Default::default()
+        }
+        .build_static_metadata()
+        .expect("static metadata should be present");
 
         let metadata = build_grpc_metadata(&handler, &context, Some(&static_metadata))
             .expect("should merge static and propagated headers");
@@ -1997,8 +2005,12 @@ mod tests {
 
         let mut static_headers = HashMap::new();
         _ = static_headers.insert("authorization".to_string(), "Basic static".to_string());
-        let static_metadata =
-            build_static_metadata(&static_headers).expect("static metadata should be present");
+        let static_metadata = GrpcClientSettings {
+            headers: static_headers,
+            ..Default::default()
+        }
+        .build_static_metadata()
+        .expect("static metadata should be present");
 
         let metadata = build_grpc_metadata(&handler, &context, Some(&static_metadata))
             .expect("should produce metadata");

--- a/rust/otap-dataflow/crates/otap/src/otap_grpc/client_settings.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_grpc/client_settings.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
 use tonic::codec::CompressionEncoding;
-use tonic::metadata::{MetadataKey, MetadataValue};
+use tonic::metadata::{MetadataKey, MetadataMap, MetadataValue};
 use tonic::transport::Channel;
 use tonic::transport::Endpoint;
 use tower::service_fn;
@@ -156,17 +156,17 @@ pub struct GrpcClientSettings {
     #[serde(default)]
     pub user_agent: Option<String>,
 
-    /// Static metadata (headers) added to every outbound OTLP/gRPC request
-    /// (e.g. an `authorization` or tenant-routing header).
+    /// Static metadata (headers) added to every outbound request (e.g. an
+    /// `authorization` or tenant-routing header).
     ///
     /// Keys and values must be valid ASCII gRPC metadata; this is enforced by
     /// [`GrpcClientSettings::validate`]. These coexist with any header
     /// propagation policy configured on the exporter.
     ///
-    /// Note: `GrpcClientSettings` is shared by the OTLP/gRPC exporter and the
-    /// OTAP (Arrow) exporter, but only the OTLP/gRPC exporter applies these
-    /// headers today. The OTAP exporter rejects a non-empty `headers` map at
-    /// config validation rather than silently dropping it.
+    /// `GrpcClientSettings` is shared by the OTLP/gRPC exporter and the OTAP
+    /// (Arrow) exporter. The OTLP/gRPC exporter applies them as per-request
+    /// metadata; the OTAP exporter applies them once as the initial metadata of
+    /// each Arrow stream (see [`build_static_metadata`]).
     #[serde(default)]
     pub headers: HashMap<String, String>,
 }
@@ -239,6 +239,55 @@ fn validate_grpc_endpoint(endpoint: &str) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+/// Builds an owned gRPC [`MetadataMap`] template from the configured static
+/// `headers`, or `None` when none are configured.
+///
+/// This is the single source of truth shared by every gRPC-based exporter
+/// (OTLP/gRPC applies it as per-request metadata; the OTAP/Arrow exporter
+/// applies it as initial stream metadata). It is intended to be called ONCE at
+/// exporter startup, outside any hot path: returning `None` for the empty case
+/// lets callers keep a zero-allocation fast path when no headers are set.
+///
+/// Header names/values are validated up front by [`GrpcClientSettings::validate`]
+/// (ASCII key/value, no reserved gRPC metadata, no case-insensitive duplicates),
+/// so the per-entry parse below cannot fail for a validated config. Any entry
+/// that somehow fails to parse (e.g. a programmatic caller that bypassed
+/// validation) is skipped defensively and logged at debug level rather than
+/// panicking, so a dropped header still leaves a breadcrumb.
+#[must_use]
+pub fn build_static_metadata(headers: &HashMap<String, String>) -> Option<MetadataMap> {
+    if headers.is_empty() {
+        return None;
+    }
+
+    let mut metadata = MetadataMap::with_capacity(headers.len());
+    for (name, value) in headers {
+        let Ok(key) = name.parse::<MetadataKey<tonic::metadata::Ascii>>() else {
+            otap_df_telemetry::otel_debug!(
+                "grpc.client.static_header_skip",
+                reason = "invalid ascii metadata key",
+                header_name = name.as_str()
+            );
+            continue;
+        };
+        let Ok(val) = MetadataValue::try_from(value.as_str()) else {
+            otap_df_telemetry::otel_debug!(
+                "grpc.client.static_header_skip",
+                reason = "invalid ascii metadata value",
+                header_name = name.as_str()
+            );
+            continue;
+        };
+        let _ = metadata.insert(key, val);
+    }
+
+    if metadata.is_empty() {
+        None
+    } else {
+        Some(metadata)
+    }
 }
 
 impl GrpcClientSettings {
@@ -794,6 +843,50 @@ mod tests {
         };
 
         assert!(settings.validate().is_ok());
+    }
+
+    #[test]
+    fn build_static_metadata_empty_returns_none() {
+        let headers: HashMap<String, String> = HashMap::new();
+        assert!(
+            build_static_metadata(&headers).is_none(),
+            "no configured headers must yield None so callers keep the zero-alloc fast path"
+        );
+    }
+
+    #[test]
+    fn build_static_metadata_builds_map() {
+        let mut headers = HashMap::new();
+        let _ = headers.insert("authorization".to_string(), "Basic abc123".to_string());
+        let _ = headers.insert("x-scope-orgid".to_string(), "tenant-1".to_string());
+
+        let metadata = build_static_metadata(&headers).expect("should build metadata");
+        assert_eq!(metadata.len(), 2);
+        assert_eq!(
+            metadata.get("authorization").unwrap().to_str().unwrap(),
+            "Basic abc123"
+        );
+        assert_eq!(
+            metadata.get("x-scope-orgid").unwrap().to_str().unwrap(),
+            "tenant-1"
+        );
+    }
+
+    #[test]
+    fn build_static_metadata_skips_invalid_entries() {
+        // Defense-in-depth: a programmatic caller that bypassed `validate()`
+        // could pass an unparseable header. The builder must drop only the bad
+        // entries (and keep the valid one) rather than panic. `validate()`
+        // normally rejects these at config load, so this path is unreachable for
+        // a validated config.
+        let mut headers = HashMap::new();
+        let _ = headers.insert("x-valid".to_string(), "ok".to_string());
+        let _ = headers.insert("bad key".to_string(), "v".to_string()); // space => invalid key
+        let _ = headers.insert("x-bad".to_string(), "bad\nvalue".to_string()); // newline => invalid value
+
+        let metadata = build_static_metadata(&headers).expect("the valid header should remain");
+        assert_eq!(metadata.len(), 1);
+        assert_eq!(metadata.get("x-valid").unwrap().to_str().unwrap(), "ok");
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/otap/src/otap_grpc/client_settings.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_grpc/client_settings.rs
@@ -241,56 +241,68 @@ fn validate_grpc_endpoint(endpoint: &str) -> Result<(), String> {
     Ok(())
 }
 
-/// Builds an owned gRPC [`MetadataMap`] template from the configured static
-/// `headers`, or `None` when none are configured.
-///
-/// This is the single source of truth shared by every gRPC-based exporter
-/// (OTLP/gRPC applies it as per-request metadata; the OTAP/Arrow exporter
-/// applies it as initial stream metadata). It is intended to be called ONCE at
-/// exporter startup, outside any hot path: returning `None` for the empty case
-/// lets callers keep a zero-allocation fast path when no headers are set.
-///
-/// Header names/values are validated up front by [`GrpcClientSettings::validate`]
-/// (ASCII key/value, no reserved gRPC metadata, no case-insensitive duplicates),
-/// so the per-entry parse below cannot fail for a validated config. Any entry
-/// that somehow fails to parse (e.g. a programmatic caller that bypassed
-/// validation) is skipped defensively and logged at debug level rather than
-/// panicking, so a dropped header still leaves a breadcrumb.
-#[must_use]
-pub fn build_static_metadata(headers: &HashMap<String, String>) -> Option<MetadataMap> {
-    if headers.is_empty() {
-        return None;
-    }
-
-    let mut metadata = MetadataMap::with_capacity(headers.len());
-    for (name, value) in headers {
-        let Ok(key) = name.parse::<MetadataKey<tonic::metadata::Ascii>>() else {
-            otap_df_telemetry::otel_debug!(
-                "grpc.client.static_header_skip",
-                reason = "invalid ascii metadata key",
-                header_name = name.as_str()
-            );
-            continue;
-        };
-        let Ok(val) = MetadataValue::try_from(value.as_str()) else {
-            otap_df_telemetry::otel_debug!(
-                "grpc.client.static_header_skip",
-                reason = "invalid ascii metadata value",
-                header_name = name.as_str()
-            );
-            continue;
-        };
-        let _ = metadata.insert(key, val);
-    }
-
-    if metadata.is_empty() {
-        None
-    } else {
-        Some(metadata)
-    }
-}
-
 impl GrpcClientSettings {
+    /// Builds an owned gRPC [`MetadataMap`] template from the configured static
+    /// `headers`, or `None` when none are configured.
+    ///
+    /// This is the single source of truth shared by every gRPC-based exporter
+    /// (OTLP/gRPC applies it as per-request metadata; the OTAP/Arrow exporter
+    /// applies it as initial stream metadata). It is intended to be called ONCE
+    /// at exporter startup, outside any hot path: returning `None` for the empty
+    /// case lets callers keep a zero-allocation fast path when no headers are set.
+    ///
+    /// Header names/values are validated up front by [`Self::validate`] (ASCII
+    /// key/value, no reserved gRPC metadata, no case-insensitive duplicates), so
+    /// the per-entry parse below cannot fail and no two entries can collapse to
+    /// the same lowercased gRPC key for a validated config. De-duplication is
+    /// therefore [`Self::validate`]'s responsibility; this builder only defends
+    /// against a programmatic caller that bypassed it — invalid entries are
+    /// skipped and key collisions overwrite, both logged at debug level so a
+    /// dropped header still leaves a breadcrumb.
+    #[must_use]
+    pub fn build_static_metadata(&self) -> Option<MetadataMap> {
+        if self.headers.is_empty() {
+            return None;
+        }
+
+        let mut metadata = MetadataMap::with_capacity(self.headers.len());
+        for (name, value) in &self.headers {
+            let Ok(key) = name.parse::<MetadataKey<tonic::metadata::Ascii>>() else {
+                otap_df_telemetry::otel_debug!(
+                    "grpc.client.static_header_skip",
+                    reason = "invalid ascii metadata key",
+                    header_name = name.as_str()
+                );
+                continue;
+            };
+            let Ok(val) = MetadataValue::try_from(value.as_str()) else {
+                otap_df_telemetry::otel_debug!(
+                    "grpc.client.static_header_skip",
+                    reason = "invalid ascii metadata value",
+                    header_name = name.as_str()
+                );
+                continue;
+            };
+            // `insert` returns the prior value when this lowercased key already
+            // existed (e.g. `X-Tenant` and `x-tenant` from an unvalidated config).
+            // For a validated config this never happens; log if it ever does so
+            // the non-deterministic survivor is at least visible.
+            if metadata.insert(key, val).is_some() {
+                otap_df_telemetry::otel_debug!(
+                    "grpc.client.static_header_collision",
+                    reason = "case-insensitive duplicate gRPC metadata key overwritten",
+                    header_name = name.as_str()
+                );
+            }
+        }
+
+        if metadata.is_empty() {
+            None
+        } else {
+            Some(metadata)
+        }
+    }
+
     /// Validates the settings at config load time.
     ///
     /// Checks that `user_agent`, when set, is non-empty and contains only
@@ -847,9 +859,9 @@ mod tests {
 
     #[test]
     fn build_static_metadata_empty_returns_none() {
-        let headers: HashMap<String, String> = HashMap::new();
+        let settings = GrpcClientSettings::default();
         assert!(
-            build_static_metadata(&headers).is_none(),
+            settings.build_static_metadata().is_none(),
             "no configured headers must yield None so callers keep the zero-alloc fast path"
         );
     }
@@ -859,8 +871,14 @@ mod tests {
         let mut headers = HashMap::new();
         let _ = headers.insert("authorization".to_string(), "Basic abc123".to_string());
         let _ = headers.insert("x-scope-orgid".to_string(), "tenant-1".to_string());
+        let settings = GrpcClientSettings {
+            headers,
+            ..GrpcClientSettings::default()
+        };
 
-        let metadata = build_static_metadata(&headers).expect("should build metadata");
+        let metadata = settings
+            .build_static_metadata()
+            .expect("should build metadata");
         assert_eq!(metadata.len(), 2);
         assert_eq!(
             metadata.get("authorization").unwrap().to_str().unwrap(),
@@ -883,8 +901,14 @@ mod tests {
         let _ = headers.insert("x-valid".to_string(), "ok".to_string());
         let _ = headers.insert("bad key".to_string(), "v".to_string()); // space => invalid key
         let _ = headers.insert("x-bad".to_string(), "bad\nvalue".to_string()); // newline => invalid value
+        let settings = GrpcClientSettings {
+            headers,
+            ..GrpcClientSettings::default()
+        };
 
-        let metadata = build_static_metadata(&headers).expect("the valid header should remain");
+        let metadata = settings
+            .build_static_metadata()
+            .expect("the valid header should remain");
         assert_eq!(metadata.len(), 1);
         assert_eq!(metadata.get("x-valid").unwrap().to_str().unwrap(), "ok");
     }

--- a/rust/otap-dataflow/crates/otap/src/otap_grpc/client_settings.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_grpc/client_settings.rs
@@ -256,7 +256,7 @@ impl GrpcClientSettings {
     /// the per-entry parse below cannot fail and no two entries can collapse to
     /// the same lowercased gRPC key for a validated config. De-duplication is
     /// therefore [`Self::validate`]'s responsibility; this builder only defends
-    /// against a programmatic caller that bypassed it — invalid entries are
+    /// against a programmatic caller that bypassed it: invalid entries are
     /// skipped and key collisions overwrite, both logged at debug level so a
     /// dropped header still leaves a breadcrumb.
     #[must_use]


### PR DESCRIPTION
Closes #3314.

## What

The native OTAP (Arrow-protocol) exporter (`urn:otel:exporter:otap`) now supports static request `headers`, attaching them as the **initial metadata of each Arrow log/metric/trace stream**. The previous config-load rejection (`reject_unsupported_headers`) is removed.

## Approach

- **Shared builder at the `GrpcClientSettings` layer** (the maintainer's preferred option from the #3303 review thread): added `build_static_metadata(&HashMap) -> Option<MetadataMap>` as a single source of truth, and refactored the OTLP/gRPC exporter to delegate to it (removing its private duplicate).
- **Attach once per stream (re)open**: in `stream_arrow_batches`, the pre-built `Option<Arc<MetadataMap>>` template is cloned onto the stream-open `Request` via `into_streaming_request()` + `metadata_mut()`. The `StreamingArrowService` trait and its impls are untouched.
- **Hot path preserved**: `create_req_stream` (the per-`BatchArrowRecords` path) is unchanged; the only added cost is one `MetadataMap` clone per stream establishment (documented in the README "Limits").
- **Validation reused**: header validation stays in `GrpcClientSettings::validate()` (ASCII, reserved gRPC metadata, case-insensitive duplicates), now also invoked from `from_config` as defense-in-depth, and skipped/invalid entries are logged.

## Tests

- Removed the 2 rejection tests; added positive config tests (accept valid headers; reject reserved) plus a `from_config` rejection test.
- End-to-end: configured headers are present as **initial stream metadata on logs, metrics, AND traces**; multiple headers; empty/absent map sends no metadata.
- Deterministic unit test that headers are re-applied on **every** stream (re)open.
- Builder unit tests (empty → `None`, builds map, skips invalid).
- `cargo xtask check` passes (structure, `fmt`, `clippy -D warnings`, workspace tests).

## Notes

Complements #3306: OTAP header **values** should later adopt the same opaque/secret type so credentials don't leak into telemetry.
