### PR TITLE
  chore(deps): update weaver crates to 351d5e5

### DIFF
--- a/rust/otap-dataflow/Cargo.lock
+++ b/rust/otap-dataflow/Cargo.lock
@@ -3257,21 +3257,18 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "gix"
-version = "0.83.0"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce52001b946a6249d5d0d3011df0a042ac3f8a4d013460db6476577b0b9c567"
+checksum = "fa8b2e38ebfc4484dfef8580ddcaf8abb7285e6f3eb6413ff6775d104ae96ca6"
 dependencies = [
  "gix-actor",
- "gix-archive",
  "gix-attributes",
- "gix-blame",
  "gix-command",
  "gix-commitgraph",
  "gix-config",
  "gix-credentials",
  "gix-date",
  "gix-diff",
- "gix-dir",
  "gix-discover",
  "gix-error",
  "gix-features",
@@ -3283,7 +3280,6 @@ dependencies = [
  "gix-ignore",
  "gix-index",
  "gix-lock",
- "gix-merge",
  "gix-negotiate",
  "gix-object",
  "gix-odb",
@@ -3298,7 +3294,6 @@ dependencies = [
  "gix-revwalk",
  "gix-sec",
  "gix-shallow",
- "gix-status",
  "gix-submodule",
  "gix-tempfile",
  "gix-trace",
@@ -3327,19 +3322,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-archive"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a20ec244b733338d4cb60e5e05eac700dab7fcc689647b1d1daa9396b119342"
-dependencies = [
- "bstr",
- "gix-date",
- "gix-error",
- "gix-object",
- "gix-worktree-stream",
-]
-
-[[package]]
 name = "gix-attributes"
 version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3363,26 +3345,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ebef0c26ad305747649e727bbcd56a7b7910754eb7cea88f6dff6f93c51283"
 dependencies = [
  "gix-error",
-]
-
-[[package]]
-name = "gix-blame"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dab9a942ab54a9661ded7397c3bf927274e7afa94494db0d75cfcbde02ca0a"
-dependencies = [
- "gix-commitgraph",
- "gix-date",
- "gix-diff",
- "gix-error",
- "gix-hash",
- "gix-object",
- "gix-revwalk",
- "gix-trace",
- "gix-traverse",
- "gix-worktree",
- "smallvec",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3423,9 +3385,9 @@ dependencies = [
 
 [[package]]
 name = "gix-config"
-version = "0.56.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c01848aebd21c67f6ba41f1de8efd46ae96df21f001954a3c9e1517e514d410"
+checksum = "a29bf266c4cdaf759e535c24ad4ce655b987aeb6911075643403cc7cc5ade583"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -3484,50 +3446,21 @@ dependencies = [
 
 [[package]]
 name = "gix-diff"
-version = "0.63.0"
+version = "0.65.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc08e0fa1a91ff5f24affeab052f198056645e1de004910bde7b82b50ea5982a"
+checksum = "92c6d56c94edf92d78203a1cd416f770e35e10b6955ede6b9d7d0c22ff88a5f3"
 dependencies = [
  "bstr",
- "gix-command",
- "gix-filter",
- "gix-fs",
  "gix-hash",
- "gix-imara-diff",
  "gix-object",
- "gix-path",
- "gix-tempfile",
- "gix-trace",
- "gix-traverse",
- "gix-worktree",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-dir"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a0fc06e9e1e430cbf0a313666976d90f822f461a6525320427aa9b8af5236c"
-dependencies = [
- "bstr",
- "gix-discover",
- "gix-fs",
- "gix-ignore",
- "gix-index",
- "gix-object",
- "gix-path",
- "gix-pathspec",
- "gix-trace",
- "gix-utils",
- "gix-worktree",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-discover"
-version = "0.51.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17852e6a501e688a1702b24ebe5b3761d4719455bc869fd29f38b0b859bcad34"
+checksum = "d624d5b23b10c1d85337645227abe353ac95ab8ff66a7bdd5ce689b2db33a722"
 dependencies = [
  "bstr",
  "dunce",
@@ -3571,9 +3504,9 @@ dependencies = [
 
 [[package]]
 name = "gix-filter"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac917dbe9653c9b615d248db91907a365bd779750c9e1b457a9d9fdeece3a08"
+checksum = "6644fb2ef97928c278675b239f366b457103d7e436f811d27331a8daf212759c"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -3653,20 +3586,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-imara-diff"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b305d85504de270ad3525d726a6b69cc59ee7b2269b014387651107ab9f0755b"
-dependencies = [
- "bstr",
- "hashbrown 0.17.1",
-]
-
-[[package]]
 name = "gix-index"
-version = "0.51.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c3ef97ad08121e4327a6226bd63fed6b9e3c6b976d48bddd4356d9d41191db"
+checksum = "36d45f82ec5a4d7542ea595e9ad16e03e26c8cb4f221e5bc9fcdcf469f63a681"
 dependencies = [
  "bitflags 2.13.0",
  "bstr",
@@ -3681,7 +3604,7 @@ dependencies = [
  "gix-traverse",
  "gix-utils",
  "gix-validate",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "itoa",
  "libc",
  "memmap2",
@@ -3702,36 +3625,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-merge"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74bbcdcc52b70a32f0a151b024dff9d0fcf56ee48f00d9503e735af9d99ea881"
-dependencies = [
- "bstr",
- "gix-command",
- "gix-diff",
- "gix-filter",
- "gix-fs",
- "gix-hash",
- "gix-imara-diff",
- "gix-index",
- "gix-object",
- "gix-path",
- "gix-quote",
- "gix-revision",
- "gix-revwalk",
- "gix-tempfile",
- "gix-trace",
- "gix-worktree",
- "nonempty",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "gix-negotiate"
-version = "0.31.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "103d42bfade1b8a96ca5005933127bdad461ce588d92422b2c2daa3ff20d780c"
+checksum = "63d6081882a5f575ace9f53924a7c85f69bbd0f96071b982df12f258ab338cc9"
 dependencies = [
  "bitflags 2.13.0",
  "gix-commitgraph",
@@ -3743,9 +3640,9 @@ dependencies = [
 
 [[package]]
 name = "gix-object"
-version = "0.60.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38075a95d7cc5df8afd38e72c617026c1456952207a4120a7f55a3fbf93b4d7"
+checksum = "019b38afc3eac1e41f9fe09a327664b313ba4a120fa5f40e3678795d0e42783e"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -3762,9 +3659,9 @@ dependencies = [
 
 [[package]]
 name = "gix-odb"
-version = "0.80.0"
+version = "0.82.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeeda12a9663120418735ecdc1250d06eeab0be75700e47b3402a981331716ba"
+checksum = "7fadc59f6fa0f9dd445eceee61060a2b59ca557f48da9fc677f567db535b782a"
 dependencies = [
  "arc-swap",
  "gix-features",
@@ -3783,9 +3680,9 @@ dependencies = [
 
 [[package]]
 name = "gix-pack"
-version = "0.70.0"
+version = "0.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf02e6f5c8f07a069c9ea5245f40d9b14856ada4086091dc99941b49002b4fa"
+checksum = "ca3e7f1726cd2c0cd1cf1fc20be8a8e623f0b163f1f8d6fc836cfb9bc8cd758b"
 dependencies = [
  "clru",
  "gix-chunk",
@@ -3857,9 +3754,9 @@ dependencies = [
 
 [[package]]
 name = "gix-protocol"
-version = "0.61.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4bee82db63ec635996b96efae71cf467c155fa3f34a556184373224a26c4fd"
+checksum = "978468bae4ea2df20c72db3b20d0bdb548a0c1090b85a83643b553e6e0e041f2"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -3894,9 +3791,9 @@ dependencies = [
 
 [[package]]
 name = "gix-ref"
-version = "0.63.0"
+version = "0.65.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8ba9cc15f558b274c99349b83130f5ec83459660828fde9718bbbb43a726167"
+checksum = "9bbfbce1dfd7d7f8469ddef6d3518376aff664348f153cbe0fc3e58ef993d24e"
 dependencies = [
  "gix-actor",
  "gix-features",
@@ -3914,9 +3811,9 @@ dependencies = [
 
 [[package]]
 name = "gix-refspec"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61755b27d57edc8940a1b1593c8c61548ca8e4c02da1ed8d5bfeda9eb2a6b761"
+checksum = "7bc36a4fb1a1540b59cf2da498783080743fa274b02a3f19ca444fc4015a9d4f"
 dependencies = [
  "bstr",
  "gix-error",
@@ -3930,11 +3827,10 @@ dependencies = [
 
 [[package]]
 name = "gix-revision"
-version = "0.45.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb5288fac706d3ea3e4e2ba9ec38b78743b8c02f422e18cb342299cfd6ab7e8"
+checksum = "885075c3c21eb9c06e0be3b3728ba5932c04e1c1011dcee7c81801980e3e986f"
 dependencies = [
- "bitflags 2.13.0",
  "bstr",
  "gix-commitgraph",
  "gix-date",
@@ -3942,15 +3838,14 @@ dependencies = [
  "gix-hash",
  "gix-object",
  "gix-revwalk",
- "gix-trace",
  "nonempty",
 ]
 
 [[package]]
 name = "gix-revwalk"
-version = "0.31.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "313813706b073a12ff7f9b2896bf3e6504cdac7cfbc97b1920114724705069f0"
+checksum = "8f11fe7ca2585193d3d70bbe0be175a2008d883a704cc7a55e454e113e689455"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -3988,33 +3883,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-status"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68c6d2a8c521ffa205fe7e268c82e6d1378ba37cd826ca10ab6129fdc29a4b65"
-dependencies = [
- "bstr",
- "filetime",
- "gix-diff",
- "gix-dir",
- "gix-features",
- "gix-filter",
- "gix-fs",
- "gix-hash",
- "gix-index",
- "gix-object",
- "gix-path",
- "gix-pathspec",
- "gix-worktree",
- "portable-atomic",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "gix-submodule"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd5fc8692890bd71a596e540fd4c364f8460eaa82c4eaaedebde6e1e3eb4d91"
+checksum = "a7f9f594f7cbda0b38ba6b633b3e9a7b7901acdc5d27bc186a16633800cd1ac8"
 dependencies = [
  "bstr",
  "gix-config",
@@ -4031,7 +3903,6 @@ version = "23.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ef60812443484e67bf84e444cc71b4c78ae62deb822221774a4fa0c57fdb17f"
 dependencies = [
- "dashmap",
  "gix-fs",
  "libc",
  "parking_lot",
@@ -4065,9 +3936,9 @@ dependencies = [
 
 [[package]]
 name = "gix-traverse"
-version = "0.57.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a14b7052c0786676c03e71fcfde7d7f0f8e8316e642b5cec6bb3998719b2ce5c"
+checksum = "5062cca8f2977565bbaf666ec31dbdb9bc9d9293beb65f9bec52e6c1121b62a1"
 dependencies = [
  "bitflags 2.13.0",
  "gix-commitgraph",
@@ -4098,7 +3969,6 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66c50966184123caf580ffa64e28031a878597f1c7fceb8fe19566c38eb1b771"
 dependencies = [
- "bstr",
  "fastrand",
  "unicode-normalization",
 ]
@@ -4114,9 +3984,9 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree"
-version = "0.52.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69955eb5e2910832f88d041964b809eee01dadd579237e0b55efec58fd406fd"
+checksum = "92399ed66f259592050c6ed9dc80105e095a2f8e87e6b83d98aa2e21d8e27036"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -4132,9 +4002,9 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree-state"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a96dccbcf9e8fe0291c55f06e08da93ebb2e691c1311276f541eefcc6d70800"
+checksum = "c0f926b6a249bdb0086b307c704b7abd9d643e08f98040efe6467f00bb6d2ef5"
 dependencies = [
  "bstr",
  "gix-features",
@@ -4150,9 +4020,9 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree-stream"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8444b8ed4662e1a0c97f3eceda29630001a1bbb2632201e50312623e594213"
+checksum = "55f3a878c89a05470ad98c644b0015777c530da24854dd29e41fe4f41176840f"
 dependencies = [
  "gix-attributes",
  "gix-error",
@@ -5362,6 +5232,15 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
 
 [[package]]
 name = "lru"
@@ -7749,7 +7628,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "itertools 0.14.0",
  "kasuari",
- "lru",
+ "lru 0.18.0",
  "palette",
  "serde",
  "strum",
@@ -10298,8 +10177,8 @@ dependencies = [
 
 [[package]]
 name = "weaver_common"
-version = "0.24.0"
-source = "git+https://github.com/open-telemetry/weaver.git?rev=9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4#9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4"
+version = "0.24.2"
+source = "git+https://github.com/open-telemetry/weaver.git?rev=351d5e5430b1e12a045a8b48fe112b3457ef2770#351d5e5430b1e12a045a8b48fe112b3457ef2770"
 dependencies = [
  "dirs",
  "flate2",
@@ -10323,8 +10202,8 @@ dependencies = [
 
 [[package]]
 name = "weaver_diff"
-version = "0.24.0"
-source = "git+https://github.com/open-telemetry/weaver.git?rev=9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4#9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4"
+version = "0.24.2"
+source = "git+https://github.com/open-telemetry/weaver.git?rev=351d5e5430b1e12a045a8b48fe112b3457ef2770#351d5e5430b1e12a045a8b48fe112b3457ef2770"
 dependencies = [
  "serde_json",
  "similar",
@@ -10333,15 +10212,15 @@ dependencies = [
 
 [[package]]
 name = "weaver_forge"
-version = "0.24.0"
-source = "git+https://github.com/open-telemetry/weaver.git?rev=9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4#9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4"
+version = "0.24.2"
+source = "git+https://github.com/open-telemetry/weaver.git?rev=351d5e5430b1e12a045a8b48fe112b3457ef2770#351d5e5430b1e12a045a8b48fe112b3457ef2770"
 dependencies = [
  "convert_case 0.11.0",
  "dirs",
  "globset",
  "include_dir",
  "indexmap 2.14.0",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "jaq-core",
  "jaq-json",
  "jaq-std",
@@ -10368,8 +10247,8 @@ dependencies = [
 
 [[package]]
 name = "weaver_resolved_schema"
-version = "0.24.0"
-source = "git+https://github.com/open-telemetry/weaver.git?rev=9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4#9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4"
+version = "0.24.2"
+source = "git+https://github.com/open-telemetry/weaver.git?rev=351d5e5430b1e12a045a8b48fe112b3457ef2770#351d5e5430b1e12a045a8b48fe112b3457ef2770"
 dependencies = [
  "log",
  "schemars 1.2.1",
@@ -10382,12 +10261,13 @@ dependencies = [
 
 [[package]]
 name = "weaver_resolver"
-version = "0.24.0"
-source = "git+https://github.com/open-telemetry/weaver.git?rev=9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4#9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4"
+version = "0.24.2"
+source = "git+https://github.com/open-telemetry/weaver.git?rev=351d5e5430b1e12a045a8b48fe112b3457ef2770#351d5e5430b1e12a045a8b48fe112b3457ef2770"
 dependencies = [
  "globset",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
+ "lru 0.16.4",
  "miette",
  "rand 0.10.1",
  "rayon",
@@ -10404,18 +10284,19 @@ dependencies = [
 
 [[package]]
 name = "weaver_semconv"
-version = "0.24.0"
-source = "git+https://github.com/open-telemetry/weaver.git?rev=9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4#9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4"
+version = "0.24.2"
+source = "git+https://github.com/open-telemetry/weaver.git?rev=351d5e5430b1e12a045a8b48fe112b3457ef2770#351d5e5430b1e12a045a8b48fe112b3457ef2770"
 dependencies = [
  "glob",
  "globset",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "jsonschema",
  "log",
  "miette",
  "regex",
  "saphyr",
  "schemars 1.2.1",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -10427,8 +10308,8 @@ dependencies = [
 
 [[package]]
 name = "weaver_version"
-version = "0.24.0"
-source = "git+https://github.com/open-telemetry/weaver.git?rev=9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4#9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4"
+version = "0.24.2"
+source = "git+https://github.com/open-telemetry/weaver.git?rev=351d5e5430b1e12a045a8b48fe112b3457ef2770#351d5e5430b1e12a045a8b48fe112b3457ef2770"
 dependencies = [
  "schemars 1.2.1",
  "semver",

--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -208,11 +208,11 @@ trybuild = "1.0"
 unsync = "0.1.2"
 url = "2.5.7"
 uuid = { version = "1.17.0", features = ["v4", "v7"] }
-weaver_common = { git = "https://github.com/open-telemetry/weaver.git", rev = "9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4" } # v0.24.0
-weaver_forge = { git = "https://github.com/open-telemetry/weaver.git", rev = "9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4" } # v0.24.0
-weaver_resolved_schema = { git = "https://github.com/open-telemetry/weaver.git", rev = "9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4" } # v0.24.0
-weaver_resolver = { git = "https://github.com/open-telemetry/weaver.git", rev = "9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4" } # v0.24.0
-weaver_semconv = { git = "https://github.com/open-telemetry/weaver.git", rev = "9b84f5cd76cb98e8aaf37bc58936b31fe0ddbab4" } # v0.24.0
+weaver_common = { git = "https://github.com/open-telemetry/weaver.git", rev = "351d5e5430b1e12a045a8b48fe112b3457ef2770" } # v0.24.0
+weaver_forge = { git = "https://github.com/open-telemetry/weaver.git", rev = "351d5e5430b1e12a045a8b48fe112b3457ef2770" } # v0.24.0
+weaver_resolved_schema = { git = "https://github.com/open-telemetry/weaver.git", rev = "351d5e5430b1e12a045a8b48fe112b3457ef2770" } # v0.24.0
+weaver_resolver = { git = "https://github.com/open-telemetry/weaver.git", rev = "351d5e5430b1e12a045a8b48fe112b3457ef2770" } # v0.24.0
+weaver_semconv = { git = "https://github.com/open-telemetry/weaver.git", rev = "351d5e5430b1e12a045a8b48fe112b3457ef2770" } # v0.24.0
 sha1 = { version = "0.11" }
 sha2 = "0.11.0"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }

--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -208,11 +208,11 @@ trybuild = "1.0"
 unsync = "0.1.2"
 url = "2.5.7"
 uuid = { version = "1.17.0", features = ["v4", "v7"] }
-weaver_common = { git = "https://github.com/open-telemetry/weaver.git", rev = "351d5e5430b1e12a045a8b48fe112b3457ef2770" } # v0.24.0
-weaver_forge = { git = "https://github.com/open-telemetry/weaver.git", rev = "351d5e5430b1e12a045a8b48fe112b3457ef2770" } # v0.24.0
-weaver_resolved_schema = { git = "https://github.com/open-telemetry/weaver.git", rev = "351d5e5430b1e12a045a8b48fe112b3457ef2770" } # v0.24.0
-weaver_resolver = { git = "https://github.com/open-telemetry/weaver.git", rev = "351d5e5430b1e12a045a8b48fe112b3457ef2770" } # v0.24.0
-weaver_semconv = { git = "https://github.com/open-telemetry/weaver.git", rev = "351d5e5430b1e12a045a8b48fe112b3457ef2770" } # v0.24.0
+weaver_common = { git = "https://github.com/open-telemetry/weaver.git", rev = "351d5e5430b1e12a045a8b48fe112b3457ef2770" } # v0.24.2
+weaver_forge = { git = "https://github.com/open-telemetry/weaver.git", rev = "351d5e5430b1e12a045a8b48fe112b3457ef2770" } # v0.24.2
+weaver_resolved_schema = { git = "https://github.com/open-telemetry/weaver.git", rev = "351d5e5430b1e12a045a8b48fe112b3457ef2770" } # v0.24.2
+weaver_resolver = { git = "https://github.com/open-telemetry/weaver.git", rev = "351d5e5430b1e12a045a8b48fe112b3457ef2770" } # v0.24.2
+weaver_semconv = { git = "https://github.com/open-telemetry/weaver.git", rev = "351d5e5430b1e12a045a8b48fe112b3457ef2770" } # v0.24.2
 sha1 = { version = "0.11" }
 sha2 = "0.11.0"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/host_metrics_receiver/procfs/tests.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/host_metrics_receiver/procfs/tests.rs
@@ -24,7 +24,7 @@ use weaver_common::{result::WResult, vdir::VirtualDirectoryPath};
 #[cfg(feature = "dev-tools")]
 use weaver_forge::registry::ResolvedRegistry;
 #[cfg(feature = "dev-tools")]
-use weaver_resolver::SchemaResolver;
+use weaver_resolver::{DefaultSchemaVisitor, WeaverResolver, WeaverResolverConfig};
 #[cfg(feature = "dev-tools")]
 use weaver_semconv::{
     attribute::{
@@ -2090,16 +2090,20 @@ fn load_semconv_registry() -> ResolvedRegistry {
     let mut semconv_errors = Vec::new();
     let registry_repo = RegistryRepo::try_new(None, &registry_path, &mut semconv_errors)
         .expect("semantic convention registry");
-    let registry = match SchemaResolver::load_semconv_repository(registry_repo, false) {
-        WResult::Ok(registry) | WResult::OkWithNFEs(registry, _) => registry,
-        WResult::FatalErr(err) => panic!("failed to load semantic convention registry: {err}"),
+    let resolver_config = WeaverResolverConfig {
+        include_unreferenced: true,
+        ..WeaverResolverConfig::default()
     };
-    let resolved_schema = match SchemaResolver::resolve(registry, true) {
-        WResult::Ok(schema) | WResult::OkWithNFEs(schema, _) => schema,
-        WResult::FatalErr(err) => {
-            panic!("failed to resolve semantic convention registry: {err}");
+    let mut resolver = WeaverResolver::new(resolver_config);
+    let resolved_schema =
+        match resolver.load_and_resolve_schema(registry_repo, DefaultSchemaVisitor) {
+            WResult::Ok(schema) | WResult::OkWithNFEs(schema, _) => schema,
+            WResult::FatalErr(err) => {
+                panic!("failed to resolve semantic convention registry: {err}");
+            }
         }
-    };
+        .into_v1()
+        .expect("semantic convention registry uses v1 schema");
 
     ResolvedRegistry::try_from_resolved_registry(
         &resolved_schema.registry,

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/compression_ratio_tests.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/compression_ratio_tests.rs
@@ -61,7 +61,7 @@ use super::synthetic_signal::static_otlp_logs_with_config;
 use prost::Message;
 use weaver_common::{result::WResult, vdir::VirtualDirectoryPath};
 use weaver_forge::registry::ResolvedRegistry;
-use weaver_resolver::SchemaResolver;
+use weaver_resolver::{DefaultSchemaVisitor, WeaverResolver, WeaverResolverConfig};
 use weaver_semconv::registry_repo::RegistryRepo;
 
 /// OTel SDK default batch size for log/span/metric exporters.
@@ -107,16 +107,20 @@ fn load_semconv_registry() -> ResolvedRegistry {
     let mut semconv_errors = Vec::new();
     let registry_repo = RegistryRepo::try_new(None, &registry_path, &mut semconv_errors)
         .expect("semantic convention registry");
-    let registry = match SchemaResolver::load_semconv_repository(registry_repo, false) {
-        WResult::Ok(registry) | WResult::OkWithNFEs(registry, _) => registry,
-        WResult::FatalErr(err) => panic!("failed to load semantic convention registry: {err}"),
+    let resolver_config = WeaverResolverConfig {
+        include_unreferenced: true,
+        ..WeaverResolverConfig::default()
     };
-    let resolved_schema = match SchemaResolver::resolve(registry, true) {
-        WResult::Ok(schema) | WResult::OkWithNFEs(schema, _) => schema,
-        WResult::FatalErr(err) => {
-            panic!("failed to resolve semantic convention registry: {err}");
+    let mut resolver = WeaverResolver::new(resolver_config);
+    let resolved_schema =
+        match resolver.load_and_resolve_schema(registry_repo, DefaultSchemaVisitor) {
+            WResult::Ok(schema) | WResult::OkWithNFEs(schema, _) => schema,
+            WResult::FatalErr(err) => {
+                panic!("failed to resolve semantic convention registry: {err}");
+            }
         }
-    };
+        .into_v1()
+        .expect("semantic convention registry uses v1 schema");
 
     ResolvedRegistry::try_from_resolved_registry(
         &resolved_schema.registry,

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/config.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/config.rs
@@ -12,7 +12,7 @@ use std::num::NonZeroU32;
 use weaver_common::result::WResult;
 use weaver_common::vdir::VirtualDirectoryPath;
 use weaver_forge::registry::ResolvedRegistry;
-use weaver_resolver::SchemaResolver;
+use weaver_resolver::{DefaultSchemaVisitor, WeaverResolver, WeaverResolverConfig};
 use weaver_semconv::registry_repo::RegistryRepo;
 
 /// Source of telemetry data schema and attributes
@@ -293,18 +293,19 @@ impl Config {
                     RegistryRepo::try_new(None, &self.registry_path, &mut semconv_errors)
                         .map_err(|err| err.to_string())?;
 
-                // Load the semantic convention registry.
-                let registry = match SchemaResolver::load_semconv_repository(registry_repo, false) {
-                    WResult::Ok(registry) => registry,
-                    WResult::OkWithNFEs(registry, _) => registry,
-                    WResult::FatalErr(err) => return Err(err.to_string()),
+                let resolver_config = WeaverResolverConfig {
+                    include_unreferenced: true,
+                    ..WeaverResolverConfig::default()
                 };
-
-                let resolved_schema = match SchemaResolver::resolve(registry, true) {
-                    WResult::Ok(resolved_schema) => resolved_schema,
-                    WResult::OkWithNFEs(resolved_schema, _) => resolved_schema,
-                    WResult::FatalErr(err) => return Err(err.to_string()),
-                };
+                let mut resolver = WeaverResolver::new(resolver_config);
+                let resolved_schema =
+                    match resolver.load_and_resolve_schema(registry_repo, DefaultSchemaVisitor) {
+                        WResult::Ok(resolved_schema) => resolved_schema,
+                        WResult::OkWithNFEs(resolved_schema, _) => resolved_schema,
+                        WResult::FatalErr(err) => return Err(err.to_string()),
+                    }
+                    .into_v1()
+                    .map_err(|err| err.to_string())?;
 
                 let resolved_registry = ResolvedRegistry::try_from_resolved_registry(
                     &resolved_schema.registry,

--- a/rust/otap-dataflow/crates/validation/src/encode_decode.rs
+++ b/rust/otap-dataflow/crates/validation/src/encode_decode.rs
@@ -68,7 +68,7 @@ mod test {
     use weaver_common::result::WResult;
     use weaver_common::vdir::VirtualDirectoryPath;
     use weaver_forge::registry::ResolvedRegistry;
-    use weaver_resolver::SchemaResolver;
+    use weaver_resolver::{DefaultSchemaVisitor, WeaverResolver, WeaverResolverConfig};
     use weaver_semconv::registry_repo::RegistryRepo;
 
     const LOG_SIGNAL_COUNT: usize = 100;
@@ -89,26 +89,21 @@ mod test {
         )
         .expect("all registries are definied under the model folder in semantic convention repo");
 
-        // Load the semantic convention registry.
-        let registry = match SchemaResolver::load_semconv_repository(registry_repo, false) {
-            WResult::Ok(registry) => registry,
-            WResult::OkWithNFEs(registry, _) => registry,
-            WResult::FatalErr(_err) => {
-                panic!("Failed to load semantic convention specs");
-            }
+        let resolver_config = WeaverResolverConfig {
+            include_unreferenced: true,
+            ..WeaverResolverConfig::default()
         };
-
-        // Resolve the semantic convention specifications.
-        // If there are any resolution errors, they should be captured into the ongoing list of
-        // diagnostic messages and returned immediately because there is no point in continuing
-        // as the resolution is a prerequisite for the next stages.
-        let resolved_schema = match SchemaResolver::resolve(registry, true) {
-            WResult::Ok(resolved_schema) => resolved_schema,
-            WResult::OkWithNFEs(resolved_schema, _) => resolved_schema,
-            WResult::FatalErr(_err) => {
-                panic!("Failed to resolve semantic convetion schema");
+        let mut resolver = WeaverResolver::new(resolver_config);
+        let resolved_schema =
+            match resolver.load_and_resolve_schema(registry_repo, DefaultSchemaVisitor) {
+                WResult::Ok(resolved_schema) => resolved_schema,
+                WResult::OkWithNFEs(resolved_schema, _) => resolved_schema,
+                WResult::FatalErr(_err) => {
+                    panic!("Failed to resolve semantic convetion schema");
+                }
             }
-        };
+            .into_v1()
+            .expect("semantic convention registry uses v1 schema");
 
         ResolvedRegistry::try_from_resolved_registry(
             &resolved_schema.registry,


### PR DESCRIPTION
# Change Summary

  Updates the Weaver crates to `351d5e5`.

  Also updates otap-dataflow's semantic-convention registry loading code for the newer Weaver resolver API, where `SchemaResolver` has been replaced by `WeaverResolver`. See - https://github.com/open-telemetry/weaver/pull/1504

  This replaces https://github.com/open-telemetry/otel-arrow/pull/3377.

  ## What issue does this PR close?

  None.

  ## How are these changes tested?

  - `cargo check -p otap-df-core-nodes`
  - `cargo check -p otap-df-validation`
  - `cargo check -p otap-df-core-nodes --all-targets`
  - `cargo check -p otap-df-validation --all-targets`
  - `cargo test -p otap-df-core-nodes --lib`

  ## Are there any user-facing changes?

  No.

  ### Changelog

  - [ ] Added a `.chloggen/*.yaml` entry
  - [x] This PR is a `chore` (indicated in title)
  - [ ] This is a documentation-only PR.