### PR TITLE
feat(engine/topic): foundation & primitives for broadcast all ack mode (PR 1/3)

### DIFF
--- a/rust/otap-dataflow/.chloggen/broadcast-ack-all-primitives.yaml
+++ b/rust/otap-dataflow/.chloggen/broadcast-ack-all-primitives.yaml
@@ -1,0 +1,23 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: engine
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add internal primitives for a broadcast `all` (quorum) Ack/Nack mode for topic hops
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [2252]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Not yet usable: this is internal-only foundation work with no behavior change. It adds the
+  `TopicBroadcastAckMode` enum, a quorum-capable publish tracker, and a reserve/commit ring split,
+  all gated behind callers that still pass `First`. The `all` mode is not wired into the broadcast
+  engine and is not configurable yet — those land in follow-up PRs under #2252.

--- a/rust/otap-dataflow/.chloggen/broadcast-ack-all-primitives.yaml
+++ b/rust/otap-dataflow/.chloggen/broadcast-ack-all-primitives.yaml
@@ -8,7 +8,7 @@ change_type: enhancement
 component: engine
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add internal primitives for a broadcast `all` (quorum) Ack/Nack mode for topic hops
+note: Add internal primitives for a broadcast `all` (consensus) Ack/Nack mode for topic hops
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [2252]
@@ -18,6 +18,6 @@ issues: [2252]
 # Use pipe (|) for multiline entries.
 subtext: |
   Not yet usable: this is internal-only foundation work with no behavior change. It adds the
-  `TopicBroadcastAckMode` enum, a quorum-capable publish tracker, and a reserve/commit ring split,
+  `TopicBroadcastAckMode` enum, a consensus-capable publish tracker, and a reserve/commit ring split,
   all gated behind callers that still pass `First`. The `all` mode is not wired into the broadcast
   engine and is not configurable yet — those land in follow-up PRs under #2252.

--- a/rust/otap-dataflow/benchmarks/benches/topic_broadcast/main.rs
+++ b/rust/otap-dataflow/benchmarks/benches/topic_broadcast/main.rs
@@ -30,8 +30,8 @@ use std::sync::Arc;
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use otap_df_engine::topic::{
-    InMemoryBackend, RecvItem, SubscriberOptions, SubscriptionMode, TopicBroadcastOnLagPolicy,
-    TopicBroker, TopicOptions,
+    InMemoryBackend, RecvItem, SubscriberOptions, SubscriptionMode, TopicBroadcastAckMode,
+    TopicBroadcastOnLagPolicy, TopicBroker, TopicOptions,
 };
 use tokio::runtime::Runtime;
 
@@ -147,6 +147,7 @@ async fn run_topic_broadcast_lag_case(msg_size: usize) {
             TopicOptions::BroadcastOnly {
                 capacity: LAG_CAPACITY,
                 on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                ack_mode: TopicBroadcastAckMode::First,
             },
         )
         .expect("benchmark topic creation failed");
@@ -237,6 +238,7 @@ fn bench_topic_broadcast_vs_tokio(c: &mut Criterion) {
                         TopicOptions::BroadcastOnly {
                             capacity: BROADCAST_CAPACITY,
                             on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                            ack_mode: TopicBroadcastAckMode::First,
                         },
                     )
                 });
@@ -270,6 +272,7 @@ fn bench_topic_mixed_broadcast_vs_tokio(c: &mut Criterion) {
                             balanced_capacity: TopicOptions::DEFAULT_BALANCED_CAPACITY,
                             broadcast_capacity: BROADCAST_CAPACITY,
                             on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                            ack_mode: TopicBroadcastAckMode::First,
                         },
                     )
                 });

--- a/rust/otap-dataflow/crates/config/src/topic.rs
+++ b/rust/otap-dataflow/crates/config/src/topic.rs
@@ -356,6 +356,33 @@ pub enum TopicBroadcastOnLagPolicy {
     Disconnect,
 }
 
+/// Broadcast Ack/Nack aggregation mode for tracked publishes.
+///
+/// Controls how upstream Ack/Nack resolves when a tracked message is broadcast
+/// to multiple subscribers. Only meaningful when
+/// [`TopicAckPropagationMode::Auto`] is in effect.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum TopicBroadcastAckMode {
+    /// The first broadcast subscriber to Ack/Nack resolves the upstream message.
+    #[default]
+    First,
+    /// The upstream message Acks only when all broadcast subscribers eligible at
+    /// publish time Ack; any Nack (or a required subscriber disappearing)
+    /// resolves the upstream message as Nack.
+    All,
+}
+
+impl std::fmt::Display for TopicBroadcastAckMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let value = match self {
+            Self::First => "first",
+            Self::All => "all",
+        };
+        f.write_str(value)
+    }
+}
+
 /// Policy controlling whether topic hops can bridge Ack/Nack across pipelines.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
@@ -386,7 +413,7 @@ const fn default_topic_ack_propagation_timeout() -> Duration {
 #[cfg(test)]
 mod tests {
     use super::{
-        SubscriptionGroupName, TopicAckPropagationMode, TopicBackendKind,
+        SubscriptionGroupName, TopicAckPropagationMode, TopicBackendKind, TopicBroadcastAckMode,
         TopicBroadcastOnLagPolicy, TopicImplSelectionPolicy, TopicName, TopicQueueOnFullPolicy,
         TopicSpec,
     };
@@ -536,6 +563,23 @@ impl_selection: force_mixed
             topic.impl_selection,
             Some(TopicImplSelectionPolicy::ForceMixed)
         );
+    }
+
+    #[test]
+    fn topic_broadcast_ack_mode_defaults_and_serde() {
+        assert_eq!(
+            TopicBroadcastAckMode::default(),
+            TopicBroadcastAckMode::First
+        );
+        assert_eq!(
+            serde_yaml::to_string(&TopicBroadcastAckMode::All)
+                .expect("ack mode should serialize")
+                .trim(),
+            "all"
+        );
+        let parsed: TopicBroadcastAckMode =
+            serde_yaml::from_str("first").expect("ack mode should parse");
+        assert_eq!(parsed, TopicBroadcastAckMode::First);
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/config/src/topic.rs
+++ b/rust/otap-dataflow/crates/config/src/topic.rs
@@ -294,6 +294,8 @@ pub struct TopicBroadcastPolicies {
     /// Behavior when a broadcast subscriber falls behind the retained ring window.
     #[serde(default)]
     pub on_lag: TopicBroadcastOnLagPolicy,
+    // TODO(#2252 PR3): add a user-facing `ack_mode` field here and reject the
+    // config combinations that aren't safe (e.g. `all` with a lossy lag policy).
 }
 
 impl Default for TopicBroadcastPolicies {

--- a/rust/otap-dataflow/crates/controller/src/lib.rs
+++ b/rust/otap-dataflow/crates/controller/src/lib.rs
@@ -611,6 +611,8 @@ impl<
         let balanced_capacity = spec.policies.balanced.queue_capacity.max(1);
         let broadcast_capacity = spec.policies.broadcast.queue_capacity.max(1);
         let broadcast_on_lag = spec.policies.broadcast.on_lag;
+        // TODO(#2252 PR3): pass the configured `ack_mode` through instead of
+        // hardcoding `first`, and reject `all` on non-broadcast-only topics.
         match inferred_mode {
             InferredTopicMode::Mixed => TopicOptions::Mixed {
                 balanced_capacity,

--- a/rust/otap-dataflow/crates/controller/src/lib.rs
+++ b/rust/otap-dataflow/crates/controller/src/lib.rs
@@ -59,8 +59,8 @@ use otap_df_config::policy::{
     ChannelCapacityPolicy, CoreAllocation, CoreAllocationStrategy, TelemetryPolicy,
 };
 use otap_df_config::topic::{
-    TopicAckPropagationMode, TopicBackendKind, TopicBroadcastOnLagPolicy, TopicImplSelectionPolicy,
-    TopicSpec,
+    TopicAckPropagationMode, TopicBackendKind, TopicBroadcastAckMode, TopicBroadcastOnLagPolicy,
+    TopicImplSelectionPolicy, TopicSpec,
 };
 use otap_df_config::transport_headers_policy::TransportHeadersPolicy;
 use otap_df_config::{
@@ -616,6 +616,7 @@ impl<
                 balanced_capacity,
                 broadcast_capacity,
                 on_lag: broadcast_on_lag,
+                ack_mode: TopicBroadcastAckMode::First,
             },
             InferredTopicMode::BalancedOnly => TopicOptions::BalancedOnly {
                 capacity: balanced_capacity,
@@ -623,6 +624,7 @@ impl<
             InferredTopicMode::BroadcastOnly => TopicOptions::BroadcastOnly {
                 capacity: broadcast_capacity,
                 on_lag: broadcast_on_lag,
+                ack_mode: TopicBroadcastAckMode::First,
             },
         }
     }

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/topic_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/topic_exporter/mod.rs
@@ -603,8 +603,8 @@ mod tests {
     use otap_df_engine::testing::exporter::create_test_pipeline_context;
     use otap_df_engine::testing::{create_not_send_channel, setup_test_runtime, test_node};
     use otap_df_engine::topic::{
-        PipelineTopicBinding, SubscriberOptions, SubscriptionMode, TopicBroadcastOnLagPolicy,
-        TopicBroker, TopicOptions, TopicSet,
+        PipelineTopicBinding, SubscriberOptions, SubscriptionMode, TopicBroadcastAckMode,
+        TopicBroadcastOnLagPolicy, TopicBroker, TopicOptions, TopicSet,
     };
     use otap_df_otap::pdata::OtapPdata;
     use otap_df_otap::testing::{TestCallData, create_test_pdata, next_ack, next_nack};
@@ -662,6 +662,7 @@ mod tests {
                         balanced_capacity: 16,
                         broadcast_capacity: 16,
                         on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                        ack_mode: TopicBroadcastAckMode::First,
                     },
                 )
                 .expect("topic should be created");
@@ -803,6 +804,7 @@ mod tests {
                         balanced_capacity: 1,
                         broadcast_capacity: 1,
                         on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                        ack_mode: TopicBroadcastAckMode::First,
                     },
                 )
                 .expect("topic should be created");
@@ -969,6 +971,7 @@ mod tests {
                         balanced_capacity: 1,
                         broadcast_capacity: 1,
                         on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                        ack_mode: TopicBroadcastAckMode::First,
                     },
                 )
                 .expect("topic should be created");
@@ -1149,6 +1152,7 @@ mod tests {
                         balanced_capacity: 1,
                         broadcast_capacity: 1,
                         on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                        ack_mode: TopicBroadcastAckMode::First,
                     },
                 )
                 .expect("topic should be created");

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/topic_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/topic_receiver/mod.rs
@@ -743,8 +743,8 @@ mod tests {
     use otap_df_engine::testing::exporter::create_test_pipeline_context;
     use otap_df_engine::testing::{create_not_send_channel, setup_test_runtime, test_node};
     use otap_df_engine::topic::{
-        PipelineTopicBinding, TopicBroadcastOnLagPolicy, TopicBroker, TopicOptions, TopicSet,
-        TrackedPublishOutcome,
+        PipelineTopicBinding, TopicBroadcastAckMode, TopicBroadcastOnLagPolicy, TopicBroker,
+        TopicOptions, TopicSet, TrackedPublishOutcome,
     };
     use otap_df_otap::pdata::OtapPdata;
     use otap_df_otap::testing::{create_test_pdata, next_ack};
@@ -814,6 +814,7 @@ mod tests {
                         balanced_capacity: 16,
                         broadcast_capacity: 16,
                         on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                        ack_mode: TopicBroadcastAckMode::First,
                     },
                 )
                 .expect("topic should be created");
@@ -919,6 +920,7 @@ mod tests {
                     TopicOptions::BroadcastOnly {
                         capacity: 4,
                         on_lag: TopicBroadcastOnLagPolicy::Disconnect,
+                        ack_mode: TopicBroadcastAckMode::First,
                     },
                 )
                 .expect("topic should be created");
@@ -1015,6 +1017,7 @@ mod tests {
                         balanced_capacity: 16,
                         broadcast_capacity: 16,
                         on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                        ack_mode: TopicBroadcastAckMode::First,
                     },
                 )
                 .expect("topic should be created");
@@ -1110,6 +1113,7 @@ mod tests {
                         balanced_capacity: 16,
                         broadcast_capacity: 16,
                         on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                        ack_mode: TopicBroadcastAckMode::First,
                     },
                 )
                 .expect("topic should be created");
@@ -1230,6 +1234,7 @@ mod tests {
                         balanced_capacity: 16,
                         broadcast_capacity: 16,
                         on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                        ack_mode: TopicBroadcastAckMode::First,
                     },
                 )
                 .expect("topic should be created");

--- a/rust/otap-dataflow/crates/engine/src/topic/mod.rs
+++ b/rust/otap-dataflow/crates/engine/src/topic/mod.rs
@@ -28,7 +28,7 @@ pub use otap_df_config::{SubscriptionGroupName, TopicName};
 pub use subscription::{Delivery, RecvDelivery, Subscription};
 pub use topic_set::TopicSet;
 pub use types::{
-    AckFromResult, Envelope, PublishOutcome, RecvItem, SubscriberId, SubscriberOptions,
+    AckFromResult, Envelope, PublishOutcome, RecvItem, BroadcastSubscriberId, SubscriberOptions,
     SubscriptionMode, TopicOptions, TopicPublishOutcomeConfig, TrackedPublishOutcome,
     TrackedPublishPermit, TrackedPublishReceipt, TrackedPublishTracker, TrackedTryPublishOutcome,
 };

--- a/rust/otap-dataflow/crates/engine/src/topic/mod.rs
+++ b/rust/otap-dataflow/crates/engine/src/topic/mod.rs
@@ -28,7 +28,7 @@ pub use otap_df_config::{SubscriptionGroupName, TopicName};
 pub use subscription::{Delivery, RecvDelivery, Subscription};
 pub use topic_set::TopicSet;
 pub use types::{
-    AckFromResult, Envelope, PublishOutcome, RecvItem, BroadcastSubscriberId, SubscriberOptions,
+    AckFromResult, BroadcastSubscriberId, Envelope, PublishOutcome, RecvItem, SubscriberOptions,
     SubscriptionMode, TopicOptions, TopicPublishOutcomeConfig, TrackedPublishOutcome,
     TrackedPublishPermit, TrackedPublishReceipt, TrackedPublishTracker, TrackedTryPublishOutcome,
 };

--- a/rust/otap-dataflow/crates/engine/src/topic/mod.rs
+++ b/rust/otap-dataflow/crates/engine/src/topic/mod.rs
@@ -21,13 +21,14 @@ pub use binding::PipelineTopicBinding;
 pub use broker::TopicBroker;
 pub use handle::{TopicHandle, TrackedTopicPublisher};
 pub use otap_df_config::topic::{
-    TopicAckPropagationMode, TopicBroadcastOnLagPolicy, TopicQueueOnFullPolicy,
+    TopicAckPropagationMode, TopicBroadcastAckMode, TopicBroadcastOnLagPolicy,
+    TopicQueueOnFullPolicy,
 };
 pub use otap_df_config::{SubscriptionGroupName, TopicName};
 pub use subscription::{Delivery, RecvDelivery, Subscription};
 pub use topic_set::TopicSet;
 pub use types::{
-    Envelope, PublishOutcome, RecvItem, SubscriberOptions, SubscriptionMode, TopicOptions,
-    TopicPublishOutcomeConfig, TrackedPublishOutcome, TrackedPublishPermit, TrackedPublishReceipt,
-    TrackedPublishTracker, TrackedTryPublishOutcome,
+    AckFromResult, Envelope, PublishOutcome, RecvItem, SubscriberId, SubscriberOptions,
+    SubscriptionMode, TopicOptions, TopicPublishOutcomeConfig, TrackedPublishOutcome,
+    TrackedPublishPermit, TrackedPublishReceipt, TrackedPublishTracker, TrackedTryPublishOutcome,
 };

--- a/rust/otap-dataflow/crates/engine/src/topic/tests.rs
+++ b/rust/otap-dataflow/crates/engine/src/topic/tests.rs
@@ -2182,12 +2182,12 @@ async fn tracked_publish_tracker_register_after_close_resolves_immediately() {
 }
 
 // =========================================================================
-// TrackedPublishTracker quorum (`all`-mode) primitives
+// TrackedPublishTracker consensus (`all`-mode) primitives
 //
 // These exercise the tracker primitive directly
 // =========================================================================
 
-fn quorum_permit_from(sem: &Arc<Semaphore>) -> TrackedPublishPermit {
+fn consensus_permit_from(sem: &Arc<Semaphore>) -> TrackedPublishPermit {
     TrackedPublishPermit::from_tokio_owned(
         sem.clone()
             .try_acquire_owned()
@@ -2195,23 +2195,23 @@ fn quorum_permit_from(sem: &Arc<Semaphore>) -> TrackedPublishPermit {
     )
 }
 
-fn quorum_permit() -> TrackedPublishPermit {
-    quorum_permit_from(&Arc::new(Semaphore::new(1)))
+fn consensus_permit() -> TrackedPublishPermit {
+    consensus_permit_from(&Arc::new(Semaphore::new(1)))
 }
 
 fn subscriber_set(ids: impl IntoIterator<Item = u64>) -> HashSet<BroadcastSubscriberId> {
     ids.into_iter().map(BroadcastSubscriberId).collect()
 }
 
-// A quorum entry resolves as Ack only once every required subscriber has acked,
+// A consensus entry resolves as Ack only once every required subscriber has acked,
 // and further acks for that message are no longer tracked.
 #[tokio::test]
-async fn quorum_resolves_ack_only_after_all_subscribers_ack() {
+async fn consensus_resolves_ack_only_after_all_subscribers_ack() {
     let tracker = TrackedPublishTracker::new();
-    let receipt = tracker.register_quorum(
+    let receipt = tracker.register_consensus(
         7,
         Duration::from_secs(30),
-        quorum_permit(),
+        consensus_permit(),
         subscriber_set([1, 2]),
     );
 
@@ -2231,14 +2231,14 @@ async fn quorum_resolves_ack_only_after_all_subscribers_ack() {
     );
 }
 
-// A repeated ack from the same subscriber must not falsely complete the quorum.
+// A repeated ack from the same subscriber must not falsely complete the consensus.
 #[tokio::test]
-async fn quorum_duplicate_ack_does_not_complete() {
+async fn consensus_duplicate_ack_does_not_complete() {
     let tracker = TrackedPublishTracker::new();
-    let _receipt = tracker.register_quorum(
+    let _receipt = tracker.register_consensus(
         1,
         Duration::from_secs(30),
-        quorum_permit(),
+        consensus_permit(),
         subscriber_set([1, 2]),
     );
 
@@ -2258,10 +2258,14 @@ async fn quorum_duplicate_ack_does_not_complete() {
 
 // Zero eligible subscribers resolves immediately as Ack without registering.
 #[tokio::test]
-async fn quorum_empty_set_resolves_ack_immediately() {
+async fn consensus_empty_set_resolves_ack_immediately() {
     let tracker = TrackedPublishTracker::new();
-    let receipt =
-        tracker.register_quorum(1, Duration::from_secs(30), quorum_permit(), HashSet::new());
+    let receipt = tracker.register_consensus(
+        1,
+        Duration::from_secs(30),
+        consensus_permit(),
+        HashSet::new(),
+    );
 
     assert_eq!(receipt.wait_for_outcome().await, TrackedPublishOutcome::Ack);
     assert_eq!(
@@ -2272,7 +2276,7 @@ async fn quorum_empty_set_resolves_ack_immediately() {
 
 // Acking an unknown message id is reported as not-tracked.
 #[tokio::test]
-async fn quorum_resolve_ack_from_unknown_message_not_tracked() {
+async fn consensus_resolve_ack_from_unknown_message_not_tracked() {
     let tracker = TrackedPublishTracker::new();
     assert_eq!(
         tracker.resolve_ack_from(99, BroadcastSubscriberId(1)),
@@ -2280,14 +2284,14 @@ async fn quorum_resolve_ack_from_unknown_message_not_tracked() {
     );
 }
 
-// A required subscriber disappearing nacks its outstanding quorum entries.
+// A required subscriber disappearing nacks its outstanding consensus entries.
 #[tokio::test]
-async fn quorum_subscriber_disappearance_nacks_outstanding() {
+async fn consensus_subscriber_disappearance_nacks_outstanding() {
     let tracker = TrackedPublishTracker::new();
-    let receipt = tracker.register_quorum(
+    let receipt = tracker.register_consensus(
         5,
         Duration::from_secs(30),
-        quorum_permit(),
+        consensus_permit(),
         subscriber_set([1, 2]),
     );
 
@@ -2308,18 +2312,18 @@ async fn quorum_subscriber_disappearance_nacks_outstanding() {
 
 // Disconnecting a subscriber only nacks entries that still require it.
 #[tokio::test]
-async fn quorum_disappearance_only_nacks_entries_requiring_subscriber() {
+async fn consensus_disappearance_only_nacks_entries_requiring_subscriber() {
     let tracker = TrackedPublishTracker::new();
-    let r1 = tracker.register_quorum(
+    let r1 = tracker.register_consensus(
         1,
         Duration::from_secs(30),
-        quorum_permit(),
+        consensus_permit(),
         subscriber_set([1]),
     );
-    let r2 = tracker.register_quorum(
+    let r2 = tracker.register_consensus(
         2,
         Duration::from_secs(30),
-        quorum_permit(),
+        consensus_permit(),
         subscriber_set([2]),
     );
 
@@ -2336,14 +2340,14 @@ async fn quorum_disappearance_only_nacks_entries_requiring_subscriber() {
     assert_eq!(r2.wait_for_outcome().await, TrackedPublishOutcome::Ack);
 }
 
-// A single Nack via the standard resolve path overrides an incomplete quorum.
+// A single Nack via the standard resolve path overrides an incomplete consensus.
 #[tokio::test]
-async fn quorum_single_resolve_nack_overrides_quorum() {
+async fn consensus_single_resolve_nack_overrides_consensus() {
     let tracker = TrackedPublishTracker::new();
-    let receipt = tracker.register_quorum(
+    let receipt = tracker.register_consensus(
         1,
         Duration::from_secs(30),
-        quorum_permit(),
+        consensus_permit(),
         subscriber_set([1, 2]),
     );
 
@@ -2367,15 +2371,15 @@ async fn quorum_single_resolve_nack_overrides_quorum() {
     );
 }
 
-// First terminal transition wins: an ack that completes the quorum makes a
+// First terminal transition wins: an ack that completes the consensus makes a
 // later disconnect of the (already satisfied) subscriber a no-op.
 #[tokio::test]
-async fn quorum_ack_completion_beats_late_disconnect() {
+async fn consensus_ack_completion_beats_late_disconnect() {
     let tracker = TrackedPublishTracker::new();
-    let receipt = tracker.register_quorum(
+    let receipt = tracker.register_consensus(
         1,
         Duration::from_secs(30),
-        quorum_permit(),
+        consensus_permit(),
         subscriber_set([1]),
     );
 
@@ -2387,15 +2391,15 @@ async fn quorum_ack_completion_beats_late_disconnect() {
     assert_eq!(receipt.wait_for_outcome().await, TrackedPublishOutcome::Ack);
 }
 
-// Registering a quorum entry against a closed tracker resolves immediately.
+// Registering a consensus entry against a closed tracker resolves immediately.
 #[tokio::test]
-async fn quorum_register_after_close_resolves_topic_closed() {
+async fn consensus_register_after_close_resolves_topic_closed() {
     let tracker = TrackedPublishTracker::new();
     tracker.close_all();
-    let receipt = tracker.register_quorum(
+    let receipt = tracker.register_consensus(
         1,
         Duration::from_secs(30),
-        quorum_permit(),
+        consensus_permit(),
         subscriber_set([1]),
     );
     assert_eq!(
@@ -2404,15 +2408,15 @@ async fn quorum_register_after_close_resolves_topic_closed() {
     );
 }
 
-// The in-flight permit is released exactly once the quorum entry resolves.
+// The in-flight permit is released exactly once the consensus entry resolves.
 #[tokio::test]
-async fn quorum_releases_permit_on_resolution() {
+async fn consensus_releases_permit_on_resolution() {
     let sem = Arc::new(Semaphore::new(1));
     let tracker = TrackedPublishTracker::new();
-    let receipt = tracker.register_quorum(
+    let receipt = tracker.register_consensus(
         1,
         Duration::from_secs(30),
-        quorum_permit_from(&sem),
+        consensus_permit_from(&sem),
         subscriber_set([1]),
     );
 

--- a/rust/otap-dataflow/crates/engine/src/topic/tests.rs
+++ b/rust/otap-dataflow/crates/engine/src/topic/tests.rs
@@ -27,12 +27,12 @@ use crate::error::Error;
 use crate::topic::backend::{InMemoryBackend, SubscriptionBackend};
 use crate::topic::subscription::{DeliveryBackend, DeliveryStorageKind};
 use crate::topic::types::{
-    Envelope, PublishOutcome, RecvItem, SubscriberOptions, SubscriptionMode, TopicOptions,
-    TopicPublishOutcomeConfig, TrackedPublishOutcome, TrackedPublishPermit, TrackedPublishTracker,
-    TrackedTryPublishOutcome,
+    AckFromResult, Envelope, PublishOutcome, RecvItem, SubscriberId, SubscriberOptions,
+    SubscriptionMode, TopicOptions, TopicPublishOutcomeConfig, TrackedPublishOutcome,
+    TrackedPublishPermit, TrackedPublishTracker, TrackedTryPublishOutcome,
 };
 use crate::topic::{Delivery, RecvDelivery, Subscription, TopicBroker, TopicSet};
-use otap_df_config::topic::TopicBroadcastOnLagPolicy;
+use otap_df_config::topic::{TopicBroadcastAckMode, TopicBroadcastOnLagPolicy};
 use otap_df_config::{SubscriptionGroupName, TopicName};
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -310,6 +310,7 @@ async fn broadcast_all_subscribers_see_all_messages_in_order() {
                 balanced_capacity: TopicOptions::DEFAULT_BALANCED_CAPACITY,
                 broadcast_capacity: 1024,
                 on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                ack_mode: TopicBroadcastAckMode::First,
             },
         )
         .unwrap();
@@ -355,6 +356,7 @@ async fn broadcast_lag_reported_on_slow_subscriber() {
                 balanced_capacity: TopicOptions::DEFAULT_BALANCED_CAPACITY,
                 broadcast_capacity: 8,
                 on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                ack_mode: TopicBroadcastAckMode::First,
             },
         )
         .unwrap();
@@ -406,6 +408,7 @@ async fn broadcast_slow_subscriber_does_not_block_fast_subscriber() {
                 balanced_capacity: TopicOptions::DEFAULT_BALANCED_CAPACITY,
                 broadcast_capacity: 4,
                 on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                ack_mode: TopicBroadcastAckMode::First,
             },
         )
         .unwrap();
@@ -440,6 +443,7 @@ async fn broadcast_disconnects_slow_subscriber_on_lag() {
             TopicOptions::BroadcastOnly {
                 capacity: 8,
                 on_lag: TopicBroadcastOnLagPolicy::Disconnect,
+                ack_mode: TopicBroadcastAckMode::First,
             },
             InMemoryBackend,
         )
@@ -473,6 +477,7 @@ async fn mixed_async_publish_waits_for_balanced_admission_before_broadcast() {
                 balanced_capacity: 1,
                 broadcast_capacity: 16,
                 on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                ack_mode: TopicBroadcastAckMode::First,
             },
             InMemoryBackend,
         )
@@ -562,6 +567,7 @@ async fn mixed_async_publish_does_not_reserve_free_groups_while_waiting() {
                 balanced_capacity: 1,
                 broadcast_capacity: 16,
                 on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                ack_mode: TopicBroadcastAckMode::First,
             },
             InMemoryBackend,
         )
@@ -644,6 +650,7 @@ async fn mixed_async_publish_drop_does_not_publish_to_broadcast() {
                 balanced_capacity: 1,
                 broadcast_capacity: 16,
                 on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                ack_mode: TopicBroadcastAckMode::First,
             },
             InMemoryBackend,
         )
@@ -755,6 +762,7 @@ async fn broadcast_delivery_commit_advances_to_next_message() {
             TopicOptions::BroadcastOnly {
                 capacity: 16,
                 on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                ack_mode: TopicBroadcastAckMode::First,
             },
             InMemoryBackend,
         )
@@ -835,6 +843,7 @@ async fn broadcast_delivery_uses_specialized_inline_storage() {
             TopicOptions::BroadcastOnly {
                 capacity: 16,
                 on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                ack_mode: TopicBroadcastAckMode::First,
             },
             InMemoryBackend,
         )
@@ -981,6 +990,7 @@ async fn mixed_disconnects_only_lagging_broadcast_subscriber() {
                 balanced_capacity: 32,
                 broadcast_capacity: 4,
                 on_lag: TopicBroadcastOnLagPolicy::Disconnect,
+                ack_mode: TopicBroadcastAckMode::First,
             },
         )
         .unwrap();
@@ -1197,6 +1207,7 @@ async fn balanced_backpressure_blocks_publisher() {
                 balanced_capacity: 2,
                 broadcast_capacity: TopicOptions::DEFAULT_BROADCAST_CAPACITY,
                 on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                ack_mode: TopicBroadcastAckMode::First,
             },
             InMemoryBackend,
         )
@@ -1308,6 +1319,7 @@ async fn broadcast_multi_threaded_all_receive() {
                 balanced_capacity: TopicOptions::DEFAULT_BALANCED_CAPACITY,
                 broadcast_capacity: 2048,
                 on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                ack_mode: TopicBroadcastAckMode::First,
             },
             InMemoryBackend,
         )
@@ -1576,6 +1588,7 @@ async fn mixed_rejects_balanced_subscribe_after_close() {
                 balanced_capacity: TopicOptions::DEFAULT_BALANCED_CAPACITY,
                 broadcast_capacity: TopicOptions::DEFAULT_BROADCAST_CAPACITY,
                 on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                ack_mode: TopicBroadcastAckMode::First,
             },
             InMemoryBackend,
         )
@@ -1657,6 +1670,7 @@ async fn broadcast_only_basic_delivery() {
             TopicOptions::BroadcastOnly {
                 capacity: 1024,
                 on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                ack_mode: TopicBroadcastAckMode::First,
             },
             InMemoryBackend,
         )
@@ -1698,6 +1712,7 @@ async fn broadcast_only_rejects_balanced() {
             TopicOptions::BroadcastOnly {
                 capacity: TopicOptions::DEFAULT_BROADCAST_CAPACITY,
                 on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                ack_mode: TopicBroadcastAckMode::First,
             },
             InMemoryBackend,
         )
@@ -1726,6 +1741,7 @@ async fn broadcast_only_lag_reported() {
             TopicOptions::BroadcastOnly {
                 capacity: 8,
                 on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                ack_mode: TopicBroadcastAckMode::First,
             },
             InMemoryBackend,
         )
@@ -1823,6 +1839,7 @@ async fn tracked_publish_broadcast_mode() {
             TopicOptions::BroadcastOnly {
                 capacity: 1024,
                 on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                ack_mode: TopicBroadcastAckMode::First,
             },
             InMemoryBackend,
         )
@@ -1894,6 +1911,7 @@ async fn try_publish_mixed_rejects_broadcast_when_balanced_is_full() {
                 balanced_capacity: 1,
                 broadcast_capacity: 8,
                 on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                ack_mode: TopicBroadcastAckMode::First,
             },
             InMemoryBackend,
         )
@@ -2161,6 +2179,247 @@ async fn tracked_publish_tracker_register_after_close_resolves_immediately() {
         receipt.wait_for_outcome().await,
         TrackedPublishOutcome::TopicClosed
     );
+}
+
+// =========================================================================
+// TrackedPublishTracker quorum (`all`-mode) primitives
+//
+// These exercise the tracker primitive directly
+// =========================================================================
+
+fn quorum_permit_from(sem: &Arc<Semaphore>) -> TrackedPublishPermit {
+    TrackedPublishPermit::from_tokio_owned(
+        sem.clone()
+            .try_acquire_owned()
+            .expect("semaphore permit available"),
+    )
+}
+
+fn quorum_permit() -> TrackedPublishPermit {
+    quorum_permit_from(&Arc::new(Semaphore::new(1)))
+}
+
+fn subscriber_set(ids: impl IntoIterator<Item = u64>) -> HashSet<SubscriberId> {
+    ids.into_iter().map(SubscriberId).collect()
+}
+
+// A quorum entry resolves as Ack only once every required subscriber has acked,
+// and further acks for that message are no longer tracked.
+#[tokio::test]
+async fn quorum_resolves_ack_only_after_all_subscribers_ack() {
+    let tracker = TrackedPublishTracker::new();
+    let receipt = tracker.register_quorum(
+        7,
+        Duration::from_secs(30),
+        quorum_permit(),
+        subscriber_set([1, 2]),
+    );
+
+    assert_eq!(
+        tracker.resolve_ack_from(7, SubscriberId(1)),
+        AckFromResult::StillPending
+    );
+    assert_eq!(
+        tracker.resolve_ack_from(7, SubscriberId(2)),
+        AckFromResult::Resolved
+    );
+    assert_eq!(receipt.wait_for_outcome().await, TrackedPublishOutcome::Ack);
+
+    assert_eq!(
+        tracker.resolve_ack_from(7, SubscriberId(1)),
+        AckFromResult::NotTracked
+    );
+}
+
+// A repeated ack from the same subscriber must not falsely complete the quorum.
+#[tokio::test]
+async fn quorum_duplicate_ack_does_not_complete() {
+    let tracker = TrackedPublishTracker::new();
+    let _receipt = tracker.register_quorum(
+        1,
+        Duration::from_secs(30),
+        quorum_permit(),
+        subscriber_set([1, 2]),
+    );
+
+    assert_eq!(
+        tracker.resolve_ack_from(1, SubscriberId(1)),
+        AckFromResult::StillPending
+    );
+    assert_eq!(
+        tracker.resolve_ack_from(1, SubscriberId(1)),
+        AckFromResult::StillPending
+    );
+    assert_eq!(
+        tracker.resolve_ack_from(1, SubscriberId(2)),
+        AckFromResult::Resolved
+    );
+}
+
+// Zero eligible subscribers resolves immediately as Ack without registering.
+#[tokio::test]
+async fn quorum_empty_set_resolves_ack_immediately() {
+    let tracker = TrackedPublishTracker::new();
+    let receipt =
+        tracker.register_quorum(1, Duration::from_secs(30), quorum_permit(), HashSet::new());
+
+    assert_eq!(receipt.wait_for_outcome().await, TrackedPublishOutcome::Ack);
+    assert_eq!(
+        tracker.resolve_ack_from(1, SubscriberId(1)),
+        AckFromResult::NotTracked
+    );
+}
+
+// Acking an unknown message id is reported as not-tracked.
+#[tokio::test]
+async fn quorum_resolve_ack_from_unknown_message_not_tracked() {
+    let tracker = TrackedPublishTracker::new();
+    assert_eq!(
+        tracker.resolve_ack_from(99, SubscriberId(1)),
+        AckFromResult::NotTracked
+    );
+}
+
+// A required subscriber disappearing nacks its outstanding quorum entries.
+#[tokio::test]
+async fn quorum_subscriber_disappearance_nacks_outstanding() {
+    let tracker = TrackedPublishTracker::new();
+    let receipt = tracker.register_quorum(
+        5,
+        Duration::from_secs(30),
+        quorum_permit(),
+        subscriber_set([1, 2]),
+    );
+
+    tracker.nack_pending_for_subscriber(SubscriberId(2), Arc::from("subscriber disconnected"));
+
+    match receipt.wait_for_outcome().await {
+        TrackedPublishOutcome::Nack { reason } => assert_eq!(&*reason, "subscriber disconnected"),
+        other => panic!("expected Nack, got {other:?}"),
+    }
+    assert_eq!(
+        tracker.resolve_ack_from(5, SubscriberId(1)),
+        AckFromResult::NotTracked
+    );
+}
+
+// Disconnecting a subscriber only nacks entries that still require it.
+#[tokio::test]
+async fn quorum_disappearance_only_nacks_entries_requiring_subscriber() {
+    let tracker = TrackedPublishTracker::new();
+    let r1 = tracker.register_quorum(
+        1,
+        Duration::from_secs(30),
+        quorum_permit(),
+        subscriber_set([1]),
+    );
+    let r2 = tracker.register_quorum(
+        2,
+        Duration::from_secs(30),
+        quorum_permit(),
+        subscriber_set([2]),
+    );
+
+    tracker.nack_pending_for_subscriber(SubscriberId(1), Arc::from("gone"));
+
+    assert!(matches!(
+        r1.wait_for_outcome().await,
+        TrackedPublishOutcome::Nack { .. }
+    ));
+    assert_eq!(
+        tracker.resolve_ack_from(2, SubscriberId(2)),
+        AckFromResult::Resolved
+    );
+    assert_eq!(r2.wait_for_outcome().await, TrackedPublishOutcome::Ack);
+}
+
+// A single Nack via the standard resolve path overrides an incomplete quorum.
+#[tokio::test]
+async fn quorum_single_resolve_nack_overrides_quorum() {
+    let tracker = TrackedPublishTracker::new();
+    let receipt = tracker.register_quorum(
+        1,
+        Duration::from_secs(30),
+        quorum_permit(),
+        subscriber_set([1, 2]),
+    );
+
+    assert_eq!(
+        tracker.resolve_ack_from(1, SubscriberId(1)),
+        AckFromResult::StillPending
+    );
+    assert!(tracker.resolve(
+        1,
+        TrackedPublishOutcome::Nack {
+            reason: Arc::from("boom")
+        }
+    ));
+    assert!(matches!(
+        receipt.wait_for_outcome().await,
+        TrackedPublishOutcome::Nack { .. }
+    ));
+    assert_eq!(
+        tracker.resolve_ack_from(1, SubscriberId(2)),
+        AckFromResult::NotTracked
+    );
+}
+
+// First terminal transition wins: an ack that completes the quorum makes a
+// later disconnect of the (already satisfied) subscriber a no-op.
+#[tokio::test]
+async fn quorum_ack_completion_beats_late_disconnect() {
+    let tracker = TrackedPublishTracker::new();
+    let receipt = tracker.register_quorum(
+        1,
+        Duration::from_secs(30),
+        quorum_permit(),
+        subscriber_set([1]),
+    );
+
+    assert_eq!(
+        tracker.resolve_ack_from(1, SubscriberId(1)),
+        AckFromResult::Resolved
+    );
+    tracker.nack_pending_for_subscriber(SubscriberId(1), Arc::from("late"));
+    assert_eq!(receipt.wait_for_outcome().await, TrackedPublishOutcome::Ack);
+}
+
+// Registering a quorum entry against a closed tracker resolves immediately.
+#[tokio::test]
+async fn quorum_register_after_close_resolves_topic_closed() {
+    let tracker = TrackedPublishTracker::new();
+    tracker.close_all();
+    let receipt = tracker.register_quorum(
+        1,
+        Duration::from_secs(30),
+        quorum_permit(),
+        subscriber_set([1]),
+    );
+    assert_eq!(
+        receipt.wait_for_outcome().await,
+        TrackedPublishOutcome::TopicClosed
+    );
+}
+
+// The in-flight permit is released exactly once the quorum entry resolves.
+#[tokio::test]
+async fn quorum_releases_permit_on_resolution() {
+    let sem = Arc::new(Semaphore::new(1));
+    let tracker = TrackedPublishTracker::new();
+    let receipt = tracker.register_quorum(
+        1,
+        Duration::from_secs(30),
+        quorum_permit_from(&sem),
+        subscriber_set([1]),
+    );
+
+    assert_eq!(sem.available_permits(), 0);
+    assert_eq!(
+        tracker.resolve_ack_from(1, SubscriberId(1)),
+        AckFromResult::Resolved
+    );
+    let _ = receipt.wait_for_outcome().await;
+    assert_eq!(sem.available_permits(), 1);
 }
 
 // =========================================================================

--- a/rust/otap-dataflow/crates/engine/src/topic/tests.rs
+++ b/rust/otap-dataflow/crates/engine/src/topic/tests.rs
@@ -27,7 +27,7 @@ use crate::error::Error;
 use crate::topic::backend::{InMemoryBackend, SubscriptionBackend};
 use crate::topic::subscription::{DeliveryBackend, DeliveryStorageKind};
 use crate::topic::types::{
-    AckFromResult, Envelope, PublishOutcome, RecvItem, SubscriberId, SubscriberOptions,
+    AckFromResult, Envelope, PublishOutcome, RecvItem, BroadcastSubscriberId, SubscriberOptions,
     SubscriptionMode, TopicOptions, TopicPublishOutcomeConfig, TrackedPublishOutcome,
     TrackedPublishPermit, TrackedPublishTracker, TrackedTryPublishOutcome,
 };
@@ -2199,8 +2199,8 @@ fn quorum_permit() -> TrackedPublishPermit {
     quorum_permit_from(&Arc::new(Semaphore::new(1)))
 }
 
-fn subscriber_set(ids: impl IntoIterator<Item = u64>) -> HashSet<SubscriberId> {
-    ids.into_iter().map(SubscriberId).collect()
+fn subscriber_set(ids: impl IntoIterator<Item = u64>) -> HashSet<BroadcastSubscriberId> {
+    ids.into_iter().map(BroadcastSubscriberId).collect()
 }
 
 // A quorum entry resolves as Ack only once every required subscriber has acked,
@@ -2216,17 +2216,17 @@ async fn quorum_resolves_ack_only_after_all_subscribers_ack() {
     );
 
     assert_eq!(
-        tracker.resolve_ack_from(7, SubscriberId(1)),
+        tracker.resolve_ack_from(7, BroadcastSubscriberId(1)),
         AckFromResult::StillPending
     );
     assert_eq!(
-        tracker.resolve_ack_from(7, SubscriberId(2)),
+        tracker.resolve_ack_from(7, BroadcastSubscriberId(2)),
         AckFromResult::Resolved
     );
     assert_eq!(receipt.wait_for_outcome().await, TrackedPublishOutcome::Ack);
 
     assert_eq!(
-        tracker.resolve_ack_from(7, SubscriberId(1)),
+        tracker.resolve_ack_from(7, BroadcastSubscriberId(1)),
         AckFromResult::NotTracked
     );
 }
@@ -2243,15 +2243,15 @@ async fn quorum_duplicate_ack_does_not_complete() {
     );
 
     assert_eq!(
-        tracker.resolve_ack_from(1, SubscriberId(1)),
+        tracker.resolve_ack_from(1, BroadcastSubscriberId(1)),
         AckFromResult::StillPending
     );
     assert_eq!(
-        tracker.resolve_ack_from(1, SubscriberId(1)),
+        tracker.resolve_ack_from(1, BroadcastSubscriberId(1)),
         AckFromResult::StillPending
     );
     assert_eq!(
-        tracker.resolve_ack_from(1, SubscriberId(2)),
+        tracker.resolve_ack_from(1, BroadcastSubscriberId(2)),
         AckFromResult::Resolved
     );
 }
@@ -2265,7 +2265,7 @@ async fn quorum_empty_set_resolves_ack_immediately() {
 
     assert_eq!(receipt.wait_for_outcome().await, TrackedPublishOutcome::Ack);
     assert_eq!(
-        tracker.resolve_ack_from(1, SubscriberId(1)),
+        tracker.resolve_ack_from(1, BroadcastSubscriberId(1)),
         AckFromResult::NotTracked
     );
 }
@@ -2275,7 +2275,7 @@ async fn quorum_empty_set_resolves_ack_immediately() {
 async fn quorum_resolve_ack_from_unknown_message_not_tracked() {
     let tracker = TrackedPublishTracker::new();
     assert_eq!(
-        tracker.resolve_ack_from(99, SubscriberId(1)),
+        tracker.resolve_ack_from(99, BroadcastSubscriberId(1)),
         AckFromResult::NotTracked
     );
 }
@@ -2291,14 +2291,14 @@ async fn quorum_subscriber_disappearance_nacks_outstanding() {
         subscriber_set([1, 2]),
     );
 
-    tracker.nack_pending_for_subscriber(SubscriberId(2), Arc::from("subscriber disconnected"));
+    tracker.nack_pending_for_subscriber(BroadcastSubscriberId(2), Arc::from("subscriber disconnected"));
 
     match receipt.wait_for_outcome().await {
         TrackedPublishOutcome::Nack { reason } => assert_eq!(&*reason, "subscriber disconnected"),
         other => panic!("expected Nack, got {other:?}"),
     }
     assert_eq!(
-        tracker.resolve_ack_from(5, SubscriberId(1)),
+        tracker.resolve_ack_from(5, BroadcastSubscriberId(1)),
         AckFromResult::NotTracked
     );
 }
@@ -2320,14 +2320,14 @@ async fn quorum_disappearance_only_nacks_entries_requiring_subscriber() {
         subscriber_set([2]),
     );
 
-    tracker.nack_pending_for_subscriber(SubscriberId(1), Arc::from("gone"));
+    tracker.nack_pending_for_subscriber(BroadcastSubscriberId(1), Arc::from("gone"));
 
     assert!(matches!(
         r1.wait_for_outcome().await,
         TrackedPublishOutcome::Nack { .. }
     ));
     assert_eq!(
-        tracker.resolve_ack_from(2, SubscriberId(2)),
+        tracker.resolve_ack_from(2, BroadcastSubscriberId(2)),
         AckFromResult::Resolved
     );
     assert_eq!(r2.wait_for_outcome().await, TrackedPublishOutcome::Ack);
@@ -2345,7 +2345,7 @@ async fn quorum_single_resolve_nack_overrides_quorum() {
     );
 
     assert_eq!(
-        tracker.resolve_ack_from(1, SubscriberId(1)),
+        tracker.resolve_ack_from(1, BroadcastSubscriberId(1)),
         AckFromResult::StillPending
     );
     assert!(tracker.resolve(
@@ -2359,7 +2359,7 @@ async fn quorum_single_resolve_nack_overrides_quorum() {
         TrackedPublishOutcome::Nack { .. }
     ));
     assert_eq!(
-        tracker.resolve_ack_from(1, SubscriberId(2)),
+        tracker.resolve_ack_from(1, BroadcastSubscriberId(2)),
         AckFromResult::NotTracked
     );
 }
@@ -2377,10 +2377,10 @@ async fn quorum_ack_completion_beats_late_disconnect() {
     );
 
     assert_eq!(
-        tracker.resolve_ack_from(1, SubscriberId(1)),
+        tracker.resolve_ack_from(1, BroadcastSubscriberId(1)),
         AckFromResult::Resolved
     );
-    tracker.nack_pending_for_subscriber(SubscriberId(1), Arc::from("late"));
+    tracker.nack_pending_for_subscriber(BroadcastSubscriberId(1), Arc::from("late"));
     assert_eq!(receipt.wait_for_outcome().await, TrackedPublishOutcome::Ack);
 }
 
@@ -2415,7 +2415,7 @@ async fn quorum_releases_permit_on_resolution() {
 
     assert_eq!(sem.available_permits(), 0);
     assert_eq!(
-        tracker.resolve_ack_from(1, SubscriberId(1)),
+        tracker.resolve_ack_from(1, BroadcastSubscriberId(1)),
         AckFromResult::Resolved
     );
     let _ = receipt.wait_for_outcome().await;

--- a/rust/otap-dataflow/crates/engine/src/topic/tests.rs
+++ b/rust/otap-dataflow/crates/engine/src/topic/tests.rs
@@ -2284,6 +2284,22 @@ async fn consensus_resolve_ack_from_unknown_message_not_tracked() {
     );
 }
 
+// resolve_ack_from is consensus-only: a first-wins (`First`-kind) entry reports
+// not-tracked and is left pending, so the first-wins resolve path still works.
+#[tokio::test]
+async fn resolve_ack_from_first_kind_entry_is_not_tracked() {
+    let tracker = TrackedPublishTracker::new();
+    let receipt = tracker.register(1, Duration::from_secs(30), consensus_permit());
+
+    assert_eq!(
+        tracker.resolve_ack_from(1, BroadcastSubscriberId(1)),
+        AckFromResult::NotTracked
+    );
+    // Still pending: the first-wins path resolves it.
+    assert!(tracker.resolve(1, TrackedPublishOutcome::Ack));
+    assert_eq!(receipt.wait_for_outcome().await, TrackedPublishOutcome::Ack);
+}
+
 // A required subscriber disappearing nacks its outstanding consensus entries.
 #[tokio::test]
 async fn consensus_subscriber_disappearance_nacks_outstanding() {

--- a/rust/otap-dataflow/crates/engine/src/topic/tests.rs
+++ b/rust/otap-dataflow/crates/engine/src/topic/tests.rs
@@ -27,7 +27,7 @@ use crate::error::Error;
 use crate::topic::backend::{InMemoryBackend, SubscriptionBackend};
 use crate::topic::subscription::{DeliveryBackend, DeliveryStorageKind};
 use crate::topic::types::{
-    AckFromResult, Envelope, PublishOutcome, RecvItem, BroadcastSubscriberId, SubscriberOptions,
+    AckFromResult, BroadcastSubscriberId, Envelope, PublishOutcome, RecvItem, SubscriberOptions,
     SubscriptionMode, TopicOptions, TopicPublishOutcomeConfig, TrackedPublishOutcome,
     TrackedPublishPermit, TrackedPublishTracker, TrackedTryPublishOutcome,
 };
@@ -2291,7 +2291,10 @@ async fn quorum_subscriber_disappearance_nacks_outstanding() {
         subscriber_set([1, 2]),
     );
 
-    tracker.nack_pending_for_subscriber(BroadcastSubscriberId(2), Arc::from("subscriber disconnected"));
+    tracker.nack_pending_for_subscriber(
+        BroadcastSubscriberId(2),
+        Arc::from("subscriber disconnected"),
+    );
 
     match receipt.wait_for_outcome().await {
         TrackedPublishOutcome::Nack { reason } => assert_eq!(&*reason, "subscriber disconnected"),

--- a/rust/otap-dataflow/crates/engine/src/topic/topic.rs
+++ b/rust/otap-dataflow/crates/engine/src/topic/topic.rs
@@ -166,7 +166,7 @@ impl<T: Send + Sync + 'static> FastBroadcastRing<T> {
     /// [`FastBroadcastRing::reserve_seq`] immediately followed by
     /// [`FastBroadcastRing::commit_slot`]. The two are split so `all`-mode
     /// broadcast publish can reserve the sequence under the subscriber-registry
-    /// lock (to snapshot the exact quorum membership for that sequence) and then
+    /// lock (to snapshot the exact consensus membership for that sequence) and then
     /// perform the heavier slot write plus waker fan-out after releasing the
     /// lock. See `reserve_seq`/`commit_slot` for the reserved-but-uncommitted
     /// window, which is read-safe (readers see `NotReady` and re-park).
@@ -270,7 +270,7 @@ impl<T: Send + Sync + 'static> TopicInner<T> {
                 TopicInner::BalancedOnly(BalancedOnlyTopic::new(name, capacity))
             }
             // TODO(#2252 PR2): honor `ack_mode` here so broadcast topics support
-            // `all` (quorum) resolution. Ignored in PR1 (always behaves as `first`).
+            // `all` (consensus) resolution. Ignored in PR1 (always behaves as `first`).
             TopicOptions::BroadcastOnly {
                 capacity,
                 on_lag,
@@ -1038,7 +1038,7 @@ pub(crate) struct BroadcastSub<T: Send + Sync + 'static> {
     on_lag: TopicBroadcastOnLagPolicy,
     ack_state: AckState,
     // TODO(#2252 PR2): in `all` mode, track this subscriber's identity so its
-    // acks count toward the quorum and its disconnect/drop nacks any messages it
+    // acks count toward the consensus and its disconnect/drop nacks any messages it
     // still owes. `first` mode is unchanged.
 }
 

--- a/rust/otap-dataflow/crates/engine/src/topic/topic.rs
+++ b/rust/otap-dataflow/crates/engine/src/topic/topic.rs
@@ -160,6 +160,16 @@ impl<T: Send + Sync + 'static> FastBroadcastRing<T> {
         }
     }
 
+    /// Publish an envelope: reserve the next sequence, then write its slot.
+    ///
+    /// This is the default (`First`-mode) path and is equivalent to calling
+    /// [`FastBroadcastRing::reserve_seq`] immediately followed by
+    /// [`FastBroadcastRing::commit_slot`]. The two are split so `all`-mode
+    /// broadcast publish can reserve the sequence under the subscriber-registry
+    /// lock (to snapshot the exact quorum membership for that sequence) and then
+    /// perform the heavier slot write plus waker fan-out after releasing the
+    /// lock. See `reserve_seq`/`commit_slot` for the reserved-but-uncommitted
+    /// window, which is read-safe (readers see `NotReady` and re-park).
     pub(crate) fn publish(&self, envelope: Envelope<T>) {
         let seq = self.reserve_seq();
         self.commit_slot(seq, envelope);
@@ -259,11 +269,15 @@ impl<T: Send + Sync + 'static> TopicInner<T> {
             TopicOptions::BalancedOnly { capacity } => {
                 TopicInner::BalancedOnly(BalancedOnlyTopic::new(name, capacity))
             }
+            // TODO(#2252 PR2): honor `ack_mode` here so broadcast topics support
+            // `all` (quorum) resolution. Ignored in PR1 (always behaves as `first`).
             TopicOptions::BroadcastOnly {
                 capacity,
                 on_lag,
                 ack_mode: _,
             } => TopicInner::BroadcastOnly(BroadcastOnlyTopic::new(name, capacity, on_lag)),
+            // `ack_mode` is intentionally ignored for Mixed: PR3 rejects `all` on
+            // any non-broadcast-only topic, so Mixed is always `first`.
             TopicOptions::Mixed {
                 balanced_capacity,
                 broadcast_capacity,
@@ -579,6 +593,9 @@ pub(crate) struct BroadcastOnlyTopic<T: Send + Sync + 'static> {
     broadcast_on_lag: TopicBroadcastOnLagPolicy,
     outcomes: TrackedPublishTracker,
     closed: AtomicBool,
+    // TODO(#2252 PR2): add a broadcast subscriber registry, used only in `all`
+    // mode, to track which subscribers must ack each message. `first` mode never
+    // touches it.
 }
 
 impl<T: Send + Sync + 'static> BroadcastOnlyTopic<T> {
@@ -626,6 +643,8 @@ impl<T: Send + Sync + 'static> BroadcastOnlyTopic<T> {
             return Err(TopicClosed);
         }
 
+        // TODO(#2252 PR2): in `all` mode, record the set of subscribers that must
+        // ack this message before resolving upstream. `first` mode is unchanged.
         let id = self.next_message_id();
         let receipt = self.outcomes.register(id, timeout, permit);
         self.broadcast_ring.publish(Envelope {
@@ -652,6 +671,8 @@ impl<T: Send + Sync + 'static> BroadcastOnlyTopic<T> {
     }
 
     fn subscribe_broadcast(&self, _opts: SubscriberOptions) -> BroadcastSub<T> {
+        // TODO(#2252 PR2): in `all` mode, register this subscriber so it can be
+        // included in the must-ack set of future messages. `first` mode is unchanged.
         let start_seq = self.broadcast_ring.current_seq() + 1;
         BroadcastSub {
             ring: Arc::clone(&self.broadcast_ring),
@@ -1016,6 +1037,9 @@ pub(crate) struct BroadcastSub<T: Send + Sync + 'static> {
     cursor: Arc<Mutex<BroadcastCursor>>,
     on_lag: TopicBroadcastOnLagPolicy,
     ack_state: AckState,
+    // TODO(#2252 PR2): in `all` mode, track this subscriber's identity so its
+    // acks count toward the quorum and its disconnect/drop nacks any messages it
+    // still owes. `first` mode is unchanged.
 }
 
 impl<T: Send + Sync + 'static> SubscriptionBackend<T> for BroadcastSub<T> {
@@ -1115,6 +1139,8 @@ impl<T: Send + Sync + 'static> BroadcastSub<T> {
                 cursor.spun = false;
                 if self.on_lag == TopicBroadcastOnLagPolicy::Disconnect {
                     cursor.disconnected_on_lag = true;
+                    // TODO(#2252 PR2): in `all` mode, a lag-disconnect here must
+                    // nack any messages this subscriber still owes an ack for.
                 }
                 Some(Ok(RecvDelivery::Lagged { missed }))
             }

--- a/rust/otap-dataflow/crates/engine/src/topic/topic.rs
+++ b/rust/otap-dataflow/crates/engine/src/topic/topic.rs
@@ -161,7 +161,28 @@ impl<T: Send + Sync + 'static> FastBroadcastRing<T> {
     }
 
     pub(crate) fn publish(&self, envelope: Envelope<T>) {
-        let seq = self.write_seq.fetch_add(1, Ordering::Release) + 1;
+        let seq = self.reserve_seq();
+        self.commit_slot(seq, envelope);
+    }
+
+    /// Reserve the next ring sequence without writing a slot.
+    ///
+    /// Paired with [`FastBroadcastRing::commit_slot`]. Splitting the reservation
+    /// from the slot write lets `all`-mode broadcast publish reserve the
+    /// sequence under the subscriber-registry lock and perform the (more
+    /// expensive) slot write plus waker fan-out after releasing that lock.
+    ///
+    /// Between a reserve and its matching commit, `write_seq` is advanced but the
+    /// slot is not yet written; [`FastBroadcastRing::try_read`] returns
+    /// [`BroadcastReadResult::NotReady`] for that window and the reader re-parks
+    /// on the waker, which fires from `commit_slot`.
+    pub(crate) fn reserve_seq(&self) -> u64 {
+        self.write_seq.fetch_add(1, Ordering::Release) + 1
+    }
+
+    /// Write the envelope into the slot reserved by [`FastBroadcastRing::reserve_seq`]
+    /// and wake parked readers.
+    pub(crate) fn commit_slot(&self, seq: u64, envelope: Envelope<T>) {
         let idx = ((seq - 1) as usize) & self.mask;
         *self.slots[idx].lock() = Some((seq, envelope));
         self.waker_set.wake_all();
@@ -238,13 +259,16 @@ impl<T: Send + Sync + 'static> TopicInner<T> {
             TopicOptions::BalancedOnly { capacity } => {
                 TopicInner::BalancedOnly(BalancedOnlyTopic::new(name, capacity))
             }
-            TopicOptions::BroadcastOnly { capacity, on_lag } => {
-                TopicInner::BroadcastOnly(BroadcastOnlyTopic::new(name, capacity, on_lag))
-            }
+            TopicOptions::BroadcastOnly {
+                capacity,
+                on_lag,
+                ack_mode: _,
+            } => TopicInner::BroadcastOnly(BroadcastOnlyTopic::new(name, capacity, on_lag)),
             TopicOptions::Mixed {
                 balanced_capacity,
                 broadcast_capacity,
                 on_lag,
+                ack_mode: _,
             } => TopicInner::Mixed(MixedTopic::new(
                 name,
                 balanced_capacity,

--- a/rust/otap-dataflow/crates/engine/src/topic/types.rs
+++ b/rust/otap-dataflow/crates/engine/src/topic/types.rs
@@ -268,8 +268,9 @@ impl TrackedPublishTracker {
     /// Returns [`AckFromResult::Resolved`] if this Ack completed the consensus (the
     /// entry resolved as Ack and was removed), [`AckFromResult::StillPending`] if
     /// the Ack was recorded but other subscribers are still required, or
-    /// [`AckFromResult::NotTracked`] if the message id is unknown or already
-    /// resolved.
+    /// [`AckFromResult::NotTracked`] if the message id is unknown, already
+    /// resolved, or not a consensus (`all`-mode) entry. First-wins (`First`-kind)
+    /// publishes must be resolved via [`TrackedPublishTracker::resolve`] instead.
     ///
     /// Lock order is map -> entry (matching the timeout worker); the entry mutex
     /// is the single linearization point for terminal resolution.
@@ -590,20 +591,16 @@ impl TrackedPublishEntry {
     /// Apply a single subscriber's Ack to a consensus (`all`-mode) entry.
     ///
     /// Removes `subscriber_id` from the pending set; when the set empties the
-    /// entry resolves as Ack. A `First`-kind entry resolves as Ack on the first
-    /// call. Already-resolved entries are left untouched. Idempotent: a repeated
-    /// Ack from the same subscriber never falsely completes the consensus.
+    /// entry resolves as Ack. This is the consensus (`all`-mode) path only: a
+    /// `First`-kind entry returns [`AckFromResult::NotTracked`] (first-wins
+    /// callers must use the tracker's `resolve(message_id, Ack)` instead).
+    /// Already-resolved entries are left untouched. Idempotent: a repeated Ack
+    /// from the same subscriber never falsely completes the consensus.
     pub(crate) fn resolve_ack_from(&self, subscriber_id: BroadcastSubscriberId) -> AckFromResult {
         let mut state = self.state.lock();
         match &mut *state {
             TrackedPublishState::Resolved(_) => AckFromResult::NotTracked,
-            TrackedPublishState::Pending(PendingKind::First) => {
-                *state = TrackedPublishState::Resolved(TrackedPublishOutcome::Ack);
-                drop(state);
-                _ = self.permit.lock().take();
-                self.notify.notify_waiters();
-                AckFromResult::Resolved
-            }
+            TrackedPublishState::Pending(PendingKind::First) => AckFromResult::NotTracked,
             TrackedPublishState::Pending(PendingKind::All { pending }) => {
                 let _ = pending.remove(&subscriber_id);
                 if pending.is_empty() {

--- a/rust/otap-dataflow/crates/engine/src/topic/types.rs
+++ b/rust/otap-dataflow/crates/engine/src/topic/types.rs
@@ -274,7 +274,11 @@ impl TrackedPublishTracker {
     /// Lock order is map -> entry (matching the timeout worker); the entry mutex
     /// is the single linearization point for terminal resolution.
     #[must_use]
-    pub fn resolve_ack_from(&self, message_id: u64, subscriber_id: BroadcastSubscriberId) -> AckFromResult {
+    pub fn resolve_ack_from(
+        &self,
+        message_id: u64,
+        subscriber_id: BroadcastSubscriberId,
+    ) -> AckFromResult {
         let mut entries = self.inner.entries.lock();
         let Some(entry) = entries.get(&message_id).cloned() else {
             return AckFromResult::NotTracked;
@@ -297,7 +301,11 @@ impl TrackedPublishTracker {
     /// Called when a required subscriber disappears (lag-disconnect or
     /// drop/close) before acking outstanding messages. Idempotent and a no-op
     /// for entries that do not require the subscriber.
-    pub fn nack_pending_for_subscriber(&self, subscriber_id: BroadcastSubscriberId, reason: Arc<str>) {
+    pub fn nack_pending_for_subscriber(
+        &self,
+        subscriber_id: BroadcastSubscriberId,
+        reason: Arc<str>,
+    ) {
         let mut entries = self.inner.entries.lock();
         let to_remove: Vec<u64> = entries
             .iter()
@@ -617,7 +625,11 @@ impl TrackedPublishEntry {
     /// Used when a required subscriber disappears (lag-disconnect or drop/close)
     /// before acking. No-op for `First`-kind, already-resolved, or unrelated
     /// entries.
-    pub(crate) fn nack_if_requires(&self, subscriber_id: BroadcastSubscriberId, reason: Arc<str>) -> bool {
+    pub(crate) fn nack_if_requires(
+        &self,
+        subscriber_id: BroadcastSubscriberId,
+        reason: Arc<str>,
+    ) -> bool {
         let mut state = self.state.lock();
         let requires = matches!(
             &*state,

--- a/rust/otap-dataflow/crates/engine/src/topic/types.rs
+++ b/rust/otap-dataflow/crates/engine/src/topic/types.rs
@@ -197,7 +197,7 @@ impl TrackedPublishTracker {
         TrackedPublishReceipt::new(message_id, entry)
     }
 
-    /// Register one tracked publish that resolves via `all`-mode quorum.
+    /// Register one tracked publish that resolves via `all`-mode consensus.
     ///
     /// The entry resolves as Ack only once every subscriber in `pending` has
     /// acked (via [`TrackedPublishTracker::resolve_ack_from`]); a Nack or a
@@ -212,9 +212,9 @@ impl TrackedPublishTracker {
     /// As with [`TrackedPublishTracker::register`], a closed tracker resolves the
     /// returned receipt immediately as [`TrackedPublishOutcome::TopicClosed`].
     ///
-    // TODO(#2252 PR2): this quorum API is unit-tested but has no engine caller
+    // TODO(#2252 PR2): this consensus API is unit-tested but has no engine caller
     // yet; it gets wired into broadcast publish/ack/disconnect in PR2.
-    pub fn register_quorum(
+    pub fn register_consensus(
         &self,
         message_id: u64,
         timeout: Duration,
@@ -222,7 +222,7 @@ impl TrackedPublishTracker {
         pending: HashSet<BroadcastSubscriberId>,
     ) -> TrackedPublishReceipt {
         if self.inner.closed.load(Ordering::Acquire) {
-            let entry = Arc::new(TrackedPublishEntry::new_quorum(
+            let entry = Arc::new(TrackedPublishEntry::new_consensus(
                 Instant::now(),
                 permit,
                 pending,
@@ -232,7 +232,7 @@ impl TrackedPublishTracker {
         }
 
         if pending.is_empty() {
-            let entry = Arc::new(TrackedPublishEntry::new_quorum(
+            let entry = Arc::new(TrackedPublishEntry::new_consensus(
                 Instant::now(),
                 permit,
                 pending,
@@ -242,7 +242,7 @@ impl TrackedPublishTracker {
         }
 
         self.ensure_timeout_worker();
-        let entry = Arc::new(TrackedPublishEntry::new_quorum(
+        let entry = Arc::new(TrackedPublishEntry::new_consensus(
             Instant::now() + timeout,
             permit,
             pending,
@@ -265,7 +265,7 @@ impl TrackedPublishTracker {
 
     /// Apply a single broadcast subscriber's Ack to an `all`-mode tracked publish.
     ///
-    /// Returns [`AckFromResult::Resolved`] if this Ack completed the quorum (the
+    /// Returns [`AckFromResult::Resolved`] if this Ack completed the consensus (the
     /// entry resolved as Ack and was removed), [`AckFromResult::StillPending`] if
     /// the Ack was recorded but other subscribers are still required, or
     /// [`AckFromResult::NotTracked`] if the message id is unknown or already
@@ -498,15 +498,15 @@ impl TrackedPublishReceipt {
 /// Unique identifier for a broadcast subscriber within a single topic.
 ///
 /// Allocated by the broadcast-only topic's subscriber registry and used by the
-/// tracked publish tracker to drive `all`-mode quorum aggregation.
+/// tracked publish tracker to drive `all`-mode consensus aggregation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct BroadcastSubscriberId(pub u64);
 
 /// Outcome of applying a single broadcast subscriber's Ack to a tracked publish
-/// in `all` (quorum) mode.
+/// in `all` (consensus) mode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AckFromResult {
-    /// This Ack completed the quorum; the entry resolved as Ack.
+    /// This Ack completed the consensus; the entry resolved as Ack.
     Resolved,
     /// The Ack was recorded but other required subscribers are still pending.
     StillPending,
@@ -519,7 +519,7 @@ enum PendingKind {
     /// The first terminal resolution wins. Used by normal tracked publishes and
     /// by `first`-mode broadcast. The tracker does not track per-subscriber acks.
     First,
-    /// Quorum aggregation: the entry resolves as Ack only once every subscriber
+    /// Consensus aggregation: the entry resolves as Ack only once every subscriber
     /// in `pending` has acked. Any Nack or required-subscriber disappearance
     /// resolves it as Nack.
     All {
@@ -552,7 +552,7 @@ impl TrackedPublishEntry {
         }
     }
 
-    pub(crate) fn new_quorum(
+    pub(crate) fn new_consensus(
         deadline: Instant,
         permit: TrackedPublishPermit,
         pending: HashSet<BroadcastSubscriberId>,
@@ -587,12 +587,12 @@ impl TrackedPublishEntry {
         true
     }
 
-    /// Apply a single subscriber's Ack to a quorum (`all`-mode) entry.
+    /// Apply a single subscriber's Ack to a consensus (`all`-mode) entry.
     ///
     /// Removes `subscriber_id` from the pending set; when the set empties the
     /// entry resolves as Ack. A `First`-kind entry resolves as Ack on the first
     /// call. Already-resolved entries are left untouched. Idempotent: a repeated
-    /// Ack from the same subscriber never falsely completes the quorum.
+    /// Ack from the same subscriber never falsely completes the consensus.
     pub(crate) fn resolve_ack_from(&self, subscriber_id: BroadcastSubscriberId) -> AckFromResult {
         let mut state = self.state.lock();
         match &mut *state {
@@ -619,7 +619,7 @@ impl TrackedPublishEntry {
         }
     }
 
-    /// Resolve a quorum (`all`-mode) entry as Nack if it still requires
+    /// Resolve a consensus (`all`-mode) entry as Nack if it still requires
     /// `subscriber_id`. Returns `true` if this call resolved the entry.
     ///
     /// Used when a required subscriber disappears (lag-disconnect or drop/close)

--- a/rust/otap-dataflow/crates/engine/src/topic/types.rs
+++ b/rust/otap-dataflow/crates/engine/src/topic/types.rs
@@ -211,6 +211,9 @@ impl TrackedPublishTracker {
     ///
     /// As with [`TrackedPublishTracker::register`], a closed tracker resolves the
     /// returned receipt immediately as [`TrackedPublishOutcome::TopicClosed`].
+    ///
+    // TODO(#2252 PR2): this quorum API is unit-tested but has no engine caller
+    // yet; it gets wired into broadcast publish/ack/disconnect in PR2.
     pub fn register_quorum(
         &self,
         message_id: u64,

--- a/rust/otap-dataflow/crates/engine/src/topic/types.rs
+++ b/rust/otap-dataflow/crates/engine/src/topic/types.rs
@@ -219,7 +219,7 @@ impl TrackedPublishTracker {
         message_id: u64,
         timeout: Duration,
         permit: TrackedPublishPermit,
-        pending: HashSet<SubscriberId>,
+        pending: HashSet<BroadcastSubscriberId>,
     ) -> TrackedPublishReceipt {
         if self.inner.closed.load(Ordering::Acquire) {
             let entry = Arc::new(TrackedPublishEntry::new_quorum(
@@ -274,17 +274,20 @@ impl TrackedPublishTracker {
     /// Lock order is map -> entry (matching the timeout worker); the entry mutex
     /// is the single linearization point for terminal resolution.
     #[must_use]
-    pub fn resolve_ack_from(&self, message_id: u64, subscriber_id: SubscriberId) -> AckFromResult {
+    pub fn resolve_ack_from(&self, message_id: u64, subscriber_id: BroadcastSubscriberId) -> AckFromResult {
         let mut entries = self.inner.entries.lock();
         let Some(entry) = entries.get(&message_id).cloned() else {
             return AckFromResult::NotTracked;
         };
         let result = entry.resolve_ack_from(subscriber_id);
-        if matches!(result, AckFromResult::Resolved) {
+        let resolved = matches!(result, AckFromResult::Resolved);
+        if resolved {
             let _ = entries.remove(&message_id);
         }
         drop(entries);
-        self.inner.wakeups.notify_one();
+        if resolved {
+            self.inner.wakeups.notify_one();
+        }
         result
     }
 
@@ -294,7 +297,7 @@ impl TrackedPublishTracker {
     /// Called when a required subscriber disappears (lag-disconnect or
     /// drop/close) before acking outstanding messages. Idempotent and a no-op
     /// for entries that do not require the subscriber.
-    pub fn nack_pending_for_subscriber(&self, subscriber_id: SubscriberId, reason: Arc<str>) {
+    pub fn nack_pending_for_subscriber(&self, subscriber_id: BroadcastSubscriberId, reason: Arc<str>) {
         let mut entries = self.inner.entries.lock();
         let to_remove: Vec<u64> = entries
             .iter()
@@ -489,7 +492,7 @@ impl TrackedPublishReceipt {
 /// Allocated by the broadcast-only topic's subscriber registry and used by the
 /// tracked publish tracker to drive `all`-mode quorum aggregation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct SubscriberId(pub u64);
+pub struct BroadcastSubscriberId(pub u64);
 
 /// Outcome of applying a single broadcast subscriber's Ack to a tracked publish
 /// in `all` (quorum) mode.
@@ -513,7 +516,7 @@ enum PendingKind {
     /// resolves it as Nack.
     All {
         /// Subscribers eligible at publish time that have not yet acked.
-        pending: HashSet<SubscriberId>,
+        pending: HashSet<BroadcastSubscriberId>,
     },
 }
 
@@ -544,7 +547,7 @@ impl TrackedPublishEntry {
     pub(crate) fn new_quorum(
         deadline: Instant,
         permit: TrackedPublishPermit,
-        pending: HashSet<SubscriberId>,
+        pending: HashSet<BroadcastSubscriberId>,
     ) -> Self {
         Self {
             state: Mutex::new(TrackedPublishState::Pending(PendingKind::All { pending })),
@@ -582,7 +585,7 @@ impl TrackedPublishEntry {
     /// entry resolves as Ack. A `First`-kind entry resolves as Ack on the first
     /// call. Already-resolved entries are left untouched. Idempotent: a repeated
     /// Ack from the same subscriber never falsely completes the quorum.
-    pub(crate) fn resolve_ack_from(&self, subscriber_id: SubscriberId) -> AckFromResult {
+    pub(crate) fn resolve_ack_from(&self, subscriber_id: BroadcastSubscriberId) -> AckFromResult {
         let mut state = self.state.lock();
         match &mut *state {
             TrackedPublishState::Resolved(_) => AckFromResult::NotTracked,
@@ -614,7 +617,7 @@ impl TrackedPublishEntry {
     /// Used when a required subscriber disappears (lag-disconnect or drop/close)
     /// before acking. No-op for `First`-kind, already-resolved, or unrelated
     /// entries.
-    pub(crate) fn nack_if_requires(&self, subscriber_id: SubscriberId, reason: Arc<str>) -> bool {
+    pub(crate) fn nack_if_requires(&self, subscriber_id: BroadcastSubscriberId, reason: Arc<str>) -> bool {
         let mut state = self.state.lock();
         let requires = matches!(
             &*state,

--- a/rust/otap-dataflow/crates/engine/src/topic/types.rs
+++ b/rust/otap-dataflow/crates/engine/src/topic/types.rs
@@ -4,10 +4,10 @@
 //! Core value types shared across the topic crate.
 
 use otap_df_config::SubscriptionGroupName;
-use otap_df_config::topic::TopicBroadcastOnLagPolicy;
+use otap_df_config::topic::{TopicBroadcastAckMode, TopicBroadcastOnLagPolicy};
 use otap_df_telemetry::otel_warn;
 use parking_lot::Mutex;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
@@ -197,6 +197,120 @@ impl TrackedPublishTracker {
         TrackedPublishReceipt::new(message_id, entry)
     }
 
+    /// Register one tracked publish that resolves via `all`-mode quorum.
+    ///
+    /// The entry resolves as Ack only once every subscriber in `pending` has
+    /// acked (via [`TrackedPublishTracker::resolve_ack_from`]); a Nack or a
+    /// required subscriber disappearing (via
+    /// [`TrackedPublishTracker::nack_pending_for_subscriber`]) resolves it as
+    /// Nack. `pending` must be non-empty; callers resolve the zero-subscriber
+    /// case as an immediate Ack without registering.
+    ///
+    /// As a defensive measure the primitive also resolves an empty `pending` set
+    /// immediately as Ack (without registering or arming a timeout).
+    ///
+    /// As with [`TrackedPublishTracker::register`], a closed tracker resolves the
+    /// returned receipt immediately as [`TrackedPublishOutcome::TopicClosed`].
+    pub fn register_quorum(
+        &self,
+        message_id: u64,
+        timeout: Duration,
+        permit: TrackedPublishPermit,
+        pending: HashSet<SubscriberId>,
+    ) -> TrackedPublishReceipt {
+        if self.inner.closed.load(Ordering::Acquire) {
+            let entry = Arc::new(TrackedPublishEntry::new_quorum(
+                Instant::now(),
+                permit,
+                pending,
+            ));
+            let _resolved = entry.resolve(TrackedPublishOutcome::TopicClosed);
+            return TrackedPublishReceipt::new(message_id, entry);
+        }
+
+        if pending.is_empty() {
+            let entry = Arc::new(TrackedPublishEntry::new_quorum(
+                Instant::now(),
+                permit,
+                pending,
+            ));
+            let _resolved = entry.resolve(TrackedPublishOutcome::Ack);
+            return TrackedPublishReceipt::new(message_id, entry);
+        }
+
+        self.ensure_timeout_worker();
+        let entry = Arc::new(TrackedPublishEntry::new_quorum(
+            Instant::now() + timeout,
+            permit,
+            pending,
+        ));
+        let replaced = self
+            .inner
+            .entries
+            .lock()
+            .insert(message_id, Arc::clone(&entry));
+        if replaced.is_some() {
+            otel_warn!(
+                "topic.tracked_publish.duplicate_message_id",
+                message_id = message_id,
+                message = "Tracked publish tracker registered a duplicate message id and overwrote the previous entry"
+            );
+        }
+        self.inner.wakeups.notify_one();
+        TrackedPublishReceipt::new(message_id, entry)
+    }
+
+    /// Apply a single broadcast subscriber's Ack to an `all`-mode tracked publish.
+    ///
+    /// Returns [`AckFromResult::Resolved`] if this Ack completed the quorum (the
+    /// entry resolved as Ack and was removed), [`AckFromResult::StillPending`] if
+    /// the Ack was recorded but other subscribers are still required, or
+    /// [`AckFromResult::NotTracked`] if the message id is unknown or already
+    /// resolved.
+    ///
+    /// Lock order is map -> entry (matching the timeout worker); the entry mutex
+    /// is the single linearization point for terminal resolution.
+    #[must_use]
+    pub fn resolve_ack_from(&self, message_id: u64, subscriber_id: SubscriberId) -> AckFromResult {
+        let mut entries = self.inner.entries.lock();
+        let Some(entry) = entries.get(&message_id).cloned() else {
+            return AckFromResult::NotTracked;
+        };
+        let result = entry.resolve_ack_from(subscriber_id);
+        if matches!(result, AckFromResult::Resolved) {
+            let _ = entries.remove(&message_id);
+        }
+        drop(entries);
+        self.inner.wakeups.notify_one();
+        result
+    }
+
+    /// Resolve every pending `all`-mode entry that still requires
+    /// `subscriber_id` as Nack with `reason`.
+    ///
+    /// Called when a required subscriber disappears (lag-disconnect or
+    /// drop/close) before acking outstanding messages. Idempotent and a no-op
+    /// for entries that do not require the subscriber.
+    pub fn nack_pending_for_subscriber(&self, subscriber_id: SubscriberId, reason: Arc<str>) {
+        let mut entries = self.inner.entries.lock();
+        let to_remove: Vec<u64> = entries
+            .iter()
+            .filter_map(|(id, entry)| {
+                entry
+                    .nack_if_requires(subscriber_id, Arc::clone(&reason))
+                    .then_some(*id)
+            })
+            .collect();
+        for id in &to_remove {
+            let _ = entries.remove(id);
+        }
+        let resolved_any = !to_remove.is_empty();
+        drop(entries);
+        if resolved_any {
+            self.inner.wakeups.notify_one();
+        }
+    }
+
     /// Resolve one tracked publish by message id.
     ///
     /// Returns `true` if this call resolved a pending publish. Returns `false`
@@ -367,9 +481,42 @@ impl TrackedPublishReceipt {
     }
 }
 
+/// Unique identifier for a broadcast subscriber within a single topic.
+///
+/// Allocated by the broadcast-only topic's subscriber registry and used by the
+/// tracked publish tracker to drive `all`-mode quorum aggregation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SubscriberId(pub u64);
+
+/// Outcome of applying a single broadcast subscriber's Ack to a tracked publish
+/// in `all` (quorum) mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AckFromResult {
+    /// This Ack completed the quorum; the entry resolved as Ack.
+    Resolved,
+    /// The Ack was recorded but other required subscribers are still pending.
+    StillPending,
+    /// The message was not tracked (already resolved, timed out, or unknown id).
+    NotTracked,
+}
+
+#[derive(Debug, Clone)]
+enum PendingKind {
+    /// The first terminal resolution wins. Used by normal tracked publishes and
+    /// by `first`-mode broadcast. The tracker does not track per-subscriber acks.
+    First,
+    /// Quorum aggregation: the entry resolves as Ack only once every subscriber
+    /// in `pending` has acked. Any Nack or required-subscriber disappearance
+    /// resolves it as Nack.
+    All {
+        /// Subscribers eligible at publish time that have not yet acked.
+        pending: HashSet<SubscriberId>,
+    },
+}
+
 #[derive(Debug, Clone)]
 enum TrackedPublishState {
-    Pending,
+    Pending(PendingKind),
     Resolved(TrackedPublishOutcome),
 }
 
@@ -384,7 +531,20 @@ pub(crate) struct TrackedPublishEntry {
 impl TrackedPublishEntry {
     pub(crate) fn new(deadline: Instant, permit: TrackedPublishPermit) -> Self {
         Self {
-            state: Mutex::new(TrackedPublishState::Pending),
+            state: Mutex::new(TrackedPublishState::Pending(PendingKind::First)),
+            deadline,
+            permit: Mutex::new(Some(permit)),
+            notify: Notify::new(),
+        }
+    }
+
+    pub(crate) fn new_quorum(
+        deadline: Instant,
+        permit: TrackedPublishPermit,
+        pending: HashSet<SubscriberId>,
+    ) -> Self {
+        Self {
+            state: Mutex::new(TrackedPublishState::Pending(PendingKind::All { pending })),
             deadline,
             permit: Mutex::new(Some(permit)),
             notify: Notify::new(),
@@ -398,7 +558,7 @@ impl TrackedPublishEntry {
 
     #[must_use]
     pub(crate) fn is_pending(&self) -> bool {
-        matches!(*self.state.lock(), TrackedPublishState::Pending)
+        matches!(*self.state.lock(), TrackedPublishState::Pending(_))
     }
 
     pub(crate) fn resolve(&self, outcome: TrackedPublishOutcome) -> bool {
@@ -407,6 +567,61 @@ impl TrackedPublishEntry {
             return false;
         }
         *state = TrackedPublishState::Resolved(outcome);
+        drop(state);
+        _ = self.permit.lock().take();
+        self.notify.notify_waiters();
+        true
+    }
+
+    /// Apply a single subscriber's Ack to a quorum (`all`-mode) entry.
+    ///
+    /// Removes `subscriber_id` from the pending set; when the set empties the
+    /// entry resolves as Ack. A `First`-kind entry resolves as Ack on the first
+    /// call. Already-resolved entries are left untouched. Idempotent: a repeated
+    /// Ack from the same subscriber never falsely completes the quorum.
+    pub(crate) fn resolve_ack_from(&self, subscriber_id: SubscriberId) -> AckFromResult {
+        let mut state = self.state.lock();
+        match &mut *state {
+            TrackedPublishState::Resolved(_) => AckFromResult::NotTracked,
+            TrackedPublishState::Pending(PendingKind::First) => {
+                *state = TrackedPublishState::Resolved(TrackedPublishOutcome::Ack);
+                drop(state);
+                _ = self.permit.lock().take();
+                self.notify.notify_waiters();
+                AckFromResult::Resolved
+            }
+            TrackedPublishState::Pending(PendingKind::All { pending }) => {
+                let _ = pending.remove(&subscriber_id);
+                if pending.is_empty() {
+                    *state = TrackedPublishState::Resolved(TrackedPublishOutcome::Ack);
+                    drop(state);
+                    _ = self.permit.lock().take();
+                    self.notify.notify_waiters();
+                    AckFromResult::Resolved
+                } else {
+                    AckFromResult::StillPending
+                }
+            }
+        }
+    }
+
+    /// Resolve a quorum (`all`-mode) entry as Nack if it still requires
+    /// `subscriber_id`. Returns `true` if this call resolved the entry.
+    ///
+    /// Used when a required subscriber disappears (lag-disconnect or drop/close)
+    /// before acking. No-op for `First`-kind, already-resolved, or unrelated
+    /// entries.
+    pub(crate) fn nack_if_requires(&self, subscriber_id: SubscriberId, reason: Arc<str>) -> bool {
+        let mut state = self.state.lock();
+        let requires = matches!(
+            &*state,
+            TrackedPublishState::Pending(PendingKind::All { pending })
+                if pending.contains(&subscriber_id)
+        );
+        if !requires {
+            return false;
+        }
+        *state = TrackedPublishState::Resolved(TrackedPublishOutcome::Nack { reason });
         drop(state);
         _ = self.permit.lock().take();
         self.notify.notify_waiters();
@@ -425,7 +640,7 @@ impl TrackedPublishEntry {
 
     fn current_outcome(&self) -> Option<TrackedPublishOutcome> {
         match &*self.state.lock() {
-            TrackedPublishState::Pending => None,
+            TrackedPublishState::Pending(_) => None,
             TrackedPublishState::Resolved(outcome) => Some(outcome.clone()),
         }
     }
@@ -461,6 +676,8 @@ pub enum TopicOptions {
         capacity: usize,
         /// Behavior when a broadcast subscriber falls behind the retained ring window.
         on_lag: TopicBroadcastOnLagPolicy,
+        /// Aggregation mode for tracked broadcast Ack/Nack resolution.
+        ack_mode: TopicBroadcastAckMode,
     },
     /// Both balanced and broadcast subscriptions.
     Mixed {
@@ -470,6 +687,8 @@ pub enum TopicOptions {
         broadcast_capacity: usize,
         /// Behavior when a broadcast subscriber falls behind the retained ring window.
         on_lag: TopicBroadcastOnLagPolicy,
+        /// Aggregation mode for tracked broadcast Ack/Nack resolution.
+        ack_mode: TopicBroadcastAckMode,
     },
 }
 
@@ -486,6 +705,7 @@ impl Default for TopicOptions {
             balanced_capacity: TopicOptions::DEFAULT_BALANCED_CAPACITY,
             broadcast_capacity: TopicOptions::DEFAULT_BROADCAST_CAPACITY,
             on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+            ack_mode: TopicBroadcastAckMode::First,
         }
     }
 }

--- a/rust/otap-dataflow/crates/otap/tests/topic_pipeline_flow_tests.rs
+++ b/rust/otap-dataflow/crates/otap/tests/topic_pipeline_flow_tests.rs
@@ -19,7 +19,9 @@ use otap_df_engine::message::{Receiver as PDataReceiver, Sender as PDataSender};
 use otap_df_engine::node::{NodeWithPDataReceiver, NodeWithPDataSender};
 use otap_df_engine::testing::exporter::create_test_pipeline_context;
 use otap_df_engine::testing::{create_not_send_channel, setup_test_runtime, test_node};
-use otap_df_engine::topic::{TopicBroadcastOnLagPolicy, TopicBroker, TopicOptions, TopicSet};
+use otap_df_engine::topic::{
+    TopicBroadcastAckMode, TopicBroadcastOnLagPolicy, TopicBroker, TopicOptions, TopicSet,
+};
 use otap_df_otap::pdata::OtapPdata;
 use otap_df_pdata::OtlpProtoBytes;
 use otap_df_telemetry::reporter::MetricsReporter;
@@ -48,6 +50,7 @@ fn topic_exporter_to_topic_receiver_transfers_pdata() {
                     balanced_capacity: 16,
                     broadcast_capacity: 16,
                     on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                    ack_mode: TopicBroadcastAckMode::First,
                 },
             )
             .expect("topic should be created");
@@ -200,6 +203,7 @@ fn topic_receiver_applies_source_tag_when_enabled() {
                     balanced_capacity: 16,
                     broadcast_capacity: 16,
                     on_lag: TopicBroadcastOnLagPolicy::DropOldest,
+                    ack_mode: TopicBroadcastAckMode::First,
                 },
             )
             .expect("topic should be created");


### PR DESCRIPTION
> Copy of #3250, recreated after a bad rebase

# Change Summary

Part of #2252. First of three independently shippable PRs adding a broadcast `all` ack mode for topic hops.

## Why

Today a broadcast topic acks upstream as soon as the **first** subscriber acks. The target use case needs strict fan-out: ack upstream only once **every** downstream pipeline acks. So we're adding an opt-in `ack_mode: all`. The modes differ fundamentally: `first` asks "has *anyone* acked?", while `all` asks "have *all required* subscribers acked?" — which means `all` must know the exact required set per message.

## Scope: groundwork only, no behavior change

Lands the types and primitives (unit-tested) but **nothing honors `all` yet** — every caller passes `First` and the engine ignores it, so behavior is identical to today. PR 2 wires the engine; PR 3 adds the config knob, validation, and docs.

## What's included

- **Mode enum** (`config/src/topic.rs`): `TopicBroadcastAckMode { First, All }`, default `First`. The config field using it lands in PR 3.
- **Consensus-aware tracker** (`engine/src/topic/types.rs`): the publish tracker can now hold the *set of subscribers still owing an ack* for a message, resolving Ack when it empties or Nack when any required subscriber nacks/disappears. Tested, not yet called.
- **Ring split** (`engine/src/topic/topic.rs`): `publish()` is now a wrapper over `reserve_seq()` (claim the sequence) + `commit_slot()` (write + wake). Called back-to-back, so behavior is unchanged; PR 2 needs them separate (below).
- **Options field**: `ack_mode` threaded through all topic construction sites as `First`; the engine ignores it.

## Why the ring is split

`all` mode must record, at publish time, the required ack set for a message — and it must match who actually *receives* it (a subscriber gets message N only if it joined at/before N). If a publish and a new subscription interleave wrong, a message can either hang forever waiting on a subscriber that never got it (liveness bug) or silently drop one that did (correctness bug). PR 2 fixes this by claiming the sequence and snapshotting subscribers together under one short lock — with only the cheap `reserve_seq` inside it and the expensive `commit_slot` (slot write + wake) after release. **This PR just creates that seam**; no lock or caller yet. The reserved-but-uncommitted window is already reader-safe (readers see "not ready" and re-park until the commit wakes them). `first` mode builds no required set, so it stays lock-free.

## How the consensus resolves

A message registered with required subscribers `{A, B, C}`:

- stays **pending** as acks arrive, until the set empties -> **Ack**;
- **Nack** the moment any required subscriber nacks or disappears (lag-disconnect/drop) before acking;
- **Ack** immediately if there are zero eligible subscribers at publish time;
- ignores duplicate/late acks once resolved (first outcome wins; permit released exactly once).

Topic close still resolves as `TopicClosed`, not Nack. The `first`/untracked/timeout paths are untouched.

## Relationship to `fanout_processor`

Broadcast `all` is the cross-pipeline cousin of `fanout`'s `await_ack: all` — same *"all must Ack, any Nack -> fail-fast"* contract, different substrate:

| | `fanout_processor` (`await_ack: all`) | Topic broadcast `ack_mode: all` |
| --- | --- | --- |
| Scope | Within one pipeline | Across pipelines (topic hop) |
| Who must ack | Fixed config ports | Snapshotted per-message from live subscribers |
| Failure handling | Rich fallback routing | No fallback; nack/disappearance -> Nack |

`fanout`'s "late ack after timeout is ignored" is the same first-outcome-wins rule the tracker uses.

## Not in this PR

- **PR 2:** subscriber registry + publish/ack/disconnect wiring that honors `all`.
- **PR 3:** `broadcast.ack_mode` config field, validation, controller mapping, docs, example, changelog.

## What issue does this PR close?

* Part of #2252 

## How are these changes tested?

Unit tests

## Are there any user-facing changes?

No

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
