### PR TITLE
fix(condense_attributes): Preserve OTLP values that are not easily representable in scalar condensed format

### DIFF
--- a/rust/otap-dataflow/.chloggen/condense-attributes-preserve-values.yaml
+++ b/rust/otap-dataflow/.chloggen/condense-attributes-preserve-values.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: pipeline
+note: Preserve bytes, arrays, maps, and empty values that cannot be condensed by the Condense Attributes processor.
+issues: [1694]

--- a/rust/otap-dataflow/crates/contrib-nodes/Cargo.toml
+++ b/rust/otap-dataflow/crates/contrib-nodes/Cargo.toml
@@ -166,6 +166,7 @@ contrib-processors = [
     "resource-validator-processor",
 ]
 condense-attributes-processor = []
+condense-attributes-processor-bench = ["condense-attributes-processor"]
 recordset-kql-processor = [
     "dep:data_engine_expressions",
     "dep:data_engine_kql_parser",
@@ -226,7 +227,7 @@ required-features = ["recordset-kql-processor"]
 name = "condense_attributes"
 path = "benches/processors/condense_attributes_processor.rs"
 harness = false
-required-features = ["condense-attributes-processor"]
+required-features = ["condense-attributes-processor-bench"]
 
 [[test]]
 name = "otlp_kql_recordset"

--- a/rust/otap-dataflow/crates/contrib-nodes/Cargo.toml
+++ b/rust/otap-dataflow/crates/contrib-nodes/Cargo.toml
@@ -222,6 +222,12 @@ path = "benches/processors/recordset_kql_processor/extend.rs"
 harness = false
 required-features = ["recordset-kql-processor"]
 
+[[bench]]
+name = "condense_attributes"
+path = "benches/processors/condense_attributes_processor.rs"
+harness = false
+required-features = ["condense-attributes-processor"]
+
 [[test]]
 name = "otlp_kql_recordset"
 path = "tests/processors/recordset_kql_processor/otlp_kql_recordset.rs"

--- a/rust/otap-dataflow/crates/contrib-nodes/benches/processors/condense_attributes_processor.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/benches/processors/condense_attributes_processor.rs
@@ -1,0 +1,94 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Benchmarks for the Condense Attributes processor.
+
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
+use otap_df_contrib_nodes::processors::condense_attributes_processor::CondenseAttributesProcessor;
+use otap_df_engine::testing::test_pipeline_ctx;
+use otap_df_pdata::TryIntoWithOptions;
+use otap_df_pdata::proto::opentelemetry::{
+    collector::logs::v1::ExportLogsServiceRequest,
+    common::v1::{AnyValue, KeyValue},
+    logs::v1::{LogRecord, ResourceLogs, ScopeLogs},
+};
+use otap_df_pdata::{OtapArrowRecords, OtlpProtoBytes};
+use prost::Message as _;
+use serde_json::json;
+use std::hint::black_box;
+
+fn generate_records(log_count: usize) -> OtapArrowRecords {
+    let log_records = (0..log_count)
+        .map(|index| LogRecord {
+            attributes: vec![
+                KeyValue::new("service.name", AnyValue::new_string("checkout")),
+                KeyValue::new("host.name", AnyValue::new_string("host-01")),
+                KeyValue::new("http.method", AnyValue::new_string("GET")),
+                KeyValue::new("http.status_code", AnyValue::new_int(200)),
+                KeyValue::new("payload", AnyValue::new_bytes(b"preserved bytes")),
+                KeyValue::new(
+                    "labels",
+                    AnyValue::new_kvlist(vec![KeyValue::new(
+                        "region",
+                        AnyValue::new_string("us-east"),
+                    )]),
+                ),
+            ],
+            time_unix_nano: index as u64,
+            ..Default::default()
+        })
+        .collect();
+    let request = ExportLogsServiceRequest {
+        resource_logs: vec![ResourceLogs {
+            scope_logs: vec![ScopeLogs {
+                log_records,
+                ..Default::default()
+            }],
+            ..Default::default()
+        }],
+    };
+
+    OtlpProtoBytes::ExportLogsRequest(request.encode_to_vec().into())
+        .try_into_with_default()
+        .expect("convert generated logs to Arrow records")
+}
+
+fn bench_condense(c: &mut Criterion) {
+    let (pipeline_ctx, _) = test_pipeline_ctx();
+    let processor = CondenseAttributesProcessor::from_config(
+        pipeline_ctx,
+        &json!({
+            "destination_key": "condensed",
+            "delimiter": ";",
+            "source_keys": ["service.name", "host.name", "http.method", "http.status_code"]
+        }),
+    )
+    .expect("create processor");
+    let mut group = c.benchmark_group("condense_attributes");
+
+    for log_count in [32, 1024, 8192] {
+        let records = generate_records(log_count);
+        let _ = group.bench_with_input(
+            BenchmarkId::new("logs", log_count),
+            &records,
+            |b, records| {
+                b.iter_batched_ref(
+                    || records.clone(),
+                    |records| {
+                        let condensed = processor
+                            .condense(records)
+                            .expect("condense generated records");
+                        let _ = black_box(condensed);
+                        let _ = black_box(records);
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_condense);
+criterion_main!(benches);

--- a/rust/otap-dataflow/crates/contrib-nodes/benches/processors/condense_attributes_processor.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/benches/processors/condense_attributes_processor.rs
@@ -76,7 +76,7 @@ fn bench_condense(c: &mut Criterion) {
                     || records.clone(),
                     |records| {
                         let condensed = processor
-                            .condense(records)
+                            .condense_for_benchmark(records)
                             .expect("condense generated records");
                         let _ = black_box(condensed);
                         let _ = black_box(records);

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/condense_attributes_processor/README.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/condense_attributes_processor/README.md
@@ -75,6 +75,10 @@ config:
   Configuration validation will fail if this occurs.
 - If an input attribute has the same key as `destination_key`, it will be
   automatically skipped (not condensed) to prevent circular references.
+- Only string, integer, double, and boolean values are condensed. Bytes, arrays,
+  maps, and empty values remain separate attributes, even when selected by
+  `source_keys` or not excluded by `exclude_keys`. This avoids introducing an
+  ambiguous serialization format for non-scalar values.
 
 ## Behavior
 

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/condense_attributes_processor/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/condense_attributes_processor/mod.rs
@@ -10,8 +10,8 @@
 //!
 
 use arrow::array::{
-    Array, BooleanArray, DictionaryArray, Float64Array, Int64Array, StringArray, UInt8Array,
-    UInt16Array,
+    Array, BinaryArray, BooleanArray, DictionaryArray, Float64Array, Int64Array, StringArray,
+    UInt8Array, UInt16Array,
 };
 use arrow::datatypes::{UInt8Type, UInt16Type};
 use async_trait::async_trait;
@@ -167,6 +167,10 @@ enum CachedAttributeValue {
     Int(i64),
     Double(f64),
     Bool(bool),
+    Bytes(Vec<u8>),
+    Slice(Vec<u8>),
+    Map(Vec<u8>),
+    Empty,
 }
 
 fn engine_err(msg: &str) -> Error {
@@ -231,7 +235,7 @@ impl CondenseAttributesProcessor {
 
     /// Condenses attributes in the given record batch according to the processor configuration.
     /// Returns the number of individual attributes that were condensed.
-    fn condense(&self, records: &mut OtapArrowRecords) -> Result<u64, Error> {
+    pub fn condense(&self, records: &mut OtapArrowRecords) -> Result<u64, Error> {
         let rb = match records.get(ArrowPayloadType::LogAttrs) {
             Some(rb) => rb,
             None => {
@@ -273,6 +277,8 @@ impl CondenseAttributesProcessor {
         let int_col = rb.column_by_name(consts::ATTRIBUTE_INT);
         let double_col = rb.column_by_name(consts::ATTRIBUTE_DOUBLE);
         let bool_col = rb.column_by_name(consts::ATTRIBUTE_BOOL);
+        let bytes_col = rb.column_by_name(consts::ATTRIBUTE_BYTES);
+        let ser_col = rb.column_by_name(consts::ATTRIBUTE_SER);
         let delimiter_str = self.config.delimiter.to_string();
 
         // Pre-extract key arrays
@@ -360,9 +366,55 @@ impl CondenseAttributesProcessor {
                     })
                     .map(|v| v.to_string())
                 }),
-                // If needed, add handling for Map, Slice, and Bytes?
+                // Future support could serialize arrays and maps as compact JSON, bytes as base64,
+                // and empty values as `null`. Preserve these values unchanged until that format is
+                // explicitly configured and documented.
                 _ => None,
             }
+        };
+
+        let get_cached_value = |value_type: AttributeValueType, i: usize| match value_type {
+            AttributeValueType::Str => str_col.and_then(|col| {
+                Self::extract_value_from_column(col, i, |arr: &StringArray, index| {
+                    arr.value(index).to_string()
+                })
+                .map(CachedAttributeValue::Str)
+            }),
+            AttributeValueType::Int => int_col.and_then(|col| {
+                Self::extract_value_from_column(col, i, |arr: &Int64Array, index| arr.value(index))
+                    .map(CachedAttributeValue::Int)
+            }),
+            AttributeValueType::Double => double_col.and_then(|col| {
+                Self::extract_value_from_column(col, i, |arr: &Float64Array, index| {
+                    arr.value(index)
+                })
+                .map(CachedAttributeValue::Double)
+            }),
+            AttributeValueType::Bool => bool_col.and_then(|col| {
+                Self::extract_value_from_column(col, i, |arr: &BooleanArray, index| {
+                    arr.value(index)
+                })
+                .map(CachedAttributeValue::Bool)
+            }),
+            AttributeValueType::Bytes => bytes_col.and_then(|col| {
+                Self::extract_value_from_column(col, i, |arr: &BinaryArray, index| {
+                    arr.value(index).to_vec()
+                })
+                .map(CachedAttributeValue::Bytes)
+            }),
+            AttributeValueType::Slice => ser_col.and_then(|col| {
+                Self::extract_value_from_column(col, i, |arr: &BinaryArray, index| {
+                    arr.value(index).to_vec()
+                })
+                .map(CachedAttributeValue::Slice)
+            }),
+            AttributeValueType::Map => ser_col.and_then(|col| {
+                Self::extract_value_from_column(col, i, |arr: &BinaryArray, index| {
+                    arr.value(index).to_vec()
+                })
+                .map(CachedAttributeValue::Map)
+            }),
+            AttributeValueType::Empty => Some(CachedAttributeValue::Empty),
         };
 
         // parent_to_attrs uses borrowed &str keys from Arrow arrays, so cannot be easily reused across calls.
@@ -398,60 +450,19 @@ impl CondenseAttributesProcessor {
                 (None, None) => true,
             };
 
-            if !should_condense {
-                if type_arr.is_null(i) {
-                    continue;
-                }
-
-                let value_type = type_arr.value(i);
-                if let Ok(value_type_enum) = AttributeValueType::try_from(value_type) {
-                    let cached_value = match value_type_enum {
-                        AttributeValueType::Str => str_col.and_then(|col| {
-                            Self::extract_value_from_column(col, i, |arr: &StringArray, index| {
-                                arr.value(index).to_string()
-                            })
-                            .map(CachedAttributeValue::Str)
-                        }),
-                        AttributeValueType::Int => int_col.and_then(|col| {
-                            Self::extract_value_from_column(col, i, |arr: &Int64Array, index| {
-                                arr.value(index)
-                            })
-                            .map(CachedAttributeValue::Int)
-                        }),
-                        AttributeValueType::Double => double_col.and_then(|col| {
-                            Self::extract_value_from_column(col, i, |arr: &Float64Array, index| {
-                                arr.value(index)
-                            })
-                            .map(CachedAttributeValue::Double)
-                        }),
-                        AttributeValueType::Bool => bool_col.and_then(|col| {
-                            Self::extract_value_from_column(col, i, |arr: &BooleanArray, index| {
-                                arr.value(index)
-                            })
-                            .map(CachedAttributeValue::Bool)
-                        }),
-                        _ => None,
-                    };
-
-                    if let Some(cached_value) = cached_value {
-                        preserved_attrs.push((parent_id, key, cached_value));
-                    }
-                }
-
-                continue;
-            }
-
             if type_arr.is_null(i) {
                 continue;
             }
             let value_type = type_arr.value(i);
 
             if let Ok(value_type_enum) = AttributeValueType::try_from(value_type) {
-                if let Some(val) = get_value_str(value_type_enum, i) {
+                if should_condense && let Some(val) = get_value_str(value_type_enum, i) {
                     parent_to_attrs
                         .entry(parent_id)
                         .or_default()
                         .push((key, val));
+                } else if let Some(cached_value) = get_cached_value(value_type_enum, i) {
+                    preserved_attrs.push((parent_id, key, cached_value));
                 }
             }
         }
@@ -523,18 +534,23 @@ impl CondenseAttributesProcessor {
                 CachedAttributeValue::Bool(val) => {
                     builder.any_values_builder.append_bool(val);
                 }
+                CachedAttributeValue::Bytes(val) => {
+                    builder.any_values_builder.append_bytes(&val);
+                }
+                CachedAttributeValue::Slice(val) => {
+                    builder.any_values_builder.append_slice(&val);
+                }
+                CachedAttributeValue::Map(val) => {
+                    builder.any_values_builder.append_map(&val);
+                }
+                CachedAttributeValue::Empty => {
+                    builder.any_values_builder.append_empty();
+                }
             }
         }
 
-        // TODO: This rebuild path is copy-heavy.
-        // `RecordBatch` is immutable, so true in-place mutation is not possible today.
-        // A more efficient approach could be:
-        // - filter/delete condensed source rows from the existing batch,
-        // - append computed condensed rows,
-        // - concatenate/reconcile schemas as needed.
-        // Note: `transform.rs` insert only supports predefined literal values; condense requires
-        // per-parent computed values, so we cannot reuse that insert path directly.
-        // Follow-up optimization tracked in https://github.com/open-telemetry/otel-arrow/issues/1694
+        // Arrow RecordBatches are immutable, so filtering and concatenating them performs
+        // two materializations and is slower than reconstructing this single output batch.
         let new_batch = builder.finish().map_err(|e| {
             engine_err(&format!(
                 "Failed to build condensed attributes batch: {}",
@@ -845,6 +861,45 @@ mod condense_tests {
         let expected_attrs = vec![
             KeyValue::new("condensed", AnyValue::new_string("attr2=42;attr3=true")),
             KeyValue::new("attr1", AnyValue::new_string("value1")),
+        ];
+
+        test_condense_single_log(input, cfg, expected_attrs);
+    }
+
+    /// Scenario: Condensing selected scalar values alongside selected non-scalar OTLP AnyValues.
+    /// Guarantees: Values that cannot be represented in the condensed string remain unchanged.
+    #[test]
+    fn test_condense_preserves_non_scalar_attributes() {
+        let input = build_log_with_attrs(vec![
+            KeyValue::new("condense_me", AnyValue::new_string("value")),
+            KeyValue::new("bytes", AnyValue::new_bytes(b"bytes")),
+            KeyValue::new(
+                "array",
+                AnyValue::new_array(vec![AnyValue::new_int(1), AnyValue::new_bool(true)]),
+            ),
+            KeyValue::new(
+                "map",
+                AnyValue::new_kvlist(vec![KeyValue::new("nested", AnyValue::new_double(1.5))]),
+            ),
+            KeyValue::new("empty", AnyValue::default()),
+        ]);
+        let cfg = json!({
+            "destination_key": "condensed",
+            "delimiter": ";",
+            "source_keys": ["condense_me", "bytes", "array", "map", "empty"]
+        });
+        let expected_attrs = vec![
+            KeyValue::new("condensed", AnyValue::new_string("condense_me=value")),
+            KeyValue::new("bytes", AnyValue::new_bytes(b"bytes")),
+            KeyValue::new(
+                "array",
+                AnyValue::new_array(vec![AnyValue::new_int(1), AnyValue::new_bool(true)]),
+            ),
+            KeyValue::new(
+                "map",
+                AnyValue::new_kvlist(vec![KeyValue::new("nested", AnyValue::new_double(1.5))]),
+            ),
+            KeyValue::new("empty", AnyValue::default()),
         ];
 
         test_condense_single_log(input, cfg, expected_attrs);

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/condense_attributes_processor/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/condense_attributes_processor/mod.rs
@@ -162,17 +162,6 @@ pub struct CondenseAttributesProcessor {
     compute_duration: ComputeDuration,
 }
 
-enum CachedAttributeValue {
-    Str(String),
-    Int(i64),
-    Double(f64),
-    Bool(bool),
-    Bytes(Vec<u8>),
-    Slice(Vec<u8>),
-    Map(Vec<u8>),
-    Empty,
-}
-
 fn engine_err(msg: &str) -> Error {
     Error::PdataConversionError {
         error: msg.to_string(),
@@ -235,7 +224,7 @@ impl CondenseAttributesProcessor {
 
     /// Condenses attributes in the given record batch according to the processor configuration.
     /// Returns the number of individual attributes that were condensed.
-    pub fn condense(&self, records: &mut OtapArrowRecords) -> Result<u64, Error> {
+    fn condense(&self, records: &mut OtapArrowRecords) -> Result<u64, Error> {
         let rb = match records.get(ArrowPayloadType::LogAttrs) {
             Some(rb) => rb,
             None => {
@@ -373,55 +362,10 @@ impl CondenseAttributesProcessor {
             }
         };
 
-        let get_cached_value = |value_type: AttributeValueType, i: usize| match value_type {
-            AttributeValueType::Str => str_col.and_then(|col| {
-                Self::extract_value_from_column(col, i, |arr: &StringArray, index| {
-                    arr.value(index).to_string()
-                })
-                .map(CachedAttributeValue::Str)
-            }),
-            AttributeValueType::Int => int_col.and_then(|col| {
-                Self::extract_value_from_column(col, i, |arr: &Int64Array, index| arr.value(index))
-                    .map(CachedAttributeValue::Int)
-            }),
-            AttributeValueType::Double => double_col.and_then(|col| {
-                Self::extract_value_from_column(col, i, |arr: &Float64Array, index| {
-                    arr.value(index)
-                })
-                .map(CachedAttributeValue::Double)
-            }),
-            AttributeValueType::Bool => bool_col.and_then(|col| {
-                Self::extract_value_from_column(col, i, |arr: &BooleanArray, index| {
-                    arr.value(index)
-                })
-                .map(CachedAttributeValue::Bool)
-            }),
-            AttributeValueType::Bytes => bytes_col.and_then(|col| {
-                Self::extract_value_from_column(col, i, |arr: &BinaryArray, index| {
-                    arr.value(index).to_vec()
-                })
-                .map(CachedAttributeValue::Bytes)
-            }),
-            AttributeValueType::Slice => ser_col.and_then(|col| {
-                Self::extract_value_from_column(col, i, |arr: &BinaryArray, index| {
-                    arr.value(index).to_vec()
-                })
-                .map(CachedAttributeValue::Slice)
-            }),
-            AttributeValueType::Map => ser_col.and_then(|col| {
-                Self::extract_value_from_column(col, i, |arr: &BinaryArray, index| {
-                    arr.value(index).to_vec()
-                })
-                .map(CachedAttributeValue::Map)
-            }),
-            AttributeValueType::Empty => Some(CachedAttributeValue::Empty),
-        };
-
         // parent_to_attrs uses borrowed &str keys from Arrow arrays, so cannot be easily reused across calls.
         // TODO: is reusing a HashMap<u16, Vec<(String, String)>> worth it?
         let mut parent_to_attrs: HashMap<u16, Vec<(&str, String)>> = HashMap::new();
-        let mut preserved_attrs: Vec<(u16, &str, CachedAttributeValue)> =
-            Vec::with_capacity(num_rows);
+        let mut preserved_rows = Vec::with_capacity(num_rows);
         let mut removed_existing_destination = false;
         let mut removed_existing_destination_count = 0u64;
 
@@ -461,8 +405,8 @@ impl CondenseAttributesProcessor {
                         .entry(parent_id)
                         .or_default()
                         .push((key, val));
-                } else if let Some(cached_value) = get_cached_value(value_type_enum, i) {
-                    preserved_attrs.push((parent_id, key, cached_value));
+                } else {
+                    preserved_rows.push(i);
                 }
             }
         }
@@ -516,34 +460,89 @@ impl CondenseAttributesProcessor {
             }
         }
 
-        // Add preserved attributes
-        for (parent_id, key, value) in preserved_attrs {
-            builder.append_parent_id(&parent_id);
-            builder.append_key(key);
+        // Re-read preserved rows so their Arrow-backed values can be appended without temporary copies.
+        for i in preserved_rows {
+            let parent_id = parent_id_arr.value(i);
+            let key = get_key(i).expect("key was validated as non-null");
+            let value_type =
+                AttributeValueType::try_from(type_arr.value(i)).expect("type was validated");
 
-            match value {
-                CachedAttributeValue::Str(val) => {
-                    builder.any_values_builder.append_str(val.as_bytes());
+            match value_type {
+                AttributeValueType::Str => {
+                    if let Some(col) = str_col {
+                        let _ =
+                            Self::extract_value_from_column(col, i, |arr: &StringArray, index| {
+                                builder.append_parent_id(&parent_id);
+                                builder.append_key(key);
+                                builder
+                                    .any_values_builder
+                                    .append_str(arr.value(index).as_bytes());
+                            });
+                    }
                 }
-                CachedAttributeValue::Int(val) => {
-                    builder.any_values_builder.append_int(val);
+                AttributeValueType::Int => {
+                    if let Some(col) = int_col {
+                        let _ =
+                            Self::extract_value_from_column(col, i, |arr: &Int64Array, index| {
+                                builder.append_parent_id(&parent_id);
+                                builder.append_key(key);
+                                builder.any_values_builder.append_int(arr.value(index));
+                            });
+                    }
                 }
-                CachedAttributeValue::Double(val) => {
-                    builder.any_values_builder.append_double(val);
+                AttributeValueType::Double => {
+                    if let Some(col) = double_col {
+                        let _ =
+                            Self::extract_value_from_column(col, i, |arr: &Float64Array, index| {
+                                builder.append_parent_id(&parent_id);
+                                builder.append_key(key);
+                                builder.any_values_builder.append_double(arr.value(index));
+                            });
+                    }
                 }
-                CachedAttributeValue::Bool(val) => {
-                    builder.any_values_builder.append_bool(val);
+                AttributeValueType::Bool => {
+                    if let Some(col) = bool_col {
+                        let _ =
+                            Self::extract_value_from_column(col, i, |arr: &BooleanArray, index| {
+                                builder.append_parent_id(&parent_id);
+                                builder.append_key(key);
+                                builder.any_values_builder.append_bool(arr.value(index));
+                            });
+                    }
                 }
-                CachedAttributeValue::Bytes(val) => {
-                    builder.any_values_builder.append_bytes(&val);
+                AttributeValueType::Bytes => {
+                    if let Some(col) = bytes_col {
+                        let _ =
+                            Self::extract_value_from_column(col, i, |arr: &BinaryArray, index| {
+                                builder.append_parent_id(&parent_id);
+                                builder.append_key(key);
+                                builder.any_values_builder.append_bytes(arr.value(index));
+                            });
+                    }
                 }
-                CachedAttributeValue::Slice(val) => {
-                    builder.any_values_builder.append_slice(&val);
+                AttributeValueType::Slice => {
+                    if let Some(col) = ser_col {
+                        let _ =
+                            Self::extract_value_from_column(col, i, |arr: &BinaryArray, index| {
+                                builder.append_parent_id(&parent_id);
+                                builder.append_key(key);
+                                builder.any_values_builder.append_slice(arr.value(index));
+                            });
+                    }
                 }
-                CachedAttributeValue::Map(val) => {
-                    builder.any_values_builder.append_map(&val);
+                AttributeValueType::Map => {
+                    if let Some(col) = ser_col {
+                        let _ =
+                            Self::extract_value_from_column(col, i, |arr: &BinaryArray, index| {
+                                builder.append_parent_id(&parent_id);
+                                builder.append_key(key);
+                                builder.any_values_builder.append_map(arr.value(index));
+                            });
+                    }
                 }
-                CachedAttributeValue::Empty => {
+                AttributeValueType::Empty => {
+                    builder.append_parent_id(&parent_id);
+                    builder.append_key(key);
                     builder.any_values_builder.append_empty();
                 }
             }
@@ -563,14 +562,20 @@ impl CondenseAttributesProcessor {
         Ok(condensed_count)
     }
 
+    #[cfg(feature = "condense-attributes-processor-bench")]
+    #[doc(hidden)]
+    pub fn condense_for_benchmark(&self, records: &mut OtapArrowRecords) -> Result<u64, Error> {
+        self.condense(records)
+    }
+
     fn extract_value_from_column<T, PlainArr, F>(
         col: &Arc<dyn Array>,
         i: usize,
-        extract_plain: F,
+        mut extract_plain: F,
     ) -> Option<T>
     where
         PlainArr: Array + 'static,
-        F: Fn(&PlainArr, usize) -> T,
+        F: FnMut(&PlainArr, usize) -> T,
     {
         if let Some(arr) = col.as_any().downcast_ref::<PlainArr>() {
             if arr.is_null(i) {
@@ -887,6 +892,44 @@ mod condense_tests {
             "destination_key": "condensed",
             "delimiter": ";",
             "source_keys": ["condense_me", "bytes", "array", "map", "empty"]
+        });
+        let expected_attrs = vec![
+            KeyValue::new("condensed", AnyValue::new_string("condense_me=value")),
+            KeyValue::new("bytes", AnyValue::new_bytes(b"bytes")),
+            KeyValue::new(
+                "array",
+                AnyValue::new_array(vec![AnyValue::new_int(1), AnyValue::new_bool(true)]),
+            ),
+            KeyValue::new(
+                "map",
+                AnyValue::new_kvlist(vec![KeyValue::new("nested", AnyValue::new_double(1.5))]),
+            ),
+            KeyValue::new("empty", AnyValue::default()),
+        ];
+
+        test_condense_single_log(input, cfg, expected_attrs);
+    }
+
+    /// Scenario: Condensing all attributes in a log containing scalar and non-scalar OTLP values.
+    /// Guarantees: Non-scalar values remain separate when no source or exclude key filter is set.
+    #[test]
+    fn test_condense_all_preserves_non_scalar_attributes() {
+        let input = build_log_with_attrs(vec![
+            KeyValue::new("condense_me", AnyValue::new_string("value")),
+            KeyValue::new("bytes", AnyValue::new_bytes(b"bytes")),
+            KeyValue::new(
+                "array",
+                AnyValue::new_array(vec![AnyValue::new_int(1), AnyValue::new_bool(true)]),
+            ),
+            KeyValue::new(
+                "map",
+                AnyValue::new_kvlist(vec![KeyValue::new("nested", AnyValue::new_double(1.5))]),
+            ),
+            KeyValue::new("empty", AnyValue::default()),
+        ]);
+        let cfg = json!({
+            "destination_key": "condensed",
+            "delimiter": ";"
         });
         let expected_attrs = vec![
             KeyValue::new("condensed", AnyValue::new_string("condense_me=value")),


### PR DESCRIPTION
# Change Summary

Fix Condense Attributes dropping supported OTLP values that cannot be easily represented in its scalar `key=value` format.

Strings, integers, doubles, and booleans are condensed. Bytes, arrays, maps, and empty values remain as separate attributes, including when selected by `source_keys`, to avoid an ambiguous serialization format and prevent data loss

Also added a benchmark for this operation as a way to measure a potential improvement to address #1694. It confirms that filtering and concatenating Arrow RecordBatches regresses performance, so the processor retains its existing single-batch rebuild.

The implementation evaluated filtering condensed source rows from the existing RecordBatch and concatenating a batch of computed attributes. Because Arrow RecordBatches are immutable, that approach materializes the preserved rows and then materializes the concatenated output.

| Logs | Existing single-batch rebuild | Filter and concat | Regression |
| --- | ---: | ---: | ---: |
| 32 | 25.6 us | 52.5 us | 129% |
| 1,024 | 673.7 us | 820.8 us | 22% |
| 8,192 | 6.24 ms | 6.82 ms | 9% |

This PR therefore retains the existing single-batch rebuild.

## What issue does this PR close?

<!--We highly recommend correlation of every PR to an issue-->

* Closes #1694
  * Without more intensive arrow-level support for this operation, there isn't a meaningful optimization available at this time.

## How are these changes tested?

Unit tests

## Are there any user-facing changes?

Yes, bytes, arrays, maps, and empty values are now preserved through the processor's execution.

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry
* [ ] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
