### PR TITLE
fix(admin): redact credential header values in config snapshot APIs (#3328)

### DIFF
--- a/rust/otap-dataflow/.chloggen/admin-redact-config-header-secrets.yaml
+++ b/rust/otap-dataflow/.chloggen/admin-redact-config-header-secrets.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: engine
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: >-
+  Credential header values are now redacted from the admin config snapshot APIs
+  (`GET /api/v1/config`, the per-group detail endpoint, and the per-pipeline
+  detail endpoint). Static exporter `headers` values (e.g. an `Authorization`
+  token or tenant API key) were previously returned in cleartext from the raw
+  node `config`, bypassing the `secrecy::SecretString` protection on the typed
+  settings; they are now replaced with `[REDACTED]` in the response while the
+  header keys are preserved so operators can still see which headers are
+  configured.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [3328]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: >-
+  Redaction is applied to the API response only; the controller's stored
+  configuration retains the original values, so reconciliation and runtime
+  behavior are unchanged.

--- a/rust/otap-dataflow/crates/admin/src/engine_config.rs
+++ b/rust/otap-dataflow/crates/admin/src/engine_config.rs
@@ -28,9 +28,13 @@ fn operation_error_response(status: StatusCode, error: crate::ControlPlaneError)
 }
 
 /// Returns the full controller-owned engine configuration.
+///
+/// Credential header values are redacted from the response (see
+/// [`OtelDataflowSpec::redacted_for_snapshot`]) so secrets configured in node
+/// `headers` are not exposed in cleartext through this endpoint.
 pub async fn show_config(State(state): State<AppState>) -> impl IntoResponse {
     match state.controller.engine_config_snapshot() {
-        Ok(config) => (StatusCode::OK, Json(config)).into_response(),
+        Ok(config) => (StatusCode::OK, Json(config.redacted_for_snapshot())).into_response(),
         Err(error) => operation_error_response(StatusCode::INTERNAL_SERVER_ERROR, error),
     }
 }
@@ -244,6 +248,54 @@ mod tests {
         let decoded: OtelDataflowSpec =
             serde_json::from_slice(&body).expect("config body should deserialize");
         assert_eq!(decoded, config);
+    }
+
+    /// Scenario: a node config contains credential header values.
+    /// Guarantees: `show_config` redacts them so the raw credential never
+    /// appears in the response body.
+    #[tokio::test]
+    async fn show_config_redacts_credential_header_values() {
+        let yaml = r#"
+version: otel_dataflow/v1
+engine: {}
+groups:
+  default:
+    pipelines:
+      main:
+        nodes:
+          receiver:
+            type: "urn:test:receiver:example"
+            config: null
+          exporter:
+            type: "urn:test:exporter:example"
+            config:
+              headers:
+                authorization: "Bearer super-secret-token"
+        connections:
+          - from: receiver
+            to: exporter
+"#;
+        let config = OtelDataflowSpec::from_yaml(yaml).expect("spec should parse and validate");
+        let response = show_config(State(test_app_state(stub(
+            Ok(config),
+            Ok(reconcile_status(EngineConfigReconcileState::Succeeded)),
+        ))))
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body should collect");
+        let text = String::from_utf8(body.to_vec()).expect("config body is utf-8");
+        assert!(
+            !text.contains("Bearer super-secret-token"),
+            "raw credential must not appear in the config response: {text}"
+        );
+        assert!(
+            text.contains("[REDACTED]"),
+            "redacted placeholder should appear in the config response: {text}"
+        );
     }
 
     /// Scenario: the active control plane does not support full config

--- a/rust/otap-dataflow/crates/admin/src/engine_config.rs
+++ b/rust/otap-dataflow/crates/admin/src/engine_config.rs
@@ -31,7 +31,7 @@ fn operation_error_response(status: StatusCode, error: crate::ControlPlaneError)
 ///
 /// Credential header values are redacted from the response (see
 /// [`OtelDataflowSpec::redacted_for_snapshot`]) so secrets configured in node
-/// `headers` are not exposed in cleartext through this endpoint.
+/// and extension `headers` are not exposed in cleartext through this endpoint.
 pub async fn show_config(State(state): State<AppState>) -> impl IntoResponse {
     match state.controller.engine_config_snapshot() {
         Ok(config) => (StatusCode::OK, Json(config.redacted_for_snapshot())).into_response(),

--- a/rust/otap-dataflow/crates/admin/src/pipeline.rs
+++ b/rust/otap-dataflow/crates/admin/src/pipeline.rs
@@ -127,6 +127,10 @@ fn shutdown_is_success(state: &str) -> bool {
 }
 
 /// Returns committed configuration details for one logical pipeline.
+///
+/// Credential header values are redacted from the response (see
+/// [`otap_df_config::pipeline::PipelineConfig::redacted_for_snapshot`]) so
+/// secrets configured in node `headers` are not exposed in cleartext.
 pub async fn show_pipeline(
     Path((pipeline_group_id, pipeline_id)): Path<(String, String)>,
     State(state): State<AppState>,
@@ -135,7 +139,10 @@ pub async fn show_pipeline(
         .controller
         .pipeline_details(&pipeline_group_id, &pipeline_id)
     {
-        Ok(Some(details)) => Ok(Json(details)),
+        Ok(Some(mut details)) => {
+            details.pipeline = details.pipeline.redacted_for_snapshot();
+            Ok(Json(details))
+        }
         Ok(None) => Err(StatusCode::NOT_FOUND),
         Err(
             crate::ControlPlaneError::PipelineNotFound | crate::ControlPlaneError::GroupNotFound,
@@ -626,6 +633,102 @@ mod tests {
             shutdown: None,
             failure_reason: (state != "succeeded").then(|| "delete failed".to_string()),
         }
+    }
+
+    /// Minimal control plane that serves a configured `pipeline_details`, used
+    /// to exercise the `show_pipeline` redaction path end-to-end.
+    struct PipelineDetailsStub {
+        details: Result<Option<PipelineDetails>, ControlPlaneError>,
+    }
+
+    impl ControlPlane for PipelineDetailsStub {
+        fn shutdown_all(&self, _timeout_secs: u64) -> Result<(), ControlPlaneError> {
+            Ok(())
+        }
+        fn shutdown_pipeline(
+            &self,
+            _pipeline_group_id: &str,
+            _pipeline_id: &str,
+            _timeout_secs: u64,
+        ) -> Result<ShutdownStatus, ControlPlaneError> {
+            Err(ControlPlaneError::PipelineNotFound)
+        }
+        fn reconfigure_pipeline(
+            &self,
+            _pipeline_group_id: &str,
+            _pipeline_id: &str,
+            _request: crate::ReconfigureRequest,
+        ) -> Result<RolloutStatus, ControlPlaneError> {
+            Err(ControlPlaneError::PipelineNotFound)
+        }
+        fn pipeline_details(
+            &self,
+            _pipeline_group_id: &str,
+            _pipeline_id: &str,
+        ) -> Result<Option<PipelineDetails>, ControlPlaneError> {
+            self.details.clone()
+        }
+        fn rollout_status(
+            &self,
+            _pipeline_group_id: &str,
+            _pipeline_id: &str,
+            _rollout_id: &str,
+        ) -> Result<Option<RolloutStatus>, ControlPlaneError> {
+            Ok(None)
+        }
+        fn shutdown_status(
+            &self,
+            _pipeline_group_id: &str,
+            _pipeline_id: &str,
+            _shutdown_id: &str,
+        ) -> Result<Option<ShutdownStatus>, ControlPlaneError> {
+            Ok(None)
+        }
+    }
+
+    /// Scenario: a pipeline's node config contains credential header values.
+    /// Guarantees: `show_pipeline` redacts them so the raw credential never
+    /// appears in the response body.
+    #[tokio::test]
+    async fn show_pipeline_redacts_credential_header_values() {
+        let details: PipelineDetails = serde_json::from_value(json!({
+            "pipelineGroupId": "default",
+            "pipelineId": "main",
+            "pipeline": {
+                "nodes": {
+                    "exporter": {
+                        "type": "urn:test:exporter:example",
+                        "config": {
+                            "headers": { "authorization": "Bearer super-secret-token" }
+                        }
+                    }
+                }
+            }
+        }))
+        .expect("pipeline details fixture should deserialize");
+
+        let response = show_pipeline(
+            Path(("default".to_string(), "main".to_string())),
+            State(test_app_state(Arc::new(PipelineDetailsStub {
+                details: Ok(Some(details)),
+            }))),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body should collect");
+        let text = String::from_utf8(body.to_vec()).expect("pipeline body is utf-8");
+        assert!(
+            !text.contains("Bearer super-secret-token"),
+            "raw credential must not appear in the pipeline response: {text}"
+        );
+        assert!(
+            text.contains("[REDACTED]"),
+            "redacted placeholder should appear in the pipeline response: {text}"
+        );
     }
 
     /// Scenario: the control plane rejects a pipeline reconfigure request

--- a/rust/otap-dataflow/crates/admin/src/pipeline.rs
+++ b/rust/otap-dataflow/crates/admin/src/pipeline.rs
@@ -130,7 +130,8 @@ fn shutdown_is_success(state: &str) -> bool {
 ///
 /// Credential header values are redacted from the response (see
 /// [`otap_df_config::pipeline::PipelineConfig::redacted_for_snapshot`]) so
-/// secrets configured in node `headers` are not exposed in cleartext.
+/// secrets configured in node and extension `headers` are not exposed in
+/// cleartext.
 pub async fn show_pipeline(
     Path((pipeline_group_id, pipeline_id)): Path<(String, String)>,
     State(state): State<AppState>,

--- a/rust/otap-dataflow/crates/admin/src/pipeline_group.rs
+++ b/rust/otap-dataflow/crates/admin/src/pipeline_group.rs
@@ -71,7 +71,7 @@ fn operation_error_response(status: StatusCode, error: crate::ControlPlaneError)
 ///
 /// Credential header values are redacted from the response (see
 /// [`PipelineGroupConfig::redacted_for_snapshot`]) so secrets configured in
-/// node `headers` are not exposed in cleartext.
+/// node and extension `headers` are not exposed in cleartext.
 pub async fn show_group(
     Path(pipeline_group_id): Path<String>,
     State(state): State<AppState>,

--- a/rust/otap-dataflow/crates/admin/src/pipeline_group.rs
+++ b/rust/otap-dataflow/crates/admin/src/pipeline_group.rs
@@ -68,12 +68,16 @@ fn operation_error_response(status: StatusCode, error: crate::ControlPlaneError)
 }
 
 /// Returns the committed configuration for one pipeline group.
+///
+/// Credential header values are redacted from the response (see
+/// [`PipelineGroupConfig::redacted_for_snapshot`]) so secrets configured in
+/// node `headers` are not exposed in cleartext.
 pub async fn show_group(
     Path(pipeline_group_id): Path<String>,
     State(state): State<AppState>,
 ) -> Result<Json<PipelineGroupConfig>, StatusCode> {
     match state.controller.group_details(&pipeline_group_id) {
-        Ok(Some(group)) => Ok(Json(group)),
+        Ok(Some(group)) => Ok(Json(group.redacted_for_snapshot())),
         Ok(None) | Err(crate::ControlPlaneError::GroupNotFound) => Err(StatusCode::NOT_FOUND),
         Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR),
     }
@@ -91,7 +95,7 @@ pub async fn create_group(
     );
 
     match state.controller.create_group(&pipeline_group_id, group) {
-        Ok(group) => (StatusCode::CREATED, Json(group)).into_response(),
+        Ok(group) => (StatusCode::CREATED, Json(group.redacted_for_snapshot())).into_response(),
         Err(error @ crate::ControlPlaneError::GroupAlreadyExists)
         | Err(error @ crate::ControlPlaneError::RolloutConflict) => {
             operation_error_response(StatusCode::CONFLICT, error)
@@ -394,6 +398,55 @@ mod tests {
         assert_eq!(decoded, group);
     }
 
+    /// Scenario: a pipeline group contains a node with credential headers.
+    /// Guarantees: `show_group` redacts them so the raw credential never
+    /// appears in the response body.
+    #[tokio::test]
+    async fn show_group_redacts_credential_header_values() {
+        let group: PipelineGroupConfig = serde_json::from_value(serde_json::json!({
+            "pipelines": {
+                "main": {
+                    "nodes": {
+                        "receiver": { "type": "urn:test:receiver:example", "config": null },
+                        "exporter": {
+                            "type": "urn:test:exporter:example",
+                            "config": {
+                                "headers": { "authorization": "Bearer super-secret-token" }
+                            }
+                        }
+                    },
+                    "connections": [ { "from": "receiver", "to": "exporter" } ]
+                }
+            }
+        }))
+        .expect("group should deserialize");
+
+        let response = show_group(
+            Path("default".to_string()),
+            State(test_app_state(stub(
+                Ok(Some(group.clone())),
+                Ok(group.clone()),
+                Ok(delete_status("succeeded")),
+            ))),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body should collect");
+        let text = String::from_utf8(body.to_vec()).expect("group body is utf-8");
+        assert!(
+            !text.contains("Bearer super-secret-token"),
+            "raw credential must not appear in the group response: {text}"
+        );
+        assert!(
+            text.contains("[REDACTED]"),
+            "redaction placeholder should appear in the group response: {text}"
+        );
+    }
+
     /// Scenario: a caller creates an empty pipeline group.
     /// Guarantees: the handler returns HTTP 201 with the committed group
     /// configuration.
@@ -419,6 +472,55 @@ mod tests {
         let decoded: PipelineGroupConfig =
             serde_json::from_slice(&body).expect("group body should deserialize");
         assert_eq!(decoded, group);
+    }
+
+    /// Scenario: a created group's nodes carry credential headers.
+    /// Guarantees: `create_group` redacts them in its echoed response so the
+    /// raw credential never appears in the response body (responses are often
+    /// logged by clients/proxies).
+    #[tokio::test]
+    async fn create_group_redacts_credential_header_values() {
+        let group: PipelineGroupConfig = serde_json::from_value(serde_json::json!({
+            "pipelines": {
+                "main": {
+                    "nodes": {
+                        "exporter": {
+                            "type": "urn:test:exporter:example",
+                            "config": {
+                                "headers": { "authorization": "Bearer super-secret-token" }
+                            }
+                        }
+                    }
+                }
+            }
+        }))
+        .expect("group should deserialize");
+
+        let response = create_group(
+            Path("default".to_string()),
+            State(test_app_state(stub(
+                Ok(None),
+                Ok(group.clone()),
+                Ok(delete_status("succeeded")),
+            ))),
+            Json(group.clone()),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body should collect");
+        let text = String::from_utf8(body.to_vec()).expect("group body is utf-8");
+        assert!(
+            !text.contains("Bearer super-secret-token"),
+            "raw credential must not appear in the create response: {text}"
+        );
+        assert!(
+            text.contains("[REDACTED]"),
+            "redacted placeholder should appear in the create response: {text}"
+        );
     }
 
     /// Scenario: the control plane rejects group creation as invalid.

--- a/rust/otap-dataflow/crates/config/src/engine.rs
+++ b/rust/otap-dataflow/crates/config/src/engine.rs
@@ -61,9 +61,9 @@ pub struct OtelDataflowSpec {
 }
 
 impl OtelDataflowSpec {
-    /// Returns a clone of this engine config with every node's credential
-    /// header values redacted, for safe exposure through the admin config
-    /// snapshot API (`GET /api/v1/config`). See
+    /// Returns a clone of this engine config with every node's and
+    /// extension's credential header values redacted, for safe exposure
+    /// through the admin config snapshot API (`GET /api/v1/config`). See
     /// [`PipelineConfig::redacted_for_snapshot`]. The stored config is left
     /// unchanged.
     #[must_use]

--- a/rust/otap-dataflow/crates/config/src/engine.rs
+++ b/rust/otap-dataflow/crates/config/src/engine.rs
@@ -60,6 +60,22 @@ pub struct OtelDataflowSpec {
     pub groups: HashMap<PipelineGroupId, PipelineGroupConfig>,
 }
 
+impl OtelDataflowSpec {
+    /// Returns a clone of this engine config with every node's credential
+    /// header values redacted, for safe exposure through the admin config
+    /// snapshot API (`GET /api/v1/config`). See
+    /// [`PipelineConfig::redacted_for_snapshot`]. The stored config is left
+    /// unchanged.
+    #[must_use]
+    pub fn redacted_for_snapshot(&self) -> OtelDataflowSpec {
+        let mut redacted = self.clone();
+        for group in redacted.groups.values_mut() {
+            *group = group.redacted_for_snapshot();
+        }
+        redacted
+    }
+}
+
 /// Top-level engine configuration section.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, PartialEq)]
 #[serde(deny_unknown_fields)]
@@ -364,6 +380,51 @@ groups:
             to: exporter
 "#
         )
+    }
+
+    #[test]
+    fn redacted_for_snapshot_masks_node_headers_across_groups() {
+        let yaml = r#"
+version: otel_dataflow/v1
+engine: {}
+groups:
+  default:
+    pipelines:
+      main:
+        nodes:
+          receiver:
+            type: "urn:test:receiver:example"
+            config: null
+          exporter:
+            type: "urn:test:exporter:example"
+            config:
+              endpoint: "https://backend.example"
+              headers:
+                authorization: "Bearer super-secret-token"
+        connections:
+          - from: receiver
+            to: exporter
+"#;
+        let spec = OtelDataflowSpec::from_yaml(yaml).expect("spec should parse and validate");
+        let redacted = spec.redacted_for_snapshot();
+
+        let redacted_json = serde_json::to_string(&redacted).expect("redacted spec serializes");
+        assert!(
+            !redacted_json.contains("Bearer super-secret-token"),
+            "credential must not survive redaction: {redacted_json}"
+        );
+        assert!(
+            redacted_json.contains(crate::node::REDACTED_HEADER_VALUE),
+            "redaction placeholder should be present: {redacted_json}"
+        );
+
+        // Redaction is a copy: the original snapshot keeps the cleartext for the
+        // controller's own use (it is never the thing serialized to clients).
+        let original_json = serde_json::to_string(&spec).expect("spec serializes");
+        assert!(
+            original_json.contains("Bearer super-secret-token"),
+            "original spec must retain the cleartext credential"
+        );
     }
 
     fn write_temp_file(ext: &str, contents: &str) -> PathBuf {

--- a/rust/otap-dataflow/crates/config/src/engine.rs
+++ b/rust/otap-dataflow/crates/config/src/engine.rs
@@ -120,7 +120,7 @@ pub struct EngineConfig {
 impl EngineConfig {
     /// Returns a clone of this engine config with credential header values
     /// redacted from the engine-scoped config that the admin/config snapshot
-    /// API (`GET /api/v1/config`) exposes. Three engine subtrees carry raw,
+    /// API (`GET /api/v1/config`) exposes. Four engine subtrees carry raw,
     /// header-bearing config and are redacted with the same policy as pipeline
     /// nodes/extensions:
     ///
@@ -132,11 +132,22 @@ impl EngineConfig {
     /// - `telemetry.metrics.readers[].exporter.config` — each metrics reader's
     ///   opaque exporter `config` [`Value`]. See
     ///   [`TelemetryConfig::redacted_for_snapshot`].
+    /// - `custom` — opaque, freeform metadata the engine never interprets, but
+    ///   the most likely place an embedder stashes arbitrary config (including
+    ///   auth `headers`). The whole map is walked with the same
+    ///   [`redact_secret_headers`](crate::node::redact_secret_headers) helper
+    ///   used by the structured arms, so any value under a `headers` key — map
+    ///   or `[{key, value}]` list form, at any depth, including a top-level
+    ///   `custom.headers` — is masked. Matching is on the conventional
+    ///   lowercase `headers` key only.
     ///
     /// The remaining strongly-typed engine settings (`observed_state`,
-    /// `topics`) have no opaque `headers`-bearing config, and `custom` is
-    /// opaque application metadata the engine never interprets as credentials,
-    /// so none are touched. The stored config is left unchanged.
+    /// `topics`) have no opaque `headers`-bearing config, so none are touched.
+    /// This masks credential *header* values only; other secret classes that can
+    /// appear in raw config (inline TLS keys, proxy URLs with embedded
+    /// passwords, component-specific secrets, and credentials hidden under
+    /// non-`headers` or case-variant keys) are out of scope here and tracked in
+    /// #3347. The stored config is left unchanged.
     #[must_use]
     pub fn redacted_for_snapshot(&self) -> EngineConfig {
         let mut redacted = self.clone();
@@ -144,6 +155,17 @@ impl EngineConfig {
         redacted.controller.extensions = redacted.controller.extensions.redacted_for_snapshot();
         if let Some(pipeline) = redacted.observability.pipeline.as_mut() {
             pipeline.nodes = pipeline.nodes.redacted_for_snapshot();
+        }
+        // Redact `headers` anywhere in the freeform `custom` metadata. Wrap the
+        // whole map into one `Value::Object` so a top-level key literally named
+        // `headers` is matched the same way it is in the structured arms: the
+        // helper only masks a `headers` key found as a *child* of the object it
+        // is handed, so walking each value individually would drop that
+        // top-level key layer and leak `custom.headers.*`.
+        let mut custom = Value::Object(std::mem::take(&mut redacted.custom).into_iter().collect());
+        crate::node::redact_secret_headers(&mut custom);
+        if let Value::Object(map) = custom {
+            redacted.custom = map.into_iter().collect();
         }
         redacted
     }
@@ -546,6 +568,72 @@ engine:
                 && original_json.contains("telemetry-super-secret"),
             "original spec must retain the cleartext credentials: {original_json}"
         );
+    }
+
+    #[test]
+    fn redacted_for_snapshot_masks_headers_under_engine_custom() {
+        // `engine.custom` is freeform metadata the engine never interprets, but
+        // `/api/v1/config` still serializes it — so auth `headers` an embedder
+        // stashes there must be masked too, matching the policy applied to the
+        // structured engine arms. The whole map is treated as one object so a
+        // *top-level* `custom.headers` is caught just like a nested one, and the
+        // list form (`[{key, value}]`) and non-object scalars are handled.
+        let yaml = r#"
+version: otel_dataflow/v1
+engine:
+  custom:
+    headers:
+      authorization: "Bearer toplevel-super-secret"
+    fleet_management:
+      endpoint: "https://fleet.example/api"
+      headers:
+        authorization: "Bearer nested-super-secret"
+    setter:
+      headers:
+        - key: Authorization
+          value: "Bearer list-super-secret"
+    schema_version: 3
+"#;
+        let spec: OtelDataflowSpec = serde_yaml::from_str(yaml).expect("spec should deserialize");
+        let redacted = spec.redacted_for_snapshot();
+
+        let redacted_json = serde_json::to_string(&redacted).expect("redacted spec serializes");
+        // Top-level (map form), nested, and list-form `headers` under `custom`
+        // must all be masked.
+        for secret in [
+            "toplevel-super-secret",
+            "nested-super-secret",
+            "list-super-secret",
+        ] {
+            assert!(
+                !redacted_json.contains(secret),
+                "custom header credential `{secret}` must not survive redaction: {redacted_json}"
+            );
+        }
+        assert!(
+            redacted_json.contains(crate::node::REDACTED_HEADER_VALUE),
+            "redaction placeholder should be present: {redacted_json}"
+        );
+        // Non-header values under `custom`, including non-object scalars, are
+        // preserved.
+        assert!(
+            redacted_json.contains("https://fleet.example/api")
+                && redacted_json.contains("schema_version"),
+            "non-header custom values must be preserved: {redacted_json}"
+        );
+
+        // Redaction is a copy: the stored spec keeps the cleartext.
+        let original_json = serde_json::to_string(&spec).expect("spec serializes");
+        for secret in [
+            "toplevel-super-secret",
+            "nested-super-secret",
+            "list-super-secret",
+        ] {
+            assert!(
+                original_json.contains(secret),
+                "original spec must retain cleartext `{secret}`: {original_json}"
+            );
+        }
     }
 
     fn write_temp_file(ext: &str, contents: &str) -> PathBuf {

--- a/rust/otap-dataflow/crates/config/src/engine.rs
+++ b/rust/otap-dataflow/crates/config/src/engine.rs
@@ -63,12 +63,16 @@ pub struct OtelDataflowSpec {
 impl OtelDataflowSpec {
     /// Returns a clone of this engine config with every node's and
     /// extension's credential header values redacted, for safe exposure
-    /// through the admin config snapshot API (`GET /api/v1/config`). See
-    /// [`PipelineConfig::redacted_for_snapshot`]. The stored config is left
+    /// through the admin config snapshot API (`GET /api/v1/config`). This
+    /// covers both pipeline groups and engine-scoped config. See
+    /// [`PipelineConfig::redacted_for_snapshot`] and
+    /// [`EngineConfig::redacted_for_snapshot`] (the latter enumerates the
+    /// engine subtrees). The stored config is left
     /// unchanged.
     #[must_use]
     pub fn redacted_for_snapshot(&self) -> OtelDataflowSpec {
         let mut redacted = self.clone();
+        redacted.engine = redacted.engine.redacted_for_snapshot();
         for group in redacted.groups.values_mut() {
             *group = group.redacted_for_snapshot();
         }
@@ -111,6 +115,38 @@ pub struct EngineConfig {
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     #[schemars(extend("x-kubernetes-preserve-unknown-fields" = true))]
     pub custom: HashMap<String, Value>,
+}
+
+impl EngineConfig {
+    /// Returns a clone of this engine config with credential header values
+    /// redacted from the engine-scoped config that the admin/config snapshot
+    /// API (`GET /api/v1/config`) exposes. Three engine subtrees carry raw,
+    /// header-bearing config and are redacted with the same policy as pipeline
+    /// nodes/extensions:
+    ///
+    /// - `controller.extensions` — controller-owned extensions whose `config`
+    ///   is the same opaque [`Value`] as a node's. See
+    ///   [`ControllerExtensions::redacted_for_snapshot`].
+    /// - `observability.pipeline.nodes` — the engine observability pipeline's
+    ///   node set. See [`PipelineNodes::redacted_for_snapshot`].
+    /// - `telemetry.metrics.readers[].exporter.config` — each metrics reader's
+    ///   opaque exporter `config` [`Value`]. See
+    ///   [`TelemetryConfig::redacted_for_snapshot`].
+    ///
+    /// The remaining strongly-typed engine settings (`observed_state`,
+    /// `topics`) have no opaque `headers`-bearing config, and `custom` is
+    /// opaque application metadata the engine never interprets as credentials,
+    /// so none are touched. The stored config is left unchanged.
+    #[must_use]
+    pub fn redacted_for_snapshot(&self) -> EngineConfig {
+        let mut redacted = self.clone();
+        redacted.telemetry = redacted.telemetry.redacted_for_snapshot();
+        redacted.controller.extensions = redacted.controller.extensions.redacted_for_snapshot();
+        if let Some(pipeline) = redacted.observability.pipeline.as_mut() {
+            pipeline.nodes = pipeline.nodes.redacted_for_snapshot();
+        }
+        redacted
+    }
 }
 
 /// Controller-specific configuration.
@@ -224,6 +260,20 @@ impl ControllerExtensions {
     /// Returns an iterator over extension IDs.
     pub fn keys(&self) -> impl Iterator<Item = &ExtensionId> {
         self.0.keys()
+    }
+
+    /// Returns a clone of these controller extensions with every extension's
+    /// credential header values redacted, for safe exposure through the
+    /// admin/config snapshot APIs. See
+    /// [`ExtensionUserConfig::redacted_for_snapshot`]. The stored config is left
+    /// unchanged.
+    #[must_use]
+    pub fn redacted_for_snapshot(&self) -> ControllerExtensions {
+        let mut redacted = self.clone();
+        for extension in redacted.0.values_mut() {
+            *extension = Arc::new(extension.redacted_for_snapshot());
+        }
+        redacted
     }
 }
 
@@ -424,6 +474,77 @@ groups:
         assert!(
             original_json.contains("Bearer super-secret-token"),
             "original spec must retain the cleartext credential"
+        );
+    }
+
+    #[test]
+    fn redacted_for_snapshot_masks_engine_scoped_headers() {
+        // `/api/v1/config` serializes the whole spec, including engine-scoped
+        // config. Controller extensions, the engine observability pipeline's
+        // nodes, and each telemetry metrics reader's opaque exporter `config`
+        // all carry raw header-bearing config, so redaction must reach them too
+        // — not just `groups`. Deserialize directly (no validation) to keep the
+        // test focused on redaction.
+        let yaml = r#"
+version: otel_dataflow/v1
+engine:
+  controller:
+    extensions:
+      ctrl_auth:
+        type: "urn:otap:extension:headers_setter"
+        config:
+          headers:
+            authorization: "Bearer controller-super-secret"
+  observability:
+    pipeline:
+      nodes:
+        obs_exporter:
+          type: "urn:otel:exporter:otlp"
+          config:
+            headers:
+              authorization: "Bearer observability-super-secret"
+  telemetry:
+    metrics:
+      readers:
+        - periodic:
+            exporter:
+              type: otlp
+              config:
+                endpoint: "http://backend.example:4318/v1/metrics"
+                protocol: "http/protobuf"
+                headers:
+                  authorization: "Bearer telemetry-super-secret"
+            interval: "10s"
+"#;
+        let spec: OtelDataflowSpec = serde_yaml::from_str(yaml).expect("spec should deserialize");
+        let redacted = spec.redacted_for_snapshot();
+
+        let redacted_json = serde_json::to_string(&redacted).expect("redacted spec serializes");
+        assert!(
+            !redacted_json.contains("controller-super-secret"),
+            "controller extension credential must not survive redaction: {redacted_json}"
+        );
+        assert!(
+            !redacted_json.contains("observability-super-secret"),
+            "observability node credential must not survive redaction: {redacted_json}"
+        );
+        assert!(
+            !redacted_json.contains("telemetry-super-secret"),
+            "telemetry exporter credential must not survive redaction: {redacted_json}"
+        );
+        assert!(
+            redacted_json.contains(crate::node::REDACTED_HEADER_VALUE),
+            "redaction placeholder should be present: {redacted_json}"
+        );
+
+        // Redaction is a copy: the stored spec keeps the cleartext for the
+        // controller's own use (it is never the thing serialized to clients).
+        let original_json = serde_json::to_string(&spec).expect("spec serializes");
+        assert!(
+            original_json.contains("controller-super-secret")
+                && original_json.contains("observability-super-secret")
+                && original_json.contains("telemetry-super-secret"),
+            "original spec must retain the cleartext credentials: {original_json}"
         );
     }
 

--- a/rust/otap-dataflow/crates/config/src/extension.rs
+++ b/rust/otap-dataflow/crates/config/src/extension.rs
@@ -53,6 +53,23 @@ impl ExtensionUserConfig {
             config: Value::Null,
         }
     }
+
+    /// Returns a clone of this extension config with credential header values
+    /// redacted, for safe exposure through the admin/config snapshot APIs.
+    ///
+    /// Extension `config` is the same raw [`Value`] mechanism as
+    /// [`NodeUserConfig::config`](crate::node::NodeUserConfig::config), so an
+    /// extension that carries static `headers` (credentials) is redacted with
+    /// the same policy as a node: every value under any `headers` object is
+    /// replaced with
+    /// [`REDACTED_HEADER_VALUE`](crate::node::REDACTED_HEADER_VALUE) while the
+    /// keys are preserved. The stored config is left unchanged.
+    #[must_use]
+    pub fn redacted_for_snapshot(&self) -> ExtensionUserConfig {
+        let mut redacted = self.clone();
+        crate::node::redact_secret_headers(&mut redacted.config);
+        redacted
+    }
 }
 
 #[cfg(test)]
@@ -80,5 +97,26 @@ capabilities:
 "#;
         let result: Result<ExtensionUserConfig, _> = serde_yaml::from_str(yaml);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn redacted_for_snapshot_masks_extension_headers() {
+        let yaml = r#"
+type: "urn:otap:extension:headers_setter"
+config:
+  headers:
+    authorization: "Bearer ext-super-secret"
+"#;
+        let cfg: ExtensionUserConfig = serde_yaml::from_str(yaml).unwrap();
+        let redacted = cfg.redacted_for_snapshot();
+        assert_eq!(
+            redacted.config["headers"]["authorization"],
+            crate::node::REDACTED_HEADER_VALUE
+        );
+        // The original extension config is left untouched (redaction is a copy).
+        assert_eq!(
+            cfg.config["headers"]["authorization"],
+            "Bearer ext-super-secret"
+        );
     }
 }

--- a/rust/otap-dataflow/crates/config/src/node.rs
+++ b/rust/otap-dataflow/crates/config/src/node.rs
@@ -339,6 +339,85 @@ impl NodeUserConfig {
     pub const fn kind(&self) -> NodeKind {
         self.r#type.kind()
     }
+
+    /// Returns a clone of this node config with credential header values
+    /// redacted, for safe exposure through the admin/config snapshot APIs
+    /// (e.g. `GET /api/v1/config`).
+    ///
+    /// Static request `headers` values are credentials (an `Authorization`
+    /// token, a tenant API key). The typed exporter settings wrap them in
+    /// `secrecy::SecretString`, but the raw [`Self::config`] retains the
+    /// original cleartext. This produces a redacted *copy*: every value under
+    /// any `headers` object in `config` is replaced with
+    /// [`REDACTED_HEADER_VALUE`] while the keys are preserved, so operators can
+    /// still see which headers are set without seeing their values. The stored
+    /// config is left unchanged.
+    #[must_use]
+    pub fn redacted_for_snapshot(&self) -> NodeUserConfig {
+        let mut redacted = self.clone();
+        redact_secret_headers(&mut redacted.config);
+        redacted
+    }
+}
+
+/// Placeholder substituted for credential values that have been redacted from a
+/// config snapshot exposed through the admin/config APIs.
+pub const REDACTED_HEADER_VALUE: &str = "[REDACTED]";
+
+/// Recursively redacts credential values held under any `headers` field,
+/// replacing them with [`REDACTED_HEADER_VALUE`].
+///
+/// Two header shapes carry credentials in the OpenTelemetry ecosystem and are
+/// both handled, since node/extension `config` is opaque JSON:
+///
+/// - **Map form** — `headers: { name: value }` (e.g. `config.headers` for
+///   OTAP/gRPC, `config.http.headers` for OTLP/HTTP exporters). Every value is
+///   masked; the keys are preserved so a snapshot still shows which headers are
+///   configured.
+/// - **List form** — `headers: [ { key, value, ... }, ... ]` (e.g. the
+///   `headers_setter` schema). The static `value` of each entry is masked;
+///   reference fields such as `from_context` / `from_attribute` are not secrets
+///   and are left intact.
+///
+/// Other subtrees are traversed so a `headers` field is redacted regardless of
+/// nesting depth. Shared with
+/// [`ExtensionUserConfig::redacted_for_snapshot`](crate::extension::ExtensionUserConfig::redacted_for_snapshot).
+pub(crate) fn redact_secret_headers(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            for (key, child) in map.iter_mut() {
+                if key == "headers" {
+                    match child {
+                        Value::Object(headers) => {
+                            for header_value in headers.values_mut() {
+                                *header_value = Value::String(REDACTED_HEADER_VALUE.to_owned());
+                            }
+                            continue;
+                        }
+                        Value::Array(entries) => {
+                            for entry in entries.iter_mut() {
+                                if let Value::Object(fields) = entry {
+                                    if let Some(static_value) = fields.get_mut("value") {
+                                        *static_value =
+                                            Value::String(REDACTED_HEADER_VALUE.to_owned());
+                                    }
+                                }
+                            }
+                            continue;
+                        }
+                        _ => {}
+                    }
+                }
+                redact_secret_headers(child);
+            }
+        }
+        Value::Array(items) => {
+            for item in items.iter_mut() {
+                redact_secret_headers(item);
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
 }
 
 /// Entity configuration for a node, aligned with the semantic conventions model.
@@ -712,5 +791,135 @@ capabilities:
             msg.contains("duplicate"),
             "error should mention duplicate: {msg}"
         );
+    }
+
+    #[test]
+    fn redacted_for_snapshot_masks_nested_http_headers() {
+        // OTLP/HTTP exporter shape: `config.http.headers.*`.
+        let json = r#"{
+            "type": "urn:otel:exporter:otlp_http",
+            "config": {
+                "endpoint": "https://backend.example/v1/logs",
+                "http": {
+                    "headers": {
+                        "authorization": "Bearer super-secret-token",
+                        "x-scope-orgid": "tenant-1"
+                    }
+                }
+            }
+        }"#;
+        let cfg: NodeUserConfig = serde_json::from_str(json).unwrap();
+        let redacted = cfg.redacted_for_snapshot();
+
+        let headers = &redacted.config["http"]["headers"];
+        assert_eq!(
+            headers["authorization"],
+            Value::String(REDACTED_HEADER_VALUE.to_owned())
+        );
+        assert_eq!(
+            headers["x-scope-orgid"],
+            Value::String(REDACTED_HEADER_VALUE.to_owned())
+        );
+        // Non-credential fields and the header keys themselves are preserved.
+        assert_eq!(
+            redacted.config["endpoint"],
+            "https://backend.example/v1/logs"
+        );
+        assert!(headers.get("authorization").is_some());
+
+        // The original config is left untouched (redaction is a copy).
+        assert_eq!(
+            cfg.config["http"]["headers"]["authorization"],
+            "Bearer super-secret-token"
+        );
+    }
+
+    #[test]
+    fn redacted_for_snapshot_masks_flattened_grpc_headers() {
+        // OTAP/gRPC exporter shape: `headers` is flattened to `config.headers.*`.
+        let json = r#"{
+            "type": "urn:otel:exporter:otap",
+            "config": {
+                "grpc_endpoint": "https://backend.example:4317",
+                "headers": {
+                    "authorization": "Basic abc123"
+                }
+            }
+        }"#;
+        let cfg: NodeUserConfig = serde_json::from_str(json).unwrap();
+        let redacted = cfg.redacted_for_snapshot();
+
+        assert_eq!(
+            redacted.config["headers"]["authorization"],
+            Value::String(REDACTED_HEADER_VALUE.to_owned())
+        );
+        // Non-header sibling settings are untouched.
+        assert_eq!(
+            redacted.config["grpc_endpoint"],
+            "https://backend.example:4317"
+        );
+    }
+
+    #[test]
+    fn redacted_for_snapshot_without_headers_is_noop() {
+        let json = r#"{
+            "type": "urn:otel:processor:batch",
+            "config": { "send_batch_size": 1024, "timeout": "5s" }
+        }"#;
+        let cfg: NodeUserConfig = serde_json::from_str(json).unwrap();
+        let redacted = cfg.redacted_for_snapshot();
+        assert_eq!(cfg, redacted, "config without headers must be unchanged");
+    }
+
+    #[test]
+    fn redacted_for_snapshot_masks_headers_inside_arrays() {
+        // Defense-in-depth: a `headers` map nested under an array element must
+        // still be redacted (the walk descends through arrays).
+        let json = r#"{
+            "type": "urn:otel:exporter:multi",
+            "config": {
+                "backends": [
+                    { "headers": { "authorization": "secret-a" } },
+                    { "headers": { "x-api-key": "secret-b" } }
+                ]
+            }
+        }"#;
+        let cfg: NodeUserConfig = serde_json::from_str(json).unwrap();
+        let redacted = cfg.redacted_for_snapshot();
+        assert_eq!(
+            redacted.config["backends"][0]["headers"]["authorization"],
+            REDACTED_HEADER_VALUE
+        );
+        assert_eq!(
+            redacted.config["backends"][1]["headers"]["x-api-key"],
+            REDACTED_HEADER_VALUE
+        );
+    }
+
+    #[test]
+    fn redacted_for_snapshot_masks_list_form_headers() {
+        // `headers_setter`-style schema: `headers` is a list of entries. The
+        // static `value` is a credential and must be masked; reference fields
+        // (`from_context`) and the `key` are not secrets and are left intact.
+        let json = r#"{
+            "type": "urn:test:processor:headers_setter",
+            "config": {
+                "headers": [
+                    { "action": "upsert", "key": "Authorization", "value": "Bearer super-secret" },
+                    { "key": "X-Scope-OrgID", "from_context": "X-Scope-OrgID" }
+                ]
+            }
+        }"#;
+        let cfg: NodeUserConfig = serde_json::from_str(json).unwrap();
+        let redacted = cfg.redacted_for_snapshot();
+
+        let entries = redacted.config["headers"].as_array().unwrap();
+        assert_eq!(entries[0]["value"], REDACTED_HEADER_VALUE);
+        assert_eq!(entries[0]["key"], "Authorization");
+        // The reference-only entry is untouched (no static secret to mask).
+        assert_eq!(entries[1]["from_context"], "X-Scope-OrgID");
+        assert!(entries[1].get("value").is_none());
+        // Original config retains the cleartext (redaction is a copy).
+        assert_eq!(cfg.config["headers"][0]["value"], "Bearer super-secret");
     }
 }

--- a/rust/otap-dataflow/crates/config/src/pipeline.rs
+++ b/rust/otap-dataflow/crates/config/src/pipeline.rs
@@ -378,6 +378,19 @@ impl PipelineNodes {
         self.0.contains_key(id)
     }
 
+    /// Returns a clone of this node set with every node's credential header
+    /// values redacted, for safe exposure through the admin/config snapshot
+    /// APIs. See [`NodeUserConfig::redacted_for_snapshot`]. The stored config is
+    /// left unchanged.
+    #[must_use]
+    pub fn redacted_for_snapshot(&self) -> PipelineNodes {
+        let mut redacted = self.clone();
+        for node in redacted.0.values_mut() {
+            *node = Arc::new(node.redacted_for_snapshot());
+        }
+        redacted
+    }
+
     /// Returns an iterator visiting all nodes.
     pub fn iter(&self) -> impl Iterator<Item = (&NodeId, &Arc<NodeUserConfig>)> {
         self.0.iter()

--- a/rust/otap-dataflow/crates/config/src/pipeline.rs
+++ b/rust/otap-dataflow/crates/config/src/pipeline.rs
@@ -629,6 +629,24 @@ impl PipelineConfig {
         &self.nodes
     }
 
+    /// Returns a clone of this pipeline config with every node's and
+    /// extension's credential header values redacted, for safe exposure through
+    /// the admin/config snapshot APIs. See
+    /// [`NodeUserConfig::redacted_for_snapshot`] and
+    /// [`ExtensionUserConfig::redacted_for_snapshot`]. The stored config is left
+    /// unchanged.
+    #[must_use]
+    pub fn redacted_for_snapshot(&self) -> PipelineConfig {
+        let mut redacted = self.clone();
+        for node in redacted.nodes.0.values_mut() {
+            *node = Arc::new(node.redacted_for_snapshot());
+        }
+        for extension in redacted.extensions.0.values_mut() {
+            *extension = Arc::new(extension.redacted_for_snapshot());
+        }
+        redacted
+    }
+
     /// Returns a reference to the pipeline extensions.
     #[must_use]
     pub const fn extensions(&self) -> &PipelineExtensions {
@@ -3241,6 +3259,74 @@ extensions:
         assert!(
             msg.contains("duplicate extension key"),
             "error should mention duplicate extension key: {msg}"
+        );
+    }
+
+    #[test]
+    fn redacted_for_snapshot_masks_exporter_headers() {
+        let yaml = r#"
+            nodes:
+              receiver:
+                type: "urn:otel:receiver:otlp"
+                config: {}
+              exporter:
+                type: "urn:otel:exporter:otlp_http"
+                config:
+                  endpoint: "https://backend.example"
+                  http:
+                    headers:
+                      authorization: "Bearer super-secret-token"
+            connections:
+              - from: receiver
+                to: exporter
+        "#;
+        let config = super::PipelineConfig::from_yaml("group".into(), "pipe".into(), yaml)
+            .expect("pipeline should parse and validate");
+        let redacted = config.redacted_for_snapshot();
+
+        let redacted_json = serde_json::to_string(&redacted).expect("redacted serializes");
+        assert!(
+            !redacted_json.contains("Bearer super-secret-token"),
+            "credential must not survive redaction: {redacted_json}"
+        );
+        assert!(
+            redacted_json.contains(crate::node::REDACTED_HEADER_VALUE),
+            "redaction placeholder should be present"
+        );
+        // The stored pipeline config keeps the cleartext for runtime use.
+        let original_json = serde_json::to_string(&config).expect("config serializes");
+        assert!(original_json.contains("Bearer super-secret-token"));
+    }
+
+    #[test]
+    fn redacted_for_snapshot_masks_extension_headers() {
+        // Extensions carry the same raw `config` Value as nodes; an extension
+        // that holds static `headers` must be redacted too. Deserialize
+        // directly (no validation) so the test stays focused on redaction.
+        let yaml = r#"
+            nodes:
+              receiver:
+                type: "urn:otel:receiver:otlp"
+                config: {}
+            extensions:
+              auth:
+                type: "urn:otap:extension:headers_setter"
+                config:
+                  headers:
+                    authorization: "Bearer ext-super-secret"
+        "#;
+        let config: super::PipelineConfig =
+            serde_yaml::from_str(yaml).expect("pipeline should deserialize");
+        let redacted = config.redacted_for_snapshot();
+
+        let redacted_json = serde_json::to_string(&redacted).expect("redacted serializes");
+        assert!(
+            !redacted_json.contains("Bearer ext-super-secret"),
+            "extension credential must not survive redaction: {redacted_json}"
+        );
+        assert!(
+            redacted_json.contains(crate::node::REDACTED_HEADER_VALUE),
+            "redaction placeholder should be present"
         );
     }
 }

--- a/rust/otap-dataflow/crates/config/src/pipeline/telemetry.rs
+++ b/rust/otap-dataflow/crates/config/src/pipeline/telemetry.rs
@@ -43,6 +43,36 @@ impl TelemetryConfig {
         }
         self.metrics.validate()
     }
+
+    /// Returns a clone of this telemetry config with credential header values
+    /// redacted from every metrics reader's opaque exporter `config`, for safe
+    /// exposure through the admin/config snapshot APIs.
+    ///
+    /// Each reader's exporter `config` is a raw [`serde_json::Value`] (the same
+    /// opaque mechanism as a node's [`config`](crate::node::NodeUserConfig::config))
+    /// that is retained verbatim and re-serialized. The periodic OTLP exporter
+    /// schema (`OtlpExporterConfig`) does not reject unknown fields, so an
+    /// operator who sets a static `headers` map (e.g. an `authorization` token
+    /// for an OTLP telemetry backend) would otherwise have those values served
+    /// in cleartext. Both reader arms are masked here for defensive consistency
+    /// with pipeline nodes/extensions — even the pull/Prometheus schema, which
+    /// rejects unknown fields today, since the stored value is still opaque. The
+    /// stored config is left unchanged.
+    #[must_use]
+    pub fn redacted_for_snapshot(&self) -> TelemetryConfig {
+        let mut redacted = self.clone();
+        for reader in &mut redacted.metrics.readers {
+            match reader {
+                metrics::readers::MetricsReaderConfig::Periodic(periodic) => {
+                    crate::node::redact_secret_headers(&mut periodic.exporter.config);
+                }
+                metrics::readers::MetricsReaderConfig::Pull(pull) => {
+                    crate::node::redact_secret_headers(&mut pull.exporter.config);
+                }
+            }
+        }
+        redacted
+    }
 }
 
 impl Default for TelemetryConfig {
@@ -412,6 +442,61 @@ mod tests {
             panic!("Expected service.version to be a String attribute value");
         }
         assert_eq!(config.metrics.readers.len(), 1);
+    }
+
+    #[test]
+    fn redacted_for_snapshot_masks_metrics_exporter_headers() {
+        // Each metrics reader's exporter `config` is a raw JSON value that
+        // retains unknown fields (the exporter schemas ignore them), so static
+        // credential `headers` set there would otherwise be served in cleartext
+        // by the admin/config snapshot API. `redacted_for_snapshot` must mask
+        // them on both the periodic and pull reader variants.
+        let yaml_str = r#"
+            metrics:
+                readers:
+                    - periodic:
+                        exporter:
+                            type: otlp
+                            config:
+                                endpoint: "http://backend.example:4318/v1/metrics"
+                                protocol: "http/protobuf"
+                                headers:
+                                    authorization: "Bearer periodic-super-secret"
+                        interval: "10s"
+                    - pull:
+                        exporter:
+                            type: prometheus
+                            config:
+                                host: "0.0.0.0"
+                                port: 9090
+                                headers:
+                                    authorization: "Bearer pull-super-secret"
+            "#;
+        let config: TelemetryConfig =
+            serde_yaml::from_str(yaml_str).expect("telemetry config deserializes");
+        let redacted = config.redacted_for_snapshot();
+
+        let redacted_json = serde_json::to_string(&redacted).expect("redacted serializes");
+        assert!(
+            !redacted_json.contains("periodic-super-secret"),
+            "periodic exporter credential must not survive redaction: {redacted_json}"
+        );
+        assert!(
+            !redacted_json.contains("pull-super-secret"),
+            "pull exporter credential must not survive redaction: {redacted_json}"
+        );
+        assert!(
+            redacted_json.contains(crate::node::REDACTED_HEADER_VALUE),
+            "redaction placeholder should be present: {redacted_json}"
+        );
+
+        // Redaction is a copy: the stored config keeps the cleartext.
+        let original_json = serde_json::to_string(&config).expect("config serializes");
+        assert!(
+            original_json.contains("periodic-super-secret")
+                && original_json.contains("pull-super-secret"),
+            "original telemetry config must retain the cleartext credentials: {original_json}"
+        );
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/config/src/pipeline_group.rs
+++ b/rust/otap-dataflow/crates/config/src/pipeline_group.rs
@@ -119,3 +119,55 @@ impl Default for PipelineGroupConfig {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacted_for_snapshot_masks_node_and_extension_headers() {
+        // A pipeline group whose pipeline carries credential headers on BOTH a
+        // node and an extension. `redacted_for_snapshot()` must scrub both
+        // before the config is exposed through the admin/config snapshot APIs.
+        // Deserialize directly (no validation) to keep the test focused on
+        // redaction.
+        let yaml = r#"
+            pipelines:
+              main:
+                nodes:
+                  exporter:
+                    type: "urn:otel:exporter:otlp"
+                    config:
+                      headers:
+                        authorization: "Bearer node-super-secret"
+                extensions:
+                  auth:
+                    type: "urn:otap:extension:headers_setter"
+                    config:
+                      headers:
+                        authorization: "Bearer ext-super-secret"
+        "#;
+        let group: PipelineGroupConfig =
+            serde_yaml::from_str(yaml).expect("pipeline group should deserialize");
+        let redacted = group.redacted_for_snapshot();
+
+        let redacted_json = serde_json::to_string(&redacted).expect("redacted serializes");
+        assert!(
+            !redacted_json.contains("node-super-secret"),
+            "node credential must not survive redaction: {redacted_json}"
+        );
+        assert!(
+            !redacted_json.contains("ext-super-secret"),
+            "extension credential must not survive redaction: {redacted_json}"
+        );
+        assert!(
+            redacted_json.contains(crate::node::REDACTED_HEADER_VALUE),
+            "redaction placeholder should be present: {redacted_json}"
+        );
+
+        // Redaction returns a copy; the original group keeps the cleartext.
+        let original_json = serde_json::to_string(&group).expect("original serializes");
+        assert!(original_json.contains("node-super-secret"));
+        assert!(original_json.contains("ext-super-secret"));
+    }
+}

--- a/rust/otap-dataflow/crates/config/src/pipeline_group.rs
+++ b/rust/otap-dataflow/crates/config/src/pipeline_group.rs
@@ -41,6 +41,20 @@ impl PipelineGroupConfig {
         }
     }
 
+    /// Returns a clone of this pipeline group with every node's credential
+    /// header values redacted, for safe exposure through the admin/config
+    /// snapshot APIs. See
+    /// [`PipelineConfig::redacted_for_snapshot`](crate::pipeline::PipelineConfig::redacted_for_snapshot).
+    /// The stored config is left unchanged.
+    #[must_use]
+    pub fn redacted_for_snapshot(&self) -> PipelineGroupConfig {
+        let mut redacted = self.clone();
+        for pipeline in redacted.pipelines.values_mut() {
+            *pipeline = pipeline.redacted_for_snapshot();
+        }
+        redacted
+    }
+
     /// Adds a pipeline to the pipeline group.
     pub fn add_pipeline(
         &mut self,

--- a/rust/otap-dataflow/crates/config/src/pipeline_group.rs
+++ b/rust/otap-dataflow/crates/config/src/pipeline_group.rs
@@ -41,9 +41,9 @@ impl PipelineGroupConfig {
         }
     }
 
-    /// Returns a clone of this pipeline group with every node's credential
-    /// header values redacted, for safe exposure through the admin/config
-    /// snapshot APIs. See
+    /// Returns a clone of this pipeline group with every node's and
+    /// extension's credential header values redacted, for safe exposure
+    /// through the admin/config snapshot APIs. See
     /// [`PipelineConfig::redacted_for_snapshot`](crate::pipeline::PipelineConfig::redacted_for_snapshot).
     /// The stored config is left unchanged.
     #[must_use]


### PR DESCRIPTION
# Change Summary

Redact credential header values from the admin config snapshot APIs. These endpoints serialize the controller's stored config, which retains each node's and extension's raw `serde_json::Value` (`NodeUserConfig.config` / `ExtensionUserConfig.config`). Static exporter `headers` values are credentials (an `Authorization` token, a tenant API key); PR #3322 wrapped the **typed** settings in `secrecy::SecretString`, but the raw config still held cleartext and was returned by these endpoints — bypassing that protection (the gap reported in #3328).

Add `redacted_for_snapshot` to the config types — `NodeUserConfig`, `ExtensionUserConfig`, `PipelineConfig`, `PipelineGroupConfig`, `OtelDataflowSpec` — which return a redacted **copy** where credential header values are replaced with `[REDACTED]` while the header keys are preserved (operators still see which headers are configured). Both header shapes in the OTel ecosystem are handled:

- **Map form** — `headers: { name: value }` (OTLP/HTTP `config.http.headers`, OTAP/gRPC `config.headers`).
- **List form** — `headers: [ { key, value } ]` (the `headers_setter` schema): the static `value` of each entry is masked; reference fields (`from_context` / `from_attribute`) and `key` are left intact.

Redaction is applied at the response boundary in the GET handlers `show_config` (`GET /api/v1/config`), `show_pipeline`, and `show_group`, and on the `create_group` echo response. It operates on a clone, so the controller's stored config is unchanged — reconciliation and runtime behavior are unaffected.

## What issue does this PR close?

* Closes #3328 (follow-up to #3322 / #3306)

## How are these changes tested?

* `cargo xtask check` (structure, `fmt`, `clippy -D warnings`, full test suite) passes.
* Config-crate unit tests: map form (`config.headers`, `config.http.headers`), list form (`headers_setter` arrays), headers nested inside arrays, no-headers no-op, extension headers, and non-mutation (the original retains the cleartext after redaction).
* Admin-crate handler tests assert the raw credential is **absent** and `[REDACTED]` is **present** in the response body of `show_config`, `show_pipeline`, `show_group`, and `create_group`.

## Are there any user-facing changes?

Yes. Credential header values configured under node/extension `headers` no longer appear in cleartext in admin config snapshot responses (`GET /api/v1/config`, the per-group and per-pipeline detail endpoints, and the create-group echo); they are returned as `[REDACTED]`. The stored configuration and all runtime/reconcile behavior are unchanged.

### Changelog

* [x] Added a `.chloggen/*.yaml` entry (`change_type: bug_fix`, `component: engine`).
