### PR TITLE
security(admin): attach hardened response headers to API routes Description:

### DIFF
--- a/rust/otap-dataflow/.chloggen/fix-otap-exporter-shutdown-deadlock.yaml
+++ b/rust/otap-dataflow/.chloggen/fix-otap-exporter-shutdown-deadlock.yaml
@@ -1,4 +1,4 @@
-﻿# Use this changelog template to create an entry for release notes.
+# Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
 change_type: bug_fix

--- a/rust/otap-dataflow/.chloggen/fix-otap-exporter-shutdown-deadlock.yaml
+++ b/rust/otap-dataflow/.chloggen/fix-otap-exporter-shutdown-deadlock.yaml
@@ -1,0 +1,20 @@
+﻿# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: pipeline
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix shutdown deadlock in OTAPExporter when stream queues are full and the downstream receiver is unreachable."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [3411]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  gRPC connection attempts are now abortable on shutdown to ensure fast, graceful termination even when reconnecting.

--- a/rust/otap-dataflow/crates/admin/README.md
+++ b/rust/otap-dataflow/crates/admin/README.md
@@ -103,7 +103,7 @@ guidance, see [`docs/admin/architecture.md`](../../docs/admin/architecture.md).
   `POST /api/v1/groups/{pipeline_group_id}/pipelines/{pipeline_id}/shutdown`,
   and `POST /api/v1/groups/shutdown` with stricter access controls than
   read-only endpoints.
-- [ ] Apply the same hardened response headers to API endpoints
+- [x] Apply the same hardened response headers to API endpoints
   (`/api/v1/status`, `/api/v1/livez`, `/api/v1/readyz`,
   `/api/v1/telemetry/*`, `/api/v1/metrics`), not only UI/static.
 - [ ] Harden CSP further by removing `style-src 'unsafe-inline'` (move toward

--- a/rust/otap-dataflow/crates/admin/src/lib.rs
+++ b/rust/otap-dataflow/crates/admin/src/lib.rs
@@ -13,6 +13,7 @@ mod pipeline_group;
 mod telemetry;
 
 use axum::Router;
+use axum::response::Response;
 pub use otap_df_admin_types::engine::{
     ConfigChangeAction, ConfigChangeStatus, EngineConfigReconcileRequest,
     EngineConfigReconcileState, EngineConfigReconcileStatus, GroupDeleteStatus,
@@ -260,6 +261,33 @@ impl AppState {
     }
 }
 
+/// Attaches hardened security headers to every `/api/v1/*` response.
+///
+/// These are the same policies already applied to UI/static routes in
+/// `dashboard.rs`. Centralising them here as a layer on `api_routes` means
+/// any new endpoint added to the router automatically inherits them.
+async fn attach_api_security_headers(mut response: Response) -> Response {
+    use axum::http::{HeaderName, HeaderValue, header};
+    let h = response.headers_mut();
+    let _ = h.insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("no-store, no-cache, must-revalidate"),
+    );
+    let _ = h.insert(
+        HeaderName::from_static("x-content-type-options"),
+        HeaderValue::from_static("nosniff"),
+    );
+    let _ = h.insert(
+        HeaderName::from_static("x-frame-options"),
+        HeaderValue::from_static("DENY"),
+    );
+    let _ = h.insert(
+        HeaderName::from_static("referrer-policy"),
+        HeaderValue::from_static("no-referrer"),
+    );
+    response
+}
+
 /// Run the admin HTTP server until shutdown is requested.
 pub async fn run(
     config: HttpAdminSettings,
@@ -287,7 +315,8 @@ pub async fn run(
         .merge(telemetry::routes())
         .merge(engine_config::routes())
         .merge(pipeline_group::routes())
-        .merge(pipeline::routes());
+        .merge(pipeline::routes())
+        .layer(axum::middleware::map_response(attach_api_security_headers));
 
     let app = Router::new()
         .nest("/api/v1", api_routes)

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/mod.rs
@@ -1,4 +1,4 @@
-// Copyright The OpenTelemetry Authors
+﻿// Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Implementation of the OTAP exporter node
@@ -56,6 +56,11 @@ pub const OTAP_EXPORTER_URN: &str = "urn:otel:exporter:otap";
 
 pub mod config;
 use config::Config;
+
+enum EnqueueResult {
+    Done,
+    Shutdown { deadline: Instant, reason: String },
+}
 
 /// Exporter that sends OTAP data via gRPC
 pub struct OTAPExporter {
@@ -298,7 +303,8 @@ impl OTAPExporter {
         message: OtapArrowRecords,
         pdata_metrics_rx: &mut Receiver<PDataMetricsUpdate>,
         effect_handler: &local::EffectHandler<OtapPdata>,
-    ) -> Result<(), Error> {
+        msg_chan: &mut ExporterInbox<OtapPdata>,
+    ) -> Result<EnqueueResult, Error> {
         let queue_depth = sender.max_capacity() - sender.capacity();
         self.async_metrics
             .stream_enqueue_depth
@@ -315,7 +321,7 @@ impl OTAPExporter {
                     self.async_metrics
                         .stream_enqueue_duration_ns
                         .record(elapsed_nanos(enqueue_start));
-                    return Ok(());
+                    return Ok(EnqueueResult::Done);
                 }
                 Err(tokio::sync::mpsc::error::TrySendError::Full(item)) => {
                     pending = Some(item);
@@ -324,7 +330,7 @@ impl OTAPExporter {
                     self.async_metrics
                         .stream_enqueue_duration_ns
                         .record(elapsed_nanos(enqueue_start));
-                    return Ok(());
+                    return Ok(EnqueueResult::Done);
                 }
             }
 
@@ -338,19 +344,42 @@ impl OTAPExporter {
                             self.async_metrics
                                 .stream_enqueue_duration_ns
                                 .record(elapsed_nanos(enqueue_start));
-                            return Ok(());
+                            return Ok(EnqueueResult::Done);
                         }
                         Err(_) => {
                             self.async_metrics
                                 .stream_enqueue_duration_ns
                                 .record(elapsed_nanos(enqueue_start));
-                            return Ok(());
+                            return Ok(EnqueueResult::Done);
                         }
                     }
                 }
                 metrics_update = pdata_metrics_rx.recv() => {
                     if let Some(update) = metrics_update {
                         self.handle_pdata_metrics_update(update, effect_handler).await?;
+                    }
+                }
+                msg = msg_chan.recv_when(false) => {
+                    let control_msg = msg.map_err(|e| Error::ExporterError {
+                        exporter: effect_handler.exporter_id(),
+                        kind: ExporterErrorKind::Other,
+                        error: format!("Inbox receive failed: {e}"),
+                        source_detail: "".to_owned(),
+                    })?;
+                    match control_msg {
+                        Message::Control(NodeControlMsg::CollectTelemetry { mut metrics_reporter }) => {
+                            self.export_latency_window
+                                .report_into(&mut self.async_metrics);
+                            _ = metrics_reporter.report(&mut self.pdata_metrics);
+                            _ = metrics_reporter.report(&mut self.async_metrics);
+                        }
+                        Message::Control(NodeControlMsg::Shutdown { deadline, reason }) => {
+                            if let Some((pdata, _)) = pending.take() {
+                                effect_handler.notify_nack(NackMsg::new("exporter shutting down", pdata)).await?;
+                            }
+                            return Ok(EnqueueResult::Shutdown { deadline, reason });
+                        }
+                        _ => {}
                     }
                 }
             }
@@ -610,14 +639,41 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
                             SignalType::Metrics => least_loaded_stream_sender(&metrics_senders),
                             SignalType::Traces => least_loaded_stream_sender(&traces_senders),
                         };
-                        self.enqueue_stream_batch(
+                        match self.enqueue_stream_batch(
                             sender,
                             pdata,
                             message,
                             &mut pdata_metrics_rx,
                             &effect_handler,
+                            &mut msg_chan,
                         )
-                        .await?;
+                        .await? {
+                            EnqueueResult::Done => {}
+                            EnqueueResult::Shutdown { deadline, reason: _reason } => {
+                                otel_info!(
+                                    "otap_exporter.shutdown",
+                                    message = "OTAP Exporter shutting down"
+                                );
+                                _ = shutdown_tx.send_replace(true);
+                                drop(pdata_metrics_tx);
+                                self.await_stream_handles_and_drain_metrics(
+                                    logs_handles
+                                        .into_iter()
+                                        .chain(metrics_handles)
+                                        .chain(traces_handles)
+                                        .collect(),
+                                    &mut pdata_metrics_rx,
+                                    &effect_handler,
+                                )
+                                .await?;
+                                self.export_latency_window
+                                    .report_into(&mut self.async_metrics);
+                                return Ok(TerminalState::new(
+                                    deadline,
+                                    [self.pdata_metrics.snapshot(), self.async_metrics.snapshot()],
+                                ))
+                            }
+                        }
                     }
                     _ => {
                         return Err(Error::ExporterError {
@@ -815,7 +871,21 @@ async fn stream_arrow_batches<T: StreamingArrowService>(
                     *req_stream.metadata_mut() = (**static_metadata).clone();
                 }
 
-                match client.handle_req_stream(req_stream).await {
+                let req_fut = client.handle_req_stream(req_stream);
+                let connect_res = tokio::select! {
+                    res = req_fut => res,
+                    _ = shutdown_rx.changed() => {
+                        drop(correlation_tx);
+                        _ = pdata_metrics_tx.send(PDataMetricsUpdate::IncFailed(
+                            signal_type,
+                            first_pdata_fallback,
+                            None,
+                        )).await;
+                        break;
+                    }
+                };
+
+                match connect_res {
                     Ok(res) => {
                         // reset the reconnect timeout backoff
                         failed_request_backoff = INITIAL_BACKOFF;
@@ -2982,5 +3052,206 @@ mod tests {
                 "authorization header missing on stream open #{i} (must be re-applied per open)"
             );
         }
+    }
+    #[test]
+    fn test_otap_exporter_connection_failure_backoff() {
+        use std::ops::Add;
+        use tokio::runtime::Runtime;
+        use tokio::time::timeout;
+
+        let tokio_rt = Runtime::new().unwrap();
+        let test_runtime = TestRuntime::<OtapPdata>::new();
+        let node_config = Arc::new(NodeUserConfig::new_exporter_config(OTAP_EXPORTER_URN));
+        let telemetry_registry_handle = TelemetryRegistryHandle::new();
+        let controller_ctx = ControllerContext::new(telemetry_registry_handle);
+        let node_id = test_node(test_runtime.config().name.clone());
+        let pipeline_ctx =
+            controller_ctx.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+
+        // Use an unused local port to reduce collision risk in parallel test runs while still
+        // keeping the endpoint unreachable (connection refused).
+        let grpc_port = portpicker::pick_unused_port().expect("No free ports");
+        let grpc_endpoint = format!("http://127.0.0.1:{grpc_port}");
+
+        let mut exporter = ExporterWrapper::local(
+            OTAPExporter::from_config(
+                pipeline_ctx,
+                &serde_json::json!({
+                    "grpc_endpoint": grpc_endpoint,
+                    "compression_method": "none",
+                    "stream_queue_capacity": 10,
+                }),
+            )
+            .unwrap(),
+            node_id.clone(),
+            node_config,
+            test_runtime.config(),
+        );
+
+        let control_sender = exporter.control_sender();
+        let (pdata_tx, pdata_rx) = create_not_send_channel::<OtapPdata>(1);
+        let pdata_tx = Sender::Local(LocalSender::mpsc(pdata_tx));
+        let pdata_rx = Receiver::Local(LocalReceiver::mpsc(pdata_rx));
+        let (runtime_ctrl_msg_tx, _runtime_ctrl_msg_rx) = runtime_ctrl_msg_channel(16);
+        let (pipeline_completion_msg_tx, _pipeline_completion_msg_rx) =
+            pipeline_completion_msg_channel(16);
+        exporter
+            .set_pdata_receiver(node_id.clone(), pdata_rx)
+            .unwrap();
+
+        let (_metrics_rx, metrics_reporter) = MetricsReporter::create_new_and_receiver(1);
+
+        tokio_rt.block_on(async move {
+            let local_set = tokio::task::LocalSet::new();
+            let exporter_handle = local_set.spawn_local(async move {
+                exporter
+                    .start(
+                        runtime_ctrl_msg_tx,
+                        pipeline_completion_msg_tx,
+                        metrics_reporter,
+                        Interests::empty(),
+                    )
+                    .await
+            });
+
+            local_set
+                .run_until(async move {
+                    let log_message = create_otap_batch(LOG_BATCH_ID, ArrowPayloadType::Logs);
+                    let pdata1 = OtapPdata::new_default(log_message.into());
+                    pdata_tx.send(pdata1).await.unwrap();
+
+                    // Wait enough time for handle_req_stream to fail with connection refused
+                    // and enter the Err(e) branch which sleeps for 10ms (INITIAL_BACKOFF).
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+
+                    control_sender
+                        .send(NodeControlMsg::Shutdown {
+                            deadline: Instant::now().add(Duration::from_millis(500)),
+                            reason: "shutdown test".into(),
+                        })
+                        .await
+                        .unwrap();
+
+                    let _ = timeout(Duration::from_secs(1), exporter_handle)
+                        .await
+                        .expect("exporter shutdown timed out")
+                        .expect("exporter task failed")
+                        .expect("exporter returned error");
+                })
+                .await;
+        });
+    }
+
+    #[test]
+    fn test_otap_exporter_deadlock_on_full_queue_shutdown() {
+        use std::ops::Add;
+        use tokio::runtime::Runtime;
+        use tokio::time::timeout;
+
+        let tokio_rt = Runtime::new().unwrap();
+
+        let test_runtime = TestRuntime::<OtapPdata>::new();
+        let node_config = Arc::new(NodeUserConfig::new_exporter_config(OTAP_EXPORTER_URN));
+        let telemetry_registry_handle = TelemetryRegistryHandle::new();
+        let controller_ctx = ControllerContext::new(telemetry_registry_handle);
+        let node_id = test_node(test_runtime.config().name.clone());
+        let pipeline_ctx =
+            controller_ctx.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+
+        // Use an unused local port to reduce collision risk in parallel test runs while still
+        // keeping the endpoint unreachable (connection refused).
+        let grpc_port = portpicker::pick_unused_port().expect("No free ports");
+        let grpc_endpoint = format!("http://127.0.0.1:{grpc_port}");
+
+        let mut exporter = ExporterWrapper::local(
+            OTAPExporter::from_config(
+                pipeline_ctx,
+                &serde_json::json!({
+                    "grpc_endpoint": grpc_endpoint,
+                    "compression_method": "none",
+                    "stream_queue_capacity": 1,
+                }),
+            )
+            .unwrap(),
+            node_id.clone(),
+            node_config,
+            test_runtime.config(),
+        );
+
+        let control_sender = exporter.control_sender();
+        let (pdata_tx, pdata_rx) = create_not_send_channel::<OtapPdata>(1);
+        let pdata_tx = Sender::Local(LocalSender::mpsc(pdata_tx));
+        let pdata_rx = Receiver::Local(LocalReceiver::mpsc(pdata_rx));
+        let (runtime_ctrl_msg_tx, _runtime_ctrl_msg_rx) = runtime_ctrl_msg_channel(16);
+        let (pipeline_completion_msg_tx, _pipeline_completion_msg_rx) =
+            pipeline_completion_msg_channel(16);
+        exporter
+            .set_pdata_receiver(node_id.clone(), pdata_rx)
+            .expect("Failed to set PData Receiver");
+
+        let (_metrics_rx, metrics_reporter) = MetricsReporter::create_new_and_receiver(1);
+
+        tokio_rt.block_on(async move {
+            let local_set = tokio::task::LocalSet::new();
+            let exporter_handle = local_set.spawn_local(async move {
+                exporter
+                    .start(
+                        runtime_ctrl_msg_tx,
+                        pipeline_completion_msg_tx,
+                        metrics_reporter,
+                        Interests::empty(),
+                    )
+                    .await
+            });
+
+            local_set
+                .run_until(async move {
+                    // Send first batch — exporter forwards it to a stream worker.
+                    let log_message = create_otap_batch(LOG_BATCH_ID, ArrowPayloadType::Logs);
+                    let pdata1 = OtapPdata::new_default(log_message.into());
+                    pdata_tx.send(pdata1).await.unwrap();
+
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+
+                    // Send second batch — fills the stream queue (capacity=1).
+                    let log_message = create_otap_batch(LOG_BATCH_ID + 1, ArrowPayloadType::Logs);
+                    let pdata2 = OtapPdata::new_default(log_message.into());
+                    pdata_tx.send(pdata2).await.unwrap();
+
+                    // Send third batch in a background task — this will block inside
+                    // enqueue_stream_batch waiting for queue space, simulating full
+                    // backpressure with an unreachable downstream.
+                    let log_message = create_otap_batch(LOG_BATCH_ID + 2, ArrowPayloadType::Logs);
+                    let pdata3 = OtapPdata::new_default(log_message.into());
+                    let pdata_tx_clone = pdata_tx.clone();
+                    let send_handle = tokio::task::spawn_local(async move {
+                        _ = pdata_tx_clone.send(pdata3).await;
+                    });
+
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+
+                    // Request shutdown — before the fix, the exporter would deadlock
+                    // because the main loop was blocked in enqueue_stream_batch and
+                    // could never process this Shutdown control message.
+                    control_sender
+                        .send(NodeControlMsg::Shutdown {
+                            deadline: Instant::now().add(Duration::from_millis(10)),
+                            reason: "shutdown test".into(),
+                        })
+                        .await
+                        .unwrap();
+
+                    // The exporter must shut down within 200ms, not hang forever.
+                    let _ = timeout(Duration::from_millis(200), exporter_handle)
+                        .await
+                        .expect("exporter shutdown timed out")
+                        .expect("exporter task failed")
+                        .expect("exporter returned error");
+
+                    send_handle.abort();
+                    drop(pdata_tx);
+                })
+                .await;
+        });
     }
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/mod.rs
@@ -1,4 +1,4 @@
-﻿// Copyright The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Implementation of the OTAP exporter node
@@ -375,9 +375,18 @@ impl OTAPExporter {
                         }
                         Message::Control(NodeControlMsg::Shutdown { deadline, reason }) => {
                             if let Some((pdata, _)) = pending.take() {
-                                effect_handler.notify_nack(NackMsg::new("exporter shutting down", pdata)).await?;
+                                effect_handler
+                                    .notify_nack(NackMsg::new("exporter shutting down", pdata))
+                                    .await?;
                             }
                             return Ok(EnqueueResult::Shutdown { deadline, reason });
+                        }
+                        // NACK any pdata that arrives while we are waiting for queue
+                        // space — the exporter is shutting down so we won't forward it.
+                        Message::PData(data) => {
+                            effect_handler
+                                .notify_nack(NackMsg::new("exporter shutting down", data))
+                                .await?;
                         }
                         _ => {}
                     }
@@ -875,12 +884,25 @@ async fn stream_arrow_batches<T: StreamingArrowService>(
                 let connect_res = tokio::select! {
                     res = req_fut => res,
                     _ = shutdown_rx.changed() => {
+                        // Drop the sender so the correlation receiver sees EOF,
+                        // then drain any pdata already queued before we got here.
                         drop(correlation_tx);
-                        _ = pdata_metrics_tx.send(PDataMetricsUpdate::IncFailed(
-                            signal_type,
-                            first_pdata_fallback,
-                            None,
-                        )).await;
+                        let mut drained = false;
+                        while let Ok(correlated) = correlation_rx.try_recv() {
+                            drained = true;
+                            _ = pdata_metrics_tx.send(PDataMetricsUpdate::IncFailed(
+                                signal_type,
+                                correlated.pdata,
+                                Some(elapsed_nanos(correlated.sent_at)),
+                            )).await;
+                        }
+                        if !drained {
+                            _ = pdata_metrics_tx.send(PDataMetricsUpdate::IncFailed(
+                                signal_type,
+                                first_pdata_fallback,
+                                None,
+                            )).await;
+                        }
                         break;
                     }
                 };


### PR DESCRIPTION
Closes #3445

Applies hardened security headers (`X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Cache-Control`) to all `/api/v1/*` endpoints using `axum::middleware::map_response`.

Previously these headers were only set on static UI routes in `dashboard.rs`. Adding a single layer on `api_routes` in `lib.rs` means any new endpoint added in future automatically inherits them — no per-handler changes needed.

Also marks the corresponding security checklist item in `crates/admin/README.md` as done.