### PR TITLE
feat(geneva-exporter): support agent-fed credentials

### DIFF
--- a/rust/otap-dataflow/.chloggen/agent-fed-credential-provider-capability.yaml
+++ b/rust/otap-dataflow/.chloggen/agent-fed-credential-provider-capability.yaml
@@ -1,0 +1,13 @@
+change_type: enhancement
+
+component: engine
+
+note: Add the `AgentFedCredentialProvider` capability, which supplies a bearer token and its vendor-defined routing attributes as one atomically-published snapshot.
+
+issues: [3275]
+
+subtext: |
+  The capability returns an immutable token/routing snapshot from one host-state
+  read, preventing mixed generations during rotation. The existing
+  `bearer_token_provider` and `vendor_bundle` capabilities remain available
+  when atomic pairing is unnecessary.

--- a/rust/otap-dataflow/.chloggen/agent-fed-exporter-sources.yaml
+++ b/rust/otap-dataflow/.chloggen/agent-fed-exporter-sources.yaml
@@ -10,7 +10,7 @@ subtext: |
   The Geneva exporter binds a fail-closed `AgentFedGenevaSource` when
   `auth.type=agentfed`, bridging the agent-fed capabilities to
   geneva-uploader's agent-fed credential source. Both capabilities must bind
-  to the same extension instance. The exporter selects `moniker_map` by the
+  to the same configured extension. The exporter selects `moniker_map` by the
   configured account, then `default`, then a sole entry, and rejects ambiguous
   maps. The Azure Monitor exporter already consumes the `BearerTokenProvider`
   capability, so an agent-fed host extension bound to that capability serves

--- a/rust/otap-dataflow/.chloggen/agent-fed-exporter-sources.yaml
+++ b/rust/otap-dataflow/.chloggen/agent-fed-exporter-sources.yaml
@@ -2,20 +2,12 @@ change_type: enhancement
 
 component: pipeline
 
-note: Let the Geneva exporter use agent-fed credentials by resolving the `BearerTokenProvider` and `VendorBundle` capabilities instead of driving its own config-service handshake.
+note: Let the Geneva exporter use an atomic `AgentFedCredentialProvider` snapshot instead of driving its own config-service handshake.
 
 issues: [3275]
 
 subtext: |
-  The Geneva exporter binds a fail-closed `AgentFedGenevaSource` when
-  `auth.type=agentfed`, bridging the agent-fed capabilities to
-  geneva-uploader's agent-fed credential source. Both capabilities must bind
-  to the same configured extension. The exporter selects `moniker_map` by the
-  configured account, then `default`, then a sole entry, and rejects ambiguous
-  or malformed maps. Extension clones must share one `Arc`-backed token/routing
-  snapshot. Token and bundle reads are non-atomic, so the host and backend must
-  make transient mixed-generation pairs safe or reject them. A rejected upload
-  is NACKed so the pipeline's retry policy can read the capabilities again.
-  The Azure Monitor exporter already consumes the `BearerTokenProvider`
-  capability, so an agent-fed host extension bound to that capability serves
-  it with no exporter change.
+  Agent-fed auth gets endpoint, moniker, and token from one atomic snapshot.
+  It requires HTTPS and an exact-account/default URL-safe moniker, rejects
+  invalid or near-expiry data, supports rotation, and uses zeroizing token/header
+  buffers. Other auth modes still reject blank endpoint or region.

--- a/rust/otap-dataflow/.chloggen/agent-fed-exporter-sources.yaml
+++ b/rust/otap-dataflow/.chloggen/agent-fed-exporter-sources.yaml
@@ -12,6 +12,10 @@ subtext: |
   geneva-uploader's agent-fed credential source. Both capabilities must bind
   to the same configured extension. The exporter selects `moniker_map` by the
   configured account, then `default`, then a sole entry, and rejects ambiguous
-  maps. The Azure Monitor exporter already consumes the `BearerTokenProvider`
+  or malformed maps. Extension clones must share one `Arc`-backed token/routing
+  snapshot. Token and bundle reads are non-atomic, so the host and backend must
+  make transient mixed-generation pairs safe or reject them. A rejected upload
+  is NACKed so the pipeline's retry policy can read the capabilities again.
+  The Azure Monitor exporter already consumes the `BearerTokenProvider`
   capability, so an agent-fed host extension bound to that capability serves
   it with no exporter change.

--- a/rust/otap-dataflow/.chloggen/agent-fed-exporter-sources.yaml
+++ b/rust/otap-dataflow/.chloggen/agent-fed-exporter-sources.yaml
@@ -9,6 +9,9 @@ issues: [3275]
 subtext: |
   The Geneva exporter binds a fail-closed `AgentFedGenevaSource` when
   `auth.type=agentfed`, bridging the agent-fed capabilities to
-  geneva-uploader's agent-fed credential source. The Azure Monitor exporter
-  already consumes the `BearerTokenProvider` capability, so an agent-fed
-  host extension bound to that capability serves it with no exporter change.
+  geneva-uploader's agent-fed credential source. Both capabilities must bind
+  to the same extension instance. The exporter selects `moniker_map` by the
+  configured account, then `default`, then a sole entry, and rejects ambiguous
+  maps. The Azure Monitor exporter already consumes the `BearerTokenProvider`
+  capability, so an agent-fed host extension bound to that capability serves
+  it with no exporter change.

--- a/rust/otap-dataflow/.chloggen/agent-fed-exporter-sources.yaml
+++ b/rust/otap-dataflow/.chloggen/agent-fed-exporter-sources.yaml
@@ -1,0 +1,14 @@
+change_type: enhancement
+
+component: pipeline
+
+note: Let the Geneva exporter use agent-fed credentials by resolving the `BearerTokenProvider` and `VendorBundle` capabilities instead of driving its own config-service handshake.
+
+issues: [3275]
+
+subtext: |
+  The Geneva exporter binds a fail-closed `AgentFedGenevaSource` when
+  `auth.type=agentfed`, bridging the agent-fed capabilities to
+  geneva-uploader's agent-fed credential source. The Azure Monitor exporter
+  already consumes the `BearerTokenProvider` capability, so an agent-fed
+  host extension bound to that capability serves it with no exporter change.

--- a/rust/otap-dataflow/Cargo.lock
+++ b/rust/otap-dataflow/Cargo.lock
@@ -4009,11 +4009,12 @@ dependencies = [
 [[package]]
 name = "geneva-uploader"
 version = "0.5.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust-contrib.git?rev=98aa6dc8717b372ab34ebe3247262379d4e33799#98aa6dc8717b372ab34ebe3247262379d4e33799"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust-contrib.git?rev=75a2b0ad0e19ecb1322c3c2095dc6e69a2de7e9d#75a2b0ad0e19ecb1322c3c2095dc6e69a2de7e9d"
 dependencies = [
  "azure_core 0.29.1",
  "azure_identity 0.29.0",
  "base64",
+ "bytes",
  "chrono",
  "hex",
  "lz4_flex 0.11.6",
@@ -4025,6 +4026,7 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
+ "secrecy",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
@@ -7284,6 +7286,7 @@ dependencies = [
  "tracepoint_decode",
  "tracing",
  "tracing-subscriber",
+ "url",
  "urlencoding",
  "uuid",
  "wiremock",

--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -283,7 +283,7 @@ tracepoint_decode = "0.5.0"
 tracelogging = "1.2.4"
 tracelogging_dynamic = "1.2.4"
 urlencoding = "2"
-geneva-uploader = { git = "https://github.com/open-telemetry/opentelemetry-rust-contrib.git", rev = "98aa6dc8717b372ab34ebe3247262379d4e33799", default-features = false, features = ["tls-rustls"] }
+geneva-uploader = { git = "https://github.com/open-telemetry/opentelemetry-rust-contrib.git", rev = "75a2b0ad0e19ecb1322c3c2095dc6e69a2de7e9d", default-features = false, features = ["tls-rustls"] }
 # Pinned to a rev containing upstream resource detector work. Swap to a published version once
 # contrib cuts one.
 opentelemetry-resource-detectors = { git = "https://github.com/open-telemetry/opentelemetry-rust-contrib.git", rev = "4f5296b92b2a8e50d2078e011fa04371b69a5cf6" }

--- a/rust/otap-dataflow/crates/contrib-nodes/Cargo.toml
+++ b/rust/otap-dataflow/crates/contrib-nodes/Cargo.toml
@@ -71,6 +71,7 @@ paste = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true, features = ["rustls-no-provider"] }
 sysinfo = { workspace = true, optional = true }
+url = { workspace = true, optional = true }
 urlencoding = { workspace = true, optional = true }
 
 [target.'cfg(target_env = "musl")'.dependencies]
@@ -146,6 +147,7 @@ clickhouse-exporter = [
 geneva-exporter = [
     "dep:geneva-uploader",
     "dep:opentelemetry-proto",
+    "dep:url",
 ]
 azure-monitor-exporter = [
     "dep:opentelemetry-proto",

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/README.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/README.md
@@ -73,6 +73,9 @@ The `attributes` object in each credential snapshot must use this shape:
 the ingestion endpoint through the credential snapshot's `endpoint` attribute.
 That attribute must be a non-empty absolute HTTPS URL with a host and cannot
 contain embedded credentials, a query string, or a fragment. The exporter
+canonicalizes it before use. The uploader uses that canonical value as both the
+upload base URL and the `endpoint=` query fallback when a token has no usable
+Endpoint claim. The exporter
 selects a non-empty string from `moniker_map` by the configured `account`,
 falling back only to an explicit `default`. A map containing neither key is
 rejected, even if it has a single entry. Empty or malformed routing is also
@@ -89,6 +92,10 @@ rotation cannot produce a mixed-generation token/routing pair. Subsequent
 uploads observe the new snapshot without reconstructing the exporter. Tokens
 with a known expiry must remain usable for more than 30 seconds; expired or
 near-expiry snapshots fail closed while the provider refreshes them.
+Credential lookup, including time waiting for another lookup to release the
+provider, is limited to five seconds. Provider futures must be cancellation-safe
+and should normally clone an already-published snapshot instead of performing
+network I/O.
 
 Capability bindings are checked when the exporter is created because the
 factory's earlier config-validation hook receives only the `config` object.

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/README.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/README.md
@@ -35,6 +35,35 @@ config:
   max_concurrent_uploads: 4
 ```
 
+### Agent-fed credentials
+
+When the embedding host supplies the Geneva token and routing metadata, bind
+both capabilities to the same host extension instance and use `agentfed`
+authentication:
+
+```yaml
+type: urn:microsoft:exporter:geneva
+capabilities:
+  bearer_token_provider: agent-auth
+  vendor_bundle: agent-auth
+config:
+  environment: production
+  account: "my-account"
+  namespace: "my-namespace"
+  config_major_version: 1
+  tenant: "my-tenant"
+  role_name: "df-engine"
+  role_instance: "instance-001"
+  auth:
+    type: agentfed
+  max_concurrent_uploads: 4
+```
+
+`endpoint` and `region` are not required in this mode because the host supplies
+the ingestion endpoint through `vendor_bundle`. The exporter selects a moniker
+from `moniker_map` by the configured `account`, then `default`, then a sole map
+entry. A map with multiple entries and no account/default match is rejected.
+
 ## Build df_engine with Geneva Exporter
 
 From the `otap-dataflow` directory:
@@ -70,7 +99,8 @@ You should see `urn:microsoft:exporter:geneva` in the Exporters list.
 ```yaml
 type: urn:microsoft:exporter:geneva
 config:
-  # Geneva endpoint and routing identity (all required).
+  # Geneva config-service endpoint and region are required for every
+  # authentication method except "agentfed".
   endpoint: "https://geneva.example.com"
   environment: production
   account: "my-account"
@@ -82,8 +112,8 @@ config:
   role_instance: "instance-001"
 
   # Authentication method. Other supported values are "certificate",
-  # "usermanagedidentity", "usermanagedidentitybyarmresourceid", and
-  # "workloadidentity".
+  # "usermanagedidentity", "usermanagedidentitybyarmresourceid",
+  # "workloadidentity", and "agentfed".
   auth:
     type: systemmanagedidentity
     msi_resource: "https://monitor.azure.com/"

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/README.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/README.md
@@ -38,7 +38,7 @@ config:
 ### Agent-fed credentials
 
 When the embedding host supplies the Geneva token and routing metadata, bind
-both capabilities to the same host extension instance and use `agentfed`
+both capabilities to the same configured host extension and use `agentfed`
 authentication:
 
 ```yaml
@@ -63,6 +63,8 @@ config:
 the ingestion endpoint through `vendor_bundle`. The exporter selects a moniker
 from `moniker_map` by the configured `account`, then `default`, then a sole map
 entry. A map with multiple entries and no account/default match is rejected.
+Capability bindings are checked when the exporter is created because the
+factory's earlier config-validation hook receives only the `config` object.
 
 ## Build df_engine with Geneva Exporter
 

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/README.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/README.md
@@ -65,6 +65,15 @@ from `moniker_map` by the configured `account`, then `default`, then a sole map
 entry. A map with multiple entries and no account/default match is rejected.
 Capability bindings are checked when the exporter is created because the
 factory's earlier config-validation hook receives only the `config` object.
+Capability factories create a clone for each consumer, so the host extension's
+clones must share one `Arc`-backed token and routing snapshot.
+
+The token and vendor bundle are separate capability reads and are not an atomic
+snapshot. A host rotation can therefore produce transiently mismatched
+token/routing pairs, which the exporter cannot identify by generation. The host
+and Geneva backend must make such pairs safe or reject them. A rejected upload
+causes the exporter to NACK the payload, allowing a configured retry to read
+the capabilities again; an accepted upload is ACKed normally.
 
 ## Build df_engine with Geneva Exporter
 

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/README.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/README.md
@@ -38,14 +38,12 @@ config:
 ### Agent-fed credentials
 
 When the embedding host supplies the Geneva token and routing metadata, bind
-both capabilities to the same configured host extension and use `agentfed`
-authentication:
+the combined credential-provider capability and use `agentfed` authentication:
 
 ```yaml
 type: urn:microsoft:exporter:geneva
 capabilities:
-  bearer_token_provider: agent-auth
-  vendor_bundle: agent-auth
+  agent_fed_credential_provider: agent-auth
 config:
   environment: production
   account: "my-account"
@@ -59,21 +57,46 @@ config:
   max_concurrent_uploads: 4
 ```
 
+The `attributes` object in each credential snapshot must use this shape:
+
+```json
+{
+  "endpoint": "https://ingest.example.com",
+  "moniker_map": {
+    "my-account": "my-moniker",
+    "default": "fallback-moniker"
+  }
+}
+```
+
 `endpoint` and `region` are not required in this mode because the host supplies
-the ingestion endpoint through `vendor_bundle`. The exporter selects a moniker
-from `moniker_map` by the configured `account`, then `default`, then a sole map
-entry. A map with multiple entries and no account/default match is rejected.
+the ingestion endpoint through the credential snapshot's `endpoint` attribute.
+That attribute must be a non-empty absolute HTTPS URL with a host and cannot
+contain embedded credentials, a query string, or a fragment. The exporter
+selects a non-empty string from `moniker_map` by the configured `account`,
+falling back only to an explicit `default`. A map containing neither key is
+rejected, even if it has a single entry. Empty or malformed routing is also
+rejected. If the configured account or `default` key exists with an invalid
+value, the snapshot is rejected instead of falling back to another entry. The
+selected moniker must be safe to use as one URL query value without additional
+encoding. Surrounding whitespace is trimmed; the remaining value may contain
+only ASCII letters, digits, hyphen, dot, underscore, and tilde. Embedded
+whitespace, non-ASCII text, and reserved delimiters are rejected.
+
+The provider must load the token and routing attributes from one atomically
+published host snapshot. Each upload consumes one immutable snapshot, so a host
+rotation cannot produce a mixed-generation token/routing pair. Subsequent
+uploads observe the new snapshot without reconstructing the exporter. Tokens
+with a known expiry must remain usable for more than 30 seconds; expired or
+near-expiry snapshots fail closed while the provider refreshes them.
+
 Capability bindings are checked when the exporter is created because the
 factory's earlier config-validation hook receives only the `config` object.
 Capability factories create a clone for each consumer, so the host extension's
-clones must share one `Arc`-backed token and routing snapshot.
-
-The token and vendor bundle are separate capability reads and are not an atomic
-snapshot. A host rotation can therefore produce transiently mismatched
-token/routing pairs, which the exporter cannot identify by generation. The host
-and Geneva backend must make such pairs safe or reject them. A rejected upload
-causes the exporter to NACK the payload, allowing a configured retry to read
-the capabilities again; an accepted upload is ACKed normally.
+clones must share the same atomically swapped snapshot state. The host extension
+must register `agent_fed_credential_provider` for the shared execution model;
+a local-only registration cannot satisfy the uploader's thread-safe credential
+source.
 
 ## Build df_engine with Geneva Exporter
 

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/agent_fed_source.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/agent_fed_source.rs
@@ -10,7 +10,7 @@
 use geneva_uploader::client::{
     AgentFedCredential, AgentFedCredentialFuture, AgentFedCredentialSource,
 };
-use otap_df_engine::shared::capability::bearer_token_provider::BearerTokenProvider;
+use otap_df_engine::shared::capability::auth::bearer_token_provider::BearerTokenProvider;
 use otap_df_engine::shared::capability::vendor_bundle::VendorBundle;
 use otap_df_telemetry::otel_warn;
 use serde_json::{Map, Value};
@@ -186,8 +186,10 @@ mod tests {
     use super::*;
     use async_trait::async_trait;
     use futures::StreamExt;
-    use otap_df_engine::capability::bearer_token_provider::BearerTokenProvider as BearerTokenProviderCap;
-    use otap_df_engine::capability::bearer_token_provider::{BearerToken, TokenStream};
+    use otap_df_engine::capability::auth::BearerToken;
+    use otap_df_engine::capability::auth::bearer_token_provider::{
+        BearerTokenProvider as BearerTokenProviderCap, TokenStream,
+    };
     use otap_df_engine::capability::vendor_bundle::VendorBundle as VendorBundleCap;
     use otap_df_engine::capability::{CapabilityError, CapabilityErrorSource};
     use serde_json::{Map, Value, json};
@@ -207,7 +209,7 @@ mod tests {
                 // would drop the result here.
                 tokio::task::yield_now().await;
             }
-            Ok(BearerToken::new(self.token.clone(), None))
+            Ok(BearerToken::without_expiry(self.token.clone()))
         }
         fn token_stream(&self) -> TokenStream {
             futures::stream::empty::<BearerToken>().boxed()
@@ -392,7 +394,7 @@ mod tests {
     impl BearerTokenProvider for RotatingBearer {
         async fn get_token(&self) -> Result<BearerToken, CapabilityError> {
             let sequence = self.0.fetch_add(1, Ordering::Relaxed) + 1;
-            Ok(BearerToken::new(format!("token-{sequence}"), None))
+            Ok(BearerToken::without_expiry(format!("token-{sequence}")))
         }
 
         fn token_stream(&self) -> TokenStream {

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/agent_fed_source.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/agent_fed_source.rs
@@ -1,0 +1,206 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Agent-fed credential adapter for the Geneva exporter.
+//!
+//! Bridges the agent-fed `bearer_token_provider` + `vendor_bundle` capabilities
+//! to geneva-uploader's [`AgentFedCredentialSource`], so the uploader uses the
+//! host-provisioned token and routing instead of the GCS handshake.
+
+use geneva_uploader::client::{
+    AgentFedCredential, AgentFedCredentialFuture, AgentFedCredentialSource,
+};
+use otap_df_engine::shared::capability::bearer_token_provider::BearerTokenProvider;
+use otap_df_engine::shared::capability::vendor_bundle::VendorBundle;
+use serde_json::Value;
+use tokio::sync::Mutex;
+
+/// Adapts the agent-fed bearer-token + vendor-bundle capabilities to
+/// geneva-uploader's agent-fed credential source.
+///
+/// The resolved `shared` trait objects are `Send` but not `Sync`; a
+/// [`tokio::sync::Mutex`] restores `Sync` and lets reads await under a `Send`
+/// guard (satisfying `AgentFedCredentialSource: Send + Sync`).
+pub(crate) struct AgentFedGenevaSource {
+    bearer: Mutex<Box<dyn BearerTokenProvider>>,
+    vendor: Mutex<Box<dyn VendorBundle>>,
+}
+
+impl std::fmt::Debug for AgentFedGenevaSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("AgentFedGenevaSource")
+    }
+}
+
+impl AgentFedGenevaSource {
+    /// Builds the adapter from the resolved shared capabilities.
+    pub(crate) fn new(bearer: Box<dyn BearerTokenProvider>, vendor: Box<dyn VendorBundle>) -> Self {
+        Self {
+            bearer: Mutex::new(bearer),
+            vendor: Mutex::new(vendor),
+        }
+    }
+}
+
+impl AgentFedCredentialSource for AgentFedGenevaSource {
+    fn current(&self) -> AgentFedCredentialFuture<'_> {
+        Box::pin(async move {
+            // Await the token so a cache-miss credential call completes (not dropped).
+            let token = match self.bearer.lock().await.get_token().await {
+                Ok(t) => t.expose_token().to_owned(),
+                Err(_) => return None,
+            };
+            if token.is_empty() {
+                return None;
+            }
+
+            let attributes = match self.vendor.lock().await.attributes() {
+                Ok(a) => a,
+                Err(_) => return None,
+            };
+            let endpoint = attributes
+                .get("endpoint")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_owned();
+            let monitoring_endpoint = attributes
+                .get("telemetry_endpoint")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_owned();
+            // Prefer "default"; else the lowest key (deterministic).
+            let moniker = attributes
+                .get("moniker_map")
+                .and_then(Value::as_object)
+                .and_then(|m| {
+                    m.get("default")
+                        .or_else(|| m.keys().min().and_then(|k| m.get(k)))
+                })
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_owned();
+
+            // Fail closed on partial routing; the host reseeds when ready.
+            if endpoint.is_empty() || moniker.is_empty() {
+                return None;
+            }
+
+            Some(AgentFedCredential {
+                token,
+                endpoint,
+                moniker,
+                monitoring_endpoint,
+            })
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use futures::StreamExt;
+    use otap_df_engine::capability::CapabilityError;
+    use otap_df_engine::capability::bearer_token_provider::{BearerToken, TokenStream};
+    use serde_json::{Map, Value, json};
+    use std::sync::Arc;
+
+    struct MockBearer {
+        token: String,
+        yield_first: bool,
+    }
+
+    #[async_trait]
+    impl BearerTokenProvider for MockBearer {
+        async fn get_token(&self) -> Result<BearerToken, CapabilityError> {
+            if self.yield_first {
+                // Force the future to be pending once; a `now_or_never` poll
+                // would drop the result here.
+                tokio::task::yield_now().await;
+            }
+            Ok(BearerToken::new(self.token.clone(), None))
+        }
+        fn token_stream(&self) -> TokenStream {
+            futures::stream::empty::<BearerToken>().boxed()
+        }
+    }
+
+    struct MockVendor(Arc<Map<String, Value>>);
+
+    impl VendorBundle for MockVendor {
+        fn attributes(&self) -> Result<Arc<Map<String, Value>>, CapabilityError> {
+            Ok(self.0.clone())
+        }
+    }
+
+    fn obj(v: Value) -> Arc<Map<String, Value>> {
+        Arc::new(v.as_object().cloned().unwrap_or_default())
+    }
+
+    fn source(token: &str, yield_first: bool, attrs: Value) -> AgentFedGenevaSource {
+        AgentFedGenevaSource::new(
+            Box::new(MockBearer {
+                token: token.to_owned(),
+                yield_first,
+            }),
+            Box::new(MockVendor(obj(attrs))),
+        )
+    }
+
+    fn full_attrs() -> Value {
+        json!({
+            "endpoint": "https://ep",
+            "telemetry_endpoint": "https://tel",
+            "moniker_map": { "default": "mon" },
+        })
+    }
+
+    #[tokio::test]
+    async fn returns_credential_when_token_and_routing_present() {
+        let s = source("tok", false, full_attrs());
+        let c = s.current().await.expect("credential");
+        assert_eq!(c.token, "tok");
+        assert_eq!(c.endpoint, "https://ep");
+        assert_eq!(c.monitoring_endpoint, "https://tel");
+        assert_eq!(c.moniker, "mon");
+    }
+
+    #[tokio::test]
+    async fn awaits_pending_provider_future() {
+        // Regression for the old `now_or_never()`: a provider whose future is
+        // not immediately ready must still yield a credential.
+        let s = source("tok", true, full_attrs());
+        assert!(s.current().await.is_some());
+    }
+
+    #[tokio::test]
+    async fn fails_closed_on_empty_token() {
+        let s = source("", false, full_attrs());
+        assert!(s.current().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn fails_closed_on_missing_endpoint() {
+        let attrs = json!({ "moniker_map": { "default": "mon" } });
+        let s = source("tok", false, attrs);
+        assert!(s.current().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn fails_closed_on_missing_moniker() {
+        let attrs = json!({ "endpoint": "https://ep" });
+        let s = source("tok", false, attrs);
+        assert!(s.current().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn moniker_prefers_default_then_lowest_key() {
+        // No "default": the lowest key wins, deterministically.
+        let attrs = json!({
+            "endpoint": "https://ep",
+            "moniker_map": { "b": "mb", "a": "ma" },
+        });
+        let s = source("tok", false, attrs);
+        assert_eq!(s.current().await.unwrap().moniker, "ma");
+    }
+}

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/agent_fed_source.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/agent_fed_source.rs
@@ -24,6 +24,7 @@ const MONIKER_MAP_KEY: &str = "moniker_map";
 const DEFAULT_MONIKER_KEY: &str = "default";
 const TOKEN_USABLE_MARGIN: Duration = Duration::from_secs(30);
 
+// TODO: Move this reusable failure-log sampling helper to `crates/telemetry`.
 #[derive(Default)]
 struct FailureLogLimiter {
     consecutive_failures: AtomicU64,

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/agent_fed_source.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/agent_fed_source.rs
@@ -3,23 +3,26 @@
 
 //! Agent-fed credential adapter for the Geneva exporter.
 //!
-//! Bridges the agent-fed `bearer_token_provider` + `vendor_bundle` capabilities
-//! to geneva-uploader's [`AgentFedCredentialSource`], so the uploader uses the
-//! host-provisioned token and routing instead of the GCS handshake.
+//! Bridges the atomic engine
+//! `agent_fed_credential_provider` capability to geneva-uploader's
+//! [`AgentFedCredentialSource`], so the uploader uses the host-provisioned token
+//! and routing instead of the GCS handshake.
 
 use geneva_uploader::client::{
     AgentFedCredential, AgentFedCredentialFuture, AgentFedCredentialSource,
 };
-use otap_df_engine::shared::capability::auth::bearer_token_provider::BearerTokenProvider;
-use otap_df_engine::shared::capability::vendor_bundle::VendorBundle;
+use otap_df_engine::shared::capability::auth::agent_fed_credential_provider::AgentFedCredentialProvider;
 use otap_df_telemetry::otel_warn;
 use serde_json::{Map, Value};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
+use url::Url;
 
 const ENDPOINT_KEY: &str = "endpoint";
 const MONIKER_MAP_KEY: &str = "moniker_map";
 const DEFAULT_MONIKER_KEY: &str = "default";
+const TOKEN_USABLE_MARGIN: Duration = Duration::from_secs(30);
 
 #[derive(Default)]
 struct FailureLogLimiter {
@@ -41,19 +44,17 @@ impl FailureLogLimiter {
     }
 }
 
-/// Adapts the agent-fed bearer-token + vendor-bundle capabilities to
-/// geneva-uploader's agent-fed credential source.
+/// Adapts the engine's atomic agent-fed credential capability to the uploader.
 ///
-/// The resolved `shared` trait objects are `Send` but not `Sync`; a
+/// The resolved `shared` trait object is `Send` but not necessarily `Sync`; a
 /// [`tokio::sync::Mutex`] restores `Sync` and lets reads await under a `Send`
 /// guard (satisfying `AgentFedCredentialSource: Send + Sync`).
 pub(crate) struct AgentFedGenevaSource {
-    bearer: Mutex<Box<dyn BearerTokenProvider>>,
-    vendor: Mutex<Box<dyn VendorBundle>>,
+    credential_provider: Mutex<Box<dyn AgentFedCredentialProvider>>,
     account: String,
-    bearer_failures: FailureLogLimiter,
-    vendor_failures: FailureLogLimiter,
+    credential_failures: FailureLogLimiter,
     empty_token_failures: FailureLogLimiter,
+    expiry_failures: FailureLogLimiter,
     routing_failures: FailureLogLimiter,
 }
 
@@ -64,19 +65,17 @@ impl std::fmt::Debug for AgentFedGenevaSource {
 }
 
 impl AgentFedGenevaSource {
-    /// Builds the adapter from the resolved shared capabilities.
+    /// Builds the adapter from the resolved shared capability.
     pub(crate) fn new(
-        bearer: Box<dyn BearerTokenProvider>,
-        vendor: Box<dyn VendorBundle>,
+        credential_provider: Box<dyn AgentFedCredentialProvider>,
         account: String,
     ) -> Self {
         Self {
-            bearer: Mutex::new(bearer),
-            vendor: Mutex::new(vendor),
+            credential_provider: Mutex::new(credential_provider),
             account,
-            bearer_failures: FailureLogLimiter::default(),
-            vendor_failures: FailureLogLimiter::default(),
+            credential_failures: FailureLogLimiter::default(),
             empty_token_failures: FailureLogLimiter::default(),
+            expiry_failures: FailureLogLimiter::default(),
             routing_failures: FailureLogLimiter::default(),
         }
     }
@@ -95,19 +94,15 @@ impl AgentFedGenevaSource {
 impl AgentFedCredentialSource for AgentFedGenevaSource {
     fn current(&self) -> AgentFedCredentialFuture<'_> {
         Box::pin(async move {
-            // Await the token so a cache-miss credential call completes (not dropped).
-            let token = match self.bearer.lock().await.get_token().await {
-                Ok(token) => {
-                    self.bearer_failures.record_success();
-                    // The uploader credential owns a String, so this is the
-                    // required plaintext copy at the adapter boundary. Its
-                    // Debug implementation redacts the token.
-                    token.expose_token().to_owned()
+            let snapshot = match self.credential_provider.lock().await.get_credential().await {
+                Ok(snapshot) => {
+                    self.credential_failures.record_success();
+                    snapshot
                 }
                 Err(error) => {
-                    if let Some(consecutive_failures) = self.bearer_failures.record_failure() {
+                    if let Some(consecutive_failures) = self.credential_failures.record_failure() {
                         otel_warn!(
-                            "geneva_exporter.agent_fed.bearer_token_unavailable",
+                            "geneva_exporter.agent_fed.credential_unavailable",
                             error = %error,
                             consecutive_failures = consecutive_failures
                         );
@@ -115,7 +110,8 @@ impl AgentFedCredentialSource for AgentFedGenevaSource {
                     return None;
                 }
             };
-            if token.trim().is_empty() {
+            let token = snapshot.token();
+            if token.expose_token().trim().is_empty() {
                 Self::log_invalid_credential(
                     &self.empty_token_failures,
                     "bearer token is empty or whitespace",
@@ -123,24 +119,19 @@ impl AgentFedCredentialSource for AgentFedGenevaSource {
                 return None;
             }
             self.empty_token_failures.record_success();
+            if token
+                .expires_on()
+                .is_some_and(|expires_on| expires_on <= Instant::now() + TOKEN_USABLE_MARGIN)
+            {
+                Self::log_invalid_credential(
+                    &self.expiry_failures,
+                    "bearer token is expired or near expiry",
+                );
+                return None;
+            }
+            self.expiry_failures.record_success();
 
-            let attributes = match self.vendor.lock().await.attributes() {
-                Ok(attributes) => {
-                    self.vendor_failures.record_success();
-                    attributes
-                }
-                Err(error) => {
-                    if let Some(consecutive_failures) = self.vendor_failures.record_failure() {
-                        otel_warn!(
-                            "geneva_exporter.agent_fed.vendor_bundle_unavailable",
-                            error = %error,
-                            consecutive_failures = consecutive_failures
-                        );
-                    }
-                    return None;
-                }
-            };
-            let (endpoint, moniker) = match resolve_routing(&attributes, &self.account) {
+            let (endpoint, moniker) = match resolve_routing(snapshot.attributes(), &self.account) {
                 Ok(routing) => {
                     self.routing_failures.record_success();
                     routing
@@ -151,11 +142,13 @@ impl AgentFedCredentialSource for AgentFedGenevaSource {
                 }
             };
 
-            Some(AgentFedCredential {
-                token,
-                endpoint: endpoint.to_owned(),
-                moniker: moniker.to_owned(),
-            })
+            // Keep the engine token secret-wrapped across the routing lookup;
+            // the uploader creates its zeroizing owned copy only after success.
+            Some(AgentFedCredential::new(
+                token.expose_token(),
+                endpoint,
+                moniker,
+            ))
         })
     }
 }
@@ -167,30 +160,71 @@ fn non_blank_string(value: Option<&Value>) -> Option<&str> {
         .filter(|value| !value.is_empty())
 }
 
+fn validated_moniker<'a>(
+    value: Option<&'a Value>,
+    invalid_reason: &'static str,
+) -> Result<&'a str, &'static str> {
+    let moniker = non_blank_string(value).ok_or(invalid_reason)?;
+    if !moniker
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~'))
+    {
+        return Err(
+            "agent-fed routing selected moniker must contain only ASCII URL-unreserved characters",
+        );
+    }
+    Ok(moniker)
+}
+
+fn validated_endpoint(value: Option<&Value>) -> Result<&str, &'static str> {
+    let endpoint =
+        non_blank_string(value).ok_or("agent-fed routing endpoint is missing or empty")?;
+    let parsed = Url::parse(endpoint)
+        .map_err(|_| "agent-fed routing endpoint is not a valid absolute URL")?;
+
+    if parsed.scheme() != "https" {
+        return Err("agent-fed routing endpoint must use https");
+    }
+    if parsed.host_str().is_none() {
+        return Err("agent-fed routing endpoint must include a host");
+    }
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err("agent-fed routing endpoint must not include credentials");
+    }
+    if parsed.query().is_some() || parsed.fragment().is_some() {
+        return Err("agent-fed routing endpoint must not include a query or fragment");
+    }
+
+    Ok(endpoint)
+}
+
 fn resolve_routing<'a>(
     attributes: &'a Map<String, Value>,
     account: &str,
 ) -> Result<(&'a str, &'a str), &'static str> {
-    let endpoint = non_blank_string(attributes.get(ENDPOINT_KEY))
-        .ok_or("vendor bundle endpoint is missing or empty")?;
+    let endpoint = validated_endpoint(attributes.get(ENDPOINT_KEY))?;
     let moniker_map = attributes
         .get(MONIKER_MAP_KEY)
         .and_then(Value::as_object)
-        .ok_or("vendor bundle moniker_map is missing or invalid")?;
+        .ok_or("agent-fed routing moniker_map is missing or invalid")?;
 
     let account = account.trim();
     let moniker = if let Some(value) = moniker_map.get(account) {
-        non_blank_string(Some(value))
-            .ok_or("vendor bundle moniker for the configured account is invalid or empty")?
+        validated_moniker(
+            Some(value),
+            "agent-fed routing moniker for the configured account is invalid or empty",
+        )?
     } else if let Some(value) = moniker_map.get(DEFAULT_MONIKER_KEY) {
-        non_blank_string(Some(value)).ok_or("vendor bundle default moniker is invalid or empty")?
-    } else if moniker_map.len() == 1 {
-        non_blank_string(moniker_map.values().next())
-            .ok_or("vendor bundle sole moniker is invalid or empty")?
+        validated_moniker(
+            Some(value),
+            "agent-fed routing default moniker is invalid or empty",
+        )?
     } else if moniker_map.is_empty() {
-        return Err("vendor bundle moniker_map is empty");
+        return Err("agent-fed routing moniker_map is empty");
     } else {
-        return Err("vendor bundle moniker_map is ambiguous for the configured account");
+        return Err(
+            "agent-fed routing moniker_map has no entry for the configured account or default",
+        );
     };
 
     Ok((endpoint, moniker))
@@ -200,42 +234,31 @@ fn resolve_routing<'a>(
 mod tests {
     use super::*;
     use async_trait::async_trait;
-    use futures::StreamExt;
     use otap_df_engine::capability::auth::BearerToken;
-    use otap_df_engine::capability::auth::bearer_token_provider::{
-        BearerTokenProvider as BearerTokenProviderCap, TokenStream,
+    use otap_df_engine::capability::auth::agent_fed_credential_provider::{
+        AgentFedCredentialProvider as AgentFedCredentialProviderCap, AgentFedCredentialSnapshot,
     };
-    use otap_df_engine::capability::vendor_bundle::VendorBundle as VendorBundleCap;
     use otap_df_engine::capability::{CapabilityError, CapabilityErrorSource};
     use serde_json::{Map, Value, json};
-    use std::sync::Arc;
     use std::sync::atomic::AtomicUsize;
+    use std::sync::{Arc, RwLock};
 
-    struct MockBearer {
-        token: String,
+    struct MockCredential {
+        token: BearerToken,
         yield_first: bool,
+        attributes: Arc<Map<String, Value>>,
     }
 
     #[async_trait]
-    impl BearerTokenProvider for MockBearer {
-        async fn get_token(&self) -> Result<BearerToken, CapabilityError> {
+    impl AgentFedCredentialProvider for MockCredential {
+        async fn get_credential(&self) -> Result<Arc<AgentFedCredentialSnapshot>, CapabilityError> {
             if self.yield_first {
-                // Force the future to be pending once; a `now_or_never` poll
-                // would drop the result here.
                 tokio::task::yield_now().await;
             }
-            Ok(BearerToken::without_expiry(self.token.clone()))
-        }
-        fn token_stream(&self) -> TokenStream {
-            futures::stream::empty::<BearerToken>().boxed()
-        }
-    }
-
-    struct MockVendor(Arc<Map<String, Value>>);
-
-    impl VendorBundle for MockVendor {
-        fn attributes(&self) -> Result<Arc<Map<String, Value>>, CapabilityError> {
-            Ok(self.0.clone())
+            Ok(Arc::new(AgentFedCredentialSnapshot::new(
+                self.token.clone(),
+                Arc::clone(&self.attributes),
+            )))
         }
     }
 
@@ -253,12 +276,26 @@ mod tests {
         attrs: Value,
         account: &str,
     ) -> AgentFedGenevaSource {
+        source_with_token(
+            BearerToken::without_expiry(token.to_owned()),
+            yield_first,
+            attrs,
+            account,
+        )
+    }
+
+    fn source_with_token(
+        token: BearerToken,
+        yield_first: bool,
+        attrs: Value,
+        account: &str,
+    ) -> AgentFedGenevaSource {
         AgentFedGenevaSource::new(
-            Box::new(MockBearer {
-                token: token.to_owned(),
+            Box::new(MockCredential {
+                token,
                 yield_first,
+                attributes: obj(attrs),
             }),
-            Box::new(MockVendor(obj(attrs))),
             account.to_owned(),
         )
     }
@@ -270,18 +307,18 @@ mod tests {
         })
     }
 
-    /// Scenario: The provider returns a token and the bundle contains valid routing.
+    /// Scenario: The provider returns a snapshot containing valid token and routing data.
     /// Guarantees: The adapter returns the exact token, endpoint, and moniker.
     #[tokio::test]
     async fn returns_credential_when_token_and_routing_present() {
         let s = source("tok", false, full_attrs());
         let c = s.current().await.expect("credential");
-        assert_eq!(c.token, "tok");
+        assert_eq!(c.expose_token(), "tok");
         assert_eq!(c.endpoint, "https://ep");
         assert_eq!(c.moniker, "mon");
     }
 
-    /// Scenario: The token provider future yields once before returning a token.
+    /// Scenario: The credential-provider future yields once before returning a snapshot.
     /// Guarantees: The adapter awaits the future instead of dropping a pending result.
     #[tokio::test]
     async fn awaits_pending_provider_future() {
@@ -307,7 +344,33 @@ mod tests {
         assert!(s.current().await.is_none());
     }
 
-    /// Scenario: The vendor bundle omits the ingestion endpoint.
+    /// Scenario: A credential token is expired, near expiry, or comfortably usable.
+    /// Guarantees: Uploads reject tokens inside the safety margin and accept later expiry.
+    #[tokio::test]
+    async fn token_expiry_enforces_safety_margin() {
+        for expires_on in [Instant::now(), Instant::now() + TOKEN_USABLE_MARGIN] {
+            let s = source_with_token(
+                BearerToken::with_expiry("tok".to_owned(), Some(expires_on)),
+                false,
+                full_attrs(),
+                "account",
+            );
+            assert!(s.current().await.is_none());
+        }
+
+        let s = source_with_token(
+            BearerToken::with_expiry(
+                "tok".to_owned(),
+                Some(Instant::now() + TOKEN_USABLE_MARGIN + Duration::from_secs(60)),
+            ),
+            false,
+            full_attrs(),
+            "account",
+        );
+        assert!(s.current().await.is_some());
+    }
+
+    /// Scenario: The credential snapshot omits the ingestion endpoint.
     /// Guarantees: Missing endpoint routing causes the adapter to fail closed.
     #[tokio::test]
     async fn fails_closed_on_missing_endpoint() {
@@ -343,13 +406,91 @@ mod tests {
         );
     }
 
-    /// Scenario: The vendor bundle omits the moniker map.
+    /// Scenario: The credential snapshot supplies an unsafe or malformed ingestion endpoint.
+    /// Guarantees: Only absolute HTTPS endpoints without credentials, queries, or fragments pass.
+    #[tokio::test]
+    async fn fails_closed_on_invalid_endpoint_urls() {
+        for endpoint in [
+            "not a url",
+            "http://ep",
+            "https://user:password@ep",
+            "https://ep?query=value",
+            "https://ep#fragment",
+        ] {
+            let attrs = json!({
+                "endpoint": endpoint,
+                "moniker_map": { "default": "mon" },
+            });
+            assert!(
+                source("tok", false, attrs).current().await.is_none(),
+                "endpoint should be rejected: {endpoint}"
+            );
+        }
+    }
+
+    /// Scenario: The credential snapshot omits the moniker map.
     /// Guarantees: Missing moniker routing causes the adapter to fail closed.
     #[tokio::test]
     async fn fails_closed_on_missing_moniker() {
         let attrs = json!({ "endpoint": "https://ep" });
         let s = source("tok", false, attrs);
         assert!(s.current().await.is_none());
+    }
+
+    /// Scenario: The moniker map is empty or is not a JSON object.
+    /// Guarantees: Malformed routing cannot produce an uploader credential.
+    #[tokio::test]
+    async fn fails_closed_on_invalid_moniker_map_shapes() {
+        for moniker_map in [json!({}), json!(["not", "an", "object"])] {
+            let attrs = json!({
+                "endpoint": "https://ep",
+                "moniker_map": moniker_map,
+            });
+            assert!(source("tok", false, attrs).current().await.is_none());
+        }
+    }
+
+    /// Scenario: The selected moniker contains bytes that require URL encoding.
+    /// Guarantees: Reserved, whitespace, and non-ASCII values cannot alter the upload query.
+    #[tokio::test]
+    async fn fails_closed_on_monikers_requiring_url_encoding() {
+        for moniker in [
+            "moniker&namespace=other",
+            "moniker#fragment",
+            "moniker with space",
+            "moniker%26encoded",
+            "moniker*reserved",
+            "moniker/non-ascii-\u{00e9}",
+        ] {
+            let attrs = json!({
+                "endpoint": "https://ep",
+                "moniker_map": { "default": moniker },
+            });
+            assert!(
+                source("tok", false, attrs).current().await.is_none(),
+                "moniker should be rejected: {moniker}"
+            );
+        }
+    }
+
+    /// Scenario: The selected moniker uses every supported URL-safe character class.
+    /// Guarantees: ASCII letters, digits, hyphen, dot, underscore, and tilde remain valid.
+    #[tokio::test]
+    async fn accepts_ascii_url_unreserved_moniker() {
+        let moniker = "AZaz09-._~";
+        let attrs = json!({
+            "endpoint": "https://ep",
+            "moniker_map": { "default": moniker },
+        });
+
+        assert_eq!(
+            source("tok", false, attrs)
+                .current()
+                .await
+                .expect("credential")
+                .moniker,
+            moniker
+        );
     }
 
     /// Scenario: The map contains both account-specific and default monikers.
@@ -382,37 +523,55 @@ mod tests {
         assert_eq!(s.current().await.unwrap().moniker, "default-moniker");
     }
 
-    /// Scenario: The map has one non-default entry and no account match.
-    /// Guarantees: A sole unambiguous entry is accepted as the moniker.
+    /// Scenario: The map has one unrelated entry and no account or default match.
+    /// Guarantees: A sole unrelated entry is rejected instead of selected implicitly.
     #[tokio::test]
-    async fn moniker_falls_back_to_sole_entry() {
+    async fn fails_closed_on_sole_unmatched_moniker() {
         let attrs = json!({
             "endpoint": "https://ep",
             "moniker_map": { "only": "sole-moniker" },
         });
         let s = source("tok", false, attrs);
-        assert_eq!(s.current().await.unwrap().moniker, "sole-moniker");
+        assert!(s.current().await.is_none());
     }
 
-    /// Scenario: The account-specific entry is present but malformed.
-    /// Guarantees: Invalid account routing fails instead of silently using default.
+    /// Scenario: An explicitly selected account or default entry is malformed.
+    /// Guarantees: Invalid selected routing fails instead of using another map entry.
     #[tokio::test]
-    async fn invalid_account_moniker_does_not_fall_back_to_default() {
-        let attrs = json!({
+    async fn invalid_selected_moniker_does_not_fall_back() {
+        let invalid_account = json!({
             "endpoint": "https://ep",
             "moniker_map": {
                 "account": 42,
                 "default": "default-moniker"
             },
         });
-        let s = source("tok", false, attrs);
-        assert!(s.current().await.is_none());
+        assert!(
+            source("tok", false, invalid_account)
+                .current()
+                .await
+                .is_none()
+        );
+
+        let invalid_default = json!({
+            "endpoint": "https://ep",
+            "moniker_map": {
+                "default": 42,
+                "other": "other-moniker"
+            },
+        });
+        assert!(
+            source("tok", false, invalid_default)
+                .current()
+                .await
+                .is_none()
+        );
     }
 
-    /// Scenario: Multiple map entries exist with no account or default match.
-    /// Guarantees: Ambiguous routing is rejected instead of selecting arbitrarily.
+    /// Scenario: Multiple unrelated entries exist with no account or default match.
+    /// Guarantees: Unmatched routing is rejected instead of selecting arbitrarily.
     #[tokio::test]
-    async fn fails_closed_on_ambiguous_moniker_map() {
+    async fn fails_closed_on_multiple_unmatched_monikers() {
         let attrs = json!({
             "endpoint": "https://ep",
             "moniker_map": { "b": "mb", "a": "ma" },
@@ -421,136 +580,151 @@ mod tests {
         assert!(s.current().await.is_none());
     }
 
-    struct ErrorBearer;
+    struct ErrorCredential;
 
     #[async_trait]
-    impl BearerTokenProvider for ErrorBearer {
-        async fn get_token(&self) -> Result<BearerToken, CapabilityError> {
-            Err(
-                CapabilityErrorSource::<BearerTokenProviderCap>::new("mock-bearer".into())
-                    .error("token unavailable"),
+    impl AgentFedCredentialProvider for ErrorCredential {
+        async fn get_credential(&self) -> Result<Arc<AgentFedCredentialSnapshot>, CapabilityError> {
+            Err(CapabilityErrorSource::<AgentFedCredentialProviderCap>::new(
+                "mock-credential".into(),
             )
-        }
-
-        fn token_stream(&self) -> TokenStream {
-            futures::stream::empty::<BearerToken>().boxed()
+            .error("credential unavailable"))
         }
     }
 
-    struct ErrorVendor;
-
-    impl VendorBundle for ErrorVendor {
-        fn attributes(&self) -> Result<Arc<Map<String, Value>>, CapabilityError> {
-            Err(
-                CapabilityErrorSource::<VendorBundleCap>::new("mock-vendor".into())
-                    .error("bundle unavailable"),
-            )
-        }
-    }
-
-    struct RecoveringBearer(AtomicUsize);
+    struct RecoveringCredential(AtomicUsize);
 
     #[async_trait]
-    impl BearerTokenProvider for RecoveringBearer {
-        async fn get_token(&self) -> Result<BearerToken, CapabilityError> {
+    impl AgentFedCredentialProvider for RecoveringCredential {
+        async fn get_credential(&self) -> Result<Arc<AgentFedCredentialSnapshot>, CapabilityError> {
             if self.0.fetch_add(1, Ordering::Relaxed) == 0 {
-                return Err(CapabilityErrorSource::<BearerTokenProviderCap>::new(
-                    "recovering-bearer".into(),
+                return Err(CapabilityErrorSource::<AgentFedCredentialProviderCap>::new(
+                    "recovering-credential".into(),
                 )
-                .error("token unavailable"));
+                .error("credential unavailable"));
             }
-            Ok(BearerToken::without_expiry("recovered-token".to_owned()))
-        }
-
-        fn token_stream(&self) -> TokenStream {
-            futures::stream::empty::<BearerToken>().boxed()
+            Ok(Arc::new(AgentFedCredentialSnapshot::new(
+                BearerToken::without_expiry("recovered-token".to_owned()),
+                obj(full_attrs()),
+            )))
         }
     }
 
-    struct RecoveringVendor(AtomicUsize);
-
-    impl VendorBundle for RecoveringVendor {
-        fn attributes(&self) -> Result<Arc<Map<String, Value>>, CapabilityError> {
-            if self.0.fetch_add(1, Ordering::Relaxed) == 0 {
-                return Err(CapabilityErrorSource::<VendorBundleCap>::new(
-                    "recovering-vendor".into(),
-                )
-                .error("bundle unavailable"));
-            }
-            Ok(obj(full_attrs()))
-        }
-    }
-
-    /// Scenario: The bearer-token capability reports an error.
+    /// Scenario: The atomic credential capability reports an error.
     /// Guarantees: Capability failure does not produce a partial credential.
     #[tokio::test]
-    async fn fails_closed_when_token_provider_errors() {
-        let source = AgentFedGenevaSource::new(
-            Box::new(ErrorBearer),
-            Box::new(MockVendor(obj(full_attrs()))),
-            "account".to_owned(),
-        );
+    async fn fails_closed_when_credential_provider_errors() {
+        let source = AgentFedGenevaSource::new(Box::new(ErrorCredential), "account".to_owned());
         assert!(source.current().await.is_none());
     }
 
-    /// Scenario: The vendor-bundle capability reports an error.
-    /// Guarantees: Routing failure does not produce a token-only credential.
+    /// Scenario: The credential provider recovers after an initial failure.
+    /// Guarantees: Subsequent reads recover without reconstructing the exporter.
     #[tokio::test]
-    async fn fails_closed_when_vendor_bundle_errors() {
+    async fn recovers_when_credential_becomes_available() {
         let source = AgentFedGenevaSource::new(
-            Box::new(MockBearer {
-                token: "tok".to_owned(),
-                yield_first: false,
-            }),
-            Box::new(ErrorVendor),
-            "account".to_owned(),
-        );
-        assert!(source.current().await.is_none());
-    }
-
-    /// Scenario: Token and bundle providers recover after initial failures.
-    /// Guarantees: Subsequent reads converge without reconstructing the exporter.
-    #[tokio::test]
-    async fn recovers_when_capabilities_become_available() {
-        let source = AgentFedGenevaSource::new(
-            Box::new(RecoveringBearer(AtomicUsize::new(0))),
-            Box::new(RecoveringVendor(AtomicUsize::new(0))),
+            Box::new(RecoveringCredential(AtomicUsize::new(0))),
             "account".to_owned(),
         );
 
-        assert!(source.current().await.is_none());
         assert!(source.current().await.is_none());
         let credential = source.current().await.expect("recovered credential");
-        assert_eq!(credential.token, "recovered-token");
+        assert_eq!(credential.expose_token(), "recovered-token");
         assert_eq!(credential.endpoint, "https://ep");
         assert_eq!(credential.moniker, "mon");
     }
 
-    struct RotatingBearer(AtomicUsize);
+    struct RotatingCredential(AtomicUsize);
 
     #[async_trait]
-    impl BearerTokenProvider for RotatingBearer {
-        async fn get_token(&self) -> Result<BearerToken, CapabilityError> {
+    impl AgentFedCredentialProvider for RotatingCredential {
+        async fn get_credential(&self) -> Result<Arc<AgentFedCredentialSnapshot>, CapabilityError> {
             let sequence = self.0.fetch_add(1, Ordering::Relaxed) + 1;
-            Ok(BearerToken::without_expiry(format!("token-{sequence}")))
-        }
-
-        fn token_stream(&self) -> TokenStream {
-            futures::stream::empty::<BearerToken>().boxed()
+            Ok(Arc::new(AgentFedCredentialSnapshot::new(
+                BearerToken::without_expiry(format!("token-{sequence}")),
+                obj(json!({
+                    "endpoint": format!("https://endpoint-{sequence}"),
+                    "moniker_map": { "default": format!("moniker-{sequence}") },
+                })),
+            )))
         }
     }
 
-    /// Scenario: The provider changes its cached bearer token between reads.
-    /// Guarantees: Every upload lookup observes the provider's current token.
+    /// Scenario: The provider rotates its complete credential snapshot.
+    /// Guarantees: Every lookup observes token and routing from one generation.
     #[tokio::test]
-    async fn observes_token_rotation_on_each_read() {
+    async fn observes_coherent_rotation_on_each_read() {
         let source = AgentFedGenevaSource::new(
-            Box::new(RotatingBearer(AtomicUsize::new(0))),
-            Box::new(MockVendor(obj(full_attrs()))),
+            Box::new(RotatingCredential(AtomicUsize::new(0))),
             "account".to_owned(),
         );
-        assert_eq!(source.current().await.unwrap().token, "token-1");
-        assert_eq!(source.current().await.unwrap().token, "token-2");
+
+        let first = source.current().await.expect("first credential");
+        assert_eq!(first.expose_token(), "token-1");
+        assert_eq!(first.endpoint, "https://endpoint-1");
+        assert_eq!(first.moniker, "moniker-1");
+
+        let second = source.current().await.expect("second credential");
+        assert_eq!(second.expose_token(), "token-2");
+        assert_eq!(second.endpoint, "https://endpoint-2");
+        assert_eq!(second.moniker, "moniker-2");
+    }
+
+    struct RotateAfterLoadCredential {
+        current: Arc<RwLock<Arc<AgentFedCredentialSnapshot>>>,
+        replacement: Arc<AgentFedCredentialSnapshot>,
+    }
+
+    #[async_trait]
+    impl AgentFedCredentialProvider for RotateAfterLoadCredential {
+        async fn get_credential(&self) -> Result<Arc<AgentFedCredentialSnapshot>, CapabilityError> {
+            let loaded = {
+                let mut current = self.current.write().expect("snapshot write lock");
+                let loaded = Arc::clone(&current);
+                *current = Arc::clone(&self.replacement);
+                loaded
+            };
+            tokio::task::yield_now().await;
+            Ok(loaded)
+        }
+    }
+
+    fn snapshot(token: &str, endpoint: &str, moniker: &str) -> Arc<AgentFedCredentialSnapshot> {
+        Arc::new(AgentFedCredentialSnapshot::new(
+            BearerToken::without_expiry(token.to_owned()),
+            obj(json!({
+                "endpoint": endpoint,
+                "moniker_map": { "default": moniker },
+            })),
+        ))
+    }
+
+    /// Scenario: Host state rotates after the provider atomically loads a snapshot.
+    /// Guarantees: The in-flight read returns one complete generation, never a mixed pair.
+    #[tokio::test]
+    async fn rotation_during_read_preserves_atomic_snapshot() {
+        let before = snapshot(
+            "token-before-rotation",
+            "https://endpoint-before-rotation",
+            "moniker-before-rotation",
+        );
+        let after = snapshot(
+            "token-after-rotation",
+            "https://endpoint-after-rotation",
+            "moniker-after-rotation",
+        );
+        let source = AgentFedGenevaSource::new(
+            Box::new(RotateAfterLoadCredential {
+                current: Arc::new(RwLock::new(before)),
+                replacement: Arc::clone(&after),
+            }),
+            "account".to_owned(),
+        );
+
+        let credential = source.current().await.expect("atomic credential");
+        assert_eq!(credential.expose_token(), "token-before-rotation");
+        assert_eq!(credential.endpoint, "https://endpoint-before-rotation");
+        assert_eq!(credential.moniker, "moniker-before-rotation");
     }
 
     /// Scenario: Credential failures continue and later recover.
@@ -566,14 +740,15 @@ mod tests {
         assert_eq!(limiter.record_failure(), Some(1));
     }
 
-    /// Scenario: Empty-token and routing validation fail independently.
-    /// Guarantees: One failure category cannot suppress another category's warning.
+    /// Scenario: Empty-token, expiry, and routing validation fail independently.
+    /// Guarantees: One invalid-data category cannot suppress another category's warning.
     #[test]
     fn failure_categories_are_sampled_independently() {
         let source = source("tok", false, full_attrs());
 
         assert_eq!(source.empty_token_failures.record_failure(), Some(1));
         assert_eq!(source.empty_token_failures.record_failure(), Some(2));
+        assert_eq!(source.expiry_failures.record_failure(), Some(1));
         assert_eq!(source.routing_failures.record_failure(), Some(1));
     }
 }

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/agent_fed_source.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/agent_fed_source.rs
@@ -12,8 +12,30 @@ use geneva_uploader::client::{
 };
 use otap_df_engine::shared::capability::bearer_token_provider::BearerTokenProvider;
 use otap_df_engine::shared::capability::vendor_bundle::VendorBundle;
-use serde_json::Value;
+use otap_df_telemetry::otel_warn;
+use serde_json::{Map, Value};
+use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::sync::Mutex;
+
+#[derive(Default)]
+struct FailureLogLimiter {
+    consecutive_failures: AtomicU64,
+}
+
+impl FailureLogLimiter {
+    fn record_success(&self) {
+        self.consecutive_failures.store(0, Ordering::Relaxed);
+    }
+
+    fn record_failure(&self) -> Option<u64> {
+        let count = self
+            .consecutive_failures
+            .fetch_add(1, Ordering::Relaxed)
+            .saturating_add(1);
+        // Log failures 1, 2, 4, 8, ... and reset after recovery.
+        count.is_power_of_two().then_some(count)
+    }
+}
 
 /// Adapts the agent-fed bearer-token + vendor-bundle capabilities to
 /// geneva-uploader's agent-fed credential source.
@@ -24,6 +46,10 @@ use tokio::sync::Mutex;
 pub(crate) struct AgentFedGenevaSource {
     bearer: Mutex<Box<dyn BearerTokenProvider>>,
     vendor: Mutex<Box<dyn VendorBundle>>,
+    account: String,
+    bearer_failures: FailureLogLimiter,
+    vendor_failures: FailureLogLimiter,
+    credential_failures: FailureLogLimiter,
 }
 
 impl std::fmt::Debug for AgentFedGenevaSource {
@@ -34,10 +60,28 @@ impl std::fmt::Debug for AgentFedGenevaSource {
 
 impl AgentFedGenevaSource {
     /// Builds the adapter from the resolved shared capabilities.
-    pub(crate) fn new(bearer: Box<dyn BearerTokenProvider>, vendor: Box<dyn VendorBundle>) -> Self {
+    pub(crate) fn new(
+        bearer: Box<dyn BearerTokenProvider>,
+        vendor: Box<dyn VendorBundle>,
+        account: String,
+    ) -> Self {
         Self {
             bearer: Mutex::new(bearer),
             vendor: Mutex::new(vendor),
+            account,
+            bearer_failures: FailureLogLimiter::default(),
+            vendor_failures: FailureLogLimiter::default(),
+            credential_failures: FailureLogLimiter::default(),
+        }
+    }
+
+    fn log_invalid_credential(&self, reason: &'static str) {
+        if let Some(consecutive_failures) = self.credential_failures.record_failure() {
+            otel_warn!(
+                "geneva_exporter.agent_fed.invalid_credential",
+                reason = reason,
+                consecutive_failures = consecutive_failures
+            );
         }
     }
 }
@@ -47,46 +91,94 @@ impl AgentFedCredentialSource for AgentFedGenevaSource {
         Box::pin(async move {
             // Await the token so a cache-miss credential call completes (not dropped).
             let token = match self.bearer.lock().await.get_token().await {
-                Ok(t) => t.expose_token().to_owned(),
-                Err(_) => return None,
+                Ok(token) => {
+                    self.bearer_failures.record_success();
+                    token.expose_token().to_owned()
+                }
+                Err(error) => {
+                    if let Some(consecutive_failures) = self.bearer_failures.record_failure() {
+                        otel_warn!(
+                            "geneva_exporter.agent_fed.bearer_token_unavailable",
+                            error = %error,
+                            consecutive_failures = consecutive_failures
+                        );
+                    }
+                    return None;
+                }
             };
             if token.is_empty() {
+                self.log_invalid_credential("bearer token is empty");
                 return None;
             }
 
             let attributes = match self.vendor.lock().await.attributes() {
-                Ok(a) => a,
-                Err(_) => return None,
+                Ok(attributes) => {
+                    self.vendor_failures.record_success();
+                    attributes
+                }
+                Err(error) => {
+                    if let Some(consecutive_failures) = self.vendor_failures.record_failure() {
+                        otel_warn!(
+                            "geneva_exporter.agent_fed.vendor_bundle_unavailable",
+                            error = %error,
+                            consecutive_failures = consecutive_failures
+                        );
+                    }
+                    return None;
+                }
             };
-            let endpoint = attributes
-                .get("endpoint")
-                .and_then(Value::as_str)
-                .unwrap_or_default()
-                .to_owned();
-            // Prefer "default"; else the lowest key (deterministic).
-            let moniker = attributes
-                .get("moniker_map")
-                .and_then(Value::as_object)
-                .and_then(|m| {
-                    m.get("default")
-                        .or_else(|| m.keys().min().and_then(|k| m.get(k)))
-                })
-                .and_then(Value::as_str)
-                .unwrap_or_default()
-                .to_owned();
-
-            // Fail closed on partial routing; the host reseeds when ready.
-            if endpoint.is_empty() || moniker.is_empty() {
-                return None;
-            }
+            let (endpoint, moniker) = match resolve_routing(&attributes, &self.account) {
+                Ok(routing) => {
+                    self.credential_failures.record_success();
+                    routing
+                }
+                Err(reason) => {
+                    self.log_invalid_credential(reason);
+                    return None;
+                }
+            };
 
             Some(AgentFedCredential {
                 token,
-                endpoint,
-                moniker,
+                endpoint: endpoint.to_owned(),
+                moniker: moniker.to_owned(),
             })
         })
     }
+}
+
+fn non_empty_string(value: Option<&Value>) -> Option<&str> {
+    value
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+}
+
+fn resolve_routing<'a>(
+    attributes: &'a Map<String, Value>,
+    account: &str,
+) -> Result<(&'a str, &'a str), &'static str> {
+    let endpoint = non_empty_string(attributes.get("endpoint"))
+        .ok_or("vendor bundle endpoint is missing or empty")?;
+    let moniker_map = attributes
+        .get("moniker_map")
+        .and_then(Value::as_object)
+        .ok_or("vendor bundle moniker_map is missing or invalid")?;
+
+    let moniker = non_empty_string(moniker_map.get(account))
+        .or_else(|| non_empty_string(moniker_map.get("default")))
+        .or_else(|| {
+            (moniker_map.len() == 1)
+                .then(|| moniker_map.values().next())
+                .flatten()
+                .and_then(|value| non_empty_string(Some(value)))
+        })
+        .ok_or(if moniker_map.len() > 1 {
+            "vendor bundle moniker_map is ambiguous for the configured account"
+        } else {
+            "vendor bundle moniker is missing or empty"
+        })?;
+
+    Ok((endpoint, moniker))
 }
 
 #[cfg(test)]
@@ -94,10 +186,13 @@ mod tests {
     use super::*;
     use async_trait::async_trait;
     use futures::StreamExt;
-    use otap_df_engine::capability::CapabilityError;
+    use otap_df_engine::capability::bearer_token_provider::BearerTokenProvider as BearerTokenProviderCap;
     use otap_df_engine::capability::bearer_token_provider::{BearerToken, TokenStream};
+    use otap_df_engine::capability::vendor_bundle::VendorBundle as VendorBundleCap;
+    use otap_df_engine::capability::{CapabilityError, CapabilityErrorSource};
     use serde_json::{Map, Value, json};
     use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
 
     struct MockBearer {
         token: String,
@@ -132,12 +227,22 @@ mod tests {
     }
 
     fn source(token: &str, yield_first: bool, attrs: Value) -> AgentFedGenevaSource {
+        source_for_account(token, yield_first, attrs, "account")
+    }
+
+    fn source_for_account(
+        token: &str,
+        yield_first: bool,
+        attrs: Value,
+        account: &str,
+    ) -> AgentFedGenevaSource {
         AgentFedGenevaSource::new(
             Box::new(MockBearer {
                 token: token.to_owned(),
                 yield_first,
             }),
             Box::new(MockVendor(obj(attrs))),
+            account.to_owned(),
         )
     }
 
@@ -186,13 +291,134 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn moniker_prefers_default_then_lowest_key() {
-        // No "default": the lowest key wins, deterministically.
+    async fn moniker_prefers_configured_account() {
+        let attrs = json!({
+            "endpoint": "https://ep",
+            "moniker_map": {
+                "account": "account-moniker",
+                "default": "default-moniker"
+            },
+        });
+        let s = source("tok", false, attrs);
+        assert_eq!(s.current().await.unwrap().moniker, "account-moniker");
+    }
+
+    #[tokio::test]
+    async fn moniker_falls_back_to_default() {
+        let attrs = json!({
+            "endpoint": "https://ep",
+            "moniker_map": {
+                "other": "other-moniker",
+                "default": "default-moniker"
+            },
+        });
+        let s = source("tok", false, attrs);
+        assert_eq!(s.current().await.unwrap().moniker, "default-moniker");
+    }
+
+    #[tokio::test]
+    async fn moniker_falls_back_to_sole_entry() {
+        let attrs = json!({
+            "endpoint": "https://ep",
+            "moniker_map": { "only": "sole-moniker" },
+        });
+        let s = source("tok", false, attrs);
+        assert_eq!(s.current().await.unwrap().moniker, "sole-moniker");
+    }
+
+    #[tokio::test]
+    async fn fails_closed_on_ambiguous_moniker_map() {
         let attrs = json!({
             "endpoint": "https://ep",
             "moniker_map": { "b": "mb", "a": "ma" },
         });
         let s = source("tok", false, attrs);
-        assert_eq!(s.current().await.unwrap().moniker, "ma");
+        assert!(s.current().await.is_none());
+    }
+
+    struct ErrorBearer;
+
+    #[async_trait]
+    impl BearerTokenProvider for ErrorBearer {
+        async fn get_token(&self) -> Result<BearerToken, CapabilityError> {
+            Err(
+                CapabilityErrorSource::<BearerTokenProviderCap>::new("mock-bearer".into())
+                    .error("token unavailable"),
+            )
+        }
+
+        fn token_stream(&self) -> TokenStream {
+            futures::stream::empty::<BearerToken>().boxed()
+        }
+    }
+
+    struct ErrorVendor;
+
+    impl VendorBundle for ErrorVendor {
+        fn attributes(&self) -> Result<Arc<Map<String, Value>>, CapabilityError> {
+            Err(
+                CapabilityErrorSource::<VendorBundleCap>::new("mock-vendor".into())
+                    .error("bundle unavailable"),
+            )
+        }
+    }
+
+    #[tokio::test]
+    async fn fails_closed_when_token_provider_errors() {
+        let source = AgentFedGenevaSource::new(
+            Box::new(ErrorBearer),
+            Box::new(MockVendor(obj(full_attrs()))),
+            "account".to_owned(),
+        );
+        assert!(source.current().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn fails_closed_when_vendor_bundle_errors() {
+        let source = AgentFedGenevaSource::new(
+            Box::new(MockBearer {
+                token: "tok".to_owned(),
+                yield_first: false,
+            }),
+            Box::new(ErrorVendor),
+            "account".to_owned(),
+        );
+        assert!(source.current().await.is_none());
+    }
+
+    struct RotatingBearer(AtomicUsize);
+
+    #[async_trait]
+    impl BearerTokenProvider for RotatingBearer {
+        async fn get_token(&self) -> Result<BearerToken, CapabilityError> {
+            let sequence = self.0.fetch_add(1, Ordering::Relaxed) + 1;
+            Ok(BearerToken::new(format!("token-{sequence}"), None))
+        }
+
+        fn token_stream(&self) -> TokenStream {
+            futures::stream::empty::<BearerToken>().boxed()
+        }
+    }
+
+    #[tokio::test]
+    async fn observes_token_rotation_on_each_read() {
+        let source = AgentFedGenevaSource::new(
+            Box::new(RotatingBearer(AtomicUsize::new(0))),
+            Box::new(MockVendor(obj(full_attrs()))),
+            "account".to_owned(),
+        );
+        assert_eq!(source.current().await.unwrap().token, "token-1");
+        assert_eq!(source.current().await.unwrap().token, "token-2");
+    }
+
+    #[test]
+    fn failure_log_limiter_uses_exponential_sampling_and_resets() {
+        let limiter = FailureLogLimiter::default();
+        assert_eq!(limiter.record_failure(), Some(1));
+        assert_eq!(limiter.record_failure(), Some(2));
+        assert_eq!(limiter.record_failure(), None);
+        assert_eq!(limiter.record_failure(), Some(4));
+        limiter.record_success();
+        assert_eq!(limiter.record_failure(), Some(1));
     }
 }

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/agent_fed_source.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/agent_fed_source.rs
@@ -23,6 +23,7 @@ const ENDPOINT_KEY: &str = "endpoint";
 const MONIKER_MAP_KEY: &str = "moniker_map";
 const DEFAULT_MONIKER_KEY: &str = "default";
 const TOKEN_USABLE_MARGIN: Duration = Duration::from_secs(30);
+const CREDENTIAL_LOOKUP_TIMEOUT: Duration = Duration::from_secs(5);
 
 // TODO: Move this reusable failure-log sampling helper to `crates/telemetry`.
 #[derive(Default)]
@@ -95,16 +96,27 @@ impl AgentFedGenevaSource {
 impl AgentFedCredentialSource for AgentFedGenevaSource {
     fn current(&self) -> AgentFedCredentialFuture<'_> {
         Box::pin(async move {
-            let snapshot = match self.credential_provider.lock().await.get_credential().await {
-                Ok(snapshot) => {
+            let lookup = async { self.credential_provider.lock().await.get_credential().await };
+            let snapshot = match tokio::time::timeout(CREDENTIAL_LOOKUP_TIMEOUT, lookup).await {
+                Ok(Ok(snapshot)) => {
                     self.credential_failures.record_success();
                     snapshot
                 }
-                Err(error) => {
+                Ok(Err(error)) => {
                     if let Some(consecutive_failures) = self.credential_failures.record_failure() {
                         otel_warn!(
                             "geneva_exporter.agent_fed.credential_unavailable",
                             error = %error,
+                            consecutive_failures = consecutive_failures
+                        );
+                    }
+                    return None;
+                }
+                Err(_) => {
+                    if let Some(consecutive_failures) = self.credential_failures.record_failure() {
+                        otel_warn!(
+                            "geneva_exporter.agent_fed.credential_unavailable",
+                            error = "credential lookup timed out",
                             consecutive_failures = consecutive_failures
                         );
                     }
@@ -145,9 +157,11 @@ impl AgentFedCredentialSource for AgentFedGenevaSource {
 
             // Keep the engine token secret-wrapped across the routing lookup;
             // the uploader creates its zeroizing owned copy only after success.
+            // The uploader also uses this canonical endpoint as the `endpoint=`
+            // fallback when the token has no usable Endpoint claim.
             Some(AgentFedCredential::new(
                 token.expose_token(),
-                endpoint,
+                endpoint.to_string(),
                 moniker,
             ))
         })
@@ -166,6 +180,8 @@ fn validated_moniker<'a>(
     invalid_reason: &'static str,
 ) -> Result<&'a str, &'static str> {
     let moniker = non_blank_string(value).ok_or(invalid_reason)?;
+    // The pinned uploader interpolates moniker directly into its query string.
+    // Keep it URL-unreserved until the uploader applies its own encoding.
     if !moniker
         .bytes()
         .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~'))
@@ -177,7 +193,7 @@ fn validated_moniker<'a>(
     Ok(moniker)
 }
 
-fn validated_endpoint(value: Option<&Value>) -> Result<&str, &'static str> {
+fn validated_endpoint(value: Option<&Value>) -> Result<Url, &'static str> {
     let endpoint =
         non_blank_string(value).ok_or("agent-fed routing endpoint is missing or empty")?;
     let parsed = Url::parse(endpoint)
@@ -196,13 +212,13 @@ fn validated_endpoint(value: Option<&Value>) -> Result<&str, &'static str> {
         return Err("agent-fed routing endpoint must not include a query or fragment");
     }
 
-    Ok(endpoint)
+    Ok(parsed)
 }
 
 fn resolve_routing<'a>(
     attributes: &'a Map<String, Value>,
     account: &str,
-) -> Result<(&'a str, &'a str), &'static str> {
+) -> Result<(Url, &'a str), &'static str> {
     let endpoint = validated_endpoint(attributes.get(ENDPOINT_KEY))?;
     let moniker_map = attributes
         .get(MONIKER_MAP_KEY)
@@ -315,8 +331,25 @@ mod tests {
         let s = source("tok", false, full_attrs());
         let c = s.current().await.expect("credential");
         assert_eq!(c.expose_token(), "tok");
-        assert_eq!(c.endpoint, "https://ep");
+        assert_eq!(c.endpoint, "https://ep/");
         assert_eq!(c.moniker, "mon");
+    }
+
+    /// Scenario: The supplied endpoint uses a valid but non-canonical URL spelling.
+    /// Guarantees: The credential carries the canonical value used for both the upload base URL
+    /// and the uploader's claimless-token `endpoint=` fallback.
+    #[tokio::test]
+    async fn returns_canonical_validated_endpoint() {
+        let attrs = json!({
+            "endpoint": "HTTPS://EXAMPLE.COM",
+            "moniker_map": { "default": "mon" },
+        });
+
+        let credential = source("tok", false, attrs)
+            .current()
+            .await
+            .expect("credential");
+        assert_eq!(credential.endpoint, "https://example.com/");
     }
 
     /// Scenario: The credential-provider future yields once before returning a snapshot.
@@ -631,8 +664,46 @@ mod tests {
         assert!(source.current().await.is_none());
         let credential = source.current().await.expect("recovered credential");
         assert_eq!(credential.expose_token(), "recovered-token");
-        assert_eq!(credential.endpoint, "https://ep");
+        assert_eq!(credential.endpoint, "https://ep/");
         assert_eq!(credential.moniker, "mon");
+    }
+
+    struct PendingThenReadyCredential(AtomicUsize);
+
+    #[async_trait]
+    impl AgentFedCredentialProvider for PendingThenReadyCredential {
+        async fn get_credential(&self) -> Result<Arc<AgentFedCredentialSnapshot>, CapabilityError> {
+            if self.0.fetch_add(1, Ordering::Relaxed) == 0 {
+                return std::future::pending().await;
+            }
+            Ok(snapshot("recovered-token", "https://ep", "mon"))
+        }
+    }
+
+    /// Scenario: The provider never completes its first credential lookup.
+    /// Guarantees: The lookup times out, releases the mutex, and a later read can recover.
+    #[tokio::test(start_paused = true)]
+    async fn times_out_stuck_provider_and_recovers() {
+        let source = AgentFedGenevaSource::new(
+            Box::new(PendingThenReadyCredential(AtomicUsize::new(0))),
+            "account".to_owned(),
+        );
+
+        assert!(source.current().await.is_none());
+        let credential = source.current().await.expect("recovered credential");
+        assert_eq!(credential.expose_token(), "recovered-token");
+    }
+
+    /// Scenario: Another credential lookup holds the provider mutex past the deadline.
+    /// Guarantees: Waiting for the mutex is bounded and a later lookup succeeds.
+    #[tokio::test(start_paused = true)]
+    async fn times_out_waiting_for_provider_mutex_and_recovers() {
+        let source = source("tok", false, full_attrs());
+        let guard = source.credential_provider.lock().await;
+
+        assert!(source.current().await.is_none());
+        drop(guard);
+        assert!(source.current().await.is_some());
     }
 
     struct RotatingCredential(AtomicUsize);
@@ -662,12 +733,12 @@ mod tests {
 
         let first = source.current().await.expect("first credential");
         assert_eq!(first.expose_token(), "token-1");
-        assert_eq!(first.endpoint, "https://endpoint-1");
+        assert_eq!(first.endpoint, "https://endpoint-1/");
         assert_eq!(first.moniker, "moniker-1");
 
         let second = source.current().await.expect("second credential");
         assert_eq!(second.expose_token(), "token-2");
-        assert_eq!(second.endpoint, "https://endpoint-2");
+        assert_eq!(second.endpoint, "https://endpoint-2/");
         assert_eq!(second.moniker, "moniker-2");
     }
 
@@ -724,7 +795,7 @@ mod tests {
 
         let credential = source.current().await.expect("atomic credential");
         assert_eq!(credential.expose_token(), "token-before-rotation");
-        assert_eq!(credential.endpoint, "https://endpoint-before-rotation");
+        assert_eq!(credential.endpoint, "https://endpoint-before-rotation/");
         assert_eq!(credential.moniker, "moniker-before-rotation");
     }
 

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/agent_fed_source.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/agent_fed_source.rs
@@ -63,11 +63,6 @@ impl AgentFedCredentialSource for AgentFedGenevaSource {
                 .and_then(Value::as_str)
                 .unwrap_or_default()
                 .to_owned();
-            let monitoring_endpoint = attributes
-                .get("telemetry_endpoint")
-                .and_then(Value::as_str)
-                .unwrap_or_default()
-                .to_owned();
             // Prefer "default"; else the lowest key (deterministic).
             let moniker = attributes
                 .get("moniker_map")
@@ -89,7 +84,6 @@ impl AgentFedCredentialSource for AgentFedGenevaSource {
                 token,
                 endpoint,
                 moniker,
-                monitoring_endpoint,
             })
         })
     }
@@ -150,7 +144,6 @@ mod tests {
     fn full_attrs() -> Value {
         json!({
             "endpoint": "https://ep",
-            "telemetry_endpoint": "https://tel",
             "moniker_map": { "default": "mon" },
         })
     }
@@ -161,7 +154,6 @@ mod tests {
         let c = s.current().await.expect("credential");
         assert_eq!(c.token, "tok");
         assert_eq!(c.endpoint, "https://ep");
-        assert_eq!(c.monitoring_endpoint, "https://tel");
         assert_eq!(c.moniker, "mon");
     }
 

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/agent_fed_source.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/agent_fed_source.rs
@@ -49,7 +49,8 @@ pub(crate) struct AgentFedGenevaSource {
     account: String,
     bearer_failures: FailureLogLimiter,
     vendor_failures: FailureLogLimiter,
-    credential_failures: FailureLogLimiter,
+    empty_token_failures: FailureLogLimiter,
+    routing_failures: FailureLogLimiter,
 }
 
 impl std::fmt::Debug for AgentFedGenevaSource {
@@ -71,12 +72,13 @@ impl AgentFedGenevaSource {
             account,
             bearer_failures: FailureLogLimiter::default(),
             vendor_failures: FailureLogLimiter::default(),
-            credential_failures: FailureLogLimiter::default(),
+            empty_token_failures: FailureLogLimiter::default(),
+            routing_failures: FailureLogLimiter::default(),
         }
     }
 
-    fn log_invalid_credential(&self, reason: &'static str) {
-        if let Some(consecutive_failures) = self.credential_failures.record_failure() {
+    fn log_invalid_credential(limiter: &FailureLogLimiter, reason: &'static str) {
+        if let Some(consecutive_failures) = limiter.record_failure() {
             otel_warn!(
                 "geneva_exporter.agent_fed.invalid_credential",
                 reason = reason,
@@ -93,6 +95,9 @@ impl AgentFedCredentialSource for AgentFedGenevaSource {
             let token = match self.bearer.lock().await.get_token().await {
                 Ok(token) => {
                     self.bearer_failures.record_success();
+                    // The uploader credential owns a String, so this is the
+                    // required plaintext copy at the adapter boundary. Its
+                    // Debug implementation redacts the token.
                     token.expose_token().to_owned()
                 }
                 Err(error) => {
@@ -107,9 +112,10 @@ impl AgentFedCredentialSource for AgentFedGenevaSource {
                 }
             };
             if token.is_empty() {
-                self.log_invalid_credential("bearer token is empty");
+                Self::log_invalid_credential(&self.empty_token_failures, "bearer token is empty");
                 return None;
             }
+            self.empty_token_failures.record_success();
 
             let attributes = match self.vendor.lock().await.attributes() {
                 Ok(attributes) => {
@@ -129,11 +135,11 @@ impl AgentFedCredentialSource for AgentFedGenevaSource {
             };
             let (endpoint, moniker) = match resolve_routing(&attributes, &self.account) {
                 Ok(routing) => {
-                    self.credential_failures.record_success();
+                    self.routing_failures.record_success();
                     routing
                 }
                 Err(reason) => {
-                    self.log_invalid_credential(reason);
+                    Self::log_invalid_credential(&self.routing_failures, reason);
                     return None;
                 }
             };
@@ -422,5 +428,14 @@ mod tests {
         assert_eq!(limiter.record_failure(), Some(4));
         limiter.record_success();
         assert_eq!(limiter.record_failure(), Some(1));
+    }
+
+    #[test]
+    fn failure_categories_are_sampled_independently() {
+        let source = source("tok", false, full_attrs());
+
+        assert_eq!(source.empty_token_failures.record_failure(), Some(1));
+        assert_eq!(source.empty_token_failures.record_failure(), Some(2));
+        assert_eq!(source.routing_failures.record_failure(), Some(1));
     }
 }

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/agent_fed_source.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/agent_fed_source.rs
@@ -17,6 +17,10 @@ use serde_json::{Map, Value};
 use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::sync::Mutex;
 
+const ENDPOINT_KEY: &str = "endpoint";
+const MONIKER_MAP_KEY: &str = "moniker_map";
+const DEFAULT_MONIKER_KEY: &str = "default";
+
 #[derive(Default)]
 struct FailureLogLimiter {
     consecutive_failures: AtomicU64,
@@ -111,8 +115,11 @@ impl AgentFedCredentialSource for AgentFedGenevaSource {
                     return None;
                 }
             };
-            if token.is_empty() {
-                Self::log_invalid_credential(&self.empty_token_failures, "bearer token is empty");
+            if token.trim().is_empty() {
+                Self::log_invalid_credential(
+                    &self.empty_token_failures,
+                    "bearer token is empty or whitespace",
+                );
                 return None;
             }
             self.empty_token_failures.record_success();
@@ -153,9 +160,10 @@ impl AgentFedCredentialSource for AgentFedGenevaSource {
     }
 }
 
-fn non_empty_string(value: Option<&Value>) -> Option<&str> {
+fn non_blank_string(value: Option<&Value>) -> Option<&str> {
     value
         .and_then(Value::as_str)
+        .map(str::trim)
         .filter(|value| !value.is_empty())
 }
 
@@ -163,26 +171,27 @@ fn resolve_routing<'a>(
     attributes: &'a Map<String, Value>,
     account: &str,
 ) -> Result<(&'a str, &'a str), &'static str> {
-    let endpoint = non_empty_string(attributes.get("endpoint"))
+    let endpoint = non_blank_string(attributes.get(ENDPOINT_KEY))
         .ok_or("vendor bundle endpoint is missing or empty")?;
     let moniker_map = attributes
-        .get("moniker_map")
+        .get(MONIKER_MAP_KEY)
         .and_then(Value::as_object)
         .ok_or("vendor bundle moniker_map is missing or invalid")?;
 
-    let moniker = non_empty_string(moniker_map.get(account))
-        .or_else(|| non_empty_string(moniker_map.get("default")))
-        .or_else(|| {
-            (moniker_map.len() == 1)
-                .then(|| moniker_map.values().next())
-                .flatten()
-                .and_then(|value| non_empty_string(Some(value)))
-        })
-        .ok_or(if moniker_map.len() > 1 {
-            "vendor bundle moniker_map is ambiguous for the configured account"
-        } else {
-            "vendor bundle moniker is missing or empty"
-        })?;
+    let account = account.trim();
+    let moniker = if let Some(value) = moniker_map.get(account) {
+        non_blank_string(Some(value))
+            .ok_or("vendor bundle moniker for the configured account is invalid or empty")?
+    } else if let Some(value) = moniker_map.get(DEFAULT_MONIKER_KEY) {
+        non_blank_string(Some(value)).ok_or("vendor bundle default moniker is invalid or empty")?
+    } else if moniker_map.len() == 1 {
+        non_blank_string(moniker_map.values().next())
+            .ok_or("vendor bundle sole moniker is invalid or empty")?
+    } else if moniker_map.is_empty() {
+        return Err("vendor bundle moniker_map is empty");
+    } else {
+        return Err("vendor bundle moniker_map is ambiguous for the configured account");
+    };
 
     Ok((endpoint, moniker))
 }
@@ -261,6 +270,8 @@ mod tests {
         })
     }
 
+    /// Scenario: The provider returns a token and the bundle contains valid routing.
+    /// Guarantees: The adapter returns the exact token, endpoint, and moniker.
     #[tokio::test]
     async fn returns_credential_when_token_and_routing_present() {
         let s = source("tok", false, full_attrs());
@@ -270,6 +281,8 @@ mod tests {
         assert_eq!(c.moniker, "mon");
     }
 
+    /// Scenario: The token provider future yields once before returning a token.
+    /// Guarantees: The adapter awaits the future instead of dropping a pending result.
     #[tokio::test]
     async fn awaits_pending_provider_future() {
         // Regression for the old `now_or_never()`: a provider whose future is
@@ -278,12 +291,24 @@ mod tests {
         assert!(s.current().await.is_some());
     }
 
+    /// Scenario: The bearer token is empty.
+    /// Guarantees: The adapter fails closed and does not emit a credential.
     #[tokio::test]
     async fn fails_closed_on_empty_token() {
         let s = source("", false, full_attrs());
         assert!(s.current().await.is_none());
     }
 
+    /// Scenario: The bearer token contains only whitespace.
+    /// Guarantees: Whitespace cannot be sent as an apparently valid credential.
+    #[tokio::test]
+    async fn fails_closed_on_whitespace_only_token() {
+        let s = source("   ", false, full_attrs());
+        assert!(s.current().await.is_none());
+    }
+
+    /// Scenario: The vendor bundle omits the ingestion endpoint.
+    /// Guarantees: Missing endpoint routing causes the adapter to fail closed.
     #[tokio::test]
     async fn fails_closed_on_missing_endpoint() {
         let attrs = json!({ "moniker_map": { "default": "mon" } });
@@ -291,6 +316,35 @@ mod tests {
         assert!(s.current().await.is_none());
     }
 
+    /// Scenario: The endpoint or selected moniker contains only whitespace.
+    /// Guarantees: Blank routing values are rejected instead of reaching the uploader.
+    #[tokio::test]
+    async fn fails_closed_on_whitespace_only_routing() {
+        let blank_endpoint = json!({
+            "endpoint": "   ",
+            "moniker_map": { "default": "mon" },
+        });
+        assert!(
+            source("tok", false, blank_endpoint)
+                .current()
+                .await
+                .is_none()
+        );
+
+        let blank_moniker = json!({
+            "endpoint": "https://ep",
+            "moniker_map": { "default": "   " },
+        });
+        assert!(
+            source("tok", false, blank_moniker)
+                .current()
+                .await
+                .is_none()
+        );
+    }
+
+    /// Scenario: The vendor bundle omits the moniker map.
+    /// Guarantees: Missing moniker routing causes the adapter to fail closed.
     #[tokio::test]
     async fn fails_closed_on_missing_moniker() {
         let attrs = json!({ "endpoint": "https://ep" });
@@ -298,6 +352,8 @@ mod tests {
         assert!(s.current().await.is_none());
     }
 
+    /// Scenario: The map contains both account-specific and default monikers.
+    /// Guarantees: The configured account mapping takes precedence over default.
     #[tokio::test]
     async fn moniker_prefers_configured_account() {
         let attrs = json!({
@@ -311,6 +367,8 @@ mod tests {
         assert_eq!(s.current().await.unwrap().moniker, "account-moniker");
     }
 
+    /// Scenario: The configured account has no entry and a default is present.
+    /// Guarantees: The adapter selects the explicit default moniker.
     #[tokio::test]
     async fn moniker_falls_back_to_default() {
         let attrs = json!({
@@ -324,6 +382,8 @@ mod tests {
         assert_eq!(s.current().await.unwrap().moniker, "default-moniker");
     }
 
+    /// Scenario: The map has one non-default entry and no account match.
+    /// Guarantees: A sole unambiguous entry is accepted as the moniker.
     #[tokio::test]
     async fn moniker_falls_back_to_sole_entry() {
         let attrs = json!({
@@ -334,6 +394,23 @@ mod tests {
         assert_eq!(s.current().await.unwrap().moniker, "sole-moniker");
     }
 
+    /// Scenario: The account-specific entry is present but malformed.
+    /// Guarantees: Invalid account routing fails instead of silently using default.
+    #[tokio::test]
+    async fn invalid_account_moniker_does_not_fall_back_to_default() {
+        let attrs = json!({
+            "endpoint": "https://ep",
+            "moniker_map": {
+                "account": 42,
+                "default": "default-moniker"
+            },
+        });
+        let s = source("tok", false, attrs);
+        assert!(s.current().await.is_none());
+    }
+
+    /// Scenario: Multiple map entries exist with no account or default match.
+    /// Guarantees: Ambiguous routing is rejected instead of selecting arbitrarily.
     #[tokio::test]
     async fn fails_closed_on_ambiguous_moniker_map() {
         let attrs = json!({
@@ -371,6 +448,41 @@ mod tests {
         }
     }
 
+    struct RecoveringBearer(AtomicUsize);
+
+    #[async_trait]
+    impl BearerTokenProvider for RecoveringBearer {
+        async fn get_token(&self) -> Result<BearerToken, CapabilityError> {
+            if self.0.fetch_add(1, Ordering::Relaxed) == 0 {
+                return Err(CapabilityErrorSource::<BearerTokenProviderCap>::new(
+                    "recovering-bearer".into(),
+                )
+                .error("token unavailable"));
+            }
+            Ok(BearerToken::without_expiry("recovered-token".to_owned()))
+        }
+
+        fn token_stream(&self) -> TokenStream {
+            futures::stream::empty::<BearerToken>().boxed()
+        }
+    }
+
+    struct RecoveringVendor(AtomicUsize);
+
+    impl VendorBundle for RecoveringVendor {
+        fn attributes(&self) -> Result<Arc<Map<String, Value>>, CapabilityError> {
+            if self.0.fetch_add(1, Ordering::Relaxed) == 0 {
+                return Err(CapabilityErrorSource::<VendorBundleCap>::new(
+                    "recovering-vendor".into(),
+                )
+                .error("bundle unavailable"));
+            }
+            Ok(obj(full_attrs()))
+        }
+    }
+
+    /// Scenario: The bearer-token capability reports an error.
+    /// Guarantees: Capability failure does not produce a partial credential.
     #[tokio::test]
     async fn fails_closed_when_token_provider_errors() {
         let source = AgentFedGenevaSource::new(
@@ -381,6 +493,8 @@ mod tests {
         assert!(source.current().await.is_none());
     }
 
+    /// Scenario: The vendor-bundle capability reports an error.
+    /// Guarantees: Routing failure does not produce a token-only credential.
     #[tokio::test]
     async fn fails_closed_when_vendor_bundle_errors() {
         let source = AgentFedGenevaSource::new(
@@ -392,6 +506,24 @@ mod tests {
             "account".to_owned(),
         );
         assert!(source.current().await.is_none());
+    }
+
+    /// Scenario: Token and bundle providers recover after initial failures.
+    /// Guarantees: Subsequent reads converge without reconstructing the exporter.
+    #[tokio::test]
+    async fn recovers_when_capabilities_become_available() {
+        let source = AgentFedGenevaSource::new(
+            Box::new(RecoveringBearer(AtomicUsize::new(0))),
+            Box::new(RecoveringVendor(AtomicUsize::new(0))),
+            "account".to_owned(),
+        );
+
+        assert!(source.current().await.is_none());
+        assert!(source.current().await.is_none());
+        let credential = source.current().await.expect("recovered credential");
+        assert_eq!(credential.token, "recovered-token");
+        assert_eq!(credential.endpoint, "https://ep");
+        assert_eq!(credential.moniker, "mon");
     }
 
     struct RotatingBearer(AtomicUsize);
@@ -408,6 +540,8 @@ mod tests {
         }
     }
 
+    /// Scenario: The provider changes its cached bearer token between reads.
+    /// Guarantees: Every upload lookup observes the provider's current token.
     #[tokio::test]
     async fn observes_token_rotation_on_each_read() {
         let source = AgentFedGenevaSource::new(
@@ -419,6 +553,8 @@ mod tests {
         assert_eq!(source.current().await.unwrap().token, "token-2");
     }
 
+    /// Scenario: Credential failures continue and later recover.
+    /// Guarantees: Warning sampling follows powers of two and resets after success.
     #[test]
     fn failure_log_limiter_uses_exponential_sampling_and_resets() {
         let limiter = FailureLogLimiter::default();
@@ -430,6 +566,8 @@ mod tests {
         assert_eq!(limiter.record_failure(), Some(1));
     }
 
+    /// Scenario: Empty-token and routing validation fail independently.
+    /// Guarantees: One failure category cannot suppress another category's warning.
     #[test]
     fn failure_categories_are_sampled_independently() {
         let source = source("tok", false, full_attrs());

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/mod.rs
@@ -70,6 +70,12 @@ use otap_df_otap::metrics::ExporterPDataExportMetrics;
 use otap_df_otap::pdata::OtapPdata;
 use otap_df_telemetry::common_attributes::{Outcome, SignalOutcomeAttributes};
 
+mod agent_fed_source;
+
+use agent_fed_source::AgentFedGenevaSource;
+use otap_df_engine::capability::bearer_token_provider::BearerTokenProvider as BearerTokenProviderCap;
+use otap_df_engine::capability::vendor_bundle::VendorBundle as VendorBundleCap;
+
 /// The URN for the Geneva exporter
 pub const GENEVA_EXPORTER_URN: &str = "urn:microsoft:exporter:geneva";
 
@@ -657,6 +663,12 @@ pub enum AuthConfig {
         /// MSI resource identifier
         msi_resource: String,
     },
+    /// Agent-fed credentials: the host agent supplies the
+    /// GIG token and routing attributes through the `bearer_token_provider`
+    /// and `vendor_bundle` capabilities, so the uploader skips the GCS
+    /// config-service handshake. Carries no config fields; the capabilities
+    /// are bound to a host extension via the node's `capabilities` block.
+    AgentFed,
 }
 
 /// Geneva exporter metrics.
@@ -768,6 +780,7 @@ impl GenevaExporter {
     pub fn from_config(
         pipeline_ctx: PipelineContext,
         config: &serde_json::Value,
+        capabilities: &otap_df_engine::capability::registry::Capabilities,
     ) -> Result<Self, otap_df_config::error::Error> {
         let pdata_metrics = ExporterPDataExportMetrics::register(&pipeline_ctx);
         let metrics = pipeline_ctx.register_metrics::<ExporterMetrics>();
@@ -794,12 +807,39 @@ impl GenevaExporter {
             });
         }
 
-        // Initialize Geneva client
-        let geneva_client = GenevaClient::new(client_config).map_err(|e| {
-            otap_df_config::error::Error::InvalidUserConfig {
-                error: format!("Failed to initialize Geneva client: {}", e),
+        // Initialize the Geneva client. Agent-fed auth resolves the agent-fed
+        // bearer + vendor capabilities and feeds them to the uploader; all
+        // other auth methods drive the GCS config-service handshake.
+        let geneva_client = match &config.auth {
+            AuthConfig::AgentFed => {
+                let bearer = capabilities
+                    .require_shared::<BearerTokenProviderCap>()
+                    .map_err(|e| otap_df_config::error::Error::InvalidUserConfig {
+                        error: format!(
+                            "agent-fed auth requires a bound bearer_token_provider capability: {e}"
+                        ),
+                    })?;
+                let vendor = capabilities
+                    .require_shared::<VendorBundleCap>()
+                    .map_err(|e| otap_df_config::error::Error::InvalidUserConfig {
+                        error: format!(
+                            "agent-fed Geneva auth requires a bound vendor_bundle capability \
+                             (carries the endpoint/moniker routing): {e}"
+                        ),
+                    })?;
+                let source = AgentFedGenevaSource::new(bearer, vendor);
+                GenevaClient::with_agent_fed_source(client_config, Arc::new(source)).map_err(
+                    |e| otap_df_config::error::Error::InvalidUserConfig {
+                        error: format!("Failed to initialize agent-fed Geneva client: {e}"),
+                    },
+                )?
             }
-        })?;
+            _ => GenevaClient::new(client_config).map_err(|e| {
+                otap_df_config::error::Error::InvalidUserConfig {
+                    error: format!("Failed to initialize Geneva client: {}", e),
+                }
+            })?,
+        };
 
         Ok(Self {
             config,
@@ -1165,9 +1205,9 @@ pub static GENEVA_EXPORTER: ExporterFactory<OtapPdata> = ExporterFactory {
              node: NodeId,
              node_config: Arc<NodeUserConfig>,
              exporter_config: &ExporterConfig,
-             _capabilities: &otap_df_engine::capability::registry::Capabilities| {
+             capabilities: &otap_df_engine::capability::registry::Capabilities| {
         Ok(ExporterWrapper::local(
-            GenevaExporter::from_config(pipeline, &node_config.config)?,
+            GenevaExporter::from_config(pipeline, &node_config.config, capabilities)?,
             node,
             node_config,
             exporter_config,

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/mod.rs
@@ -75,9 +75,8 @@ mod agent_fed_source;
 
 use agent_fed_source::AgentFedGenevaSource;
 use otap_df_engine::capability::ExtensionCapability;
-use otap_df_engine::capability::auth::bearer_token_provider::BearerTokenProvider as BearerTokenProviderCap;
+use otap_df_engine::capability::auth::agent_fed_credential_provider::AgentFedCredentialProvider as AgentFedCredentialProviderCap;
 use otap_df_engine::capability::registry::Capabilities;
-use otap_df_engine::capability::vendor_bundle::VendorBundle as VendorBundleCap;
 
 /// The URN for the Geneva exporter
 pub const GENEVA_EXPORTER_URN: &str = "urn:microsoft:exporter:geneva";
@@ -508,9 +507,10 @@ pub struct TracesConfig {
 
 /// Configuration for the Geneva Exporter
 #[derive(Debug, Deserialize, Clone)]
-#[serde(try_from = "ConfigBuilder")]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     /// Geneva config-service endpoint URL (required except for agent-fed auth)
+    #[serde(default)]
     pub endpoint: String,
     /// Environment (e.g., "production", "staging")
     pub environment: String,
@@ -519,6 +519,7 @@ pub struct Config {
     /// Geneva namespace
     pub namespace: String,
     /// Azure region (required except for agent-fed auth)
+    #[serde(default)]
     pub region: String,
     /// Config major version (required)
     pub config_major_version: u32,
@@ -538,34 +539,11 @@ pub struct Config {
     pub spans: Option<TracesConfig>,
     /// Maximum buffer size before forcing flush (default: 1000)
     /// Note: This field is currently reserved for future use and does not affect runtime behavior.
+    #[serde(default = "default_buffer_size")]
     pub max_buffer_size: usize,
     /// Maximum concurrent uploads (default: 4)
-    pub max_concurrent_uploads: usize,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct ConfigBuilder {
-    #[serde(default)]
-    endpoint: String,
-    environment: String,
-    account: String,
-    namespace: String,
-    #[serde(default)]
-    region: String,
-    config_major_version: u32,
-    tenant: String,
-    role_name: String,
-    role_instance: String,
-    auth: AuthConfig,
-    #[serde(default)]
-    logs: Option<LogsConfig>,
-    #[serde(default)]
-    spans: Option<TracesConfig>,
-    #[serde(default = "default_buffer_size")]
-    max_buffer_size: usize,
     #[serde(default = "default_max_concurrent")]
-    max_concurrent_uploads: usize,
+    pub max_concurrent_uploads: usize,
 }
 
 const fn default_buffer_size() -> usize {
@@ -577,17 +555,29 @@ const fn default_max_concurrent() -> usize {
 }
 
 impl Config {
+    /// Deserializes and validates one exporter configuration.
+    ///
+    /// Validation lives here rather than inside `Deserialize` so `Config` stays
+    /// a plain deserializable struct with a single field list. Every path that
+    /// turns user JSON into a `Config` must go through this function.
     fn parse(config: &serde_json::Value) -> Result<Self, ConfigError> {
-        serde_json::from_value(config.clone()).map_err(|error| ConfigError::InvalidUserConfig {
-            error: error.to_string(),
-        })
+        let parsed: Self = serde_json::from_value(config.clone()).map_err(|error| {
+            ConfigError::InvalidUserConfig {
+                error: error.to_string(),
+            }
+        })?;
+        parsed
+            .validate()
+            .map_err(|error| ConfigError::InvalidUserConfig { error })?;
+        Ok(parsed)
     }
 
     fn validate(&self) -> Result<(), String> {
-        if self.account.trim().is_empty() {
+        let is_agent_fed = matches!(self.auth, AuthConfig::AgentFed);
+        if is_agent_fed && self.account.trim().is_empty() {
             return Err("account must not be empty".to_owned());
         }
-        if !matches!(self.auth, AuthConfig::AgentFed) {
+        if !is_agent_fed {
             if self.endpoint.trim().is_empty() {
                 return Err("endpoint is required unless auth.type is agentfed".to_owned());
             }
@@ -644,31 +634,6 @@ impl Config {
     }
 }
 
-impl TryFrom<ConfigBuilder> for Config {
-    type Error = String;
-
-    fn try_from(builder: ConfigBuilder) -> Result<Self, Self::Error> {
-        let config = Self {
-            endpoint: builder.endpoint,
-            environment: builder.environment,
-            account: builder.account,
-            namespace: builder.namespace,
-            region: builder.region,
-            config_major_version: builder.config_major_version,
-            tenant: builder.tenant,
-            role_name: builder.role_name,
-            role_instance: builder.role_instance,
-            auth: builder.auth,
-            logs: builder.logs,
-            spans: builder.spans,
-            max_buffer_size: builder.max_buffer_size,
-            max_concurrent_uploads: builder.max_concurrent_uploads,
-        };
-        config.validate()?;
-        Ok(config)
-    }
-}
-
 /// Authentication configuration
 /// TODO - see if we directly use AuthMethod from geneva-uploader crate
 #[derive(Debug, Deserialize, Clone)]
@@ -706,11 +671,10 @@ pub enum AuthConfig {
         /// MSI resource identifier
         msi_resource: String,
     },
-    /// Agent-fed credentials: the host agent supplies the
-    /// GIG token and routing attributes through the `bearer_token_provider`
-    /// and `vendor_bundle` capabilities, so the uploader skips the GCS
-    /// config-service handshake. Carries no config fields; the capabilities
-    /// must bind to the same host extension via the node's `capabilities`
+    /// Agent-fed credentials: the host agent supplies one atomic GIG token and
+    /// routing snapshot through `agent_fed_credential_provider`, so the
+    /// uploader skips the GCS config-service handshake. Carries no config
+    /// fields; the capability is selected through the node's `capabilities`
     /// block.
     AgentFed,
 }
@@ -856,32 +820,19 @@ pub struct GenevaExporter {
 }
 
 /// Validates the node-level bindings that the config-only factory validation
-/// hook cannot inspect. Called during exporter creation before either
-/// capability is consumed.
-fn validate_agent_fed_capability_bindings(node_config: &NodeUserConfig) -> Result<(), ConfigError> {
-    let bearer_name = BearerTokenProviderCap::NAME;
-    let vendor_name = VendorBundleCap::NAME;
-    let bearer_extension = node_config.capabilities.get(bearer_name).ok_or_else(|| {
-        ConfigError::InvalidUserConfig {
-            error: format!("agent-fed Geneva auth requires a '{bearer_name}' capability binding"),
-        }
-    })?;
-    let vendor_extension = node_config.capabilities.get(vendor_name).ok_or_else(|| {
-        ConfigError::InvalidUserConfig {
-            error: format!("agent-fed Geneva auth requires a '{vendor_name}' capability binding"),
-        }
-    })?;
-
-    if bearer_extension != vendor_extension {
-        return Err(ConfigError::InvalidUserConfig {
+/// hook cannot inspect. Called during exporter creation before the capability
+/// is consumed.
+fn validate_agent_fed_capability_binding(node_config: &NodeUserConfig) -> Result<(), ConfigError> {
+    let capability_name = AgentFedCredentialProviderCap::NAME;
+    node_config
+        .capabilities
+        .get(capability_name)
+        .map(|_| ())
+        .ok_or_else(|| ConfigError::InvalidUserConfig {
             error: format!(
-                "agent-fed Geneva auth requires '{bearer_name}' and '{vendor_name}' \
-                 to bind to the same configured extension"
+                "agent-fed Geneva auth requires an '{capability_name}' capability binding"
             ),
-        });
-    }
-
-    Ok(())
+        })
 }
 
 fn ensure_crypto_provider() -> Result<(), ConfigError> {
@@ -904,9 +855,7 @@ fn validate_geneva_client_prerequisites(
     crypto_provider_check: impl FnOnce() -> Result<(), ConfigError>,
 ) -> Result<(), ConfigError> {
     if matches!(&config.auth, AuthConfig::AgentFed) {
-        // This validates configured extension identity. The extension's Clone
-        // implementation must still share one underlying token/routing snapshot.
-        validate_agent_fed_capability_bindings(node_config)?;
+        validate_agent_fed_capability_binding(node_config)?;
     }
 
     // Both GCS and agent-fed uploads use the rustls-backed HTTP client.
@@ -917,25 +866,18 @@ fn resolve_agent_fed_source(
     config: &Config,
     capabilities: &Capabilities,
 ) -> Result<AgentFedGenevaSource, ConfigError> {
-    let bearer = capabilities
-        .require_shared::<BearerTokenProviderCap>()
+    let credential_provider = capabilities
+        .require_shared::<AgentFedCredentialProviderCap>()
         .map_err(|error| ConfigError::InvalidUserConfig {
             error: format!(
-                "agent-fed Geneva auth requires a bound bearer_token_provider capability: {error}"
-            ),
-        })?;
-    let vendor = capabilities
-        .require_shared::<VendorBundleCap>()
-        .map_err(|error| ConfigError::InvalidUserConfig {
-            error: format!(
-                "agent-fed Geneva auth requires a bound vendor_bundle capability \
-                 (carries the endpoint/moniker routing): {error}"
+                "agent-fed Geneva auth requires the bound agent_fed_credential_provider \
+                 capability to provide a shared implementation; local-only registrations \
+                 are unsupported: {error}"
             ),
         })?;
 
     Ok(AgentFedGenevaSource::new(
-        bearer,
-        vendor,
+        credential_provider,
         config.account.clone(),
     ))
 }
@@ -957,20 +899,47 @@ fn create_geneva_client(
                 }
             })
         }
-        _ => GenevaClient::new(client_config).map_err(|error| ConfigError::InvalidUserConfig {
-            error: format!("Failed to initialize Geneva client: {error}"),
-        }),
+        AuthConfig::Certificate { .. }
+        | AuthConfig::SystemManagedIdentity { .. }
+        | AuthConfig::UserManagedIdentity { .. }
+        | AuthConfig::UserManagedIdentityByArmResourceId { .. }
+        | AuthConfig::WorkloadIdentity { .. } => {
+            GenevaClient::new(client_config).map_err(|error| ConfigError::InvalidUserConfig {
+                error: format!("Failed to initialize Geneva client: {error}"),
+            })
+        }
     }
 }
 
 impl GenevaExporter {
-    /// Create a new Geneva exporter from configuration
+    /// Creates a Geneva exporter from configuration for legacy authentication modes.
+    ///
+    /// Agent-fed authentication must be constructed through the registered
+    /// factory so its capability binding can be resolved.
     pub fn from_config(
+        pipeline_ctx: PipelineContext,
+        config: &serde_json::Value,
+    ) -> Result<Self, ConfigError> {
+        let config = Config::parse(config)?;
+        let node_config = NodeUserConfig::new_exporter_config(GENEVA_EXPORTER_URN);
+        Self::from_parsed_config(pipeline_ctx, config, &node_config, &Capabilities::empty())
+    }
+
+    fn from_node_config(
         pipeline_ctx: PipelineContext,
         node_config: &NodeUserConfig,
         capabilities: &Capabilities,
     ) -> Result<Self, ConfigError> {
         let config = Config::parse(&node_config.config)?;
+        Self::from_parsed_config(pipeline_ctx, config, node_config, capabilities)
+    }
+
+    fn from_parsed_config(
+        pipeline_ctx: PipelineContext,
+        config: Config,
+        node_config: &NodeUserConfig,
+        capabilities: &Capabilities,
+    ) -> Result<Self, ConfigError> {
         let geneva_client = create_geneva_client(&config, node_config, capabilities)?;
         let pdata_metrics = ExporterPDataExportMetrics::register(&pipeline_ctx);
         let metrics = pipeline_ctx.register_metrics::<ExporterMetrics>();
@@ -1327,6 +1296,14 @@ impl GenevaExporter {
     }
 }
 
+/// Validates the exporter configuration for the factory's config-only hook.
+///
+/// Routes through [`Config::parse`] so the hook applies exactly the validation
+/// the exporter applies at creation time.
+fn validate_geneva_config(config: &serde_json::Value) -> Result<(), ConfigError> {
+    Config::parse(config).map(|_| ())
+}
+
 /// Register Geneva exporter with the OTAP exporter factory
 ///
 /// Unsafe code is temporarily used here to allow the use of `distributed_slice` macro
@@ -1341,14 +1318,14 @@ pub static GENEVA_EXPORTER: ExporterFactory<OtapPdata> = ExporterFactory {
              exporter_config: &ExporterConfig,
              capabilities: &Capabilities| {
         Ok(ExporterWrapper::local(
-            GenevaExporter::from_config(pipeline, &node_config, capabilities)?,
+            GenevaExporter::from_node_config(pipeline, &node_config, capabilities)?,
             node,
             node_config,
             exporter_config,
         ))
     },
     wiring_contract: otap_df_engine::wiring_contract::WiringContract::UNRESTRICTED,
-    validate_config: otap_df_config::validation::validate_typed_config::<Config>,
+    validate_config: validate_geneva_config,
 };
 
 #[async_trait(?Send)]
@@ -1362,7 +1339,7 @@ impl Exporter<OtapPdata> for GenevaExporter {
             AuthConfig::AgentFed => {
                 otel_info!(
                     "geneva_exporter.start",
-                    endpoint_source = "vendor_bundle",
+                    endpoint_source = "agent_fed_credential_provider",
                     namespace = self.config.namespace,
                     account = self.config.account,
                     role_name = self.config.role_name,
@@ -1473,15 +1450,16 @@ mod tests {
     use bytes::Bytes;
     use geneva_uploader::client::AgentFedCredentialSource;
     use otap_df_engine::Interests;
-    use otap_df_engine::capability::SharedInstanceFactory;
     use otap_df_engine::capability::auth::BearerToken;
-    use otap_df_engine::capability::auth::bearer_token_provider::TokenStream;
+    use otap_df_engine::capability::auth::agent_fed_credential_provider::AgentFedCredentialSnapshot;
     use otap_df_engine::capability::registry::CapabilityRegistry;
-    use otap_df_engine::capability::{CapabilityError, ExtensionCapability};
+    use otap_df_engine::capability::{
+        CapabilityError, ExtensionCapability, LocalInstanceFactory, SharedInstanceFactory,
+    };
     use otap_df_engine::control::PipelineCompletionMsg;
     use otap_df_engine::extension_capabilities;
-    use otap_df_engine::shared::capability::auth::bearer_token_provider::BearerTokenProvider as SharedBearerTokenProvider;
-    use otap_df_engine::shared::capability::vendor_bundle::VendorBundle as SharedVendorBundle;
+    use otap_df_engine::local::capability::auth::agent_fed_credential_provider::AgentFedCredentialProvider as LocalAgentFedCredentialProvider;
+    use otap_df_engine::shared::capability::auth::agent_fed_credential_provider::AgentFedCredentialProvider as SharedAgentFedCredentialProvider;
     use otap_df_engine::testing::capability::resolve_bindings_for_test;
     use otap_df_engine::testing::exporter::{
         TestRuntime, create_exporter_from_factory, create_test_pipeline_context,
@@ -1662,22 +1640,14 @@ mod tests {
         })
     }
 
-    fn agent_fed_node_config(
-        bearer_extension: Option<&str>,
-        vendor_extension: Option<&str>,
-    ) -> NodeUserConfig {
+    fn agent_fed_node_config(extension: Option<&str>) -> NodeUserConfig {
         let mut node_config = NodeUserConfig::new_exporter_config(GENEVA_EXPORTER_URN);
         node_config.config = agent_fed_test_config();
-        if let Some(extension) = bearer_extension {
+        if let Some(extension) = extension {
             let _ = node_config.capabilities.insert(
-                BearerTokenProviderCap::NAME.into(),
+                AgentFedCredentialProviderCap::NAME.into(),
                 extension.to_owned().into(),
             );
-        }
-        if let Some(extension) = vendor_extension {
-            let _ = node_config
-                .capabilities
-                .insert(VendorBundleCap::NAME.into(), extension.to_owned().into());
         }
         node_config
     }
@@ -1688,28 +1658,31 @@ mod tests {
     }
 
     struct MockAgentSnapshot {
-        token: String,
+        token: BearerToken,
         attributes: Arc<serde_json::Map<String, serde_json::Value>>,
     }
 
     #[async_trait]
-    impl SharedBearerTokenProvider for MockAgentExtension {
-        async fn get_token(&self) -> Result<BearerToken, CapabilityError> {
+    impl SharedAgentFedCredentialProvider for MockAgentExtension {
+        async fn get_credential(&self) -> Result<Arc<AgentFedCredentialSnapshot>, CapabilityError> {
             let snapshot = self.snapshot.read().expect("snapshot read lock");
-            Ok(BearerToken::without_expiry(snapshot.token.clone()))
-        }
-
-        fn token_stream(&self) -> TokenStream {
-            futures::stream::empty::<BearerToken>().boxed()
+            Ok(Arc::new(AgentFedCredentialSnapshot::new(
+                snapshot.token.clone(),
+                Arc::clone(&snapshot.attributes),
+            )))
         }
     }
 
-    impl SharedVendorBundle for MockAgentExtension {
-        fn attributes(
-            &self,
-        ) -> Result<Arc<serde_json::Map<String, serde_json::Value>>, CapabilityError> {
-            let snapshot = self.snapshot.read().expect("snapshot read lock");
-            Ok(snapshot.attributes.clone())
+    #[derive(Clone)]
+    struct MockLocalAgentExtension;
+
+    #[async_trait(?Send)]
+    impl LocalAgentFedCredentialProvider for MockLocalAgentExtension {
+        async fn get_credential(&self) -> Result<Arc<AgentFedCredentialSnapshot>, CapabilityError> {
+            Ok(Arc::new(AgentFedCredentialSnapshot::new(
+                BearerToken::without_expiry("unused-token".to_owned()),
+                Arc::new(serde_json::Map::new()),
+            )))
         }
     }
 
@@ -1724,14 +1697,14 @@ mod tests {
         .cloned()
         .expect("object");
         let snapshot = Arc::new(RwLock::new(MockAgentSnapshot {
-            token: "test-token".to_owned(),
+            token: BearerToken::without_expiry("test-token".to_owned()),
             attributes: Arc::new(attributes),
         }));
         let extension = MockAgentExtension {
             snapshot: Arc::clone(&snapshot),
         };
         let extension_capabilities = extension_capabilities!(
-            shared: MockAgentExtension => [BearerTokenProviderCap, VendorBundleCap]
+            shared: MockAgentExtension => [AgentFedCredentialProviderCap]
         );
         let instance_factory =
             SharedInstanceFactory::new(move || Box::new(extension.clone()) as Box<dyn Any + Send>);
@@ -1743,6 +1716,20 @@ mod tests {
             resolve_bindings_for_test(&node_config.capabilities, &registry, &known_extensions)
                 .expect("resolve capabilities");
         (capabilities, snapshot)
+    }
+
+    fn resolved_local_only_agent_fed_capabilities(node_config: &NodeUserConfig) -> Capabilities {
+        let extension_capabilities = extension_capabilities!(
+            local: MockLocalAgentExtension => [AgentFedCredentialProviderCap]
+        );
+        let instance_factory =
+            LocalInstanceFactory::new(|| Box::new(MockLocalAgentExtension) as Box<dyn Any>);
+        let mut registry = CapabilityRegistry::new();
+        (extension_capabilities.register_local)("agent".into(), instance_factory, &mut registry)
+            .expect("register local capabilities");
+        let known_extensions = HashSet::<otap_df_config::ExtensionId>::from(["agent".into()]);
+        resolve_bindings_for_test(&node_config.capabilities, &registry, &known_extensions)
+            .expect("resolve local-only capabilities")
     }
 
     /// Scenario: The exporter receives an empty OTLP log payload with an ACK subscriber.
@@ -1947,11 +1934,67 @@ mod tests {
     /// Guarantees: The configuration remains valid and preserves the agent-fed mode.
     #[test]
     fn agent_fed_config_can_omit_gcs_endpoint_and_region() {
-        let config: Config =
-            serde_json::from_value(agent_fed_test_config()).expect("valid agent-fed config");
+        let config = Config::parse(&agent_fed_test_config()).expect("valid agent-fed config");
         assert!(config.endpoint.is_empty());
         assert!(config.region.is_empty());
         assert!(matches!(config.auth, AuthConfig::AgentFed));
+    }
+
+    /// Scenario: Agent-fed authentication is configured with log and span table routing.
+    /// Guarantees: The uploader adapter preserves both routing sections in agent-fed mode.
+    #[test]
+    fn agent_fed_config_preserves_logs_and_spans_routing() {
+        let mut config = agent_fed_test_config();
+        config["logs"] = serde_json::json!({
+            "default_event_name": "AgentLogs",
+            "event_name_mapping": {
+                "routing_key": { "log_record_attribute": "log.kind" },
+                "events": { "audit": "AuditLogs" }
+            }
+        });
+        config["spans"] = serde_json::json!({
+            "default_event_name": "AgentSpans",
+            "event_name_mapping": {
+                "routing_key": { "span_attribute": "span.kind" },
+                "events": { "SERVER": "ServerSpans" }
+            }
+        });
+
+        let parsed = Config::parse(&config).expect("valid combined agent-fed config");
+        assert!(matches!(parsed.auth, AuthConfig::AgentFed));
+
+        let client_config = parsed.to_geneva_client_config();
+        assert!(client_config.endpoint.is_empty());
+        assert!(client_config.region.is_empty());
+        assert!(client_config.msi_resource.is_none());
+
+        let logs = client_config.logs.expect("logs config should be present");
+        assert_eq!(logs.default_event_name.as_deref(), Some("AgentLogs"));
+        let logs_mapping = logs
+            .event_name_mapping
+            .expect("logs mapping should be present");
+        assert!(matches!(
+            logs_mapping.routing_key,
+            LogsEventNameRoutingKey::LogRecordAttribute(ref key) if key == "log.kind"
+        ));
+        assert_eq!(
+            logs_mapping.events.get("audit"),
+            Some(&Some("AuditLogs".to_owned()))
+        );
+
+        let spans = client_config.spans.expect("spans config should be present");
+        assert_eq!(spans.default_event_name.as_deref(), Some("AgentSpans"));
+        let spans_mapping = spans
+            .event_name_mapping
+            .expect("spans mapping should be present");
+        assert!(matches!(
+            spans_mapping.routing_key,
+            SpanEventNameRoutingKey::SpanAttribute(ref key) if key == "span.kind"
+        ));
+        assert_eq!(
+            spans_mapping.events.get("SERVER"),
+            Some(&Some("ServerSpans".to_owned()))
+        );
     }
 
     /// Scenario: A non-agent-fed configuration omits endpoint or region.
@@ -1963,8 +2006,7 @@ mod tests {
             .as_object_mut()
             .expect("object")
             .remove("endpoint");
-        let error = serde_json::from_value::<Config>(missing_endpoint)
-            .expect_err("endpoint must be required");
+        let error = Config::parse(&missing_endpoint).expect_err("endpoint must be required");
         assert!(error.to_string().contains("endpoint is required"));
 
         let mut missing_region = test_config();
@@ -1972,9 +2014,31 @@ mod tests {
             .as_object_mut()
             .expect("object")
             .remove("region");
-        let error =
-            serde_json::from_value::<Config>(missing_region).expect_err("region must be required");
+        let error = Config::parse(&missing_region).expect_err("region must be required");
         assert!(error.to_string().contains("region is required"));
+    }
+
+    /// Scenario: An existing non-agent-fed configuration contains a blank account value.
+    /// Guarantees: Agent-fed-specific validation does not tighten legacy config parsing.
+    #[test]
+    fn non_agent_fed_config_preserves_blank_account_parsing() {
+        let mut config = test_config();
+        config["account"] = serde_json::Value::String("   ".to_owned());
+
+        let parsed = Config::parse(&config).expect("legacy config should still parse");
+        assert_eq!(parsed.account, "   ");
+    }
+
+    /// Scenario: A configuration carries a field the exporter does not define.
+    /// Guarantees: Unknown configuration fields stay rejected after validation
+    /// moved out of the `Deserialize` implementation.
+    #[test]
+    fn unknown_config_fields_are_rejected() {
+        let mut config = test_config();
+        config["unexpected_field"] = serde_json::Value::Bool(true);
+
+        let error = Config::parse(&config).expect_err("unknown fields must be rejected");
+        assert!(error.to_string().contains("unexpected_field"));
     }
 
     /// Scenario: Agent-fed configuration provides an empty account.
@@ -1983,63 +2047,48 @@ mod tests {
     fn agent_fed_config_requires_account_for_moniker_selection() {
         let mut config = agent_fed_test_config();
         config["account"] = serde_json::Value::String(String::new());
-        let error = serde_json::from_value::<Config>(config).expect_err("account must be required");
+        let error = Config::parse(&config).expect_err("account must be required");
         assert!(error.to_string().contains("account must not be empty"));
     }
 
-    /// Scenario: Bearer and vendor capabilities reference different extension IDs.
-    /// Guarantees: Agent-fed startup accepts only matching configured extensions.
+    /// Scenario: The required agent-fed credential-provider binding is absent.
+    /// Guarantees: Startup reports the missing combined capability.
     #[test]
-    fn agent_fed_capabilities_must_bind_to_the_same_extension() {
-        let node_config = agent_fed_node_config(Some("agent-a"), Some("agent-b"));
-        let error = validate_agent_fed_capability_bindings(&node_config)
-            .expect_err("mismatched extensions must fail");
-        assert!(error.to_string().contains("same configured extension"));
+    fn agent_fed_credential_provider_binding_is_required() {
+        let node_config = agent_fed_node_config(None);
+        let error = validate_agent_fed_capability_binding(&node_config)
+            .expect_err("credential-provider binding must be required");
+        assert!(error.to_string().contains("agent_fed_credential_provider"));
 
-        let node_config = agent_fed_node_config(Some("agent"), Some("agent"));
-        validate_agent_fed_capability_bindings(&node_config)
-            .expect("matching extensions must pass");
+        let node_config = agent_fed_node_config(Some("agent"));
+        validate_agent_fed_capability_binding(&node_config)
+            .expect("configured credential-provider binding must pass");
     }
 
-    /// Scenario: Either required agent-fed capability binding is absent.
-    /// Guarantees: Startup reports the specific missing capability.
-    #[test]
-    fn agent_fed_capabilities_require_both_bindings() {
-        let missing_bearer = agent_fed_node_config(None, Some("agent"));
-        let error = validate_agent_fed_capability_bindings(&missing_bearer)
-            .expect_err("bearer binding must be required");
-        assert!(error.to_string().contains("bearer_token_provider"));
-
-        let missing_vendor = agent_fed_node_config(Some("agent"), None);
-        let error = validate_agent_fed_capability_bindings(&missing_vendor)
-            .expect_err("vendor binding must be required");
-        assert!(error.to_string().contains("vendor_bundle"));
-    }
-
-    /// Scenario: Agent-fed capability bindings are invalid before TLS setup is checked.
+    /// Scenario: The agent-fed capability binding is missing before TLS setup is checked.
     /// Guarantees: Binding validation short-circuits without invoking the crypto check.
     #[test]
     fn agent_fed_binding_validation_precedes_crypto_check() {
-        let node_config = agent_fed_node_config(Some("agent-a"), Some("agent-b"));
+        let node_config = agent_fed_node_config(None);
         let config = Config::parse(&node_config.config).expect("valid agent-fed config");
         let error = validate_geneva_client_prerequisites(&config, &node_config, || {
             panic!("crypto provider check must not run before binding validation")
         })
-        .expect_err("mismatched extensions must fail");
+        .expect_err("missing credential-provider binding must fail");
 
-        assert!(error.to_string().contains("same configured extension"));
+        assert!(error.to_string().contains("agent_fed_credential_provider"));
     }
 
-    /// Scenario: The factory receives missing or mismatched agent-fed bindings.
-    /// Guarantees: Exporter creation fails with the applicable binding error.
+    /// Scenario: The factory receives no agent-fed credential-provider binding.
+    /// Guarantees: Exporter creation fails with the missing capability error.
     #[test]
-    fn agent_fed_factory_fails_closed_on_invalid_bindings() {
+    fn agent_fed_factory_fails_closed_without_credential_provider() {
         let exporter_config = ExporterConfig::new("test-exporter");
 
         let missing_bindings = (GENEVA_EXPORTER.create)(
             create_test_pipeline_context(),
             test_node("test-exporter".to_owned()),
-            Arc::new(agent_fed_node_config(None, None)),
+            Arc::new(agent_fed_node_config(None)),
             &exporter_config,
             &Capabilities::empty(),
         );
@@ -2047,38 +2096,54 @@ mod tests {
             Ok(_) => panic!("missing bindings must fail exporter creation"),
             Err(error) => error,
         };
-        assert!(error.to_string().contains("bearer_token_provider"));
-
-        let mismatched_bindings = (GENEVA_EXPORTER.create)(
-            create_test_pipeline_context(),
-            test_node("test-exporter".to_owned()),
-            Arc::new(agent_fed_node_config(Some("agent-a"), Some("agent-b"))),
-            &exporter_config,
-            &Capabilities::empty(),
-        );
-        let error = match mismatched_bindings {
-            Ok(_) => panic!("mismatched bindings must fail exporter creation"),
-            Err(error) => error,
-        };
-        assert!(error.to_string().contains("same configured extension"));
+        assert!(error.to_string().contains("agent_fed_credential_provider"));
     }
 
-    /// Scenario: Registry-created capability clones share one rotating host snapshot.
-    /// Guarantees: A completed host rotation is visible through both capability handles.
+    /// Scenario: The config-only constructor receives agent-fed authentication.
+    /// Guarantees: Construction fails closed because no capability binding can be resolved.
+    #[test]
+    fn agent_fed_config_only_constructor_requires_factory_binding() {
+        let result =
+            GenevaExporter::from_config(create_test_pipeline_context(), &agent_fed_test_config());
+        let error = match result {
+            Ok(_) => panic!("config-only agent-fed construction must fail"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("agent_fed_credential_provider"));
+    }
+
+    /// Scenario: A node binds agent-fed credentials through a local-only extension.
+    /// Guarantees: Source creation rejects the binding and identifies the shared requirement.
+    #[test]
+    fn agent_fed_source_requires_shared_capability_registration() {
+        let node_config = agent_fed_node_config(Some("agent"));
+        validate_agent_fed_capability_binding(&node_config).expect("binding should be present");
+        let capabilities = resolved_local_only_agent_fed_capabilities(&node_config);
+        let config = Config::parse(&agent_fed_test_config()).expect("valid agent-fed config");
+        let error = resolve_agent_fed_source(&config, &capabilities)
+            .expect_err("shared capability implementation must be required");
+
+        assert!(
+            error
+                .to_string()
+                .contains("local-only registrations are unsupported")
+        );
+    }
+
+    /// Scenario: Registry-created credential snapshots follow a rotating host snapshot.
+    /// Guarantees: Every result contains a coherent token and routing pair from one generation.
     #[tokio::test]
-    async fn agent_fed_capability_clones_share_rotating_state() {
-        let node_config = agent_fed_node_config(Some("agent"), Some("agent"));
+    async fn agent_fed_credential_provider_rotates_coherently() {
+        let node_config = agent_fed_node_config(Some("agent"));
         let (capabilities, snapshot) = resolved_agent_fed_capabilities(&node_config);
-        let bearer = capabilities
-            .require_shared::<BearerTokenProviderCap>()
-            .expect("bearer capability");
-        let vendor = capabilities
-            .require_shared::<VendorBundleCap>()
-            .expect("vendor capability");
-        let source = AgentFedGenevaSource::new(bearer, vendor, "test-account".to_owned());
+        let credential_provider = capabilities
+            .require_shared::<AgentFedCredentialProviderCap>()
+            .expect("agent-fed credential provider");
+        let source = AgentFedGenevaSource::new(credential_provider, "test-account".to_owned());
 
         let initial = source.current().await.expect("initial credential");
-        assert_eq!(initial.token, "test-token");
+        assert_eq!(initial.expose_token(), "test-token");
         assert_eq!(initial.endpoint, "https://ep");
         assert_eq!(initial.moniker, "test-moniker");
 
@@ -2091,22 +2156,22 @@ mod tests {
         .expect("object");
         {
             let mut snapshot = snapshot.write().expect("snapshot write lock");
-            snapshot.token = "rotated-token".to_owned();
+            snapshot.token = BearerToken::without_expiry("rotated-token".to_owned());
             snapshot.attributes = Arc::new(rotated_attributes);
         }
 
         let rotated = source.current().await.expect("rotated credential");
-        assert_eq!(rotated.token, "rotated-token");
+        assert_eq!(rotated.expose_token(), "rotated-token");
         assert_eq!(rotated.endpoint, "https://rotated-ep");
         assert_eq!(rotated.moniker, "rotated-moniker");
     }
 
-    /// Scenario: Valid bindings resolve both capabilities from a shared extension.
+    /// Scenario: A valid binding resolves the combined capability from a shared extension.
     /// Guarantees: The factory constructs an agent-fed exporter successfully.
     #[test]
     fn creates_agent_fed_exporter_with_bound_capabilities() {
         otap_df_otap::crypto::ensure_crypto_provider();
-        let node_config = agent_fed_node_config(Some("agent"), Some("agent"));
+        let node_config = agent_fed_node_config(Some("agent"));
         let (capabilities, _snapshot) = resolved_agent_fed_capabilities(&node_config);
         let exporter_config = ExporterConfig::new("test-exporter");
         let result = (GENEVA_EXPORTER.create)(
@@ -2187,8 +2252,8 @@ mod tests {
         assert_eq!(GENEVA_EXPORTER_URN, "urn:microsoft:exporter:geneva");
     }
 
-    /// Scenario: Auth uses a user-assigned identity addressed by ARM resource ID.
-    /// Guarantees: The supported auth variant constructs a client successfully.
+    /// Scenario: A legacy caller uses the config-only constructor with ARM resource-ID auth.
+    /// Guarantees: The original public constructor remains source-compatible and succeeds.
     #[test]
     fn create_exporter_with_user_managed_identity_by_arm_resource_id() {
         // The Geneva uploader uses rustls (tls-rustls); reqwest needs a
@@ -2218,7 +2283,7 @@ mod tests {
             "max_buffer_size": 1000,
             "max_concurrent_uploads": 2
         });
-        let exporter = create_exporter_from_factory(&GENEVA_EXPORTER, config);
+        let exporter = GenevaExporter::from_config(create_test_pipeline_context(), &config);
         assert!(
             exporter.is_ok(),
             "Exporter should initialise with UserManagedIdentityByArmResourceId auth"

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/mod.rs
@@ -73,6 +73,7 @@ use otap_df_telemetry::common_attributes::{Outcome, SignalOutcomeAttributes};
 mod agent_fed_source;
 
 use agent_fed_source::AgentFedGenevaSource;
+use otap_df_engine::capability::ExtensionCapability;
 use otap_df_engine::capability::bearer_token_provider::BearerTokenProvider as BearerTokenProviderCap;
 use otap_df_engine::capability::vendor_bundle::VendorBundle as VendorBundleCap;
 
@@ -507,7 +508,8 @@ pub struct TracesConfig {
 #[derive(Debug, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
-    /// Geneva endpoint URL
+    /// Geneva config-service endpoint URL (required except for agent-fed auth)
+    #[serde(default)]
     pub endpoint: String,
     /// Environment (e.g., "production", "staging")
     pub environment: String,
@@ -515,7 +517,8 @@ pub struct Config {
     pub account: String,
     /// Geneva namespace
     pub namespace: String,
-    /// Azure region
+    /// Azure region (required except for agent-fed auth)
+    #[serde(default)]
     pub region: String,
     /// Config major version (required)
     pub config_major_version: u32,
@@ -551,6 +554,37 @@ const fn default_max_concurrent() -> usize {
 }
 
 impl Config {
+    fn parse(config: &serde_json::Value) -> Result<Self, otap_df_config::error::Error> {
+        let parsed: Self = serde_json::from_value(config.clone()).map_err(|error| {
+            otap_df_config::error::Error::InvalidUserConfig {
+                error: error.to_string(),
+            }
+        })?;
+        parsed.validate()?;
+        Ok(parsed)
+    }
+
+    fn validate(&self) -> Result<(), otap_df_config::error::Error> {
+        if self.account.trim().is_empty() {
+            return Err(otap_df_config::error::Error::InvalidUserConfig {
+                error: "account must not be empty".to_owned(),
+            });
+        }
+        if !matches!(self.auth, AuthConfig::AgentFed) {
+            if self.endpoint.trim().is_empty() {
+                return Err(otap_df_config::error::Error::InvalidUserConfig {
+                    error: "endpoint is required unless auth.type is agentfed".to_owned(),
+                });
+            }
+            if self.region.trim().is_empty() {
+                return Err(otap_df_config::error::Error::InvalidUserConfig {
+                    error: "region is required unless auth.type is agentfed".to_owned(),
+                });
+            }
+        }
+        Ok(())
+    }
+
     /// Build the `geneva-uploader` `GenevaClientConfig` from this exporter
     /// configuration.
     ///
@@ -580,6 +614,9 @@ impl Config {
             AuthConfig::WorkloadIdentity { msi_resource } => AuthMethod::WorkloadIdentity {
                 resource: msi_resource.clone(),
             },
+            // `with_agent_fed_source` ignores this field. The placeholder only
+            // satisfies the shared uploader configuration type.
+            AuthConfig::AgentFed => AuthMethod::SystemManagedIdentity,
         };
 
         // Get MSI resource if needed for managed identity
@@ -588,7 +625,7 @@ impl Config {
             | AuthConfig::UserManagedIdentity { msi_resource, .. }
             | AuthConfig::UserManagedIdentityByArmResourceId { msi_resource, .. }
             | AuthConfig::WorkloadIdentity { msi_resource } => Some(msi_resource.clone()),
-            AuthConfig::Certificate { .. } => None,
+            AuthConfig::Certificate { .. } | AuthConfig::AgentFed => None,
         };
 
         // Create LogsConfig and TracesConfig from the configuration
@@ -624,6 +661,10 @@ impl Config {
             obo_event_map: None,
         }
     }
+}
+
+fn validate_config(config: &serde_json::Value) -> Result<(), otap_df_config::error::Error> {
+    Config::parse(config).map(|_| ())
 }
 
 /// Authentication configuration
@@ -667,7 +708,8 @@ pub enum AuthConfig {
     /// GIG token and routing attributes through the `bearer_token_provider`
     /// and `vendor_bundle` capabilities, so the uploader skips the GCS
     /// config-service handshake. Carries no config fields; the capabilities
-    /// are bound to a host extension via the node's `capabilities` block.
+    /// must bind to the same host extension via the node's `capabilities`
+    /// block.
     AgentFed,
 }
 
@@ -775,21 +817,45 @@ pub struct GenevaExporter {
     geneva_client: GenevaClient,
 }
 
+fn validate_agent_fed_capability_bindings(
+    node_config: &NodeUserConfig,
+) -> Result<(), otap_df_config::error::Error> {
+    let bearer_name = BearerTokenProviderCap::NAME;
+    let vendor_name = VendorBundleCap::NAME;
+    let bearer_extension = node_config.capabilities.get(bearer_name).ok_or_else(|| {
+        otap_df_config::error::Error::InvalidUserConfig {
+            error: format!("agent-fed Geneva auth requires a '{bearer_name}' capability binding"),
+        }
+    })?;
+    let vendor_extension = node_config.capabilities.get(vendor_name).ok_or_else(|| {
+        otap_df_config::error::Error::InvalidUserConfig {
+            error: format!("agent-fed Geneva auth requires a '{vendor_name}' capability binding"),
+        }
+    })?;
+
+    if bearer_extension != vendor_extension {
+        return Err(otap_df_config::error::Error::InvalidUserConfig {
+            error: format!(
+                "agent-fed Geneva auth requires '{bearer_name}' and '{vendor_name}' \
+                 to bind to the same extension instance"
+            ),
+        });
+    }
+
+    Ok(())
+}
+
 impl GenevaExporter {
     /// Create a new Geneva exporter from configuration
     pub fn from_config(
         pipeline_ctx: PipelineContext,
-        config: &serde_json::Value,
+        node_config: &NodeUserConfig,
         capabilities: &otap_df_engine::capability::registry::Capabilities,
     ) -> Result<Self, otap_df_config::error::Error> {
         let pdata_metrics = ExporterPDataExportMetrics::register(&pipeline_ctx);
         let metrics = pipeline_ctx.register_metrics::<ExporterMetrics>();
 
-        let config: Config = serde_json::from_value(config.clone()).map_err(|e| {
-            otap_df_config::error::Error::InvalidUserConfig {
-                error: e.to_string(),
-            }
-        })?;
+        let config = Config::parse(&node_config.config)?;
 
         let client_config = config.to_geneva_client_config();
 
@@ -812,6 +878,7 @@ impl GenevaExporter {
         // other auth methods drive the GCS config-service handshake.
         let geneva_client = match &config.auth {
             AuthConfig::AgentFed => {
+                validate_agent_fed_capability_bindings(node_config)?;
                 let bearer = capabilities
                     .require_shared::<BearerTokenProviderCap>()
                     .map_err(|e| otap_df_config::error::Error::InvalidUserConfig {
@@ -827,7 +894,7 @@ impl GenevaExporter {
                              (carries the endpoint/moniker routing): {e}"
                         ),
                     })?;
-                let source = AgentFedGenevaSource::new(bearer, vendor);
+                let source = AgentFedGenevaSource::new(bearer, vendor, config.account.clone());
                 GenevaClient::with_agent_fed_source(client_config, Arc::new(source)).map_err(
                     |e| otap_df_config::error::Error::InvalidUserConfig {
                         error: format!("Failed to initialize agent-fed Geneva client: {e}"),
@@ -1207,14 +1274,14 @@ pub static GENEVA_EXPORTER: ExporterFactory<OtapPdata> = ExporterFactory {
              exporter_config: &ExporterConfig,
              capabilities: &otap_df_engine::capability::registry::Capabilities| {
         Ok(ExporterWrapper::local(
-            GenevaExporter::from_config(pipeline, &node_config.config, capabilities)?,
+            GenevaExporter::from_config(pipeline, &node_config, capabilities)?,
             node,
             node_config,
             exporter_config,
         ))
     },
     wiring_contract: otap_df_engine::wiring_contract::WiringContract::UNRESTRICTED,
-    validate_config: otap_df_config::validation::validate_typed_config::<Config>,
+    validate_config,
 };
 
 #[async_trait(?Send)]
@@ -1224,15 +1291,30 @@ impl Exporter<OtapPdata> for GenevaExporter {
         mut msg_chan: ExporterInbox<OtapPdata>,
         effect_handler: EffectHandler<OtapPdata>,
     ) -> Result<TerminalState, Error> {
-        otel_info!(
-            "geneva_exporter.start",
-            endpoint = self.config.endpoint,
-            namespace = self.config.namespace,
-            account = self.config.account,
-            role_name = self.config.role_name,
-            role_instance = self.config.role_instance,
-            message = "Geneva exporter starting"
-        );
+        match &self.config.auth {
+            AuthConfig::AgentFed => {
+                otel_info!(
+                    "geneva_exporter.start",
+                    endpoint_source = "vendor_bundle",
+                    namespace = self.config.namespace,
+                    account = self.config.account,
+                    role_name = self.config.role_name,
+                    role_instance = self.config.role_instance,
+                    message = "Geneva exporter starting"
+                );
+            }
+            _ => {
+                otel_info!(
+                    "geneva_exporter.start",
+                    endpoint = self.config.endpoint,
+                    namespace = self.config.namespace,
+                    account = self.config.account,
+                    role_name = self.config.role_name,
+                    role_instance = self.config.role_instance,
+                    message = "Geneva exporter starting"
+                );
+            }
+        }
 
         // Message loop
         loop {
@@ -1311,6 +1393,7 @@ impl Exporter<OtapPdata> for GenevaExporter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_trait::async_trait;
     use serde_json;
 
     use arrow::array::{
@@ -1322,14 +1405,27 @@ mod tests {
 
     use bytes::Bytes;
     use otap_df_engine::Interests;
+    use otap_df_engine::capability::SharedInstanceFactory;
+    use otap_df_engine::capability::bearer_token_provider::{BearerToken, TokenStream};
+    use otap_df_engine::capability::registry::CapabilityRegistry;
+    use otap_df_engine::capability::{CapabilityError, ExtensionCapability};
     use otap_df_engine::control::PipelineCompletionMsg;
-    use otap_df_engine::testing::exporter::{TestRuntime, create_exporter_from_factory};
+    use otap_df_engine::extension_capabilities;
+    use otap_df_engine::shared::capability::bearer_token_provider::BearerTokenProvider as SharedBearerTokenProvider;
+    use otap_df_engine::shared::capability::vendor_bundle::VendorBundle as SharedVendorBundle;
+    use otap_df_engine::testing::capability::resolve_bindings_for_test;
+    use otap_df_engine::testing::exporter::{
+        TestRuntime, create_exporter_from_factory, create_test_pipeline_context,
+    };
+    use otap_df_engine::testing::test_node;
     use otap_df_otap::testing::{TestCallData, next_ack, next_nack};
     use otap_df_pdata::otap::OtapArrowRecords;
     use otap_df_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
     use otap_df_pdata::schema::{FieldExt, consts};
     use otap_df_pdata::views::otap::OtapLogsView;
     use otap_df_pdata_views::views::logs::{LogsDataView, ResourceLogsView, ScopeLogsView};
+    use std::any::Any;
+    use std::collections::HashSet;
     use std::time::{Duration, Instant};
 
     fn plain_field(name: &str, data_type: DataType, nullable: bool) -> Field {
@@ -1478,6 +1574,95 @@ mod tests {
             "max_buffer_size": 1000,
             "max_concurrent_uploads": 2
         })
+    }
+
+    fn agent_fed_test_config() -> serde_json::Value {
+        serde_json::json!({
+            "environment": "test",
+            "account": "test-account",
+            "namespace": "test-namespace",
+            "config_major_version": 1,
+            "tenant": "test-tenant",
+            "role_name": "test-role",
+            "role_instance": "test-instance",
+            "auth": {
+                "type": "agentfed"
+            },
+            "max_buffer_size": 1000,
+            "max_concurrent_uploads": 2
+        })
+    }
+
+    fn agent_fed_node_config(
+        bearer_extension: Option<&str>,
+        vendor_extension: Option<&str>,
+    ) -> NodeUserConfig {
+        let mut node_config = NodeUserConfig::new_exporter_config(GENEVA_EXPORTER_URN);
+        node_config.config = agent_fed_test_config();
+        if let Some(extension) = bearer_extension {
+            let _ = node_config.capabilities.insert(
+                BearerTokenProviderCap::NAME.into(),
+                extension.to_owned().into(),
+            );
+        }
+        if let Some(extension) = vendor_extension {
+            let _ = node_config
+                .capabilities
+                .insert(VendorBundleCap::NAME.into(), extension.to_owned().into());
+        }
+        node_config
+    }
+
+    #[derive(Clone)]
+    struct MockAgentExtension {
+        token: String,
+        attributes: Arc<serde_json::Map<String, serde_json::Value>>,
+    }
+
+    #[async_trait]
+    impl SharedBearerTokenProvider for MockAgentExtension {
+        async fn get_token(&self) -> Result<BearerToken, CapabilityError> {
+            Ok(BearerToken::new(self.token.clone(), None))
+        }
+
+        fn token_stream(&self) -> TokenStream {
+            futures::stream::empty::<BearerToken>().boxed()
+        }
+    }
+
+    impl SharedVendorBundle for MockAgentExtension {
+        fn attributes(
+            &self,
+        ) -> Result<Arc<serde_json::Map<String, serde_json::Value>>, CapabilityError> {
+            Ok(self.attributes.clone())
+        }
+    }
+
+    fn resolved_agent_fed_capabilities(
+        node_config: &NodeUserConfig,
+    ) -> otap_df_engine::capability::registry::Capabilities {
+        let attributes = serde_json::json!({
+            "endpoint": "https://ep",
+            "moniker_map": { "test-account": "test-moniker" },
+        })
+        .as_object()
+        .cloned()
+        .expect("object");
+        let extension = MockAgentExtension {
+            token: "test-token".to_owned(),
+            attributes: Arc::new(attributes),
+        };
+        let extension_capabilities = extension_capabilities!(
+            shared: MockAgentExtension => [BearerTokenProviderCap, VendorBundleCap]
+        );
+        let instance_factory =
+            SharedInstanceFactory::new(move || Box::new(extension.clone()) as Box<dyn Any + Send>);
+        let mut registry = CapabilityRegistry::new();
+        (extension_capabilities.register_shared)("agent".into(), instance_factory, &mut registry)
+            .expect("register capabilities");
+        let known_extensions = HashSet::<otap_df_config::ExtensionId>::from(["agent".into()]);
+        resolve_bindings_for_test(&node_config.capabilities, &registry, &known_extensions)
+            .expect("resolve capabilities")
     }
 
     #[test]
@@ -1671,6 +1856,81 @@ mod tests {
     }
 
     #[test]
+    fn agent_fed_config_can_omit_gcs_endpoint_and_region() {
+        let config = Config::parse(&agent_fed_test_config()).expect("valid agent-fed config");
+        assert!(config.endpoint.is_empty());
+        assert!(config.region.is_empty());
+        assert!(matches!(config.auth, AuthConfig::AgentFed));
+    }
+
+    #[test]
+    fn non_agent_fed_config_requires_endpoint_and_region() {
+        let mut missing_endpoint = test_config();
+        let _ = missing_endpoint
+            .as_object_mut()
+            .expect("object")
+            .remove("endpoint");
+        let error = Config::parse(&missing_endpoint).expect_err("endpoint must be required");
+        assert!(error.to_string().contains("endpoint is required"));
+
+        let mut missing_region = test_config();
+        let _ = missing_region
+            .as_object_mut()
+            .expect("object")
+            .remove("region");
+        let error = Config::parse(&missing_region).expect_err("region must be required");
+        assert!(error.to_string().contains("region is required"));
+    }
+
+    #[test]
+    fn agent_fed_config_requires_account_for_moniker_selection() {
+        let mut config = agent_fed_test_config();
+        config["account"] = serde_json::Value::String(String::new());
+        let error = Config::parse(&config).expect_err("account must be required");
+        assert!(error.to_string().contains("account must not be empty"));
+    }
+
+    #[test]
+    fn agent_fed_capabilities_must_bind_to_the_same_extension() {
+        let node_config = agent_fed_node_config(Some("agent-a"), Some("agent-b"));
+        let error = validate_agent_fed_capability_bindings(&node_config)
+            .expect_err("mismatched extensions must fail");
+        assert!(error.to_string().contains("same extension instance"));
+
+        let node_config = agent_fed_node_config(Some("agent"), Some("agent"));
+        validate_agent_fed_capability_bindings(&node_config)
+            .expect("matching extensions must pass");
+    }
+
+    #[test]
+    fn agent_fed_capabilities_require_both_bindings() {
+        let missing_bearer = agent_fed_node_config(None, Some("agent"));
+        let error = validate_agent_fed_capability_bindings(&missing_bearer)
+            .expect_err("bearer binding must be required");
+        assert!(error.to_string().contains("bearer_token_provider"));
+
+        let missing_vendor = agent_fed_node_config(Some("agent"), None);
+        let error = validate_agent_fed_capability_bindings(&missing_vendor)
+            .expect_err("vendor binding must be required");
+        assert!(error.to_string().contains("vendor_bundle"));
+    }
+
+    #[test]
+    fn creates_agent_fed_exporter_with_bound_capabilities() {
+        let node_config = agent_fed_node_config(Some("agent"), Some("agent"));
+        let capabilities = resolved_agent_fed_capabilities(&node_config);
+        let exporter_config = ExporterConfig::new("test-exporter");
+        let result = (GENEVA_EXPORTER.create)(
+            create_test_pipeline_context(),
+            test_node("test-exporter".to_owned()),
+            Arc::new(node_config),
+            &exporter_config,
+            &capabilities,
+        );
+        assert!(result.is_ok(), "agent-fed exporter should initialize");
+    }
+
+    #[test]
     fn test_auth_config_variants() {
         let cert_json = serde_json::json!({
             "type": "certificate",
@@ -1721,6 +1981,12 @@ mod tests {
         });
         let workload: AuthConfig = serde_json::from_value(workload_json).unwrap();
         assert!(matches!(workload, AuthConfig::WorkloadIdentity { .. }));
+
+        let agent_fed_json = serde_json::json!({
+            "type": "agentfed"
+        });
+        let agent_fed: AuthConfig = serde_json::from_value(agent_fed_json).unwrap();
+        assert!(matches!(agent_fed, AuthConfig::AgentFed));
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/mod.rs
@@ -74,7 +74,7 @@ mod agent_fed_source;
 
 use agent_fed_source::AgentFedGenevaSource;
 use otap_df_engine::capability::ExtensionCapability;
-use otap_df_engine::capability::bearer_token_provider::BearerTokenProvider as BearerTokenProviderCap;
+use otap_df_engine::capability::auth::bearer_token_provider::BearerTokenProvider as BearerTokenProviderCap;
 use otap_df_engine::capability::vendor_bundle::VendorBundle as VendorBundleCap;
 
 /// The URN for the Geneva exporter
@@ -1406,12 +1406,13 @@ mod tests {
     use bytes::Bytes;
     use otap_df_engine::Interests;
     use otap_df_engine::capability::SharedInstanceFactory;
-    use otap_df_engine::capability::bearer_token_provider::{BearerToken, TokenStream};
+    use otap_df_engine::capability::auth::BearerToken;
+    use otap_df_engine::capability::auth::bearer_token_provider::TokenStream;
     use otap_df_engine::capability::registry::CapabilityRegistry;
     use otap_df_engine::capability::{CapabilityError, ExtensionCapability};
     use otap_df_engine::control::PipelineCompletionMsg;
     use otap_df_engine::extension_capabilities;
-    use otap_df_engine::shared::capability::bearer_token_provider::BearerTokenProvider as SharedBearerTokenProvider;
+    use otap_df_engine::shared::capability::auth::bearer_token_provider::BearerTokenProvider as SharedBearerTokenProvider;
     use otap_df_engine::shared::capability::vendor_bundle::VendorBundle as SharedVendorBundle;
     use otap_df_engine::testing::capability::resolve_bindings_for_test;
     use otap_df_engine::testing::exporter::{
@@ -1622,7 +1623,7 @@ mod tests {
     #[async_trait]
     impl SharedBearerTokenProvider for MockAgentExtension {
         async fn get_token(&self) -> Result<BearerToken, CapabilityError> {
-            Ok(BearerToken::new(self.token.clone(), None))
+            Ok(BearerToken::without_expiry(self.token.clone()))
         }
 
         fn token_stream(&self) -> TokenStream {

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/mod.rs
@@ -2144,7 +2144,7 @@ mod tests {
 
         let initial = source.current().await.expect("initial credential");
         assert_eq!(initial.expose_token(), "test-token");
-        assert_eq!(initial.endpoint, "https://ep");
+        assert_eq!(initial.endpoint, "https://ep/");
         assert_eq!(initial.moniker, "test-moniker");
 
         let rotated_attributes = serde_json::json!({
@@ -2162,7 +2162,7 @@ mod tests {
 
         let rotated = source.current().await.expect("rotated credential");
         assert_eq!(rotated.expose_token(), "rotated-token");
-        assert_eq!(rotated.endpoint, "https://rotated-ep");
+        assert_eq!(rotated.endpoint, "https://rotated-ep/");
         assert_eq!(rotated.moniker, "rotated-moniker");
     }
 

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/mod.rs
@@ -506,10 +506,9 @@ pub struct TracesConfig {
 
 /// Configuration for the Geneva Exporter
 #[derive(Debug, Deserialize, Clone)]
-#[serde(deny_unknown_fields)]
+#[serde(try_from = "ConfigBuilder")]
 pub struct Config {
     /// Geneva config-service endpoint URL (required except for agent-fed auth)
-    #[serde(default)]
     pub endpoint: String,
     /// Environment (e.g., "production", "staging")
     pub environment: String,
@@ -518,7 +517,6 @@ pub struct Config {
     /// Geneva namespace
     pub namespace: String,
     /// Azure region (required except for agent-fed auth)
-    #[serde(default)]
     pub region: String,
     /// Config major version (required)
     pub config_major_version: u32,
@@ -538,11 +536,30 @@ pub struct Config {
     pub spans: Option<TracesConfig>,
     /// Maximum buffer size before forcing flush (default: 1000)
     /// Note: This field is currently reserved for future use and does not affect runtime behavior.
-    #[serde(default = "default_buffer_size")]
     pub max_buffer_size: usize,
     /// Maximum concurrent uploads (default: 4)
-    #[serde(default = "default_max_concurrent")]
     pub max_concurrent_uploads: usize,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ConfigBuilder {
+    #[serde(default)]
+    endpoint: String,
+    environment: String,
+    account: String,
+    namespace: String,
+    #[serde(default)]
+    region: String,
+    config_major_version: u32,
+    tenant: String,
+    role_name: String,
+    role_instance: String,
+    auth: AuthConfig,
+    #[serde(default = "default_buffer_size")]
+    max_buffer_size: usize,
+    #[serde(default = "default_max_concurrent")]
+    max_concurrent_uploads: usize,
 }
 
 const fn default_buffer_size() -> usize {
@@ -555,31 +572,23 @@ const fn default_max_concurrent() -> usize {
 
 impl Config {
     fn parse(config: &serde_json::Value) -> Result<Self, otap_df_config::error::Error> {
-        let parsed: Self = serde_json::from_value(config.clone()).map_err(|error| {
+        serde_json::from_value(config.clone()).map_err(|error| {
             otap_df_config::error::Error::InvalidUserConfig {
                 error: error.to_string(),
             }
-        })?;
-        parsed.validate()?;
-        Ok(parsed)
+        })
     }
 
-    fn validate(&self) -> Result<(), otap_df_config::error::Error> {
+    fn validate(&self) -> Result<(), String> {
         if self.account.trim().is_empty() {
-            return Err(otap_df_config::error::Error::InvalidUserConfig {
-                error: "account must not be empty".to_owned(),
-            });
+            return Err("account must not be empty".to_owned());
         }
         if !matches!(self.auth, AuthConfig::AgentFed) {
             if self.endpoint.trim().is_empty() {
-                return Err(otap_df_config::error::Error::InvalidUserConfig {
-                    error: "endpoint is required unless auth.type is agentfed".to_owned(),
-                });
+                return Err("endpoint is required unless auth.type is agentfed".to_owned());
             }
             if self.region.trim().is_empty() {
-                return Err(otap_df_config::error::Error::InvalidUserConfig {
-                    error: "region is required unless auth.type is agentfed".to_owned(),
-                });
+                return Err("region is required unless auth.type is agentfed".to_owned());
             }
         }
         Ok(())
@@ -660,6 +669,29 @@ impl Config {
             spans: traces_config,
             obo_event_map: None,
         }
+    }
+}
+
+impl TryFrom<ConfigBuilder> for Config {
+    type Error = String;
+
+    fn try_from(builder: ConfigBuilder) -> Result<Self, Self::Error> {
+        let config = Self {
+            endpoint: builder.endpoint,
+            environment: builder.environment,
+            account: builder.account,
+            namespace: builder.namespace,
+            region: builder.region,
+            config_major_version: builder.config_major_version,
+            tenant: builder.tenant,
+            role_name: builder.role_name,
+            role_instance: builder.role_instance,
+            auth: builder.auth,
+            max_buffer_size: builder.max_buffer_size,
+            max_concurrent_uploads: builder.max_concurrent_uploads,
+        };
+        config.validate()?;
+        Ok(config)
     }
 }
 
@@ -817,6 +849,9 @@ pub struct GenevaExporter {
     geneva_client: GenevaClient,
 }
 
+/// Validates the node-level bindings that the config-only factory validation
+/// hook cannot inspect. Called during exporter creation before either
+/// capability is consumed.
 fn validate_agent_fed_capability_bindings(
     node_config: &NodeUserConfig,
 ) -> Result<(), otap_df_config::error::Error> {
@@ -837,7 +872,7 @@ fn validate_agent_fed_capability_bindings(
         return Err(otap_df_config::error::Error::InvalidUserConfig {
             error: format!(
                 "agent-fed Geneva auth requires '{bearer_name}' and '{vendor_name}' \
-                 to bind to the same extension instance"
+                 to bind to the same configured extension"
             ),
         });
     }
@@ -1858,7 +1893,8 @@ mod tests {
 
     #[test]
     fn agent_fed_config_can_omit_gcs_endpoint_and_region() {
-        let config = Config::parse(&agent_fed_test_config()).expect("valid agent-fed config");
+        let config: Config =
+            serde_json::from_value(agent_fed_test_config()).expect("valid agent-fed config");
         assert!(config.endpoint.is_empty());
         assert!(config.region.is_empty());
         assert!(matches!(config.auth, AuthConfig::AgentFed));
@@ -1871,7 +1907,8 @@ mod tests {
             .as_object_mut()
             .expect("object")
             .remove("endpoint");
-        let error = Config::parse(&missing_endpoint).expect_err("endpoint must be required");
+        let error = serde_json::from_value::<Config>(missing_endpoint)
+            .expect_err("endpoint must be required");
         assert!(error.to_string().contains("endpoint is required"));
 
         let mut missing_region = test_config();
@@ -1879,7 +1916,8 @@ mod tests {
             .as_object_mut()
             .expect("object")
             .remove("region");
-        let error = Config::parse(&missing_region).expect_err("region must be required");
+        let error =
+            serde_json::from_value::<Config>(missing_region).expect_err("region must be required");
         assert!(error.to_string().contains("region is required"));
     }
 
@@ -1887,7 +1925,7 @@ mod tests {
     fn agent_fed_config_requires_account_for_moniker_selection() {
         let mut config = agent_fed_test_config();
         config["account"] = serde_json::Value::String(String::new());
-        let error = Config::parse(&config).expect_err("account must be required");
+        let error = serde_json::from_value::<Config>(config).expect_err("account must be required");
         assert!(error.to_string().contains("account must not be empty"));
     }
 
@@ -1896,7 +1934,7 @@ mod tests {
         let node_config = agent_fed_node_config(Some("agent-a"), Some("agent-b"));
         let error = validate_agent_fed_capability_bindings(&node_config)
             .expect_err("mismatched extensions must fail");
-        assert!(error.to_string().contains("same extension instance"));
+        assert!(error.to_string().contains("same configured extension"));
 
         let node_config = agent_fed_node_config(Some("agent"), Some("agent"));
         validate_agent_fed_capability_bindings(&node_config)
@@ -1914,6 +1952,37 @@ mod tests {
         let error = validate_agent_fed_capability_bindings(&missing_vendor)
             .expect_err("vendor binding must be required");
         assert!(error.to_string().contains("vendor_bundle"));
+    }
+
+    #[test]
+    fn agent_fed_factory_fails_closed_on_invalid_bindings() {
+        let exporter_config = ExporterConfig::new("test-exporter");
+
+        let missing_bindings = (GENEVA_EXPORTER.create)(
+            create_test_pipeline_context(),
+            test_node("test-exporter".to_owned()),
+            Arc::new(agent_fed_node_config(None, None)),
+            &exporter_config,
+            &otap_df_engine::capability::registry::Capabilities::empty(),
+        );
+        let error = match missing_bindings {
+            Ok(_) => panic!("missing bindings must fail exporter creation"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("bearer_token_provider"));
+
+        let mismatched_bindings = (GENEVA_EXPORTER.create)(
+            create_test_pipeline_context(),
+            test_node("test-exporter".to_owned()),
+            Arc::new(agent_fed_node_config(Some("agent-a"), Some("agent-b"))),
+            &exporter_config,
+            &otap_df_engine::capability::registry::Capabilities::empty(),
+        );
+        let error = match mismatched_bindings {
+            Ok(_) => panic!("mismatched bindings must fail exporter creation"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("same configured extension"));
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/mod.rs
@@ -27,6 +27,7 @@
 use async_trait::async_trait;
 use linkme::distributed_slice;
 use otap_df_config::SignalType;
+use otap_df_config::error::Error as ConfigError;
 use otap_df_config::node::NodeUserConfig;
 use otap_df_engine::ConsumerEffectHandlerExtension;
 use otap_df_engine::ExporterFactory;
@@ -75,6 +76,7 @@ mod agent_fed_source;
 use agent_fed_source::AgentFedGenevaSource;
 use otap_df_engine::capability::ExtensionCapability;
 use otap_df_engine::capability::auth::bearer_token_provider::BearerTokenProvider as BearerTokenProviderCap;
+use otap_df_engine::capability::registry::Capabilities;
 use otap_df_engine::capability::vendor_bundle::VendorBundle as VendorBundleCap;
 
 /// The URN for the Geneva exporter
@@ -556,6 +558,10 @@ struct ConfigBuilder {
     role_name: String,
     role_instance: String,
     auth: AuthConfig,
+    #[serde(default)]
+    logs: Option<LogsConfig>,
+    #[serde(default)]
+    spans: Option<TracesConfig>,
     #[serde(default = "default_buffer_size")]
     max_buffer_size: usize,
     #[serde(default = "default_max_concurrent")]
@@ -571,11 +577,9 @@ const fn default_max_concurrent() -> usize {
 }
 
 impl Config {
-    fn parse(config: &serde_json::Value) -> Result<Self, otap_df_config::error::Error> {
-        serde_json::from_value(config.clone()).map_err(|error| {
-            otap_df_config::error::Error::InvalidUserConfig {
-                error: error.to_string(),
-            }
+    fn parse(config: &serde_json::Value) -> Result<Self, ConfigError> {
+        serde_json::from_value(config.clone()).map_err(|error| ConfigError::InvalidUserConfig {
+            error: error.to_string(),
         })
     }
 
@@ -605,38 +609,6 @@ impl Config {
     /// `GenevaClientConfig` conversion can be unit-tested without initializing
     /// a live `GenevaClient`.
     fn to_geneva_client_config(&self) -> GenevaClientConfig {
-        // Convert AuthConfig to AuthMethod
-        let auth_method = match &self.auth {
-            AuthConfig::Certificate { path, password } => AuthMethod::Certificate {
-                path: PathBuf::from(path),
-                password: password.clone(),
-            },
-            AuthConfig::SystemManagedIdentity { .. } => AuthMethod::SystemManagedIdentity,
-            AuthConfig::UserManagedIdentity { client_id, .. } => AuthMethod::UserManagedIdentity {
-                client_id: client_id.clone(),
-            },
-            AuthConfig::UserManagedIdentityByArmResourceId { resource_id, .. } => {
-                AuthMethod::UserManagedIdentityByResourceId {
-                    resource_id: resource_id.clone(),
-                }
-            }
-            AuthConfig::WorkloadIdentity { msi_resource } => AuthMethod::WorkloadIdentity {
-                resource: msi_resource.clone(),
-            },
-            // `with_agent_fed_source` ignores this field. The placeholder only
-            // satisfies the shared uploader configuration type.
-            AuthConfig::AgentFed => AuthMethod::SystemManagedIdentity,
-        };
-
-        // Get MSI resource if needed for managed identity
-        let msi_resource = match &self.auth {
-            AuthConfig::SystemManagedIdentity { msi_resource }
-            | AuthConfig::UserManagedIdentity { msi_resource, .. }
-            | AuthConfig::UserManagedIdentityByArmResourceId { msi_resource, .. }
-            | AuthConfig::WorkloadIdentity { msi_resource } => Some(msi_resource.clone()),
-            AuthConfig::Certificate { .. } | AuthConfig::AgentFed => None,
-        };
-
         // Create LogsConfig and TracesConfig from the configuration
         let logs_config = self
             .logs
@@ -660,11 +632,11 @@ impl Config {
             namespace: self.namespace.clone(),
             region: self.region.clone(),
             config_major_version: self.config_major_version,
-            auth_method,
+            auth_method: self.auth.uploader_auth_method(),
             tenant: self.tenant.clone(),
             role_name: self.role_name.clone(),
             role_instance: self.role_instance.clone(),
-            msi_resource,
+            msi_resource: self.auth.msi_resource(),
             logs: logs_config,
             spans: traces_config,
             obo_event_map: None,
@@ -687,16 +659,14 @@ impl TryFrom<ConfigBuilder> for Config {
             role_name: builder.role_name,
             role_instance: builder.role_instance,
             auth: builder.auth,
+            logs: builder.logs,
+            spans: builder.spans,
             max_buffer_size: builder.max_buffer_size,
             max_concurrent_uploads: builder.max_concurrent_uploads,
         };
         config.validate()?;
         Ok(config)
     }
-}
-
-fn validate_config(config: &serde_json::Value) -> Result<(), otap_df_config::error::Error> {
-    Config::parse(config).map(|_| ())
 }
 
 /// Authentication configuration
@@ -743,6 +713,42 @@ pub enum AuthConfig {
     /// must bind to the same host extension via the node's `capabilities`
     /// block.
     AgentFed,
+}
+
+impl AuthConfig {
+    fn uploader_auth_method(&self) -> AuthMethod {
+        match self {
+            Self::Certificate { path, password } => AuthMethod::Certificate {
+                path: PathBuf::from(path),
+                password: password.clone(),
+            },
+            Self::SystemManagedIdentity { .. } => AuthMethod::SystemManagedIdentity,
+            Self::UserManagedIdentity { client_id, .. } => AuthMethod::UserManagedIdentity {
+                client_id: client_id.clone(),
+            },
+            Self::UserManagedIdentityByArmResourceId { resource_id, .. } => {
+                AuthMethod::UserManagedIdentityByResourceId {
+                    resource_id: resource_id.clone(),
+                }
+            }
+            Self::WorkloadIdentity { msi_resource } => AuthMethod::WorkloadIdentity {
+                resource: msi_resource.clone(),
+            },
+            // `with_agent_fed_source` ignores this field. The placeholder only
+            // satisfies the shared uploader configuration type.
+            Self::AgentFed => AuthMethod::SystemManagedIdentity,
+        }
+    }
+
+    fn msi_resource(&self) -> Option<String> {
+        match self {
+            Self::SystemManagedIdentity { msi_resource }
+            | Self::UserManagedIdentity { msi_resource, .. }
+            | Self::UserManagedIdentityByArmResourceId { msi_resource, .. }
+            | Self::WorkloadIdentity { msi_resource } => Some(msi_resource.clone()),
+            Self::Certificate { .. } | Self::AgentFed => None,
+        }
+    }
 }
 
 /// Geneva exporter metrics.
@@ -852,24 +858,22 @@ pub struct GenevaExporter {
 /// Validates the node-level bindings that the config-only factory validation
 /// hook cannot inspect. Called during exporter creation before either
 /// capability is consumed.
-fn validate_agent_fed_capability_bindings(
-    node_config: &NodeUserConfig,
-) -> Result<(), otap_df_config::error::Error> {
+fn validate_agent_fed_capability_bindings(node_config: &NodeUserConfig) -> Result<(), ConfigError> {
     let bearer_name = BearerTokenProviderCap::NAME;
     let vendor_name = VendorBundleCap::NAME;
     let bearer_extension = node_config.capabilities.get(bearer_name).ok_or_else(|| {
-        otap_df_config::error::Error::InvalidUserConfig {
+        ConfigError::InvalidUserConfig {
             error: format!("agent-fed Geneva auth requires a '{bearer_name}' capability binding"),
         }
     })?;
     let vendor_extension = node_config.capabilities.get(vendor_name).ok_or_else(|| {
-        otap_df_config::error::Error::InvalidUserConfig {
+        ConfigError::InvalidUserConfig {
             error: format!("agent-fed Geneva auth requires a '{vendor_name}' capability binding"),
         }
     })?;
 
     if bearer_extension != vendor_extension {
-        return Err(otap_df_config::error::Error::InvalidUserConfig {
+        return Err(ConfigError::InvalidUserConfig {
             error: format!(
                 "agent-fed Geneva auth requires '{bearer_name}' and '{vendor_name}' \
                  to bind to the same configured extension"
@@ -880,68 +884,96 @@ fn validate_agent_fed_capability_bindings(
     Ok(())
 }
 
+fn ensure_crypto_provider() -> Result<(), ConfigError> {
+    if otap_df_otap::crypto::is_crypto_provider_installed() {
+        return Ok(());
+    }
+
+    Err(ConfigError::InvalidUserConfig {
+        error: "Geneva exporter requires a rustls CryptoProvider, but none is installed. \
+                Build with exactly one of the crypto-* features \
+                (crypto-ring, crypto-aws-lc, crypto-openssl, crypto-symcrypt) and ensure \
+                otap_df_otap::crypto::install_crypto_provider() runs at startup."
+            .to_string(),
+    })
+}
+
+fn validate_geneva_client_prerequisites(
+    config: &Config,
+    node_config: &NodeUserConfig,
+    crypto_provider_check: impl FnOnce() -> Result<(), ConfigError>,
+) -> Result<(), ConfigError> {
+    if matches!(&config.auth, AuthConfig::AgentFed) {
+        // This validates configured extension identity. The extension's Clone
+        // implementation must still share one underlying token/routing snapshot.
+        validate_agent_fed_capability_bindings(node_config)?;
+    }
+
+    // Both GCS and agent-fed uploads use the rustls-backed HTTP client.
+    crypto_provider_check()
+}
+
+fn resolve_agent_fed_source(
+    config: &Config,
+    capabilities: &Capabilities,
+) -> Result<AgentFedGenevaSource, ConfigError> {
+    let bearer = capabilities
+        .require_shared::<BearerTokenProviderCap>()
+        .map_err(|error| ConfigError::InvalidUserConfig {
+            error: format!(
+                "agent-fed Geneva auth requires a bound bearer_token_provider capability: {error}"
+            ),
+        })?;
+    let vendor = capabilities
+        .require_shared::<VendorBundleCap>()
+        .map_err(|error| ConfigError::InvalidUserConfig {
+            error: format!(
+                "agent-fed Geneva auth requires a bound vendor_bundle capability \
+                 (carries the endpoint/moniker routing): {error}"
+            ),
+        })?;
+
+    Ok(AgentFedGenevaSource::new(
+        bearer,
+        vendor,
+        config.account.clone(),
+    ))
+}
+
+fn create_geneva_client(
+    config: &Config,
+    node_config: &NodeUserConfig,
+    capabilities: &Capabilities,
+) -> Result<GenevaClient, ConfigError> {
+    validate_geneva_client_prerequisites(config, node_config, ensure_crypto_provider)?;
+    let client_config = config.to_geneva_client_config();
+
+    match &config.auth {
+        AuthConfig::AgentFed => {
+            let source = resolve_agent_fed_source(config, capabilities)?;
+            GenevaClient::with_agent_fed_source(client_config, Arc::new(source)).map_err(|error| {
+                ConfigError::InvalidUserConfig {
+                    error: format!("Failed to initialize agent-fed Geneva client: {error}"),
+                }
+            })
+        }
+        _ => GenevaClient::new(client_config).map_err(|error| ConfigError::InvalidUserConfig {
+            error: format!("Failed to initialize Geneva client: {error}"),
+        }),
+    }
+}
+
 impl GenevaExporter {
     /// Create a new Geneva exporter from configuration
     pub fn from_config(
         pipeline_ctx: PipelineContext,
         node_config: &NodeUserConfig,
-        capabilities: &otap_df_engine::capability::registry::Capabilities,
-    ) -> Result<Self, otap_df_config::error::Error> {
+        capabilities: &Capabilities,
+    ) -> Result<Self, ConfigError> {
+        let config = Config::parse(&node_config.config)?;
+        let geneva_client = create_geneva_client(&config, node_config, capabilities)?;
         let pdata_metrics = ExporterPDataExportMetrics::register(&pipeline_ctx);
         let metrics = pipeline_ctx.register_metrics::<ExporterMetrics>();
-
-        let config = Config::parse(&node_config.config)?;
-
-        let client_config = config.to_geneva_client_config();
-
-        // The Geneva exporter uses rustls for mTLS. If no process-wide crypto
-        // provider was installed at startup (i.e. the binary was built without
-        // any `crypto-*` feature), fail fast with an actionable error instead
-        // of surfacing an opaque rustls handshake failure at export time.
-        if !otap_df_otap::crypto::is_crypto_provider_installed() {
-            return Err(otap_df_config::error::Error::InvalidUserConfig {
-                error: "Geneva exporter requires a rustls CryptoProvider, but none is installed. \
-                        Build with exactly one of the crypto-* features \
-                        (crypto-ring, crypto-aws-lc, crypto-openssl, crypto-symcrypt) and ensure \
-                        otap_df_otap::crypto::install_crypto_provider() runs at startup."
-                    .to_string(),
-            });
-        }
-
-        // Initialize the Geneva client. Agent-fed auth resolves the agent-fed
-        // bearer + vendor capabilities and feeds them to the uploader; all
-        // other auth methods drive the GCS config-service handshake.
-        let geneva_client = match &config.auth {
-            AuthConfig::AgentFed => {
-                validate_agent_fed_capability_bindings(node_config)?;
-                let bearer = capabilities
-                    .require_shared::<BearerTokenProviderCap>()
-                    .map_err(|e| otap_df_config::error::Error::InvalidUserConfig {
-                        error: format!(
-                            "agent-fed auth requires a bound bearer_token_provider capability: {e}"
-                        ),
-                    })?;
-                let vendor = capabilities
-                    .require_shared::<VendorBundleCap>()
-                    .map_err(|e| otap_df_config::error::Error::InvalidUserConfig {
-                        error: format!(
-                            "agent-fed Geneva auth requires a bound vendor_bundle capability \
-                             (carries the endpoint/moniker routing): {e}"
-                        ),
-                    })?;
-                let source = AgentFedGenevaSource::new(bearer, vendor, config.account.clone());
-                GenevaClient::with_agent_fed_source(client_config, Arc::new(source)).map_err(
-                    |e| otap_df_config::error::Error::InvalidUserConfig {
-                        error: format!("Failed to initialize agent-fed Geneva client: {e}"),
-                    },
-                )?
-            }
-            _ => GenevaClient::new(client_config).map_err(|e| {
-                otap_df_config::error::Error::InvalidUserConfig {
-                    error: format!("Failed to initialize Geneva client: {}", e),
-                }
-            })?,
-        };
 
         Ok(Self {
             config,
@@ -1307,7 +1339,7 @@ pub static GENEVA_EXPORTER: ExporterFactory<OtapPdata> = ExporterFactory {
              node: NodeId,
              node_config: Arc<NodeUserConfig>,
              exporter_config: &ExporterConfig,
-             capabilities: &otap_df_engine::capability::registry::Capabilities| {
+             capabilities: &Capabilities| {
         Ok(ExporterWrapper::local(
             GenevaExporter::from_config(pipeline, &node_config, capabilities)?,
             node,
@@ -1316,7 +1348,7 @@ pub static GENEVA_EXPORTER: ExporterFactory<OtapPdata> = ExporterFactory {
         ))
     },
     wiring_contract: otap_df_engine::wiring_contract::WiringContract::UNRESTRICTED,
-    validate_config,
+    validate_config: otap_df_config::validation::validate_typed_config::<Config>,
 };
 
 #[async_trait(?Send)]
@@ -1436,9 +1468,10 @@ mod tests {
         UInt8Array, UInt16Array, UInt32Array,
     };
     use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
-    use std::sync::Arc;
+    use std::sync::{Arc, RwLock};
 
     use bytes::Bytes;
+    use geneva_uploader::client::AgentFedCredentialSource;
     use otap_df_engine::Interests;
     use otap_df_engine::capability::SharedInstanceFactory;
     use otap_df_engine::capability::auth::BearerToken;
@@ -1651,6 +1684,10 @@ mod tests {
 
     #[derive(Clone)]
     struct MockAgentExtension {
+        snapshot: Arc<RwLock<MockAgentSnapshot>>,
+    }
+
+    struct MockAgentSnapshot {
         token: String,
         attributes: Arc<serde_json::Map<String, serde_json::Value>>,
     }
@@ -1658,7 +1695,8 @@ mod tests {
     #[async_trait]
     impl SharedBearerTokenProvider for MockAgentExtension {
         async fn get_token(&self) -> Result<BearerToken, CapabilityError> {
-            Ok(BearerToken::without_expiry(self.token.clone()))
+            let snapshot = self.snapshot.read().expect("snapshot read lock");
+            Ok(BearerToken::without_expiry(snapshot.token.clone()))
         }
 
         fn token_stream(&self) -> TokenStream {
@@ -1670,13 +1708,14 @@ mod tests {
         fn attributes(
             &self,
         ) -> Result<Arc<serde_json::Map<String, serde_json::Value>>, CapabilityError> {
-            Ok(self.attributes.clone())
+            let snapshot = self.snapshot.read().expect("snapshot read lock");
+            Ok(snapshot.attributes.clone())
         }
     }
 
     fn resolved_agent_fed_capabilities(
         node_config: &NodeUserConfig,
-    ) -> otap_df_engine::capability::registry::Capabilities {
+    ) -> (Capabilities, Arc<RwLock<MockAgentSnapshot>>) {
         let attributes = serde_json::json!({
             "endpoint": "https://ep",
             "moniker_map": { "test-account": "test-moniker" },
@@ -1684,9 +1723,12 @@ mod tests {
         .as_object()
         .cloned()
         .expect("object");
-        let extension = MockAgentExtension {
+        let snapshot = Arc::new(RwLock::new(MockAgentSnapshot {
             token: "test-token".to_owned(),
             attributes: Arc::new(attributes),
+        }));
+        let extension = MockAgentExtension {
+            snapshot: Arc::clone(&snapshot),
         };
         let extension_capabilities = extension_capabilities!(
             shared: MockAgentExtension => [BearerTokenProviderCap, VendorBundleCap]
@@ -1697,10 +1739,14 @@ mod tests {
         (extension_capabilities.register_shared)("agent".into(), instance_factory, &mut registry)
             .expect("register capabilities");
         let known_extensions = HashSet::<otap_df_config::ExtensionId>::from(["agent".into()]);
-        resolve_bindings_for_test(&node_config.capabilities, &registry, &known_extensions)
-            .expect("resolve capabilities")
+        let capabilities =
+            resolve_bindings_for_test(&node_config.capabilities, &registry, &known_extensions)
+                .expect("resolve capabilities");
+        (capabilities, snapshot)
     }
 
+    /// Scenario: The exporter receives an empty OTLP log payload with an ACK subscriber.
+    /// Guarantees: The exporter skips upload and returns an empty successful ACK.
     #[test]
     fn geneva_exporter_emits_ack_for_empty_payload() {
         // The Geneva uploader uses rustls (tls-rustls); reqwest needs a
@@ -1743,6 +1789,8 @@ mod tests {
             });
     }
 
+    /// Scenario: The exporter receives malformed non-empty OTLP log bytes.
+    /// Guarantees: Decode failure returns a NACK with the original subscriber route.
     #[test]
     fn geneva_exporter_emits_nack_for_decode_failure() {
         // The Geneva uploader uses rustls (tls-rustls); reqwest needs a
@@ -1793,6 +1841,8 @@ mod tests {
             });
     }
 
+    /// Scenario: The exporter receives a representative OTAP logs record batch.
+    /// Guarantees: The logs view exposes all records after transport ID decoding.
     #[test]
     fn test_geneva_exporter_creates_view_from_otap_records() {
         // This test verifies that the Geneva exporter can successfully create
@@ -1827,6 +1877,8 @@ mod tests {
     }
 
     // Configuration tests
+    /// Scenario: A complete certificate-auth configuration is deserialized.
+    /// Guarantees: Required fields, defaults, and auth data retain their values.
     #[test]
     fn test_config_deserialization() {
         let json = serde_json::json!({
@@ -1891,6 +1943,8 @@ mod tests {
         }
     }
 
+    /// Scenario: Agent-fed configuration omits GCS-only endpoint and region fields.
+    /// Guarantees: The configuration remains valid and preserves the agent-fed mode.
     #[test]
     fn agent_fed_config_can_omit_gcs_endpoint_and_region() {
         let config: Config =
@@ -1900,6 +1954,8 @@ mod tests {
         assert!(matches!(config.auth, AuthConfig::AgentFed));
     }
 
+    /// Scenario: A non-agent-fed configuration omits endpoint or region.
+    /// Guarantees: Existing authentication modes continue to require both fields.
     #[test]
     fn non_agent_fed_config_requires_endpoint_and_region() {
         let mut missing_endpoint = test_config();
@@ -1921,6 +1977,8 @@ mod tests {
         assert!(error.to_string().contains("region is required"));
     }
 
+    /// Scenario: Agent-fed configuration provides an empty account.
+    /// Guarantees: Moniker selection cannot start without a non-empty account.
     #[test]
     fn agent_fed_config_requires_account_for_moniker_selection() {
         let mut config = agent_fed_test_config();
@@ -1929,6 +1987,8 @@ mod tests {
         assert!(error.to_string().contains("account must not be empty"));
     }
 
+    /// Scenario: Bearer and vendor capabilities reference different extension IDs.
+    /// Guarantees: Agent-fed startup accepts only matching configured extensions.
     #[test]
     fn agent_fed_capabilities_must_bind_to_the_same_extension() {
         let node_config = agent_fed_node_config(Some("agent-a"), Some("agent-b"));
@@ -1941,6 +2001,8 @@ mod tests {
             .expect("matching extensions must pass");
     }
 
+    /// Scenario: Either required agent-fed capability binding is absent.
+    /// Guarantees: Startup reports the specific missing capability.
     #[test]
     fn agent_fed_capabilities_require_both_bindings() {
         let missing_bearer = agent_fed_node_config(None, Some("agent"));
@@ -1954,6 +2016,22 @@ mod tests {
         assert!(error.to_string().contains("vendor_bundle"));
     }
 
+    /// Scenario: Agent-fed capability bindings are invalid before TLS setup is checked.
+    /// Guarantees: Binding validation short-circuits without invoking the crypto check.
+    #[test]
+    fn agent_fed_binding_validation_precedes_crypto_check() {
+        let node_config = agent_fed_node_config(Some("agent-a"), Some("agent-b"));
+        let config = Config::parse(&node_config.config).expect("valid agent-fed config");
+        let error = validate_geneva_client_prerequisites(&config, &node_config, || {
+            panic!("crypto provider check must not run before binding validation")
+        })
+        .expect_err("mismatched extensions must fail");
+
+        assert!(error.to_string().contains("same configured extension"));
+    }
+
+    /// Scenario: The factory receives missing or mismatched agent-fed bindings.
+    /// Guarantees: Exporter creation fails with the applicable binding error.
     #[test]
     fn agent_fed_factory_fails_closed_on_invalid_bindings() {
         let exporter_config = ExporterConfig::new("test-exporter");
@@ -1963,7 +2041,7 @@ mod tests {
             test_node("test-exporter".to_owned()),
             Arc::new(agent_fed_node_config(None, None)),
             &exporter_config,
-            &otap_df_engine::capability::registry::Capabilities::empty(),
+            &Capabilities::empty(),
         );
         let error = match missing_bindings {
             Ok(_) => panic!("missing bindings must fail exporter creation"),
@@ -1976,7 +2054,7 @@ mod tests {
             test_node("test-exporter".to_owned()),
             Arc::new(agent_fed_node_config(Some("agent-a"), Some("agent-b"))),
             &exporter_config,
-            &otap_df_engine::capability::registry::Capabilities::empty(),
+            &Capabilities::empty(),
         );
         let error = match mismatched_bindings {
             Ok(_) => panic!("mismatched bindings must fail exporter creation"),
@@ -1985,10 +2063,51 @@ mod tests {
         assert!(error.to_string().contains("same configured extension"));
     }
 
+    /// Scenario: Registry-created capability clones share one rotating host snapshot.
+    /// Guarantees: A completed host rotation is visible through both capability handles.
+    #[tokio::test]
+    async fn agent_fed_capability_clones_share_rotating_state() {
+        let node_config = agent_fed_node_config(Some("agent"), Some("agent"));
+        let (capabilities, snapshot) = resolved_agent_fed_capabilities(&node_config);
+        let bearer = capabilities
+            .require_shared::<BearerTokenProviderCap>()
+            .expect("bearer capability");
+        let vendor = capabilities
+            .require_shared::<VendorBundleCap>()
+            .expect("vendor capability");
+        let source = AgentFedGenevaSource::new(bearer, vendor, "test-account".to_owned());
+
+        let initial = source.current().await.expect("initial credential");
+        assert_eq!(initial.token, "test-token");
+        assert_eq!(initial.endpoint, "https://ep");
+        assert_eq!(initial.moniker, "test-moniker");
+
+        let rotated_attributes = serde_json::json!({
+            "endpoint": "https://rotated-ep",
+            "moniker_map": { "test-account": "rotated-moniker" },
+        })
+        .as_object()
+        .cloned()
+        .expect("object");
+        {
+            let mut snapshot = snapshot.write().expect("snapshot write lock");
+            snapshot.token = "rotated-token".to_owned();
+            snapshot.attributes = Arc::new(rotated_attributes);
+        }
+
+        let rotated = source.current().await.expect("rotated credential");
+        assert_eq!(rotated.token, "rotated-token");
+        assert_eq!(rotated.endpoint, "https://rotated-ep");
+        assert_eq!(rotated.moniker, "rotated-moniker");
+    }
+
+    /// Scenario: Valid bindings resolve both capabilities from a shared extension.
+    /// Guarantees: The factory constructs an agent-fed exporter successfully.
     #[test]
     fn creates_agent_fed_exporter_with_bound_capabilities() {
+        otap_df_otap::crypto::ensure_crypto_provider();
         let node_config = agent_fed_node_config(Some("agent"), Some("agent"));
-        let capabilities = resolved_agent_fed_capabilities(&node_config);
+        let (capabilities, _snapshot) = resolved_agent_fed_capabilities(&node_config);
         let exporter_config = ExporterConfig::new("test-exporter");
         let result = (GENEVA_EXPORTER.create)(
             create_test_pipeline_context(),
@@ -2000,6 +2119,8 @@ mod tests {
         assert!(result.is_ok(), "agent-fed exporter should initialize");
     }
 
+    /// Scenario: Every supported authentication tag is deserialized.
+    /// Guarantees: Serde maps each public tag to the correct auth variant.
     #[test]
     fn test_auth_config_variants() {
         let cert_json = serde_json::json!({
@@ -2059,11 +2180,15 @@ mod tests {
         assert!(matches!(agent_fed, AuthConfig::AgentFed));
     }
 
+    /// Scenario: Registration code reads the Geneva exporter URN constant.
+    /// Guarantees: The public component identifier remains stable.
     #[test]
     fn test_urn_constant() {
         assert_eq!(GENEVA_EXPORTER_URN, "urn:microsoft:exporter:geneva");
     }
 
+    /// Scenario: Auth uses a user-assigned identity addressed by ARM resource ID.
+    /// Guarantees: The supported auth variant constructs a client successfully.
     #[test]
     fn create_exporter_with_user_managed_identity_by_arm_resource_id() {
         // The Geneva uploader uses rustls (tls-rustls); reqwest needs a

--- a/rust/otap-dataflow/crates/engine/src/capability/auth/agent_fed_credential_provider.rs
+++ b/rust/otap-dataflow/crates/engine/src/capability/auth/agent_fed_credential_provider.rs
@@ -55,6 +55,12 @@ pub trait AgentFedCredentialProvider {
     /// The provider must load one host snapshot and return both values from
     /// that same generation. It must not reconstruct this result by calling
     /// separate token and vendor capabilities.
+    ///
+    /// The returned future must be cancellation-safe because consumers may
+    /// enforce a lookup deadline and drop it before completion. Cancellation
+    /// must not leave shared state or locks unusable. Implementations should
+    /// normally clone an already-published snapshot and avoid network I/O or
+    /// other unbounded work in this method.
     async fn get_credential(&self) -> Result<Arc<AgentFedCredentialSnapshot>, CapabilityError>;
 }
 

--- a/rust/otap-dataflow/crates/engine/src/capability/auth/agent_fed_credential_provider.rs
+++ b/rust/otap-dataflow/crates/engine/src/capability/auth/agent_fed_credential_provider.rs
@@ -1,0 +1,85 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! The `AgentFedCredentialProvider` capability.
+//!
+//! Supplies one immutable, atomically-published snapshot containing a bearer
+//! token and its vendor-defined routing attributes. Consumers that require the
+//! two values to stay generation-consistent must use this capability instead
+//! of reading `bearer_token_provider` and `vendor_bundle` separately.
+
+use super::BearerToken;
+use crate::capability::error::CapabilityError;
+use otap_df_engine_macros::capability;
+use serde_json::{Map, Value};
+use std::sync::Arc;
+
+/// One generation-consistent host credential and attribute snapshot.
+///
+/// `Debug` redacts the token through [`BearerToken`], but renders `attributes`
+/// verbatim, so hosts must keep secrets out of the vendor attribute map.
+#[derive(Clone, Debug)]
+pub struct AgentFedCredentialSnapshot {
+    token: BearerToken,
+    attributes: Arc<Map<String, Value>>,
+}
+
+impl AgentFedCredentialSnapshot {
+    /// Creates a snapshot from values loaded during one atomic host-state read.
+    #[must_use]
+    pub fn new(token: BearerToken, attributes: Arc<Map<String, Value>>) -> Self {
+        Self { token, attributes }
+    }
+
+    /// Returns the snapshot's bearer token.
+    #[must_use]
+    pub const fn token(&self) -> &BearerToken {
+        &self.token
+    }
+
+    /// Returns the snapshot's vendor-defined attributes.
+    #[must_use]
+    pub fn attributes(&self) -> &Map<String, Value> {
+        &self.attributes
+    }
+}
+
+/// Provides atomically-paired agent-fed credentials and vendor attributes.
+#[capability(
+    name = "agent_fed_credential_provider",
+    description = "Provides one atomic bearer-token and vendor-attribute snapshot"
+)]
+pub trait AgentFedCredentialProvider {
+    /// Returns the current immutable credential snapshot.
+    ///
+    /// The provider must load one host snapshot and return both values from
+    /// that same generation. It must not reconstruct this result by calling
+    /// separate token and vendor capabilities.
+    async fn get_credential(&self) -> Result<Arc<AgentFedCredentialSnapshot>, CapabilityError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// Scenario: A snapshot is created with a secret token and routing attributes.
+    /// Guarantees: Both values remain available from one immutable snapshot.
+    #[test]
+    fn snapshot_keeps_token_and_attributes_together() {
+        let attributes = Arc::new(
+            json!({"endpoint": "https://ingest.example"})
+                .as_object()
+                .cloned()
+                .expect("object"),
+        );
+        let snapshot = AgentFedCredentialSnapshot::new(
+            BearerToken::without_expiry("secret-token".to_owned()),
+            Arc::clone(&attributes),
+        );
+
+        assert_eq!(snapshot.token().expose_token(), "secret-token");
+        assert_eq!(snapshot.attributes(), attributes.as_ref());
+        assert!(!format!("{snapshot:?}").contains("secret-token"));
+    }
+}

--- a/rust/otap-dataflow/crates/engine/src/capability/auth/bearer_token_provider.rs
+++ b/rust/otap-dataflow/crates/engine/src/capability/auth/bearer_token_provider.rs
@@ -9,6 +9,11 @@
 //! both the shared and local execution models. Consumers depend only on
 //! the two methods below, never on how a token is produced or refreshed.
 //!
+//! Reading this capability separately from `vendor_bundle` cannot produce an
+//! atomic token-and-attributes pair. Agent-fed consumers requiring that
+//! guarantee must use
+//! [`AgentFedCredentialProvider`](super::agent_fed_credential_provider::AgentFedCredentialProvider).
+//!
 //! The `#[capability]` proc macro expands the trait into:
 //!
 //! - A `pub(crate) mod local` containing the `!Send` `BearerTokenProvider` trait variant

--- a/rust/otap-dataflow/crates/engine/src/capability/auth/mod.rs
+++ b/rust/otap-dataflow/crates/engine/src/capability/auth/mod.rs
@@ -5,14 +5,16 @@
 //!
 //! Groups the credential-facing capabilities (token provider on the outbound
 //! side, authorizer on the inbound side) with the shared data types they
-//! exchange. The capability traits live in [`bearer_token_provider`] and
-//! [`bearer_token_authorizer`]; the shared data types ([`BearerToken`],
-//! [`AuthorizedIdentity`], [`AuthzDecision`], [`DenyReason`]) live in [`models`]
-//! and are re-exported here so consumers reach them at
+//! exchange. The capability traits live in [`agent_fed_credential_provider`],
+//! [`bearer_token_provider`], and [`bearer_token_authorizer`]; the shared data
+//! types ([`BearerToken`], [`AuthorizedIdentity`], [`AuthzDecision`],
+//! [`DenyReason`]) live in [`models`] and are re-exported here so consumers
+//! reach them at
 //! `capability::auth::{BearerToken, AuthorizedIdentity, AuthzDecision, DenyReason}`.
 
 mod models;
 
+pub mod agent_fed_credential_provider;
 pub mod bearer_token_authorizer;
 pub mod bearer_token_provider;
 

--- a/rust/otap-dataflow/crates/engine/src/capability/vendor_bundle.rs
+++ b/rust/otap-dataflow/crates/engine/src/capability/vendor_bundle.rs
@@ -8,11 +8,12 @@
 //! interprets the contents; each consumer defines and reads its own keys.
 //! Supplied by an agent-fed extension; token-only scopes do not provide it.
 //!
-//! The host publishes the bundle and bearer token as one atomically-swapped
-//! record, but a consumer reads them through two separate capability calls, so a
-//! swap between the reads can transiently pair a stale token with fresh routing
-//! (or vice versa). That mismatch is acceptable: the backend rejects the bad pair
-//! and the consumer converges on the next refresh.
+//! A provider may derive this bundle and a bearer token from one coordinated
+//! snapshot, but consumers read separate capabilities independently. The
+//! capability API therefore does not guarantee an atomic cross-capability
+//! snapshot. Consumers that require strict consistency must define an explicit
+//! coordination mechanism; consumers that tolerate transient mismatches should
+//! document their retry or convergence behavior.
 //!
 //! Like [`bearer_token_provider`](super::bearer_token_provider), the trait is
 //! expanded by the `#[capability]` proc macro into `local` (!Send) and `shared`

--- a/rust/otap-dataflow/crates/engine/src/capability/vendor_bundle.rs
+++ b/rust/otap-dataflow/crates/engine/src/capability/vendor_bundle.rs
@@ -8,12 +8,17 @@
 //! interprets the contents; each consumer defines and reads its own keys.
 //! Supplied by an agent-fed extension; token-only scopes do not provide it.
 //!
-//! A provider may derive this bundle and a bearer token from one coordinated
-//! snapshot, but consumers read separate capabilities independently. The
-//! capability API therefore does not guarantee an atomic cross-capability
-//! snapshot. Consumers that require strict consistency must define an explicit
-//! coordination mechanism; consumers that tolerate transient mismatches should
-//! document their retry or convergence behavior.
+//! The host publishes the bundle and bearer token as one atomically-swapped
+//! record, but a consumer reads them through two separate capability calls, so a
+//! swap between the reads can transiently pair a stale token with fresh routing
+//! (or vice versa). The capability API cannot identify that mixed-generation
+//! pair. Consumers must tolerate it, while the host and backend must make the
+//! combination safe or reject it.
+//!
+//! Extensions exposing both capabilities from one configured instance must
+//! ensure that per-consumer clones share the same underlying snapshot, typically
+//! through an `Arc`-backed state object. The extension ID alone does not enforce
+//! shared state across capability handles.
 //!
 //! Like [`bearer_token_provider`](super::auth::bearer_token_provider), the trait is
 //! expanded by the `#[capability]` proc macro into `local` (!Send) and `shared`

--- a/rust/otap-dataflow/crates/engine/src/capability/vendor_bundle.rs
+++ b/rust/otap-dataflow/crates/engine/src/capability/vendor_bundle.rs
@@ -8,12 +8,13 @@
 //! interprets the contents; each consumer defines and reads its own keys.
 //! Supplied by an agent-fed extension; token-only scopes do not provide it.
 //!
-//! The host publishes the bundle and bearer token as one atomically-swapped
-//! record, but a consumer reads them through two separate capability calls, so a
-//! swap between the reads can transiently pair a stale token with fresh routing
-//! (or vice versa). The capability API cannot identify that mixed-generation
-//! pair. Consumers must tolerate it, while the host and backend must make the
-//! combination safe or reject it.
+//! Reading this capability separately from `bearer_token_provider` cannot
+//! produce an atomic token-and-attributes pair. For consumers whose backend
+//! safely rejects mismatched generations, a transient stale-token/fresh-routing
+//! pair can be an acceptable eventually-consistent model because the consumer
+//! converges on the next refresh. Consumers requiring generation consistency
+//! must use
+//! [`AgentFedCredentialProvider`](super::auth::agent_fed_credential_provider::AgentFedCredentialProvider).
 //!
 //! Extensions exposing both capabilities from one configured instance must
 //! ensure that per-consumer clones share the same underlying snapshot, typically

--- a/rust/otap-dataflow/crates/engine/src/capability/vendor_bundle.rs
+++ b/rust/otap-dataflow/crates/engine/src/capability/vendor_bundle.rs
@@ -15,7 +15,7 @@
 //! coordination mechanism; consumers that tolerate transient mismatches should
 //! document their retry or convergence behavior.
 //!
-//! Like [`bearer_token_provider`](super::bearer_token_provider), the trait is
+//! Like [`bearer_token_provider`](super::auth::bearer_token_provider), the trait is
 //! expanded by the `#[capability]` proc macro into `local` (!Send) and `shared`
 //! (Send) variants, a `SharedAsLocal` adapter, a zero-sized registration
 //! handle, and a `KNOWN_CAPABILITIES` distributed-slice entry.

--- a/rust/otap-dataflow/crates/engine/src/local/capability.rs
+++ b/rust/otap-dataflow/crates/engine/src/local/capability.rs
@@ -14,6 +14,10 @@
 
 /// Auth capabilities (local `!Send` trait variants).
 pub mod auth {
+    /// Local (!Send) trait variant of the agent-fed credential-provider capability.
+    pub mod agent_fed_credential_provider {
+        pub use crate::capability::auth::agent_fed_credential_provider::local::AgentFedCredentialProvider;
+    }
     /// Local (!Send) trait variant of the bearer-token-authorizer capability.
     pub mod bearer_token_authorizer {
         pub use crate::capability::auth::bearer_token_authorizer::local::BearerTokenAuthorizer;

--- a/rust/otap-dataflow/crates/engine/src/shared/capability.rs
+++ b/rust/otap-dataflow/crates/engine/src/shared/capability.rs
@@ -14,6 +14,10 @@
 
 /// Auth capabilities (shared `Send` trait variants).
 pub mod auth {
+    /// Shared (Send) trait variant of the agent-fed credential-provider capability.
+    pub mod agent_fed_credential_provider {
+        pub use crate::capability::auth::agent_fed_credential_provider::shared::AgentFedCredentialProvider;
+    }
     /// Shared (Send) trait variant of the bearer-token-authorizer capability.
     pub mod bearer_token_authorizer {
         pub use crate::capability::auth::bearer_token_authorizer::shared::BearerTokenAuthorizer;

--- a/rust/otap-dataflow/crates/engine/src/testing/capability/mod.rs
+++ b/rust/otap-dataflow/crates/engine/src/testing/capability/mod.rs
@@ -12,3 +12,27 @@
 
 pub mod no_op_stateful;
 pub mod no_op_stateless;
+
+#[cfg(any(test, feature = "test-utils"))]
+use crate::capability::registry::{
+    Capabilities, CapabilityRegistry, ConsumedTracker, resolve_bindings,
+};
+#[cfg(any(test, feature = "test-utils"))]
+use otap_df_config::{CapabilityId, ExtensionId};
+#[cfg(any(test, feature = "test-utils"))]
+use std::collections::{HashMap, HashSet};
+
+/// Resolves capability bindings for downstream component tests.
+///
+/// Production code resolves bindings as part of pipeline construction. This
+/// helper exposes the same path to tests that need a real [`Capabilities`]
+/// instance rather than [`Capabilities::empty`].
+#[cfg(any(test, feature = "test-utils"))]
+pub fn resolve_bindings_for_test(
+    bindings: &HashMap<CapabilityId, ExtensionId>,
+    registry: &CapabilityRegistry,
+    known_extensions: &HashSet<ExtensionId>,
+) -> Result<Capabilities, crate::error::Error> {
+    let mut tracker = ConsumedTracker::new();
+    resolve_bindings(bindings, registry, known_extensions, &mut tracker)
+}


### PR DESCRIPTION
# Change Summary

Adds agent-fed authentication to the Geneva exporter. An embedding host supplies one atomic token-and-routing snapshot through the `agent_fed_credential_provider` capability, bypassing the Geneva Config Service handshake.

Each upload reads one immutable snapshot, preventing token, endpoint, and moniker generations from being mixed during rotation. Invalid, unavailable, or near-expiry credentials fail closed.

The exporter validates that:

- The endpoint is an absolute HTTPS URL without credentials, query, or fragment.
- The moniker matches the configured account or an explicit `default`.
- Monikers contain only URL-unreserved ASCII characters.
- Tokens with known expiry remain valid for more than 30 seconds.

Token zeroization is preserved through the merged
[geneva-uploader hardening](https://github.com/open-telemetry/opentelemetry-rust-contrib/pull/716).

## What issue does this PR close?

* Closes #3275 

## How are these changes tested?

- All 77 Geneva exporter unit and regression tests pass.
- All 23 engine authentication capability tests pass.
- Engine and contrib-nodes all-target clippy pass with warnings denied.
- Formatting, Markdown lint, sanity, and focused dependency checks pass.
- Coverage includes capability binding, atomic rotation, routing precedence, endpoint validation, expiry handling, recovery, existing authentication modes, logs/spans routing and ACK/NACK behavior.

## Are there any user-facing changes?

Yes. Geneva exporters can select `auth.type: agentfed` and bind one capability:

```yaml
capabilities: agent_fed_credential_provider: agent-auth
config: account: my-account auth:
    type: agentfed
```

The host extension must provide this capability using the shared execution model. 
endpoint region are  are optional in agent-fed mode because the endpoint comes from the credential snapshot. For other authentication modes they remain required, and blank values now fail during configuration validation.


### Changelog

* [x] Added a `.chloggen/*.yaml` entry
* [ ] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
