### PR TITLE
chore(pipeline-perf): add container CPU-seconds metric

### DIFF
--- a/tools/pipeline_perf_test/orchestrator/lib/impl/strategies/monitoring/docker_component.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/impl/strategies/monitoring/docker_component.py
@@ -283,6 +283,15 @@ def monitor(
         "{cpu}",
         "Number of CPU cores allocated to the application running in the container",
     )
+    cpu_time_gauge = meter.create_gauge(
+        "container.cpu.time",
+        "s",
+        "Cumulative CPU time consumed by the container since start, in seconds. "
+        "Sourced from cgroup CPU accounting (docker stats total_usage). Unlike "
+        "container.cpu.usage (an instantaneous utilization ratio), this is an "
+        "absolute work measure; the report derives per-window CPU-seconds "
+        "(cpu_seconds) from it.",
+    )
     memory_usage_gauge = meter.create_gauge(
         "container.memory.usage", "By", "Memory usage of the container."
     )
@@ -331,6 +340,11 @@ def monitor(
                 # CPU usage calculation
                 cpu_stats = stat_data["cpu_stats"]
                 precpu_stats = stat_data["precpu_stats"]
+                # Cumulative CPU time (nanoseconds -> seconds). Monotonic; the
+                # report derives per-window CPU-seconds as MAX - MIN. Available
+                # on every runner (no perf/PMU needed), so it works on
+                # GitHub-hosted runners as well as dedicated hardware.
+                cpu_time_gauge.set(cpu_stats["cpu_usage"]["total_usage"] / 1e9, labels)
                 cpu_delta = (
                     cpu_stats["cpu_usage"]["total_usage"]
                     - precpu_stats["cpu_usage"]["total_usage"]

--- a/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_logs.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_logs.yaml
@@ -85,6 +85,24 @@ queries:
           with_rate AS wr
           ON wr.timestamp BETWEEN ow.start_ts AND ow.stop_ts
         GROUP BY component_name, metric_name
+  - name: Component CPU Time
+    sql: |
+      CREATE TABLE component_cpu_time AS
+        WITH metrics_filtered AS (
+          SELECT
+            "metric_attributes.component_name" AS component_name,
+            timestamp,
+            value
+          FROM metrics
+          WHERE metric_name = 'container.cpu.time'
+        )
+        SELECT
+          m.component_name,
+          MAX(m.value) - MIN(m.value) AS cpu_seconds
+        FROM observation_window AS ow
+        JOIN metrics_filtered AS m
+          ON m.timestamp BETWEEN ow.start_ts AND ow.stop_ts
+        GROUP BY m.component_name;
   - name: Component Metric Rates By Core ID
     sql: |
       CREATE TABLE send_receive_rates_by_core AS WITH
@@ -358,6 +376,14 @@ queries:
 
           UNION ALL
 
+          SELECT 'cpu_seconds' AS name, 's' AS unit, cpu_seconds AS value,
+                metadata_row."test.suite" || '/' || metadata_row."test.name" || ' - CPU Seconds' AS extra
+          FROM component_cpu_time
+          CROSS JOIN metadata_row
+          WHERE component_name IN ('go-collector', 'df-engine')
+
+          UNION ALL
+
           SELECT 'uncompressed_bytes_per_log' AS name, 'bytes/log' AS unit,
                 CASE WHEN logs.total_increase > 0
                   THEN bytes.total_increase / logs.total_increase
@@ -379,6 +405,8 @@ result_tables:
     description: Cumulative increase and average rate of various send / receive metrics
   - name: component_resource_metrics
     description: CPU and Memory metrics for the components in the Test Suite during the test.
+  - name: component_cpu_time
+    description: CPU-seconds consumed per component during the observation window (cgroup accounting).
   - name: log_loss
     description: Lost logs (failed or sent but not received) total and as a percentage
   - name: log_throughput_rates


### PR DESCRIPTION
**Draft / RFC — I don't think this should merge as-is.** Putting it up mainly to share what I measured, since the results argue against my own original idea.

### What I was actually after

The goal was to find a metric stable enough to **gate perf regressions on PRs using commodity GitHub runners**, so every PR gets checked and the dedicated bare-metal box is reserved for nightly. Throughput and CPU% are both too noisy on shared runners to gate on, so I went looking for something inherently steadier.

Two candidates, both dead ends, for two different reasons:

**1. CPU cycles / instructions (#3355).** This was the prime candidate — retired instructions are frequency-independent, so in principle they don't care about turbo, neighbors, or clock drift. Turned out you can't even collect them: the PMU isn't exposed on hosted runners, `perf stat` just returns `<not supported>` with `perf_event_paranoid=4`. Not a tuning problem, the counters aren't there. Works fine on the dedicated box (0.05–0.19%), which is the one place we don't need the help.

**2. CPU-seconds (this PR).** cgroup accounting is available everywhere, no PMU needed, and it measures work rather than utilization. Collectible on any runner — but as the numbers below show, not stable enough across runners to gate on.

So the honest conclusion is that the original goal isn't reachable this way. It's not that I picked the wrong metric; commodity runners can't support this kind of measurement at all.

### What's in the diff

One new metric, `cpu_seconds`: how much CPU time a component actually burns during the observation window. Comes from cgroup accounting (`docker stats` total_usage), recorded as a cumulative `container.cpu.time` gauge and turned into a per-window number in the report. 42 lines, two files.

### Why it doesn't work on hosted runners

This is the part worth reading. I ran the same scenario on 5 separate GitHub runner VMs (matrix jobs, so each one gets a fresh machine), twice per VM:

| VM | CPU | run 1 | run 2 |
|---|---|---|---|
| 1 | AMD EPYC 7763 | 7.290 | 7.314 |
| 2 | AMD EPYC 7763 | 7.056 | 7.070 |
| 3 | Intel Xeon Platinum 8573C | 6.457 | 6.360 |
| 4 | AMD EPYC 7763 | 7.043 | 7.023 |
| 5 | AMD EPYC 7763 | 6.986 | 6.963 |

Back-to-back on the same VM it's tight (0.1–0.8%). Across VMs it's 4.25%, with a 15% spread between the best and worst. Four of the five VMs were AMD and one was Intel, and the Intel one did the same work in ~9% less CPU time. You don't get to pick which one you land on.

To gate on that you'd need a threshold north of 12%, which won't catch anything real — actual regressions we care about are in the 2–10% range. And it's not this metric's fault: plain CPU% across those same VMs was 4.47%. The hardware underneath is heterogeneous and that dominates everything else.

Worth flagging one trap I fell into: I first measured 1.07% and thought that was good enough. But that was four iterations inside a single job, i.e. all on one VM. Within-VM stability tells you nothing about the PR-to-PR case, where each run lands on a different machine. Had to redo it as separate VMs to get the real number.

### On the dedicated box it's stable, but so is what we already have

3 runs x 6 scenarios: `cpu_seconds` lands at 0.04–0.19% CoV. Good. Problem is `cpu_percentage_normalized` is right there too, and when I compared them scenario-by-scenario it won 4 of 6. They're basically the same signal — which makes sense, they're derived from the same cgroup counter. So I can't claim this improves regression detection, which was the main thing I was going to argue.

### Other things I checked

- **Per-log normalization** (`cpu_us_per_log`, was in an earlier revision): dropped it. Noisier everywhere — 2.3% on the batch scenarios vs 0.11% for raw cpu_seconds, 3.3% under saturation. Log counts over a fixed window are bursty, so dividing by them just adds noise.
- **Saturation tests**: cpu_seconds sits at ~99% of the core because that's the definition of saturation. Stable, but it's telling you nothing. Throughput is the number that matters there.
- cpu_seconds scales with test duration where CPU% doesn't. Doesn't matter today (duration is stable to 0.04%) but it's a sharp edge.
- It's a MAX-MIN over samples, so it slightly undercounts — measured 93.5% where CPU% said 98.1%. Consistent bias, doesn't affect run-to-run comparisons.

### So what do we do with it

The metric itself is mostly redundant. Arguments for keeping it are thin: `container.cpu.time` is the semconv-correct name, it doesn't depend on `allocated_cores` being configured right, and "11.8 CPU-seconds" is a friendlier number than "64.8% of a core" if you're thinking about cost. None of that is a strong reason to add a column to the reports.

Fine by me to close this. What I'd like to keep is the conclusion both attempts point at: **perf gating on commodity runners isn't achievable** — the counters we'd want don't exist there, and the ones that do exist are swamped by hardware variance. Perf regression detection has to stay on the dedicated runner. If someone does want a per-PR signal on hosted runners, the only route I can see is deterministic instruction counting (cachegrind / iai-callgrind style), which is simulated rather than measured and would be a different kind of test entirely — microbenchmarks of hot paths, not the end-to-end docker pipeline.

Happy to move that write-up somewhere more permanent if people agree it's worth recording.

Related: #3355 — same wall, hit from the hardware counter side.
