### PR TITLE
feat: add endpoint to dump heap allocation profile

### DIFF
--- a/rust/otap-dataflow/.chloggen/admin-heap-profile-endpoint.yaml
+++ b/rust/otap-dataflow/.chloggen/admin-heap-profile-endpoint.yaml
@@ -1,0 +1,23 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: engine
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: >-
+  Add heap profiling endpoint at `/api/v1/debug/pprof/heap` that dumps
+  jemalloc heap allocations in pprof format.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [3660]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries. Breaking entries must include a `Migration:`
+# section with the specific action consumers must take. Keep notes to 200
+# characters and subtext to 300 characters.
+subtext:

--- a/rust/otap-dataflow/Cargo.lock
+++ b/rust/otap-dataflow/Cargo.lock
@@ -5675,6 +5675,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "jemalloc_pprof"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb2dfa20a68824f4c8c1aa271617d0ee0d9b707a866d56b7d7ee39c60c235a8"
+dependencies = [
+ "anyhow",
+ "libc",
+ "mappings",
+ "once_cell",
+ "pprof_util",
+ "tempfile",
+ "tikv-jemalloc-ctl",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "jiff"
 version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6292,6 +6309,19 @@ name = "macro_rules_attribute-proc_macro"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
+
+[[package]]
+name = "mappings"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bab1e61a4b76757edb59cd81fcaa7f3ba9018d43b527d9abfad877b4c6c60f2"
+dependencies = [
+ "anyhow",
+ "libc",
+ "once_cell",
+ "pprof_util",
+ "tracing",
+]
 
 [[package]]
 name = "markdown"
@@ -7116,6 +7146,7 @@ dependencies = [
  "axum",
  "chrono",
  "include_dir",
+ "jemalloc_pprof",
  "mime_guess",
  "otap-df-admin-types",
  "otap-df-config",
@@ -8365,6 +8396,20 @@ name = "ppmd-rust"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efca4c95a19a79d1c98f791f10aebd5c1363b473244630bb7dbde1dc98455a24"
+
+[[package]]
+name = "pprof_util"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea0cc524de808a6d98d192a3d99fe95617031ad4a52ec0a0f987ef4432e8fe1"
+dependencies = [
+ "anyhow",
+ "backtrace",
+ "flate2",
+ "num",
+ "paste",
+ "prost",
+]
 
 [[package]]
 name = "ppv-lite86"

--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -130,7 +130,8 @@ linkme = "0.3.35"
 local-sync = "0.1.1"
 miette = { version="7.6.0", features = ["fancy"] }
 mimalloc = { version = "0.1.52", features = ["extended", "debug"] }
-tikv-jemallocator = { version = "0.7.0" }
+jemalloc_pprof = { version = "0.9.0", features = ["symbolize"] }
+tikv-jemallocator = { version = "0.7.0", features = ["profiling", "unprefixed_malloc_on_supported_platforms"]}
 tikv-jemalloc-ctl = { version = "0.7.0", features = ["stats"] }
 tikv-jemalloc-sys = "0.7.0"
 memchr = "2.8.0"

--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -295,9 +295,12 @@ otap-df-pdata = { path = "crates/pdata" }
 otap-df-pdata-views = { path = "crates/pdata-views" }
 
 [features]
-# ToDo When jemalloc is enabled, we could use jemalloc_pprof to profile where memory is allocated. See https://crates.io/crates/jemalloc_pprof
 default = ["jemalloc", "crypto-ring", "dev-tools", "admin-live-logs-ws"]
-jemalloc = ["dep:tikv-jemallocator", "otap-df-engine/jemalloc"]
+jemalloc = [
+    "dep:tikv-jemallocator",
+    "otap-df-engine/jemalloc",
+    "otap-df-controller/jemalloc-pprof",
+]
 mimalloc = ["dep:mimalloc"]
 azure = ["otap-df-otap/azure"]
 aws = ["otap-df-otap/aws", "otap-df-contrib-nodes/aws"]

--- a/rust/otap-dataflow/PROFILING.md
+++ b/rust/otap-dataflow/PROFILING.md
@@ -56,3 +56,31 @@ for memory profiling that needs to be rendered by uploading it to:
 
 > [!NOTE]
 > `dhat` needs a clean shutdown to generate `dhat-heap.json` file.
+
+## Live heap profiling (jemalloc pprof)
+
+The admin server exposes a heap profiling endpoint at
+`/api/v1/debug/pprof/heap` that dumps unfreed heap allocations in pprof
+format. This requires jemalloc as the allocator (the default on Linux and
+macOS) with profiling enabled.
+
+**Run** with profiling enabled:
+
+```bash
+_RJEM_MALLOC_CONF="prof:true,prof_active:true,lg_prof_sample:19" \
+  cargo run -- --config ./configs/otap-noop.yaml
+```
+
+On Linux, use `MALLOC_CONF` instead of `_RJEM_MALLOC_CONF`.
+
+**Fetch** a heap profile:
+
+```bash
+curl http://localhost:8080/api/v1/debug/pprof/heap -o heap.pprof
+```
+
+**View** with `go tool pprof`:
+
+```bash
+go tool pprof -http=:18080 ./target/debug/df_engine ./heap.pprof
+```

--- a/rust/otap-dataflow/crates/admin/Cargo.toml
+++ b/rust/otap-dataflow/crates/admin/Cargo.toml
@@ -23,6 +23,7 @@ otap-df-state = { workspace = true }
 otap-df-telemetry = { workspace = true }
 otap-df-engine = { workspace = true }
 
+jemalloc_pprof = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/rust/otap-dataflow/crates/admin/Cargo.toml
+++ b/rust/otap-dataflow/crates/admin/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 [features]
 default = []
 live-logs-ws = ["axum/ws"]
+jemalloc-pprof = ["dep:jemalloc_pprof"]
 
 [dependencies]
 otap-df-admin-types = { workspace = true }
@@ -23,7 +24,6 @@ otap-df-state = { workspace = true }
 otap-df-telemetry = { workspace = true }
 otap-df-engine = { workspace = true }
 
-jemalloc_pprof = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -34,6 +34,9 @@ axum = { workspace = true }
 tower = { workspace = true }
 include_dir = { workspace = true }
 mime_guess = { workspace = true }
+
+[target.'cfg(not(windows))'.dependencies]
+jemalloc_pprof = { workspace = true, optional = true }
 
 [dev-dependencies]
 otap-df-telemetry-macros = { workspace = true }

--- a/rust/otap-dataflow/crates/admin/README.md
+++ b/rust/otap-dataflow/crates/admin/README.md
@@ -48,6 +48,14 @@ For the operator guide to live pipeline mutation, see
 - `POST /api/v1/groups/{pipeline_group_id}/pipelines/{pipeline_id}/shutdown`
 - `POST /api/v1/groups/shutdown`
 
+### Debug
+
+- `GET /api/v1/debug/pprof/heap`: dump jemalloc heap allocations in pprof
+  format. Requires jemalloc as the active allocator with profiling enabled
+  (e.g. `_RJEM_MALLOC_CONF="prof:true,prof_active:true,lg_prof_sample:19"`
+  on macOS, or `MALLOC_CONF` on Linux). Returns `application/x-protobuf`.
+  Returns HTTP 500 if profiling is unavailable or not activated.
+
 ## Embedded UI layout (crate-relative)
 
 - `ui/index.html`: UI shell and page structure.

--- a/rust/otap-dataflow/crates/admin/src/debug.rs
+++ b/rust/otap-dataflow/crates/admin/src/debug.rs
@@ -13,6 +13,8 @@ use axum::http::{StatusCode, header};
 use axum::response::Response;
 use axum::routing::get;
 
+use std::panic::AssertUnwindSafe;
+
 use crate::AppState;
 
 pub(crate) fn routes() -> Router<AppState> {
@@ -21,13 +23,21 @@ pub(crate) fn routes() -> Router<AppState> {
     router
 }
 
-async fn get_heap_profile(State(_state): State<AppState>) -> Result<Response, (StatusCode, String)> {
-    // TODO fix how this can panic if the jemalloc profiling feature not enabled.
-    let mut prof_ctl = match jemalloc_pprof::PROF_CTL.as_ref() {
-        Some(prof_ctl) => prof_ctl,
-        None => {
-            // TODO no panic
-            panic!("no pprof ctl");
+async fn get_heap_profile(
+    State(_state): State<AppState>,
+) -> Result<Response, (StatusCode, String)> {
+    // Accessing `PROF_CTL` can panic if jemalloc is not the active allocator or was compiled w/out profiling
+    // feature. Catch this panic so we return a proper HTTP error instead.
+    let prof_ctl = std::panic::catch_unwind(AssertUnwindSafe(|| jemalloc_pprof::PROF_CTL.as_ref()));
+    let mut prof_ctl = match prof_ctl {
+        Ok(Some(prof_ctl)) => prof_ctl,
+        Ok(None) | Err(_) => {
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Heap profiling not available \
+                 (jemalloc with profiling support is not the active allocator)."
+                    .into(),
+            ));
         }
     }
     .lock()
@@ -43,13 +53,18 @@ async fn get_heap_profile(State(_state): State<AppState>) -> Result<Response, (S
     match prof_ctl.dump_pprof() {
         Ok(pprof) => {
             let body = Body::from(pprof);
-            Ok(
-                Response::builder()
-                    .status(StatusCode::OK)
-                    .header(header::CONTENT_TYPE, "application/x-protobuf")
-                    .body(body)
-                    .unwrap(), // TODO no unwrap
-            )
+            let resp = Response::builder()
+                .status(StatusCode::OK)
+                .header(header::CONTENT_TYPE, "application/x-protobuf")
+                .body(body)
+                .map_err(|e| {
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("Could not dump heap pprof: {e}"),
+                    )
+                })?;
+
+            Ok(resp)
         }
         Err(e) => {
             return Err((

--- a/rust/otap-dataflow/crates/admin/src/debug.rs
+++ b/rust/otap-dataflow/crates/admin/src/debug.rs
@@ -1,0 +1,61 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Debug endpoints.
+//!
+//! - /api/v1/debug/pprof/heap - dump profile of unfreed heap allocations
+//!   (only returns 200 on linux with jemalloc allocator otherwise returns 500)
+
+use axum::Router;
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::{StatusCode, header};
+use axum::response::Response;
+use axum::routing::get;
+
+use crate::AppState;
+
+pub(crate) fn routes() -> Router<AppState> {
+    let router = Router::new().route("/debug/pprof/heap", get(get_heap_profile));
+
+    router
+}
+
+async fn get_heap_profile(State(_state): State<AppState>) -> Result<Response, (StatusCode, String)> {
+    // TODO fix how this can panic if the jemalloc profiling feature not enabled.
+    let mut prof_ctl = match jemalloc_pprof::PROF_CTL.as_ref() {
+        Some(prof_ctl) => prof_ctl,
+        None => {
+            // TODO no panic
+            panic!("no pprof ctl");
+        }
+    }
+    .lock()
+    .await;
+
+    if !prof_ctl.activated() {
+        return Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Memory Profiling not activated".into(),
+        ));
+    }
+
+    match prof_ctl.dump_pprof() {
+        Ok(pprof) => {
+            let body = Body::from(pprof);
+            Ok(
+                Response::builder()
+                    .status(StatusCode::OK)
+                    .header(header::CONTENT_TYPE, "application/x-protobuf")
+                    .body(body)
+                    .unwrap(), // TODO no unwrap
+            )
+        }
+        Err(e) => {
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Could not dump heap pprof: {e}"),
+            ));
+        }
+    }
+}

--- a/rust/otap-dataflow/crates/admin/src/debug.rs
+++ b/rust/otap-dataflow/crates/admin/src/debug.rs
@@ -3,8 +3,10 @@
 
 //! Debug endpoints.
 //!
-//! - /api/v1/debug/pprof/heap - dump profile of unfreed heap allocations
-//!   (only returns 200 on linux with jemalloc allocator otherwise returns 500)
+//! - /api/v1/debug/pprof/heap - dump profile of unfreed heap allocations. This fails unless
+//!   jemalloc is the active allocator and profiling is enabled.
+//!    
+//!   
 
 use axum::Router;
 use axum::body::Body;
@@ -31,7 +33,13 @@ async fn get_heap_profile(
     let prof_ctl = std::panic::catch_unwind(AssertUnwindSafe(|| jemalloc_pprof::PROF_CTL.as_ref()));
     let mut prof_ctl = match prof_ctl {
         Ok(Some(prof_ctl)) => prof_ctl,
-        Ok(None) | Err(_) => {
+        Ok(None) => {
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Memory Profiling not activated".into(),
+            ))
+        }
+        Err(_) => {
             return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Heap profiling not available \

--- a/rust/otap-dataflow/crates/admin/src/debug.rs
+++ b/rust/otap-dataflow/crates/admin/src/debug.rs
@@ -3,18 +3,19 @@
 
 //! Debug endpoints.
 //!
-//! - /api/v1/debug/pprof/heap - dump profile of unfreed heap allocations. This fails unless
-//!   jemalloc is the active allocator and profiling is enabled.
-//!    
-//!   
+//! - /api/v1/debug/pprof/heap -- dump profile of unfreed heap allocations.
+//!   Returns pprof-format data when jemalloc profiling is available, or
+//!   HTTP 500 when the feature is not compiled in or profiling is not enabled.
 
 use axum::Router;
-use axum::body::Body;
 use axum::extract::State;
-use axum::http::{StatusCode, header};
+use axum::http::StatusCode;
 use axum::response::Response;
 use axum::routing::get;
 
+#[cfg(all(feature = "jemalloc-pprof", not(windows)))]
+use axum::{body::Body, http::header};
+#[cfg(all(feature = "jemalloc-pprof", not(windows)))]
 use std::panic::AssertUnwindSafe;
 
 use crate::AppState;
@@ -26,55 +27,68 @@ pub(crate) fn routes() -> Router<AppState> {
 async fn get_heap_profile(
     State(_state): State<AppState>,
 ) -> Result<Response, (StatusCode, String)> {
-    // Accessing `PROF_CTL` can panic if jemalloc is not the active allocator or was compiled w/out profiling
-    // feature. Catch this panic so we return a proper HTTP error instead.
-    let prof_ctl = std::panic::catch_unwind(AssertUnwindSafe(|| jemalloc_pprof::PROF_CTL.as_ref()));
-    let mut prof_ctl = match prof_ctl {
-        Ok(Some(prof_ctl)) => prof_ctl,
-        Ok(None) => {
+    #[cfg(all(feature = "jemalloc-pprof", not(windows)))]
+    {
+        // Accessing `PROF_CTL` can panic if jemalloc is not the active allocator
+        // or was compiled without the profiling feature. Catch this panic so we
+        // return a proper HTTP error instead.
+        let prof_ctl =
+            std::panic::catch_unwind(AssertUnwindSafe(|| jemalloc_pprof::PROF_CTL.as_ref()));
+        let mut prof_ctl = match prof_ctl {
+            Ok(Some(prof_ctl)) => prof_ctl,
+            Ok(None) => {
+                return Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Memory Profiling not activated".into(),
+                ));
+            }
+            Err(_) => {
+                return Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Heap profiling not available \
+                     (jemalloc with profiling support is not the active allocator)."
+                        .into(),
+                ));
+            }
+        }
+        .lock()
+        .await;
+
+        if !prof_ctl.activated() {
             return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Memory Profiling not activated".into(),
             ));
         }
-        Err(_) => {
-            return Err((
+
+        match prof_ctl.dump_pprof() {
+            Ok(pprof) => {
+                let body = Body::from(pprof);
+                let resp = Response::builder()
+                    .status(StatusCode::OK)
+                    .header(header::CONTENT_TYPE, "application/x-protobuf")
+                    .body(body)
+                    .map_err(|e| {
+                        (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            format!("Could not dump heap pprof: {e}"),
+                        )
+                    })?;
+
+                Ok(resp)
+            }
+            Err(e) => Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
-                "Heap profiling not available \
-                 (jemalloc with profiling support is not the active allocator)."
-                    .into(),
-            ));
+                format!("Could not dump heap pprof: {e}"),
+            )),
         }
     }
-    .lock()
-    .await;
 
-    if !prof_ctl.activated() {
-        return Err((
+    #[cfg(not(all(feature = "jemalloc-pprof", not(windows))))]
+    {
+        Err((
             StatusCode::INTERNAL_SERVER_ERROR,
-            "Memory Profiling not activated".into(),
-        ));
-    }
-
-    match prof_ctl.dump_pprof() {
-        Ok(pprof) => {
-            let body = Body::from(pprof);
-            let resp = Response::builder()
-                .status(StatusCode::OK)
-                .header(header::CONTENT_TYPE, "application/x-protobuf")
-                .body(body)
-                .map_err(|e| {
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Could not dump heap pprof: {e}"),
-                    )
-                })?;
-
-            Ok(resp)
-        }
-        Err(e) => Err((
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Could not dump heap pprof: {e}"),
-        )),
+            "Heap profiling is not available in this build".into(),
+        ))
     }
 }

--- a/rust/otap-dataflow/crates/admin/src/debug.rs
+++ b/rust/otap-dataflow/crates/admin/src/debug.rs
@@ -6,6 +6,8 @@
 //! - /api/v1/debug/pprof/heap -- dump profile of unfreed heap allocations.
 //!   Returns pprof-format data when jemalloc profiling is available, or
 //!   HTTP 500 when the feature is not compiled in or profiling is not enabled.
+//!   Concurrent dumps are rejected with HTTP 429 to keep health checks and
+//!   shutdown responsive.
 
 use axum::Router;
 use axum::extract::State;
@@ -24,18 +26,29 @@ pub(crate) fn routes() -> Router<AppState> {
     Router::new().route("/debug/pprof/heap", get(get_heap_profile))
 }
 
-async fn get_heap_profile(
-    State(_state): State<AppState>,
-) -> Result<Response, (StatusCode, String)> {
+async fn get_heap_profile(State(state): State<AppState>) -> Result<Response, (StatusCode, String)> {
     #[cfg(all(feature = "jemalloc-pprof", not(windows)))]
     {
-        // Accessing `PROF_CTL` can panic if jemalloc is not the active allocator
-        // or was compiled without the profiling feature. Catch this panic so we
-        // return a proper HTTP error instead.
+        // Only one heap dump at a time -- reject excess requests immediately
+        // so health checks and shutdown remain responsive.
+        let permit = state
+            .heap_profile_permits
+            .clone()
+            .try_acquire_owned()
+            .map_err(|_| {
+                (
+                    StatusCode::TOO_MANY_REQUESTS,
+                    "A heap profile dump is already in progress".into(),
+                )
+            })?;
+
+        // Accessing `PROF_CTL` can panic if jemalloc is not the active
+        // allocator or was compiled without the profiling feature. Catch
+        // this panic so we return a proper HTTP error instead.
         let prof_ctl =
             std::panic::catch_unwind(AssertUnwindSafe(|| jemalloc_pprof::PROF_CTL.as_ref()));
-        let mut prof_ctl = match prof_ctl {
-            Ok(Some(prof_ctl)) => prof_ctl,
+        let prof_ctl = match prof_ctl {
+            Ok(Some(ctl)) => ctl.clone(),
             Ok(None) => {
                 return Err((
                     StatusCode::INTERNAL_SERVER_ERROR,
@@ -50,42 +63,52 @@ async fn get_heap_profile(
                         .into(),
                 ));
             }
-        }
-        .lock()
-        .await;
+        };
 
-        if !prof_ctl.activated() {
-            return Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Memory Profiling not activated".into(),
-            ));
-        }
-
-        match prof_ctl.dump_pprof() {
-            Ok(pprof) => {
-                let body = Body::from(pprof);
-                let resp = Response::builder()
-                    .status(StatusCode::OK)
-                    .header(header::CONTENT_TYPE, "application/x-protobuf")
-                    .body(body)
-                    .map_err(|e| {
-                        (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            format!("Could not dump heap pprof: {e}"),
-                        )
-                    })?;
-
-                Ok(resp)
+        // Offload the blocking native dump to a dedicated thread so the
+        // admin server's async runtime stays responsive.
+        let pprof = tokio::task::spawn_blocking(move || {
+            let _permit = permit;
+            let mut guard = prof_ctl.blocking_lock();
+            if !guard.activated() {
+                return Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Memory Profiling not activated".into(),
+                ));
             }
-            Err(e) => Err((
+            guard.dump_pprof().map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Could not dump heap pprof: {e}"),
+                )
+            })
+        })
+        .await
+        .map_err(|e| {
+            (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Could not dump heap pprof: {e}"),
-            )),
-        }
+                format!("Heap profile task failed to join: {e}"),
+            )
+        })??;
+
+        let body = Body::from(pprof);
+        Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, "application/x-protobuf")
+            .body(body)
+            .map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Could not build heap pprof response: {e}"),
+                )
+            })
     }
 
     #[cfg(not(all(feature = "jemalloc-pprof", not(windows))))]
     {
+        // Suppress dead-code warning for the semaphore field when the
+        // jemalloc-pprof feature is not compiled in.
+        let _ = &state.heap_profile_permits;
         Err((
             StatusCode::INTERNAL_SERVER_ERROR,
             "Heap profiling is not available in this build".into(),

--- a/rust/otap-dataflow/crates/admin/src/debug.rs
+++ b/rust/otap-dataflow/crates/admin/src/debug.rs
@@ -20,9 +20,7 @@ use std::panic::AssertUnwindSafe;
 use crate::AppState;
 
 pub(crate) fn routes() -> Router<AppState> {
-    let router = Router::new().route("/debug/pprof/heap", get(get_heap_profile));
-
-    router
+    Router::new().route("/debug/pprof/heap", get(get_heap_profile))
 }
 
 async fn get_heap_profile(
@@ -37,7 +35,7 @@ async fn get_heap_profile(
             return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Memory Profiling not activated".into(),
-            ))
+            ));
         }
         Err(_) => {
             return Err((
@@ -74,11 +72,9 @@ async fn get_heap_profile(
 
             Ok(resp)
         }
-        Err(e) => {
-            return Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Could not dump heap pprof: {e}"),
-            ));
-        }
+        Err(e) => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Could not dump heap pprof: {e}"),
+        )),
     }
 }

--- a/rust/otap-dataflow/crates/admin/src/engine_config.rs
+++ b/rust/otap-dataflow/crates/admin/src/engine_config.rs
@@ -212,6 +212,7 @@ mod tests {
             metrics_registry,
             controller,
             terminal_control_plane_permits: Arc::new(tokio::sync::Semaphore::new(1)),
+            heap_profile_permits: Arc::new(tokio::sync::Semaphore::new(1)),
             log_tap: None,
             memory_pressure_state: MemoryPressureState::default(),
             target_info: Arc::from(""),

--- a/rust/otap-dataflow/crates/admin/src/lib.rs
+++ b/rust/otap-dataflow/crates/admin/src/lib.rs
@@ -45,6 +45,7 @@ use otap_df_telemetry::registry::TelemetryRegistryHandle;
 use otap_df_telemetry::{otel_info, otel_warn};
 
 const TERMINAL_CONTROL_PLANE_PERMITS: usize = 1;
+const HEAP_PROFILE_PERMITS: usize = 1;
 
 /// Control-plane error surfaced to admin handlers.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -225,6 +226,10 @@ struct AppState {
     /// from async HTTP handlers.
     terminal_control_plane_permits: Arc<Semaphore>,
 
+    /// Limits concurrent heap profile dumps to one at a time. Excess
+    /// requests are rejected immediately with HTTP 429.
+    heap_profile_permits: Arc<Semaphore>,
+
     /// Optional internal log tap for querying retained internal logs.
     log_tap: Option<InternalLogTapHandle>,
 
@@ -325,6 +330,7 @@ pub async fn run(
         metrics_registry,
         controller,
         terminal_control_plane_permits: Arc::new(Semaphore::new(TERMINAL_CONTROL_PLANE_PERMITS)),
+        heap_profile_permits: Arc::new(Semaphore::new(HEAP_PROFILE_PERMITS)),
         log_tap,
         memory_pressure_state,
         target_info,

--- a/rust/otap-dataflow/crates/admin/src/lib.rs
+++ b/rust/otap-dataflow/crates/admin/src/lib.rs
@@ -5,6 +5,7 @@
 
 mod convert;
 mod dashboard;
+mod debug;
 mod engine_config;
 pub mod error;
 mod health;
@@ -330,6 +331,7 @@ pub async fn run(
     };
 
     let api_routes = Router::new()
+        .merge(debug::routes())
         .merge(health::routes())
         .merge(telemetry::routes())
         .merge(engine_config::routes())

--- a/rust/otap-dataflow/crates/admin/src/pipeline.rs
+++ b/rust/otap-dataflow/crates/admin/src/pipeline.rs
@@ -572,6 +572,7 @@ mod tests {
             metrics_registry,
             controller,
             terminal_control_plane_permits: Arc::new(tokio::sync::Semaphore::new(1)),
+            heap_profile_permits: Arc::new(tokio::sync::Semaphore::new(1)),
             log_tap: None,
             memory_pressure_state: MemoryPressureState::default(),
             target_info: Arc::from(""),

--- a/rust/otap-dataflow/crates/admin/src/pipeline_group.rs
+++ b/rust/otap-dataflow/crates/admin/src/pipeline_group.rs
@@ -343,6 +343,7 @@ mod tests {
             metrics_registry,
             controller,
             terminal_control_plane_permits: Arc::new(tokio::sync::Semaphore::new(1)),
+            heap_profile_permits: Arc::new(tokio::sync::Semaphore::new(1)),
             log_tap: None,
             memory_pressure_state: MemoryPressureState::default(),
             target_info: Arc::from(""),

--- a/rust/otap-dataflow/crates/admin/src/telemetry.rs
+++ b/rust/otap-dataflow/crates/admin/src/telemetry.rs
@@ -2650,6 +2650,7 @@ mod tests {
             metrics_registry,
             controller: Arc::new(NoopControlPlane),
             terminal_control_plane_permits: Arc::new(tokio::sync::Semaphore::new(1)),
+            heap_profile_permits: Arc::new(tokio::sync::Semaphore::new(1)),
             log_tap: None,
             memory_pressure_state: MemoryPressureState::default(),
             target_info: Arc::from(""),

--- a/rust/otap-dataflow/crates/controller/Cargo.toml
+++ b/rust/otap-dataflow/crates/controller/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 [features]
 testing = []
 admin-live-logs-ws = ["otap-df-admin/live-logs-ws"]
+jemalloc-pprof = ["otap-df-admin/jemalloc-pprof"]
 
 [dependencies]
 otap-df-config = { workspace = true }

--- a/rust/otap-dataflow/src/main.rs
+++ b/rust/otap-dataflow/src/main.rs
@@ -68,10 +68,6 @@ use mimalloc::MiMalloc;
 #[cfg(all(not(windows), not(feature = "dhat-heap"), feature = "jemalloc"))]
 use tikv_jemallocator::Jemalloc;
 
-#[allow(non_upper_case_globals)]
-#[unsafe(export_name = "_rjem_malloc_conf")]
-pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
-
 // -----------------------------------------------------------------------------
 // Global allocator selection.
 // -----------------------------------------------------------------------------

--- a/rust/otap-dataflow/src/main.rs
+++ b/rust/otap-dataflow/src/main.rs
@@ -68,6 +68,10 @@ use mimalloc::MiMalloc;
 #[cfg(all(not(windows), not(feature = "dhat-heap"), feature = "jemalloc"))]
 use tikv_jemallocator::Jemalloc;
 
+#[allow(non_upper_case_globals)]
+#[unsafe(export_name = "_rjem_malloc_conf")]
+pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
+
 // -----------------------------------------------------------------------------
 // Global allocator selection.
 // -----------------------------------------------------------------------------


### PR DESCRIPTION

# Change Summary

<!--Replace with a brief summary of the change in this PR-->

Adds an endpoint (/api/v1/debug/pprof/heap) that can dump the a profile (in pprof format) heap allocations.

Further reading about this solution: https://www.polarsignals.com/blog/posts/2023/12/20/rust-memory-profiling

Run the app w/ profiling enabled. `jemalloc` must be the allocator (default on linux and macos):
```sh
_RJEM_MALLOC_CONF="prof:true,prof_active:true,lg_prof_sample:19" \
cargo run -- \
 --config ./configs/trafficgen-filter-debug-noop.yaml
```

scrape the endpoint, open in your favourite pprof viewer
```
curl -XGET http://localhost:8080/api/v1/debug/pprof/heap -o out.pprof
go tool pprof -http=:18080 ./target/debug/df_engine ./out.pprof
```

<img width="1724" height="704" alt="image" src="https://github.com/user-attachments/assets/43f43503-05e9-44c4-960b-39fc664bf36e" />


This endpoint will return 500 when:
- jemalloc is not the allocator, or jemalloc is used, but was compiled without the `profiling` feature
- if the jemalloc options `prof:true,prof_active:true` are not set

## What issue does this PR close?

<!--We highly recommend correlation of every PR to an issue-->

* Closes #3660

## How are these changes tested?

Manually

## Are there any user-facing changes?

 <!-- If yes, provide further info below -->
 
 Yes, the user could call this endpoint

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry
* [ ] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
