### PR TITLE
chore(ci): restore continuous/nightly pipeline perf workflows

### DIFF
--- a/.github/workflows/pipeline-perf-on-label.yaml
+++ b/.github/workflows/pipeline-perf-on-label.yaml
@@ -23,15 +23,17 @@ jobs:
   pipeline-perf-test-dedicated:
     if: contains(github.event.pull_request.labels.*.name, 'pipelineperf')
     runs-on: oracle-bare-metal-64cpu-1024gb-x86-64-ubuntu-24
-    # Route tool-created temp files to RUNNER_TEMP, which GitHub Actions empties
-    # at the start and end of every job. Required when running directly on the
-    # shared bare-metal host (no job-level container) per
-    # https://github.com/open-telemetry/community/blob/main/docs/how-to-use-bare-metal-runner.md
-    env:
-      TMPDIR: ${{ runner.temp }}
-      TMP: ${{ runner.temp }}
-      TEMP: ${{ runner.temp }}
     steps:
+      # Route tool-created temp files to RUNNER_TEMP, which GitHub Actions empties
+      # at the start and end of every job. Required when running directly on the
+      # shared bare-metal host (no job-level container) per
+      # https://github.com/open-telemetry/community/blob/main/docs/how-to-use-bare-metal-runner.md
+      - name: Route temp files to RUNNER_TEMP
+        run: |
+          echo "TMPDIR=$RUNNER_TEMP" >> "$GITHUB_ENV"
+          echo "TMP=$RUNNER_TEMP" >> "$GITHUB_ENV"
+          echo "TEMP=$RUNNER_TEMP" >> "$GITHUB_ENV"
+
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:

--- a/.github/workflows/pipeline-perf-test-continuous.yml
+++ b/.github/workflows/pipeline-perf-test-continuous.yml
@@ -16,15 +16,17 @@ on:
 jobs:
   pipeline-perf-test:
     runs-on: oracle-bare-metal-64cpu-1024gb-x86-64-ubuntu-24
-    # Route tool-created temp files to RUNNER_TEMP, which GitHub Actions empties
-    # at the start and end of every job. Required when running directly on the
-    # shared bare-metal host (no job-level container) per
-    # https://github.com/open-telemetry/community/blob/main/docs/how-to-use-bare-metal-runner.md
-    env:
-      TMPDIR: ${{ runner.temp }}
-      TMP: ${{ runner.temp }}
-      TEMP: ${{ runner.temp }}
     steps:
+      # Route tool-created temp files to RUNNER_TEMP, which GitHub Actions empties
+      # at the start and end of every job. Required when running directly on the
+      # shared bare-metal host (no job-level container) per
+      # https://github.com/open-telemetry/community/blob/main/docs/how-to-use-bare-metal-runner.md
+      - name: Route temp files to RUNNER_TEMP
+        run: |
+          echo "TMPDIR=$RUNNER_TEMP" >> "$GITHUB_ENV"
+          echo "TMP=$RUNNER_TEMP" >> "$GITHUB_ENV"
+          echo "TEMP=$RUNNER_TEMP" >> "$GITHUB_ENV"
+
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:

--- a/.github/workflows/pipeline-perf-test-manual-pr.yaml
+++ b/.github/workflows/pipeline-perf-test-manual-pr.yaml
@@ -26,15 +26,17 @@ concurrency:
 jobs:
   pipeline-perf-test:
     runs-on: oracle-bare-metal-64cpu-1024gb-x86-64-ubuntu-24
-    # Route tool-created temp files to RUNNER_TEMP, which GitHub Actions empties
-    # at the start and end of every job. Required when running directly on the
-    # shared bare-metal host (no job-level container) per
-    # https://github.com/open-telemetry/community/blob/main/docs/how-to-use-bare-metal-runner.md
-    env:
-      TMPDIR: ${{ runner.temp }}
-      TMP: ${{ runner.temp }}
-      TEMP: ${{ runner.temp }}
     steps:
+      # Route tool-created temp files to RUNNER_TEMP, which GitHub Actions empties
+      # at the start and end of every job. Required when running directly on the
+      # shared bare-metal host (no job-level container) per
+      # https://github.com/open-telemetry/community/blob/main/docs/how-to-use-bare-metal-runner.md
+      - name: Route temp files to RUNNER_TEMP
+        run: |
+          echo "TMPDIR=$RUNNER_TEMP" >> "$GITHUB_ENV"
+          echo "TMP=$RUNNER_TEMP" >> "$GITHUB_ENV"
+          echo "TEMP=$RUNNER_TEMP" >> "$GITHUB_ENV"
+
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:

--- a/.github/workflows/pipeline-perf-test-nightly.yml
+++ b/.github/workflows/pipeline-perf-test-nightly.yml
@@ -11,15 +11,17 @@ on:
 jobs:
   pipeline-perf-test:
     runs-on: oracle-bare-metal-64cpu-1024gb-x86-64-ubuntu-24
-    # Route tool-created temp files to RUNNER_TEMP, which GitHub Actions empties
-    # at the start and end of every job. Required when running directly on the
-    # shared bare-metal host (no job-level container) per
-    # https://github.com/open-telemetry/community/blob/main/docs/how-to-use-bare-metal-runner.md
-    env:
-      TMPDIR: ${{ runner.temp }}
-      TMP: ${{ runner.temp }}
-      TEMP: ${{ runner.temp }}
     steps:
+      # Route tool-created temp files to RUNNER_TEMP, which GitHub Actions empties
+      # at the start and end of every job. Required when running directly on the
+      # shared bare-metal host (no job-level container) per
+      # https://github.com/open-telemetry/community/blob/main/docs/how-to-use-bare-metal-runner.md
+      - name: Route temp files to RUNNER_TEMP
+        run: |
+          echo "TMPDIR=$RUNNER_TEMP" >> "$GITHUB_ENV"
+          echo "TMP=$RUNNER_TEMP" >> "$GITHUB_ENV"
+          echo "TEMP=$RUNNER_TEMP" >> "$GITHUB_ENV"
+
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:


### PR DESCRIPTION
## Root cause

All four pipeline perf workflows set `TMPDIR`/`TMP`/`TEMP` in job-level `env:` using `${{ runner.temp }}`. The `runner` context is not available at job-level `env` scope (only inside `steps`), so GitHub Actions rejects the workflow at evaluation time:

> Unrecognized named-value: 'runner'. Located at position 1 within expression: runner.temp

Failing since #3164 introduced the pattern on June 8.

## Fix

Replace the job-level `env` block with a `Route temp files to RUNNER_TEMP` step at the top of `steps:` that writes `TMPDIR`/`TMP`/`TEMP` to `$GITHUB_ENV` using `$RUNNER_TEMP`. Placed before `harden-runner` so every subsequent step inherits the routed temp dirs.