### PR TITLE
feat(metrics): Migrate durable_buffer_processor metrics to the new item attribute format

### DIFF
--- a/rust/otap-dataflow/.chloggen/durable-buffer-dimensioned-metrics.yaml
+++ b/rust/otap-dataflow/.chloggen/durable-buffer-dimensioned-metrics.yaml
@@ -1,0 +1,4 @@
+change_type: breaking
+component: pipeline
+note: Consolidate durable buffer processor metrics into bounded dimensions for signal, outcome, and loss reason.
+issues: [3300]

--- a/rust/otap-dataflow/.chloggen/durable-buffer-dimensioned-metrics.yaml
+++ b/rust/otap-dataflow/.chloggen/durable-buffer-dimensioned-metrics.yaml
@@ -1,4 +1,4 @@
 change_type: breaking
 component: pipeline
-note: Consolidate durable buffer processor metrics into bounded dimensions for signal, outcome, and loss reason.
+note: Consolidate durable buffer processor metrics into bounded dimensions for signal, outcome, and loss reason, including expired segment losses.
 issues: [3300]

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/README.md
@@ -104,41 +104,14 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
 
 ### Metric Sets
 
-#### `otap.processor.durable_buffer`
-
-| Metric | Unit | Description |
+| Scope | Instrument(s) | Dimensions |
 | --- | --- | --- |
-| `otap.processor.durable_buffer.bundles_acked` | `{bundle}` | Number of bundles acknowledged by downstream. |
-| `otap.processor.durable_buffer.bundles_nacked_deferred` | `{bundle}` | Number of bundles deferred for retry after transient downstream failures. |
-| `otap.processor.durable_buffer.bundles_nacked_permanent` | `{bundle}` | Number of bundles permanently rejected by downstream (not retried). These indicate data loss due to permanent failures (e.g., malformed data). |
-| `otap.processor.durable_buffer.rejected_log_records` | `{log_record}` | Number of log records rejected. |
-| `otap.processor.durable_buffer.rejected_metric_points` | `{data_point}` | Number of metric data points rejected. |
-| `otap.processor.durable_buffer.rejected_spans` | `{span}` | Number of spans rejected. |
-| `otap.processor.durable_buffer.consumed_log_records` | `{log_record}` | Number of log records consumed (ingested to durable storage). For OTLP bytes, counted by scanning the protobuf wire format without full deserialization. |
-| `otap.processor.durable_buffer.consumed_metric_points` | `{data_point}` | Number of metric data points consumed (ingested to durable storage). For OTLP bytes, counted by scanning the protobuf wire format without full deserialization. |
-| `otap.processor.durable_buffer.consumed_spans` | `{span}` | Number of spans consumed (ingested to durable storage). For OTLP bytes, counted by scanning the protobuf wire format without full deserialization. |
-| `otap.processor.durable_buffer.produced_log_records` | `{log_record}` | Number of log records produced (sent downstream). For OTLP bytes, counted by scanning the protobuf wire format without full deserialization. |
-| `otap.processor.durable_buffer.produced_metric_points` | `{data_point}` | Number of metric data points produced (sent downstream). For OTLP bytes, counted by scanning the protobuf wire format without full deserialization. |
-| `otap.processor.durable_buffer.produced_spans` | `{span}` | Number of spans produced (sent downstream). For OTLP bytes, counted by scanning the protobuf wire format without full deserialization. |
-| `otap.processor.durable_buffer.ingest_errors` | `{error}` | Number of ingest errors (excludes backpressure/capacity rejections). |
-| `otap.processor.durable_buffer.ingest_backpressure` | `{rejection}` | Number of ingest rejections due to storage backpressure (soft cap exceeded). |
-| `otap.processor.durable_buffer.read_errors` | `{error}` | Number of read errors. |
-| `otap.processor.durable_buffer.storage_bytes_used` | `By` | Current bytes used by persistent storage (WAL + segments). |
-| `otap.processor.durable_buffer.storage_bytes_cap` | `By` | Configured storage capacity cap. |
-| `otap.processor.durable_buffer.dropped_segments` | `{segment}` | Total segments force-dropped due to DropOldest retention policy. Non-zero values indicate data loss. |
-| `otap.processor.durable_buffer.dropped_bundles` | `{bundle}` | Total bundles lost due to force-dropped segments (DropOldest policy). Non-zero values indicate data loss. |
-| `otap.processor.durable_buffer.dropped_items` | `{item}` | Total individual items (log records, data points, spans) lost due to force-dropped segments (DropOldest policy). Non-zero values indicate data loss. |
-| `otap.processor.durable_buffer.expired_bundles` | `{bundle}` | Total bundles lost due to expired segments (max_age retention). Non-zero values indicate data aged out before delivery. |
-| `otap.processor.durable_buffer.expired_items` | `{item}` | Total individual items (log records, data points, spans) lost due to expired segments (max_age retention). Non-zero values indicate data aged out before delivery. |
-| `otap.processor.durable_buffer.retries_scheduled` | `{retry}` | Number of retry attempts scheduled. |
-| `otap.processor.durable_buffer.in_flight` | `{bundle}` | Current number of bundles in-flight to downstream. |
-| `otap.processor.durable_buffer.requeued_log_records` | `{log_record}` | Number of individual log records requeued for retry after NACK. |
-| `otap.processor.durable_buffer.requeued_metric_points` | `{data_point}` | Number of individual metric data points requeued for retry after NACK. |
-| `otap.processor.durable_buffer.requeued_spans` | `{span}` | Number of individual spans requeued for retry after NACK. |
-| `otap.processor.durable_buffer.queued_log_records` | `{log_record}` | Current number of log records queued (ingested but not yet ACKed). |
-| `otap.processor.durable_buffer.queued_metric_points` | `{data_point}` | Current number of metric data points queued (ingested but not yet ACKed). |
-| `otap.processor.durable_buffer.queued_spans` | `{span}` | Current number of spans queued (ingested but not yet ACKed). |
-| `otap.processor.durable_buffer.flush_failures` | `{error}` | Number of segment finalization (flush) failures. Non-zero values indicate data at risk - check logs for root cause. Data may still be recoverable via WAL replay on restart. |
+| `processor.durable_buffer` | `read.errors`, `storage.bytes.used`, `storage.bytes.cap`, `retries.scheduled`, `in.flight`, `flush.failures`, `storage.utilization` | None |
+| `processor.durable_buffer.bundles` | `resolved` | `outcome=acked\|deferred\|permanently_rejected` |
+| `processor.durable_buffer.ingest` | `failures` | `failure=error\|backpressure` |
+| `processor.durable_buffer.items` | `rejected`, `consumed`, `produced`, `requeued`, `queued` | `signal=traces\|metrics\|logs` |
+| `processor.durable_buffer.loss` | `segments`, `bundles`, `items` | `reason=drop_oldest\|expired` |
+| `processor.durable_buffer.item_loss` | `items` | `signal=traces\|metrics\|logs`, `reason=drop_oldest\|expired` |
 
 ### Events
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/metrics.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/metrics.rs
@@ -1,0 +1,230 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Metric declarations for the durable buffer processor.
+
+use otap_df_config::SignalType;
+use otap_df_engine::context::PipelineContext;
+use otap_df_telemetry::error::Error;
+use otap_df_telemetry::instrument::{Counter, Gauge, ObserveCounter};
+use otap_df_telemetry::metrics::{MeasurementMetricSet, MetricSet};
+use otap_df_telemetry::reporter::MetricsReporter;
+use otap_df_telemetry_macros::{AttributeEnum, attribute_set, metric_set};
+
+/// Metrics that do not have a bounded item dimension.
+#[metric_set(name = "processor.durable_buffer")]
+#[derive(Debug, Default, Clone)]
+pub(super) struct DurableBufferOperationalMetrics {
+    /// Number of read errors.
+    #[metric(unit = "{error}")]
+    pub(super) read_errors: Counter<u64>,
+    /// Current bytes used by persistent storage.
+    #[metric(unit = "By")]
+    pub(super) storage_bytes_used: Gauge<u64>,
+    /// Configured storage capacity cap.
+    #[metric(unit = "By")]
+    pub(super) storage_bytes_cap: Gauge<u64>,
+    /// Number of retry attempts scheduled.
+    #[metric(unit = "{retry}")]
+    pub(super) retries_scheduled: Counter<u64>,
+    /// Current number of bundles in flight to downstream.
+    #[metric(unit = "{bundle}")]
+    pub(super) in_flight: Gauge<u64>,
+    /// Number of segment finalization failures.
+    #[metric(unit = "{error}")]
+    pub(super) flush_failures: Counter<u64>,
+    /// Current storage utilization ratio.
+    #[metric(unit = "{1}")]
+    pub(super) storage_utilization: Gauge<f64>,
+}
+
+#[derive(Debug, Clone, Copy, AttributeEnum)]
+pub(super) enum BundleOutcome {
+    Acked,
+    Deferred,
+    PermanentlyRejected,
+}
+
+#[attribute_set(item, measurement)]
+#[derive(Debug, Clone, Copy)]
+pub(super) struct BundleOutcomeAttributes {
+    pub(super) outcome: BundleOutcome,
+}
+
+/// Bundle resolution metrics partitioned by downstream outcome.
+#[metric_set(
+    name = "processor.durable_buffer.bundles",
+    measurement_attributes = BundleOutcomeAttributes
+)]
+#[derive(Debug, Default, Clone)]
+pub(super) struct DurableBufferBundleMetrics {
+    /// Number of bundles resolved by downstream outcome.
+    #[metric(unit = "{bundle}")]
+    pub(super) resolved: Counter<u64>,
+}
+
+#[derive(Debug, Clone, Copy, AttributeEnum)]
+pub(super) enum IngestFailure {
+    Error,
+    Backpressure,
+}
+
+#[attribute_set(item, measurement)]
+#[derive(Debug, Clone, Copy)]
+pub(super) struct IngestFailureAttributes {
+    pub(super) failure: IngestFailure,
+}
+
+/// Ingest failures partitioned by failure kind.
+#[metric_set(
+    name = "processor.durable_buffer.ingest",
+    measurement_attributes = IngestFailureAttributes
+)]
+#[derive(Debug, Default, Clone)]
+pub(super) struct DurableBufferIngestMetrics {
+    /// Number of failed ingest attempts.
+    #[metric(unit = "{failure}")]
+    pub(super) failures: Counter<u64>,
+}
+
+#[attribute_set(item, measurement)]
+#[derive(Debug, Clone, Copy)]
+pub(super) struct SignalAttributes {
+    pub(super) signal: SignalType,
+}
+
+/// Item operation metrics partitioned by OpenTelemetry signal.
+#[metric_set(
+    name = "processor.durable_buffer.items",
+    measurement_attributes = SignalAttributes
+)]
+#[derive(Debug, Default, Clone)]
+pub(super) struct DurableBufferItemMetrics {
+    /// Number of items in permanently rejected bundles.
+    #[metric(unit = "{item}")]
+    pub(super) rejected: Counter<u64>,
+    /// Number of items ingested to durable storage.
+    #[metric(unit = "{item}")]
+    pub(super) consumed: Counter<u64>,
+    /// Number of items sent downstream.
+    #[metric(unit = "{item}")]
+    pub(super) produced: Counter<u64>,
+    /// Number of items requeued for retry after a NACK.
+    #[metric(unit = "{item}")]
+    pub(super) requeued: Counter<u64>,
+    /// Current number of items queued in durable storage.
+    #[metric(unit = "{item}")]
+    pub(super) queued: Gauge<u64>,
+}
+
+#[derive(Debug, Clone, Copy, AttributeEnum)]
+pub(super) enum LossReason {
+    DropOldest,
+    Expired,
+}
+
+#[attribute_set(item, measurement)]
+#[derive(Debug, Clone, Copy)]
+pub(super) struct LossAttributes {
+    pub(super) reason: LossReason,
+}
+
+/// Aggregate storage loss metrics partitioned by retention reason.
+#[metric_set(
+    name = "processor.durable_buffer.loss",
+    measurement_attributes = LossAttributes
+)]
+#[derive(Debug, Default, Clone)]
+pub(super) struct DurableBufferLossMetrics {
+    /// Number of segments lost.
+    #[metric(unit = "{segment}")]
+    pub(super) segments: ObserveCounter<u64>,
+    /// Number of bundles lost.
+    #[metric(unit = "{bundle}")]
+    pub(super) bundles: ObserveCounter<u64>,
+    /// Number of items lost.
+    #[metric(unit = "{item}")]
+    pub(super) items: ObserveCounter<u64>,
+}
+
+#[attribute_set(item, measurement)]
+#[derive(Debug, Clone, Copy)]
+pub(super) struct SignalLossAttributes {
+    pub(super) signal: SignalType,
+    pub(super) reason: LossReason,
+}
+
+/// Item loss metrics partitioned by signal and retention reason.
+#[metric_set(
+    name = "processor.durable_buffer.item_loss",
+    measurement_attributes = SignalLossAttributes
+)]
+#[derive(Debug, Default, Clone)]
+pub(super) struct DurableBufferItemLossMetrics {
+    /// Number of items lost.
+    #[metric(unit = "{item}")]
+    pub(super) items: Counter<u64>,
+}
+
+/// Metric sets emitted by a durable buffer processor.
+pub(super) struct DurableBufferMetrics {
+    pub(super) operational_metrics: MetricSet<DurableBufferOperationalMetrics>,
+    pub(super) bundle_metrics: MeasurementMetricSet<DurableBufferBundleMetrics>,
+    pub(super) ingest_metrics: MeasurementMetricSet<DurableBufferIngestMetrics>,
+    pub(super) item_metrics: MeasurementMetricSet<DurableBufferItemMetrics>,
+    pub(super) loss_metrics: MeasurementMetricSet<DurableBufferLossMetrics>,
+    pub(super) item_loss_metrics: MeasurementMetricSet<DurableBufferItemLossMetrics>,
+}
+
+impl DurableBufferMetrics {
+    pub(super) fn new(pipeline_ctx: &PipelineContext) -> Self {
+        Self {
+            operational_metrics: DurableBufferOperationalMetrics::register(pipeline_ctx),
+            bundle_metrics: DurableBufferBundleMetrics::register(pipeline_ctx),
+            ingest_metrics: DurableBufferIngestMetrics::register(pipeline_ctx),
+            item_metrics: DurableBufferItemMetrics::register(pipeline_ctx),
+            loss_metrics: DurableBufferLossMetrics::register(pipeline_ctx),
+            item_loss_metrics: DurableBufferItemLossMetrics::register(pipeline_ctx),
+        }
+    }
+
+    pub(super) fn report(&mut self, reporter: &mut MetricsReporter) -> Result<(), Error> {
+        reporter
+            .report(&mut self.operational_metrics)
+            .and_then(|()| reporter.report_measurement(&mut self.bundle_metrics))
+            .and_then(|()| reporter.report_measurement(&mut self.ingest_metrics))
+            .and_then(|()| reporter.report_measurement(&mut self.item_metrics))
+            .and_then(|()| reporter.report_measurement(&mut self.loss_metrics))
+            .and_then(|()| reporter.report_measurement(&mut self.item_loss_metrics))
+    }
+
+    pub(super) fn bundles_for(
+        &mut self,
+        outcome: BundleOutcome,
+    ) -> &mut DurableBufferBundleMetrics {
+        self.bundle_metrics
+            .with(BundleOutcomeAttributes { outcome })
+    }
+
+    pub(super) fn ingest_for(&mut self, failure: IngestFailure) -> &mut DurableBufferIngestMetrics {
+        self.ingest_metrics
+            .with(IngestFailureAttributes { failure })
+    }
+
+    pub(super) fn items_for_signal(&mut self, signal: SignalType) -> &mut DurableBufferItemMetrics {
+        self.item_metrics.with(SignalAttributes { signal })
+    }
+
+    pub(super) fn loss_for(&mut self, reason: LossReason) -> &mut DurableBufferLossMetrics {
+        self.loss_metrics.with(LossAttributes { reason })
+    }
+
+    pub(super) fn item_loss_for(
+        &mut self,
+        signal: SignalType,
+        reason: LossReason,
+    ) -> &mut DurableBufferItemLossMetrics {
+        self.item_loss_metrics
+            .with(SignalLossAttributes { signal, reason })
+    }
+}

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
@@ -786,6 +786,10 @@ impl DurableBuffer {
             .observe(engine.force_dropped_items());
         self.metrics
             .loss_for(LossReason::Expired)
+            .segments
+            .observe(engine.expired_segments());
+        self.metrics
+            .loss_for(LossReason::Expired)
             .bundles
             .observe(engine.expired_bundles());
         self.metrics
@@ -1766,6 +1770,7 @@ impl otap_df_engine::local::processor::Processor<OtapPdata> for DurableBuffer {
                             engine.force_dropped_segments(),
                             engine.force_dropped_bundles(),
                             engine.force_dropped_items(),
+                            engine.expired_segments(),
                             engine.expired_bundles(),
                             engine.expired_items(),
                             engine.clone(),
@@ -1781,6 +1786,7 @@ impl otap_df_engine::local::processor::Processor<OtapPdata> for DurableBuffer {
                         dropped_segs,
                         dropped_buns,
                         dropped_items,
+                        expired_segs,
                         expired_buns,
                         expired_items,
                         engine,
@@ -1815,6 +1821,10 @@ impl otap_df_engine::local::processor::Processor<OtapPdata> for DurableBuffer {
                             .loss_for(LossReason::DropOldest)
                             .items
                             .observe(dropped_items);
+                        self.metrics
+                            .loss_for(LossReason::Expired)
+                            .segments
+                            .observe(expired_segs);
                         self.metrics
                             .loss_for(LossReason::Expired)
                             .bundles
@@ -2846,6 +2856,8 @@ mod tests {
             .validate(|_| async {});
     }
 
+    /// Scenario: DropOldest and max_age retention each remove log segments.
+    /// Guarantees: Per-signal item loss stays interval-scoped and aggregate expiry loss includes the expired segment count.
     #[tokio::test]
     async fn test_per_signal_dropped_expired_metrics() {
         let (mut processor, engine, subscriber_id, _temp_dir) =
@@ -2902,6 +2914,17 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(20)).await;
         assert_eq!(engine.cleanup_expired_segments().unwrap(), 1);
         assert_eq!(sample(&mut processor), (0, 3));
+        assert_eq!(
+            processor
+                .metrics
+                .loss_metrics
+                .get(LossAttributes {
+                    reason: LossReason::Expired,
+                })
+                .segments
+                .get(),
+            1
+        );
 
         // Interval 3: drop a 4-record segment. Dropped reports only this interval's
         // 4 (not the lifetime 9); expired was reset and reads 0.

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
@@ -65,7 +65,8 @@
 //! **Operational guidance:**
 //!
 //! - Monitor `resolved{outcome="permanently_rejected"}` to detect permanent failures (data loss)
-//! - Monitor `retries_scheduled` metric to detect persistently failing data
+//! - Monitor `retries.scheduled` in the `processor.durable_buffer` metric scope to detect
+//!   persistently failing data
 //! - Use `retention_size_cap` to bound storage; `drop_oldest` policy evicts
 //!   stuck data when space is needed for new data
 //! - `max_in_flight` limit prevents thundering herd after recovery

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
@@ -52,7 +52,8 @@
 //!
 //! - **Permanent NACKs** (e.g., malformed data, schema validation failures): The bundle
 //!   is immediately rejected via `handle.reject()` and will not be retried. Monitor the
-//!   `bundles_nacked_permanent` metric to detect data being dropped due to permanent failures.
+//!   `resolved{outcome="permanently_rejected"}` metric to detect data being dropped due to
+//!   permanent failures.
 //!
 //! - **Transient NACKs** (e.g., network issues, temporary downstream unavailability): Bundles
 //!   are retried with exponential backoff until either delivery succeeds or the data is evicted
@@ -63,7 +64,7 @@
 //!
 //! **Operational guidance:**
 //!
-//! - Monitor `bundles_nacked_permanent` metric to detect permanent failures (data loss)
+//! - Monitor `resolved{outcome="permanently_rejected"}` to detect permanent failures (data loss)
 //! - Monitor `retries_scheduled` metric to detect persistently failing data
 //! - Use `retention_size_cap` to bound storage; `drop_oldest` policy evicts
 //!   stuck data when space is needed for new data
@@ -72,6 +73,7 @@
 mod bundle_adapter;
 mod config;
 mod deferred_retry_state;
+mod metrics;
 
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
@@ -102,6 +104,9 @@ pub use config::{DurableBufferConfig, OtlpHandling, SizeCapPolicy};
 use deferred_retry_state::DeferredRetryState;
 #[cfg(test)]
 use deferred_retry_state::RETRY_WAKEUP_SLOT;
+use metrics::{BundleOutcome, DurableBufferMetrics, IngestFailure, LossReason};
+#[cfg(test)]
+use metrics::{LossAttributes, SignalAttributes, SignalLossAttributes};
 
 use otap_df_config::SignalType;
 use otap_df_config::error::Error as ConfigError;
@@ -122,9 +127,6 @@ use otap_df_engine::{
     ProcessorRuntimeRequirements, ProducerEffectHandlerExtension,
 };
 use otap_df_pdata::{OtapArrowRecords, OtapPayload};
-use otap_df_telemetry::instrument::{Counter, Gauge, ObserveCounter};
-use otap_df_telemetry::metrics::MetricSet;
-use otap_df_telemetry_macros::metric_set;
 
 /// URN for the durable buffer.
 pub const DURABLE_BUFFER_URN: &str = "urn:otel:processor:durable_buffer";
@@ -136,205 +138,6 @@ const WARN_RATE_LIMIT: Duration = Duration::from_secs(10);
 
 /// Subscriber ID used by this processor.
 const SUBSCRIBER_ID: &str = "durable-buffer";
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Metrics
-// ─────────────────────────────────────────────────────────────────────────────
-
-/// Metrics for the durable buffer processor.
-///
-/// Follows RFC-aligned telemetry conventions:
-/// - Metric set name follows `otap.<role>.<component>` pattern
-/// - Channel metrics already track bundle send/receive counts
-/// - This tracks ACK/NACK status, item counts, storage, and retries
-///
-/// Please update the documentation at Telemetry.md when adding new
-/// metrics.
-#[metric_set(name = "otap.processor.durable_buffer")]
-#[derive(Debug, Default, Clone)]
-pub struct DurableBufferMetrics {
-    // ─── ACK/NACK tracking ──────────────────────────────────────────────────
-    // Note: Bundle send/receive counts are tracked by channel metrics.
-    // These metrics track downstream acknowledgement status.
-    /// Number of bundles acknowledged by downstream.
-    #[metric(unit = "{bundle}")]
-    pub bundles_acked: Counter<u64>,
-
-    /// Number of bundles deferred for retry after transient downstream failures.
-    #[metric(unit = "{bundle}")]
-    pub bundles_nacked_deferred: Counter<u64>,
-
-    /// Number of bundles permanently rejected by downstream (not retried).
-    /// These indicate data loss due to permanent failures (e.g., malformed data).
-    #[metric(unit = "{bundle}")]
-    pub bundles_nacked_permanent: Counter<u64>,
-
-    // ─── Rejected item metrics (per signal type) ────────────────────────
-    /// Number of log records rejected.
-    #[metric(unit = "{log_record}")]
-    pub rejected_log_records: Counter<u64>,
-
-    /// Number of metric data points rejected.
-    #[metric(unit = "{data_point}")]
-    pub rejected_metric_points: Counter<u64>,
-
-    /// Number of spans rejected.
-    #[metric(unit = "{span}")]
-    pub rejected_spans: Counter<u64>,
-
-    // ─── Consumed item metrics (per signal type) ────────────────────────
-    /// Number of log records consumed (ingested to durable storage).
-    /// For OTLP bytes, counted by scanning the protobuf wire format without full deserialization.
-    #[metric(unit = "{log_record}")]
-    pub consumed_log_records: Counter<u64>,
-
-    /// Number of metric data points consumed (ingested to durable storage).
-    /// For OTLP bytes, counted by scanning the protobuf wire format without full deserialization.
-    #[metric(unit = "{data_point}")]
-    pub consumed_metric_points: Counter<u64>,
-
-    /// Number of spans consumed (ingested to durable storage).
-    /// For OTLP bytes, counted by scanning the protobuf wire format without full deserialization.
-    #[metric(unit = "{span}")]
-    pub consumed_spans: Counter<u64>,
-
-    // ─── Produced item metrics (per signal type) ────────────────────────
-    /// Number of log records produced (sent downstream).
-    /// For OTLP bytes, counted by scanning the protobuf wire format without full deserialization.
-    #[metric(unit = "{log_record}")]
-    pub produced_log_records: Counter<u64>,
-
-    /// Number of metric data points produced (sent downstream).
-    /// For OTLP bytes, counted by scanning the protobuf wire format without full deserialization.
-    #[metric(unit = "{data_point}")]
-    pub produced_metric_points: Counter<u64>,
-
-    /// Number of spans produced (sent downstream).
-    /// For OTLP bytes, counted by scanning the protobuf wire format without full deserialization.
-    #[metric(unit = "{span}")]
-    pub produced_spans: Counter<u64>,
-
-    // ─── Error and backpressure metrics ─────────────────────────────────────
-    /// Number of ingest errors (excludes backpressure/capacity rejections).
-    #[metric(unit = "{error}")]
-    pub ingest_errors: Counter<u64>,
-
-    /// Number of ingest rejections due to storage backpressure (soft cap exceeded).
-    #[metric(unit = "{rejection}")]
-    pub ingest_backpressure: Counter<u64>,
-
-    /// Number of read errors.
-    #[metric(unit = "{error}")]
-    pub read_errors: Counter<u64>,
-
-    // ─── Storage metrics (updated on telemetry collection) ──────────────────
-    /// Current bytes used by persistent storage (WAL + segments).
-    #[metric(unit = "By")]
-    pub storage_bytes_used: Gauge<u64>,
-
-    /// Configured storage capacity cap.
-    #[metric(unit = "By")]
-    pub storage_bytes_cap: Gauge<u64>,
-
-    /// Total segments force-dropped due to DropOldest retention policy.
-    /// Non-zero values indicate data loss.
-    #[metric(unit = "{segment}")]
-    pub dropped_segments: ObserveCounter<u64>,
-
-    /// Total bundles lost due to force-dropped segments (DropOldest policy).
-    /// Non-zero values indicate data loss.
-    #[metric(unit = "{bundle}")]
-    pub dropped_bundles: ObserveCounter<u64>,
-
-    /// Total individual items (log records, data points, spans) lost due to
-    /// force-dropped segments (DropOldest policy). Non-zero values indicate data loss.
-    #[metric(unit = "{item}")]
-    pub dropped_items: ObserveCounter<u64>,
-
-    /// Total bundles lost due to expired segments (max_age retention).
-    /// Non-zero values indicate data aged out before delivery.
-    #[metric(unit = "{bundle}")]
-    pub expired_bundles: ObserveCounter<u64>,
-
-    /// Total individual items (log records, data points, spans) lost due to
-    /// expired segments (max_age retention). Non-zero values indicate data
-    /// aged out before delivery.
-    #[metric(unit = "{item}")]
-    pub expired_items: ObserveCounter<u64>,
-
-    // ─── Retry metrics ──────────────────────────────────────────────────────
-    /// Number of retry attempts scheduled.
-    #[metric(unit = "{retry}")]
-    pub retries_scheduled: Counter<u64>,
-
-    /// Current number of bundles in-flight to downstream.
-    #[metric(unit = "{bundle}")]
-    pub in_flight: Gauge<u64>,
-
-    // ─── Requeued item metrics (per signal type) ────────────────────────────
-    // These count individual items in NACKed bundles when scheduled for retry.
-    /// Number of individual log records requeued for retry after NACK.
-    #[metric(unit = "{log_record}")]
-    pub requeued_log_records: Counter<u64>,
-
-    /// Number of individual metric data points requeued for retry after NACK.
-    #[metric(unit = "{data_point}")]
-    pub requeued_metric_points: Counter<u64>,
-
-    /// Number of individual spans requeued for retry after NACK.
-    #[metric(unit = "{span}")]
-    pub requeued_spans: Counter<u64>,
-
-    // ─── Queued item metrics (per signal type) ──────────────────────────────
-    /// Current number of log records queued (ingested but not yet ACKed).
-    #[metric(unit = "{log_record}")]
-    pub queued_log_records: Gauge<u64>,
-
-    /// Current number of metric data points queued (ingested but not yet ACKed).
-    #[metric(unit = "{data_point}")]
-    pub queued_metric_points: Gauge<u64>,
-
-    /// Current number of spans queued (ingested but not yet ACKed).
-    #[metric(unit = "{span}")]
-    pub queued_spans: Gauge<u64>,
-
-    // ─── Flush metrics ──────────────────────────────────────────────────────
-    /// Number of segment finalization (flush) failures.
-    /// Non-zero values indicate data at risk -- check logs for root cause.
-    /// Data may still be recoverable via WAL replay on restart.
-    #[metric(unit = "{error}")]
-    pub flush_failures: Counter<u64>,
-
-    // ─── Utilization metrics ────────────────────────────────────────────────
-    /// Current storage utilization ratio (0.0 to 1.0).
-    #[metric(unit = "{1}")]
-    pub storage_utilization: Gauge<f64>,
-
-    // ─── Data-loss metrics (per signal type) ────────────────────────────────
-    /// Log records lost due to force-dropped segments (DropOldest policy).
-    #[metric(unit = "{log_record}")]
-    pub dropped_log_records: Counter<u64>,
-
-    /// Spans lost due to force-dropped segments (DropOldest policy).
-    #[metric(unit = "{span}")]
-    pub dropped_spans: Counter<u64>,
-
-    /// Metric data points lost due to force-dropped segments (DropOldest policy).
-    #[metric(unit = "{data_point}")]
-    pub dropped_metric_datapoints: Counter<u64>,
-
-    /// Log records lost due to expired segments (max_age retention).
-    #[metric(unit = "{log_record}")]
-    pub expired_log_records: Counter<u64>,
-
-    /// Spans lost due to expired segments (max_age retention).
-    #[metric(unit = "{span}")]
-    pub expired_spans: Counter<u64>,
-
-    /// Metric data points lost due to expired segments (max_age retention).
-    #[metric(unit = "{data_point}")]
-    pub expired_metric_datapoints: Counter<u64>,
-}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // BundleRef CallData Encoding
@@ -479,7 +282,7 @@ pub struct DurableBuffer {
     num_cores: usize,
 
     /// Metrics.
-    metrics: MetricSet<DurableBufferMetrics>,
+    metrics: DurableBufferMetrics,
 
     /// Whether timer has been started.
     timer_started: bool,
@@ -519,7 +322,7 @@ impl DurableBuffer {
         config: DurableBufferConfig,
         pipeline_ctx: &PipelineContext,
     ) -> Result<Self, ConfigError> {
-        let metrics = pipeline_ctx.register_metrics::<DurableBufferMetrics>();
+        let metrics = DurableBufferMetrics::new(pipeline_ctx);
         let core_id = pipeline_ctx.core_id();
         let num_cores = pipeline_ctx.num_cores();
 
@@ -970,39 +773,44 @@ impl DurableBuffer {
         // either engine-side drain methods or a dispatcher-level fix rather than
         // reintroducing per-metric last-value bookkeeping here.
         self.metrics
-            .dropped_segments
+            .loss_for(LossReason::DropOldest)
+            .segments
             .observe(engine.force_dropped_segments());
         self.metrics
-            .dropped_bundles
+            .loss_for(LossReason::DropOldest)
+            .bundles
             .observe(engine.force_dropped_bundles());
         self.metrics
-            .dropped_items
+            .loss_for(LossReason::DropOldest)
+            .items
             .observe(engine.force_dropped_items());
         self.metrics
-            .expired_bundles
+            .loss_for(LossReason::Expired)
+            .bundles
             .observe(engine.expired_bundles());
-        self.metrics.expired_items.observe(engine.expired_items());
+        self.metrics
+            .loss_for(LossReason::Expired)
+            .items
+            .observe(engine.expired_items());
 
         // Update dropped and expired metrics by draining the engine's pending bundles
         // and aggregating by signal type via signal_type_from_slot_id(). This handles all
         // slot ranges (Arrow 10-45 and OTLP 60-62) without hardcoding any slot IDs here.
         for (slot_ids, count) in engine.drain_dropped_bundles_pending() {
-            let sig = slot_ids.iter().copied().find_map(signal_type_from_slot_id);
-            match sig {
-                Some(SignalType::Logs) => self.metrics.dropped_log_records.add(count),
-                Some(SignalType::Metrics) => self.metrics.dropped_metric_datapoints.add(count),
-                Some(SignalType::Traces) => self.metrics.dropped_spans.add(count),
-                None => {}
+            if let Some(signal) = slot_ids.iter().copied().find_map(signal_type_from_slot_id) {
+                self.metrics
+                    .item_loss_for(signal, LossReason::DropOldest)
+                    .items
+                    .add(count);
             }
         }
 
         for (slot_ids, count) in engine.drain_expired_bundles_pending() {
-            let sig = slot_ids.iter().copied().find_map(signal_type_from_slot_id);
-            match sig {
-                Some(SignalType::Logs) => self.metrics.expired_log_records.add(count),
-                Some(SignalType::Metrics) => self.metrics.expired_metric_datapoints.add(count),
-                Some(SignalType::Traces) => self.metrics.expired_spans.add(count),
-                None => {}
+            if let Some(signal) = slot_ids.iter().copied().find_map(signal_type_from_slot_id) {
+                self.metrics
+                    .item_loss_for(signal, LossReason::Expired)
+                    .items
+                    .add(count);
             }
         }
 
@@ -1010,9 +818,18 @@ impl DurableBuffer {
             .retain(|seq| progress_snapshot.contains_key(&SegmentSeq::new(*seq)));
         self.enforce_segment_cache_bound();
 
-        self.metrics.queued_log_records.set(logs);
-        self.metrics.queued_metric_points.set(metrics);
-        self.metrics.queued_spans.set(spans);
+        self.metrics
+            .items_for_signal(SignalType::Logs)
+            .queued
+            .set(logs);
+        self.metrics
+            .items_for_signal(SignalType::Metrics)
+            .queued
+            .set(metrics);
+        self.metrics
+            .items_for_signal(SignalType::Traces)
+            .queued
+            .set(spans);
     }
 
     /// Initialize the Quiver engine and subscriber.
@@ -1137,7 +954,10 @@ impl DurableBuffer {
         let engine = match self.engine() {
             Ok((engine, _)) => engine,
             Err(e) => {
-                self.metrics.ingest_errors.add(1);
+                self.metrics
+                    .ingest_for(IngestFailure::Error)
+                    .failures
+                    .add(1);
                 otel_error!("durable_buffer.engine.unavailable", error = %e);
                 let nack_pdata = OtapPdata::new(context, payload);
                 effect_handler
@@ -1174,7 +994,10 @@ impl DurableBuffer {
                             }
                             Err((e, original_bytes)) => {
                                 // Adapter creation failed - NACK with original bytes
-                                self.metrics.ingest_errors.add(1);
+                                self.metrics
+                                    .ingest_for(IngestFailure::Error)
+                                    .failures
+                                    .add(1);
                                 otel_error!("durable_buffer.otlp.adapter_failed", error = %e);
 
                                 let nack_pdata =
@@ -1212,7 +1035,10 @@ impl DurableBuffer {
                             }
                             Err(e) => {
                                 // Conversion failed - NACK with original bytes so upstream can retry
-                                self.metrics.ingest_errors.add(1);
+                                self.metrics
+                                    .ingest_for(IngestFailure::Error)
+                                    .failures
+                                    .add(1);
                                 otel_error!("durable_buffer.otlp.conversion_failed", error = %e);
 
                                 let nack_pdata =
@@ -1244,12 +1070,10 @@ impl DurableBuffer {
         // Handle ingest result
         match ingest_result {
             Ok(()) => {
-                // Track consumed items by signal type
-                match signal_type {
-                    SignalType::Logs => self.metrics.consumed_log_records.add(item_count),
-                    SignalType::Metrics => self.metrics.consumed_metric_points.add(item_count),
-                    SignalType::Traces => self.metrics.consumed_spans.add(item_count),
-                }
+                self.metrics
+                    .items_for_signal(signal_type)
+                    .consumed
+                    .add(item_count);
 
                 // ACK upstream after successful durable write.
                 // Data will be forwarded downstream via timer tick after segment finalization.
@@ -1261,7 +1085,10 @@ impl DurableBuffer {
                 if e.is_at_capacity() {
                     // Normal backpressure: soft cap exceeded. Count separately
                     // and rate-limit logging to avoid flooding.
-                    self.metrics.ingest_backpressure.add(1);
+                    self.metrics
+                        .ingest_for(IngestFailure::Backpressure)
+                        .failures
+                        .add(1);
                     let now = Instant::now();
                     let should_log = self
                         .last_backpressure_warn
@@ -1271,7 +1098,10 @@ impl DurableBuffer {
                         otel_warn!("durable_buffer.ingest.backpressure", error = %e);
                     }
                 } else {
-                    self.metrics.ingest_errors.add(1);
+                    self.metrics
+                        .ingest_for(IngestFailure::Error)
+                        .failures
+                        .add(1);
                     otel_error!("durable_buffer.ingest.failed", error = %e);
                 }
 
@@ -1308,7 +1138,7 @@ impl DurableBuffer {
         {
             let (engine, _) = self.engine()?;
             if let Err(e) = engine.flush().await {
-                self.metrics.flush_failures.add(1);
+                self.metrics.operational_metrics.flush_failures.add(1);
                 // Rate-limit flush warnings since the timer tick fires every
                 // poll_interval (~100ms).
                 let now = Instant::now();
@@ -1410,7 +1240,7 @@ impl DurableBuffer {
                     break;
                 }
                 Err(e) => {
-                    self.metrics.read_errors.add(1);
+                    self.metrics.operational_metrics.read_errors.add(1);
                     otel_error!("durable_buffer.poll.failed", error = %e);
                     break;
                 }
@@ -1504,14 +1334,10 @@ impl DurableBuffer {
                 // Try non-blocking send downstream
                 match effect_handler.try_send_message(pdata) {
                     Ok(()) => {
-                        // Track produced items by signal type
-                        match signal_type {
-                            SignalType::Logs => self.metrics.produced_log_records.add(item_count),
-                            SignalType::Metrics => {
-                                self.metrics.produced_metric_points.add(item_count)
-                            }
-                            SignalType::Traces => self.metrics.produced_spans.add(item_count),
-                        }
+                        self.metrics
+                            .items_for_signal(signal_type)
+                            .produced
+                            .add(item_count);
 
                         otel_debug!(
                             "durable_buffer.bundle.forwarded",
@@ -1532,6 +1358,7 @@ impl DurableBuffer {
                             },
                         );
                         self.metrics
+                            .operational_metrics
                             .in_flight
                             .set(self.pending_bundles.len() as u64);
                         ProcessBundleResult::Sent
@@ -1569,7 +1396,7 @@ impl DurableBuffer {
                 }
             }
             Err(e) => {
-                self.metrics.read_errors.add(1);
+                self.metrics.operational_metrics.read_errors.add(1);
                 otel_error!("durable_buffer.bundle.conversion_failed", error = %e);
                 // Reject the bundle since we can't process it
                 handle.reject();
@@ -1596,8 +1423,12 @@ impl DurableBuffer {
         // Remove from pending and acknowledge in Quiver using the stored handle
         if let Some(pending) = self.pending_bundles.remove(&key) {
             pending.handle.ack();
-            self.metrics.bundles_acked.add(1);
             self.metrics
+                .bundles_for(BundleOutcome::Acked)
+                .resolved
+                .add(1);
+            self.metrics
+                .operational_metrics
                 .in_flight
                 .set(self.pending_bundles.len() as u64);
             otel_debug!(
@@ -1639,20 +1470,20 @@ impl DurableBuffer {
         // Handle based on whether this is a permanent or transient failure
         if let Some(pending) = self.pending_bundles.remove(&key) {
             self.metrics
+                .operational_metrics
                 .in_flight
                 .set(self.pending_bundles.len() as u64);
 
             // Permanent failures should not be retried - reject the bundle immediately
             if nack.permanent {
-                // Track permanently rejected items by signal type (individual items in NACKed bundles)
-                match pending.signal_type {
-                    SignalType::Logs => self.metrics.rejected_log_records.add(pending.item_count),
-                    SignalType::Metrics => {
-                        self.metrics.rejected_metric_points.add(pending.item_count)
-                    }
-                    SignalType::Traces => self.metrics.rejected_spans.add(pending.item_count),
-                }
-                self.metrics.bundles_nacked_permanent.add(1);
+                self.metrics
+                    .items_for_signal(pending.signal_type)
+                    .rejected
+                    .add(pending.item_count);
+                self.metrics
+                    .bundles_for(BundleOutcome::PermanentlyRejected)
+                    .resolved
+                    .add(1);
 
                 otel_warn!(
                     "durable_buffer.bundle.rejected_permanent",
@@ -1669,13 +1500,14 @@ impl DurableBuffer {
             // Transient failure - schedule retry with exponential backoff
             let retry_count = pending.retry_count + 1;
 
-            // Track requeued items by signal type (individual items in NACKed bundles)
-            match pending.signal_type {
-                SignalType::Logs => self.metrics.requeued_log_records.add(pending.item_count),
-                SignalType::Metrics => self.metrics.requeued_metric_points.add(pending.item_count),
-                SignalType::Traces => self.metrics.requeued_spans.add(pending.item_count),
-            }
-            self.metrics.bundles_nacked_deferred.add(1);
+            self.metrics
+                .items_for_signal(pending.signal_type)
+                .requeued
+                .add(pending.item_count);
+            self.metrics
+                .bundles_for(BundleOutcome::Deferred)
+                .resolved
+                .add(1);
 
             // Calculate backoff delay with jitter
             let backoff = self.calculate_backoff(retry_count);
@@ -1702,7 +1534,7 @@ impl DurableBuffer {
                 backoff,
                 effect_handler,
             ) {
-                self.metrics.retries_scheduled.add(1);
+                self.metrics.operational_metrics.retries_scheduled.add(1);
             } else {
                 otel_warn!(
                     "durable_buffer.retry.schedule_failed",
@@ -1809,7 +1641,7 @@ impl DurableBuffer {
             {
                 let (engine, _) = self.engine()?;
                 if let Err(e) = engine.flush().await {
-                    self.metrics.flush_failures.add(1);
+                    self.metrics.operational_metrics.flush_failures.add(1);
                     otel_error!("durable_buffer.shutdown.flush_failed", error = %e);
                 }
             }
@@ -1955,21 +1787,42 @@ impl otap_df_engine::local::processor::Processor<OtapPdata> for DurableBuffer {
                         subscriber_id,
                     )) = quiver_metrics
                     {
-                        self.metrics.storage_bytes_used.set(used);
-                        self.metrics.storage_bytes_cap.set(cap);
+                        self.metrics
+                            .operational_metrics
+                            .storage_bytes_used
+                            .set(used);
+                        self.metrics.operational_metrics.storage_bytes_cap.set(cap);
 
                         let utilization = if cap > 0 {
                             (used.min(cap) as f64) / (cap as f64)
                         } else {
                             0.0
                         };
-                        self.metrics.storage_utilization.set(utilization);
+                        self.metrics
+                            .operational_metrics
+                            .storage_utilization
+                            .set(utilization);
 
-                        self.metrics.dropped_segments.observe(dropped_segs);
-                        self.metrics.dropped_bundles.observe(dropped_buns);
-                        self.metrics.dropped_items.observe(dropped_items);
-                        self.metrics.expired_bundles.observe(expired_buns);
-                        self.metrics.expired_items.observe(expired_items);
+                        self.metrics
+                            .loss_for(LossReason::DropOldest)
+                            .segments
+                            .observe(dropped_segs);
+                        self.metrics
+                            .loss_for(LossReason::DropOldest)
+                            .bundles
+                            .observe(dropped_buns);
+                        self.metrics
+                            .loss_for(LossReason::DropOldest)
+                            .items
+                            .observe(dropped_items);
+                        self.metrics
+                            .loss_for(LossReason::Expired)
+                            .bundles
+                            .observe(expired_buns);
+                        self.metrics
+                            .loss_for(LossReason::Expired)
+                            .items
+                            .observe(expired_items);
 
                         // Recompute queued item gauges from the subscriber
                         // registry. This is the single source of truth for
@@ -1978,8 +1831,8 @@ impl otap_df_engine::local::processor::Processor<OtapPdata> for DurableBuffer {
                         self.recompute_metrics(&engine, &subscriber_id);
                     }
 
-                    metrics_reporter
-                        .report(&mut self.metrics)
+                    self.metrics
+                        .report(&mut metrics_reporter)
                         .map_err(|e| Error::InternalError {
                             message: e.to_string(),
                         })
@@ -2052,6 +1905,7 @@ mod tests {
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow::record_batch::RecordBatch;
     use otap_df_engine::context::ControllerContext;
+    use otap_df_telemetry::attributes::AttributeEnum;
     use otap_df_telemetry::registry::TelemetryRegistryHandle;
     use otap_df_telemetry::reporter::MetricsReporter;
     use quiver::record_bundle::{
@@ -2150,17 +2004,6 @@ mod tests {
             item_count,
         }
     }
-
-    // Metric field indices matching `DurableBufferMetrics` declaration order.
-    // New metrics MUST be appended to the struct so these never shift.
-    const IDX_BUNDLES_ACKED: usize = 0;
-    const IDX_BUNDLES_NACKED_DEFERRED: usize = 1;
-    const IDX_BUNDLES_NACKED_PERMANENT: usize = 2;
-    const IDX_RETRIES_SCHEDULED: usize = 22;
-    const IDX_QUEUED_LOG_RECORDS: usize = 27;
-    const IDX_QUEUED_METRIC_POINTS: usize = 28;
-    const IDX_QUEUED_SPANS: usize = 29;
-    const EXPECTED_METRIC_COUNT: usize = 38;
 
     #[test]
     fn test_bundle_ref_encoding_roundtrip() {
@@ -2620,14 +2463,7 @@ mod tests {
         assert!(backoff100 <= Duration::from_millis(30000));
     }
 
-    /// Test that DurableBufferMetrics snapshot correctly reports NACK metrics.
-    ///
-    /// Verifies:
-    /// - bundles_nacked_deferred (index 1) and bundles_nacked_permanent (index 2)
-    ///   are distinct counters reported at the correct positions
-    /// - retries_scheduled (index 22) is correctly reported
-    /// - bundles_acked (index 0) is correctly reported
-    /// - Snapshot clears values (delta semantics)
+    /// Bundle resolution outcomes are exported as separate items.
     #[test]
     fn test_nack_metrics_snapshot_field_positions() {
         use otap_df_engine::context::ControllerContext;
@@ -2655,85 +2491,32 @@ mod tests {
 
         let mut processor = DurableBuffer::new(config, &pipeline_ctx).unwrap();
 
-        // Simulate the metric increments that handle_nack would perform
-        // for permanent NACKs:
-        processor.metrics.bundles_nacked_permanent.add(3);
+        processor
+            .metrics
+            .bundles_for(BundleOutcome::PermanentlyRejected)
+            .resolved
+            .add(3);
+        processor
+            .metrics
+            .bundles_for(BundleOutcome::Deferred)
+            .resolved
+            .add(5);
+        processor
+            .metrics
+            .bundles_for(BundleOutcome::Acked)
+            .resolved
+            .add(10);
 
-        // for transient NACKs:
-        processor.metrics.bundles_nacked_deferred.add(5);
+        let (metrics_rx, mut reporter) = MetricsReporter::create_new_and_receiver(3);
+        reporter
+            .report_measurement(&mut processor.metrics.bundle_metrics)
+            .unwrap();
 
-        // for retries scheduled (only on transient):
-        processor.metrics.retries_scheduled.add(5);
-
-        // for ACKs:
-        processor.metrics.bundles_acked.add(10);
-
-        // Take a snapshot and verify field positions
-        let (metrics_rx, mut reporter) = MetricsReporter::create_new_and_receiver(1);
-        reporter.report(&mut processor.metrics).unwrap();
-        let snapshot = metrics_rx.try_recv().unwrap();
-        let values = snapshot.get_metrics();
-
-        // Verify total metric count matches DurableBufferMetrics field count
-        assert_eq!(
-            values.len(),
-            EXPECTED_METRIC_COUNT,
-            "DurableBufferMetrics should have {EXPECTED_METRIC_COUNT} fields, got {}",
-            values.len()
-        );
-
-        assert_eq!(
-            values[IDX_BUNDLES_ACKED].to_u64_lossy(),
-            10,
-            "bundles_acked should be 10"
-        );
-
-        assert_eq!(
-            values[IDX_BUNDLES_NACKED_DEFERRED].to_u64_lossy(),
-            5,
-            "bundles_nacked_deferred should be 5"
-        );
-
-        assert_eq!(
-            values[IDX_BUNDLES_NACKED_PERMANENT].to_u64_lossy(),
-            3,
-            "bundles_nacked_permanent should be 3"
-        );
-
-        assert_eq!(
-            values[IDX_RETRIES_SCHEDULED].to_u64_lossy(),
-            5,
-            "retries_scheduled should be 5"
-        );
-
-        // Verify delta semantics: after snapshot, counters should be cleared.
-        // The NACK-related counter values we set above should now be zero.
-        // (Gauges may still report due to Gauge::clear semantics, so we verify
-        // counters specifically by taking another snapshot.)
-        reporter.report(&mut processor.metrics).unwrap_or(());
-        if let Ok(snap2) = metrics_rx.try_recv() {
-            let vals2 = snap2.get_metrics();
-            assert_eq!(
-                vals2[IDX_BUNDLES_ACKED].to_u64_lossy(),
-                0,
-                "bundles_acked should be 0 after reset"
-            );
-            assert_eq!(
-                vals2[IDX_BUNDLES_NACKED_DEFERRED].to_u64_lossy(),
-                0,
-                "bundles_nacked_deferred should be 0 after reset"
-            );
-            assert_eq!(
-                vals2[IDX_BUNDLES_NACKED_PERMANENT].to_u64_lossy(),
-                0,
-                "bundles_nacked_permanent should be 0 after reset"
-            );
-            assert_eq!(
-                vals2[IDX_RETRIES_SCHEDULED].to_u64_lossy(),
-                0,
-                "retries_scheduled should be 0 after reset"
-            );
+        let mut outcomes = [0u64; BundleOutcome::CARDINALITY];
+        while let Ok(snapshot) = metrics_rx.try_recv() {
+            outcomes[snapshot.bucket()] = snapshot.get_metrics()[0].to_u64_lossy();
         }
+        assert_eq!(outcomes, [10, 5, 3]);
     }
 
     /// Test that permanent NACKs decrement the `queued_*` gauges.
@@ -2746,7 +2529,6 @@ mod tests {
     fn test_permanent_nack_decrements_queued_gauge() {
         use otap_df_engine::context::ControllerContext;
         use otap_df_telemetry::registry::TelemetryRegistryHandle;
-        use otap_df_telemetry::reporter::MetricsReporter;
 
         let registry = TelemetryRegistryHandle::default();
         let controller_ctx = ControllerContext::new(registry);
@@ -2768,34 +2550,52 @@ mod tests {
         };
 
         let mut processor = DurableBuffer::new(config, &pipeline_ctx).unwrap();
-        let (metrics_rx, mut reporter) = MetricsReporter::create_new_and_receiver(10);
+        let logs = SignalAttributes {
+            signal: SignalType::Logs,
+        };
+        let metrics = SignalAttributes {
+            signal: SignalType::Metrics,
+        };
+        let traces = SignalAttributes {
+            signal: SignalType::Traces,
+        };
 
         // Simulate: 100 log records queued (as if 100 items were ingested).
         let mut queued_log_records = 100u64;
-        processor.metrics.queued_log_records.set(queued_log_records);
+        processor
+            .metrics
+            .item_metrics
+            .with(logs)
+            .queued
+            .set(queued_log_records);
 
         // Simulate: permanent NACK path decrements by 30 items
         // (mirrors the code in handle_nack when nack.permanent is true)
         queued_log_records = queued_log_records.saturating_sub(30);
-        processor.metrics.queued_log_records.set(queued_log_records);
+        processor
+            .metrics
+            .item_metrics
+            .with(logs)
+            .queued
+            .set(queued_log_records);
 
-        // Snapshot should show queued_log_records = 70
-        reporter.report(&mut processor.metrics).unwrap();
-        let snap = metrics_rx.try_recv().unwrap();
         assert_eq!(
-            snap.get_metrics()[IDX_QUEUED_LOG_RECORDS].to_u64_lossy(),
+            processor.metrics.item_metrics.get(logs).queued.get(),
             70,
             "queued_log_records should be 70 after decrementing 30 from 100"
         );
 
         // Simulate: ACK the remaining 70
         queued_log_records = queued_log_records.saturating_sub(70);
-        processor.metrics.queued_log_records.set(queued_log_records);
+        processor
+            .metrics
+            .item_metrics
+            .with(logs)
+            .queued
+            .set(queued_log_records);
 
-        reporter.report(&mut processor.metrics).unwrap();
-        let snap2 = metrics_rx.try_recv().unwrap();
         assert_eq!(
-            snap2.get_metrics()[IDX_QUEUED_LOG_RECORDS].to_u64_lossy(),
+            processor.metrics.item_metrics.get(logs).queued.get(),
             0,
             "queued_log_records should be 0 after all items resolved"
         );
@@ -2804,28 +2604,40 @@ mod tests {
         let mut queued_metric_points = 50u64;
         processor
             .metrics
-            .queued_metric_points
+            .item_metrics
+            .with(metrics)
+            .queued
             .set(queued_metric_points);
         queued_metric_points = queued_metric_points.saturating_sub(50);
         processor
             .metrics
-            .queued_metric_points
+            .item_metrics
+            .with(metrics)
+            .queued
             .set(queued_metric_points);
 
         let mut queued_spans = 25u64;
-        processor.metrics.queued_spans.set(queued_spans);
+        processor
+            .metrics
+            .item_metrics
+            .with(traces)
+            .queued
+            .set(queued_spans);
         queued_spans = queued_spans.saturating_sub(25);
-        processor.metrics.queued_spans.set(queued_spans);
+        processor
+            .metrics
+            .item_metrics
+            .with(traces)
+            .queued
+            .set(queued_spans);
 
-        reporter.report(&mut processor.metrics).unwrap();
-        let snap3 = metrics_rx.try_recv().unwrap();
         assert_eq!(
-            snap3.get_metrics()[IDX_QUEUED_METRIC_POINTS].to_u64_lossy(),
+            processor.metrics.item_metrics.get(metrics).queued.get(),
             0,
             "queued_metric_points should be 0"
         );
         assert_eq!(
-            snap3.get_metrics()[IDX_QUEUED_SPANS].to_u64_lossy(),
+            processor.metrics.item_metrics.get(traces).queued.get(),
             0,
             "queued_spans should be 0"
         );
@@ -2858,12 +2670,15 @@ mod tests {
 
         processor.recompute_metrics(&engine, &subscriber_id);
 
-        let (metrics_rx, mut reporter) = MetricsReporter::create_new_and_receiver(1);
-        reporter.report(&mut processor.metrics).unwrap();
-        let snap = metrics_rx.try_recv().unwrap();
-
         assert_eq!(
-            snap.get_metrics()[IDX_QUEUED_LOG_RECORDS].to_u64_lossy(),
+            processor
+                .metrics
+                .item_metrics
+                .get(SignalAttributes {
+                    signal: SignalType::Logs,
+                })
+                .queued
+                .get(),
             5,
             "queued_log_records gauge should include open-segment items"
         );
@@ -3012,9 +2827,9 @@ mod tests {
                 let snap = metrics_rx.try_recv().unwrap();
                 let metrics = snap.get_metrics();
 
-                const IDX_STORAGE_UTILIZATION: usize = 31;
-                const IDX_STORAGE_BYTES_USED: usize = 15;
-                const IDX_STORAGE_BYTES_CAP: usize = 16;
+                const IDX_STORAGE_UTILIZATION: usize = 6;
+                const IDX_STORAGE_BYTES_USED: usize = 1;
+                const IDX_STORAGE_BYTES_CAP: usize = 2;
 
                 let used = metrics[IDX_STORAGE_BYTES_USED].to_u64_lossy();
                 let cap = metrics[IDX_STORAGE_BYTES_CAP].to_u64_lossy();
@@ -3036,25 +2851,35 @@ mod tests {
         let (mut processor, engine, subscriber_id, _temp_dir) =
             setup_test_processor(Some(Duration::from_millis(5))).await;
 
-        // Data-loss Counters. As delta-native synchronous counters they are reset
-        // by the reporter after every flush, so each report carries only the loss
-        // observed in that interval.
-        const DROPPED_LOG_RECORDS: usize = 32;
-        const EXPIRED_LOG_RECORDS: usize = 35;
-
         let slot_id = SlotId::new(30);
-        let (metrics_rx, mut reporter) = MetricsReporter::create_new_and_receiver(1);
+        let (metrics_rx, mut reporter) = MetricsReporter::create_new_and_receiver(6);
 
         // Report a fresh interval; returns (dropped_log_records, expired_log_records).
         let mut sample = |p: &mut DurableBuffer| {
             p.recompute_metrics(&engine, &subscriber_id);
-            reporter.report(&mut p.metrics).unwrap();
-            let snap = metrics_rx.try_recv().unwrap();
-            let m = snap.get_metrics();
-            (
-                m[DROPPED_LOG_RECORDS].to_u64_lossy(),
-                m[EXPIRED_LOG_RECORDS].to_u64_lossy(),
-            )
+            let sample = (
+                p.metrics
+                    .item_loss_metrics
+                    .get(SignalLossAttributes {
+                        signal: SignalType::Logs,
+                        reason: LossReason::DropOldest,
+                    })
+                    .items
+                    .get(),
+                p.metrics
+                    .item_loss_metrics
+                    .get(SignalLossAttributes {
+                        signal: SignalType::Logs,
+                        reason: LossReason::Expired,
+                    })
+                    .items
+                    .get(),
+            );
+            reporter
+                .report_measurement(&mut p.metrics.item_loss_metrics)
+                .unwrap();
+            while metrics_rx.try_recv().is_ok() {}
+            sample
         };
 
         // Interval 1: drop a 5-record segment -> dropped reports 5.
@@ -3105,15 +2930,29 @@ mod tests {
 
         processor.recompute_metrics(&engine, &subscriber_id);
 
-        let (metrics_rx, mut reporter) = MetricsReporter::create_new_and_receiver(1);
-        reporter.report(&mut processor.metrics).unwrap();
-        let snap = metrics_rx.try_recv().unwrap();
-        let metrics = snap.get_metrics();
-
-        const IDX_DROPPED_METRIC_DATAPOINTS: usize = 34;
-        assert_eq!(metrics[IDX_DROPPED_METRIC_DATAPOINTS].to_u64_lossy(), 42);
-        const IDX_DROPPED_ITEMS: usize = 19;
-        assert_eq!(metrics[IDX_DROPPED_ITEMS].to_u64_lossy(), 42);
+        assert_eq!(
+            processor
+                .metrics
+                .item_loss_metrics
+                .get(SignalLossAttributes {
+                    signal: SignalType::Metrics,
+                    reason: LossReason::DropOldest,
+                })
+                .items
+                .get(),
+            42
+        );
+        assert_eq!(
+            processor
+                .metrics
+                .loss_metrics
+                .get(LossAttributes {
+                    reason: LossReason::DropOldest,
+                })
+                .items
+                .get(),
+            42
+        );
     }
 
     #[tokio::test]
@@ -3132,15 +2971,18 @@ mod tests {
 
         processor.recompute_metrics(&engine, &subscriber_id);
 
-        let (metrics_rx, mut reporter) = MetricsReporter::create_new_and_receiver(1);
-        reporter.report(&mut processor.metrics).unwrap();
-        let snap = metrics_rx.try_recv().unwrap();
-        let metrics = snap.get_metrics();
-
-        const IDX_DROPPED_SPANS: usize = 33;
-        assert_eq!(metrics[IDX_DROPPED_SPANS].to_u64_lossy(), 55);
-        const IDX_DROPPED_ITEMS: usize = 19;
-        assert_eq!(metrics[IDX_DROPPED_ITEMS].to_u64_lossy(), 55);
+        assert_eq!(
+            processor
+                .metrics
+                .item_loss_metrics
+                .get(SignalLossAttributes {
+                    signal: SignalType::Traces,
+                    reason: LossReason::DropOldest,
+                })
+                .items
+                .get(),
+            55
+        );
     }
 
     #[tokio::test]
@@ -3159,16 +3001,19 @@ mod tests {
 
         processor.recompute_metrics(&engine, &subscriber_id);
 
-        let (metrics_rx, mut reporter) = MetricsReporter::create_new_and_receiver(1);
-        reporter.report(&mut processor.metrics).unwrap();
-        let snap = metrics_rx.try_recv().unwrap();
-        let metrics = snap.get_metrics();
-
-        const IDX_DROPPED_LOG_RECORDS: usize = 32;
         // Verify we tracked the logical item count (99) rather than the batch row count (1)
-        assert_eq!(metrics[IDX_DROPPED_LOG_RECORDS].to_u64_lossy(), 99);
-        const IDX_DROPPED_ITEMS: usize = 19;
-        assert_eq!(metrics[IDX_DROPPED_ITEMS].to_u64_lossy(), 99);
+        assert_eq!(
+            processor
+                .metrics
+                .item_loss_metrics
+                .get(SignalLossAttributes {
+                    signal: SignalType::Logs,
+                    reason: LossReason::DropOldest,
+                })
+                .items
+                .get(),
+            99
+        );
     }
 
     #[tokio::test]
@@ -3223,29 +3068,36 @@ mod tests {
 
         processor.recompute_metrics(&engine, &subscriber_id);
 
-        let (metrics_rx, mut reporter) = MetricsReporter::create_new_and_receiver(1);
-        reporter.report(&mut processor.metrics).unwrap();
-        let snap = metrics_rx.try_recv().unwrap();
-        let metrics = snap.get_metrics();
-
-        const IDX_DROPPED_ITEMS: usize = 19;
-        const IDX_EXPIRED_ITEMS: usize = 21;
-        const IDX_DROPPED_LOG_RECORDS: usize = 32;
-        const IDX_DROPPED_SPANS: usize = 33;
-        const IDX_DROPPED_METRIC_DATAPOINTS: usize = 34;
-        const IDX_EXPIRED_LOG_RECORDS: usize = 35;
-        const IDX_EXPIRED_SPANS: usize = 36;
-        const IDX_EXPIRED_METRIC_DATAPOINTS: usize = 37;
-
-        let dropped_logs = metrics[IDX_DROPPED_LOG_RECORDS].to_u64_lossy();
-        let dropped_spans = metrics[IDX_DROPPED_SPANS].to_u64_lossy();
-        let dropped_metrics = metrics[IDX_DROPPED_METRIC_DATAPOINTS].to_u64_lossy();
-        let dropped_items = metrics[IDX_DROPPED_ITEMS].to_u64_lossy();
-
-        let expired_logs = metrics[IDX_EXPIRED_LOG_RECORDS].to_u64_lossy();
-        let expired_spans = metrics[IDX_EXPIRED_SPANS].to_u64_lossy();
-        let expired_metrics = metrics[IDX_EXPIRED_METRIC_DATAPOINTS].to_u64_lossy();
-        let expired_items = metrics[IDX_EXPIRED_ITEMS].to_u64_lossy();
+        let item_loss = |signal, reason| {
+            processor
+                .metrics
+                .item_loss_metrics
+                .get(SignalLossAttributes { signal, reason })
+                .items
+                .get()
+        };
+        let dropped_logs = item_loss(SignalType::Logs, LossReason::DropOldest);
+        let dropped_spans = item_loss(SignalType::Traces, LossReason::DropOldest);
+        let dropped_metrics = item_loss(SignalType::Metrics, LossReason::DropOldest);
+        let expired_logs = item_loss(SignalType::Logs, LossReason::Expired);
+        let expired_spans = item_loss(SignalType::Traces, LossReason::Expired);
+        let expired_metrics = item_loss(SignalType::Metrics, LossReason::Expired);
+        let dropped_items = processor
+            .metrics
+            .loss_metrics
+            .get(LossAttributes {
+                reason: LossReason::DropOldest,
+            })
+            .items
+            .get();
+        let expired_items = processor
+            .metrics
+            .loss_metrics
+            .get(LossAttributes {
+                reason: LossReason::Expired,
+            })
+            .items
+            .get();
 
         // Assert dropped reconciliation
         assert_eq!(dropped_logs, 10);

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/telemetry.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/telemetry.md
@@ -116,12 +116,13 @@ All events are emitted from
 When adding or changing telemetry in this module:
 
 1. **Metrics**
-     - If you add a field to `DurableBufferMetrics` in
-       `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs`,
-       add/update the corresponding row in the **Metrics** table.
-     - The effective emitted name is
-       `processor.durable_buffer.<field_name>` (or the `name` override
-       in the `#[metric(...)]` attribute if present).
+     - Declare metric sets, attributes, and instruments in
+       `crates/core-nodes/src/processors/durable_buffer_processor/metrics.rs`,
+       then add/update the corresponding row in the **Metrics** table.
+     - The effective emitted metric name is `<scope>.<instrument>` (for
+       example, `processor.durable_buffer.items.consumed`). The scope is set
+       by `#[metric_set(name = "...")]`; the instrument name is derived from
+       the field name or overridden by `#[metric(name = "...")]`.
      - Note the instrument type (`Counter`, `Gauge`, or `ObserveCounter`) in
        the **Instrument** column.
 
@@ -134,7 +135,7 @@ When adding or changing telemetry in this module:
 
 3. **Review checklist (quick)**
      - Search for new metric fields: `#[metric(` in
-       `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs`.
+       `crates/core-nodes/src/processors/durable_buffer_processor/metrics.rs`.
      - Search for new log events: `otel_(trace|debug|info|warn|error)!(` in
        `crates/core-nodes/src/processors/durable_buffer_processor/**`.
      - Confirm this document still matches current source files.

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/telemetry.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/telemetry.md
@@ -7,107 +7,17 @@ events emitted via `otel_*` log macros.
 
 ## Metrics
 
-All metrics are emitted under the metric-set name
-`otap.processor.durable_buffer`.
-The effective instrument name is `otap.processor.durable_buffer.<field_name>`.
+Each metric set has its own scope. Bounded item dimensions are emitted as
+OpenTelemetry attributes rather than encoded in instrument names.
 
-### ACK / NACK Tracking
-
-| Metric name | Unit | Instrument | Description | Produced in file |
-| --- | --- | --- | --- | --- |
-| `otap.processor.durable_buffer.bundles_acked` | `{bundle}` | Counter | Number of bundles acknowledged by downstream. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.bundles_nacked_deferred` | `{bundle}` | Counter | Number of bundles deferred for retry after a transient downstream failure. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.bundles_nacked_permanent` | `{bundle}` | Counter | Number of bundles permanently rejected by downstream (not retried). Non-zero values may indicate malformed data. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-
-### Rejected Item Counts (per signal type)
-
-| Metric name | Unit | Instrument | Description | Produced in file |
-| --- | --- | --- | --- | --- |
-| `otap.processor.durable_buffer.rejected_log_records` | `{log_record}` | Counter | Number of log records in permanently rejected bundles. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.rejected_metric_points` | `{data_point}` | Counter | Number of metric data points in permanently rejected bundles. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.rejected_spans` | `{span}` | Counter | Number of spans in permanently rejected bundles. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-
-### Consumed Item Counts (per signal type)
-
-| Metric name | Unit | Instrument | Description | Produced in file |
-| --- | --- | --- | --- | --- |
-| `otap.processor.durable_buffer.consumed_log_records` | `{log_record}` | Counter | Number of log records ingested to durable storage. For OTLP bytes, counted via a protobuf wire-format scan without full deserialization. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.consumed_metric_points` | `{data_point}` | Counter | Number of metric data points ingested to durable storage. Same counting method as above. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.consumed_spans` | `{span}` | Counter | Number of spans ingested to durable storage. Same counting method as above. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-
-### Produced Item Counts (per signal type)
-
-| Metric name | Unit | Instrument | Description | Produced in file |
-| --- | --- | --- | --- | --- |
-| `otap.processor.durable_buffer.produced_log_records` | `{log_record}` | Counter | Number of log records sent downstream. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.produced_metric_points` | `{data_point}` | Counter | Number of metric data points sent downstream. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.produced_spans` | `{span}` | Counter | Number of spans sent downstream. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-
-### Error and Backpressure
-
-| Metric name | Unit | Instrument | Description | Produced in file |
-| --- | --- | --- | --- | --- |
-| `otap.processor.durable_buffer.ingest_errors` | `{error}` | Counter | Number of ingest errors (excludes storage-backpressure rejections). | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.ingest_backpressure` | `{rejection}` | Counter | Number of ingest rejections because the storage soft cap was exceeded. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.read_errors` | `{error}` | Counter | Number of read errors (poll or bundle-conversion failures). | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-
-### Storage
-
-| Metric name | Unit | Instrument | Description | Produced in file |
-| --- | --- | --- | --- | --- |
-| `otap.processor.durable_buffer.storage_bytes_used` | `By` | Gauge | Current bytes used by persistent storage (durable storage + segments). Updated on each `CollectTelemetry` tick. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.storage_bytes_cap` | `By` | Gauge | Configured per-core storage capacity cap. Updated on each `CollectTelemetry` tick. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.dropped_segments` | `{segment}` | ObserveCounter | Cumulative segments force-dropped due to `DropOldest` retention policy. Non-zero values indicate data loss. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.dropped_bundles` | `{bundle}` | ObserveCounter | Cumulative bundles lost due to force-dropped segments. Non-zero values indicate data loss. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.dropped_items` | `{item}` | ObserveCounter | Cumulative individual items (log records, data points, spans) lost due to force-dropped segments. Non-zero values indicate data loss. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.expired_bundles` | `{bundle}` | ObserveCounter | Cumulative bundles lost due to `max_age` segment expiry. Non-zero values indicate data aged out before delivery. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.expired_items` | `{item}` | ObserveCounter | Cumulative individual items lost due to `max_age` segment expiry. Non-zero values indicate data aged out before delivery. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-
-### Flush Failures
-
-| Metric name | Unit | Instrument | Description | Produced in file |
-| --- | --- | --- | --- | --- |
-| `otap.processor.durable_buffer.flush_failures` | `{error}` | Counter | Cumulative segment finalization (flush) failures. Non-zero values indicate data at risk - check logs for root cause. Data may still be recoverable via WAL replay on restart. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-
-### Storage Utilization
-
-| Metric name | Unit | Instrument | Description | Produced in file |
-| --- | --- | --- | --- | --- |
-| `otap.processor.durable_buffer.storage_utilization` | `{1}` | Gauge | Current storage utilization ratio (`storage_bytes_used / storage_bytes_cap`), in the range `[0.0, 1.0]`. Updated on each `CollectTelemetry` tick. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-
-### Per-Signal Dropped Items (DropOldest policy)
-
-| Metric name | Unit | Instrument | Description | Produced in file |
-| --- | --- | --- | --- | --- |
-| `otap.processor.durable_buffer.dropped_log_records` | `{log_record}` | Counter | Log records lost due to force-dropped segments (`DropOldest`). Aggregated across all Arrow and OTLP log slots. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.dropped_spans` | `{span}` | Counter | Spans lost due to force-dropped segments (`DropOldest`). Aggregated across all Arrow and OTLP trace slots. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.dropped_metric_datapoints` | `{data_point}` | Counter | Metric data points lost due to force-dropped segments (`DropOldest`). Aggregated across all Arrow and OTLP metric slots (slots 11-14 for Arrow, slot 62 for OTLP). | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-
-### Per-Signal Expired Items (max_age policy)
-
-| Metric name | Unit | Instrument | Description | Produced in file |
-| --- | --- | --- | --- | --- |
-| `otap.processor.durable_buffer.expired_log_records` | `{log_record}` | Counter | Log records lost due to `max_age` segment expiry. Aggregated across all Arrow and OTLP log slots. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.expired_spans` | `{span}` | Counter | Spans lost due to `max_age` segment expiry. Aggregated across all Arrow and OTLP trace slots. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.expired_metric_datapoints` | `{data_point}` | Counter | Metric data points lost due to `max_age` segment expiry. Aggregated across all Arrow and OTLP metric slots. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-
-### In-flight and Retry
-
-| Metric name | Unit | Instrument | Description | Produced in file |
-| --- | --- | --- | --- | --- |
-| `otap.processor.durable_buffer.in_flight` | `{bundle}` | Gauge | Current number of bundles sent downstream but not yet ACKed/NACKed. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.retries_scheduled` | `{retry}` | Counter | Cumulative number of retry attempts scheduled after a transient NACK. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.requeued_log_records` | `{log_record}` | Counter | Cumulative log records in bundles requeued for retry after NACK. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.requeued_metric_points` | `{data_point}` | Counter | Cumulative metric data points in bundles requeued for retry after NACK. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.requeued_spans` | `{span}` | Counter | Cumulative spans in bundles requeued for retry after NACK. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-
-### Queued Item Gauges (ingested but not yet ACKed)
-
-| Metric name | Unit | Instrument | Description | Produced in file |
-| --- | --- | --- | --- | --- |
-| `otap.processor.durable_buffer.queued_log_records` | `{log_record}` | Gauge | Current log records queued in durable storage/segments awaiting downstream ACK. Seeded from existing segments on restart. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.queued_metric_points` | `{data_point}` | Gauge | Current metric data points queued in durable storage/segments awaiting downstream ACK. Seeded from existing segments on restart. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
-| `otap.processor.durable_buffer.queued_spans` | `{span}` | Gauge | Current spans queued in durable storage/segments awaiting downstream ACK. Seeded from existing segments on restart. | `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs` |
+| Scope | Instrument(s) | Datapoint attributes | Description |
+| --- | --- | --- | --- |
+| `processor.durable_buffer` | `read.errors`, `storage.bytes.used`, `storage.bytes.cap`, `retries.scheduled`, `in.flight`, `flush.failures`, `storage.utilization` | None | Operational storage, retry, and flush health. |
+| `processor.durable_buffer.bundles` | `resolved` | `outcome=acked\|deferred\|permanently_rejected` | Bundle resolution by downstream outcome. |
+| `processor.durable_buffer.ingest` | `failures` | `failure=error\|backpressure` | Failed ingest attempts by failure kind. |
+| `processor.durable_buffer.items` | `rejected`, `consumed`, `produced`, `requeued`, `queued` | `signal=traces\|metrics\|logs` | Item operations and queued gauges by OpenTelemetry signal. |
+| `processor.durable_buffer.loss` | `segments`, `bundles`, `items` | `reason=drop_oldest\|expired` | Aggregate retention loss by reason. |
+| `processor.durable_buffer.item_loss` | `items` | `signal=traces\|metrics\|logs`, `reason=drop_oldest\|expired` | Item loss by signal and retention reason. |
 
 ## Logs
 
@@ -210,7 +120,7 @@ When adding or changing telemetry in this module:
        `crates/core-nodes/src/processors/durable_buffer_processor/mod.rs`,
        add/update the corresponding row in the **Metrics** table.
      - The effective emitted name is
-       `otap.processor.durable_buffer.<field_name>` (or the `name` override
+       `processor.durable_buffer.<field_name>` (or the `name` override
        in the `#[metric(...)]` attribute if present).
      - Note the instrument type (`Counter`, `Gauge`, or `ObserveCounter`) in
        the **Instrument** column.

--- a/rust/otap-dataflow/crates/otap/tests/durable_buffer_processor_tests.rs
+++ b/rust/otap-dataflow/crates/otap/tests/durable_buffer_processor_tests.rs
@@ -318,12 +318,30 @@ fn run_pipeline_with_condition<F>(
     );
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct MetricIdentity {
     scope: &'static str,
     instrument: &'static str,
-    signal: Option<&'static str>,
-    outcome: Option<&'static str>,
+    attributes: Vec<(String, String)>,
+}
+
+impl MetricIdentity {
+    fn new<'a>(
+        scope: &'static str,
+        instrument: &'static str,
+        attributes: impl IntoIterator<Item = (&'a str, &'a str)>,
+    ) -> Self {
+        let mut attributes = attributes
+            .into_iter()
+            .map(|(key, value)| (key.to_owned(), value.to_owned()))
+            .collect::<Vec<_>>();
+        attributes.sort_unstable();
+        Self {
+            scope,
+            instrument,
+            attributes,
+        }
+    }
 }
 
 fn is_durable_buffer_metric_scope(scope: &str) -> bool {
@@ -338,25 +356,7 @@ fn is_durable_buffer_metric_scope(scope: &str) -> bool {
     )
 }
 
-fn signal_dimension(value: &str) -> Option<&'static str> {
-    match value {
-        "traces" => Some("traces"),
-        "metrics" => Some("metrics"),
-        "logs" => Some("logs"),
-        _ => None,
-    }
-}
-
-fn outcome_dimension(value: &str) -> Option<&'static str> {
-    match value {
-        "acked" => Some("acked"),
-        "deferred" => Some("deferred"),
-        "permanently_rejected" => Some("permanently_rejected"),
-        _ => None,
-    }
-}
-
-/// Collected metrics from a pipeline run, keyed by their new scope, instrument, and dimensions.
+/// Collected metrics from a pipeline run, keyed by scope, instrument, and dimensions.
 #[derive(Debug, Default)]
 struct CollectedMetrics {
     counters: HashMap<MetricIdentity, u64>,
@@ -371,23 +371,17 @@ impl CollectedMetrics {
             if !is_durable_buffer_metric_scope(descriptor.name) {
                 continue;
             }
-            let identity = |instrument| MetricIdentity {
-                scope: descriptor.name,
-                instrument,
-                signal: snapshot
-                    .measurement_attribute_value("signal")
-                    .and_then(signal_dimension),
-                outcome: snapshot
-                    .measurement_attribute_value("outcome")
-                    .and_then(outcome_dimension),
-            };
 
             for (field, value) in descriptor.metrics.iter().zip(snapshot.get_metrics()) {
                 let values = match field.instrument {
                     Instrument::Gauge => &mut collected.gauges,
                     _ => &mut collected.counters,
                 };
-                let metric = identity(field.name);
+                let metric = MetricIdentity::new(
+                    descriptor.name,
+                    field.name,
+                    snapshot.measurement_attributes(),
+                );
                 let value = value.to_u64_lossy();
                 if field.instrument == Instrument::Gauge {
                     let _ = values.insert(metric, value);
@@ -400,15 +394,14 @@ impl CollectedMetrics {
     }
 
     fn operational(&self, instrument: &'static str) -> u64 {
-        self.value("processor.durable_buffer", instrument, None, None)
+        self.value("processor.durable_buffer", instrument, [])
     }
 
     fn bundle_outcome(&self, outcome: &'static str) -> u64 {
         self.value(
             "processor.durable_buffer.bundles",
             "resolved",
-            None,
-            Some(outcome),
+            [("outcome", outcome)],
         )
     }
 
@@ -416,8 +409,7 @@ impl CollectedMetrics {
         self.value(
             "processor.durable_buffer.items",
             operation,
-            Some(signal),
-            None,
+            [("signal", signal)],
         )
     }
 
@@ -425,15 +417,9 @@ impl CollectedMetrics {
         &self,
         scope: &'static str,
         instrument: &'static str,
-        signal: Option<&'static str>,
-        outcome: Option<&'static str>,
+        attributes: impl IntoIterator<Item = (&'static str, &'static str)>,
     ) -> u64 {
-        let metric = MetricIdentity {
-            scope,
-            instrument,
-            signal,
-            outcome,
-        };
+        let metric = MetricIdentity::new(scope, instrument, attributes);
         self.counters
             .get(&metric)
             .or_else(|| self.gauges.get(&metric))
@@ -711,21 +697,12 @@ fn capture_durable_buffer_metrics(registry: &TelemetryRegistryHandle) -> Collect
             if !is_durable_buffer_metric_scope(descriptor.name) {
                 return;
             }
-            let signal = item_attributes
-                .iter()
-                .find_map(|(key, value)| (*key == "signal").then_some(*value))
-                .and_then(signal_dimension);
-            let outcome = item_attributes
-                .iter()
-                .find_map(|(key, value)| (*key == "outcome").then_some(*value))
-                .and_then(outcome_dimension);
             for (field, value) in iter {
-                let identity = MetricIdentity {
-                    scope: descriptor.name,
-                    instrument: field.name,
-                    signal,
-                    outcome,
-                };
+                let identity = MetricIdentity::new(
+                    descriptor.name,
+                    field.name,
+                    item_attributes.iter().copied(),
+                );
                 let values = match field.instrument {
                     Instrument::Gauge => &mut metrics.gauges,
                     _ => &mut metrics.counters,

--- a/rust/otap-dataflow/crates/otap/tests/durable_buffer_processor_tests.rs
+++ b/rust/otap-dataflow/crates/otap/tests/durable_buffer_processor_tests.rs
@@ -33,6 +33,7 @@ use otap_df_otap::OTAP_PIPELINE_FACTORY;
 use otap_df_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
 use otap_df_state::store::ObservedStateStore;
 use otap_df_telemetry::InternalTelemetrySystem;
+use otap_df_telemetry::descriptor::Instrument;
 use otap_df_telemetry::metrics::MetricSetSnapshot;
 use otap_df_telemetry::registry::TelemetryRegistryHandle;
 use otap_df_telemetry::reporter::MetricsReporter;
@@ -311,165 +312,133 @@ fn run_pipeline_with_condition<F>(
         true, // wait for telemetry cycle so metrics assertions are meaningful
     );
     assert!(
-        metrics.flush_failures() == 0,
+        metrics.operational("flush.failures") == 0,
         "segment finalization should not fail (flush_failures metric should be 0, got {})",
-        metrics.flush_failures()
+        metrics.operational("flush.failures")
     );
 }
 
-/// Field indices into `DurableBufferMetrics` snapshot (declaration order).
-/// New metrics MUST be appended to `DurableBufferMetrics` so existing indices
-/// never shift. Add new constants at the end of this block.
-const IDX_BUNDLES_ACKED: usize = 0;
-const IDX_BUNDLES_NACKED_DEFERRED: usize = 1;
-const IDX_BUNDLES_NACKED_PERMANENT: usize = 2;
-const IDX_REJECTED_LOG_RECORDS: usize = 3;
-const IDX_REJECTED_METRIC_POINTS: usize = 4;
-const IDX_REJECTED_SPANS: usize = 5;
-#[allow(dead_code)]
-const IDX_CONSUMED_LOG_RECORDS: usize = 6;
-#[allow(dead_code)]
-const IDX_CONSUMED_METRIC_POINTS: usize = 7;
-#[allow(dead_code)]
-const IDX_CONSUMED_SPANS: usize = 8;
-const IDX_PRODUCED_LOG_RECORDS: usize = 9;
-const IDX_PRODUCED_METRIC_POINTS: usize = 10;
-const IDX_PRODUCED_SPANS: usize = 11;
-#[allow(dead_code)]
-const IDX_INGEST_ERRORS: usize = 12;
-#[allow(dead_code)]
-const IDX_INGEST_BACKPRESSURE: usize = 13;
-#[allow(dead_code)]
-const IDX_READ_ERRORS: usize = 14;
-#[allow(dead_code)]
-const IDX_STORAGE_BYTES_USED: usize = 15;
-#[allow(dead_code)]
-const IDX_STORAGE_BYTES_CAP: usize = 16;
-#[allow(dead_code)]
-const IDX_DROPPED_SEGMENTS: usize = 17;
-#[allow(dead_code)]
-const IDX_DROPPED_BUNDLES: usize = 18;
-#[allow(dead_code)]
-const IDX_DROPPED_ITEMS: usize = 19;
-#[allow(dead_code)]
-const IDX_EXPIRED_BUNDLES: usize = 20;
-#[allow(dead_code)]
-const IDX_EXPIRED_ITEMS: usize = 21;
-const IDX_RETRIES_SCHEDULED: usize = 22;
-#[allow(dead_code)]
-const IDX_IN_FLIGHT: usize = 23;
-const IDX_REQUEUED_LOG_RECORDS: usize = 24;
-const IDX_REQUEUED_METRIC_POINTS: usize = 25;
-const IDX_REQUEUED_SPANS: usize = 26;
-const IDX_QUEUED_LOG_RECORDS: usize = 27;
-const IDX_QUEUED_METRIC_POINTS: usize = 28;
-const IDX_QUEUED_SPANS: usize = 29;
-const IDX_FLUSH_FAILURES: usize = 30;
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct MetricIdentity {
+    scope: &'static str,
+    instrument: &'static str,
+    signal: Option<&'static str>,
+    outcome: Option<&'static str>,
+}
 
-const DURABLE_BUFFER_METRIC_COUNT: usize = 38;
+fn is_durable_buffer_metric_scope(scope: &str) -> bool {
+    matches!(
+        scope,
+        "processor.durable_buffer"
+            | "processor.durable_buffer.bundles"
+            | "processor.durable_buffer.ingest"
+            | "processor.durable_buffer.items"
+            | "processor.durable_buffer.loss"
+            | "processor.durable_buffer.item_loss"
+    )
+}
 
-/// Collected metrics from a pipeline run, aggregated across all telemetry snapshots.
+fn signal_dimension(value: &str) -> Option<&'static str> {
+    match value {
+        "traces" => Some("traces"),
+        "metrics" => Some("metrics"),
+        "logs" => Some("logs"),
+        _ => None,
+    }
+}
+
+fn outcome_dimension(value: &str) -> Option<&'static str> {
+    match value {
+        "acked" => Some("acked"),
+        "deferred" => Some("deferred"),
+        "permanently_rejected" => Some("permanently_rejected"),
+        _ => None,
+    }
+}
+
+/// Collected metrics from a pipeline run, keyed by their new scope, instrument, and dimensions.
 #[derive(Debug, Default)]
 struct CollectedMetrics {
-    /// Accumulated metric values by field index (summed deltas - correct for Counters).
-    values: Vec<u64>,
-    /// Last-seen metric values by field index (correct for Gauges).
-    last_values: Vec<u64>,
+    counters: HashMap<MetricIdentity, u64>,
+    gauges: HashMap<MetricIdentity, u64>,
 }
 
 impl CollectedMetrics {
-    /// Aggregate durable_buffer metric snapshots by summing delta values.
-    ///
-    /// Filters snapshots to those with exactly `DURABLE_BUFFER_METRIC_COUNT` fields
-    /// (the durable buffer's metric set), then sums values across all collection cycles.
     fn from_snapshots(snapshots: &[MetricSetSnapshot]) -> Self {
-        let db_snapshots: Vec<_> = snapshots
-            .iter()
-            .filter(|s| s.get_metrics().len() == DURABLE_BUFFER_METRIC_COUNT)
-            .collect();
+        let mut collected = Self::default();
+        for snapshot in snapshots {
+            let descriptor = snapshot.descriptor();
+            if !is_durable_buffer_metric_scope(descriptor.name) {
+                continue;
+            }
+            let identity = |instrument| MetricIdentity {
+                scope: descriptor.name,
+                instrument,
+                signal: snapshot
+                    .measurement_attribute_value("signal")
+                    .and_then(signal_dimension),
+                outcome: snapshot
+                    .measurement_attribute_value("outcome")
+                    .and_then(outcome_dimension),
+            };
 
-        let mut values = vec![0u64; DURABLE_BUFFER_METRIC_COUNT];
-        let mut last_values = vec![0u64; DURABLE_BUFFER_METRIC_COUNT];
-        for snapshot in &db_snapshots {
-            for (i, metric) in snapshot.get_metrics().iter().enumerate() {
-                values[i] += metric.to_u64_lossy();
-                last_values[i] = metric.to_u64_lossy();
+            for (field, value) in descriptor.metrics.iter().zip(snapshot.get_metrics()) {
+                let values = match field.instrument {
+                    Instrument::Gauge => &mut collected.gauges,
+                    _ => &mut collected.counters,
+                };
+                let metric = identity(field.name);
+                let value = value.to_u64_lossy();
+                if field.instrument == Instrument::Gauge {
+                    let _ = values.insert(metric, value);
+                } else {
+                    *values.entry(metric).or_default() += value;
+                }
             }
         }
-        Self {
-            values,
-            last_values,
-        }
+        collected
     }
 
-    fn bundles_acked(&self) -> u64 {
-        self.values[IDX_BUNDLES_ACKED]
+    fn operational(&self, instrument: &'static str) -> u64 {
+        self.value("processor.durable_buffer", instrument, None, None)
     }
 
-    fn bundles_nacked_deferred(&self) -> u64 {
-        self.values[IDX_BUNDLES_NACKED_DEFERRED]
+    fn bundle_outcome(&self, outcome: &'static str) -> u64 {
+        self.value(
+            "processor.durable_buffer.bundles",
+            "resolved",
+            None,
+            Some(outcome),
+        )
     }
 
-    fn bundles_nacked_permanent(&self) -> u64 {
-        self.values[IDX_BUNDLES_NACKED_PERMANENT]
+    fn item_operation(&self, signal: &'static str, operation: &'static str) -> u64 {
+        self.value(
+            "processor.durable_buffer.items",
+            operation,
+            Some(signal),
+            None,
+        )
     }
 
-    fn rejected_log_records(&self) -> u64 {
-        self.values[IDX_REJECTED_LOG_RECORDS]
-    }
-
-    fn rejected_metric_points(&self) -> u64 {
-        self.values[IDX_REJECTED_METRIC_POINTS]
-    }
-
-    fn rejected_spans(&self) -> u64 {
-        self.values[IDX_REJECTED_SPANS]
-    }
-
-    fn produced_log_records(&self) -> u64 {
-        self.values[IDX_PRODUCED_LOG_RECORDS]
-    }
-
-    #[allow(dead_code)]
-    fn produced_metric_points(&self) -> u64 {
-        self.values[IDX_PRODUCED_METRIC_POINTS]
-    }
-
-    #[allow(dead_code)]
-    fn produced_spans(&self) -> u64 {
-        self.values[IDX_PRODUCED_SPANS]
-    }
-
-    fn retries_scheduled(&self) -> u64 {
-        self.values[IDX_RETRIES_SCHEDULED]
-    }
-
-    fn requeued_log_records(&self) -> u64 {
-        self.values[IDX_REQUEUED_LOG_RECORDS]
-    }
-
-    fn requeued_metric_points(&self) -> u64 {
-        self.values[IDX_REQUEUED_METRIC_POINTS]
-    }
-
-    fn requeued_spans(&self) -> u64 {
-        self.values[IDX_REQUEUED_SPANS]
-    }
-
-    fn queued_log_records(&self) -> u64 {
-        self.last_values[IDX_QUEUED_LOG_RECORDS]
-    }
-
-    fn queued_metric_points(&self) -> u64 {
-        self.last_values[IDX_QUEUED_METRIC_POINTS]
-    }
-
-    fn queued_spans(&self) -> u64 {
-        self.last_values[IDX_QUEUED_SPANS]
-    }
-
-    fn flush_failures(&self) -> u64 {
-        self.values[IDX_FLUSH_FAILURES]
+    fn value(
+        &self,
+        scope: &'static str,
+        instrument: &'static str,
+        signal: Option<&'static str>,
+        outcome: Option<&'static str>,
+    ) -> u64 {
+        let metric = MetricIdentity {
+            scope,
+            instrument,
+            signal,
+            outcome,
+        };
+        self.counters
+            .get(&metric)
+            .or_else(|| self.gauges.get(&metric))
+            .copied()
+            .unwrap_or_default()
     }
 }
 
@@ -730,62 +699,48 @@ fn count_manifest_items_in_segments(segments_dir: &std::path::Path) -> u64 {
 // Metrics Capture
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Snapshot of durable_buffer metrics captured from the telemetry registry.
-///
-/// Field names mirror `DurableBufferMetrics` in mod.rs. Values are
-/// captured via `visit_current_metrics` on the registry after the collector
-/// drains the reporting channel — so they reflect the most-recent
-/// `CollectTelemetry` snapshot produced by the processor.
-#[derive(Debug, Default)]
-struct DurableBufferMetricsSnapshot {
-    fields: HashMap<String, u64>,
-}
-
-impl DurableBufferMetricsSnapshot {
-    /// Get a metric value by its dot-separated field name (e.g. "consumed.logs").
-    fn get(&self, field: &str) -> u64 {
-        self.fields.get(field).copied().unwrap_or(u64::MAX) // Use u64::MAX to make missing fields fail assertions clearly
-    }
-
-    /// Assert that a metric equals an exact expected value.
-    fn assert_eq(&self, field: &str, expected: u64) {
-        let actual = self.get(field);
-        assert_eq!(
-            actual, expected,
-            "{field}: expected {expected}, got {actual}"
-        );
-    }
-
-    /// Assert that a metric is greater than or equal to a minimum.
-    fn assert_ge(&self, field: &str, minimum: u64) {
-        let actual = self.get(field);
-        assert!(
-            actual >= minimum,
-            "{field}: expected >= {minimum}, got {actual}"
-        );
-    }
-}
-
-/// Capture a snapshot of `otap.processor.durable_buffer` metrics from the
-/// telemetry registry.
+/// Capture durable-buffer metrics from the telemetry registry.
 ///
 /// The caller must ensure that:
 /// 1. At least one `CollectTelemetry` cycle has flushed the processor's metrics.
 /// 2. `collector.collect_pending()` has been called to drain the channel.
-fn capture_durable_buffer_metrics(
-    registry: &TelemetryRegistryHandle,
-) -> DurableBufferMetricsSnapshot {
-    let mut snapshot = DurableBufferMetricsSnapshot::default();
-    registry.visit_current_metrics(|desc, _attrs, iter| {
-        if desc.name == "otap.processor.durable_buffer" {
-            for (field, value) in iter {
-                let _ = snapshot
-                    .fields
-                    .insert(field.name.to_owned(), value.to_u64_lossy());
+fn capture_durable_buffer_metrics(registry: &TelemetryRegistryHandle) -> CollectedMetrics {
+    let mut metrics = CollectedMetrics::default();
+    registry.visit_current_metrics_with_item_attrs(
+        |descriptor, _attrs, item_attributes, iter| {
+            if !is_durable_buffer_metric_scope(descriptor.name) {
+                return;
             }
-        }
-    });
-    snapshot
+            let signal = item_attributes
+                .iter()
+                .find_map(|(key, value)| (*key == "signal").then_some(*value))
+                .and_then(signal_dimension);
+            let outcome = item_attributes
+                .iter()
+                .find_map(|(key, value)| (*key == "outcome").then_some(*value))
+                .and_then(outcome_dimension);
+            for (field, value) in iter {
+                let identity = MetricIdentity {
+                    scope: descriptor.name,
+                    instrument: field.name,
+                    signal,
+                    outcome,
+                };
+                let values = match field.instrument {
+                    Instrument::Gauge => &mut metrics.gauges,
+                    _ => &mut metrics.counters,
+                };
+                let value = value.to_u64_lossy();
+                if field.instrument == Instrument::Gauge {
+                    let _ = values.insert(identity, value);
+                } else {
+                    *values.entry(identity).or_default() += value;
+                }
+            }
+        },
+        true,
+    );
+    metrics
 }
 
 /// Run a pipeline with a shutdown condition and capture durable_buffer metrics
@@ -806,7 +761,7 @@ fn run_pipeline_and_capture_metrics<F>(
     max_duration: Duration,
     shutdown_deadline: Duration,
     shutdown_condition: F,
-) -> DurableBufferMetricsSnapshot
+) -> CollectedMetrics
 where
     F: Fn() -> bool + Send + 'static,
 {
@@ -1009,71 +964,71 @@ fn test_durable_buffer_retries_on_nack() {
     // Validate: The retry mechanism worked - data was NACKed but eventually delivered
     // This proves the durable buffer's retry logic is functioning.
 
-    // Validate metrics: transient NACKs should increment bundles_nacked_deferred
+    // Validate metrics: transient NACKs should resolve bundles as deferred.
     assert!(
-        metrics.bundles_nacked_deferred() > 0,
-        "Expected bundles_nacked_deferred metric > 0, got {}",
-        metrics.bundles_nacked_deferred()
+        metrics.bundle_outcome("deferred") > 0,
+        "Expected resolved{{outcome=deferred}} metric > 0, got {}",
+        metrics.bundle_outcome("deferred")
     );
 
     // Validate metrics: no permanent NACKs in this test
     assert_eq!(
-        metrics.bundles_nacked_permanent(),
+        metrics.bundle_outcome("permanently_rejected"),
         0,
-        "Expected bundles_nacked_permanent metric = 0 (only transient NACKs), got {}",
-        metrics.bundles_nacked_permanent()
+        "Expected resolved{{outcome=permanently_rejected}} metric = 0 (only transient NACKs), got {}",
+        metrics.bundle_outcome("permanently_rejected")
     );
 
     // Validate metrics: retries should have been scheduled
     assert!(
-        metrics.retries_scheduled() > 0,
+        metrics.operational("retries.scheduled") > 0,
         "Expected retries_scheduled metric > 0, got {}",
-        metrics.retries_scheduled()
+        metrics.operational("retries.scheduled")
     );
 
     // Validate metrics: some bundles were eventually ACKd
     assert!(
-        metrics.bundles_acked() > 0,
-        "Expected bundles_acked metric > 0, got {}",
-        metrics.bundles_acked()
+        metrics.bundle_outcome("acked") > 0,
+        "Expected resolved{{outcome=acked}} metric > 0, got {}",
+        metrics.bundle_outcome("acked")
     );
 
     // Validate per-item metrics: transient NACKs should requeue items, not reject them.
     // This test uses 100% logs, so only log counters should be non-zero.
     assert!(
-        metrics.requeued_log_records() > 0,
-        "Expected requeued_log_records metric > 0 (items requeued for retry), got {}",
-        metrics.requeued_log_records()
+        metrics.item_operation("logs", "requeued") > 0,
+        "Expected requeued{{signal=logs}} metric > 0 (items requeued for retry), got {}",
+        metrics.item_operation("logs", "requeued")
     );
     assert_eq!(
-        metrics.rejected_log_records(),
+        metrics.item_operation("logs", "rejected"),
         0,
-        "Expected rejected_log_records metric = 0 (no permanent NACKs), got {}",
-        metrics.rejected_log_records()
+        "Expected rejected{{signal=logs}} metric = 0 (no permanent NACKs), got {}",
+        metrics.item_operation("logs", "rejected")
     );
     assert_eq!(
-        metrics.rejected_metric_points(),
+        metrics.item_operation("metrics", "rejected"),
         0,
-        "Expected rejected_metric_points metric = 0 (no metrics generated), got {}",
-        metrics.rejected_metric_points()
+        "Expected rejected{{signal=metrics}} metric = 0 (no metrics generated), got {}",
+        metrics.item_operation("metrics", "rejected")
     );
     assert_eq!(
-        metrics.rejected_spans(),
+        metrics.item_operation("traces", "rejected"),
         0,
-        "Expected rejected_spans metric = 0 (no traces generated), got {}",
-        metrics.rejected_spans()
+        "Expected rejected{{signal=traces}} metric = 0 (no traces generated), got {}",
+        metrics.item_operation("traces", "rejected")
     );
 
     // Validate: items were produced (sent downstream)
     assert!(
-        metrics.produced_log_records() > 0,
-        "Expected produced_log_records metric > 0 (items sent downstream), got {}",
-        metrics.produced_log_records()
+        metrics.item_operation("logs", "produced") > 0,
+        "Expected produced{{signal=logs}} metric > 0 (items sent downstream), got {}",
+        metrics.item_operation("logs", "produced")
     );
 
     // Verify no segment finalization failures occurred.
     assert_eq!(
-        metrics.flush_failures(),
+        metrics.operational("flush.failures"),
         0,
         "segment finalization should not fail (flush_failures metric)"
     );
@@ -1350,7 +1305,7 @@ fn test_durable_buffer_convert_to_arrow_mode_with_trace_context() {
 
     // Verify no segment finalization failures occurred.
     assert_eq!(
-        metrics.flush_failures(),
+        metrics.operational("flush.failures"),
         0,
         "segment finalization should not fail (flush_failures metric)"
     );
@@ -1408,7 +1363,7 @@ fn test_durable_buffer_convert_to_arrow_mode_traces() {
     );
 
     assert_eq!(
-        metrics.flush_failures(),
+        metrics.operational("flush.failures"),
         0,
         "segment finalization should not fail for traces (flush_failures metric)"
     );
@@ -1467,7 +1422,7 @@ fn test_durable_buffer_convert_to_arrow_mode_metrics() {
     );
 
     assert_eq!(
-        metrics.flush_failures(),
+        metrics.operational("flush.failures"),
         0,
         "segment finalization should not fail for metrics (flush_failures metric)"
     );
@@ -1528,7 +1483,7 @@ fn test_durable_buffer_convert_to_arrow_mode_mixed_signals() {
     );
 
     assert_eq!(
-        metrics.flush_failures(),
+        metrics.operational("flush.failures"),
         0,
         "segment finalization should not fail for mixed signals (flush_failures metric)"
     );
@@ -1844,52 +1799,67 @@ fn test_durable_buffer_otlp_item_count_metrics() {
     );
 
     // ── Validate durable buffer telemetry metrics ───────────────────────
-    // The metrics snapshot was captured after at least one CollectTelemetry cycle
+    // The metrics were captured after at least one CollectTelemetry cycle
     // completed, so counters and gauges should reflect the pipeline's activity.
     eprintln!("Durable buffer metrics snapshot: {metrics_snapshot:?}");
 
     // Consumed counters count items ingested in THIS pipeline run only (Phase 2).
     // Phase 2 generates phase2_signals with equal weights → phase2_signals/3 each.
     let phase2_per_signal = phase2_signals / 3;
-    metrics_snapshot.assert_eq("consumed.log.records", phase2_per_signal);
-    metrics_snapshot.assert_eq("consumed.spans", phase2_per_signal);
-    metrics_snapshot.assert_eq("consumed.metric.points", phase2_per_signal);
+    assert_eq!(
+        metrics_snapshot.item_operation("logs", "consumed"),
+        phase2_per_signal
+    );
+    assert_eq!(
+        metrics_snapshot.item_operation("traces", "consumed"),
+        phase2_per_signal
+    );
+    assert_eq!(
+        metrics_snapshot.item_operation("metrics", "consumed"),
+        phase2_per_signal
+    );
 
     // Produced counters count items sent downstream (Phase 1 recovered + Phase 2 new).
     let phase1_per_signal = phase1_signals / 3;
     let produced_per_signal = phase1_per_signal + phase2_per_signal;
-    metrics_snapshot.assert_eq("produced.log.records", produced_per_signal);
-    metrics_snapshot.assert_eq("produced.spans", produced_per_signal);
-    metrics_snapshot.assert_eq("produced.metric.points", produced_per_signal);
+    assert_eq!(
+        metrics_snapshot.item_operation("logs", "produced"),
+        produced_per_signal
+    );
+    assert_eq!(
+        metrics_snapshot.item_operation("traces", "produced"),
+        produced_per_signal
+    );
+    assert_eq!(
+        metrics_snapshot.item_operation("metrics", "produced"),
+        produced_per_signal
+    );
 
     // All bundles ACKed, none NACKed (counting exporter always succeeds).
     // The exact bundle count depends on internal batching decisions (how many
     // items get grouped per bundle), but there must be at least 3 — one per
     // signal type (logs, traces, metrics).
-    metrics_snapshot.assert_ge("bundles.acked", 3);
-    metrics_snapshot.assert_eq("bundles.nacked.deferred", 0);
-    metrics_snapshot.assert_eq("bundles.nacked.permanent", 0);
+    assert!(metrics_snapshot.bundle_outcome("acked") >= 3);
+    assert_eq!(metrics_snapshot.bundle_outcome("deferred"), 0);
+    assert_eq!(metrics_snapshot.bundle_outcome("permanently_rejected"), 0);
 
     // No errors, drops, or expirations in a clean run.
-    metrics_snapshot.assert_eq("dropped.items", 0);
-    metrics_snapshot.assert_eq("dropped.bundles", 0);
-    metrics_snapshot.assert_eq("dropped.segments", 0);
-    metrics_snapshot.assert_eq("expired.items", 0);
-    metrics_snapshot.assert_eq("expired.bundles", 0);
-    metrics_snapshot.assert_eq("ingest.errors", 0);
-    metrics_snapshot.assert_eq("read.errors", 0);
+    assert_eq!(metrics_snapshot.operational("read.errors"), 0);
 
     // No NACKs → no requeues, and all data drained → queued gauges at zero.
-    metrics_snapshot.assert_eq("requeued.log.records", 0);
-    metrics_snapshot.assert_eq("requeued.metric.points", 0);
-    metrics_snapshot.assert_eq("requeued.spans", 0);
-    metrics_snapshot.assert_eq("queued.log.records", 0);
-    metrics_snapshot.assert_eq("queued.metric.points", 0);
-    metrics_snapshot.assert_eq("queued.spans", 0);
-    metrics_snapshot.assert_eq("in.flight", 0);
+    assert_eq!(metrics_snapshot.item_operation("logs", "requeued"), 0);
+    assert_eq!(metrics_snapshot.item_operation("metrics", "requeued"), 0);
+    assert_eq!(metrics_snapshot.item_operation("traces", "requeued"), 0);
+    assert_eq!(metrics_snapshot.item_operation("logs", "queued"), 0);
+    assert_eq!(metrics_snapshot.item_operation("metrics", "queued"), 0);
+    assert_eq!(metrics_snapshot.item_operation("traces", "queued"), 0);
+    assert_eq!(metrics_snapshot.operational("in.flight"), 0);
 
     // Storage cap should match the configured 256MiB retention_size_cap (per-core budget).
-    metrics_snapshot.assert_eq("storage.bytes.cap", 256 * 1024 * 1024);
+    assert_eq!(
+        metrics_snapshot.operational("storage.bytes.cap"),
+        256 * 1024 * 1024
+    );
 }
 
 /// Test drop_oldest size cap policy configuration is accepted.
@@ -1958,7 +1928,7 @@ fn test_durable_buffer_drop_oldest_policy() {
 /// - When an exporter sends a permanent NACK, the durable buffer calls
 ///   `handle.reject()` on the bundle (marks it as `AckOutcome::Dropped` in Quiver)
 /// - The bundle is NOT retried (no retry scheduling)
-/// - The `bundles_nacked_permanent` metric is incremented
+/// - The `resolved{outcome=permanently_rejected}` metric is incremented
 /// - Queued gauges are decremented (no gauge drift)
 /// - Data sent after permanent NACKs still flows correctly
 ///
@@ -2039,34 +2009,34 @@ fn test_durable_buffer_permanent_nack_rejects_without_retry() {
         "Expected items to be delivered after switching to ACK mode, got 0"
     );
 
-    // Validate metrics: bundles_nacked_permanent should be non-zero
+    // Validate metrics: permanently rejected bundle resolutions should be non-zero.
     assert!(
-        metrics.bundles_nacked_permanent() > 0,
-        "Expected bundles_nacked_permanent metric > 0, got {}",
-        metrics.bundles_nacked_permanent()
+        metrics.bundle_outcome("permanently_rejected") > 0,
+        "Expected resolved{{outcome=permanently_rejected}} metric > 0, got {}",
+        metrics.bundle_outcome("permanently_rejected")
     );
 
-    // Validate metrics: bundles_nacked_deferred should be zero (no transient NACKs)
+    // Validate metrics: deferred bundle resolutions should be zero (no transient NACKs).
     assert_eq!(
-        metrics.bundles_nacked_deferred(),
+        metrics.bundle_outcome("deferred"),
         0,
-        "Expected bundles_nacked_deferred metric = 0, got {}",
-        metrics.bundles_nacked_deferred()
+        "Expected resolved{{outcome=deferred}} metric = 0, got {}",
+        metrics.bundle_outcome("deferred")
     );
 
     // Validate metrics: retries_scheduled should be zero (permanent NACKs don't retry)
     assert_eq!(
-        metrics.retries_scheduled(),
+        metrics.operational("retries.scheduled"),
         0,
         "Expected retries_scheduled metric = 0, got {}",
-        metrics.retries_scheduled()
+        metrics.operational("retries.scheduled")
     );
 
     // Validate metrics: bundles_acked should be non-zero (data delivered in ACK phase)
     assert!(
-        metrics.bundles_acked() > 0,
-        "Expected bundles_acked metric > 0, got {}",
-        metrics.bundles_acked()
+        metrics.bundle_outcome("acked") > 0,
+        "Expected resolved{{outcome=acked}} metric > 0, got {}",
+        metrics.bundle_outcome("acked")
     );
 
     // Validate per-item metrics: permanent NACKs should reject items, not requeue them.
@@ -2074,65 +2044,67 @@ fn test_durable_buffer_permanent_nack_rejects_without_retry() {
     // NACKs it is possible (~25%) that all NACKed bundles are the same type.
     // Assert on the aggregate rather than expecting both counters to be non-zero.
     assert!(
-        metrics.rejected_log_records() + metrics.rejected_spans() > 0,
-        "Expected some items permanently rejected, got rejected_log_records={}, rejected_spans={}",
-        metrics.rejected_log_records(),
-        metrics.rejected_spans()
+        metrics.item_operation("logs", "rejected") + metrics.item_operation("traces", "rejected")
+            > 0,
+        "Expected some items permanently rejected, got rejected{{signal=logs}}={}, rejected{{signal=traces}}={}",
+        metrics.item_operation("logs", "rejected"),
+        metrics.item_operation("traces", "rejected")
     );
     assert_eq!(
-        metrics.requeued_log_records(),
+        metrics.item_operation("logs", "requeued"),
         0,
-        "Expected requeued_log_records metric = 0 (permanent NACKs don't requeue), got {}",
-        metrics.requeued_log_records()
+        "Expected requeued{{signal=logs}} metric = 0 (permanent NACKs don't requeue), got {}",
+        metrics.item_operation("logs", "requeued")
     );
     assert_eq!(
-        metrics.requeued_metric_points(),
+        metrics.item_operation("metrics", "requeued"),
         0,
-        "Expected requeued_metric_points metric = 0 (no metrics generated), got {}",
-        metrics.requeued_metric_points()
+        "Expected requeued{{signal=metrics}} metric = 0 (no metrics generated), got {}",
+        metrics.item_operation("metrics", "requeued")
     );
     assert_eq!(
-        metrics.requeued_spans(),
+        metrics.item_operation("traces", "requeued"),
         0,
-        "Expected requeued_spans metric = 0 (permanent NACKs don't requeue), got {}",
-        metrics.requeued_spans()
+        "Expected requeued{{signal=traces}} metric = 0 (permanent NACKs don't requeue), got {}",
+        metrics.item_operation("traces", "requeued")
     );
 
     // Validate: items were produced (sent downstream).
     // Signal type is random per-bundle, so check aggregate.
     assert!(
-        metrics.produced_log_records() + metrics.produced_spans() > 0,
-        "Expected some items produced, got produced_log_records={}, produced_spans={}",
-        metrics.produced_log_records(),
-        metrics.produced_spans()
+        metrics.item_operation("logs", "produced") + metrics.item_operation("traces", "produced")
+            > 0,
+        "Expected some items produced, got produced{{signal=logs}}={}, produced{{signal=traces}}={}",
+        metrics.item_operation("logs", "produced"),
+        metrics.item_operation("traces", "produced")
     );
 
     // Validate: queued gauges should reflect that permanent NACKs decremented them.
     // It may not be exactly zero because new data can be ingested between the last
     // send and shutdown. But the gauge must not exceed total consumed items
     // (a leak would show queued growing unboundedly).
-    let consumed_logs = metrics.values.get(6).copied().unwrap_or(0);
+    let consumed_logs = metrics.item_operation("logs", "consumed");
     assert!(
-        metrics.queued_log_records() <= consumed_logs,
-        "queued_log_records gauge ({}) should not exceed consumed_log_records ({}); \
+        metrics.item_operation("logs", "queued") <= consumed_logs,
+        "queued{{signal=logs}} gauge ({}) should not exceed consumed{{signal=logs}} ({}); \
          permanent NACKs may be leaking the queued gauge",
-        metrics.queued_log_records(),
+        metrics.item_operation("logs", "queued"),
         consumed_logs
     );
-    let consumed_spans = metrics.values.get(8).copied().unwrap_or(0);
+    let consumed_spans = metrics.item_operation("traces", "consumed");
     assert!(
-        metrics.queued_spans() <= consumed_spans,
-        "queued_spans gauge ({}) should not exceed consumed_spans ({}); \
+        metrics.item_operation("traces", "queued") <= consumed_spans,
+        "queued{{signal=traces}} gauge ({}) should not exceed consumed{{signal=traces}} ({}); \
          permanent NACKs may be leaking the queued gauge",
-        metrics.queued_spans(),
+        metrics.item_operation("traces", "queued"),
         consumed_spans
     );
-    // No metrics generated (pdata limitation), so queued_metric_points should be 0.
+    // No metrics generated (pdata limitation), so queued{signal=metrics} should be 0.
     assert_eq!(
-        metrics.queued_metric_points(),
+        metrics.item_operation("metrics", "queued"),
         0,
-        "queued_metric_points gauge should be 0 (no metrics generated), got {}",
-        metrics.queued_metric_points()
+        "queued{{signal=metrics}} gauge should be 0 (no metrics generated), got {}",
+        metrics.item_operation("metrics", "queued")
     );
 
     println!(
@@ -2143,17 +2115,17 @@ fn test_durable_buffer_permanent_nack_rejects_without_retry() {
         total_permanent_nacks,
         total_transient_nacks,
         delivered,
-        metrics.bundles_acked(),
-        metrics.bundles_nacked_deferred(),
-        metrics.bundles_nacked_permanent(),
-        metrics.retries_scheduled(),
-        metrics.rejected_log_records(),
-        metrics.rejected_spans(),
-        metrics.requeued_log_records(),
-        metrics.produced_log_records(),
-        metrics.queued_log_records(),
-        metrics.queued_spans(),
-        metrics.queued_metric_points()
+        metrics.bundle_outcome("acked"),
+        metrics.bundle_outcome("deferred"),
+        metrics.bundle_outcome("permanently_rejected"),
+        metrics.operational("retries.scheduled"),
+        metrics.item_operation("logs", "rejected"),
+        metrics.item_operation("traces", "rejected"),
+        metrics.item_operation("logs", "requeued"),
+        metrics.item_operation("logs", "produced"),
+        metrics.item_operation("logs", "queued"),
+        metrics.item_operation("traces", "queued"),
+        metrics.item_operation("metrics", "queued")
     );
 }
 
@@ -2165,8 +2137,7 @@ fn test_durable_buffer_permanent_nack_rejects_without_retry() {
 /// 2. Switch to permanent NACKs (bundles rejected immediately)
 /// 3. Switch to ACK mode (verify pipeline still delivers data)
 ///
-/// Validates both `bundles_nacked_deferred` and `bundles_nacked_permanent`
-/// metrics are correctly incremented.
+/// Validates both deferred and permanently rejected bundle-resolution outcomes.
 #[test]
 fn test_durable_buffer_mixed_transient_and_permanent_nacks() {
     let temp_dir = tempdir().expect("failed to create temp dir");
@@ -2277,60 +2248,60 @@ fn test_durable_buffer_mixed_transient_and_permanent_nacks() {
 
     // Validate metrics: both NACK counters should be non-zero
     assert!(
-        metrics.bundles_nacked_deferred() > 0,
-        "Expected bundles_nacked_deferred metric > 0, got {}",
-        metrics.bundles_nacked_deferred()
+        metrics.bundle_outcome("deferred") > 0,
+        "Expected resolved{{outcome=deferred}} metric > 0, got {}",
+        metrics.bundle_outcome("deferred")
     );
     assert!(
-        metrics.bundles_nacked_permanent() > 0,
-        "Expected bundles_nacked_permanent metric > 0, got {}",
-        metrics.bundles_nacked_permanent()
+        metrics.bundle_outcome("permanently_rejected") > 0,
+        "Expected resolved{{outcome=permanently_rejected}} metric > 0, got {}",
+        metrics.bundle_outcome("permanently_rejected")
     );
 
     // Validate metrics: retries should have been scheduled (from transient phase)
     assert!(
-        metrics.retries_scheduled() > 0,
+        metrics.operational("retries.scheduled") > 0,
         "Expected retries_scheduled metric > 0 from transient NACK phase, got {}",
-        metrics.retries_scheduled()
+        metrics.operational("retries.scheduled")
     );
 
     // Validate metrics: bundles_acked should be non-zero (data delivered in ACK phase)
     assert!(
-        metrics.bundles_acked() > 0,
-        "Expected bundles_acked metric > 0, got {}",
-        metrics.bundles_acked()
+        metrics.bundle_outcome("acked") > 0,
+        "Expected resolved{{outcome=acked}} metric > 0, got {}",
+        metrics.bundle_outcome("acked")
     );
 
     // Validate per-item metrics: mixed NACKs should both reject and requeue items.
     // This test uses 100% logs, so only log counters should be non-zero.
     assert!(
-        metrics.rejected_log_records() > 0,
-        "Expected rejected_log_records metric > 0 (items permanently rejected in phase 2), got {}",
-        metrics.rejected_log_records()
+        metrics.item_operation("logs", "rejected") > 0,
+        "Expected rejected{{signal=logs}} metric > 0 (items permanently rejected in phase 2), got {}",
+        metrics.item_operation("logs", "rejected")
     );
     assert!(
-        metrics.requeued_log_records() > 0,
-        "Expected requeued_log_records metric > 0 (items requeued in transient phase 1), got {}",
-        metrics.requeued_log_records()
+        metrics.item_operation("logs", "requeued") > 0,
+        "Expected requeued{{signal=logs}} metric > 0 (items requeued in transient phase 1), got {}",
+        metrics.item_operation("logs", "requeued")
     );
     assert_eq!(
-        metrics.rejected_metric_points(),
+        metrics.item_operation("metrics", "rejected"),
         0,
-        "Expected rejected_metric_points metric = 0 (no metrics generated), got {}",
-        metrics.rejected_metric_points()
+        "Expected rejected{{signal=metrics}} metric = 0 (no metrics generated), got {}",
+        metrics.item_operation("metrics", "rejected")
     );
     assert_eq!(
-        metrics.rejected_spans(),
+        metrics.item_operation("traces", "rejected"),
         0,
-        "Expected rejected_spans metric = 0 (no traces generated), got {}",
-        metrics.rejected_spans()
+        "Expected rejected{{signal=traces}} metric = 0 (no traces generated), got {}",
+        metrics.item_operation("traces", "rejected")
     );
 
     // Validate: items were produced (sent downstream)
     assert!(
-        metrics.produced_log_records() > 0,
-        "Expected produced_log_records metric > 0 (items sent downstream), got {}",
-        metrics.produced_log_records()
+        metrics.item_operation("logs", "produced") > 0,
+        "Expected produced{{signal=logs}} metric > 0 (items sent downstream), got {}",
+        metrics.item_operation("logs", "produced")
     );
 
     println!(
@@ -2342,12 +2313,12 @@ fn test_durable_buffer_mixed_transient_and_permanent_nacks() {
         permanent_nacks,
         total_permanent,
         delivered,
-        metrics.bundles_acked(),
-        metrics.bundles_nacked_deferred(),
-        metrics.bundles_nacked_permanent(),
-        metrics.retries_scheduled(),
-        metrics.rejected_log_records(),
-        metrics.requeued_log_records(),
-        metrics.produced_log_records()
+        metrics.bundle_outcome("acked"),
+        metrics.bundle_outcome("deferred"),
+        metrics.bundle_outcome("permanently_rejected"),
+        metrics.operational("retries.scheduled"),
+        metrics.item_operation("logs", "rejected"),
+        metrics.item_operation("logs", "requeued"),
+        metrics.item_operation("logs", "produced")
     );
 }

--- a/rust/otap-dataflow/crates/quiver/src/engine.rs
+++ b/rust/otap-dataflow/crates/quiver/src/engine.rs
@@ -112,6 +112,8 @@ pub struct QuiverEngine {
     /// Pending dropped bundles grouped by slot shape, for per-signal tracking.
     /// Keyed by sorted slot_ids to bound memory by unique bundle shapes.
     dropped_items_by_shape: RwLock<HashMap<Vec<crate::record_bundle::SlotId>, u64>>,
+    /// Count of segments lost due to max_age retention.
+    expired_segments: AtomicU64,
     /// Count of bundles lost due to expired segments (max_age retention).
     expired_bundles: AtomicU64,
     /// Count of individual data items lost due to expired segments.
@@ -407,6 +409,7 @@ impl QuiverEngine {
             force_dropped_bundles: AtomicU64::new(0),
             force_dropped_items: AtomicU64::new(0),
             dropped_items_by_shape: RwLock::new(HashMap::new()),
+            expired_segments: AtomicU64::new(0),
             expired_bundles: AtomicU64::new(0),
             expired_items: AtomicU64::new(0),
             expired_items_by_shape: RwLock::new(HashMap::new()),
@@ -511,6 +514,14 @@ impl QuiverEngine {
     pub fn drain_dropped_bundles_pending(&self) -> Vec<(Vec<crate::record_bundle::SlotId>, u64)> {
         let map = std::mem::take(&mut *self.dropped_items_by_shape.write());
         map.into_iter().collect()
+    }
+
+    /// Returns the total number of segments lost due to max_age retention.
+    ///
+    /// **By design** this counter resets to zero on restart. It records
+    /// losses that occurred during the current engine lifetime only.
+    pub fn expired_segments(&self) -> u64 {
+        self.expired_segments.load(Ordering::Relaxed)
     }
 
     /// Returns the total number of bundles lost due to expired segments.
@@ -1501,7 +1512,10 @@ impl QuiverEngine {
             self.registry.cleanup_segments_before(max_deleted.next());
         }
 
-        // Track expired bundles and items in the dedicated counters
+        // Track expired segments, bundles, and items in the dedicated counters.
+        let _ = self
+            .expired_segments
+            .fetch_add(expired_segments.len() as u64, Ordering::Relaxed);
         if bundles_expired > 0 {
             let _ = self
                 .expired_bundles
@@ -4727,7 +4741,8 @@ mod tests {
         );
     }
 
-    /// Test that the expired_bundles counter is tracked separately from force_dropped_bundles.
+    /// Scenario: Finalized segments exceed max_age retention while no DropOldest eviction occurs.
+    /// Guarantees: Runtime expiry increments dedicated segment and bundle counters without affecting DropOldest counters.
     #[tokio::test]
     async fn expired_bundles_counter_is_separate() {
         let dir = tempdir().expect("tempdir");
@@ -4751,6 +4766,7 @@ mod tests {
 
         // Initially both counters should be zero
         assert_eq!(engine.force_dropped_bundles(), 0);
+        assert_eq!(engine.expired_segments(), 0);
         assert_eq!(engine.expired_bundles(), 0);
 
         // Ingest data to create segments
@@ -4775,11 +4791,16 @@ mod tests {
         let expired_count = engine.cleanup_expired_segments().expect("cleanup");
         assert!(expired_count > 0, "should have expired some segments");
 
-        // expired_bundles should be incremented, force_dropped_bundles should still be zero
+        // Expiry counters should be incremented, force_dropped_bundles should still be zero.
         assert_eq!(
             engine.force_dropped_bundles(),
             0,
             "force_dropped_bundles should not be affected by expired segments"
+        );
+        assert_eq!(
+            engine.expired_segments(),
+            expired_count as u64,
+            "expired_segments should match the segments removed by expiry"
         );
         assert!(
             engine.expired_bundles() > 0,

--- a/rust/otap-dataflow/crates/telemetry/src/metrics.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/metrics.rs
@@ -313,7 +313,6 @@ impl MetricSetSnapshot {
     ///
     /// Attributes are yielded in declaration order. Callers that need an
     /// order-independent identity can sort the returned key-value pairs.
-    #[must_use]
     pub fn measurement_attributes(
         &self,
     ) -> impl Iterator<Item = (&'static str, &'static str)> + '_ {

--- a/rust/otap-dataflow/crates/telemetry/src/metrics.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/metrics.rs
@@ -309,26 +309,38 @@ impl MetricSetSnapshot {
         self.bucket
     }
 
+    /// Iterates over the measurement attributes decoded for this snapshot's bucket.
+    ///
+    /// Attributes are yielded in declaration order. Callers that need an
+    /// order-independent identity can sort the returned key-value pairs.
+    #[must_use]
+    pub fn measurement_attributes(
+        &self,
+    ) -> impl Iterator<Item = (&'static str, &'static str)> + '_ {
+        let mut rem = self.bucket;
+        self.measurement_attributes
+            .iter()
+            .filter_map(move |descriptor| {
+                let radix = descriptor.variants.len();
+                debug_assert!(
+                    radix > 0,
+                    "measurement attribute descriptor must have at least one variant"
+                );
+                if radix == 0 {
+                    return None;
+                }
+
+                let value = descriptor.variants[rem % radix];
+                rem /= radix;
+                Some((descriptor.key, value))
+            })
+    }
+
     /// Returns the value of a measurement attribute for this snapshot's bucket.
     #[must_use]
     pub fn measurement_attribute_value(&self, key: &str) -> Option<&'static str> {
-        let mut rem = self.bucket;
-        for descriptor in self.measurement_attributes {
-            let radix = descriptor.variants.len();
-            debug_assert!(
-                radix > 0,
-                "measurement attribute descriptor must have at least one variant"
-            );
-            if radix == 0 {
-                continue;
-            }
-            let value = descriptor.variants[rem % radix];
-            rem /= radix;
-            if descriptor.key == key {
-                return Some(value);
-            }
-        }
-        None
+        self.measurement_attributes()
+            .find_map(|(attribute_key, value)| (attribute_key == key).then_some(value))
     }
 
     /// get a reference to the metric values
@@ -1116,12 +1128,17 @@ mod tests {
     }
 
     impl MeasurementAttributeSet for MockMeasurementAttributes {
-        const CARDINALITY: usize = 2;
-        const DESCRIPTORS: &'static [MeasurementAttributeDescriptor] =
-            &[MeasurementAttributeDescriptor {
+        const CARDINALITY: usize = 4;
+        const DESCRIPTORS: &'static [MeasurementAttributeDescriptor] = &[
+            MeasurementAttributeDescriptor {
                 key: "outcome",
                 variants: &["first", "second"],
-            }];
+            },
+            MeasurementAttributeDescriptor {
+                key: "reason",
+                variants: &["one", "two"],
+            },
+        ];
 
         fn bucket_index(&self) -> usize {
             match self {
@@ -1204,6 +1221,8 @@ mod tests {
         assert_eq!(metrics.values[0], MetricValue::U64(0));
     }
 
+    /// Scenario: A snapshot is emitted for a measurement bucket.
+    /// Guarantees: The decoded measurement attributes are available for generic inspection.
     #[test]
     fn test_measurement_metric_set_get_and_snapshot_decode_attributes() {
         let mut entities = EntityRegistry::default();
@@ -1224,6 +1243,10 @@ mod tests {
         assert_eq!(
             snapshots[0].measurement_attribute_value("outcome"),
             Some("second")
+        );
+        assert_eq!(
+            snapshots[0].measurement_attributes().collect::<Vec<_>>(),
+            vec![("outcome", "second"), ("reason", "one")]
         );
         assert_eq!(
             snapshots[0].get_metrics(),


### PR DESCRIPTION
# Change Summary

`durable_buffer` telemetry now reports bounded `signal`, `outcome`, and loss-reason dimensions instead of separate metric names, making loss and ingest behavior consistently queryable across signals.

In addition, doing this actually revealed a gap, `quiver`'s implementation and the `durable_buffer` processor were NOT recording the expired segments combination. Also included in this PR.

### Validation

Using a sample config to fan synthetic telemetry to `acked_buffer`, which exports to `noop`, and `retrying_buffer`, whose downstream OTLP endpoint is unavailable.

### `acked_buffer`

| Scope | Evidence |
| --- | --- |
| `processor.durable_buffer.items` | `consumed_total{signal="logs"} = 220`<br>`consumed_total{signal="metrics"} = 132`<br>`consumed_total{signal="traces"} = 88`<br>`produced_total{signal="logs"} = 210`<br>`produced_total{signal="metrics"} = 120`<br>`produced_total{signal="traces"} = 80`<br>`queued{signal="logs"} = 10`<br>`queued{signal="metrics"} = 12`<br>`queued{signal="traces"} = 8`<br>`requeued_total{signal="logs"} = 0`<br>`requeued_total{signal="metrics"} = 0`<br>`requeued_total{signal="traces"} = 0`<br>`rejected_total{signal="logs"} = 0`<br>`rejected_total{signal="metrics"} = 0`<br>`rejected_total{signal="traces"} = 0` |
| `processor.durable_buffer.bundles` | `resolved_total{outcome="acked"} = 61` |
| `processor.durable_buffer` | `retries_scheduled_total{} = 0`<br>`flush_failures_total{} = 0`<br>`in_flight{} = 0`<br>`read_errors_total{} = 0`<br>`storage_bytes_cap_bytes{} = 10000000000`<br>`storage_bytes_used_bytes{} = 1884371`<br>`storage_utilization{} = 0.0001884371` |
| `processor.durable_buffer.loss` | No expired data |
| `processor.durable_buffer.item_loss` | No expired data |

### `retrying_buffer`

| Scope | Evidence |
| --- | --- |
| `processor.durable_buffer.items` | `consumed_total{signal="logs"} = 220`<br>`consumed_total{signal="metrics"} = 132`<br>`consumed_total{signal="traces"} = 88`<br>`produced_total{signal="logs"} = 370`<br>`produced_total{signal="metrics"} = 204`<br>`produced_total{signal="traces"} = 136`<br>`queued{signal="logs"} = 110`<br>`queued{signal="metrics"} = 72`<br>`queued{signal="traces"} = 48`<br>`requeued_total{signal="logs"} = 370`<br>`requeued_total{signal="metrics"} = 204`<br>`requeued_total{signal="traces"} = 136`<br>`rejected_total{signal="logs"} = 0`<br>`rejected_total{signal="metrics"} = 0`<br>`rejected_total{signal="traces"} = 0` |
| `processor.durable_buffer.bundles` | `resolved_total{outcome="deferred"} = 105` |
| `processor.durable_buffer` | `retries_scheduled_total{} = 105`<br>`flush_failures_total{} = 0`<br>`in_flight{} = 0`<br>`read_errors_total{} = 0`<br>`storage_bytes_cap_bytes{} = 10000000000`<br>`storage_bytes_used_bytes{} = 2000915`<br>`storage_utilization{} = 0.0002000915` |
| `processor.durable_buffer.loss` | `bundles{reason="expired"} = 31`<br>`items{reason="expired"} = 210`<br>**Fixed by this PR:** `segments{reason="expired"} = 5` |
| `processor.durable_buffer.item_loss` | `items_total{reason="expired",signal="logs"} = 110`<br>`items_total{reason="expired",signal="metrics"} = 60`<br>`items_total{reason="expired",signal="traces"} = 40` |

## What issue does this PR close?

Related to #3300

## How are these changes tested?

Unit/integration tests, local pipeline run

## Are there any user-facing changes?

This is a breaking telemetry change. Dashboards, alerts, and queries that use the previous `durable_buffer` metric names must move to the dimensioned metric series. `durable_buffer` metric scopes now use the standard `processor.durable_buffer...` namespace.

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry
* [ ] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
