### PR TITLE
feat(engine)!: adopt ResourceDetectors for self-telemetry

### DIFF
--- a/rust/otap-dataflow/.chloggen/resource-detectors-self-telemetry.yaml
+++ b/rust/otap-dataflow/.chloggen/resource-detectors-self-telemetry.yaml
@@ -1,0 +1,15 @@
+change_type: breaking
+
+component: engine
+
+note: Self-telemetry resource attributes are now produced by configurable OpenTelemetry ResourceDetectors, selected via `engine.telemetry.detectors`, replacing the bespoke host/container/instance detection.
+
+issues: [3177]
+
+subtext: |
+  Defaults to `["env", "service_instance"]`; `host`, `os`, `process`, `container`,
+  and `k8s` are opt-in. Static `resource` attributes still take precedence over
+  detected ones. Behavior change for the default self-telemetry resource:
+  `host.id` and `container.id` are no longer emitted unless opted in; `host.id`
+  (when enabled) now derives from machine-id rather than hostname; and
+  `service.instance.id` is a UUIDv7 instead of a base32 string.

--- a/rust/otap-dataflow/.chloggen/resource-detectors-self-telemetry.yaml
+++ b/rust/otap-dataflow/.chloggen/resource-detectors-self-telemetry.yaml
@@ -2,14 +2,11 @@ change_type: breaking
 
 component: engine
 
-note: Self-telemetry resource attributes are now produced by configurable OpenTelemetry ResourceDetectors, selected via `engine.telemetry.detectors`, replacing the bespoke host/container/instance detection.
+note: Self-telemetry resource attributes are now produced by configurable ResourceDetectors (`engine.telemetry.detectors`), replacing the bespoke host/container/instance detection.
 
 issues: [3177]
 
 subtext: |
-  Defaults to `["service_instance", "env", "service_name"]`; `host`, `os`, `process`,
-  `container`, and `k8s` are opt-in. Static `resource` attributes still take precedence over
-  detected ones. Behavior change for the default self-telemetry resource:
-  `host.id` and `container.id` are no longer emitted unless opted in; `host.id`
-  (when enabled) now derives from machine-id rather than hostname; and
-  `service.instance.id` is a UUIDv7 instead of a base32 string.
+  Migration: to keep `host.id`/`container.id` on self-telemetry, add the `host`/`container`
+  detectors to `engine.telemetry.detectors`, or set them under `engine.telemetry.resource`.
+  Defaults now run only `service_instance`, `env`, and `service_name`.

--- a/rust/otap-dataflow/.chloggen/resource-detectors-self-telemetry.yaml
+++ b/rust/otap-dataflow/.chloggen/resource-detectors-self-telemetry.yaml
@@ -7,8 +7,8 @@ note: Self-telemetry resource attributes are now produced by configurable OpenTe
 issues: [3177]
 
 subtext: |
-  Defaults to `["env", "service_instance"]`; `host`, `os`, `process`, `container`,
-  and `k8s` are opt-in. Static `resource` attributes still take precedence over
+  Defaults to `["service_instance", "env", "service_name"]`; `host`, `os`, `process`,
+  `container`, and `k8s` are opt-in. Static `resource` attributes still take precedence over
   detected ones. Behavior change for the default self-telemetry resource:
   `host.id` and `container.id` are no longer emitted unless opted in; `host.id`
   (when enabled) now derives from machine-id rather than hostname; and

--- a/rust/otap-dataflow/Cargo.lock
+++ b/rust/otap-dataflow/Cargo.lock
@@ -7010,6 +7010,7 @@ dependencies = [
  "js-sys",
  "pin-project-lite",
  "thiserror 2.0.19",
+ "tracing",
 ]
 
 [[package]]
@@ -7022,6 +7023,22 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
 ]
+
+[[package]]
+name = "opentelemetry-resource-detectors"
+version = "0.11.0"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust-contrib.git?rev=4f5296b92b2a8e50d2078e011fa04371b69a5cf6#4f5296b92b2a8e50d2078e011fa04371b69a5cf6"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c913ac17a6c451661ee255f4625d143e51647ae78ebd969b75e41c4442f4fe47"
 
 [[package]]
 name = "opentelemetry_sdk"
@@ -7720,6 +7737,9 @@ dependencies = [
  "bytes",
  "chrono",
  "flume",
+ "opentelemetry",
+ "opentelemetry-resource-detectors",
+ "opentelemetry_sdk",
  "otap-df-config",
  "otap-df-pdata",
  "otap-df-pdata-views",
@@ -7730,6 +7750,7 @@ dependencies = [
  "serde_yaml",
  "slotmap",
  "smallvec",
+ "temp-env",
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
@@ -10190,6 +10211,15 @@ name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot",
+]
 
 [[package]]
 name = "tempfile"

--- a/rust/otap-dataflow/Cargo.lock
+++ b/rust/otap-dataflow/Cargo.lock
@@ -7441,7 +7441,6 @@ dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
  "cpu-time",
- "data-encoding",
  "flume",
  "futures",
  "futures-core",
@@ -7468,7 +7467,6 @@ dependencies = [
  "tikv-jemalloc-sys",
  "tikv-jemallocator",
  "tokio",
- "uuid",
 ]
 
 [[package]]

--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -149,7 +149,8 @@ once_cell = "1.20.2"
 # exporters, hence the "logs" feature.
 opentelemetry-proto = { version = "0.32", default-features = false, features = ["gen-tonic-messages", "logs"]}
 
-# Pulled in only for the `Resource` type and `ResourceDetector` trait (detector-only), so both use
+# Detector-only use: opentelemetry_sdk provides the `Resource` type and `ResourceDetector` trait;
+# opentelemetry provides the `Key`/`Value` types those resources hold. Both use
 # `default-features = false` to drop trace/metrics/logs. Two caveats keep this from being fully slim
 # today: opentelemetry_sdk 0.32.1 predates the slimming in opentelemetry-rust #3593 (unreleased), and
 # the contrib resource-detectors crate still enables opentelemetry's default features, so they are

--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -149,6 +149,13 @@ once_cell = "1.20.2"
 # exporters, hence the "logs" feature.
 opentelemetry-proto = { version = "0.32", default-features = false, features = ["gen-tonic-messages", "logs"]}
 
+# The SDK is pulled in as a slim, detector-only dependency (`default-features = false`) for its
+# `Resource` type and the `ResourceDetector` trait. Note the work for the slim sdk is finished
+# upstream in opentelemetry-rust #3593, but pending a release. Version 0.32.1 is not slim, but the
+# next version will be.
+opentelemetry = "0.32.0"
+opentelemetry_sdk = { version = "0.32.1", default-features = false }
+
 parking_lot = "0.12.5"
 paste = "1"
 parquet = { version = "58.3", default-features = false, features = ["arrow", "async", "object_store"]}
@@ -190,6 +197,7 @@ ipnet = "2.11.0"
 syn = { version = "2.0", features = ["full", "extra-traits"] }
 zstd = "0.13"
 sysinfo = "0.39"
+temp-env = "0.3.6"
 tempfile = "3"
 thiserror = "2.0.17"
 tracing = { version = ">=0.1.40", default-features = false }
@@ -273,6 +281,9 @@ tracelogging = "1.2.4"
 tracelogging_dynamic = "1.2.4"
 urlencoding = "2"
 geneva-uploader = { git = "https://github.com/open-telemetry/opentelemetry-rust-contrib.git", rev = "16f987e29a0e91ea5dfe806121ddec5b929f8e06", default-features = false, features = ["tls-rustls"] }
+# Pinned to a rev containing upstream resource detector work. Swap to a published version once
+# contrib cuts one.
+opentelemetry-resource-detectors = { git = "https://github.com/open-telemetry/opentelemetry-rust-contrib.git", rev = "4f5296b92b2a8e50d2078e011fa04371b69a5cf6" }
 
 [patch."https://github.com/open-telemetry/otel-arrow"]
 otap-df-pdata = { path = "crates/pdata" }

--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -149,11 +149,12 @@ once_cell = "1.20.2"
 # exporters, hence the "logs" feature.
 opentelemetry-proto = { version = "0.32", default-features = false, features = ["gen-tonic-messages", "logs"]}
 
-# The SDK is pulled in as a slim, detector-only dependency (`default-features = false`) for its
-# `Resource` type and the `ResourceDetector` trait. Note the work for the slim sdk is finished
-# upstream in opentelemetry-rust #3593, but pending a release. Version 0.32.1 is not slim, but the
-# next version will be.
-opentelemetry = "0.32.0"
+# Pulled in only for the `Resource` type and `ResourceDetector` trait (detector-only), so both use
+# `default-features = false` to drop trace/metrics/logs. Two caveats keep this from being fully slim
+# today: opentelemetry_sdk 0.32.1 predates the slimming in opentelemetry-rust #3593 (unreleased), and
+# the contrib resource-detectors crate still enables opentelemetry's default features, so they are
+# pulled in transitively until fixed upstream.
+opentelemetry = { version = "0.32.0", default-features = false }
 opentelemetry_sdk = { version = "0.32.1", default-features = false }
 
 parking_lot = "0.12.5"

--- a/rust/otap-dataflow/configs/internal-telemetry-metrics.yaml
+++ b/rust/otap-dataflow/configs/internal-telemetry-metrics.yaml
@@ -24,7 +24,7 @@ engine:
     # [env, service_name, service_instance] when omitted; static `resource` attributes above
     # take precedence over detected ones. Opt into host/os/process/container/k8s to probe the
     # environment (here host.* is added); an empty list disables detection entirely.
-    detectors: [env, service_name, service_instance, host]
+    detectors: [service_instance, env, service_name, host]
   observability:
     pipeline:
       policies:

--- a/rust/otap-dataflow/configs/internal-telemetry-metrics.yaml
+++ b/rust/otap-dataflow/configs/internal-telemetry-metrics.yaml
@@ -21,9 +21,10 @@ engine:
       service.id: 1234
       service.name: test
     # Resource detectors auto-populate telemetry resource attributes. Defaults to
-    # [service_instance, env, service_name] when omitted; static `resource` attributes above
-    # take precedence over detected ones. Opt into host/os/process/container/k8s to probe the
-    # environment (here host.* is added); an empty list disables detection entirely.
+    # [service_instance, env, service_name] when omitted; explicitly configured `resource`
+    # attributes above take precedence over attributes from detectors. Opt into
+    # host/os/process/container/k8s to probe the environment (here host.* is added); an empty
+    # list disables detection entirely.
     detectors: [service_instance, env, service_name, host]
   observability:
     pipeline:

--- a/rust/otap-dataflow/configs/internal-telemetry-metrics.yaml
+++ b/rust/otap-dataflow/configs/internal-telemetry-metrics.yaml
@@ -21,7 +21,7 @@ engine:
       service.id: 1234
       service.name: test
     # Resource detectors auto-populate telemetry resource attributes. Defaults to
-    # [env, service_name, service_instance] when omitted; static `resource` attributes above
+    # [service_instance, env, service_name] when omitted; static `resource` attributes above
     # take precedence over detected ones. Opt into host/os/process/container/k8s to probe the
     # environment (here host.* is added); an empty list disables detection entirely.
     detectors: [service_instance, env, service_name, host]

--- a/rust/otap-dataflow/configs/internal-telemetry-metrics.yaml
+++ b/rust/otap-dataflow/configs/internal-telemetry-metrics.yaml
@@ -20,6 +20,11 @@ engine:
     resource:
       service.id: 1234
       service.name: test
+    # Resource detectors auto-populate telemetry resource attributes. Defaults to
+    # [env, service_name, service_instance] when omitted; static `resource` attributes above
+    # take precedence over detected ones. Opt into host/os/process/container/k8s to probe the
+    # environment (here host.* is added); an empty list disables detection entirely.
+    detectors: [env, service_name, service_instance, host]
   observability:
     pipeline:
       policies:

--- a/rust/otap-dataflow/crates/config/src/pipeline/telemetry.rs
+++ b/rust/otap-dataflow/crates/config/src/pipeline/telemetry.rs
@@ -25,6 +25,11 @@ pub struct TelemetryConfig {
     /// Resource attributes to associate with telemetry data.
     #[serde(default)]
     pub resource: HashMap<String, AttributeValue>,
+    /// Resource detectors to run for auto-detected telemetry attributes.
+    /// Defaults to `["env", "service_instance"]`. Static `resource` attributes take
+    /// precedence over detected ones. An empty list disables auto-detection.
+    #[serde(default = "default_detectors")]
+    pub detectors: Vec<String>,
 }
 
 impl TelemetryConfig {
@@ -50,6 +55,7 @@ impl Default for TelemetryConfig {
         Self {
             logs: LogsConfig::default(),
             resource: HashMap::default(),
+            detectors: default_detectors(),
             reporting_channel_size: default_reporting_channel_size(),
             reporting_interval: default_reporting_interval(),
         }
@@ -62,6 +68,15 @@ const fn default_reporting_channel_size() -> usize {
 
 const fn default_reporting_interval() -> Duration {
     Duration::from_secs(1)
+}
+
+/// Detectors run when config does not specify a `detectors` list.
+///
+/// `env` injects `OTEL_RESOURCE_ATTRIBUTES`/`OTEL_SERVICE_NAME` and `service_instance`
+/// generates a stable id; both are environment-agnostic. Host/OS/process/container/k8s
+/// detectors probe their surroundings and are opt-in.
+fn default_detectors() -> Vec<String> {
+    vec!["env".to_string(), "service_instance".to_string()]
 }
 
 /// Attribute value types for telemetry resource attributes.

--- a/rust/otap-dataflow/crates/config/src/pipeline/telemetry.rs
+++ b/rust/otap-dataflow/crates/config/src/pipeline/telemetry.rs
@@ -25,9 +25,15 @@ pub struct TelemetryConfig {
     /// Resource attributes to associate with telemetry data.
     #[serde(default)]
     pub resource: HashMap<String, AttributeValue>,
-    /// Resource detectors to run for auto-detected telemetry attributes.
-    /// Defaults to `["service_instance", "env", "service_name"]`. Static `resource`
-    /// attributes take precedence over detected ones. An empty list disables auto-detection.
+    /// Resource detectors to run for auto-detected telemetry attributes. Explicitly configured
+    /// `resource` attributes take precedence over attributes from detectors. An empty list
+    /// disables auto-detection; an unrecognized detector name fails engine startup.
+    ///
+    /// Defaults to `["service_instance", "env", "service_name"]`. Supported detectors: `env`,
+    /// `service_name`, `service_instance`, `host`, `os`, `process`, `container`, `k8s`. See the
+    /// [`opentelemetry_sdk::resource`](https://docs.rs/opentelemetry_sdk/latest/opentelemetry_sdk/resource/)
+    /// and [`opentelemetry-resource-detectors`](https://docs.rs/opentelemetry-resource-detectors)
+    /// docs for what each detector emits.
     #[serde(default = "default_detectors")]
     pub detectors: Vec<String>,
 }

--- a/rust/otap-dataflow/crates/config/src/pipeline/telemetry.rs
+++ b/rust/otap-dataflow/crates/config/src/pipeline/telemetry.rs
@@ -26,8 +26,8 @@ pub struct TelemetryConfig {
     #[serde(default)]
     pub resource: HashMap<String, AttributeValue>,
     /// Resource detectors to run for auto-detected telemetry attributes.
-    /// Defaults to `["env", "service_instance"]`. Static `resource` attributes take
-    /// precedence over detected ones. An empty list disables auto-detection.
+    /// Defaults to `["env", "service_name", "service_instance"]`. Static `resource`
+    /// attributes take precedence over detected ones. An empty list disables auto-detection.
     #[serde(default = "default_detectors")]
     pub detectors: Vec<String>,
 }
@@ -72,11 +72,15 @@ const fn default_reporting_interval() -> Duration {
 
 /// Detectors run when config does not specify a `detectors` list.
 ///
-/// `env` injects `OTEL_RESOURCE_ATTRIBUTES`/`OTEL_SERVICE_NAME` and `service_instance`
-/// generates a stable id; both are environment-agnostic. Host/OS/process/container/k8s
-/// detectors probe their surroundings and are opt-in.
+/// `env` injects `OTEL_RESOURCE_ATTRIBUTES`, `service_name` sets `service.name` (from
+/// `OTEL_SERVICE_NAME`, falling back to `unknown_service`), and `service_instance` generates
+/// a stable id. Host/OS/process/container/k8s detectors probe their surroundings and are opt-in.
 fn default_detectors() -> Vec<String> {
-    vec!["env".to_string(), "service_instance".to_string()]
+    vec![
+        "env".to_string(),
+        "service_name".to_string(),
+        "service_instance".to_string(),
+    ]
 }
 
 /// Attribute value types for telemetry resource attributes.

--- a/rust/otap-dataflow/crates/config/src/pipeline/telemetry.rs
+++ b/rust/otap-dataflow/crates/config/src/pipeline/telemetry.rs
@@ -26,7 +26,7 @@ pub struct TelemetryConfig {
     #[serde(default)]
     pub resource: HashMap<String, AttributeValue>,
     /// Resource detectors to run for auto-detected telemetry attributes.
-    /// Defaults to `["env", "service_name", "service_instance"]`. Static `resource`
+    /// Defaults to `["service_instance", "env", "service_name"]`. Static `resource`
     /// attributes take precedence over detected ones. An empty list disables auto-detection.
     #[serde(default = "default_detectors")]
     pub detectors: Vec<String>,
@@ -72,14 +72,15 @@ const fn default_reporting_interval() -> Duration {
 
 /// Detectors run when config does not specify a `detectors` list.
 ///
-/// `env` injects `OTEL_RESOURCE_ATTRIBUTES`, `service_name` sets `service.name` (from
-/// `OTEL_SERVICE_NAME`, falling back to `unknown_service`), and `service_instance` generates
-/// a stable id. Host/OS/process/container/k8s detectors probe their surroundings and are opt-in.
+/// `service_instance` generates a stable id, `env` injects `OTEL_RESOURCE_ATTRIBUTES`,
+/// and `service_name` sets `service.name` (from `OTEL_SERVICE_NAME`, falling back to
+/// `unknown_service`). Host/OS/process/container/k8s detectors probe their surroundings
+/// and are opt-in.
 fn default_detectors() -> Vec<String> {
     vec![
+        "service_instance".to_string(),
         "env".to_string(),
         "service_name".to_string(),
-        "service_instance".to_string(),
     ]
 }
 

--- a/rust/otap-dataflow/crates/controller/src/lib.rs
+++ b/rust/otap-dataflow/crates/controller/src/lib.rs
@@ -51,7 +51,6 @@ use otap_df_config::engine::{
 };
 use otap_df_config::extension::{ExtensionUrn, ExtensionUserConfig};
 use otap_df_config::node::{NodeKind, NodeUserConfig};
-use otap_df_config::pipeline::telemetry::AttributeValue;
 use otap_df_config::pipeline_group::PipelineGroupConfig;
 use otap_df_config::policy::MemoryLimiterMode;
 use otap_df_config::policy::{
@@ -95,7 +94,7 @@ use otap_df_telemetry::registry::TelemetryRegistryHandle;
 use otap_df_telemetry::reporter::MetricsReporter;
 use otap_df_telemetry::{
     InternalTelemetrySettings, InternalTelemetrySystem, TracingSetup, otel_error, otel_info,
-    otel_info_span, otel_warn, self_tracing::LogContext,
+    otel_info_span, otel_warn, resource_detectors, self_tracing::LogContext,
 };
 use smallvec::smallvec;
 use std::collections::{HashMap, HashSet};
@@ -1225,16 +1224,18 @@ impl<
         let telemetry_registry = TelemetryRegistryHandle::new();
         let controller_ctx = ControllerContext::new(telemetry_registry.clone());
 
-        // Inject auto-detected process/host resource attributes (host.id,
-        // container.id, service.instance.id) into the telemetry resource map so
+        // Inject auto-detected resource attributes into the telemetry resource map so
         // they surface on the OTLP Resource / Prometheus target_info. Explicit
-        // config-provided keys take precedence over auto-detected values.
-        for (key, value) in controller_ctx.resource_attributes() {
-            let _ = engine
-                .telemetry
-                .resource
-                .entry(key)
-                .or_insert_with(|| AttributeValue::String(value));
+        // config-provided keys take precedence over detected ones.
+        let detected = resource_detectors::detect(&engine.telemetry.detectors).map_err(|e| {
+            Error::InvalidConfiguration {
+                errors: vec![otap_df_config::error::Error::InvalidUserConfig {
+                    error: format!("engine.telemetry.detectors: {e}"),
+                }],
+            }
+        })?;
+        for (key, value) in detected {
+            let _ = engine.telemetry.resource.entry(key).or_insert(value);
         }
 
         // Snapshot the resolved resource map (config + auto-detected) for the admin

--- a/rust/otap-dataflow/crates/engine/Cargo.toml
+++ b/rust/otap-dataflow/crates/engine/Cargo.toml
@@ -39,8 +39,6 @@ bitflags = { workspace = true }
 bytemuck = { workspace = true }
 smallvec = { workspace = true }
 socket2 = { workspace = true }
-uuid = { workspace = true }
-data-encoding = { workspace = true }
 prost = { workspace = true }
 cpu-time = { workspace = true }
 memory-stats = { workspace = true }

--- a/rust/otap-dataflow/crates/engine/src/context.rs
+++ b/rust/otap-dataflow/crates/engine/src/context.rs
@@ -23,6 +23,7 @@ use otap_df_telemetry::metrics::{
 };
 use otap_df_telemetry::registry::{EntityKey, MetricSetKey, TelemetryRegistryHandle};
 use std::any::Any;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -31,84 +32,10 @@ use std::sync::Arc;
 /// (without index numbers) to their engine-specific pipeline indices.
 pub type NodeNameIndex = Arc<HashMap<ConfigNodeId, EngineNodeId>>;
 
-// Generate a stable, unique identifier per process instance (base32-encoded UUID v7)
-// Choose UUID v7 for better sortability in telemetry signals
-use data_encoding::BASE32_NOPAD;
-use std::borrow::Cow;
-use std::sync::LazyLock;
-use uuid::Uuid;
-
-static PROCESS_INSTANCE_ID: LazyLock<Cow<'static, str>> = LazyLock::new(|| {
-    let uuid = Uuid::now_v7();
-    let encoded = BASE32_NOPAD.encode(uuid.as_bytes());
-    Cow::Owned(encoded)
-});
-
-// Best-effort host id detection
-fn detect_host_id() -> Option<String> {
-    // Priority 1: HOSTNAME env var
-    if let Ok(h) = std::env::var("HOSTNAME") {
-        if !h.is_empty() {
-            return Some(h);
-        }
-    }
-    // Priority 2: /etc/hostname
-    if let Ok(s) = std::fs::read_to_string("/etc/hostname") {
-        let h = s.trim().to_string();
-        if !h.is_empty() {
-            return Some(h);
-        }
-    }
-    None
-}
-
-// Best-effort container id detection (Docker/containerd/k8s) from /proc/self/cgroup
-fn detect_container_id() -> Option<String> {
-    let Ok(cg) = std::fs::read_to_string("/proc/self/cgroup") else {
-        return None;
-    };
-    // Look for 64-hex tokens which commonly represent container IDs
-    for line in cg.lines() {
-        // Format: hierarchy-ID:controller-list:cgroup-path
-        let path = line.split(':').nth(2).unwrap_or("");
-        for part in path.split('/') {
-            let token = part.trim();
-            if token.len() >= 32 && token.len() <= 128 {
-                // Heuristic: mostly hex
-                if token
-                    .chars()
-                    .all(|c| c.is_ascii_hexdigit() || c == '.' || c == '-' || c == '_')
-                {
-                    // Pick the longest plausible hex-ish token
-                    // Further refine: prefer 64-hex
-                    let hex_only: String =
-                        token.chars().filter(|c| c.is_ascii_hexdigit()).collect();
-                    if hex_only.len() >= 32 {
-                        return Some(token.to_string());
-                    }
-                }
-            }
-        }
-    }
-    None
-}
-
-static HOST_ID: LazyLock<Cow<'static, str>> =
-    LazyLock::new(|| detect_host_id().map_or(Cow::Borrowed(""), Cow::Owned));
-
-static CONTAINER_ID: LazyLock<Cow<'static, str>> =
-    LazyLock::new(|| detect_container_id().map_or(Cow::Borrowed(""), Cow::Owned));
-
 /// A lightweight/cloneable controller context.
 #[derive(Clone, Debug)]
 pub struct ControllerContext {
     telemetry_registry_handle: TelemetryRegistryHandle,
-    /// Unique process instance identifier (base32-encoded UUID v7).
-    process_instance_id: Cow<'static, str>,
-    /// Host identifier, when available (e.g. hostname).
-    host_id: Cow<'static, str>,
-    /// Container identifier, when available (e.g. Docker or containerd container ID).
-    container_id: Cow<'static, str>,
     numa_node_id: usize,
     memory_pressure_state: MemoryPressureState,
 }
@@ -165,35 +92,11 @@ pub struct EntityMetricSetRegistrar<'a> {
 
 impl ControllerContext {
     /// Creates a new `ControllerContext`.
+    #[must_use]
     pub fn new(telemetry_registry_handle: TelemetryRegistryHandle) -> Self {
         Self {
             telemetry_registry_handle,
-            process_instance_id: PROCESS_INSTANCE_ID.clone(),
-            host_id: HOST_ID.clone(),
-            container_id: CONTAINER_ID.clone(),
             numa_node_id: 0, // ToDo(LQ): Set NUMA node ID if available
-            memory_pressure_state: MemoryPressureState::default(),
-        }
-    }
-
-    /// Creates a `ControllerContext` with explicit auto-detected identity values.
-    ///
-    /// Test-only: the production [`new`](Self::new) constructor derives these
-    /// from the host environment, which is unsuitable for asserting the
-    /// semantic-convention mapping in [`resource_attributes`](Self::resource_attributes).
-    #[cfg(test)]
-    fn new_with_identity(
-        telemetry_registry_handle: TelemetryRegistryHandle,
-        process_instance_id: impl Into<Cow<'static, str>>,
-        host_id: impl Into<Cow<'static, str>>,
-        container_id: impl Into<Cow<'static, str>>,
-    ) -> Self {
-        Self {
-            telemetry_registry_handle,
-            process_instance_id: process_instance_id.into(),
-            host_id: host_id.into(),
-            container_id: container_id.into(),
-            numa_node_id: 0,
             memory_pressure_state: MemoryPressureState::default(),
         }
     }
@@ -251,27 +154,6 @@ impl ControllerContext {
     pub fn register_engine_entity(&self) -> EntityKey {
         self.telemetry_registry_handle
             .register_entity(EngineEntityAttributeSet)
-    }
-
-    /// Returns the auto-detected process/host resource attributes mapped to
-    /// OpenTelemetry semantic-convention keys. Empty values are omitted.
-    /// Keys: `host.id`, `container.id`, `service.instance.id`.
-    #[must_use]
-    pub fn resource_attributes(&self) -> Vec<(String, String)> {
-        let mut out = Vec::new();
-        if !self.host_id.is_empty() {
-            out.push(("host.id".to_string(), self.host_id.to_string()));
-        }
-        if !self.container_id.is_empty() {
-            out.push(("container.id".to_string(), self.container_id.to_string()));
-        }
-        if !self.process_instance_id.is_empty() {
-            out.push((
-                "service.instance.id".to_string(),
-                self.process_instance_id.to_string(),
-            ));
-        }
-        out
     }
 
     /// Returns a handle to the telemetry registry.
@@ -965,48 +847,5 @@ impl ExtensionContext {
         self.controller_context
             .telemetry_registry_handle
             .register_metric_set_for_entity::<T>(entity_key)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn resource_attributes_maps_semconv_keys() {
-        let ctx = ControllerContext::new_with_identity(
-            TelemetryRegistryHandle::new(),
-            "proc-123",
-            "machine-abc",
-            "container-xyz",
-        );
-
-        // All three identities present: emitted in a stable order under their
-        // OpenTelemetry semantic-convention keys.
-        assert_eq!(
-            ctx.resource_attributes(),
-            vec![
-                ("host.id".to_string(), "machine-abc".to_string()),
-                ("container.id".to_string(), "container-xyz".to_string()),
-                ("service.instance.id".to_string(), "proc-123".to_string()),
-            ]
-        );
-    }
-
-    #[test]
-    fn resource_attributes_omits_empty_values() {
-        // Empty host/container should be skipped entirely (no empty-valued
-        // attributes), leaving only the populated service.instance.id.
-        let ctx = ControllerContext::new_with_identity(
-            TelemetryRegistryHandle::new(),
-            "proc-123",
-            "",
-            "",
-        );
-
-        assert_eq!(
-            ctx.resource_attributes(),
-            vec![("service.instance.id".to_string(), "proc-123".to_string())]
-        );
     }
 }

--- a/rust/otap-dataflow/crates/telemetry/Cargo.toml
+++ b/rust/otap-dataflow/crates/telemetry/Cargo.toml
@@ -39,6 +39,11 @@ smallvec = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter","registry", "std", "fmt"] }
 
+opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true }
+opentelemetry-resource-detectors = { workspace = true }
+
 [dev-dependencies]
+temp-env = { workspace = true }
 tempfile = { workspace = true }
 otap-df-pdata = { workspace = true, features = ["testing"] }

--- a/rust/otap-dataflow/crates/telemetry/src/collector.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/collector.rs
@@ -338,6 +338,7 @@ mod tests {
             reporting_interval: Duration::from_millis(reporting_interval_ms),
             logs: LogsConfig::default(),
             resource: HashMap::new(),
+            detectors: Vec::new(),
         }
     }
 

--- a/rust/otap-dataflow/crates/telemetry/src/lib.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/lib.rs
@@ -51,6 +51,7 @@ pub mod log_tap;
 pub mod metrics;
 pub mod registry;
 pub mod reporter;
+pub mod resource_detectors;
 pub mod self_tracing;
 pub mod semconv;
 /// Tokio tracing subscriber initialization.

--- a/rust/otap-dataflow/crates/telemetry/src/resource_detectors.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/resource_detectors.rs
@@ -1,0 +1,208 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Resource detection for self-telemetry.
+//!
+//! A registry mapping detector names to their OpenTelemetry SDK and contrib `ResourceDetector`
+//! implementations. Config (`engine.telemetry.detectors`) selects which run. Detected
+//! attributes are converted to typed [`AttributeValue`]s and merged.
+//!
+//! `env` and `service_instance` run by default (see `default_detectors` in config); the
+//! detectors that probe the host/OS/process/container/k8s environment are opt-in.
+
+use std::collections::BTreeMap;
+
+use opentelemetry_resource_detectors::{
+    ContainerResourceDetector, HostResourceDetector, K8sResourceDetector, OsResourceDetector,
+    ProcessResourceDetector, ServiceInstanceIdResourceDetector,
+};
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::resource::{EnvResourceDetector, ResourceDetector};
+use otap_df_config::pipeline::telemetry::{AttributeValue, AttributeValueArray};
+
+/// Selectable detectors, keyed by config name.
+const REGISTRY: &[(&str, fn() -> Box<dyn ResourceDetector>)] = &[
+    ("env", || Box::new(EnvResourceDetector::default())),
+    ("host", || Box::new(HostResourceDetector::default())),
+    ("os", || Box::new(OsResourceDetector)),
+    ("process", || Box::new(ProcessResourceDetector)),
+    ("container", || Box::new(ContainerResourceDetector)),
+    ("k8s", || Box::new(K8sResourceDetector)),
+    ("service_instance", || {
+        Box::new(ServiceInstanceIdResourceDetector)
+    }),
+];
+
+/// Error raised for an unrecognized detector name in configuration.
+#[derive(thiserror::Error, Debug)]
+pub enum DetectorError {
+    /// A configured detector name has no registered detector.
+    #[error(
+        "unknown resource detector `{0}` (known: {known})",
+        known = known_detector_names().collect::<Vec<_>>().join(", ")
+    )]
+    Unknown(String),
+}
+
+/// Detector names known to the registry.
+fn known_detector_names() -> impl Iterator<Item = &'static str> {
+    REGISTRY.iter().map(|(name, _)| *name)
+}
+
+/// Look up a detector by its config name.
+fn detector_by_name(name: &str) -> Result<Box<dyn ResourceDetector>, DetectorError> {
+    REGISTRY
+        .iter()
+        .find(|(n, _)| *n == name)
+        .map(|(_, factory)| factory())
+        .ok_or_else(|| DetectorError::Unknown(name.to_owned()))
+}
+
+/// Convert an SDK [`opentelemetry::Value`] into a config [`AttributeValue`], preserving
+/// the scalar/array type rather than flattening to a string. `opentelemetry::Value` and
+/// `opentelemetry::Array` are `#[non_exhaustive]`; unknown variants fall back to `Display`.
+fn value_to_attr(value: &opentelemetry::Value) -> AttributeValue {
+    use opentelemetry::{Array, Value};
+    match value {
+        Value::Bool(b) => AttributeValue::Bool(*b),
+        Value::I64(i) => AttributeValue::I64(*i),
+        Value::F64(f) => AttributeValue::F64(*f),
+        Value::String(s) => AttributeValue::String(s.as_str().to_owned()),
+        Value::Array(Array::Bool(v)) => AttributeValue::Array(AttributeValueArray::Bool(v.clone())),
+        Value::Array(Array::I64(v)) => AttributeValue::Array(AttributeValueArray::I64(v.clone())),
+        Value::Array(Array::F64(v)) => AttributeValue::Array(AttributeValueArray::F64(v.clone())),
+        Value::Array(Array::String(v)) => AttributeValue::Array(AttributeValueArray::String(
+            v.iter().map(|s| s.as_str().to_owned()).collect(),
+        )),
+        other => AttributeValue::String(other.to_string()),
+    }
+}
+
+/// Convert a detected SDK [`Resource`] into typed key/value attributes.
+fn resource_to_attrs(resource: &Resource) -> Vec<(String, AttributeValue)> {
+    resource
+        .iter()
+        .map(|(k, v)| (k.to_string(), value_to_attr(v)))
+        .collect()
+}
+
+/// Run the named detectors and merge their attributes into one set (later detector wins
+/// on key conflicts).
+///
+/// # Errors
+/// Returns [`DetectorError::Unknown`] if any name has no registered detector.
+pub fn detect(names: &[String]) -> Result<Vec<(String, AttributeValue)>, DetectorError> {
+    let merged: BTreeMap<String, AttributeValue> = names
+        .iter()
+        .map(|n| detector_by_name(n))
+        .collect::<Result<Vec<_>, _>>()?
+        .iter()
+        .flat_map(|d| resource_to_attrs(&d.detect()))
+        .collect();
+
+    Ok(merged.into_iter().collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn detect_map(names: &[&str]) -> HashMap<String, AttributeValue> {
+        let names: Vec<String> = names.iter().map(|s| s.to_string()).collect();
+        detect(&names).unwrap().into_iter().collect()
+    }
+
+    #[test]
+    fn value_to_attr_maps_each_variant() {
+        use opentelemetry::{Array, Value};
+        assert_eq!(
+            value_to_attr(&Value::Bool(true)),
+            AttributeValue::Bool(true)
+        );
+        assert_eq!(value_to_attr(&Value::I64(42)), AttributeValue::I64(42));
+        assert_eq!(value_to_attr(&Value::F64(1.5)), AttributeValue::F64(1.5));
+        assert_eq!(
+            value_to_attr(&Value::String("x".into())),
+            AttributeValue::String("x".into())
+        );
+        assert_eq!(
+            value_to_attr(&Value::Array(Array::I64(vec![1, 2, 3]))),
+            AttributeValue::Array(AttributeValueArray::I64(vec![1, 2, 3]))
+        );
+    }
+
+    #[test]
+    fn unknown_detector_names_the_culprit() {
+        assert!(matches!(
+            detect(&["bogus".to_string()]),
+            Err(DetectorError::Unknown(name)) if name == "bogus"
+        ));
+    }
+
+    #[test]
+    fn empty_list_detects_nothing() {
+        assert!(detect(&[]).unwrap().is_empty());
+    }
+
+    #[test]
+    fn every_registered_detector_resolves_and_runs() {
+        // Every registry row must build and run
+        for name in known_detector_names() {
+            let _ = detect(&[name.to_string()]).unwrap_or_else(|e| panic!("{name}: {e}"));
+        }
+    }
+
+    #[test]
+    fn env_detector_parses_otel_resource_attributes() {
+        temp_env::with_var("OTEL_RESOURCE_ATTRIBUTES", Some("foo=bar,baz=qux"), || {
+            let attrs = detect_map(&["env"]);
+            assert_eq!(
+                attrs.get("foo"),
+                Some(&AttributeValue::String("bar".into()))
+            );
+            assert_eq!(
+                attrs.get("baz"),
+                Some(&AttributeValue::String("qux".into()))
+            );
+        });
+    }
+
+    #[test]
+    fn service_instance_detector_emits_uuid() {
+        let attrs = detect_map(&["service_instance"]);
+        match attrs.get("service.instance.id") {
+            Some(AttributeValue::String(id)) => {
+                assert_eq!(id.len(), 36, "expected valid UUID, got {id:?}");
+            }
+            other => panic!("expected a string service.instance.id, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resource_to_attrs_preserves_typed_values() {
+        let resource = Resource::builder_empty()
+            .with_attribute(opentelemetry::KeyValue::new("process.pid", 4321_i64))
+            .build();
+        assert_eq!(
+            resource_to_attrs(&resource),
+            vec![("process.pid".to_string(), AttributeValue::I64(4321))]
+        );
+    }
+
+    #[test]
+    fn later_detector_wins_on_key_conflict() {
+        // Both detectors set service.instance.id; env runs last in the list and wins.
+        temp_env::with_var(
+            "OTEL_RESOURCE_ATTRIBUTES",
+            Some("service.instance.id=from-env"),
+            || {
+                let attrs = detect_map(&["service_instance", "env"]);
+                assert_eq!(
+                    attrs.get("service.instance.id"),
+                    Some(&AttributeValue::String("from-env".into()))
+                );
+            },
+        );
+    }
+}

--- a/rust/otap-dataflow/crates/telemetry/src/resource_detectors.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/resource_detectors.rs
@@ -113,6 +113,9 @@ mod tests {
         detect(&names).unwrap().into_iter().collect()
     }
 
+    /// Scenario: each `opentelemetry::Value` variant is converted via `value_to_attr`.
+    /// Guarantees: scalars and arrays map to the matching `AttributeValue` variant rather
+    /// than being flattened to a string.
     #[test]
     fn value_to_attr_maps_each_variant() {
         use opentelemetry::{Array, Value};
@@ -132,6 +135,8 @@ mod tests {
         );
     }
 
+    /// Scenario: `detect` is given a name with no registered detector.
+    /// Guarantees: it returns `DetectorError::Unknown` carrying the missing name.
     #[test]
     fn unknown_detector_names_the_culprit() {
         assert!(matches!(
@@ -140,19 +145,24 @@ mod tests {
         ));
     }
 
+    /// Scenario: `detect` is called with an empty detector list.
+    /// Guarantees: no attributes are produced.
     #[test]
     fn empty_list_detects_nothing() {
         assert!(detect(&[]).unwrap().is_empty());
     }
 
+    /// Scenario: every name in the registry is run through `detect`.
+    /// Guarantees: each row's factory builds and its detector runs without error.
     #[test]
     fn every_registered_detector_resolves_and_runs() {
-        // Every registry row must build and run
         for name in known_detector_names() {
             let _ = detect(&[name.to_string()]).unwrap_or_else(|e| panic!("{name}: {e}"));
         }
     }
 
+    /// Scenario: the `env` detector runs with `OTEL_RESOURCE_ATTRIBUTES` set.
+    /// Guarantees: each `key=value` pair is parsed into a string `AttributeValue`.
     #[test]
     fn env_detector_parses_otel_resource_attributes() {
         temp_env::with_var("OTEL_RESOURCE_ATTRIBUTES", Some("foo=bar,baz=qux"), || {
@@ -168,6 +178,8 @@ mod tests {
         });
     }
 
+    /// Scenario: the `service_instance` detector runs.
+    /// Guarantees: it emits `service.instance.id` as a 36-char hyphenated UUID string.
     #[test]
     fn service_instance_detector_emits_uuid() {
         let attrs = detect_map(&["service_instance"]);
@@ -179,6 +191,8 @@ mod tests {
         }
     }
 
+    /// Scenario: a `Resource` holding a typed (I64) attribute is converted.
+    /// Guarantees: `resource_to_attrs` preserves the I64 type instead of flattening to a string.
     #[test]
     fn resource_to_attrs_preserves_typed_values() {
         let resource = Resource::builder_empty()
@@ -190,9 +204,10 @@ mod tests {
         );
     }
 
+    /// Scenario: two detectors emit the same key, with `env` listed last.
+    /// Guarantees: the later detector's value wins the merge.
     #[test]
     fn later_detector_wins_on_key_conflict() {
-        // Both detectors set service.instance.id; env runs last in the list and wins.
         temp_env::with_var(
             "OTEL_RESOURCE_ATTRIBUTES",
             Some("service.instance.id=from-env"),

--- a/rust/otap-dataflow/crates/telemetry/src/resource_detectors.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/resource_detectors.rs
@@ -7,8 +7,8 @@
 //! implementations. Config (`engine.telemetry.detectors`) selects which run. Detected
 //! attributes are converted to typed [`AttributeValue`]s and merged.
 //!
-//! `env` and `service_instance` run by default (see `default_detectors` in config); the
-//! detectors that probe the host/OS/process/container/k8s environment are opt-in.
+//! `env`, `service_name`, and `service_instance` run by default (see `default_detectors` in
+//! config); the detectors that probe the host/OS/process/container/k8s environment are opt-in.
 
 use std::collections::BTreeMap;
 
@@ -17,12 +17,15 @@ use opentelemetry_resource_detectors::{
     ProcessResourceDetector, ServiceInstanceIdResourceDetector,
 };
 use opentelemetry_sdk::Resource;
-use opentelemetry_sdk::resource::{EnvResourceDetector, ResourceDetector};
+use opentelemetry_sdk::resource::{
+    EnvResourceDetector, ResourceDetector, SdkProvidedResourceDetector,
+};
 use otap_df_config::pipeline::telemetry::{AttributeValue, AttributeValueArray};
 
 /// Selectable detectors, keyed by config name.
 const REGISTRY: &[(&str, fn() -> Box<dyn ResourceDetector>)] = &[
     ("env", || Box::new(EnvResourceDetector::default())),
+    ("service_name", || Box::new(SdkProvidedResourceDetector)),
     ("host", || Box::new(HostResourceDetector::default())),
     ("os", || Box::new(OsResourceDetector)),
     ("process", || Box::new(ProcessResourceDetector)),
@@ -189,6 +192,44 @@ mod tests {
             }
             other => panic!("expected a string service.instance.id, got {other:?}"),
         }
+    }
+
+    /// Scenario: the `service_name` detector runs with `OTEL_SERVICE_NAME` set.
+    /// Guarantees: it emits `service.name` from `OTEL_SERVICE_NAME`.
+    #[test]
+    fn service_name_detector_honors_otel_service_name() {
+        temp_env::with_var("OTEL_SERVICE_NAME", Some("my-svc"), || {
+            let attrs = detect_map(&["service_name"]);
+            assert_eq!(
+                attrs.get("service.name"),
+                Some(&AttributeValue::String("my-svc".into()))
+            );
+        });
+    }
+
+    /// Scenario: the `service_name` detector runs with no service name configured in the env.
+    /// Guarantees: it falls back to an `unknown_service` placeholder rather than emitting
+    /// an empty `service.name`.
+    #[test]
+    fn service_name_detector_falls_back_to_unknown_service() {
+        temp_env::with_vars(
+            [
+                ("OTEL_SERVICE_NAME", None::<&str>),
+                ("OTEL_RESOURCE_ATTRIBUTES", None::<&str>),
+            ],
+            || {
+                let attrs = detect_map(&["service_name"]);
+                match attrs.get("service.name") {
+                    Some(AttributeValue::String(name)) => {
+                        assert!(
+                            name.starts_with("unknown_service"),
+                            "expected unknown_service fallback, got {name:?}"
+                        );
+                    }
+                    other => panic!("expected a string service.name, got {other:?}"),
+                }
+            },
+        );
     }
 
     /// Scenario: a `Resource` holding a typed (I64) attribute is converted.

--- a/rust/otap-dataflow/crates/telemetry/src/resource_detectors.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/resource_detectors.rs
@@ -7,7 +7,7 @@
 //! implementations. Config (`engine.telemetry.detectors`) selects which run. Detected
 //! attributes are converted to typed [`AttributeValue`]s and merged.
 //!
-//! `env`, `service_name`, and `service_instance` run by default (see `default_detectors` in
+//! `service_instance`, `env`, and `service_name` run by default (see `default_detectors` in
 //! config); the detectors that probe the host/OS/process/container/k8s environment are opt-in.
 
 use std::collections::BTreeMap;
@@ -257,6 +257,25 @@ mod tests {
                 assert_eq!(
                     attrs.get("service.instance.id"),
                     Some(&AttributeValue::String("from-env".into()))
+                );
+            },
+        );
+    }
+
+    /// Scenario: the default detector order runs with `service.instance.id` set via
+    /// `OTEL_RESOURCE_ATTRIBUTES`.
+    /// Guarantees: the user-provided id wins over `service_instance`'s generated UUID.
+    #[test]
+    fn env_service_instance_id_wins_over_generated_default() {
+        // Mirrors config's default_detectors order.
+        temp_env::with_var(
+            "OTEL_RESOURCE_ATTRIBUTES",
+            Some("service.instance.id=user-provided"),
+            || {
+                let attrs = detect_map(&["service_instance", "env", "service_name"]);
+                assert_eq!(
+                    attrs.get("service.instance.id"),
+                    Some(&AttributeValue::String("user-provided".into()))
                 );
             },
         );


### PR DESCRIPTION
# Change Summary

- Replaces bespoke resource detection by adopting resource detectors from upstream Rust SDK and contrib projects.
- Default detectors were changed to `env`, `service_instance` which mirrors the Go collector's defaults for self-telemetry. `host`, `os`, `process`, `container`, and `k8s` are opt-in.
- Supporting work was done upstream in both opentelemetry-rust and opentelemetry-rust-contrib, but is not yet released. We'll update the deps in this PR to use the pending releases before merging.
  - https://github.com/open-telemetry/opentelemetry-rust/pull/3593 enables a slim build (the only dep is the API). The dep added in this PR is the current release which results in a heavier build.
  - `opentelemetry-resource-detectors` is pinned to https://github.com/open-telemetry/opentelemetry-rust-contrib/commit/4f5296b92b2a8e50d2078e011fa04371b69a5cf6 as it contains new detectors and updates to existing ones.

## What issue does this PR close?

* Closes #3177

## How are these changes tested?
- New unit tests
- `cargo xtask check`

## Are there any user-facing changes?

Yes, breaking. Default self-telemetry no longer emits `host.id` and `container.id` (now opt-in). When opted in, `host.id` derives from machine-id rather than hostname, and `service.instance.id` is a plain UUIDv7 instead of a base32 string.

### Changelog

* [x] Added a `.chloggen/*.yaml` entry
* [ ] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
