### PR TITLE
chore(clickhouse-exporter): fix misleading password and TTL examples in docs

### DIFF
--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/README.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/README.md
@@ -41,7 +41,7 @@ Not implemented yet:
 ### 1. Start ClickHouse
 
 ```bash
-docker run -it -p 8123:8123 -p 9000:9000 -e CLICKHOUSE_PASSWORD=TODO-TEST \
+docker run -it -p 8123:8123 -p 9000:9000 -e CLICKHOUSE_PASSWORD=test \
   --name clickhouse-server --ulimit nofile=262144:262144 \
   clickhouse/clickhouse-server
 ```
@@ -58,7 +58,7 @@ cargo run --features clickhouse-exporter -- --config configs/trafficgen-clickhou
 ### 3. Query ClickHouse
 
 ```bash
-docker exec -it clickhouse-server clickhouse-client --password TODO-TEST
+docker exec -it clickhouse-server clickhouse-client --password test
 ```
 
 Then:

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/config.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/config.rs
@@ -113,7 +113,7 @@ pub struct TableConfig {
     /// Logical name (users query this)
     pub name: String,
 
-    /// TTL, e.g., "72h"
+    /// TTL, e.g., "72 HOUR"
     pub ttl: Option<String>,
 
     /// Optional table engine override; falls back to top-level default
@@ -300,7 +300,7 @@ mod tests {
             },
             "tables": {
                 "logs": {
-                    "ttl": "12h"
+                    "ttl": "12 HOUR"
                 },
                 "metrics": {
                     "gauge": {
@@ -331,7 +331,7 @@ mod tests {
 
         // --- Tables ---
         assert_eq!(config.tables.logs.name, "otel_logs");
-        assert_eq!(config.tables.logs.ttl.as_deref(), Some("12h"));
+        assert_eq!(config.tables.logs.ttl.as_deref(), Some("12 HOUR"));
 
         // Defaulted tables still present
         assert_eq!(config.tables.traces.name, "otel_traces");

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/tables.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/tables.rs
@@ -232,7 +232,7 @@ fn validate_engine_params(params: &str) -> Result<(), ClickhouseExporterError> {
 struct FinalTableConfig {
     /// Logical name (users query this)
     pub name: String,
-    /// TTL, e.g., "72h"
+    /// TTL, e.g., "72 HOUR"
     pub ttl: Option<String>,
     /// Optional table engine override
     pub engine: TableEngine,


### PR DESCRIPTION
Follow-up to #3291.

- README Quick Start: docker `CLICKHOUSE_PASSWORD=TODO-TEST` → `test` so it matches the sample config's fallback and the three-step flow works with no extra env setup.
- Doc-comments on `TableConfig.ttl` / `FinalTableConfig.ttl` and the `test_config_deserialization` fixture: `"72h"`/`"12h"` → `"72 HOUR"`/`"12 HOUR"`, since `validate_ttl` requires a time-unit keyword.

No behavior change.