### PR TITLE
fix(journald): follow new entries for start_at: end (anchor after seek_tail)

### DIFF
--- a/rust/otap-dataflow/.chloggen/journald-start-at-end-follow-tail.yaml
+++ b/rust/otap-dataflow/.chloggen/journald-start-at-end-follow-tail.yaml
@@ -1,0 +1,36 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: pipeline
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: >-
+  The journald receiver now follows newly appended entries when `start_at: end`
+  and no checkpoint exists — including on an empty journal, or one whose filters
+  match none of the existing entries. Previously it sought the journal tail but
+  never anchored the read head, so the follow loop never advanced onto new
+  entries: a fresh `start_at: end` receiver emitted no records and never
+  committed a checkpoint.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [3395]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: >-
+  `sd_journal_seek_tail()` parks the read head after the most recent entry
+  without making any entry current, and `sd_journal_next()` at the tail is
+  documented to behave like `sd_journal_previous()` (it moves backward). The
+  fresh `StartAt::End` start now issues `sd_journal_seek_tail()` then a single
+  `sd_journal_previous()` to anchor on the last existing entry, so the worker's
+  first `next()` steps forward onto genuinely new entries. When `previous()`
+  finds no entry (empty or fully-filtered journal) the head is repositioned with
+  `sd_journal_seek_head()` to avoid a permanent stall at the tail. This is the
+  accepted best-effort idiom (see systemd/systemd#17662); across rotated or
+  multi-file journals the tail position is approximate, and `start_at: end` has
+  no durable resume anchor until the first checkpoint commit.

--- a/rust/otap-dataflow/.chloggen/journald-start-at-end-follow-tail.yaml
+++ b/rust/otap-dataflow/.chloggen/journald-start-at-end-follow-tail.yaml
@@ -24,9 +24,12 @@ issues: [3395]
 # Use pipe (|) for multiline entries.
 subtext: >-
   `sd_journal_seek_tail()` parks the read head after the most recent entry
-  without making any entry current, and `sd_journal_next()` at the tail is
-  documented to behave like `sd_journal_previous()` (it moves backward). The
-  fresh `StartAt::End` start now issues `sd_journal_seek_tail()` then a single
+  without making any entry current; from there a bare `sd_journal_next()`
+  advances toward a following entry, finds none, and returns `0` (the EOF
+  marker) without anchoring; it does not move backward. (It is
+  `sd_journal_step_one()`, not `sd_journal_next()`, that libsystemd documents
+  as behaving like `sd_journal_previous()` at the tail.) The fresh
+  `StartAt::End` start now issues `sd_journal_seek_tail()` then a single
   `sd_journal_previous()` to anchor on the last existing entry, so the worker's
   first `next()` steps forward onto genuinely new entries. When `previous()`
   finds no entry (empty or fully-filtered journal) the head is repositioned with

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
@@ -30,25 +30,34 @@ trait JournalSeek {
 /// forward from the first entry (the documented `SD_JOURNAL_FOREACH` idiom).
 ///
 /// `StartAt::End` is subtle. `sd_journal_seek_tail()` parks the read head
-/// *after* the most recent entry without making any entry current, and
-/// `sd_journal_next()` at the tail is documented to behave like
-/// `sd_journal_previous()` (it moves backward and ignores the advance). A bare
-/// `next()`/`wait()` follow loop therefore never advances onto entries appended
-/// after startup. So we step back once with `previous()` to anchor on the last
-/// existing entry; the worker's first `next()` then steps forward onto genuinely
-/// new entries.
+/// *after* the most recent entry without making any entry current. From there a
+/// bare `sd_journal_next()` advances toward a *following* entry, finds none, and
+/// returns `0` (the documented EOF marker) without anchoring — so a plain
+/// `next()`/`wait()` follow loop started at the raw tail never advances onto
+/// entries appended after startup (verified against real journald). (It is
+/// `sd_journal_step_one()`, not `sd_journal_next()`, that libsystemd documents as
+/// behaving like `sd_journal_previous()` at the tail.) So we step back once with
+/// `previous()` — documented to seek the closest *preceding* entry — to anchor on
+/// the last existing entry; the worker's first `next()` then steps forward onto
+/// genuinely new entries.
 ///
 /// When the journal is empty — or a filter matches none of the existing
 /// entries — `previous()` returns `0` and anchors nothing, leaving the read head
 /// parked at the tail where `next()` keeps returning `0` even after `wait()`
 /// reports appends (the same permanent stall the tail branch exists to avoid,
 /// verified against real journald). In that case we reposition to the head with
-/// `seek_head()`; because a well-behaved `previous()` returns `0` only when no
-/// matching entry exists yet, `next()` then follows onto the first entry
-/// appended after startup without replaying history. This assumes a reliable
-/// `seek_tail()` + `previous()`; a very old/buggy libsystemd of the
-/// systemd#17662 class that spuriously reports `0` while matching entries exist
-/// would replay that history once at startup (not observed on modern systemd).
+/// `seek_head()` so the follow loop can make progress. This does not replay
+/// history: `sd-journal` merges *all* open journal files (active plus
+/// rotated/archived) into a single view, and with the receiver's matches
+/// installed a well-behaved `previous()` returns `0` only when no matching entry
+/// exists in ANY of them yet — so `seek_head()` + `next()` land on the first
+/// matching entry appended *after* startup, with nothing older to replay. Replay
+/// would require `seek_tail()` + `previous()` to spuriously report `0` while
+/// matching entries actually exist (the multi-file positioning bug of the
+/// systemd#17662 class noted below); on such an old/buggy libsystemd it would
+/// replay that history once at startup (not observed on modern systemd). Bounding
+/// replay even under that bug would need a durable tail-boundary guard, which
+/// `start_at: end` deliberately omits (see the resume-anchor note below).
 ///
 /// Returns `Err((operation, rc))` with the failing call's name and its negative
 /// return code. `seek_tail`/`seek_head` return `0` on success; `previous`

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
@@ -3,13 +3,202 @@
 
 //! Linux `sd-journal` reader abstraction.
 
+#[cfg(any(target_os = "linux", test))]
+use crate::receivers::journald_receiver::config::StartAt;
+#[cfg(any(target_os = "linux", test))]
+use std::ffi::c_int;
+
+/// Minimal seam over the `sd-journal` seek/step calls used to position a freshly
+/// opened journal when no checkpoint cursor exists. Abstracting the three raw
+/// FFI calls lets [`position_for_fresh_start`] — including its empty-journal
+/// handling — be unit-tested without a live `sd-journal`. Each method returns
+/// the raw libsystemd code (`>= 0` on success, `< 0` is `-errno`).
+#[cfg(any(target_os = "linux", test))]
+trait JournalSeek {
+    /// `sd_journal_seek_head`: position before the first entry.
+    fn seek_head(&mut self) -> c_int;
+    /// `sd_journal_seek_tail`: position after the most recent entry.
+    fn seek_tail(&mut self) -> c_int;
+    /// `sd_journal_previous`: step to the previous entry. Returns `1` when an
+    /// entry is now current, `0` when there is none, `< 0` on error.
+    fn previous(&mut self) -> c_int;
+}
+
+/// Positions a freshly opened journal (no checkpoint cursor) for `start_at`.
+///
+/// `StartAt::Beginning` seeks the head; the worker's `next()` then iterates
+/// forward from the first entry (the documented `SD_JOURNAL_FOREACH` idiom).
+///
+/// `StartAt::End` is subtle. `sd_journal_seek_tail()` parks the read head
+/// *after* the most recent entry without making any entry current, and
+/// `sd_journal_next()` at the tail is documented to behave like
+/// `sd_journal_previous()` (it moves backward and ignores the advance). A bare
+/// `next()`/`wait()` follow loop therefore never advances onto entries appended
+/// after startup. So we step back once with `previous()` to anchor on the last
+/// existing entry; the worker's first `next()` then steps forward onto genuinely
+/// new entries.
+///
+/// When the journal is empty — or a filter matches none of the existing
+/// entries — `previous()` returns `0` and anchors nothing, leaving the read head
+/// parked at the tail where `next()` keeps returning `0` even after `wait()`
+/// reports appends (the same permanent stall the tail branch exists to avoid,
+/// verified against real journald). In that case we reposition to the head with
+/// `seek_head()`; because a well-behaved `previous()` returns `0` only when no
+/// matching entry exists yet, `next()` then follows onto the first entry
+/// appended after startup without replaying history. This assumes a reliable
+/// `seek_tail()` + `previous()`; a very old/buggy libsystemd of the
+/// systemd#17662 class that spuriously reports `0` while matching entries exist
+/// would replay that history once at startup (not observed on modern systemd).
+///
+/// Returns `Err((operation, rc))` with the failing call's name and its negative
+/// return code. `seek_tail`/`seek_head` return `0` on success; `previous`
+/// returning `0` is the empty/no-match case above, not an error.
+///
+/// `seek_tail()` + `previous()` is the accepted best-effort idiom (see
+/// systemd/systemd#17662, coreos/go-systemd `sdjournal`). Across rotated or
+/// multi-file journals the tail position is approximate, and an entry appended
+/// in the race window between `seek_tail()` and `previous()` may be anchored and
+/// skipped — acceptable under `start_at: end`, which has no durable resume
+/// anchor until the first checkpoint commit.
+#[cfg(any(target_os = "linux", test))]
+fn position_for_fresh_start<J: JournalSeek>(
+    seek: &mut J,
+    start_at: StartAt,
+) -> Result<(), (&'static str, c_int)> {
+    fn require_nonneg(rc: c_int, operation: &'static str) -> Result<(), (&'static str, c_int)> {
+        if rc < 0 { Err((operation, rc)) } else { Ok(()) }
+    }
+
+    match start_at {
+        StartAt::Beginning => require_nonneg(seek.seek_head(), "sd_journal_seek_head"),
+        StartAt::End => {
+            require_nonneg(seek.seek_tail(), "sd_journal_seek_tail")?;
+            let anchored = seek.previous();
+            require_nonneg(anchored, "sd_journal_previous")?;
+            if anchored == 0 {
+                require_nonneg(seek.seek_head(), "sd_journal_seek_head")?;
+            }
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod fresh_start_tests {
+    use super::{JournalSeek, position_for_fresh_start};
+    use crate::receivers::journald_receiver::config::StartAt;
+    use std::ffi::c_int;
+
+    #[derive(Default)]
+    struct RecordingSeek {
+        calls: Vec<&'static str>,
+        seek_head_rc: c_int,
+        seek_tail_rc: c_int,
+        previous_rc: c_int,
+    }
+
+    impl JournalSeek for RecordingSeek {
+        fn seek_head(&mut self) -> c_int {
+            self.calls.push("seek_head");
+            self.seek_head_rc
+        }
+        fn seek_tail(&mut self) -> c_int {
+            self.calls.push("seek_tail");
+            self.seek_tail_rc
+        }
+        fn previous(&mut self) -> c_int {
+            self.calls.push("previous");
+            self.previous_rc
+        }
+    }
+
+    #[test]
+    fn beginning_seeks_head_only() {
+        let mut seek = RecordingSeek::default();
+        assert!(position_for_fresh_start(&mut seek, StartAt::Beginning).is_ok());
+        assert_eq!(seek.calls, ["seek_head"]);
+    }
+
+    #[test]
+    fn end_with_existing_entries_anchors_with_previous() {
+        // previous() finds the last existing entry (rc = 1): tail + previous and
+        // NO seek_head — rewinding to the head would replay historical records.
+        let mut seek = RecordingSeek {
+            previous_rc: 1,
+            ..Default::default()
+        };
+        assert!(position_for_fresh_start(&mut seek, StartAt::End).is_ok());
+        assert_eq!(seek.calls, ["seek_tail", "previous"]);
+    }
+
+    #[test]
+    fn end_on_empty_journal_repositions_to_head() {
+        // Regression guard for the empty/no-match permanent stall: previous()
+        // returns 0 (nothing to anchor), so the read head must be unparked with
+        // seek_head() or the next()/wait() loop never advances onto new entries.
+        let mut seek = RecordingSeek {
+            previous_rc: 0,
+            ..Default::default()
+        };
+        assert!(position_for_fresh_start(&mut seek, StartAt::End).is_ok());
+        assert_eq!(seek.calls, ["seek_tail", "previous", "seek_head"]);
+    }
+
+    #[test]
+    fn end_propagates_previous_error() {
+        let mut seek = RecordingSeek {
+            previous_rc: -5,
+            ..Default::default()
+        };
+        let err = position_for_fresh_start(&mut seek, StartAt::End).unwrap_err();
+        assert_eq!(err, ("sd_journal_previous", -5));
+        assert_eq!(seek.calls, ["seek_tail", "previous"]);
+    }
+
+    #[test]
+    fn end_propagates_seek_tail_error_without_stepping() {
+        let mut seek = RecordingSeek {
+            seek_tail_rc: -1,
+            ..Default::default()
+        };
+        let err = position_for_fresh_start(&mut seek, StartAt::End).unwrap_err();
+        assert_eq!(err, ("sd_journal_seek_tail", -1));
+        assert_eq!(seek.calls, ["seek_tail"]);
+    }
+
+    #[test]
+    fn end_propagates_seek_head_recovery_error() {
+        // On the empty path (previous() == 0) a failing recovery seek_head()
+        // surfaces as a seek_head error, distinct from seek_tail/previous.
+        let mut seek = RecordingSeek {
+            previous_rc: 0,
+            seek_head_rc: -22,
+            ..Default::default()
+        };
+        let err = position_for_fresh_start(&mut seek, StartAt::End).unwrap_err();
+        assert_eq!(err, ("sd_journal_seek_head", -22));
+        assert_eq!(seek.calls, ["seek_tail", "previous", "seek_head"]);
+    }
+
+    #[test]
+    fn beginning_propagates_seek_head_error() {
+        let mut seek = RecordingSeek {
+            seek_head_rc: -1,
+            ..Default::default()
+        };
+        let err = position_for_fresh_start(&mut seek, StartAt::Beginning).unwrap_err();
+        assert_eq!(err, ("sd_journal_seek_head", -1));
+        assert_eq!(seek.calls, ["seek_head"]);
+    }
+}
+
 #[cfg(target_os = "linux")]
 mod imp {
     #![allow(unsafe_code)]
 
     use crate::receivers::journald_receiver::arrow_records_encoder::{JournalEntry, JournalField};
     use crate::receivers::journald_receiver::config::{
-        ExtractionConfig, LargeFieldPolicy, RuntimeConfig, StartAt,
+        ExtractionConfig, LargeFieldPolicy, RuntimeConfig,
     };
 
     use libc::{RTLD_NOW, c_char, c_int, c_void, size_t};
@@ -28,6 +217,7 @@ mod imp {
     type OpenDirectoryFn = unsafe extern "C" fn(*mut *mut SdJournal, *const c_char, c_int) -> c_int;
     type CloseFn = unsafe extern "C" fn(*mut SdJournal);
     type NextFn = unsafe extern "C" fn(*mut SdJournal) -> c_int;
+    type PreviousFn = unsafe extern "C" fn(*mut SdJournal) -> c_int;
     type WaitFn = unsafe extern "C" fn(*mut SdJournal, u64) -> c_int;
     type SeekHeadFn = unsafe extern "C" fn(*mut SdJournal) -> c_int;
     type SeekTailFn = unsafe extern "C" fn(*mut SdJournal) -> c_int;
@@ -86,6 +276,7 @@ mod imp {
         open_directory: OpenDirectoryFn,
         close: CloseFn,
         next: NextFn,
+        previous: PreviousFn,
         wait: WaitFn,
         seek_head: SeekHeadFn,
         seek_tail: SeekTailFn,
@@ -136,6 +327,7 @@ mod imp {
                 open_directory: sym!("sd_journal_open_directory", OpenDirectoryFn),
                 close: sym!("sd_journal_close", CloseFn),
                 next: sym!("sd_journal_next", NextFn),
+                previous: sym!("sd_journal_previous", PreviousFn),
                 wait: sym!("sd_journal_wait", WaitFn),
                 seek_head: sym!("sd_journal_seek_head", SeekHeadFn),
                 seek_tail: sym!("sd_journal_seek_tail", SeekTailFn),
@@ -234,16 +426,12 @@ mod imp {
 
             self.configure_matches(config)?;
 
-            match config.start_at {
-                StartAt::Beginning => check(
-                    unsafe { (self.lib.seek_head)(self.journal.as_ptr()) },
-                    "sd_journal_seek_head",
-                ),
-                StartAt::End => check(
-                    unsafe { (self.lib.seek_tail)(self.journal.as_ptr()) },
-                    "sd_journal_seek_tail",
-                ),
-            }
+            // Position the read head for a fresh (no-checkpoint) start. For
+            // `StartAt::End` this anchors past existing entries (and unparks an
+            // empty journal from the tail) so the worker's next()/wait() loop
+            // follows only newly appended records; see `position_for_fresh_start`.
+            super::position_for_fresh_start(self, config.start_at)
+                .map_err(|(operation, rc)| JournalError::SystemdCall { operation, rc })
         }
 
         fn configure_matches(&mut self, config: &RuntimeConfig) -> Result<(), JournalError> {
@@ -484,6 +672,18 @@ mod imp {
             .saturating_add(FIELD_NAME_THRESHOLD_HEADROOM_BYTES)
             .min(extraction.max_entry_bytes)
             .max(1)
+    }
+
+    impl super::JournalSeek for SdJournalReader {
+        fn seek_head(&mut self) -> c_int {
+            unsafe { (self.lib.seek_head)(self.journal.as_ptr()) }
+        }
+        fn seek_tail(&mut self) -> c_int {
+            unsafe { (self.lib.seek_tail)(self.journal.as_ptr()) }
+        }
+        fn previous(&mut self) -> c_int {
+            unsafe { (self.lib.previous)(self.journal.as_ptr()) }
+        }
     }
 
     impl Drop for SdJournalReader {


### PR DESCRIPTION
## Summary

Fixes #3395. A fresh `start_at: end` journald receiver (no checkpoint) emitted
**zero records forever** and never committed a checkpoint.

`SdJournalReader::configure()` positioned `StartAt::End` with only
`sd_journal_seek_tail()`, and the worker follow loop only calls
`sd_journal_next()` + `sd_journal_wait()`. Per sd-journal semantics:

- `sd_journal_seek_tail(3)` parks the read head *after* the most recent entry
  and makes **no** entry current.
- From there a bare `sd_journal_next(3)` advances toward a *following* entry,
  finds none, and returns `0` (the EOF marker) **without anchoring** — it does
  not move backward. (It is `sd_journal_step_one(3)`, not `sd_journal_next(3)`,
  that libsystemd documents as behaving like `sd_journal_previous()` at the
  tail.)

So a bare `next()`/`wait()` loop never advances onto entries appended after
startup. Because it never reads an entry it never Acks, so it never commits a
cursor, and the (correct) checkpoint-resume path never takes over on restart.
`start_at: end` was permanently stuck at zero.

## Fix

Fresh `StartAt::End` now does `seek_tail()` → `previous()` to anchor on the last
existing entry, so the worker's first `next()` steps forward onto genuinely new
entries. When `previous()` returns `0` (empty journal, or a filter that matches
none of the existing entries) it anchors nothing and the head stays parked at
the tail — the same permanent stall — so the head is repositioned with
`seek_head()`; since no entry matched yet, `next()` then follows the first entry
appended after startup with no risk of replaying old records.

The seek/step FFI is abstracted behind a small `JournalSeek` seam so the
positioning logic (`position_for_fresh_start`) — including the empty-journal
path and error propagation — is unit-tested with a recording mock.
`StartAt::Beginning` (`seek_head()` + `next()`) and the checkpoint-resume
(`seek_cursor()` + `next()`) paths are unchanged.

Refs: `sd_journal_next(3)`, `sd_journal_seek_tail(3)`, systemd/systemd#17662,
coreos/go-systemd `sdjournal` tail-follow.

## Testing

**Unit tests** (`position_for_fresh_start` via a recording mock; run on all
platforms): `Beginning → [seek_head]`; `End` populated → `[seek_tail, previous]`;
`End` empty → `[seek_tail, previous, seek_head]`; `previous` error; `seek_tail`
error.

**Verified against a live journald** (mirroring the receiver's exact sequence; a
matching entry is appended *after* the seek):

| sequence | pre-existing matching entries | result |
| --- | --- | --- |
| `seek_tail` only (old behavior) | yes | STUCK — reproduces the bug |
| `seek_tail` + `previous` | yes | follows new only, no replay |
| `seek_tail` + `previous` | none | STUCK |
| `seek_tail` + `previous` + `seek_head` (this PR) | none | follows new |

`cargo check` / `clippy --all-targets -D warnings` / `cargo fmt` are clean on
Linux; unit tests pass.

## Performance

This is a startup-path fix; the per-entry read hot path is unchanged.

- **Hot path untouched.** The diff is confined to the one-time `configure()`
  positioning path, the `JournalSeek` seam, and the changelog. The per-entry
  read loop (`next_entry_with_wait_timeout` → `current_entry`) is byte-for-byte
  identical to `main`, so steady-state throughput and per-entry allocations are
  unaffected.
- **Startup cost.** Fresh `StartAt::End` now issues one extra
  `sd_journal_previous()`, plus one conditional `sd_journal_seek_head()` only
  when no matching entry exists yet. These run once per journal open (worker
  start) and once per rare `Rewind`/Nack — never per entry; the cost is one-time
  and microsecond-scale.
- **No dynamic dispatch.** `position_for_fresh_start` is generic over
  `JournalSeek` and monomorphized (static dispatch), so the seam adds no vtable
  or allocation overhead.

## Caveats (scope)

`seek_tail()` + `previous()` is the accepted best-effort idiom
(systemd/systemd#17662). Across rotated / multi-file journals the tail position
is approximate, and an entry appended in the race window between `seek_tail()`
and `previous()` may be anchored and skipped. This is acceptable under
`start_at: end`, which has no durable resume anchor until the first checkpoint
commit (already documented in the receiver README/design notes).

The empty/no-match handling (`seek_head()` when `previous()` returns `0`) is
replay-free because a well-behaved `previous()` returns `0` only when no
matching entry exists yet. This was verified end-to-end against live journald on
modern systemd (255), including a 20-file rotated journal with archived-only
matches. A very old/buggy libsystemd of the systemd#17662 class that spuriously
reports `0` while matching entries exist would replay that history once at
startup; this was not observed on modern systemd, and the receiver `dlopen`s the
host libsystemd at runtime.

