### PR TITLE
feat(metrics): Require scope keyword on scope attribute_set declarations

### DIFF
--- a/rust/otap-dataflow/.chloggen/require-scope-attribute-set-keyword.yaml
+++ b/rust/otap-dataflow/.chloggen/require-scope-attribute-set-keyword.yaml
@@ -1,0 +1,4 @@
+change_type: breaking
+component: observability
+note: "Require the `scope` keyword on scope `attribute_set` declarations."
+issues: [3513]

--- a/rust/otap-dataflow/.chloggen/require-scope-attribute-set-keyword.yaml
+++ b/rust/otap-dataflow/.chloggen/require-scope-attribute-set-keyword.yaml
@@ -1,4 +1,4 @@
 change_type: breaking
 component: observability
-note: "Require the `scope` keyword on scope `attribute_set` declarations."
+note: "Require the `scope` keyword on scope `attribute_set` declarations and remove support for named measurement attribute sets."
 issues: [3513]

--- a/rust/otap-dataflow/benchmarks/benches/internal_metrics_bridge/main.rs
+++ b/rust/otap-dataflow/benchmarks/benches/internal_metrics_bridge/main.rs
@@ -45,7 +45,7 @@ const METRICS_PER_SET: u64 = 8;
 const SCOPE_NAME: &str = "benchmark.internal_metrics_bridge";
 const WORKLOAD_KIND: &str = "representative";
 
-#[attribute_set(name = "benchmark.internal_metrics_bridge.attrs")]
+#[attribute_set(scope, name = "benchmark.internal_metrics_bridge.attrs")]
 #[derive(Debug, Clone, Hash)]
 struct BenchmarkAttributes {
     /// Unique entity identifier.

--- a/rust/otap-dataflow/crates/admin/src/telemetry.rs
+++ b/rust/otap-dataflow/crates/admin/src/telemetry.rs
@@ -3571,7 +3571,7 @@ mod tests {
         }
     }
 
-    #[attribute_set(name = "test.prometheus.scope")]
+    #[attribute_set(scope, name = "test.prometheus.scope")]
     #[derive(Debug, Clone)]
     struct PrometheusScopeAttributes {
         #[attribute_key = "foo"]

--- a/rust/otap-dataflow/crates/controller/src/controller_monitor.rs
+++ b/rust/otap-dataflow/crates/controller/src/controller_monitor.rs
@@ -167,7 +167,7 @@ fn start_controller_monitor_extension(
     }))
 }
 
-#[attribute_set(name = "controller.monitor.attrs")]
+#[attribute_set(scope, name = "controller.monitor.attrs")]
 #[derive(Debug, Clone)]
 struct ControllerMonitorAttributes {
     /// Configured controller monitor extension instance identifier.

--- a/rust/otap-dataflow/crates/engine/src/attributes.rs
+++ b/rust/otap-dataflow/crates/engine/src/attributes.rs
@@ -47,7 +47,7 @@ pub fn config_map_to_telemetry(
 }
 
 /// Engine attributes (core id, numa node id, ...).
-#[attribute_set(name = "controller.attrs")]
+#[attribute_set(scope, name = "controller.attrs")]
 #[derive(Debug, Clone, Default, Hash)]
 pub struct EngineAttributeSet {
     /// Core identifier.
@@ -79,7 +79,7 @@ impl AttributeSetHandler for EngineEntityAttributeSet {
 }
 
 /// Pipeline attributes.
-#[attribute_set(name = "pipeline.attrs")]
+#[attribute_set(scope, name = "pipeline.attrs")]
 #[derive(Debug, Clone, Default, Hash)]
 pub struct PipelineAttributeSet {
     /// Pipeline identifier as defined in the configuration.
@@ -109,7 +109,7 @@ pub struct PipelineAttributeSet {
 /// add a corresponding `#[compose]` payload field below and a matching
 /// constructor; existing constructors keep new payloads at `Default` so the
 /// descriptor stays stable across scope kinds.
-#[attribute_set(name = "extension.scope.attrs")]
+#[attribute_set(scope, name = "extension.scope.attrs")]
 #[derive(Debug, Clone, Hash)]
 pub struct ExtensionScopeAttributeSet {
     /// Scope kind discriminator. Always paired with the populated payload
@@ -153,7 +153,7 @@ impl ExtensionScopeAttributeSet {
 }
 
 /// Extension attributes, including the host scope.
-#[attribute_set(name = "extension.attrs")]
+#[attribute_set(scope, name = "extension.attrs")]
 #[derive(Debug, Clone, Default, Hash)]
 pub struct ExtensionAttributeSet {
     /// Extension unique identifier within its host scope.
@@ -169,7 +169,7 @@ pub struct ExtensionAttributeSet {
 }
 
 /// Node attributes.
-#[attribute_set(name = "node.attrs")]
+#[attribute_set(scope, name = "node.attrs")]
 #[derive(Debug, Clone, Default, Hash)]
 pub struct NodeAttributeSet {
     /// Node unique identifier (in scope of the pipeline).
@@ -191,7 +191,7 @@ pub struct NodeAttributeSet {
 /// This is used only when a node has non-empty `entity.extend.identity_attributes` in its config.
 /// Nodes without custom attributes use [`NodeAttributeSet`] directly, avoiding
 /// empty `custom={}` noise in telemetry output.
-#[attribute_set(name = "node.custom.attrs")]
+#[attribute_set(scope, name = "node.custom.attrs")]
 #[derive(Debug, Clone, Default, Hash)]
 pub struct NodeWithCustomAttributeSet {
     /// Base node attributes.
@@ -204,7 +204,7 @@ pub struct NodeWithCustomAttributeSet {
 }
 
 /// Node attributes extended with a topic name.
-#[attribute_set(name = "node.topic.attrs")]
+#[attribute_set(scope, name = "node.topic.attrs")]
 #[derive(Debug, Clone, Default, Hash)]
 pub struct NodeWithTopicAttributeSet {
     /// Base node attributes.
@@ -215,7 +215,7 @@ pub struct NodeWithTopicAttributeSet {
 }
 
 /// Node attributes (including custom telemetry attributes) extended with a topic name.
-#[attribute_set(name = "node.custom.topic.attrs")]
+#[attribute_set(scope, name = "node.custom.topic.attrs")]
 #[derive(Debug, Clone, Default, Hash)]
 pub struct NodeWithCustomTopicAttributeSet {
     /// Base node + custom telemetry attributes.
@@ -317,7 +317,7 @@ mod tests {
 }
 
 /// Channel endpoint attributes for a node-hosted channel.
-#[attribute_set(name = "node.channel.attrs")]
+#[attribute_set(scope, name = "node.channel.attrs")]
 #[derive(Debug, Clone, Default, Hash)]
 pub struct NodeChannelAttributeSet {
     /// Unique channel identifier within the host scope.
@@ -353,7 +353,7 @@ pub struct NodeChannelAttributeSet {
 ///
 /// Extensions only have a single control-channel kind (MPSC), so `channel.kind`
 /// and `channel.type` are intentionally omitted as invariants.
-#[attribute_set(name = "extension.channel.attrs")]
+#[attribute_set(scope, name = "extension.channel.attrs")]
 #[derive(Debug, Clone, Default, Hash)]
 pub struct ExtensionChannelAttributeSet {
     /// Unique channel identifier within the host scope.

--- a/rust/otap-dataflow/crates/engine/src/flow_metrics.rs
+++ b/rust/otap-dataflow/crates/engine/src/flow_metrics.rs
@@ -66,7 +66,7 @@ pub struct FlowSignalsDroppedMetrics {
 }
 
 /// Entity attributes that scope a flow metric set.
-#[attribute_set(name = "flow.attrs")]
+#[attribute_set(scope, name = "flow.attrs")]
 #[derive(Debug, Clone, Default, Hash)]
 pub struct FlowAttributeSet {
     /// User-given flow identifier.

--- a/rust/otap-dataflow/crates/engine/tests/enum_attribute_metrics.rs
+++ b/rust/otap-dataflow/crates/engine/tests/enum_attribute_metrics.rs
@@ -48,13 +48,6 @@ pub struct ExplicitMeasurementAttributes {
     pub outcome: LossOutcome,
 }
 
-/// Named measurement sets remain supported for existing metric declarations.
-#[attribute_set(item, measurement, name = "test.legacy.measurement")]
-#[derive(Debug, Clone, Copy)]
-pub struct LegacyMeasurementAttributes {
-    pub outcome: LossOutcome,
-}
-
 /// Registration fields also use their field names as keys without annotations.
 #[attribute_set(item, registration)]
 #[derive(Debug, Clone, Copy)]
@@ -252,14 +245,6 @@ fn signal_type_uses_canonical_values() {
 #[test]
 fn measurement_attribute_set_descriptors_and_bucketing() {
     assert_eq!(ImplicitMeasurementAttributes::CARDINALITY, 6);
-    assert_eq!(LegacyMeasurementAttributes::CARDINALITY, 2);
-    assert_eq!(
-        LegacyMeasurementAttributes {
-            outcome: LossOutcome::Dropped,
-        }
-        .schema_name(),
-        "test.legacy.measurement"
-    );
     let descriptors = ImplicitMeasurementAttributes::DESCRIPTORS;
     assert_eq!(descriptors.len(), 2);
     assert_eq!(descriptors[0].key, "signal");

--- a/rust/otap-dataflow/crates/engine/tests/enum_attribute_metrics.rs
+++ b/rust/otap-dataflow/crates/engine/tests/enum_attribute_metrics.rs
@@ -49,7 +49,7 @@ pub struct ExplicitMeasurementAttributes {
 }
 
 /// Named measurement sets remain supported for existing metric declarations.
-#[attribute_set(name = "test.legacy.measurement", measurement)]
+#[attribute_set(item, measurement, name = "test.legacy.measurement")]
 #[derive(Debug, Clone, Copy)]
 pub struct LegacyMeasurementAttributes {
     pub outcome: LossOutcome,
@@ -69,7 +69,7 @@ pub struct TextRegistrationAttributes {
     pub label: String,
 }
 
-#[attribute_set(name = "test.scope")]
+#[attribute_set(scope, name = "test.scope")]
 #[derive(Debug, Clone)]
 pub struct TestScopeAttributes {
     pub scope: String,

--- a/rust/otap-dataflow/crates/otap/tests/internal_telemetry_metrics.rs
+++ b/rust/otap-dataflow/crates/otap/tests/internal_telemetry_metrics.rs
@@ -116,7 +116,7 @@ struct TestMetrics {
     emitted: Counter<u64>,
 }
 
-#[attribute_set(name = "test.its.pipeline.attrs")]
+#[attribute_set(scope, name = "test.its.pipeline.attrs")]
 #[derive(Debug, Clone)]
 struct TestAttributes {
     /// Test route used to select one metric-set entity.

--- a/rust/otap-dataflow/crates/telemetry-macros/src/lib.rs
+++ b/rust/otap-dataflow/crates/telemetry-macros/src/lib.rs
@@ -1003,36 +1003,33 @@ pub fn metric_set(attr: TokenStream, item: TokenStream) -> TokenStream {
     quote!( #s #marker_impl ).into()
 }
 
-/// Declares either a named scope/entity attribute set or an emitted-item
-/// attribute set.
-///
-/// ```ignore
-/// #[attribute_set(name = "node.scope")] // scope or entity attributes
-/// #[attribute_set(item, registration)] // fixed item attributes
-/// #[attribute_set(item, measurement)] // per-recording metric item attributes
-/// ```
-#[proc_macro_attribute]
-pub fn attribute_set(attr: TokenStream, item: TokenStream) -> TokenStream {
-    // Parse `name = "..."` or the bare item modes.
-    let args = proc_macro2::TokenStream::from(attr);
-    let mut name_val: Option<String> = None;
-    let mut is_item = false;
-    let mut is_registration = false;
-    let mut is_measurement = false;
-    if let Err(err) = syn::parse::Parser::parse2(
+#[derive(Debug, Default)]
+struct AttributeSetArgs {
+    name: Option<String>,
+    scope: bool,
+    item: bool,
+    registration: bool,
+    measurement: bool,
+}
+
+fn parse_attribute_set_args(args: proc_macro2::TokenStream) -> syn::Result<AttributeSetArgs> {
+    let mut parsed = AttributeSetArgs::default();
+    syn::parse::Parser::parse2(
         |input: syn::parse::ParseStream<'_>| -> syn::Result<()> {
             while !input.is_empty() {
                 let ident: syn::Ident = input.parse()?;
                 if ident == "name" {
                     let _: syn::Token![=] = input.parse()?;
                     let lit: LitStr = input.parse()?;
-                    name_val = Some(lit.value());
+                    parsed.name = Some(lit.value());
+                } else if ident == "scope" {
+                    parsed.scope = true;
                 } else if ident == "item" {
-                    is_item = true;
+                    parsed.item = true;
                 } else if ident == "registration" {
-                    is_registration = true;
+                    parsed.registration = true;
                 } else if ident == "measurement" {
-                    is_measurement = true;
+                    parsed.measurement = true;
                 } else {
                     return Err(syn::Error::new(
                         ident.span(),
@@ -1046,54 +1043,72 @@ pub fn attribute_set(attr: TokenStream, item: TokenStream) -> TokenStream {
             Ok(())
         },
         args,
-    ) {
-        return err.to_compile_error().into();
+    )?;
+
+    if parsed.scope && (parsed.item || parsed.registration || parsed.measurement) {
+        return Err(syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "`scope` cannot be combined with item modes",
+        ));
     }
+    if parsed.scope && parsed.name.is_none() {
+        return Err(syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "`scope` requires `name = \"...\"`",
+        ));
+    }
+    if parsed.registration && !parsed.item {
+        return Err(syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "`registration` requires `item`",
+        ));
+    }
+    if parsed.measurement && !parsed.item {
+        return Err(syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "`measurement` requires `item`",
+        ));
+    }
+    if parsed.name.is_some() && parsed.registration {
+        return Err(syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "`name` cannot be combined with `item, registration`",
+        ));
+    }
+    if parsed.item && parsed.registration == parsed.measurement {
+        return Err(syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "`item` requires exactly one of `registration` or `measurement`",
+        ));
+    }
+    if !parsed.scope && !parsed.item {
+        return Err(syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "missing `scope, name = \"...\"` or `item, registration|measurement` in attribute_set attribute",
+        ));
+    }
+
+    Ok(parsed)
+}
+
+/// Declares either a named scope attribute set or an emitted-item attribute set.
+///
+/// ```ignore
+/// #[attribute_set(scope, name = "node.scope")] // scope attributes
+/// #[attribute_set(item, registration)] // fixed item attributes
+/// #[attribute_set(item, measurement)] // per-recording metric item attributes
+/// ```
+#[proc_macro_attribute]
+pub fn attribute_set(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let args = match parse_attribute_set_args(proc_macro2::TokenStream::from(attr)) {
+        Ok(args) => args,
+        Err(error) => return error.to_compile_error().into(),
+    };
 
     // Parse the struct item
     let mut s = parse_macro_input!(item as ItemStruct);
-    if is_registration && !is_item {
-        return syn::Error::new(
-            proc_macro2::Span::call_site(),
-            "`registration` requires `item`",
-        )
-        .to_compile_error()
-        .into();
-    }
-    if is_measurement && !is_item && name_val.is_none() {
-        return syn::Error::new(
-            proc_macro2::Span::call_site(),
-            "`measurement` requires `item`",
-        )
-        .to_compile_error()
-        .into();
-    }
-    if name_val.is_some() && (is_item || is_registration) {
-        return syn::Error::new(
-            proc_macro2::Span::call_site(),
-            "`name` and item modes cannot be combined",
-        )
-        .to_compile_error()
-        .into();
-    }
-    if is_item && is_registration == is_measurement {
-        return syn::Error::new(
-            proc_macro2::Span::call_site(),
-            "`item` requires exactly one of `registration` or `measurement`",
-        )
-        .to_compile_error()
-        .into();
-    }
-    if !is_item && name_val.is_none() {
-        return syn::Error::new(
-            proc_macro2::Span::call_site(),
-            "missing `name = \"...\"` or `item, registration|measurement` in attribute_set attribute",
-        )
-        .to_compile_error()
-        .into();
-    }
 
-    let measurement_impl = if is_measurement {
+    let measurement_impl = if args.measurement {
         match build_measurement_attribute_set_impl_for_fields(&s.ident, &s.fields, s.span()) {
             Ok(measurement_impl) => measurement_impl,
             Err(error) => return error.to_compile_error().into(),
@@ -1101,7 +1116,7 @@ pub fn attribute_set(attr: TokenStream, item: TokenStream) -> TokenStream {
     } else {
         proc_macro2::TokenStream::new()
     };
-    let attributes_name = match name_val {
+    let attributes_name = match args.name {
         Some(name) if name.is_empty() => {
             return syn::Error::new(s.span(), "attribute set name must not be empty")
                 .to_compile_error()
@@ -1388,6 +1403,23 @@ mod tests {
         assert_eq!(
             error.to_string(),
             "attribute_key must use the form #[attribute_key = \"...\"]"
+        );
+    }
+
+    /// Scenario: a named attribute set is declared for telemetry scope attributes.
+    /// Guarantees: scope declarations require the explicit `scope` keyword.
+    #[test]
+    fn scope_attribute_sets_require_the_scope_keyword() {
+        let scope = parse_attribute_set_args(quote::quote!(scope, name = "test.scope"))
+            .expect("explicit scope attribute sets should parse");
+        assert_eq!(scope.name.as_deref(), Some("test.scope"));
+        assert!(scope.scope);
+
+        let error = parse_attribute_set_args(quote::quote!(name = "test.scope"))
+            .expect_err("named attribute sets without a scope must fail");
+        assert_eq!(
+            error.to_string(),
+            "missing `scope, name = \"...\"` or `item, registration|measurement` in attribute_set attribute"
         );
     }
 }

--- a/rust/otap-dataflow/crates/telemetry-macros/src/lib.rs
+++ b/rust/otap-dataflow/crates/telemetry-macros/src/lib.rs
@@ -1069,10 +1069,10 @@ fn parse_attribute_set_args(args: proc_macro2::TokenStream) -> syn::Result<Attri
             "`measurement` requires `item`",
         ));
     }
-    if parsed.name.is_some() && parsed.registration {
+    if parsed.name.is_some() && parsed.item {
         return Err(syn::Error::new(
             proc_macro2::Span::call_site(),
-            "`name` cannot be combined with `item, registration`",
+            "`name` cannot be combined with `item`",
         ));
     }
     if parsed.item && parsed.registration == parsed.measurement {
@@ -1421,5 +1421,19 @@ mod tests {
             error.to_string(),
             "missing `scope, name = \"...\"` or `item, registration|measurement` in attribute_set attribute"
         );
+    }
+
+    /// Scenario: an item attribute set attempts to declare a schema name.
+    /// Guarantees: registration and measurement item attribute sets remain unnamed.
+    #[test]
+    fn item_attribute_sets_cannot_be_named() {
+        for args in [
+            quote::quote!(item, measurement, name = "test.measurement"),
+            quote::quote!(item, registration, name = "test.registration"),
+        ] {
+            let error = parse_attribute_set_args(args)
+                .expect_err("item attribute sets must not declare names");
+            assert_eq!(error.to_string(), "`name` cannot be combined with `item`");
+        }
     }
 }

--- a/rust/otap-dataflow/crates/telemetry-macros/src/lib.rs
+++ b/rust/otap-dataflow/crates/telemetry-macros/src/lib.rs
@@ -1423,17 +1423,31 @@ mod tests {
         );
     }
 
-    /// Scenario: an item attribute set attempts to declare a schema name.
-    /// Guarantees: registration and measurement item attribute sets remain unnamed.
+    /// Scenario: registration and measurement attribute sets use a schema name.
+    /// Guarantees: names are reserved for explicitly declared scope attribute sets.
     #[test]
     fn item_attribute_sets_cannot_be_named() {
-        for args in [
-            quote::quote!(item, measurement, name = "test.measurement"),
-            quote::quote!(item, registration, name = "test.registration"),
+        for (args, expected_error) in [
+            (
+                quote::quote!(item, measurement, name = "test.measurement"),
+                "`name` cannot be combined with `item`",
+            ),
+            (
+                quote::quote!(item, registration, name = "test.registration"),
+                "`name` cannot be combined with `item`",
+            ),
+            (
+                quote::quote!(name = "test.measurement", measurement),
+                "`measurement` requires `item`",
+            ),
+            (
+                quote::quote!(name = "test.registration", registration),
+                "`registration` requires `item`",
+            ),
         ] {
             let error = parse_attribute_set_args(args)
                 .expect_err("item attribute sets must not declare names");
-            assert_eq!(error.to_string(), "`name` cannot be combined with `item`");
+            assert_eq!(error.to_string(), expected_error);
         }
     }
 }

--- a/rust/otap-dataflow/docs/telemetry/item-attributes.md
+++ b/rust/otap-dataflow/docs/telemetry/item-attributes.md
@@ -32,6 +32,33 @@ include measurement `outcome`. One metric set can combine both kinds: use a
 registration attribute for context shared by every recording and measurement
 attributes for the dimensions that vary.
 
+## Declare attribute attachment
+
+`#[attribute_set]` explicitly declares where attributes attach:
+
+```rust
+// Stable entity context, exported as instrumentation scope attributes.
+#[attribute_set(scope, name = "component.scope")]
+struct ComponentScopeAttributes {
+    component_id: String,
+}
+
+// Fixed attributes emitted on every item from one metric-set registration.
+#[attribute_set(item, registration)]
+struct RegistrationAttributes {
+    signal: SignalType,
+}
+
+// Bounded attributes emitted with each metric recording.
+#[attribute_set(item, measurement)]
+struct MeasurementAttributes {
+    outcome: LossOutcome,
+}
+```
+
+Scope attribute sets MUST declare both `scope` and `name`. Registration and
+measurement attribute sets MUST declare `item` and MUST NOT declare `name`.
+
 ## Declare closed values
 
 Derive `AttributeEnum` for every value type. Variant order defines the internal
@@ -85,8 +112,8 @@ applies to every emitted item from that registration.
 Every non-composed field in an attribute set becomes an attribute. Its key
 defaults to the field name with underscores replaced by dots. Use
 `#[attribute_key = "..."]` only when the exported key differs from that default.
-Unlike scope and entity attribute sets, registration attributes do not need a
-schema name because they are emitted directly on telemetry items.
+Registration attributes are emitted directly on telemetry items, so they do not
+have a schema name.
 
 ```rust
 // This component only works on logs.


### PR DESCRIPTION
# Change Summary

Require `scope` on every scope-level `#[attribute_set]` declaration so the intended telemetry attachment point is explicit and unambiguous.

Follow-up from https://github.com/open-telemetry/otel-arrow/pull/3499#issuecomment-5004841970

## What issue does this PR close?

<!--We highly recommend correlation of every PR to an issue-->

* Closes #3513

## How are these changes tested?

Unit tests

## Are there any user-facing changes?

 <!-- If yes, provide further info below -->

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry
* [ ] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
