### PR TITLE
feat(metrics): Use enum attributes for OTLP receiver and shared exporter outcomes

### DIFF
--- a/rust/otap-dataflow/.chloggen/otlp-enum-attribute-metrics.yaml
+++ b/rust/otap-dataflow/.chloggen/otlp-enum-attribute-metrics.yaml
@@ -1,0 +1,7 @@
+# Use this changelog template to create an entry for release notes.
+
+change_type: breaking
+component: pipeline
+note: Consolidate shared exporter outcome and OTLP receiver metrics into bounded signal, outcome, protocol, and error type dimensions.
+issues: [3300]
+subtext:

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/metrics.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/metrics.rs
@@ -8,7 +8,13 @@ use std::rc::Rc;
 
 use otap_df_config::SignalType;
 use otap_df_engine::context::PipelineContext;
-use otap_df_telemetry::common_attributes::{HttpResponse, Outcome};
+use otap_df_telemetry::common_attributes::{
+    HttpResponse, Outcome, OutcomeAttributes, SignalRegistrationAttributes,
+};
+pub use otap_df_telemetry::common_attributes::{
+    HttpResponseAttributes, OutcomeAttributes as ExportOutcomeAttributes,
+    SignalRegistrationAttributes as ExportSignalAttributes,
+};
 use otap_df_telemetry::error::Error as TelemetryError;
 use otap_df_telemetry::instrument::{Counter, Gauge, Mmsc, MmscSnapshot};
 use otap_df_telemetry::metrics::{MeasurementMetricSet, MetricSet};
@@ -45,27 +51,11 @@ pub struct AzureMonitorExporterOperationalMetrics {
     pub log_entries_too_large: Counter<u64>,
 }
 
-#[attribute_set(item, measurement)]
-#[derive(Debug, Clone, Copy)]
-/// Attributes that partition completed exports by outcome.
-pub struct ExportOutcomeAttributes {
-    /// Outcome of the completed export.
-    pub outcome: Outcome,
-}
-
-#[attribute_set(item, registration)]
-#[derive(Debug, Clone, Copy)]
-/// Fixed signal context for Azure Monitor exports.
-pub struct ExportSignalAttributes {
-    /// Signal exported by this logs-only component.
-    pub signal: SignalType,
-}
-
 /// Export completion metrics partitioned by outcome.
 #[metric_set(
     name = "exporter.azure_monitor.exports",
-    registration_attributes = ExportSignalAttributes,
-    measurement_attributes = ExportOutcomeAttributes
+    registration_attributes = SignalRegistrationAttributes,
+    measurement_attributes = OutcomeAttributes
 )]
 #[derive(Debug, Default, Clone)]
 pub struct AzureMonitorExporterExportMetrics {
@@ -78,14 +68,6 @@ pub struct AzureMonitorExporterExportMetrics {
     /// Number of messages resolved by export outcome.
     #[metric(unit = "{message}")]
     pub messages: Counter<u64>,
-}
-
-#[attribute_set(item, measurement)]
-#[derive(Debug, Clone, Copy)]
-/// Attributes that partition HTTP attempts by response category.
-pub struct HttpResponseAttributes {
-    /// Response category from an HTTP export attempt.
-    pub response: HttpResponse,
 }
 
 /// HTTP export attempts partitioned by response category.
@@ -131,7 +113,7 @@ struct AzureMonitorExporterStateMetrics {
 /// Heartbeat send metrics partitioned by outcome.
 #[metric_set(
     name = "exporter.azure_monitor.heartbeats",
-    measurement_attributes = ExportOutcomeAttributes
+    measurement_attributes = OutcomeAttributes
 )]
 #[derive(Debug, Default, Clone)]
 pub struct AzureMonitorExporterHeartbeatMetrics {
@@ -164,7 +146,7 @@ impl AzureMonitorExporterMetricsTracker {
             operational_metrics: AzureMonitorExporterOperationalMetrics::register(pipeline_ctx),
             export_metrics: AzureMonitorExporterExportMetrics::register(
                 pipeline_ctx,
-                &ExportSignalAttributes {
+                &SignalRegistrationAttributes {
                     signal: SignalType::Logs,
                 },
             ),
@@ -200,7 +182,7 @@ impl AzureMonitorExporterMetricsTracker {
     #[inline]
     #[must_use]
     pub(super) fn export_for(&self, outcome: Outcome) -> &AzureMonitorExporterExportMetrics {
-        self.export_metrics.get(ExportOutcomeAttributes { outcome })
+        self.export_metrics.get(OutcomeAttributes { outcome })
     }
 
     #[inline]
@@ -217,9 +199,7 @@ impl AzureMonitorExporterMetricsTracker {
 
     #[inline]
     pub(super) fn record_export(&mut self, outcome: Outcome, items: u64, messages: u64) {
-        let metrics = self
-            .export_metrics
-            .with(ExportOutcomeAttributes { outcome });
+        let metrics = self.export_metrics.with(OutcomeAttributes { outcome });
         metrics.items.add(items);
         metrics.batches.inc();
         metrics.messages.add(messages);
@@ -270,7 +250,7 @@ impl AzureMonitorExporterMetricsTracker {
     #[inline]
     pub(super) fn record_heartbeat(&mut self, outcome: Outcome) {
         self.heartbeat_metrics
-            .with(ExportOutcomeAttributes { outcome })
+            .with(OutcomeAttributes { outcome })
             .sends
             .inc();
     }
@@ -388,7 +368,7 @@ mod tests {
         assert_eq!(
             metrics
                 .heartbeat_metrics
-                .get(ExportOutcomeAttributes {
+                .get(OutcomeAttributes {
                     outcome: Outcome::Success,
                 })
                 .sends
@@ -398,7 +378,7 @@ mod tests {
         assert_eq!(
             metrics
                 .heartbeat_metrics
-                .get(ExportOutcomeAttributes {
+                .get(OutcomeAttributes {
                     outcome: Outcome::Failure,
                 })
                 .sends

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/mod.rs
@@ -42,13 +42,14 @@ use otap_df_engine::message::{ExporterInbox, Message};
 use otap_df_engine::node::NodeId;
 use otap_df_engine::terminal_state::TerminalState;
 use otap_df_otap::OTAP_EXPORTER_FACTORIES;
-use otap_df_otap::metrics::ExporterPDataMetrics;
+use otap_df_otap::metrics::ExporterPDataExportMetrics;
 use otap_df_otap::pdata::OtapPdata;
 use otap_df_pdata::OtapArrowRecords;
 use otap_df_pdata::TryIntoWithOptions;
 use otap_df_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
-use otap_df_telemetry::metrics::MetricSet;
+use otap_df_telemetry::common_attributes::{Outcome, SignalOutcomeAttributes};
 use otap_df_telemetry::metrics::MetricSetHandler;
+use otap_df_telemetry::metrics::{MeasurementMetricSet, MetricSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -89,7 +90,7 @@ const SUPPORTED_ARROW_PAYLOAD_TYPES: &[ArrowPayloadType] = &[
 /// Clickhouse exporter that sends OTAP data to Clickhouse backend
 pub struct ClickhouseExporter {
     config: Config,
-    pdata_metrics: MetricSet<ExporterPDataMetrics>,
+    pdata_metrics: MeasurementMetricSet<ExporterPDataExportMetrics>,
     ch_metrics: MetricSet<ClickhouseExporterMetrics>,
 }
 
@@ -100,7 +101,7 @@ impl ClickhouseExporter {
         config: &serde_json::Value,
     ) -> Result<Self, otap_df_config::error::Error> {
         let ch_metrics = pipeline_ctx.register_metrics::<ClickhouseExporterMetrics>();
-        let pdata_metrics = pipeline_ctx.register_metrics::<ExporterPDataMetrics>();
+        let pdata_metrics = ExporterPDataExportMetrics::register(&pipeline_ctx);
 
         let patch: ConfigPatch = serde_json::from_value(config.clone()).map_err(|e| {
             otap_df_config::error::Error::InvalidUserConfig {
@@ -124,14 +125,12 @@ impl ClickhouseExporter {
 
     fn terminal_state(
         deadline: Instant,
-        pdata_metrics: MetricSet<ExporterPDataMetrics>,
+        mut pdata_metrics: MeasurementMetricSet<ExporterPDataExportMetrics>,
         ch_metrics: MetricSet<ClickhouseExporterMetrics>,
     ) -> TerminalState {
         let mut snapshots = Vec::new();
 
-        if pdata_metrics.needs_flush() {
-            snapshots.push(pdata_metrics.snapshot());
-        }
+        snapshots.extend(pdata_metrics.terminal_snapshots());
         if ch_metrics.needs_flush() {
             snapshots.push(ch_metrics.snapshot());
         }
@@ -214,14 +213,11 @@ impl Exporter<OtapPdata> for ClickhouseExporter {
                 Message::Control(NodeControlMsg::CollectTelemetry {
                     mut metrics_reporter,
                 }) => {
-                    _ = metrics_reporter.report(&mut self.pdata_metrics);
+                    _ = metrics_reporter.report_measurement(&mut self.pdata_metrics);
                     _ = metrics_reporter.report(&mut self.ch_metrics);
                 }
                 Message::PData(pdata) => {
                     let signal_type = pdata.signal_type();
-
-                    // Mark as consumed for this signal
-                    self.pdata_metrics.inc_consumed(signal_type);
 
                     let (_context, payload) = pdata.into_parts();
 
@@ -229,7 +225,13 @@ impl Exporter<OtapPdata> for ClickhouseExporter {
                     {
                         Ok(arrow_records) => arrow_records,
                         Err(e) => {
-                            self.pdata_metrics.inc_failed(signal_type);
+                            self.pdata_metrics
+                                .with(SignalOutcomeAttributes {
+                                    signal: signal_type,
+                                    outcome: Outcome::Failure,
+                                })
+                                .messages
+                                .inc();
                             otap_df_telemetry::otel_warn!(
                                 "clickhouse.exporter.convert.error",
                                 message =
@@ -244,7 +246,13 @@ impl Exporter<OtapPdata> for ClickhouseExporter {
                     arrow_records
                         .decode_transport_optimized_ids()
                         .map_err(|e| {
-                            self.pdata_metrics.inc_failed(signal_type);
+                            self.pdata_metrics
+                                .with(SignalOutcomeAttributes {
+                                    signal: signal_type,
+                                    outcome: Outcome::Failure,
+                                })
+                                .messages
+                                .inc();
                             let source_detail = format_error_sources(&e);
                             Error::ExporterError {
                                 exporter: exporter_id.clone(),
@@ -257,7 +265,13 @@ impl Exporter<OtapPdata> for ClickhouseExporter {
                     let write_batches = match batch_transformer.apply_plan(arrow_records) {
                         Ok(batches) => batches,
                         Err(e) => {
-                            self.pdata_metrics.inc_failed(signal_type);
+                            self.pdata_metrics
+                                .with(SignalOutcomeAttributes {
+                                    signal: signal_type,
+                                    outcome: Outcome::Failure,
+                                })
+                                .messages
+                                .inc();
                             otap_df_telemetry::otel_warn!(
                                 "clickhouse.exporter.transform.error",
                                 message = "Error transforming batch for export.",
@@ -272,10 +286,22 @@ impl Exporter<OtapPdata> for ClickhouseExporter {
                         .await
                     {
                         Ok(_) => {
-                            self.pdata_metrics.inc_exported(signal_type);
+                            self.pdata_metrics
+                                .with(SignalOutcomeAttributes {
+                                    signal: signal_type,
+                                    outcome: Outcome::Success,
+                                })
+                                .messages
+                                .inc();
                         }
                         Err(e) => {
-                            self.pdata_metrics.inc_failed(signal_type);
+                            self.pdata_metrics
+                                .with(SignalOutcomeAttributes {
+                                    signal: signal_type,
+                                    outcome: Outcome::Failure,
+                                })
+                                .messages
+                                .inc();
                             otap_df_telemetry::otel_warn!(
                                 "clickhouse.exporter.write.error",
                                 message = format!("Error writing batch to clickhouse: {}", e),

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/mod.rs
@@ -46,7 +46,7 @@ use otap_df_pdata::views::otap::OtapLogsView;
 use otap_df_pdata::views::otlp::bytes::logs::RawLogsData;
 use otap_df_pdata::{OtapArrowRecords, OtapPayload};
 use otap_df_telemetry::instrument::{Counter, Mmsc};
-use otap_df_telemetry::metrics::MetricSet;
+use otap_df_telemetry::metrics::{MeasurementMetricSet, MetricSet};
 use otap_df_telemetry::otel_info;
 use otap_df_telemetry_macros::metric_set;
 use serde::Deserialize;
@@ -63,8 +63,9 @@ use prost::Message as ProstMessage;
 
 // Use crate-relative paths since we're now a module within otap
 use otap_df_otap::OTAP_EXPORTER_FACTORIES;
-use otap_df_otap::metrics::ExporterPDataMetrics;
+use otap_df_otap::metrics::ExporterPDataExportMetrics;
 use otap_df_otap::pdata::OtapPdata;
+use otap_df_telemetry::common_attributes::{Outcome, SignalOutcomeAttributes};
 
 /// The URN for the Geneva exporter
 pub const GENEVA_EXPORTER_URN: &str = "urn:microsoft:exporter:geneva";
@@ -248,7 +249,7 @@ struct ExporterMetrics {
 /// Geneva exporter that sends OTAP data to Geneva backend
 pub struct GenevaExporter {
     config: Config,
-    pdata_metrics: MetricSet<ExporterPDataMetrics>,
+    pdata_metrics: MeasurementMetricSet<ExporterPDataExportMetrics>,
     metrics: MetricSet<ExporterMetrics>,
     geneva_client: GenevaClient,
 }
@@ -259,7 +260,7 @@ impl GenevaExporter {
         pipeline_ctx: PipelineContext,
         config: &serde_json::Value,
     ) -> Result<Self, otap_df_config::error::Error> {
-        let pdata_metrics = pipeline_ctx.register_metrics::<ExporterPDataMetrics>();
+        let pdata_metrics = ExporterPDataExportMetrics::register(&pipeline_ctx);
         let metrics = pipeline_ctx.register_metrics::<ExporterMetrics>();
 
         let config: Config = serde_json::from_value(config.clone()).map_err(|e| {
@@ -720,21 +721,21 @@ impl Exporter<OtapPdata> for GenevaExporter {
                         message = "Geneva exporter shutting down"
                     );
 
-                    return Ok(TerminalState::new(
-                        deadline,
-                        [self.pdata_metrics.snapshot(), self.metrics.snapshot()],
-                    ));
+                    return Ok(TerminalState::new(deadline, {
+                        let mut snapshots = self.pdata_metrics.terminal_snapshots();
+                        snapshots.push(self.metrics.snapshot());
+                        snapshots
+                    }));
                 }
                 Message::Control(NodeControlMsg::CollectTelemetry {
                     mut metrics_reporter,
                 }) => {
-                    _ = metrics_reporter.report(&mut self.pdata_metrics);
+                    _ = metrics_reporter.report_measurement(&mut self.pdata_metrics);
                     _ = metrics_reporter.report(&mut self.metrics);
                 }
                 Message::PData(pdata) => {
                     let (context, payload) = pdata.into_parts();
                     let signal_type = payload.signal_type();
-                    self.pdata_metrics.inc_consumed(signal_type);
 
                     let saved_payload = if context.may_return_payload() {
                         payload.clone()
@@ -744,13 +745,25 @@ impl Exporter<OtapPdata> for GenevaExporter {
 
                     match self.export_payload(payload, &effect_handler).await {
                         Ok(_batches_uploaded) => {
-                            self.pdata_metrics.inc_exported(signal_type);
+                            self.pdata_metrics
+                                .with(SignalOutcomeAttributes {
+                                    signal: signal_type,
+                                    outcome: Outcome::Success,
+                                })
+                                .messages
+                                .inc();
                             effect_handler
                                 .notify_ack(AckMsg::new(OtapPdata::new(context, saved_payload)))
                                 .await?;
                         }
                         Err(e) => {
-                            self.pdata_metrics.inc_failed(signal_type);
+                            self.pdata_metrics
+                                .with(SignalOutcomeAttributes {
+                                    signal: signal_type,
+                                    outcome: Outcome::Failure,
+                                })
+                                .messages
+                                .inc();
                             otel_info!(
                                 "geneva_exporter.error",
                                 error = e,

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/README.md
@@ -86,19 +86,15 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
 
 ### Metric Sets
 
-#### `exporter.pdata`
+Input PData message volume is reported by the engine through
+`channel.receiver.recv.count` on the PData input channel and is not duplicated
+by the exporter.
 
-| Metric | Unit | Description |
-| --- | --- | --- |
-| `exporter.pdata.metrics_consumed` | `{msg}` | Number of pdata metrics consumed by this exporter. |
-| `exporter.pdata.metrics_exported` | `{msg}` | Number of pdata metrics successfully exported. |
-| `exporter.pdata.metrics_failed` | `{msg}` | Number of pdata metrics that failed to be exported. |
-| `exporter.pdata.logs_consumed` | `{msg}` | Number of pdata logs consumed by this exporter. |
-| `exporter.pdata.logs_exported` | `{msg}` | Number of pdata logs successfully exported. |
-| `exporter.pdata.logs_failed` | `{msg}` | Number of pdata logs that failed to be exported. |
-| `exporter.pdata.traces_consumed` | `{msg}` | Number of pdata traces consumed by this exporter. |
-| `exporter.pdata.traces_exported` | `{msg}` | Number of pdata traces successfully exported. |
-| `exporter.pdata.traces_failed` | `{msg}` | Number of pdata traces that failed to be exported. |
+#### `exporter.pdata.exports`
+
+| Metric | Unit | Attributes | Description |
+| --- | --- | --- | --- |
+| `exporter.pdata.exports.messages` | `{message}` | `signal`, `outcome` | Number of PData messages whose export reached a terminal outcome. |
 
 #### `otap.exporter.grpc.async`
 

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/mod.rs
@@ -24,7 +24,7 @@ use otap_df_engine::message::{ExporterInbox, Message};
 use otap_df_engine::node::NodeId;
 use otap_df_engine::terminal_state::TerminalState;
 use otap_df_otap::OTAP_EXPORTER_FACTORIES;
-use otap_df_otap::metrics::ExporterPDataMetrics;
+use otap_df_otap::metrics::ExporterPDataExportMetrics;
 use otap_df_otap::pdata::OtapPdata;
 use otap_df_pdata::Producer;
 use otap_df_pdata::TryIntoWithOptions;
@@ -36,8 +36,9 @@ use otap_df_pdata::proto::opentelemetry::arrow::v1::{
     arrow_metrics_service_client::ArrowMetricsServiceClient,
     arrow_traces_service_client::ArrowTracesServiceClient,
 };
+use otap_df_telemetry::common_attributes::{Outcome, SignalOutcomeAttributes};
 use otap_df_telemetry::instrument::{Gauge, Mmsc};
-use otap_df_telemetry::metrics::MetricSet;
+use otap_df_telemetry::metrics::{MeasurementMetricSet, MetricSet};
 use otap_df_telemetry::{otel_debug, otel_error, otel_info, otel_warn};
 use otap_df_telemetry_macros::metric_set;
 use serde_json::Value;
@@ -60,7 +61,7 @@ use config::Config;
 /// Exporter that sends OTAP data via gRPC
 pub struct OTAPExporter {
     config: Config,
-    pdata_metrics: MetricSet<ExporterPDataMetrics>,
+    pdata_metrics: MeasurementMetricSet<ExporterPDataExportMetrics>,
     async_metrics: MetricSet<OtapGrpcAsyncMetrics>,
     export_latency_window: ExportLatencyWindow,
 }
@@ -207,7 +208,7 @@ impl OTAPExporter {
     /// Creates a new OTAPExporter
     #[must_use]
     pub fn new(pipeline_ctx: PipelineContext, config: Config) -> Self {
-        let pdata_metrics = pipeline_ctx.register_metrics::<ExporterPDataMetrics>();
+        let pdata_metrics = ExporterPDataExportMetrics::register(&pipeline_ctx);
         let async_metrics = pipeline_ctx.register_metrics::<OtapGrpcAsyncMetrics>();
         OTAPExporter {
             config,
@@ -257,7 +258,13 @@ impl OTAPExporter {
                         .record(duration_ns);
                     self.export_latency_window.record(duration_ns);
                 }
-                self.pdata_metrics.inc_failed(signal_type);
+                self.pdata_metrics
+                    .with(SignalOutcomeAttributes {
+                        signal: signal_type,
+                        outcome: Outcome::Failure,
+                    })
+                    .messages
+                    .inc();
                 effect_handler
                     .notify_nack(NackMsg::new("export failed", pdata))
                     .await?;
@@ -267,7 +274,13 @@ impl OTAPExporter {
                     .export_rpc_duration_ns
                     .record(response_duration_ns);
                 self.export_latency_window.record(response_duration_ns);
-                self.pdata_metrics.inc_exported(signal_type);
+                self.pdata_metrics
+                    .with(SignalOutcomeAttributes {
+                        signal: signal_type,
+                        outcome: Outcome::Success,
+                    })
+                    .messages
+                    .inc();
                 effect_handler.notify_ack(AckMsg::new(pdata)).await?;
             }
             PDataMetricsUpdate::RecordStreamEncodeDuration(duration_ns) => {
@@ -549,7 +562,7 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
                     }) => {
                         self.export_latency_window
                             .report_into(&mut self.async_metrics);
-                        _ = metrics_reporter.report(&mut self.pdata_metrics);
+                        _ = metrics_reporter.report_measurement(&mut self.pdata_metrics);
                         _ = metrics_reporter.report(&mut self.async_metrics);
                     }
                     // shutdown the exporter
@@ -580,20 +593,29 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
                             .report_into(&mut self.async_metrics);
                         return Ok(TerminalState::new(
                             deadline,
-                            [self.pdata_metrics.snapshot(), self.async_metrics.snapshot()],
+                            {
+                                let mut snapshots = self.pdata_metrics.terminal_snapshots();
+                                snapshots.push(self.async_metrics.snapshot());
+                                snapshots
+                            },
                         ))
                     }
                     //send data
                     Message::PData(mut pdata) => {
                         let signal_type = pdata.signal_type();
 
-                        self.pdata_metrics.inc_consumed(signal_type);
                         let payload = pdata.take_payload();
 
                         let message: OtapArrowRecords = match payload.try_into_with_default() {
                             Ok(m) => m,
                             Err(e) => {
-                                self.pdata_metrics.inc_failed(signal_type);
+                                self.pdata_metrics
+                                    .with(SignalOutcomeAttributes {
+                                        signal: signal_type,
+                                        outcome: Outcome::Failure,
+                                    })
+                                    .messages
+                                    .inc();
                                 effect_handler.notify_nack(NackMsg::new("payload conversion failed", pdata)).await?;
                                 return Err(e.into());
                             }
@@ -1677,6 +1699,8 @@ mod tests {
         );
     }
 
+    /// Scenario: The OTAP endpoint becomes available after an initial failed logs export.
+    /// Guarantees: Reconnection succeeds and one success plus one failure are reported for logs.
     #[test]
     fn test_receiver_not_ready_on_start() {
         let grpc_addr = "127.0.0.1";
@@ -1812,10 +1836,25 @@ mod tests {
                 })
                 .await
                 .unwrap();
-            let metrics = metrics_receiver.recv_async().await.unwrap();
-            let logs_exported_count = metrics.get_metrics()[4].to_u64_lossy(); // logs exported
+            let mut logs_exported_count = 0;
+            let mut logs_failed_count = 0;
+            for _ in 0..3 {
+                let metrics = metrics_receiver.recv_async().await.unwrap();
+                if metrics.descriptor().name == "exporter.pdata.exports"
+                    && metrics.measurement_attribute_value("signal") == Some("logs")
+                {
+                    match metrics.measurement_attribute_value("outcome") {
+                        Some("success") => {
+                            logs_exported_count = metrics.get_metrics()[0].to_u64_lossy();
+                        }
+                        Some("failure") => {
+                            logs_failed_count = metrics.get_metrics()[0].to_u64_lossy();
+                        }
+                        _ => {}
+                    }
+                }
+            }
             assert_eq!(logs_exported_count, 1);
-            let logs_failed_count = metrics.get_metrics()[5].to_u64_lossy(); // logs failed
             assert_eq!(logs_failed_count, 1);
 
             control_sender
@@ -1864,7 +1903,7 @@ mod tests {
             )
             .await;
         });
-        let (metrics_rx, metrics_reporter) = MetricsReporter::create_new_and_receiver(1);
+        let (metrics_rx, metrics_reporter) = MetricsReporter::create_new_and_receiver(3);
 
         let _ = tokio_rt.block_on(async move {
             let local_set = tokio::task::LocalSet::new();

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/README.md
@@ -100,19 +100,15 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
 
 ### Metric Sets
 
-#### `exporter.pdata`
+Input PData message volume is reported by the engine through
+`channel.receiver.recv.count` on the PData input channel and is not duplicated
+by the exporter.
 
-| Metric | Unit | Description |
-| --- | --- | --- |
-| `exporter.pdata.metrics_consumed` | `{msg}` | Number of pdata metrics consumed by this exporter. |
-| `exporter.pdata.metrics_exported` | `{msg}` | Number of pdata metrics successfully exported. |
-| `exporter.pdata.metrics_failed` | `{msg}` | Number of pdata metrics that failed to be exported. |
-| `exporter.pdata.logs_consumed` | `{msg}` | Number of pdata logs consumed by this exporter. |
-| `exporter.pdata.logs_exported` | `{msg}` | Number of pdata logs successfully exported. |
-| `exporter.pdata.logs_failed` | `{msg}` | Number of pdata logs that failed to be exported. |
-| `exporter.pdata.traces_consumed` | `{msg}` | Number of pdata traces consumed by this exporter. |
-| `exporter.pdata.traces_exported` | `{msg}` | Number of pdata traces successfully exported. |
-| `exporter.pdata.traces_failed` | `{msg}` | Number of pdata traces that failed to be exported. |
+#### `exporter.pdata.exports`
+
+| Metric | Unit | Attributes | Description |
+| --- | --- | --- | --- |
+| `exporter.pdata.exports.messages` | `{message}` | `signal`, `outcome` | Number of PData messages whose export reached a terminal outcome. |
 
 ### Events
 

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/mod.rs
@@ -28,7 +28,7 @@ use otap_df_engine::message::{ExporterInbox, Message};
 use otap_df_engine::node::NodeId;
 use otap_df_engine::terminal_state::TerminalState;
 use otap_df_otap::OTAP_EXPORTER_FACTORIES;
-use otap_df_otap::metrics::ExporterPDataMetrics;
+use otap_df_otap::metrics::ExporterPDataExportMetrics;
 use otap_df_otap::otap_grpc::client_settings::GrpcClientSettings;
 use otap_df_otap::otap_grpc::otlp::client::{
     LogsServiceClient, MetricsServiceClient, TraceServiceClient,
@@ -40,8 +40,8 @@ use otap_df_pdata::otlp::metrics::MetricsProtoBytesEncoder;
 use otap_df_pdata::otlp::traces::TracesProtoBytesEncoder;
 use otap_df_pdata::otlp::{ProtoBuffer, ProtoBytesEncoder};
 use otap_df_pdata::{OtapArrowRecords, OtapPayload, OtapPayloadHelpers, OtlpProtoBytes};
-use otap_df_telemetry::instrument::Counter;
-use otap_df_telemetry::metrics::MetricSet;
+use otap_df_telemetry::common_attributes::{Outcome, SignalOutcomeAttributes};
+use otap_df_telemetry::metrics::MeasurementMetricSet;
 use otap_df_telemetry::{otel_debug, otel_info, otel_warn};
 use serde::Deserialize;
 use std::collections::VecDeque;
@@ -83,7 +83,7 @@ pub(crate) const fn default_num_connections() -> usize {
 /// Exporter that sends OTLP data via gRPC
 pub struct OTLPExporter {
     config: Config,
-    pdata_metrics: MetricSet<ExporterPDataMetrics>,
+    pdata_metrics: MeasurementMetricSet<ExporterPDataExportMetrics>,
 }
 
 /// Declare the OTLP Exporter as a local exporter factory
@@ -132,7 +132,7 @@ impl OTLPExporter {
         pipeline_ctx: PipelineContext,
         config: &serde_json::Value,
     ) -> Result<Self, otap_df_config::error::Error> {
-        let pdata_metrics = pipeline_ctx.register_metrics::<ExporterPDataMetrics>();
+        let pdata_metrics = ExporterPDataExportMetrics::register(&pipeline_ctx);
 
         let config: Config = serde_json::from_value(config.clone()).map_err(|e| {
             otap_df_config::error::Error::InvalidUserConfig {
@@ -301,12 +301,15 @@ impl Exporter<OtapPdata> for OTLPExporter {
                             grpc_clients.release(client);
                         }
                     }
-                    return Ok(TerminalState::new(deadline, [self.pdata_metrics]));
+                    return Ok(TerminalState::new(
+                        deadline,
+                        self.pdata_metrics.terminal_snapshots(),
+                    ));
                 }
                 Message::Control(NodeControlMsg::CollectTelemetry {
                     mut metrics_reporter,
                 }) => {
-                    _ = metrics_reporter.report(&mut self.pdata_metrics);
+                    _ = metrics_reporter.report_measurement(&mut self.pdata_metrics);
                 }
                 Message::PData(pdata) => {
                     if inflight_exports.len() >= max_in_flight {
@@ -316,7 +319,6 @@ impl Exporter<OtapPdata> for OTLPExporter {
 
                     let signal_type = pdata.signal_type();
                     let (context, payload) = pdata.into_parts();
-                    self.pdata_metrics.inc_consumed(signal_type);
 
                     // Build gRPC metadata from configured static headers and
                     // any propagated transport headers. Computed once before
@@ -341,7 +343,7 @@ impl Exporter<OtapPdata> for OTLPExporter {
                                     make_export_future(encoded, client)
                                 },
                                 &mut inflight_exports,
-                                &mut self.pdata_metrics.logs_failed,
+                                &mut self.pdata_metrics,
                                 &effect_handler,
                             )
                             .await;
@@ -360,7 +362,7 @@ impl Exporter<OtapPdata> for OTLPExporter {
                                     make_export_future(encoded, client)
                                 },
                                 &mut inflight_exports,
-                                &mut self.pdata_metrics.metrics_failed,
+                                &mut self.pdata_metrics,
                                 &effect_handler,
                             )
                             .await;
@@ -379,7 +381,7 @@ impl Exporter<OtapPdata> for OTLPExporter {
                                     make_export_future(encoded, client)
                                 },
                                 &mut inflight_exports,
-                                &mut self.pdata_metrics.traces_failed,
+                                &mut self.pdata_metrics,
                                 &effect_handler,
                             )
                             .await;
@@ -675,7 +677,7 @@ async fn dispatch_otap_export<Enc, Fut, MakeFuture>(
     encoder: &mut Enc,
     make_future: MakeFuture,
     inflight: &mut InFlightExports<Fut, CompletedExport>,
-    failed_counter: &mut Counter<u64>,
+    pdata_metrics: &mut MeasurementMetricSet<ExporterPDataExportMetrics>,
     effect_handler: &EffectHandler<OtapPdata>,
 ) where
     Enc: ProtoBytesEncoder,
@@ -695,7 +697,13 @@ async fn dispatch_otap_export<Enc, Fut, MakeFuture>(
             inflight.push(make_future(encoded));
         }
         Err(error) => {
-            failed_counter.inc();
+            pdata_metrics
+                .with(SignalOutcomeAttributes {
+                    signal: signal_type,
+                    outcome: Outcome::Failure,
+                })
+                .messages
+                .inc();
             _ = notify_prepare_error(error, effect_handler).await;
         }
     }
@@ -727,7 +735,7 @@ async fn notify_prepare_error(
 async fn finalize_completed_export(
     completed: CompletedExport,
     effect_handler: &EffectHandler<OtapPdata>,
-    pdata_metrics: &mut MetricSet<ExporterPDataMetrics>,
+    pdata_metrics: &mut MeasurementMetricSet<ExporterPDataExportMetrics>,
 ) -> SignalClient {
     let CompletedExport {
         result,
@@ -738,14 +746,28 @@ async fn finalize_completed_export(
     } = completed;
 
     match route_export_result(result, context, saved_payload, effect_handler).await {
-        Ok(()) => pdata_metrics.add_exported(signal_type, 1),
+        Ok(()) => {
+            pdata_metrics
+                .with(SignalOutcomeAttributes {
+                    signal: signal_type,
+                    outcome: Outcome::Success,
+                })
+                .messages
+                .inc();
+        }
         Err(e) => {
             otel_warn!(
                 "otlp.exporter.http.export_error",
                 message = "OTLP Exporter gRPC service request did not succeed",
                 error = %e
             );
-            pdata_metrics.add_failed(signal_type, 1)
+            pdata_metrics
+                .with(SignalOutcomeAttributes {
+                    signal: signal_type,
+                    outcome: Outcome::Failure,
+                })
+                .messages
+                .inc();
         }
     }
 
@@ -1327,7 +1349,7 @@ mod tests {
                     max_in_flight: 32,
                     num_connections: default_num_connections(),
                 },
-                pdata_metrics: pipeline_ctx.register_metrics::<ExporterPDataMetrics>(),
+                pdata_metrics: ExporterPDataExportMetrics::register(&pipeline_ctx),
             },
             test_node(test_runtime.config().name.clone()),
             node_config,
@@ -1451,7 +1473,7 @@ mod tests {
                     max_in_flight: 32,
                     num_connections: default_num_connections(),
                 },
-                pdata_metrics: pipeline_ctx.register_metrics::<ExporterPDataMetrics>(),
+                pdata_metrics: ExporterPDataExportMetrics::register(&pipeline_ctx),
             },
             test_node(test_runtime.config().name.clone()),
             node_config,
@@ -1489,6 +1511,8 @@ mod tests {
         );
     }
 
+    /// Scenario: The OTLP gRPC endpoint repeatedly stops and restarts while exporting logs.
+    /// Guarantees: The exporter reconnects and reports one terminal outcome per export operation.
     #[test]
     fn test_receiver_not_ready_on_start_and_reconnect() {
         // the purpose of this test is to that the exporter behaves as expected in the face of
@@ -1521,7 +1545,7 @@ mod tests {
                     max_in_flight: 32,
                     num_connections: default_num_connections(),
                 },
-                pdata_metrics: pipeline_ctx.register_metrics::<ExporterPDataMetrics>(),
+                pdata_metrics: ExporterPDataExportMetrics::register(&pipeline_ctx),
             },
             node_id.clone(),
             node_config,
@@ -1689,10 +1713,25 @@ mod tests {
                 })
                 .await
                 .unwrap();
-            let metrics = metrics_receiver.recv_async().await.unwrap();
-            let logs_exported_count = metrics.get_metrics()[4].to_u64_lossy(); // logs exported
+            let mut logs_exported_count = 0;
+            let mut logs_failed_count = 0;
+            for _ in 0..2 {
+                let metrics = metrics_receiver.recv_async().await.unwrap();
+                if metrics.descriptor().name == "exporter.pdata.exports"
+                    && metrics.measurement_attribute_value("signal") == Some("logs")
+                {
+                    match metrics.measurement_attribute_value("outcome") {
+                        Some("success") => {
+                            logs_exported_count = metrics.get_metrics()[0].to_u64_lossy();
+                        }
+                        Some("failure") => {
+                            logs_failed_count = metrics.get_metrics()[0].to_u64_lossy();
+                        }
+                        _ => {}
+                    }
+                }
+            }
             assert_eq!(logs_exported_count, 2);
-            let logs_failed_count = metrics.get_metrics()[5].to_u64_lossy(); // logs failed
             assert_eq!(logs_failed_count, 2);
 
             control_sender
@@ -1756,7 +1795,7 @@ mod tests {
             .await;
         });
 
-        let (metrics_rx, metrics_reporter) = MetricsReporter::create_new_and_receiver(1);
+        let (metrics_rx, metrics_reporter) = MetricsReporter::create_new_and_receiver(3);
 
         let (exporter_result, test_drive_result) = tokio_rt.block_on(async move {
             tokio::join!(
@@ -2068,7 +2107,7 @@ mod tests {
                     max_in_flight: 1,
                     num_connections: default_num_connections(),
                 },
-                pdata_metrics: pipeline_ctx.register_metrics::<ExporterPDataMetrics>(),
+                pdata_metrics: ExporterPDataExportMetrics::register(&pipeline_ctx),
             },
             node_id.clone(),
             node_config,

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/README.md
@@ -108,19 +108,15 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
 
 ### Metric Sets
 
-#### `exporter.pdata`
+Input PData message volume is reported by the engine through
+`channel.receiver.recv.count` on the PData input channel and is not duplicated
+by the exporter.
 
-| Metric | Unit | Description |
-| --- | --- | --- |
-| `exporter.pdata.metrics_consumed` | `{msg}` | Number of pdata metrics consumed by this exporter. |
-| `exporter.pdata.metrics_exported` | `{msg}` | Number of pdata metrics successfully exported. |
-| `exporter.pdata.metrics_failed` | `{msg}` | Number of pdata metrics that failed to be exported. |
-| `exporter.pdata.logs_consumed` | `{msg}` | Number of pdata logs consumed by this exporter. |
-| `exporter.pdata.logs_exported` | `{msg}` | Number of pdata logs successfully exported. |
-| `exporter.pdata.logs_failed` | `{msg}` | Number of pdata logs that failed to be exported. |
-| `exporter.pdata.traces_consumed` | `{msg}` | Number of pdata traces consumed by this exporter. |
-| `exporter.pdata.traces_exported` | `{msg}` | Number of pdata traces successfully exported. |
-| `exporter.pdata.traces_failed` | `{msg}` | Number of pdata traces that failed to be exported. |
+#### `exporter.pdata.exports`
+
+| Metric | Unit | Attributes | Description |
+| --- | --- | --- | --- |
+| `exporter.pdata.exports.messages` | `{message}` | `signal`, `outcome` | Number of PData messages whose export reached a terminal outcome. |
 
 ### Events
 

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs
@@ -49,7 +49,8 @@ use otap_df_pdata::proto::opentelemetry::collector::trace::v1::{
     ExportTracePartialSuccess, ExportTraceServiceResponse,
 };
 use otap_df_pdata::{OtapPayload, OtapPayloadHelpers};
-use otap_df_telemetry::metrics::MetricSet;
+use otap_df_telemetry::common_attributes::{Outcome, SignalOutcomeAttributes};
+use otap_df_telemetry::metrics::MeasurementMetricSet;
 use otap_df_telemetry::{otel_debug, otel_info, otel_warn};
 use prost::Message as _;
 use reqwest::{Client, Response};
@@ -58,7 +59,7 @@ use secrecy::ExposeSecret;
 use self::config::Config;
 use crate::exporters::otlp_grpc_exporter::InFlightExports;
 use otap_df_otap::OTAP_EXPORTER_FACTORIES;
-use otap_df_otap::metrics::ExporterPDataMetrics;
+use otap_df_otap::metrics::ExporterPDataExportMetrics;
 use otap_df_otap::otlp_http::client_settings::{HttpClientError, HttpClientSettings};
 use otap_df_otap::otlp_http::{LOGS_PATH, METRICS_PATH, PROTOBUF_CONTENT_TYPE, TRACES_PATH};
 use otap_df_otap::pdata::{Context, OtapPdata};
@@ -71,7 +72,7 @@ pub const OTLP_HTTP_EXPORTER_URN: &str = "urn:otel:exporter:otlp_http";
 /// Exporter that sends OTLP data via HTTP
 pub struct OtlpHttpExporter {
     config: Config,
-    pdata_metrics: MetricSet<ExporterPDataMetrics>,
+    pdata_metrics: MeasurementMetricSet<ExporterPDataExportMetrics>,
 }
 
 /// Declare the OTLP HTTP Exporter as a local exporter factory
@@ -123,7 +124,7 @@ impl OtlpHttpExporter {
         pipeline_ctx: PipelineContext,
         config: &serde_json::Value,
     ) -> Result<Self, ConfigError> {
-        let pdata_metrics = pipeline_ctx.register_metrics::<ExporterPDataMetrics>();
+        let pdata_metrics = ExporterPDataExportMetrics::register(&pipeline_ctx);
 
         let config: Config = serde_json::from_value(config.clone()).map_err(|e| {
             otap_df_config::error::Error::InvalidUserConfig {
@@ -334,11 +335,14 @@ impl Exporter<OtapPdata> for OtlpHttpExporter {
                             .await;
                         }
                     }
-                    return Ok(TerminalState::new(deadline, [self.pdata_metrics]));
+                    return Ok(TerminalState::new(
+                        deadline,
+                        self.pdata_metrics.terminal_snapshots(),
+                    ));
                 }
                 Message::Control(NodeControlMsg::CollectTelemetry {
                     mut metrics_reporter,
-                }) => _ = metrics_reporter.report(&mut self.pdata_metrics),
+                }) => _ = metrics_reporter.report_measurement(&mut self.pdata_metrics),
                 Message::PData(pdata) => {
                     let signal_type = pdata.signal_type();
                     let (context, payload) = pdata.into_parts();
@@ -395,7 +399,13 @@ impl Exporter<OtapPdata> for OtlpHttpExporter {
                                 );
                                 nack.permanent = true;
                                 _ = effect_handler.notify_nack(nack).await;
-                                self.pdata_metrics.add_failed(signal_type, 1);
+                                self.pdata_metrics
+                                    .with(SignalOutcomeAttributes {
+                                        signal: signal_type,
+                                        outcome: Outcome::Failure,
+                                    })
+                                    .messages
+                                    .inc();
                                 continue;
                             }
 
@@ -418,7 +428,13 @@ impl Exporter<OtapPdata> for OtlpHttpExporter {
                                 );
                                 nack.permanent = true;
                                 _ = effect_handler.notify_nack(nack).await;
-                                self.pdata_metrics.add_failed(signal_type, 1);
+                                self.pdata_metrics
+                                    .with(SignalOutcomeAttributes {
+                                        signal: signal_type,
+                                        outcome: Outcome::Failure,
+                                    })
+                                    .messages
+                                    .inc();
                                 continue;
                             }
                             Bytes::copy_from_slice(&compressed_buffer)
@@ -657,7 +673,7 @@ async fn collect_body(response: Response, max_len: usize) -> Result<Bytes, Servi
 async fn finalize_completed_export(
     completed: CompletedExport,
     effect_handler: &EffectHandler<OtapPdata>,
-    pdata_metrics: &mut MetricSet<ExporterPDataMetrics>,
+    pdata_metrics: &mut MeasurementMetricSet<ExporterPDataExportMetrics>,
 ) {
     let CompletedExport {
         result,
@@ -705,7 +721,6 @@ async fn finalize_completed_export(
                 message = err_msg,
                 retryable = retryable
             );
-            pdata_metrics.add_failed(signal_type, 1);
             let mut nack = NackMsg::new(&err_msg, pdata);
             nack.permanent = !retryable;
             _ = effect_handler.notify_nack(nack).await;
@@ -713,11 +728,18 @@ async fn finalize_completed_export(
         }
     };
 
-    if export_and_notify_success {
-        pdata_metrics.add_exported(signal_type, 1)
+    let outcome = if export_and_notify_success {
+        Outcome::Success
     } else {
-        pdata_metrics.add_failed(signal_type, 1)
-    }
+        Outcome::Failure
+    };
+    pdata_metrics
+        .with(SignalOutcomeAttributes {
+            signal: signal_type,
+            outcome,
+        })
+        .messages
+        .inc();
 }
 
 /// A simple pool of HTTP clients to allow for concurrent exports.
@@ -849,6 +871,7 @@ mod test {
     use otap_df_pdata::proto::opentelemetry::trace::v1::{ResourceSpans, TracesData};
     use otap_df_pdata::testing::equiv::assert_equivalent;
     use otap_df_pdata::testing::round_trip::otlp_to_otap;
+    use otap_df_telemetry::registry::TelemetryRegistryHandle;
     use otap_df_telemetry::reporter::MetricsReporter;
 
     use parking_lot::lock_api::Mutex;
@@ -903,7 +926,7 @@ mod test {
         tune_max_concurrent_requests(&mut server_settings, 1);
 
         let ack_registry = AckRegistry::new(None, None, None);
-        let server_metrics = pipeline_ctx.register_metrics::<OtlpReceiverMetrics>();
+        let server_metrics = OtlpReceiverMetrics::register(pipeline_ctx);
         let server_cancellation_token = CancellationToken::new();
         let server_cancellation_token2 = server_cancellation_token.clone();
 
@@ -1231,7 +1254,7 @@ mod test {
         tune_max_concurrent_requests(&mut server_settings, 1);
 
         let ack_registry = AckRegistry::new(None, None, None);
-        let server_metrics = pipeline_ctx.register_metrics::<OtlpReceiverMetrics>();
+        let server_metrics = OtlpReceiverMetrics::register(pipeline_ctx);
         let server_cancellation_token = CancellationToken::new();
         let server_cancellation_token2 = server_cancellation_token.clone();
 
@@ -1277,7 +1300,7 @@ mod test {
         let exporter = ExporterWrapper::local(
             OtlpHttpExporter {
                 config,
-                pdata_metrics: pipeline_ctx.register_metrics::<ExporterPDataMetrics>(),
+                pdata_metrics: ExporterPDataExportMetrics::register(&pipeline_ctx),
             },
             node_id.clone(),
             node_config,
@@ -1481,7 +1504,6 @@ mod test {
             })
             .run_validation(|mut ctx, result| {
                 Box::pin(async move {
-                    // ensure exit success
                     result.unwrap();
 
                     // ensure we got back all the signals we expected ...
@@ -1633,6 +1655,8 @@ mod test {
             })
     }
 
+    /// Scenario: The OTLP HTTP server returns retryable and permanent non-success statuses.
+    /// Guarantees: Each consumed request yields one Nack and exactly one failed export outcome.
     #[test]
     fn test_handles_non_200_response_status() {
         let test_cases = [(500, false), (429, true), (503, true), (504, true)];
@@ -1640,6 +1664,56 @@ mod test {
         for (status, retryable) in test_cases {
             run_error_status_code_test(status, retryable);
         }
+    }
+
+    /// Scenario: An OTLP HTTP export finishes with a terminal service-request error.
+    /// Guarantees: Finalization records exactly one failure for the exported signal.
+    #[test]
+    fn failed_export_finalization_records_one_terminal_outcome() {
+        let registry = TelemetryRegistryHandle::new();
+        let controller = ControllerContext::new(registry);
+        let pipeline_ctx =
+            controller.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+        let mut metrics = ExporterPDataExportMetrics::register(&pipeline_ctx);
+
+        let (_metrics_rx, metrics_reporter) = MetricsReporter::create_new_and_receiver(1);
+        let effect_handler = EffectHandler::new(test_node("test-exporter"), metrics_reporter);
+        let completed = CompletedExport {
+            result: Err(ServiceRequestError::BodyTooLarge {
+                body_size: 2,
+                max_size: 1,
+            }),
+            context: Context::default(),
+            saved_payload: OtlpProtoBytes::ExportLogsRequest(Bytes::new()).into(),
+            signal_type: SignalType::Logs,
+        };
+
+        Runtime::new().unwrap().block_on(finalize_completed_export(
+            completed,
+            &effect_handler,
+            &mut metrics,
+        ));
+
+        assert_eq!(
+            metrics
+                .get(SignalOutcomeAttributes {
+                    signal: SignalType::Logs,
+                    outcome: Outcome::Failure,
+                })
+                .messages
+                .get(),
+            1
+        );
+        assert_eq!(
+            metrics
+                .get(SignalOutcomeAttributes {
+                    signal: SignalType::Logs,
+                    outcome: Outcome::Success,
+                })
+                .messages
+                .get(),
+            0
+        );
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/parquet_exporter/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/parquet_exporter/README.md
@@ -79,19 +79,15 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
 
 ### Metric Sets
 
-#### `exporter.pdata`
+Input PData message volume is reported by the engine through
+`channel.receiver.recv.count` on the PData input channel and is not duplicated
+by the exporter.
 
-| Metric | Unit | Description |
-| --- | --- | --- |
-| `exporter.pdata.metrics_consumed` | `{msg}` | Number of pdata metrics consumed by this exporter. |
-| `exporter.pdata.metrics_exported` | `{msg}` | Number of pdata metrics successfully exported. |
-| `exporter.pdata.metrics_failed` | `{msg}` | Number of pdata metrics that failed to be exported. |
-| `exporter.pdata.logs_consumed` | `{msg}` | Number of pdata logs consumed by this exporter. |
-| `exporter.pdata.logs_exported` | `{msg}` | Number of pdata logs successfully exported. |
-| `exporter.pdata.logs_failed` | `{msg}` | Number of pdata logs that failed to be exported. |
-| `exporter.pdata.traces_consumed` | `{msg}` | Number of pdata traces consumed by this exporter. |
-| `exporter.pdata.traces_exported` | `{msg}` | Number of pdata traces successfully exported. |
-| `exporter.pdata.traces_failed` | `{msg}` | Number of pdata traces that failed to be exported. |
+#### `exporter.pdata.exports`
+
+| Metric | Unit | Attributes | Description |
+| --- | --- | --- | --- |
+| `exporter.pdata.exports.messages` | `{message}` | `signal`, `outcome` | Number of PData messages whose export reached a terminal outcome. |
 
 #### `otap.exporter.parquet`
 

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/parquet_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/parquet_exporter/mod.rs
@@ -52,11 +52,12 @@ use otap_df_engine::message::{ExporterInbox, Message};
 use otap_df_engine::node::NodeId;
 use otap_df_engine::terminal_state::TerminalState;
 use otap_df_otap::OTAP_EXPORTER_FACTORIES;
-use otap_df_otap::metrics::ExporterPDataMetrics;
+use otap_df_otap::metrics::ExporterPDataExportMetrics;
 use otap_df_otap::pdata::OtapPdata;
 use otap_df_pdata::TryIntoWithOptions;
 use otap_df_pdata::otap::OtapArrowRecords;
-use otap_df_telemetry::metrics::{MetricSet, MetricSetHandler};
+use otap_df_telemetry::common_attributes::{Outcome, SignalOutcomeAttributes};
+use otap_df_telemetry::metrics::{MeasurementMetricSet, MetricSet, MetricSetHandler};
 use otap_df_telemetry::otel_warn;
 use std::io::ErrorKind;
 use std::sync::Arc;
@@ -68,7 +69,7 @@ const PARQUET_EXPORTER_URN: &str = "urn:otel:exporter:parquet";
 /// Parquet exporter for OTAP Data
 pub struct ParquetExporter {
     config: config::Config,
-    pdata_metrics: Option<MetricSet<ExporterPDataMetrics>>,
+    pdata_metrics: Option<MeasurementMetricSet<ExporterPDataExportMetrics>>,
     io_metrics: Option<MetricSet<metrics::ParquetExporterMetrics>>,
 }
 
@@ -120,7 +121,7 @@ impl ParquetExporter {
             }
         })?;
 
-        let pdata_metrics = pipeline_ctx.register_metrics::<ExporterPDataMetrics>();
+        let pdata_metrics = ExporterPDataExportMetrics::register(&pipeline_ctx);
         let io_metrics = pipeline_ctx.register_metrics::<metrics::ParquetExporterMetrics>();
 
         Ok(ParquetExporter {
@@ -132,15 +133,13 @@ impl ParquetExporter {
 
     fn terminal_state(
         deadline: Instant,
-        pdata_metrics: Option<MetricSet<ExporterPDataMetrics>>,
+        mut pdata_metrics: Option<MeasurementMetricSet<ExporterPDataExportMetrics>>,
         io_metrics: Option<MetricSet<metrics::ParquetExporterMetrics>>,
     ) -> TerminalState {
         let mut snapshots = Vec::new();
 
-        if let Some(metrics) = &pdata_metrics {
-            if metrics.needs_flush() {
-                snapshots.push(metrics.snapshot());
-            }
+        if let Some(metrics) = &mut pdata_metrics {
+            snapshots.extend(metrics.terminal_snapshots());
         }
 
         if let Some(metrics) = &io_metrics {
@@ -240,7 +239,7 @@ impl Exporter<OtapPdata> for ParquetExporter {
                     mut metrics_reporter,
                 }) => {
                     if let Some(metrics) = self.pdata_metrics.as_mut() {
-                        _ = metrics_reporter.report(metrics);
+                        _ = metrics_reporter.report_measurement(metrics);
                     }
                     if let Some(metrics) = self.io_metrics.as_mut() {
                         _ = metrics_reporter.report(metrics);
@@ -308,15 +307,16 @@ impl Exporter<OtapPdata> for ParquetExporter {
                     // Note: context is not used
                     let (_context, payload) = pdata.into_parts();
 
-                    // Mark as consumed for this signal
-                    if let Some(metrics) = self.pdata_metrics.as_mut() {
-                        metrics.inc_consumed(signal_type);
-                    }
-
                     let mut otap_batch: OtapArrowRecords =
                         payload.try_into_with_default().inspect_err(|_| {
                             if let Some(metrics) = self.pdata_metrics.as_mut() {
-                                metrics.inc_failed(signal_type);
+                                metrics
+                                    .with(SignalOutcomeAttributes {
+                                        signal: signal_type,
+                                        outcome: Outcome::Failure,
+                                    })
+                                    .messages
+                                    .inc();
                             }
                         })?;
 
@@ -324,7 +324,13 @@ impl Exporter<OtapPdata> for ParquetExporter {
                     // to unvalidated parquet records
                     otap_batch.decode_transport_optimized_ids().map_err(|e| {
                         if let Some(metrics) = self.pdata_metrics.as_mut() {
-                            metrics.inc_failed(signal_type);
+                            metrics
+                                .with(SignalOutcomeAttributes {
+                                    signal: signal_type,
+                                    outcome: Outcome::Failure,
+                                })
+                                .messages
+                                .inc();
                         }
                         let source_detail = format_error_sources(&e);
                         Error::ExporterError {
@@ -343,7 +349,13 @@ impl Exporter<OtapPdata> for ParquetExporter {
                     if let Err(e) = id_gen_result {
                         // mark failure before returning
                         if let Some(metrics) = self.pdata_metrics.as_mut() {
-                            metrics.inc_failed(signal_type);
+                            metrics
+                                .with(SignalOutcomeAttributes {
+                                    signal: signal_type,
+                                    outcome: Outcome::Failure,
+                                })
+                                .messages
+                                .inc();
                         }
                         // TODO - this is not the error handling we want long term.
                         // eventually we should have the concept of retryable & non-retryable errors and
@@ -362,7 +374,13 @@ impl Exporter<OtapPdata> for ParquetExporter {
                     transform_to_known_schema(&mut otap_batch).map_err(|e| {
                         // mark failure before returning
                         if let Some(metrics) = self.pdata_metrics.as_mut() {
-                            metrics.inc_failed(signal_type);
+                            metrics
+                                .with(SignalOutcomeAttributes {
+                                    signal: signal_type,
+                                    outcome: Outcome::Failure,
+                                })
+                                .messages
+                                .inc();
                         }
                         // TODO - Ack/Nack instead of returning error
                         let source_detail = format_error_sources(&e);
@@ -399,7 +417,13 @@ impl Exporter<OtapPdata> for ParquetExporter {
                         Ok(stats) => {
                             // successful write
                             if let Some(metrics) = self.pdata_metrics.as_mut() {
-                                metrics.inc_exported(signal_type);
+                                metrics
+                                    .with(SignalOutcomeAttributes {
+                                        signal: signal_type,
+                                        outcome: Outcome::Success,
+                                    })
+                                    .messages
+                                    .inc();
                             }
                             if let Some(io) = self.io_metrics.as_mut() {
                                 record_io_metrics(io, stats);
@@ -408,7 +432,13 @@ impl Exporter<OtapPdata> for ParquetExporter {
                         Err(e) => {
                             // mark failure before returning
                             if let Some(metrics) = self.pdata_metrics.as_mut() {
-                                metrics.inc_failed(signal_type);
+                                metrics
+                                    .with(SignalOutcomeAttributes {
+                                        signal: signal_type,
+                                        outcome: Outcome::Failure,
+                                    })
+                                    .messages
+                                    .inc();
                             }
                             if let Some(io) = self.io_metrics.as_mut() {
                                 record_io_metrics(io, e.stats);
@@ -1410,6 +1440,8 @@ mod test {
             });
     }
 
+    /// Scenario: The Parquet exporter successfully writes a PData message.
+    /// Guarantees: The shared terminal export metric set is reported.
     #[test]
     fn test_collect_telemetry_reports_metrics() {
         use otap_df_engine::context::ControllerContext;
@@ -1488,7 +1520,7 @@ mod test {
             pdata_tx: Sender<OtapPdata>,
             reporter: otap_df_telemetry::reporter::MetricsReporter,
         ) {
-            // Send minimal pdata to increment pdata metrics (consumed)
+            // Send minimal pdata to increment export outcome metrics.
             let logs = Consumer::default()
                 .consume_bar(&mut fixtures::create_simple_logs_arrow_record_batches(
                     SimpleDataGenOptions {
@@ -1545,26 +1577,16 @@ mod test {
             )
         }));
 
-        // Inspect registry to ensure exporter.pdata registered counters were reported
-        let mut saw_exporter_pdata = false;
-        let mut any_positive = false;
+        let mut saw_exports = false;
         telemetry_registry.visit_current_metrics(|desc, _attrs, iter| {
-            if desc.name == "exporter.pdata" {
-                saw_exporter_pdata = true;
-                for (_field, value) in iter {
-                    if value.to_f64() > 0.0 {
-                        any_positive = true;
-                    }
-                }
+            let has_positive_value = iter.into_iter().any(|(_, value)| value.to_f64() > 0.0);
+            if desc.name == "exporter.pdata.exports" && has_positive_value {
+                saw_exports = true;
             }
         });
         assert!(
-            saw_exporter_pdata,
-            "expected exporter.pdata metric set to be registered"
-        );
-        assert!(
-            any_positive,
-            "expected at least one exporter.pdata counter > 0"
+            saw_exports,
+            "expected exporter.pdata.exports metrics to be reported"
         );
     }
 

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/perf_exporter/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/perf_exporter/README.md
@@ -64,19 +64,15 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
 
 ### Metric Sets
 
-#### `exporter.pdata`
+Input PData message volume is reported by the engine through
+`channel.receiver.recv.count` on the PData input channel and is not duplicated
+by the exporter.
 
-| Metric | Unit | Description |
-| --- | --- | --- |
-| `exporter.pdata.metrics_consumed` | `{msg}` | Number of pdata metrics consumed by this exporter. |
-| `exporter.pdata.metrics_exported` | `{msg}` | Number of pdata metrics successfully exported. |
-| `exporter.pdata.metrics_failed` | `{msg}` | Number of pdata metrics that failed to be exported. |
-| `exporter.pdata.logs_consumed` | `{msg}` | Number of pdata logs consumed by this exporter. |
-| `exporter.pdata.logs_exported` | `{msg}` | Number of pdata logs successfully exported. |
-| `exporter.pdata.logs_failed` | `{msg}` | Number of pdata logs that failed to be exported. |
-| `exporter.pdata.traces_consumed` | `{msg}` | Number of pdata traces consumed by this exporter. |
-| `exporter.pdata.traces_exported` | `{msg}` | Number of pdata traces successfully exported. |
-| `exporter.pdata.traces_failed` | `{msg}` | Number of pdata traces that failed to be exported. |
+#### `exporter.pdata.exports`
+
+| Metric | Unit | Attributes | Description |
+| --- | --- | --- | --- |
+| `exporter.pdata.exports.messages` | `{message}` | `signal`, `outcome` | Number of PData messages whose export reached a terminal outcome. |
 
 #### `exporter.perf.pdata`
 

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/perf_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/perf_exporter/mod.rs
@@ -39,9 +39,10 @@ use otap_df_engine::message::{ExporterInbox, Message};
 use otap_df_engine::node::NodeId;
 use otap_df_engine::terminal_state::TerminalState;
 use otap_df_otap::OTAP_EXPORTER_FACTORIES;
-use otap_df_otap::metrics::ExporterPDataMetrics;
+use otap_df_otap::metrics::ExporterPDataExportMetrics;
 use otap_df_otap::pdata::OtapPdata;
-use otap_df_telemetry::metrics::{MetricSet, MetricSetHandler};
+use otap_df_telemetry::common_attributes::{Outcome, SignalOutcomeAttributes};
+use otap_df_telemetry::metrics::{MeasurementMetricSet, MetricSet, MetricSetHandler};
 use otap_df_telemetry::otel_info;
 use serde_json::Value;
 use std::sync::Arc;
@@ -54,7 +55,7 @@ pub const OTAP_PERF_EXPORTER_URN: &str = "urn:otel:exporter:perf";
 pub struct PerfExporter {
     config: Config,
     metrics: MetricSet<PerfExporterPdataMetrics>,
-    pdata_metrics: MetricSet<ExporterPDataMetrics>,
+    pdata_metrics: MeasurementMetricSet<ExporterPDataExportMetrics>,
 }
 
 /// Declares the OTAP Perf exporter as a local exporter factory
@@ -86,7 +87,7 @@ impl PerfExporter {
     #[must_use]
     pub fn new(pipeline_ctx: PipelineContext, config: Config) -> Self {
         let metrics = pipeline_ctx.register_metrics::<PerfExporterPdataMetrics>();
-        let pdata_metrics = pipeline_ctx.register_metrics::<ExporterPDataMetrics>();
+        let pdata_metrics = ExporterPDataExportMetrics::register(&pipeline_ctx);
 
         PerfExporter {
             config,
@@ -110,16 +111,14 @@ impl PerfExporter {
         ))
     }
 
-    fn terminal_state(&self, deadline: Instant) -> TerminalState {
+    fn terminal_state(&mut self, deadline: Instant) -> TerminalState {
         let mut snapshots = Vec::new();
 
         if self.metrics.needs_flush() {
             snapshots.push(self.metrics.snapshot());
         }
 
-        if self.pdata_metrics.needs_flush() {
-            snapshots.push(self.pdata_metrics.snapshot());
-        }
+        snapshots.extend(self.pdata_metrics.terminal_snapshots());
 
         TerminalState::new(deadline, snapshots)
     }
@@ -149,7 +148,7 @@ impl local::Exporter<OtapPdata> for PerfExporter {
                     mut metrics_reporter,
                 }) => {
                     _ = metrics_reporter.report(&mut self.metrics);
-                    _ = metrics_reporter.report(&mut self.pdata_metrics);
+                    _ = metrics_reporter.report_measurement(&mut self.pdata_metrics);
                 }
                 // ToDo: Handle configuration changes
                 Message::Control(NodeControlMsg::Config { .. }) => {}
@@ -159,9 +158,6 @@ impl local::Exporter<OtapPdata> for PerfExporter {
                 Message::PData(mut pdata) => {
                     // Capture signal type before moving pdata into try_from
                     let signal_type = pdata.signal_type();
-
-                    // Increment consumed for this signal
-                    self.pdata_metrics.inc_consumed(signal_type);
 
                     let payload = pdata.take_payload();
                     let _ = effect_handler.notify_ack(AckMsg::new(pdata)).await?;
@@ -219,7 +215,13 @@ impl local::Exporter<OtapPdata> for PerfExporter {
                     // }
 
                     // Successful perf reporting: mark as exported for this signal
-                    self.pdata_metrics.inc_exported(signal_type);
+                    self.pdata_metrics
+                        .with(SignalOutcomeAttributes {
+                            signal: signal_type,
+                            outcome: Outcome::Success,
+                        })
+                        .messages
+                        .inc();
 
                     // ToDo Report disk, io, cpu, mem usage once gauge metrics are implemented
                 }

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/metrics.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/metrics.rs
@@ -5,6 +5,7 @@
 
 use otap_df_config::SignalType;
 use otap_df_engine::context::PipelineContext;
+use otap_df_telemetry::common_attributes::SignalAttributes;
 use otap_df_telemetry::error::Error;
 use otap_df_telemetry::instrument::{Counter, Gauge, ObserveCounter};
 use otap_df_telemetry::metrics::{MeasurementMetricSet, MetricSet};
@@ -85,12 +86,6 @@ pub(super) struct DurableBufferIngestMetrics {
     /// Number of failed ingest attempts.
     #[metric(unit = "{failure}")]
     pub(super) failures: Counter<u64>,
-}
-
-#[attribute_set(item, measurement)]
-#[derive(Debug, Clone, Copy)]
-pub(super) struct SignalAttributes {
-    pub(super) signal: SignalType,
 }
 
 /// Item operation metrics partitioned by OpenTelemetry signal.

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
@@ -107,7 +107,7 @@ use deferred_retry_state::DeferredRetryState;
 use deferred_retry_state::RETRY_WAKEUP_SLOT;
 use metrics::{BundleOutcome, DurableBufferMetrics, IngestFailure, LossReason};
 #[cfg(test)]
-use metrics::{LossAttributes, SignalAttributes, SignalLossAttributes};
+use metrics::{LossAttributes, SignalLossAttributes};
 
 use otap_df_config::SignalType;
 use otap_df_config::error::Error as ConfigError;
@@ -128,6 +128,8 @@ use otap_df_engine::{
     ProcessorRuntimeRequirements, ProducerEffectHandlerExtension,
 };
 use otap_df_pdata::{OtapArrowRecords, OtapPayload};
+#[cfg(test)]
+use otap_df_telemetry::common_attributes::SignalAttributes;
 
 /// URN for the durable buffer.
 pub const DURABLE_BUFFER_URN: &str = "urn:otel:processor:durable_buffer";

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/otlp_receiver/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/otlp_receiver/README.md
@@ -94,7 +94,7 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
 | --- | --- | --- | --- |
 | `receiver.otlp.requests.started` | `{request}` | `signal`, `protocol` | Number of requests admitted to the pipeline send path. |
 | `receiver.otlp.requests.completed` | `{request}` | `signal`, `protocol` | Number of admitted requests whose receiver work terminated. |
-| `receiver.otlp.requests.payload_size` | `By` | `signal`, `protocol` | Decompressed payload bytes for successfully decoded requests. |
+| `receiver.otlp.requests.payload_size` | `By` | `signal`, `protocol` | Decompressed payload bytes for requests admitted to the pipeline send path. |
 
 #### `receiver.otlp.rejections`
 

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/otlp_receiver/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/otlp_receiver/README.md
@@ -88,19 +88,36 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
 
 ### Metric Sets
 
-#### `receiver.otlp`
+#### `receiver.otlp.requests`
 
-| Metric | Unit | Description |
-| --- | --- | --- |
-| `receiver.otlp.acks_received` | `{acks}` | Number of acks received from downstream (routed back to the caller). |
-| `receiver.otlp.nacks_received` | `{nacks}` | Number of nacks received from downstream (routed back to the caller). |
-| `receiver.otlp.acks_nacks_invalid_or_expired` | `{ack_or_nack}` | Number of invalid/expired acks/nacks. |
-| `receiver.otlp.requests_started` | `{requests}` | Number of OTLP RPCs started. |
-| `receiver.otlp.requests_completed` | `{requests}` | Number of OTLP RPCs completed (success + nack). |
-| `receiver.otlp.rejected_requests` | `{requests}` | Number of OTLP RPCs rejected before entering the pipeline (e.g. slot exhaustion). |
-| `receiver.otlp.refused_memory_pressure` | `{requests}` | Number of OTLP RPCs rejected specifically because process-wide memory pressure was active. |
-| `receiver.otlp.transport_errors` | `{errors}` | Number of transport-level errors surfaced by tonic/server. |
-| `receiver.otlp.request_bytes` | `By` | Total decompressed payload bytes for successfully received OTLP requests. |
+| Metric | Unit | Attributes | Description |
+| --- | --- | --- | --- |
+| `receiver.otlp.requests.started` | `{request}` | `signal`, `protocol` | Number of requests admitted to the pipeline send path. |
+| `receiver.otlp.requests.completed` | `{request}` | `signal`, `protocol` | Number of admitted requests whose receiver work terminated. |
+| `receiver.otlp.requests.payload_size` | `By` | `signal`, `protocol` | Decompressed payload bytes for successfully decoded requests. |
+
+#### `receiver.otlp.rejections`
+
+| Metric | Unit | Attributes | Description |
+| --- | --- | --- | --- |
+| `receiver.otlp.rejections.requests` | `{request}` | `protocol`, `error.type` | Number of requests rejected before pipeline admission. |
+
+#### `receiver.otlp.acknowledgements`
+
+| Metric | Unit | Attributes | Description |
+| --- | --- | --- | --- |
+| `receiver.otlp.acknowledgements.responses` | `{response}` | `signal`, `outcome` | Number of routed or invalid acknowledgement responses. |
+
+#### `receiver.otlp.transport`
+
+| Metric | Unit | Attributes | Description |
+| --- | --- | --- | --- |
+| `receiver.otlp.transport.errors` | `{error}` | `protocol` | Number of transport-level server errors. |
+
+Attribute values are bounded: `signal` is `traces`, `metrics`, or `logs`;
+`protocol` is `grpc` or `http`; `outcome` is `success`, `failure`, or
+`refused`; and `error.type` is `memory_pressure`, `concurrency_limit`,
+`payload_too_large`, `invalid_request`, or `internal`.
 
 ### Events
 

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/otlp_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/otlp_receiver/mod.rs
@@ -14,12 +14,12 @@
 //! - serve the gRPC endpoints with the tuned concurrency settings derived from downstream channel
 //!   capacity.
 //!
-//! Periodic telemetry snapshots update the `OtlpReceiverMetrics` counters, which focus on ACK/NACK
-//! behaviour today.
+//! Periodic telemetry snapshots partition request lifecycle, rejection, acknowledgement, and
+//! transport counters by bounded signal, protocol, outcome, and error-type attributes.
 
 use otap_df_otap::OTAP_RECEIVER_FACTORIES;
 use otap_df_otap::otap_grpc::otlp::server_new::{
-    LogsServiceServer, MetricsServiceServer, OtlpServerSettings, TraceServiceServer,
+    LogsServiceServer, MetricsServiceServer, OtlpServerSettings, RouteResponse, TraceServiceServer,
 };
 use otap_df_otap::pdata::OtapPdata;
 use otap_df_otap::tls_utils::{build_tls_acceptor, create_tls_stream};
@@ -45,9 +45,9 @@ use otap_df_otap::otap_grpc::common;
 use otap_df_otap::otap_grpc::common::AckRegistry;
 use otap_df_otap::otap_grpc::server_settings::GrpcServerSettings;
 use otap_df_otap::otlp_http::HttpServerSettings;
-use otap_df_otap::otlp_metrics::OtlpReceiverMetrics;
+use otap_df_otap::otlp_metrics::{OtlpProtocol, OtlpReceiverMetrics};
 use otap_df_otap::shared_concurrency::SharedConcurrencyLayer;
-use otap_df_telemetry::metrics::MetricSet;
+use otap_df_telemetry::common_attributes::Outcome;
 use parking_lot::Mutex;
 use serde::Deserialize;
 use serde_json::Value;
@@ -177,13 +177,13 @@ impl Protocols {
 ///   to decode lazily.
 /// - `AckRegistry` maintains per-signal ACK subscription slots so `wait_for_result` lookups avoid
 ///   extra bookkeeping and route responses directly back to callers.
-/// - Metrics are wired through a `MetricSet`, letting periodic snapshots flush ACK/NACK counters
-///   without rebuilding instruments.
+/// - Metrics use bounded enum attributes, letting periodic snapshots report only combinations
+///   observed during the collection interval.
 pub struct OTLPReceiver {
     config: Config,
     // Arc<Mutex<...>> so we can share metrics with the gRPC services which are `Send` due to
     // tonic requirements.
-    metrics: Arc<Mutex<MetricSet<OtlpReceiverMetrics>>>,
+    metrics: Arc<Mutex<OtlpReceiverMetrics>>,
     admission_state: SharedReceiverAdmissionState,
     // Global concurrency cap derived from downstream capacity. When both gRPC and HTTP are
     // enabled, this prevents combined ingress from exceeding what the pipeline can absorb.
@@ -259,9 +259,7 @@ impl OTLPReceiver {
         }
 
         // Register OTLP receiver metrics for this node.
-        let metrics = Arc::new(Mutex::new(
-            pipeline_ctx.register_metrics::<OtlpReceiverMetrics>(),
-        ));
+        let metrics = Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx)));
 
         Ok(Self {
             config,
@@ -363,25 +361,29 @@ impl OTLPReceiver {
     }
 
     fn handle_ack(&mut self, registry: &AckRegistry, ack: AckMsg<OtapPdata>) {
+        let signal = ack.accepted.signal_type();
         let resp = common::route_ack_response(registry, ack);
         let mut metrics = self.metrics.lock();
-        common::handle_route_response(
-            resp,
-            &mut *metrics,
-            |metrics| metrics.acks_received.inc(),
-            |metrics| metrics.acks_nacks_invalid_or_expired.inc(),
-        );
+        match resp {
+            RouteResponse::Sent => metrics.record_acknowledgement(signal, Outcome::Success),
+            RouteResponse::Expired | RouteResponse::Invalid => {
+                metrics.record_acknowledgement(signal, Outcome::Failure);
+            }
+            RouteResponse::None => {}
+        }
     }
 
     fn handle_nack(&mut self, registry: &AckRegistry, nack: NackMsg<OtapPdata>) {
+        let signal = nack.refused.signal_type();
         let resp = common::route_nack_response(registry, nack);
         let mut metrics = self.metrics.lock();
-        common::handle_route_response(
-            resp,
-            &mut *metrics,
-            |metrics| metrics.nacks_received.inc(),
-            |metrics| metrics.acks_nacks_invalid_or_expired.inc(),
-        );
+        match resp {
+            RouteResponse::Sent => metrics.record_acknowledgement(signal, Outcome::Refused),
+            RouteResponse::Expired | RouteResponse::Invalid => {
+                metrics.record_acknowledgement(signal, Outcome::Failure);
+            }
+            RouteResponse::None => {}
+        }
     }
 
     async fn handle_control_message(
@@ -393,7 +395,7 @@ impl OTLPReceiver {
             NodeControlMsg::CollectTelemetry {
                 mut metrics_reporter,
             } => {
-                _ = metrics_reporter.report(&mut *self.metrics.lock());
+                _ = self.metrics.lock().report(&mut metrics_reporter);
             }
             NodeControlMsg::MemoryPressureChanged { update } => {
                 self.admission_state.apply(update);
@@ -667,7 +669,7 @@ impl OTLPReceiver {
         let mut draining_deadline: Option<Instant> = None;
         let mut draining_reason: Option<String> = None;
         let mut drain_deadline_sleep: Option<clock::Sleep> = None;
-        let terminal_state: TerminalState;
+        let terminal_deadline: Instant;
 
         loop {
             if let Some(deadline) = draining_deadline {
@@ -689,7 +691,7 @@ impl OTLPReceiver {
 
                 if grpc_task_done && http_task_done && ack_registry.is_empty() {
                     effect_handler.notify_receiver_drained().await?;
-                    terminal_state = TerminalState::new(deadline, [self.metrics.lock().snapshot()]);
+                    terminal_deadline = deadline;
                     break;
                 }
             } else {
@@ -731,7 +733,7 @@ impl OTLPReceiver {
                                     grpc_shutdown.cancel();
                                     http_shutdown.cancel();
                                     ack_registry.force_shutdown(&reason);
-                                    terminal_state = TerminalState::new(deadline, [self.metrics.lock().snapshot()]);
+                                    terminal_deadline = deadline;
                                     break;
                                 }
                                 other => {
@@ -753,14 +755,13 @@ impl OTLPReceiver {
                 result = &mut grpc_fut, if grpc_enabled && !grpc_task_done => {
                     grpc_task_done = true;
                     if let Err(error) = result {
-                        self.metrics.lock().transport_errors.inc();
+                        self.metrics
+                            .lock()
+                            .record_transport_error(OtlpProtocol::Grpc);
                         return Err(self.map_transport_error(effect_handler, error));
                     }
                     if draining_deadline.is_none() {
-                        terminal_state = TerminalState::new(
-                            clock::now().add(Duration::from_secs(1)),
-                            [self.metrics.lock().snapshot()],
-                        );
+                        terminal_deadline = clock::now().add(Duration::from_secs(1));
                         http_shutdown.cancel();
                         break;
                     }
@@ -769,15 +770,14 @@ impl OTLPReceiver {
                 // HTTP serving loop; exits on IO error.
                 result = &mut http_fut, if http_enabled && !http_task_done => {
                     if let Err(error) = result {
-                        self.metrics.lock().transport_errors.inc();
+                        self.metrics
+                            .lock()
+                            .record_transport_error(OtlpProtocol::Http);
                         return Err(self.map_transport_error(effect_handler, error));
                     }
                     http_task_done = true;
                     if draining_deadline.is_none() {
-                        terminal_state = TerminalState::new(
-                            clock::now().add(Duration::from_secs(1)),
-                            [self.metrics.lock().snapshot()],
-                        );
+                        terminal_deadline = clock::now().add(Duration::from_secs(1));
                         break;
                     }
                 }
@@ -800,19 +800,26 @@ impl OTLPReceiver {
 
         if grpc_enabled && !grpc_task_done {
             if let Err(error) = grpc_fut.await {
-                self.metrics.lock().transport_errors.inc();
+                self.metrics
+                    .lock()
+                    .record_transport_error(OtlpProtocol::Grpc);
                 return Err(self.map_transport_error(effect_handler, error));
             }
         }
 
         if http_enabled && !http_task_done {
             if let Err(error) = http_fut.await {
-                self.metrics.lock().transport_errors.inc();
+                self.metrics
+                    .lock()
+                    .record_transport_error(OtlpProtocol::Http);
                 return Err(self.map_transport_error(effect_handler, error));
             }
         }
 
-        Ok(terminal_state)
+        Ok(TerminalState::new(
+            terminal_deadline,
+            self.metrics.lock().terminal_snapshots(),
+        ))
     }
 }
 
@@ -1043,9 +1050,7 @@ mod tests {
 
             let mut receiver = OTLPReceiver {
                 config: test_config_http_only(listen_addr),
-                metrics: Arc::new(Mutex::new(
-                    pipeline_ctx.register_metrics::<OtlpReceiverMetrics>(),
-                )),
+                metrics: Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx))),
                 admission_state: SharedReceiverAdmissionState::from_process_state(
                     &pipeline_ctx.memory_pressure_state(),
                 ),
@@ -1861,9 +1866,7 @@ mod tests {
         let receiver = ReceiverWrapper::shared(
             OTLPReceiver {
                 config: test_config(addr),
-                metrics: Arc::new(Mutex::new(
-                    pipeline_ctx.register_metrics::<OtlpReceiverMetrics>(),
-                )),
+                metrics: Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx))),
                 global_max_concurrent_requests: None,
                 admission_state: SharedReceiverAdmissionState::from_process_state(
                     &pipeline_ctx.memory_pressure_state(),
@@ -1909,9 +1912,7 @@ mod tests {
         let receiver = ReceiverWrapper::shared(
             OTLPReceiver {
                 config,
-                metrics: Arc::new(Mutex::new(
-                    pipeline_ctx.register_metrics::<OtlpReceiverMetrics>(),
-                )),
+                metrics: Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx))),
                 global_max_concurrent_requests: None,
                 admission_state: SharedReceiverAdmissionState::from_process_state(
                     &pipeline_ctx.memory_pressure_state(),
@@ -2002,9 +2003,7 @@ mod tests {
         let receiver = ReceiverWrapper::shared(
             OTLPReceiver {
                 config,
-                metrics: Arc::new(Mutex::new(
-                    pipeline_ctx.register_metrics::<OtlpReceiverMetrics>(),
-                )),
+                metrics: Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx))),
                 global_max_concurrent_requests: None,
                 admission_state: SharedReceiverAdmissionState::from_process_state(
                     &pipeline_ctx.memory_pressure_state(),
@@ -2102,9 +2101,7 @@ mod tests {
         let receiver = ReceiverWrapper::shared(
             OTLPReceiver {
                 config,
-                metrics: Arc::new(Mutex::new(
-                    pipeline_ctx.register_metrics::<OtlpReceiverMetrics>(),
-                )),
+                metrics: Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx))),
                 global_max_concurrent_requests: None,
                 admission_state: SharedReceiverAdmissionState::from_process_state(
                     &pipeline_ctx.memory_pressure_state(),
@@ -2165,9 +2162,7 @@ mod tests {
         let receiver = ReceiverWrapper::shared(
             OTLPReceiver {
                 config,
-                metrics: Arc::new(Mutex::new(
-                    pipeline_ctx.register_metrics::<OtlpReceiverMetrics>(),
-                )),
+                metrics: Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx))),
                 global_max_concurrent_requests: None,
                 admission_state: SharedReceiverAdmissionState::from_process_state(
                     &pipeline_ctx.memory_pressure_state(),
@@ -2237,9 +2232,7 @@ mod tests {
         let receiver = ReceiverWrapper::shared(
             OTLPReceiver {
                 config,
-                metrics: Arc::new(Mutex::new(
-                    pipeline_ctx.register_metrics::<OtlpReceiverMetrics>(),
-                )),
+                metrics: Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx))),
                 global_max_concurrent_requests: None,
                 admission_state: SharedReceiverAdmissionState::from_process_state(
                     &pipeline_ctx.memory_pressure_state(),
@@ -2328,9 +2321,7 @@ mod tests {
         let receiver = ReceiverWrapper::shared(
             OTLPReceiver {
                 config,
-                metrics: Arc::new(Mutex::new(
-                    pipeline_ctx.register_metrics::<OtlpReceiverMetrics>(),
-                )),
+                metrics: Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx))),
                 global_max_concurrent_requests: None,
                 admission_state: SharedReceiverAdmissionState::from_process_state(
                     &pipeline_ctx.memory_pressure_state(),
@@ -2393,9 +2384,7 @@ mod tests {
         let receiver = ReceiverWrapper::shared(
             OTLPReceiver {
                 config,
-                metrics: Arc::new(Mutex::new(
-                    pipeline_ctx.register_metrics::<OtlpReceiverMetrics>(),
-                )),
+                metrics: Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx))),
                 global_max_concurrent_requests: None,
                 admission_state: SharedReceiverAdmissionState::from_process_state(
                     &pipeline_ctx.memory_pressure_state(),
@@ -2457,9 +2446,7 @@ mod tests {
         let receiver = ReceiverWrapper::shared(
             OTLPReceiver {
                 config,
-                metrics: Arc::new(Mutex::new(
-                    pipeline_ctx.register_metrics::<OtlpReceiverMetrics>(),
-                )),
+                metrics: Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx))),
                 global_max_concurrent_requests: None,
                 admission_state: SharedReceiverAdmissionState::from_process_state(
                     &pipeline_ctx.memory_pressure_state(),
@@ -2558,9 +2545,7 @@ mod tests {
         let receiver = ReceiverWrapper::shared(
             OTLPReceiver {
                 config: test_config(grpc_listen),
-                metrics: Arc::new(Mutex::new(
-                    pipeline_ctx.register_metrics::<OtlpReceiverMetrics>(),
-                )),
+                metrics: Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx))),
                 admission_state: SharedReceiverAdmissionState::from_process_state(
                     &pipeline_ctx.memory_pressure_state(),
                 ),
@@ -2642,9 +2627,7 @@ mod tests {
         let receiver = ReceiverWrapper::shared(
             OTLPReceiver {
                 config: test_config_http_only(http_listen),
-                metrics: Arc::new(Mutex::new(
-                    pipeline_ctx.register_metrics::<OtlpReceiverMetrics>(),
-                )),
+                metrics: Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx))),
                 admission_state: SharedReceiverAdmissionState::from_process_state(
                     &pipeline_ctx.memory_pressure_state(),
                 ),
@@ -2741,9 +2724,7 @@ mod tests {
         let receiver = ReceiverWrapper::shared(
             OTLPReceiver {
                 config,
-                metrics: Arc::new(Mutex::new(
-                    pipeline_ctx.register_metrics::<OtlpReceiverMetrics>(),
-                )),
+                metrics: Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx))),
                 global_max_concurrent_requests: None,
                 admission_state: SharedReceiverAdmissionState::from_process_state(
                     &pipeline_ctx.memory_pressure_state(),
@@ -2822,9 +2803,7 @@ mod tests {
         let receiver = ReceiverWrapper::shared(
             OTLPReceiver {
                 config,
-                metrics: Arc::new(Mutex::new(
-                    pipeline_ctx.register_metrics::<OtlpReceiverMetrics>(),
-                )),
+                metrics: Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx))),
                 global_max_concurrent_requests: None,
                 admission_state: SharedReceiverAdmissionState::from_process_state(
                     &pipeline_ctx.memory_pressure_state(),
@@ -2887,9 +2866,7 @@ mod tests {
         let receiver = ReceiverWrapper::shared(
             OTLPReceiver {
                 config,
-                metrics: Arc::new(Mutex::new(
-                    pipeline_ctx.register_metrics::<OtlpReceiverMetrics>(),
-                )),
+                metrics: Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx))),
                 global_max_concurrent_requests: None,
                 admission_state: SharedReceiverAdmissionState::from_process_state(
                     &pipeline_ctx.memory_pressure_state(),
@@ -2953,9 +2930,7 @@ mod tests {
         let receiver = ReceiverWrapper::shared(
             OTLPReceiver {
                 config: test_config(addr),
-                metrics: Arc::new(Mutex::new(
-                    pipeline_ctx.register_metrics::<OtlpReceiverMetrics>(),
-                )),
+                metrics: Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx))),
                 global_max_concurrent_requests: None,
                 admission_state: SharedReceiverAdmissionState::from_process_state(
                     &pipeline_ctx.memory_pressure_state(),
@@ -3042,9 +3017,7 @@ mod tests {
         let receiver = ReceiverWrapper::shared(
             OTLPReceiver {
                 config,
-                metrics: Arc::new(Mutex::new(
-                    pipeline_ctx.register_metrics::<OtlpReceiverMetrics>(),
-                )),
+                metrics: Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx))),
                 global_max_concurrent_requests: None,
                 admission_state: SharedReceiverAdmissionState::from_process_state(
                     &pipeline_ctx.memory_pressure_state(),
@@ -3144,9 +3117,7 @@ mod tests {
         let receiver = ReceiverWrapper::shared(
             OTLPReceiver {
                 config,
-                metrics: Arc::new(Mutex::new(
-                    pipeline_ctx.register_metrics::<OtlpReceiverMetrics>(),
-                )),
+                metrics: Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx))),
                 global_max_concurrent_requests: None,
                 admission_state: SharedReceiverAdmissionState::from_process_state(
                     &pipeline_ctx.memory_pressure_state(),
@@ -3227,9 +3198,7 @@ mod tests {
         let receiver = ReceiverWrapper::shared(
             OTLPReceiver {
                 config,
-                metrics: Arc::new(Mutex::new(
-                    pipeline_ctx.register_metrics::<OtlpReceiverMetrics>(),
-                )),
+                metrics: Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx))),
                 global_max_concurrent_requests: None,
                 admission_state: SharedReceiverAdmissionState::from_process_state(
                     &pipeline_ctx.memory_pressure_state(),
@@ -3318,9 +3287,7 @@ mod tests {
         let receiver = ReceiverWrapper::shared(
             OTLPReceiver {
                 config,
-                metrics: Arc::new(Mutex::new(
-                    pipeline_ctx.register_metrics::<OtlpReceiverMetrics>(),
-                )),
+                metrics: Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx))),
                 global_max_concurrent_requests: None,
                 admission_state: SharedReceiverAdmissionState::from_process_state(
                     &pipeline_ctx.memory_pressure_state(),
@@ -3375,9 +3342,7 @@ mod tests {
         let receiver = ReceiverWrapper::shared(
             OTLPReceiver {
                 config,
-                metrics: Arc::new(Mutex::new(
-                    pipeline_ctx.register_metrics::<OtlpReceiverMetrics>(),
-                )),
+                metrics: Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx))),
                 global_max_concurrent_requests: None,
                 admission_state: SharedReceiverAdmissionState::from_process_state(
                     &pipeline_ctx.memory_pressure_state(),
@@ -3437,9 +3402,7 @@ mod tests {
         let receiver = ReceiverWrapper::shared(
             OTLPReceiver {
                 config,
-                metrics: Arc::new(Mutex::new(
-                    pipeline_ctx.register_metrics::<OtlpReceiverMetrics>(),
-                )),
+                metrics: Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx))),
                 global_max_concurrent_requests: None,
                 admission_state: SharedReceiverAdmissionState::from_process_state(
                     &pipeline_ctx.memory_pressure_state(),
@@ -3559,9 +3522,7 @@ mod tests {
         let receiver = ReceiverWrapper::shared(
             OTLPReceiver {
                 config,
-                metrics: Arc::new(Mutex::new(
-                    pipeline_ctx.register_metrics::<OtlpReceiverMetrics>(),
-                )),
+                metrics: Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx))),
                 global_max_concurrent_requests: Some(1),
                 admission_state: SharedReceiverAdmissionState::from_process_state(
                     &pipeline_ctx.memory_pressure_state(),
@@ -3722,9 +3683,7 @@ mod tests {
         let receiver = ReceiverWrapper::shared(
             OTLPReceiver {
                 config: test_config(addr),
-                metrics: Arc::new(Mutex::new(
-                    pipeline_ctx.register_metrics::<OtlpReceiverMetrics>(),
-                )),
+                metrics: Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx))),
                 global_max_concurrent_requests: None,
                 admission_state: SharedReceiverAdmissionState::from_process_state(
                     &pipeline_ctx.memory_pressure_state(),
@@ -3836,9 +3795,7 @@ mod tests {
         let receiver = ReceiverWrapper::shared(
             OTLPReceiver {
                 config: test_config(addr),
-                metrics: Arc::new(Mutex::new(
-                    pipeline_ctx.register_metrics::<OtlpReceiverMetrics>(),
-                )),
+                metrics: Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx))),
                 global_max_concurrent_requests: None,
                 admission_state: SharedReceiverAdmissionState::from_process_state(
                     &pipeline_ctx.memory_pressure_state(),
@@ -3953,9 +3910,7 @@ mod tests {
         let receiver = ReceiverWrapper::shared(
             OTLPReceiver {
                 config: test_config(addr),
-                metrics: Arc::new(Mutex::new(
-                    pipeline_ctx.register_metrics::<OtlpReceiverMetrics>(),
-                )),
+                metrics: Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx))),
                 global_max_concurrent_requests: None,
                 admission_state: SharedReceiverAdmissionState::from_process_state(
                     &pipeline_ctx.memory_pressure_state(),
@@ -4060,9 +4015,7 @@ mod tests {
         let receiver = ReceiverWrapper::shared(
             OTLPReceiver {
                 config,
-                metrics: Arc::new(Mutex::new(
-                    pipeline_ctx.register_metrics::<OtlpReceiverMetrics>(),
-                )),
+                metrics: Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx))),
                 global_max_concurrent_requests: None,
                 admission_state: SharedReceiverAdmissionState::from_process_state(
                     &pipeline_ctx.memory_pressure_state(),
@@ -4155,9 +4108,7 @@ mod tests {
         let receiver = ReceiverWrapper::shared(
             OTLPReceiver {
                 config: test_config_http_only(http_listen),
-                metrics: Arc::new(Mutex::new(
-                    pipeline_ctx.register_metrics::<OtlpReceiverMetrics>(),
-                )),
+                metrics: Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx))),
                 global_max_concurrent_requests: None,
                 admission_state: SharedReceiverAdmissionState::from_process_state(
                     &pipeline_ctx.memory_pressure_state(),

--- a/rust/otap-dataflow/crates/otap/src/memory_pressure_layer.rs
+++ b/rust/otap-dataflow/crates/otap/src/memory_pressure_layer.rs
@@ -6,14 +6,13 @@
 use futures::future::BoxFuture;
 use http::{Request, Response};
 use otap_df_engine::memory_limiter::SharedReceiverAdmissionState;
-use otap_df_telemetry::metrics::MetricSet;
 use parking_lot::Mutex;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use tonic::{Code, Status, body::Body, metadata::MetadataMap};
 use tower::{Layer, Service};
 
-use crate::otlp_metrics::OtlpReceiverMetrics;
+use crate::otlp_metrics::{OtlpProtocol, OtlpReceiverMetrics, OtlpRejectionErrorType};
 
 /// Records request rejections before they enter the pipeline.
 pub trait ReceiverRejectionMetrics: Send + Sync {
@@ -41,15 +40,15 @@ pub fn grpc_memory_pressure_status(state: &SharedReceiverAdmissionState) -> Stat
     Status::with_metadata(Code::ResourceExhausted, "memory pressure", metadata)
 }
 
-impl ReceiverRejectionMetrics for Mutex<MetricSet<OtlpReceiverMetrics>> {
+impl ReceiverRejectionMetrics for Mutex<OtlpReceiverMetrics> {
     fn record_rejection(&self) {
-        self.lock().rejected_requests.inc();
+        self.lock()
+            .record_rejection(OtlpProtocol::Grpc, OtlpRejectionErrorType::ConcurrencyLimit);
     }
 
     fn record_memory_pressure_rejection(&self) {
-        let mut metrics = self.lock();
-        metrics.rejected_requests.inc();
-        metrics.refused_memory_pressure.inc();
+        self.lock()
+            .record_rejection(OtlpProtocol::Grpc, OtlpRejectionErrorType::MemoryPressure);
     }
 }
 
@@ -89,7 +88,7 @@ impl MemoryPressureLayer {
     #[must_use]
     pub fn with_otlp_metrics(
         state: SharedReceiverAdmissionState,
-        metrics: Arc<Mutex<MetricSet<OtlpReceiverMetrics>>>,
+        metrics: Arc<Mutex<OtlpReceiverMetrics>>,
     ) -> Self {
         Self::with_metrics(state, metrics)
     }

--- a/rust/otap-dataflow/crates/otap/src/memory_pressure_layer.rs
+++ b/rust/otap-dataflow/crates/otap/src/memory_pressure_layer.rs
@@ -12,7 +12,8 @@ use std::task::{Context, Poll};
 use tonic::{Code, Status, body::Body, metadata::MetadataMap};
 use tower::{Layer, Service};
 
-use crate::otlp_metrics::{OtlpProtocol, OtlpReceiverMetrics, OtlpRejectionErrorType};
+use crate::otlp_metrics::{OtlpProtocol, OtlpReceiverMetrics};
+use otap_df_telemetry::common_attributes::ReceiverRejectionErrorType;
 
 /// Records request rejections before they enter the pipeline.
 pub trait ReceiverRejectionMetrics: Send + Sync {
@@ -42,13 +43,17 @@ pub fn grpc_memory_pressure_status(state: &SharedReceiverAdmissionState) -> Stat
 
 impl ReceiverRejectionMetrics for Mutex<OtlpReceiverMetrics> {
     fn record_rejection(&self) {
-        self.lock()
-            .record_rejection(OtlpProtocol::Grpc, OtlpRejectionErrorType::ConcurrencyLimit);
+        self.lock().record_rejection(
+            OtlpProtocol::Grpc,
+            ReceiverRejectionErrorType::ConcurrencyLimit,
+        );
     }
 
     fn record_memory_pressure_rejection(&self) {
-        self.lock()
-            .record_rejection(OtlpProtocol::Grpc, OtlpRejectionErrorType::MemoryPressure);
+        self.lock().record_rejection(
+            OtlpProtocol::Grpc,
+            ReceiverRejectionErrorType::MemoryPressure,
+        );
     }
 }
 

--- a/rust/otap-dataflow/crates/otap/src/metrics.rs
+++ b/rust/otap-dataflow/crates/otap/src/metrics.rs
@@ -6,102 +6,111 @@
 //! Note: We try as much as possible to follow the following
 //! [RFC Pipeline Component Telemetry](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/rfcs/component-universal-telemetry.md).
 
-use otap_df_config::SignalType;
+use otap_df_telemetry::common_attributes::SignalOutcomeAttributes;
 use otap_df_telemetry::instrument::Counter;
 use otap_df_telemetry_macros::metric_set;
 
-/// PData metrics for exporters.
-/// Namespace grouped under `exporter.pdata`.
-/// Uses a monotonic counter per outcome.
-#[metric_set(name = "exporter.pdata")]
+/// Completed PData export operations.
+#[metric_set(
+    name = "exporter.pdata.exports",
+    measurement_attributes = SignalOutcomeAttributes
+)]
 #[derive(Debug, Default, Clone)]
-pub struct ExporterPDataMetrics {
-    /// Number of pdata metrics consumed by this exporter.
-    #[metric(unit = "{msg}")]
-    pub metrics_consumed: Counter<u64>,
-
-    /// Number of pdata metrics successfully exported.
-    #[metric(unit = "{msg}")]
-    pub metrics_exported: Counter<u64>,
-
-    /// Number of pdata metrics that failed to be exported.
-    #[metric(unit = "{msg}")]
-    pub metrics_failed: Counter<u64>,
-
-    /// Number of pdata logs consumed by this exporter.
-    #[metric(unit = "{msg}")]
-    pub logs_consumed: Counter<u64>,
-
-    /// Number of pdata logs successfully exported.
-    #[metric(unit = "{msg}")]
-    pub logs_exported: Counter<u64>,
-
-    /// Number of pdata logs that failed to be exported.
-    #[metric(unit = "{msg}")]
-    pub logs_failed: Counter<u64>,
-
-    /// Number of pdata traces consumed by this exporter.
-    #[metric(unit = "{msg}")]
-    pub traces_consumed: Counter<u64>,
-
-    /// Number of pdata traces successfully exported.
-    #[metric(unit = "{msg}")]
-    pub traces_exported: Counter<u64>,
-
-    /// Number of pdata traces that failed to be exported.
-    #[metric(unit = "{msg}")]
-    pub traces_failed: Counter<u64>,
+pub struct ExporterPDataExportMetrics {
+    /// Number of PData messages whose export reached a terminal outcome.
+    #[metric(unit = "{message}")]
+    pub messages: Counter<u64>,
 }
 
-impl ExporterPDataMetrics {
-    /// Increment the number of pdata messages consumed.
-    pub const fn inc_consumed(&mut self, st: SignalType) {
-        self.add_consumed(st, 1);
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use otap_df_config::SignalType;
+    use otap_df_engine::context::ControllerContext;
+    use otap_df_telemetry::common_attributes::Outcome;
+    use otap_df_telemetry::metrics::MeasurementMetricSet;
+    use otap_df_telemetry::registry::TelemetryRegistryHandle;
+
+    fn new_test_metrics() -> MeasurementMetricSet<ExporterPDataExportMetrics> {
+        let registry = TelemetryRegistryHandle::new();
+        let controller = ControllerContext::new(registry);
+        let pipeline_ctx =
+            controller.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+        ExporterPDataExportMetrics::register(&pipeline_ctx)
     }
 
-    /// Increment the number of pdata messages exported.
-    pub const fn inc_exported(&mut self, st: SignalType) {
-        self.add_exported(st, 1);
+    /// Scenario: An exporter completes successful and failed exports for multiple signals.
+    /// Guarantees: Terminal export counts are isolated by signal and outcome.
+    #[test]
+    fn exporter_metrics_are_partitioned_by_signal_and_outcome() {
+        let mut metrics = new_test_metrics();
+        metrics
+            .with(SignalOutcomeAttributes {
+                signal: SignalType::Logs,
+                outcome: Outcome::Success,
+            })
+            .messages
+            .add(2);
+        metrics
+            .with(SignalOutcomeAttributes {
+                signal: SignalType::Logs,
+                outcome: Outcome::Failure,
+            })
+            .messages
+            .inc();
+
+        assert_eq!(
+            metrics
+                .get(SignalOutcomeAttributes {
+                    signal: SignalType::Logs,
+                    outcome: Outcome::Success,
+                })
+                .messages
+                .get(),
+            2
+        );
+        assert_eq!(
+            metrics
+                .get(SignalOutcomeAttributes {
+                    signal: SignalType::Logs,
+                    outcome: Outcome::Failure,
+                })
+                .messages
+                .get(),
+            1
+        );
+        assert_eq!(
+            metrics
+                .get(SignalOutcomeAttributes {
+                    signal: SignalType::Metrics,
+                    outcome: Outcome::Success,
+                })
+                .messages
+                .get(),
+            0
+        );
     }
 
-    /// Increment the number of pdata messages that failed to be exported.
-    pub const fn inc_failed(&mut self, st: SignalType) {
-        self.add_failed(st, 1);
-    }
+    /// Scenario: Export outcome metrics are handed off during terminal shutdown twice.
+    /// Guarantees: Only touched buckets are emitted and each bucket is cleared after handoff.
+    #[test]
+    fn terminal_snapshots_emit_touched_buckets_once() {
+        let mut metrics = new_test_metrics();
+        metrics
+            .with(SignalOutcomeAttributes {
+                signal: SignalType::Traces,
+                outcome: Outcome::Success,
+            })
+            .messages
+            .inc();
 
-    /// Add to the number of pdata messages consumed.
-    pub const fn add_consumed(&mut self, st: SignalType, count: u64) {
-        if count == 0 {
-            return;
-        }
-        match st {
-            SignalType::Metrics => self.metrics_consumed.add(count),
-            SignalType::Logs => self.logs_consumed.add(count),
-            SignalType::Traces => self.traces_consumed.add(count),
-        }
-    }
-
-    /// Add to the number of pdata messages exported.
-    pub const fn add_exported(&mut self, st: SignalType, count: u64) {
-        if count == 0 {
-            return;
-        }
-        match st {
-            SignalType::Metrics => self.metrics_exported.add(count),
-            SignalType::Logs => self.logs_exported.add(count),
-            SignalType::Traces => self.traces_exported.add(count),
-        }
-    }
-
-    /// Add to the number of pdata messages that failed to be exported.
-    pub const fn add_failed(&mut self, st: SignalType, count: u64) {
-        if count == 0 {
-            return;
-        }
-        match st {
-            SignalType::Metrics => self.metrics_failed.add(count),
-            SignalType::Logs => self.logs_failed.add(count),
-            SignalType::Traces => self.traces_failed.add(count),
-        }
+        let snapshots = metrics.terminal_snapshots();
+        assert_eq!(snapshots.len(), 1);
+        assert!(snapshots.iter().any(|snapshot| {
+            snapshot.descriptor().name == "exporter.pdata.exports"
+                && snapshot.measurement_attribute_value("signal") == Some("traces")
+                && snapshot.measurement_attribute_value("outcome") == Some("success")
+        }));
+        assert!(metrics.terminal_snapshots().is_empty());
     }
 }

--- a/rust/otap-dataflow/crates/otap/src/otap_grpc/otlp/server_new.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_grpc/otlp/server_new.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use std::task::Poll;
 
 use crate::accessory::slots::{Key as SlotKey, State as SlotsState};
-use crate::otlp_metrics::{OtlpProtocol, OtlpReceiverMetrics, OtlpRejectionErrorType};
+use crate::otlp_metrics::{OtlpProtocol, OtlpReceiverMetrics};
 use crate::pdata::{Context, OtapPdata};
 use bytes::{BufMut, Bytes};
 use futures::future::BoxFuture;
@@ -33,6 +33,7 @@ use otap_df_pdata::OtlpProtoBytes;
 use otap_df_pdata::proto::opentelemetry::collector::logs::v1::ExportLogsServiceResponse;
 use otap_df_pdata::proto::opentelemetry::collector::metrics::v1::ExportMetricsServiceResponse;
 use otap_df_pdata::proto::opentelemetry::collector::trace::v1::ExportTraceServiceResponse;
+use otap_df_telemetry::common_attributes::ReceiverRejectionErrorType;
 use parking_lot::Mutex;
 use prost::Message;
 use prost::bytes::Buf;
@@ -451,7 +452,7 @@ impl UnaryService<OtapPdata> for OtapBatchService {
                     None => {
                         metrics.lock().record_rejection(
                             OtlpProtocol::Grpc,
-                            OtlpRejectionErrorType::ConcurrencyLimit,
+                            ReceiverRejectionErrorType::ConcurrencyLimit,
                         );
                         return Err(Status::resource_exhausted("Too many concurrent requests"));
                     }

--- a/rust/otap-dataflow/crates/otap/src/otap_grpc/otlp/server_new.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_grpc/otlp/server_new.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use std::task::Poll;
 
 use crate::accessory::slots::{Key as SlotKey, State as SlotsState};
-use crate::otlp_metrics::OtlpReceiverMetrics;
+use crate::otlp_metrics::{OtlpProtocol, OtlpReceiverMetrics, OtlpRejectionErrorType};
 use crate::pdata::{Context, OtapPdata};
 use bytes::{BufMut, Bytes};
 use futures::future::BoxFuture;
@@ -33,7 +33,6 @@ use otap_df_pdata::OtlpProtoBytes;
 use otap_df_pdata::proto::opentelemetry::collector::logs::v1::ExportLogsServiceResponse;
 use otap_df_pdata::proto::opentelemetry::collector::metrics::v1::ExportMetricsServiceResponse;
 use otap_df_pdata::proto::opentelemetry::collector::trace::v1::ExportTraceServiceResponse;
-use otap_df_telemetry::metrics::MetricSet;
 use parking_lot::Mutex;
 use prost::Message;
 use prost::bytes::Buf;
@@ -215,14 +214,14 @@ struct OtlpBytesCodec {
     /// Whether to pre-reserve a context frame (when wait_for_result is on).
     preallocate_frame: bool,
     /// Metrics sink for request tracking.
-    metrics: Arc<Mutex<MetricSet<OtlpReceiverMetrics>>>,
+    metrics: Arc<Mutex<OtlpReceiverMetrics>>,
 }
 
 impl OtlpBytesCodec {
     const fn new(
         signal: SignalType,
         preallocate_frame: bool,
-        metrics: Arc<Mutex<MetricSet<OtlpReceiverMetrics>>>,
+        metrics: Arc<Mutex<OtlpReceiverMetrics>>,
     ) -> Self {
         Self {
             signal,
@@ -276,14 +275,14 @@ impl Encoder for OtlpResponseEncoder {
 struct OtlpBytesDecoder {
     signal: SignalType,
     preallocate_frame: bool,
-    metrics: Arc<Mutex<MetricSet<OtlpReceiverMetrics>>>,
+    metrics: Arc<Mutex<OtlpReceiverMetrics>>,
 }
 
 impl OtlpBytesDecoder {
     const fn new(
         signal: SignalType,
         preallocate_frame: bool,
-        metrics: Arc<Mutex<MetricSet<OtlpReceiverMetrics>>>,
+        metrics: Arc<Mutex<OtlpReceiverMetrics>>,
     ) -> Self {
         Self {
             signal,
@@ -302,8 +301,11 @@ impl Decoder for OtlpBytesDecoder {
         // Use copy_to_bytes so we copy once while advancing the buffer.
         let len = src.remaining();
         let bytes = src.copy_to_bytes(len);
-        let mut guard = self.metrics.lock();
-        guard.request_bytes.add(len as u64);
+        self.metrics.lock().record_request_payload_size(
+            self.signal,
+            OtlpProtocol::Grpc,
+            len as u64,
+        );
         let result = match self.signal {
             SignalType::Logs => OtlpProtoBytes::ExportLogsRequest(bytes),
             SignalType::Metrics => OtlpProtoBytes::ExportMetricsRequest(bytes),
@@ -326,7 +328,7 @@ impl Decoder for OtlpBytesDecoder {
 fn new_grpc(
     signal: SignalType,
     settings: OtlpServerSettings,
-    metrics: Arc<Mutex<MetricSet<OtlpReceiverMetrics>>>,
+    metrics: Arc<Mutex<OtlpReceiverMetrics>>,
 ) -> Grpc<OtlpBytesCodec> {
     let codec = OtlpBytesCodec::new(signal, settings.wait_for_result, metrics);
     let mut grpc = Grpc::new(codec);
@@ -345,20 +347,37 @@ fn new_grpc(
 struct OtapBatchService {
     effect_handler: Option<EffectHandler<OtapPdata>>,
     state: Option<AckSlot>,
-    metrics: Arc<Mutex<MetricSet<OtlpReceiverMetrics>>>,
+    metrics: Arc<Mutex<OtlpReceiverMetrics>>,
+    signal: SignalType,
 }
 
 impl OtapBatchService {
     const fn new(
         effect_handler: EffectHandler<OtapPdata>,
         state: Option<AckSlot>,
-        metrics: Arc<Mutex<MetricSet<OtlpReceiverMetrics>>>,
+        metrics: Arc<Mutex<OtlpReceiverMetrics>>,
+        signal: SignalType,
     ) -> Self {
         Self {
             effect_handler: Some(effect_handler),
             state,
             metrics,
+            signal,
         }
+    }
+}
+
+/// Records request completion when the gRPC future returns or is cancelled.
+struct RequestCompletionGuard {
+    metrics: Arc<Mutex<OtlpReceiverMetrics>>,
+    signal: SignalType,
+}
+
+impl Drop for RequestCompletionGuard {
+    fn drop(&mut self) {
+        self.metrics
+            .lock()
+            .record_request_completed(self.signal, OtlpProtocol::Grpc);
     }
 }
 
@@ -425,12 +444,15 @@ impl UnaryService<OtapPdata> for OtapBatchService {
 
         let state = self.state.clone();
         let metrics = self.metrics.clone();
+        let signal = self.signal;
         Box::pin(async move {
-            metrics.lock().requests_started.inc();
             let cancel_rx = if let Some(state) = state {
                 let (key, rx) = match state.allocate_slot() {
                     None => {
-                        metrics.lock().rejected_requests.inc();
+                        metrics.lock().record_rejection(
+                            OtlpProtocol::Grpc,
+                            OtlpRejectionErrorType::ConcurrencyLimit,
+                        );
                         return Err(Status::resource_exhausted("Too many concurrent requests"));
                     }
                     Some(pair) => pair,
@@ -445,6 +467,14 @@ impl UnaryService<OtapPdata> for OtapBatchService {
                 Some((SlotGuard { key, state }, rx))
             } else {
                 None
+            };
+
+            metrics
+                .lock()
+                .record_request_started(signal, OtlpProtocol::Grpc);
+            let _completion_guard = RequestCompletionGuard {
+                metrics: metrics.clone(),
+                signal,
             };
 
             // Send and wait for Ack/Nack
@@ -472,8 +502,6 @@ impl UnaryService<OtapPdata> for OtapBatchService {
                 }
             }
 
-            metrics.lock().requests_completed.inc();
-
             Ok(tonic::Response::new(()))
         })
     }
@@ -500,7 +528,7 @@ pub struct ServerCommon {
     effect_handler: EffectHandler<OtapPdata>,
     state: Option<AckSlot>,
     settings: OtlpServerSettings,
-    metrics: Arc<Mutex<MetricSet<OtlpReceiverMetrics>>>,
+    metrics: Arc<Mutex<OtlpReceiverMetrics>>,
 }
 
 impl ServerCommon {
@@ -513,7 +541,7 @@ impl ServerCommon {
     fn new(
         effect_handler: EffectHandler<OtapPdata>,
         settings: &OtlpServerSettings,
-        metrics: Arc<Mutex<MetricSet<OtlpReceiverMetrics>>>,
+        metrics: Arc<Mutex<OtlpReceiverMetrics>>,
         state: Option<AckSlot>,
     ) -> Self {
         Self {
@@ -538,7 +566,7 @@ impl LogsServiceServer {
     pub fn new(
         effect_handler: EffectHandler<OtapPdata>,
         settings: &OtlpServerSettings,
-        metrics: Arc<Mutex<MetricSet<OtlpReceiverMetrics>>>,
+        metrics: Arc<Mutex<OtlpReceiverMetrics>>,
         state: Option<AckSlot>,
     ) -> Self {
         Self {
@@ -569,6 +597,7 @@ impl tower_service::Service<Request<Body>> for LogsServiceServer {
                     common.effect_handler,
                     common.state,
                     common.metrics.clone(),
+                    SignalType::Logs,
                 );
                 Box::pin(async move { Ok(grpc.unary(service, req).await) })
             }
@@ -594,7 +623,7 @@ impl MetricsServiceServer {
     pub fn new(
         effect_handler: EffectHandler<OtapPdata>,
         settings: &OtlpServerSettings,
-        metrics: Arc<Mutex<MetricSet<OtlpReceiverMetrics>>>,
+        metrics: Arc<Mutex<OtlpReceiverMetrics>>,
         state: Option<AckSlot>,
     ) -> Self {
         Self {
@@ -625,6 +654,7 @@ impl tower_service::Service<Request<Body>> for MetricsServiceServer {
                     common.effect_handler,
                     common.state,
                     common.metrics.clone(),
+                    SignalType::Metrics,
                 );
                 Box::pin(async move { Ok(grpc.unary(service, req).await) })
             }
@@ -650,7 +680,7 @@ impl TraceServiceServer {
     pub fn new(
         effect_handler: EffectHandler<OtapPdata>,
         settings: &OtlpServerSettings,
-        metrics: Arc<Mutex<MetricSet<OtlpReceiverMetrics>>>,
+        metrics: Arc<Mutex<OtlpReceiverMetrics>>,
         state: Option<AckSlot>,
     ) -> Self {
         Self {
@@ -681,6 +711,7 @@ impl tower_service::Service<Request<Body>> for TraceServiceServer {
                     common.effect_handler,
                     common.state,
                     common.metrics.clone(),
+                    SignalType::Traces,
                 );
                 Box::pin(async move { Ok(grpc.unary(service, req).await) })
             }

--- a/rust/otap-dataflow/crates/otap/src/otap_grpc/otlp/server_new.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_grpc/otlp/server_new.rs
@@ -214,20 +214,13 @@ struct OtlpBytesCodec {
     signal: SignalType,
     /// Whether to pre-reserve a context frame (when wait_for_result is on).
     preallocate_frame: bool,
-    /// Metrics sink for request tracking.
-    metrics: Arc<Mutex<OtlpReceiverMetrics>>,
 }
 
 impl OtlpBytesCodec {
-    const fn new(
-        signal: SignalType,
-        preallocate_frame: bool,
-        metrics: Arc<Mutex<OtlpReceiverMetrics>>,
-    ) -> Self {
+    const fn new(signal: SignalType, preallocate_frame: bool) -> Self {
         Self {
             signal,
             preallocate_frame,
-            metrics,
         }
     }
 }
@@ -244,7 +237,7 @@ impl Codec for OtlpBytesCodec {
     }
 
     fn decoder(&mut self) -> Self::Decoder {
-        OtlpBytesDecoder::new(self.signal, self.preallocate_frame, self.metrics.clone())
+        OtlpBytesDecoder::new(self.signal, self.preallocate_frame)
     }
 }
 
@@ -276,19 +269,13 @@ impl Encoder for OtlpResponseEncoder {
 struct OtlpBytesDecoder {
     signal: SignalType,
     preallocate_frame: bool,
-    metrics: Arc<Mutex<OtlpReceiverMetrics>>,
 }
 
 impl OtlpBytesDecoder {
-    const fn new(
-        signal: SignalType,
-        preallocate_frame: bool,
-        metrics: Arc<Mutex<OtlpReceiverMetrics>>,
-    ) -> Self {
+    const fn new(signal: SignalType, preallocate_frame: bool) -> Self {
         Self {
             signal,
             preallocate_frame,
-            metrics,
         }
     }
 }
@@ -302,11 +289,6 @@ impl Decoder for OtlpBytesDecoder {
         // Use copy_to_bytes so we copy once while advancing the buffer.
         let len = src.remaining();
         let bytes = src.copy_to_bytes(len);
-        self.metrics.lock().record_request_payload_size(
-            self.signal,
-            OtlpProtocol::Grpc,
-            len as u64,
-        );
         let result = match self.signal {
             SignalType::Logs => OtlpProtoBytes::ExportLogsRequest(bytes),
             SignalType::Metrics => OtlpProtoBytes::ExportMetricsRequest(bytes),
@@ -326,12 +308,8 @@ impl Decoder for OtlpBytesDecoder {
 /// appropriate signal.  Note! This is an inexpensive call, called for
 /// each request instead of a Clone + Sync + Send trait binding that
 /// would require Arc<Mutex<_>>.
-fn new_grpc(
-    signal: SignalType,
-    settings: OtlpServerSettings,
-    metrics: Arc<Mutex<OtlpReceiverMetrics>>,
-) -> Grpc<OtlpBytesCodec> {
-    let codec = OtlpBytesCodec::new(signal, settings.wait_for_result, metrics);
+fn new_grpc(signal: SignalType, settings: OtlpServerSettings) -> Grpc<OtlpBytesCodec> {
+    let codec = OtlpBytesCodec::new(signal, settings.wait_for_result);
     let mut grpc = Grpc::new(codec);
     if let Some(limit) = settings.max_decoding_message_size {
         grpc = grpc.max_decoding_message_size(limit);
@@ -443,6 +421,8 @@ impl UnaryService<OtapPdata> for OtapBatchService {
             }
         }
 
+        let payload_bytes = otap_batch.payload_ref().num_bytes().unwrap_or(0) as u64;
+
         let state = self.state.clone();
         let metrics = self.metrics.clone();
         let signal = self.signal;
@@ -472,7 +452,7 @@ impl UnaryService<OtapPdata> for OtapBatchService {
 
             metrics
                 .lock()
-                .record_request_started(signal, OtlpProtocol::Grpc);
+                .record_request_admitted(signal, OtlpProtocol::Grpc, payload_bytes);
             let _completion_guard = RequestCompletionGuard {
                 metrics: metrics.clone(),
                 signal,
@@ -589,11 +569,7 @@ impl tower_service::Service<Request<Body>> for LogsServiceServer {
         match req.uri().path() {
             super::LOGS_SERVICE_EXPORT_PATH => {
                 let common = self.common.clone();
-                let mut grpc = new_grpc(
-                    SignalType::Logs,
-                    common.settings.clone(),
-                    common.metrics.clone(),
-                );
+                let mut grpc = new_grpc(SignalType::Logs, common.settings.clone());
                 let service = OtapBatchService::new(
                     common.effect_handler,
                     common.state,
@@ -646,11 +622,7 @@ impl tower_service::Service<Request<Body>> for MetricsServiceServer {
         match req.uri().path() {
             super::METRICS_SERVICE_EXPORT_PATH => {
                 let common = self.common.clone();
-                let mut grpc = new_grpc(
-                    SignalType::Metrics,
-                    common.settings.clone(),
-                    common.metrics.clone(),
-                );
+                let mut grpc = new_grpc(SignalType::Metrics, common.settings.clone());
                 let service = OtapBatchService::new(
                     common.effect_handler,
                     common.state,
@@ -703,11 +675,7 @@ impl tower_service::Service<Request<Body>> for TraceServiceServer {
         match req.uri().path() {
             super::TRACE_SERVICE_EXPORT_PATH => {
                 let common = self.common.clone();
-                let mut grpc = new_grpc(
-                    SignalType::Traces,
-                    common.settings.clone(),
-                    common.metrics.clone(),
-                );
+                let mut grpc = new_grpc(SignalType::Traces, common.settings.clone());
                 let service = OtapBatchService::new(
                     common.effect_handler,
                     common.state,
@@ -728,8 +696,45 @@ impl NamedService for TraceServiceServer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use otap_df_engine::control::runtime_ctrl_msg_channel;
+    use otap_df_engine::shared::message::SharedSender;
+    use otap_df_engine::testing::test_node;
     use otap_df_pdata::OtlpProtoBytes;
+    use otap_df_telemetry::registry::TelemetryRegistryHandle;
+    use otap_df_telemetry::reporter::MetricsReporter;
+    use std::collections::HashMap;
+    use tokio::sync::mpsc as tokio_mpsc;
     use tonic::Code;
+
+    fn new_test_metrics() -> Arc<Mutex<OtlpReceiverMetrics>> {
+        let registry = TelemetryRegistryHandle::new();
+        let controller = otap_df_engine::context::ControllerContext::new(registry);
+        let pipeline_ctx =
+            controller.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+        Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx)))
+    }
+
+    fn new_test_service(
+        state: Option<AckSlot>,
+        metrics: Arc<Mutex<OtlpReceiverMetrics>>,
+    ) -> (OtapBatchService, tokio_mpsc::Receiver<OtapPdata>) {
+        let (msg_tx, msg_rx) = tokio_mpsc::channel(1);
+        let mut senders = HashMap::new();
+        let _ = senders.insert("default".into(), SharedSender::mpsc(msg_tx));
+        let (ctrl_tx, _ctrl_rx) = runtime_ctrl_msg_channel(1);
+        let (_metrics_rx, metrics_reporter) = MetricsReporter::create_new_and_receiver(1);
+        let effect_handler = EffectHandler::new(
+            test_node("grpc_admission_metrics"),
+            senders,
+            None,
+            ctrl_tx,
+            metrics_reporter,
+        );
+        (
+            OtapBatchService::new(effect_handler, state, metrics, SignalType::Logs),
+            msg_rx,
+        )
+    }
 
     fn make_nack(permanent: bool) -> NackMsg<OtapPdata> {
         let pdata = OtapPdata::new_default(OtlpProtoBytes::ExportLogsRequest(Bytes::new()).into());
@@ -771,6 +776,60 @@ mod tests {
             status.message().contains("transient failure"),
             "message: {}",
             status.message()
+        );
+    }
+
+    /// Scenario: A non-empty gRPC request does not require an acknowledgement slot.
+    /// Guarantees: Successful admission records its started, completed, and payload-byte values.
+    #[tokio::test]
+    async fn admitted_grpc_request_records_payload_bytes() {
+        let metrics = new_test_metrics();
+        let (mut service, mut msg_rx) = new_test_service(None, metrics.clone());
+        let payload = Bytes::from_static(b"grpc-payload");
+        let payload_bytes = payload.len() as u64;
+        let pdata = OtapPdata::new_default(OtlpProtoBytes::ExportLogsRequest(payload).into());
+
+        let result = UnaryService::call(&mut service, tonic::Request::new(pdata)).await;
+
+        assert!(result.is_ok());
+        let _ = msg_rx.recv().await.expect("request forwarded downstream");
+        let metrics = metrics.lock();
+        let requests = metrics.requests_for(SignalType::Logs, OtlpProtocol::Grpc);
+        assert_eq!(requests.started.get(), 1);
+        assert_eq!(requests.completed.get(), 1);
+        assert_eq!(requests.payload_size.get(), payload_bytes);
+    }
+
+    /// Scenario: A non-empty gRPC request cannot allocate its acknowledgement slot.
+    /// Guarantees: The request is rejected without recording admission, completion, or payload bytes.
+    #[tokio::test]
+    async fn rejected_grpc_request_does_not_record_payload_bytes() {
+        let metrics = new_test_metrics();
+        let (mut service, mut msg_rx) = new_test_service(Some(AckSlot::new(0)), metrics.clone());
+        let payload = Bytes::from_static(b"grpc-rejected-payload");
+        let pdata = OtapPdata::new_default(OtlpProtoBytes::ExportLogsRequest(payload).into());
+
+        let result = UnaryService::call(&mut service, tonic::Request::new(pdata)).await;
+
+        assert_eq!(
+            result.expect_err("request rejected").code(),
+            Code::ResourceExhausted
+        );
+        assert!(msg_rx.try_recv().is_err());
+        let metrics = metrics.lock();
+        let requests = metrics.requests_for(SignalType::Logs, OtlpProtocol::Grpc);
+        assert_eq!(requests.started.get(), 0);
+        assert_eq!(requests.completed.get(), 0);
+        assert_eq!(requests.payload_size.get(), 0);
+        assert_eq!(
+            metrics
+                .rejections_for(
+                    OtlpProtocol::Grpc,
+                    ReceiverRejectionErrorType::ConcurrencyLimit,
+                )
+                .requests
+                .get(),
+            1
         );
     }
 }

--- a/rust/otap-dataflow/crates/otap/src/otlp_http.rs
+++ b/rust/otap-dataflow/crates/otap/src/otlp_http.rs
@@ -13,6 +13,7 @@
 
 use crate::otap_grpc::common::AckRegistry;
 use crate::otap_grpc::otlp::server_new::AckSlot;
+use crate::otlp_metrics::{OtlpProtocol, OtlpReceiverMetrics, OtlpRejectionErrorType};
 use crate::pdata::{Context, OtapPdata};
 use crate::socket_options;
 
@@ -35,7 +36,6 @@ use otap_df_pdata::OtlpProtoBytes;
 use otap_df_pdata::proto::opentelemetry::collector::logs::v1::ExportLogsServiceResponse;
 use otap_df_pdata::proto::opentelemetry::collector::metrics::v1::ExportMetricsServiceResponse;
 use otap_df_pdata::proto::opentelemetry::collector::trace::v1::ExportTraceServiceResponse;
-use otap_df_telemetry::metrics::MetricSet;
 use parking_lot::Mutex;
 use prost::Message;
 use prost_types::Any;
@@ -355,7 +355,7 @@ fn decode_content_encoding(
     headers: &http::HeaderMap,
     body: Bytes,
     max_len: usize,
-) -> Result<Bytes, Response<Full<Bytes>>> {
+) -> Result<Bytes, DecodeContentError> {
     let encoding = headers
         .get(http::header::CONTENT_ENCODING)
         .and_then(|v| v.to_str().ok())
@@ -367,7 +367,7 @@ fn decode_content_encoding(
     }
 
     if !accept_compressed_requests {
-        return Err(unsupported_media_type());
+        return Err(DecodeContentError::invalid_request(unsupported_media_type()));
     }
 
     // Decompress into a bounded buffer.
@@ -384,7 +384,7 @@ fn decode_content_encoding(
                     max_len = max_len,
                     error = err_msg.as_str()
                 );
-                limited_body_too_large()
+                DecodeContentError::payload_too_large(limited_body_too_large())
             } else {
                 // Format/corruption error
                 otap_df_telemetry::otel_debug!(
@@ -393,11 +393,11 @@ fn decode_content_encoding(
                     encoding = "gzip",
                     error = err_msg.as_str()
                 );
-                rpc_status_response(
+                DecodeContentError::invalid_request(rpc_status_response(
                     StatusCode::BAD_REQUEST,
                     3,
                     format!("gzip decode failed: {err_msg}"),
-                )
+                ))
             }
         })?;
         Ok(Bytes::from(decoded))
@@ -414,7 +414,7 @@ fn decode_content_encoding(
                     max_len = max_len,
                     error = err_msg.as_str()
                 );
-                limited_body_too_large()
+                DecodeContentError::payload_too_large(limited_body_too_large())
             } else {
                 // Format/corruption error
                 otap_df_telemetry::otel_debug!(
@@ -423,11 +423,11 @@ fn decode_content_encoding(
                     encoding = "deflate",
                     error = err_msg.as_str()
                 );
-                rpc_status_response(
+                DecodeContentError::invalid_request(rpc_status_response(
                     StatusCode::BAD_REQUEST,
                     3,
                     format!("deflate decode failed: {err_msg}"),
-                )
+                ))
             }
         })?;
         Ok(Bytes::from(decoded))
@@ -440,11 +440,11 @@ fn decode_content_encoding(
                 encoding = "zstd",
                 error = err_msg.as_str()
             );
-            rpc_status_response(
+            DecodeContentError::invalid_request(rpc_status_response(
                 StatusCode::BAD_REQUEST,
                 3,
                 format!("zstd decode failed: {err_msg}"),
-            )
+            ))
         })?;
 
         let decoded = read_to_end_limited(&mut decoder, max_len).map_err(|e| {
@@ -457,7 +457,7 @@ fn decode_content_encoding(
                     max_len = max_len,
                     error = err_msg.as_str()
                 );
-                limited_body_too_large()
+                DecodeContentError::payload_too_large(limited_body_too_large())
             } else {
                 otap_df_telemetry::otel_debug!(
                     "otlp_http_receiver.request_rejected",
@@ -465,17 +465,38 @@ fn decode_content_encoding(
                     encoding = "zstd",
                     error = err_msg.as_str()
                 );
-                rpc_status_response(
+                DecodeContentError::invalid_request(rpc_status_response(
                     StatusCode::BAD_REQUEST,
                     3,
                     format!("zstd decode failed: {err_msg}"),
-                )
+                ))
             }
         })?;
 
         Ok(Bytes::from(decoded))
     } else {
-        Err(unsupported_media_type())
+        Err(DecodeContentError::invalid_request(unsupported_media_type()))
+    }
+}
+
+struct DecodeContentError {
+    error_type: OtlpRejectionErrorType,
+    response: Response<Full<Bytes>>,
+}
+
+impl DecodeContentError {
+    fn invalid_request(response: Response<Full<Bytes>>) -> Self {
+        Self {
+            error_type: OtlpRejectionErrorType::InvalidRequest,
+            response,
+        }
+    }
+
+    fn payload_too_large(response: Response<Full<Bytes>>) -> Self {
+        Self {
+            error_type: OtlpRejectionErrorType::PayloadTooLarge,
+            response,
+        }
     }
 }
 
@@ -507,7 +528,7 @@ fn read_to_end_limited<R: std::io::Read>(
 struct HttpHandler {
     effect_handler: EffectHandler<OtapPdata>,
     ack_registry: AckRegistry,
-    metrics: Arc<Mutex<MetricSet<crate::otlp_metrics::OtlpReceiverMetrics>>>,
+    metrics: Arc<Mutex<OtlpReceiverMetrics>>,
     settings: HttpServerSettings,
     admission_state: SharedReceiverAdmissionState,
     /// Optional global semaphore shared across protocols (e.g., gRPC + HTTP) to enforce
@@ -522,16 +543,25 @@ struct HttpHandler {
 }
 
 impl HttpHandler {
+    fn record_rejection(&self, error_type: OtlpRejectionErrorType) {
+        self.metrics
+            .lock()
+            .record_rejection(OtlpProtocol::Http, error_type);
+    }
+
     async fn handle(self, req: Request<Incoming>) -> Result<Response<Full<Bytes>>, Infallible> {
         let Some(signal) = map_path_to_signal(req.uri().path()) else {
+            self.record_rejection(OtlpRejectionErrorType::InvalidRequest);
             return Ok(not_found());
         };
 
         if req.method() != Method::POST {
+            self.record_rejection(OtlpRejectionErrorType::InvalidRequest);
             return Ok(method_not_allowed());
         }
 
         if !content_type_is_protobuf(req.headers()) {
+            self.record_rejection(OtlpRejectionErrorType::InvalidRequest);
             return Ok(unsupported_media_type());
         }
 
@@ -549,9 +579,7 @@ impl HttpHandler {
 
         let fut = async move {
             if self.admission_state.should_shed_ingress() {
-                let mut metrics = self.metrics.lock();
-                metrics.rejected_requests.inc();
-                metrics.refused_memory_pressure.inc();
+                self.record_rejection(OtlpRejectionErrorType::MemoryPressure);
                 return Err(memory_pressure_unavailable(
                     self.admission_state.retry_after_secs(),
                 ));
@@ -571,7 +599,7 @@ impl HttpHandler {
                             kind = "global",
                             path = path_for_fut.as_str()
                         );
-                        self.metrics.lock().rejected_requests.inc();
+                        self.record_rejection(OtlpRejectionErrorType::Internal);
                         return Err(internal_error());
                     }
                     Err(_) => {
@@ -581,7 +609,7 @@ impl HttpHandler {
                             path = path_for_fut.as_str(),
                             timeout_ms = permit_timeout.as_millis() as u64
                         );
-                        self.metrics.lock().rejected_requests.inc();
+                        self.record_rejection(OtlpRejectionErrorType::ConcurrencyLimit);
                         return Err(service_unavailable());
                     }
                 }
@@ -592,9 +620,7 @@ impl HttpHandler {
             // Re-check after potentially waiting for the global permit: pressure may have
             // escalated while this request was queued.
             if self.admission_state.should_shed_ingress() {
-                let mut metrics = self.metrics.lock();
-                metrics.rejected_requests.inc();
-                metrics.refused_memory_pressure.inc();
+                self.record_rejection(OtlpRejectionErrorType::MemoryPressure);
                 return Err(memory_pressure_unavailable(
                     self.admission_state.retry_after_secs(),
                 ));
@@ -613,7 +639,7 @@ impl HttpHandler {
                         kind = "local",
                         path = path_for_fut.as_str()
                     );
-                    self.metrics.lock().rejected_requests.inc();
+                    self.record_rejection(OtlpRejectionErrorType::Internal);
                     return Err(internal_error());
                 }
                 Err(_) => {
@@ -625,22 +651,18 @@ impl HttpHandler {
                         max_concurrent = self.settings.max_concurrent_requests,
                         timeout_ms = permit_timeout.as_millis() as u64
                     );
-                    self.metrics.lock().rejected_requests.inc();
+                    self.record_rejection(OtlpRejectionErrorType::ConcurrencyLimit);
                     return Err(service_unavailable());
                 }
             };
 
             // Re-check after waiting for the local permit.
             if self.admission_state.should_shed_ingress() {
-                let mut metrics = self.metrics.lock();
-                metrics.rejected_requests.inc();
-                metrics.refused_memory_pressure.inc();
+                self.record_rejection(OtlpRejectionErrorType::MemoryPressure);
                 return Err(memory_pressure_unavailable(
                     self.admission_state.retry_after_secs(),
                 ));
             }
-
-            self.metrics.lock().requests_started.inc();
 
             let max_len = self.settings.max_request_body_size as usize;
 
@@ -658,7 +680,7 @@ impl HttpHandler {
                         size_hint = upper,
                         path = parts.uri.path().to_string()
                     );
-                    self.metrics.lock().rejected_requests.inc();
+                    self.record_rejection(OtlpRejectionErrorType::PayloadTooLarge);
                     return Err(limited_body_too_large());
                 }
             }
@@ -671,7 +693,7 @@ impl HttpHandler {
                         max_len = max_len,
                         path = parts.uri.path().to_string()
                     );
-                    self.metrics.lock().rejected_requests.inc();
+                    self.record_rejection(OtlpRejectionErrorType::PayloadTooLarge);
                     return limited_body_too_large();
                 }
 
@@ -679,6 +701,7 @@ impl HttpHandler {
                     "otlp_http_receiver.body_collection_failed",
                     error = e.to_string()
                 );
+                self.record_rejection(OtlpRejectionErrorType::Internal);
                 internal_error()
             })?;
             let body = collected.to_bytes();
@@ -688,8 +711,16 @@ impl HttpHandler {
                 &headers,
                 body,
                 max_len,
-            )?;
-            self.metrics.lock().request_bytes.add(body.len() as u64);
+            )
+            .map_err(|error| {
+                self.record_rejection(error.error_type);
+                error.response
+            })?;
+            self.metrics.lock().record_request_payload_size(
+                signal,
+                OtlpProtocol::Http,
+                body.len() as u64,
+            );
 
             let context = if self.settings.wait_for_result {
                 Context::with_capacity(1)
@@ -726,12 +757,13 @@ impl HttpHandler {
                 };
 
                 let Some(state) = state else {
+                    self.record_rejection(OtlpRejectionErrorType::Internal);
                     return Err(internal_error());
                 };
 
                 let (key, rx) = match state.allocate_slot() {
                     None => {
-                        self.metrics.lock().rejected_requests.inc();
+                        self.record_rejection(OtlpRejectionErrorType::ConcurrencyLimit);
                         return Err(service_unavailable());
                     }
                     Some(pair) => pair,
@@ -747,6 +779,14 @@ impl HttpHandler {
                 Some((SlotGuard { key, state }, rx))
             } else {
                 None
+            };
+
+            self.metrics
+                .lock()
+                .record_request_started(signal, OtlpProtocol::Http);
+            let _completion_guard = RequestCompletionGuard {
+                metrics: self.metrics.clone(),
+                signal,
             };
 
             if self
@@ -785,7 +825,6 @@ impl HttpHandler {
                 }
             }
 
-            self.metrics.lock().requests_completed.inc();
             Ok(ok_response(signal))
         };
 
@@ -815,6 +854,19 @@ struct SlotGuard {
     state: AckSlot,
 }
 
+struct RequestCompletionGuard {
+    metrics: Arc<Mutex<OtlpReceiverMetrics>>,
+    signal: SignalType,
+}
+
+impl Drop for RequestCompletionGuard {
+    fn drop(&mut self) {
+        self.metrics
+            .lock()
+            .record_request_completed(self.signal, OtlpProtocol::Http);
+    }
+}
+
 impl Drop for SlotGuard {
     fn drop(&mut self) {
         self.state.cancel_slot(self.key);
@@ -834,7 +886,7 @@ pub async fn serve(
     effect_handler: EffectHandler<OtapPdata>,
     settings: HttpServerSettings,
     ack_registry: AckRegistry,
-    metrics: Arc<Mutex<MetricSet<crate::otlp_metrics::OtlpReceiverMetrics>>>,
+    metrics: Arc<Mutex<OtlpReceiverMetrics>>,
     admission_state: SharedReceiverAdmissionState,
     global_semaphore: Option<Arc<Semaphore>>,
     shutdown: CancellationToken,
@@ -1031,9 +1083,7 @@ mod tests {
             otap_df_engine::context::ControllerContext::new(metrics_registry_handle);
         let pipeline_ctx =
             controller_ctx.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
-        let metrics = Arc::new(Mutex::new(
-            pipeline_ctx.register_metrics::<crate::otlp_metrics::OtlpReceiverMetrics>(),
-        ));
+        let metrics = Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx)));
 
         let ack_registry = AckRegistry::new(Some(AckSlot::new(4)), None, None);
 
@@ -1117,6 +1167,8 @@ mod tests {
         assert!(server_result.unwrap().is_ok());
     }
 
+    /// Scenario: Memory pressure turns hard while an HTTP request waits for a shared permit.
+    /// Guarantees: The request is rejected as memory pressure without starting or reading a body.
     #[tokio::test]
     async fn queued_request_rechecks_process_memory_pressure_before_body_read() {
         use hyper::Method;
@@ -1171,9 +1223,7 @@ mod tests {
             otap_df_engine::context::ControllerContext::new(metrics_registry_handle);
         let pipeline_ctx =
             controller_ctx.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
-        let metrics = Arc::new(Mutex::new(
-            pipeline_ctx.register_metrics::<crate::otlp_metrics::OtlpReceiverMetrics>(),
-        ));
+        let metrics = Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx)));
         let memory_pressure_state = MemoryPressureState::default();
         let admission_state =
             SharedReceiverAdmissionState::from_process_state(&memory_pressure_state);
@@ -1247,10 +1297,16 @@ mod tests {
 
         {
             let metrics = metrics.lock();
-            assert_eq!(metrics.requests_started.get(), 0);
-            assert_eq!(metrics.request_bytes.get(), 0);
-            assert_eq!(metrics.rejected_requests.get(), 1);
-            assert_eq!(metrics.refused_memory_pressure.get(), 1);
+            let requests = metrics.requests_for(SignalType::Logs, OtlpProtocol::Http);
+            assert_eq!(requests.started.get(), 0);
+            assert_eq!(requests.payload_size.get(), 0);
+            assert_eq!(
+                metrics
+                    .rejections_for(OtlpProtocol::Http, OtlpRejectionErrorType::MemoryPressure)
+                    .requests
+                    .get(),
+                1
+            );
         }
 
         shutdown.cancel();
@@ -1260,6 +1316,8 @@ mod tests {
         assert!(server_result.unwrap().is_ok());
     }
 
+    /// Scenario: Memory pressure turns soft while an HTTP request waits for a shared permit.
+    /// Guarantees: Soft pressure admits the request and records its lifecycle without rejection.
     #[tokio::test]
     async fn soft_pressure_does_not_reject_after_waiting_for_permit() {
         use http_body_util::Full;
@@ -1301,9 +1359,7 @@ mod tests {
             otap_df_engine::context::ControllerContext::new(metrics_registry_handle);
         let pipeline_ctx =
             controller_ctx.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
-        let metrics = Arc::new(Mutex::new(
-            pipeline_ctx.register_metrics::<crate::otlp_metrics::OtlpReceiverMetrics>(),
-        ));
+        let metrics = Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx)));
 
         let local_semaphore = Arc::new(Semaphore::new(1));
         let held_permit = local_semaphore
@@ -1375,9 +1431,16 @@ mod tests {
 
         {
             let metrics = metrics.lock();
-            assert_eq!(metrics.rejected_requests.get(), 0);
-            assert_eq!(metrics.refused_memory_pressure.get(), 0);
-            assert_eq!(metrics.requests_started.get(), 1);
+            assert_eq!(
+                metrics
+                    .rejections_for(OtlpProtocol::Http, OtlpRejectionErrorType::MemoryPressure)
+                    .requests
+                    .get(),
+                0
+            );
+            let requests = metrics.requests_for(SignalType::Logs, OtlpProtocol::Http);
+            assert_eq!(requests.started.get(), 1);
+            assert_eq!(requests.completed.get(), 1);
         }
 
         let _ = msg_rx.recv().await.expect("request forwarded downstream");

--- a/rust/otap-dataflow/crates/otap/src/otlp_http.rs
+++ b/rust/otap-dataflow/crates/otap/src/otlp_http.rs
@@ -13,7 +13,7 @@
 
 use crate::otap_grpc::common::AckRegistry;
 use crate::otap_grpc::otlp::server_new::AckSlot;
-use crate::otlp_metrics::{OtlpProtocol, OtlpReceiverMetrics, OtlpRejectionErrorType};
+use crate::otlp_metrics::{OtlpProtocol, OtlpReceiverMetrics};
 use crate::pdata::{Context, OtapPdata};
 use crate::socket_options;
 
@@ -36,6 +36,7 @@ use otap_df_pdata::OtlpProtoBytes;
 use otap_df_pdata::proto::opentelemetry::collector::logs::v1::ExportLogsServiceResponse;
 use otap_df_pdata::proto::opentelemetry::collector::metrics::v1::ExportMetricsServiceResponse;
 use otap_df_pdata::proto::opentelemetry::collector::trace::v1::ExportTraceServiceResponse;
+use otap_df_telemetry::common_attributes::ReceiverRejectionErrorType;
 use parking_lot::Mutex;
 use prost::Message;
 use prost_types::Any;
@@ -480,21 +481,21 @@ fn decode_content_encoding(
 }
 
 struct DecodeContentError {
-    error_type: OtlpRejectionErrorType,
+    error_type: ReceiverRejectionErrorType,
     response: Response<Full<Bytes>>,
 }
 
 impl DecodeContentError {
     fn invalid_request(response: Response<Full<Bytes>>) -> Self {
         Self {
-            error_type: OtlpRejectionErrorType::InvalidRequest,
+            error_type: ReceiverRejectionErrorType::InvalidRequest,
             response,
         }
     }
 
     fn payload_too_large(response: Response<Full<Bytes>>) -> Self {
         Self {
-            error_type: OtlpRejectionErrorType::PayloadTooLarge,
+            error_type: ReceiverRejectionErrorType::PayloadTooLarge,
             response,
         }
     }
@@ -543,7 +544,7 @@ struct HttpHandler {
 }
 
 impl HttpHandler {
-    fn record_rejection(&self, error_type: OtlpRejectionErrorType) {
+    fn record_rejection(&self, error_type: ReceiverRejectionErrorType) {
         self.metrics
             .lock()
             .record_rejection(OtlpProtocol::Http, error_type);
@@ -551,17 +552,17 @@ impl HttpHandler {
 
     async fn handle(self, req: Request<Incoming>) -> Result<Response<Full<Bytes>>, Infallible> {
         let Some(signal) = map_path_to_signal(req.uri().path()) else {
-            self.record_rejection(OtlpRejectionErrorType::InvalidRequest);
+            self.record_rejection(ReceiverRejectionErrorType::InvalidRequest);
             return Ok(not_found());
         };
 
         if req.method() != Method::POST {
-            self.record_rejection(OtlpRejectionErrorType::InvalidRequest);
+            self.record_rejection(ReceiverRejectionErrorType::InvalidRequest);
             return Ok(method_not_allowed());
         }
 
         if !content_type_is_protobuf(req.headers()) {
-            self.record_rejection(OtlpRejectionErrorType::InvalidRequest);
+            self.record_rejection(ReceiverRejectionErrorType::InvalidRequest);
             return Ok(unsupported_media_type());
         }
 
@@ -579,7 +580,7 @@ impl HttpHandler {
 
         let fut = async move {
             if self.admission_state.should_shed_ingress() {
-                self.record_rejection(OtlpRejectionErrorType::MemoryPressure);
+                self.record_rejection(ReceiverRejectionErrorType::MemoryPressure);
                 return Err(memory_pressure_unavailable(
                     self.admission_state.retry_after_secs(),
                 ));
@@ -599,7 +600,7 @@ impl HttpHandler {
                             kind = "global",
                             path = path_for_fut.as_str()
                         );
-                        self.record_rejection(OtlpRejectionErrorType::Internal);
+                        self.record_rejection(ReceiverRejectionErrorType::Internal);
                         return Err(internal_error());
                     }
                     Err(_) => {
@@ -609,7 +610,7 @@ impl HttpHandler {
                             path = path_for_fut.as_str(),
                             timeout_ms = permit_timeout.as_millis() as u64
                         );
-                        self.record_rejection(OtlpRejectionErrorType::ConcurrencyLimit);
+                        self.record_rejection(ReceiverRejectionErrorType::ConcurrencyLimit);
                         return Err(service_unavailable());
                     }
                 }
@@ -620,7 +621,7 @@ impl HttpHandler {
             // Re-check after potentially waiting for the global permit: pressure may have
             // escalated while this request was queued.
             if self.admission_state.should_shed_ingress() {
-                self.record_rejection(OtlpRejectionErrorType::MemoryPressure);
+                self.record_rejection(ReceiverRejectionErrorType::MemoryPressure);
                 return Err(memory_pressure_unavailable(
                     self.admission_state.retry_after_secs(),
                 ));
@@ -639,7 +640,7 @@ impl HttpHandler {
                         kind = "local",
                         path = path_for_fut.as_str()
                     );
-                    self.record_rejection(OtlpRejectionErrorType::Internal);
+                    self.record_rejection(ReceiverRejectionErrorType::Internal);
                     return Err(internal_error());
                 }
                 Err(_) => {
@@ -651,14 +652,14 @@ impl HttpHandler {
                         max_concurrent = self.settings.max_concurrent_requests,
                         timeout_ms = permit_timeout.as_millis() as u64
                     );
-                    self.record_rejection(OtlpRejectionErrorType::ConcurrencyLimit);
+                    self.record_rejection(ReceiverRejectionErrorType::ConcurrencyLimit);
                     return Err(service_unavailable());
                 }
             };
 
             // Re-check after waiting for the local permit.
             if self.admission_state.should_shed_ingress() {
-                self.record_rejection(OtlpRejectionErrorType::MemoryPressure);
+                self.record_rejection(ReceiverRejectionErrorType::MemoryPressure);
                 return Err(memory_pressure_unavailable(
                     self.admission_state.retry_after_secs(),
                 ));
@@ -680,7 +681,7 @@ impl HttpHandler {
                         size_hint = upper,
                         path = parts.uri.path().to_string()
                     );
-                    self.record_rejection(OtlpRejectionErrorType::PayloadTooLarge);
+                    self.record_rejection(ReceiverRejectionErrorType::PayloadTooLarge);
                     return Err(limited_body_too_large());
                 }
             }
@@ -693,7 +694,7 @@ impl HttpHandler {
                         max_len = max_len,
                         path = parts.uri.path().to_string()
                     );
-                    self.record_rejection(OtlpRejectionErrorType::PayloadTooLarge);
+                    self.record_rejection(ReceiverRejectionErrorType::PayloadTooLarge);
                     return limited_body_too_large();
                 }
 
@@ -701,7 +702,7 @@ impl HttpHandler {
                     "otlp_http_receiver.body_collection_failed",
                     error = e.to_string()
                 );
-                self.record_rejection(OtlpRejectionErrorType::Internal);
+                self.record_rejection(ReceiverRejectionErrorType::Internal);
                 internal_error()
             })?;
             let body = collected.to_bytes();
@@ -757,13 +758,13 @@ impl HttpHandler {
                 };
 
                 let Some(state) = state else {
-                    self.record_rejection(OtlpRejectionErrorType::Internal);
+                    self.record_rejection(ReceiverRejectionErrorType::Internal);
                     return Err(internal_error());
                 };
 
                 let (key, rx) = match state.allocate_slot() {
                     None => {
-                        self.record_rejection(OtlpRejectionErrorType::ConcurrencyLimit);
+                        self.record_rejection(ReceiverRejectionErrorType::ConcurrencyLimit);
                         return Err(service_unavailable());
                     }
                     Some(pair) => pair,
@@ -1302,7 +1303,10 @@ mod tests {
             assert_eq!(requests.payload_size.get(), 0);
             assert_eq!(
                 metrics
-                    .rejections_for(OtlpProtocol::Http, OtlpRejectionErrorType::MemoryPressure)
+                    .rejections_for(
+                        OtlpProtocol::Http,
+                        ReceiverRejectionErrorType::MemoryPressure,
+                    )
                     .requests
                     .get(),
                 1
@@ -1433,7 +1437,10 @@ mod tests {
             let metrics = metrics.lock();
             assert_eq!(
                 metrics
-                    .rejections_for(OtlpProtocol::Http, OtlpRejectionErrorType::MemoryPressure)
+                    .rejections_for(
+                        OtlpProtocol::Http,
+                        ReceiverRejectionErrorType::MemoryPressure,
+                    )
                     .requests
                     .get(),
                 0

--- a/rust/otap-dataflow/crates/otap/src/otlp_http.rs
+++ b/rust/otap-dataflow/crates/otap/src/otlp_http.rs
@@ -717,11 +717,7 @@ impl HttpHandler {
                 self.record_rejection(error.error_type);
                 error.response
             })?;
-            self.metrics.lock().record_request_payload_size(
-                signal,
-                OtlpProtocol::Http,
-                body.len() as u64,
-            );
+            let payload_bytes = body.len() as u64;
 
             let context = if self.settings.wait_for_result {
                 Context::with_capacity(1)
@@ -784,7 +780,7 @@ impl HttpHandler {
 
             self.metrics
                 .lock()
-                .record_request_started(signal, OtlpProtocol::Http);
+                .record_request_admitted(signal, OtlpProtocol::Http, payload_bytes);
             let _completion_guard = RequestCompletionGuard {
                 metrics: self.metrics.clone(),
                 signal,
@@ -1162,6 +1158,126 @@ mod tests {
         let (status, _) = response.await.unwrap();
         assert_eq!(status, StatusCode::OK);
 
+        let server_result = tokio::time::timeout(Duration::from_secs(2), server)
+            .await
+            .expect("server finished");
+        assert!(server_result.unwrap().is_ok());
+    }
+
+    /// Scenario: A non-empty HTTP request cannot allocate its acknowledgement slot.
+    /// Guarantees: The request is rejected without recording admission, completion, or payload bytes.
+    #[tokio::test]
+    async fn rejected_http_request_does_not_record_payload_bytes() {
+        use hyper::Method;
+        use hyper::client::conn::http1;
+        use hyper::header::{CONTENT_TYPE, HOST};
+        use hyper_util::rt::TokioIo;
+        use otap_df_engine::control::runtime_ctrl_msg_channel;
+        use otap_df_engine::shared::message::SharedSender;
+        use otap_df_engine::testing::test_node;
+        use otap_df_pdata::proto::opentelemetry::collector::logs::v1::ExportLogsServiceRequest;
+        use otap_df_pdata::proto::opentelemetry::logs::v1::ResourceLogs;
+        use otap_df_telemetry::registry::TelemetryRegistryHandle;
+        use otap_df_telemetry::reporter::MetricsReporter;
+        use tokio::net::TcpStream;
+        use tokio::sync::mpsc as tokio_mpsc;
+        use tokio_util::sync::CancellationToken;
+
+        let port = otap_df_test_net::pick_unused_loopback_tcp_port();
+        let addr: SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
+
+        let (msg_tx, mut msg_rx) = tokio_mpsc::channel(1);
+        let mut senders = HashMap::new();
+        let _ = senders.insert("default".into(), SharedSender::mpsc(msg_tx));
+        let (ctrl_tx, _ctrl_rx) = runtime_ctrl_msg_channel(1);
+        let (_metrics_rx, metrics_reporter) = MetricsReporter::create_new_and_receiver(1);
+        let effect_handler = EffectHandler::new(
+            test_node("http_admission_metrics"),
+            senders,
+            None,
+            ctrl_tx,
+            metrics_reporter,
+        );
+
+        let settings = HttpServerSettings {
+            listening_addr: addr,
+            max_concurrent_requests: 1,
+            wait_for_result: true,
+            ..Default::default()
+        };
+        let shutdown = CancellationToken::new();
+
+        let metrics_registry_handle = TelemetryRegistryHandle::new();
+        let controller_ctx =
+            otap_df_engine::context::ControllerContext::new(metrics_registry_handle);
+        let pipeline_ctx =
+            controller_ctx.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+        let metrics = Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx)));
+
+        let server = tokio::spawn(serve(
+            effect_handler,
+            settings,
+            AckRegistry::new(Some(AckSlot::new(0)), None, None),
+            metrics.clone(),
+            SharedReceiverAdmissionState::default(),
+            None,
+            shutdown.clone(),
+        ));
+
+        let mut stream = None;
+        for _ in 0..10 {
+            match TcpStream::connect(addr).await {
+                Ok(connected) => {
+                    stream = Some(connected);
+                    break;
+                }
+                Err(_) => tokio::time::sleep(Duration::from_millis(50)).await,
+            }
+        }
+        let stream = stream.expect("Failed to connect to server");
+        let (mut sender, conn) = http1::handshake(TokioIo::new(stream)).await.unwrap();
+        drop(tokio::spawn(async move {
+            let _ = conn.await;
+        }));
+
+        let mut request_bytes = Vec::new();
+        ExportLogsServiceRequest {
+            resource_logs: vec![ResourceLogs::default()],
+        }
+        .encode(&mut request_bytes)
+        .unwrap();
+        assert!(!request_bytes.is_empty());
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/v1/logs")
+            .header(HOST, "localhost")
+            .header(CONTENT_TYPE, PROTOBUF_CONTENT_TYPE)
+            .body(Full::new(Bytes::from(request_bytes)))
+            .unwrap();
+
+        let status = sender.send_request(request).await.unwrap().status();
+
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert!(msg_rx.try_recv().is_err());
+        {
+            let metrics = metrics.lock();
+            let requests = metrics.requests_for(SignalType::Logs, OtlpProtocol::Http);
+            assert_eq!(requests.started.get(), 0);
+            assert_eq!(requests.completed.get(), 0);
+            assert_eq!(requests.payload_size.get(), 0);
+            assert_eq!(
+                metrics
+                    .rejections_for(
+                        OtlpProtocol::Http,
+                        ReceiverRejectionErrorType::ConcurrencyLimit,
+                    )
+                    .requests
+                    .get(),
+                1
+            );
+        }
+
+        shutdown.cancel();
         let server_result = tokio::time::timeout(Duration::from_secs(2), server)
             .await
             .expect("server finished");

--- a/rust/otap-dataflow/crates/otap/src/otlp_metrics.rs
+++ b/rust/otap-dataflow/crates/otap/src/otlp_metrics.rs
@@ -5,7 +5,9 @@
 
 use otap_df_config::SignalType;
 use otap_df_engine::context::PipelineContext;
-use otap_df_telemetry::common_attributes::{Outcome, SignalOutcomeAttributes};
+use otap_df_telemetry::common_attributes::{
+    Outcome, ReceiverRejectionErrorType, SignalOutcomeAttributes,
+};
 use otap_df_telemetry::error::Error as TelemetryError;
 use otap_df_telemetry::instrument::Counter;
 use otap_df_telemetry::metrics::{MeasurementMetricSet, MetricSetSnapshot};
@@ -19,21 +21,6 @@ pub enum OtlpProtocol {
     Grpc,
     /// OTLP over HTTP.
     Http,
-}
-
-/// Bounded classification for requests rejected before pipeline admission.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, AttributeEnum)]
-pub enum OtlpRejectionErrorType {
-    /// The process is refusing ingress because memory pressure is active.
-    MemoryPressure,
-    /// No configured concurrency or acknowledgement slot is available.
-    ConcurrencyLimit,
-    /// The encoded or decoded payload exceeds the configured size limit.
-    PayloadTooLarge,
-    /// The request path, method, content type, encoding, or payload is invalid.
-    InvalidRequest,
-    /// Receiver state or an internal channel failed unexpectedly.
-    Internal,
 }
 
 /// Signal and protocol dimensions for an accepted OTLP request.
@@ -54,7 +41,7 @@ pub struct OtlpRejectionAttributes {
     pub protocol: OtlpProtocol,
     /// Reason the request was rejected.
     #[attribute_key = "error.type"]
-    pub error_type: OtlpRejectionErrorType,
+    pub error_type: ReceiverRejectionErrorType,
 }
 
 /// Protocol dimension for a transport-level receiver error.
@@ -173,7 +160,11 @@ impl OtlpReceiverMetrics {
     }
 
     /// Records a request rejected before pipeline admission.
-    pub fn record_rejection(&mut self, protocol: OtlpProtocol, error_type: OtlpRejectionErrorType) {
+    pub fn record_rejection(
+        &mut self,
+        protocol: OtlpProtocol,
+        error_type: ReceiverRejectionErrorType,
+    ) {
         self.rejections
             .with(OtlpRejectionAttributes {
                 protocol,
@@ -211,7 +202,7 @@ impl OtlpReceiverMetrics {
     pub fn rejections_for(
         &self,
         protocol: OtlpProtocol,
-        error_type: OtlpRejectionErrorType,
+        error_type: ReceiverRejectionErrorType,
     ) -> &OtlpRejectionMetrics {
         self.rejections.get(OtlpRejectionAttributes {
             protocol,
@@ -276,7 +267,10 @@ mod tests {
         metrics.record_request_started(SignalType::Logs, OtlpProtocol::Grpc);
         metrics.record_request_payload_size(SignalType::Logs, OtlpProtocol::Grpc, 42);
         metrics.record_request_completed(SignalType::Logs, OtlpProtocol::Grpc);
-        metrics.record_rejection(OtlpProtocol::Http, OtlpRejectionErrorType::InvalidRequest);
+        metrics.record_rejection(
+            OtlpProtocol::Http,
+            ReceiverRejectionErrorType::InvalidRequest,
+        );
         metrics.record_acknowledgement(SignalType::Logs, Outcome::Refused);
         metrics.record_transport_error(OtlpProtocol::Grpc);
 
@@ -293,7 +287,10 @@ mod tests {
         );
         assert_eq!(
             metrics
-                .rejections_for(OtlpProtocol::Http, OtlpRejectionErrorType::InvalidRequest)
+                .rejections_for(
+                    OtlpProtocol::Http,
+                    ReceiverRejectionErrorType::InvalidRequest,
+                )
                 .requests
                 .get(),
             1
@@ -314,7 +311,10 @@ mod tests {
     fn terminal_snapshots_preserve_enum_attribute_values_once() {
         let mut metrics = new_test_metrics();
         metrics.record_request_started(SignalType::Metrics, OtlpProtocol::Http);
-        metrics.record_rejection(OtlpProtocol::Grpc, OtlpRejectionErrorType::MemoryPressure);
+        metrics.record_rejection(
+            OtlpProtocol::Grpc,
+            ReceiverRejectionErrorType::MemoryPressure,
+        );
 
         let snapshots = metrics.terminal_snapshots();
         assert_eq!(snapshots.len(), 2);

--- a/rust/otap-dataflow/crates/otap/src/otlp_metrics.rs
+++ b/rust/otap-dataflow/crates/otap/src/otlp_metrics.rs
@@ -3,46 +3,331 @@
 
 //! Shared OTLP receiver metric definitions.
 
+use otap_df_config::SignalType;
+use otap_df_engine::context::PipelineContext;
+use otap_df_telemetry::common_attributes::{Outcome, SignalOutcomeAttributes};
+use otap_df_telemetry::error::Error as TelemetryError;
 use otap_df_telemetry::instrument::Counter;
-use otap_df_telemetry_macros::metric_set;
+use otap_df_telemetry::metrics::{MeasurementMetricSet, MetricSetSnapshot};
+use otap_df_telemetry::reporter::MetricsReporter;
+use otap_df_telemetry_macros::{AttributeEnum, attribute_set, metric_set};
 
-/// OTLP receiver metrics.
-#[metric_set(name = "receiver.otlp")]
+/// Transport protocol used to receive an OTLP request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, AttributeEnum)]
+pub enum OtlpProtocol {
+    /// OTLP over gRPC.
+    Grpc,
+    /// OTLP over HTTP.
+    Http,
+}
+
+/// Bounded classification for requests rejected before pipeline admission.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, AttributeEnum)]
+pub enum OtlpRejectionErrorType {
+    /// The process is refusing ingress because memory pressure is active.
+    MemoryPressure,
+    /// No configured concurrency or acknowledgement slot is available.
+    ConcurrencyLimit,
+    /// The encoded or decoded payload exceeds the configured size limit.
+    PayloadTooLarge,
+    /// The request path, method, content type, encoding, or payload is invalid.
+    InvalidRequest,
+    /// Receiver state or an internal channel failed unexpectedly.
+    Internal,
+}
+
+/// Signal and protocol dimensions for an accepted OTLP request.
+#[attribute_set(item, measurement)]
+#[derive(Debug, Clone, Copy)]
+pub struct OtlpRequestAttributes {
+    /// Signal carried by the request.
+    pub signal: SignalType,
+    /// OTLP transport used by the request.
+    pub protocol: OtlpProtocol,
+}
+
+/// Protocol and bounded error type dimensions for a rejected request.
+#[attribute_set(item, measurement)]
+#[derive(Debug, Clone, Copy)]
+pub struct OtlpRejectionAttributes {
+    /// OTLP transport on which the request was rejected.
+    pub protocol: OtlpProtocol,
+    /// Reason the request was rejected.
+    #[attribute_key = "error.type"]
+    pub error_type: OtlpRejectionErrorType,
+}
+
+/// Protocol dimension for a transport-level receiver error.
+#[attribute_set(item, measurement)]
+#[derive(Debug, Clone, Copy)]
+pub struct OtlpTransportAttributes {
+    /// OTLP transport that surfaced the error.
+    pub protocol: OtlpProtocol,
+}
+
+/// Lifecycle and payload metrics for accepted OTLP requests.
+#[metric_set(
+    name = "receiver.otlp.requests",
+    measurement_attributes = OtlpRequestAttributes
+)]
 #[derive(Debug, Default, Clone)]
-pub struct OtlpReceiverMetrics {
-    /// Number of acks received from downstream (routed back to the caller).
-    #[metric(unit = "{acks}")]
-    pub acks_received: Counter<u64>,
-
-    /// Number of nacks received from downstream (routed back to the caller).
-    #[metric(unit = "{nacks}")]
-    pub nacks_received: Counter<u64>,
-
-    /// Number of invalid/expired acks/nacks.
-    #[metric(unit = "{ack_or_nack}")]
-    pub acks_nacks_invalid_or_expired: Counter<u64>,
-
-    /// Number of OTLP RPCs started.
-    #[metric(unit = "{requests}")]
-    pub requests_started: Counter<u64>,
-
-    /// Number of OTLP RPCs completed (success + nack).
-    #[metric(unit = "{requests}")]
-    pub requests_completed: Counter<u64>,
-
-    /// Number of OTLP RPCs rejected before entering the pipeline (e.g. slot exhaustion).
-    #[metric(unit = "{requests}")]
-    pub rejected_requests: Counter<u64>,
-
-    /// Number of OTLP RPCs rejected specifically because process-wide memory pressure was active.
-    #[metric(unit = "{requests}")]
-    pub refused_memory_pressure: Counter<u64>,
-
-    /// Number of transport-level errors surfaced by tonic/server.
-    #[metric(unit = "{errors}")]
-    pub transport_errors: Counter<u64>,
-
-    /// Total decompressed payload bytes for successfully received OTLP requests.
+pub struct OtlpRequestMetrics {
+    /// Number of requests admitted to the pipeline send path.
+    #[metric(unit = "{request}")]
+    pub started: Counter<u64>,
+    /// Number of admitted requests whose receiver work terminated.
+    #[metric(unit = "{request}")]
+    pub completed: Counter<u64>,
+    /// Decompressed payload bytes for successfully decoded requests.
     #[metric(unit = "By")]
-    pub request_bytes: Counter<u64>,
+    pub payload_size: Counter<u64>,
+}
+
+/// Requests rejected before pipeline admission.
+#[metric_set(
+    name = "receiver.otlp.rejections",
+    measurement_attributes = OtlpRejectionAttributes
+)]
+#[derive(Debug, Default, Clone)]
+pub struct OtlpRejectionMetrics {
+    /// Number of rejected requests.
+    #[metric(unit = "{request}")]
+    pub requests: Counter<u64>,
+}
+
+/// Downstream acknowledgement routing results.
+#[metric_set(
+    name = "receiver.otlp.acknowledgements",
+    measurement_attributes = SignalOutcomeAttributes
+)]
+#[derive(Debug, Default, Clone)]
+pub struct OtlpAcknowledgementMetrics {
+    /// Number of routed or invalid acknowledgement responses.
+    #[metric(unit = "{response}")]
+    pub responses: Counter<u64>,
+}
+
+/// Transport-level OTLP receiver errors.
+#[metric_set(
+    name = "receiver.otlp.transport",
+    measurement_attributes = OtlpTransportAttributes
+)]
+#[derive(Debug, Default, Clone)]
+pub struct OtlpTransportMetrics {
+    /// Number of transport-level server errors.
+    #[metric(unit = "{error}")]
+    pub errors: Counter<u64>,
+}
+
+/// Shared bounded-cardinality OTLP receiver metrics tracker.
+#[derive(Debug)]
+pub struct OtlpReceiverMetrics {
+    requests: MeasurementMetricSet<OtlpRequestMetrics>,
+    rejections: MeasurementMetricSet<OtlpRejectionMetrics>,
+    acknowledgements: MeasurementMetricSet<OtlpAcknowledgementMetrics>,
+    transport: MeasurementMetricSet<OtlpTransportMetrics>,
+}
+
+impl OtlpReceiverMetrics {
+    /// Registers all OTLP receiver metric sets for a pipeline node.
+    #[must_use]
+    pub fn register(pipeline_ctx: &PipelineContext) -> Self {
+        Self {
+            requests: OtlpRequestMetrics::register(pipeline_ctx),
+            rejections: OtlpRejectionMetrics::register(pipeline_ctx),
+            acknowledgements: OtlpAcknowledgementMetrics::register(pipeline_ctx),
+            transport: OtlpTransportMetrics::register(pipeline_ctx),
+        }
+    }
+
+    /// Records a request entering the pipeline send path.
+    pub fn record_request_started(&mut self, signal: SignalType, protocol: OtlpProtocol) {
+        self.requests
+            .with(OtlpRequestAttributes { signal, protocol })
+            .started
+            .inc();
+    }
+
+    /// Records termination of receiver work for an admitted request.
+    pub fn record_request_completed(&mut self, signal: SignalType, protocol: OtlpProtocol) {
+        self.requests
+            .with(OtlpRequestAttributes { signal, protocol })
+            .completed
+            .inc();
+    }
+
+    /// Records decompressed payload bytes for a successfully decoded request.
+    pub fn record_request_payload_size(
+        &mut self,
+        signal: SignalType,
+        protocol: OtlpProtocol,
+        bytes: u64,
+    ) {
+        if bytes == 0 {
+            return;
+        }
+        self.requests
+            .with(OtlpRequestAttributes { signal, protocol })
+            .payload_size
+            .add(bytes);
+    }
+
+    /// Records a request rejected before pipeline admission.
+    pub fn record_rejection(&mut self, protocol: OtlpProtocol, error_type: OtlpRejectionErrorType) {
+        self.rejections
+            .with(OtlpRejectionAttributes {
+                protocol,
+                error_type,
+            })
+            .requests
+            .inc();
+    }
+
+    /// Records the outcome of routing an acknowledgement response.
+    pub fn record_acknowledgement(&mut self, signal: SignalType, outcome: Outcome) {
+        self.acknowledgements
+            .with(SignalOutcomeAttributes { signal, outcome })
+            .responses
+            .inc();
+    }
+
+    /// Records a transport-level server error.
+    pub fn record_transport_error(&mut self, protocol: OtlpProtocol) {
+        self.transport
+            .with(OtlpTransportAttributes { protocol })
+            .errors
+            .inc();
+    }
+
+    /// Returns a request bucket for inspection without marking it for export.
+    #[must_use]
+    pub fn requests_for(&self, signal: SignalType, protocol: OtlpProtocol) -> &OtlpRequestMetrics {
+        self.requests
+            .get(OtlpRequestAttributes { signal, protocol })
+    }
+
+    /// Returns a rejection bucket for inspection without marking it for export.
+    #[must_use]
+    pub fn rejections_for(
+        &self,
+        protocol: OtlpProtocol,
+        error_type: OtlpRejectionErrorType,
+    ) -> &OtlpRejectionMetrics {
+        self.rejections.get(OtlpRejectionAttributes {
+            protocol,
+            error_type,
+        })
+    }
+
+    /// Returns an acknowledgement bucket for inspection without marking it for export.
+    #[must_use]
+    pub fn acknowledgements_for(
+        &self,
+        signal: SignalType,
+        outcome: Outcome,
+    ) -> &OtlpAcknowledgementMetrics {
+        self.acknowledgements
+            .get(SignalOutcomeAttributes { signal, outcome })
+    }
+
+    /// Returns a transport bucket for inspection without marking it for export.
+    #[must_use]
+    pub fn transport_for(&self, protocol: OtlpProtocol) -> &OtlpTransportMetrics {
+        self.transport.get(OtlpTransportAttributes { protocol })
+    }
+
+    /// Reports every touched OTLP receiver metric bucket.
+    pub fn report(&mut self, reporter: &mut MetricsReporter) -> Result<(), TelemetryError> {
+        reporter.report_measurement(&mut self.requests)?;
+        reporter.report_measurement(&mut self.rejections)?;
+        reporter.report_measurement(&mut self.acknowledgements)?;
+        reporter.report_measurement(&mut self.transport)
+    }
+
+    /// Takes every touched OTLP receiver metric bucket for terminal handoff.
+    pub fn terminal_snapshots(&mut self) -> Vec<MetricSetSnapshot> {
+        let mut snapshots = self.requests.terminal_snapshots();
+        snapshots.extend(self.rejections.terminal_snapshots());
+        snapshots.extend(self.acknowledgements.terminal_snapshots());
+        snapshots.extend(self.transport.terminal_snapshots());
+        snapshots
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use otap_df_engine::context::ControllerContext;
+    use otap_df_telemetry::registry::TelemetryRegistryHandle;
+
+    fn new_test_metrics() -> OtlpReceiverMetrics {
+        let registry = TelemetryRegistryHandle::new();
+        let controller = ControllerContext::new(registry);
+        let pipeline_ctx =
+            controller.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+        OtlpReceiverMetrics::register(&pipeline_ctx)
+    }
+
+    /// Scenario: Requests, rejections, acknowledgements, and transport errors span dimensions.
+    /// Guarantees: Every counter is isolated by its bounded enum-based measurement attributes.
+    #[test]
+    fn receiver_metrics_are_partitioned_by_context() {
+        let mut metrics = new_test_metrics();
+        metrics.record_request_started(SignalType::Logs, OtlpProtocol::Grpc);
+        metrics.record_request_payload_size(SignalType::Logs, OtlpProtocol::Grpc, 42);
+        metrics.record_request_completed(SignalType::Logs, OtlpProtocol::Grpc);
+        metrics.record_rejection(OtlpProtocol::Http, OtlpRejectionErrorType::InvalidRequest);
+        metrics.record_acknowledgement(SignalType::Logs, Outcome::Refused);
+        metrics.record_transport_error(OtlpProtocol::Grpc);
+
+        let requests = metrics.requests_for(SignalType::Logs, OtlpProtocol::Grpc);
+        assert_eq!(requests.started.get(), 1);
+        assert_eq!(requests.completed.get(), 1);
+        assert_eq!(requests.payload_size.get(), 42);
+        assert_eq!(
+            metrics
+                .requests_for(SignalType::Logs, OtlpProtocol::Http)
+                .started
+                .get(),
+            0
+        );
+        assert_eq!(
+            metrics
+                .rejections_for(OtlpProtocol::Http, OtlpRejectionErrorType::InvalidRequest)
+                .requests
+                .get(),
+            1
+        );
+        assert_eq!(
+            metrics
+                .acknowledgements_for(SignalType::Logs, Outcome::Refused)
+                .responses
+                .get(),
+            1
+        );
+        assert_eq!(metrics.transport_for(OtlpProtocol::Grpc).errors.get(), 1);
+    }
+
+    /// Scenario: OTLP receiver metrics are transferred into terminal snapshots twice.
+    /// Guarantees: Touched buckets carry enum wire values once and are then cleared.
+    #[test]
+    fn terminal_snapshots_preserve_enum_attribute_values_once() {
+        let mut metrics = new_test_metrics();
+        metrics.record_request_started(SignalType::Metrics, OtlpProtocol::Http);
+        metrics.record_rejection(OtlpProtocol::Grpc, OtlpRejectionErrorType::MemoryPressure);
+
+        let snapshots = metrics.terminal_snapshots();
+        assert_eq!(snapshots.len(), 2);
+        assert!(snapshots.iter().any(|snapshot| {
+            snapshot.descriptor().name == "receiver.otlp.requests"
+                && snapshot.measurement_attribute_value("signal") == Some("metrics")
+                && snapshot.measurement_attribute_value("protocol") == Some("http")
+        }));
+        assert!(snapshots.iter().any(|snapshot| {
+            snapshot.descriptor().name == "receiver.otlp.rejections"
+                && snapshot.measurement_attribute_value("protocol") == Some("grpc")
+                && snapshot.measurement_attribute_value("error.type") == Some("memory_pressure")
+        }));
+        assert!(metrics.terminal_snapshots().is_empty());
+    }
 }

--- a/rust/otap-dataflow/crates/otap/src/otlp_metrics.rs
+++ b/rust/otap-dataflow/crates/otap/src/otlp_metrics.rs
@@ -52,7 +52,7 @@ pub struct OtlpTransportAttributes {
     pub protocol: OtlpProtocol,
 }
 
-/// Lifecycle and payload metrics for accepted OTLP requests.
+/// Lifecycle and payload metrics for admitted OTLP requests.
 #[metric_set(
     name = "receiver.otlp.requests",
     measurement_attributes = OtlpRequestAttributes
@@ -65,7 +65,7 @@ pub struct OtlpRequestMetrics {
     /// Number of admitted requests whose receiver work terminated.
     #[metric(unit = "{request}")]
     pub completed: Counter<u64>,
-    /// Decompressed payload bytes for successfully decoded requests.
+    /// Decompressed payload bytes for requests admitted to the pipeline send path.
     #[metric(unit = "By")]
     pub payload_size: Counter<u64>,
 }
@@ -127,12 +127,20 @@ impl OtlpReceiverMetrics {
         }
     }
 
-    /// Records a request entering the pipeline send path.
-    pub fn record_request_started(&mut self, signal: SignalType, protocol: OtlpProtocol) {
-        self.requests
-            .with(OtlpRequestAttributes { signal, protocol })
-            .started
-            .inc();
+    /// Records a request and its decompressed payload bytes after pipeline admission succeeds.
+    pub fn record_request_admitted(
+        &mut self,
+        signal: SignalType,
+        protocol: OtlpProtocol,
+        payload_bytes: u64,
+    ) {
+        let requests = self
+            .requests
+            .with(OtlpRequestAttributes { signal, protocol });
+        requests.started.inc();
+        if payload_bytes > 0 {
+            requests.payload_size.add(payload_bytes);
+        }
     }
 
     /// Records termination of receiver work for an admitted request.
@@ -141,22 +149,6 @@ impl OtlpReceiverMetrics {
             .with(OtlpRequestAttributes { signal, protocol })
             .completed
             .inc();
-    }
-
-    /// Records decompressed payload bytes for a successfully decoded request.
-    pub fn record_request_payload_size(
-        &mut self,
-        signal: SignalType,
-        protocol: OtlpProtocol,
-        bytes: u64,
-    ) {
-        if bytes == 0 {
-            return;
-        }
-        self.requests
-            .with(OtlpRequestAttributes { signal, protocol })
-            .payload_size
-            .add(bytes);
     }
 
     /// Records a request rejected before pipeline admission.
@@ -264,8 +256,7 @@ mod tests {
     #[test]
     fn receiver_metrics_are_partitioned_by_context() {
         let mut metrics = new_test_metrics();
-        metrics.record_request_started(SignalType::Logs, OtlpProtocol::Grpc);
-        metrics.record_request_payload_size(SignalType::Logs, OtlpProtocol::Grpc, 42);
+        metrics.record_request_admitted(SignalType::Logs, OtlpProtocol::Grpc, 42);
         metrics.record_request_completed(SignalType::Logs, OtlpProtocol::Grpc);
         metrics.record_rejection(
             OtlpProtocol::Http,
@@ -305,12 +296,24 @@ mod tests {
         assert_eq!(metrics.transport_for(OtlpProtocol::Grpc).errors.get(), 1);
     }
 
+    /// Scenario: An admitted OTLP request has an empty decompressed payload.
+    /// Guarantees: Admission is counted even though the payload-size counter remains unchanged.
+    #[test]
+    fn admitted_empty_request_still_records_started() {
+        let mut metrics = new_test_metrics();
+        metrics.record_request_admitted(SignalType::Logs, OtlpProtocol::Http, 0);
+
+        let requests = metrics.requests_for(SignalType::Logs, OtlpProtocol::Http);
+        assert_eq!(requests.started.get(), 1);
+        assert_eq!(requests.payload_size.get(), 0);
+    }
+
     /// Scenario: OTLP receiver metrics are transferred into terminal snapshots twice.
     /// Guarantees: Touched buckets carry enum wire values once and are then cleared.
     #[test]
     fn terminal_snapshots_preserve_enum_attribute_values_once() {
         let mut metrics = new_test_metrics();
-        metrics.record_request_started(SignalType::Metrics, OtlpProtocol::Http);
+        metrics.record_request_admitted(SignalType::Metrics, OtlpProtocol::Http, 0);
         metrics.record_rejection(
             OtlpProtocol::Grpc,
             ReceiverRejectionErrorType::MemoryPressure,

--- a/rust/otap-dataflow/crates/telemetry/src/common_attributes.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/common_attributes.rs
@@ -1,11 +1,11 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//! Reusable closed-set attributes for internal telemetry metrics.
+//! Reusable bounded-cardinality attributes and attribute sets for internal telemetry metrics.
 
 use crate::attributes::AttributeEnum;
 use otap_df_config::SignalType;
-use otap_df_telemetry_macros::AttributeEnum;
+use otap_df_telemetry_macros::{AttributeEnum, attribute_set};
 
 // SignalType belongs to the configuration model because it describes pipeline
 // data independently of telemetry. Implement the telemetry-specific trait here
@@ -36,6 +36,40 @@ pub enum Outcome {
     Failure,
     /// A downstream component refused the operation.
     Refused,
+}
+
+/// Outcome dimension shared by pipeline component metrics.
+#[attribute_set(item, measurement)]
+#[derive(Debug, Clone, Copy)]
+pub struct OutcomeAttributes {
+    /// Terminal outcome of the recorded operation.
+    pub outcome: Outcome,
+}
+
+/// Signal dimension shared by pipeline component metrics.
+#[attribute_set(item, measurement)]
+#[derive(Debug, Clone, Copy)]
+pub struct SignalAttributes {
+    /// Pipeline signal associated with the metric recording.
+    pub signal: SignalType,
+}
+
+/// Fixed signal context shared by single-signal pipeline component metrics.
+#[attribute_set(item, registration)]
+#[derive(Debug, Clone, Copy)]
+pub struct SignalRegistrationAttributes {
+    /// Pipeline signal associated with every metric in the registration.
+    pub signal: SignalType,
+}
+
+/// Signal and outcome dimensions shared by pipeline component metrics.
+#[attribute_set(item, measurement)]
+#[derive(Debug, Clone, Copy)]
+pub struct SignalOutcomeAttributes {
+    /// Pipeline signal associated with the metric recording.
+    pub signal: SignalType,
+    /// Terminal outcome of the recorded operation.
+    pub outcome: Outcome,
 }
 
 /// Result category for an HTTP request attempt.
@@ -69,4 +103,12 @@ pub enum HttpResponse {
     NetworkError,
     /// A response that is not otherwise classified.
     Other,
+}
+
+/// HTTP response dimension shared by pipeline component metrics.
+#[attribute_set(item, measurement)]
+#[derive(Debug, Clone, Copy)]
+pub struct HttpResponseAttributes {
+    /// Result category for the recorded HTTP request attempt.
+    pub response: HttpResponse,
 }

--- a/rust/otap-dataflow/crates/telemetry/src/common_attributes.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/common_attributes.rs
@@ -38,6 +38,21 @@ pub enum Outcome {
     Refused,
 }
 
+/// Bounded classification for requests rejected before receiver pipeline admission.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, AttributeEnum)]
+pub enum ReceiverRejectionErrorType {
+    /// The process is refusing ingress because memory pressure is active.
+    MemoryPressure,
+    /// No configured admission or concurrency capacity is available.
+    ConcurrencyLimit,
+    /// The encoded or decoded payload exceeds the configured size limit.
+    PayloadTooLarge,
+    /// The request is malformed or otherwise invalid.
+    InvalidRequest,
+    /// Receiver state or an internal channel failed unexpectedly.
+    Internal,
+}
+
 /// Outcome dimension shared by pipeline component metrics.
 #[attribute_set(item, measurement)]
 #[derive(Debug, Clone, Copy)]

--- a/rust/otap-dataflow/docs/memory-limiter-phase1.md
+++ b/rust/otap-dataflow/docs/memory-limiter-phase1.md
@@ -369,8 +369,7 @@ All engine metrics are registered under the `engine` metric-set.
 <!-- markdownlint-disable MD013 -->
 | Metric | Receiver | Description |
 | --- | --- | --- |
-| `receiver.otlp.refused_memory_pressure` | OTLP (gRPC + HTTP) | Requests rejected due to memory pressure |
-| `receiver.otlp.rejected_requests` | OTLP (gRPC + HTTP) | Total rejected requests (includes memory pressure) |
+| `receiver.otlp.rejections.requests{error.type="memory_pressure"}` | OTLP (gRPC + HTTP) | Requests rejected due to memory pressure, partitioned by `protocol` |
 | `receiver.otap.refused_memory_pressure` | OTAP gRPC | Requests rejected due to memory pressure |
 | `receiver.otap.rejected_requests` | OTAP gRPC | Total rejected requests (includes memory pressure) |
 | `receiver.syslog_cef.tcp_connections_rejected_memory_pressure` | Syslog / CEF TCP | Connections rejected or closed |

--- a/rust/otap-dataflow/docs/otlp-receiver.md
+++ b/rust/otap-dataflow/docs/otlp-receiver.md
@@ -288,12 +288,17 @@ Result:
 
 ### Unified Metrics
 
-A single `MetricSet` tracks receiver activity across both protocols:
+The receiver reports bounded, enum-based measurement attributes across both
+protocols:
 
-- `requests_started` / `requests_completed`
-- `acks_received` / `nacks_received`
-- `rejected_requests`
-- `transport_errors`
+- `receiver.otlp.requests.started`, `completed`, and `payload_size` use
+  `signal` and `protocol`.
+- `receiver.otlp.rejections.requests` uses `protocol` and `error.type`.
+- `receiver.otlp.acknowledgements.responses` uses `signal` and `outcome`.
+- `receiver.otlp.transport.errors` uses `protocol`.
+
+The attributes are measurement-time dimensions only; no registration-time
+copies of these dimensions are emitted.
 
 ## Configuration
 


### PR DESCRIPTION
# Change Summary

This PR migrates two related internal telemetry surfaces to bounded enum-based measurement attributes:

- Shared PData exporter outcome metrics now use signal and outcome dimensions for terminally completed exports.
- OTLP receiver metrics now use bounded signal, protocol, outcome, and rejection error type dimensions across the receiver and its HTTP, gRPC, and memory-pressure paths.

The broader exporter scope is intentional. OTAP, OTLP gRPC, OTLP HTTP, Parquet, Perf, ClickHouse, and Geneva all report the same PData export outcomes, so they directly register and report the shared `ExporterPDataExportMetrics` measurement metric set instead of maintaining component-specific copies or a wrapper tracker.

Exporter input volume is not duplicated at the component level. The engine already records every successful PData dequeue through `channel.receiver.recv.count`. A follow-up PR will add the `signal` attribute to the engine-level channel metric set, automatically providing consumed-per-signal counts for every PData consumer, including processors and exporters. Individual components will therefore not need to declare or increment their own consumed metric sets, while exporter telemetry in this PR can focus on the component-specific terminal export result.

The shared attributes introduced by related PRs #3516 and #3519 are reused where their semantics match, including `SignalOutcomeAttributes`. Rejection classification is also promoted to the shared `ReceiverRejectionErrorType` in `telemetry::common_attributes`, making it reusable by non-OTLP receivers. `OtlpProtocol` and the OTLP-specific attribute sets remain local because their semantics are transport-specific.

The resulting exporter schema is:

- `exporter.pdata.exports.messages{signal,outcome}`

The resulting OTLP receiver schemas are:

- `receiver.otlp.requests.started{signal,protocol}`
- `receiver.otlp.requests.completed{signal,protocol}`
- `receiver.otlp.requests.payload_size{signal,protocol}`
- `receiver.otlp.rejections.requests{protocol,error.type}`
- `receiver.otlp.acknowledgements.responses{signal,outcome}`
- `receiver.otlp.transport.errors{protocol}`

## What issue does this PR close?

* Related to #3300

## How are these changes tested?

- Unit tests verify exporter outcome partitioning by signal and outcome and terminal snapshot behavior.
- Exporter tests verify failure finalization, reconnect outcome reporting, and telemetry collection.
- Receiver tests verify bounded attribute dimensions and exact metric values.
- `cargo check` passed for the affected OTAP, core-nodes, and contrib-nodes crates.
- `cargo xtask check` passed for the full Rust workspace.
- Markdown lint and repository sanity checks passed.

## Are there any user-facing changes?

Yes. The internal telemetry schema for `receiver.otlp` and shared `exporter.pdata` metrics changes from separate metric names to bounded dimensions.

Exporter input volume remains available from the engine-owned `channel.receiver.recv.count` metric. Terminal exporter results are reported by `exporter.pdata.exports.messages{signal,outcome}`. Adding `signal` to the engine-level channel metric set is intentionally deferred to a follow-up PR; that change will automatically expose consumed-per-signal counts for all processors and exporters.

### Changelog

- [x] Added a `.chloggen/*.yaml` entry
- [ ] This PR is a `chore` (indicated in title)
- [ ] This is a documentation-only PR.