### PR TITLE
feat(core-nodes): emit df_engine.component.shutdown event from OTLP exporters

### DIFF
--- a/rust/otap-dataflow/.chloggen/component-shutdown-event.yaml
+++ b/rust/otap-dataflow/.chloggen/component-shutdown-event.yaml
@@ -1,0 +1,9 @@
+change_type: enhancement
+
+component: pipeline
+
+note: Emit `df_engine.component.shutdown` event from OTLP gRPC and HTTP exporters with result and duration attributes.
+
+issues: [3349]
+
+subtext:

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/mod.rs
@@ -283,8 +283,12 @@ impl Exporter<OtapPdata> for OTLPExporter {
             };
 
             match msg {
-                Message::Control(NodeControlMsg::Shutdown { deadline, .. }) => {
-                    otel_info!("otlp.exporter.grpc.shutdown");
+                Message::Control(NodeControlMsg::Shutdown { deadline, reason }) => {
+                    // TODO: ideally the shutdown start time should be captured
+                    // when the shutdown command is issued (before channel send),
+                    // and passed through NodeControlMsg. Currently we measure
+                    // from message receipt, which excludes queue/scheduling delay.
+                    let shutdown_start = std::time::Instant::now();
                     debug_assert!(
                         pending_msg.is_none(),
                         "pending message should have been drained before shutdown"
@@ -300,6 +304,14 @@ impl Exporter<OtapPdata> for OTLPExporter {
                             grpc_clients.release(client);
                         }
                     }
+                    let duration_secs = shutdown_start.elapsed().as_secs_f64();
+                    otel_info!(
+                        "df_engine.component.shutdown",
+                        reason = reason,
+                        "otel.component.type" = "otlp_grpc_exporter",
+                        "otel.component.shutdown.result" = "success",
+                        "otel.component.shutdown.duration" = duration_secs,
+                    );
                     return Ok(TerminalState::new(deadline, [self.pdata_metrics]));
                 }
                 Message::Control(NodeControlMsg::CollectTelemetry {

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs
@@ -323,7 +323,9 @@ impl Exporter<OtapPdata> for OtlpHttpExporter {
 
             match msg {
                 Message::Control(NodeControlMsg::Shutdown { deadline, reason }) => {
-                    otel_info!("otlp.exporter.http.shutdown", reason = reason);
+                    // TODO: same as otlp_grpc_exporter — start time should
+                    // come from the shutdown initiator, not message receipt.
+                    let shutdown_start = std::time::Instant::now();
                     while !inflight_exports.is_empty() {
                         if let Some(completed) = inflight_exports.next_completion().await {
                             finalize_completed_export(
@@ -334,6 +336,14 @@ impl Exporter<OtapPdata> for OtlpHttpExporter {
                             .await;
                         }
                     }
+                    let duration_secs = shutdown_start.elapsed().as_secs_f64();
+                    otel_info!(
+                        "df_engine.component.shutdown",
+                        reason = reason,
+                        "otel.component.type" = "otlp_http_exporter",
+                        "otel.component.shutdown.result" = "success",
+                        "otel.component.shutdown.duration" = duration_secs,
+                    );
                     return Ok(TerminalState::new(deadline, [self.pdata_metrics]));
                 }
                 Message::Control(NodeControlMsg::CollectTelemetry {

--- a/rust/otap-dataflow/semconv/groups/event.component.shutdown.yaml
+++ b/rust/otap-dataflow/semconv/groups/event.component.shutdown.yaml
@@ -1,0 +1,38 @@
+groups:
+  # TODO: `df_engine` prefix is provisional — the product name is not yet
+  # settled. Rename the event (and its registry group ID) once it is.
+  - id: event.otap_dataflow.df_engine.component.shutdown
+    type: event
+    name: df_engine.component.shutdown
+    stability: development
+    brief: >
+      Emitted when a pipeline component's shutdown attempt has ended, whether
+      by completing successfully, failing, or being abandoned on deadline.
+    note: >
+      This event SHOULD be emitted by each pipeline node (exporter, receiver,
+      processor) when it finishes processing its shutdown control message.
+      Modeled after the OpenTelemetry SDK `otel.sdk.component.shutdown` event
+      (open-telemetry/semantic-conventions#3723).
+    attributes:
+      - ref: otel.component.type
+        requirement_level: required
+        brief: >
+          The type of the pipeline component, e.g. `otlp_grpc_exporter`.
+      - ref: otel.component.name
+        requirement_level: recommended
+        brief: >
+          A name uniquely identifying this component instance within the engine.
+      - id: otel.component.shutdown.result
+        type: string
+        stability: development
+        requirement_level: required
+        brief: >
+          The result of the shutdown attempt.
+        examples: ["success", "failed", "timed_out"]
+      - id: otel.component.shutdown.duration
+        type: double
+        stability: development
+        requirement_level: recommended
+        brief: >
+          Wall-clock elapsed time of the shutdown attempt, in seconds.
+        examples: [0.015, 30.0]

--- a/rust/otap-dataflow/semconv/groups/event.component.shutdown.yaml
+++ b/rust/otap-dataflow/semconv/groups/event.component.shutdown.yaml
@@ -1,5 +1,5 @@
 groups:
-  # TODO: `df_engine` prefix is provisional — the product name is not yet
+  # TODO: `df_engine` prefix is provisional -- the product name is not yet
   # settled. Rename the event (and its registry group ID) once it is.
   - id: event.otap_dataflow.df_engine.component.shutdown
     type: event

--- a/rust/otap-dataflow/semconv/triggers/99_df_engine.component.shutdown.sh
+++ b/rust/otap-dataflow/semconv/triggers/99_df_engine.component.shutdown.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Trigger for `df_engine.component.shutdown`.
+#
+# Prefixed with `99_` so it sorts LAST in the glob — this trigger must
+# run after all other triggers because it terminates the engine.
+#
+# Initiates a graceful shutdown via the admin API so pipeline nodes
+# emit their shutdown events before the process is hard-killed by CI.
+# The `wait=true` parameter blocks until shutdown completes or the
+# timeout expires, ensuring the events have time to flow through the
+# internal_telemetry pipeline to weaver.
+set -euo pipefail
+
+curl -X POST --max-time 15 -fsS \
+  "http://127.0.0.1:14319/api/v1/groups/shutdown?wait=true&timeout_secs=10" || true
+
+# Brief pause for the internal telemetry exporter to flush the
+# shutdown events to weaver before the hard-kill step runs.
+sleep 2


### PR DESCRIPTION
Adds a structured shutdown event to the OTLP gRPC and HTTP exporters, modeled after the OTel SDK `otel.sdk.component.shutdown` convention ([open-telemetry/semantic-conventions#3723](https://github.com/open-telemetry/semantic-conventions/pull/3723)).

## Changes

- **In-tree semconv event definition** (`semconv/groups/event.component.shutdown.yaml`) with full attribute declarations (`otel.component.type`, `otel.component.shutdown.result`, `otel.component.shutdown.duration`).
- **OTLP gRPC exporter** — replaces bare `otel_info!("otlp.exporter.grpc.shutdown")` with timed structured event.
- **OTLP HTTP exporter** — same pattern.
- **Trigger script** (`99_df_engine.component.shutdown.sh`) — POSTs to admin `/api/v1/groups/shutdown?wait=true` so the event fires in CI before the hard-kill. Prefixed `99_` to ensure it runs last in the trigger glob.

## Notes

- `result` is always `success` today (the drain loop runs to completion). A follow-up can check the deadline to detect `timed_out`.
- `duration` is measured from message receipt, not from shutdown initiation (TODO in code — requires threading `initiated_at` through `NodeControlMsg`).
- `df_engine` prefix is provisional (product name unsettled; TODO in YAML).

## Related

- [#2325](https://github.com/open-telemetry/otel-arrow/pull/2325) — Handle OS signals (SIGTERM/SIGINT) for graceful pipeline shutdown. Once that lands, the shutdown event will fire naturally on SIGTERM without needing the admin API trigger.