### PR TITLE
chore(deps): Group updates of opentelemetry-rust crates together

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -64,6 +64,18 @@
       ],
     },
     {
+      // group these dependencies that are tagged and released together
+      "groupName": "opentelemetry crates",
+      "matchManagers": ["cargo"],
+      "matchDepNames": [
+        "opentelemetry",
+        "opentelemetry_sdk",
+        "opentelemetry-stdout",
+        "opentelemetry-otlp",
+        "opentelemetry-prometheus",
+      ],
+    },
+    {
       // group together all github action workflow changes
       // it is very rare to have issues with these upgrades
       // fine to take them together

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -73,6 +73,7 @@
         "opentelemetry-stdout",
         "opentelemetry-otlp",
         "opentelemetry-prometheus",
+        "opentelemetry-proto"
       ],
     },
     {


### PR DESCRIPTION
# Change Summary

Saw #3331 and #3332 that were both opened independently.

Ideally, these would come together, as manually done in #3333.

## What issue does this PR close?

N/A

## How are these changes tested?

N/A

## Are there any user-facing changes?

N/A

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
