### PR TITLE
chore(repo): Avoid untrusted shell execution of PR labels/title

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -32,9 +32,12 @@ jobs:
     steps:
       - name: Detect changelog bypass conditions
         id: detect_bypass
+        env:
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ' ') }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          labels="${{ join(github.event.pull_request.labels.*.name, ' ') }}"
-          title="${{ github.event.pull_request.title }}"
+          labels="$PR_LABELS"
+          title="$PR_TITLE"
 
           skip=false
           for label in dependencies chore skipchangelog; do


### PR DESCRIPTION
# Change Summary

Address problem introduced in #3360 

## What issue does this PR close?

N/A

## How are these changes tested?

N/A

## Are there any user-facing changes?

N/A

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
