### PR TITLE
chore: bind test/dev servers to loopback to avoid Windows firewall prompts

### DIFF
--- a/rust/otap-dataflow/CONTRIBUTING.md
+++ b/rust/otap-dataflow/CONTRIBUTING.md
@@ -31,15 +31,16 @@ not offset the limited parallelism gains.
 ## Test and example server bind addresses
 
 When a test or example starts a listening server, bind it to the loopback
-interface (`127.0.0.1`), not `0.0.0.0` (all interfaces). Prefer an ephemeral
-port (`127.0.0.1:0`) and read the assigned port back from the listener.
+interface (`127.0.0.1`, or `[::1]` for IPv6), not an all-interfaces address
+(`0.0.0.0`, or `[::]`/`[::]:0` for IPv6). Prefer an ephemeral port
+(`127.0.0.1:0`) and read the assigned port back from the listener.
 
 Windows Defender Firewall exempts loopback binds from its allow/deny prompt, so
 a loopback bind avoids the repeated firewall prompts that an all-interfaces bind
 triggers on every `cargo test` / `cargo xtask check` rebuild (test binaries are
 named by content hash, so a granted exception does not persist across rebuilds).
 Production defaults that intentionally serve external traffic may still bind
-`0.0.0.0`.
+`0.0.0.0` (or `[::]`).
 
 ## Changelog entries
 

--- a/rust/otap-dataflow/CONTRIBUTING.md
+++ b/rust/otap-dataflow/CONTRIBUTING.md
@@ -28,6 +28,19 @@ the full check path, likely because many of the longest tests are concentrated
 in a few large integration-style binaries, so the extra runner orchestration did
 not offset the limited parallelism gains.
 
+## Test and example server bind addresses
+
+When a test or example starts a listening server, bind it to the loopback
+interface (`127.0.0.1`), not `0.0.0.0` (all interfaces). Prefer an ephemeral
+port (`127.0.0.1:0`) and read the assigned port back from the listener.
+
+Windows Defender Firewall exempts loopback binds from its allow/deny prompt, so
+a loopback bind avoids the repeated firewall prompts that an all-interfaces bind
+triggers on every `cargo test` / `cargo xtask check` rebuild (test binaries are
+named by content hash, so a granted exception does not persist across rebuilds).
+Production defaults that intentionally serve external traffic may still bind
+`0.0.0.0`.
+
 ## Changelog entries
 
 User-facing Rust changes are recorded in

--- a/rust/otap-dataflow/crates/contrib-nodes/examples/mock_la_server.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/examples/mock_la_server.rs
@@ -345,7 +345,7 @@ async fn main() {
     let port = cli.port;
 
     println!("[mock-la] Mock Azure Monitor Logs Ingestion API Server");
-    println!("[mock-la] Listening on 0.0.0.0:{port}");
+    println!("[mock-la] Listening on 127.0.0.1:{port}");
 
     if cli.fail_rate > 0.0 {
         if let Some(retry_secs) = cli.retry_after {
@@ -403,7 +403,7 @@ async fn main() {
         )
         .with_state(state);
 
-    let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{port}"))
+    let listener = tokio::net::TcpListener::bind(format!("127.0.0.1:{port}"))
         .await
         .expect("failed to bind to port");
 

--- a/rust/otap-dataflow/crates/telemetry/src/otel_sdk/meter_provider.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/otel_sdk/meter_provider.rs
@@ -221,7 +221,7 @@ mod tests {
                 exporter: MetricsPullExporterConfig {
                     exporter_type: MetricsPullExporterType::Prometheus,
                     config: serde_json::json!({
-                        "host": "0.0.0.0",
+                        "host": "127.0.0.1",
                         "port": 9090,
                         "path": "/metrics"
                     }),


### PR DESCRIPTION
## What

On Windows, running the Rust test suite — especially a full `cargo xtask check` —
repeatedly triggers the Windows Defender Firewall allow/deny prompt. A handful of
**test/dev** code paths bind listening sockets to `0.0.0.0` (all interfaces);
Windows exempts loopback (`127.0.0.1`) binds from the prompt. Because cargo names
test binaries by content hash, a granted "Allow" does not persist across
rebuilds, so the prompt recurs on essentially every change.

Fixes #3351.

## Changes

- **`crates/telemetry/src/otel_sdk/meter_provider.rs`** (test): the Prometheus
  pull-exporter test configured `host: "0.0.0.0", port: 9090`, which
  `MeterProvider::configure` → `start_async_prometheus_server` actually binds.
  This is the **only test that opens a non-loopback socket during `cargo test`**.
  Host → `127.0.0.1`.
- **`crates/contrib-nodes/examples/mock_la_server.rs`** (dev example): mock Azure
  Monitor Logs Ingestion server, documented for `http://localhost:9999`, bound
  `0.0.0.0:{port}`. Bind + banner → `127.0.0.1`.
- **`CONTRIBUTING.md`**: documents the loopback test/example bind convention so
  this stays consistent.

## Acceptance criterion

A full `cargo xtask check` on Windows now completes with no Windows Firewall
prompts — no test server binds a non-loopback interface. Verified locally:
structure ✅, `cargo fmt` ✅, `cargo clippy --workspace --all-targets -D warnings`
✅, `cargo test --workspace` ✅. The example compiles under
`--features azure-monitor-exporter`.

## Scope / non-goals (deliberate)

- **`GrpcServerSettings::default()` (`server_settings.rs:316`, `0.0.0.0:0`) is left
  unchanged.** It is a production default, and a full sweep confirms **no test
  binds via the bare default** — every gRPC/HTTP/UDP server test passes an
  explicit `127.0.0.1` address. Per the issue's non-goals, production defaults
  that intentionally serve external traffic stay as-is (same for the Prometheus
  pull `default_host()`).
- **Other `0.0.0.0` occurrences in the Rust workspace are left as-is because they
  do not bind a socket:** deserialize/`validate_config` tests that assert the kept
  production default (`readers.rs`, `pull.rs`, `prometheus_exporter_provider.rs`),
  the `otlp_receiver` test that specifically exercises the unspecified-address
  conflict path, the clap arg-parse test, and doc/CIDR/CEF strings.
- **Out of scope:** non-Rust demo/perf assets that intentionally bind all
  interfaces (e.g. the Python `tools/pipeline_perf_test` Docker templates, and the
  bundled demo `configs/*.yaml`). These are not exercised by `cargo xtask check`
  and do not affect the acceptance criterion; a Windows dev who manually runs one
  of those demos may still see a prompt.
- The fixed port `9090` in the meter-provider test is kept (the issue asked only
  to change the host); the spawned bind result is ignored, so a port collision
  cannot fail the test.

## Changelog

Test/dev-example only — no shipped/production behavior change — so this is a
`chore` with no `.chloggen` entry, per the repo convention.

## On a regression guard

An automated lint that rejects new non-loopback binds in test/example code was
considered but **deferred**: it would need an allow-list for the several
legitimate non-binding `0.0.0.0` usages above, making it brittle. The convention
is documented in `CONTRIBUTING.md` instead.

Reply posted by [GS] @timr-dev Copilot AI Assistant.
