### PR TITLE
fix(filter): reject unknown config fields

### DIFF
--- a/rust/otap-dataflow/.chloggen/filter-processor-reject-unknown-config-fields.yaml
+++ b/rust/otap-dataflow/.chloggen/filter-processor-reject-unknown-config-fields.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: pipeline
+note: Reject unknown top-level fields in filter processor configuration.
+issues: [3568]

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/config.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/config.rs
@@ -9,6 +9,7 @@ use otap_df_pdata::otap::filter::{logs::LogFilter, metrics::MetricFilter, traces
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     #[serde(default = "default_metric_filter")]
     metrics: MetricFilter,
@@ -67,5 +68,25 @@ impl Config {
     #[must_use]
     pub const fn trace_filters(&self) -> &TraceFilter {
         &self.traces
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Config;
+    use serde_json::json;
+
+    /// Scenario: filter processor configuration contains an unknown top-level field.
+    /// Guarantees: typed startup validation rejects the field and identifies it by name.
+    #[test]
+    fn rejects_unknown_top_level_field() {
+        let error =
+            otap_df_config::validation::validate_typed_config::<Config>(&json!({"__bogus__": 1}))
+                .expect_err("unknown filter processor fields must be rejected");
+
+        assert!(
+            error.to_string().contains("unknown field `__bogus__`"),
+            "unexpected validation error: {error}"
+        );
     }
 }


### PR DESCRIPTION
# Change Summary

Reject unknown top-level fields in `processor:filter` configuration so `--validate-and-exit` catches typos instead of silently discarding them.

The filter processor already registers `validate_typed_config::<Config>`, but its typed config was the exception among strict engine and component schemas because it did not use Serde's `deny_unknown_fields`. This adds that schema contract and a focused regression test that verifies the offending field is named in the diagnostic.

## What issue does this PR close?

* Closes #3568

## How are these changes tested?

* `cargo +1.96.1 check -p otap-df-core-nodes`
* `cargo +1.96.1 test -p otap-df-core-nodes rejects_unknown_top_level_field -- --nocapture`
* Before/after `df_engine --validate-and-exit` reproduction using the issue configuration
* `python3 tools/sanitycheck.py`
* Changelog validation with the repository-pinned `chloggen` v0.30.0
* `cargo +1.96.1 xtask check`

## Are there any user-facing changes?

Yes. Invalid filter processor configuration now fails validation with an explicit unknown-field error instead of being accepted.

### Changelog

* [x] Added a `.chloggen/*.yaml` entry
* [ ] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.

AI tooling assisted with code navigation and drafting; the behavior was reproduced and the full repository-required validation suite was run by the contributor.
