### PR TITLE
fix(pdata): prevent metrics encoding column mismatch

### DIFF
--- a/rust/otap-dataflow/.chloggen/pdata-fix-missing-metrics-resource.yaml
+++ b/rust/otap-dataflow/.chloggen/pdata-fix-missing-metrics-resource.yaml
@@ -1,0 +1,5 @@
+change_type: bug_fix
+component: pdata
+note: Prevent metrics encoding panics from missing resources or misaligned scope schema rows.
+issues: [3565]
+subtext:

--- a/rust/otap-dataflow/crates/pdata/src/encode/mod.rs
+++ b/rust/otap-dataflow/crates/pdata/src/encode/mod.rs
@@ -719,31 +719,30 @@ where
     let mut curr_metric_id: u16 = 0;
 
     for resource_metric in metrics_view.resources() {
-        if let Some(resource) = resource_metric.resource() {
-            let metric_count = resource_metric
-                .scopes()
-                .map(|scope| scope.metrics().count())
-                .sum();
-            let schema_url = resource_metric.schema_url();
-            metrics
-                .resource
-                .append_schema_url_n(schema_url, metric_count);
-            metrics.resource.append_id_n(curr_resource_id, metric_count);
-            metrics.resource.append_dropped_attributes_count_n(
-                resource.dropped_attributes_count(),
-                metric_count,
-            );
+        let metric_count = resource_metric
+            .scopes()
+            .map(|scope| scope.metrics().count())
+            .sum();
+        let resource_dropped_attributes_count = if let Some(resource) = resource_metric.resource() {
             for kv in resource.attributes() {
                 resource_attrs.append_parent_id(&curr_resource_id);
                 append_attribute_value(&mut resource_attrs, &kv)?;
             }
-        }
+            resource.dropped_attributes_count()
+        } else {
+            0
+        };
+
+        metrics
+            .resource
+            .append_schema_url_n(resource_metric.schema_url(), metric_count);
+        metrics.resource.append_id_n(curr_resource_id, metric_count);
+        metrics
+            .resource
+            .append_dropped_attributes_count_n(resource_dropped_attributes_count, metric_count);
 
         for scope_metric in resource_metric.scopes() {
-            let metric_count = scope_metric.metrics().count();
             let scope_schema_url = scope_metric.schema_url();
-            metrics.append_scope_schema_url_n(scope_schema_url, metric_count);
-
             let scope = scope_metric.scope();
             let scope_name = scope.as_ref().and_then(|s| s.name());
             let scope_version = scope.as_ref().and_then(|s| s.version());
@@ -751,20 +750,24 @@ where
                 .as_ref()
                 .map(|s| s.dropped_attributes_count())
                 .unwrap_or(0);
-            metrics.scope.append_id_n(curr_scope_id, metric_count);
-            metrics.scope.append_name_n(scope_name, metric_count);
-            metrics.scope.append_version_n(scope_version, metric_count);
-            metrics
-                .scope
-                .append_dropped_attributes_count_n(scope_dropped_attributes_count, metric_count);
-            if let Some(scope) = scope {
-                for kv in scope.attributes() {
+            if let Some(ref scope_ref) = scope {
+                for kv in scope_ref.attributes() {
                     scope_attrs.append_parent_id(&curr_scope_id);
                     append_attribute_value(&mut scope_attrs, &kv)?;
                 }
             }
 
             for metric in scope_metric.metrics() {
+                // Append scope fields per metric so raw protobuf traversal stays single-pass and
+                // all columns stay aligned.
+                metrics.append_scope_schema_url(scope_schema_url);
+                metrics.scope.append_id(Some(curr_scope_id));
+                metrics.scope.append_name(scope_name);
+                metrics.scope.append_version(scope_version);
+                metrics
+                    .scope
+                    .append_dropped_attributes_count(scope_dropped_attributes_count);
+
                 metrics.append_id(curr_metric_id);
                 let data_obj = metric.data();
                 let data = data_obj.as_ref();
@@ -3264,6 +3267,111 @@ mod test {
             .map(|b| b.bucket_counts().collect())
             .unwrap_or_default();
         assert!(neg_counts.is_empty(), "expected no negative bucket counts");
+    }
+
+    /// Scenario: Metrics data mixes resource metrics with present and absent resource messages.
+    /// Guarantees: Encoding emits one correctly identified resource row per metric definition.
+    #[test]
+    fn test_metrics_with_mixed_resource_presence() {
+        use crate::proto::opentelemetry::metrics::v1::{
+            Gauge, Metric, MetricsData, ResourceMetrics, ScopeMetrics,
+        };
+
+        let metric = |name| {
+            Metric::build()
+                .name(name)
+                .data_gauge(Gauge::new(vec![]))
+                .finish()
+        };
+        let metrics_data = MetricsData::new(vec![
+            ResourceMetrics {
+                resource: Some(Resource::build().dropped_attributes_count(7u32).finish()),
+                scope_metrics: vec![ScopeMetrics {
+                    scope: None,
+                    metrics: vec![metric("with-resource")],
+                    schema_url: String::new(),
+                }],
+                schema_url: "resource-schema".to_string(),
+            },
+            ResourceMetrics {
+                resource: None,
+                scope_metrics: vec![ScopeMetrics {
+                    scope: None,
+                    metrics: vec![metric("without-resource")],
+                    schema_url: String::new(),
+                }],
+                schema_url: String::new(),
+            },
+        ]);
+
+        let otap_batch = encode_metrics_otap_batch(&metrics_data).expect("encode metrics");
+        let metrics = otap_batch
+            .get(ArrowPayloadType::UnivariateMetrics)
+            .expect("metrics definition batch");
+        assert_eq!(metrics.num_rows(), 2);
+
+        let resources = metrics
+            .column_by_name(consts::RESOURCE)
+            .expect("resource column")
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .expect("resource struct");
+        let resource_ids = resources
+            .column_by_name(consts::ID)
+            .expect("resource id column")
+            .as_any()
+            .downcast_ref::<UInt16Array>()
+            .expect("resource ids");
+        let dropped_attributes_counts = resources
+            .column_by_name(consts::DROPPED_ATTRIBUTES_COUNT)
+            .expect("resource dropped attributes count column")
+            .as_any()
+            .downcast_ref::<UInt32Array>()
+            .expect("resource dropped attributes counts");
+
+        assert_eq!(resource_ids.values(), &[0, 1]);
+        assert_eq!(dropped_attributes_counts.values(), &[7, 0]);
+    }
+
+    /// Scenario: Serialized metrics contain two empty-schema rows before a non-empty scope schema.
+    /// Guarantees: Raw protobuf encoding emits one aligned scope schema value for every metric.
+    #[test]
+    fn test_metrics_proto_bytes_scope_schema_alignment() {
+        use crate::proto::opentelemetry::metrics::v1::{
+            Gauge, Metric, MetricsData, ResourceMetrics, ScopeMetrics,
+        };
+        use crate::views::otlp::bytes::metrics::RawMetricsData;
+
+        let metric = |name| {
+            Metric::build()
+                .name(name)
+                .data_gauge(Gauge::new(vec![]))
+                .finish()
+        };
+        let metrics_data = MetricsData::new(vec![ResourceMetrics::new(
+            Resource::default(),
+            vec![
+                ScopeMetrics {
+                    scope: None,
+                    metrics: vec![metric("first"), metric("second")],
+                    schema_url: String::new(),
+                },
+                ScopeMetrics {
+                    scope: None,
+                    metrics: vec![metric("third")],
+                    schema_url: "scope-schema".to_string(),
+                },
+            ],
+        )]);
+
+        let bytes = metrics_data.encode_to_vec();
+        let metrics_view = RawMetricsData::new(&bytes);
+        let otap_batch = encode_metrics_otap_batch(&metrics_view).expect("encode metrics");
+        let metrics = otap_batch
+            .get(ArrowPayloadType::UnivariateMetrics)
+            .expect("metrics definition batch");
+
+        assert_eq!(metrics.num_rows(), 3);
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/pdata/src/encode/mod.rs
+++ b/rust/otap-dataflow/crates/pdata/src/encode/mod.rs
@@ -719,10 +719,7 @@ where
     let mut curr_metric_id: u16 = 0;
 
     for resource_metric in metrics_view.resources() {
-        let metric_count = resource_metric
-            .scopes()
-            .map(|scope| scope.metrics().count())
-            .sum();
+        let resource_schema_url = resource_metric.schema_url();
         let resource_dropped_attributes_count = if let Some(resource) = resource_metric.resource() {
             for kv in resource.attributes() {
                 resource_attrs.append_parent_id(&curr_resource_id);
@@ -732,14 +729,7 @@ where
         } else {
             0
         };
-
-        metrics
-            .resource
-            .append_schema_url_n(resource_metric.schema_url(), metric_count);
-        metrics.resource.append_id_n(curr_resource_id, metric_count);
-        metrics
-            .resource
-            .append_dropped_attributes_count_n(resource_dropped_attributes_count, metric_count);
+        let mut resource_metric_count = 0usize;
 
         for scope_metric in resource_metric.scopes() {
             let scope_schema_url = scope_metric.schema_url();
@@ -756,18 +746,9 @@ where
                     append_attribute_value(&mut scope_attrs, &kv)?;
                 }
             }
+            let mut scope_metric_count = 0usize;
 
             for metric in scope_metric.metrics() {
-                // Append scope fields per metric so raw protobuf traversal stays single-pass and
-                // all columns stay aligned.
-                metrics.append_scope_schema_url(scope_schema_url);
-                metrics.scope.append_id(Some(curr_scope_id));
-                metrics.scope.append_name(scope_name);
-                metrics.scope.append_version(scope_version);
-                metrics
-                    .scope
-                    .append_dropped_attributes_count(scope_dropped_attributes_count);
-
                 metrics.append_id(curr_metric_id);
                 let data_obj = metric.data();
                 let data = data_obj.as_ref();
@@ -946,14 +927,42 @@ where
                     }
                 }
 
+                scope_metric_count += 1;
                 curr_metric_id = curr_metric_id
                     .checked_add(1)
                     .ok_or(Error::U16OverflowError)?;
             }
+
+            // Builders are independent, so scope columns can be appended in bulk after the
+            // single pass over this scope's metrics.
+            metrics.append_scope_schema_url_n(scope_schema_url, scope_metric_count);
+            metrics.scope.append_id_n(curr_scope_id, scope_metric_count);
+            metrics.scope.append_name_n(scope_name, scope_metric_count);
+            metrics
+                .scope
+                .append_version_n(scope_version, scope_metric_count);
+            metrics.scope.append_dropped_attributes_count_n(
+                scope_dropped_attributes_count,
+                scope_metric_count,
+            );
+            resource_metric_count += scope_metric_count;
+
             curr_scope_id = curr_scope_id
                 .checked_add(1)
                 .ok_or(Error::U16OverflowError)?;
         }
+
+        metrics
+            .resource
+            .append_schema_url_n(resource_schema_url, resource_metric_count);
+        metrics
+            .resource
+            .append_id_n(curr_resource_id, resource_metric_count);
+        metrics.resource.append_dropped_attributes_count_n(
+            resource_dropped_attributes_count,
+            resource_metric_count,
+        );
+
         curr_resource_id = curr_resource_id
             .checked_add(1)
             .ok_or(Error::U16OverflowError)?;
@@ -1012,6 +1021,7 @@ mod test {
 
     use super::*;
 
+    use crate::arrays::StringArrayAccessor;
     use arrow::array::{
         Array, ArrayRef, ArrowPrimitiveType, BinaryArray, BooleanArray, DictionaryArray,
         DurationNanosecondArray, FixedSizeBinaryArray, Float64Array, Int32Array, Int64Array,
@@ -3269,8 +3279,8 @@ mod test {
         assert!(neg_counts.is_empty(), "expected no negative bucket counts");
     }
 
-    /// Scenario: Metrics data mixes resource metrics with present and absent resource messages.
-    /// Guarantees: Encoding emits one correctly identified resource row per metric definition.
+    /// Scenario: Two metrics without a resource precede one metric with resource metadata.
+    /// Guarantees: Each metric receives aligned resource IDs, schema URLs, and dropped counts.
     #[test]
     fn test_metrics_with_mixed_resource_presence() {
         use crate::proto::opentelemetry::metrics::v1::{
@@ -3285,6 +3295,18 @@ mod test {
         };
         let metrics_data = MetricsData::new(vec![
             ResourceMetrics {
+                resource: None,
+                scope_metrics: vec![ScopeMetrics {
+                    scope: None,
+                    metrics: vec![
+                        metric("without-resource-first"),
+                        metric("without-resource-second"),
+                    ],
+                    schema_url: String::new(),
+                }],
+                schema_url: String::new(),
+            },
+            ResourceMetrics {
                 resource: Some(Resource::build().dropped_attributes_count(7u32).finish()),
                 scope_metrics: vec![ScopeMetrics {
                     scope: None,
@@ -3293,22 +3315,13 @@ mod test {
                 }],
                 schema_url: "resource-schema".to_string(),
             },
-            ResourceMetrics {
-                resource: None,
-                scope_metrics: vec![ScopeMetrics {
-                    scope: None,
-                    metrics: vec![metric("without-resource")],
-                    schema_url: String::new(),
-                }],
-                schema_url: String::new(),
-            },
         ]);
 
         let otap_batch = encode_metrics_otap_batch(&metrics_data).expect("encode metrics");
         let metrics = otap_batch
             .get(ArrowPayloadType::UnivariateMetrics)
             .expect("metrics definition batch");
-        assert_eq!(metrics.num_rows(), 2);
+        assert_eq!(metrics.num_rows(), 3);
 
         let resources = metrics
             .column_by_name(consts::RESOURCE)
@@ -3328,9 +3341,21 @@ mod test {
             .as_any()
             .downcast_ref::<UInt32Array>()
             .expect("resource dropped attributes counts");
+        let resource_schema_urls = StringArrayAccessor::try_new(
+            resources
+                .column_by_name(consts::SCHEMA_URL)
+                .expect("resource schema URL column"),
+        )
+        .expect("resource schema URLs");
 
-        assert_eq!(resource_ids.values(), &[0, 1]);
-        assert_eq!(dropped_attributes_counts.values(), &[7, 0]);
+        assert_eq!(resource_ids.values(), &[0, 0, 1]);
+        assert_eq!(dropped_attributes_counts.values(), &[0, 0, 7]);
+        assert_eq!(
+            (0..3)
+                .map(|index| resource_schema_urls.str_at(index))
+                .collect::<Vec<_>>(),
+            vec![None, None, Some("resource-schema")]
+        );
     }
 
     /// Scenario: Serialized metrics contain two empty-schema rows before a non-empty scope schema.
@@ -3370,8 +3395,20 @@ mod test {
         let metrics = otap_batch
             .get(ArrowPayloadType::UnivariateMetrics)
             .expect("metrics definition batch");
+        let scope_schema_urls = StringArrayAccessor::try_new(
+            metrics
+                .column_by_name(consts::SCHEMA_URL)
+                .expect("scope schema URL column"),
+        )
+        .expect("scope schema URLs");
 
         assert_eq!(metrics.num_rows(), 3);
+        assert_eq!(
+            (0..3)
+                .map(|index| scope_schema_urls.str_at(index))
+                .collect::<Vec<_>>(),
+            vec![Some(""), Some(""), Some("scope-schema")]
+        );
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/pdata/src/encode/record/array.rs
+++ b/rust/otap-dataflow/crates/pdata/src/encode/record/array.rs
@@ -346,6 +346,7 @@ macro_rules! handle_append {
         $self:ident,
         $method:ident ( $($arg:expr),* ),
         default_check = $default_check:expr,
+        prefix_count = $prefix_count:expr,
         retry = $retry:block
     ) => {
         match &mut $self.inner {
@@ -365,7 +366,7 @@ macro_rules! handle_append {
             }
             InnerBuilder::Uninitialized(prefix) => {
                 if $default_check {
-                    prefix.append_value();
+                    prefix.append_values($prefix_count);
                 } else {
                     let mut prefix = $self.initialize_inner().expect("can get prefix");
                     prefix.init_builder($self, $self.default_value.clone());
@@ -381,6 +382,7 @@ macro_rules! handle_append_checked {
         $self:ident,
         $method:ident ( $($arg:expr),* ),
         default_check = $default_check:expr,
+        prefix_count = $prefix_count:expr,
         retry = $retry:block
     ) => {
         paste! {
@@ -408,7 +410,7 @@ macro_rules! handle_append_checked {
                 }
                 InnerBuilder::Uninitialized(prefix) => {
                     if $default_check {
-                        prefix.append_value();
+                        prefix.append_values($prefix_count);
                         Ok(())
                     } else {
                         // safety: initialize_inner will return the prefix if the inner variant is
@@ -450,15 +452,20 @@ where
             self,
             append_value(value),
             default_check = Self::is_default_value(&self.default_value, value),
+            prefix_count = 1,
             retry = { self.append_value(value) }
         );
     }
 
     fn append_value_n(&mut self, value: &Self::Native, n: usize) {
+        if n == 0 {
+            return;
+        }
         handle_append!(
             self,
             append_value_n(value, n),
             default_check = Self::is_default_value(&self.default_value, value),
+            prefix_count = n,
             retry = { self.append_value_n(value, n) }
         );
     }
@@ -492,15 +499,20 @@ where
             self,
             append_str(value),
             default_check = Self::is_default_value(&self.default_value, &value),
+            prefix_count = 1,
             retry = { self.append_str(value) }
         );
     }
 
     fn append_str_n(&mut self, value: &str, n: usize) {
+        if n == 0 {
+            return;
+        }
         handle_append!(
             self,
             append_str_n(value, n),
             default_check = Self::is_default_value(&self.default_value, &value),
+            prefix_count = n,
             retry = { self.append_str_n(value, n) }
         );
     }
@@ -538,15 +550,20 @@ where
             self,
             append_slice(value),
             default_check = Self::is_default_value(&self.default_value, &value),
+            prefix_count = 1,
             retry = { self.append_slice(value) }
         )
     }
 
     fn append_slice_n(&mut self, value: &[Self::Native], n: usize) {
+        if n == 0 {
+            return;
+        }
         handle_append!(
             self,
             append_slice_n(value, n),
             default_check = Self::is_default_value(&self.default_value, &value),
+            prefix_count = n,
             retry = { self.append_slice_n(value, n) }
         )
     }
@@ -580,6 +597,7 @@ where
             self,
             append_value(value),
             default_check = Self::is_default_value(&self.default_value, value),
+            prefix_count = 1,
             retry = { self.append_value(value) }
         )
     }
@@ -619,15 +637,20 @@ where
             self,
             append_slice(value),
             default_check = Self::is_default_value(&self.default_value, &value),
+            prefix_count = 1,
             retry = { self.append_slice(value) }
         )
     }
 
     fn append_slice_n(&mut self, value: &[Self::Native], n: usize) -> Result<(), ArrowError> {
+        if n == 0 {
+            return Ok(());
+        }
         handle_append_checked!(
             self,
             append_slice_n(value, n),
             default_check = Self::is_default_value(&self.default_value, &value),
+            prefix_count = n,
             retry = { self.append_slice_n(value, n) }
         )
     }
@@ -817,7 +840,9 @@ fn binary_dict_to_utf8_dict_array<K: ArrowDictionaryKeyType>(
 pub mod test {
     use super::*;
 
-    use arrow::array::{Array, DictionaryArray, FixedSizeBinaryArray, UInt8Array, UInt16Array};
+    use arrow::array::{
+        Array, DictionaryArray, FixedSizeBinaryArray, UInt8Array, UInt16Array, UInt32Array,
+    };
     use arrow::datatypes::{DataType, TimeUnit};
 
     fn test_array_builder_generic<T, TArgs, TN, TD8, TD16>(
@@ -1097,6 +1122,94 @@ pub mod test {
             vec![2, 1],
             DataType::Duration(TimeUnit::Nanosecond),
         );
+    }
+
+    /// Scenario: Adaptive builders receive multiple default values before a non-default value.
+    /// Guarantees: Every bulk API preserves the full default prefix when initializing its array.
+    #[test]
+    fn test_bulk_default_prefix_preserves_count() {
+        let options = || ArrayOptions {
+            optional: true,
+            dictionary_options: None,
+            ..Default::default()
+        };
+
+        let mut primitive = UInt32ArrayBuilder::new(options());
+        primitive.append_value_n(&0, 2);
+        primitive.append_value(&7);
+        let primitive = primitive.finish().expect("primitive array");
+        let primitive = primitive
+            .as_any()
+            .downcast_ref::<UInt32Array>()
+            .expect("u32 array");
+        assert_eq!(primitive.values(), &[0, 0, 7]);
+
+        let mut string = StringArrayBuilder::new(options());
+        string.append_str_n("", 2);
+        string.append_str("value");
+        let string = string.finish().expect("string array");
+        let string = string
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("string array");
+        assert_eq!(string.value(0), "");
+        assert_eq!(string.value(1), "");
+        assert_eq!(string.value(2), "value");
+
+        let mut binary = BinaryArrayBuilder::new(options());
+        binary.append_slice_n(b"", 2);
+        binary.append_slice(b"value");
+        let binary = binary.finish().expect("binary array");
+        let binary = binary
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .expect("binary array");
+        assert_eq!(binary.value(0), b"");
+        assert_eq!(binary.value(1), b"");
+        assert_eq!(binary.value(2), b"value");
+
+        let mut fixed = FixedSizeBinaryArrayBuilder::new_with_args(options(), 1);
+        fixed
+            .append_slice_n(b"\0", 2)
+            .expect("append default fixed-size values");
+        fixed.append_slice(b"a").expect("append fixed-size value");
+        let fixed = fixed.finish().expect("fixed-size binary array");
+        let fixed = fixed
+            .as_any()
+            .downcast_ref::<FixedSizeBinaryArray>()
+            .expect("fixed-size binary array");
+        assert_eq!(fixed.value(0), b"\0");
+        assert_eq!(fixed.value(1), b"\0");
+        assert_eq!(fixed.value(2), b"a");
+    }
+
+    /// Scenario: Adaptive builders receive a bulk append request with a zero count.
+    /// Guarantees: Zero-count bulk appends are no-ops and do not initialize optional arrays.
+    #[test]
+    fn test_zero_count_bulk_append_is_noop() {
+        let options = || ArrayOptions {
+            optional: true,
+            dictionary_options: None,
+            ..Default::default()
+        };
+
+        let mut primitive = UInt32ArrayBuilder::new(options());
+        primitive.append_value_n(&7, 0);
+        assert!(primitive.finish().is_none());
+
+        let mut string = StringArrayBuilder::new(options());
+        string.append_str_n("value", 0);
+        assert!(string.finish().is_none());
+
+        let mut binary = BinaryArrayBuilder::new(options());
+        binary.append_slice_n(b"value", 0);
+        assert!(binary.finish().is_none());
+
+        let mut fixed = FixedSizeBinaryArrayBuilder::new_with_args(options(), 1);
+        fixed
+            .append_slice_n(b"a", 0)
+            .expect("zero-count fixed-size append");
+        assert!(fixed.finish().is_none());
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/pdata/src/encode/record/array/prefix.rs
+++ b/rust/otap-dataflow/crates/pdata/src/encode/record/array/prefix.rs
@@ -37,6 +37,10 @@ impl ArrayPrefixBuilder {
         self.null_buffer_builder.append_non_null();
     }
 
+    pub fn append_values(&mut self, n: usize) {
+        self.null_buffer_builder.append_n_non_nulls(n);
+    }
+
     pub fn append_null(&mut self) {
         self.null_buffer_builder.append_null();
     }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/fork.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/fork.rs
@@ -207,6 +207,8 @@ mod test {
         assert_eq!(result.resource_logs.len(), 0);
     }
 
+    /// Scenario: A metrics fork duplicates one metric and updates each branch independently.
+    /// Guarantees: Each branch retains its own resource group and metric description.
     #[tokio::test]
     async fn test_fork_metrics() {
         let metrics = vec![Metric::build().name("my_metric").finish()];
@@ -223,6 +225,7 @@ mod test {
         )
         .await;
 
+        assert_eq!(result.resource_metrics.len(), 2);
         assert_eq!(
             &result.resource_metrics[0].scope_metrics[0].metrics,
             &[Metric::build()
@@ -232,7 +235,7 @@ mod test {
         );
 
         assert_eq!(
-            &result.resource_metrics[0].scope_metrics[1].metrics,
+            &result.resource_metrics[1].scope_metrics[0].metrics,
             &[Metric::build()
                 .name("my_metric")
                 .description("some metric")


### PR DESCRIPTION
# Change Summary

Fix metrics OTAP encoding panics caused by mismatched Arrow column lengths.

The metrics encoder now:
- Emits resource columns when `ResourceMetrics.resource` is absent, using a dropped-attributes count of zero.
- Appends scope metadata alongside each metric, keeping scope columns aligned during raw protobuf encoding.
- Preserves resource grouping when metrics pass through query-engine fork branches.

Regression tests cover missing resources and serialized metrics containing multiple metrics across scopes with different schema URLs.

## What issue does this PR close?

* Closes #3565

## How are these changes tested?

- Added a regression test mixing present and absent `ResourceMetrics.resource` values.
- Added a raw-protobuf regression test covering scope-schema column alignment.
- Updated the query-engine fork test to verify the resulting resource groups.
- Ran `cargo xtask check`.

## Are there any user-facing changes?

Yes. Valid OTLP metrics that previously caused an encoding panic are now converted to OTAP Arrow records successfully.

### Changelog

* [x] Added a `.chloggen/*.yaml` entry
* [ ] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.