### PR TITLE
chore(repo): Revise pull request template and AGENTS.md for better guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,10 @@
 # Change Summary
 
-<!--
-Replace with a brief summary of the change in this PR
--->
+<!--Replace with a brief summary of the change in this PR-->
 
 ## What issue does this PR close?
 
-<!--
-We highly recommend correlation of every PR to an issue
--->
+<!--We highly recommend correlation of every PR to an issue-->
 
 * Closes #NNN
 
@@ -26,4 +22,4 @@ in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
 If not required, include `chore` in the PR title.
 -->
 
-* [ ] Added a `.chloggen/*.yaml` entry, OR this PR is a `chore` (indicated in title).
+* [ ] Added a `.chloggen/*.yaml` entry, this PR is a `chore` (indicated in title), or this is a documentation-only PR.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,4 +22,6 @@ in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
 If not required, include `chore` in the PR title.
 -->
 
-* [ ] Added a `.chloggen/*.yaml` entry, this PR is a `chore` (indicated in title), or this is a documentation-only PR.
+* [ ] Added a `.chloggen/*.yaml` entry
+* [ ] This PR is a `chore` (indicated in title)
+* [ ] This is a documentation-only PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,9 @@ Required fields: `change_type` (one of `breaking`, `deprecation`,
 directory's `config.yaml`), `note`, and `issues`.
 
 Skip the entry only when the change is not user-facing (build chores, internal
-refactors, doc-only edits, dev-only dependency bumps). In that case include
+refactors, dev-only dependency bumps). In that case include
 `chore` in the PR title.
+
+Doc-only PRs are also excluded from the changelog requirement.
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md#changelog-entries) for full details.

--- a/rust/otap-dataflow/AGENTS.md
+++ b/rust/otap-dataflow/AGENTS.md
@@ -121,6 +121,8 @@ Required fields: `change_type` (one of `breaking`, `deprecation`,
 Skip the entry only when the change is not user-facing. In that case include
 `chore` in the PR title.
 
+Doc-only PRs are also excluded from the changelog requirement.
+
 See [`.chloggen/README.md`](.chloggen/README.md) for full details.
 
 ## Before finalizing changes


### PR DESCRIPTION
Updated the pull request template to improve clarity and instructions.

# Change Summary

Update PR template to mention doc-only PRs to prevent AI comments like https://github.com/open-telemetry/otel-arrow/pull/3369#discussion_r3484154450:

> PR description indicates the changelog requirement is satisfied (either a .chloggen/*.yaml entry was added or the PR title is a chore), but this PR appears to add only documentation and the title is docs:. Per rust/otap-dataflow/AGENTS.md:110-123, skipping a Rust changelog entry requires chore in the PR title; otherwise add a .chloggen/*.yaml entry if this doc is considered user-facing.

## What issue does this PR close?

N/A

## How are these changes tested?

N/A

## Are there any user-facing changes?

Yes, changes to PR description

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [ ] Added a `.chloggen/*.yaml` entry
* [x] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.