### PR TITLE
ci: bump weaver to v0.24.0

### DIFF
--- a/.github/workflows/df-engine-internal-observability.yml
+++ b/.github/workflows/df-engine-internal-observability.yml
@@ -32,7 +32,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  WEAVER_VERSION: v0.23.0
+  WEAVER_VERSION: v0.24.0
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -54,7 +54,7 @@ jobs:
           workspaces: ./rust/otap-dataflow
           cache-bin: false
       - name: Setup Weaver
-        uses: open-telemetry/weaver/.github/actions/setup-weaver@3a3b7cc98e08f84bccda45c0f20522b51d64a88c # v0.23.0
+        uses: open-telemetry/weaver/.github/actions/setup-weaver@9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4 # v0.24.0
         with:
           version: ${{ env.WEAVER_VERSION }}
       - name: Generate self-signed TLS cert
@@ -73,14 +73,11 @@ jobs:
         working-directory: ./rust/otap-dataflow
       # Weaver listener lifecycle (start, readiness probe, /stop, report
       # capture, artifact upload) is owned by the upstream composite
-      # actions below. Pinned to the weaver#1448 merge commit on
-      # weaver `main`; no released weaver tag contains these actions
-      # yet (latest = v0.23.0). The actions are pure bash wrappers and
-      # only use weaver flags that v0.23.0 already supports, so the
-      # WEAVER_VERSION binary above is unaffected.
+      # actions below. Pinned to the published v0.24.0 release, which is
+      # the first tag to ship these actions.
       - name: Start weaver live-check listener
         id: weaver-start
-        uses: open-telemetry/weaver/.github/actions/weaver-live-check-start@3e9b722324783f871d2828f62c8cf706e046c83a
+        uses: open-telemetry/weaver/.github/actions/weaver-live-check-start@9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4 # v0.24.0
         with:
           registry: rust/otap-dataflow/semconv
           otlp-grpc-port: '4317'
@@ -154,7 +151,7 @@ jobs:
       - name: Stop weaver live-check and collect report
         id: weaver-stop
         if: always()
-        uses: open-telemetry/weaver/.github/actions/weaver-live-check-stop@3e9b722324783f871d2828f62c8cf706e046c83a
+        uses: open-telemetry/weaver/.github/actions/weaver-live-check-stop@9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4 # v0.24.0
         with:
           # Match the explicit state dir from the start action so this
           # works even if start failed before exporting it via env.

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -726,7 +726,7 @@ jobs:
   host-metrics-weaver-live-check:
     runs-on: ubuntu-latest
     env:
-      WEAVER_VERSION: v0.23.0
+      WEAVER_VERSION: v0.24.0
       # Semantic-conventions tag to validate against. Keep in sync with
       # the `VERSION` constant in
       # rust/otap-dataflow/crates/core-nodes/src/receivers/host_metrics_receiver/semconv.rs
@@ -748,7 +748,7 @@ jobs:
           workspaces: ./rust/otap-dataflow
           cache-bin: false
       - name: Setup Weaver
-        uses: open-telemetry/weaver/.github/actions/setup-weaver@3a3b7cc98e08f84bccda45c0f20522b51d64a88c # v0.23.0
+        uses: open-telemetry/weaver/.github/actions/setup-weaver@9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4 # v0.24.0
         with:
           version: ${{ env.WEAVER_VERSION }}
       - name: Build df_engine


### PR DESCRIPTION
Move the df-engine internal-observability workflow from weaver v0.23.0 (binary) + unreleased composite-action SHA-pin (weaver#1448) to the published v0.24.0 release.

v0.24.0 is the first tag to ship the `weaver-live-check-start` / `weaver-live-check-stop` composite actions, so this replaces the previous "pinned to a merge commit on main" workaround with a real tag (SHA-pinned to `9b84f5c`). The `WEAVER_VERSION` binary moves to v0.24.0 in lockstep.

Also bumps `host-metrics-weaver-live-check` in `rust-ci.yml` to v0.24.0 so both weaver-driven CI jobs stay on the same release. The Python summary script in that job reads `signal_type` / `signal_name` from `all_advice[]` (PolicyFinding fields), unchanged in v0.24.0.

v0.24.0 has breaking renames in the `--emit-otlp-logs` schema, but neither workflow consumes that surface — they parse the JSON report (`samples[].log.event_name`, `live_check_result.highest_advice_level`, `all_advice[].signal_type/signal_name`), all of which are unchanged.
