### PR TITLE
feat(otap-exporter): redact static exporter header values (#3306)

### DIFF
--- a/rust/otap-dataflow/.chloggen/otlp-exporter-opaque-header-values.yaml
+++ b/rust/otap-dataflow/.chloggen/otlp-exporter-opaque-header-values.yaml
@@ -9,12 +9,13 @@ component: pipeline
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: >-
-  Static exporter `headers` values are now wrapped in `secrecy::SecretString`,
-  so a header credential (e.g. an `Authorization` token or tenant API key) can
-  no longer leak through `Debug`/telemetry output of `HttpClientSettings` or
-  `GrpcClientSettings`. The cleartext is only read via an explicit
-  `expose_secret()` accessor at the request-construction site; behavior is
-  otherwise unchanged.
+  Static exporter `headers` values are now wrapped in `secrecy::SecretString`
+  and marked sensitive on the wire, so a header credential (e.g. an
+  `Authorization` token or tenant API key) is redacted in the `Debug`/telemetry
+  output of the typed `HttpClientSettings` / `GrpcClientSettings` and excluded
+  from HTTP/2 HPACK indexing. The cleartext is read only via an explicit
+  `expose_secret()` accessor (during validation and when building the request);
+  behavior is otherwise unchanged.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [3306]
@@ -23,11 +24,8 @@ issues: [3306]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: >-
-  `user_agent` is intentionally left as a plain `String`: it is a
-  non-credential client identifier, mirroring the Go Collector's use of
-  `configopaque` for auth/credential headers rather than the User-Agent.
-  `secrecy` (and its `zeroize` transitive dependency) was already present in
-  the build graph, so this adds no new crate; it was preferred over the
-  Microsoft Oxidizer `data_privacy` crate, which would have pulled in four
-  pre-1.0 crates plus taxonomy/redaction-engine boilerplate for a need that is
-  just type-level redaction.
+  Scope: this protects the typed settings and the values placed on the wire. It
+  does not redact the raw configuration snapshot returned by the admin config
+  endpoints (e.g. `GET /api/v1/config`), which still serialize the original
+  config value; that broader redaction is tracked in #3328. `user_agent` is
+  intentionally left a plain `String` as a non-credential client identifier.

--- a/rust/otap-dataflow/.chloggen/otlp-exporter-opaque-header-values.yaml
+++ b/rust/otap-dataflow/.chloggen/otlp-exporter-opaque-header-values.yaml
@@ -1,0 +1,33 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: pipeline
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: >-
+  Static exporter `headers` values are now wrapped in `secrecy::SecretString`,
+  so a header credential (e.g. an `Authorization` token or tenant API key) can
+  no longer leak through `Debug`/telemetry output of `HttpClientSettings` or
+  `GrpcClientSettings`. The cleartext is only read via an explicit
+  `expose_secret()` accessor at the request-construction site; behavior is
+  otherwise unchanged.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [3306]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: >-
+  `user_agent` is intentionally left as a plain `String`: it is a
+  non-credential client identifier, mirroring the Go Collector's use of
+  `configopaque` for auth/credential headers rather than the User-Agent.
+  `secrecy` (and its `zeroize` transitive dependency) was already present in
+  the build graph, so this adds no new crate; it was preferred over the
+  Microsoft Oxidizer `data_privacy` crate, which would have pulled in four
+  pre-1.0 crates plus taxonomy/redaction-engine boilerplate for a need that is
+  just type-level redaction.

--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -165,6 +165,7 @@ rustls-native-certs = "0.8.2"
 rustls-openssl = "0.3"
 rustls-symcrypt = "0.2.2"
 schemars = { version = "1.0.0" }
+secrecy = { version = "0.10.3", features = ["serde"] }
 serde = { version = "1.0.228", features = ["derive", "rc"] }
 serde_cbor = "0.11.2"
 serde_json = { version = "1.0.149" }

--- a/rust/otap-dataflow/crates/core-nodes/Cargo.toml
+++ b/rust/otap-dataflow/crates/core-nodes/Cargo.toml
@@ -56,6 +56,7 @@ tokio-util.workspace = true
 reqwest.workspace = true
 parking_lot.workspace = true
 http.workspace = true
+secrecy.workspace = true
 async-stream.workspace = true
 arrow-ipc.workspace = true
 uuid.workspace = true

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/mod.rs
@@ -1132,6 +1132,7 @@ mod tests {
         ArrowLogsServiceMock, ArrowMetricsServiceMock, ArrowTracesServiceMock, create_otap_batch,
     };
     use otap_df_otap::pdata::OtapPdata;
+    use secrecy::ExposeSecret;
 
     use otap_df_config::SignalType;
     use otap_df_config::node::NodeUserConfig;
@@ -1506,7 +1507,7 @@ mod tests {
                 .grpc
                 .headers
                 .get("authorization")
-                .map(String::as_str),
+                .map(|v| v.expose_secret()),
             Some("Basic dXNlcjpwYXNz")
         );
         assert_eq!(
@@ -1515,7 +1516,7 @@ mod tests {
                 .grpc
                 .headers
                 .get("x-scope-orgid")
-                .map(String::as_str),
+                .map(|v| v.expose_secret()),
             Some("tenant-1")
         );
     }
@@ -2942,7 +2943,7 @@ mod tests {
         drop(batches_tx);
 
         let mut headers = std::collections::HashMap::new();
-        let _ = headers.insert(HDR_AUTH.to_string(), HDR_AUTH_VAL.to_string());
+        let _ = headers.insert(HDR_AUTH.to_string(), HDR_AUTH_VAL.into());
         let settings = otap_df_otap::otap_grpc::client_settings::GrpcClientSettings {
             headers,
             ..Default::default()

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/mod.rs
@@ -1323,7 +1323,7 @@ mod tests {
         let mut headers = HashMap::new();
         _ = headers.insert(
             "authorization".to_string(),
-            "Bearer secret-token-123".to_string(),
+            "Bearer secret-token-123".into(),
         );
 
         let exporter = ExporterWrapper::local(
@@ -1936,7 +1936,7 @@ mod tests {
         let context = context_without_headers();
 
         let mut headers = HashMap::new();
-        _ = headers.insert("authorization".to_string(), "Basic abc123".to_string());
+        _ = headers.insert("authorization".to_string(), "Basic abc123".into());
         let static_metadata = GrpcClientSettings {
             headers,
             ..Default::default()
@@ -1966,7 +1966,7 @@ mod tests {
         let context = context_with_headers(transport);
 
         let mut static_headers = HashMap::new();
-        _ = static_headers.insert("authorization".to_string(), "Basic abc123".to_string());
+        _ = static_headers.insert("authorization".to_string(), "Basic abc123".into());
         let static_metadata = GrpcClientSettings {
             headers: static_headers,
             ..Default::default()
@@ -2004,7 +2004,7 @@ mod tests {
         let context = context_with_headers(transport);
 
         let mut static_headers = HashMap::new();
-        _ = static_headers.insert("authorization".to_string(), "Basic static".to_string());
+        _ = static_headers.insert("authorization".to_string(), "Basic static".into());
         let static_metadata = GrpcClientSettings {
             headers: static_headers,
             ..Default::default()

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs
@@ -53,6 +53,7 @@ use otap_df_telemetry::metrics::MetricSet;
 use otap_df_telemetry::{otel_debug, otel_info, otel_warn};
 use prost::Message as _;
 use reqwest::{Client, Response};
+use secrecy::ExposeSecret;
 
 use self::config::Config;
 use crate::exporters::otlp_grpc_exporter::InFlightExports;
@@ -749,9 +750,12 @@ impl HttpClientPool {
             let header_name = http::HeaderName::from_bytes(name.as_bytes()).map_err(|e| {
                 HttpClientError::InvalidConfig(format!("invalid header name \"{name}\": {e}"))
             })?;
-            let header_value = HeaderValue::from_str(value).map_err(|e| {
+            let mut header_value = HeaderValue::from_str(value.expose_secret()).map_err(|e| {
                 HttpClientError::InvalidConfig(format!("invalid value for header \"{name}\": {e}"))
             })?;
+            // Mark the value sensitive so it is redacted in any `HeaderMap`
+            // `Debug` output and excluded from HTTP/2 HPACK indexing.
+            header_value.set_sensitive(true);
             _ = default_headers.insert(header_name, header_value);
         }
 
@@ -1094,11 +1098,8 @@ mod test {
         wait_for_port_ready(&endpoint_addr);
 
         let mut headers = HashMap::new();
-        _ = headers.insert(
-            "authorization".to_string(),
-            "Basic dXNlcjpwYXNz".to_string(),
-        );
-        _ = headers.insert("x-test".to_string(), "abc".to_string());
+        _ = headers.insert("authorization".to_string(), "Basic dXNlcjpwYXNz".into());
+        _ = headers.insert("x-test".to_string(), "abc".into());
         let settings = HttpClientSettings {
             headers,
             ..Default::default()

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs
@@ -735,17 +735,25 @@ struct HttpClientPool {
 }
 
 impl HttpClientPool {
-    async fn try_new(
+    /// Builds the user-configured static request headers, marking every value
+    /// sensitive so it is redacted in any `HeaderMap` `Debug` output and
+    /// excluded from HTTP/2 HPACK indexing. This mirrors the OTLP/gRPC
+    /// `GrpcClientSettings::build_static_metadata` path, which marks its
+    /// metadata values sensitive for the same reasons.
+    ///
+    /// `reserve_extra` pre-sizes the returned map for additional headers the
+    /// caller will insert afterwards (e.g. the protocol `Content-Type` /
+    /// `Accept` headers), so construction stays single-allocation.
+    ///
+    /// Header names/values are validated up front by
+    /// [`HttpClientSettings::validate`], so for a validated config the per-entry
+    /// parse below cannot fail; the fallible path defends against a programmatic
+    /// caller that bypassed validation.
+    fn build_static_headers(
         client_settings: &HttpClientSettings,
-        pool_size: NonZeroUsize,
-    ) -> Result<Self, HttpClientError> {
-        // Pre-size for the configured static headers plus the two protocol
-        // headers (Content-Type, Accept) inserted below, so the map is built
-        // with a single allocation and never resizes during construction.
-        let mut default_headers = HeaderMap::with_capacity(client_settings.headers.len() + 2);
-
-        // User-configured static headers are inserted first so the protocol
-        // headers below always win on any (already validated against) collision.
+        reserve_extra: usize,
+    ) -> Result<HeaderMap, HttpClientError> {
+        let mut headers = HeaderMap::with_capacity(client_settings.headers.len() + reserve_extra);
         for (name, value) in &client_settings.headers {
             let header_name = http::HeaderName::from_bytes(name.as_bytes()).map_err(|e| {
                 HttpClientError::InvalidConfig(format!("invalid header name \"{name}\": {e}"))
@@ -756,8 +764,19 @@ impl HttpClientPool {
             // Mark the value sensitive so it is redacted in any `HeaderMap`
             // `Debug` output and excluded from HTTP/2 HPACK indexing.
             header_value.set_sensitive(true);
-            _ = default_headers.insert(header_name, header_value);
+            _ = headers.insert(header_name, header_value);
         }
+        Ok(headers)
+    }
+
+    async fn try_new(
+        client_settings: &HttpClientSettings,
+        pool_size: NonZeroUsize,
+    ) -> Result<Self, HttpClientError> {
+        // Build the user-configured static headers first (pre-sized for the two
+        // protocol headers added below) so the protocol headers always win on
+        // any (already validated against) collision.
+        let mut default_headers = Self::build_static_headers(client_settings, 2)?;
 
         // TODO eventually this header value should be dynamic once we support JSON OTLP payloads
         _ = default_headers.insert(
@@ -1138,6 +1157,44 @@ mod test {
                 .to_str()
                 .unwrap(),
             PROTOBUF_CONTENT_TYPE
+        );
+    }
+
+    #[test]
+    fn build_static_headers_marks_values_sensitive() {
+        // Symmetric with the OTLP/gRPC `build_static_metadata_builds_map` test:
+        // every static header value the exporter puts on the wire must be marked
+        // sensitive so it is excluded from HTTP/2 HPACK indexing and redacted in
+        // any `HeaderMap` `Debug` output. (The wire-capture test above cannot
+        // assert this: the sensitive flag is a client-side `HeaderValue`
+        // property that is not transmitted to the server.)
+        let mut headers = HashMap::new();
+        _ = headers.insert("authorization".to_string(), "Basic abc123".into());
+        _ = headers.insert("x-scope-orgid".to_string(), "tenant-1".into());
+        let settings = HttpClientSettings {
+            headers,
+            ..Default::default()
+        };
+
+        let built =
+            HttpClientPool::build_static_headers(&settings, 0).expect("should build headers");
+        assert_eq!(built.len(), 2);
+        assert_eq!(
+            built.get("authorization").unwrap().to_str().unwrap(),
+            "Basic abc123"
+        );
+        assert_eq!(
+            built.get("x-scope-orgid").unwrap().to_str().unwrap(),
+            "tenant-1"
+        );
+        assert!(
+            built.get("authorization").unwrap().is_sensitive(),
+            "static header values must be marked sensitive so they are excluded from HPACK \
+             indexing and redacted in HeaderMap Debug output"
+        );
+        assert!(
+            built.get("x-scope-orgid").unwrap().is_sensitive(),
+            "every static header value must be marked sensitive, not just the first"
         );
     }
 

--- a/rust/otap-dataflow/crates/otap/Cargo.toml
+++ b/rust/otap-dataflow/crates/otap/Cargo.toml
@@ -44,6 +44,7 @@ otap-df-telemetry-macros = { workspace = true }
 
 tower-service.workspace = true
 serde.workspace = true
+secrecy.workspace = true
 tokio-stream.workspace = true
 tokio-util = { workspace = true, features = ["rt"] }
 humantime.workspace = true

--- a/rust/otap-dataflow/crates/otap/src/otap_grpc/client_settings.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_grpc/client_settings.rs
@@ -10,6 +10,7 @@ use http::header::HeaderValue;
 use hyper_util::rt::TokioIo;
 use otap_df_config::byte_units;
 use otap_df_config::tls::TlsClientConfig;
+use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
 use std::io;
@@ -163,12 +164,17 @@ pub struct GrpcClientSettings {
     /// [`GrpcClientSettings::validate`]. These coexist with any header
     /// propagation policy configured on the exporter.
     ///
+    /// Values are wrapped in [`SecretString`] so a metadata credential is not
+    /// accidentally leaked through `Debug`/telemetry; the cleartext is only
+    /// reachable via [`ExposeSecret::expose_secret`] at the
+    /// metadata-construction site.
+    ///
     /// `GrpcClientSettings` is shared by the OTLP/gRPC exporter and the OTAP
     /// (Arrow) exporter. The OTLP/gRPC exporter applies them as per-request
     /// metadata; the OTAP exporter applies them once as the initial metadata of
     /// each Arrow stream (see [`build_static_metadata`]).
     #[serde(default)]
-    pub headers: HashMap<String, String>,
+    pub headers: HashMap<String, SecretString>,
 }
 
 /// Error returned when building a gRPC [`Endpoint`] (including TLS/mTLS setup).
@@ -275,7 +281,7 @@ impl GrpcClientSettings {
                 );
                 continue;
             };
-            let Ok(val) = MetadataValue::try_from(value.as_str()) else {
+            let Ok(mut val) = MetadataValue::try_from(value.expose_secret()) else {
                 otap_df_telemetry::otel_debug!(
                     "grpc.client.static_header_skip",
                     reason = "invalid ascii metadata value",
@@ -283,6 +289,9 @@ impl GrpcClientSettings {
                 );
                 continue;
             };
+            // Mark the value sensitive so it is redacted in any `MetadataMap`
+            // `Debug` output and excluded from HTTP/2 HPACK indexing.
+            val.set_sensitive(true);
             // `insert` returns the prior value when this lowercased key already
             // existed (e.g. `X-Tenant` and `x-tenant` from an unvalidated config).
             // For a validated config this never happens; log if it ever does so
@@ -354,7 +363,7 @@ impl GrpcClientSettings {
                      `headers`; it is managed by the exporter"
                 )));
             }
-            if MetadataValue::try_from(value.as_str()).is_err() {
+            if MetadataValue::try_from(value.expose_secret()).is_err() {
                 return Err(GrpcEndpointError::InvalidConfig(format!(
                     "header \"{name}\" has a value that cannot be represented as ASCII gRPC \
                      metadata (must be visible ASCII)"
@@ -817,7 +826,7 @@ mod tests {
     #[test]
     fn validate_rejects_invalid_header_name() {
         let mut headers = HashMap::new();
-        let _ = headers.insert("bad header".to_string(), "value".to_string());
+        let _ = headers.insert("bad header".to_string(), "value".into());
         let settings = GrpcClientSettings {
             headers,
             ..GrpcClientSettings::default()
@@ -832,7 +841,7 @@ mod tests {
     #[test]
     fn validate_rejects_invalid_header_value() {
         let mut headers = HashMap::new();
-        let _ = headers.insert("x-test".to_string(), "bad\nvalue".to_string());
+        let _ = headers.insert("x-test".to_string(), "bad\nvalue".into());
         let settings = GrpcClientSettings {
             headers,
             ..GrpcClientSettings::default()
@@ -847,8 +856,8 @@ mod tests {
     #[test]
     fn validate_accepts_valid_headers() {
         let mut headers = HashMap::new();
-        let _ = headers.insert("authorization".to_string(), "Basic abc123".to_string());
-        let _ = headers.insert("x-scope-orgid".to_string(), "tenant-1".to_string());
+        let _ = headers.insert("authorization".to_string(), "Basic abc123".into());
+        let _ = headers.insert("x-scope-orgid".to_string(), "tenant-1".into());
         let settings = GrpcClientSettings {
             headers,
             ..GrpcClientSettings::default()
@@ -869,8 +878,8 @@ mod tests {
     #[test]
     fn build_static_metadata_builds_map() {
         let mut headers = HashMap::new();
-        let _ = headers.insert("authorization".to_string(), "Basic abc123".to_string());
-        let _ = headers.insert("x-scope-orgid".to_string(), "tenant-1".to_string());
+        let _ = headers.insert("authorization".to_string(), "Basic abc123".into());
+        let _ = headers.insert("x-scope-orgid".to_string(), "tenant-1".into());
         let settings = GrpcClientSettings {
             headers,
             ..GrpcClientSettings::default()
@@ -888,6 +897,41 @@ mod tests {
             metadata.get("x-scope-orgid").unwrap().to_str().unwrap(),
             "tenant-1"
         );
+        assert!(
+            metadata.get("authorization").unwrap().is_sensitive(),
+            "static metadata values must be marked sensitive so they are excluded from HPACK \
+             indexing and redacted in MetadataMap Debug output"
+        );
+    }
+
+    #[test]
+    fn debug_redacts_metadata_secret_values() {
+        let mut headers = HashMap::new();
+        let _ = headers.insert(
+            "authorization".to_string(),
+            "Basic super-secret-token".into(),
+        );
+        let settings = GrpcClientSettings {
+            headers,
+            ..GrpcClientSettings::default()
+        };
+        let dbg = format!("{settings:?}");
+        assert!(
+            !dbg.contains("super-secret-token"),
+            "Debug output must not contain the plaintext metadata value: {dbg}"
+        );
+        assert!(
+            dbg.contains("REDACTED"),
+            "Debug output should mark the metadata value as redacted: {dbg}"
+        );
+        assert_eq!(
+            settings
+                .headers
+                .get("authorization")
+                .map(|v| v.expose_secret()),
+            Some("Basic super-secret-token"),
+            "the cleartext must remain reachable via the explicit accessor"
+        );
     }
 
     #[test]
@@ -898,9 +942,9 @@ mod tests {
         // normally rejects these at config load, so this path is unreachable for
         // a validated config.
         let mut headers = HashMap::new();
-        let _ = headers.insert("x-valid".to_string(), "ok".to_string());
-        let _ = headers.insert("bad key".to_string(), "v".to_string()); // space => invalid key
-        let _ = headers.insert("x-bad".to_string(), "bad\nvalue".to_string()); // newline => invalid value
+        let _ = headers.insert("x-valid".to_string(), "ok".into());
+        let _ = headers.insert("bad key".to_string(), "v".into()); // space => invalid key
+        let _ = headers.insert("x-bad".to_string(), "bad\nvalue".into()); // newline => invalid value
         let settings = GrpcClientSettings {
             headers,
             ..GrpcClientSettings::default()
@@ -916,8 +960,8 @@ mod tests {
     #[test]
     fn validate_rejects_case_insensitive_duplicate_headers() {
         let mut headers = HashMap::new();
-        let _ = headers.insert("X-Tenant".to_string(), "a".to_string());
-        let _ = headers.insert("x-tenant".to_string(), "b".to_string());
+        let _ = headers.insert("X-Tenant".to_string(), "a".into());
+        let _ = headers.insert("x-tenant".to_string(), "b".into());
         let settings = GrpcClientSettings {
             headers,
             ..GrpcClientSettings::default()
@@ -940,7 +984,7 @@ mod tests {
             "grpc-accept-encoding",
         ] {
             let mut headers = HashMap::new();
-            let _ = headers.insert(reserved.to_string(), "x".to_string());
+            let _ = headers.insert(reserved.to_string(), "x".into());
             let settings = GrpcClientSettings {
                 headers,
                 ..GrpcClientSettings::default()
@@ -964,11 +1008,17 @@ mod tests {
         .unwrap();
         assert_eq!(settings.headers.len(), 2);
         assert_eq!(
-            settings.headers.get("authorization").map(String::as_str),
+            settings
+                .headers
+                .get("authorization")
+                .map(|v| v.expose_secret()),
             Some("Basic abc123")
         );
         assert_eq!(
-            settings.headers.get("x-scope-orgid").map(String::as_str),
+            settings
+                .headers
+                .get("x-scope-orgid")
+                .map(|v| v.expose_secret()),
             Some("tenant-1")
         );
 

--- a/rust/otap-dataflow/crates/otap/src/otap_grpc/client_settings.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_grpc/client_settings.rs
@@ -165,9 +165,9 @@ pub struct GrpcClientSettings {
     /// propagation policy configured on the exporter.
     ///
     /// Values are wrapped in [`SecretString`] so a metadata credential is not
-    /// accidentally leaked through `Debug`/telemetry; the cleartext is only
-    /// reachable via [`ExposeSecret::expose_secret`] at the
-    /// metadata-construction site.
+    /// accidentally leaked through `Debug`/telemetry; the cleartext is reached
+    /// only through an explicit [`ExposeSecret::expose_secret`] call — during
+    /// [`GrpcClientSettings::validate`] and at the metadata-construction site.
     ///
     /// `GrpcClientSettings` is shared by the OTLP/gRPC exporter and the OTAP
     /// (Arrow) exporter. The OTLP/gRPC exporter applies them as per-request

--- a/rust/otap-dataflow/crates/otap/src/otlp_http/client_settings.rs
+++ b/rust/otap-dataflow/crates/otap/src/otlp_http/client_settings.rs
@@ -78,9 +78,9 @@ pub struct HttpClientSettings {
     /// `Authorization` or backend routing header).
     ///
     /// Values are wrapped in [`SecretString`] so a header credential is not
-    /// accidentally leaked through `Debug`/telemetry; the cleartext is only
-    /// reachable via [`ExposeSecret::expose_secret`] at the request-construction
-    /// site.
+    /// accidentally leaked through `Debug`/telemetry; the cleartext is reached
+    /// only through an explicit [`ExposeSecret::expose_secret`] call — during
+    /// [`HttpClientSettings::validate`] and at the request-construction site.
     ///
     /// Protocol headers (`Content-Type` / `Content-Encoding` /
     /// `Content-Length` / `Host`) and response-negotiation headers

--- a/rust/otap-dataflow/crates/otap/src/otlp_http/client_settings.rs
+++ b/rust/otap-dataflow/crates/otap/src/otlp_http/client_settings.rs
@@ -5,6 +5,7 @@
 
 use reqwest::ClientBuilder;
 use reqwest::header::HeaderValue;
+use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
 use std::io;
@@ -76,12 +77,17 @@ pub struct HttpClientSettings {
     /// Static headers added to every outbound OTLP/HTTP request (e.g. an
     /// `Authorization` or backend routing header).
     ///
+    /// Values are wrapped in [`SecretString`] so a header credential is not
+    /// accidentally leaked through `Debug`/telemetry; the cleartext is only
+    /// reachable via [`ExposeSecret::expose_secret`] at the request-construction
+    /// site.
+    ///
     /// Protocol headers (`Content-Type` / `Content-Encoding` /
     /// `Content-Length` / `Host`) and response-negotiation headers
     /// (`Accept` / `Accept-Encoding`) cannot be set here and are rejected by
     /// [`HttpClientSettings::validate`]; they are managed by the exporter.
     #[serde(default)]
-    pub headers: HashMap<String, String>,
+    pub headers: HashMap<String, SecretString>,
 }
 
 impl HttpClientSettings {
@@ -119,7 +125,7 @@ impl HttpClientSettings {
                     "header name \"{name}\" is not a valid HTTP header name"
                 ))
             })?;
-            if HeaderValue::from_str(value).is_err() {
+            if HeaderValue::from_str(value.expose_secret()).is_err() {
                 return Err(HttpClientError::InvalidConfig(format!(
                     "header \"{name}\" has a value that cannot be represented as an HTTP header \
                      value (must be visible ASCII)"
@@ -411,7 +417,7 @@ mod tests {
     #[test]
     fn validate_rejects_invalid_header_name() {
         let mut headers = HashMap::new();
-        let _ = headers.insert("bad header".to_string(), "value".to_string());
+        let _ = headers.insert("bad header".to_string(), "value".into());
         let settings = HttpClientSettings {
             headers,
             ..HttpClientSettings::default()
@@ -426,7 +432,7 @@ mod tests {
     #[test]
     fn validate_rejects_invalid_header_value() {
         let mut headers = HashMap::new();
-        let _ = headers.insert("x-test".to_string(), "bad\nvalue".to_string());
+        let _ = headers.insert("x-test".to_string(), "bad\nvalue".into());
         let settings = HttpClientSettings {
             headers,
             ..HttpClientSettings::default()
@@ -452,7 +458,7 @@ mod tests {
             "Accept-Encoding",
         ] {
             let mut headers = HashMap::new();
-            let _ = headers.insert(reserved.to_string(), "x".to_string());
+            let _ = headers.insert(reserved.to_string(), "x".into());
             let settings = HttpClientSettings {
                 headers,
                 ..HttpClientSettings::default()
@@ -468,8 +474,8 @@ mod tests {
     #[test]
     fn validate_accepts_valid_headers() {
         let mut headers = HashMap::new();
-        let _ = headers.insert("authorization".to_string(), "Basic abc123".to_string());
-        let _ = headers.insert("x-scope-orgid".to_string(), "tenant-1".to_string());
+        let _ = headers.insert("authorization".to_string(), "Basic abc123".into());
+        let _ = headers.insert("x-scope-orgid".to_string(), "tenant-1".into());
         let settings = HttpClientSettings {
             headers,
             ..HttpClientSettings::default()
@@ -481,8 +487,8 @@ mod tests {
     #[test]
     fn validate_rejects_case_insensitive_duplicate_headers() {
         let mut headers = HashMap::new();
-        let _ = headers.insert("X-Tenant".to_string(), "a".to_string());
-        let _ = headers.insert("x-tenant".to_string(), "b".to_string());
+        let _ = headers.insert("X-Tenant".to_string(), "a".into());
+        let _ = headers.insert("x-tenant".to_string(), "b".into());
         let settings = HttpClientSettings {
             headers,
             ..HttpClientSettings::default()
@@ -495,6 +501,36 @@ mod tests {
     }
 
     #[test]
+    fn debug_redacts_header_secret_values() {
+        let mut headers = HashMap::new();
+        let _ = headers.insert(
+            "authorization".to_string(),
+            "Basic super-secret-token".into(),
+        );
+        let settings = HttpClientSettings {
+            headers,
+            ..HttpClientSettings::default()
+        };
+        let dbg = format!("{settings:?}");
+        assert!(
+            !dbg.contains("super-secret-token"),
+            "Debug output must not contain the plaintext header value: {dbg}"
+        );
+        assert!(
+            dbg.contains("REDACTED"),
+            "Debug output should mark the header value as redacted: {dbg}"
+        );
+        assert_eq!(
+            settings
+                .headers
+                .get("authorization")
+                .map(|v| v.expose_secret()),
+            Some("Basic super-secret-token"),
+            "the cleartext must remain reachable via the explicit accessor"
+        );
+    }
+
+    #[test]
     fn deserialize_accepts_headers_and_keeps_deny_unknown_fields() {
         let settings: HttpClientSettings = serde_json::from_str(
             r#"{ "headers": { "authorization": "Basic abc123", "stream-name": "default" } }"#,
@@ -502,11 +538,17 @@ mod tests {
         .unwrap();
         assert_eq!(settings.headers.len(), 2);
         assert_eq!(
-            settings.headers.get("authorization").map(String::as_str),
+            settings
+                .headers
+                .get("authorization")
+                .map(|v| v.expose_secret()),
             Some("Basic abc123")
         );
         assert_eq!(
-            settings.headers.get("stream-name").map(String::as_str),
+            settings
+                .headers
+                .get("stream-name")
+                .map(|v| v.expose_secret()),
             Some("default")
         );
 


### PR DESCRIPTION
# Change Summary

Wrap `HttpClientSettings::headers` and `GrpcClientSettings::headers` **values** in `secrecy::SecretString` so a header credential (an `Authorization` token, a tenant API key) can no longer leak through the `Debug`/telemetry output of the settings structs. Cleartext is read only via an explicit `expose_secret()` accessor at the request-construction sites (`validate`, `build_static_metadata`, and `HttpClientPool::build_static_headers`); behavior is otherwise unchanged.

**Defense-in-depth:** the constructed wire values are additionally marked sensitive (`HeaderValue::set_sensitive` / `MetadataValue::set_sensitive`), so the credential is redacted in any `HeaderMap`/`MetadataMap` `Debug` output and excluded from HTTP/2 HPACK indexing.

`user_agent` is intentionally left a plain `String` — it is a non-credential client identifier — mirroring the Go Collector's use of `configopaque` for auth/credential headers only.

**Why `secrecy` over the maintainer-suggested Microsoft Oxidizer `data_privacy`:** `secrecy` (and its `zeroize` transitive dependency) was already in the build graph, so this adds **zero net-new crates**. `data_privacy` would have pulled in four pre-1.0 crates plus taxonomy / classified-container / redaction-engine boilerplate for what is, here, just type-level redaction. Runtime cost is a wash — header values are materialized once at exporter startup, never on the per-export hot path — and `secrecy` adds free zeroize-on-drop.

## Scope / known limitation

This protects the **typed** settings (`Debug`/telemetry) and the values placed on the wire. It does **not** redact the raw configuration snapshot returned by the admin config APIs: `NodeUserConfig.config` retains the original `serde_json::Value`, which the admin endpoints (`GET /api/v1/config` and the per-pipeline detail API) serialize as-is, so a credential header still appears in cleartext there. Redacting the raw config snapshot is broader than this exporter-scoped change (it touches a shared, type-erased config value across all node kinds and the admin API contract), so it is tracked separately in #3328. The changelog wording is scoped accordingly.

## What issue does this PR close?

* Closes #3306

## How are these changes tested?

* `cargo xtask check` (structure, fmt, clippy `-D warnings`, full test suite) passes.
* New unit tests assert the secret value is **absent** from each settings struct's `Debug` output while remaining reachable via `expose_secret()`, for both `HttpClientSettings` and `GrpcClientSettings`.
* `build_static_metadata_builds_map` asserts the constructed gRPC `MetadataValue` reports `is_sensitive() == true`; the symmetric `build_static_headers_marks_values_sensitive` asserts the same for every constructed HTTP `HeaderValue`.
* Existing exporter tests were updated for the `SecretString` field type and continue to pass.

## Are there any user-facing changes?

Yes. The `headers` values on `HttpClientSettings` and `GrpcClientSettings` change type from `String` to `secrecy::SecretString`. End-user configuration is unaffected — values still deserialize from plain strings — but they no longer appear in `Debug`/serialized output, and any in-process code reading these fields must now go through `expose_secret()`. Wire behavior is unchanged.

### Changelog

* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).

Entry: `rust/otap-dataflow/.chloggen/otlp-exporter-opaque-header-values.yaml` (`change_type: enhancement`, `component: pipeline`).
