### PR TITLE
feat(transform_processor): Record signals.dropped from the transform processor

### DIFF
--- a/rust/otap-dataflow/.chloggen/transform-processor-dropped-flow-metric.yaml
+++ b/rust/otap-dataflow/.chloggen/transform-processor-dropped-flow-metric.yaml
@@ -1,0 +1,23 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: pipeline
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Record the `signals.dropped` flow metric from the transform processor
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [2859]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The transform processor now declares the drop-decision capability and records the
+  number of records removed by the query engine's filter (`where`) stages, so a
+  telemetry policy that enables `signals_dropped` can observe dropped counts for a
+  transform node.

--- a/rust/otap-dataflow/configs/trafficgen-flow-metrics-demo.yaml
+++ b/rust/otap-dataflow/configs/trafficgen-flow-metrics-demo.yaml
@@ -1,51 +1,13 @@
-# Demonstrates the distributed flow metrics feature, including two drop
-# decision nodes within a single flow range.
+# Demonstrates distributed flow metrics with multiple drop decision nodes inside a
+# single flow range:
 #
-#   receiver -> attr1 -> sampler -> attr2 -> attr3 -> filter -> attr4 -> noop
-#
-#   flow metric "ingest_pipeline" - covers attr1 through attr4. Both decision
-#   nodes (sampler, filter) sit in the interior of the range.
-#
-# Flow metrics sum per-processor wall-clock compute time across each node in
-# the range. The engine arms an Instant send-marker before each `process()` call
-# and advances it on every `send_message`; the elapsed delta is accumulated
-# onto the message's flow metric context and recorded at the end node. This
-# captures synchronous compute plus any await/I/O that occurs inside
-# `process()` between sends; it excludes time the message spends queued in
-# inbound channels.
-#
-# Metrics emitted on the `flow` metric set:
-#   - compute.duration (MMSC histogram, nanoseconds)
-#   - signals.incoming   (MMSC, items observed at the start node)
-#   - signals.outgoing   (MMSC, items observed at the end node)
-#   - signals.dropped    (MMSC, items a decision node dropped)
-#
-# With the sampler in place, `signals.incoming` (at attr1) reflects the full
-# input volume while `signals.outgoing` (at attr4) reflects what survives both
-# decision nodes, so the difference is directly visible.
-#
-# `signals.dropped` is recorded only by processors that declare the drop
-# capability and lie within a flow range. This flow has TWO such decision nodes,
-# both interior to the range:
-#   - sampler (between attr1 and attr2): keeps ~1/3 of log records.
-#   - filter  (between attr3 and attr4): drops records matching its exclude rule.
-# Each decision node's count carries a `flow.node.decision` attribute set to that
-# node's name ("sampler" / "filter"), so the two are not conflated. The flow's
-# incoming/outgoing/duration entity carries an empty `flow.node.decision` value.
-#
-# There is no per-node "kept" metric. `signals.dropped` sums correctly across
-# `flow.node.decision` (drops at different nodes are disjoint), so the total
-# equals signals.incoming - signals.outgoing. The flow-wide kept count is just
-# signals.outgoing; a per-node survivor count would be non-additive and is not
-# emitted.
-#
-# Note: only non-overlapping flow metric ranges are supported. A message can
-# be inside at most one flow metric range at a time. Two flows may not share an
-# interior decision node.
+# The "ingest_pipeline" flow covers attr1..attr4. The sampler, filter, and
+# transform nodes each drop records and record `signals.dropped` tagged with a
+# `flow.node.decision` attribute of their node name.
 #
 # Query metrics while running:
 #   curl -s 'http://127.0.0.1:8080/api/v1/telemetry/metrics?format=json' \
-#     | jq '[.metric_sets[] | select(.name == "flow" or .name == "processor.compute")]'
+#     | jq '[.metric_sets[] | select(.name == "flow")]'
 
 version: otel_dataflow/v1
 engine: {}
@@ -68,7 +30,13 @@ groups:
                   end_node: attr4
                 # metrics is optional
                 # if omitted, all supported metrics are recorded
-                metrics: [compute_duration, signals_incoming, signals_outgoing, signals_dropped]
+                metrics:
+                  [
+                    compute_duration,
+                    signals_incoming,
+                    signals_outgoing,
+                    signals_dropped,
+                  ]
 
         nodes:
           receiver:
@@ -79,15 +47,11 @@ groups:
                 signals_per_second: 10
                 log_weight: 100
               # Synthetic data source emits deterministic log attributes
-              # (thread.id, thread.name) so the filter below drops a
-              # predictable fraction regardless of registry contents.
+              # (thread.id, thread.name) so the downstream filter/transform drop
+              # a predictable fraction.
               data_source: synthetic
 
-          # Decision node #1 (interior of the flow range, between attr1 and
-          # attr2). Deterministically keeps
-          # ~1/3 of log records and drops the rest, independent of payload
-          # content. Records signals.dropped with
-          # flow.node.decision="sampler".
+          # Decision node #1: keeps ~1/3 of log records.
           sampler:
             type: processor:log_sampling
             config:
@@ -112,13 +76,7 @@ groups:
                   key: pipeline.stage2
                   value: "2"
 
-          # Decision node #2 (interior of the flow range, between attr3 and
-          # attr4). Drops log records whose
-          # thread.name matches the exclude rule. The ratio sampler upstream keeps
-          # a per-batch prefix, so the records reaching here cycle through the
-          # first few synthetic thread.name values (main, worker-1, worker-2,
-          # worker-3); excluding two of them drops roughly half of the survivors.
-          # Records signals.dropped with flow.node.decision="filter".
+          # Decision node #2: drops log records whose thread.name is worker-1.
           filter:
             type: processor:filter
             config:
@@ -128,8 +86,13 @@ groups:
                   record_attributes:
                     - key: thread.name
                       value: worker-1
-                    - key: thread.name
-                      value: worker-3
+
+          # Decision node #3: transform processor dropping worker-3 via a KQL
+          # `where` predicate, proving it records signals.dropped too.
+          transform:
+            type: processor:transform
+            config:
+              kql_query: 'logs | where attributes["thread.name"] != "worker-3"'
 
           attr3:
             type: processor:attribute
@@ -163,6 +126,8 @@ groups:
           - from: attr3
             to: filter
           - from: filter
+            to: transform
+          - from: transform
             to: attr4
           - from: attr4
             to: noop

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
@@ -30,7 +30,7 @@ use otap_df_engine::{
     local::processor::{EffectHandler, Processor},
     message::Message,
     node::NodeId,
-    processor::ProcessorWrapper,
+    processor::{ProcessorRuntimeRequirements, ProcessorWrapper},
 };
 use otap_df_otap::{
     OTAP_PROCESSOR_FACTORIES,
@@ -43,7 +43,11 @@ use otap_df_pdata::{
 };
 use otap_df_query_engine::{
     parser::default_parser_options,
-    pipeline::{Pipeline, PipelineOptions, routing::RouterExtType, state::ExecutionState},
+    pipeline::{
+        Pipeline, PipelineOptions,
+        routing::RouterExtType,
+        state::{ExecutionCounters, ExecutionState},
+    },
 };
 use otap_df_query_engine_languages::{opl::parser::OplParser, ottl::parser::OttlParser};
 use otap_df_telemetry::metrics::MetricSet;
@@ -201,6 +205,7 @@ impl TransformProcessor {
         &mut self,
         inbound_context: Context,
         pipeline_result: Result<OtapArrowRecords, EngineError>,
+        counters: ExecutionCounters,
         effect_handler: &mut EffectHandler<OtapPdata>,
     ) -> Result<(), EngineError> {
         let router_impl = self
@@ -225,6 +230,9 @@ impl TransformProcessor {
                 return Err(e);
             }
         };
+
+        // Record flow metrics from the engine's per-batch execution counters
+        effect_handler.record_flow_signals_dropped(counters.filtered as u64);
 
         if self.sanitize_results {
             sanitize_otap_batch(&mut default_otap_batch);
@@ -401,6 +409,13 @@ pub static TRANSFORM_PROCESSOR_FACTORY: ProcessorFactory<OtapPdata> = ProcessorF
 
 #[async_trait(?Send)]
 impl Processor<OtapPdata> for TransformProcessor {
+    fn runtime_requirements(&self) -> ProcessorRuntimeRequirements {
+        // The transform processor can drop signal items via filtering (e.g. a
+        // KQL `where`), so it records `signals.dropped` when it lies within a
+        // flow that enables it.
+        ProcessorRuntimeRequirements::none().with_drop_decisions()
+    }
+
     async fn process(
         &mut self,
         message: Message<OtapPdata>,
@@ -446,6 +461,11 @@ impl Processor<OtapPdata> for TransformProcessor {
                 let mut payload = Some(payload);
                 let mut transformed = false;
                 let mut transform_error = None;
+
+                // Reset the engine's record-removal counters so that, after the
+                // transform loop, they reflect only the drops caused by this
+                // batch.
+                self.execution_state.reset_counters();
 
                 // Execute all transforms. We skip transforms where the batch's signal type is not
                 // selected by the signal scope, and lazily convert the pdata payload to OTAP
@@ -524,7 +544,10 @@ impl Processor<OtapPdata> for TransformProcessor {
                             }
                         }
                     };
-                    self.handle_exec_result(context, result, effect_handler)
+                    // Hand the engine's per-batch counters to the result handler,
+                    // which records the corresponding flow metrics.
+                    let counters = self.execution_state.counters();
+                    self.handle_exec_result(context, result, counters, effect_handler)
                         .await?;
                 } else {
                     // safety: payload is initialized to Some, and only modified if any transforms
@@ -678,6 +701,33 @@ mod test {
         runtime: &TestRuntime<OtapPdata>,
     ) -> Result<ProcessorWrapper<OtapPdata>, ConfigError> {
         try_create_with_config(json!({ "kql_query": query }), runtime)
+    }
+
+    #[test]
+    fn test_declares_drop_decisions() {
+        // The transform processor filters records (e.g. via a KQL `where`), so
+        // it must declare the drop-decision capability; otherwise the engine
+        // never wires its `signals.dropped` flow metric.
+        let runtime = TestRuntime::<OtapPdata>::new();
+        let telemetry_registry_handle = runtime.metrics_registry();
+        let controller_context = ControllerContext::new(telemetry_registry_handle);
+        let pipeline_context = controller_context.pipeline_context_with(
+            "group_id".into(),
+            "pipeline_id".into(),
+            0,
+            1,
+            0,
+        );
+        let processor = TransformProcessor::from_config(
+            &pipeline_context,
+            &json!({ "kql_query": "logs | where severity_text == \"ERROR\"" }),
+        )
+        .expect("created processor");
+
+        assert!(
+            processor.runtime_requirements().makes_drop_decisions,
+            "transform processor must declare drop decisions so signals.dropped is wired"
+        );
     }
 
     fn try_create_with_opl_query(

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
@@ -54,7 +54,7 @@ impl PipelineStage for FilterPipelineStage {
         session_context: &SessionContext,
         _config_options: &ConfigOptions,
         _task_context: Arc<TaskContext>,
-        _exec_state: &mut ExecutionState,
+        exec_state: &mut ExecutionState,
     ) -> Result<OtapArrowRecords> {
         let root_rb = match otap_batch.root_record_batch() {
             Some(rb) => rb,
@@ -87,6 +87,13 @@ impl PipelineStage for FilterPipelineStage {
                 }
             }
         };
+
+        // Record the number of root records removed by this filter so callers
+        // can observe genuine drops without inferring them from batch sizes.
+        // Rows whose predicate result is null are treated as not passing (see
+        // `scoped_value_to_boolean_array`), so `true_count` is exactly the rows
+        // kept.
+        exec_state.add_filtered(num_rows.saturating_sub(selection_vec.true_count()));
 
         let otap_batch = filter_otap_batch(&selection_vec, &otap_batch, &mut self.id_bitmap_pool)?;
 
@@ -568,6 +575,65 @@ mod test {
         let result_where_false =
             exec_logs_pipeline::<OplParser>("logs | where false", to_logs_data(log_records)).await;
         assert_eq!(result_where_false.resource_logs.len(), 0);
+    }
+
+    /// The engine must report the exact number of root records removed by a
+    /// filter predicate via `ExecutionState`, so callers can observe genuine
+    /// drops without inferring them from batch sizes.
+    #[tokio::test]
+    async fn test_filter_reports_dropped_count_in_exec_state() {
+        let log_records = vec![
+            LogRecord::build()
+                .severity_text("TRACE")
+                .event_name("1")
+                .finish(),
+            LogRecord::build()
+                .severity_text("INFO")
+                .event_name("2")
+                .finish(),
+            LogRecord::build()
+                .severity_text("ERROR")
+                .event_name("3")
+                .finish(),
+        ];
+
+        async fn dropped_count(query: &str, records: &[LogRecord]) -> usize {
+            let parser_result = KqlParser::parse(query).unwrap();
+            let mut pipeline = Pipeline::new(parser_result.pipeline);
+            let mut exec_state = ExecutionState::new();
+            let _ = pipeline
+                .execute_with_state(to_otap_logs(records.to_vec()), &mut exec_state)
+                .await
+                .unwrap();
+            exec_state.counters().filtered
+        }
+
+        // 2 of 3 records removed.
+        assert_eq!(
+            dropped_count("logs | where severity_text == \"ERROR\"", &log_records).await,
+            2
+        );
+        // All records removed.
+        assert_eq!(dropped_count("logs | where false", &log_records).await, 3);
+        // No records removed.
+        assert_eq!(dropped_count("logs | where true", &log_records).await, 0);
+        // A non-filtering transform drops nothing.
+        assert_eq!(
+            dropped_count("logs | extend attributes[\"x\"] = 1", &log_records).await,
+            0
+        );
+
+        // Counters accumulate across stages and reset on demand.
+        let parser_result = KqlParser::parse("logs | where severity_text == \"ERROR\"").unwrap();
+        let mut pipeline = Pipeline::new(parser_result.pipeline);
+        let mut exec_state = ExecutionState::new();
+        let _ = pipeline
+            .execute_with_state(to_otap_logs(log_records.clone()), &mut exec_state)
+            .await
+            .unwrap();
+        assert_eq!(exec_state.counters().filtered, 2);
+        exec_state.reset_counters();
+        assert_eq!(exec_state.counters().filtered, 0);
     }
 
     async fn test_simple_attrs_filter<P: Parser>() {

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/state.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/state.rs
@@ -59,7 +59,7 @@ impl ExecutionState {
         self.counters
     }
 
-    /// Records that `count` records were removed by a filter predicate.
+    /// Record that `count` records were removed by a filter predicate.
     pub fn add_filtered(&mut self, count: usize) {
         self.counters.filtered = self.counters.filtered.saturating_add(count);
     }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/state.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/state.rs
@@ -26,13 +26,50 @@ use std::hash::{BuildHasherDefault, Hasher};
 #[derive(Default)]
 pub struct ExecutionState {
     extensions: Option<ExtensionMap>,
+    counters: ExecutionCounters,
+}
+
+/// Engine-level counters accumulated while a pipeline executes.
+///
+/// This is the home for any per-execution count the engine wants to expose to
+/// its caller — tracked by the engine itself rather than inferred from batch
+/// sizes. Callers read these after execution (e.g. to emit telemetry) and reset
+/// them between batches when the `ExecutionState` is reused. Add new fields here
+/// as the engine gains more to report; keep each counter distinct so callers can
+/// attribute counts to the specific reason a record left the stream.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExecutionCounters {
+    /// Records removed by a filter predicate (e.g. a `where` clause).
+    pub filtered: usize,
 }
 
 impl ExecutionState {
     /// Create new execution options.
     #[must_use]
     pub fn new() -> Self {
-        Self { extensions: None }
+        Self {
+            extensions: None,
+            counters: ExecutionCounters::default(),
+        }
+    }
+
+    /// Returns the engine's record-removal counters accumulated so far.
+    #[must_use]
+    pub fn counters(&self) -> ExecutionCounters {
+        self.counters
+    }
+
+    /// Records that `count` records were removed by a filter predicate.
+    pub fn add_filtered(&mut self, count: usize) {
+        self.counters.filtered = self.counters.filtered.saturating_add(count);
+    }
+
+    /// Resets the record-removal counters to zero.
+    ///
+    /// Call this before executing a pipeline for a fresh batch when the
+    /// `ExecutionState` is reused across batches.
+    pub fn reset_counters(&mut self) {
+        self.counters = ExecutionCounters::default();
     }
 
     /// Get extension of type T, if it exists.


### PR DESCRIPTION
# Change Summary

Extends the `signals.dropped` flow metric (#2859) to the transform processor so pipelines can observe how many records it filters out using the same flow-metric mechanism already used by `filter_processor` and `log_sampling_processor`.

## Validation

Ran `configs/trafficgen-flow-metrics-demo.yaml`, which places the transform processor as one of three interior decision nodes (sampler keeps ~1/3, filter drops `worker-1`, transform drops `worker-3`) in a single `ingest_pipeline` flow range. Each decision node's drops are tagged with a distinct `flow.node.decision`, and the counts reconcile exactly against incoming/outgoing (1820 − 1213 − 182 − 61 = 364).

| `flow.node.decision` | Metric | Sum | Count |
| --- | --- | ---: | ---: |
| _(range)_ | signals.incoming | 1820 | 182 |
| sampler | signals.dropped | 1213 | 182 |
| filter | signals.dropped | 182 | 182 |
| **transform** | **signals.dropped** | **61** | 182 |
| _(range)_ | signals.outgoing | 364 | 182 |

The `transform` row confirms the processor records `signals.dropped` under its own decision attribute, exactly like the existing `filter`/`sampler` decision nodes.

## What issue does this PR close?

<!--We highly recommend correlation of every PR to an issue-->

* Related to #2859

## How are these changes tested?

Unit tests and demo config

## Are there any user-facing changes?

 <!-- If yes, provide further info below -->

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry
* [ ] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
