### PR TITLE
feat(contrib-extensions): Add Azure Identity Auth extension

### DIFF
--- a/rust/otap-dataflow/.chloggen/azure-identity-auth-extension.yaml
+++ b/rust/otap-dataflow/.chloggen/azure-identity-auth-extension.yaml
@@ -1,0 +1,18 @@
+change_type: new_component
+
+component: pipeline
+
+note: Add the `azure_identity_auth` extension, a `BearerTokenProvider` backed by Azure identity flows.
+
+issues: [3356]
+
+subtext: |
+  New `otap-df-contrib-extensions` crate (feature `azure-identity-auth-extension`,
+  URN `urn:microsoft:extension:azure_identity_auth`) that acquires and refreshes
+  Azure access tokens and exposes them to data-path nodes via the shared
+  `BearerTokenProvider` capability. Supports Managed Identity, developer tooling
+  (`development`), and Workload Identity Federation auth methods. Tokens are
+  cached and refreshed ahead of expiry in a background task, concurrent cache
+  misses are coalesced onto a single credential call, and the extension gates
+  pipeline startup on the first successful token publish. Emits success/failure/
+  publish counters and acquisition-latency telemetry.

--- a/rust/otap-dataflow/Cargo.lock
+++ b/rust/otap-dataflow/Cargo.lock
@@ -6219,6 +6219,7 @@ dependencies = [
  "azure_core 1.0.0",
  "azure_identity 1.0.0",
  "futures",
+ "humantime-serde",
  "linkme",
  "otap-df-config",
  "otap-df-engine",
@@ -6230,7 +6231,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tracing",
 ]
 
 [[package]]

--- a/rust/otap-dataflow/Cargo.lock
+++ b/rust/otap-dataflow/Cargo.lock
@@ -6120,6 +6120,7 @@ dependencies = [
  "dhat",
  "mimalloc",
  "otap-df-config",
+ "otap-df-contrib-extensions",
  "otap-df-contrib-nodes",
  "otap-df-controller",
  "otap-df-core-nodes",
@@ -6208,6 +6209,28 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "wiremock",
+]
+
+[[package]]
+name = "otap-df-contrib-extensions"
+version = "0.49.0"
+dependencies = [
+ "async-trait",
+ "azure_core 1.0.0",
+ "azure_identity 1.0.0",
+ "futures",
+ "linkme",
+ "otap-df-config",
+ "otap-df-engine",
+ "otap-df-otap",
+ "otap-df-telemetry",
+ "otap-df-telemetry-macros",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
 ]
 
 [[package]]

--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -31,6 +31,7 @@ path = "src/main.rs"
 
 [dependencies]
 otap-df-config.workspace = true
+otap-df-contrib-extensions.workspace = true
 otap-df-contrib-nodes.workspace = true
 otap-df-controller.workspace = true
 otap-df-core-nodes.workspace = true
@@ -50,6 +51,7 @@ otap-df-admin-types = { path = "crates/admin-types" }
 otap-df-pdata-otlp-macros = { path = "./crates/pdata/src/otlp/macros"}
 otap-df-pdata-otlp-model = { path = "./crates/pdata/src/otlp/model"}
 otap-df-config = { path = "crates/config" }
+otap-df-contrib-extensions = { path = "crates/contrib-extensions" }
 otap-df-contrib-nodes = { path = "crates/contrib-nodes" }
 otap-df-control-channel = { path = "crates/control-channel" }
 otap-df-controller = { path = "crates/controller" }
@@ -300,6 +302,9 @@ crypto-openssl = ["otap-df-otap/crypto-openssl"]
 contrib-exporters = ["otap-df-contrib-nodes/contrib-exporters"]
 geneva-exporter = ["otap-df-contrib-nodes/geneva-exporter"]
 azure-monitor-exporter = ["otap-df-contrib-nodes/azure-monitor-exporter"]
+# Contrib extensions (opt-in) - in contrib-extensions
+contrib-extensions = ["otap-df-contrib-extensions/contrib-extensions"]
+azure-identity-auth-extension = ["otap-df-contrib-extensions/azure-identity-auth-extension"]
 # Contrib receivers (opt-in) - now in contrib-nodes
 contrib-receivers = ["otap-df-contrib-nodes/contrib-receivers"]
 user_events-receiver = ["otap-df-contrib-nodes/user_events-receiver"]

--- a/rust/otap-dataflow/crates/contrib-extensions/Cargo.toml
+++ b/rust/otap-dataflow/crates/contrib-extensions/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "otap-df-contrib-extensions"
+description = "OTAP Contrib extensions"
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+publish.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+serde.workspace = true
+thiserror.workspace = true
+azure_core = { workspace = true, optional = true }
+
+[features]
+# Umbrella feature enabling all contrib extensions.
+contrib-extensions = ["azure-identity-auth-extension"]
+# Azure Identity authentication extension (BearerTokenProvider capability).
+azure-identity-auth-extension = ["dep:azure_core"]

--- a/rust/otap-dataflow/crates/contrib-extensions/Cargo.toml
+++ b/rust/otap-dataflow/crates/contrib-extensions/Cargo.toml
@@ -38,4 +38,5 @@ azure-identity-auth-extension = ["dep:azure_core", "dep:azure_identity"]
 
 [dev-dependencies]
 otap-df-engine = { workspace = true, features = ["test-utils"] }
+otap-df-otap = { workspace = true, features = ["crypto-ring"] }
 tokio = { workspace = true, features = ["test-util"] }

--- a/rust/otap-dataflow/crates/contrib-extensions/Cargo.toml
+++ b/rust/otap-dataflow/crates/contrib-extensions/Cargo.toml
@@ -13,8 +13,20 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
+# Workspace crates
+otap-df-config = { workspace = true }
+otap-df-engine = { workspace = true }
+otap-df-otap = { workspace = true }
+
+async-trait.workspace = true
+futures.workspace = true
+linkme.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 thiserror.workspace = true
+tokio.workspace = true
+tokio-stream.workspace = true
+tracing.workspace = true
 azure_core = { workspace = true, optional = true }
 
 [features]
@@ -22,3 +34,7 @@ azure_core = { workspace = true, optional = true }
 contrib-extensions = ["azure-identity-auth-extension"]
 # Azure Identity authentication extension (BearerTokenProvider capability).
 azure-identity-auth-extension = ["dep:azure_core"]
+
+[dev-dependencies]
+otap-df-engine = { workspace = true, features = ["test-utils"] }
+tokio = { workspace = true, features = ["test-util"] }

--- a/rust/otap-dataflow/crates/contrib-extensions/Cargo.toml
+++ b/rust/otap-dataflow/crates/contrib-extensions/Cargo.toml
@@ -28,15 +28,15 @@ serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
-tracing.workspace = true
 azure_core = { workspace = true, optional = true, features = ["reqwest"] }
 azure_identity = { workspace = true, optional = true }
+humantime-serde = { workspace = true, optional = true }
 
 [features]
 # Umbrella feature enabling all contrib extensions.
 contrib-extensions = ["azure-identity-auth-extension"]
 # Azure Identity authentication extension (BearerTokenProvider capability).
-azure-identity-auth-extension = ["dep:azure_core", "dep:azure_identity"]
+azure-identity-auth-extension = ["dep:azure_core", "dep:azure_identity", "dep:humantime-serde"]
 
 [dev-dependencies]
 otap-df-engine = { workspace = true, features = ["test-utils"] }

--- a/rust/otap-dataflow/crates/contrib-extensions/Cargo.toml
+++ b/rust/otap-dataflow/crates/contrib-extensions/Cargo.toml
@@ -27,13 +27,14 @@ thiserror.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
 tracing.workspace = true
-azure_core = { workspace = true, optional = true }
+azure_core = { workspace = true, optional = true, features = ["reqwest"] }
+azure_identity = { workspace = true, optional = true }
 
 [features]
 # Umbrella feature enabling all contrib extensions.
 contrib-extensions = ["azure-identity-auth-extension"]
 # Azure Identity authentication extension (BearerTokenProvider capability).
-azure-identity-auth-extension = ["dep:azure_core"]
+azure-identity-auth-extension = ["dep:azure_core", "dep:azure_identity"]
 
 [dev-dependencies]
 otap-df-engine = { workspace = true, features = ["test-utils"] }

--- a/rust/otap-dataflow/crates/contrib-extensions/Cargo.toml
+++ b/rust/otap-dataflow/crates/contrib-extensions/Cargo.toml
@@ -17,6 +17,8 @@ workspace = true
 otap-df-config = { workspace = true }
 otap-df-engine = { workspace = true }
 otap-df-otap = { workspace = true }
+otap-df-telemetry = { workspace = true }
+otap-df-telemetry-macros = { workspace = true }
 
 async-trait.workspace = true
 futures.workspace = true

--- a/rust/otap-dataflow/crates/contrib-extensions/README.md
+++ b/rust/otap-dataflow/crates/contrib-extensions/README.md
@@ -22,14 +22,3 @@ Extensions are enabled through individual feature gates or the aggregate
 `contrib-extensions` feature gate. An extension documented as `Experimental`,
 `Alpha`, or `Draft` has no stable compatibility guarantee yet, and its behavior
 or configuration can change between releases.
-
-## Crypto provider requirement
-
-The Azure Identity Auth extension talks to Azure over TLS via the Azure SDK's
-`reqwest`/`rustls` client, which requires a process-wide `rustls` crypto
-provider to be installed. The deployed binary **must** enable exactly one
-`crypto-*` feature (`crypto-ring`, `crypto-aws-lc`, `crypto-openssl`, or
-`crypto-symcrypt`, forwarded to `otap-df-otap`); the workspace binary's default
-build includes `crypto-ring`. A build that enables
-`azure-identity-auth-extension` without any `crypto-*` feature installs no
-provider, and token acquisition panics at runtime with "No provider set".

--- a/rust/otap-dataflow/crates/contrib-extensions/README.md
+++ b/rust/otap-dataflow/crates/contrib-extensions/README.md
@@ -22,3 +22,14 @@ Extensions are enabled through individual feature gates or the aggregate
 `contrib-extensions` feature gate. An extension documented as `Experimental`,
 `Alpha`, or `Draft` has no stable compatibility guarantee yet, and its behavior
 or configuration can change between releases.
+
+## Crypto provider requirement
+
+The Azure Identity Auth extension talks to Azure over TLS via the Azure SDK's
+`reqwest`/`rustls` client, which requires a process-wide `rustls` crypto
+provider to be installed. The deployed binary **must** enable exactly one
+`crypto-*` feature (`crypto-ring`, `crypto-aws-lc`, `crypto-openssl`, or
+`crypto-symcrypt`, forwarded to `otap-df-otap`); the workspace binary's default
+build includes `crypto-ring`. A build that enables
+`azure-identity-auth-extension` without any `crypto-*` feature installs no
+provider, and token acquisition panics at runtime with "No provider set".

--- a/rust/otap-dataflow/crates/contrib-extensions/README.md
+++ b/rust/otap-dataflow/crates/contrib-extensions/README.md
@@ -1,0 +1,24 @@
+<!-- markdownlint-disable MD013 -->
+
+# Contrib Extensions
+
+Contrib extensions are optional, feature-gated extensions that extend the
+default OTel Arrow Dataflow Engine build. Extensions provide cross-cutting
+capabilities (such as authentication) that data-path nodes bind to via their
+`capabilities:` map, rather than processing pipeline data themselves.
+
+For help writing runtime YAML, start at
+[`docs/configuration.md`](../../docs/configuration.md). For exact runtime
+configuration semantics, see
+[`docs/configuration-model.md`](../../docs/configuration-model.md).
+
+## Extensions
+
+| Extension | URN | Feature gate | Capability | Docs |
+| --- | --- | --- | --- | --- |
+| Azure Identity Auth | `urn:microsoft:extension:azure_identity_auth` | `azure-identity-auth-extension` | `bearer_token_provider` | [`docs/azure-identity-auth-extension.md`](../../docs/azure-identity-auth-extension.md) |
+
+Extensions are enabled through individual feature gates or the aggregate
+`contrib-extensions` feature gate. An extension documented as `Experimental`,
+`Alpha`, or `Draft` has no stable compatibility guarantee yet, and its behavior
+or configuration can change between releases.

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/README.md
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/README.md
@@ -1,0 +1,33 @@
+<!-- markdownlint-disable MD013 -->
+
+# Azure Identity Auth Extension
+
+**Status:** Draft
+
+| | |
+| --- | --- |
+| **URN** | `urn:microsoft:extension:azure_identity_auth` |
+| **Feature gate** | `azure-identity-auth-extension` |
+| **Capability** | `bearer_token_provider` |
+| **Execution model** | Active + Shared |
+
+Acquires and refreshes Azure OAuth access tokens via the `azure_identity` SDK
+and exposes them to data-path nodes through the `BearerTokenProvider`
+capability, so nodes never construct credentials or manage token refresh
+themselves. Supported flows: Managed Identity, developer tooling, and Workload
+Identity Federation.
+
+For the full design -- problem, goals, lifecycle, configuration reference, and
+security considerations -- see
+[`docs/azure-identity-auth-extension.md`](../../../../docs/azure-identity-auth-extension.md).
+
+## Crypto provider requirement
+
+The Azure Identity Auth extension talks to Azure over TLS via the Azure SDK's
+`reqwest`/`rustls` client, which requires a process-wide `rustls` crypto
+provider to be installed. The deployed binary **must** enable exactly one
+`crypto-*` feature (`crypto-ring`, `crypto-aws-lc`, `crypto-openssl`, or
+`crypto-symcrypt`, forwarded to `otap-df-otap`); the workspace binary's default
+build includes `crypto-ring`. A build that enables
+`azure-identity-auth-extension` without any `crypto-*` feature installs no
+provider, and token acquisition panics at runtime with "No provider set".

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/auth.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/auth.rs
@@ -48,7 +48,10 @@ impl Auth {
             .map_err(|source| Error::TokenAcquisition { source })?;
 
         let expires_on = instant_from_unix_expiry(access.expires_on);
-        Ok(BearerToken::new(access.token.secret().to_owned(), expires_on))
+        Ok(BearerToken::new(
+            access.token.secret().to_owned(),
+            expires_on,
+        ))
     }
 
     /// Builds an `Auth` from an already-constructed credential. Test-only.

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/auth.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/auth.rs
@@ -1,0 +1,28 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Azure credential construction and token acquisition.
+
+use otap_df_engine::capability::BearerToken;
+
+use super::config::Config;
+use super::error::Error;
+
+/// Acquires Azure access tokens for a configured scope.
+///
+/// This is a placeholder: it returns a fixed, non-expiring token so the
+/// extension skeleton can run end-to-end. The real Azure credential
+/// construction and token acquisition are added in a later change.
+pub struct Auth;
+
+impl Auth {
+    /// Builds an `Auth` from the extension configuration.
+    pub fn new(_config: &Config) -> Result<Self, Error> {
+        Ok(Self)
+    }
+
+    /// Acquires a single token (no retries).
+    pub async fn get_token(&self) -> Result<BearerToken, Error> {
+        Ok(BearerToken::new("stub-token".to_owned(), None))
+    }
+}

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/auth.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/auth.rs
@@ -10,7 +10,8 @@ use azure_core::credentials::{TokenCredential, TokenRequestOptions};
 use azure_core::time::OffsetDateTime;
 use azure_identity::{
     DeveloperToolsCredential, DeveloperToolsCredentialOptions, ManagedIdentityCredential,
-    ManagedIdentityCredentialOptions, UserAssignedId,
+    ManagedIdentityCredentialOptions, UserAssignedId, WorkloadIdentityCredential,
+    WorkloadIdentityCredentialOptions,
 };
 use otap_df_engine::capability::BearerToken;
 
@@ -91,13 +92,20 @@ fn create_credential(config: &Config) -> Result<Arc<dyn TokenCredential>, Error>
                     })?;
             Ok(cred)
         }
-        // Implemented in a later change.
-        method @ AuthMethod::WorkloadIdentity => Err(Error::CreateCredential {
-            method,
-            source: azure_core::error::Error::with_message(
-                azure_core::error::ErrorKind::Other,
-                "auth method not yet supported",
-            ),
-        }),
+        AuthMethod::WorkloadIdentity => {
+            let options = WorkloadIdentityCredentialOptions {
+                client_id: config.client_id.clone(),
+                tenant_id: config.tenant_id.clone(),
+                token_file_path: config.token_file_path.clone(),
+                ..Default::default()
+            };
+            let cred = WorkloadIdentityCredential::new(Some(options)).map_err(|source| {
+                Error::CreateCredential {
+                    method: AuthMethod::WorkloadIdentity,
+                    source,
+                }
+            })?;
+            Ok(cred)
+        }
     }
 }

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/auth.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/auth.rs
@@ -8,7 +8,10 @@ use std::time::{Duration, Instant};
 
 use azure_core::credentials::{TokenCredential, TokenRequestOptions};
 use azure_core::time::OffsetDateTime;
-use azure_identity::{ManagedIdentityCredential, ManagedIdentityCredentialOptions, UserAssignedId};
+use azure_identity::{
+    DeveloperToolsCredential, DeveloperToolsCredentialOptions, ManagedIdentityCredential,
+    ManagedIdentityCredentialOptions, UserAssignedId,
+};
 use otap_df_engine::capability::BearerToken;
 
 use super::config::{AuthMethod, Config};
@@ -79,15 +82,22 @@ fn create_credential(config: &Config) -> Result<Arc<dyn TokenCredential>, Error>
             })?;
             Ok(cred)
         }
-        // Implemented in later changes.
-        method @ (AuthMethod::Development | AuthMethod::WorkloadIdentity) => {
-            Err(Error::CreateCredential {
-                method,
-                source: azure_core::error::Error::with_message(
-                    azure_core::error::ErrorKind::Other,
-                    "auth method not yet supported",
-                ),
-            })
+        AuthMethod::Development => {
+            let cred =
+                DeveloperToolsCredential::new(Some(DeveloperToolsCredentialOptions::default()))
+                    .map_err(|source| Error::CreateCredential {
+                        method: AuthMethod::Development,
+                        source,
+                    })?;
+            Ok(cred)
         }
+        // Implemented in a later change.
+        method @ AuthMethod::WorkloadIdentity => Err(Error::CreateCredential {
+            method,
+            source: azure_core::error::Error::with_message(
+                azure_core::error::ErrorKind::Other,
+                "auth method not yet supported",
+            ),
+        }),
     }
 }

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/auth.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/auth.rs
@@ -4,10 +4,8 @@
 //! Azure credential construction and token acquisition.
 
 use std::sync::Arc;
-use std::time::{Duration, Instant};
 
 use azure_core::credentials::{TokenCredential, TokenRequestOptions};
-use azure_core::time::OffsetDateTime;
 use azure_identity::{
     DeveloperToolsCredential, DeveloperToolsCredentialOptions, ManagedIdentityCredential,
     ManagedIdentityCredentialOptions, UserAssignedId, WorkloadIdentityCredential,
@@ -47,10 +45,11 @@ impl Auth {
             .await
             .map_err(|source| Error::TokenAcquisition { source })?;
 
-        let expires_on = instant_from_unix_expiry(access.expires_on);
-        Ok(BearerToken::new(
+        // Let the capability crate centralize the absolute-expiry -> monotonic
+        // `Instant` conversion so every provider handles it the same way.
+        Ok(BearerToken::from_absolute_expiry(
             access.token.secret().to_owned(),
-            expires_on,
+            access.expires_on.into(),
         ))
     }
 
@@ -59,15 +58,6 @@ impl Auth {
     pub(crate) fn from_credential(credential: Arc<dyn TokenCredential>, scope: String) -> Self {
         Self { credential, scope }
     }
-}
-
-/// Converts an absolute UNIX expiry timestamp into a monotonic [`Instant`]
-/// anchored at "now". After this single conversion the schedule is immune to
-/// wall-clock jumps. Saturates at zero for already-expired timestamps.
-fn instant_from_unix_expiry(expires_on: OffsetDateTime) -> Option<Instant> {
-    let now_unix = OffsetDateTime::now_utc().unix_timestamp();
-    let secs_until_expiry = expires_on.unix_timestamp().saturating_sub(now_unix).max(0);
-    Some(Instant::now() + Duration::from_secs(secs_until_expiry as u64))
 }
 
 /// Constructs an Azure credential for the configured authentication method.

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/auth.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/auth.rs
@@ -46,6 +46,12 @@ impl Auth {
         let expires_on = instant_from_unix_expiry(access.expires_on);
         Ok(BearerToken::new(access.token.secret().to_owned(), expires_on))
     }
+
+    /// Builds an `Auth` from an already-constructed credential. Test-only.
+    #[cfg(test)]
+    pub(crate) fn from_credential(credential: Arc<dyn TokenCredential>, scope: String) -> Self {
+        Self { credential, scope }
+    }
 }
 
 /// Converts an absolute UNIX expiry timestamp into a monotonic [`Instant`]

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/auth.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/auth.rs
@@ -3,26 +3,85 @@
 
 //! Azure credential construction and token acquisition.
 
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use azure_core::credentials::{TokenCredential, TokenRequestOptions};
+use azure_core::time::OffsetDateTime;
+use azure_identity::{ManagedIdentityCredential, ManagedIdentityCredentialOptions, UserAssignedId};
 use otap_df_engine::capability::BearerToken;
 
-use super::config::Config;
+use super::config::{AuthMethod, Config};
 use super::error::Error;
 
-/// Acquires Azure access tokens for a configured scope.
-///
-/// This is a placeholder: it returns a fixed, non-expiring token so the
-/// extension skeleton can run end-to-end. The real Azure credential
-/// construction and token acquisition are added in a later change.
-pub struct Auth;
+/// Wraps an Azure credential plus the scope it acquires tokens for.
+#[derive(Clone)]
+pub struct Auth {
+    credential: Arc<dyn TokenCredential>,
+    scope: String,
+}
 
 impl Auth {
     /// Builds an `Auth` from the extension configuration.
-    pub fn new(_config: &Config) -> Result<Self, Error> {
-        Ok(Self)
+    pub fn new(config: &Config) -> Result<Self, Error> {
+        // Azure credentials use a `reqwest`/`rustls` HTTP client, which requires
+        // a process-wide crypto provider to be installed.
+        otap_df_otap::crypto::ensure_crypto_provider();
+        let credential = create_credential(config)?;
+        Ok(Self {
+            credential,
+            scope: config.scope.clone(),
+        })
     }
 
-    /// Acquires a single token (no retries).
+    /// Acquires a single token (no retries) and converts it into a
+    /// [`BearerToken`].
     pub async fn get_token(&self) -> Result<BearerToken, Error> {
-        Ok(BearerToken::new("stub-token".to_owned(), None))
+        let access = self
+            .credential
+            .get_token(&[&self.scope], Some(TokenRequestOptions::default()))
+            .await
+            .map_err(|source| Error::TokenAcquisition { source })?;
+
+        let expires_on = instant_from_unix_expiry(access.expires_on);
+        Ok(BearerToken::new(access.token.secret().to_owned(), expires_on))
+    }
+}
+
+/// Converts an absolute UNIX expiry timestamp into a monotonic [`Instant`]
+/// anchored at "now". After this single conversion the schedule is immune to
+/// wall-clock jumps. Saturates at zero for already-expired timestamps.
+fn instant_from_unix_expiry(expires_on: OffsetDateTime) -> Option<Instant> {
+    let now_unix = OffsetDateTime::now_utc().unix_timestamp();
+    let secs_until_expiry = expires_on.unix_timestamp().saturating_sub(now_unix).max(0);
+    Some(Instant::now() + Duration::from_secs(secs_until_expiry as u64))
+}
+
+/// Constructs an Azure credential for the configured authentication method.
+fn create_credential(config: &Config) -> Result<Arc<dyn TokenCredential>, Error> {
+    match config.method {
+        AuthMethod::ManagedIdentity => {
+            let mut options = ManagedIdentityCredentialOptions::default();
+            if let Some(client_id) = &config.client_id {
+                options.user_assigned_id = Some(UserAssignedId::ClientId(client_id.clone()));
+            }
+            let cred = ManagedIdentityCredential::new(Some(options)).map_err(|source| {
+                Error::CreateCredential {
+                    method: AuthMethod::ManagedIdentity,
+                    source,
+                }
+            })?;
+            Ok(cred)
+        }
+        // Implemented in later changes.
+        method @ (AuthMethod::Development | AuthMethod::WorkloadIdentity) => {
+            Err(Error::CreateCredential {
+                method,
+                source: azure_core::error::Error::with_message(
+                    azure_core::error::ErrorKind::Other,
+                    "auth method not yet supported",
+                ),
+            })
+        }
     }
 }

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/config.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/config.rs
@@ -121,9 +121,7 @@ impl Config {
         // `client_id` selects a user-assigned Managed Identity or the WIF
         // application id; it has no meaning for developer tooling.
         if self.method == AuthMethod::Development && self.client_id.is_some() {
-            return Err(
-                "`client_id` is not valid for the `development` method".to_string(),
-            );
+            return Err("`client_id` is not valid for the `development` method".to_string());
         }
 
         Ok(())

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/config.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/config.rs
@@ -4,12 +4,23 @@
 //! Configuration for the Azure Identity Auth extension.
 
 use std::path::PathBuf;
+use std::time::Duration;
 
 use serde::Deserialize;
 
 /// Default OAuth scope requested when none is configured.
 fn default_scope() -> String {
     "https://monitor.azure.com/.default".to_string()
+}
+
+/// Default startup readiness timeout.
+///
+/// Larger than the engine's 5 s readiness-probe default: Azure cold-start
+/// acquisition (IMDS Managed Identity, or Workload Identity Federation with
+/// SDK-internal retries/backoff) can exceed 5 s, and a failed first attempt is
+/// retried on a ~10 s cadence, so the gate must allow room for a retry.
+fn default_startup_timeout() -> Duration {
+    Duration::from_secs(30)
 }
 
 /// Azure identity authentication flow.
@@ -69,6 +80,11 @@ pub struct Config {
     /// OAuth scope to request tokens for. Must be non-empty.
     #[serde(default = "default_scope")]
     pub scope: String,
+    /// How long the engine holds data-path node startup waiting for this
+    /// extension to publish its first token, before aborting pipeline startup.
+    /// Accepts human-readable durations (e.g. `30s`, `1m`). Must be non-zero.
+    #[serde(with = "humantime_serde", default = "default_startup_timeout")]
+    pub startup_timeout: Duration,
 }
 
 impl Config {
@@ -79,6 +95,10 @@ impl Config {
     pub fn validate(&self) -> Result<(), String> {
         if self.scope.trim().is_empty() {
             return Err("`scope` must not be empty".to_string());
+        }
+
+        if self.startup_timeout.is_zero() {
+            return Err("`startup_timeout` must be greater than zero".to_string());
         }
 
         // `tenant_id` and `token_file_path` are Workload Identity Federation

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/config.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/config.rs
@@ -1,0 +1,84 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Configuration for the Azure Identity Auth extension.
+
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+/// Default OAuth scope requested when none is configured.
+fn default_scope() -> String {
+    "https://monitor.azure.com/.default".to_string()
+}
+
+/// Azure identity authentication flow.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AuthMethod {
+    /// Azure Managed Identity (system- or user-assigned).
+    #[serde(alias = "msi", alias = "managed_identity")]
+    #[default]
+    ManagedIdentity,
+    /// Local developer tooling (Azure CLI / `azd`). Local development only.
+    #[serde(alias = "dev", alias = "developer", alias = "cli")]
+    Development,
+    /// Workload Identity Federation (projected ServiceAccount token).
+    #[serde(alias = "wif", alias = "workload_identity")]
+    WorkloadIdentity,
+}
+
+impl AuthMethod {
+    /// Returns a stable, human-readable name for the method.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            AuthMethod::ManagedIdentity => "managed_identity",
+            AuthMethod::Development => "development",
+            AuthMethod::WorkloadIdentity => "workload_identity",
+        }
+    }
+}
+
+impl std::fmt::Display for AuthMethod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Configuration for the Azure Identity Auth extension.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Config {
+    /// Authentication flow to use.
+    #[serde(default)]
+    pub method: AuthMethod,
+    /// Entra client ID. User-assigned MSI client ID for `managed_identity`
+    /// (omit for system-assigned); application client ID for
+    /// `workload_identity` (falls back to `AZURE_CLIENT_ID`).
+    #[serde(default)]
+    pub client_id: Option<String>,
+    /// Entra tenant ID. Only for `workload_identity` (falls back to
+    /// `AZURE_TENANT_ID`).
+    #[serde(default)]
+    pub tenant_id: Option<String>,
+    /// Path to the projected federated token file. Only for
+    /// `workload_identity` (falls back to `AZURE_FEDERATED_TOKEN_FILE`).
+    #[serde(default)]
+    pub token_file_path: Option<PathBuf>,
+    /// OAuth scope to request tokens for. Must be non-empty.
+    #[serde(default = "default_scope")]
+    pub scope: String,
+}
+
+impl Config {
+    /// Validates the configuration beyond what deserialization checks.
+    ///
+    /// Rejects an empty or whitespace-only `scope`.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.scope.trim().is_empty() {
+            return Err("`scope` must not be empty".to_string());
+        }
+        Ok(())
+    }
+}

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/config.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/config.rs
@@ -74,11 +74,38 @@ pub struct Config {
 impl Config {
     /// Validates the configuration beyond what deserialization checks.
     ///
-    /// Rejects an empty or whitespace-only `scope`.
+    /// Rejects an empty/whitespace-only `scope` and any per-method field that
+    /// does not apply to the selected [`AuthMethod`].
     pub fn validate(&self) -> Result<(), String> {
         if self.scope.trim().is_empty() {
             return Err("`scope` must not be empty".to_string());
         }
+
+        // `tenant_id` and `token_file_path` are Workload Identity Federation
+        // inputs; they are meaningless for the other methods.
+        if self.method != AuthMethod::WorkloadIdentity {
+            if self.tenant_id.is_some() {
+                return Err(format!(
+                    "`tenant_id` is only valid for the `workload_identity` method, not `{}`",
+                    self.method
+                ));
+            }
+            if self.token_file_path.is_some() {
+                return Err(format!(
+                    "`token_file_path` is only valid for the `workload_identity` method, not `{}`",
+                    self.method
+                ));
+            }
+        }
+
+        // `client_id` selects a user-assigned Managed Identity or the WIF
+        // application id; it has no meaning for developer tooling.
+        if self.method == AuthMethod::Development && self.client_id.is_some() {
+            return Err(
+                "`client_id` is not valid for the `development` method".to_string(),
+            );
+        }
+
         Ok(())
     }
 }

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/error.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/error.rs
@@ -1,0 +1,26 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Error types for the Azure Identity Auth extension.
+
+use super::config::AuthMethod;
+
+/// Errors raised while constructing credentials or acquiring tokens.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Constructing the Azure credential failed.
+    #[error("failed to create {method} credential: {source}")]
+    CreateCredential {
+        /// Authentication method that failed to construct.
+        method: AuthMethod,
+        /// Underlying Azure SDK error.
+        source: azure_core::Error,
+    },
+
+    /// Acquiring a token from the credential failed.
+    #[error("token acquisition failed: {source}")]
+    TokenAcquisition {
+        /// Underlying Azure SDK error.
+        source: azure_core::Error,
+    },
+}

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/extension.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/extension.rs
@@ -5,7 +5,7 @@
 //! `BearerTokenProvider` capability implementation, and the background refresh
 //! loop driven by the active `Extension::start()` task.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
@@ -24,6 +24,7 @@ use tokio::sync::watch;
 use tokio_stream::wrappers::WatchStream;
 
 use super::auth::Auth;
+use super::metrics::AzureIdentityAuthMetricsTracker;
 
 /// Refresh this many seconds before `expires_on`.
 const TOKEN_EXPIRY_BUFFER_SECS: u64 = 299;
@@ -55,6 +56,9 @@ struct Inner {
     cap_err: CapabilityErrorSource<BearerTokenProviderCap>,
     /// Coalesces concurrent slow-path fetches onto one in-flight request.
     fetch_lock: tokio::sync::Mutex<()>,
+    /// Metric tracker. Its critical sections are short and never span an
+    /// `.await`, so a `std` `Mutex` is appropriate.
+    metrics: Mutex<AzureIdentityAuthMetricsTracker>,
 }
 
 impl AzureIdentityAuthExtension {
@@ -64,6 +68,7 @@ impl AzureIdentityAuthExtension {
         name: &str,
         auth: Auth,
         tx: watch::Sender<Option<BearerToken>>,
+        metrics: AzureIdentityAuthMetricsTracker,
     ) -> Self {
         Self {
             inner: Arc::new(Inner {
@@ -71,6 +76,7 @@ impl AzureIdentityAuthExtension {
                 tx,
                 cap_err: CapabilityErrorSource::new(name.to_owned().into()),
                 fetch_lock: tokio::sync::Mutex::new(()),
+                metrics: Mutex::new(metrics),
             }),
         }
     }
@@ -100,12 +106,29 @@ impl Inner {
 
     /// Acquires a token and publishes it to consumers.
     async fn refresh_once(&self) -> Result<BearerToken, super::error::Error> {
-        let token = self.auth.get_token().await?;
-        // Publish the token to consumers and update the cache. Using
-        // `send_replace` (rather than `send`) ensures the cache is updated even
-        // when no receivers are currently subscribed.
-        let _ = self.tx.send_replace(Some(token.clone()));
-        Ok(token)
+        let start = Instant::now();
+        match self.auth.get_token().await {
+            Ok(token) => {
+                let latency_ms = start.elapsed().as_secs_f64() * 1_000.0;
+                if let Ok(mut metrics) = self.metrics.lock() {
+                    metrics.record_success(latency_ms);
+                }
+                // Publish the token to consumers and update the cache. Using
+                // `send_replace` (rather than `send`) ensures the cache is
+                // updated even when no receivers are currently subscribed.
+                let _ = self.tx.send_replace(Some(token.clone()));
+                if let Ok(mut metrics) = self.metrics.lock() {
+                    metrics.record_publish();
+                }
+                Ok(token)
+            }
+            Err(err) => {
+                if let Ok(mut metrics) = self.metrics.lock() {
+                    metrics.record_failure();
+                }
+                Err(err)
+            }
+        }
     }
 
     /// Computes the next refresh instant from a freshly acquired token.
@@ -179,8 +202,11 @@ impl SharedExtension for AzureIdentityAuthExtension {
                         // Refresh cadence is governed by token lifetime; live
                         // reconfiguration is a no-op in v1.
                         Ok(ExtensionControlMsg::Config { .. }) => {}
-                        // Telemetry is wired in a later change.
-                        Ok(ExtensionControlMsg::CollectTelemetry { .. }) => {}
+                        Ok(ExtensionControlMsg::CollectTelemetry { mut metrics_reporter }) => {
+                            if let Ok(mut metrics) = inner.metrics.lock() {
+                                let _ = metrics.report(&mut metrics_reporter);
+                            }
+                        }
                     }
                 }
                 _ = tokio::time::sleep_until(next_refresh) => {

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/extension.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/extension.rs
@@ -210,6 +210,11 @@ impl SharedExtension for AzureIdentityAuthExtension {
                     }
                 }
                 _ = tokio::time::sleep_until(next_refresh) => {
+                    // Take the same `fetch_lock` the slow-path `get_token` uses,
+                    // so a scheduled refresh and a concurrent cache-miss fetch
+                    // coalesce onto one in-flight credential call instead of
+                    // both hitting the token endpoint.
+                    let _guard = inner.fetch_lock.lock().await;
                     match inner.refresh_once().await {
                         Ok(token) => {
                             next_refresh = inner.schedule_next(&token);

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/extension.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/extension.rs
@@ -28,6 +28,13 @@ use super::metrics::AzureIdentityAuthMetricsTracker;
 
 /// Refresh this many seconds before `expires_on`.
 const TOKEN_EXPIRY_BUFFER_SECS: u64 = 299;
+/// Safety margin before actual expiry within which a cached token is treated as
+/// no longer usable. Deliberately much smaller than `TOKEN_EXPIRY_BUFFER_SECS`:
+/// the background loop refreshes ~5 min early, but if that refresh is failing a
+/// still-valid token should keep being served (not treated as unusable 5 min
+/// early), which also avoids stampeding the token endpoint during a transient
+/// outage.
+const TOKEN_USABLE_MARGIN_SECS: u64 = 30;
 /// Floor between successful refreshes; avoids busy-looping on near-expired
 /// tokens.
 const MIN_TOKEN_REFRESH_INTERVAL_SECS: u64 = 10;
@@ -56,6 +63,9 @@ struct Inner {
     cap_err: CapabilityErrorSource<BearerTokenProviderCap>,
     /// Coalesces concurrent slow-path fetches onto one in-flight request.
     fetch_lock: tokio::sync::Mutex<()>,
+    /// Instant of the most recent failed acquisition (negative cache). Used to
+    /// throttle slow-path retries so a failing token endpoint is not stampeded.
+    last_failure: Mutex<Option<Instant>>,
     /// Metric tracker. Its critical sections are short and never span an
     /// `.await`, so a `std` `Mutex` is appropriate.
     metrics: Mutex<AzureIdentityAuthMetricsTracker>,
@@ -76,6 +86,7 @@ impl AzureIdentityAuthExtension {
                 tx,
                 cap_err: CapabilityErrorSource::new(name.to_owned().into()),
                 fetch_lock: tokio::sync::Mutex::new(()),
+                last_failure: Mutex::new(None),
                 metrics: Mutex::new(metrics),
             }),
         }
@@ -83,8 +94,8 @@ impl AzureIdentityAuthExtension {
 }
 
 impl Inner {
-    /// Returns the cached token if it is present and not within the
-    /// refresh-skew window of its expiry. Non-expiring tokens are always fresh.
+    /// Returns the cached token if it is present and still comfortably before
+    /// its expiry (outside the usability safety margin).
     fn current_fresh_token(&self) -> Option<BearerToken> {
         // The token lives inside the watch channel behind a temporary read
         // guard; clone it out so we can return an owned value (and release the
@@ -93,14 +104,36 @@ impl Inner {
         let token = self.tx.borrow().clone()?;
         match token.expires_on() {
             Some(expires_on) => {
-                let skew = Duration::from_secs(TOKEN_EXPIRY_BUFFER_SECS);
-                if Instant::now() + skew < expires_on {
+                let margin = Duration::from_secs(TOKEN_USABLE_MARGIN_SECS);
+                if Instant::now() + margin < expires_on {
                     Some(token)
                 } else {
                     None
                 }
             }
             None => Some(token),
+        }
+    }
+
+    /// Returns true if the most recent acquisition failed within the retry
+    /// cooldown window. Used as a negative cache to throttle slow-path retries.
+    fn recently_failed(&self) -> bool {
+        // Open the shared box holding the last-failure timestamp. If the lock
+        // is somehow poisoned, treat it as "no recent failure" and allow a
+        // retry rather than failing here.
+        let guard = match self.last_failure.lock() {
+            Ok(guard) => guard,
+            Err(_) => return false,
+        };
+
+        // If a failure timestamp is recorded, we are throttling only while it
+        // is still within the cooldown window; otherwise (no failure recorded)
+        // we are not throttling.
+        match *guard {
+            Some(failed_at) => {
+                failed_at.elapsed() < Duration::from_secs(TOKEN_REFRESH_RETRY_SECS)
+            }
+            None => false,
         }
     }
 
@@ -120,11 +153,20 @@ impl Inner {
                 if let Ok(mut metrics) = self.metrics.lock() {
                     metrics.record_publish();
                 }
+                // Clear the negative cache: acquisitions are healthy again.
+                if let Ok(mut f) = self.last_failure.lock() {
+                    *f = None;
+                }
                 Ok(token)
             }
             Err(err) => {
                 if let Ok(mut metrics) = self.metrics.lock() {
                     metrics.record_failure();
+                }
+                // Record the failure instant so the slow path can throttle
+                // further attempts until the cooldown elapses.
+                if let Ok(mut f) = self.last_failure.lock() {
+                    *f = Some(Instant::now());
                 }
                 Err(err)
             }
@@ -161,6 +203,15 @@ impl SharedBearerTokenProvider for AzureIdentityAuthExtension {
         let _guard = self.inner.fetch_lock.lock().await;
         if let Some(token) = self.inner.current_fresh_token() {
             return Ok(token);
+        }
+        // Negative cache: if the most recent acquisition failed within the
+        // cooldown window, surface the throttle instead of hitting the token
+        // endpoint again. The background loop keeps retrying on its own cadence.
+        if self.inner.recently_failed() {
+            return Err(self
+                .inner
+                .cap_err
+                .error("token acquisition throttled after recent failure"));
         }
         self.inner
             .refresh_once()

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/extension.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/extension.rs
@@ -20,6 +20,7 @@ use otap_df_engine::extension::EffectHandler;
 use otap_df_engine::shared::capability::BearerTokenProvider as SharedBearerTokenProvider;
 use otap_df_engine::shared::extension::{ControlChannel, Extension as SharedExtension};
 use otap_df_engine::terminal_state::TerminalState;
+use otap_df_telemetry::otel_warn;
 use tokio::sync::watch;
 use tokio_stream::wrappers::WatchStream;
 
@@ -143,14 +144,13 @@ impl Inner {
         match self.auth.get_token().await {
             Ok(token) => {
                 let latency_ms = start.elapsed().as_secs_f64() * 1_000.0;
-                if let Ok(mut metrics) = self.metrics.lock() {
-                    metrics.record_success(latency_ms);
-                }
                 // Publish the token to consumers and update the cache. Using
                 // `send_replace` (rather than `send`) ensures the cache is
                 // updated even when no receivers are currently subscribed.
                 let _ = self.tx.send_replace(Some(token.clone()));
+                // Record success + publish under a single metrics lock.
                 if let Ok(mut metrics) = self.metrics.lock() {
+                    metrics.record_success(latency_ms);
                     metrics.record_publish();
                 }
                 // Clear the negative cache: acquisitions are healthy again.
@@ -249,7 +249,17 @@ impl SharedExtension for AzureIdentityAuthExtension {
             tokio::select! {
                 ctrl_msg = ctrl.recv() => {
                     match ctrl_msg {
-                        Ok(ExtensionControlMsg::Shutdown { .. }) | Err(_) => break,
+                        // Graceful shutdown: return the final metric snapshot in
+                        // the terminal state (the same contract nodes follow).
+                        Ok(ExtensionControlMsg::Shutdown { deadline, .. }) => {
+                            let snapshot = inner.metrics.lock().ok().map(|m| m.snapshot());
+                            return Ok(match snapshot {
+                                Some(snapshot) => TerminalState::new(deadline, [snapshot]),
+                                None => TerminalState::default(),
+                            });
+                        }
+                        // Control channel closed: exit without a snapshot.
+                        Err(_) => break,
                         // Refresh cadence is governed by token lifetime; live
                         // reconfiguration is a no-op in v1.
                         Ok(ExtensionControlMsg::Config { .. }) => {}
@@ -275,9 +285,9 @@ impl SharedExtension for AzureIdentityAuthExtension {
                             }
                         }
                         Err(error) => {
-                            tracing::warn!(
-                                %error,
-                                "azure_identity_auth: token refresh failed; retrying"
+                            otel_warn!(
+                                "azure_identity_auth.token_refresh_failed",
+                                error = %error
                             );
                             next_refresh = tokio::time::Instant::now()
                                 + Duration::from_secs(TOKEN_REFRESH_RETRY_SECS);

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/extension.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/extension.rs
@@ -1,0 +1,210 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! The Azure Identity Auth extension: `Arc<Inner>` state, the
+//! `BearerTokenProvider` capability implementation, and the background refresh
+//! loop driven by the active `Extension::start()` task.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use otap_df_engine::capability::{
+    BearerToken, BearerTokenProvider as BearerTokenProviderCap, CapabilityError,
+    CapabilityErrorSource, TokenStream,
+};
+use otap_df_engine::control::ExtensionControlMsg;
+use otap_df_engine::error::Error as EngineError;
+use otap_df_engine::extension::EffectHandler;
+use otap_df_engine::shared::capability::BearerTokenProvider as SharedBearerTokenProvider;
+use otap_df_engine::shared::extension::{ControlChannel, Extension as SharedExtension};
+use otap_df_engine::terminal_state::TerminalState;
+use tokio::sync::watch;
+use tokio_stream::wrappers::WatchStream;
+
+use super::auth::Auth;
+
+/// Refresh this many seconds before `expires_on`.
+const TOKEN_EXPIRY_BUFFER_SECS: u64 = 299;
+/// Floor between successful refreshes; avoids busy-looping on near-expired
+/// tokens.
+const MIN_TOKEN_REFRESH_INTERVAL_SECS: u64 = 10;
+/// Reschedule delay after a failed acquisition.
+const TOKEN_REFRESH_RETRY_SECS: u64 = 10;
+/// Next-refresh delay used for non-expiring tokens (~1 year). The loop is still
+/// woken by control messages in the meantime.
+const NON_EXPIRING_REFRESH_SECS: u64 = 365 * 24 * 60 * 60;
+
+/// Shared, clonable Azure Identity Auth extension.
+///
+/// Every clone (consumers + the background refresh task) observes the same
+/// [`Inner`] state via `Arc`, so they share one token cache and refresh loop.
+#[derive(Clone)]
+pub struct AzureIdentityAuthExtension {
+    inner: Arc<Inner>,
+}
+
+/// Shared state behind [`AzureIdentityAuthExtension`].
+struct Inner {
+    /// Azure credential + scope used to acquire tokens.
+    auth: Auth,
+    /// Token cache + pub/sub for `token_stream()`.
+    tx: watch::Sender<Option<BearerToken>>,
+    /// Pre-tagged capability error builder.
+    cap_err: CapabilityErrorSource<BearerTokenProviderCap>,
+    /// Coalesces concurrent slow-path fetches onto one in-flight request.
+    fetch_lock: tokio::sync::Mutex<()>,
+}
+
+impl AzureIdentityAuthExtension {
+    /// Builds a new extension instance.
+    #[must_use]
+    pub fn new(
+        name: &str,
+        auth: Auth,
+        tx: watch::Sender<Option<BearerToken>>,
+    ) -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                auth,
+                tx,
+                cap_err: CapabilityErrorSource::new(name.to_owned().into()),
+                fetch_lock: tokio::sync::Mutex::new(()),
+            }),
+        }
+    }
+}
+
+impl Inner {
+    /// Returns the cached token if it is present and not within the
+    /// refresh-skew window of its expiry. Non-expiring tokens are always fresh.
+    fn current_fresh_token(&self) -> Option<BearerToken> {
+        // The token lives inside the watch channel behind a temporary read
+        // guard; clone it out so we can return an owned value (and release the
+        // guard, which would otherwise block the writer). `BearerToken` clones
+        // are cheap: a refcount bump on the shared secret.
+        let token = self.tx.borrow().clone()?;
+        match token.expires_on() {
+            Some(expires_on) => {
+                let skew = Duration::from_secs(TOKEN_EXPIRY_BUFFER_SECS);
+                if Instant::now() + skew < expires_on {
+                    Some(token)
+                } else {
+                    None
+                }
+            }
+            None => Some(token),
+        }
+    }
+
+    /// Acquires a token and publishes it to consumers.
+    async fn refresh_once(&self) -> Result<BearerToken, super::error::Error> {
+        let token = self.auth.get_token().await?;
+        // Publish the token to consumers and update the cache. Using
+        // `send_replace` (rather than `send`) ensures the cache is updated even
+        // when no receivers are currently subscribed.
+        let _ = self.tx.send_replace(Some(token.clone()));
+        Ok(token)
+    }
+
+    /// Computes the next refresh instant from a freshly acquired token.
+    fn schedule_next(&self, token: &BearerToken) -> tokio::time::Instant {
+        let now = tokio::time::Instant::now();
+        let min_next = now + Duration::from_secs(MIN_TOKEN_REFRESH_INTERVAL_SECS);
+        match token.expires_on() {
+            Some(expires_on) => {
+                let target = tokio::time::Instant::from_std(expires_on)
+                    .checked_sub(Duration::from_secs(TOKEN_EXPIRY_BUFFER_SECS))
+                    .unwrap_or(now);
+                target.max(min_next)
+            }
+            None => now + Duration::from_secs(NON_EXPIRING_REFRESH_SECS),
+        }
+    }
+}
+
+#[async_trait]
+impl SharedBearerTokenProvider for AzureIdentityAuthExtension {
+    async fn get_token(&self) -> Result<BearerToken, CapabilityError> {
+        // Fast path: lock-free read of the watch cache.
+        if let Some(token) = self.inner.current_fresh_token() {
+            return Ok(token);
+        }
+
+        // Slow path: coalesce concurrent cache-miss callers onto a single
+        // in-flight credential call, with a double-check after acquiring the
+        // lock.
+        let _guard = self.inner.fetch_lock.lock().await;
+        if let Some(token) = self.inner.current_fresh_token() {
+            return Ok(token);
+        }
+        self.inner
+            .refresh_once()
+            .await
+            .map_err(|err| self.inner.cap_err.error(err))
+    }
+
+    fn token_stream(&self) -> TokenStream {
+        let rx = self.inner.tx.subscribe();
+        // Yield the current cached value immediately, then each refresh. The
+        // initial `None` (and any future `None`) is filtered out. The stream
+        // item is a plain `BearerToken`: a refresh failure does not terminate
+        // the subscription, it simply does not emit until the next success.
+        let stream = WatchStream::new(rx).filter_map(|opt| async move { opt });
+        Box::pin(stream)
+    }
+}
+
+#[async_trait]
+impl SharedExtension for AzureIdentityAuthExtension {
+    async fn start(
+        self: Box<Self>,
+        mut ctrl: ControlChannel,
+        effect_handler: EffectHandler,
+    ) -> Result<TerminalState, EngineError> {
+        let inner = Arc::clone(&self.inner);
+        // Refresh immediately on startup.
+        let mut next_refresh = tokio::time::Instant::now();
+        // The engine holds data-path node startup until we signal readiness
+        // (see `with_readiness_probe`). Fire once, after the first token is
+        // published, so consumers never observe an empty cache.
+        let mut ready_signaled = false;
+
+        loop {
+            tokio::select! {
+                ctrl_msg = ctrl.recv() => {
+                    match ctrl_msg {
+                        Ok(ExtensionControlMsg::Shutdown { .. }) | Err(_) => break,
+                        // Refresh cadence is governed by token lifetime; live
+                        // reconfiguration is a no-op in v1.
+                        Ok(ExtensionControlMsg::Config { .. }) => {}
+                        // Telemetry is wired in a later change.
+                        Ok(ExtensionControlMsg::CollectTelemetry { .. }) => {}
+                    }
+                }
+                _ = tokio::time::sleep_until(next_refresh) => {
+                    match inner.refresh_once().await {
+                        Ok(token) => {
+                            next_refresh = inner.schedule_next(&token);
+                            if !ready_signaled {
+                                effect_handler.signal_ready();
+                                ready_signaled = true;
+                            }
+                        }
+                        Err(error) => {
+                            tracing::warn!(
+                                %error,
+                                "azure_identity_auth: token refresh failed; retrying"
+                            );
+                            next_refresh = tokio::time::Instant::now()
+                                + Duration::from_secs(TOKEN_REFRESH_RETRY_SECS);
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(TerminalState::default())
+    }
+}

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/extension.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/extension.rs
@@ -131,9 +131,7 @@ impl Inner {
         // is still within the cooldown window; otherwise (no failure recorded)
         // we are not throttling.
         match *guard {
-            Some(failed_at) => {
-                failed_at.elapsed() < Duration::from_secs(TOKEN_REFRESH_RETRY_SECS)
-            }
+            Some(failed_at) => failed_at.elapsed() < Duration::from_secs(TOKEN_REFRESH_RETRY_SECS),
             None => false,
         }
     }
@@ -172,20 +170,25 @@ impl Inner {
             }
         }
     }
+}
 
-    /// Computes the next refresh instant from a freshly acquired token.
-    fn schedule_next(&self, token: &BearerToken) -> tokio::time::Instant {
-        let now = tokio::time::Instant::now();
-        let min_next = now + Duration::from_secs(MIN_TOKEN_REFRESH_INTERVAL_SECS);
-        match token.expires_on() {
-            Some(expires_on) => {
-                let target = tokio::time::Instant::from_std(expires_on)
-                    .checked_sub(Duration::from_secs(TOKEN_EXPIRY_BUFFER_SECS))
-                    .unwrap_or(now);
-                target.max(min_next)
-            }
-            None => now + Duration::from_secs(NON_EXPIRING_REFRESH_SECS),
+/// Computes the next refresh instant from a freshly acquired token.
+///
+/// Refreshes `TOKEN_EXPIRY_BUFFER_SECS` before expiry, but never sooner than
+/// `MIN_TOKEN_REFRESH_INTERVAL_SECS` from now; a non-expiring token pushes the
+/// next refresh far into the future (the loop is still woken by control
+/// messages in the meantime).
+pub(crate) fn schedule_next(token: &BearerToken) -> tokio::time::Instant {
+    let now = tokio::time::Instant::now();
+    let min_next = now + Duration::from_secs(MIN_TOKEN_REFRESH_INTERVAL_SECS);
+    match token.expires_on() {
+        Some(expires_on) => {
+            let target = tokio::time::Instant::from_std(expires_on)
+                .checked_sub(Duration::from_secs(TOKEN_EXPIRY_BUFFER_SECS))
+                .unwrap_or(now);
+            target.max(min_next)
         }
+        None => now + Duration::from_secs(NON_EXPIRING_REFRESH_SECS),
     }
 }
 
@@ -278,7 +281,7 @@ impl SharedExtension for AzureIdentityAuthExtension {
                     let _guard = inner.fetch_lock.lock().await;
                     match inner.refresh_once().await {
                         Ok(token) => {
-                            next_refresh = inner.schedule_next(&token);
+                            next_refresh = schedule_next(&token);
                             if !ready_signaled {
                                 effect_handler.signal_ready();
                                 ready_signaled = true;

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/metrics.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/metrics.rs
@@ -5,7 +5,7 @@
 
 use otap_df_telemetry::error::Error as TelemetryError;
 use otap_df_telemetry::instrument::{Counter, Mmsc};
-use otap_df_telemetry::metrics::MetricSet;
+use otap_df_telemetry::metrics::{MetricSet, MetricSetSnapshot};
 use otap_df_telemetry::reporter::MetricsReporter;
 use otap_df_telemetry_macros::metric_set;
 
@@ -48,6 +48,13 @@ impl AzureIdentityAuthMetricsTracker {
     /// Flushes the metric set to the telemetry reporter.
     pub fn report(&mut self, reporter: &mut MetricsReporter) -> Result<(), TelemetryError> {
         reporter.report(&mut self.metrics)
+    }
+
+    /// Returns a point-in-time snapshot of the metric set, e.g. to attach to
+    /// the terminal state on shutdown.
+    #[must_use]
+    pub fn snapshot(&self) -> MetricSetSnapshot {
+        self.metrics.snapshot()
     }
 
     /// Records a successful acquisition with its latency in milliseconds.

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/metrics.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/metrics.rs
@@ -1,0 +1,68 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Telemetry for the Azure Identity Auth extension.
+
+use otap_df_telemetry::error::Error as TelemetryError;
+use otap_df_telemetry::instrument::{Counter, Mmsc};
+use otap_df_telemetry::metrics::MetricSet;
+use otap_df_telemetry::reporter::MetricsReporter;
+use otap_df_telemetry_macros::metric_set;
+
+/// Telemetry metrics for the Azure Identity Auth extension.
+#[metric_set(name = "extension.azure_identity_auth")]
+#[derive(Debug, Default, Clone)]
+pub struct AzureIdentityAuthMetrics {
+    /// Number of successful credential acquisitions.
+    #[metric(unit = "{acquisition}")]
+    pub auth_successes: Counter<u64>,
+    /// Number of failed credential acquisitions.
+    #[metric(unit = "{acquisition}")]
+    pub auth_failures: Counter<u64>,
+    /// Number of tokens published to consumers via the watch channel.
+    #[metric(unit = "{token}")]
+    pub auth_token_publish: Counter<u64>,
+    /// Latency of successful acquisitions in milliseconds (min/max/sum/count).
+    #[metric(unit = "ms")]
+    pub auth_success_latency: Mmsc,
+}
+
+/// Tracks and flushes the extension's metric set.
+pub struct AzureIdentityAuthMetricsTracker {
+    metrics: MetricSet<AzureIdentityAuthMetrics>,
+}
+
+impl std::fmt::Debug for AzureIdentityAuthMetricsTracker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AzureIdentityAuthMetricsTracker").finish()
+    }
+}
+
+impl AzureIdentityAuthMetricsTracker {
+    /// Creates a new tracker wrapping a registered metric set.
+    #[must_use]
+    pub fn new(metrics: MetricSet<AzureIdentityAuthMetrics>) -> Self {
+        Self { metrics }
+    }
+
+    /// Flushes the metric set to the telemetry reporter.
+    pub fn report(&mut self, reporter: &mut MetricsReporter) -> Result<(), TelemetryError> {
+        reporter.report(&mut self.metrics)
+    }
+
+    /// Records a successful acquisition with its latency in milliseconds.
+    pub fn record_success(&mut self, latency_ms: f64) {
+        self.metrics.auth_successes.inc();
+        self.metrics.auth_success_latency.record(latency_ms);
+    }
+
+    /// Records a failed acquisition.
+    pub fn record_failure(&mut self) {
+        self.metrics.auth_failures.inc();
+    }
+
+    /// Records a token publication to consumers.
+    pub fn record_publish(&mut self) {
+        self.metrics.auth_token_publish.inc();
+    }
+}

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/mod.rs
@@ -82,7 +82,7 @@ fn create(
 
     ExtensionWrapper::builder(name, ext_config, extension_config)
         .active()
-        .with_readiness_probe()
+        .with_readiness_probe_timeout_override(config.startup_timeout)
         .shared::<AzureIdentityAuthExtension>(extension)
         .build()
         .map_err(|e| ConfigError::InvalidUserConfig {

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/mod.rs
@@ -7,10 +7,11 @@
 //! nodes through the `BearerTokenProvider` capability. See
 //! `docs/azure-identity-auth-extension.md` for the design.
 
+mod auth;
 pub mod config;
 pub mod error;
-mod auth;
 mod extension;
+mod metrics;
 
 #[cfg(test)]
 mod tests;
@@ -24,6 +25,7 @@ use otap_df_engine::ExtensionFactory;
 use otap_df_engine::capability::BearerTokenProvider;
 use otap_df_engine::config::ExtensionConfig;
 use otap_df_engine::context::ExtensionContext;
+use otap_df_engine::extension::wrapper::ExtensionVariant;
 use otap_df_engine::extension::{ExtensionBundle, ExtensionWrapper};
 use otap_df_engine::extension_capabilities;
 use otap_df_otap::OTAP_EXTENSION_FACTORIES;
@@ -32,6 +34,7 @@ use tokio::sync::watch;
 use self::auth::Auth;
 use self::config::Config;
 use self::extension::AzureIdentityAuthExtension;
+use self::metrics::{AzureIdentityAuthMetrics, AzureIdentityAuthMetricsTracker};
 
 /// URN under which this extension is registered.
 pub const AZURE_IDENTITY_AUTH_URN: &str = "urn:microsoft:extension:azure_identity_auth";
@@ -55,7 +58,7 @@ fn validate_config(config: &serde_json::Value) -> Result<(), ConfigError> {
 
 /// Builds an `AzureIdentityAuthExtension` bundle.
 fn create(
-    _ext_ctx: &ExtensionContext,
+    ext_ctx: &ExtensionContext,
     name: otap_df_config::ExtensionId,
     ext_config: Arc<ExtensionUserConfig>,
     extension_config: &ExtensionConfig,
@@ -63,16 +66,19 @@ fn create(
     // Validate config now so a bad config fails fast at wiring time.
     let config = parse_config(&ext_config.config)?;
 
-    // Placeholder credential for now; the Azure-backed implementation lands in
-    // a later change.
     let auth = Auth::new(&config).map_err(|e| ConfigError::InvalidUserConfig {
         error: format!("failed to initialize Azure credential: {e}"),
     })?;
 
+    // Register a dedicated entity + metric set for this extension instance.
+    let entity_key = ext_ctx.register_extension_entity(name.clone(), ExtensionVariant::Shared);
+    let metric_set = ext_ctx.register_metric_set_for_entity::<AzureIdentityAuthMetrics>(entity_key);
+    let tracker = AzureIdentityAuthMetricsTracker::new(metric_set);
+
     // Empty token cache; the background refresh loop publishes the first token.
     let (tx, _rx) = watch::channel(None);
 
-    let extension = AzureIdentityAuthExtension::new(&name, auth, tx);
+    let extension = AzureIdentityAuthExtension::new(&name, auth, tx, tracker);
 
     ExtensionWrapper::builder(name, ext_config, extension_config)
         .active()

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/mod.rs
@@ -3,9 +3,94 @@
 
 //! Azure Identity Auth extension.
 //!
-//! Acquires and refreshes Azure access tokens via the `azure_identity` SDK and
-//! exposes them to data-path nodes through the `BearerTokenProvider`
-//! capability. See `docs/azure-identity-auth-extension.md` for the design.
+//! Acquires and refreshes Azure access tokens and exposes them to data-path
+//! nodes through the `BearerTokenProvider` capability. See
+//! `docs/azure-identity-auth-extension.md` for the design.
 
 pub mod config;
 pub mod error;
+mod auth;
+mod extension;
+
+use std::sync::Arc;
+
+use linkme::distributed_slice;
+use otap_df_config::error::Error as ConfigError;
+use otap_df_config::extension::ExtensionUserConfig;
+use otap_df_engine::ExtensionFactory;
+use otap_df_engine::capability::BearerTokenProvider;
+use otap_df_engine::config::ExtensionConfig;
+use otap_df_engine::context::ExtensionContext;
+use otap_df_engine::extension::{ExtensionBundle, ExtensionWrapper};
+use otap_df_engine::extension_capabilities;
+use otap_df_otap::OTAP_EXTENSION_FACTORIES;
+use tokio::sync::watch;
+
+use self::auth::Auth;
+use self::config::Config;
+use self::extension::AzureIdentityAuthExtension;
+
+/// URN under which this extension is registered.
+pub const AZURE_IDENTITY_AUTH_URN: &str = "urn:microsoft:extension:azure_identity_auth";
+
+/// Deserializes and validates the extension's user configuration.
+fn parse_config(config: &serde_json::Value) -> Result<Config, ConfigError> {
+    let parsed: Config =
+        serde_json::from_value(config.clone()).map_err(|e| ConfigError::InvalidUserConfig {
+            error: e.to_string(),
+        })?;
+    parsed
+        .validate()
+        .map_err(|error| ConfigError::InvalidUserConfig { error })?;
+    Ok(parsed)
+}
+
+/// Static config validation hook for the factory.
+fn validate_config(config: &serde_json::Value) -> Result<(), ConfigError> {
+    parse_config(config).map(|_| ())
+}
+
+/// Builds an `AzureIdentityAuthExtension` bundle.
+fn create(
+    _ext_ctx: &ExtensionContext,
+    name: otap_df_config::ExtensionId,
+    ext_config: Arc<ExtensionUserConfig>,
+    extension_config: &ExtensionConfig,
+) -> Result<ExtensionBundle, ConfigError> {
+    // Validate config now so a bad config fails fast at wiring time.
+    let config = parse_config(&ext_config.config)?;
+
+    // Placeholder credential for now; the Azure-backed implementation lands in
+    // a later change.
+    let auth = Auth::new(&config).map_err(|e| ConfigError::InvalidUserConfig {
+        error: format!("failed to initialize Azure credential: {e}"),
+    })?;
+
+    // Empty token cache; the background refresh loop publishes the first token.
+    let (tx, _rx) = watch::channel(None);
+
+    let extension = AzureIdentityAuthExtension::new(&name, auth, tx);
+
+    ExtensionWrapper::builder(name, ext_config, extension_config)
+        .active()
+        .with_readiness_probe()
+        .shared::<AzureIdentityAuthExtension>(extension)
+        .build()
+        .map_err(|e| ConfigError::InvalidUserConfig {
+            error: e.to_string(),
+        })
+}
+
+/// Factory registration for the Azure Identity Auth extension.
+#[allow(unsafe_code)]
+#[distributed_slice(OTAP_EXTENSION_FACTORIES)]
+pub static AZURE_IDENTITY_AUTH_EXTENSION: ExtensionFactory = ExtensionFactory {
+    name: AZURE_IDENTITY_AUTH_URN,
+    description: "Active+Shared extension exposing BearerTokenProvider via azure_identity",
+    documentation_url: "",
+    capabilities: Some(extension_capabilities!(
+        shared: AzureIdentityAuthExtension => [BearerTokenProvider]
+    )),
+    create,
+    validate_config,
+};

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/mod.rs
@@ -1,0 +1,11 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Azure Identity Auth extension.
+//!
+//! Acquires and refreshes Azure access tokens via the `azure_identity` SDK and
+//! exposes them to data-path nodes through the `BearerTokenProvider`
+//! capability. See `docs/azure-identity-auth-extension.md` for the design.
+
+pub mod config;
+pub mod error;

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/mod.rs
@@ -12,6 +12,9 @@ pub mod error;
 mod auth;
 mod extension;
 
+#[cfg(test)]
+mod tests;
+
 use std::sync::Arc;
 
 use linkme::distributed_slice;

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/tests.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/tests.rs
@@ -74,6 +74,40 @@ fn unknown_fields_are_rejected() {
 }
 
 #[test]
+fn per_method_fields_are_validated() {
+    // `tenant_id` / `token_file_path` only apply to workload_identity.
+    assert!(
+        config_from_json(serde_json::json!({ "method": "managed_identity", "tenant_id": "t" }))
+            .is_err()
+    );
+    assert!(
+        config_from_json(
+            serde_json::json!({ "method": "development", "token_file_path": "/tmp/x" })
+        )
+        .is_err()
+    );
+    // `client_id` is not valid for developer tooling.
+    assert!(
+        config_from_json(serde_json::json!({ "method": "development", "client_id": "c" }))
+            .is_err()
+    );
+    // Valid combinations still pass.
+    assert!(
+        config_from_json(serde_json::json!({ "method": "managed_identity", "client_id": "c" }))
+            .is_ok()
+    );
+    assert!(
+        config_from_json(serde_json::json!({
+            "method": "workload_identity",
+            "tenant_id": "t",
+            "token_file_path": "/tmp/x",
+            "client_id": "c",
+        }))
+        .is_ok()
+    );
+}
+
+#[test]
 fn validate_config_hook_accepts_valid_config() {
     assert!(validate_config(&serde_json::json!({ "method": "managed_identity" })).is_ok());
 }

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/tests.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/tests.rs
@@ -164,7 +164,9 @@ impl TokenCredential for MockCredential {
 }
 
 #[derive(Debug)]
-struct FailingCredential;
+struct FailingCredential {
+    call_count: Arc<AtomicUsize>,
+}
 
 #[async_trait::async_trait]
 impl TokenCredential for FailingCredential {
@@ -173,6 +175,7 @@ impl TokenCredential for FailingCredential {
         _scopes: &[&str],
         _options: Option<TokenRequestOptions<'_>>,
     ) -> azure_core::Result<AccessToken> {
+        let _ = self.call_count.fetch_add(1, Ordering::SeqCst);
         Err(azure_core::error::Error::with_message(
             azure_core::error::ErrorKind::Credential,
             "mock credential failure",
@@ -219,10 +222,10 @@ async fn get_token_slow_path_then_fast_path_caches() {
 #[tokio::test]
 async fn near_expiry_token_is_refreshed() {
     let calls = Arc::new(AtomicUsize::new(0));
-    // Expiry well inside the refresh-skew window -> always treated as stale.
+    // Expiry inside the usability safety margin -> always treated as stale.
     let credential = Arc::new(MockCredential {
         token: "tok".to_string(),
-        expires_in: AzureDuration::seconds(30),
+        expires_in: AzureDuration::seconds(5),
         call_count: Arc::clone(&calls),
     });
     let ext = make_extension(credential);
@@ -238,13 +241,34 @@ async fn near_expiry_token_is_refreshed() {
 
 #[tokio::test]
 async fn get_token_error_maps_to_capability_error() {
-    let ext = make_extension(Arc::new(FailingCredential));
+    let ext = make_extension(Arc::new(FailingCredential {
+        call_count: Arc::new(AtomicUsize::new(0)),
+    }));
     let err = ext
         .get_token()
         .await
         .expect_err("failing credential errors");
     assert_eq!(err.capability, "bearer_token_provider");
     assert_eq!(err.extension, "test-ext");
+}
+
+#[tokio::test]
+async fn get_token_throttles_after_recent_failure() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let ext = make_extension(Arc::new(FailingCredential {
+        call_count: Arc::clone(&calls),
+    }));
+
+    // First miss actually hits the credential and fails.
+    let _ = ext.get_token().await.expect_err("first attempt fails");
+    // Second miss within the cooldown is throttled by the negative cache: it
+    // errors without a further credential call.
+    let _ = ext.get_token().await.expect_err("second attempt throttled");
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "recent failure must throttle the next slow-path fetch"
+    );
 }
 
 #[tokio::test]

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/tests.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/tests.rs
@@ -109,15 +109,20 @@ fn managed_identity_user_assigned_credential_constructs() {
 }
 
 #[test]
-fn unsupported_methods_error_for_now() {
+fn development_credential_constructs() {
     otap_df_otap::crypto::ensure_crypto_provider();
-    for method in ["development", "workload_identity"] {
-        let cfg = config_from_json(serde_json::json!({ "method": method })).unwrap();
-        assert!(
-            matches!(Auth::new(&cfg), Err(Error::CreateCredential { .. })),
-            "method `{method}` should currently be unsupported"
-        );
-    }
+    let cfg = config_from_json(serde_json::json!({ "method": "development" })).unwrap();
+    assert!(Auth::new(&cfg).is_ok());
+}
+
+#[test]
+fn workload_identity_not_yet_supported() {
+    otap_df_otap::crypto::ensure_crypto_provider();
+    let cfg = config_from_json(serde_json::json!({ "method": "workload_identity" })).unwrap();
+    assert!(
+        matches!(Auth::new(&cfg), Err(Error::CreateCredential { .. })),
+        "workload_identity should currently be unsupported"
+    );
 }
 
 // ── Token acquisition / cache tests ───────────────────────────

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/tests.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/tests.rs
@@ -101,8 +101,7 @@ fn per_method_fields_are_validated() {
     );
     // `client_id` is not valid for developer tooling.
     assert!(
-        config_from_json(serde_json::json!({ "method": "development", "client_id": "c" }))
-            .is_err()
+        config_from_json(serde_json::json!({ "method": "development", "client_id": "c" })).is_err()
     );
     // Valid combinations still pass.
     assert!(
@@ -333,4 +332,87 @@ async fn token_stream_yields_published_token() {
     let _ = ext.get_token().await.expect("token acquired");
     let published = stream.next().await.expect("stream yields a value");
     assert_eq!(published.expose_secret(), "streamed");
+}
+
+#[tokio::test]
+async fn token_stream_skips_initial_none() {
+    use std::time::Duration;
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let credential = Arc::new(MockCredential {
+        token: "streamed".to_string(),
+        expires_in: AzureDuration::minutes(60),
+        call_count: Arc::clone(&calls),
+    });
+    let ext = make_extension(credential);
+
+    let mut stream = ext.token_stream();
+    // The cache starts as `None`; the stream must filter it out and stay
+    // pending rather than yielding a spurious value.
+    let before = tokio::time::timeout(Duration::from_millis(50), stream.next()).await;
+    assert!(
+        before.is_err(),
+        "stream must not yield before a token is published"
+    );
+
+    // Once a token is published, the stream yields it.
+    let _ = ext.get_token().await.expect("token acquired");
+    let published = tokio::time::timeout(Duration::from_millis(200), stream.next())
+        .await
+        .expect("stream yields after publish")
+        .expect("stream is not closed");
+    assert_eq!(published.expose_secret(), "streamed");
+}
+
+// ── schedule_next timing tests ────────────────────────────────
+
+#[tokio::test]
+async fn schedule_next_refreshes_before_expiry() {
+    use otap_df_engine::capability::BearerToken;
+    use std::time::{Duration, Instant};
+
+    let token = BearerToken::new(
+        "t".to_owned(),
+        Some(Instant::now() + Duration::from_secs(3600)),
+    );
+    let refresh_at = extension::schedule_next(&token);
+    let secs = refresh_at
+        .saturating_duration_since(tokio::time::Instant::now())
+        .as_secs_f64();
+    // 3600 - TOKEN_EXPIRY_BUFFER_SECS (299) = 3301, allowing execution slack.
+    assert!((secs - 3301.0).abs() < 5.0, "expected ~3301s, got {secs}");
+}
+
+#[tokio::test]
+async fn schedule_next_floors_near_expiry() {
+    use otap_df_engine::capability::BearerToken;
+    use std::time::{Duration, Instant};
+
+    // Expires in 5s: the refresh target underflows past `now`, so the
+    // MIN_TOKEN_REFRESH_INTERVAL_SECS (10s) floor applies.
+    let token = BearerToken::new(
+        "t".to_owned(),
+        Some(Instant::now() + Duration::from_secs(5)),
+    );
+    let refresh_at = extension::schedule_next(&token);
+    let secs = refresh_at
+        .saturating_duration_since(tokio::time::Instant::now())
+        .as_secs_f64();
+    assert!((secs - 10.0).abs() < 2.0, "expected ~10s floor, got {secs}");
+}
+
+#[tokio::test]
+async fn schedule_next_pushes_non_expiring_far_out() {
+    use otap_df_engine::capability::BearerToken;
+
+    let token = BearerToken::new("t".to_owned(), None);
+    let refresh_at = extension::schedule_next(&token);
+    let secs = refresh_at
+        .saturating_duration_since(tokio::time::Instant::now())
+        .as_secs();
+    // Non-expiring tokens push the refresh ~1 year out.
+    assert!(
+        secs > 300 * 24 * 60 * 60,
+        "expected far-future refresh, got {secs}s"
+    );
 }

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/tests.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/tests.rs
@@ -116,13 +116,24 @@ fn development_credential_constructs() {
 }
 
 #[test]
-fn workload_identity_not_yet_supported() {
+fn workload_identity_credential_construct_is_attempted() {
     otap_df_otap::crypto::ensure_crypto_provider();
-    let cfg = config_from_json(serde_json::json!({ "method": "workload_identity" })).unwrap();
-    assert!(
-        matches!(Auth::new(&cfg), Err(Error::CreateCredential { .. })),
-        "workload_identity should currently be unsupported"
-    );
+    let cfg = config_from_json(serde_json::json!({
+        "method": "workload_identity",
+        "client_id": "test-client",
+        "tenant_id": "test-tenant",
+        "token_file_path": "/tmp/does-not-exist",
+    }))
+    .unwrap();
+    // Construction only validates configuration; a missing env/file surfaces as
+    // a CreateCredential error. Both outcomes are acceptable here.
+    match Auth::new(&cfg) {
+        Ok(_) => {}
+        Err(Error::CreateCredential { method, .. }) => {
+            assert_eq!(method, AuthMethod::WorkloadIdentity);
+        }
+        Err(other) => panic!("unexpected error: {other:?}"),
+    }
 }
 
 // ── Token acquisition / cache tests ───────────────────────────

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/tests.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/tests.rs
@@ -36,6 +36,19 @@ fn config_defaults_apply() {
     assert!(cfg.client_id.is_none());
     assert!(cfg.tenant_id.is_none());
     assert!(cfg.token_file_path.is_none());
+    assert_eq!(cfg.startup_timeout, std::time::Duration::from_secs(30));
+}
+
+#[test]
+fn startup_timeout_parses_and_rejects_zero() {
+    let cfg = config_from_json(serde_json::json!({ "startup_timeout": "45s" }))
+        .expect("human-readable duration parses");
+    assert_eq!(cfg.startup_timeout, std::time::Duration::from_secs(45));
+
+    assert!(
+        config_from_json(serde_json::json!({ "startup_timeout": "0s" })).is_err(),
+        "zero startup_timeout must be rejected"
+    );
 }
 
 #[test]

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/tests.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/tests.rs
@@ -11,12 +11,15 @@ use azure_core::time::{Duration as AzureDuration, OffsetDateTime};
 use futures::StreamExt;
 use otap_df_config::error::Error as ConfigError;
 use otap_df_engine::shared::capability::BearerTokenProvider as SharedBearerTokenProvider;
+use otap_df_telemetry::registry::TelemetryRegistryHandle;
+use otap_df_telemetry::testing::EmptyAttributes;
 use tokio::sync::watch;
 
 use super::auth::Auth;
 use super::config::{AuthMethod, Config};
 use super::error::Error;
 use super::extension::AzureIdentityAuthExtension;
+use super::metrics::{AzureIdentityAuthMetrics, AzureIdentityAuthMetricsTracker};
 use super::*;
 
 // ── Config tests ───────────────────────────────────────────
@@ -180,7 +183,13 @@ impl TokenCredential for FailingCredential {
 fn make_extension(credential: Arc<dyn TokenCredential>) -> AzureIdentityAuthExtension {
     let auth = Auth::from_credential(credential, "test_scope".to_string());
     let (tx, _rx) = watch::channel(None);
-    AzureIdentityAuthExtension::new("test-ext", auth, tx)
+    AzureIdentityAuthExtension::new("test-ext", auth, tx, make_tracker())
+}
+
+fn make_tracker() -> AzureIdentityAuthMetricsTracker {
+    let registry = TelemetryRegistryHandle::new();
+    let metric_set = registry.register_metric_set::<AzureIdentityAuthMetrics>(EmptyAttributes());
+    AzureIdentityAuthMetricsTracker::new(metric_set)
 }
 
 #[tokio::test]

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/tests.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/tests.rs
@@ -338,6 +338,43 @@ async fn clones_share_one_token_cache() {
     assert_eq!(streamed.expose_secret(), "shared");
 }
 
+// ── Metrics tracker tests ─────────────────────────────────────
+
+#[test]
+fn metrics_tracker_records_snapshots_and_reports() {
+    let mut tracker = make_tracker();
+
+    // Debug formatting is exercised for observability tooling.
+    assert!(format!("{tracker:?}").contains("AzureIdentityAuthMetricsTracker"));
+
+    // A fresh tracker snapshots to all-zero values.
+    let before = tracker.snapshot();
+    assert!(
+        before.get_metrics().iter().all(|m| m.is_zero()),
+        "a new tracker starts at zero"
+    );
+
+    tracker.record_success(12.5);
+    tracker.record_failure();
+    tracker.record_publish();
+
+    // Every metric is non-zero once each counter/latency has been recorded.
+    let after = tracker.snapshot();
+    assert!(
+        after.get_metrics().iter().all(|m| !m.is_zero()),
+        "every metric is non-zero after recording"
+    );
+
+    // Reporting flushes the recorded metrics to the telemetry channel.
+    let (rx, mut reporter) =
+        otap_df_telemetry::reporter::MetricsReporter::create_new_and_receiver(4);
+    tracker.report(&mut reporter).expect("report succeeds");
+    assert!(
+        rx.try_recv().is_ok(),
+        "reporter received the metric snapshot"
+    );
+}
+
 #[tokio::test]
 async fn get_token_throttles_after_recent_failure() {
     let calls = Arc::new(AtomicUsize::new(0));

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/tests.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/tests.rs
@@ -1,0 +1,240 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Unit tests for the Azure Identity Auth extension.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use azure_core::credentials::{AccessToken, TokenCredential, TokenRequestOptions};
+use azure_core::time::{Duration as AzureDuration, OffsetDateTime};
+use futures::StreamExt;
+use otap_df_config::error::Error as ConfigError;
+use otap_df_engine::shared::capability::BearerTokenProvider as SharedBearerTokenProvider;
+use tokio::sync::watch;
+
+use super::auth::Auth;
+use super::config::{AuthMethod, Config};
+use super::error::Error;
+use super::extension::AzureIdentityAuthExtension;
+use super::*;
+
+// ── Config tests ───────────────────────────────────────────
+
+fn config_from_json(value: serde_json::Value) -> Result<Config, ConfigError> {
+    parse_config(&value)
+}
+
+#[test]
+fn config_defaults_apply() {
+    let cfg = config_from_json(serde_json::json!({})).expect("empty config is valid");
+    assert_eq!(cfg.method, AuthMethod::ManagedIdentity);
+    assert_eq!(cfg.scope, "https://monitor.azure.com/.default");
+    assert!(cfg.client_id.is_none());
+    assert!(cfg.tenant_id.is_none());
+    assert!(cfg.token_file_path.is_none());
+}
+
+#[test]
+fn method_aliases_deserialize() {
+    let cases = [
+        ("msi", AuthMethod::ManagedIdentity),
+        ("managed_identity", AuthMethod::ManagedIdentity),
+        ("managedidentity", AuthMethod::ManagedIdentity),
+        ("dev", AuthMethod::Development),
+        ("developer", AuthMethod::Development),
+        ("cli", AuthMethod::Development),
+        ("development", AuthMethod::Development),
+        ("wif", AuthMethod::WorkloadIdentity),
+        ("workload_identity", AuthMethod::WorkloadIdentity),
+        ("workloadidentity", AuthMethod::WorkloadIdentity),
+    ];
+    for (alias, expected) in cases {
+        let cfg = config_from_json(serde_json::json!({ "method": alias }))
+            .unwrap_or_else(|e| panic!("alias `{alias}` should deserialize: {e}"));
+        assert_eq!(cfg.method, expected, "alias `{alias}`");
+    }
+}
+
+#[test]
+fn empty_scope_is_rejected() {
+    let err = config_from_json(serde_json::json!({ "scope": "   " }))
+        .expect_err("whitespace scope must be rejected");
+    assert!(matches!(err, ConfigError::InvalidUserConfig { .. }));
+}
+
+#[test]
+fn unknown_fields_are_rejected() {
+    let err = config_from_json(serde_json::json!({ "bogus": true }))
+        .expect_err("unknown field must be rejected");
+    assert!(matches!(err, ConfigError::InvalidUserConfig { .. }));
+}
+
+#[test]
+fn validate_config_hook_accepts_valid_config() {
+    assert!(validate_config(&serde_json::json!({ "method": "managed_identity" })).is_ok());
+}
+
+#[test]
+fn factory_is_registered_with_capability() {
+    assert_eq!(AZURE_IDENTITY_AUTH_EXTENSION.name, AZURE_IDENTITY_AUTH_URN);
+    let capabilities = AZURE_IDENTITY_AUTH_EXTENSION
+        .capabilities
+        .as_ref()
+        .expect("active extension advertises capabilities");
+    assert!(
+        capabilities.shared.contains(&"bearer_token_provider"),
+        "BearerTokenProvider must be advertised as a shared capability"
+    );
+}
+
+// ── Credential construction tests ──────────────────────────────
+
+#[test]
+fn managed_identity_system_assigned_credential_constructs() {
+    otap_df_otap::crypto::ensure_crypto_provider();
+    let cfg = config_from_json(serde_json::json!({ "method": "managed_identity" })).unwrap();
+    assert!(Auth::new(&cfg).is_ok());
+}
+
+#[test]
+fn managed_identity_user_assigned_credential_constructs() {
+    otap_df_otap::crypto::ensure_crypto_provider();
+    let cfg = config_from_json(serde_json::json!({
+        "method": "managed_identity",
+        "client_id": "00000000-0000-0000-0000-000000000000",
+    }))
+    .unwrap();
+    assert!(Auth::new(&cfg).is_ok());
+}
+
+#[test]
+fn unsupported_methods_error_for_now() {
+    otap_df_otap::crypto::ensure_crypto_provider();
+    for method in ["development", "workload_identity"] {
+        let cfg = config_from_json(serde_json::json!({ "method": method })).unwrap();
+        assert!(
+            matches!(Auth::new(&cfg), Err(Error::CreateCredential { .. })),
+            "method `{method}` should currently be unsupported"
+        );
+    }
+}
+
+// ── Token acquisition / cache tests ───────────────────────────
+
+#[derive(Debug)]
+struct MockCredential {
+    token: String,
+    expires_in: AzureDuration,
+    call_count: Arc<AtomicUsize>,
+}
+
+#[async_trait::async_trait]
+impl TokenCredential for MockCredential {
+    async fn get_token(
+        &self,
+        _scopes: &[&str],
+        _options: Option<TokenRequestOptions<'_>>,
+    ) -> azure_core::Result<AccessToken> {
+        let _ = self.call_count.fetch_add(1, Ordering::SeqCst);
+        Ok(AccessToken {
+            token: self.token.clone().into(),
+            expires_on: OffsetDateTime::now_utc() + self.expires_in,
+        })
+    }
+}
+
+#[derive(Debug)]
+struct FailingCredential;
+
+#[async_trait::async_trait]
+impl TokenCredential for FailingCredential {
+    async fn get_token(
+        &self,
+        _scopes: &[&str],
+        _options: Option<TokenRequestOptions<'_>>,
+    ) -> azure_core::Result<AccessToken> {
+        Err(azure_core::error::Error::with_message(
+            azure_core::error::ErrorKind::Credential,
+            "mock credential failure",
+        ))
+    }
+}
+
+fn make_extension(credential: Arc<dyn TokenCredential>) -> AzureIdentityAuthExtension {
+    let auth = Auth::from_credential(credential, "test_scope".to_string());
+    let (tx, _rx) = watch::channel(None);
+    AzureIdentityAuthExtension::new("test-ext", auth, tx)
+}
+
+#[tokio::test]
+async fn get_token_slow_path_then_fast_path_caches() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let credential = Arc::new(MockCredential {
+        token: "tok".to_string(),
+        expires_in: AzureDuration::minutes(60),
+        call_count: Arc::clone(&calls),
+    });
+    let ext = make_extension(credential);
+
+    let first = ext.get_token().await.expect("first acquisition");
+    assert_eq!(first.expose_secret(), "tok");
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+    // Fresh cached token is returned without another credential call.
+    let second = ext.get_token().await.expect("cached acquisition");
+    assert_eq!(second.expose_secret(), "tok");
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "fast path must not re-fetch"
+    );
+}
+
+#[tokio::test]
+async fn near_expiry_token_is_refreshed() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    // Expiry well inside the refresh-skew window -> always treated as stale.
+    let credential = Arc::new(MockCredential {
+        token: "tok".to_string(),
+        expires_in: AzureDuration::seconds(30),
+        call_count: Arc::clone(&calls),
+    });
+    let ext = make_extension(credential);
+
+    let _ = ext.get_token().await.expect("first");
+    let _ = ext.get_token().await.expect("second");
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        2,
+        "stale token must be refreshed on each call"
+    );
+}
+
+#[tokio::test]
+async fn get_token_error_maps_to_capability_error() {
+    let ext = make_extension(Arc::new(FailingCredential));
+    let err = ext
+        .get_token()
+        .await
+        .expect_err("failing credential errors");
+    assert_eq!(err.capability, "bearer_token_provider");
+    assert_eq!(err.extension, "test-ext");
+}
+
+#[tokio::test]
+async fn token_stream_yields_published_token() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let credential = Arc::new(MockCredential {
+        token: "streamed".to_string(),
+        expires_in: AzureDuration::minutes(60),
+        call_count: Arc::clone(&calls),
+    });
+    let ext = make_extension(credential);
+
+    let mut stream = ext.token_stream();
+    // Acquiring a token publishes it onto the watch channel.
+    let _ = ext.get_token().await.expect("token acquired");
+    let published = stream.next().await.expect("stream yields a value");
+    assert_eq!(published.expose_secret(), "streamed");
+}

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/tests.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/tests.rs
@@ -299,6 +299,46 @@ async fn get_token_error_maps_to_capability_error() {
 }
 
 #[tokio::test]
+async fn clones_share_one_token_cache() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let credential = Arc::new(MockCredential {
+        token: "shared".to_string(),
+        expires_in: AzureDuration::minutes(60),
+        call_count: Arc::clone(&calls),
+    });
+
+    // The engine hands the capability to each consumer as a clone of the same
+    // extension; model that with two clones sharing one `Arc<Inner>`.
+    let consumer_a = make_extension(credential);
+    let consumer_b = consumer_a.clone();
+
+    // Consumer A's first call takes the slow path and fetches exactly once.
+    let a = consumer_a.get_token().await.expect("A acquires");
+    assert_eq!(a.expose_secret(), "shared");
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+    // Consumer B (a separate clone) sees the same cached token on the fast
+    // path -- no second credential call. This proves clones share one cache
+    // and refresh loop rather than each keeping its own.
+    let b = consumer_b.get_token().await.expect("B acquires");
+    assert_eq!(b.expose_secret(), "shared");
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "clones must share one cache; B must not re-fetch"
+    );
+
+    // A token published through one clone is also visible via another clone's
+    // stream subscription (shared watch channel).
+    let mut stream_b = consumer_b.token_stream();
+    let streamed = stream_b
+        .next()
+        .await
+        .expect("stream yields the shared token");
+    assert_eq!(streamed.expose_secret(), "shared");
+}
+
+#[tokio::test]
 async fn get_token_throttles_after_recent_failure() {
     let calls = Arc::new(AtomicUsize::new(0));
     let ext = make_extension(Arc::new(FailingCredential {

--- a/rust/otap-dataflow/crates/contrib-extensions/src/lib.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/lib.rs
@@ -1,0 +1,11 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! OTAP Contrib extensions.
+//!
+//! Each extension is gated behind an opt-in feature and registers itself into
+//! the OTAP pipeline factory's extension slice via `linkme` when its feature is
+//! enabled.
+
+#[cfg(feature = "azure-identity-auth-extension")]
+pub mod azure_identity_auth;

--- a/rust/otap-dataflow/docs/azure-identity-auth-extension.md
+++ b/rust/otap-dataflow/docs/azure-identity-auth-extension.md
@@ -265,10 +265,13 @@ groups:
 | `tenant_id` | `string?` | *none* | Entra tenant ID. Only for `workload_identity`; falls back to `AZURE_TENANT_ID`. |
 | `token_file_path` | `string?` (path) | *none* | Path to the projected federated token file. Only for `workload_identity`; falls back to `AZURE_FEDERATED_TOKEN_FILE`. |
 | `scope` | `string` | `https://monitor.azure.com/.default` | OAuth scope to request tokens for. Must be non-empty. |
+| `startup_timeout` | duration | `30s` | How long the engine holds data-path node startup waiting for the first token publish before aborting (see [Lifecycle](#lifecycle)). Accepts human-readable durations (e.g. `30s`, `1m`); must be non-zero. Larger than the engine's 5 s readiness default to accommodate Azure cold-start plus a retry. |
 
 The config struct uses `#[serde(deny_unknown_fields)]` and is validated by the
 factory's `validate_config` hook before the pipeline starts. Validation rejects
-an empty/whitespace `scope`.
+an empty/whitespace `scope`, a zero `startup_timeout`, and any per-method field
+that does not apply to the selected method (`tenant_id`/`token_file_path` are
+`workload_identity`-only; `client_id` is not valid for `development`).
 
 ### Auth methods
 
@@ -397,10 +400,13 @@ Metrics are recorded in both the background refresh loop and the slow-path
    publishes a token onto the `watch` channel, then calls
    `EffectHandler::signal_ready()`.
 3. The engine holds data-path node spawning on the extension's readiness probe
-   (`wait_all_ready`) until that signal fires, bounded by the probe timeout
-   (default 5s; override via `with_readiness_probe_timeout_override`). If the
-   first token is not acquired in time, startup aborts with a readiness-timeout
-   error rather than starting nodes without a token.
+   (`wait_all_ready`) until that signal fires, bounded by the probe timeout. The
+   extension sets this via `with_readiness_probe_timeout_override` from the
+   `startup_timeout` config field (default `30s`, larger than the engine's 5 s
+   default because Azure cold-start plus the ~10 s failure-retry cadence needs
+   room for a retry inside the gate). If the first token is not acquired in
+   time, startup aborts with a readiness-timeout error rather than starting
+   nodes without a token.
 4. Data-path nodes then start. Each consumer resolves the capability once at
    construction (`require_local()` / `require_shared()`) and holds the typed
    handle for its lifetime - no capability resolution on the hot path. Because

--- a/rust/otap-dataflow/src/main.rs
+++ b/rust/otap-dataflow/src/main.rs
@@ -8,8 +8,8 @@ use clap::Parser;
 use otap_df_config::config_provider::{ConfigFormat, resolve_config};
 use otap_df_config::engine::OtelDataflowSpec;
 use otap_df_config::policy::{CoreAllocation, CoreRange};
-// Keep this side-effect import so the crate is linked and its `linkme`
-// distributed-slice registrations (contrib nodes) are visible
+// Keep these side-effect imports so the crates are linked and their `linkme`
+// distributed-slice registrations (contrib nodes and extensions) are visible
 // in `OTAP_PIPELINE_FACTORY` at runtime.
 use otap_df_contrib_extensions as _;
 use otap_df_contrib_nodes as _;

--- a/rust/otap-dataflow/src/main.rs
+++ b/rust/otap-dataflow/src/main.rs
@@ -11,6 +11,7 @@ use otap_df_config::policy::{CoreAllocation, CoreRange};
 // Keep this side-effect import so the crate is linked and its `linkme`
 // distributed-slice registrations (contrib nodes) are visible
 // in `OTAP_PIPELINE_FACTORY` at runtime.
+use otap_df_contrib_extensions as _;
 use otap_df_contrib_nodes as _;
 use otap_df_controller::startup;
 use otap_df_controller::{Controller, ControllerRunOptions};


### PR DESCRIPTION
# Change Summary

Adds a new `azure_identity_auth` extension (in a new `otap-df-contrib-extensions`
crate) that acquires and refreshes Azure OAuth access tokens and exposes them
to data-path nodes through the shared `BearerTokenProvider` capability (merged
in #3372).

## What issue does this PR close?

* Related to #3356

## How are these changes tested?

Unit tests

## Are there any user-facing changes?

Yes — a new opt-in extension is available. It is not enabled by default; users
must build with `--features azure-identity-auth-extension` and reference the
URN `urn:microsoft:extension:azure_identity_auth` in their pipeline config.

### Changelog

* [x] Added a `.chloggen/*.yaml` entry
* [ ] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
