### PR TITLE
chore(ci): Make PR Size Labeler also work on ready_for_review events

### DIFF
--- a/.github/workflows/pr-size-label.yml
+++ b/.github/workflows/pr-size-label.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   size-label:


### PR DESCRIPTION
# Change Summary

Noticed gap while looking at https://github.com/open-telemetry/otel-arrow/pull/3483

## What issue does this PR close?

<!--We highly recommend correlation of every PR to an issue-->

N/A

## How are these changes tested?

N/A

## Are there any user-facing changes?

N/A

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [ ] Added a `.chloggen/*.yaml` entry
* [x] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
