### PR TITLE
Fix saturation scaling test engine template path (missing .j2 extension)

### DIFF
--- a/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-cores-template.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-cores-template.yaml.j2
@@ -72,7 +72,7 @@ tests:
       path: test_suites/integration/templates/test_steps/df-loadgen-steps-docker.yaml
       variables:
         result_dir: "continuous_saturation_{{num_cores}}core_otlp"
-        engine_config_template: test_suites/integration/templates/configs/engine/backpressure/otlp-attr-otlp.yaml
+        engine_config_template: test_suites/integration/templates/configs/engine/backpressure/otlp-attr-otlp.yaml.j2
         loadgen_exporter_type: otlp
         backend_receiver_type: otlp
         observation_interval: 60

--- a/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-otap-cores-template.yaml.j2
+++ b/tools/pipeline_perf_test/test_suites/integration/continuous/saturation-otap-cores-template.yaml.j2
@@ -73,7 +73,7 @@ tests:
       path: test_suites/integration/templates/test_steps/df-loadgen-steps-docker.yaml
       variables:
         result_dir: "continuous_saturation_{{num_cores}}core_otap"
-        engine_config_template: test_suites/integration/templates/configs/engine/backpressure/otap-attr-otap.yaml
+        engine_config_template: test_suites/integration/templates/configs/engine/backpressure/otap-attr-otap.yaml.j2
         loadgen_exporter_type: otap
         backend_receiver_type: otap
         observation_interval: 60


### PR DESCRIPTION
Fixes the saturation scaling test's engine config reference to include the `.j2` extension, matching the file rename in #3244 that silently broke the nightly suite on 2026-06-08. Verified locally that the engine template now renders and deploys end-to-end.

CI error this fixes:

```
Template rendering failed: 'otlp-attr-otlp.yaml' not found in search path: 'test_suites/integration/templates/configs/engine/backpressure'
Error: Test Step: Deploy Dataflow Engine failed: 'otlp-attr-otlp.yaml' not found in search path: 'test_suites/integration/templates/configs/engine/backpressure'
```