### PR TITLE
chore: Azure Identity Auth extension - Follow up

### DIFF
--- a/rust/otap-dataflow/Cargo.lock
+++ b/rust/otap-dataflow/Cargo.lock
@@ -6225,6 +6225,7 @@ dependencies = [
  "otap-df-otap",
  "otap-df-telemetry",
  "otap-df-telemetry-macros",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/rust/otap-dataflow/crates/contrib-extensions/Cargo.toml
+++ b/rust/otap-dataflow/crates/contrib-extensions/Cargo.toml
@@ -31,12 +31,13 @@ tokio-stream.workspace = true
 azure_core = { workspace = true, optional = true, features = ["reqwest"] }
 azure_identity = { workspace = true, optional = true }
 humantime-serde = { workspace = true, optional = true }
+rand = { workspace = true, optional = true }
 
 [features]
 # Umbrella feature enabling all contrib extensions.
 contrib-extensions = ["azure-identity-auth-extension"]
 # Azure Identity authentication extension (BearerTokenProvider capability).
-azure-identity-auth-extension = ["dep:azure_core", "dep:azure_identity", "dep:humantime-serde"]
+azure-identity-auth-extension = ["dep:azure_core", "dep:azure_identity", "dep:humantime-serde", "dep:rand"]
 
 [dev-dependencies]
 otap-df-engine = { workspace = true, features = ["test-utils"] }

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/extension.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/extension.rs
@@ -233,11 +233,19 @@ fn jittered_backoff(base_secs: u64) -> Duration {
 /// refresh instant so many per-core extensions do not refresh on the same tick.
 ///
 /// Jitter only ever moves the refresh earlier (never later, which would risk
-/// serving a token past its safety buffer) and never before `now`.
-fn jitter_refresh(target: tokio::time::Instant) -> tokio::time::Instant {
+/// serving a token past its safety buffer) and never earlier than the
+/// `MIN_TOKEN_REFRESH_INTERVAL_SECS` floor that `schedule_next` enforces -
+/// otherwise a near-floor target could be pulled all the way to `now` and
+/// busy-loop the refresh task while the token is still fresh.
+pub(crate) fn jitter_refresh(target: tokio::time::Instant) -> tokio::time::Instant {
     let now = tokio::time::Instant::now();
-    // Bound jitter by how far out the target is so we never move it before now.
-    let max_jitter = REFRESH_JITTER_SECS.min(target.saturating_duration_since(now).as_secs());
+    // Only jitter the slack *above* the minimum refresh interval, so the
+    // earliest possible result is `now + MIN_TOKEN_REFRESH_INTERVAL_SECS`.
+    let slack = target
+        .saturating_duration_since(now)
+        .as_secs()
+        .saturating_sub(MIN_TOKEN_REFRESH_INTERVAL_SECS);
+    let max_jitter = REFRESH_JITTER_SECS.min(slack);
     if max_jitter == 0 {
         return target;
     }

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/extension.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/extension.rs
@@ -343,12 +343,23 @@ impl SharedExtension for AzureIdentityAuthExtension {
                     // concurrent cache-miss fetch coalesce onto one in-flight
                     // credential call instead of both hitting the token endpoint.
                     let refresh = async {
+                        // Note the current cache version before contending for
+                        // the lock so we can tell whether another caller
+                        // publishes a new token while we wait.
+                        let mut rx = inner.tx.subscribe();
+                        let _ = rx.borrow_and_update();
                         let _guard = inner.fetch_lock.lock().await;
-                        // A concurrent `get_token` may have refreshed the cache
-                        // while we waited for the lock. If so, fully coalesce:
-                        // reuse that token and skip a redundant credential call.
-                        if let Some(token) = inner.current_fresh_token() {
-                            return Ok(token);
+                        // Only coalesce when a concurrent slow-path `get_token`
+                        // actually published a fresh token while we waited for
+                        // the lock. We must NOT skip merely because the cached
+                        // token is still "usable": the loop refreshes ~5 min
+                        // before expiry, but a token stays usable until ~30 s
+                        // before expiry, so reusing it here would defer the
+                        // planned early refresh far too long.
+                        if rx.has_changed().unwrap_or(false) {
+                            if let Some(token) = inner.current_fresh_token() {
+                                return Ok(token);
+                            }
                         }
                         inner.refresh_once().await
                     };

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/extension.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/extension.rs
@@ -21,6 +21,7 @@ use otap_df_engine::shared::capability::BearerTokenProvider as SharedBearerToken
 use otap_df_engine::shared::extension::{ControlChannel, Extension as SharedExtension};
 use otap_df_engine::terminal_state::TerminalState;
 use otap_df_telemetry::otel_warn;
+use rand::RngExt;
 use tokio::sync::watch;
 use tokio_stream::wrappers::WatchStream;
 
@@ -39,8 +40,16 @@ const TOKEN_USABLE_MARGIN_SECS: u64 = 30;
 /// Floor between successful refreshes; avoids busy-looping on near-expired
 /// tokens.
 const MIN_TOKEN_REFRESH_INTERVAL_SECS: u64 = 10;
-/// Reschedule delay after a failed acquisition.
+/// Base reschedule delay after a failed acquisition. Consecutive failures grow
+/// this exponentially (with jitter) up to `MAX_TOKEN_REFRESH_RETRY_SECS`.
 const TOKEN_REFRESH_RETRY_SECS: u64 = 10;
+/// Upper bound on the retry backoff after repeated failures.
+const MAX_TOKEN_REFRESH_RETRY_SECS: u64 = 300;
+/// Maximum random jitter subtracted from a scheduled (successful) refresh
+/// instant. Spreads the otherwise-aligned refresh ticks of many per-core
+/// extensions so they do not hit the token endpoint on the same second. Only
+/// ever moves the refresh earlier, never past the expiry safety buffer.
+const REFRESH_JITTER_SECS: u64 = 60;
 /// Next-refresh delay used for non-expiring tokens (~1 year). The loop is still
 /// woken by control messages in the meantime.
 const NON_EXPIRING_REFRESH_SECS: u64 = 365 * 24 * 60 * 60;
@@ -192,6 +201,50 @@ pub(crate) fn schedule_next(token: &BearerToken) -> tokio::time::Instant {
     }
 }
 
+/// Base (un-jittered) backoff before retrying after a failed acquisition.
+///
+/// Grows exponentially with the number of consecutive prior failures, from
+/// `TOKEN_REFRESH_RETRY_SECS` up to `MAX_TOKEN_REFRESH_RETRY_SECS`, so a
+/// sustained token-endpoint outage settles into infrequent retries instead of a
+/// tight loop.
+pub(crate) fn retry_backoff_secs(consecutive_failures: u32) -> u64 {
+    // Cap the shift so `1 << shift` cannot overflow; the value is clamped to the
+    // max below long before the shift approaches that bound.
+    let shift = consecutive_failures.min(16);
+    TOKEN_REFRESH_RETRY_SECS
+        .saturating_mul(1u64 << shift)
+        .min(MAX_TOKEN_REFRESH_RETRY_SECS)
+}
+
+/// Applies "equal jitter" to a backoff: half the delay is a fixed floor and the
+/// other half is randomized, yielding a delay in `[base/2, base]`. This keeps
+/// per-core extensions from retrying in lockstep during an outage.
+fn jittered_backoff(base_secs: u64) -> Duration {
+    let half = base_secs / 2;
+    let jitter = if half == 0 {
+        0
+    } else {
+        rand::rng().random_range(0..=half)
+    };
+    Duration::from_secs(half + jitter)
+}
+
+/// Subtracts random jitter (up to `REFRESH_JITTER_SECS`) from a scheduled
+/// refresh instant so many per-core extensions do not refresh on the same tick.
+///
+/// Jitter only ever moves the refresh earlier (never later, which would risk
+/// serving a token past its safety buffer) and never before `now`.
+fn jitter_refresh(target: tokio::time::Instant) -> tokio::time::Instant {
+    let now = tokio::time::Instant::now();
+    // Bound jitter by how far out the target is so we never move it before now.
+    let max_jitter = REFRESH_JITTER_SECS.min(target.saturating_duration_since(now).as_secs());
+    if max_jitter == 0 {
+        return target;
+    }
+    let jitter = rand::rng().random_range(0..=max_jitter);
+    target - Duration::from_secs(jitter)
+}
+
 #[async_trait]
 impl SharedBearerTokenProvider for AzureIdentityAuthExtension {
     async fn get_token(&self) -> Result<BearerToken, CapabilityError> {
@@ -247,6 +300,9 @@ impl SharedExtension for AzureIdentityAuthExtension {
         // (see `with_readiness_probe`). Fire once, after the first token is
         // published, so consumers never observe an empty cache.
         let mut ready_signaled = false;
+        // Consecutive failed acquisitions; drives exponential retry backoff and
+        // is reset on any successful (or already-fresh) refresh.
+        let mut consecutive_failures: u32 = 0;
 
         loop {
             tokio::select! {
@@ -274,14 +330,60 @@ impl SharedExtension for AzureIdentityAuthExtension {
                     }
                 }
                 _ = tokio::time::sleep_until(next_refresh) => {
-                    // Take the same `fetch_lock` the slow-path `get_token` uses,
-                    // so a scheduled refresh and a concurrent cache-miss fetch
-                    // coalesce onto one in-flight credential call instead of
-                    // both hitting the token endpoint.
-                    let _guard = inner.fetch_lock.lock().await;
-                    match inner.refresh_once().await {
+                    // The acquisition itself: take the same `fetch_lock` the
+                    // slow-path `get_token` uses so a scheduled refresh and a
+                    // concurrent cache-miss fetch coalesce onto one in-flight
+                    // credential call instead of both hitting the token endpoint.
+                    let refresh = async {
+                        let _guard = inner.fetch_lock.lock().await;
+                        // A concurrent `get_token` may have refreshed the cache
+                        // while we waited for the lock. If so, fully coalesce:
+                        // reuse that token and skip a redundant credential call.
+                        if let Some(token) = inner.current_fresh_token() {
+                            return Ok(token);
+                        }
+                        inner.refresh_once().await
+                    };
+                    tokio::pin!(refresh);
+
+                    // Keep the refresh cancellable: race it against the control
+                    // channel so a slow token call cannot delay shutdown past its
+                    // deadline. Config/telemetry messages are still serviced while
+                    // the refresh is in flight; only shutdown or channel closure
+                    // ends the loop (dropping the in-flight refresh future).
+                    let outcome = loop {
+                        tokio::select! {
+                            outcome = &mut refresh => break outcome,
+                            ctrl_msg = ctrl.recv() => {
+                                match ctrl_msg {
+                                    Ok(ExtensionControlMsg::Shutdown { deadline, .. }) => {
+                                        let snapshot =
+                                            inner.metrics.lock().ok().map(|m| m.snapshot());
+                                        return Ok(match snapshot {
+                                            Some(snapshot) => {
+                                                TerminalState::new(deadline, [snapshot])
+                                            }
+                                            None => TerminalState::default(),
+                                        });
+                                    }
+                                    Err(_) => return Ok(TerminalState::default()),
+                                    Ok(ExtensionControlMsg::Config { .. }) => {}
+                                    Ok(ExtensionControlMsg::CollectTelemetry {
+                                        mut metrics_reporter,
+                                    }) => {
+                                        if let Ok(mut metrics) = inner.metrics.lock() {
+                                            let _ = metrics.report(&mut metrics_reporter);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    };
+
+                    match outcome {
                         Ok(token) => {
-                            next_refresh = schedule_next(&token);
+                            consecutive_failures = 0;
+                            next_refresh = jitter_refresh(schedule_next(&token));
                             if !ready_signaled {
                                 effect_handler.signal_ready();
                                 ready_signaled = true;
@@ -292,8 +394,13 @@ impl SharedExtension for AzureIdentityAuthExtension {
                                 "azure_identity_auth.token_refresh_failed",
                                 error = %error
                             );
-                            next_refresh = tokio::time::Instant::now()
-                                + Duration::from_secs(TOKEN_REFRESH_RETRY_SECS);
+                            // Bounded exponential backoff with jitter so many
+                            // per-core extensions do not stampede the token
+                            // endpoint on the same cadence during an outage.
+                            let backoff =
+                                jittered_backoff(retry_backoff_secs(consecutive_failures));
+                            consecutive_failures = consecutive_failures.saturating_add(1);
+                            next_refresh = tokio::time::Instant::now() + backoff;
                         }
                     }
                 }

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/tests.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/tests.rs
@@ -511,3 +511,48 @@ fn retry_backoff_grows_exponentially_and_caps() {
     // A very large failure count must not overflow the shift.
     assert_eq!(extension::retry_backoff_secs(u32::MAX), 300);
 }
+
+// ── jitter_refresh tests ──────────────────────────────────────
+
+#[tokio::test]
+async fn jitter_refresh_preserves_min_interval_floor() {
+    use std::time::Duration;
+
+    // A target exactly at the 10s minimum-refresh floor has no slack to jitter,
+    // so it must be returned unchanged rather than pulled toward `now` (which
+    // would busy-loop the refresh task while the token is still fresh).
+    let target = tokio::time::Instant::now() + Duration::from_secs(10);
+    for _ in 0..1000 {
+        assert_eq!(
+            extension::jitter_refresh(target),
+            target,
+            "near-floor target must not be jittered earlier"
+        );
+    }
+}
+
+#[tokio::test]
+async fn jitter_refresh_stays_within_bounds() {
+    use std::time::Duration;
+
+    // A far-out target is jittered earlier by at most REFRESH_JITTER_SECS (60s)
+    // and never earlier than the 10s floor from `now`.
+    let now = tokio::time::Instant::now();
+    let target = now + Duration::from_secs(3600);
+    let floor = now + Duration::from_secs(10);
+    for _ in 0..1000 {
+        let jittered = extension::jitter_refresh(target);
+        assert!(
+            jittered <= target,
+            "jitter must only move the refresh earlier"
+        );
+        assert!(
+            jittered >= target - Duration::from_secs(60),
+            "jitter must not exceed REFRESH_JITTER_SECS"
+        );
+        assert!(
+            jittered >= floor,
+            "jitter must not precede the min-interval floor"
+        );
+    }
+}

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/tests.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/tests.rs
@@ -493,3 +493,21 @@ async fn schedule_next_pushes_non_expiring_far_out() {
         "expected far-future refresh, got {secs}s"
     );
 }
+
+// ── retry backoff tests ───────────────────────────────────────
+
+#[test]
+fn retry_backoff_grows_exponentially_and_caps() {
+    // Zero prior failures starts at the base retry interval (10s).
+    assert_eq!(extension::retry_backoff_secs(0), 10);
+    // Each consecutive failure doubles the base delay.
+    assert_eq!(extension::retry_backoff_secs(1), 20);
+    assert_eq!(extension::retry_backoff_secs(2), 40);
+    assert_eq!(extension::retry_backoff_secs(3), 80);
+    assert_eq!(extension::retry_backoff_secs(4), 160);
+    // Growth is clamped at the max (300s) and stays there.
+    assert_eq!(extension::retry_backoff_secs(5), 300);
+    assert_eq!(extension::retry_backoff_secs(6), 300);
+    // A very large failure count must not overflow the shift.
+    assert_eq!(extension::retry_backoff_secs(u32::MAX), 300);
+}

--- a/rust/otap-dataflow/docs/azure-identity-auth-extension.md
+++ b/rust/otap-dataflow/docs/azure-identity-auth-extension.md
@@ -103,9 +103,9 @@ path free of authentication plumbing.
 | Startup gating | Opt into the engine readiness probe; `signal_ready()` after the first token publish so the engine holds data-path node startup until a token exists (bounded by the probe timeout). |
 | Sharing model | All state behind `Arc<Inner>`; every clone (consumers + background task) observes one token cache. At pipeline scope this is per pipeline instance (per core). |
 | Token cache | `tokio::sync::watch<Option<BearerToken>>` - lock-free fast-path read + pub/sub for `token_stream()`. |
-| Slow-path coalescing | An async `fetch_lock` with double-checked caching so concurrent cache-miss callers share one in-flight credential call. |
+| Slow-path coalescing | An async `fetch_lock` with double-checked caching so concurrent cache-miss callers - and the background refresh - share one in-flight credential call. |
 | Auth methods (v1) | `managed_identity` (system- or user-assigned), `development` (local dev tooling), and `workload_identity` (federated ServiceAccount token). |
-| Refresh tuning | Fixed constants (skew before expiry, retry delay, min cadence); not user-configurable. |
+| Refresh tuning | Fixed constants (skew before expiry, exponential-backoff-with-jitter retry, min cadence, refresh jitter); not user-configurable. |
 | Expiry handling | Absolute UNIX expiry converted once to a monotonic `Instant`, immune to wall-clock jumps thereafter. |
 | Registration | `#[distributed_slice(OTAP_EXTENSION_FACTORIES)]` link-time discovery, same mechanism as nodes. |
 | Telemetry | `MetricSet`-backed counters + latency histogram, flushed via `ExtensionControlMsg::CollectTelemetry`. |
@@ -286,25 +286,36 @@ that does not apply to the selected method (`tenant_id`/`token_file_path` are
 `start()` runs a `select!` loop with two arms:
 
 1. **Control channel** (`ctrl.recv()`):
-   - `Shutdown` - log and break, terminating the extension cleanly.
+   - `Shutdown` - return the final metric snapshot as the terminal state. The
+     control channel is polled even while a refresh is in flight, so a shutdown
+     arriving mid-acquisition cancels the in-progress token call rather than
+     letting a slow request run past the shutdown deadline.
    - `Config` - currently a no-op; refresh cadence is governed by token
      lifetime.
-   - `CollectTelemetry` - best-effort flush of the metric set to the reporter.
+   - `CollectTelemetry` - best-effort flush of the metric set to the reporter,
+     serviced without interrupting an in-flight refresh.
 2. **Refresh timer** (`sleep_until(next_refresh)`):
    - On success: publish the token with `send_replace` (which updates the cache
      regardless of receiver count, unlike `send`, which drops the value when
      there are no subscribers), then compute `next_refresh` from the token's
-     `expires_on` minus the skew buffer (clamped to a minimum cadence).
-   - On failure: log the error and reschedule after the fixed retry delay; keep
-     retrying for the lifetime of the extension.
+     `expires_on` minus the skew buffer (clamped to a minimum cadence), with a
+     small negative jitter so per-core extensions do not all refresh on the same
+     tick.
+   - On failure: log the error and reschedule using bounded exponential backoff
+     with jitter (from the base retry delay up to the cap), tracking consecutive
+     failures; keep retrying for the lifetime of the extension. The backoff
+     spreads retries across cores so a token-endpoint outage is not stampeded on
+     a fixed cadence.
 
 Tuning constants:
 
 | Constant | Value | Purpose |
 | --- | --- | --- |
 | `TOKEN_EXPIRY_BUFFER_SECS` | 299 (~5m) | Refresh this many seconds before `expires_on`. |
-| `MIN_TOKEN_REFRESH_INTERVAL_SECS` | 10 | Floor between successful refreshes; avoids busy-looping on near-expired tokens. |
-| `TOKEN_REFRESH_RETRY_SECS` | 10 | Reschedule delay after a failed acquisition. |
+| `MIN_TOKEN_REFRESH_INTERVAL_SECS` | 10 | Floor between successful refreshes; also the earliest a jittered refresh may land. Avoids busy-looping on near-expired tokens. |
+| `TOKEN_REFRESH_RETRY_SECS` | 10 | Base reschedule delay after a failed acquisition; doubles per consecutive failure. |
+| `MAX_TOKEN_REFRESH_RETRY_SECS` | 300 (5m) | Ceiling for the exponential retry backoff. |
+| `REFRESH_JITTER_SECS` | 60 | Max negative jitter applied to a scheduled refresh (never pulling it below the min cadence), to de-correlate per-core refreshes. |
 
 ### Expiry handling
 
@@ -420,8 +431,10 @@ Metrics are recorded in both the background refresh loop and the slow-path
 1. The engine drains data-path nodes first. The exporter finishes in-flight
    work and drops its capability handle.
 2. After all consumers drain, the engine sends `ExtensionControlMsg::Shutdown`
-   on the control channel. The refresh loop logs and breaks, dropping the
-   credential and the `watch` sender.
+   on the control channel. The refresh loop returns the final metric snapshot as
+   its terminal state and drops the credential and `watch` sender; a token
+   acquisition in flight at that moment is cancelled (see
+   [Refresh Loop](#refresh-loop)) so shutdown is not delayed by a slow request.
 
 ### Live reconfiguration
 
@@ -509,9 +522,13 @@ registration takes effect.
   on the same core share one `Arc<Inner>`); it does not share across cores.
   Consequently, **slow-path coalescing (`fetch_lock`) bounds the startup
   thundering herd to N concurrent acquisitions (one per core), but does not
-  eliminate it** - the per-core loops are uncoordinated. A future move to a
-  broader scope (group/engine) would let a single instance be shared across
-  cores without code changes (see
+  eliminate it** - the per-core loops are uncoordinated. To stop those
+  uncoordinated loops from realigning after startup, scheduled refreshes carry
+  negative jitter and failed acquisitions use bounded exponential backoff with
+  jitter, so steady-state refreshes and outage retries stay spread across cores
+  rather than firing on a shared cadence. A future move to a broader scope
+  (group/engine) would let a single instance be shared across cores without code
+  changes (see
   [Extension Scopes](extension-requirements.md#extension-scopes)).
 - **Runtime discipline.** The refresh loop runs on the per-core async runtime;
   all I/O is async (`reqwest` via the Azure SDK), so it never blocks other
@@ -547,8 +564,8 @@ Additional scenario coverage:
   result in a single credential call (one `auth_successes` increment), not a
   stampede.
 - **Refresh failure / retry.** A failing credential increments `auth_failures`,
-  the loop reschedules after the retry delay, and a subsequent success recovers
-  without restarting the extension.
+  the loop reschedules with bounded exponential backoff plus jitter, and a
+  subsequent success recovers without restarting the extension.
 - **Shutdown ordering.** The exporter drains before the extension receives
   `Shutdown`; no token is requested after shutdown begins.
 


### PR DESCRIPTION
# Change Summary

- Coalesce token fetch calls correctly
- Add jitter and back off
- Make token fetch interruptible by shutdown

## What issue does this PR close?

* Related to #3356

## How are these changes tested?

Unit tests

## Are there any user-facing changes?

no

### Changelog

* [ ] Added a `.chloggen/*.yaml` entry
* [x] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
