### PR TITLE
chore(ci): Reject non-ascii text in changelog entries

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -123,6 +123,17 @@ jobs:
           echo "Touched chloggen entries:"
           echo "$touched"
 
+          mapfile -t touched_files <<< "$touched"
+          non_ascii=$(LC_ALL=C grep -a -nP '[\x80-\xFF]' -- "${touched_files[@]}" || true)
+          if [ -n "$non_ascii" ]; then
+            echo "Error: .chloggen entries must contain only ASCII characters."
+            echo
+            echo "$non_ascii"
+            echo
+            echo "Replace typographic punctuation and other non-ASCII characters with ASCII equivalents."
+            exit 1
+          fi
+
       - name: Validate .chloggen/*.yaml entries
         if: ${{ steps.detect_bypass.outputs.skip != 'true' && steps.check_docs_only.outputs.is_doc_only != 'true' }}
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,9 @@ Required fields: `change_type` (one of `breaking`, `deprecation`,
 `new_component`, `enhancement`, `bug_fix`), `component` (must be listed in the
 directory's `config.yaml`), `note`, and `issues`.
 
+Changelog entries must use ASCII characters only. Replace typographic punctuation
+and other non-ASCII characters with ASCII equivalents.
+
 Skip the entry only when the change is not user-facing (build chores, internal
 refactors, dev-only dependency bumps). In that case include
 `chore` in the PR title.

--- a/go/.chloggen/README.md
+++ b/go/.chloggen/README.md
@@ -31,6 +31,10 @@ make chlog-validate
 make chlog-preview             # renders entries without modifying CHANGELOGs
 ```
 
+Changelog entries must use ASCII characters only. Replace typographic punctuation
+and other non-ASCII characters with ASCII equivalents so generated changelogs
+pass repository validation.
+
 ## When no entry is needed
 
 Skip the entry when the change is not user-facing. The PR-validation

--- a/rust/otap-dataflow/.chloggen/README.md
+++ b/rust/otap-dataflow/.chloggen/README.md
@@ -30,6 +30,10 @@ make chlog-validate
 make chlog-preview             # renders entries without modifying CHANGELOGs
 ```
 
+Changelog entries must use ASCII characters only. Replace typographic punctuation
+and other non-ASCII characters with ASCII equivalents so generated changelogs
+pass repository validation.
+
 ## When no entry is needed
 
 Skip the entry when the change is not user-facing. The PR-validation

--- a/rust/otap-dataflow/AGENTS.md
+++ b/rust/otap-dataflow/AGENTS.md
@@ -130,6 +130,9 @@ Required fields: `change_type` (one of `breaking`, `deprecation`,
 `new_component`, `enhancement`, `bug_fix`), `component` (must be listed in
 [`.chloggen/config.yaml`](.chloggen/config.yaml)), `note`, and `issues`.
 
+Changelog entries must use ASCII characters only. Replace typographic punctuation
+and other non-ASCII characters with ASCII equivalents.
+
 Skip the entry only when the change is not user-facing. In that case include
 `chore` in the PR title.
 


### PR DESCRIPTION
# Change Summary

Leads to problems in generated `CHANGELOG.md`: https://github.com/open-telemetry/otel-arrow/actions/runs/29615608277/job/87999924730?pr=3520

## What issue does this PR close?

N/A

## How are these changes tested?

N/A

## Are there any user-facing changes?

N/A

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [ ] Added a `.chloggen/*.yaml` entry
* [x] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
