### PR TITLE
chore(deps): bump weaver_* crates to v0.24.0

### DIFF
--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -207,11 +207,11 @@ trybuild = "1.0"
 unsync = "0.1.2"
 url = "2.5.7"
 uuid = { version = "1.17.0", features = ["v4", "v7"] }
-weaver_common = { git = "https://github.com/open-telemetry/weaver.git", rev = "5b88e68483ea1fac176e38f69e4fa2ccfe7404c0"}
-weaver_forge = { git = "https://github.com/open-telemetry/weaver.git", rev = "5b88e68483ea1fac176e38f69e4fa2ccfe7404c0" }
-weaver_resolved_schema = { git = "https://github.com/open-telemetry/weaver.git", rev = "5b88e68483ea1fac176e38f69e4fa2ccfe7404c0"}
-weaver_resolver = { git = "https://github.com/open-telemetry/weaver.git", rev = "5b88e68483ea1fac176e38f69e4fa2ccfe7404c0"}
-weaver_semconv = { git = "https://github.com/open-telemetry/weaver.git", rev = "5b88e68483ea1fac176e38f69e4fa2ccfe7404c0"}
+weaver_common = { git = "https://github.com/open-telemetry/weaver.git", rev = "9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4"} # v0.24.0
+weaver_forge = { git = "https://github.com/open-telemetry/weaver.git", rev = "9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4" } # v0.24.0
+weaver_resolved_schema = { git = "https://github.com/open-telemetry/weaver.git", rev = "9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4"} # v0.24.0
+weaver_resolver = { git = "https://github.com/open-telemetry/weaver.git", rev = "9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4"} # v0.24.0
+weaver_semconv = { git = "https://github.com/open-telemetry/weaver.git", rev = "9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4"} # v0.24.0
 sha1 = { version = "0.11" }
 sha2 = "0.11.0"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }

--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -207,11 +207,11 @@ trybuild = "1.0"
 unsync = "0.1.2"
 url = "2.5.7"
 uuid = { version = "1.17.0", features = ["v4", "v7"] }
-weaver_common = { git = "https://github.com/open-telemetry/weaver.git", rev = "9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4"} # v0.24.0
+weaver_common = { git = "https://github.com/open-telemetry/weaver.git", rev = "9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4" } # v0.24.0
 weaver_forge = { git = "https://github.com/open-telemetry/weaver.git", rev = "9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4" } # v0.24.0
-weaver_resolved_schema = { git = "https://github.com/open-telemetry/weaver.git", rev = "9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4"} # v0.24.0
-weaver_resolver = { git = "https://github.com/open-telemetry/weaver.git", rev = "9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4"} # v0.24.0
-weaver_semconv = { git = "https://github.com/open-telemetry/weaver.git", rev = "9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4"} # v0.24.0
+weaver_resolved_schema = { git = "https://github.com/open-telemetry/weaver.git", rev = "9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4" } # v0.24.0
+weaver_resolver = { git = "https://github.com/open-telemetry/weaver.git", rev = "9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4" } # v0.24.0
+weaver_semconv = { git = "https://github.com/open-telemetry/weaver.git", rev = "9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4" } # v0.24.0
 sha1 = { version = "0.11" }
 sha2 = "0.11.0"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/host_metrics_receiver/procfs/tests.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/host_metrics_receiver/procfs/tests.rs
@@ -2146,6 +2146,7 @@ fn semconv_host_metric_shapes(registry: &ResolvedRegistry) -> BTreeMap<String, M
                     group
                         .entity_associations
                         .iter()
+                        .flat_map(|assoc| assoc.referenced_entities())
                         .filter_map(|entity| entity_attributes.get(entity))
                         .flatten()
                         .map(|attr| attr.name.clone()),
@@ -2162,6 +2163,7 @@ fn semconv_host_metric_shapes(registry: &ResolvedRegistry) -> BTreeMap<String, M
                     group
                         .entity_associations
                         .iter()
+                        .flat_map(|assoc| assoc.referenced_entities())
                         .filter_map(|entity| entity_attributes.get(entity))
                         .flatten(),
                 )
@@ -2183,6 +2185,7 @@ fn semconv_host_metric_shapes(registry: &ResolvedRegistry) -> BTreeMap<String, M
                     group
                         .entity_associations
                         .iter()
+                        .flat_map(|assoc| assoc.referenced_entities())
                         .filter_map(|entity| entity_attributes.get(entity))
                         .flatten(),
                 )

--- a/rust/otap-dataflow/deny.toml
+++ b/rust/otap-dataflow/deny.toml
@@ -76,14 +76,6 @@ ignore = [
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
     { id="RUSTSEC-2024-0436", reason="unmaintained `paste` crate is a dependency of parquet"},
     { id="RUSTSEC-2021-0127", reason="`serde_cbor` is archived, but current implementation meets needs" },
-    { id="RUSTSEC-2025-0021", reason="security vulnurability from `gix-features` crate" }, # remove after next weaver release
-    { id="RUSTSEC-2023-0018", reason="security vulnurability from `remove_dir_all` crate" }, # remove after next weaver release
-    { id="RUSTSEC-2025-0140", reason="security vulnerability from `gix-date` crate" }, # remove after next weaver release
-    { id="RUSTSEC-2023-0028", reason = "unmaintained `buf_redux` crate that is a dependency of weaver_semconv"}, # is a warning level in weaver deny.toml
-    { id="RUSTSEC-2023-0050", reason = "unmaintained `multipart` crate that is a dependency of weaver_semconv and weaver_forge"}, # is a warning level in weaver deny.toml
-    { id="RUSTSEC-2023-0081", reason = "unmaintained `safemem` crate that is a dependency of weaver_semconv"}, # is a warning level in weaver deny.toml
-    { id="RUSTSEC-2018-0017", reason = "unmaintained `tempdir` crate that is a dependency of weaver_semconv and weaver_forge"}, # is a warning level in weaver deny.toml
-    { id="RUSTSEC-2021-0146", reason = "unmaintained `twoway` crate that is a dependency of weaver_semconv and weaver_forge"} # is a warning level in weaver deny.toml
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.


### PR DESCRIPTION
Bumps the in-tree `weaver_common` / `weaver_forge` / `weaver_resolved_schema` / `weaver_resolver` / `weaver_semconv` git deps from the previous v0.23.0 SHA-pin to the published v0.24.0 release commit (`9b84f5c`). Crate consumers: `traffic_generator`, the `host_metrics_receiver` semconv-drift test, the `validation` crate, the `otap` integration-tests feature, and the `transport_optimize` benchmark.

Companion to #3324 which bumped the CI-side weaver CLI / composite actions to the same v0.24.0 release; this PR realigns the in-process Rust API surface so both halves are on the same weaver version.

v0.24.0 release notes include v2-signal `requirement_level` additions, `dependency_resolution.exclude`, `one_of`/`all_of` entity-association combinators, and a V2 resolver span-name fix — none of which require source changes here.

Also drops 8 weaver-related advisory ignores from `deny.toml` (the 3 `# remove after next weaver release` entries plus 5 unmaintained-crate ignores noted as `# is a warning level in weaver deny.toml`). `cargo deny check advisories` locally reports all 8 as "no crate matched advisory criteria" against the v0.24.0 dep tree — `remove_dir_all`, `buf_redux`, `multipart`, `safemem`, `tempdir`, and `twoway` are gone, and the `gix-features` / `gix-date` advisories no longer flag the versions weaver now pulls. Marked draft so CI's `deny_required` job can confirm.
