### PR TITLE
fix(type_router): validate declared outputs

### DIFF
--- a/rust/otap-dataflow/.chloggen/type-router-declared-outputs.yaml
+++ b/rust/otap-dataflow/.chloggen/type-router-declared-outputs.yaml
@@ -1,0 +1,5 @@
+change_type: bug_fix
+component: pipeline
+note: "Reject signal type router configurations without declared outputs during startup validation."
+issues: [3569]
+subtext:

--- a/rust/otap-dataflow/crates/controller/src/startup.rs
+++ b/rust/otap-dataflow/crates/controller/src/startup.rs
@@ -83,13 +83,14 @@ pub fn apply_cli_overrides(
 
 /// Validates that every node and extension in a single pipeline references a
 /// component URN registered in the given [`PipelineFactory`], and runs
-/// per-component config validation.
+/// per-component config and wiring-contract validation.
 ///
 /// Structural config validation (connections, node references, policies) is
 /// already performed during config deserialization
 /// ([`OtelDataflowSpec::from_file`]).  This function adds the semantic check
 /// that all referenced components are actually compiled into the binary, and
-/// validates their node/extension-specific config statically.
+/// validates their node/extension-specific config and node wiring contracts
+/// statically.
 ///
 /// **Scope:** This is *static* validation only -- it checks that config values
 /// can be deserialized into the expected types.  It does **not** detect runtime
@@ -183,6 +184,17 @@ pub fn validate_pipeline_components<PData: 'static + Clone + Debug>(
             }
         }
     }
+
+    factory
+        .validate_wiring_contracts(pipeline_cfg)
+        .map_err(|e| {
+            std::io::Error::other(format!(
+                "Invalid wiring in pipeline_group={} pipeline={}: {}",
+                pipeline_group_id.as_ref(),
+                pipeline_id.as_ref(),
+                e
+            ))
+        })?;
 
     Ok(())
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/fanout_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/fanout_processor/mod.rs
@@ -1190,9 +1190,7 @@ pub static FANOUT_PROCESSOR_FACTORY: ProcessorFactory<OtapPdata> = ProcessorFact
              _capabilities: &otap_df_engine::capability::registry::Capabilities| {
         create_fanout_processor(pipeline_ctx, node, node_config, proc_cfg)
     },
-    wiring_contract: otap_df_engine::wiring_contract::WiringContract {
-        output_fanout: otap_df_engine::wiring_contract::OutputFanoutRule::AtMostPerOutput(1),
-    },
+    wiring_contract: otap_df_engine::wiring_contract::WiringContract::at_most_per_output(1),
     validate_config: otap_df_config::validation::validate_typed_config::<FanoutConfig>,
 };
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/signal_type_router/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/signal_type_router/mod.rs
@@ -698,7 +698,7 @@ pub static SIGNAL_TYPE_ROUTER_FACTORY: ProcessorFactory<OtapPdata> = ProcessorFa
 
         Ok(ProcessorWrapper::local(router, node, node_config, proc_cfg))
     },
-    wiring_contract: otap_df_engine::wiring_contract::WiringContract::UNRESTRICTED,
+    wiring_contract: otap_df_engine::wiring_contract::WiringContract::at_least_declared_outputs(1),
     validate_config: otap_df_config::validation::validate_typed_config::<SignalTypeRouterConfig>,
 };
 

--- a/rust/otap-dataflow/crates/engine/src/error.rs
+++ b/rust/otap-dataflow/crates/engine/src/error.rs
@@ -412,6 +412,19 @@ pub enum Error {
         actual_destinations: Vec<NodeName>,
     },
 
+    /// A connected node declares fewer output ports than its contract requires.
+    #[error(
+        "Invalid wiring for node `{node}`: requires at least {minimum_outputs} declared output port(s), found {actual_outputs}"
+    )]
+    InsufficientDeclaredOutputs {
+        /// The source node.
+        node: NodeName,
+        /// Minimum number of declared output ports.
+        minimum_outputs: usize,
+        /// Actual number of declared output ports.
+        actual_outputs: usize,
+    },
+
     /// A task error that occurred during the execution of a join task.
     #[error("Join task error: {error}, cancelled: {is_canceled}, panic: {is_panic}")]
     JoinTaskError {
@@ -639,6 +652,7 @@ impl Error {
             Error::UnknownReceiver { .. } => "UnknownReceiver",
             Error::UnsupportedNodeKind { .. } => "UnsupportedNodeKind",
             Error::InvalidNodeWiring { .. } => "InvalidNodeWiring",
+            Error::InsufficientDeclaredOutputs { .. } => "InsufficientDeclaredOutputs",
             Error::TopicAlreadyExists { .. } => "TopicAlreadyExists",
             Error::UnknownTopic { .. } => "UnknownTopic",
             Error::MessageNotTracked => "MessageNotTracked",

--- a/rust/otap-dataflow/crates/engine/src/lib.rs
+++ b/rust/otap-dataflow/crates/engine/src/lib.rs
@@ -776,7 +776,7 @@ impl<PData: 'static + Clone + Debug> PipelineFactory<PData> {
             return Err(Error::EmptyPipeline);
         }
 
-        self.validate_connection_wiring_contracts(&config)?;
+        self.validate_wiring_contracts(&config)?;
 
         let channel_metrics_enabled = telemetry_policy.runtime_metrics >= MetricLevel::Basic;
 
@@ -1200,9 +1200,12 @@ impl<PData: 'static + Clone + Debug> PipelineFactory<PData> {
         Ok(pipeline)
     }
 
-    fn validate_connection_wiring_contracts(&self, config: &PipelineConfig) -> Result<(), Error> {
-        let mut contracts_by_node: HashMap<NodeName, wiring_contract::WiringContract> =
-            HashMap::new();
+    /// Validates the pipeline topology against each node factory's wiring contract.
+    pub fn validate_wiring_contracts(&self, config: &PipelineConfig) -> Result<(), Error> {
+        let mut contracts_by_node: HashMap<
+            NodeName,
+            (wiring_contract::WiringContract, Vec<PortName>),
+        > = HashMap::new();
 
         for (node_name, node_config) in config.node_iter() {
             let contract = match node_config.kind() {
@@ -1252,7 +1255,10 @@ impl<PData: 'static + Clone + Debug> PipelineFactory<PData> {
                 }
             };
 
-            _ = contracts_by_node.insert(node_name.as_ref().to_string().into(), contract);
+            _ = contracts_by_node.insert(
+                node_name.as_ref().to_string().into(),
+                (contract, node_config.outputs.clone()),
+            );
         }
 
         let mut destinations_by_source_output: HashMap<(NodeName, PortName), HashSet<NodeName>> =
@@ -1279,10 +1285,14 @@ impl<PData: 'static + Clone + Debug> PipelineFactory<PData> {
             }
         }
 
+        let mut validated_sources = HashSet::new();
         for ((source, output), destination_set) in destinations_by_source_output {
-            let Some(contract) = contracts_by_node.get(&source) else {
+            let Some((contract, declared_outputs)) = contracts_by_node.get(&source) else {
                 return Err(Error::UnknownNode { node: source });
             };
+            if validated_sources.insert(source.clone()) {
+                contract.validate_declared_outputs(&source, declared_outputs)?;
+            }
             let mut destinations: Vec<NodeName> = destination_set.into_iter().collect();
             destinations.sort_unstable_by(|left, right| left.as_ref().cmp(right.as_ref()));
             contract.validate_output_destinations(&source, &output, &destinations)?;

--- a/rust/otap-dataflow/crates/engine/src/wiring_contract.rs
+++ b/rust/otap-dataflow/crates/engine/src/wiring_contract.rs
@@ -22,12 +22,15 @@ pub enum OutputFanoutRule {
 pub struct WiringContract {
     /// Constraint on per-output destination fanout.
     pub output_fanout: OutputFanoutRule,
+    /// Minimum number of output ports the node must declare.
+    pub minimum_declared_outputs: usize,
 }
 
 impl WiringContract {
-    /// Unrestricted wiring contract (no per-output destination limit).
+    /// Unrestricted wiring contract.
     pub const UNRESTRICTED: Self = Self {
         output_fanout: OutputFanoutRule::Unrestricted,
+        minimum_declared_outputs: 0,
     };
 
     /// Creates an unrestricted wiring contract.
@@ -41,7 +44,34 @@ impl WiringContract {
     pub const fn at_most_per_output(max: usize) -> Self {
         Self {
             output_fanout: OutputFanoutRule::AtMostPerOutput(max),
+            minimum_declared_outputs: 0,
         }
+    }
+
+    /// Creates a contract requiring a minimum number of declared output ports.
+    #[must_use]
+    pub const fn at_least_declared_outputs(minimum: usize) -> Self {
+        Self {
+            output_fanout: OutputFanoutRule::Unrestricted,
+            minimum_declared_outputs: minimum,
+        }
+    }
+
+    /// Validates the node's declared output ports against this contract.
+    pub fn validate_declared_outputs(
+        &self,
+        node: &NodeName,
+        outputs: &[PortName],
+    ) -> Result<(), Error> {
+        if outputs.len() >= self.minimum_declared_outputs {
+            return Ok(());
+        }
+
+        Err(Error::InsufficientDeclaredOutputs {
+            node: node.clone(),
+            minimum_outputs: self.minimum_declared_outputs,
+            actual_outputs: outputs.len(),
+        })
     }
 
     /// Validates a source output against this contract.

--- a/rust/otap-dataflow/crates/validation/src/fanout_processor.rs
+++ b/rust/otap-dataflow/crates/validation/src/fanout_processor.rs
@@ -54,9 +54,7 @@ pub static FANOUT_PROCESSOR_FACTORY: ProcessorFactory<OtapPdata> = ProcessorFact
             processor_config,
         ))
     },
-    wiring_contract: otap_df_engine::wiring_contract::WiringContract {
-        output_fanout: otap_df_engine::wiring_contract::OutputFanoutRule::AtMostPerOutput(1),
-    },
+    wiring_contract: otap_df_engine::wiring_contract::WiringContract::at_most_per_output(1),
     validate_config: otap_df_config::validation::no_config,
 };
 

--- a/rust/otap-dataflow/src/main.rs
+++ b/rust/otap-dataflow/src/main.rs
@@ -456,6 +456,50 @@ connections:
         assert!(err.to_string().contains("Unknown receiver component"));
     }
 
+    /// Scenario: a signal type router is connected without any declared output ports.
+    /// Guarantees: startup validation rejects the config before runtime pipeline construction.
+    #[test]
+    fn validate_type_router_requires_declared_outputs() {
+        use otap_df_config::pipeline::PipelineConfig;
+        use otap_df_config::{PipelineGroupId, PipelineId};
+
+        let pipeline_group_id: PipelineGroupId = "test_group".into();
+        let pipeline_id: PipelineId = "test_pipeline".into();
+        let yaml = r#"
+nodes:
+  receiver:
+    type: receiver:internal_telemetry
+    config: {}
+  router:
+    type: processor:type_router
+    config: {}
+  exporter:
+    type: exporter:noop
+    config: {}
+connections:
+  - from: receiver
+    to: router
+  - from: router
+    to: exporter
+"#;
+
+        let pipeline_cfg =
+            PipelineConfig::from_yaml(pipeline_group_id.clone(), pipeline_id.clone(), yaml)
+                .expect("pipeline YAML should parse");
+
+        let err = startup::validate_pipeline_components(
+            &pipeline_group_id,
+            &pipeline_id,
+            &pipeline_cfg,
+            &OTAP_PIPELINE_FACTORY,
+        )
+        .expect_err("type router without declared outputs should fail validation");
+        assert!(
+            err.to_string()
+                .contains("requires at least 1 declared output")
+        );
+    }
+
     #[test]
     fn parse_license_flag() {
         let args = Args::parse_from(["df_engine", "--license"]);


### PR DESCRIPTION
Fixes #3569

## Summary
- add a minimum declared-output requirement to node wiring contracts
- apply wiring-contract validation during static startup validation as well as pipeline construction
- require `processor:type_router` to declare at least one output and cover the invalid fully connected topology with a regression test

## Testing
- `cargo test --offline --bin df_engine --no-default-features --features crypto-ring validate_type_router_requires_declared_outputs -- --nocapture`
- `cargo check -p otap-df-engine -p otap-df-controller -p otap-df-core-nodes -p otap-df-validation`
- `cargo clippy -p otap-df-engine -p otap-df-controller -p otap-df-core-nodes -p otap-df-validation --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `chloggen validate --config rust/otap-dataflow/.chloggen/config.yaml`

## AI assistance
Codex assisted with repository navigation, implementation drafting, and local test orchestration. I reviewed the changes and verified the behavior with the checks above.