### PR TITLE
chore: upgrade OpenTelemetry Rust dependencies to 0.32

### DIFF
--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -134,13 +134,13 @@ once_cell = "1.20.2"
 # this dependency, as it means moving the derive macros used in our
 # tests upstream. This is currently used by experimental logs
 # exporters, hence the "logs" feature.
-opentelemetry-proto = { version = "0.31", default-features = false, features = ["gen-tonic-messages", "logs"]}
+opentelemetry-proto = { version = "0.32", default-features = false, features = ["gen-tonic-messages", "logs"]}
 
-opentelemetry = "0.31.0"
-opentelemetry_sdk = { version = "0.31.0", default-features = false, features = ["metrics", "internal-logs"] }
-opentelemetry-stdout = { version = "0.31.0", default-features = false, features = ["metrics"] }
-opentelemetry-otlp = { version = "0.31.1", default-features = false, features = ["http-proto", "reqwest-blocking-client", "metrics", "internal-logs"] }
-opentelemetry-prometheus = { version = "0.31.0", default-features = false, features = ["internal-logs"] }
+opentelemetry = "0.32.0"
+opentelemetry_sdk = { version = "0.32.0", default-features = false, features = ["metrics", "internal-logs"] }
+opentelemetry-stdout = { version = "0.32.0", default-features = false, features = ["metrics"] }
+opentelemetry-otlp = { version = "0.32.0", default-features = false, features = ["http-proto", "http-json", "reqwest-blocking-client", "metrics", "internal-logs"] }
+opentelemetry-prometheus = { version = "0.32.0", default-features = false, features = ["internal-logs"] }
 parking_lot = "0.12.5"
 paste = "1"
 parquet = { version = "58.3", default-features = false, features = ["arrow", "async", "object_store"]}
@@ -256,7 +256,7 @@ tracepoint_decode = "0.5.0"
 tracelogging = "1.2.4"
 tracelogging_dynamic = "1.2.4"
 urlencoding = "2"
-geneva-uploader = { git = "https://github.com/open-telemetry/opentelemetry-rust-contrib.git", rev = "7098c4b51bc5e2cd02bb6caa52621c1cb7f023c5" }
+geneva-uploader = { git = "https://github.com/open-telemetry/opentelemetry-rust-contrib.git", rev = "70f2dd38178ad28be886c4c56553067aee1c022d" }
 
 [patch."https://github.com/open-telemetry/otel-arrow"]
 otap-df-pdata = { path = "crates/pdata" }

--- a/rust/otap-dataflow/crates/contrib-nodes/benches/processors/recordset_kql_processor/extend.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/benches/processors/recordset_kql_processor/extend.rs
@@ -38,12 +38,14 @@ fn generate_logs_batch(batch_size: usize) -> Vec<u8> {
                     value: Some(AnyValue {
                         value: Some(Value::StringValue(namespace.into())),
                     }),
+                    ..Default::default()
                 },
                 KeyValue {
                     key: "code.line.number".into(),
                     value: Some(AnyValue {
                         value: Some(Value::IntValue((i % 5) as i64)),
                     }),
+                    ..Default::default()
                 },
             ];
 

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/transformer.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/transformer.rs
@@ -679,6 +679,7 @@ mod tests {
                         value: Some(AnyValue {
                             value: Some(OtelAnyValueEnum::StringValue("my-service".into())),
                         }),
+                        ..Default::default()
                     }],
                     dropped_attributes_count: 0,
                     entity_refs: vec![],
@@ -692,6 +693,7 @@ mod tests {
                             value: Some(AnyValue {
                                 value: Some(OtelAnyValueEnum::StringValue("my-scope".into())),
                             }),
+                            ..Default::default()
                         }],
                         dropped_attributes_count: 0,
                     }),
@@ -705,6 +707,7 @@ mod tests {
                             value: Some(AnyValue {
                                 value: Some(OtelAnyValueEnum::BoolValue(true)),
                             }),
+                            ..Default::default()
                         }],
                         ..Default::default()
                     }],
@@ -836,6 +839,7 @@ mod tests {
                                     value: Some(AnyValue {
                                         value: Some(OtelAnyValueEnum::StringValue("value".into())),
                                     }),
+                                    ..Default::default()
                                 }],
                             })),
                         }),
@@ -985,6 +989,7 @@ mod tests {
                         value: Some(AnyValue {
                             value: Some(OtelAnyValueEnum::StringValue("value".into())),
                         }),
+                        ..Default::default()
                     }],
                     dropped_attributes_count: 0,
                     entity_refs: vec![],
@@ -1019,6 +1024,7 @@ mod tests {
                     attributes: vec![KeyValue {
                         key: "service.name".into(),
                         value: None, // No value
+                        ..Default::default()
                     }],
                     dropped_attributes_count: 0,
                     entity_refs: vec![],
@@ -1030,6 +1036,7 @@ mod tests {
                         attributes: vec![KeyValue {
                             key: "scope.name".into(),
                             value: None, // No value
+                            ..Default::default()
                         }],
                         dropped_attributes_count: 0,
                     }),
@@ -1037,6 +1044,7 @@ mod tests {
                         attributes: vec![KeyValue {
                             key: "test.attr".into(),
                             value: None, // No value
+                            ..Default::default()
                         }],
                         ..Default::default()
                     }],
@@ -1201,6 +1209,7 @@ mod tests {
                         value: Some(AnyValue {
                             value: Some(OtelAnyValueEnum::DoubleValue(f64::NAN)),
                         }),
+                        ..Default::default()
                     }],
                     dropped_attributes_count: 0,
                     entity_refs: vec![],
@@ -1287,6 +1296,7 @@ mod tests {
                         value: Some(AnyValue {
                             value: Some(OtelAnyValueEnum::StringValue("my-service".into())),
                         }),
+                        ..Default::default()
                     }],
                     dropped_attributes_count: 0,
                     entity_refs: vec![],
@@ -1300,6 +1310,7 @@ mod tests {
                             value: Some(AnyValue {
                                 value: Some(OtelAnyValueEnum::StringValue("my-scope".into())),
                             }),
+                            ..Default::default()
                         }],
                         dropped_attributes_count: 0,
                     }),
@@ -1313,6 +1324,7 @@ mod tests {
                             value: Some(AnyValue {
                                 value: Some(OtelAnyValueEnum::BoolValue(true)),
                             }),
+                            ..Default::default()
                         }],
                         ..Default::default()
                     }],
@@ -1516,30 +1528,35 @@ mod tests {
                                 value: Some(AnyValue {
                                     value: Some(OtelAnyValueEnum::StringValue("hello".into())),
                                 }),
+                                ..Default::default()
                             },
                             KeyValue {
                                 key: "int_attr".into(),
                                 value: Some(AnyValue {
                                     value: Some(OtelAnyValueEnum::IntValue(42)),
                                 }),
+                                ..Default::default()
                             },
                             KeyValue {
                                 key: "dbl_attr".into(),
                                 value: Some(AnyValue {
                                     value: Some(OtelAnyValueEnum::DoubleValue(2.72)),
                                 }),
+                                ..Default::default()
                             },
                             KeyValue {
                                 key: "bool_attr".into(),
                                 value: Some(AnyValue {
                                     value: Some(OtelAnyValueEnum::BoolValue(true)),
                                 }),
+                                ..Default::default()
                             },
                             KeyValue {
                                 key: "bytes_attr".into(),
                                 value: Some(AnyValue {
                                     value: Some(OtelAnyValueEnum::BytesValue(vec![0xCA, 0xFE])),
                                 }),
+                                ..Default::default()
                             },
                         ],
                         ..Default::default()
@@ -1574,12 +1591,14 @@ mod tests {
                                 value: Some(AnyValue {
                                     value: Some(OtelAnyValueEnum::DoubleValue(f64::NAN)),
                                 }),
+                                ..Default::default()
                             },
                             KeyValue {
                                 key: "int_attr".into(),
                                 value: Some(AnyValue {
                                     value: Some(OtelAnyValueEnum::DoubleValue(f64::INFINITY)),
                                 }),
+                                ..Default::default()
                             },
                         ],
                         ..Default::default()
@@ -1610,6 +1629,7 @@ mod tests {
                             value: Some(AnyValue {
                                 value: Some(OtelAnyValueEnum::BoolValue(false)),
                             }),
+                            ..Default::default()
                         }],
                         ..Default::default()
                     }],

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/bridge.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/bridge.rs
@@ -629,7 +629,7 @@ mod tests {
                                     value: Some(OtlpAnyValue {
                                         value: Some(OtlpValue::IntValue(18)),
                                     }),
-                                    key_strindex: 0,
+                                    ..Default::default()
                                 }],
                                 dropped_attributes_count: 18,
                             }),

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/bridge.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/bridge.rs
@@ -609,6 +609,7 @@ mod tests {
                             value: Some(OtlpAnyValue {
                                 value: Some(OtlpValue::IntValue(18)),
                             }),
+                            ..Default::default()
                         }],
                         dropped_attributes_count: 18,
                         entity_refs: vec![OtlpEntityRef {
@@ -628,6 +629,7 @@ mod tests {
                                     value: Some(OtlpAnyValue {
                                         value: Some(OtlpValue::IntValue(18)),
                                     }),
+                                    key_strindex: 0,
                                 }],
                                 dropped_attributes_count: 18,
                             }),
@@ -644,6 +646,7 @@ mod tests {
                                     value: Some(OtlpAnyValue {
                                         value: Some(OtlpValue::IntValue(18)),
                                     }),
+                                    ..Default::default()
                                 }],
                                 dropped_attributes_count: 18,
                                 flags: 1,

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/serializer/otlp_reader.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/serializer/otlp_reader.rs
@@ -522,16 +522,19 @@ mod tests {
                         OtlpKeyValue {
                             key: "key1".into(),
                             value: None,
+                            ..Default::default()
                         },
                         OtlpKeyValue {
                             key: "key2".into(),
                             value: Some(OtlpAnyValue { value: None }),
+                            ..Default::default()
                         },
                         OtlpKeyValue {
                             key: "key3".into(),
                             value: Some(OtlpAnyValue {
                                 value: Some(OtlpValue::IntValue(18)),
                             }),
+                            ..Default::default()
                         },
                     ],
                 })),
@@ -604,6 +607,7 @@ mod tests {
             OtlpKeyValue {
                 key: "".into(),
                 value: None,
+                ..Default::default()
             },
             None,
         );
@@ -612,6 +616,7 @@ mod tests {
             OtlpKeyValue {
                 key: "".into(),
                 value: Some(OtlpAnyValue { value: None }),
+                ..Default::default()
             },
             None,
         );
@@ -620,6 +625,7 @@ mod tests {
             OtlpKeyValue {
                 key: "key1".into(),
                 value: None,
+                ..Default::default()
             },
             Some(("key1".into(), AnyValue::Null)),
         );
@@ -628,6 +634,7 @@ mod tests {
             OtlpKeyValue {
                 key: "key1".into(),
                 value: Some(OtlpAnyValue { value: None }),
+                ..Default::default()
             },
             Some(("key1".into(), AnyValue::Null)),
         );
@@ -638,6 +645,7 @@ mod tests {
                 value: Some(OtlpAnyValue {
                     value: Some(OtlpValue::IntValue(18)),
                 }),
+                ..Default::default()
             },
             Some((
                 "key1".into(),
@@ -684,12 +692,14 @@ mod tests {
                     OtlpKeyValue {
                         key: "key1".into(),
                         value: None,
+                        ..Default::default()
                     },
                     OtlpKeyValue {
                         key: "key2".into(),
                         value: Some(OtlpAnyValue {
                             value: Some(OtlpValue::IntValue(18)),
                         }),
+                        ..Default::default()
                     },
                 ],
                 dropped_attributes_count: 0,
@@ -773,12 +783,14 @@ mod tests {
                     OtlpKeyValue {
                         key: "key1".into(),
                         value: None,
+                        ..Default::default()
                     },
                     OtlpKeyValue {
                         key: "key2".into(),
                         value: Some(OtlpAnyValue {
                             value: Some(OtlpValue::IntValue(18)),
                         }),
+                        ..Default::default()
                     },
                 ],
                 dropped_attributes_count: 0,
@@ -932,20 +944,24 @@ mod tests {
                     OtlpKeyValue {
                         key: "".into(),
                         value: None,
+                        ..Default::default()
                     },
                     OtlpKeyValue {
                         key: "key1".into(),
                         value: None,
+                        ..Default::default()
                     },
                     OtlpKeyValue {
                         key: "key2".into(),
                         value: Some(OtlpAnyValue { value: None }),
+                        ..Default::default()
                     },
                     OtlpKeyValue {
                         key: "key3".into(),
                         value: Some(OtlpAnyValue {
                             value: Some(OtlpValue::IntValue(18)),
                         }),
+                        ..Default::default()
                     },
                 ],
                 dropped_attributes_count: 0,

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/serializer/otlp_writer.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/serializer/otlp_writer.rs
@@ -318,6 +318,7 @@ mod tests {
             OtlpKeyValue {
                 key: "".into(),
                 value: None,
+                ..Default::default()
             },
         );
 
@@ -326,6 +327,7 @@ mod tests {
             OtlpKeyValue {
                 key: "key1".into(),
                 value: None,
+                ..Default::default()
             },
         );
 
@@ -341,6 +343,7 @@ mod tests {
                 value: Some(OtlpAnyValue {
                     value: Some(OtlpValue::StringValue("value1".into())),
                 }),
+                ..Default::default()
             },
         );
     }
@@ -509,16 +512,19 @@ mod tests {
                         OtlpKeyValue {
                             key: "".into(),
                             value: None,
+                            ..Default::default()
                         },
                         OtlpKeyValue {
                             key: "key1".into(),
                             value: None,
+                            ..Default::default()
                         },
                         OtlpKeyValue {
                             key: "key2".into(),
                             value: Some(OtlpAnyValue {
                                 value: Some(OtlpValue::IntValue(18)),
                             }),
+                            ..Default::default()
                         },
                     ],
                 })),
@@ -612,12 +618,14 @@ mod tests {
                     OtlpKeyValue {
                         key: "key1".into(),
                         value: None,
+                        ..Default::default()
                     },
                     OtlpKeyValue {
                         key: "key2".into(),
                         value: Some(OtlpAnyValue {
                             value: Some(OtlpValue::IntValue(18)),
                         }),
+                        ..Default::default()
                     },
                 ],
                 dropped_attributes_count: 0,
@@ -708,12 +716,14 @@ mod tests {
                     OtlpKeyValue {
                         key: "key1".into(),
                         value: None,
+                        ..Default::default()
                     },
                     OtlpKeyValue {
                         key: "key2".into(),
                         value: Some(OtlpAnyValue {
                             value: Some(OtlpValue::IntValue(18)),
                         }),
+                        ..Default::default()
                     },
                 ],
                 dropped_attributes_count: 0,
@@ -826,12 +836,14 @@ mod tests {
                     OtlpKeyValue {
                         key: "key1".into(),
                         value: None,
+                        ..Default::default()
                     },
                     OtlpKeyValue {
                         key: "key2".into(),
                         value: Some(OtlpAnyValue {
                             value: Some(OtlpValue::IntValue(18)),
                         }),
+                        ..Default::default()
                     },
                 ],
                 dropped_attributes_count: 0,

--- a/rust/otap-dataflow/crates/telemetry/Cargo.toml
+++ b/rust/otap-dataflow/crates/telemetry/Cargo.toml
@@ -52,3 +52,4 @@ tower = { workspace = true }
 tempfile = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["testing"] }
 otap-df-pdata = { workspace = true, features = ["testing"] }
+rustls = { workspace = true, features = ["ring"] }

--- a/rust/otap-dataflow/crates/telemetry/src/lib.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/lib.rs
@@ -104,6 +104,15 @@ where
     }
 }
 
+#[cfg(test)]
+pub(crate) fn ensure_test_crypto_provider() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}
+
 // Re-export _private module from internal_events for macro usage.
 // This allows the otel_info!, otel_warn!, etc. macros to work in other crates
 // without requiring them to add tracing as a direct dependency.

--- a/rust/otap-dataflow/crates/telemetry/src/otel_sdk/meter_provider.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/otel_sdk/meter_provider.rs
@@ -146,6 +146,8 @@ mod tests {
 
     #[test]
     fn test_meter_provider_configure_with_non_runtime_readers() -> Result<(), Error> {
+        crate::ensure_test_crypto_provider();
+
         let resource = Resource::builder().build();
         let metric_readers = vec![
             MetricsReaderConfig::Periodic(MetricsReaderPeriodicConfig {

--- a/rust/otap-dataflow/crates/telemetry/src/otel_sdk/meter_provider/otlp_exporter_provider.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/otel_sdk/meter_provider/otlp_exporter_provider.rs
@@ -155,6 +155,8 @@ mod tests {
 
     #[test]
     fn test_configure_http_binary_exporter() {
+        crate::ensure_test_crypto_provider();
+
         let sdk_meter_builder = SdkMeterProvider::builder();
         let otlp_config = OtlpExporterConfig {
             protocol: OtlpProtocol::HttpBinary,
@@ -173,6 +175,8 @@ mod tests {
 
     #[test]
     fn test_configure_http_json_exporter() {
+        crate::ensure_test_crypto_provider();
+
         let sdk_meter_builder = SdkMeterProvider::builder();
         let otlp_config = OtlpExporterConfig {
             protocol: OtlpProtocol::HttpJson,


### PR DESCRIPTION
# Change Summary

  Upgrade OTAP Dataflow OpenTelemetry Rust dependencies to 0.32 and bump the Geneva uploader pin to a compatible revision.


## What issue does this PR close?


* Closes #NNN

## How are these changes tested?

## Are there any user-facing changes?

No

### Changelog


 * [x] This PR is a `chore` (indicated in title).
