### PR TITLE
azure-monitor-exporter: fix auth error display

### DIFF
--- a/rust/otap-dataflow/.chloggen/azure-monitor-exporter-auth-error-fix.yaml
+++ b/rust/otap-dataflow/.chloggen/azure-monitor-exporter-auth-error-fix.yaml
@@ -6,7 +6,7 @@ change_type: enhancement
 component: pipeline
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: add additional details to auth handler creation error for azure monitor exporter
+note: Add additional details to auth handler creation error for azure monitor exporter
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [3409]

--- a/rust/otap-dataflow/.chloggen/azure-monitor-exportr-auth-error-fix.yaml
+++ b/rust/otap-dataflow/.chloggen/azure-monitor-exportr-auth-error-fix.yaml
@@ -9,7 +9,7 @@ component: pipeline
 note: add additional details to auth handler creation error for azure monitor exporter
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [3409]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/rust/otap-dataflow/.chloggen/azure-monitor-exportr-auth-error-fix.yaml
+++ b/rust/otap-dataflow/.chloggen/azure-monitor-exportr-auth-error-fix.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: pipeline
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add additional details to auth handler creation error for azure monitor exporter
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/error.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/error.rs
@@ -123,7 +123,7 @@ pub enum Error {
     ChannelRecv(#[source] otap_df_channel::error::RecvError),
 
     /// Failed to create auth handler.
-    #[error("Failed to create auth handler")]
+    #[error("Failed to create auth handler: {0}")]
     AuthHandlerCreation(#[source] Box<Error>),
 
     /// Client pool initialization failed.
@@ -574,7 +574,10 @@ mod tests {
     fn test_auth_handler_creation_message() {
         let inner = Error::Config("test".to_string());
         let error = Error::AuthHandlerCreation(Box::new(inner));
-        assert_eq!(error.to_string(), "Failed to create auth handler");
+        assert_eq!(
+            error.to_string(),
+            "Failed to create auth handler: Configuration error: test"
+        );
         assert!(error.source().is_some());
     }
 


### PR DESCRIPTION
# Change Summary

add additional details (inner error) to auth handler creation error for azure monitor exporter

## What issue does this PR close?

## How are these changes tested?

* cargo xtask check
* cargo test --profile test --features azure-monitor-exporter

## Are there any user-facing changes?

Yes, previously if there was an error creating an auth handler, the error would be:

> ERROR controller.pipeline_runtime_failed: Pipeline terminated with a runtime error [core_id=4, error=Internal error: Failed to create auth handler]

now it will be:

> ERROR controller.pipeline_runtime_failed: Pipeline terminated with a runtime error [core_id=4, error=Internal error: Failed to create auth handler: Configuration error: the error goes here]

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry
* [ ] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
