### PR TITLE
chore: upgrade kube rust crate versions

### DIFF
--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -109,8 +109,8 @@ humantime-serde = "1.1.1"
 iso8601 = "0.6.3"
 itoa = "1"
 itertools = "0.14.0"
-k8s-openapi = { version = "0.27.0", features = ["latest"] }
-kube = {version = "3.0.1", features = ["derive"] }
+k8s-openapi = { version = "0.28.0", features = ["latest"] }
+kube = {version = "4.0.0", features = ["derive"] }
 linkme = "0.3.35"
 local-sync = "0.1.1"
 miette = { version="7.6.0", features = ["fancy"] }


### PR DESCRIPTION
# Change Summary

<!--
Replace with a brief summary of the change in this PR
-->

upgrade k8s-openapi to 0.28.0
upgrade kube to 4.0.0

hopefully fix compile issue w/ https://github.com/open-telemetry/otel-arrow/pull/3330

## What issue does this PR close?

<!--
We highly recommend correlation of every PR to an issue
-->

* Closes #NNN

## How are these changes tested?

## Are there any user-facing changes?

 <!-- If yes, provide further info below -->

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [ ] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
