### PR TITLE
feat: Explore E2E pipeline latency measurement via synthetic probes (approach 1)

### DIFF
--- a/rust/otap-dataflow/.chloggen/probe-e2e-latency-poc.yaml
+++ b/rust/otap-dataflow/.chloggen/probe-e2e-latency-poc.yaml
@@ -1,0 +1,9 @@
+change_type: new_component
+component: pipeline
+note: |
+  Add `urn:otel:receiver:probe_emitter` and `urn:otel:processor:probe_sink` for
+  end-to-end pipeline latency measurement. The receiver periodically emits a
+  synthetic OTLP log record stamped with a probe id and Unix-nanos timestamp;
+  the sink processor detects those probes, records a latency histogram, and
+  (by default) drops them before they reach downstream exporters.
+issues: [2325]

--- a/rust/otap-dataflow/.chloggen/probe-e2e-latency-poc.yaml
+++ b/rust/otap-dataflow/.chloggen/probe-e2e-latency-poc.yaml
@@ -1,9 +1,0 @@
-change_type: new_component
-component: pipeline
-note: |
-  Add `urn:otel:receiver:probe_emitter` and `urn:otel:processor:probe_sink` for
-  end-to-end pipeline latency measurement. The receiver periodically emits a
-  synthetic OTLP log record stamped with a probe id and Unix-nanos timestamp;
-  the sink processor detects those probes, records a latency histogram, and
-  (by default) drops them before they reach downstream exporters.
-issues: [2325]

--- a/rust/otap-dataflow/crates/contrib-nodes/examples/mock_la_server.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/examples/mock_la_server.rs
@@ -38,7 +38,7 @@
 use std::io::Read;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use axum::Router;
 use axum::body::Bytes;
@@ -254,7 +254,11 @@ fn decompress_and_count(body: &[u8], headers: &HeaderMap) -> Result<DecompressRe
         serde_json::from_slice(&json_bytes).map_err(|e| format!("JSON parse error: {e}"))?;
 
     let entry_count = match value.as_array() {
-        Some(arr) => arr.len() as u64,
+        Some(arr) => {
+            // Check for probe entries and compute E2E latency.
+            detect_and_report_probes(arr);
+            arr.len() as u64
+        }
         None => 1, // Single object counts as 1 entry.
     };
 
@@ -262,6 +266,48 @@ fn decompress_and_count(body: &[u8], headers: &HeaderMap) -> Result<DecompressRe
         entry_count,
         decompressed_size,
     })
+}
+
+/// Detect probe entries in the ingested JSON array and print E2E latency.
+///
+/// A probe is identified by the presence of a `ProbeOriginTimestampNanos` field
+/// (or `_otap_internal.probe.emitted_at_unix_nanos` for raw attribute passthrough).
+/// The latency is computed as `now() - origin_timestamp`.
+fn detect_and_report_probes(entries: &[serde_json::Value]) {
+    let now_nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as i64)
+        .unwrap_or(0);
+
+    for entry in entries {
+        // Try mapped field name first, then raw attribute name.
+        let origin_nanos = entry
+            .get("ProbeOriginTimestampNanos")
+            .or_else(|| entry.get("_otap_internal.probe.emitted_at_unix_nanos"))
+            .and_then(|v| v.as_i64());
+
+        if let Some(origin) = origin_nanos {
+            let latency_ns = (now_nanos - origin).max(0);
+            let latency_ms = latency_ns as f64 / 1_000_000.0;
+
+            let probe_id = entry
+                .get("ProbeId")
+                .or_else(|| entry.get("_otap_internal.probe.id"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("?");
+
+            let source = entry
+                .get("ProbeSource")
+                .or_else(|| entry.get("_otap_internal.probe.source"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("?");
+
+            println!(
+                "[mock-la] 🏓 PROBE E2E latency: {latency_ms:.1}ms | \
+                 source={source} | id={probe_id}"
+            );
+        }
+    }
 }
 
 /// Format a byte count as a human-readable string.

--- a/rust/otap-dataflow/crates/contrib-nodes/examples/mock_la_server.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/examples/mock_la_server.rs
@@ -270,9 +270,9 @@ fn decompress_and_count(body: &[u8], headers: &HeaderMap) -> Result<DecompressRe
 
 /// Detect probe entries in the ingested JSON array and print E2E latency.
 ///
-/// A probe is identified by the presence of a `ProbeOriginTimestampNanos` field
-/// (or `_otap_internal.probe.emitted_at_unix_nanos` for raw attribute passthrough).
-/// The latency is computed as `now() - origin_timestamp`.
+/// A probe is identified by `body == "_OTAP_PROBE"` (mapped as `"Message"`
+/// in the schema config). The leading `_` allows backends to short-circuit
+/// with a single-byte prefix check on non-probe logs.
 fn detect_and_report_probes(entries: &[serde_json::Value]) {
     let now_nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -280,33 +280,48 @@ fn detect_and_report_probes(entries: &[serde_json::Value]) {
         .unwrap_or(0);
 
     for entry in entries {
-        // Try mapped field name first, then raw attribute name.
+        // Fast path: check body / Message field for the well-known probe marker.
+        let body = entry
+            .get("Message")
+            .or_else(|| entry.get("body"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+
+        // O(1) prefix check, then full comparison only if prefix matches.
+        if !body.starts_with('_') || body != "_OTAP_PROBE" {
+            continue;
+        }
+
+        // Probe detected — read origin timestamp from attributes.
         let origin_nanos = entry
             .get("ProbeOriginTimestampNanos")
             .or_else(|| entry.get("_otap_internal.probe.emitted_at_unix_nanos"))
             .and_then(|v| v.as_i64());
 
-        if let Some(origin) = origin_nanos {
-            let latency_ns = (now_nanos - origin).max(0);
-            let latency_ms = latency_ns as f64 / 1_000_000.0;
+        let Some(origin) = origin_nanos else {
+            println!("[mock-la] ⚠️  PROBE detected but missing origin timestamp");
+            continue;
+        };
 
-            let probe_id = entry
-                .get("ProbeId")
-                .or_else(|| entry.get("_otap_internal.probe.id"))
-                .and_then(|v| v.as_str())
-                .unwrap_or("?");
+        let latency_ns = (now_nanos - origin).max(0);
+        let latency_ms = latency_ns as f64 / 1_000_000.0;
 
-            let source = entry
-                .get("ProbeSource")
-                .or_else(|| entry.get("_otap_internal.probe.source"))
-                .and_then(|v| v.as_str())
-                .unwrap_or("?");
+        let probe_id = entry
+            .get("ProbeId")
+            .or_else(|| entry.get("_otap_internal.probe.id"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("?");
 
-            println!(
-                "[mock-la] 🏓 PROBE E2E latency: {latency_ms:.1}ms | \
-                 source={source} | id={probe_id}"
-            );
-        }
+        let source = entry
+            .get("ProbeSource")
+            .or_else(|| entry.get("_otap_internal.probe.source"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("?");
+
+        println!(
+            "[mock-la] 🏓 PROBE E2E latency: {latency_ms:.1}ms | \
+             source={source} | id={probe_id}"
+        );
     }
 }
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/mod.rs
@@ -42,3 +42,6 @@ pub mod log_sampling_processor;
 
 /// Temporal reaggregation processor.
 pub mod temporal_reaggregation_processor;
+
+/// Probe sink processor (records end-to-end latency for synthetic probes).
+pub mod probe_sink_processor;

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/probe_sink_processor/config.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/probe_sink_processor/config.rs
@@ -1,0 +1,22 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Configuration for the probe-sink processor.
+
+use serde::{Deserialize, Serialize};
+
+/// Configuration for the `probe_sink` processor.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct Config {
+    /// When `true` (default), probe log records are dropped after their
+    /// latency is recorded so they never reach downstream exporters. When
+    /// `false`, probes are passed through unchanged (useful for debugging
+    /// or for inspecting probe records in test sinks).
+    #[serde(default = "default_drop_probes")]
+    pub drop_probes: bool,
+}
+
+fn default_drop_probes() -> bool {
+    true
+}

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/probe_sink_processor/metrics.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/probe_sink_processor/metrics.rs
@@ -1,0 +1,34 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Metrics for the probe-sink processor.
+
+use otap_df_telemetry::instrument::{Counter, Mmsc};
+use otap_df_telemetry_macros::metric_set;
+
+/// Metrics for the probe-sink processor.
+///
+/// `pipeline_e2e_latency_ns` is a Min/Mean/Max/Sum-Count histogram-equivalent
+/// over the per-probe latency observed at this sink. Pair it with
+/// `probes_observed` to derive averages and rates.
+#[metric_set(name = "processor.probe_sink")]
+#[derive(Debug, Default, Clone)]
+pub struct ProbeSinkMetrics {
+    /// Total number of probe records observed at this sink.
+    #[metric(unit = "{probe}")]
+    pub probes_observed: Counter<u64>,
+    /// Number of probe records dropped (forwarded only when `drop_probes` = false).
+    #[metric(unit = "{probe}")]
+    pub probes_dropped: Counter<u64>,
+    /// Number of incoming log records that were not probes (passed through).
+    #[metric(unit = "{log}")]
+    pub non_probe_logs_forwarded: Counter<u64>,
+    /// Number of probe records that were ill-formed (missing emitted_at
+    /// attribute or wrong type).
+    #[metric(unit = "{probe}")]
+    pub probes_invalid: Counter<u64>,
+    /// End-to-end latency of a probe, in nanoseconds, measured between the
+    /// emitter's wall-clock stamp and the sink's wall-clock observation.
+    #[metric(name = "pipeline.e2e.latency", unit = "ns")]
+    pub pipeline_e2e_latency_ns: Mmsc,
+}

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/probe_sink_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/probe_sink_processor/mod.rs
@@ -1,0 +1,442 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Processor that detects probe log records emitted by `probe_emitter`,
+//! records an end-to-end pipeline latency histogram, and (by default) drops
+//! the probes so they do not reach downstream exporters.
+//!
+//! A "probe" is any [`LogRecord`] carrying the reserved attribute
+//! [`PROBE_ID_ATTR`] together with [`PROBE_EMITTED_AT_ATTR`] holding the
+//! emitter-side Unix-nanos timestamp. Real (non-probe) logs are forwarded
+//! downstream unchanged.
+//!
+//! # Configuration
+//!
+//! ```yaml
+//! probe-sink:
+//!   type: urn:otel:processor:probe_sink
+//!   config:
+//!     drop_probes: true  # default; set to false to forward probes for debugging
+//! ```
+//!
+//! The PoC accepts only `OtlpProtoBytes::ExportLogsRequest` log payloads. Non-log
+//! payloads and `OtapArrowRecords` log payloads pass through untouched.
+
+use async_trait::async_trait;
+use bytes::BytesMut;
+use linkme::distributed_slice;
+use otap_df_config::SignalType;
+use otap_df_config::error::Error as ConfigError;
+use otap_df_config::node::NodeUserConfig;
+use otap_df_engine::MessageSourceLocalEffectHandlerExtension;
+use otap_df_engine::ProcessorFactory;
+use otap_df_engine::config::ProcessorConfig;
+use otap_df_engine::context::PipelineContext;
+use otap_df_engine::control::NodeControlMsg;
+use otap_df_engine::error::{Error, ProcessorErrorKind};
+use otap_df_engine::local::processor as local;
+use otap_df_engine::message::Message;
+use otap_df_engine::node::NodeId;
+use otap_df_engine::processor::ProcessorWrapper;
+use otap_df_otap::OTAP_PROCESSOR_FACTORIES;
+use otap_df_otap::pdata::OtapPdata;
+use otap_df_pdata::OtapPayload;
+use otap_df_pdata::OtlpProtoBytes;
+use otap_df_pdata::proto::opentelemetry::collector::logs::v1::ExportLogsServiceRequest;
+use otap_df_pdata::proto::opentelemetry::common::v1::any_value::Value as AnyValueOneof;
+use otap_df_pdata::proto::opentelemetry::logs::v1::LogRecord;
+use otap_df_telemetry::metrics::MetricSet;
+use prost::Message as _;
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use crate::receivers::probe_emitter_receiver::config::{PROBE_EMITTED_AT_ATTR, PROBE_ID_ATTR};
+
+use self::config::Config;
+use self::metrics::ProbeSinkMetrics;
+
+pub mod config;
+pub mod metrics;
+
+/// URN identifying the probe-sink processor.
+pub const PROBE_SINK_PROCESSOR_URN: &str = "urn:otel:processor:probe_sink";
+
+/// Registers the probe-sink processor as an OTAP processor factory.
+#[allow(unsafe_code)]
+#[distributed_slice(OTAP_PROCESSOR_FACTORIES)]
+pub static PROBE_SINK_PROCESSOR_FACTORY: ProcessorFactory<OtapPdata> = ProcessorFactory {
+    name: PROBE_SINK_PROCESSOR_URN,
+    create: create_probe_sink_processor,
+    wiring_contract: otap_df_engine::wiring_contract::WiringContract::UNRESTRICTED,
+    validate_config: otap_df_config::validation::validate_typed_config::<Config>,
+};
+
+/// Factory function building a `ProbeSinkProcessor` wrapper.
+pub fn create_probe_sink_processor(
+    pipeline_ctx: PipelineContext,
+    node: NodeId,
+    node_config: Arc<NodeUserConfig>,
+    processor_config: &ProcessorConfig,
+    _capabilities: &otap_df_engine::capability::registry::Capabilities,
+) -> Result<ProcessorWrapper<OtapPdata>, ConfigError> {
+    let config: Config = serde_json::from_value(node_config.config.clone()).map_err(|e| {
+        ConfigError::InvalidUserConfig {
+            error: format!("Failed to parse probe_sink configuration: {e}"),
+        }
+    })?;
+    let metrics = pipeline_ctx.register_metrics::<ProbeSinkMetrics>();
+    Ok(ProcessorWrapper::local(
+        ProbeSinkProcessor { config, metrics },
+        node,
+        node_config,
+        processor_config,
+    ))
+}
+
+/// Per-batch processing outcome used by [`ProbeSinkProcessor::process_logs`].
+struct ProbeScanOutcome {
+    /// Encoded `ExportLogsServiceRequest` to forward downstream, if any.
+    /// `None` means every log was a dropped probe and the entire batch can be skipped.
+    forward_bytes: Option<BytesMut>,
+    /// Number of probes observed in this batch.
+    probes_observed: u64,
+    /// Number of probes dropped (zero when `drop_probes` is false).
+    probes_dropped: u64,
+    /// Number of non-probe log records forwarded.
+    non_probe_forwarded: u64,
+    /// Number of probe records that were ill-formed.
+    probes_invalid: u64,
+    /// Latency samples (ns) recorded for valid probes, in observation order.
+    latency_samples_ns: Vec<u64>,
+}
+
+/// Processor that records end-to-end probe latency and optionally drops probes.
+pub struct ProbeSinkProcessor {
+    config: Config,
+    metrics: MetricSet<ProbeSinkMetrics>,
+}
+
+impl ProbeSinkProcessor {
+    /// Scan a decoded `ExportLogsServiceRequest`, record latency for any probes,
+    /// and (when configured) drop them in-place. Returns counters and a
+    /// re-encoded payload ready to forward, or `None` if every log was a
+    /// dropped probe.
+    fn process_logs(
+        &self,
+        mut request: ExportLogsServiceRequest,
+        now_unix_nanos: i64,
+    ) -> Result<ProbeScanOutcome, EncodeError> {
+        let mut probes_observed: u64 = 0;
+        let mut probes_dropped: u64 = 0;
+        let mut non_probe_forwarded: u64 = 0;
+        let mut probes_invalid: u64 = 0;
+        let mut latency_samples_ns: Vec<u64> = Vec::new();
+
+        for resource in request.resource_logs.iter_mut() {
+            for scope in resource.scope_logs.iter_mut() {
+                let mut kept: Vec<LogRecord> = Vec::with_capacity(scope.log_records.len());
+                for log in std::mem::take(&mut scope.log_records) {
+                    match classify_log(&log) {
+                        ProbeClassification::NotProbe => {
+                            non_probe_forwarded += 1;
+                            kept.push(log);
+                        }
+                        ProbeClassification::ProbeMalformed => {
+                            probes_observed += 1;
+                            probes_invalid += 1;
+                            if !self.config.drop_probes {
+                                kept.push(log);
+                            } else {
+                                probes_dropped += 1;
+                            }
+                        }
+                        ProbeClassification::Probe {
+                            emitted_at_unix_nanos,
+                        } => {
+                            probes_observed += 1;
+                            let latency_ns = (now_unix_nanos - emitted_at_unix_nanos).max(0) as u64;
+                            latency_samples_ns.push(latency_ns);
+                            if !self.config.drop_probes {
+                                kept.push(log);
+                            } else {
+                                probes_dropped += 1;
+                            }
+                        }
+                    }
+                }
+                scope.log_records = kept;
+            }
+            // Prune scopes that became empty so we don't emit empty wrappers.
+            resource.scope_logs.retain(|s| !s.log_records.is_empty());
+        }
+        request.resource_logs.retain(|r| !r.scope_logs.is_empty());
+
+        let forward_bytes = if request.resource_logs.is_empty() {
+            None
+        } else {
+            let mut buf = BytesMut::with_capacity(request.encoded_len());
+            request
+                .encode(&mut buf)
+                .map_err(|e| EncodeError(format!("failed to re-encode logs: {e}")))?;
+            Some(buf)
+        };
+
+        Ok(ProbeScanOutcome {
+            forward_bytes,
+            probes_observed,
+            probes_dropped,
+            non_probe_forwarded,
+            probes_invalid,
+            latency_samples_ns,
+        })
+    }
+}
+
+#[async_trait(?Send)]
+impl local::Processor<OtapPdata> for ProbeSinkProcessor {
+    async fn process(
+        &mut self,
+        msg: Message<OtapPdata>,
+        effect_handler: &mut local::EffectHandler<OtapPdata>,
+    ) -> Result<(), Error> {
+        match msg {
+            Message::Control(NodeControlMsg::CollectTelemetry {
+                mut metrics_reporter,
+            }) => {
+                let _ = metrics_reporter.report(&mut self.metrics);
+                Ok(())
+            }
+            Message::Control(_) => Ok(()),
+            Message::PData(pdata) => {
+                if pdata.signal_type() != SignalType::Logs {
+                    effect_handler.send_message_with_source_node(pdata).await?;
+                    return Ok(());
+                }
+                let (context, payload) = pdata.into_parts();
+                let OtapPayload::OtlpBytes(OtlpProtoBytes::ExportLogsRequest(bytes)) = payload
+                else {
+                    // Non-OTLP-bytes log payloads (e.g. OtapArrowRecords) are
+                    // out of scope for the PoC; pass them through untouched.
+                    effect_handler
+                        .send_message_with_source_node(OtapPdata::new(context, payload))
+                        .await?;
+                    return Ok(());
+                };
+
+                let request = ExportLogsServiceRequest::decode(bytes.as_ref()).map_err(|e| {
+                    Error::ProcessorError {
+                        processor: effect_handler.processor_id(),
+                        kind: ProcessorErrorKind::Other,
+                        error: format!("failed to decode ExportLogsRequest: {e}"),
+                        source_detail: String::new(),
+                    }
+                })?;
+
+                let now_unix_nanos: i64 = SystemTime::now()
+                    .duration_since(SystemTime::UNIX_EPOCH)
+                    .map(|d| i64::try_from(d.as_nanos()).unwrap_or(i64::MAX))
+                    .unwrap_or(0);
+
+                let outcome =
+                    self.process_logs(request, now_unix_nanos)
+                        .map_err(|EncodeError(msg)| Error::ProcessorError {
+                            processor: effect_handler.processor_id(),
+                            kind: ProcessorErrorKind::Other,
+                            error: msg,
+                            source_detail: String::new(),
+                        })?;
+
+                self.metrics.probes_observed.add(outcome.probes_observed);
+                self.metrics.probes_dropped.add(outcome.probes_dropped);
+                self.metrics
+                    .non_probe_logs_forwarded
+                    .add(outcome.non_probe_forwarded);
+                self.metrics.probes_invalid.add(outcome.probes_invalid);
+                for sample in outcome.latency_samples_ns {
+                    self.metrics.pipeline_e2e_latency_ns.record(sample as f64);
+                }
+
+                if let Some(buf) = outcome.forward_bytes {
+                    let forwarded = OtapPdata::new(
+                        context,
+                        OtlpProtoBytes::ExportLogsRequest(buf.freeze()).into(),
+                    );
+                    effect_handler
+                        .send_message_with_source_node(forwarded)
+                        .await?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+/// Local error type so `process_logs` can stay decoupled from the engine's
+/// `Error` enum (we only have the processor id available at the call site).
+#[derive(Debug)]
+struct EncodeError(String);
+
+/// Classification of a single [`LogRecord`] relative to probe attributes.
+enum ProbeClassification {
+    /// The record carries no probe id attribute.
+    NotProbe,
+    /// The record has a probe id but is missing or has malformed
+    /// `emitted_at_unix_nanos`.
+    ProbeMalformed,
+    /// A well-formed probe with the extracted emit timestamp.
+    Probe { emitted_at_unix_nanos: i64 },
+}
+
+fn classify_log(log: &LogRecord) -> ProbeClassification {
+    let mut has_probe_id = false;
+    let mut emitted_at: Option<i64> = None;
+    for kv in &log.attributes {
+        if kv.key == PROBE_ID_ATTR {
+            has_probe_id = true;
+        } else if kv.key == PROBE_EMITTED_AT_ATTR {
+            if let Some(AnyValueOneof::IntValue(ns)) =
+                kv.value.as_ref().and_then(|v| v.value.as_ref())
+            {
+                emitted_at = Some(*ns);
+            }
+        }
+    }
+    if !has_probe_id {
+        return ProbeClassification::NotProbe;
+    }
+    match emitted_at {
+        Some(ns) => ProbeClassification::Probe {
+            emitted_at_unix_nanos: ns,
+        },
+        None => ProbeClassification::ProbeMalformed,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use otap_df_engine::context::ControllerContext;
+    use otap_df_pdata::proto::opentelemetry::common::v1::{AnyValue, KeyValue};
+    use otap_df_pdata::proto::opentelemetry::logs::v1::{LogRecord, ResourceLogs, ScopeLogs};
+    use otap_df_telemetry::registry::TelemetryRegistryHandle;
+
+    fn fresh_processor(drop_probes: bool) -> ProbeSinkProcessor {
+        let registry = TelemetryRegistryHandle::new();
+        let controller = ControllerContext::new(registry);
+        let pipeline_ctx = controller.pipeline_context_with("g".into(), "p".into(), 0, 1, 0);
+        ProbeSinkProcessor {
+            config: Config { drop_probes },
+            metrics: pipeline_ctx.register_metrics::<ProbeSinkMetrics>(),
+        }
+    }
+
+    fn probe_log(emitted_at_ns: i64) -> LogRecord {
+        LogRecord {
+            attributes: vec![
+                KeyValue::new(PROBE_ID_ATTR, AnyValue::new_string("abc")),
+                KeyValue::new(PROBE_EMITTED_AT_ATTR, AnyValue::new_int(emitted_at_ns)),
+            ],
+            ..Default::default()
+        }
+    }
+
+    fn non_probe_log() -> LogRecord {
+        LogRecord {
+            attributes: vec![KeyValue::new("k", AnyValue::new_string("v"))],
+            ..Default::default()
+        }
+    }
+
+    fn wrap(logs: Vec<LogRecord>) -> ExportLogsServiceRequest {
+        ExportLogsServiceRequest {
+            resource_logs: vec![ResourceLogs {
+                scope_logs: vec![ScopeLogs {
+                    log_records: logs,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        }
+    }
+
+    #[test]
+    fn probe_only_batch_dropped_when_drop_probes_true() {
+        let proc = fresh_processor(true);
+        let now_ns: i64 = 1_000_000_000;
+        let req = wrap(vec![probe_log(now_ns - 5_000_000)]); // emitted 5ms ago
+        let outcome = proc.process_logs(req, now_ns).expect("process");
+        assert!(
+            outcome.forward_bytes.is_none(),
+            "batch must be skipped entirely"
+        );
+        assert_eq!(outcome.probes_observed, 1);
+        assert_eq!(outcome.probes_dropped, 1);
+        assert_eq!(outcome.non_probe_forwarded, 0);
+        assert_eq!(outcome.latency_samples_ns, vec![5_000_000]);
+    }
+
+    #[test]
+    fn mixed_batch_keeps_only_non_probes_when_dropping() {
+        let proc = fresh_processor(true);
+        let now_ns: i64 = 2_000_000_000;
+        let req = wrap(vec![
+            non_probe_log(),
+            probe_log(now_ns - 1_000_000),
+            non_probe_log(),
+        ]);
+        let outcome = proc.process_logs(req, now_ns).expect("process");
+        let buf = outcome.forward_bytes.expect("must forward remaining logs");
+        let forwarded = ExportLogsServiceRequest::decode(buf.as_ref()).expect("decode");
+        assert_eq!(
+            forwarded.resource_logs[0].scope_logs[0].log_records.len(),
+            2
+        );
+        assert_eq!(outcome.probes_observed, 1);
+        assert_eq!(outcome.probes_dropped, 1);
+        assert_eq!(outcome.non_probe_forwarded, 2);
+        assert_eq!(outcome.latency_samples_ns, vec![1_000_000]);
+    }
+
+    #[test]
+    fn drop_probes_false_passes_probes_through() {
+        let proc = fresh_processor(false);
+        let now_ns: i64 = 5_000;
+        let req = wrap(vec![probe_log(now_ns - 1_000), non_probe_log()]);
+        let outcome = proc.process_logs(req, now_ns).expect("process");
+        let buf = outcome.forward_bytes.expect("must forward");
+        let forwarded = ExportLogsServiceRequest::decode(buf.as_ref()).expect("decode");
+        assert_eq!(
+            forwarded.resource_logs[0].scope_logs[0].log_records.len(),
+            2
+        );
+        assert_eq!(outcome.probes_dropped, 0);
+        assert_eq!(outcome.probes_observed, 1);
+    }
+
+    #[test]
+    fn malformed_probe_counted_as_invalid() {
+        let proc = fresh_processor(true);
+        // probe id present but no emitted_at attribute
+        let log = LogRecord {
+            attributes: vec![KeyValue::new(PROBE_ID_ATTR, AnyValue::new_string("x"))],
+            ..Default::default()
+        };
+        let req = wrap(vec![log]);
+        let outcome = proc.process_logs(req, 1_000).expect("process");
+        assert_eq!(outcome.probes_observed, 1);
+        assert_eq!(outcome.probes_invalid, 1);
+        assert!(outcome.latency_samples_ns.is_empty());
+    }
+
+    #[test]
+    fn classify_negative_skew_clamps_to_zero() {
+        // If the receiver's clock is slightly ahead of the sink's, the
+        // subtraction can go negative; we should clamp to 0 rather than
+        // wrap or panic.
+        let proc = fresh_processor(true);
+        let now_ns: i64 = 100;
+        let req = wrap(vec![probe_log(now_ns + 1_000)]); // emitted "in the future"
+        let outcome = proc.process_logs(req, now_ns).expect("process");
+        assert_eq!(outcome.latency_samples_ns, vec![0]);
+    }
+}

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/mod.rs
@@ -25,3 +25,6 @@ pub mod host_metrics_receiver;
 
 /// Journald receiver.
 pub mod journald_receiver;
+
+/// Probe emitter receiver (synthetic probes for end-to-end latency measurement).
+pub mod probe_emitter_receiver;

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/probe_emitter_receiver/config.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/probe_emitter_receiver/config.rs
@@ -9,6 +9,11 @@ use std::time::Duration;
 /// Default emission interval (1 probe per second).
 pub const DEFAULT_INTERVAL: Duration = Duration::from_secs(1);
 
+/// Well-known log body value that backends can use for fast O(1) probe
+/// detection. Starts with `_` so a single-byte prefix check short-circuits
+/// for every non-probe log.
+pub const PROBE_BODY: &str = "_OTAP_PROBE";
+
 /// Reserved attribute key carrying the probe's unique id.
 pub const PROBE_ID_ATTR: &str = "_otap_internal.probe.id";
 

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/probe_emitter_receiver/config.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/probe_emitter_receiver/config.rs
@@ -1,0 +1,51 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Configuration for the probe-emitter receiver.
+
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+/// Default emission interval (1 probe per second).
+pub const DEFAULT_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Reserved attribute key carrying the probe's unique id.
+pub const PROBE_ID_ATTR: &str = "_otap_internal.probe.id";
+
+/// Reserved attribute key carrying the probe's source timestamp (Unix nanos).
+pub const PROBE_EMITTED_AT_ATTR: &str = "_otap_internal.probe.emitted_at_unix_nanos";
+
+/// Reserved attribute key carrying the probe's source name.
+pub const PROBE_SOURCE_ATTR: &str = "_otap_internal.probe.source";
+
+/// Configuration for the `probe_emitter` receiver.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Config {
+    /// How often to emit a single-row probe log batch.
+    /// Format: humantime (e.g., "500ms", "1s", "5s"). Defaults to `1s`.
+    #[serde(default = "default_interval", with = "humantime_serde")]
+    pub interval: Duration,
+
+    /// Logical identifier of this probe source, propagated as an attribute so
+    /// the sink can group latency by source. Defaults to `"default"`.
+    #[serde(default = "default_source")]
+    pub source: String,
+}
+
+fn default_interval() -> Duration {
+    DEFAULT_INTERVAL
+}
+
+fn default_source() -> String {
+    "default".to_owned()
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            interval: DEFAULT_INTERVAL,
+            source: default_source(),
+        }
+    }
+}

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/probe_emitter_receiver/metrics.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/probe_emitter_receiver/metrics.rs
@@ -1,0 +1,19 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Metrics for the probe-emitter receiver.
+
+use otap_df_telemetry::instrument::Counter;
+use otap_df_telemetry_macros::metric_set;
+
+/// Metrics for the probe-emitter receiver.
+#[metric_set(name = "receiver.probe_emitter")]
+#[derive(Debug, Default, Clone)]
+pub struct ProbeEmitterMetrics {
+    /// Number of probe records emitted into the pipeline.
+    #[metric(unit = "{probe}")]
+    pub probes_emitted: Counter<u64>,
+    /// Number of probes that failed to send (channel full / closed).
+    #[metric(unit = "{probe}")]
+    pub probes_send_failed: Counter<u64>,
+}

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/probe_emitter_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/probe_emitter_receiver/mod.rs
@@ -1,0 +1,277 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! A receiver that periodically emits a synthetic OTLP log record stamped
+//! with probe metadata, used for end-to-end pipeline latency measurement.
+//!
+//! Each emitted [`LogRecord`] carries three reserved attributes:
+//! - `_otap_internal.probe.id` — a UUIDv4 string uniquely identifying the probe
+//! - `_otap_internal.probe.emitted_at_unix_nanos` — emission timestamp in Unix
+//!   nanoseconds (the wall-clock used for latency math at the sink)
+//! - `_otap_internal.probe.source` — caller-configured source identifier
+//!
+//! Pair this receiver with the `probe_sink_processor`, which detects probe
+//! records, records an end-to-end latency histogram, and drops them so they
+//! do not reach the real backend.
+//!
+//! # Configuration
+//!
+//! ```yaml
+//! probe:
+//!   type: urn:otel:receiver:probe_emitter
+//!   config:
+//!     interval: 1s        # humantime duration, default: 1s
+//!     source: ingest-pod  # logical source name, default: "default"
+//! ```
+
+use async_trait::async_trait;
+use bytes::BytesMut;
+use linkme::distributed_slice;
+use otap_df_config::node::NodeUserConfig;
+use otap_df_engine::ReceiverFactory;
+use otap_df_engine::config::ReceiverConfig;
+use otap_df_engine::context::PipelineContext;
+use otap_df_engine::control::NodeControlMsg;
+use otap_df_engine::error::Error;
+use otap_df_engine::local::receiver as local;
+use otap_df_engine::node::NodeId;
+use otap_df_engine::receiver::ReceiverWrapper;
+use otap_df_engine::terminal_state::TerminalState;
+use otap_df_otap::OTAP_RECEIVER_FACTORIES;
+use otap_df_otap::pdata::{Context, OtapPdata};
+use otap_df_pdata::OtlpProtoBytes;
+use otap_df_pdata::proto::opentelemetry::collector::logs::v1::ExportLogsServiceRequest;
+use otap_df_pdata::proto::opentelemetry::common::v1::{AnyValue, KeyValue};
+use otap_df_pdata::proto::opentelemetry::logs::v1::{LogRecord, ResourceLogs, ScopeLogs};
+use otap_df_telemetry::metrics::{MetricSet, MetricSetSnapshot};
+use prost::Message;
+use serde_json::Value;
+use std::sync::Arc;
+use std::time::SystemTime;
+use tokio::time::{MissedTickBehavior, interval};
+use uuid::Uuid;
+
+use self::config::{Config, PROBE_EMITTED_AT_ATTR, PROBE_ID_ATTR, PROBE_SOURCE_ATTR};
+use self::metrics::ProbeEmitterMetrics;
+
+pub mod config;
+pub mod metrics;
+
+/// URN identifying the probe-emitter receiver.
+pub const PROBE_EMITTER_RECEIVER_URN: &str = "urn:otel:receiver:probe_emitter";
+
+/// Registers the probe-emitter receiver as an OTAP receiver factory.
+#[allow(unsafe_code)]
+#[distributed_slice(OTAP_RECEIVER_FACTORIES)]
+pub static PROBE_EMITTER_RECEIVER: ReceiverFactory<OtapPdata> = ReceiverFactory {
+    name: PROBE_EMITTER_RECEIVER_URN,
+    create: |pipeline_ctx: PipelineContext,
+             node: NodeId,
+             node_config: Arc<NodeUserConfig>,
+             receiver_config: &ReceiverConfig,
+             _capabilities: &otap_df_engine::capability::registry::Capabilities| {
+        let config = ProbeEmitterReceiver::parse_config(&node_config.config)?;
+        Ok(ReceiverWrapper::local(
+            ProbeEmitterReceiver::new(pipeline_ctx, config),
+            node,
+            node_config,
+            receiver_config,
+        ))
+    },
+    wiring_contract: otap_df_engine::wiring_contract::WiringContract::UNRESTRICTED,
+    validate_config: otap_df_config::validation::validate_typed_config::<Config>,
+};
+
+/// Receiver that periodically emits probe log records.
+pub struct ProbeEmitterReceiver {
+    config: Config,
+    metrics: MetricSet<ProbeEmitterMetrics>,
+}
+
+impl ProbeEmitterReceiver {
+    /// Create a new receiver with the given configuration.
+    #[must_use]
+    pub fn new(pipeline_ctx: PipelineContext, config: Config) -> Self {
+        let metrics = pipeline_ctx.register_metrics::<ProbeEmitterMetrics>();
+        Self { config, metrics }
+    }
+
+    /// Parse configuration from a JSON value.
+    pub fn parse_config(config: &Value) -> Result<Config, otap_df_config::error::Error> {
+        serde_json::from_value(config.clone()).map_err(|e| {
+            otap_df_config::error::Error::InvalidUserConfig {
+                error: e.to_string(),
+            }
+        })
+    }
+
+    /// Build an `OtapPdata` carrying a single probe log record stamped with
+    /// the current Unix-nanos timestamp and a freshly minted UUID.
+    fn build_probe_pdata(source: &str) -> OtapPdata {
+        let emitted_at_unix_nanos: i64 = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map(|d| i64::try_from(d.as_nanos()).unwrap_or(i64::MAX))
+            .unwrap_or(0);
+        let probe_id = Uuid::new_v4().to_string();
+
+        let log = LogRecord {
+            time_unix_nano: emitted_at_unix_nanos as u64,
+            observed_time_unix_nano: emitted_at_unix_nanos as u64,
+            attributes: vec![
+                KeyValue::new(PROBE_ID_ATTR, AnyValue::new_string(probe_id)),
+                KeyValue::new(
+                    PROBE_EMITTED_AT_ATTR,
+                    AnyValue::new_int(emitted_at_unix_nanos),
+                ),
+                KeyValue::new(PROBE_SOURCE_ATTR, AnyValue::new_string(source.to_owned())),
+            ],
+            ..Default::default()
+        };
+
+        let request = ExportLogsServiceRequest {
+            resource_logs: vec![ResourceLogs {
+                scope_logs: vec![ScopeLogs {
+                    log_records: vec![log],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        };
+
+        let mut buf = BytesMut::with_capacity(request.encoded_len());
+        request
+            .encode(&mut buf)
+            .expect("encode ExportLogsServiceRequest");
+
+        OtapPdata::new(
+            Context::default(),
+            OtlpProtoBytes::ExportLogsRequest(buf.freeze()).into(),
+        )
+    }
+}
+
+#[async_trait(?Send)]
+impl local::Receiver<OtapPdata> for ProbeEmitterReceiver {
+    async fn start(
+        self: Box<Self>,
+        mut ctrl_msg_recv: local::ControlChannel<OtapPdata>,
+        effect_handler: local::EffectHandler<OtapPdata>,
+    ) -> Result<TerminalState, Error> {
+        let mut metrics = self.metrics;
+        let source = self.config.source.clone();
+        let mut ticker = interval(self.config.interval);
+        ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        // First tick fires immediately; consume it so the first probe is
+        // delayed by `interval` rather than fired at startup.
+        let _ = ticker.tick().await;
+
+        loop {
+            tokio::select! {
+                biased;
+
+                ctrl_msg = ctrl_msg_recv.recv() => {
+                    match ctrl_msg {
+                        Ok(NodeControlMsg::DrainIngress { deadline, .. }) => {
+                            effect_handler.notify_receiver_drained().await?;
+                            return Ok(TerminalState::new::<[MetricSetSnapshot; 0]>(
+                                deadline,
+                                [],
+                            ));
+                        }
+                        Ok(NodeControlMsg::Shutdown { deadline, .. }) => {
+                            return Ok(TerminalState::new::<[MetricSetSnapshot; 0]>(
+                                deadline,
+                                [],
+                            ));
+                        }
+                        Ok(NodeControlMsg::CollectTelemetry {
+                            mut metrics_reporter,
+                        }) => {
+                            let _ = metrics_reporter.report(&mut metrics);
+                        }
+                        Ok(_) => { /* ignore other control messages */ }
+                        Err(e) => return Err(Error::ChannelRecvError(e)),
+                    }
+                }
+
+                _ = ticker.tick() => {
+                    let pdata = Self::build_probe_pdata(&source);
+                    match effect_handler.send_message(pdata).await {
+                        Ok(()) => metrics.probes_emitted.inc(),
+                        Err(_) => metrics.probes_send_failed.inc(),
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use self::config::DEFAULT_INTERVAL;
+    use super::*;
+    use otap_df_pdata::proto::opentelemetry::common::v1::any_value::Value as AnyValueOneof;
+
+    #[test]
+    fn build_probe_pdata_encodes_required_attributes() {
+        let pdata = ProbeEmitterReceiver::build_probe_pdata("unit-test");
+        assert_eq!(pdata.signal_type(), otap_df_config::SignalType::Logs);
+
+        let (_ctx, payload) = pdata.into_parts();
+        let bytes = match payload {
+            otap_df_pdata::OtapPayload::OtlpBytes(OtlpProtoBytes::ExportLogsRequest(b)) => b,
+            other => panic!("expected ExportLogsRequest payload, got {other:?}"),
+        };
+
+        let req =
+            ExportLogsServiceRequest::decode(bytes.as_ref()).expect("decode ExportLogsRequest");
+        assert_eq!(req.resource_logs.len(), 1);
+        assert_eq!(req.resource_logs[0].scope_logs.len(), 1);
+        assert_eq!(req.resource_logs[0].scope_logs[0].log_records.len(), 1);
+
+        let log = &req.resource_logs[0].scope_logs[0].log_records[0];
+        let mut saw_id = false;
+        let mut saw_emitted = false;
+        let mut saw_source = false;
+        for kv in &log.attributes {
+            match kv.key.as_str() {
+                PROBE_ID_ATTR => {
+                    saw_id = true;
+                    let inner = kv.value.as_ref().and_then(|v| v.value.as_ref());
+                    assert!(matches!(inner, Some(AnyValueOneof::StringValue(s)) if !s.is_empty()));
+                }
+                PROBE_EMITTED_AT_ATTR => {
+                    saw_emitted = true;
+                    let inner = kv.value.as_ref().and_then(|v| v.value.as_ref());
+                    assert!(matches!(inner, Some(AnyValueOneof::IntValue(ns)) if *ns > 0));
+                }
+                PROBE_SOURCE_ATTR => {
+                    saw_source = true;
+                    let inner = kv.value.as_ref().and_then(|v| v.value.as_ref());
+                    assert!(
+                        matches!(inner, Some(AnyValueOneof::StringValue(s)) if s == "unit-test")
+                    );
+                }
+                _ => {}
+            }
+        }
+        assert!(
+            saw_id && saw_emitted && saw_source,
+            "probe must carry id, emitted_at, and source attributes"
+        );
+    }
+
+    #[test]
+    fn config_uses_defaults_when_unspecified() {
+        let cfg: Config = serde_json::from_value(serde_json::json!({})).expect("default config");
+        assert_eq!(cfg.interval, DEFAULT_INTERVAL);
+        assert_eq!(cfg.source, "default");
+    }
+
+    #[test]
+    fn config_parses_humantime_interval() {
+        let cfg: Config =
+            serde_json::from_value(serde_json::json!({"interval": "250ms"})).expect("parse cfg");
+        assert_eq!(cfg.interval, std::time::Duration::from_millis(250));
+    }
+}

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/probe_emitter_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/probe_emitter_receiver/mod.rs
@@ -51,7 +51,9 @@ use std::time::SystemTime;
 use tokio::time::{MissedTickBehavior, interval};
 use uuid::Uuid;
 
-use self::config::{Config, PROBE_EMITTED_AT_ATTR, PROBE_ID_ATTR, PROBE_SOURCE_ATTR};
+use self::config::{
+    Config, PROBE_BODY, PROBE_EMITTED_AT_ATTR, PROBE_ID_ATTR, PROBE_SOURCE_ATTR,
+};
 use self::metrics::ProbeEmitterMetrics;
 
 pub mod config;
@@ -117,6 +119,7 @@ impl ProbeEmitterReceiver {
         let log = LogRecord {
             time_unix_nano: emitted_at_unix_nanos as u64,
             observed_time_unix_nano: emitted_at_unix_nanos as u64,
+            body: Some(AnyValue::new_string(PROBE_BODY)),
             attributes: vec![
                 KeyValue::new(PROBE_ID_ATTR, AnyValue::new_string(probe_id)),
                 KeyValue::new(

--- a/rust/otap-dataflow/e2e-latency-probe-poc.yaml
+++ b/rust/otap-dataflow/e2e-latency-probe-poc.yaml
@@ -1,0 +1,64 @@
+# E2E Latency Probe POC
+#
+# Demonstrates end-to-end latency measurement for Azure Monitor Pipeline:
+# - probe_emitter receiver stamps synthetic log records with origin time
+# - azure_monitor_exporter ships them to the mock LA server
+# - mock LA server detects probes, computes and prints E2E latency
+#
+# Usage:
+#   1. Start the mock LA server (with probe latency detection):
+#      cargo run --example mock_la_server -p otap-df-contrib-nodes --features azure-monitor-exporter -- --port 9999
+#
+#   2. Run the pipeline:
+#      cargo run --release --features azure-monitor-exporter -- --config rust/otap-dataflow/e2e-latency-probe-poc.yaml --num-cores 1
+#
+#   3. Observe stdout of the mock server — it will print per-probe E2E latency.
+
+version: otel_dataflow/v1
+
+policies:
+  channel_capacity:
+    control:
+      node: 100
+      pipeline: 100
+    pdata: 16
+
+engine:
+  telemetry:
+    logs:
+      level: "info"
+
+groups:
+  default:
+    pipelines:
+      main:
+        nodes:
+          probe-emitter:
+            type: "urn:otel:receiver:probe_emitter"
+            config:
+              interval: 1s
+              source: "e2e-latency-poc"
+
+          azure-monitor-exporter:
+            type: "urn:microsoft:exporter:azure_monitor"
+            config:
+              api:
+                dcr_endpoint: "http://localhost:9999"
+                stream_name: "Custom-ProbeLatency_CL"
+                dcr: "dcr-probe-poc"
+                schema:
+                  resource_mapping: {}
+                  log_record_mapping:
+                    "body": "Message"
+                    "time_unix_nano": "TimeGenerated"
+                    "attributes":
+                      "_otap_internal.probe.id": "ProbeId"
+                      "_otap_internal.probe.emitted_at_unix_nanos": "ProbeOriginTimestampNanos"
+                      "_otap_internal.probe.source": "ProbeSource"
+
+              auth:
+                method: "dev"
+
+        connections:
+          - from: probe-emitter
+            to: azure-monitor-exporter


### PR DESCRIPTION
## Context

Exploring how to measure end-to-end pipeline latency — the time from when a record enters the pipeline to when it is received by the backend.

This PR explores a **lightweight approach** that does not require any changes to the df-engine itself. The trade-off is that it requires backend cooperation — the backend must recognize probe records and compute the latency. An engine-native approach (where the engine itself tracks and reports latency) would be more self-contained but is likely more complex and expensive to implement correctly. Both directions are worth exploring; this PR starts with the simpler one to validate the concept.

## Approach: Synthetic probe traffic + backend-side latency computation

1. A synthetic log record is periodically injected into the pipeline with `body = "_OTAP_PROBE"` and an `_otap_internal.probe.emitted_at_unix_nanos` attribute carrying the wall-clock timestamp at emission.

2. Probes flow through the **entire real pipeline path** as ordinary data — same processors, same exporter batching, same wire format. No special handling anywhere in the engine.

3. The **backend** detects probes (check if `body == "_OTAP_PROBE"`), computes `now() - emitted_at`, emits a latency metric, and drops the record.

### Probe generation options

The probe traffic can be generated by:

- **`probe_emitter` receiver** (included in this PR) — a minimal in-engine receiver that emits one probe log per configurable interval.
- **`traffic_generator` receiver** — the existing traffic generator could serve this purpose once it gains the ability to stamp an origin timestamp on generated telemetry.
- **An external script or sidecar** — any process that sends an OTLP log with the expected body and attribute to the pipeline's receiver endpoint. No in-engine component needed at all.

### Backend convention

Any backend that follows the `_OTAP_PROBE` convention can participate:

1. On ingest, check if `body == "_OTAP_PROBE"` (O(1) string check; short-circuit on first byte `_`)
2. If match: read `_otap_internal.probe.emitted_at_unix_nanos`, compute `now() - emitted_at`, emit a latency metric
3. Drop the record (don't index it)

### Why backend-side?

Any measurement taken inside the engine structurally cannot include exporter time (batching, serialization, compression, network, ack) — which is typically the dominant contributor to E2E latency. The backend is the only observer that sees the full path.

## Demo

The POC uses the Azure Monitor exporter + mock LA server as an example backend, but the same convention would work with any backend that implements the `_OTAP_PROBE` detection.

### To try locally

```bash
# Terminal 1 — mock backend (uses mock LA server as example)
cargo run --example mock_la_server -p otap-df-contrib-nodes \
    --features azure-monitor-exporter -- --port 9999

# Terminal 2 — pipeline with probe emitter
cargo run --features azure-monitor-exporter -- \
    --config e2e-latency-probe-poc.yaml --num-cores 1
```

Output from the mock backend:
```
🏓 PROBE E2E latency: 450.3ms | source=e2e-latency-poc | id=6e8cc3d2-...
🏓 PROBE E2E latency: 1451.8ms | source=e2e-latency-poc | id=d29009a7-...
🏓 PROBE E2E latency: 2448.2ms | source=e2e-latency-poc | id=feedf721-...
```

In steady state, probe latency reflects the exporter's batch flush interval. With the default 3s flush, probes show ~450ms–2450ms depending on position in the batch. With a 1s flush, all probes converge to ~450ms. This confirms the measurement captures real pipeline behavior.

## What's included

| File | Purpose |
|---|---|
| `crates/core-nodes/src/receivers/probe_emitter_receiver/` | Probe emitter receiver (config, metrics, mod) |
| `crates/core-nodes/src/processors/probe_sink_processor/` | Engine-internal probe sink — detects probes and computes latency *within* the engine (i.e., up to the processor stage, excluding exporter/network time). Included for comparison but **not the recommended approach** since it misses the dominant latency contributor (exporter + network). |
| `e2e-latency-probe-poc.yaml` | Ready-to-run config: probe_emitter → azure_monitor_exporter → localhost:9999 |
| `crates/contrib-nodes/examples/mock_la_server.rs` | Mock backend with probe detection (~40 lines added) |

## Trade-offs

**Pros:**
- Zero engine changes — probes are just ordinary log records
- Measures the full real path including exporter batching, network, and backend ingestion
- Probe generation is flexible: in-engine receiver, existing traffic generator, or external script

**Cons:**
- Requires backends to implement the `_OTAP_PROBE` convention
- Does not give per-stage breakdown within the engine (existing per-node flow metrics already cover that)
- Probes can be dropped by content-based filters if filter rules happen to match the probe body