### PR TITLE
chore: Use one_collect from crates.io

### DIFF
--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -219,7 +219,7 @@ zip = "=8.6.0"
 byte-unit = { version = "5.2.0", features = ["serde"] }
 cpu-time = "1.0.0"
 
-one_collect = { git = "https://github.com/microsoft/one-collect.git", rev = "a242d3db8deadc216a4ca28adbd7a3f866169b58" }
+one_collect = "0.1.34532"
 
 azure_core = {version = "1.0.0", default-features = false }
 azure_identity = {version = "1.0.0", default-features = false }


### PR DESCRIPTION
# Change Summary

- Use `one_collect` from crates.io: https://crates.io/crates/one_collect

## How are these changes tested?

## Are there any user-facing changes?

 <!-- If yes, provide further info below -->

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [ ] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
