### PR TITLE
feat(recordset_kql_processor): Record signals.dropped in recordset_kql_processor

### DIFF
--- a/rust/experimental/query_engine/engine-recordset/src/engine.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/engine.rs
@@ -293,7 +293,7 @@ fn process_record<'a, TRecord: Record + 'static>(
                         execution_context.add_diagnostic_if_enabled(
                             RecordSetEngineDiagnosticLevel::Info,
                             s,
-                            || "Record summarized and dropped".into(),
+                            || "Record summarized".into(),
                         );
 
                         return RecordSetEngineResult::Summarized(execution_context.into());

--- a/rust/experimental/query_engine/engine-recordset/src/engine.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/engine.rs
@@ -110,6 +110,7 @@ pub struct RecordSetEngineBatch<'a, 'b, TRecord: Record> {
     global_variables: RefCell<MapValueStorage<OwnedValue>>,
     summaries: Summaries<'a>,
     included_records: Vec<RecordSetEngineRecord<'a, TRecord>>,
+    counters: RecordSetEngineCounters,
 }
 
 impl<'a, 'b, TRecord: Record + 'static> RecordSetEngineBatch<'a, 'b, TRecord> {
@@ -124,6 +125,7 @@ impl<'a, 'b, TRecord: Record + 'static> RecordSetEngineBatch<'a, 'b, TRecord> {
             global_variables: RefCell::new(MapValueStorage::new(HashMap::new())),
             summaries: Summaries::new(engine.summary_cardinality_limit),
             included_records: Vec::new(),
+            counters: RecordSetEngineCounters::default(),
         }
     }
 
@@ -189,8 +191,18 @@ impl<'a, 'b, TRecord: Record + 'static> RecordSetEngineBatch<'a, 'b, TRecord> {
         records.drain(&mut |attached_records, record| match self
             .process_record(attached_records, record)
         {
-            RecordSetEngineResult::Drop(d) => dropped_records.push(d),
-            RecordSetEngineResult::Include(i) => self.included_records.push(i),
+            RecordSetEngineResult::Drop(d) => {
+                self.counters.dropped += 1;
+                dropped_records.push(d);
+            }
+            RecordSetEngineResult::Include(i) => {
+                self.counters.included += 1;
+                self.included_records.push(i);
+            }
+            RecordSetEngineResult::Summarized(_) => {
+                // Folded into an aggregation; counted separately from filter-drops.
+                self.counters.summarized += 1;
+            }
         });
 
         dropped_records
@@ -209,6 +221,7 @@ impl<'a, 'b, TRecord: Record + 'static> RecordSetEngineBatch<'a, 'b, TRecord> {
             ),
             self.included_records,
             Vec::new(),
+            self.counters,
         )
     }
 
@@ -283,7 +296,7 @@ fn process_record<'a, TRecord: Record + 'static>(
                             || "Record summarized and dropped".into(),
                         );
 
-                        return RecordSetEngineResult::Drop(execution_context.into());
+                        return RecordSetEngineResult::Summarized(execution_context.into());
                     }
                     Err(e) => {
                         execution_context.add_diagnostic_if_enabled(
@@ -362,7 +375,7 @@ fn process_summaries<'a>(
             );
 
             match process_record(execution_context, post_expressions) {
-                RecordSetEngineResult::Drop(r) => {
+                RecordSetEngineResult::Drop(r) | RecordSetEngineResult::Summarized(r) => {
                     dropped_summaries.push(RecordSetEngineSummary::new(
                         Some(pipeline),
                         r.diagnostics,
@@ -426,6 +439,10 @@ pub trait AttachedRecords {
 pub enum RecordSetEngineResult<'a, TRecord: Record> {
     Drop(RecordSetEngineRecord<'a, TRecord>),
     Include(RecordSetEngineRecord<'a, TRecord>),
+    /// Consumed by a `summarize` aggregation: not emitted individually and
+    /// counted separately from filter-drops (see
+    /// [`RecordSetEngineCounters::summarized`]).
+    Summarized(RecordSetEngineRecord<'a, TRecord>),
 }
 
 #[derive(Debug)]
@@ -605,6 +622,24 @@ pub struct RecordSetEngineResults<'a, TRecord: Record> {
     pub summaries: RecordSetEngineSummaryResults<'a>,
     pub included_records: Vec<RecordSetEngineRecord<'a, TRecord>>,
     pub dropped_records: Vec<RecordSetEngineRecord<'a, TRecord>>,
+    /// Per-input-record classification counts for the batch. See
+    /// [`RecordSetEngineCounters`].
+    pub counters: RecordSetEngineCounters,
+}
+
+/// Per-input-record classification counts accumulated while a batch is
+/// processed, tracked by the engine rather than inferred from batch sizes (e.g.
+/// `input - output`). The counts are disjoint: each input record is counted in
+/// exactly one field.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RecordSetEngineCounters {
+    /// Records emitted individually (passed all filters and were not folded into
+    /// an aggregation).
+    pub included: usize,
+    /// Records removed by a filter predicate (e.g. a `where` clause).
+    pub dropped: usize,
+    /// Records folded into a `summarize` aggregation.
+    pub summarized: usize,
 }
 
 impl<'a, TRecord: Record> RecordSetEngineResults<'a, TRecord> {
@@ -614,6 +649,7 @@ impl<'a, TRecord: Record> RecordSetEngineResults<'a, TRecord> {
         summaries: RecordSetEngineSummaryResults<'a>,
         included_records: Vec<RecordSetEngineRecord<'a, TRecord>>,
         dropped_records: Vec<RecordSetEngineRecord<'a, TRecord>>,
+        counters: RecordSetEngineCounters,
     ) -> RecordSetEngineResults<'a, TRecord> {
         Self {
             pipeline,
@@ -621,6 +657,7 @@ impl<'a, TRecord: Record> RecordSetEngineResults<'a, TRecord> {
             summaries,
             included_records,
             dropped_records,
+            counters,
         }
     }
 
@@ -803,11 +840,13 @@ mod tests {
         let mut batch = engine.begin_batch(&pipeline).unwrap();
 
         let dropped_records = batch.push_records(&mut records);
-
-        assert_eq!(3, dropped_records.len());
+        assert_eq!(0, dropped_records.len());
 
         let results = batch.flush();
 
+        assert_eq!(3, results.counters.summarized);
+        assert_eq!(0, results.counters.dropped);
+        assert_eq!(0, results.counters.included);
         assert_eq!(2, results.summaries.included_summaries.len());
         assert_eq!(0, results.summaries.dropped_summaries.len());
         assert_eq!(0, results.included_records.len());
@@ -895,11 +934,13 @@ mod tests {
         let mut batch = engine.begin_batch(&pipeline).unwrap();
 
         let dropped_records = batch.push_records(&mut records);
-
-        assert_eq!(3, dropped_records.len());
+        assert_eq!(0, dropped_records.len());
 
         let results = batch.flush();
 
+        assert_eq!(3, results.counters.summarized);
+        assert_eq!(0, results.counters.dropped);
+        assert_eq!(0, results.counters.included);
         assert_eq!(1, results.summaries.included_summaries.len());
         assert_eq!(1, results.summaries.dropped_summaries.len());
         assert_eq!(0, results.included_records.len());

--- a/rust/otap-dataflow/.chloggen/recordset-kql-dropped-flow-metric.yaml
+++ b/rust/otap-dataflow/.chloggen/recordset-kql-dropped-flow-metric.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: pipeline
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Record the `signals.dropped` flow metric from the recordset_kql processor
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [2859]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The recordset_kql processor now declares the drop-decision capability and records
+  the number of records it filters out, so a telemetry policy that enables
+  `signals_dropped` can observe dropped counts for the node (e.g. a KQL `where`
+  filter). Records folded into a `summarize` aggregation are excluded from the
+  dropped count: the recordset engine now reports summarized records separately from
+  genuinely filtered ones, so aggregation is no longer miscounted as dropping.

--- a/rust/otap-dataflow/configs/trafficgen-flow-metrics-demo.yaml
+++ b/rust/otap-dataflow/configs/trafficgen-flow-metrics-demo.yaml
@@ -1,9 +1,10 @@
 # Demonstrates distributed flow metrics with multiple drop decision nodes inside a
 # single flow range:
 #
-# The "ingest_pipeline" flow covers attr1..attr4. The sampler, filter, and
-# transform nodes each drop records and record `signals.dropped` tagged with a
-# `flow.node.decision` attribute of their node name.
+# The "ingest_pipeline" flow covers attr1..attr4. The sampler, filter,
+# transform, and recordset_kql nodes each drop records and record
+# `signals.dropped` tagged with a `flow.node.decision` attribute of their node
+# name.
 #
 # Query metrics while running:
 #   curl -s 'http://127.0.0.1:8080/api/v1/telemetry/metrics?format=json' \
@@ -51,13 +52,13 @@ groups:
               # a predictable fraction.
               data_source: synthetic
 
-          # Decision node #1: keeps ~1/3 of log records.
+          # Decision node #1: keeps ~2/3 of log records.
           sampler:
             type: processor:log_sampling
             config:
               policy:
                 ratio:
-                  emit: 1
+                  emit: 2
                   out_of: 3
 
           attr1:
@@ -94,6 +95,13 @@ groups:
             config:
               kql_query: 'logs | where attributes["thread.name"] != "worker-3"'
 
+          # Decision node #4: recordset_kql processor dropping worker-2 via a KQL
+          # `where` predicate, proving it records signals.dropped too.
+          recordset:
+            type: "urn:microsoft:processor:recordset_kql"
+            config:
+              query: "source | where attributes['thread.name'] != 'worker-2'"
+
           attr3:
             type: processor:attribute
             config:
@@ -128,6 +136,8 @@ groups:
           - from: filter
             to: transform
           - from: transform
+            to: recordset
+          - from: recordset
             to: attr4
           - from: attr4
             to: noop

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/bridge.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/bridge.rs
@@ -74,19 +74,26 @@ impl BridgePipeline {
 
 #[derive(Debug)]
 pub struct BridgeResponse {
-    pub included_records: Option<ExportLogsServiceRequest>,
-    pub included_record_count: usize,
+    /// Records emitted on the output channel: individually included records
+    /// plus any synthetic rows produced by a `summarize` aggregation. This is
+    /// the OTLP payload forwarded downstream, and is distinct from the
+    /// per-input-record `counters.included` count (a summary row is emitted
+    /// here even though no input record was individually included).
+    pub output_records: Option<ExportLogsServiceRequest>,
+    /// Records removed by a filter (`where`), serialized only when the pipeline
+    /// is configured to include dropped records.
     pub dropped_records: Option<ExportLogsServiceRequest>,
-    pub dropped_record_count: usize,
+    /// Per-input-record classification counts (included / dropped / summarized).
+    pub counters: RecordSetEngineCounters,
 }
 
 impl BridgeResponse {
     pub fn into_otlp_bytes(self) -> Result<(Vec<u8>, Vec<u8>), BridgeError> {
-        let mut included_records_otlp_response = Vec::new();
-        if let Some(ref included) = self.included_records {
-            match ExportLogsServiceRequest::to_protobuf(included, OTLP_BUFFER_INITIAL_CAPACITY) {
+        let mut output_records_otlp_response = Vec::new();
+        if let Some(ref output) = self.output_records {
+            match ExportLogsServiceRequest::to_protobuf(output, OTLP_BUFFER_INITIAL_CAPACITY) {
                 Ok(r) => {
-                    included_records_otlp_response = r.to_vec();
+                    output_records_otlp_response = r.to_vec();
                 }
                 Err(e) => {
                     return Err(BridgeError::OtlpProtobufWriteError(e));
@@ -106,10 +113,7 @@ impl BridgeResponse {
             }
         }
 
-        Ok((
-            included_records_otlp_response,
-            dropped_records_otlp_response,
-        ))
+        Ok((output_records_otlp_response, dropped_records_otlp_response))
     }
 }
 
@@ -238,9 +242,10 @@ pub fn process_export_logs_service_request_using_pipeline(
     let initial_dropped_records = batch.push_records(&mut export_logs_service_request);
 
     let mut final_results = batch.flush();
+    let counters = final_results.counters;
 
     let mut dropped_records = None;
-    let dropped_record_count = if pipeline.options.get_include_dropped_records() {
+    if pipeline.options.get_include_dropped_records() {
         for record in initial_dropped_records.into_iter() {
             final_results.dropped_records.push(record);
         }
@@ -267,8 +272,6 @@ pub fn process_export_logs_service_request_using_pipeline(
                 dropped_records_request.resource_logs.push(resource_logs);
             }
 
-            let count = final_results.dropped_records.len();
-
             process_log_record_results(
                 pipeline.options.get_diagnostic_options(),
                 &mut dropped_records_request,
@@ -276,19 +279,12 @@ pub fn process_export_logs_service_request_using_pipeline(
             );
 
             dropped_records = Some(dropped_records_request);
-
-            count
-        } else {
-            0
         }
-    } else {
-        initial_dropped_records.len() + final_results.dropped_records.len()
-    };
+    }
 
-    let mut included_records = None;
+    let mut output_records = None;
 
-    let mut included_record_count = final_results.included_records.len();
-    let has_included_records = included_record_count > 0;
+    let has_included_records = !final_results.included_records.is_empty();
 
     let has_summaries = !final_results.summaries.included_summaries.is_empty();
     if has_summaries || has_included_records {
@@ -380,7 +376,6 @@ pub fn process_export_logs_service_request_using_pipeline(
                 );
 
                 log_records.push(log_record);
-                included_record_count += 1;
             }
 
             let summary_otlp = ResourceLogs::new().with_scope_logs(
@@ -396,14 +391,13 @@ pub fn process_export_logs_service_request_using_pipeline(
             export_logs_service_request.resource_logs.push(summary_otlp);
         }
 
-        included_records = Some(export_logs_service_request);
+        output_records = Some(export_logs_service_request);
     }
 
     Ok(BridgeResponse {
-        included_records,
-        included_record_count,
+        output_records,
         dropped_records,
-        dropped_record_count,
+        counters,
     })
 }
 
@@ -733,7 +727,7 @@ mod tests {
                 )
                 .unwrap();
 
-            assert_eq!(1, response.dropped_record_count);
+            assert_eq!(1, response.counters.dropped);
             assert!(response.dropped_records.is_none())
         }
     }
@@ -753,12 +747,13 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(0, response.included_record_count);
-        assert_eq!(1, response.dropped_record_count);
+        assert_eq!(0, response.counters.included);
+        assert_eq!(0, response.counters.summarized);
+        assert_eq!(1, response.counters.dropped);
 
-        let (included_records, dropped_records) = response.into_otlp_bytes().unwrap();
+        let (output_records, dropped_records) = response.into_otlp_bytes().unwrap();
 
-        assert!(included_records.is_empty());
+        assert!(output_records.is_empty());
         assert!(!dropped_records.is_empty());
     }
 
@@ -777,12 +772,12 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(1, response.included_record_count);
-        assert_eq!(0, response.dropped_record_count);
+        assert_eq!(1, response.counters.included);
+        assert_eq!(0, response.counters.dropped);
 
-        let (included_records, dropped_records) = response.into_otlp_bytes().unwrap();
+        let (output_records, dropped_records) = response.into_otlp_bytes().unwrap();
 
-        assert!(!included_records.is_empty());
+        assert!(!output_records.is_empty());
         assert!(dropped_records.is_empty());
     }
 
@@ -802,13 +797,13 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(1, response.included_record_count);
-        assert_eq!(1, response.dropped_record_count);
-
-        let (included_records, dropped_records) = response.into_otlp_bytes().unwrap();
-
-        assert!(!included_records.is_empty());
-        assert!(!dropped_records.is_empty());
+        // No input record was individually included or dropped; the single
+        // input was folded into the aggregation. The aggregation still emits
+        // one synthetic summary row on the output channel.
+        assert_eq!(0, response.counters.included);
+        assert_eq!(0, response.counters.dropped);
+        assert_eq!(1, response.counters.summarized);
+        assert!(response.output_records.is_some());
     }
 
     #[test]
@@ -834,10 +829,11 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(2, response.included_record_count);
-        assert_eq!(2, response.dropped_record_count);
+        assert_eq!(0, response.counters.included);
+        assert_eq!(0, response.counters.dropped);
+        assert_eq!(2, response.counters.summarized);
 
-        let response_otlp = response.included_records.as_mut().unwrap();
+        let response_otlp = response.output_records.as_mut().unwrap();
 
         let response_summaries = &mut response_otlp.resource_logs[1].scope_logs[0].log_records;
 
@@ -885,10 +881,10 @@ mod tests {
                 .map(|v| v.to_value())
         );
 
-        let (included_records, dropped_records) = response.into_otlp_bytes().unwrap();
+        let (output_records, dropped_records) = response.into_otlp_bytes().unwrap();
 
-        assert!(!included_records.is_empty());
-        assert!(!dropped_records.is_empty());
+        assert!(!output_records.is_empty());
+        assert!(dropped_records.is_empty());
     }
 
     #[test]
@@ -911,10 +907,10 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(2, response.included_record_count);
-        assert_eq!(2, response.dropped_record_count);
+        assert_eq!(0, response.counters.dropped);
+        assert_eq!(2, response.counters.summarized);
 
-        let response_otlp = response.included_records.as_mut().unwrap();
+        let response_otlp = response.output_records.as_mut().unwrap();
 
         let response_summaries = &mut response_otlp.resource_logs[1].scope_logs[0].log_records;
 
@@ -992,10 +988,10 @@ mod tests {
                 .map(|v| v.to_value())
         );
 
-        let (included_records, dropped_records) = response.into_otlp_bytes().unwrap();
+        let (output_records, dropped_records) = response.into_otlp_bytes().unwrap();
 
-        assert!(!included_records.is_empty());
-        assert!(!dropped_records.is_empty());
+        assert!(!output_records.is_empty());
+        assert!(dropped_records.is_empty());
     }
 
     #[test]
@@ -1094,12 +1090,12 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(1, response.included_record_count);
-        assert_eq!(0, response.dropped_record_count);
+        assert_eq!(1, response.counters.included);
+        assert_eq!(0, response.counters.dropped);
 
-        let (included_records, dropped_records) = response.into_otlp_bytes().unwrap();
+        let (output_records, dropped_records) = response.into_otlp_bytes().unwrap();
 
-        assert!(!included_records.is_empty());
+        assert!(!output_records.is_empty());
         assert!(dropped_records.is_empty());
     }
 
@@ -1242,13 +1238,9 @@ mod tests {
         )
         .unwrap();
 
-        let canonical_logs = &response_canonical.included_records.unwrap().resource_logs[0]
-            .scope_logs[0]
-            .log_records;
-        let aliased_logs = &response_with_aliases
-            .included_records
-            .unwrap()
-            .resource_logs[0]
+        let canonical_logs =
+            &response_canonical.output_records.unwrap().resource_logs[0].scope_logs[0].log_records;
+        let aliased_logs = &response_with_aliases.output_records.unwrap().resource_logs[0]
             .scope_logs[0]
             .log_records;
 

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/processor.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/processor.rs
@@ -11,7 +11,7 @@ use super::otlp_bridge::{
     process_protobuf_otlp_export_logs_service_request_using_pipeline,
 };
 use async_trait::async_trait;
-use data_engine_recordset::RecordSetEngineDiagnosticLevel;
+use data_engine_recordset::{RecordSetEngineCounters, RecordSetEngineDiagnosticLevel};
 use linkme::distributed_slice;
 use otap_df_config::SignalType;
 use otap_df_config::error::Error as ConfigError;
@@ -23,6 +23,7 @@ use otap_df_engine::{
     local::processor::{EffectHandler, Processor},
     message::Message,
     process_duration::ComputeDuration,
+    processor::ProcessorRuntimeRequirements,
 };
 use otap_df_pdata::TryIntoWithOptions;
 use otap_df_pdata::{OtapPayload, OtlpProtoBytes};
@@ -45,6 +46,13 @@ pub struct RecordsetKqlProcessor {
     config: RecordsetKqlProcessorConfig,
     pipeline: BridgePipeline,
     compute_duration: ComputeDuration,
+}
+
+/// Result of processing a single signal payload: the transformed bytes plus the
+/// engine counters observed while producing them.
+struct ProcessedSignal {
+    payload: OtlpProtoBytes,
+    counters: RecordSetEngineCounters,
 }
 
 impl RecordsetKqlProcessor {
@@ -150,9 +158,9 @@ impl RecordsetKqlProcessor {
         });
 
         match result {
-            Ok(processed_bytes) => {
+            Ok(ProcessedSignal { payload, counters }) => {
                 // Convert back to OtapPayload and reconstruct OtapPdata
-                let payload: OtapPayload = processed_bytes.into();
+                let payload: OtapPayload = payload.into();
                 // Note! we are recomputing the number of matched items, which
                 // the engine could tell us.
                 let output_items = payload.num_items() as u64;
@@ -161,7 +169,12 @@ impl RecordsetKqlProcessor {
                     "recordset_kql_processor.success",
                     input_items,
                     output_items,
+                    dropped_items = counters.dropped as u64,
                 );
+
+                // No-op unless this node is a decision node in a flow that
+                // enables `signals.dropped`.
+                effect_handler.record_flow_signals_dropped(counters.dropped as u64);
 
                 let processed_data = OtapPdata::new(ctx, payload);
 
@@ -191,7 +204,7 @@ impl RecordsetKqlProcessor {
         &self,
         bytes: bytes::Bytes,
         signal: SignalType,
-    ) -> Result<OtlpProtoBytes, Error> {
+    ) -> Result<ProcessedSignal, Error> {
         let response = process_protobuf_otlp_export_logs_service_request_using_pipeline(
             &self.pipeline,
             RecordSetEngineDiagnosticLevel::Warn,
@@ -199,12 +212,16 @@ impl RecordsetKqlProcessor {
         )
         .map_err(|e| Self::map_bridge_error(e, signal))?;
 
-        let included_records = response
+        let counters = response.counters;
+        let output_records = response
             .into_otlp_bytes()
             .map_err(|e| Self::map_bridge_error(e, signal))?
             .0;
 
-        Ok(OtlpProtoBytes::ExportLogsRequest(included_records.into()))
+        Ok(ProcessedSignal {
+            payload: OtlpProtoBytes::ExportLogsRequest(output_records.into()),
+            counters,
+        })
     }
 
     fn map_bridge_error(error: BridgeError, signal: SignalType) -> Error {
@@ -216,6 +233,11 @@ impl RecordsetKqlProcessor {
 
 #[async_trait(?Send)]
 impl Processor<OtapPdata> for RecordsetKqlProcessor {
+    fn runtime_requirements(&self) -> ProcessorRuntimeRequirements {
+        // Filtering (e.g. a KQL `where`) can drop signal items.
+        ProcessorRuntimeRequirements::none().with_drop_decisions()
+    }
+
     async fn process(
         &mut self,
         msg: Message<OtapPdata>,
@@ -1113,5 +1135,28 @@ mod tests {
                 assert!(counts.contains(&1), "Should have a bin with count=1");
             },
         );
+    }
+
+    /// The processor always declares drop decisions (correct for every query
+    /// shape) so the `signals.dropped` flow metric can be wired.
+    #[test]
+    fn test_declares_drop_decisions() {
+        fn declares_drops(query: &str) -> bool {
+            let telemetry_registry_handle = TelemetryRegistryHandle::new();
+            let controller_ctx = ControllerContext::new(telemetry_registry_handle);
+            let pipeline_ctx =
+                controller_ctx.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+            let config = RecordsetKqlProcessorConfig {
+                query: query.to_string(),
+                bridge_options: None,
+            };
+            let processor = RecordsetKqlProcessor::with_pipeline_ctx(pipeline_ctx, config)
+                .expect("processor builds");
+            processor.runtime_requirements().makes_drop_decisions
+        }
+
+        assert!(declares_drops("source | where severityText == \"ERROR\""));
+        assert!(declares_drops("source | extend foo = 1"));
+        assert!(declares_drops("source | summarize Count = count()"));
     }
 }

--- a/rust/otap-dataflow/crates/contrib-nodes/tests/processors/recordset_kql_processor/otlp_kql_recordset.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/tests/processors/recordset_kql_processor/otlp_kql_recordset.rs
@@ -34,8 +34,8 @@ fn test_project_keep() {
 
     let results = process_records(&pipeline, &engine, &mut request);
 
-    assert_eq!(results.included_records.len(), 1);
-    assert_eq!(results.dropped_records.len(), 0);
+    assert_eq!(results.counters.included, 1);
+    assert_eq!(results.counters.dropped, 0);
 
     let log = results.included_records.first().unwrap().get_record();
 
@@ -71,8 +71,8 @@ fn test_project_away() {
 
     let results = process_records(&pipeline, &engine, &mut request);
 
-    assert_eq!(results.included_records.len(), 1);
-    assert_eq!(results.dropped_records.len(), 0);
+    assert_eq!(results.counters.included, 1);
+    assert_eq!(results.counters.dropped, 0);
 
     let log = results.included_records.first().unwrap().get_record();
 
@@ -109,8 +109,9 @@ fn test_summarize_count_only() {
 
     assert_eq!(results.summaries.included_summaries.len(), 1);
     assert_eq!(results.summaries.dropped_summaries.len(), 0);
-    assert_eq!(results.included_records.len(), 0);
-    assert_eq!(results.dropped_records.len(), 2);
+    assert_eq!(results.counters.included, 0);
+    assert_eq!(results.counters.dropped, 0);
+    assert_eq!(results.counters.summarized, 2);
 
     let summary = results.summaries.included_summaries.first().unwrap();
 
@@ -163,8 +164,9 @@ fn test_summarize_count_and_group_by() {
 
     assert_eq!(results.summaries.included_summaries.len(), 2);
     assert_eq!(results.summaries.dropped_summaries.len(), 0);
-    assert_eq!(results.included_records.len(), 0);
-    assert_eq!(results.dropped_records.len(), 3);
+    assert_eq!(results.counters.included, 0);
+    assert_eq!(results.counters.dropped, 0);
+    assert_eq!(results.counters.summarized, 3);
 
     let mut summaries = results.summaries.included_summaries;
     summaries.sort_by(|l, r| l.summary_id.cmp(&r.summary_id));
@@ -242,8 +244,9 @@ fn test_summarize_count_and_group_by_with_bin() {
 
     assert_eq!(results.summaries.included_summaries.len(), 2);
     assert_eq!(results.summaries.dropped_summaries.len(), 0);
-    assert_eq!(results.included_records.len(), 0);
-    assert_eq!(results.dropped_records.len(), 3);
+    assert_eq!(results.counters.included, 0);
+    assert_eq!(results.counters.dropped, 0);
+    assert_eq!(results.counters.summarized, 3);
 
     let mut summaries = results.summaries.included_summaries;
     summaries.sort_by(|l, r| l.summary_id.cmp(&r.summary_id));
@@ -321,8 +324,9 @@ fn test_summarize_with_pipeline() {
 
     assert_eq!(results.summaries.included_summaries.len(), 1);
     assert_eq!(results.summaries.dropped_summaries.len(), 1);
-    assert_eq!(results.included_records.len(), 0);
-    assert_eq!(results.dropped_records.len(), 3);
+    assert_eq!(results.counters.included, 0);
+    assert_eq!(results.counters.dropped, 0);
+    assert_eq!(results.counters.summarized, 3);
 
     let summary = results.summaries.included_summaries.first().unwrap();
 
@@ -384,8 +388,8 @@ fn test_strlen_function() {
 
     let results = process_records(&pipeline, &engine, &mut request);
 
-    assert_eq!(results.included_records.len(), 1);
-    assert_eq!(results.dropped_records.len(), 0);
+    assert_eq!(results.counters.included, 1);
+    assert_eq!(results.counters.dropped, 0);
 
     let log = results.included_records.first().unwrap().get_record();
 
@@ -438,8 +442,8 @@ fn test_strcat_function() {
 
     let results = process_records(&pipeline, &engine, &mut request);
 
-    assert_eq!(results.included_records.len(), 1);
-    assert_eq!(results.dropped_records.len(), 0);
+    assert_eq!(results.counters.included, 1);
+    assert_eq!(results.counters.dropped, 0);
 
     let log = results.included_records.first().unwrap().get_record();
 
@@ -485,8 +489,8 @@ fn test_replace_string_function() {
 
     let results = process_records(&pipeline, &engine, &mut request);
 
-    assert_eq!(results.included_records.len(), 1);
-    assert_eq!(results.dropped_records.len(), 0);
+    assert_eq!(results.counters.included, 1);
+    assert_eq!(results.counters.dropped, 0);
 
     let log = results.included_records.first().unwrap().get_record();
 
@@ -544,8 +548,8 @@ fn test_substring_function() {
 
         let results = process_records(&pipeline, &engine, &mut request);
 
-        assert_eq!(results.included_records.len(), 1);
-        assert_eq!(results.dropped_records.len(), 0);
+        assert_eq!(results.counters.included, 1);
+        assert_eq!(results.counters.dropped, 0);
 
         let log = results.included_records.first().unwrap().get_record();
 
@@ -590,8 +594,8 @@ fn test_coalesce_function() {
 
         let results = process_records(&pipeline, &engine, &mut request);
 
-        assert_eq!(results.included_records.len(), 1);
-        assert_eq!(results.dropped_records.len(), 0);
+        assert_eq!(results.counters.included, 1);
+        assert_eq!(results.counters.dropped, 0);
 
         let log = results.included_records.first().unwrap().get_record();
 
@@ -637,8 +641,8 @@ fn test_now_global_variable() {
 
     let results = process_records(&pipeline, &engine, &mut request);
 
-    assert_eq!(results.included_records.len(), 1);
-    assert_eq!(results.dropped_records.len(), 0);
+    assert_eq!(results.counters.included, 1);
+    assert_eq!(results.counters.dropped, 0);
 
     let log = results.included_records.first().unwrap().get_record();
 


### PR DESCRIPTION
# Change Summary

Extends the `signals.dropped` flow metric (#2859) to the recordset_kql processor so pipelines can observe how many records it filters out. Together with the earlier transform-processor change, this gives every KQL-based decision node the same queryable dropped count already provided by `filter_processor` and `log_sampling_processor`.

Very similar to recent PR #3473.

### Validation

Ran `configs/trafficgen-flow-metrics-demo.yaml` (with `--features recordset-kql-processor`), which places the recordset_kql processor as one of four interior decision nodes in a single `ingest_pipeline` flow range: the sampler keeps ~2/3, filter drops `worker-1`, transform drops `worker-3`, and recordset drops `worker-2`. Each decision node's drops are tagged with a distinct `flow.node.decision`, and the counts reconcile exactly against incoming/outgoing (480 − 160 − 48 − 48 − 48 = 176).

| `flow.node.decision` | Metric | Sum | Count |
| --- | --- | ---: | ---: |
| _(range)_ | signals.incoming | 480 | 48 |
| sampler | signals.dropped | 160 | 48 |
| filter | signals.dropped | 48 | 48 |
| transform | signals.dropped | 48 | 48 |
| **recordset** | **signals.dropped** | **48** | 48 |
| _(range)_ | signals.outgoing | 176 | 48 |

The `recordset` row confirms the processor records `signals.dropped` under its own decision attribute, exactly like the existing `filter`/`transform`/`sampler` decision nodes.

## What issue does this PR close?

<!--We highly recommend correlation of every PR to an issue-->

* Related to #2859 

## How are these changes tested?

* Unit tests and demo config

## Are there any user-facing changes?

 <!-- If yes, provide further info below -->

Additional `flow.dropped` metric source

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry
* [ ] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
