### PR TITLE
fix(telemetry): export cumulative counters as async monotonic sums honoring reader temporality

### DIFF
--- a/rust/otap-dataflow/.chloggen/telemetry-cumulative-counters-as-sums.yaml
+++ b/rust/otap-dataflow/.chloggen/telemetry-cumulative-counters-as-sums.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: observability
+note: Self-telemetry cumulative counters (`ObserveCounter`) are now exported as asynchronous monotonic sums instead of gauges, so the metrics reader's requested temporality (cumulative or delta) is honored.
+issues: [3397]

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
@@ -960,15 +960,12 @@ impl DurableBuffer {
         self.segment_cache
             .retain(|seq, _| progress_snapshot.contains_key(&SegmentSeq::new(*seq)));
 
-        // NOTE (temporality inconsistency): these aggregate loss metrics are
-        // still cumulative ObserveCounters sourced from monotonic engine atomics
-        // via .observe(), so the dispatcher exports them as gauges regardless of
-        // reader temporality. Their per-signal breakdowns below are now delta
-        // Counters, so `dropped_items` will NOT equal the sum of the per-signal
-        // `dropped_*` across intervals. Making these delta-native (and every other
-        // ObserveCounter temporality-aware) is tracked as a follow-up; it needs
-        // either engine-side drain methods or a dispatcher-level fix rather than
-        // reintroducing per-metric last-value bookkeeping here.
+        // These aggregate loss metrics are cumulative ObserveCounters sourced
+        // from monotonic engine atomics via .observe(). The telemetry
+        // dispatcher exports them as asynchronous monotonic sums, so the
+        // reader's requested temporality applies: cumulative totals, or
+        // per-interval deltas that align with the per-signal delta Counters
+        // below.
         self.metrics
             .dropped_segments
             .observe(engine.force_dropped_segments());

--- a/rust/otap-dataflow/crates/telemetry/src/metrics/dispatcher.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/metrics/dispatcher.rs
@@ -3,9 +3,13 @@
 
 //! Metrics dispatcher that handles internal telemetry metrics.
 
+use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
+use opentelemetry::metrics::ObservableCounter;
 use opentelemetry::{InstrumentationScope, global, metrics::Meter, metrics::MeterProvider};
+use parking_lot::Mutex;
 use tokio::time::{MissedTickBehavior, interval};
 use tokio_util::sync::CancellationToken;
 
@@ -22,18 +26,102 @@ use crate::{
 pub struct MetricsDispatcher {
     metrics_handler: TelemetryRegistryHandle,
     reporting_interval: std::time::Duration,
+    /// Observable-counter series backing cumulative sums, keyed by scope
+    /// series key, then by metric name. Each series holds the shared value
+    /// read by an SDK callback registered once per series; the SDK reader
+    /// then performs cumulative/delta temporality conversion itself.
+    ///
+    /// The series currently live for the process lifetime. Naive eviction is
+    /// unsafe because dropping these instrument handles does not unregister
+    /// their SDK callbacks; see #3413 for lifecycle-aware pruning.
+    cumulative_series: Mutex<HashMap<String, HashMap<&'static str, CumulativeCounterSeries>>>,
+}
+
+/// Backing state for one exported cumulative counter series.
+///
+/// The `value` slot is shared with an SDK observable-counter callback that
+/// reports the latest total at every SDK collection. The instrument handle is
+/// retained so the registration lives as long as the series.
+enum CumulativeCounterSeries {
+    /// Series for a `u64` cumulative counter.
+    U64 {
+        value: Arc<AtomicU64>,
+        _instrument: ObservableCounter<u64>,
+    },
+    /// Series for an `f64` cumulative counter; the atomic stores the bit
+    /// pattern of the current value.
+    F64 {
+        value: Arc<AtomicU64>,
+        _instrument: ObservableCounter<f64>,
+    },
+}
+
+impl CumulativeCounterSeries {
+    fn build(field: &MetricsField, initial: MetricValue, meter: &Meter) -> Self {
+        match initial {
+            MetricValue::U64(v) => {
+                let value = Arc::new(AtomicU64::new(v));
+                let observed = Arc::clone(&value);
+                let instrument = meter
+                    .u64_observable_counter(field.name)
+                    .with_description(field.brief)
+                    .with_unit(field.unit)
+                    .with_callback(move |observer| {
+                        observer.observe(observed.load(Ordering::Relaxed), &[]);
+                    })
+                    .build();
+                Self::U64 {
+                    value,
+                    _instrument: instrument,
+                }
+            }
+            MetricValue::F64(v) => {
+                let value = Arc::new(AtomicU64::new(v.to_bits()));
+                let observed = Arc::clone(&value);
+                let instrument = meter
+                    .f64_observable_counter(field.name)
+                    .with_description(field.brief)
+                    .with_unit(field.unit)
+                    .with_callback(move |observer| {
+                        observer.observe(f64::from_bits(observed.load(Ordering::Relaxed)), &[]);
+                    })
+                    .build();
+                Self::F64 {
+                    value,
+                    _instrument: instrument,
+                }
+            }
+            MetricValue::Mmsc(_) => unreachable!("Counter instrument cannot have Mmsc value"),
+        }
+    }
+
+    fn store(&self, value: MetricValue) {
+        match (self, value) {
+            (Self::U64 { value: slot, .. }, MetricValue::U64(v)) => {
+                slot.store(v, Ordering::Relaxed);
+            }
+            (Self::F64 { value: slot, .. }, MetricValue::F64(v)) => {
+                slot.store(v.to_bits(), Ordering::Relaxed);
+            }
+            _ => debug_assert!(
+                false,
+                "metric value type must not change between dispatches"
+            ),
+        }
+    }
 }
 
 impl MetricsDispatcher {
     /// Create a new metrics dispatcher
     #[must_use]
-    pub const fn new(
+    pub fn new(
         metrics_handler: TelemetryRegistryHandle,
         reporting_interval: std::time::Duration,
     ) -> Self {
         Self {
             metrics_handler,
             reporting_interval,
+            cumulative_series: Mutex::new(HashMap::new()),
         }
     }
 
@@ -69,6 +157,7 @@ impl MetricsDispatcher {
         self.metrics_handler
             .visit_metrics_and_reset(|descriptor, attributes, metrics_iter| {
                 let scope_attributes = Self::to_opentelemetry_attributes(attributes);
+                let scope_key = Self::scope_series_key(descriptor.name, &scope_attributes);
                 let meter = if scope_attributes.is_empty() {
                     meter_provider.meter(descriptor.name)
                 } else {
@@ -82,7 +171,7 @@ impl MetricsDispatcher {
                 // Entity attributes live on the instrumentation scope so OTel Views can
                 // target them via scope_attributes selectors; data points carry none.
                 for (field, value) in metrics_iter {
-                    self.add_opentelemetry_metric(field, value, &[], &meter);
+                    self.add_opentelemetry_metric(field, value, &[], &meter, &scope_key);
                 }
             });
 
@@ -117,26 +206,35 @@ impl MetricsDispatcher {
         opentelemetry::KeyValue::new(key.to_string(), otel_value)
     }
 
+    /// Builds a stable identifier for the series cache from the scope name and
+    /// its entity attributes (which are fixed for a registered metric set).
+    fn scope_series_key(scope_name: &str, attributes: &[opentelemetry::KeyValue]) -> String {
+        use std::fmt::Write;
+        let mut key = String::from(scope_name);
+        for kv in attributes {
+            let _ = write!(key, "\u{1f}{}\u{1f}{}", kv.key, kv.value);
+        }
+        key
+    }
+
     fn add_opentelemetry_metric(
         &self,
         field: &MetricsField,
         value: MetricValue,
         attributes: &[opentelemetry::KeyValue],
         meter: &Meter,
+        scope_key: &str,
     ) {
         match field.instrument {
             Instrument::Counter => match field.temporality {
                 Some(Temporality::Delta) => {
                     self.add_opentelemetry_counter(field, value, attributes, meter)
                 }
-                Some(Temporality::Cumulative) | None => {
-                    debug_assert!(
-                        field.temporality.is_some(),
-                        "sum-like instrument must have a temporality"
-                    );
-                    // Cumulative counters are exported as gauges to avoid double-counting.
-                    // Note for reviewers: This is a temporary workaround until we figure out a
-                    // better way to handle cumulative sums via the Rust Client SDK.
+                Some(Temporality::Cumulative) => {
+                    self.observe_cumulative_counter(field, value, meter, scope_key)
+                }
+                None => {
+                    debug_assert!(false, "sum-like instrument must have a temporality");
                     self.add_opentelemetry_gauge(field, value, attributes, meter)
                 }
             },
@@ -149,9 +247,11 @@ impl MetricsDispatcher {
                         field.temporality.is_some(),
                         "sum-like instrument must have a temporality"
                     );
-                    // Cumulative up-down counters are exported as gauges to avoid double-counting.
-                    // Note for reviewers: This is a temporary workaround until we figure out a
-                    // better way to handle cumulative sums via the Rust Client SDK.
+                    // Cumulative up-down counters are still exported as gauges to avoid
+                    // double-counting. They cannot reuse the observable-counter path
+                    // below: the registry zeroes values after each visit, and unlike a
+                    // monotonic total, a legitimate up-down value of zero cannot be
+                    // distinguished from "no fresh observation this interval".
                     self.add_opentelemetry_gauge(field, value, attributes, meter)
                 }
             },
@@ -195,6 +295,39 @@ impl MetricsDispatcher {
                 counter.add(v, attributes);
             }
             MetricValue::Mmsc(_) => unreachable!("Counter instrument cannot have Mmsc value"),
+        }
+    }
+
+    /// Publishes the latest total of a cumulative counter through an SDK
+    /// observable counter, so the configured reader performs the
+    /// cumulative/delta temporality conversion.
+    ///
+    /// The observable instrument and its callback are created once per series
+    /// and cached; later dispatches only update the shared value slot.
+    ///
+    /// Zero updates to existing series are skipped: the registry zeroes
+    /// accumulated values after every visit, so a zero for an already-created
+    /// monotonic series means "no fresh observation this interval". Initial
+    /// zero values still create a series so readers can observe a legitimate
+    /// zero starting total.
+    fn observe_cumulative_counter(
+        &self,
+        field: &MetricsField,
+        value: MetricValue,
+        meter: &Meter,
+        scope_key: &str,
+    ) {
+        let mut scopes = self.cumulative_series.lock();
+        if let Some(series) = scopes.get(scope_key).and_then(|s| s.get(field.name)) {
+            if !value.is_zero() {
+                series.store(value);
+            }
+        } else {
+            let series = CumulativeCounterSeries::build(field, value, meter);
+            let _ = scopes
+                .entry(scope_key.to_owned())
+                .or_default()
+                .insert(field.name, series);
         }
     }
 
@@ -616,7 +749,7 @@ mod tests {
             TelemetryRegistryHandle::new(),
             std::time::Duration::from_secs(10),
         );
-        dispatcher.add_opentelemetry_metric(&field, value, &attributes, &meter);
+        dispatcher.add_opentelemetry_metric(&field, value, &attributes, &meter, "test_scope");
         // Nothing to assert here. Test the function call and it should not panic.
     }
 
@@ -637,7 +770,7 @@ mod tests {
             TelemetryRegistryHandle::new(),
             std::time::Duration::from_secs(10),
         );
-        dispatcher.add_opentelemetry_metric(&field, value, &attributes, &meter);
+        dispatcher.add_opentelemetry_metric(&field, value, &attributes, &meter, "test_scope");
         // Nothing to assert here. Test the function call and it should not panic.
     }
 
@@ -658,7 +791,7 @@ mod tests {
             TelemetryRegistryHandle::new(),
             std::time::Duration::from_secs(10),
         );
-        dispatcher.add_opentelemetry_metric(&field, value, &attributes, &meter);
+        dispatcher.add_opentelemetry_metric(&field, value, &attributes, &meter, "test_scope");
         // Nothing to assert here. Test the function call and it should not panic.
     }
 
@@ -679,7 +812,7 @@ mod tests {
             TelemetryRegistryHandle::new(),
             std::time::Duration::from_secs(10),
         );
-        dispatcher.add_opentelemetry_metric(&field, value, &attributes, &meter);
+        dispatcher.add_opentelemetry_metric(&field, value, &attributes, &meter, "test_scope");
         // Nothing to assert here. Test the function call and it should not panic.
     }
 
@@ -707,7 +840,7 @@ mod tests {
             sum: 0.0,
             count: 0,
         });
-        dispatcher.add_opentelemetry_metric(&field, value, &attributes, &meter);
+        dispatcher.add_opentelemetry_metric(&field, value, &attributes, &meter, "test_scope");
 
         // Test with count == 1
         let value = MetricValue::Mmsc(MmscSnapshot {
@@ -716,7 +849,7 @@ mod tests {
             sum: 5.0,
             count: 1,
         });
-        dispatcher.add_opentelemetry_metric(&field, value, &attributes, &meter);
+        dispatcher.add_opentelemetry_metric(&field, value, &attributes, &meter, "test_scope");
 
         // Test with count == 2
         let value = MetricValue::Mmsc(MmscSnapshot {
@@ -725,7 +858,7 @@ mod tests {
             sum: 10.0,
             count: 2,
         });
-        dispatcher.add_opentelemetry_metric(&field, value, &attributes, &meter);
+        dispatcher.add_opentelemetry_metric(&field, value, &attributes, &meter, "test_scope");
 
         // Test with count >= 3
         let value = MetricValue::Mmsc(MmscSnapshot {
@@ -734,7 +867,7 @@ mod tests {
             sum: 25.0,
             count: 5,
         });
-        dispatcher.add_opentelemetry_metric(&field, value, &attributes, &meter);
+        dispatcher.add_opentelemetry_metric(&field, value, &attributes, &meter, "test_scope");
         // Nothing to assert here. Test the function call and it should not panic.
     }
 
@@ -837,6 +970,287 @@ mod tests {
             found,
             "histogram metric 'latency' not found in exported data"
         );
+    }
+
+    // --- Cumulative counter dispatch tests ---------------------------------
+    //
+    // These cover the observable-counter path for cumulative sums: the
+    // dispatcher publishes the latest total through an SDK async instrument,
+    // and the reader performs the cumulative/delta temporality conversion.
+
+    static CUMULATIVE_METRICS_DESCRIPTOR: MetricsDescriptor = MetricsDescriptor {
+        name: "cumulative_dispatch_test",
+        metrics: &[
+            MetricsField {
+                name: "events_total",
+                unit: "{event}",
+                brief: "lifetime event count",
+                instrument: Instrument::Counter,
+                temporality: Some(Temporality::Cumulative),
+                value_type: MetricValueType::U64,
+            },
+            MetricsField {
+                name: "ticks",
+                unit: "{tick}",
+                brief: "per-interval tick count",
+                instrument: Instrument::Counter,
+                temporality: Some(Temporality::Delta),
+                value_type: MetricValueType::U64,
+            },
+        ],
+    };
+
+    #[derive(Debug, Default)]
+    struct CumulativeMetricSet {
+        events_total: crate::instrument::ObserveCounter<u64>,
+        ticks: crate::instrument::Counter<u64>,
+    }
+
+    impl MetricSetHandler for CumulativeMetricSet {
+        fn descriptor(&self) -> &'static MetricsDescriptor {
+            &CUMULATIVE_METRICS_DESCRIPTOR
+        }
+        fn snapshot_values(&self) -> Vec<MetricValue> {
+            vec![
+                MetricValue::from(self.events_total.get()),
+                MetricValue::from(self.ticks.get()),
+            ]
+        }
+        fn clear_values(&mut self) {
+            // Mirrors the derive macro: delta counters reset, observe
+            // counters keep their last observed total.
+            self.ticks.reset();
+        }
+        fn needs_flush(&self) -> bool {
+            true
+        }
+    }
+
+    /// Returns `(value, is_monotonic)` of the single data point exported for
+    /// the u64 sum named `name` in one collected batch, or `None` if the
+    /// metric is absent from the batch.
+    fn find_u64_sum(rm: &ResourceMetrics, name: &str) -> Option<(u64, bool)> {
+        let mut found = None;
+        for sm in rm.scope_metrics() {
+            for metric in sm.metrics() {
+                if metric.name() == name {
+                    assert!(
+                        found.is_none(),
+                        "expected exactly one metric named '{name}'"
+                    );
+                    let AggregatedMetrics::U64(MetricData::Sum(sum)) = metric.data() else {
+                        panic!("expected metric '{name}' to be exported as a u64 Sum");
+                    };
+                    let data_points: Vec<_> = sum.data_points().collect();
+                    assert_eq!(data_points.len(), 1, "expected one data point for '{name}'");
+                    found = Some((data_points[0].value(), sum.is_monotonic()));
+                }
+            }
+        }
+        found
+    }
+
+    /// Snapshots `metric_set` into the registry, dispatches through
+    /// `meter_provider`, and returns the newly collected batch.
+    fn accumulate_and_collect(
+        registry: &TelemetryRegistryHandle,
+        metric_set: &crate::metrics::MetricSet<CumulativeMetricSet>,
+        dispatcher: &MetricsDispatcher,
+        meter_provider: &SdkMeterProvider,
+        exporter: &InMemoryMetricExporter,
+    ) -> ResourceMetrics {
+        let snapshot = metric_set.snapshot();
+        registry.accumulate_metric_set_snapshot(snapshot.key, &snapshot.metrics);
+        dispatcher
+            .dispatch_metrics_to(meter_provider)
+            .expect("dispatch_metrics_to failed");
+        meter_provider.force_flush().expect("force_flush failed");
+        exporter
+            .get_finished_metrics()
+            .expect("get_finished_metrics failed")
+            .pop()
+            .expect("no batch collected")
+    }
+
+    #[test]
+    fn test_cumulative_counter_exported_as_monotonic_sum() {
+        let registry = TelemetryRegistryHandle::new();
+        let mut metric_set = registry.register_metric_set::<CumulativeMetricSet>(ScopeAttrs {
+            descriptor: &NO_ATTRS_DESCRIPTOR,
+            values: vec![],
+        });
+        let dispatcher =
+            MetricsDispatcher::new(registry.clone(), std::time::Duration::from_secs(1));
+        let exporter = InMemoryMetricExporter::default();
+        let meter_provider = SdkMeterProvider::builder()
+            .with_periodic_exporter(exporter.clone())
+            .build();
+
+        metric_set.events_total.observe(10);
+        metric_set.ticks.add(1);
+        let batch = accumulate_and_collect(
+            &registry,
+            &metric_set,
+            &dispatcher,
+            &meter_provider,
+            &exporter,
+        );
+        let (value, monotonic) = find_u64_sum(&batch, "events_total").expect("metric not exported");
+        assert!(monotonic, "cumulative counter must export as monotonic sum");
+        assert_eq!(value, 10);
+
+        // A later, larger total replaces the previous one; a cumulative
+        // reader must report 25, not a double-counted 35.
+        metric_set.events_total.observe(25);
+        metric_set.ticks.add(1);
+        let batch = accumulate_and_collect(
+            &registry,
+            &metric_set,
+            &dispatcher,
+            &meter_provider,
+            &exporter,
+        );
+        let (value, _) = find_u64_sum(&batch, "events_total").expect("metric not exported");
+        assert_eq!(value, 25, "cumulative total must be replaced, not summed");
+    }
+
+    #[test]
+    fn test_cumulative_counter_honors_delta_reader_temporality() {
+        use opentelemetry_sdk::metrics::InMemoryMetricExporterBuilder;
+
+        let registry = TelemetryRegistryHandle::new();
+        let mut metric_set = registry.register_metric_set::<CumulativeMetricSet>(ScopeAttrs {
+            descriptor: &NO_ATTRS_DESCRIPTOR,
+            values: vec![],
+        });
+        let dispatcher =
+            MetricsDispatcher::new(registry.clone(), std::time::Duration::from_secs(1));
+        let exporter = InMemoryMetricExporterBuilder::new()
+            .with_temporality(opentelemetry_sdk::metrics::Temporality::Delta)
+            .build();
+        let meter_provider = SdkMeterProvider::builder()
+            .with_periodic_exporter(exporter.clone())
+            .build();
+
+        metric_set.events_total.observe(10);
+        let batch = accumulate_and_collect(
+            &registry,
+            &metric_set,
+            &dispatcher,
+            &meter_provider,
+            &exporter,
+        );
+        let (value, _) = find_u64_sum(&batch, "events_total").expect("metric not exported");
+        assert_eq!(
+            value, 10,
+            "first delta observation reports the initial total"
+        );
+
+        metric_set.events_total.observe(25);
+        let batch = accumulate_and_collect(
+            &registry,
+            &metric_set,
+            &dispatcher,
+            &meter_provider,
+            &exporter,
+        );
+        let (value, _) = find_u64_sum(&batch, "events_total").expect("metric not exported");
+        assert_eq!(
+            value, 15,
+            "delta reader must receive the per-interval difference"
+        );
+    }
+
+    #[test]
+    fn test_cumulative_counter_creates_series_on_initial_zero() {
+        let registry = TelemetryRegistryHandle::new();
+        let mut metric_set = registry.register_metric_set::<CumulativeMetricSet>(ScopeAttrs {
+            descriptor: &NO_ATTRS_DESCRIPTOR,
+            values: vec![],
+        });
+        let dispatcher =
+            MetricsDispatcher::new(registry.clone(), std::time::Duration::from_secs(1));
+        let exporter = InMemoryMetricExporter::default();
+        let meter_provider = SdkMeterProvider::builder()
+            .with_periodic_exporter(exporter.clone())
+            .build();
+
+        // The nonzero delta sibling forces a registry visit; the cumulative
+        // counter's first observed total is legitimately zero and should still
+        // create an observable series.
+        metric_set.events_total.observe(0);
+        metric_set.ticks.add(1);
+        let batch = accumulate_and_collect(
+            &registry,
+            &metric_set,
+            &dispatcher,
+            &meter_provider,
+            &exporter,
+        );
+        let (value, monotonic) = find_u64_sum(&batch, "events_total").expect("metric not exported");
+        assert!(monotonic, "cumulative counter must export as monotonic sum");
+        assert_eq!(value, 0);
+
+        // A later nonzero value must update the existing series. The helper
+        // asserts that exactly one metric and data point are exported.
+        metric_set.events_total.observe(7);
+        metric_set.ticks.add(1);
+        let batch = accumulate_and_collect(
+            &registry,
+            &metric_set,
+            &dispatcher,
+            &meter_provider,
+            &exporter,
+        );
+        let (value, _) = find_u64_sum(&batch, "events_total").expect("metric not exported");
+        assert_eq!(value, 7);
+    }
+
+    #[test]
+    fn test_cumulative_counter_ignores_zeroed_registry_values() {
+        let registry = TelemetryRegistryHandle::new();
+        let mut metric_set = registry.register_metric_set::<CumulativeMetricSet>(ScopeAttrs {
+            descriptor: &NO_ATTRS_DESCRIPTOR,
+            values: vec![],
+        });
+        let dispatcher =
+            MetricsDispatcher::new(registry.clone(), std::time::Duration::from_secs(1));
+        let exporter = InMemoryMetricExporter::default();
+        let meter_provider = SdkMeterProvider::builder()
+            .with_periodic_exporter(exporter.clone())
+            .build();
+
+        metric_set.events_total.observe(10);
+        metric_set.ticks.add(1);
+        let batch = accumulate_and_collect(
+            &registry,
+            &metric_set,
+            &dispatcher,
+            &meter_provider,
+            &exporter,
+        );
+        let (value, _) = find_u64_sum(&batch, "events_total").expect("metric not exported");
+        assert_eq!(value, 10);
+
+        // Simulate an interval where only the delta counter was reported:
+        // the registry visit then yields a zero for the cumulative field,
+        // which must not clobber the previously observed total.
+        let snapshot_key = metric_set.snapshot().key;
+        registry.accumulate_metric_set_snapshot(
+            snapshot_key,
+            &[MetricValue::U64(0), MetricValue::U64(1)],
+        );
+        dispatcher
+            .dispatch_metrics_to(&meter_provider)
+            .expect("dispatch_metrics_to failed");
+        meter_provider.force_flush().expect("force_flush failed");
+        let batch = exporter
+            .get_finished_metrics()
+            .expect("get_finished_metrics failed")
+            .pop()
+            .expect("no batch collected");
+        let (value, _) = find_u64_sum(&batch, "events_total").expect("metric not exported");
+        assert_eq!(value, 10, "zeroed registry value must not reset the total");
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/telemetry/src/metrics/dispatcher.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/metrics/dispatcher.rs
@@ -27,9 +27,10 @@ pub struct MetricsDispatcher {
     metrics_handler: TelemetryRegistryHandle,
     reporting_interval: std::time::Duration,
     /// Observable-counter series backing cumulative sums, keyed by scope
-    /// series key, then by metric name. Each series holds the shared value
-    /// read by an SDK callback registered once per series; the SDK reader
-    /// then performs cumulative/delta temporality conversion itself.
+    /// series key, then by metric name. Each series holds one value slot per
+    /// attribute set, shared with an SDK callback registered once per series;
+    /// the SDK reader then performs cumulative/delta temporality conversion
+    /// itself.
     ///
     /// The series currently live for the process lifetime. Naive eviction is
     /// unsafe because dropping these instrument handles does not unregister
@@ -37,57 +38,87 @@ pub struct MetricsDispatcher {
     cumulative_series: Mutex<HashMap<String, HashMap<&'static str, CumulativeCounterSeries>>>,
 }
 
+/// One value slot per attribute set reported for a cumulative series, keyed
+/// by the encoded attribute set. Each slot pairs the attribute list passed to
+/// `observe` with the shared atomic holding the latest total (`f64` totals
+/// store their bit pattern).
+type SlotMap = HashMap<String, (Vec<opentelemetry::KeyValue>, Arc<AtomicU64>)>;
+
 /// Backing state for one exported cumulative counter series.
 ///
-/// The `value` slot is shared with an SDK observable-counter callback that
-/// reports the latest total at every SDK collection. The instrument handle is
-/// retained so the registration lives as long as the series.
+/// The slot map is shared with an SDK observable-counter callback that
+/// reports every slot's latest total at each SDK collection, one data point
+/// per attribute set. Data points carry no attributes today, so the map holds
+/// a single empty-attribute slot, but the shape is ready for datapoint-level
+/// attributes (#3369). The instrument handle is retained so the registration
+/// lives as long as the series.
 enum CumulativeCounterSeries {
     /// Series for a `u64` cumulative counter.
     U64 {
-        value: Arc<AtomicU64>,
+        slots: Arc<Mutex<SlotMap>>,
         _instrument: ObservableCounter<u64>,
     },
-    /// Series for an `f64` cumulative counter; the atomic stores the bit
-    /// pattern of the current value.
+    /// Series for an `f64` cumulative counter; slots store the bit pattern
+    /// of the current value.
     F64 {
-        value: Arc<AtomicU64>,
+        slots: Arc<Mutex<SlotMap>>,
         _instrument: ObservableCounter<f64>,
     },
 }
 
 impl CumulativeCounterSeries {
-    fn build(field: &MetricsField, initial: MetricValue, meter: &Meter) -> Self {
+    fn initial_slots(
+        attr_key: &str,
+        attributes: &[opentelemetry::KeyValue],
+        raw: u64,
+    ) -> Arc<Mutex<SlotMap>> {
+        Arc::new(Mutex::new(HashMap::from([(
+            attr_key.to_owned(),
+            (attributes.to_vec(), Arc::new(AtomicU64::new(raw))),
+        )])))
+    }
+
+    fn build(
+        field: &MetricsField,
+        initial: MetricValue,
+        attributes: &[opentelemetry::KeyValue],
+        attr_key: &str,
+        meter: &Meter,
+    ) -> Self {
         match initial {
             MetricValue::U64(v) => {
-                let value = Arc::new(AtomicU64::new(v));
-                let observed = Arc::clone(&value);
+                let slots = Self::initial_slots(attr_key, attributes, v);
+                let observed = Arc::clone(&slots);
                 let instrument = meter
                     .u64_observable_counter(field.name)
                     .with_description(field.brief)
                     .with_unit(field.unit)
                     .with_callback(move |observer| {
-                        observer.observe(observed.load(Ordering::Relaxed), &[]);
+                        for (attrs, slot) in observed.lock().values() {
+                            observer.observe(slot.load(Ordering::Relaxed), attrs);
+                        }
                     })
                     .build();
                 Self::U64 {
-                    value,
+                    slots,
                     _instrument: instrument,
                 }
             }
             MetricValue::F64(v) => {
-                let value = Arc::new(AtomicU64::new(v.to_bits()));
-                let observed = Arc::clone(&value);
+                let slots = Self::initial_slots(attr_key, attributes, v.to_bits());
+                let observed = Arc::clone(&slots);
                 let instrument = meter
                     .f64_observable_counter(field.name)
                     .with_description(field.brief)
                     .with_unit(field.unit)
                     .with_callback(move |observer| {
-                        observer.observe(f64::from_bits(observed.load(Ordering::Relaxed)), &[]);
+                        for (attrs, slot) in observed.lock().values() {
+                            observer.observe(f64::from_bits(slot.load(Ordering::Relaxed)), attrs);
+                        }
                     })
                     .build();
                 Self::F64 {
-                    value,
+                    slots,
                     _instrument: instrument,
                 }
             }
@@ -95,18 +126,31 @@ impl CumulativeCounterSeries {
         }
     }
 
-    fn store(&self, value: MetricValue) {
-        match (self, value) {
-            (Self::U64 { value: slot, .. }, MetricValue::U64(v)) => {
-                slot.store(v, Ordering::Relaxed);
+    /// Records `value` in the slot identified by `attr_key`, creating the
+    /// slot on first sight (even at zero). Zero updates to an existing slot
+    /// are skipped; see [`MetricsDispatcher::observe_cumulative_counter`].
+    fn observe(&self, value: MetricValue, attributes: &[opentelemetry::KeyValue], attr_key: &str) {
+        let (slots, raw) = match (self, value) {
+            (Self::U64 { slots, .. }, MetricValue::U64(v)) => (slots, v),
+            (Self::F64 { slots, .. }, MetricValue::F64(v)) => (slots, v.to_bits()),
+            _ => {
+                debug_assert!(
+                    false,
+                    "metric value type must not change between dispatches"
+                );
+                return;
             }
-            (Self::F64 { value: slot, .. }, MetricValue::F64(v)) => {
-                slot.store(v.to_bits(), Ordering::Relaxed);
+        };
+        let mut slots = slots.lock();
+        if let Some((_, slot)) = slots.get(attr_key) {
+            if !value.is_zero() {
+                slot.store(raw, Ordering::Relaxed);
             }
-            _ => debug_assert!(
-                false,
-                "metric value type must not change between dispatches"
-            ),
+        } else {
+            let _ = slots.insert(
+                attr_key.to_owned(),
+                (attributes.to_vec(), Arc::new(AtomicU64::new(raw))),
+            );
         }
     }
 }
@@ -206,14 +250,21 @@ impl MetricsDispatcher {
         opentelemetry::KeyValue::new(key.to_string(), otel_value)
     }
 
-    /// Builds a stable identifier for the series cache from the scope name and
-    /// its entity attributes (which are fixed for a registered metric set).
-    fn scope_series_key(scope_name: &str, attributes: &[opentelemetry::KeyValue]) -> String {
+    /// Encodes an attribute list into a stable map key.
+    fn attr_set_key(attributes: &[opentelemetry::KeyValue]) -> String {
         use std::fmt::Write;
-        let mut key = String::from(scope_name);
+        let mut key = String::new();
         for kv in attributes {
             let _ = write!(key, "\u{1f}{}\u{1f}{}", kv.key, kv.value);
         }
+        key
+    }
+
+    /// Builds a stable identifier for the series cache from the scope name and
+    /// its entity attributes (which are fixed for a registered metric set).
+    fn scope_series_key(scope_name: &str, attributes: &[opentelemetry::KeyValue]) -> String {
+        let mut key = String::from(scope_name);
+        key.push_str(&Self::attr_set_key(attributes));
         key
     }
 
@@ -231,7 +282,7 @@ impl MetricsDispatcher {
                     self.add_opentelemetry_counter(field, value, attributes, meter)
                 }
                 Some(Temporality::Cumulative) => {
-                    self.observe_cumulative_counter(field, value, meter, scope_key)
+                    self.observe_cumulative_counter(field, value, attributes, meter, scope_key)
                 }
                 None => {
                     debug_assert!(false, "sum-like instrument must have a temporality");
@@ -303,27 +354,29 @@ impl MetricsDispatcher {
     /// cumulative/delta temporality conversion.
     ///
     /// The observable instrument and its callback are created once per series
-    /// and cached; later dispatches only update the shared value slot.
+    /// and cached; later dispatches only update the value slot matching the
+    /// data-point attribute set (one slot per attribute set, so the series
+    /// stays correct when datapoint-level attributes arrive with #3369).
     ///
-    /// Zero updates to existing series are skipped: the registry zeroes
+    /// Zero updates to an existing slot are skipped: the registry zeroes
     /// accumulated values after every visit, so a zero for an already-created
-    /// monotonic series means "no fresh observation this interval". Initial
-    /// zero values still create a series so readers can observe a legitimate
+    /// monotonic slot means "no fresh observation this interval". Initial
+    /// zero values still create the slot so readers can observe a legitimate
     /// zero starting total.
     fn observe_cumulative_counter(
         &self,
         field: &MetricsField,
         value: MetricValue,
+        attributes: &[opentelemetry::KeyValue],
         meter: &Meter,
         scope_key: &str,
     ) {
+        let attr_key = Self::attr_set_key(attributes);
         let mut scopes = self.cumulative_series.lock();
         if let Some(series) = scopes.get(scope_key).and_then(|s| s.get(field.name)) {
-            if !value.is_zero() {
-                series.store(value);
-            }
+            series.observe(value, attributes, &attr_key);
         } else {
-            let series = CumulativeCounterSeries::build(field, value, meter);
+            let series = CumulativeCounterSeries::build(field, value, attributes, &attr_key, meter);
             let _ = scopes
                 .entry(scope_key.to_owned())
                 .or_default()
@@ -1204,6 +1257,71 @@ mod tests {
         );
         let (value, _) = find_u64_sum(&batch, "events_total").expect("metric not exported");
         assert_eq!(value, 7);
+    }
+
+    /// Drives the cumulative path directly with distinct data-point attribute
+    /// sets (the registry cannot yield them yet; see #3369) and verifies each
+    /// set gets its own slot and data point under a single instrument.
+    #[test]
+    fn test_cumulative_counter_reports_one_data_point_per_attribute_set() {
+        let exporter = InMemoryMetricExporter::default();
+        let meter_provider = SdkMeterProvider::builder()
+            .with_periodic_exporter(exporter.clone())
+            .build();
+        let meter = meter_provider.meter("dp_attr_dispatch_test");
+        let field = MetricsField {
+            name: "events_total",
+            unit: "{event}",
+            brief: "lifetime event count",
+            instrument: Instrument::Counter,
+            temporality: Some(Temporality::Cumulative),
+            value_type: MetricValueType::U64,
+        };
+        let dispatcher = MetricsDispatcher::new(
+            TelemetryRegistryHandle::new(),
+            std::time::Duration::from_secs(1),
+        );
+
+        let logs = [opentelemetry::KeyValue::new("signal", "logs")];
+        let traces = [opentelemetry::KeyValue::new("signal", "traces")];
+        dispatcher.add_opentelemetry_metric(&field, MetricValue::U64(10), &logs, &meter, "dp");
+        dispatcher.add_opentelemetry_metric(&field, MetricValue::U64(4), &traces, &meter, "dp");
+        // A later total must land in the slot matching its attribute set.
+        dispatcher.add_opentelemetry_metric(&field, MetricValue::U64(25), &logs, &meter, "dp");
+        meter_provider.force_flush().expect("force_flush failed");
+
+        let batch = exporter
+            .get_finished_metrics()
+            .expect("get_finished_metrics failed")
+            .pop()
+            .expect("no batch collected");
+        let mut points = Vec::new();
+        for sm in batch.scope_metrics() {
+            for metric in sm.metrics() {
+                if metric.name() == "events_total" {
+                    let AggregatedMetrics::U64(MetricData::Sum(sum)) = metric.data() else {
+                        panic!("expected a u64 Sum");
+                    };
+                    assert!(sum.is_monotonic());
+                    for dp in sum.data_points() {
+                        let signal = dp
+                            .attributes()
+                            .find(|kv| kv.key.as_str() == "signal")
+                            .map(|kv| kv.value.to_string());
+                        points.push((signal, dp.value()));
+                    }
+                }
+            }
+        }
+        points.sort();
+        assert_eq!(
+            points,
+            vec![
+                (Some("logs".to_string()), 25),
+                (Some("traces".to_string()), 4),
+            ],
+            "each attribute set must report its own slot"
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Change Summary

Self-telemetry cumulative sum-like instruments (`ObserveCounter`) were exported as gauges by the metrics dispatcher — a documented workaround to avoid double-counting through the SDK's synchronous counter API. As a result, the metrics reader's requested temporality was ignored, and operators could not obtain per-interval values for metrics such as the durable buffer's aggregate loss counters (`dropped_bundles`, `dropped_items`, `expired_bundles`, `expired_items`).

This PR implements the issue's preferred option (1): the dispatcher now routes cumulative counters through real SDK **asynchronous observable counters**. Each series gets one observable instrument (created once and cached, keyed by instrumentation scope + metric name) whose callback reports the latest total from a shared atomic slot; the SDK reader then performs the cumulative/delta temporality conversion itself, per spec.

Design notes:

* **Zero-valued visits are skipped.** The registry zeroes accumulated values after every visit, so a zero at dispatch time means "no fresh observation this interval", not an actual total of zero (a monotonic total never returns to zero within a process lifetime). The previously observed total simply remains visible to the reader.
* **Cumulative up-down counters keep the gauge fallback.** Unlike a monotonic total, a legitimate up-down value of zero (e.g. `task_active_count`, queue sizes) cannot be distinguished from a zeroed registry slot, so routing them through observable up-down counters needs registry-level support first (e.g. persisting cumulative slots across visits instead of zeroing). The code comment on that branch now explains this instead of calling it a temporary workaround. Happy to file a follow-up issue.
* The stale NOTE in `durable_buffer_processor` (which tracked this dispatcher fix as a follow-up) is updated: with a delta reader, the aggregate loss counters now align with their per-signal delta `Counter` breakdowns.

## What issue does this PR close?

* Closes #3397

## How are these changes tested?

New end-to-end tests in `crates/telemetry/src/metrics/dispatcher.rs` drive the real `dispatch_metrics_to` path against dedicated in-memory meter providers (no global state, parallel-safe):

* `test_cumulative_counter_exported_as_monotonic_sum` — cumulative reader: exported as a **monotonic Sum** (not a gauge), and a later total of 25 after 10 reports 25, not a double-counted 35.
* `test_cumulative_counter_honors_delta_reader_temporality` — delta reader: successive totals 10 → 25 export per-interval values 10 → 15.
* `test_cumulative_counter_ignores_zeroed_registry_values` — an interval where only a sibling delta counter was reported (registry yields zero for the cumulative field) does not reset the exported total.

`cargo test -p otap-df-telemetry` (140 tests), `cargo clippy -p otap-df-telemetry --all-targets`, and `cargo check -p otap-df-core-nodes` all pass.

## Are there any user-facing changes?

Yes: self-telemetry metrics declared as `ObserveCounter` are now exported as asynchronous monotonic sums instead of gauges, and honor the configured reader temporality. Backends that previously stored these series as gauges will see the instrument type change (e.g. Prometheus will now treat them as counters).

### Changelog

* [x] Added a `.chloggen/*.yaml` entry
* [ ] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)