### PR TITLE
fix(otap): default gRPC server settings to loopback bind

### DIFF
--- a/rust/otap-dataflow/.chloggen/otap-grpc-server-loopback-default.yaml
+++ b/rust/otap-dataflow/.chloggen/otap-grpc-server-loopback-default.yaml
@@ -1,0 +1,26 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: otap
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: >-
+  `GrpcServerSettings::default()` now binds the loopback interface
+  (`127.0.0.1:0`) instead of all interfaces (`0.0.0.0:0`). Production is
+  unaffected because `listening_addr` is a required config field; the default is
+  only reached when a gRPC server is built programmatically via
+  `..Default::default()`, where the previous all-interfaces default tripped the
+  Windows Defender Firewall prompt during `cargo test` and exposed
+  builder-constructed servers to the local network.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [3400]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/rust/otap-dataflow/crates/otap/src/otap_grpc/server_settings.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_grpc/server_settings.rs
@@ -313,7 +313,14 @@ const fn default_wait_for_result() -> bool {
 impl Default for GrpcServerSettings {
     fn default() -> Self {
         Self {
-            listening_addr: ([0, 0, 0, 0], 0).into(),
+            // Loopback ephemeral port by default. This default is only reached
+            // via `..Default::default()` in Rust (tests/builders): production
+            // sets `listening_addr` from config, a required field with no serde
+            // default. Binding loopback (not the all-interfaces `0.0.0.0`) keeps
+            // tests/examples from tripping the Windows Defender Firewall prompt
+            // (see CONTRIBUTING, "Test and example server bind addresses").
+            // Servers that must serve external traffic set an explicit address.
+            listening_addr: ([127, 0, 0, 1], 0).into(),
             request_compression: None,
             response_compression: None,
             max_concurrent_requests: default_max_concurrent_requests(),
@@ -392,5 +399,24 @@ mod tests {
         let (req, resp) = settings.compression_encodings();
         assert!(req.is_enabled(CompressionEncoding::Deflate));
         assert!(resp.is_enabled(CompressionEncoding::Deflate));
+    }
+
+    #[test]
+    fn default_listening_addr_is_loopback() {
+        // Regression guard against the Windows firewall recurrence: any
+        // test/builder that reaches this default must bind loopback, never an
+        // all-interfaces address (0.0.0.0 / [::]). The port must also stay
+        // ephemeral (0) so parallel tests don't collide on a fixed port. See
+        // CONTRIBUTING, "Test and example server bind addresses".
+        let addr = GrpcServerSettings::default().listening_addr;
+        assert!(
+            addr.ip().is_loopback(),
+            "default listening_addr must be loopback, got {addr}"
+        );
+        assert_eq!(
+            addr.port(),
+            0,
+            "default listening_addr must use an ephemeral port (0), got {addr}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

`GrpcServerSettings::default()`
(`crates/otap/src/otap_grpc/server_settings.rs`) defaulted `listening_addr` to
`([0, 0, 0, 0], 0)` = **`0.0.0.0:0`** (all interfaces, ephemeral port). The
ephemeral port `0` shows this default is test/builder-oriented (a real server
needs a known port), but an all-interfaces bind triggers the **Windows Defender
Firewall prompt** during `cargo test` — the exact issue the "Test and example
server bind addresses" guidance in `CONTRIBUTING.md` (added in #3353) exists to
prevent.

This changes the default to **`127.0.0.1:0`** (loopback ephemeral).

## Why this is safe

- `listening_addr` is a **required** config field (the struct is
  `#[serde(deny_unknown_fields)]` with no `#[serde(default)]` on the field), so
  config-driven deployments always set it explicitly — production behavior is
  unchanged.
- The only in-tree consumer of the bare default today is a compression unit
  test that never binds a socket; this is a latent-risk fix, not a behavior fix
  for existing tests.
- A server that must serve external traffic still sets an explicit
  all-interfaces address in config (`CONTRIBUTING.md` explicitly allows
  production defaults to bind `0.0.0.0`).

## Testing

- New regression test `default_listening_addr_is_loopback` pins the default to a
  loopback address — it fails if the default is ever changed back to `0.0.0.0` /
  `[::]`.
- `cargo clippy -p otap-df-otap --all-targets -- -D warnings` — clean.
- `cargo test -p otap-df-otap --lib server_settings` — passes.
- `cargo fmt` — clean.

Changelog: a `bug_fix` entry under `.chloggen` (component `otap`), since
`GrpcServerSettings` is a `pub` type and its `Default` bind behavior changes for
programmatic Rust API consumers (the crate is `publish = false`, so there are no
external consumers).
