### PR TITLE
fix(pdata): Fix silent attribute loss when decoding OTAP batches whose root IDs are not monotonic in resource/scope visitation order

### DIFF
--- a/rust/otap-dataflow/.chloggen/pdata-child-index-iter-non-monotonic-parent.yaml
+++ b/rust/otap-dataflow/.chloggen/pdata-child-index-iter-non-monotonic-parent.yaml
@@ -1,0 +1,25 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: pdata
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix silent attribute loss when decoding OTAP batches whose root IDs are not monotonic in resource/scope visitation order
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [3448]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The OTLP decoder joined child records (attributes, datapoints, span
+  events/links) to parents with a shared forward-only cursor that assumed parent
+  IDs were visited in ascending order. When root IDs are not monotonic along
+  `(resource_id, scope_id, id)` visitation order, a later-visited smaller-ID
+  record's child rows were skipped, silently dropping all of that record's
+  attributes with no error. `ChildIndexIter::new` now binary-searches
+  (`SortedBatchCursor::seek_to_parent`) to each parent's rows, making the join
+  order-independent for logs, metrics, and traces.

--- a/rust/otap-dataflow/crates/pdata/src/otlp/common.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/common.rs
@@ -1077,13 +1077,13 @@ impl SortedBatchCursor {
     ) where
         T::Native: PartialOrd,
     {
-        self.curr_index = self
-            .sorted_indices
-            .partition_point(|&idx| match parent_id_col.value_at(idx) {
-                Some(v) => v < target,
-                // nulls sort last, so treat them as `>= target` (never part of a match range)
-                None => false,
-            });
+        self.curr_index =
+            self.sorted_indices
+                .partition_point(|&idx| match parent_id_col.value_at(idx) {
+                    Some(v) => v < target,
+                    // nulls sort last, so treat them as `>= target` (never part of a match range)
+                    None => false,
+                });
     }
 }
 

--- a/rust/otap-dataflow/crates/pdata/src/otlp/common.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/common.rs
@@ -1087,7 +1087,12 @@ impl SortedBatchCursor {
         // (value_at == None) fall through to the search, as does the very first seek of a batch.
         if self.curr_index > 0 {
             if let Some(prev) = parent_id_col.value_at(self.sorted_indices[self.curr_index - 1]) {
-                if !(target < prev) {
+                // `target >= prev`: forward scan suffices. Incomparable values (partial_cmp ==
+                // None) fall through to the search as a safe default.
+                if matches!(
+                    target.partial_cmp(&prev),
+                    Some(Ordering::Greater | Ordering::Equal)
+                ) {
                     return;
                 }
             }

--- a/rust/otap-dataflow/crates/pdata/src/otlp/common.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/common.rs
@@ -1054,6 +1054,37 @@ impl SortedBatchCursor {
     pub const fn finished(&self) -> bool {
         self.curr_index >= self.sorted_indices.len()
     }
+
+    /// Position the cursor at the first sorted index whose parent-id value is `>= target`.
+    ///
+    /// The cursor's `sorted_indices` are ordered by the child's parent-id column (ascending,
+    /// with nulls sorted last), so this seeks to the start of `target`'s equal-range. Seeking
+    /// by absolute binary search — rather than relying on the cursor's prior forward position —
+    /// makes child attribute lookups independent of the order in which parents request their
+    /// children.
+    ///
+    /// This matters because the root record visitation order is `(resource_id, scope_id, id)`,
+    /// which is not necessarily ascending in `id` alone: e.g. after `extend attributes[...]`
+    /// fills null root ids with `max + 1`, an earlier-visited scope can carry a *larger* id than
+    /// a later-visited one. A purely forward cursor would then skip (permanently consume) the
+    /// later, lower-id parent's child rows, silently dropping all of its attributes. Re-seeking
+    /// per parent avoids that. Each parent id is queried at most once per batch, so re-seeking
+    /// never re-yields rows for an already-emitted parent.
+    fn seek_to_parent<T: ArrowPrimitiveType>(
+        &mut self,
+        target: T::Native,
+        parent_id_col: &MaybeDictArrayAccessor<'_, PrimitiveArray<T>>,
+    ) where
+        T::Native: PartialOrd,
+    {
+        self.curr_index = self
+            .sorted_indices
+            .partition_point(|&idx| match parent_id_col.value_at(idx) {
+                Some(v) => v < target,
+                // nulls sort last, so treat them as `>= target` (never part of a match range)
+                None => false,
+            });
+    }
 }
 
 /// This is used to initialize the [`SortedBatchCursor`]. It does this by sorting the IDs and then
@@ -1249,12 +1280,16 @@ pub(crate) struct ChildIndexIter<'a, T: ArrowPrimitiveType> {
 impl<'a, T> ChildIndexIter<'a, T>
 where
     T: ArrowPrimitiveType,
+    T::Native: PartialOrd,
 {
-    pub const fn new(
+    pub fn new(
         parent_id: T::Native,
         parent_id_col: &'a MaybeDictArrayAccessor<'a, PrimitiveArray<T>>,
         cursor: &'a mut SortedBatchCursor,
     ) -> Self {
+        // Seek to the start of this parent's child rows via binary search, so that lookups do
+        // not depend on parents being visited in ascending-id order. See `seek_to_parent`.
+        cursor.seek_to_parent(parent_id, parent_id_col);
         Self {
             parent_id,
             parent_id_col,
@@ -1347,6 +1382,41 @@ mod test {
             // check we don't try to iterate past the end
             let mut id_3_iter = ChildIndexIter::new(3, &parent_ids, &mut cursor);
             assert_eq!(id_3_iter.next(), None)
+        }
+    }
+
+    /// Regression test: parents may be visited in *non-ascending* id order against a shared
+    /// cursor. The root visitation order is `(resource_id, scope_id, id)`, so `id` alone is not
+    /// always ascending (e.g. after `extend attributes[...]` fills null root ids with `max + 1`).
+    /// A purely forward cursor would consume rows for a lower id while seeking a higher one and
+    /// then return nothing for the lower id, silently dropping its attributes. Each parent must
+    /// find its own child rows regardless of visitation order.
+    #[test]
+    fn test_child_index_iter_non_monotonic_parent_order() {
+        let mut cursor = SortedBatchCursor::new();
+        // rows: parent_id 0 -> row0, parent_id 2 -> row1, parent_id 1 -> row2, parent_id 2 -> row3
+        let tmp = UInt16Array::from_iter_values(vec![0, 2, 1, 2]);
+        let parent_ids = MaybeDictArrayAccessor::Native(&tmp);
+        BatchSorter::new().init_cursor_for_u16_id_column(&parent_ids, &mut cursor);
+
+        // Visit parents in the order 0, 2, 1 (mirrors the `[0, 2, 1]` root-id sequence produced
+        // by null-id fill). The middle visit (id 2) must not consume id 1's row.
+        {
+            let mut id_0_iter = ChildIndexIter::<UInt16Type>::new(0, &parent_ids, &mut cursor);
+            assert_eq!(id_0_iter.next(), Some(0));
+            assert_eq!(id_0_iter.next(), None);
+        }
+        {
+            let mut id_2_iter = ChildIndexIter::<UInt16Type>::new(2, &parent_ids, &mut cursor);
+            assert_eq!(id_2_iter.next(), Some(1));
+            assert_eq!(id_2_iter.next(), Some(3));
+            assert_eq!(id_2_iter.next(), None);
+        }
+        {
+            // Before the fix this returned None because id 2's visit consumed past row2.
+            let mut id_1_iter = ChildIndexIter::<UInt16Type>::new(1, &parent_ids, &mut cursor);
+            assert_eq!(id_1_iter.next(), Some(2));
+            assert_eq!(id_1_iter.next(), None);
         }
     }
 

--- a/rust/otap-dataflow/crates/pdata/src/otlp/common.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/common.rs
@@ -1058,18 +1058,23 @@ impl SortedBatchCursor {
     /// Position the cursor at the first sorted index whose parent-id value is `>= target`.
     ///
     /// The cursor's `sorted_indices` are ordered by the child's parent-id column (ascending,
-    /// with nulls sorted last), so this seeks to the start of `target`'s equal-range. Seeking
-    /// by absolute binary search — rather than relying on the cursor's prior forward position —
-    /// makes child attribute lookups independent of the order in which parents request their
-    /// children.
+    /// with nulls sorted last), so this seeks to the start of `target`'s equal-range.
     ///
-    /// This matters because the root record visitation order is `(resource_id, scope_id, id)`,
-    /// which is not necessarily ascending in `id` alone: e.g. after `extend attributes[...]`
-    /// fills null root ids with `max + 1`, an earlier-visited scope can carry a *larger* id than
-    /// a later-visited one. A purely forward cursor would then skip (permanently consume) the
-    /// later, lower-id parent's child rows, silently dropping all of its attributes. Re-seeking
-    /// per parent avoids that. Each parent id is queried at most once per batch, so re-seeking
-    /// never re-yields rows for an already-emitted parent.
+    /// Seeking makes child attribute lookups independent of the order in which parents request
+    /// their children. This matters because the root record visitation order is
+    /// `(resource_id, scope_id, id)`, which is not necessarily ascending in `id` alone: e.g. after
+    /// `extend attributes[...]` fills null root ids with `max + 1`, an earlier-visited scope can
+    /// carry a *larger* id than a later-visited one. A purely forward cursor would then skip
+    /// (permanently consume) the later, lower-id parent's child rows, silently dropping all of its
+    /// attributes. Each parent id is queried at most once per batch, so re-seeking never re-yields
+    /// rows for an already-emitted parent.
+    ///
+    /// Fast path: parents are *usually* visited in ascending id order, in which case the cursor is
+    /// already at (or before) `target`'s range and [`ChildIndexIter::next`] can scan forward to it
+    /// without a search. We therefore only pay for the `O(log n)` binary search when a *backward*
+    /// jump is required - i.e. `target` is smaller than a parent we have already passed - which is
+    /// exactly the non-monotonic case the seek exists to handle. This keeps the common,
+    /// already-sorted case at the same cost as a plain forward cursor.
     fn seek_to_parent<T: ArrowPrimitiveType>(
         &mut self,
         target: T::Native,
@@ -1077,6 +1082,17 @@ impl SortedBatchCursor {
     ) where
         T::Native: PartialOrd,
     {
+        // If the most recently consumed row's parent id is `<= target`, then `target`'s rows (if
+        // any) are at or after `curr_index`, so a forward scan suffices — no search needed. Nulls
+        // (value_at == None) fall through to the search, as does the very first seek of a batch.
+        if self.curr_index > 0 {
+            if let Some(prev) = parent_id_col.value_at(self.sorted_indices[self.curr_index - 1]) {
+                if !(target < prev) {
+                    return;
+                }
+            }
+        }
+
         self.curr_index =
             self.sorted_indices
                 .partition_point(|&idx| match parent_id_col.value_at(idx) {

--- a/rust/otap-dataflow/crates/pdata/src/otlp/logs.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/logs.rs
@@ -893,4 +893,164 @@ mod test {
         )]);
         assert_eq!(result, expected);
     }
+
+    #[test]
+    fn test_proto_encode_when_scope_ids_non_monotonic_across_resources() {
+        let res_struct_fields = Fields::from(vec![
+            Field::new(consts::ID, DataType::UInt16, true).with_plain_encoding(),
+        ]);
+        let scope_struct_fields = Fields::from(vec![
+            Field::new(consts::ID, DataType::UInt16, true).with_plain_encoding(),
+            Field::new(consts::NAME, DataType::Utf8, true),
+        ]);
+        let body_struct_fields = Fields::from(vec![
+            Field::new(consts::ATTRIBUTE_TYPE, DataType::UInt8, false),
+            Field::new(consts::ATTRIBUTE_STR, DataType::Utf8, true),
+        ]);
+
+        let logs_record_batch = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new(
+                    consts::RESOURCE,
+                    DataType::Struct(res_struct_fields.clone()),
+                    true,
+                ),
+                Field::new(
+                    consts::SCOPE,
+                    DataType::Struct(scope_struct_fields.clone()),
+                    true,
+                ),
+                Field::new(consts::ID, DataType::UInt16, true).with_plain_encoding(),
+                Field::new(
+                    consts::TIME_UNIX_NANO,
+                    DataType::Timestamp(TimeUnit::Nanosecond, None),
+                    false,
+                ),
+                Field::new(consts::SEVERITY_TEXT, DataType::Utf8, true),
+                Field::new(
+                    consts::BODY,
+                    DataType::Struct(body_struct_fields.clone()),
+                    true,
+                ),
+            ])),
+            vec![
+                Arc::new(StructArray::new(
+                    res_struct_fields.clone(),
+                    vec![Arc::new(UInt16Array::from_iter_values([0, 1, 1]))],
+                    None,
+                )),
+                Arc::new(StructArray::new(
+                    scope_struct_fields.clone(),
+                    vec![
+                        Arc::new(UInt16Array::from_iter_values([5, 2, 3])),
+                        Arc::new(StringArray::from_iter_values(vec![
+                            "scope5", "scope2", "scope3",
+                        ])),
+                    ],
+                    None,
+                )),
+                Arc::new(UInt16Array::from_iter_values(vec![0, 1, 2])),
+                Arc::new(TimestampNanosecondArray::from_iter_values([1, 2, 3])),
+                Arc::new(StringArray::from_iter_values(vec![
+                    "ERROR", "INFO", "DEBUG",
+                ])),
+                Arc::new(StructArray::new(
+                    body_struct_fields.clone(),
+                    vec![
+                        Arc::new(UInt8Array::from_iter_values(std::iter::repeat_n(
+                            AttributeValueType::Str as u8,
+                            3,
+                        ))),
+                        Arc::new(StringArray::from_iter_values(vec!["a", "b", "c"])),
+                    ],
+                    None,
+                )),
+            ],
+        )
+        .unwrap();
+
+        // ScopeAttrs parent IDs stored sorted ascending: parent 2 -> "v2", 3 -> "v3", 5 -> "v5".
+        let scope_attrs_record_batch = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new(consts::PARENT_ID, DataType::UInt16, false),
+                Field::new(consts::ATTRIBUTE_TYPE, DataType::UInt8, false),
+                Field::new(consts::ATTRIBUTE_KEY, DataType::Utf8, false),
+                Field::new(consts::ATTRIBUTE_STR, DataType::Utf8, true),
+            ])),
+            vec![
+                Arc::new(UInt16Array::from_iter_values(vec![2, 3, 5])),
+                Arc::new(UInt8Array::from_iter_values(std::iter::repeat_n(
+                    AttributeValueType::Str as u8,
+                    3,
+                ))),
+                Arc::new(StringArray::from_iter_values(vec!["k", "k", "k"])),
+                Arc::new(StringArray::from_iter_values(vec!["v2", "v3", "v5"])),
+            ],
+        )
+        .unwrap();
+
+        let mut otap_batch = OtapArrowRecords::Logs(Logs::default());
+        otap_batch
+            .set(ArrowPayloadType::Logs, logs_record_batch)
+            .unwrap();
+        otap_batch
+            .set(ArrowPayloadType::ScopeAttrs, scope_attrs_record_batch)
+            .unwrap();
+        let mut result_buf = ProtoBuffer::default();
+        let mut encoder = LogsProtoBytesEncoder::new();
+        encoder.encode(&mut otap_batch, &mut result_buf).unwrap();
+        let result = LogsData::decode(result_buf.as_ref()).unwrap();
+
+        let expected = LogsData::new(vec![
+            ResourceLogs::new(
+                Resource::default(),
+                vec![ScopeLogs::new(
+                    InstrumentationScope::build()
+                        .name("scope5")
+                        .attributes(vec![KeyValue::new("k", AnyValue::new_string("v5"))])
+                        .finish(),
+                    vec![
+                        LogRecord::build()
+                            .time_unix_nano(1u64)
+                            .severity_text("ERROR")
+                            .body(AnyValue::new_string("a"))
+                            .finish(),
+                    ],
+                )],
+            ),
+            ResourceLogs::new(
+                Resource::default(),
+                vec![
+                    ScopeLogs::new(
+                        InstrumentationScope::build()
+                            .name("scope2")
+                            .attributes(vec![KeyValue::new("k", AnyValue::new_string("v2"))])
+                            .finish(),
+                        vec![
+                            LogRecord::build()
+                                .time_unix_nano(2u64)
+                                .severity_text("INFO")
+                                .body(AnyValue::new_string("b"))
+                                .finish(),
+                        ],
+                    ),
+                    ScopeLogs::new(
+                        InstrumentationScope::build()
+                            .name("scope3")
+                            .attributes(vec![KeyValue::new("k", AnyValue::new_string("v3"))])
+                            .finish(),
+                        vec![
+                            LogRecord::build()
+                                .time_unix_nano(3u64)
+                                .severity_text("DEBUG")
+                                .body(AnyValue::new_string("c"))
+                                .finish(),
+                        ],
+                    ),
+                ],
+            ),
+        ]);
+
+        assert_eq!(result, expected);
+    }
 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
@@ -8255,4 +8255,87 @@ mod test {
     async fn test_update_attr_using_rtrim_kql_parser() {
         test_update_attr_using_rtrim::<KqlParser>().await
     }
+
+    /// When a logs batch spans multiple scopes and only *some* records carry root
+    /// attributes, `extend attributes[...]` fills the null root-id column with `max+1`
+    /// ids. That can place a larger id on an earlier-visited scope than a later one,
+    /// breaking the monotonic-id invariant the OTLP decoder's attribute-join cursor
+    /// relies on — silently dropping *all* attributes from an unrelated record.
+    ///
+    /// Each record here lives under its own scope; the `error` attribute follows the
+    /// pattern `[present, absent, present]`. Every record must keep its original
+    /// attributes AND gain the newly-assigned `eventName`.
+    async fn test_extend_attrs_sparse_multi_scope<P: Parser>() {
+        // err_pattern controls whether each record has a pre-existing `error` attribute.
+        let err_pattern = [true, false, true];
+
+        let scope_logs: Vec<ScopeLogs> = err_pattern
+            .iter()
+            .enumerate()
+            .map(|(i, has_err)| {
+                let event_name = format!("evt{i}");
+                let mut builder = LogRecord::build().event_name(event_name.clone());
+                if *has_err {
+                    builder = builder
+                        .attributes(vec![KeyValue::new("error", AnyValue::new_string("E"))]);
+                }
+                ScopeLogs::new(
+                    InstrumentationScope::build().name(format!("scope{i}")).finish(),
+                    vec![builder.finish()],
+                )
+            })
+            .collect();
+
+        let logs_data = LogsData::new(vec![ResourceLogs::new(
+            Resource::build().finish(),
+            scope_logs,
+        )]);
+
+        let result = exec_logs_pipeline::<P>(
+            "logs | extend attributes[\"eventName\"] = event_name",
+            logs_data,
+        )
+        .await;
+
+        // Collect (event_name -> attribute keys) across every scope/record.
+        let mut by_event: std::collections::BTreeMap<String, Vec<String>> = Default::default();
+        for rl in &result.resource_logs {
+            for sl in &rl.scope_logs {
+                for lr in &sl.log_records {
+                    let keys: Vec<String> =
+                        lr.attributes.iter().map(|kv| kv.key.clone()).collect();
+                    let _ = by_event.insert(lr.event_name.clone(), keys);
+                }
+            }
+        }
+
+        assert_eq!(by_event.len(), 3, "expected 3 records, got {by_event:?}");
+
+        for (i, has_err) in err_pattern.iter().enumerate() {
+            let event_name = format!("evt{i}");
+            let keys = by_event
+                .get(&event_name)
+                .unwrap_or_else(|| panic!("missing record {event_name}"));
+            assert!(
+                keys.contains(&"eventName".to_string()),
+                "record {event_name} lost the newly-assigned eventName attribute: {keys:?}"
+            );
+            if *has_err {
+                assert!(
+                    keys.contains(&"error".to_string()),
+                    "record {event_name} lost its original error attribute: {keys:?}"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_extend_attrs_sparse_multi_scope_opl_parser() {
+        test_extend_attrs_sparse_multi_scope::<OplParser>().await
+    }
+
+    #[tokio::test]
+    async fn test_extend_attrs_sparse_multi_scope_kql_parser() {
+        test_extend_attrs_sparse_multi_scope::<KqlParser>().await
+    }
 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
@@ -8276,11 +8276,13 @@ mod test {
                 let event_name = format!("evt{i}");
                 let mut builder = LogRecord::build().event_name(event_name.clone());
                 if *has_err {
-                    builder = builder
-                        .attributes(vec![KeyValue::new("error", AnyValue::new_string("E"))]);
+                    builder =
+                        builder.attributes(vec![KeyValue::new("error", AnyValue::new_string("E"))]);
                 }
                 ScopeLogs::new(
-                    InstrumentationScope::build().name(format!("scope{i}")).finish(),
+                    InstrumentationScope::build()
+                        .name(format!("scope{i}"))
+                        .finish(),
                     vec![builder.finish()],
                 )
             })
@@ -8302,8 +8304,7 @@ mod test {
         for rl in &result.resource_logs {
             for sl in &rl.scope_logs {
                 for lr in &sl.log_records {
-                    let keys: Vec<String> =
-                        lr.attributes.iter().map(|kv| kv.key.clone()).collect();
+                    let keys: Vec<String> = lr.attributes.iter().map(|kv| kv.key.clone()).collect();
                     let _ = by_event.insert(lr.event_name.clone(), keys);
                 }
             }


### PR DESCRIPTION
# Change Summary

Addresses a follow-up from #2421.

On that PR review, it was noted that a 'truly pathological' OTAP batch might drop attributes in certain cases if root IDs are not in expected order. However, with query-engine, it is easily possible to construct such a batch when adding attributes to a record which previously didn't have any.

The OTLP decoder joined child records (attributes, datapoints, span events/links) to parents with a shared forward-only cursor that assumed parents were visited in ascending ID order. When root IDs aren't monotonic in `(resource_id, scope_id, id)` visitation order, a later-visited smaller-ID record's child rows were skipped — silently dropping all of that record's attributes with no error. 

`ChildIndexIter::new` now binary-searches to each parent's rows (`SortedBatchCursor::seek_to_parent`), making the join order-independent across logs, metrics, and traces. Adds regression tests in `pdata` and `query-engine`.

This could have a minor performance impact adding a `O(P * log n)` search where `P` is the number of parent records and `n` is the number of child rows.

## What issue does this PR close?

* Closes #3448 

## How are these changes tested?

Unit tests

## Are there any user-facing changes?

 <!-- If yes, provide further info below -->

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry
* [ ] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
