### PR TITLE
chore(ci): move license_header_check_required to rust-required-status-check.needs

### DIFF
--- a/.github/workflows/repo-lint.yaml
+++ b/.github/workflows/repo-lint.yaml
@@ -53,9 +53,3 @@ jobs:
 
     - name: Validate Renovate config
       run: npx --yes --package renovate -- renovate-config-validator --strict
-
-  license-header-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: korandoru/hawkeye@c57037afedf940370c41eb660837c8aa928d472a # v6.5.1

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1088,6 +1088,16 @@ jobs:
           cd tools/pipeline_perf_test
           python orchestrator/run_orchestrator.py --config test_suites/integration/continuous/100klrps-docker.yaml
 
+  # License header check (korandoru/hawkeye, config in licenserc.toml). Covers
+  # both *.go and *.rs; hosted here so it can be made a required check
+  # transitively via rust-required-status-check.needs without editing the
+  # branch-protection ruleset.
+  license-header-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: korandoru/hawkeye@c57037afedf940370c41eb660837c8aa928d472a # v6.5.1
+
   # Aggregated status check - depends only on the required matrix combinations.
   # Add/remove jobs from the needs list to change what is required via PR,
   # rather than updating GitHub branch protection settings directly.
@@ -1108,6 +1118,7 @@ jobs:
       - host-metrics-semconv
       - user_events_linux_smoke
       - etw_windows_smoke
+      - license-header-check
     steps:
       - name: Check if all required jobs succeeded
         run: |
@@ -1157,6 +1168,10 @@ jobs:
           fi
           if [[ "${{ needs.etw_windows_smoke.result }}" != "success" ]]; then
             echo "etw_windows_smoke failed or was cancelled"
+            exit 1
+          fi
+          if [[ "${{ needs.license-header-check.result }}" != "success" ]]; then
+            echo "license-header-check failed or was cancelled"
             exit 1
           fi
           echo "All required checks passed!"


### PR DESCRIPTION
# Change Summary

 Promote the `license-header-check` (korandoru/hawkeye) job from an optional check to a **required** one, so PRs missing an `Apache-2.0` SPDX header can no longer be merged

## What issue does this PR close?

<!--
We highly recommend correlation of every PR to an issue
-->

* Closes #1333 

## How are these changes tested?

## Are there any user-facing changes?

 <!-- If yes, provide further info below -->

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
