### PR TITLE
docs: standardize node stability markers across otap-dataflow

### DIFF
--- a/rust/otap-dataflow/.chloggen/standardize-node-stability-markers.yaml
+++ b/rust/otap-dataflow/.chloggen/standardize-node-stability-markers.yaml
@@ -1,0 +1,9 @@
+change_type: enhancement
+component: pipeline
+note: Standardize node stability markers on a single lowercase enum (experimental, alpha, beta, stable, deprecated) defined in docs/node-stability.md, and align every node README and catalog table to it.
+issues: [3242]
+subtext: |
+  Replaces ad-hoc markers (WIP, mixed casing, and level+caveat strings such as
+  "Alpha; supports logs only") with a single documented level per node. The
+  clickhouse exporter, which had no marker, now declares one. Signal-coverage
+  and performance caveats move from the stability marker into node prose.

--- a/rust/otap-dataflow/.chloggen/standardize-node-stability-markers.yaml
+++ b/rust/otap-dataflow/.chloggen/standardize-node-stability-markers.yaml
@@ -1,9 +1,0 @@
-change_type: enhancement
-component: pipeline
-note: Standardize node stability markers on a single lowercase enum (experimental, alpha, beta, stable, deprecated) defined in docs/node-stability.md, and align every node README and catalog table to it.
-issues: [3242]
-subtext: |
-  Replaces ad-hoc markers (WIP, mixed casing, and level+caveat strings such as
-  "Alpha; supports logs only") with a single documented level per node. The
-  clickhouse exporter, which had no marker, now declares one. Signal-coverage
-  and performance caveats move from the stability marker into node prose.

--- a/rust/otap-dataflow/crates/contrib-nodes/README.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/README.md
@@ -26,9 +26,10 @@ Each node page follows the same general shape:
 
 Contrib nodes are enabled through individual feature gates or aggregate feature
 gates such as `contrib-receivers`, `contrib-processors`, and
-`contrib-exporters`. A node documented as `Experimental`, `Alpha`, or `WIP` has
-no stable compatibility guarantee yet, and its behavior or configuration can
-change between releases.
+`contrib-exporters`. The `Stability` column uses the levels defined in
+[`docs/node-stability.md`](../../docs/node-stability.md). A node documented as
+`experimental` or `alpha` has no stable compatibility guarantee yet, and its
+behavior or configuration can change between releases.
 
 ## Node Type Syntax
 
@@ -51,30 +52,31 @@ For the canonical node URN format, see [`docs/urns.md`](../../docs/urns.md).
 
 Receivers ingest data into a pipeline.
 
-| Type                                                                                | Feature                | Stability    | Description                                      |
-| ----------------------------------------------------------------------------------- | ---------------------- | ------------ | ------------------------------------------------ |
-| [`receiver:kafka`](src/receivers/kafka_receiver/README.md)                          | `kafka-receiver`       | Experimental | Consumes traces, metrics, and logs from Kafka.   |
-| [`receiver:user_events`](src/receivers/user_events_receiver/README.md)              | `user_events-receiver` | Experimental | Ingests Linux `user_events` tracepoints as logs. |
+| Type                                                                   | Feature                | Stability    | Description                                      |
+| ---------------------------------------------------------------------- | ---------------------- | ------------ | ------------------------------------------------ |
+| [`receiver:kafka`](src/receivers/kafka_receiver/README.md)             | `kafka-receiver`       | experimental | Consumes traces, metrics, and logs from Kafka.   |
+| [`receiver:user_events`](src/receivers/user_events_receiver/README.md) | `user_events-receiver` | experimental | Ingests Linux `user_events` tracepoints as logs. |
 
 ## Processors
 
 Processors transform or validate data already moving through a pipeline.
 
-| Type                                                                                                 | Feature                         | Stability    | Description                                                  |
-| ---------------------------------------------------------------------------------------------------- | ------------------------------- | ------------ | ------------------------------------------------------------ |
-| [`processor:condense_attributes`](src/processors/condense_attributes_processor/README.md)            | `condense-attributes-processor` | WIP          | Condenses multiple log attributes into one string attribute. |
-| [`urn:microsoft:processor:recordset_kql`](src/processors/recordset_kql_processor/README.md)          | `recordset-kql-processor`       | Experimental | Runs KQL expressions over OTAP data in an opinionated shape. |
-| [`processor:resource_validator`](src/processors/resource_validator_processor/README.md)              | `resource-validator-processor`  | Experimental | NACKs data missing required resource attribute values.       |
+| Type                                                                                        | Feature                         | Stability    | Description                                                  |
+| ------------------------------------------------------------------------------------------- | ------------------------------- | ------------ | ------------------------------------------------------------ |
+| [`processor:condense_attributes`](src/processors/condense_attributes_processor/README.md)   | `condense-attributes-processor` | experimental | Condenses multiple log attributes into one string attribute. |
+| [`urn:microsoft:processor:recordset_kql`](src/processors/recordset_kql_processor/README.md) | `recordset-kql-processor`       | experimental | Runs KQL expressions over OTAP data in an opinionated shape. |
+| [`processor:resource_validator`](src/processors/resource_validator_processor/README.md)     | `resource-validator-processor`  | experimental | NACKs data missing required resource attribute values.       |
 
 ## Exporters
 
 Exporters send data out of a pipeline.
 
-| Type                                                                                              | Feature                  | Stability               | Description                                      |
-| ------------------------------------------------------------------------------------------------- | ------------------------ | ----------------------- | ------------------------------------------------ |
-| [`urn:microsoft:exporter:azure_monitor`](src/exporters/azure_monitor_exporter/README.md)          | `azure-monitor-exporter` | Alpha; supports logs    | Sends OpenTelemetry logs to Azure Monitor.       |
-| [`urn:microsoft:exporter:geneva`](src/exporters/geneva_exporter/README.md)                        | `geneva-exporter`        | Alpha; logs and traces  | Sends telemetry to Microsoft's Geneva backend.   |
-| [`exporter:kafka`](src/exporters/kafka_exporter/README.md)                                        | `kafka-exporter`         | Experimental            | Produces traces, metrics, and logs to Kafka.     |
+| Type                                                                                     | Feature                  | Stability    | Description                                             |
+| ---------------------------------------------------------------------------------------- | ------------------------ | ------------ | ------------------------------------------------------- |
+| [`urn:microsoft:exporter:azure_monitor`](src/exporters/azure_monitor_exporter/README.md) | `azure-monitor-exporter` | alpha        | Sends OpenTelemetry logs to Azure Monitor.              |
+| [`exporter:clickhouse`](src/exporters/clickhouse_exporter/README.md)                     | `clickhouse-exporter`    | experimental | Inserts OTAP logs and traces into ClickHouse over HTTP. |
+| [`urn:microsoft:exporter:geneva`](src/exporters/geneva_exporter/README.md)               | `geneva-exporter`        | alpha        | Sends telemetry to Microsoft's Geneva backend.          |
+| [`exporter:kafka`](src/exporters/kafka_exporter/README.md)                               | `kafka-exporter`         | experimental | Produces traces, metrics, and logs to Kafka.            |
 
 ## Feature Aggregates
 

--- a/rust/otap-dataflow/crates/contrib-nodes/README.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/README.md
@@ -54,6 +54,7 @@ Receivers ingest data into a pipeline.
 
 | Type                                                                   | Feature                | Stability    | Description                                      |
 | ---------------------------------------------------------------------- | ---------------------- | ------------ | ------------------------------------------------ |
+| [`receiver:etw`](src/receivers/etw_receiver/README.md)                 | `etw-receiver`         | experimental | Ingests Windows ETW provider events as logs.     |
 | [`receiver:kafka`](src/receivers/kafka_receiver/README.md)             | `kafka-receiver`       | experimental | Consumes traces, metrics, and logs from Kafka.   |
 | [`receiver:user_events`](src/receivers/user_events_receiver/README.md) | `user_events-receiver` | experimental | Ingests Linux `user_events` tracepoints as logs. |
 

--- a/rust/otap-dataflow/crates/contrib-nodes/README.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/README.md
@@ -28,8 +28,8 @@ Contrib nodes are enabled through individual feature gates or aggregate feature
 gates such as `contrib-receivers`, `contrib-processors`, and
 `contrib-exporters`. The `Stability` column uses the levels defined in
 [`docs/node-stability.md`](../../docs/node-stability.md). A node documented as
-`experimental` or `alpha` has no stable compatibility guarantee yet, and its
-behavior or configuration can change between releases.
+`experimental`, `alpha`, or `beta` has no stable compatibility guarantee yet,
+and its behavior or configuration can change between releases.
 
 ## Node Type Syntax
 

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/README.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/README.md
@@ -4,7 +4,7 @@
 
 - Type: `urn:microsoft:exporter:azure_monitor`
 - Feature gate: `azure-monitor-exporter`
-- Stability: Alpha; supports logs only
+- Stability: alpha
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/README.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/README.md
@@ -18,6 +18,12 @@ The current architecture is intentionally simple:
 The schema and transform behavior are aligned with the Go OpenTelemetry
 Collector ClickHouse exporter where practical.
 
+## Metadata
+
+- Type: `exporter:clickhouse` (`urn:otel:exporter:clickhouse`)
+- Feature gate: `clickhouse-exporter` (also enabled by `contrib-exporters`)
+- Stability: experimental
+
 ## Status
 
 Implemented:

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/README.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/README.md
@@ -4,7 +4,7 @@
 
 - Type: `urn:microsoft:exporter:geneva`
 - Feature gate: `geneva-exporter`
-- Stability: Alpha; supports logs and traces
+- Stability: alpha
 
 ## Overview
 
@@ -12,6 +12,8 @@ The Geneva Exporter is designed for Microsoft products to send telemetry data
 to Microsoft's Geneva monitoring backend. It is not meant to be used outside
 of Microsoft products and is open sourced to demonstrate best practices and to
 be transparent about what is being collected.
+
+It currently supports exporting logs and traces.
 
 ## Getting Started
 

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/README.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/README.md
@@ -5,7 +5,7 @@
 - Type: `urn:microsoft:exporter:geneva`
 - Feature gate: `geneva-exporter`
 - Optional certificate authentication: `geneva-certificate-auth` (disabled by default)
-- Stability: Alpha; supports logs and traces
+- Stability: alpha
 
 ## Overview
 
@@ -13,6 +13,8 @@ The Geneva Exporter is designed for Microsoft products to send telemetry data
 to Microsoft's Geneva monitoring backend. It is not meant to be used outside
 of Microsoft products and is open sourced to demonstrate best practices and to
 be transparent about what is being collected.
+
+It currently supports exporting logs and traces.
 
 ## Getting Started
 

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/kafka_exporter/README.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/kafka_exporter/README.md
@@ -6,7 +6,7 @@
 
 - Type: `exporter:kafka` (`urn:otel:exporter:kafka`)
 - Feature gate: `kafka-exporter` (also enabled by `contrib-exporters`)
-- Stability: Experimental (pending performance optimization)
+- Stability: experimental
 
 ## Overview
 
@@ -535,6 +535,7 @@ This node does not emit structured events.
 
 ## Limits
 
+- This exporter is functional but still pending performance optimization.
 - AWS MSK IAM authentication (`AWS_MSK_IAM_OAUTHBEARER`) requires the `aws`
   feature to be enabled at build time.
 - `producer_config` entries that conflict with built-in fields are silently

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/kafka_exporter/README.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/kafka_exporter/README.md
@@ -6,7 +6,7 @@
 
 - Type: `exporter:kafka` (`urn:otel:exporter:kafka`)
 - Feature gate: `kafka-exporter` (also enabled by `contrib-exporters`)
-- Stability: Experimental (pending performance optimization)
+- Stability: experimental
 
 ## Overview
 
@@ -716,6 +716,7 @@ metric attributes, which keeps cardinality bounded for dynamic tenant routing.
 
 ## Limits
 
+- This exporter is functional but still pending performance optimization.
 - AWS MSK IAM authentication (`AWS_MSK_IAM_OAUTHBEARER`) requires the `aws`
   feature to be enabled at build time.
 - `producer_config` entries that conflict with built-in fields are silently

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/condense_attributes_processor/README.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/condense_attributes_processor/README.md
@@ -4,7 +4,7 @@
 
 - Type: `processor:condense_attributes` (`urn:otel:processor:condense_attributes`)
 - Feature gate: `condense-attributes-processor`
-- Stability: WIP
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/README.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/README.md
@@ -4,7 +4,7 @@
 
 - Type: `urn:microsoft:processor:recordset_kql`
 - Feature gate: `recordset-kql-processor`
-- Stability: Experimental
+- Stability: experimental
 
 An OTAP-Dataflow processor that filters and transforms OpenTelemetry data using
 Kusto Query Language (KQL) expressions over OpenTelemetry data in an opinionated

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/resource_validator_processor/README.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/resource_validator_processor/README.md
@@ -4,7 +4,7 @@
 
 - Type: `processor:resource_validator` (`urn:otel:processor:resource_validator`)
 - Feature gate: `resource-validator-processor`
-- Stability: Experimental
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/contrib-nodes/src/receivers/etw_receiver/README.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/receivers/etw_receiver/README.md
@@ -1,0 +1,72 @@
+<!-- markdownlint-disable MD013 -->
+
+# ETW Receiver
+
+## Metadata
+
+- Type: `receiver:etw` (`urn:otel:receiver:etw`)
+- Feature gate: `etw-receiver`
+- Stability: experimental
+- Platform: Windows only (compiled under `#[cfg(target_os = "windows")]`)
+
+## Overview
+
+This receiver subscribes to Windows
+[Event Tracing for Windows (ETW)](https://learn.microsoft.com/windows/win32/etw/about-event-tracing)
+providers, decodes the emitted events, and converts them into OTAP logs for
+downstream processing.
+
+It is compiled only on Windows; on other platforms the node type is not
+registered.
+
+### Multi-core fan-out
+
+Windows allows only one real-time ETW session per session name, while the engine
+may instantiate the receiver once per allocated core. To reconcile these two
+models, a single OS trace session is created per `session_name` with one
+consumer channel per core. The `ProcessTrace` callback round-robins events
+across the channels so each core receives an even share of the event stream.
+
+## Getting Started
+
+Subscribe to at least one ETW provider (identified by `name` or `guid`):
+
+```yaml
+type: receiver:etw
+config:
+  providers:
+    - name: "Microsoft-Windows-Kernel-Process"
+      level: information
+  session_name: "OtelArrowETW"
+  batching:
+    max_size: 512
+    max_duration: 100ms
+```
+
+## Configuration
+
+- `providers` (required): one or more ETW providers to trace. Each provider
+  accepts:
+  - `name` or `guid` (required): the ETW provider name (e.g.
+    `"Microsoft-Windows-Kernel-Process"`) or GUID. Exactly one of the two must
+    be set - specifying both, or neither, is rejected.
+  - `level` (optional): trace level filter, one of `critical`, `error`,
+    `warning`, `information`, or `verbose`. Defaults to `information`.
+  - `keywords` (optional): a keyword bitmask that further filters events. When
+    omitted, all keywords are matched.
+- `session_name` (optional): name of the ETW trace session. Defaults to
+  `"OtelArrowETW"`. Because Windows permits only one real-time session per
+  name, distinct receivers that must run concurrently need distinct names.
+- `batching` (optional): OTAP log batching limits.
+  - `max_size` (optional): maximum number of log records per emitted batch.
+    Must be greater than zero. Defaults to `512`.
+  - `max_duration` (optional): maximum time to hold a non-empty batch before
+    flushing it downstream. Defaults to `100ms`.
+
+At least one provider must be configured, and `batching.max_duration`, when
+set, must be greater than zero.
+
+## Related Docs
+
+- Catalog: [`contrib-nodes` README](../../../README.md)
+- Node stability levels: [`docs/node-stability.md`](../../../../../docs/node-stability.md)

--- a/rust/otap-dataflow/crates/contrib-nodes/src/receivers/kafka_receiver/README.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/receivers/kafka_receiver/README.md
@@ -6,7 +6,7 @@
 
 - Type: `receiver:kafka` (`urn:otel:receiver:kafka`)
 - Feature gate: `kafka-receiver` (also enabled by `contrib-receivers`)
-- Stability: Experimental (pending performance optimization)
+- Stability: experimental
 
 ## Overview
 
@@ -902,6 +902,7 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
 
 ## Limits
 
+- This receiver is functional but still pending performance optimization.
 - AWS MSK IAM authentication (`AWS_MSK_IAM_OAUTHBEARER`) requires the `aws`
   feature to be enabled at build time.
 - The engine supports one periodic timer per node; the commit interval

--- a/rust/otap-dataflow/crates/contrib-nodes/src/receivers/kafka_receiver/README.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/receivers/kafka_receiver/README.md
@@ -6,7 +6,7 @@
 
 - Type: `receiver:kafka` (`urn:otel:receiver:kafka`)
 - Feature gate: `kafka-receiver` (also enabled by `contrib-receivers`)
-- Stability: Experimental (pending performance optimization)
+- Stability: experimental
 
 ## Overview
 
@@ -1013,6 +1013,7 @@ an empty assignment resets it to zero.
 
 ## Limits
 
+- This receiver is functional but still pending performance optimization.
 - AWS MSK IAM authentication (`AWS_MSK_IAM_OAUTHBEARER`) requires the `aws`
   feature to be enabled at build time.
 - The engine supports one periodic timer per node; the commit interval

--- a/rust/otap-dataflow/crates/contrib-nodes/src/receivers/user_events_receiver/README.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/receivers/user_events_receiver/README.md
@@ -6,7 +6,7 @@
 
 - Type: `receiver:user_events` (`urn:otel:receiver:user_events`)
 - Feature gate: `user_events-receiver`; `event_header` decoding requires `user_events-eventheader`
-- Stability: Experimental
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/core-nodes/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/README.md
@@ -24,9 +24,10 @@ Each node page follows the same general shape:
 
 Most nodes in this catalog are available in the default engine build. If the
 `Feature` column names a non-default feature, the node is available only in
-builds that enable that feature. A node documented as `experimental` has no
-stable compatibility guarantee yet, and its behavior or configuration can
-change between releases.
+builds that enable that feature. The `Stability` column uses the levels
+defined in [`docs/node-stability.md`](../../docs/node-stability.md). A node
+documented as `experimental` has no stable compatibility guarantee yet, and
+its behavior or configuration can change between releases.
 
 ## Node Type Syntax
 
@@ -119,8 +120,10 @@ Exporters send data out of a pipeline.
   node.
 - Keep per-node README headings predictable: `Metadata`, `Overview`,
   `Configuration`, `Examples`, `Telemetry`, `Limits`, and `Related Docs`.
-- Document node stability as `Experimental` when there is no explicit
-  compatibility guarantee.
+- Document node stability using a level from
+  [`docs/node-stability.md`](../../docs/node-stability.md), written in
+  lowercase. Default to `experimental` when there is no explicit compatibility
+  guarantee.
 - Render `Metadata` as a list with one field per list item instead of a table.
 - Omit implementation file names from metadata because the README already sits
   next to the source.

--- a/rust/otap-dataflow/crates/core-nodes/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/README.md
@@ -24,9 +24,10 @@ Each node page follows the same general shape:
 
 Most nodes in this catalog are available in the default engine build. If the
 `Feature` column names a non-default feature, the node is available only in
-builds that enable that feature. A node documented as `experimental` has no
-stable compatibility guarantee yet, and its behavior or configuration can
-change between releases.
+builds that enable that feature. The `Stability` column uses the levels
+defined in [`docs/node-stability.md`](../../docs/node-stability.md). A node
+documented as `experimental` has no stable compatibility guarantee yet, and
+its behavior or configuration can change between releases.
 
 ## Node Type Syntax
 
@@ -120,8 +121,10 @@ Exporters send data out of a pipeline.
   node.
 - Keep per-node README headings predictable: `Metadata`, `Overview`,
   `Configuration`, `Examples`, `Telemetry`, `Limits`, and `Related Docs`.
-- Document node stability as `Experimental` when there is no explicit
-  compatibility guarantee.
+- Document node stability using a level from
+  [`docs/node-stability.md`](../../docs/node-stability.md), written in
+  lowercase. Default to `experimental` when there is no explicit compatibility
+  guarantee.
 - Render `Metadata` as a list with one field per list item instead of a table.
 - Omit implementation file names from metadata because the README already sits
   next to the source.

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/README.md
@@ -6,7 +6,7 @@
 
 - Type: `exporter:console` (`urn:otel:exporter:console`)
 - Feature gate: Default
-- Stability: Experimental
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/error_exporter/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/error_exporter/README.md
@@ -6,7 +6,7 @@
 
 - Type: `exporter:error` (`urn:otel:exporter:error`)
 - Feature gate: Default
-- Stability: Experimental
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/noop_exporter/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/noop_exporter/README.md
@@ -6,7 +6,7 @@
 
 - Type: `exporter:noop` (`urn:otel:exporter:noop`)
 - Feature gate: Default
-- Stability: Experimental
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/README.md
@@ -6,7 +6,7 @@
 
 - Type: `exporter:otap` (`urn:otel:exporter:otap`)
 - Feature gate: Default
-- Stability: Experimental
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/README.md
@@ -6,7 +6,7 @@
 
 - Type: `exporter:otlp_grpc` (`urn:otel:exporter:otlp_grpc`)
 - Feature gate: Default
-- Stability: Experimental
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/README.md
@@ -6,7 +6,7 @@
 
 - Type: `exporter:otlp_http` (`urn:otel:exporter:otlp_http`)
 - Feature gate: Default
-- Stability: Experimental
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/parquet_exporter/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/parquet_exporter/README.md
@@ -6,7 +6,7 @@
 
 - Type: `exporter:parquet` (`urn:otel:exporter:parquet`)
 - Feature gate: Default; cloud backends require crate features
-- Stability: Experimental
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/perf_exporter/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/perf_exporter/README.md
@@ -6,7 +6,7 @@
 
 - Type: `exporter:perf` (`urn:otel:exporter:perf`)
 - Feature gate: Default
-- Stability: Experimental
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/topic_exporter/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/topic_exporter/README.md
@@ -6,7 +6,7 @@
 
 - Type: `exporter:topic` (`urn:otel:exporter:topic`)
 - Feature gate: Default
-- Stability: Experimental
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/attributes_processor/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/attributes_processor/README.md
@@ -6,7 +6,7 @@
 
 - Type: `processor:attribute` (`urn:otel:processor:attribute`)
 - Feature gate: Default
-- Stability: Experimental
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/README.md
@@ -6,7 +6,7 @@
 
 - Type: `processor:batch` (`urn:otel:processor:batch`)
 - Feature gate: Default
-- Stability: Experimental
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/content_router/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/content_router/README.md
@@ -6,7 +6,7 @@
 
 - Type: `processor:content_router` (`urn:otel:processor:content_router`)
 - Feature gate: Default
-- Stability: Experimental
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/debug_processor/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/debug_processor/README.md
@@ -6,7 +6,7 @@
 
 - Type: `processor:debug` (`urn:otel:processor:debug`)
 - Feature gate: Default
-- Stability: Experimental
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/delay_processor/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/delay_processor/README.md
@@ -6,7 +6,7 @@
 
 - Type: `processor:delay` (`urn:otel:processor:delay`)
 - Feature gate: Default
-- Stability: Experimental
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/README.md
@@ -6,7 +6,7 @@
 
 - Type: `processor:durable_buffer` (`urn:otel:processor:durable_buffer`)
 - Feature gate: Default
-- Stability: Experimental
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/fanout_processor/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/fanout_processor/README.md
@@ -6,7 +6,7 @@
 
 - Type: `processor:fanout` (`urn:otel:processor:fanout`)
 - Feature gate: Default
-- Stability: Experimental
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/README.md
@@ -6,7 +6,7 @@
 
 - Type: `processor:filter` (`urn:otel:processor:filter`)
 - Feature gate: Default
-- Stability: Experimental
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/log_sampling_processor/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/log_sampling_processor/README.md
@@ -6,7 +6,7 @@
 
 - Type: `processor:log_sampling` (`urn:otel:processor:log_sampling`)
 - Feature gate: Default
-- Stability: Experimental
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/partition_processor/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/partition_processor/README.md
@@ -6,7 +6,7 @@
 
 - Type: `processor:partition` (`urn:otel:processor:partition`)
 - Feature gate: Default
-- Stability: Experimental
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/retry_processor/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/retry_processor/README.md
@@ -6,7 +6,7 @@
 
 - Type: `processor:retry` (`urn:otel:processor:retry`)
 - Feature gate: Default
-- Stability: Experimental
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/signal_type_router/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/signal_type_router/README.md
@@ -6,7 +6,7 @@
 
 - Type: `processor:type_router` (`urn:otel:processor:type_router`)
 - Feature gate: Default
-- Stability: Experimental
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/README.md
@@ -6,7 +6,7 @@
 
 - Type: `processor:temporal_reaggregation` (`urn:otel:processor:temporal_reaggregation`)
 - Feature gate: Default
-- Stability: Experimental
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/README.md
@@ -6,7 +6,7 @@
 
 - Type: `processor:transform` (`urn:otel:processor:transform`)
 - Feature gate: Default
-- Stability: Experimental
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/host_metrics_receiver/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/host_metrics_receiver/README.md
@@ -6,7 +6,7 @@
 
 - Type: `receiver:host_metrics` (`urn:otel:receiver:host_metrics`)
 - Feature gate: Default
-- Stability: Experimental
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/internal_telemetry_receiver/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/internal_telemetry_receiver/README.md
@@ -6,7 +6,7 @@
 
 - Type: `receiver:internal_telemetry` (`urn:otel:receiver:internal_telemetry`)
 - Feature gate: Default
-- Stability: Experimental
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/README.md
@@ -6,7 +6,7 @@
 
 - Type: `receiver:journald` (`urn:otel:receiver:journald`)
 - Feature gate: Default
-- Stability: Experimental
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/otap_receiver/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/otap_receiver/README.md
@@ -6,7 +6,7 @@
 
 - Type: `receiver:otap` (`urn:otel:receiver:otap`)
 - Feature gate: Default
-- Stability: Experimental
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/otlp_receiver/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/otlp_receiver/README.md
@@ -6,7 +6,7 @@
 
 - Type: `receiver:otlp` (`urn:otel:receiver:otlp`)
 - Feature gate: Default
-- Stability: Experimental
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/syslog_cef_receiver/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/syslog_cef_receiver/README.md
@@ -6,7 +6,7 @@
 
 - Type: `receiver:syslog_cef` (`urn:otel:receiver:syslog_cef`)
 - Feature gate: Default
-- Stability: Experimental
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/topic_receiver/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/topic_receiver/README.md
@@ -6,7 +6,7 @@
 
 - Type: `receiver:topic` (`urn:otel:receiver:topic`)
 - Feature gate: Default
-- Stability: Experimental
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/README.md
@@ -6,7 +6,7 @@
 
 - Type: `receiver:traffic_generator` (`urn:otel:receiver:traffic_generator`)
 - Feature gate: `dev-tools`
-- Stability: Experimental
+- Stability: experimental
 
 ## Overview
 

--- a/rust/otap-dataflow/docs/node-stability.md
+++ b/rust/otap-dataflow/docs/node-stability.md
@@ -1,0 +1,68 @@
+# Node stability levels
+
+This document defines the stability levels used by OTAP Dataflow Engine nodes
+(receivers, processors, and exporters) and the rules for declaring them.
+
+It is the single source of truth for what each level means. Node READMEs and
+the crate catalogs ([`core-nodes`](../crates/core-nodes/README.md),
+[`contrib-nodes`](../crates/contrib-nodes/README.md)) declare a level from this
+enum; they must not invent new values or ad-hoc variants.
+
+This complements the
+[Stability and Compatibility Guide](telemetry/stability-compatibility-guide.md),
+which covers the stability of emitted telemetry rather than of the nodes
+themselves. Both use the same lowercase level vocabulary.
+
+## Levels
+
+A node declares exactly one of the following levels. The ladder mirrors the
+OpenTelemetry Collector component stability levels, using this project's
+existing name `experimental` for the earliest rung.
+
+- **experimental**
+  - Default for new nodes.
+  - No backward-compatibility guarantee. Configuration, behavior, and
+    telemetry may change, and the node may be removed, between releases.
+  - May implement only a subset of signals or features.
+- **alpha**
+  - Usable by early adopters; core behavior is in place.
+  - The configuration surface, defaults, or signal coverage may still change.
+    Breaking changes can occur between releases but are called out.
+- **beta**
+  - Feature-complete for its intended scope and being hardened.
+  - Breaking configuration or behavior changes are rare and are announced
+    ahead of a release.
+- **stable**
+  - Only backward-compatible evolution is allowed.
+  - Breaking changes require a new major version and a documented migration
+    path.
+- **deprecated**
+  - Superseded by another node or approach.
+  - Still available for a migration window, with a documented replacement and
+    a planned removal.
+
+## Declaring a node's stability
+
+- Write the level in lowercase everywhere. Lowercase matches the enum's
+  serialized form and the level vocabulary already used by the catalog tables
+  and the telemetry stability guide.
+- Each node README declares the level in its `## Metadata` section:
+
+  ```markdown
+  - Stability: experimental
+  ```
+
+- The crate catalog tables (`core-nodes/README.md`,
+  `contrib-nodes/README.md`) repeat the level in their `Stability` column. The
+  catalog value must match the node README.
+- The `Stability` marker holds only the level. Qualifiers such as which
+  signals a node supports, or that it is pending performance work, belong in
+  the node's `Overview` or `Limits` prose, not inside the marker.
+
+## Future direction
+
+Issue [#3242](https://github.com/open-telemetry/otel-arrow/issues/3242) tracks
+declaring each node's stability in code (as part of the node metadata) so that
+the READMEs and catalog tables can be generated from, or checked against, a
+single source of truth. Until that exists, keep the README marker and the
+catalog table entry in sync by hand.

--- a/rust/otap-dataflow/docs/node-stability.md
+++ b/rust/otap-dataflow/docs/node-stability.md
@@ -11,7 +11,9 @@ enum; they must not invent new values or ad-hoc variants.
 This complements the
 [Stability and Compatibility Guide](telemetry/stability-compatibility-guide.md),
 which covers the stability of emitted telemetry rather than of the nodes
-themselves. Both use the same lowercase level vocabulary.
+themselves. That guide works in terms of `experimental`, `stable`, and
+`deprecated`; the ladder below adds `alpha` and `beta` between the first two.
+Levels that appear in both are spelled the same way and mean the same thing.
 
 ## Levels
 
@@ -43,9 +45,11 @@ existing name `experimental` for the earliest rung.
 
 ## Declaring a node's stability
 
-- Write the level in lowercase everywhere. Lowercase matches the enum's
-  serialized form and the level vocabulary already used by the catalog tables
-  and the telemetry stability guide.
+- Write the level in lowercase everywhere, matching the vocabulary already
+  used by the catalog tables and the telemetry stability guide. These levels are
+  a documentation convention: the component inventory deliberately carries no
+  stability field (see the note in `crates/engine/src/inventory.rs`), so a node
+  README is the canonical place a level is recorded.
 - Each node README declares the level in its `## Metadata` section:
 
   ```markdown


### PR DESCRIPTION
## Description

Node READMEs in `rust/otap-dataflow` declared stability with inconsistent, ad-hoc markers. This standardizes them, per #3242.

**What was inconsistent:** per-node files used capitalized `Experimental` while the catalog tables used lowercase `experimental` (the casing mismatch flagged on #3213); `condense_attributes_processor` used an undefined `WIP`; `azure_monitor` / `geneva` / `kafka` mixed the level with caveats (`Alpha; supports logs only`, `Experimental (pending performance optimization)`); `clickhouse_exporter` had no marker, no `## Metadata` section, and no catalog row.

**What this does:**
- Adds `rust/otap-dataflow/docs/node-stability.md` — a single source of truth defining the enum `experimental / alpha / beta / stable / deprecated`. I used **lowercase** to match the repo's existing `docs/telemetry/stability-compatibility-guide.md` and the crate catalog tables (the two in-repo conventions conflicted, so some files had to change either way; happy to flip to capitalized if you prefer).
- Normalizes every node README (40 nodes) + both crate catalogs to declare exactly one enum level, moving signal-coverage / perf caveats into prose (`## Overview` / `## Limits`).
- Adds the missing `clickhouse_exporter` `## Metadata` block + catalog row (values confirmed from `mod.rs` + `Cargo.toml`).

**Scope note (part 3 deferred):** the issue also mentions declaring stability *in code* so READMEs can be generated/checked against a source of truth. That is a larger maintainer-design change (there is no stability field in node metadata today and no README generator), so I scoped this PR to the complete free-form-text standardization (all 40 node READMEs now consistent) and recorded the in-code/generation direction as tracked follow-up in the new doc. Happy to take that on separately.

**Verified:** a case-sensitive marker sweep finds no remaining capitalized/ad-hoc markers; `markdownlint-cli2` (repo config) reports 0 issues across all 43 changed/new `.md` files. Docs-only, no Rust/Go source touched. Included a chloggen fragment (the change touches `crates/**/README.md`, not only `docs/`); happy to drop it if a docs-titled PR is preferred.

---

*AI disclosure: this PR was drafted with Claude Code (AI-assisted). Verified with a case-sensitive stability-marker sweep and markdownlint-cli2 (0 issues) across all changed files.*
