### PR TITLE
fix(engine): size default memory-limiter hysteresis to a small recovery band

### DIFF
--- a/rust/otap-dataflow/.chloggen/memory-limiter-hysteresis-default.yaml
+++ b/rust/otap-dataflow/.chloggen/memory-limiter-hysteresis-default.yaml
@@ -1,0 +1,21 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: engine
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Size the default memory-limiter hysteresis as `min(hard_limit - soft_limit, soft_limit / 10)` so an omitted hysteresis recovers from Soft once usage falls modestly below the soft limit.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [2425]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Previously a wide soft-to-hard gap defaulted the band to `soft_limit - 1`, so the
+  limiter reported Soft pressure until usage fell to nearly zero. Policies with an
+  explicit `hysteresis`, and `source: auto` setups where the gap is already narrow,
+  are unaffected.

--- a/rust/otap-dataflow/crates/config/src/policy.rs
+++ b/rust/otap-dataflow/crates/config/src/policy.rs
@@ -554,6 +554,11 @@ pub struct MemoryLimiterPolicy {
     #[schemars(with = "Option<String>")]
     pub hard_limit: Option<u64>,
     /// Bytes below the soft limit required to leave `Soft` pressure.
+    ///
+    /// When omitted, defaults to the smaller of the soft-to-hard gap and 10% of
+    /// the soft limit (`min(hard_limit - soft_limit, soft_limit / 10)`), a
+    /// narrow recovery band so pressure leaves `Soft` once usage falls modestly
+    /// below `soft_limit`.
     #[serde(default, deserialize_with = "byte_units::deserialize_u64")]
     #[schemars(with = "Option<String>")]
     pub hysteresis: Option<u64>,

--- a/rust/otap-dataflow/crates/engine/src/memory_limiter.rs
+++ b/rust/otap-dataflow/crates/engine/src/memory_limiter.rs
@@ -487,10 +487,16 @@ impl EffectiveMemoryLimiter {
             );
         }
 
+        // When `hysteresis` is omitted, derive a small recovery band below the
+        // soft limit: the smaller of the soft->hard gap and 10% of the soft
+        // limit. Capping at `soft_limit / 10` (rather than `soft_limit - 1`)
+        // keeps the band narrow even when the soft->hard gap is wide, so the
+        // limiter recovers to `Normal` once usage falls modestly below
+        // `soft_limit` instead of only after usage collapses toward zero.
         let hysteresis_bytes = policy.hysteresis.unwrap_or_else(|| {
             hard_limit_bytes
                 .saturating_sub(soft_limit_bytes)
-                .min(soft_limit_bytes.saturating_sub(1))
+                .min(soft_limit_bytes / 10)
         });
 
         if hysteresis_bytes >= soft_limit_bytes {
@@ -1154,7 +1160,131 @@ mod tests {
         })
         .expect("limiter should accept omitted hysteresis");
 
-        assert_eq!(limiter.hysteresis_bytes, 99);
+        // Derived band = min(hard - soft = 150, soft / 10 = 10) = 10 bytes, a
+        // narrow recovery margin below the soft limit (not soft_limit - 1).
+        assert_eq!(limiter.hysteresis_bytes, 10);
+    }
+
+    #[test]
+    fn soft_pressure_recovers_to_normal_with_default_hysteresis() {
+        // Regression: with an omitted `hysteresis`, a wide soft->hard gap must
+        // still yield a recovery band small enough to return to `Normal` once
+        // usage falls modestly below `soft_limit` -- not stay latched in `Soft`
+        // until usage collapses toward zero. Any consumer of the Soft-pressure
+        // signal (the pressure gauge, downstream throttling) stays engaged for
+        // the whole latched window, so the Soft->Normal transition timing is the
+        // user-visible contract. Samples are driven through `tick()` so the
+        // policy-derived hysteresis governs classification, exercising the
+        // defaulting and the pressure-state machine together (not a hand-forced
+        // level).
+        let mut limiter = EffectiveMemoryLimiter::from_policy(&MemoryLimiterPolicy {
+            mode: MemoryLimiterMode::Enforce,
+            source: MemoryLimiterSource::Rss,
+            check_interval: Duration::from_secs(1),
+            soft_limit: Some(100),
+            hard_limit: Some(250),
+            hysteresis: None,
+            retry_after_secs: 1,
+            fail_readiness_on_hard: true,
+            purge_on_hard: false,
+            purge_min_interval: Duration::from_secs(5),
+        })
+        .expect("limiter should accept omitted hysteresis");
+
+        // min(hard - soft = 150, soft / 10 = 10) = 10.
+        assert_eq!(limiter.hysteresis_bytes, 10);
+
+        // Feed usage 100 (== soft_limit) then 50 (well below soft_limit).
+        limiter.sampler = MemoryUsageSampler::from_test_probes(
+            Box::new(SequenceProbe {
+                samples: VecDeque::from([
+                    MemorySample {
+                        usage_bytes: 100,
+                        source: MemorySampleSource::Rss,
+                    },
+                    MemorySample {
+                        usage_bytes: 50,
+                        source: MemorySampleSource::Rss,
+                    },
+                ]),
+            }),
+            None,
+        );
+
+        let state = MemoryPressureState::default();
+
+        // A sample at the soft limit enters Soft pressure.
+        let entered = limiter.tick(&state).expect("tick should succeed");
+        assert_eq!(entered.current_level, MemoryPressureLevel::Soft);
+        assert_eq!(state.level(), MemoryPressureLevel::Soft);
+
+        // Usage of 50 is below soft_limit - hysteresis (90), so pressure
+        // recovers to Normal and the shared state reflects it.
+        let recovered = limiter.tick(&state).expect("tick should succeed");
+        assert_eq!(recovered.current_level, MemoryPressureLevel::Normal);
+        assert_eq!(state.level(), MemoryPressureLevel::Normal);
+    }
+
+    #[test]
+    fn soft_recovery_boundary_uses_strict_below_soft_minus_hysteresis() {
+        // Pins the exact Soft->Normal recovery threshold. With soft=100 and the
+        // derived default hysteresis of 10, recovery is a strict `<` at 90:
+        // usage == 90 stays Soft, usage == 89 recovers to Normal. Driven through
+        // `tick()` so the real classify()/publish path is exercised.
+        fn limiter_with(second_sample: u64) -> (EffectiveMemoryLimiter, MemoryPressureState) {
+            let mut limiter = EffectiveMemoryLimiter::from_policy(&MemoryLimiterPolicy {
+                mode: MemoryLimiterMode::Enforce,
+                source: MemoryLimiterSource::Rss,
+                check_interval: Duration::from_secs(1),
+                soft_limit: Some(100),
+                hard_limit: Some(250),
+                hysteresis: None,
+                retry_after_secs: 1,
+                fail_readiness_on_hard: true,
+                purge_on_hard: false,
+                purge_min_interval: Duration::from_secs(5),
+            })
+            .expect("limiter should accept omitted hysteresis");
+            limiter.sampler = MemoryUsageSampler::from_test_probes(
+                Box::new(SequenceProbe {
+                    samples: VecDeque::from([
+                        MemorySample {
+                            usage_bytes: 100,
+                            source: MemorySampleSource::Rss,
+                        },
+                        MemorySample {
+                            usage_bytes: second_sample,
+                            source: MemorySampleSource::Rss,
+                        },
+                    ]),
+                }),
+                None,
+            );
+            (limiter, MemoryPressureState::default())
+        }
+
+        // First tick (usage 100) enters Soft; second tick at usage == 90 stays
+        // Soft because recovery is a strict `<` (90 is not < 90).
+        let (mut at_boundary, state) = limiter_with(90);
+        assert_eq!(
+            at_boundary.tick(&state).expect("tick").current_level,
+            MemoryPressureLevel::Soft
+        );
+        assert_eq!(
+            at_boundary.tick(&state).expect("tick").current_level,
+            MemoryPressureLevel::Soft
+        );
+
+        // Second tick at usage == 89 (soft_limit - hysteresis - 1) recovers.
+        let (mut below_boundary, state2) = limiter_with(89);
+        assert_eq!(
+            below_boundary.tick(&state2).expect("tick").current_level,
+            MemoryPressureLevel::Soft
+        );
+        assert_eq!(
+            below_boundary.tick(&state2).expect("tick").current_level,
+            MemoryPressureLevel::Normal
+        );
     }
 
     #[test]

--- a/rust/otap-dataflow/docs/memory-limiter-phase1.md
+++ b/rust/otap-dataflow/docs/memory-limiter-phase1.md
@@ -277,7 +277,10 @@ stateDiagram-v2
   when the threshold is crossed.
 - **Recovery from Soft** requires usage to drop below
   `soft_limit - hysteresis` before returning to `Normal`. This prevents
-  oscillation when usage hovers near the soft threshold.
+  oscillation when usage hovers near the soft threshold. When `hysteresis` is
+  omitted it defaults to `min(hard_limit - soft_limit, soft_limit / 10)`, a
+  narrow band so recovery happens once usage falls modestly below `soft_limit`
+  rather than only after it collapses toward zero.
 - **Recovery from Hard** requires usage to drop below `soft_limit`
   before returning to `Soft`.
 - Phase 1 does **not** implement cooldown timers. Those are planned for a


### PR DESCRIPTION
## Summary

Fixes a bug in how the memory-limiter's `hysteresis` is defaulted when it is
omitted from a `MemoryLimiterPolicy`. The default was
`min(hard_limit - soft_limit, soft_limit - 1)`, which for a wide soft-to-hard gap
collapses to `soft_limit - 1`. That makes the Soft-to-Normal recovery threshold
(`usage < soft_limit - hysteresis`) land at `usage < 1`, so the limiter latches
in **Soft** pressure until usage falls to nearly zero.

The default is now `min(hard_limit - soft_limit, soft_limit / 10)` -- a recovery
band of at most ~10% of the soft limit -- so the limiter returns to **Normal**
once usage falls modestly below `soft_limit`.

## Scope

This PR is now **only** the hysteresis-default bug fix. The earlier
`soft_action` graduated-shed mechanism has been dropped: its Soft-pressure
admission control overlaps with the direction in #3529 per merged RFC 0002, and
maintainers preferred a single mechanism rather than two overlapping ones. No
`soft_action` config surface is introduced or referenced.

## Correctness

- `soft_limit / 10 <= soft_limit - 1` for every `soft_limit >= 1`, so recovery is
  only ever **earlier or equal** to the old default -- no slower-recovery regression.
- When `soft_limit < 10`, `soft_limit / 10 == 0`; a `hysteresis` of `0` was
  already reachable on `main` (at `soft_limit == 1`) and passes validation
  (`0 >= soft_limit` is false for `soft_limit >= 1`), giving recovery at
  `usage < soft_limit`. In production soft limits are GiB-scale, so the band sits
  well above zero.

## Tests

Two recovery tests drive the real `tick()` -> `classify()` -> publish path (not a
hand-forced level), asserting the Soft-to-Normal transition on both the tick
result and the published pressure state:

- `soft_pressure_recovers_to_normal_with_default_hysteresis`
- `soft_recovery_boundary_uses_strict_below_soft_minus_hysteresis` -- pins the
  strict `<`: with soft=100 / hysteresis=10, usage 90 stays **Soft**, usage 89 ->
  **Normal**.

Both fail if the fix is reverted (old default => hysteresis 99 => threshold `usage < 1`).

## Validation

- `otap-df-engine` memory_limiter: **19/19**
- `otap-df-config`: **332/0**
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`: clean
- changelog note/subtext within enforced limits; markdownlint clean

## Files

- `crates/engine/src/memory_limiter.rs` -- fix + explanatory comment + 2 tests
- `crates/config/src/policy.rs` -- `hysteresis` field doc (omitted-default behavior)
- `docs/memory-limiter-phase1.md` -- recovery-from-Soft doc (omitted-default behavior)
- `.chloggen/memory-limiter-hysteresis-default.yaml` -- `bug_fix` / `engine`
