### PR TITLE
chore: Make azure-monitor-exporter feature pull in azure-identity-auth

### DIFF
--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -304,7 +304,12 @@ crypto-openssl = ["otap-df-otap/crypto-openssl"]
 # Contrib exporters (opt-in) - now in contrib-nodes
 contrib-exporters = ["otap-df-contrib-nodes/contrib-exporters"]
 geneva-exporter = ["otap-df-contrib-nodes/geneva-exporter"]
-azure-monitor-exporter = ["otap-df-contrib-nodes/azure-monitor-exporter"]
+# The Azure Monitor exporter requires the Azure Identity auth extension to
+# authenticate outbound requests, so enabling it pulls in that extension.
+azure-monitor-exporter = [
+    "otap-df-contrib-nodes/azure-monitor-exporter",
+    "azure-identity-auth-extension",
+]
 # Contrib extensions (opt-in) - in contrib-extensions
 contrib-extensions = ["otap-df-contrib-extensions/contrib-extensions"]
 azure-identity-auth-extension = ["otap-df-contrib-extensions/azure-identity-auth-extension"]


### PR DESCRIPTION
# Change Summary

The Azure Monitor exporter requires the Azure Identity auth extension to authenticate outbound requests. Previously users had to enable both features manually, and forgetting the extension caused a runtime error: 'Unknown extension component urn:microsoft:extension:azure_identity_auth'. Enabling azure-monitor-exporter now brings in the extension automatically.

## What issue does this PR close?

* Related to #3356

## How are these changes tested?

Unit tests and cargo builds

### Changelog

* [ ] Added a `.chloggen/*.yaml` entry
* [x] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
