### PR TITLE
ci: open tracking issues when perftest workflows fail

### DIFF
--- a/.github/workflows/pipeline-perf-test-continuous.yml
+++ b/.github/workflows/pipeline-perf-test-continuous.yml
@@ -136,3 +136,14 @@ jobs:
         run: |
           echo "### Benchmark Results" >> $GITHUB_STEP_SUMMARY
           echo "[View the pipeline benchmark results here](https://open-telemetry.github.io/otel-arrow/benchmarks/continuous/)" >> $GITHUB_STEP_SUMMARY
+
+  workflow-notification:
+    permissions:
+      issues: write
+    needs:
+      - pipeline-perf-test
+      - update-benchmarks
+    if: always()
+    uses: open-telemetry/shared-workflows/.github/workflows/workflow-failure-issue.yml@62d5939b47144252763c5ff9fffe8c20d76cd806 # v0.4.0
+    with:
+      success: ${{ needs.pipeline-perf-test.result == 'success' && needs.update-benchmarks.result == 'success' }}

--- a/.github/workflows/pipeline-perf-test-nightly.yml
+++ b/.github/workflows/pipeline-perf-test-nightly.yml
@@ -599,3 +599,14 @@ jobs:
         run: |
           echo "### Benchmark Results" >> $GITHUB_STEP_SUMMARY
           echo "[View the benchmark results here](https://open-telemetry.github.io/otel-arrow/benchmarks/nightly/)" >> $GITHUB_STEP_SUMMARY
+
+  workflow-notification:
+    permissions:
+      issues: write
+    needs:
+      - pipeline-perf-test
+      - update-benchmarks
+    if: always()
+    uses: open-telemetry/shared-workflows/.github/workflows/workflow-failure-issue.yml@62d5939b47144252763c5ff9fffe8c20d76cd806 # v0.4.0
+    with:
+      success: ${{ needs.pipeline-perf-test.result == 'success' && needs.update-benchmarks.result == 'success' }}


### PR DESCRIPTION
Per Trask's suggestion in open-telemetry/community#3563, adds the shared
`workflow-failure-issue` reusable workflow to the nightly and continuous
pipeline-perf-test workflows so failures (e.g. bare-metal runner offline)
open a tracking issue visible to the whole team, instead of silently
failing until someone notices the benchmarks graph is stale.

Pinned to v0.4.0 (SHA `62d5939b47144252763c5ff9fffe8c20d76cd806`), matching
the Java repo.