### PR TITLE
feat(engine): add BearerTokenProvider capability

### DIFF
--- a/rust/otap-dataflow/.chloggen/bearer-token-provider-capability.yaml
+++ b/rust/otap-dataflow/.chloggen/bearer-token-provider-capability.yaml
@@ -1,0 +1,15 @@
+change_type: enhancement
+
+component: engine
+
+note: Add the `BearerTokenProvider` capability (with `BearerToken` and `CapabilityError`) so extensions can hand OAuth bearer tokens to data-path nodes.
+
+issues: [3356]
+
+subtext: |
+  Defines the engine-side capability surface: the `#[capability]`-generated
+  `BearerTokenProvider` trait (`get_token` and `token_stream`), the
+  secret-redacting `BearerToken` type, and `CapabilityError` /
+  `CapabilityErrorSource` for attributing runtime capability failures to the
+  failing `(extension, capability)` pair. No provider implementation is
+  included.

--- a/rust/otap-dataflow/Cargo.lock
+++ b/rust/otap-dataflow/Cargo.lock
@@ -6427,6 +6427,7 @@ dependencies = [
  "otap-df-telemetry-macros",
  "parking_lot",
  "prost",
+ "secrecy",
  "serde_json",
  "serde_yaml",
  "smallvec",

--- a/rust/otap-dataflow/crates/engine/Cargo.toml
+++ b/rust/otap-dataflow/crates/engine/Cargo.toml
@@ -33,6 +33,7 @@ tokio = { workspace = true }
 linkme = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }
+secrecy = { workspace = true }
 flume = { workspace = true }
 bitflags = { workspace = true }
 bytemuck = { workspace = true }

--- a/rust/otap-dataflow/crates/engine/src/capability/bearer_token_provider.rs
+++ b/rust/otap-dataflow/crates/engine/src/capability/bearer_token_provider.rs
@@ -1,0 +1,129 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! The `BearerTokenProvider` capability.
+//!
+//! A small, purpose-built capability that hands out OAuth bearer tokens
+//! to data-path nodes. It is intentionally provider- and execution-model
+//! agnostic: the same trait serves active and passive providers across
+//! both the shared and local execution models. Consumers depend only on
+//! the two methods below, never on how a token is produced or refreshed.
+//!
+//! The `#[capability]` proc macro expands the trait into:
+//!
+//! - `pub mod local::BearerTokenProvider` (`!Send` trait variant)
+//! - `pub mod shared::BearerTokenProvider` (`Send` trait variant)
+//! - A `SharedAsLocalBearerTokenProvider` adapter
+//! - A zero-sized `pub struct BearerTokenProvider` registration handle
+//! - `local_entry::<E>` / `shared_entry::<E>` factory bridges
+//! - A `KNOWN_CAPABILITIES` distributed-slice entry
+
+use super::error::CapabilityError;
+use futures::Stream;
+use otap_df_engine_macros::capability;
+use std::fmt;
+use std::pin::Pin;
+use std::time::Instant;
+
+/// An OAuth bearer token plus its (optional) expiry.
+///
+/// The secret is held in memory only and is never emitted by [`Debug`]
+/// (see the manual impl below) so it cannot leak into logs or telemetry.
+/// `expires_on` is a monotonic [`Instant`] — providers convert the
+/// credential's absolute wall-clock expiry to an `Instant` once, so the
+/// value is immune to wall-clock jumps thereafter. `None` means the token
+/// does not expire (or no expiry was reported).
+#[derive(Clone)]
+pub struct BearerToken {
+    secret: String,
+    expires_on: Option<Instant>,
+}
+
+impl BearerToken {
+    /// Creates a token from its secret and optional monotonic expiry.
+    #[must_use]
+    pub fn new(secret: String, expires_on: Option<Instant>) -> Self {
+        Self { secret, expires_on }
+    }
+
+    /// The bearer token secret, for injection into an `Authorization`
+    /// header or an `object_store` credential.
+    #[must_use]
+    pub fn secret(&self) -> &str {
+        &self.secret
+    }
+
+    /// The monotonic instant at which this token expires, if known.
+    #[must_use]
+    pub fn expires_on(&self) -> Option<Instant> {
+        self.expires_on
+    }
+}
+
+// Manual `Debug` that redacts the secret. Never print `self.secret`.
+impl fmt::Debug for BearerToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BearerToken")
+            .field("secret", &"<redacted>")
+            .field("expires_on", &self.expires_on)
+            .finish()
+    }
+}
+
+/// A per-consumer subscription to token refreshes.
+///
+/// Boxed to hide the concrete stream type so providers can back it
+/// differently (e.g. a `watch` channel or an `unfold`) without changing
+/// the signature. The `Send` bound is intentionally omitted: the
+/// subscription is always consumed on the core that created it
+/// (thread-per-core), so it need not be `Send`. The `#[capability]`
+/// macro emits this signature into both the `local` (`?Send`) and
+/// `shared` (`Send`) trait variants unchanged.
+pub type TokenStream = Pin<Box<dyn Stream<Item = Result<BearerToken, CapabilityError>> + 'static>>;
+
+/// Hands out OAuth bearer tokens to data-path nodes.
+#[capability(
+    name = "bearer_token_provider",
+    description = "Provides OAuth bearer tokens, refreshed in the background"
+)]
+pub trait BearerTokenProvider {
+    /// Returns the current valid token.
+    ///
+    /// The fast path reads a cached token; the slow path performs a
+    /// single (coalesced) credential call on a cache miss. Returns a
+    /// [`CapabilityError`] if no valid token can be produced.
+    async fn get_token(&self) -> Result<BearerToken, CapabilityError>;
+
+    /// Subscribes to the stream of token refreshes.
+    ///
+    /// Yields each newly published token for the lifetime of the
+    /// extension. Each call returns an independent subscription.
+    fn token_stream(&self) -> TokenStream;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accessors_round_trip() {
+        let now = Instant::now();
+        let token = BearerToken::new("super-secret".to_owned(), Some(now));
+        assert_eq!(token.secret(), "super-secret");
+        assert_eq!(token.expires_on(), Some(now));
+
+        let non_expiring = BearerToken::new("s".to_owned(), None);
+        assert_eq!(non_expiring.expires_on(), None);
+    }
+
+    #[test]
+    fn debug_redacts_secret() {
+        let token = BearerToken::new("super-secret".to_owned(), None);
+        let rendered = format!("{token:?}");
+        assert!(
+            !rendered.contains("super-secret"),
+            "secret leaked: {rendered}"
+        );
+        assert!(rendered.contains("<redacted>"));
+    }
+}

--- a/rust/otap-dataflow/crates/engine/src/capability/bearer_token_provider.rs
+++ b/rust/otap-dataflow/crates/engine/src/capability/bearer_token_provider.rs
@@ -21,36 +21,73 @@
 use super::error::CapabilityError;
 use futures::Stream;
 use otap_df_engine_macros::capability;
-use std::fmt;
+use secrecy::{ExposeSecret, SecretString};
 use std::pin::Pin;
-use std::time::Instant;
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime};
 
 /// An OAuth bearer token plus its (optional) expiry.
 ///
-/// The secret is held in memory only and is never emitted by [`Debug`]
-/// (see the manual impl below) so it cannot leak into logs or telemetry.
+/// The secret is wrapped in [`SecretString`], which zeroizes on drop and
+/// masks itself in [`Debug`] output, so it cannot leak into logs or
+/// telemetry. The `SecretString` sits behind an [`Arc`] so cloning a
+/// token (handing it to multiple `token_stream` subscribers, or returning
+/// it from `get_token` on the hot path) is a cheap refcount bump that
+/// shares one plaintext allocation rather than copying the secret bytes.
+///
 /// `expires_on` is a monotonic [`Instant`] — providers convert the
 /// credential's absolute wall-clock expiry to an `Instant` once, so the
 /// value is immune to wall-clock jumps thereafter. `None` means the token
 /// does not expire (or no expiry was reported).
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct BearerToken {
-    secret: String,
+    secret: Arc<SecretString>,
     expires_on: Option<Instant>,
 }
 
 impl BearerToken {
     /// Creates a token from its secret and optional monotonic expiry.
+    ///
+    /// Accepts anything convertible into [`SecretString`] (e.g. a
+    /// `String`), which is then shared behind an [`Arc`].
     #[must_use]
-    pub fn new(secret: String, expires_on: Option<Instant>) -> Self {
-        Self { secret, expires_on }
+    pub fn new(secret: impl Into<SecretString>, expires_on: Option<Instant>) -> Self {
+        Self {
+            secret: Arc::new(secret.into()),
+            expires_on,
+        }
     }
 
-    /// The bearer token secret, for injection into an `Authorization`
-    /// header or an `object_store` credential.
+    /// Creates a token from its secret and an **absolute** wall-clock
+    /// expiry.
+    ///
+    /// Credential services that report an absolute expiry often give it as
+    /// calendar time ([`SystemTime`]), but [`BearerToken`] stores a
+    /// monotonic [`Instant`] (see the field docs for why). Every such
+    /// provider has to perform the same wall-clock-to-monotonic
+    /// conversion; this constructor centralizes it so no provider gets it
+    /// subtly wrong.
+    ///
+    /// It measures how far `expires_on` is from *now* and offsets the
+    /// current `Instant` by that duration. An `expires_on` already in the
+    /// past (or a backwards clock) clamps to "expires immediately"
+    /// (`Instant::now()`) rather than producing a time before now.
     #[must_use]
-    pub fn secret(&self) -> &str {
-        &self.secret
+    pub fn from_absolute_expiry(secret: impl Into<SecretString>, expires_on: SystemTime) -> Self {
+        let remaining = expires_on
+            .duration_since(SystemTime::now())
+            .unwrap_or(Duration::ZERO);
+        Self::new(secret, Some(Instant::now() + remaining))
+    }
+
+    /// Exposes the bearer token secret, for injection into an
+    /// `Authorization` header or an `object_store` credential.
+    ///
+    /// Named `expose_secret` (rather than a plain getter) so every
+    /// plaintext access is explicit and greppable.
+    #[must_use]
+    pub fn expose_secret(&self) -> &str {
+        self.secret.expose_secret()
     }
 
     /// The monotonic instant at which this token expires, if known.
@@ -60,17 +97,14 @@ impl BearerToken {
     }
 }
 
-// Manual `Debug` that redacts the secret. Never print `self.secret`.
-impl fmt::Debug for BearerToken {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("BearerToken")
-            .field("secret", &"<redacted>")
-            .field("expires_on", &self.expires_on)
-            .finish()
-    }
-}
-
 /// A per-consumer subscription to token refreshes.
+///
+/// The item is a plain [`BearerToken`], not a `Result`: a refresh
+/// failure does not terminate the subscription. The stream simply does
+/// not emit until the next successful refresh, and failures surface via
+/// [`BearerTokenProvider::get_token`] and telemetry instead. Because the
+/// item is [`Clone`], a provider can fan one refreshed token out to all
+/// subscribers via a `watch`/`broadcast` channel.
 ///
 /// Boxed to hide the concrete stream type so providers can back it
 /// differently (e.g. a `watch` channel or an `unfold`) without changing
@@ -79,7 +113,7 @@ impl fmt::Debug for BearerToken {
 /// (thread-per-core), so it need not be `Send`. The `#[capability]`
 /// macro emits this signature into both the `local` (`?Send`) and
 /// `shared` (`Send`) trait variants unchanged.
-pub type TokenStream = Pin<Box<dyn Stream<Item = Result<BearerToken, CapabilityError>> + 'static>>;
+pub type TokenStream = Pin<Box<dyn Stream<Item = BearerToken> + 'static>>;
 
 /// Hands out OAuth bearer tokens to data-path nodes.
 #[capability(
@@ -87,17 +121,31 @@ pub type TokenStream = Pin<Box<dyn Stream<Item = Result<BearerToken, CapabilityE
     description = "Provides OAuth bearer tokens, refreshed in the background"
 )]
 pub trait BearerTokenProvider {
-    /// Returns the current valid token.
+    /// Returns the current valid token for the provider's configured
+    /// scope(s).
     ///
-    /// The fast path reads a cached token; the slow path performs a
-    /// single (coalesced) credential call on a cache miss. Returns a
+    /// The fast path reads a cached token; on a cache miss the provider
+    /// performs a credential call. A provider that shares its cache and
+    /// refresh state across cloned instances can coalesce concurrent
+    /// misses into a single call — but that is a provider implementation
+    /// detail, not a guarantee of this trait. Returns a
     /// [`CapabilityError`] if no valid token can be produced.
+    ///
+    /// The token is scoped to the resource(s) the provider was configured
+    /// for. There is no wiring-time check that a consumer's target
+    /// resource matches the provider's scope, so a mismatch surfaces at
+    /// the service as an auth failure (e.g. HTTP 401) rather than at
+    /// startup. Consumers must bind to a provider configured for their
+    /// resource.
     async fn get_token(&self) -> Result<BearerToken, CapabilityError>;
 
     /// Subscribes to the stream of token refreshes.
     ///
     /// Yields each newly published token for the lifetime of the
-    /// extension. Each call returns an independent subscription.
+    /// extension; each call returns an independent subscription. The
+    /// stream does not carry errors: a failed refresh does not end the
+    /// subscription, and the next successful refresh still yields a token
+    /// (see [`TokenStream`]).
     fn token_stream(&self) -> TokenStream;
 }
 
@@ -109,7 +157,7 @@ mod tests {
     fn accessors_round_trip() {
         let now = Instant::now();
         let token = BearerToken::new("super-secret".to_owned(), Some(now));
-        assert_eq!(token.secret(), "super-secret");
+        assert_eq!(token.expose_secret(), "super-secret");
         assert_eq!(token.expires_on(), Some(now));
 
         let non_expiring = BearerToken::new("s".to_owned(), None);
@@ -117,13 +165,51 @@ mod tests {
     }
 
     #[test]
-    fn debug_redacts_secret() {
+    fn from_absolute_expiry_converts_future_wall_clock_to_instant() {
+        let before = Instant::now();
+        let token = BearerToken::from_absolute_expiry(
+            "s".to_owned(),
+            SystemTime::now() + Duration::from_secs(60),
+        );
+        let after = Instant::now();
+        let expiry = token.expires_on().expect("future expiry is set");
+        // The converted instant lands ~60s ahead of when we called it.
+        assert!(expiry >= before + Duration::from_secs(59));
+        assert!(expiry <= after + Duration::from_secs(61));
+    }
+
+    #[test]
+    fn from_absolute_expiry_clamps_past_wall_clock_to_now() {
+        let before = Instant::now();
+        let token = BearerToken::from_absolute_expiry(
+            "s".to_owned(),
+            SystemTime::now() - Duration::from_secs(60),
+        );
+        let after = Instant::now();
+        let expiry = token.expires_on().expect("expiry is set");
+        // A past expiry clamps to "now", never a time before now.
+        assert!(expiry >= before);
+        assert!(expiry <= after);
+    }
+
+    #[test]
+    fn clone_shares_the_same_secret_allocation() {
+        let token = BearerToken::new("super-secret".to_owned(), None);
+        let cloned = token.clone();
+        // Both handles observe the same plaintext...
+        assert_eq!(token.expose_secret(), cloned.expose_secret());
+        // ...backed by one shared allocation (a clone is a refcount bump,
+        // not a fresh copy of the secret bytes).
+        assert!(std::ptr::eq(token.expose_secret(), cloned.expose_secret()));
+    }
+
+    #[test]
+    fn debug_never_leaks_the_secret() {
         let token = BearerToken::new("super-secret".to_owned(), None);
         let rendered = format!("{token:?}");
         assert!(
             !rendered.contains("super-secret"),
             "secret leaked: {rendered}"
         );
-        assert!(rendered.contains("<redacted>"));
     }
 }

--- a/rust/otap-dataflow/crates/engine/src/capability/error.rs
+++ b/rust/otap-dataflow/crates/engine/src/capability/error.rs
@@ -1,0 +1,115 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Runtime error surface for capability method calls.
+//!
+//! [`CapabilityError`] is the error a capability method returns when an
+//! *invocation* fails at run time (e.g. a `BearerTokenProvider` cannot
+//! acquire a token). It is distinct from the engine's resolution/
+//! registration errors ([`crate::error::Error::CapabilityNotBound`],
+//! [`crate::error::Error::CapabilityAlreadyConsumed`]), which surface at
+//! *wiring* time when a node binds a capability.
+//!
+//! Every `CapabilityError` carries the `(extension, capability)` identity
+//! of the failing provider plus the underlying source error.
+//! [`CapabilityErrorSource`] is the small, capability-typed helper an
+//! extension stores once and uses to stamp that identity onto each error
+//! it mints, so the capability name is taken from the type system rather
+//! than re-typed at every call site.
+
+use super::ExtensionCapability;
+use otap_df_config::ExtensionId;
+use std::marker::PhantomData;
+
+/// The error returned by a failed capability method invocation.
+///
+/// Carries the identity of the provider that failed — the extension
+/// instance id and the capability name — alongside the underlying
+/// `source` error, so a consumer can attribute the failure without
+/// knowing the provider's internal error types.
+#[derive(Debug, thiserror::Error)]
+#[error("capability '{capability}' on extension '{extension}' failed: {source}")]
+pub struct CapabilityError {
+    /// The extension instance whose capability invocation failed.
+    pub extension: ExtensionId,
+    /// The capability name (e.g. `"bearer_token_provider"`).
+    pub capability: &'static str,
+    /// The underlying error that caused the failure.
+    #[source]
+    pub source: Box<dyn std::error::Error + Send + Sync + 'static>,
+}
+
+/// A capability-typed factory for [`CapabilityError`]s.
+///
+/// An extension constructs one of these once (at `create()` time) with
+/// its own [`ExtensionId`] and stores it. Each call to [`error`](Self::error)
+/// stamps the stored extension id and the capability name — read from
+/// `C::NAME` via the [`ExtensionCapability`] type — onto a fresh
+/// `CapabilityError`. This keeps the capability name a compile-time fact
+/// rather than a string repeated at every failure site.
+///
+/// `C` appears only in [`PhantomData`], so the source is `Send + Sync +
+/// Clone` regardless of `C`.
+pub struct CapabilityErrorSource<C: ExtensionCapability> {
+    extension: ExtensionId,
+    _capability: PhantomData<fn() -> C>,
+}
+
+impl<C: ExtensionCapability> CapabilityErrorSource<C> {
+    /// Creates a source that stamps `extension` and `C`'s capability name
+    /// onto every error it mints.
+    #[must_use]
+    pub fn new(extension: ExtensionId) -> Self {
+        Self {
+            extension,
+            _capability: PhantomData,
+        }
+    }
+
+    /// Mints a [`CapabilityError`] wrapping `source`, tagged with the
+    /// stored extension id and `C`'s capability name.
+    pub fn error<E>(&self, source: E) -> CapabilityError
+    where
+        E: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    {
+        CapabilityError {
+            extension: self.extension.clone(),
+            capability: C::NAME,
+            source: source.into(),
+        }
+    }
+}
+
+// Manual `Clone`: deriving would add a `C: Clone` bound, but `C` is only
+// a `PhantomData<fn() -> C>` marker and never cloned, so the source is
+// always cloneable.
+impl<C: ExtensionCapability> Clone for CapabilityErrorSource<C> {
+    fn clone(&self) -> Self {
+        Self {
+            extension: self.extension.clone(),
+            _capability: PhantomData,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capability::BearerTokenProvider;
+
+    #[test]
+    fn stamps_extension_and_capability_identity() {
+        let source = CapabilityErrorSource::<BearerTokenProvider>::new("azure_identity".into());
+        let err = source.error("boom");
+        assert_eq!(err.extension, "azure_identity");
+        assert_eq!(err.capability, "bearer_token_provider");
+        assert_eq!(err.source.to_string(), "boom");
+    }
+
+    #[test]
+    fn clone_preserves_identity_without_c_clone_bound() {
+        let source = CapabilityErrorSource::<BearerTokenProvider>::new("ext-a".into());
+        let cloned = source.clone();
+        assert_eq!(cloned.error("x").extension, "ext-a");
+    }
+}

--- a/rust/otap-dataflow/crates/engine/src/capability/error.rs
+++ b/rust/otap-dataflow/crates/engine/src/capability/error.rs
@@ -27,8 +27,13 @@ use std::marker::PhantomData;
 /// instance id and the capability name — alongside the underlying
 /// `source` error, so a consumer can attribute the failure without
 /// knowing the provider's internal error types.
+///
+/// Marked `#[non_exhaustive]` so fields can be added later without it
+/// being a breaking change for downstream crates. Construct instances
+/// through [`CapabilityErrorSource::error`] rather than a struct literal.
 #[derive(Debug, thiserror::Error)]
-#[error("capability '{capability}' on extension '{extension}' failed: {source}")]
+#[error("capability '{capability}' on extension '{extension}' failed")]
+#[non_exhaustive]
 pub struct CapabilityError {
     /// The extension instance whose capability invocation failed.
     pub extension: ExtensionId,

--- a/rust/otap-dataflow/crates/engine/src/capability/mod.rs
+++ b/rust/otap-dataflow/crates/engine/src/capability/mod.rs
@@ -12,9 +12,13 @@
 //! re-exported from [`local::capability`](crate::local::capability) and
 //! [`shared::capability`](crate::shared::capability).
 
+pub mod bearer_token_provider;
+pub mod error;
 pub mod factory;
 pub mod registry;
 
+pub use bearer_token_provider::{BearerToken, BearerTokenProvider, TokenStream};
+pub use error::{CapabilityError, CapabilityErrorSource};
 pub use factory::{LocalInstanceFactory, SharedInstanceFactory};
 
 // ── Sealed ExtensionCapability trait ─────────────────────────────────────────
@@ -100,10 +104,6 @@ pub trait ExtensionCapability: private::Sealed + 'static {
 /// inside this crate, so external crates still can't reach `Sealed` to
 /// forge an `ExtensionCapability` impl.
 #[doc(hidden)]
-// Suppressed until the first `#[capability]` invocation lands alongside
-// its first consumer (PR4+). Until then no generated code references the
-// re-export and rustc would otherwise warn.
-#[allow(unused_imports)]
 pub(crate) use private::Sealed as CapabilitySealed;
 
 // ── KNOWN_CAPABILITIES (link-time registration) ──────────────────────────────

--- a/rust/otap-dataflow/crates/engine/src/capability/mod.rs
+++ b/rust/otap-dataflow/crates/engine/src/capability/mod.rs
@@ -12,9 +12,14 @@
 //! re-exported from [`local::capability`](crate::local::capability) and
 //! [`shared::capability`](crate::shared::capability).
 
-pub mod bearer_token_provider;
-pub mod error;
-pub mod factory;
+// These modules are crate-private: nothing outside the crate needs the raw
+// module path, and every public item is re-exported at `capability::` (below)
+// or via `{local,shared}::capability`. Keeping them `pub(crate)` collapses each
+// item to a single canonical public path. `registry` stays `pub` because
+// `registry::Capabilities` is not re-exported at the root.
+pub(crate) mod bearer_token_provider;
+pub(crate) mod error;
+pub(crate) mod factory;
 pub mod registry;
 
 pub use bearer_token_provider::{BearerToken, BearerTokenProvider, TokenStream};

--- a/rust/otap-dataflow/crates/engine/src/local/capability.rs
+++ b/rust/otap-dataflow/crates/engine/src/local/capability.rs
@@ -9,3 +9,5 @@
 //! [`capability`](crate::capability). Test-only reference capabilities
 //! live under [`crate::testing::capability`] and are intentionally not
 //! re-exported here.
+
+pub use crate::capability::bearer_token_provider::local::BearerTokenProvider;

--- a/rust/otap-dataflow/crates/engine/src/shared/capability.rs
+++ b/rust/otap-dataflow/crates/engine/src/shared/capability.rs
@@ -9,3 +9,5 @@
 //! [`capability`](crate::capability). Test-only reference capabilities
 //! live under [`crate::testing::capability`] and are intentionally not
 //! re-exported here.
+
+pub use crate::capability::bearer_token_provider::shared::BearerTokenProvider;

--- a/rust/otap-dataflow/docs/azure-identity-auth-extension.md
+++ b/rust/otap-dataflow/docs/azure-identity-auth-extension.md
@@ -121,10 +121,9 @@ methods:
 /// A per-consumer subscription to token refreshes. Boxed to hide the concrete
 /// stream type so providers can back it differently (e.g. a `watch` channel or
 /// an `unfold`) without changing the signature.
-pub type TokenStream =
-    Pin<Box<dyn Stream<Item = Result<BearerToken, CapabilityError>> + 'static>>;
+pub type TokenStream = Pin<Box<dyn Stream<Item = BearerToken> + 'static>>;
 
-#[async_trait]
+#[capability(name = "bearer_token_provider", description = "...")]
 pub trait BearerTokenProvider {
     /// Return the current valid token. Fast path reads the cache; slow path
     /// performs a single credential call on a cache miss.
@@ -137,9 +136,10 @@ pub trait BearerTokenProvider {
 ```
 
 `BearerToken` is a hand-written shared data type carrying the secret token
-string and an optional `expires_on: Instant`. Errors are surfaced as
-`CapabilityError`, which carries the `(extension, capability)` identity plus the
-underlying source error.
+and an optional `expires_on: Instant`. Refresh failures are surfaced only via
+`get_token()`, which returns a `CapabilityError` carrying the
+`(extension, capability)` identity plus the underlying source error; the
+stream itself carries only successfully published tokens.
 
 The `TokenStream` alias omits a `Send` bound: the subscription is always
 consumed on the core that created it (thread-per-core), so it need not be `Send`.


### PR DESCRIPTION
# Change Summary

Introduce the engine-side capability surface for the Azure Identity Auth extension:

- BearerTokenProvider trait (via #[capability]) with get_token() and token_stream(), plus the secret-redacting BearerToken data type.
- CapabilityError + CapabilityErrorSource to attribute runtime capability failures to the failing (extension, capability) pair.
- Re-export the local/shared trait variants from {local,shared}::capability.

## What issue does this PR close?

* Related to #3356

## How are these changes tested?

Unit tests

## Are there any user-facing changes?

No

### Changelog

* [x] Added a `.chloggen/*.yaml` entry
* [ ] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
