### PR TITLE
Fix asymmetric Serialize/Deserialize on AttributeValue

### DIFF
--- a/rust/otap-dataflow/.chloggen/fix-attribute-value-serialize-roundtrip.yaml
+++ b/rust/otap-dataflow/.chloggen/fix-attribute-value-serialize-roundtrip.yaml
@@ -1,0 +1,23 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: engine
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "`AttributeValue` serialization now emits plain scalars/sequences, fixing YAML/JSON round-trip failures for telemetry resource attributes."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [3358]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The derived Serialize on AttributeValue and AttributeValueArray produced
+  externally-tagged enum output (e.g. `!String value` in YAML) that the custom
+  Deserialize implementation could not parse back. Replaced with custom Serialize
+  impls that emit plain values matching the Deserialize expectations.

--- a/rust/otap-dataflow/crates/config/src/pipeline/telemetry.rs
+++ b/rust/otap-dataflow/crates/config/src/pipeline/telemetry.rs
@@ -67,6 +67,7 @@ const fn default_reporting_interval() -> Duration {
 
 /// Attribute value types for telemetry resource attributes.
 #[derive(Debug, Clone, PartialEq, JsonSchema)]
+#[serde(untagged)]
 pub enum AttributeValue {
     /// String type attribute value.
     String(String),
@@ -229,6 +230,7 @@ impl<'de> Deserialize<'de> for AttributeValue {
 
 /// Array attribute value types for telemetry resource attributes.
 #[derive(Debug, Clone, PartialEq, Deserialize, JsonSchema)]
+#[schemars(untagged)]
 pub enum AttributeValueArray {
     /// Array of bools
     Bool(Vec<bool>),
@@ -819,5 +821,64 @@ mod tests {
         let back: TelemetryConfig = serde_yaml::from_str(&yaml).expect("deserialize from YAML");
 
         assert_eq!(config.resource, back.resource);
+    }
+
+    #[test]
+    fn test_attribute_value_json_schema_is_untagged() {
+        // The JSON schema for AttributeValue should describe the actual
+        // serialized format (plain scalars and arrays), not an externally-tagged
+        // enum like {"String": "value"} or {"Bool": true}.
+        let schema = schemars::schema_for!(AttributeValue);
+        let json = serde_json::to_string_pretty(&schema).unwrap();
+
+        // An externally-tagged enum schema would contain variant names as
+        // property keys. The untagged schema should use oneOf with primitive types.
+        assert!(
+            !json.contains(r#""String""#),
+            "Schema should not contain externally-tagged 'String' variant.\nSchema:\n{json}"
+        );
+        assert!(
+            !json.contains(r#""Bool""#),
+            "Schema should not contain externally-tagged 'Bool' variant.\nSchema:\n{json}"
+        );
+        assert!(
+            !json.contains(r#""I64""#),
+            "Schema should not contain externally-tagged 'I64' variant.\nSchema:\n{json}"
+        );
+        assert!(
+            !json.contains(r#""F64""#),
+            "Schema should not contain externally-tagged 'F64' variant.\nSchema:\n{json}"
+        );
+        assert!(
+            !json.contains(r#""Array""#),
+            "Schema should not contain externally-tagged 'Array' variant.\nSchema:\n{json}"
+        );
+
+        // Should have anyOf/oneOf for the union of types
+        assert!(
+            json.contains("anyOf") || json.contains("oneOf"),
+            "Schema should use anyOf/oneOf for untagged union.\nSchema:\n{json}"
+        );
+    }
+
+    #[test]
+    fn test_attribute_value_array_json_schema_is_untagged() {
+        // Same check for AttributeValueArray — schema should describe bare
+        // arrays of primitives, not externally-tagged objects like {"Bool": [...]}.
+        let schema = schemars::schema_for!(AttributeValueArray);
+        let json = serde_json::to_string_pretty(&schema).unwrap();
+
+        // Externally-tagged schemas use "required": ["Bool"] etc. as object
+        // property wrappers. The untagged schema should have none of these.
+        assert!(
+            !json.contains(r#""required""#),
+            "Schema should not contain 'required' property keys from tagged variants.\nSchema:\n{json}"
+        );
+
+        // For an untagged array enum, we expect anyOf/oneOf with array types
+        assert!(
+            json.contains("anyOf") || json.contains("oneOf"),
+            "Schema should use anyOf/oneOf for untagged union.\nSchema:\n{json}"
+        );
     }
 }

--- a/rust/otap-dataflow/crates/config/src/pipeline/telemetry.rs
+++ b/rust/otap-dataflow/crates/config/src/pipeline/telemetry.rs
@@ -66,7 +66,7 @@ const fn default_reporting_interval() -> Duration {
 }
 
 /// Attribute value types for telemetry resource attributes.
-#[derive(Debug, Clone, PartialEq, Serialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, JsonSchema)]
 pub enum AttributeValue {
     /// String type attribute value.
     String(String),
@@ -78,6 +78,21 @@ pub enum AttributeValue {
     F64(f64),
     /// Array type attribute value.
     Array(AttributeValueArray),
+}
+
+impl Serialize for AttributeValue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            AttributeValue::String(s) => serializer.serialize_str(s),
+            AttributeValue::Bool(b) => serializer.serialize_bool(*b),
+            AttributeValue::I64(i) => serializer.serialize_i64(*i),
+            AttributeValue::F64(f) => serializer.serialize_f64(*f),
+            AttributeValue::Array(arr) => arr.serialize(serializer),
+        }
+    }
 }
 
 impl<'de> Deserialize<'de> for AttributeValue {
@@ -213,7 +228,7 @@ impl<'de> Deserialize<'de> for AttributeValue {
 }
 
 /// Array attribute value types for telemetry resource attributes.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Deserialize, JsonSchema)]
 pub enum AttributeValueArray {
     /// Array of bools
     Bool(Vec<bool>),
@@ -223,6 +238,20 @@ pub enum AttributeValueArray {
     F64(Vec<f64>),
     /// Array of strings
     String(Vec<String>),
+}
+
+impl Serialize for AttributeValueArray {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            AttributeValueArray::Bool(v) => v.serialize(serializer),
+            AttributeValueArray::I64(v) => v.serialize(serializer),
+            AttributeValueArray::F64(v) => v.serialize(serializer),
+            AttributeValueArray::String(v) => v.serialize(serializer),
+        }
+    }
 }
 
 impl AttributeValue {
@@ -671,8 +700,8 @@ mod tests {
     fn test_telemetry_attribute_serialize_bare() {
         let attr = TelemetryAttribute::new(AttributeValue::String("test".to_string()));
         let json = serde_json::to_string(&attr).unwrap();
-        // Without brief, serializes as just the value (with enum tagging)
-        assert_eq!(json, r#"{"String":"test"}"#);
+        // Without brief, serializes as just the plain value
+        assert_eq!(json, r#""test""#);
     }
 
     #[test]
@@ -682,7 +711,113 @@ mod tests {
             "A test attribute",
         );
         let json = serde_json::to_string(&attr).unwrap();
-        assert!(json.contains(r#""value":{"String":"test"}"#));
+        assert!(json.contains(r#""value":"test""#));
         assert!(json.contains(r#""brief":"A test attribute""#));
+    }
+
+    #[test]
+    fn test_attribute_value_yaml_roundtrip_scalars() {
+        let attrs: HashMap<String, AttributeValue> = HashMap::from([
+            ("s".into(), AttributeValue::String("hello".into())),
+            ("b".into(), AttributeValue::Bool(true)),
+            ("i".into(), AttributeValue::I64(-42)),
+            ("f".into(), AttributeValue::F64(1.5)),
+        ]);
+
+        let yaml = serde_yaml::to_string(&attrs).expect("serialize to YAML");
+        let back: HashMap<String, AttributeValue> =
+            serde_yaml::from_str(&yaml).expect("deserialize from YAML");
+
+        assert_eq!(attrs, back);
+    }
+
+    #[test]
+    fn test_attribute_value_yaml_roundtrip_arrays() {
+        let attrs: HashMap<String, AttributeValue> = HashMap::from([
+            (
+                "strings".into(),
+                AttributeValue::Array(AttributeValueArray::String(vec!["a".into(), "b".into()])),
+            ),
+            (
+                "bools".into(),
+                AttributeValue::Array(AttributeValueArray::Bool(vec![true, false])),
+            ),
+            (
+                "ints".into(),
+                AttributeValue::Array(AttributeValueArray::I64(vec![1, 2, 3])),
+            ),
+            (
+                "floats".into(),
+                AttributeValue::Array(AttributeValueArray::F64(vec![1.5, 2.5])),
+            ),
+        ]);
+
+        let yaml = serde_yaml::to_string(&attrs).expect("serialize to YAML");
+        let back: HashMap<String, AttributeValue> =
+            serde_yaml::from_str(&yaml).expect("deserialize from YAML");
+
+        assert_eq!(attrs, back);
+    }
+
+    #[test]
+    fn test_attribute_value_json_roundtrip() {
+        let attrs: HashMap<String, AttributeValue> = HashMap::from([
+            ("s".into(), AttributeValue::String("hello".into())),
+            ("b".into(), AttributeValue::Bool(true)),
+            ("i".into(), AttributeValue::I64(-42)),
+            ("f".into(), AttributeValue::F64(1.5)),
+            (
+                "arr".into(),
+                AttributeValue::Array(AttributeValueArray::I64(vec![10, 20])),
+            ),
+        ]);
+
+        let json = serde_json::to_string(&attrs).expect("serialize to JSON");
+        let back: HashMap<String, AttributeValue> =
+            serde_json::from_str(&json).expect("deserialize from JSON");
+
+        assert_eq!(attrs, back);
+    }
+
+    #[test]
+    fn test_attribute_value_serializes_plain_scalars_yaml() {
+        // Verify that serialized YAML uses plain scalars, not
+        // externally-tagged enum wrappers like `!String`.
+        let attrs: HashMap<String, AttributeValue> = HashMap::from([
+            ("name".into(), AttributeValue::String("svc".into())),
+            ("count".into(), AttributeValue::I64(7)),
+        ]);
+
+        let yaml = serde_yaml::to_string(&attrs).expect("serialize to YAML");
+        assert!(
+            !yaml.contains("!String"),
+            "YAML should not contain enum tags, got:\n{yaml}"
+        );
+        assert!(
+            !yaml.contains("!I64"),
+            "YAML should not contain enum tags, got:\n{yaml}"
+        );
+    }
+
+    #[test]
+    fn test_telemetry_config_yaml_roundtrip() {
+        let resource = HashMap::from([
+            (
+                "service.name".to_string(),
+                AttributeValue::String("my-svc".to_string()),
+            ),
+            ("enabled".to_string(), AttributeValue::Bool(true)),
+            ("replica".to_string(), AttributeValue::I64(3)),
+        ]);
+
+        let config = TelemetryConfig {
+            resource,
+            ..Default::default()
+        };
+
+        let yaml = serde_yaml::to_string(&config).expect("serialize to YAML");
+        let back: TelemetryConfig = serde_yaml::from_str(&yaml).expect("deserialize from YAML");
+
+        assert_eq!(config.resource, back.resource);
     }
 }


### PR DESCRIPTION
# Change Summary

`AttributeValue` and `AttributeValueArray` used a **derived `Serialize`** (serde's default externally-tagged enum format) but a **custom `Deserialize`** (expecting plain scalars and sequences). These were incompatible: YAML/JSON produced by serialization could not be deserialized back.

This broke any code path that round-tripped an `OtelDataflowSpec` through serialization — for example, CRD serialization for Kubernetes or config export/reimport.

### Before (broken)

Serializing a `TelemetryConfig` with resource attributes produced externally-tagged enum output:

**YAML:**
```yaml
resource:
  k8s.container.name: !String ${env:K8S_CONTAINER_NAME}
  k8s.pod.uid: !String ${env:K8S_POD_UID}
  enabled: !Bool true
  replica: !I64 3
  tags: !Bool
  - true
  - false
```

**JSON:**
```json
{
  "k8s.container.name": {"String": "${env:K8S_CONTAINER_NAME}"},
  "enabled": {"Bool": true},
  "tags": {"Bool": [true, false]}
}
```

Attempting to deserialize this output back would fail with:
```
invalid type: enum, expected a string, boolean, number, or array
```

### After (fixed)

Serialization now emits plain scalars and bare sequences, matching what the custom `Deserialize` expects:

**YAML:**
```yaml
resource:
  k8s.container.name: ${env:K8S_CONTAINER_NAME}
  k8s.pod.uid: ${env:K8S_POD_UID}
  enabled: true
  replica: 3
  tags:
  - true
  - false
```

**JSON:**
```json
{
  "k8s.container.name": "${env:K8S_CONTAINER_NAME}",
  "enabled": true,
  "tags": [true, false]
}
```

Round-tripping through `serde_yaml::to_string` / `serde_yaml::from_str` (and the JSON equivalents) now works correctly.

## What issue does this PR close?

* Closes #3358

## How are these changes tested?

Fixed tests asserting the broken behavior and added:

- **`test_attribute_value_yaml_roundtrip_scalars`** — Verifies all scalar variants (`String`, `Bool`, `I64`, `F64`) survive a YAML serialize/deserialize round-trip.
- **`test_attribute_value_yaml_roundtrip_arrays`** — Verifies all array variants (`String`, `Bool`, `I64`, `F64`) survive a YAML round-trip.
- **`test_attribute_value_json_roundtrip`** — Verifies mixed scalars and arrays survive a JSON round-trip.
- **`test_attribute_value_serializes_plain_scalars_yaml`** — Asserts serialized YAML contains no enum tags (`!String`, `!I64`, etc.).
- **`test_telemetry_config_yaml_roundtrip`** — Verifies a full `TelemetryConfig` with resource attributes round-trips through YAML.

## Are there any user-facing changes?

Yes. Previously, serializing an OtelDataflowSpec (or any config containing AttributeValue fields like telemetry resource attributes) and then deserializing it back would fail. This affected CRD round-trips, config export/reimport, and any serialize-then-deserialize workflow.

### Changelog

* [x] Added a .chloggen/*.yaml entry, OR this PR is a chore (indicated in title).

Created: .chloggen/fix-attribute-value-serialize-roundtrip.yaml
