### PR TITLE
feat(telemetry): add runtime EventName filtering for internal logs

### DIFF
--- a/rust/otap-dataflow/.chloggen/eventname-runtime-filter.yaml
+++ b/rust/otap-dataflow/.chloggen/eventname-runtime-filter.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: observability
+note: Add runtime EventName filtering for internal telemetry logs through static and remotely reconciled engine configuration.
+issues: [3387]

--- a/rust/otap-dataflow/Cargo.lock
+++ b/rust/otap-dataflow/Cargo.lock
@@ -7715,6 +7715,7 @@ dependencies = [
 name = "otap-df-telemetry"
 version = "0.50.0"
 dependencies = [
+ "arc-swap",
  "bytes",
  "chrono",
  "flume",

--- a/rust/otap-dataflow/benchmarks/Cargo.toml
+++ b/rust/otap-dataflow/benchmarks/Cargo.toml
@@ -30,7 +30,7 @@ otap-df-pdata = { workspace = true, features = ["bench", "testing"] }
 otap-df-pdata-views = { workspace = true }
 
 tracing.workspace = true
-tracing-subscriber = { workspace = true, features = ["registry"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "registry"] }
 
 fluke-hpack.workspace = true
 futures-channel.workspace = true

--- a/rust/otap-dataflow/benchmarks/benches/self_tracing/main.rs
+++ b/rust/otap-dataflow/benchmarks/benches/self_tracing/main.rs
@@ -28,6 +28,7 @@ use std::thread;
 use std::time::SystemTime;
 use tracing::{Event, Subscriber};
 use tracing_subscriber::EnvFilter;
+use tracing_subscriber::filter::FilterExt;
 use tracing_subscriber::layer::Layer;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::registry::LookupSpan;
@@ -261,6 +262,13 @@ fn emit_disabled_level() {
     otap_df_telemetry::otel_info!("benchmark.disabled_level", value = std::hint::black_box(42));
 }
 
+fn emit_disabled_level_with_filter() {
+    otap_df_telemetry::otel_info!(
+        "benchmark.disabled_level_with_filter",
+        value = std::hint::black_box(42)
+    );
+}
+
 fn emit_enabled_allow_all() {
     otap_df_telemetry::otel_info!(
         "benchmark.enabled_allow_all",
@@ -278,6 +286,20 @@ fn emit_enabled_exact_match() {
 fn emit_disabled_exact_miss() {
     otap_df_telemetry::otel_info!(
         "benchmark.disabled_exact_miss",
+        value = std::hint::black_box(42)
+    );
+}
+
+fn emit_enabled_prefix_match() {
+    otap_df_telemetry::otel_info!(
+        "benchmark.enabled_prefix_match",
+        value = std::hint::black_box(42)
+    );
+}
+
+fn emit_disabled_prefix_miss() {
+    otap_df_telemetry::otel_info!(
+        "benchmark.disabled_prefix_miss",
         value = std::hint::black_box(42)
     );
 }
@@ -310,8 +332,7 @@ fn run_its_emission_bench(
     let dispatch = match event_filter {
         Some(filter) => tracing::Dispatch::new(
             tracing_subscriber::registry()
-                .with(EnvFilter::new(level))
-                .with(ItsNoopLayer { reporter }.with_filter(filter)),
+                .with(ItsNoopLayer { reporter }.with_filter(EnvFilter::new(level).and(filter))),
         ),
         None => tracing::Dispatch::new(
             tracing_subscriber::registry()
@@ -347,6 +368,15 @@ fn bench_its_emission(c: &mut Criterion) {
     _ = group.bench_function("disabled/baseline_level_off", |b| {
         run_its_emission_bench(b, "off", None, emit_disabled_level, false);
     });
+    _ = group.bench_function("disabled/level_off_with_filter_allow_all", |b| {
+        run_its_emission_bench(
+            b,
+            "off",
+            Some(EventNameFilter::allow_all()),
+            emit_disabled_level_with_filter,
+            false,
+        );
+    });
     _ = group.bench_function("enabled/event_filter_allow_all", |b| {
         run_its_emission_bench(
             b,
@@ -374,6 +404,45 @@ fn bench_its_emission(c: &mut Criterion) {
             false,
         );
     });
+    _ = group.bench_function("enabled/event_filter_prefix_match", |b| {
+        run_its_emission_bench(
+            b,
+            "info",
+            Some(EventNameFilter::allowing(["benchmark.enabled_prefix*"])),
+            emit_enabled_prefix_match,
+            true,
+        );
+    });
+    _ = group.bench_function("disabled/event_filter_prefix_miss", |b| {
+        run_its_emission_bench(
+            b,
+            "info",
+            Some(EventNameFilter::allowing(["benchmark.some_other_prefix*"])),
+            emit_disabled_prefix_miss,
+            false,
+        );
+    });
+
+    group.finish();
+}
+
+fn bench_event_filter_policy_update(c: &mut Criterion) {
+    let mut group = c.benchmark_group("event_filter_policy_update");
+
+    for pattern_count in [1, 10, 100] {
+        let patterns = (0..pattern_count)
+            .map(|index| format!("benchmark.event_{index}"))
+            .collect::<Vec<_>>();
+        let (_filter, handle) = EventNameFilter::new();
+
+        _ = group.bench_with_input(
+            BenchmarkId::new("exact_patterns", pattern_count),
+            &patterns,
+            |b, patterns| {
+                b.iter(|| handle.allow(std::hint::black_box(patterns)));
+            },
+        );
+    }
 
     group.finish();
 }
@@ -533,7 +602,7 @@ mod bench_entry {
         config = Criterion::default();
         targets = bench_new_record, bench_format, bench_format_new_record, bench_encode_proto,
                   bench_encode_proto_with_scope, bench_format_with_entity, bench_realistic,
-                  bench_its_emission
+                  bench_its_emission, bench_event_filter_policy_update
     );
 }
 

--- a/rust/otap-dataflow/benchmarks/benches/self_tracing/main.rs
+++ b/rust/otap-dataflow/benchmarks/benches/self_tracing/main.rs
@@ -304,7 +304,21 @@ fn emit_disabled_prefix_miss() {
     );
 }
 
-/// Measures one producer-side emission while an unbounded noop consumer drains
+fn emit_enabled_deny_miss() {
+    otap_df_telemetry::otel_info!(
+        "benchmark.enabled_deny_miss",
+        value = std::hint::black_box(42)
+    );
+}
+
+fn emit_disabled_deny_match() {
+    otap_df_telemetry::otel_info!(
+        "benchmark.disabled_deny_match",
+        value = std::hint::black_box(42)
+    );
+}
+
+/// Measures one producer-side emission while a bounded noop consumer drains
 /// accepted events. The consumer prevents backpressure but is not timed.
 fn run_its_emission_bench(
     b: &mut criterion::Bencher<'_>,
@@ -313,7 +327,7 @@ fn run_its_emission_bench(
     emit: fn(),
     expected_enabled: bool,
 ) {
-    let (sender, receiver) = flume::unbounded();
+    let (sender, receiver) = flume::bounded(4096);
     let reporter = ObservedEventReporter::new(
         SendPolicy {
             blocking_timeout: None,
@@ -336,8 +350,7 @@ fn run_its_emission_bench(
         ),
         None => tracing::Dispatch::new(
             tracing_subscriber::registry()
-                .with(EnvFilter::new(level))
-                .with(ItsNoopLayer { reporter }),
+                .with(ItsNoopLayer { reporter }.with_filter(EnvFilter::new(level))),
         ),
     };
 
@@ -422,26 +435,90 @@ fn bench_its_emission(c: &mut Criterion) {
             false,
         );
     });
+    _ = group.bench_function("enabled/event_filter_deny_miss", |b| {
+        run_its_emission_bench(
+            b,
+            "info",
+            Some(EventNameFilter::denying(["benchmark.disabled_deny_match"])),
+            emit_enabled_deny_miss,
+            true,
+        );
+    });
+    _ = group.bench_function("disabled/event_filter_deny_match", |b| {
+        run_its_emission_bench(
+            b,
+            "info",
+            Some(EventNameFilter::denying(["benchmark.disabled_deny_match"])),
+            emit_disabled_deny_match,
+            false,
+        );
+    });
 
     group.finish();
 }
 
+struct PolicyUpdateNoopLayer;
+
+impl<S> Layer<S> for PolicyUpdateNoopLayer where S: Subscriber {}
+
+fn register_policy_update_callsites() {
+    tracing::info!(name: "benchmark.event_0", value = 0);
+    tracing::info!(name: "benchmark.event_1", value = 1);
+    tracing::info!(name: "benchmark.event_2", value = 2);
+    tracing::info!(name: "benchmark.event_3", value = 3);
+    tracing::info!(name: "benchmark.event_4", value = 4);
+    tracing::info!(name: "benchmark.event_5", value = 5);
+    tracing::info!(name: "benchmark.event_6", value = 6);
+    tracing::info!(name: "benchmark.event_7", value = 7);
+}
+
+/// Measures total policy replacement cost for the callsites registered in this
+/// benchmark binary. Production update cost also scales with the collector
+/// binary's total registered callsite count.
 fn bench_event_filter_policy_update(c: &mut Criterion) {
     let mut group = c.benchmark_group("event_filter_policy_update");
 
     for pattern_count in [1, 10, 100] {
-        let patterns = (0..pattern_count)
-            .map(|index| format!("benchmark.event_{index}"))
-            .collect::<Vec<_>>();
-        let (_filter, handle) = EventNameFilter::new();
+        for (pattern_kind, patterns) in [
+            (
+                "exact",
+                (0..pattern_count)
+                    .map(|index| format!("benchmark.event_{index}"))
+                    .collect::<Vec<_>>(),
+            ),
+            (
+                "prefix",
+                (0..pattern_count)
+                    .map(|index| format!("benchmark.event_{index}*"))
+                    .collect::<Vec<_>>(),
+            ),
+        ] {
+            for mode in ["allow", "deny"] {
+                let (filter, handle) = EventNameFilter::new();
+                let subscriber = tracing_subscriber::registry()
+                    .with(PolicyUpdateNoopLayer.with_filter(EnvFilter::new("info").and(filter)));
+                let dispatch = tracing::Dispatch::new(subscriber);
 
-        _ = group.bench_with_input(
-            BenchmarkId::new("exact_patterns", pattern_count),
-            &patterns,
-            |b, patterns| {
-                b.iter(|| handle.allow(std::hint::black_box(patterns)));
-            },
-        );
+                _ = group.bench_with_input(
+                    BenchmarkId::new(format!("{mode}_{pattern_kind}"), pattern_count),
+                    &patterns,
+                    |b, patterns| {
+                        tracing::dispatcher::with_default(&dispatch, || {
+                            register_policy_update_callsites();
+                            match mode {
+                                "allow" => {
+                                    b.iter(|| handle.allow(std::hint::black_box(patterns)));
+                                }
+                                "deny" => {
+                                    b.iter(|| handle.deny(std::hint::black_box(patterns)));
+                                }
+                                _ => unreachable!("benchmark mode is fixed"),
+                            }
+                        });
+                    },
+                );
+            }
+        }
     }
 
     group.finish();

--- a/rust/otap-dataflow/benchmarks/benches/self_tracing/main.rs
+++ b/rust/otap-dataflow/benchmarks/benches/self_tracing/main.rs
@@ -11,17 +11,23 @@
 //! Example: `encode/3_attrs/1000_events` = 300 us -> 300 ns per event
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use otap_df_config::observed_state::SendPolicy;
 use otap_df_pdata::otlp::ProtoBuffer;
 use otap_df_telemetry::attributes::{AttributeSetHandler, AttributeValue};
 use otap_df_telemetry::descriptor::{AttributeField, AttributeValueType, AttributesDescriptor};
-use otap_df_telemetry::event::LogEvent;
+use otap_df_telemetry::event::{LogEvent, ObservedEvent, ObservedEventReporter};
+use otap_df_telemetry::eventname_filter::EventNameFilter;
 use otap_df_telemetry::registry::TelemetryRegistryHandle;
 use otap_df_telemetry::self_tracing::{
     DirectLogRecordEncoder, LogContext, LogRecord, ScopeToBytesMap, encode_export_logs_request,
     format_log_record_to_string,
 };
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::thread;
 use std::time::SystemTime;
 use tracing::{Event, Subscriber};
+use tracing_subscriber::EnvFilter;
 use tracing_subscriber::layer::Layer;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::registry::LookupSpan;
@@ -226,6 +232,152 @@ where
     }
 }
 
+/// ITS producer-side sink that constructs the same `LogEvent` as the production
+/// structured logging layer and sends it to a continuously drained channel.
+struct ItsNoopLayer {
+    reporter: ObservedEventReporter,
+}
+
+impl<S> Layer<S> for ItsNoopLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: tracing_subscriber::layer::Context<'_, S>) {
+        self.reporter.log(LogEvent {
+            time: SystemTime::now(),
+            record: LogRecord::new(event, LogContext::new()),
+        });
+    }
+}
+
+fn emit_enabled_baseline() {
+    otap_df_telemetry::otel_info!(
+        "benchmark.enabled_baseline",
+        value = std::hint::black_box(42)
+    );
+}
+
+fn emit_disabled_level() {
+    otap_df_telemetry::otel_info!("benchmark.disabled_level", value = std::hint::black_box(42));
+}
+
+fn emit_enabled_allow_all() {
+    otap_df_telemetry::otel_info!(
+        "benchmark.enabled_allow_all",
+        value = std::hint::black_box(42)
+    );
+}
+
+fn emit_enabled_exact_match() {
+    otap_df_telemetry::otel_info!(
+        "benchmark.enabled_exact_match",
+        value = std::hint::black_box(42)
+    );
+}
+
+fn emit_disabled_exact_miss() {
+    otap_df_telemetry::otel_info!(
+        "benchmark.disabled_exact_miss",
+        value = std::hint::black_box(42)
+    );
+}
+
+/// Measures one producer-side emission while an unbounded noop consumer drains
+/// accepted events. The consumer prevents backpressure but is not timed.
+fn run_its_emission_bench(
+    b: &mut criterion::Bencher<'_>,
+    level: &str,
+    event_filter: Option<EventNameFilter>,
+    emit: fn(),
+    expected_enabled: bool,
+) {
+    let (sender, receiver) = flume::unbounded();
+    let reporter = ObservedEventReporter::new(
+        SendPolicy {
+            blocking_timeout: None,
+            console_fallback: false,
+        },
+        sender,
+    );
+    let received = Arc::new(AtomicU64::new(0));
+    let received_by_consumer = Arc::clone(&received);
+    let consumer = thread::spawn(move || {
+        while let Ok(ObservedEvent::Log(_)) = receiver.recv() {
+            _ = received_by_consumer.fetch_add(1, Ordering::Relaxed);
+        }
+    });
+
+    let dispatch = match event_filter {
+        Some(filter) => tracing::Dispatch::new(
+            tracing_subscriber::registry()
+                .with(EnvFilter::new(level))
+                .with(ItsNoopLayer { reporter }.with_filter(filter)),
+        ),
+        None => tracing::Dispatch::new(
+            tracing_subscriber::registry()
+                .with(EnvFilter::new(level))
+                .with(ItsNoopLayer { reporter }),
+        ),
+    };
+
+    tracing::dispatcher::with_default(&dispatch, || b.iter(emit));
+    drop(dispatch);
+    consumer.join().expect("noop ITS consumer should stop");
+
+    if expected_enabled {
+        assert!(
+            received.load(Ordering::Relaxed) > 0,
+            "enabled benchmark must reach the noop sink"
+        );
+    } else {
+        assert_eq!(
+            received.load(Ordering::Relaxed),
+            0,
+            "disabled benchmark must be filtered before ITS"
+        );
+    }
+}
+
+fn bench_its_emission(c: &mut Criterion) {
+    let mut group = c.benchmark_group("its_emission");
+
+    _ = group.bench_function("enabled/baseline_no_event_filter", |b| {
+        run_its_emission_bench(b, "info", None, emit_enabled_baseline, true);
+    });
+    _ = group.bench_function("disabled/baseline_level_off", |b| {
+        run_its_emission_bench(b, "off", None, emit_disabled_level, false);
+    });
+    _ = group.bench_function("enabled/event_filter_allow_all", |b| {
+        run_its_emission_bench(
+            b,
+            "info",
+            Some(EventNameFilter::allow_all()),
+            emit_enabled_allow_all,
+            true,
+        );
+    });
+    _ = group.bench_function("enabled/event_filter_exact_match", |b| {
+        run_its_emission_bench(
+            b,
+            "info",
+            Some(EventNameFilter::allowing(["benchmark.enabled_exact_match"])),
+            emit_enabled_exact_match,
+            true,
+        );
+    });
+    _ = group.bench_function("disabled/event_filter_exact_miss", |b| {
+        run_its_emission_bench(
+            b,
+            "info",
+            Some(EventNameFilter::allowing(["benchmark.some_other_event"])),
+            emit_disabled_exact_miss,
+            false,
+        );
+    });
+
+    group.finish();
+}
+
 /// Macro to generate benchmark functions for different attribute counts.
 /// Each variant emits a consistent log statement for fair comparison.
 macro_rules! emit_log {
@@ -380,7 +532,8 @@ mod bench_entry {
         name = benches;
         config = Criterion::default();
         targets = bench_new_record, bench_format, bench_format_new_record, bench_encode_proto,
-                  bench_encode_proto_with_scope, bench_format_with_entity, bench_realistic
+                  bench_encode_proto_with_scope, bench_format_with_entity, bench_realistic,
+                  bench_its_emission
     );
 }
 

--- a/rust/otap-dataflow/crates/config/src/pipeline/telemetry.rs
+++ b/rust/otap-dataflow/crates/config/src/pipeline/telemetry.rs
@@ -477,6 +477,20 @@ mod tests {
     }
 
     #[test]
+    fn test_invalid_logs_config_rejected() {
+        let mut config = TelemetryConfig::default();
+        config.logs.events.allow = vec!["receiver.*".into()];
+        config.logs.events.deny = vec!["receiver.stop".into()];
+
+        let err = config.validate().unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("logs.events cannot set both 'allow' and 'deny'"),
+            "expected EventName filter validation error, got: {err}"
+        );
+    }
+
+    #[test]
     fn test_attribute_value_deserialize_yaml() {
         let yaml_str = r#"
             string_attr: "example"

--- a/rust/otap-dataflow/crates/config/src/settings/telemetry/logs.rs
+++ b/rust/otap-dataflow/crates/config/src/settings/telemetry/logs.rs
@@ -33,6 +33,38 @@ pub struct LogsConfig {
     /// Internal log tap configuration.
     #[serde(default)]
     pub tap: InternalLogTapConfig,
+
+    /// EventName-based filtering applied on top of `level`.
+    ///
+    /// While `level` gates internal logs by level and target (crate), `events`
+    /// filters by the OpenTelemetry EventName (e.g. `receiver.start`), allowing
+    /// much finer selection. The two are combined: an event is emitted only if
+    /// it passes both `level` and `events`. When `events` is empty (the
+    /// default), no EventName filtering is applied.
+    #[serde(default)]
+    pub events: EventsConfig,
+}
+
+/// EventName-based filtering of internal logs.
+///
+/// At most one of `allow` / `deny` may be set:
+/// - `allow` — emit only EventNames matching one of the patterns ("zoom in").
+/// - `deny` — emit every EventName except those matching a pattern ("zoom out
+///   but suppress known noise").
+/// - neither — no EventName filtering (default).
+///
+/// Each pattern is either an exact EventName (`receiver.start`) or, with a
+/// trailing `*`, a prefix match over the dotted EventName hierarchy
+/// (`receiver.*` matches `receiver.start`, `receiver.stop`, ...).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Default)]
+pub struct EventsConfig {
+    /// Allowlist of EventName patterns. Empty means "no allowlist".
+    #[serde(default)]
+    pub allow: Vec<String>,
+
+    /// Denylist of EventName patterns. Empty means "no denylist".
+    #[serde(default)]
+    pub deny: Vec<String>,
 }
 
 /// Configuration for the internal log tap used by admin/MCP-style consumers.
@@ -220,6 +252,7 @@ impl Default for LogsConfig {
             level: LogLevel::default(),
             providers: default_providers(),
             tap: InternalLogTapConfig::default(),
+            events: EventsConfig::default(),
         }
     }
 }
@@ -268,6 +301,45 @@ impl LogsConfig {
             });
         }
 
+        self.events.validate()?;
+
+        Ok(())
+    }
+}
+
+impl EventsConfig {
+    /// Returns true if no EventName filtering is configured.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.allow.is_empty() && self.deny.is_empty()
+    }
+
+    /// Validate the EventName filter configuration.
+    ///
+    /// Returns an error if both `allow` and `deny` are set, or if any pattern
+    /// is empty or contains whitespace (EventNames are short, stable
+    /// identifiers such as `receiver.start`).
+    pub fn validate(&self) -> Result<(), Error> {
+        if !self.allow.is_empty() && !self.deny.is_empty() {
+            return Err(Error::InvalidUserConfig {
+                error: "logs.events cannot set both 'allow' and 'deny'".into(),
+            });
+        }
+        for pattern in self.allow.iter().chain(self.deny.iter()) {
+            if pattern.is_empty() {
+                return Err(Error::InvalidUserConfig {
+                    error: "logs.events patterns must not be empty".into(),
+                });
+            }
+            if pattern.chars().any(char::is_whitespace) {
+                return Err(Error::InvalidUserConfig {
+                    error: format!(
+                        "logs.events pattern '{pattern}' must not contain whitespace; \
+                         use a short EventName identifier (e.g. 'receiver.start' or 'receiver.*')"
+                    ),
+                });
+            }
+        }
         Ok(())
     }
 }
@@ -477,5 +549,42 @@ mod tests {
         assert!(providers(Noop, ITS, Noop, Noop).routes_logs_through_its());
         assert!(providers(Noop, Noop, Noop, ITS).routes_logs_through_its());
         assert!(!providers(Noop, Noop, ITS, Noop).routes_logs_through_its());
+    }
+
+    #[test]
+    fn test_events_default_is_empty() {
+        let config = LogsConfig::default();
+        assert!(config.events.is_empty());
+        assert!(config.validate().is_ok());
+
+        let parsed = parse("{}");
+        assert!(parsed.events.is_empty());
+    }
+
+    #[test]
+    fn test_events_parsing() {
+        let config = parse("events: { allow: [\"receiver.start\", \"channel.*\"] }");
+        assert_eq!(config.events.allow, vec!["receiver.start", "channel.*"]);
+        assert!(config.events.deny.is_empty());
+        assert!(config.validate().is_ok());
+
+        let config = parse("events: { deny: [\"exporter.heartbeat\"] }");
+        assert_eq!(config.events.deny, vec!["exporter.heartbeat"]);
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_events_rejects_both_allow_and_deny() {
+        let config = parse("events: { allow: [\"a\"], deny: [\"b\"] }");
+        assert_invalid(&config, "cannot set both 'allow' and 'deny'");
+    }
+
+    #[test]
+    fn test_events_rejects_empty_and_whitespace_patterns() {
+        let config = parse("events: { allow: [\"\"] }");
+        assert_invalid(&config, "must not be empty");
+
+        let config = parse("events: { deny: [\"has space\"] }");
+        assert_invalid(&config, "must not contain whitespace");
     }
 }

--- a/rust/otap-dataflow/crates/config/src/settings/telemetry/logs.rs
+++ b/rust/otap-dataflow/crates/config/src/settings/telemetry/logs.rs
@@ -48,10 +48,10 @@ pub struct LogsConfig {
 /// EventName-based filtering of internal logs.
 ///
 /// At most one of `allow` / `deny` may be set:
-/// - `allow` — emit only EventNames matching one of the patterns ("zoom in").
-/// - `deny` — emit every EventName except those matching a pattern ("zoom out
+/// - `allow` -> emit only EventNames matching one of the patterns ("zoom in").
+/// - `deny` -> emit every EventName except those matching a pattern ("zoom out
 ///   but suppress known noise").
-/// - neither — no EventName filtering (default).
+/// - neither -> no EventName filtering (default).
 ///
 /// Each pattern is either an exact EventName (`receiver.start`) or, with a
 /// trailing `*`, a prefix match over the dotted EventName hierarchy

--- a/rust/otap-dataflow/crates/controller/src/lib.rs
+++ b/rust/otap-dataflow/crates/controller/src/lib.rs
@@ -94,8 +94,9 @@ use otap_df_telemetry::event::{EngineEvent, ErrorSummary, ObservedEventReporter}
 use otap_df_telemetry::registry::TelemetryRegistryHandle;
 use otap_df_telemetry::reporter::MetricsReporter;
 use otap_df_telemetry::{
-    InternalTelemetrySettings, InternalTelemetrySystem, TracingSetup, otel_error, otel_info,
-    otel_info_span, otel_warn, self_tracing::LogContext,
+    InternalTelemetrySettings, InternalTelemetrySystem, TracingSetup,
+    eventname_filter::EventNameFilterHandle, otel_error, otel_info, otel_info_span, otel_warn,
+    self_tracing::LogContext,
 };
 use smallvec::smallvec;
 use std::collections::{HashMap, HashSet};
@@ -1423,6 +1424,7 @@ impl<
             declared_topics,
             all_cores.clone(),
             telemetry_system.engine_tracing_setup(),
+            telemetry_system.event_filter_handle(),
             telemetry_reporting_interval,
             memory_pressure_tx.clone(),
             engine_config.clone(),

--- a/rust/otap-dataflow/crates/controller/src/live_control/mod.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control/mod.rs
@@ -79,6 +79,8 @@ pub(super) struct ControllerRuntime<PData: 'static + Clone + Send + Sync + std::
     available_core_ids: Vec<CoreId>,
     /// Tracing setup cloned into launched runtime threads.
     engine_tracing_setup: TracingSetup,
+    /// Applies reconciled EventName policy to every tracing setup.
+    event_filter_handle: EventNameFilterHandle,
     /// Runtime telemetry reporting cadence.
     telemetry_reporting_interval: Duration,
     /// Memory-pressure signal fanout shared with pipeline runtimes.
@@ -126,6 +128,7 @@ impl<
         declared_topics: DeclaredTopics<PData>,
         available_core_ids: Vec<CoreId>,
         engine_tracing_setup: TracingSetup,
+        event_filter_handle: EventNameFilterHandle,
         telemetry_reporting_interval: Duration,
         memory_pressure_tx: tokio::sync::watch::Sender<MemoryPressureChanged>,
         live_config: OtelDataflowSpec,
@@ -140,6 +143,7 @@ impl<
             declared_topics,
             available_core_ids,
             engine_tracing_setup,
+            event_filter_handle,
             telemetry_reporting_interval,
             memory_pressure_tx,
             controller_thread: thread::current(),

--- a/rust/otap-dataflow/crates/controller/src/live_control/planning.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control/planning.rs
@@ -1180,6 +1180,8 @@ impl<
             .state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        self.event_filter_handle
+            .apply_config(&desired_config.engine.telemetry.logs.events);
         if delete_missing {
             state.live_config = desired_config.clone();
             return;

--- a/rust/otap-dataflow/crates/controller/src/live_control_tests.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control_tests.rs
@@ -2389,6 +2389,28 @@ engine:
     assert!(!event_filter_handle.allows("receiver.start"));
 }
 
+/// Scenario: a full-config reconciliation sets both EventName policy modes.
+/// Guarantees: validation rejects the request without changing the live filter.
+#[test]
+fn reconcile_engine_config_rejects_invalid_event_filter_config() {
+    let config = empty_engine_config();
+    let (runtime, event_filter_handle) = test_runtime_with_event_filter(&config);
+    let mut desired = config.clone();
+    desired.engine.telemetry.logs.events.allow = vec!["channel.*".into()];
+    desired.engine.telemetry.logs.events.deny = vec!["channel.drop".into()];
+
+    let err = runtime
+        .reconcile_engine_config(reconcile_request(desired, true))
+        .expect_err("conflicting EventName policies should be rejected");
+
+    assert!(matches!(
+        err,
+        ControlPlaneError::InvalidRequest { ref message }
+            if message.contains("logs.events cannot set both 'allow' and 'deny'")
+    ));
+    assert!(event_filter_handle.allows("channel.drop"));
+}
+
 /// Scenario: a full-config reconciliation request omits live stopped
 /// resources with `delete_missing` enabled.
 /// Guarantees: reconciliation deletes the omitted pipeline and then the

--- a/rust/otap-dataflow/crates/controller/src/live_control_tests.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control_tests.rs
@@ -23,6 +23,7 @@ use otap_df_state::pipeline_status::PipelineStatus;
 use otap_df_telemetry::TracingSetup;
 use otap_df_telemetry::event::EngineEvent;
 use otap_df_telemetry::metrics::MetricSetSnapshot;
+use otap_df_telemetry::eventname_filter::{EventNameFilter, EventNameFilterHandle};
 use otap_df_telemetry::tracing_init::ProviderSetup;
 use tokio_util::sync::CancellationToken;
 
@@ -259,6 +260,19 @@ fn test_runtime_with_factory(
     config: &OtelDataflowSpec,
     pipeline_factory: &'static PipelineFactory<()>,
 ) -> Arc<ControllerRuntime<()>> {
+    test_runtime_with_factory_and_event_filter(config, pipeline_factory).0
+}
+
+fn test_runtime_with_event_filter(
+    config: &OtelDataflowSpec,
+) -> (Arc<ControllerRuntime<()>>, EventNameFilterHandle) {
+    test_runtime_with_factory_and_event_filter(config, &TEST_PIPELINE_FACTORY)
+}
+
+fn test_runtime_with_factory_and_event_filter(
+    config: &OtelDataflowSpec,
+    pipeline_factory: &'static PipelineFactory<()>,
+) -> (Arc<ControllerRuntime<()>>, EventNameFilterHandle) {
     let registry = TelemetryRegistryHandle::new();
     let observed_state_store =
         ObservedStateStore::new(&ObservedStateSettings::default(), registry.clone());
@@ -269,21 +283,27 @@ fn test_runtime_with_factory(
         Controller::<()>::declare_topics(config).expect("declared topics should be valid");
     let (memory_pressure_tx, _memory_pressure_rx) =
         tokio::sync::watch::channel(MemoryPressureChanged::initial());
+    let (event_filter, event_filter_handle) = EventNameFilter::new();
 
-    Arc::new(ControllerRuntime::new(
-        pipeline_factory,
-        ControllerContext::new(registry),
-        observed_state_store,
-        observed_state_handle,
-        engine_event_reporter,
-        metrics_reporter,
-        declared_topics,
-        available_core_ids(),
-        TracingSetup::new(ProviderSetup::Noop, LogLevel::default(), engine_context),
-        Duration::from_secs(1),
-        memory_pressure_tx,
-        config.clone(),
-    ))
+    (
+        Arc::new(ControllerRuntime::new(
+            pipeline_factory,
+            ControllerContext::new(registry),
+            observed_state_store,
+            observed_state_handle,
+            engine_event_reporter,
+            metrics_reporter,
+            declared_topics,
+            available_core_ids(),
+            TracingSetup::new(ProviderSetup::Noop, LogLevel::default(), engine_context)
+                .with_event_filter(event_filter),
+            event_filter_handle.clone(),
+            Duration::from_secs(1),
+            memory_pressure_tx,
+            config.clone(),
+        )),
+        event_filter_handle,
+    )
 }
 
 struct ObservedStateRunner {
@@ -2340,6 +2360,35 @@ fn reconcile_engine_config_reports_noop_for_matching_live_config() {
     );
 }
 
+/// Scenario: a full-config reconciliation changes only the EventName allowlist.
+/// Guarantees: the live filter changes without rebuilding tracing subscribers.
+#[test]
+fn reconcile_engine_config_applies_event_filter_config() {
+    let config = empty_engine_config();
+    let (runtime, event_filter_handle) = test_runtime_with_event_filter(&config);
+    assert!(event_filter_handle.allows("receiver.start"));
+
+    let desired = OtelDataflowSpec::from_yaml(
+        r#"
+version: otel_dataflow/v1
+engine:
+  telemetry:
+    logs:
+      events:
+        allow: ["channel.*"]
+"#,
+    )
+    .expect("desired config should parse");
+
+    let status = runtime
+        .reconcile_engine_config(reconcile_request(desired, true))
+        .expect("EventName config should reconcile");
+
+    assert_eq!(status.state, EngineConfigReconcileState::Succeeded);
+    assert!(event_filter_handle.allows("channel.full"));
+    assert!(!event_filter_handle.allows("receiver.start"));
+}
+
 /// Scenario: a full-config reconciliation request omits live stopped
 /// resources with `delete_missing` enabled.
 /// Guarantees: reconciliation deletes the omitted pipeline and then the
@@ -2413,7 +2462,7 @@ fn reconcile_engine_config_preserves_missing_resources_when_requested() {
 #[test]
 fn reconcile_engine_config_does_not_publish_scaffold_on_conflict() {
     let config = engine_config_with_pipeline(simple_pipeline_yaml());
-    let runtime = test_runtime(&config);
+    let (runtime, event_filter_handle) = test_runtime_with_event_filter(&config);
     let pipeline_key = PipelineKey::new("g1".into(), "p1".into());
     {
         let mut state = runtime
@@ -2430,6 +2479,7 @@ fn reconcile_engine_config_does_not_publish_scaffold_on_conflict() {
         .engine
         .custom
         .insert("desired".to_owned(), serde_json::json!({"enabled": true}));
+    desired.engine.telemetry.logs.events.allow = vec!["channel.*".to_owned()];
 
     let err = runtime
         .reconcile_engine_config(reconcile_request(desired, true))
@@ -2437,6 +2487,7 @@ fn reconcile_engine_config_does_not_publish_scaffold_on_conflict() {
 
     assert_eq!(err, ControlPlaneError::RolloutConflict);
     assert!(runtime.engine_config_snapshot().engine.custom.is_empty());
+    assert!(event_filter_handle.allows("receiver.start"));
 }
 
 /// Scenario: full-config reconciliation would change an existing topic

--- a/rust/otap-dataflow/crates/controller/src/live_control_tests.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control_tests.rs
@@ -22,8 +22,8 @@ use otap_df_engine::{ExporterFactory, ProcessorFactory, ReceiverFactory};
 use otap_df_state::pipeline_status::PipelineStatus;
 use otap_df_telemetry::TracingSetup;
 use otap_df_telemetry::event::EngineEvent;
-use otap_df_telemetry::metrics::MetricSetSnapshot;
 use otap_df_telemetry::eventname_filter::{EventNameFilter, EventNameFilterHandle};
+use otap_df_telemetry::metrics::MetricSetSnapshot;
 use otap_df_telemetry::tracing_init::ProviderSetup;
 use tokio_util::sync::CancellationToken;
 

--- a/rust/otap-dataflow/crates/telemetry/Cargo.toml
+++ b/rust/otap-dataflow/crates/telemetry/Cargo.toml
@@ -36,6 +36,7 @@ parking_lot = { workspace = true }
 prost = { workspace = true }
 serde = { workspace = true }
 smallvec = { workspace = true }
+arc-swap = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter","registry", "std", "fmt"] }
 

--- a/rust/otap-dataflow/crates/telemetry/README.md
+++ b/rust/otap-dataflow/crates/telemetry/README.md
@@ -141,13 +141,13 @@ configuration in
 
 ### Filtering internal logs by EventName
 
-The `service::telemetry::logs::level` field gates internal logs by level and
+The `engine.telemetry.logs.level` field gates internal logs by level and
 target (crate), using a [`RUST_LOG`-style
 directive](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives).
 It cannot select an individual event, because a `RUST_LOG` directive has no
 syntax for an event's name.
 
-The `service::telemetry::logs::events` field adds a finer filter *on top of*
+The `engine.telemetry.logs.events` field adds a finer filter *on top of*
 `level`, matching each internal log by its OpenTelemetry EventName (the first
 argument to `otel_info!` and friends, e.g. `receiver.start`). An event is
 emitted only if it passes both `level` and `events`.
@@ -172,6 +172,11 @@ engine:
           - "receiver.start"   # exact
           - "channel.*"        # every channel.* event
 ```
+
+Full-engine reconciliation, including configuration received through the OpAMP
+controller extension, applies `events` to the running engine. The next event
+observes the new filter without rebuilding tracing subscribers or restarting
+the process.
 
 ## Roadmap
 

--- a/rust/otap-dataflow/crates/telemetry/README.md
+++ b/rust/otap-dataflow/crates/telemetry/README.md
@@ -139,6 +139,40 @@ document](../../docs/self_tracing_architecture.md). See a sample
 configuration in
 [configs/internal-telemetry.yaml](../../configs/internal-telemetry.yaml).
 
+### Filtering internal logs by EventName
+
+The `service::telemetry::logs::level` field gates internal logs by level and
+target (crate), using a [`RUST_LOG`-style
+directive](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives).
+It cannot select an individual event, because a `RUST_LOG` directive has no
+syntax for an event's name.
+
+The `service::telemetry::logs::events` field adds a finer filter *on top of*
+`level`, matching each internal log by its OpenTelemetry EventName (the first
+argument to `otel_info!` and friends, e.g. `receiver.start`). An event is
+emitted only if it passes both `level` and `events`.
+
+At most one of `allow` / `deny` may be set:
+
+- `allow`: emit only EventNames matching a pattern ("zoom in").
+- `deny`: emit every EventName except those matching a pattern ("zoom out",
+  suppressing known noise).
+- neither (default): no EventName filtering.
+
+Each pattern is either an exact EventName or, with a trailing `*`, a prefix
+match over the dotted EventName hierarchy:
+
+```yaml
+engine:
+  telemetry:
+    logs:
+      level: "info"
+      events:
+        allow:
+          - "receiver.start"   # exact
+          - "channel.*"        # every channel.* event
+```
+
 ## Roadmap
 
 - Generate OpenTelemetry Semantic Registry from the schema.

--- a/rust/otap-dataflow/crates/telemetry/src/eventname_filter.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/eventname_filter.rs
@@ -1,0 +1,298 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-EventName runtime filtering for internal telemetry logs.
+//!
+//! The internal telemetry macros (`otel_info!`, `otel_warn!`, ...) set the
+//! tracing event's *metadata name* to the OpenTelemetry **EventName** (a short,
+//! stable identifier such as `receiver.start` or `channel.full`). See
+//! [`crate::internal_events`]. `tracing`'s built-in [`EnvFilter`] can only gate
+//! on *target + level*, never on this EventName, so it cannot single out one
+//! event (or one subsystem) at runtime.
+//!
+//! [`EventNameFilter`] closes that gap. It is a per-layer
+//! [`Filter`](tracing_subscriber::layer::Filter) that matches
+//! `metadata.name()` against a dynamically updatable set of EventName patterns,
+//! enabling the "zoom in / zoom out" model at the granularity of a single event
+//! or a whole subsystem.
+//!
+//! # Matching
+//!
+//! Each pattern is either:
+//! - **Exact** — `receiver.start` matches only that EventName; or
+//! - **Prefix** — a trailing `*` (`receiver.*`, or `receiver*`) matches every
+//!   EventName starting with the stem. This maps naturally onto the dotted,
+//!   hierarchical EventName convention ("zoom into a whole subsystem").
+//!
+//! Mid-string globs and regular expressions are intentionally *not* supported:
+//! the matcher stays a hash lookup plus a short prefix scan, which is cheap on
+//! the per-event hot path. The matcher can be swapped later without touching
+//! the [`Filter`](tracing_subscriber::layer::Filter) / [`Interest`] plumbing.
+//!
+//! # Runtime dynamism (the important part)
+//!
+//! `tracing` caches per-callsite [`Interest`]. If [`callsite_enabled`] returned
+//! [`Interest::always`] or [`Interest::never`], the decision would be cached
+//! once per callsite and later changes to the pattern set would silently have
+//! no effect. To keep the set changeable at runtime, [`callsite_enabled`]
+//! returns [`Interest::sometimes`], which forces `enabled` to run on every
+//! event. The active mode lives behind an [`ArcSwap`] so a control plane can
+//! swap it in without blocking readers and without rebuilding the subscriber.
+//!
+//! [`EnvFilter`]: tracing_subscriber::EnvFilter
+//! [`callsite_enabled`]: tracing_subscriber::layer::Filter::callsite_enabled
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use tracing::subscriber::Interest;
+use tracing::{Metadata, Subscriber};
+use tracing_subscriber::layer::{Context, Filter};
+
+/// A compiled set of EventName patterns split into exact matches and prefixes.
+#[derive(Clone, Debug, Default)]
+struct Patterns {
+    /// Exact EventName matches; `O(1)` lookup on the hot path.
+    exact: HashSet<Box<str>>,
+    /// Prefix stems (from patterns ending in `*`); scanned linearly. Expected
+    /// to be short, so `starts_with` over this list stays cheap.
+    prefixes: Vec<Box<str>>,
+}
+
+impl Patterns {
+    /// Compile pattern specs. A spec ending in `*` becomes a prefix match on
+    /// the preceding stem; every other spec is an exact match.
+    fn compile<I, S>(specs: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut exact = HashSet::new();
+        let mut prefixes = Vec::new();
+        for spec in specs {
+            let spec = spec.as_ref();
+            if let Some(stem) = spec.strip_suffix('*') {
+                prefixes.push(Box::from(stem));
+            } else {
+                let _ = exact.insert(Box::from(spec));
+            }
+        }
+        Self { exact, prefixes }
+    }
+
+    /// Returns `true` if `name` matches any exact entry or prefix stem.
+    fn matches(&self, name: &str) -> bool {
+        if self.exact.contains(name) {
+            return true;
+        }
+        self.prefixes.iter().any(|stem| name.starts_with(&**stem))
+    }
+}
+
+/// The active matching mode.
+#[derive(Clone, Debug, Default)]
+enum Mode {
+    /// Every EventName passes. This is the default and preserves the behavior
+    /// of a pipeline with no EventName filtering configured.
+    #[default]
+    AllowAll,
+    /// Only EventNames matching one of these patterns pass ("zoom in").
+    Allow(Patterns),
+    /// Every EventName passes *except* those matching one of these patterns
+    /// ("zoom out but suppress known noise").
+    Deny(Patterns),
+}
+
+impl Mode {
+    /// Applies the mode to a single EventName.
+    #[inline]
+    fn allows(&self, name: &str) -> bool {
+        match self {
+            Mode::AllowAll => true,
+            Mode::Allow(patterns) => patterns.matches(name),
+            Mode::Deny(patterns) => !patterns.matches(name),
+        }
+    }
+}
+
+/// A per-layer [`Filter`](tracing_subscriber::layer::Filter) that gates events
+/// by their OpenTelemetry EventName (the tracing metadata `name`).
+///
+/// Create one with [`EventNameFilter::new`], attach it to a layer with
+/// [`Layer::with_filter`](tracing_subscriber::Layer::with_filter), and mutate it
+/// at runtime through the paired [`EventNameFilterHandle`]. Defaults to
+/// [`Mode::AllowAll`], so installing it is a no-op until the handle narrows it.
+///
+/// Cloning shares the same underlying mode, so the filter and its handle always
+/// observe each other's updates.
+#[derive(Clone)]
+pub struct EventNameFilter {
+    mode: Arc<ArcSwap<Mode>>,
+}
+
+/// A cheaply cloneable handle for updating an [`EventNameFilter`] at runtime.
+///
+/// Updates are lock-free swaps and take effect on the next event, without
+/// rebuilding the tracing subscriber.
+#[derive(Clone)]
+pub struct EventNameFilterHandle {
+    mode: Arc<ArcSwap<Mode>>,
+}
+
+impl EventNameFilter {
+    /// Creates a filter (defaulting to [`Mode::AllowAll`]) and a handle that
+    /// controls it.
+    #[must_use]
+    pub fn new() -> (Self, EventNameFilterHandle) {
+        let mode = Arc::new(ArcSwap::from_pointee(Mode::AllowAll));
+        (Self { mode: mode.clone() }, EventNameFilterHandle { mode })
+    }
+}
+
+impl EventNameFilterHandle {
+    /// Let every EventName pass (the default).
+    pub fn allow_all(&self) {
+        self.mode.store(Arc::new(Mode::AllowAll));
+    }
+
+    /// Pass only EventNames matching one of `specs`. An empty set drops every
+    /// internal-telemetry event. A spec ending in `*` is a prefix match.
+    pub fn allow<I, S>(&self, specs: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.mode
+            .store(Arc::new(Mode::Allow(Patterns::compile(specs))));
+    }
+
+    /// Pass every EventName except those matching one of `specs`. A spec ending
+    /// in `*` is a prefix match.
+    pub fn deny<I, S>(&self, specs: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.mode
+            .store(Arc::new(Mode::Deny(Patterns::compile(specs))));
+    }
+}
+
+impl<S: Subscriber> Filter<S> for EventNameFilter {
+    #[inline]
+    fn enabled(&self, meta: &Metadata<'_>, _cx: &Context<'_, S>) -> bool {
+        // `meta.name()` is the OpenTelemetry EventName set by the `otel_*!`
+        // macros (e.g. "receiver.start").
+        self.mode.load().allows(meta.name())
+    }
+
+    fn callsite_enabled(&self, _meta: &'static Metadata<'static>) -> Interest {
+        // The decision depends on the mutable mode, so it must be re-evaluated
+        // per event. Returning `sometimes()` (rather than `always`/`never`)
+        // defeats `tracing`'s per-callsite interest cache and is what makes
+        // runtime enable/disable actually take effect.
+        Interest::sometimes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tracing::{Event, Subscriber};
+    use tracing_subscriber::Registry;
+    use tracing_subscriber::layer::{Context, Layer};
+    use tracing_subscriber::prelude::*;
+
+    #[test]
+    fn patterns_exact_and_prefix() {
+        let p = Patterns::compile(["receiver.start", "channel.*"]);
+        assert!(p.matches("receiver.start"));
+        assert!(!p.matches("receiver.stop"));
+        assert!(p.matches("channel.full"));
+        assert!(p.matches("channel.drop"));
+        assert!(!p.matches("exporter.start"));
+    }
+
+    #[test]
+    fn empty_allowlist_matches_nothing() {
+        let p = Patterns::compile(Vec::<&str>::new());
+        assert!(!p.matches("anything"));
+    }
+
+    /// A layer that counts events it receives (i.e. events that passed filters).
+    struct CountingLayer(Arc<AtomicUsize>);
+    impl<S: Subscriber> Layer<S> for CountingLayer {
+        fn on_event(&self, _event: &Event<'_>, _cx: Context<'_, S>) {
+            let _ = self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    /// Exercises a *single* callsite repeatedly across mode changes. This is the
+    /// core proof that runtime toggling works: because each `emit_start()` call
+    /// hits the same callsite, a stale cached `Interest` would freeze the very
+    /// first decision. The assertions below only hold because
+    /// `callsite_enabled` returns `Interest::sometimes()`.
+    #[test]
+    fn same_callsite_re_evaluates_across_mode_changes() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let (filter, handle) = EventNameFilter::new();
+        let subscriber = Registry::default().with(CountingLayer(count.clone()).with_filter(filter));
+
+        tracing::subscriber::with_default(subscriber, || {
+            // Read and reset the counter.
+            let delta = || count.swap(0, Ordering::SeqCst);
+            // Every call below is the SAME callsite (one source line).
+            let emit_start = || tracing::info!(name: "receiver.start", detail = "x");
+
+            // Default AllowAll: passes.
+            emit_start();
+            assert_eq!(delta(), 1, "AllowAll should pass");
+
+            // Narrow to an allowlist that excludes it: dropped.
+            handle.allow(["exporter.start"]);
+            emit_start();
+            assert_eq!(delta(), 0, "excluded by allowlist");
+
+            // Add it to the allowlist: passes again (same callsite re-evaluated).
+            handle.allow(["receiver.start"]);
+            emit_start();
+            assert_eq!(delta(), 1, "included by allowlist");
+
+            // Back to AllowAll: passes.
+            handle.allow_all();
+            emit_start();
+            assert_eq!(delta(), 1, "AllowAll again");
+
+            // Deny it: dropped.
+            handle.deny(["receiver.*"]);
+            emit_start();
+            assert_eq!(delta(), 0, "excluded by denylist prefix");
+        });
+    }
+
+    #[test]
+    fn prefix_and_exact_distinguish_sibling_events() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let (filter, handle) = EventNameFilter::new();
+        let subscriber = Registry::default().with(CountingLayer(count.clone()).with_filter(filter));
+
+        tracing::subscriber::with_default(subscriber, || {
+            let delta = || count.swap(0, Ordering::SeqCst);
+
+            // Exact allow: only receiver.start, not its sibling.
+            handle.allow(["receiver.start"]);
+            tracing::info!(name: "receiver.start", detail = "x");
+            tracing::info!(name: "receiver.stop", detail = "x");
+            assert_eq!(delta(), 1, "only the exact match passes");
+
+            // Prefix allow: both receiver.* siblings, but not exporter.*.
+            handle.allow(["receiver.*"]);
+            tracing::info!(name: "receiver.start", detail = "x");
+            tracing::info!(name: "receiver.stop", detail = "x");
+            tracing::info!(name: "exporter.start", detail = "x");
+            assert_eq!(delta(), 2, "both receiver.* pass, exporter.* does not");
+        });
+    }
+}

--- a/rust/otap-dataflow/crates/telemetry/src/eventname_filter.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/eventname_filter.rs
@@ -148,6 +148,44 @@ impl EventNameFilter {
         let mode = Arc::new(ArcSwap::from_pointee(Mode::AllowAll));
         (Self { mode: mode.clone() }, EventNameFilterHandle { mode })
     }
+
+    /// Builds a filter fixed to `mode`, with no external handle.
+    fn from_mode(mode: Mode) -> Self {
+        Self {
+            mode: Arc::new(ArcSwap::from_pointee(mode)),
+        }
+    }
+
+    /// A static filter that lets every EventName pass. Installing it is a no-op
+    /// relative to having no EventName filter at all.
+    #[must_use]
+    pub fn allow_all() -> Self {
+        Self::from_mode(Mode::AllowAll)
+    }
+
+    /// A static filter that passes only EventNames matching one of `specs`.
+    ///
+    /// An empty set drops every internal-telemetry event. A spec ending in `*`
+    /// is a prefix match.
+    #[must_use]
+    pub fn allowing<I, S>(specs: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        Self::from_mode(Mode::Allow(Patterns::compile(specs)))
+    }
+
+    /// A static filter that passes every EventName except those matching one of
+    /// `specs`. A spec ending in `*` is a prefix match.
+    #[must_use]
+    pub fn denying<I, S>(specs: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        Self::from_mode(Mode::Deny(Patterns::compile(specs)))
+    }
 }
 
 impl EventNameFilterHandle {

--- a/rust/otap-dataflow/crates/telemetry/src/eventname_filter.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/eventname_filter.rs
@@ -31,13 +31,12 @@
 //!
 //! # Runtime dynamism (the important part)
 //!
-//! `tracing` caches per-callsite [`Interest`]. If [`callsite_enabled`] returned
-//! [`Interest::always`] or [`Interest::never`], the decision would be cached
-//! once per callsite and later changes to the pattern set would silently have
-//! no effect. To keep the set changeable at runtime, [`callsite_enabled`]
-//! returns [`Interest::sometimes`], which forces `enabled` to run on every
-//! event. The active mode lives behind an [`ArcSwap`] so a control plane can
-//! swap it in without blocking readers and without rebuilding the subscriber.
+//! `tracing` caches per-callsite [`Interest`], and an event's metadata name is
+//! static for the lifetime of that callsite. [`callsite_enabled`] therefore
+//! resolves the current policy once and returns [`Interest::always`] or
+//! [`Interest::never`], keeping policy checks off the per-event hot path. A
+//! policy update swaps the mode through [`ArcSwap`] and rebuilds tracing's
+//! interest cache so every existing callsite is resolved against the new mode.
 //!
 //! [`EnvFilter`]: tracing_subscriber::EnvFilter
 //! [`callsite_enabled`]: tracing_subscriber::layer::Filter::callsite_enabled
@@ -190,6 +189,11 @@ impl EventNameFilter {
 }
 
 impl EventNameFilterHandle {
+    fn replace_mode(&self, mode: Mode) {
+        self.mode.store(Arc::new(mode));
+        tracing::callsite::rebuild_interest_cache();
+    }
+
     /// Applies a validated EventName filter configuration atomically.
     pub fn apply_config(&self, config: &EventsConfig) {
         if !config.deny.is_empty() {
@@ -209,7 +213,7 @@ impl EventNameFilterHandle {
 
     /// Let every EventName pass (the default).
     pub fn allow_all(&self) {
-        self.mode.store(Arc::new(Mode::AllowAll));
+        self.replace_mode(Mode::AllowAll);
     }
 
     /// Pass only EventNames matching one of `specs`. An empty set drops every
@@ -219,8 +223,7 @@ impl EventNameFilterHandle {
         I: IntoIterator<Item = S>,
         S: AsRef<str>,
     {
-        self.mode
-            .store(Arc::new(Mode::Allow(Patterns::compile(specs))));
+        self.replace_mode(Mode::Allow(Patterns::compile(specs)));
     }
 
     /// Pass every EventName except those matching one of `specs`. A spec ending
@@ -230,8 +233,7 @@ impl EventNameFilterHandle {
         I: IntoIterator<Item = S>,
         S: AsRef<str>,
     {
-        self.mode
-            .store(Arc::new(Mode::Deny(Patterns::compile(specs))));
+        self.replace_mode(Mode::Deny(Patterns::compile(specs)));
     }
 }
 
@@ -243,12 +245,12 @@ impl<S: Subscriber> Filter<S> for EventNameFilter {
         self.mode.load().allows(meta.name())
     }
 
-    fn callsite_enabled(&self, _meta: &'static Metadata<'static>) -> Interest {
-        // The decision depends on the mutable mode, so it must be re-evaluated
-        // per event. Returning `sometimes()` (rather than `always`/`never`)
-        // defeats `tracing`'s per-callsite interest cache and is what makes
-        // runtime enable/disable actually take effect.
-        Interest::sometimes()
+    fn callsite_enabled(&self, meta: &'static Metadata<'static>) -> Interest {
+        if self.mode.load().allows(meta.name()) {
+            Interest::always()
+        } else {
+            Interest::never()
+        }
     }
 }
 
@@ -288,8 +290,8 @@ mod tests {
     /// Exercises a *single* callsite repeatedly across mode changes. This is the
     /// core proof that runtime toggling works: because each `emit_start()` call
     /// hits the same callsite, a stale cached `Interest` would freeze the very
-    /// first decision. The assertions below only hold because
-    /// `callsite_enabled` returns `Interest::sometimes()`.
+    /// first decision. The assertions below prove that rebuilding the interest
+    /// cache after each policy update refreshes that cached decision.
     #[test]
     fn same_callsite_re_evaluates_across_mode_changes() {
         let count = Arc::new(AtomicUsize::new(0));

--- a/rust/otap-dataflow/crates/telemetry/src/eventname_filter.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/eventname_filter.rs
@@ -46,6 +46,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use arc_swap::ArcSwap;
+use otap_df_config::settings::telemetry::logs::EventsConfig;
 use tracing::subscriber::Interest;
 use tracing::{Metadata, Subscriber};
 use tracing_subscriber::layer::{Context, Filter};
@@ -189,6 +190,23 @@ impl EventNameFilter {
 }
 
 impl EventNameFilterHandle {
+    /// Applies a validated EventName filter configuration atomically.
+    pub fn apply_config(&self, config: &EventsConfig) {
+        if !config.deny.is_empty() {
+            self.deny(&config.deny);
+        } else if !config.allow.is_empty() {
+            self.allow(&config.allow);
+        } else {
+            self.allow_all();
+        }
+    }
+
+    /// Returns whether the active filter allows `event_name`.
+    #[must_use]
+    pub fn allows(&self, event_name: &str) -> bool {
+        self.mode.load().allows(event_name)
+    }
+
     /// Let every EventName pass (the default).
     pub fn allow_all(&self) {
         self.mode.store(Arc::new(Mode::AllowAll));

--- a/rust/otap-dataflow/crates/telemetry/src/eventname_filter.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/eventname_filter.rs
@@ -19,8 +19,8 @@
 //! # Matching
 //!
 //! Each pattern is either:
-//! - **Exact** — `receiver.start` matches only that EventName; or
-//! - **Prefix** — a trailing `*` (`receiver.*`, or `receiver*`) matches every
+//! - **Exact** -> `receiver.start` matches only that EventName; or
+//! - **Prefix** -> a trailing `*` (`receiver.*`, or `receiver*`) matches every
 //!   EventName starting with the stem. This maps naturally onto the dotted,
 //!   hierarchical EventName convention ("zoom into a whole subsystem").
 //!

--- a/rust/otap-dataflow/crates/telemetry/src/lib.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/lib.rs
@@ -27,10 +27,13 @@
 
 use crate::error::Error;
 use crate::event::{ObservedEvent, ObservedEventReporter};
+use crate::eventname_filter::EventNameFilter;
 use crate::registry::TelemetryRegistryHandle;
 use otap_df_config::observed_state::SendPolicy;
 use otap_df_config::pipeline::telemetry::TelemetryConfig;
-use otap_df_config::settings::telemetry::logs::{LogLevel, LoggingProviders, ProviderMode};
+use otap_df_config::settings::telemetry::logs::{
+    EventsConfig, LogLevel, LoggingProviders, ProviderMode,
+};
 use self_tracing::LogContextFn;
 use std::sync::Arc;
 use tracing_init::ProviderSetup;
@@ -169,6 +172,20 @@ impl std::fmt::Debug for InternalTelemetrySettings {
 pub mod entity;
 pub mod testing;
 
+/// Builds an [`EventNameFilter`] from `logs.events` configuration.
+///
+/// `deny` and `allow` are mutually exclusive (enforced by config validation);
+/// when both are empty the filter allows all EventNames.
+fn event_filter_from_config(events: &EventsConfig) -> EventNameFilter {
+    if !events.deny.is_empty() {
+        EventNameFilter::denying(&events.deny)
+    } else if !events.allow.is_empty() {
+        EventNameFilter::allowing(&events.allow)
+    } else {
+        EventNameFilter::allow_all()
+    }
+}
+
 /// The internal telemetry system - unified entry point for all telemetry.
 ///
 /// This system manages:
@@ -191,6 +208,10 @@ pub struct InternalTelemetrySystem {
 
     /// The logging providers.
     provider_modes: LoggingProviders,
+
+    /// EventName filter built from `logs.events`, applied on top of the level
+    /// filter. Shared (cloned) into every per-thread `TracingSetup`.
+    event_filter: EventNameFilter,
 
     /// Entity key providers for associating log events with their source entity context.
     context_fn: LogContextFn,
@@ -271,6 +292,7 @@ impl InternalTelemetrySystem {
             metrics_reporter,
             log_level: config.logs.level.clone(),
             provider_modes: config.logs.providers.clone(),
+            event_filter: event_filter_from_config(&config.logs.events),
             context_fn,
             console_async_reporter,
             its_reporter,
@@ -316,6 +338,7 @@ impl InternalTelemetrySystem {
         };
 
         TracingSetup::new(provider, self.log_level.clone(), self.context_fn)
+            .with_event_filter(self.event_filter.clone())
     }
 
     /// Returns a `TracingSetup` for engine threads.

--- a/rust/otap-dataflow/crates/telemetry/src/lib.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/lib.rs
@@ -27,13 +27,11 @@
 
 use crate::error::Error;
 use crate::event::{ObservedEvent, ObservedEventReporter};
-use crate::eventname_filter::EventNameFilter;
+use crate::eventname_filter::{EventNameFilter, EventNameFilterHandle};
 use crate::registry::TelemetryRegistryHandle;
 use otap_df_config::observed_state::SendPolicy;
 use otap_df_config::pipeline::telemetry::TelemetryConfig;
-use otap_df_config::settings::telemetry::logs::{
-    EventsConfig, LogLevel, LoggingProviders, ProviderMode,
-};
+use otap_df_config::settings::telemetry::logs::{LogLevel, LoggingProviders, ProviderMode};
 use self_tracing::LogContextFn;
 use std::sync::Arc;
 use tracing_init::ProviderSetup;
@@ -172,20 +170,6 @@ impl std::fmt::Debug for InternalTelemetrySettings {
 pub mod entity;
 pub mod testing;
 
-/// Builds an [`EventNameFilter`] from `logs.events` configuration.
-///
-/// `deny` and `allow` are mutually exclusive (enforced by config validation);
-/// when both are empty the filter allows all EventNames.
-fn event_filter_from_config(events: &EventsConfig) -> EventNameFilter {
-    if !events.deny.is_empty() {
-        EventNameFilter::denying(&events.deny)
-    } else if !events.allow.is_empty() {
-        EventNameFilter::allowing(&events.allow)
-    } else {
-        EventNameFilter::allow_all()
-    }
-}
-
 /// The internal telemetry system - unified entry point for all telemetry.
 ///
 /// This system manages:
@@ -212,6 +196,9 @@ pub struct InternalTelemetrySystem {
     /// EventName filter built from `logs.events`, applied on top of the level
     /// filter. Shared (cloned) into every per-thread `TracingSetup`.
     event_filter: EventNameFilter,
+
+    /// Runtime handle used to apply reconciled `logs.events` configuration.
+    event_filter_handle: EventNameFilterHandle,
 
     /// Entity key providers for associating log events with their source entity context.
     context_fn: LogContextFn,
@@ -286,13 +273,17 @@ impl InternalTelemetrySystem {
             )
         };
 
+        let (event_filter, event_filter_handle) = EventNameFilter::new();
+        event_filter_handle.apply_config(&config.logs.events);
+
         Ok(Self {
             registry: telemetry_registry,
             collector,
             metrics_reporter,
             log_level: config.logs.level.clone(),
             provider_modes: config.logs.providers.clone(),
-            event_filter: event_filter_from_config(&config.logs.events),
+            event_filter,
+            event_filter_handle,
             context_fn,
             console_async_reporter,
             its_reporter,
@@ -345,6 +336,12 @@ impl InternalTelemetrySystem {
     #[must_use]
     pub fn engine_tracing_setup(&self) -> TracingSetup {
         self.tracing_setup_for(self.provider_modes.engine)
+    }
+
+    /// Returns the handle used to update EventName filtering at runtime.
+    #[must_use]
+    pub fn event_filter_handle(&self) -> EventNameFilterHandle {
+        self.event_filter_handle.clone()
     }
 
     /// Returns a `TracingSetup` for admin threads.

--- a/rust/otap-dataflow/crates/telemetry/src/lib.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/lib.rs
@@ -43,6 +43,8 @@ pub mod descriptor;
 pub mod error;
 /// Event types for lifecycle and log events.
 pub mod event;
+/// Per-EventName runtime filtering of internal telemetry logs.
+pub mod eventname_filter;
 pub mod instrument;
 /// Internal logs/events module for engine.
 pub mod internal_events;

--- a/rust/otap-dataflow/crates/telemetry/src/tracing_init.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/tracing_init.rs
@@ -13,6 +13,7 @@ use crate::self_tracing::{ConsoleWriter, LogContextFn, LogRecord};
 use otap_df_config::settings::telemetry::logs::LogLevel;
 use std::time::SystemTime;
 use tracing::{Dispatch, Event, Subscriber};
+use tracing_subscriber::filter::FilterExt;
 use tracing_subscriber::layer::{Context, Layer as TracingLayer};
 use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::{EnvFilter, Registry, layer::SubscriberExt};
@@ -127,18 +128,14 @@ impl ProviderSetup {
                 let layer =
                     StructuredLoggingLayer::new(Some(ConsoleWriter::color()), None, context_fn);
                 Dispatch::new(
-                    Registry::default()
-                        .with(filter)
-                        .with(layer.with_filter(event_filter.clone())),
+                    Registry::default().with(layer.with_filter(filter.and(event_filter.clone()))),
                 )
             }
 
             ProviderSetup::InternalAsync { reporter } => {
                 let layer = StructuredLoggingLayer::new(None, Some(reporter.clone()), context_fn);
                 Dispatch::new(
-                    Registry::default()
-                        .with(filter)
-                        .with(layer.with_filter(event_filter.clone())),
+                    Registry::default().with(layer.with_filter(filter.and(event_filter.clone()))),
                 )
             }
         }

--- a/rust/otap-dataflow/crates/telemetry/src/tracing_init.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/tracing_init.rs
@@ -8,6 +8,7 @@
 //! trace events are captured and routed.
 
 use crate::event::{LogEvent, ObservedEventReporter};
+use crate::eventname_filter::EventNameFilter;
 use crate::self_tracing::{ConsoleWriter, LogContextFn, LogRecord};
 use otap_df_config::settings::telemetry::logs::LogLevel;
 use std::time::SystemTime;
@@ -41,6 +42,9 @@ pub struct TracingSetup {
     pub log_level: LogLevel,
     /// Context function.
     pub context_fn: LogContextFn,
+    /// EventName-based filter, composed on top of the level/target `EnvFilter`.
+    /// Defaults to allow-all (no EventName filtering).
+    event_filter: EventNameFilter,
 }
 
 impl TracingSetup {
@@ -51,13 +55,21 @@ impl TracingSetup {
             provider,
             log_level,
             context_fn,
+            event_filter: EventNameFilter::allow_all(),
         }
+    }
+
+    /// Sets the EventName filter applied on top of the level/target filter.
+    #[must_use]
+    pub fn with_event_filter(mut self, event_filter: EventNameFilter) -> Self {
+        self.event_filter = event_filter;
+        self
     }
 
     /// Initialize this setup as the global tracing subscriber.
     pub fn try_init_global(&self) -> Result<(), tracing::dispatcher::SetGlobalDefaultError> {
         self.provider
-            .try_init_global(&self.log_level, self.context_fn)
+            .try_init_global(&self.log_level, self.context_fn, &self.event_filter)
     }
 
     /// Run a closure with the appropriate tracing subscriber for this setup.
@@ -66,7 +78,7 @@ impl TracingSetup {
         F: FnOnce() -> R,
     {
         self.provider
-            .with_subscriber(&self.log_level, self.context_fn, f)
+            .with_subscriber(&self.log_level, self.context_fn, &self.event_filter, f)
     }
 
     #[cfg(test)]
@@ -74,8 +86,12 @@ impl TracingSetup {
     where
         F: FnOnce() -> R,
     {
-        self.provider
-            .with_subscriber_ignoring_env(&self.log_level, self.context_fn, f)
+        self.provider.with_subscriber_ignoring_env(
+            &self.log_level,
+            self.context_fn,
+            &self.event_filter,
+            f,
+        )
     }
 }
 
@@ -98,26 +114,44 @@ pub enum ProviderSetup {
 }
 
 impl ProviderSetup {
-    fn build_dispatch_with_filter(&self, filter: EnvFilter, context_fn: LogContextFn) -> Dispatch {
+    fn build_dispatch_with_filter(
+        &self,
+        filter: EnvFilter,
+        context_fn: LogContextFn,
+        event_filter: &EventNameFilter,
+    ) -> Dispatch {
         match self {
             ProviderSetup::Noop => Dispatch::new(tracing::subscriber::NoSubscriber::new()),
 
             ProviderSetup::ConsoleDirect => {
                 let layer =
                     StructuredLoggingLayer::new(Some(ConsoleWriter::color()), None, context_fn);
-                Dispatch::new(Registry::default().with(filter).with(layer))
+                Dispatch::new(
+                    Registry::default()
+                        .with(filter)
+                        .with(layer.with_filter(event_filter.clone())),
+                )
             }
 
             ProviderSetup::InternalAsync { reporter } => {
                 let layer = StructuredLoggingLayer::new(None, Some(reporter.clone()), context_fn);
-                Dispatch::new(Registry::default().with(filter).with(layer))
+                Dispatch::new(
+                    Registry::default()
+                        .with(filter)
+                        .with(layer.with_filter(event_filter.clone())),
+                )
             }
         }
     }
 
     /// Build a `Dispatch` for this provider setup with the given log level.
-    fn build_dispatch(&self, log_level: &LogLevel, context_fn: LogContextFn) -> Dispatch {
-        self.build_dispatch_with_filter(create_env_filter(log_level), context_fn)
+    fn build_dispatch(
+        &self,
+        log_level: &LogLevel,
+        context_fn: LogContextFn,
+        event_filter: &EventNameFilter,
+    ) -> Dispatch {
+        self.build_dispatch_with_filter(create_env_filter(log_level), context_fn, event_filter)
     }
 
     /// Initialize this setup as the global tracing subscriber.
@@ -125,17 +159,24 @@ impl ProviderSetup {
         &self,
         log_level: &LogLevel,
         context_fn: LogContextFn,
+        event_filter: &EventNameFilter,
     ) -> Result<(), tracing::dispatcher::SetGlobalDefaultError> {
-        let dispatch = self.build_dispatch(log_level, context_fn);
+        let dispatch = self.build_dispatch(log_level, context_fn, event_filter);
         tracing::dispatcher::set_global_default(dispatch)
     }
 
     /// Run a closure with the appropriate tracing subscriber for this setup.
-    pub fn with_subscriber<F, R>(&self, log_level: &LogLevel, context_fn: LogContextFn, f: F) -> R
+    pub fn with_subscriber<F, R>(
+        &self,
+        log_level: &LogLevel,
+        context_fn: LogContextFn,
+        event_filter: &EventNameFilter,
+        f: F,
+    ) -> R
     where
         F: FnOnce() -> R,
     {
-        let dispatch = self.build_dispatch(log_level, context_fn);
+        let dispatch = self.build_dispatch(log_level, context_fn, event_filter);
         tracing::dispatcher::with_default(&dispatch, f)
     }
 
@@ -144,13 +185,17 @@ impl ProviderSetup {
         &self,
         log_level: &LogLevel,
         context_fn: LogContextFn,
+        event_filter: &EventNameFilter,
         f: F,
     ) -> R
     where
         F: FnOnce() -> R,
     {
-        let dispatch =
-            self.build_dispatch_with_filter(EnvFilter::new(log_level.as_str()), context_fn);
+        let dispatch = self.build_dispatch_with_filter(
+            EnvFilter::new(log_level.as_str()),
+            context_fn,
+            event_filter,
+        );
         tracing::dispatcher::with_default(&dispatch, f)
     }
 }
@@ -571,18 +616,30 @@ mod tests {
     fn provider_setup_with_subscriber_all_variants() {
         crate::with_cleared_rust_log(|| {
             let info = level("info");
-            noop_provider().with_subscriber_ignoring_env(&info, LogContext::new, || {
-                otel_info!("noop");
-            });
+            let allow_all = EventNameFilter::allow_all();
+            noop_provider().with_subscriber_ignoring_env(
+                &info,
+                LogContext::new,
+                &allow_all,
+                || {
+                    otel_info!("noop");
+                },
+            );
 
-            console_direct_provider().with_subscriber_ignoring_env(&info, LogContext::new, || {
-                otel_info!("console_direct");
-            });
+            console_direct_provider().with_subscriber_ignoring_env(
+                &info,
+                LogContext::new,
+                &allow_all,
+                || {
+                    otel_info!("console_direct");
+                },
+            );
 
             let (reporter, _rx) = test_reporter();
             internal_async_provider(reporter).with_subscriber_ignoring_env(
                 &info,
                 LogContext::new,
+                &allow_all,
                 || {
                     otel_info!("console_async");
                 },
@@ -612,6 +669,57 @@ mod tests {
 
     /// Scenario: one asynchronous subscriber is temporarily nested inside another.
     /// Guarantees: inner events remain isolated while outer events return to the outer channel.
+    #[test]
+    fn event_name_filter_composes_with_level_filter() {
+        use crate::eventname_filter::EventNameFilter;
+
+        // Allowlist by EventName, layered on top of the level filter. Only
+        // events whose EventName passes *both* filters should be reported.
+        crate::with_cleared_rust_log(|| {
+            let (reporter, receiver) = test_reporter();
+            let setup = test_setup(internal_async_provider(reporter), level("info"))
+                .with_event_filter(EventNameFilter::allowing(["receiver.start", "channel.*"]));
+
+            setup.with_subscriber_ignoring_env(|| {
+                otel_info!("receiver.start"); // allowed (exact)
+                otel_info!("receiver.stop"); // dropped (not in allowlist)
+                otel_warn!("channel.full"); // allowed (prefix)
+                otel_error!("exporter.fail"); // dropped (not in allowlist)
+            });
+            drop(setup);
+
+            assert_eq!(
+                receiver.into_iter().count(),
+                2,
+                "only receiver.start and channel.full pass the EventName allowlist"
+            );
+        });
+    }
+
+    #[test]
+    fn event_name_deny_filter_suppresses_matches() {
+        use crate::eventname_filter::EventNameFilter;
+
+        crate::with_cleared_rust_log(|| {
+            let (reporter, receiver) = test_reporter();
+            let setup = test_setup(internal_async_provider(reporter), level("info"))
+                .with_event_filter(EventNameFilter::denying(["noisy.*"]));
+
+            setup.with_subscriber_ignoring_env(|| {
+                otel_info!("noisy.tick"); // dropped (denied prefix)
+                otel_info!("noisy.tock"); // dropped (denied prefix)
+                otel_warn!("important.event"); // passes
+            });
+            drop(setup);
+
+            assert_eq!(
+                receiver.into_iter().count(),
+                1,
+                "only the non-denied event passes"
+            );
+        });
+    }
+
     #[test]
     fn nested_with_subscriber() {
         crate::with_cleared_rust_log(|| {


### PR DESCRIPTION
# Change Summary

Adds EventName-level filtering for `df_engine` internal telemetry logs. The new `engine.telemetry.logs.events` configuration is combined with the existing level and target filter, and supports mutually exclusive allow and deny lists with exact or trailing-wildcard prefix patterns.

```yaml
engine:
  telemetry:
    logs:
      level: "info"
      events:
        allow:
          - "receiver.start"
          - "channel.*"
```

The filter reads the OpenTelemetry EventName from `tracing::Metadata::name()`. Because the EventName is static for each tracing callsite, the filter caches an `Interest::always()` or `Interest::never()` decision instead of evaluating the policy for every event. Policy updates use `ArcSwap` for atomic replacement and rebuild tracing's callsite interest cache, moving matching cost to configuration updates and keeping it off the emission hot path.

Successful full-engine reconciliation applies the validated EventName policy to the shared runtime filter, including configuration received through the OpAMP controller extension. Failed or invalid reconciliation preserves the active filter.

## What issue does this PR close?

Relates to #3387

## Are there any user-facing changes?

Yes. Users can filter internal telemetry logs by EventName through static configuration or full-engine remote configuration without restarting the engine or rebuilding tracing subscribers.

### Changelog

- [x] Added a `.chloggen/*.yaml` entry
- [ ] This PR is a `chore` (indicated in title)
- [ ] This is a documentation-only PR.
