### PR TITLE
chore: Rename ctl title bar to say Otel-Arrow instead of OpenTelemetry Arrow

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ repository](https://github.com/open-telemetry/community/blob/main/guides/contrib
 
 ### Thanks to all of our contributors
 
-[![OpenTelemetry-Arrow
+[![OTel-Arrow
 contributors](https://contributors-img.web.app/image?repo=open-telemetry/otel-arrow)](https://github.com/open-telemetry/otel-arrow/graphs/contributors)
 
 ## Documentation

--- a/rust/otap-dataflow/crates/ctl/src/ui/view/chrome.rs
+++ b/rust/otap-dataflow/crates/ctl/src/ui/view/chrome.rs
@@ -93,11 +93,11 @@ pub(super) fn draw_top_tabs(frame: &mut Frame<'_>, area: Rect, app: &AppState) {
     draw_tab_bar(frame, area, &titles, selected, app.color_enabled);
 }
 
-/// Draw the title, OpenTelemetry brand label, and current target URL.
+/// Draw the title, OTel-Arrow brand label, and current target URL.
 pub(super) fn draw_title_bar(frame: &mut Frame<'_>, area: Rect, app: &AppState) {
     let mut spans = brand_spans(app);
     spans.extend([
-        Span::styled(" - Arrow Dataflow Engine", title_style(app.color_enabled)),
+        Span::styled(" Dataflow Engine", title_style(app.color_enabled)),
         Span::styled("  |  ", separator_style(app.color_enabled)),
         Span::styled("target ", muted_style(app.color_enabled)),
         Span::styled(app.target_url(), target_style(app.color_enabled)),
@@ -109,16 +109,16 @@ pub(super) fn draw_title_bar(frame: &mut Frame<'_>, area: Rect, app: &AppState) 
     frame.render_widget(title, area);
 }
 
-/// Build the styled OpenTelemetry brand spans, shimmering them while background activity runs.
+/// Build the styled OTel-Arrow brand spans, shimmering them while background activity runs.
 pub(super) fn brand_spans(app: &AppState) -> Vec<Span<'static>> {
     if !app.color_enabled || !app.is_activity_active() {
         return vec![
-            Span::styled("Open", open_brand_style(app.color_enabled)),
-            Span::styled("Telemetry", telemetry_brand_style(app.color_enabled)),
+            Span::styled("OTel", open_brand_style(app.color_enabled)),
+            Span::styled("-Arrow", telemetry_brand_style(app.color_enabled)),
         ];
     }
 
-    "OpenTelemetry"
+    "OTel-Arrow"
         .chars()
         .enumerate()
         .map(|(index, character)| {
@@ -131,12 +131,12 @@ pub(super) fn brand_spans(app: &AppState) -> Vec<Span<'static>> {
 }
 
 fn shimmering_brand_style(index: usize, frame: u16) -> Style {
-    let base_style = if index < "Open".len() {
+    let base_style = if index < "OTel".len() {
         open_brand_style(true)
     } else {
         telemetry_brand_style(true)
     };
-    let brand_len = "OpenTelemetry".len();
+    let brand_len = "OTel-Arrow".len();
     let cycle_len = brand_len + 4;
     let center = (usize::from(frame) % cycle_len) as isize - 2;
     let distance = (index as isize - center).unsigned_abs();

--- a/rust/otap-dataflow/crates/ctl/src/ui/view/tests.rs
+++ b/rust/otap-dataflow/crates/ctl/src/ui/view/tests.rs
@@ -118,7 +118,7 @@ fn title_bar_and_command_overlay_render() {
         .iter()
         .map(|cell| cell.symbol())
         .collect::<String>();
-    assert!(rendered.contains("OpenTelemetry - Arrow Dataflow Engine"));
+    assert!(rendered.contains("OTel-Arrow Dataflow Engine"));
     assert!(rendered.contains("Equivalent CLI"));
     assert!(rendered.contains("telemetry logs watch"));
     assert!(rendered.contains("https://admin.example.com:8443/engine-a"));
@@ -126,7 +126,7 @@ fn title_bar_and_command_overlay_render() {
 
 /// Scenario: activity is in progress while the title bar is rendered.
 /// Guarantees: the shimmer splits the brand into fixed-position character
-/// spans without changing the visible OpenTelemetry label text.
+/// spans without changing the visible OTel-Arrow label text.
 #[test]
 fn active_brand_shimmer_preserves_label_text() {
     let mut app = AppState::new(UiStartView::Pipelines, true, 200);
@@ -141,8 +141,8 @@ fn active_brand_shimmer_preserves_label_text() {
         .iter()
         .map(|span| span.content.as_ref())
         .collect::<String>();
-    assert_eq!(label, "OpenTelemetry");
-    assert_eq!(active_spans.len(), "OpenTelemetry".len());
+    assert_eq!(label, "OTel-Arrow");
+    assert_eq!(active_spans.len(), "OTel-Arrow".len());
     assert!(
         active_spans
             .iter()

--- a/rust/otap-dataflow/crates/pdata/README.md
+++ b/rust/otap-dataflow/crates/pdata/README.md
@@ -31,7 +31,7 @@ materializing intermediate OTLP records.  We recommend [PData
 Views](./otap-dataflow/crates/pdata-views/README.md) for producing and
 consuming OTLP bytes in the OTAP-Dataflow engine.
 
-Rust reference implementation for the [OpenTelemetry-Arrow Protocol
+Rust reference implementation for the [OTel-Arrow Protocol
 (OTAP)](../../../../README.md). Here are some of the main data use-cases:
 
 ## High-level interfaces


### PR DESCRIPTION
# Change Summary

Follow-up to #3416 
- Fix the title bar for ctl utility
- Fix two other READMEs that sill pointed to the incorrect name

## How are these changes tested?

## Are there any user-facing changes?

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [ ] Added a `.chloggen/*.yaml` entry
* [x] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
