### PR TITLE
chore(deny): ignore RUSTSEC-2026-0194/0195 pending object_store upgrade

### DIFF
--- a/rust/otap-dataflow/deny.toml
+++ b/rust/otap-dataflow/deny.toml
@@ -76,6 +76,8 @@ ignore = [
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
     { id="RUSTSEC-2024-0436", reason="unmaintained `paste` crate is a dependency of parquet"},
     { id="RUSTSEC-2021-0127", reason="`serde_cbor` is archived, but current implementation meets needs" },
+    { id="RUSTSEC-2026-0194", reason="`quick-xml` <0.41 DoS via crafted untrusted XML; pulled transitively via datafusion → object_store. Fix merged upstream (apache/arrow-rs-object-store#785, 2026-07-02) but not yet in a released version. Remove once a new `object_store` (>0.14.0) is available."},
+    { id="RUSTSEC-2026-0195", reason="`quick-xml` <0.41 DoS via unbounded namespace-declaration allocation in `NsReader`. Same transitive path and fix as RUSTSEC-2026-0194."},
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.


### PR DESCRIPTION
Ignores `RUSTSEC-2026-0194` and `RUSTSEC-2026-0195` (both `quick-xml` <0.41 DoS) pulled in transitively via `datafusion` → `object_store`. Upstream fix already merged (apache/arrow-rs-object-store#785) but not yet released; `object_store 0.14.0` still pins `quick-xml ^0.40.1`. Unblocks all open PRs. Follows existing precedent (`RUSTSEC-2024-0436`, `RUSTSEC-2021-0127`).