### PR TITLE
chore(release): Update lockfile after version bump

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -102,8 +102,12 @@ jobs:
           sed -i 's/^version = "[0-9]\+\.[0-9]\+\.[0-9]\+"/version = "${{ inputs.version }}"/g' rust/otap-dataflow/Cargo.toml
           echo "Updated rust/otap-dataflow/Cargo.toml to ${{ inputs.version }}"
 
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        with:
+          toolchain: stable
+
       - name: Update Rust lockfile
-        run: cargo check --manifest-path rust/otap-dataflow/Cargo.toml -p otap-df
+        run: cargo generate-lockfile --manifest-path rust/otap-dataflow/Cargo.toml
 
       - name: Extract release notes for PR body
         id: changelog

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -102,23 +102,29 @@ jobs:
           sed -i 's/^version = "[0-9]\+\.[0-9]\+\.[0-9]\+"/version = "${{ inputs.version }}"/g' rust/otap-dataflow/Cargo.toml
           echo "Updated rust/otap-dataflow/Cargo.toml to ${{ inputs.version }}"
 
+      - name: Update Rust lockfile
+        run: cargo check --manifest-path rust/otap-dataflow/Cargo.toml -p otap-df
+
       - name: Extract release notes for PR body
         id: changelog
         run: |
           # Pull the freshly-rendered section from each CHANGELOG and
           # combine them under per-language `## What's Changed (...)`
-          # headings for embedding in the PR body. --allow-missing keeps
-          # the workflow working if one side had no chloggen entries
-          # this release.
+          # headings for embedding in the PR body. The changelog retains
+          # entry subtext; the PR body includes only concise entry summaries.
+          # --allow-missing keeps the workflow working if one side had no
+          # chloggen entries this release.
           ./.github/workflows/scripts/extract-changelog.sh \
             --version "${{ inputs.version }}" \
             --file go/CHANGELOG.md \
             --allow-missing \
+            --omit-subtext \
             /tmp/go_release_content.txt
           ./.github/workflows/scripts/extract-changelog.sh \
             --version "${{ inputs.version }}" \
             --file rust/otap-dataflow/CHANGELOG.md \
             --allow-missing \
+            --omit-subtext \
             /tmp/rust_release_content.txt
 
           {

--- a/.github/workflows/scripts/extract-changelog.sh
+++ b/.github/workflows/scripts/extract-changelog.sh
@@ -16,7 +16,7 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 usage() {
-    echo "Usage: $0 --version <ver> [--file <path>] [--allow-missing] [output_file]"
+    echo "Usage: $0 --version <ver> [--file <path>] [--allow-missing] [--omit-subtext] [output_file]"
     echo ""
     echo "Extract a release section from a chloggen-managed CHANGELOG.md."
     echo "Output preserves the section as rendered by chloggen and can be"
@@ -28,6 +28,7 @@ usage() {
     echo "Options:"
     echo "  --file <path>       CHANGELOG file to read (default: CHANGELOG.md)."
     echo "  --allow-missing     Exit 0 with empty output if the version section is absent."
+    echo "  --omit-subtext      Exclude indented entry subtext from the extracted output."
     echo "  output_file         Output file (default: /tmp/release_content.txt)."
     echo ""
     echo "Examples:"
@@ -40,6 +41,7 @@ VERSION=""
 FILE="CHANGELOG.md"
 OUTPUT_FILE=""
 ALLOW_MISSING=false
+OMIT_SUBTEXT=false
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -53,6 +55,10 @@ while [ $# -gt 0 ]; do
             ;;
         --allow-missing)
             ALLOW_MISSING=true
+            shift
+            ;;
+        --omit-subtext)
+            OMIT_SUBTEXT=true
             shift
             ;;
         -h|--help)
@@ -120,6 +126,11 @@ CONTENT=$(echo "$CONTENT" | awk '
         for (i = first; i <= last; i++) print lines[i]
     }
 ')
+
+if [ "$OMIT_SUBTEXT" = true ]; then
+    # Chloggen renders optional entry subtext as indented continuation lines.
+    CONTENT=$(echo "$CONTENT" | awk '!/^  /')
+fi
 
 if [ -z "$CONTENT" ]; then
     if [ "$ALLOW_MISSING" = true ]; then


### PR DESCRIPTION
# Change Summary

Since we use the lockfile now, we have to regenerate it during `Prepare Release` workflow, else cargo commands fail: https://github.com/open-telemetry/otel-arrow/actions/runs/29609915091/job/87981905932?pr=3517.

In addition, decided we don't need to display subtext from every changelog entry in the Prepare Release PR.

## What issue does this PR close?

N/A

## How are these changes tested?

Manually

## Are there any user-facing changes?

N/A

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [ ] Added a `.chloggen/*.yaml` entry
* [x] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
