### PR TITLE
chore(deps): Schedule more Renovate updates for beginning of the week

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -37,7 +37,7 @@
         "patch"
       ],
       "schedule": [
-        "before 8am every weekday"
+        "before 8am on Monday"
       ]
     },
     {
@@ -62,6 +62,9 @@
         "weaver_resolver",
         "weaver_semconv"
       ],
+      "schedule": [
+        "before 8am on Monday"
+      ]
     },
     {
       // group these dependencies that are tagged and released together
@@ -75,6 +78,9 @@
         "opentelemetry-prometheus",
         "opentelemetry-proto"
       ],
+      "schedule": [
+        "before 8am on Monday"
+      ]
     },
     {
       // group together all github action workflow changes
@@ -119,6 +125,9 @@
       "matchFileNames": [
         "tools/pipeline_perf_test/**/requirements.lock.txt",
         "tools/pipeline_perf_test/**/requirements.txt"
+      ],
+      "schedule": [
+        "before 8am on Monday"
       ]
     },
     {


### PR DESCRIPTION
# Change Summary

Motivated by https://github.com/open-telemetry/otel-arrow/pull/3570

Attempt to schedule most Renovate PRs for beginning of the week only to reduce churn

## What issue does this PR close?

N/A

## How are these changes tested?

N/A

## Are there any user-facing changes?

No

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [ ] Added a `.chloggen/*.yaml` entry
* [x] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
