### PR TITLE
[azure_identity_auth] update azure sdk to bleeding edge for Arc identity support

### DIFF
--- a/rust/otap-dataflow/.chloggen/azure-arc-support.yaml
+++ b/rust/otap-dataflow/.chloggen/azure-arc-support.yaml
@@ -11,7 +11,7 @@ component: pipeline
 note: Add support for Arc-connected servers to azure_identity_auth extension
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [3549]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/rust/otap-dataflow/.chloggen/azure-arc-support.yaml
+++ b/rust/otap-dataflow/.chloggen/azure-arc-support.yaml
@@ -1,0 +1,19 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: pipeline
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for Arc-connected servers to azure_identity_auth extension
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/rust/otap-dataflow/Cargo.lock
+++ b/rust/otap-dataflow/Cargo.lock
@@ -1090,13 +1090,12 @@ dependencies = [
 
 [[package]]
 name = "azure_core"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e41cbd819986ba41904c207d8ffc4106f8f8352a548d773e9554906379bb2fb"
+version = "1.2.0-beta.1"
+source = "git+https://github.com/Azure/azure-sdk-for-rust.git?rev=fd7c3dcfb2b9f55ccb6e98b8cf148cd536460f00#fd7c3dcfb2b9f55ccb6e98b8cf148cd536460f00"
 dependencies = [
  "async-lock",
  "async-trait",
- "azure_core_macros 1.0.0",
+ "azure_core_macros 1.1.0-beta.1",
  "bytes",
  "futures",
  "pin-project",
@@ -1104,8 +1103,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tracing",
- "typespec 1.1.0",
- "typespec_client_core 1.1.0",
+ "typespec 1.2.0-beta.1",
+ "typespec_client_core 1.2.0-beta.1",
 ]
 
 [[package]]
@@ -1123,9 +1122,8 @@ dependencies = [
 
 [[package]]
 name = "azure_core_macros"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b52dba6a345f3ad2d42ff8d0d63df9d0994cfa29657bf18ffdbf149f78a4f5"
+version = "1.1.0-beta.1"
+source = "git+https://github.com/Azure/azure-sdk-for-rust.git?rev=fd7c3dcfb2b9f55ccb6e98b8cf148cd536460f00#fd7c3dcfb2b9f55ccb6e98b8cf148cd536460f00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1152,13 +1150,12 @@ dependencies = [
 
 [[package]]
 name = "azure_identity"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32edf96b356ca7c51d7590c4925cc36efc3947a5da4468e8e0b25c56ecbb3de5"
+version = "1.1.0-beta.1"
+source = "git+https://github.com/Azure/azure-sdk-for-rust.git?rev=fd7c3dcfb2b9f55ccb6e98b8cf148cd536460f00#fd7c3dcfb2b9f55ccb6e98b8cf148cd536460f00"
 dependencies = [
  "async-lock",
  "async-trait",
- "azure_core 1.1.0",
+ "azure_core 1.2.0-beta.1",
  "futures",
  "pin-project",
  "serde",
@@ -6874,8 +6871,8 @@ name = "otap-df-contrib-extensions"
 version = "0.50.0"
 dependencies = [
  "async-trait",
- "azure_core 1.1.0",
- "azure_identity 1.0.0",
+ "azure_core 1.2.0-beta.1",
+ "azure_identity 1.1.0-beta.1",
  "futures",
  "humantime-serde",
  "linkme",
@@ -7164,8 +7161,8 @@ dependencies = [
  "arc-swap",
  "arrow",
  "async-trait",
- "azure_core 1.1.0",
- "azure_identity 1.0.0",
+ "azure_core 1.2.0-beta.1",
+ "azure_identity 1.1.0-beta.1",
  "base64",
  "bytes",
  "cfg-if",
@@ -10474,9 +10471,8 @@ dependencies = [
 
 [[package]]
 name = "typespec"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "753a2fe021e407d4fc9ee6f4f0a33403cc306d5c54c4e4ebe1b8cbde0ca052b9"
+version = "1.2.0-beta.1"
+source = "git+https://github.com/Azure/azure-sdk-for-rust.git?rev=fd7c3dcfb2b9f55ccb6e98b8cf148cd536460f00#fd7c3dcfb2b9f55ccb6e98b8cf148cd536460f00"
 dependencies = [
  "base64",
  "bytes",
@@ -10513,9 +10509,8 @@ dependencies = [
 
 [[package]]
 name = "typespec_client_core"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0373af0f9d4f580b3a1a9d9639cedaabe015ed262b35bfbe13941bfb14fe1ea6"
+version = "1.2.0-beta.1"
+source = "git+https://github.com/Azure/azure-sdk-for-rust.git?rev=fd7c3dcfb2b9f55ccb6e98b8cf148cd536460f00#fd7c3dcfb2b9f55ccb6e98b8cf148cd536460f00"
 dependencies = [
  "async-trait",
  "base64",
@@ -10529,8 +10524,8 @@ dependencies = [
  "serde_json",
  "time",
  "tracing",
- "typespec 1.1.0",
- "typespec_macros 1.0.0",
+ "typespec 1.2.0-beta.1",
+ "typespec_macros 1.1.0-beta.1",
  "url",
  "uuid",
 ]
@@ -10549,9 +10544,8 @@ dependencies = [
 
 [[package]]
 name = "typespec_macros"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c608f4427943f8adb211abc95c87672b1b98847152783507d54e3246e502f60"
+version = "1.1.0-beta.1"
+source = "git+https://github.com/Azure/azure-sdk-for-rust.git?rev=fd7c3dcfb2b9f55ccb6e98b8cf148cd536460f00#fd7c3dcfb2b9f55ccb6e98b8cf148cd536460f00"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -229,6 +229,7 @@ cpu-time = "1.0.0"
 
 one_collect = "0.1.34811"
 
+# TODO: un-pin these dependencies as soon as Arc support is available in a released version: https://github.com/Azure/azure-sdk-for-rust/issues/4841
 azure_core = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "fd7c3dcfb2b9f55ccb6e98b8cf148cd536460f00", default-features = false }
 azure_identity = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "fd7c3dcfb2b9f55ccb6e98b8cf148cd536460f00", default-features = false }
 flate2 = "1.1.5"

--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -229,8 +229,8 @@ cpu-time = "1.0.0"
 
 one_collect = "0.1.34811"
 
-azure_core = {version = "1.0.0", default-features = false }
-azure_identity = {version = "1.0.0", default-features = false }
+azure_core = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "fd7c3dcfb2b9f55ccb6e98b8cf148cd536460f00", default-features = false }
+azure_identity = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "fd7c3dcfb2b9f55ccb6e98b8cf148cd536460f00", default-features = false }
 flate2 = "1.1.5"
 
 # Keep reqwest default features off to avoid pulling in default-tls (and aws-lc-rs via reqwest's rustls feature).

--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -229,7 +229,7 @@ cpu-time = "1.0.0"
 
 one_collect = "0.1.34811"
 
-# TODO: un-pin these dependencies as soon as Arc support is available in a released version: https://github.com/Azure/azure-sdk-for-rust/issues/4841
+# TODO: un-pin these dependencies as soon as Arc support is available in a released version: https://github.com/open-telemetry/otel-arrow/issues/3551
 azure_core = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "fd7c3dcfb2b9f55ccb6e98b8cf148cd536460f00", default-features = false }
 azure_identity = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "fd7c3dcfb2b9f55ccb6e98b8cf148cd536460f00", default-features = false }
 flate2 = "1.1.5"


### PR DESCRIPTION
# Change Summary

I recently added support for Arc-connected servers to the Azure SDK's identity provider. This change updates the Azure SDK version used to a bleeding edge version so that otel arrow can work on Arc-connected servers. I'll update the dependency to a named version as soon as it is released.

## What issue does this PR close?

N/A

## How are these changes tested?

I produced an otel arrow distribution with these changes and deployed it to an Arc-connected server manually.

## Are there any user-facing changes?

Users can obtain a managed identity from azure_identity_auth on Arc-connected servers

### Changelog


* [x] Added a `.chloggen/*.yaml` entry
* [ ] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
