### PR TITLE
feat(quiver): add segment idempotency keys in qseg v2

### DIFF
--- a/rust/otap-dataflow/.chloggen/quiver-segment-uuidv7.yaml
+++ b/rust/otap-dataflow/.chloggen/quiver-segment-uuidv7.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: engine
+note: Persist a UUIDv7 idempotency key based on the first bundle ingestion time in each new Quiver segment and expose it to subscribers.
+issues: [3584]
+subtext:

--- a/rust/otap-dataflow/Cargo.lock
+++ b/rust/otap-dataflow/Cargo.lock
@@ -7672,6 +7672,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/rust/otap-dataflow/crates/quiver/ARCHITECTURE.md
+++ b/rust/otap-dataflow/crates/quiver/ARCHITECTURE.md
@@ -831,6 +831,9 @@ future versions to extend the footer without breaking backwards compatibility:
 |    - directory_length: u32                                              |
 |    - manifest_offset: u64                                               |
 |    - manifest_length: u32                                               |
+|  Version 2 (50 bytes):                                                  |
+|    - all version 1 fields                                               |
+|    - idempotency_key: UUIDv7 (16 bytes)                                 |
 |  (Future versions may add fields here)                                  |
 +-------------------------------------------------------------------------+
 |                         Trailer (fixed 16 bytes)                        |
@@ -849,6 +852,10 @@ future versions to extend the footer without breaking backwards compatibility:
 4. Seek back `footer_size` bytes, read the variable-size footer
 5. Parse version from footer to determine how to interpret remaining fields
 6. Use directory/manifest offsets to locate metadata sections
+
+Writers emit version 2 segments. Readers accept both versions; version 1
+segments have no idempotency key. A version 2 key is assigned on the first
+successful append, using that bundle's ingestion timestamp for its UUIDv7 time.
 
 #### Segment File Naming
 

--- a/rust/otap-dataflow/crates/quiver/Cargo.toml
+++ b/rust/otap-dataflow/crates/quiver/Cargo.toml
@@ -37,6 +37,7 @@ serde = { workspace = true, optional = true }
 thiserror.workspace = true
 tracing.workspace = true
 memmap2 = { workspace = true, optional = true }
+uuid.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 nix.workspace = true

--- a/rust/otap-dataflow/crates/quiver/src/engine.rs
+++ b/rust/otap-dataflow/crates/quiver/src/engine.rs
@@ -4990,6 +4990,8 @@ mod tests {
     // WAL Replay Tests
     // -----------------------------------------------------------------------------
 
+    /// Scenario: Unfinalized bundles are rebuilt from the WAL after a restart.
+    /// Guarantees: Replay restores the bundles and their first-ingestion UUIDv7 timestamp.
     #[tokio::test]
     async fn wal_replay_recovers_bundles_not_finalized_to_segments() {
         let dir = tempdir().expect("tempdir");
@@ -5009,13 +5011,15 @@ mod tests {
 
         // First run: ingest some bundles (they go to WAL + open segment, but NOT finalized)
         let bundles_ingested = 5;
+        let ingestion_time =
+            UNIX_EPOCH + Duration::from_secs(1_700_000_000) + Duration::from_millis(456);
         {
             let engine = QuiverEngine::open(config.clone(), test_budget())
                 .await
                 .expect("engine");
 
             for _ in 0..bundles_ingested {
-                let bundle = DummyBundle::with_rows(10);
+                let bundle = TimestampedBundle::with_rows_and_time(10, ingestion_time);
                 engine.ingest(&bundle).await.expect("ingest");
             }
 
@@ -5075,11 +5079,21 @@ mod tests {
             );
 
             // Check open segment has our replayed bundles
-            let open_segment_bundles = engine.open_segment.lock().bundle_count();
+            let open_segment = engine.open_segment.lock();
+            let open_segment_bundles = open_segment.bundle_count();
             assert_eq!(
                 open_segment_bundles, bundles_ingested,
                 "open segment should have {} replayed bundles after recovery, got {}",
                 bundles_ingested, open_segment_bundles
+            );
+            assert_eq!(
+                open_segment
+                    .idempotency_key()
+                    .expect("replayed segment key")
+                    .get_timestamp()
+                    .expect("UUIDv7 timestamp")
+                    .to_unix(),
+                (1_700_000_000, 456_000_000)
             );
         }
     }

--- a/rust/otap-dataflow/crates/quiver/src/segment/open_segment.rs
+++ b/rust/otap-dataflow/crates/quiver/src/segment/open_segment.rs
@@ -21,9 +21,10 @@
 //! [`SegmentWriter::write_segment`]: super::SegmentWriter::write_segment
 
 use std::collections::HashMap;
-use std::time::Instant;
+use std::time::{Instant, UNIX_EPOCH};
 
 use arrow_schema::SchemaRef;
+use uuid::{NoContext, Timestamp, Uuid};
 
 use super::error::SegmentError;
 use super::stream_accumulator::StreamAccumulator;
@@ -48,6 +49,8 @@ pub struct OpenSegment {
     finalized: bool,
     /// Timestamp when the first bundle was appended (None if empty).
     opened_at: Option<Instant>,
+    /// Durable UUIDv7 assigned from the first bundle's ingestion timestamp.
+    idempotency_key: Option<Uuid>,
 }
 
 impl OpenSegment {
@@ -60,6 +63,7 @@ impl OpenSegment {
             manifest: Vec::new(),
             finalized: false,
             opened_at: None,
+            idempotency_key: None,
         }
     }
 
@@ -93,6 +97,12 @@ impl OpenSegment {
     #[must_use]
     pub const fn opened_at(&self) -> Option<Instant> {
         self.opened_at
+    }
+
+    /// Returns the segment idempotency key, if the segment contains data.
+    #[must_use]
+    pub const fn idempotency_key(&self) -> Option<Uuid> {
+        self.idempotency_key
     }
 
     /// Subtracts `offset` from `opened_at`, making the segment appear
@@ -157,6 +167,23 @@ impl OpenSegment {
             });
         }
 
+        let first_idempotency_key = if self.idempotency_key.is_none() {
+            let ingestion_time =
+                bundle
+                    .ingestion_time()
+                    .duration_since(UNIX_EPOCH)
+                    .map_err(|_| SegmentError::InvalidFormat {
+                        message: "bundle ingestion timestamp predates Unix epoch".to_string(),
+                    })?;
+            Some(Uuid::new_v7(Timestamp::from_unix(
+                NoContext,
+                ingestion_time.as_secs(),
+                ingestion_time.subsec_nanos(),
+            )))
+        } else {
+            None
+        };
+
         // Track when the first bundle was appended for time-based finalization
         if self.opened_at.is_none() {
             self.opened_at = Some(Instant::now());
@@ -196,6 +223,9 @@ impl OpenSegment {
             }
         }
 
+        if let Some(idempotency_key) = first_idempotency_key {
+            self.idempotency_key = Some(idempotency_key);
+        }
         self.manifest.push(entry.clone());
         Ok(entry)
     }
@@ -221,7 +251,7 @@ impl OpenSegment {
 
     /// Consumes the segment, returning components for streaming finalization.
     ///
-    /// Returns the stream accumulators (sorted by stream ID) and the manifest.
+    /// Returns the stream accumulators (sorted by stream ID), manifest, and key.
     /// This is used by [`SegmentWriter::write_segment`](super::SegmentWriter::write_segment)
     /// to stream IPC data directly to disk without buffering in memory.
     ///
@@ -231,7 +261,7 @@ impl OpenSegment {
     /// Returns [`SegmentError::EmptySegment`] if no bundles were appended.
     pub(super) fn into_parts(
         mut self,
-    ) -> Result<(Vec<StreamAccumulator>, Vec<ManifestEntry>), SegmentError> {
+    ) -> Result<(Vec<StreamAccumulator>, Vec<ManifestEntry>, Uuid), SegmentError> {
         if self.finalized {
             return Err(SegmentError::AccumulatorFinalized);
         }
@@ -239,13 +269,18 @@ impl OpenSegment {
             return Err(SegmentError::EmptySegment);
         }
         self.finalized = true;
+        let idempotency_key = self
+            .idempotency_key
+            .ok_or_else(|| SegmentError::InvalidFormat {
+                message: "non-empty segment has no idempotency key".to_string(),
+            })?;
 
         // Sort by stream ID for deterministic output order
         let mut stream_entries: Vec<_> = self.streams.into_iter().collect();
         stream_entries.sort_by_key(|(_, acc)| acc.stream_id());
 
         let accumulators = stream_entries.into_iter().map(|(_, acc)| acc).collect();
-        Ok((accumulators, self.manifest))
+        Ok((accumulators, self.manifest, idempotency_key))
     }
 
     /// Returns an iterator over the manifest entries.
@@ -300,6 +335,7 @@ impl std::fmt::Debug for OpenSegment {
 #[cfg(test)]
 mod tests {
     use std::io::Cursor;
+    use std::time::{Duration, UNIX_EPOCH};
 
     use arrow_ipc::reader::FileReader;
 
@@ -308,6 +344,8 @@ mod tests {
     use crate::segment::ChunkIndex;
     use crate::segment::test_utils::{TestBundle, make_batch, slot_descriptors, test_schema};
 
+    /// Scenario: A newly allocated segment has not accepted a bundle.
+    /// Guarantees: It has no streams, timing state, or idempotency key.
     #[test]
     fn new_segment_is_empty() {
         let seg = OpenSegment::new();
@@ -316,24 +354,40 @@ mod tests {
         assert_eq!(seg.stream_count(), 0);
         assert!(!seg.is_finalized());
         assert!(seg.opened_at().is_none());
+        assert!(seg.idempotency_key().is_none());
     }
 
+    /// Scenario: The first bundle appended to an empty segment has a known ingestion timestamp.
+    /// Guarantees: The segment UUIDv7 uses that timestamp and remains stable across later appends.
     #[test]
     fn opened_at_is_set_on_first_append() {
         let mut seg = OpenSegment::new();
         let schema = test_schema();
         let batch = make_batch(&schema, &[1], &["a"]);
         let fp = [0x11u8; 32];
+        let ingestion_time =
+            UNIX_EPOCH + Duration::from_secs(1_700_000_000) + Duration::from_millis(123);
 
         // Before append, opened_at should be None
         assert!(seg.opened_at().is_none());
+        assert!(seg.idempotency_key().is_none());
 
-        let bundle = TestBundle::new(slot_descriptors()).with_payload(SlotId::new(0), fp, batch);
+        let bundle = TestBundle::new(slot_descriptors())
+            .with_ingestion_time(ingestion_time)
+            .with_payload(SlotId::new(0), fp, batch);
         let _ = seg.append(&bundle).expect("append succeeds");
 
         // After append, opened_at should be set
         assert!(seg.opened_at().is_some());
         let opened_at = seg.opened_at().unwrap();
+        let idempotency_key = seg.idempotency_key().expect("first append assigns key");
+        assert_eq!(
+            idempotency_key
+                .get_timestamp()
+                .expect("UUIDv7 timestamp")
+                .to_unix(),
+            (1_700_000_000, 123_000_000)
+        );
 
         // A second append should not change opened_at
         let batch2 = make_batch(&test_schema(), &[2], &["b"]);
@@ -345,6 +399,7 @@ mod tests {
             opened_at,
             "opened_at should not change after first bundle"
         );
+        assert_eq!(seg.idempotency_key(), Some(idempotency_key));
     }
 
     #[test]
@@ -462,6 +517,8 @@ mod tests {
         assert_ne!(stream_id1, stream_id2);
     }
 
+    /// Scenario: A populated open segment is consumed for streaming serialization.
+    /// Guarantees: Its streams, manifest, and first-append idempotency key are preserved.
     #[test]
     fn into_parts_produces_valid_accumulators() {
         let mut seg = OpenSegment::new();
@@ -484,11 +541,14 @@ mod tests {
 
         let _ = seg.append(&bundle1).unwrap();
         let _ = seg.append(&bundle2).unwrap();
+        let expected_idempotency_key = seg.idempotency_key().expect("populated segment key");
 
-        let (mut accumulators, manifest) = seg.into_parts().expect("into_parts should succeed");
+        let (mut accumulators, manifest, idempotency_key) =
+            seg.into_parts().expect("into_parts should succeed");
 
         assert_eq!(accumulators.len(), 2);
         assert_eq!(manifest.len(), 2);
+        assert_eq!(idempotency_key, expected_idempotency_key);
 
         // Pop accumulators in reverse order (sorted by stream_id)
         let acc_1 = accumulators.pop().unwrap();

--- a/rust/otap-dataflow/crates/quiver/src/segment/reader.rs
+++ b/rust/otap-dataflow/crates/quiver/src/segment/reader.rs
@@ -50,6 +50,7 @@ use arrow_ipc::convert::fb_to_schema;
 use arrow_ipc::reader::{FileDecoder, read_footer_length};
 use arrow_ipc::{Block, root_as_footer};
 use crc32fast::Hasher;
+use uuid::Uuid;
 
 use super::error::SegmentError;
 use super::types::{
@@ -76,6 +77,8 @@ use crate::record_bundle::{ArrowPrimitive, SlotId};
 pub struct ReconstructedBundle {
     /// The bundle index from the manifest.
     bundle_index: u32,
+    /// Durable idempotency key of the segment containing this bundle.
+    idempotency_key: Option<Uuid>,
     /// Payload batches by slot ID.
     payloads: HashMap<SlotId, RecordBatch>,
     /// Keeps the backing buffer alive (may be mmap or heap allocation).
@@ -89,6 +92,7 @@ impl ReconstructedBundle {
     pub fn empty() -> Self {
         Self {
             bundle_index: 0,
+            idempotency_key: None,
             payloads: HashMap::new(),
             _backing: Arc::new(Buffer::from_vec(Vec::<u8>::new())),
         }
@@ -98,6 +102,14 @@ impl ReconstructedBundle {
     #[must_use]
     pub const fn bundle_index(&self) -> u32 {
         self.bundle_index
+    }
+
+    /// Returns the durable idempotency key of the containing segment.
+    ///
+    /// Returns `None` only for version 1 segments.
+    #[must_use]
+    pub const fn idempotency_key(&self) -> Option<Uuid> {
+        self.idempotency_key
     }
 
     /// Returns the payload batches by slot ID.
@@ -548,6 +560,14 @@ impl SegmentReader {
         self.footer.version
     }
 
+    /// Returns the durable idempotency key of this segment.
+    ///
+    /// Returns `None` only for version 1 segments.
+    #[must_use]
+    pub const fn idempotency_key(&self) -> Option<Uuid> {
+        self.footer.idempotency_key
+    }
+
     /// Returns the total file size in bytes.
     #[must_use]
     pub fn file_size(&self) -> usize {
@@ -636,6 +656,7 @@ impl SegmentReader {
 
         Ok(ReconstructedBundle {
             bundle_index: entry.bundle_index,
+            idempotency_key: self.footer.idempotency_key,
             payloads,
             _backing: Arc::clone(&self.buffer),
         })
@@ -1101,7 +1122,9 @@ mod tests {
     use super::*;
     use crate::record_bundle::SlotDescriptor;
     use crate::segment::test_utils::{TestBundle, make_batch, slot_descriptors, test_schema};
-    use crate::segment::types::FOOTER_V1_SIZE;
+    use crate::segment::types::{
+        FOOTER_V1_SIZE, SEGMENT_VERSION, SEGMENT_VERSION_V1, SEGMENT_VERSION_V2,
+    };
     use crate::segment::{OpenSegment, SegmentSeq, SegmentWriter};
 
     /// Test helper that creates a segment file in a temporary directory.
@@ -1158,6 +1181,45 @@ mod tests {
         }
     }
 
+    /// Writes a copy of a segment using the legacy 34-byte footer.
+    fn write_legacy_footer_copy(source: &Path, target: &Path) {
+        let bytes = std::fs::read(source).expect("read source segment");
+        let trailer_start = bytes.len() - TRAILER_SIZE;
+        let trailer_bytes: &[u8; TRAILER_SIZE] = bytes[trailer_start..]
+            .try_into()
+            .expect("fixed-size trailer");
+        let (trailer, _) = Trailer::decode(trailer_bytes).expect("decode trailer");
+        let footer_start = trailer_start - trailer.footer_size as usize;
+        let footer =
+            Footer::decode(&bytes[footer_start..trailer_start]).expect("decode source footer");
+        let legacy_footer = Footer {
+            version: SEGMENT_VERSION_V1,
+            idempotency_key: None,
+            ..footer
+        }
+        .encode()
+        .expect("encode legacy footer");
+        assert_eq!(legacy_footer.len(), FOOTER_V1_SIZE);
+
+        let mut legacy_bytes = bytes[..footer_start].to_vec();
+        legacy_bytes.extend_from_slice(&legacy_footer);
+        legacy_bytes.extend_from_slice(
+            &Trailer {
+                footer_size: legacy_footer.len() as u32,
+            }
+            .encode(),
+        );
+
+        let mut hasher = Hasher::new();
+        hasher.update(&legacy_bytes[..legacy_bytes.len() - 4]);
+        let crc = hasher.finalize();
+        let crc_start = legacy_bytes.len() - 4;
+        legacy_bytes[crc_start..].copy_from_slice(&crc.to_le_bytes());
+        std::fs::write(target, legacy_bytes).expect("write legacy segment");
+    }
+
+    /// Scenario: A newly finalized segment is opened by the reader.
+    /// Guarantees: The segment uses format version 2 and contains a UUIDv7 idempotency key.
     #[tokio::test]
     async fn reader_opens_valid_segment() {
         let seg = TestSegment::new().await;
@@ -1166,7 +1228,51 @@ mod tests {
 
         assert_eq!(reader.stream_count(), seg.stream_count);
         assert_eq!(reader.bundle_count(), seg.bundle_count);
-        assert_eq!(reader.version(), 1);
+        assert_eq!(reader.version(), SEGMENT_VERSION);
+        assert_eq!(
+            reader
+                .idempotency_key()
+                .expect("version 2 segment has an idempotency key")
+                .get_version_num(),
+            7
+        );
+    }
+
+    /// Scenario: A persisted segment is closed and reopened.
+    /// Guarantees: Its UUIDv7 idempotency key is read from disk and remains unchanged.
+    #[tokio::test]
+    async fn reader_preserves_idempotency_key_across_reopens() {
+        let seg = TestSegment::new().await;
+
+        let first_key = SegmentReader::open(&seg.path)
+            .expect("first open")
+            .idempotency_key()
+            .expect("version 2 segment has an idempotency key");
+        let second_key = SegmentReader::open(&seg.path)
+            .expect("second open")
+            .idempotency_key()
+            .expect("reopened segment has an idempotency key");
+
+        assert_eq!(second_key, first_key);
+    }
+
+    /// Scenario: A legacy segment has the original 34-byte version 1 footer.
+    /// Guarantees: The reader accepts it and reports no durable idempotency key.
+    #[tokio::test]
+    async fn reader_opens_v1_footer_without_idempotency_key() {
+        let seg = TestSegment::new().await;
+        let legacy_path = seg.dir.path().join("legacy.qseg");
+        write_legacy_footer_copy(&seg.path, &legacy_path);
+
+        let reader = SegmentReader::open(&legacy_path).expect("open legacy segment");
+
+        assert_eq!(reader.version(), SEGMENT_VERSION_V1);
+        assert_eq!(reader.idempotency_key(), None);
+        let bundle = reader
+            .read_bundle(&reader.manifest()[0])
+            .expect("read legacy bundle");
+        assert_eq!(bundle.idempotency_key(), None);
+        assert_eq!(bundle.slot_count(), 1);
     }
 
     #[tokio::test]
@@ -1194,6 +1300,8 @@ mod tests {
         assert_eq!(manifest[1].bundle_index, 1);
     }
 
+    /// Scenario: A bundle is reconstructed from a segment carrying a UUIDv7 idempotency key.
+    /// Guarantees: The reconstructed bundle exposes the same durable idempotency key.
     #[tokio::test]
     async fn reader_reads_bundle() {
         let seg = TestSegment::new().await;
@@ -1204,6 +1312,7 @@ mod tests {
         let bundle = reader.read_bundle(&entry).expect("read_bundle");
 
         assert_eq!(bundle.bundle_index(), 0);
+        assert_eq!(bundle.idempotency_key(), reader.idempotency_key());
         assert_eq!(bundle.slot_count(), 1);
         assert!(bundle.payload(SlotId::new(0)).is_some());
         assert_eq!(
@@ -1305,6 +1414,20 @@ mod tests {
 
         assert!(
             matches!(result, Err(SegmentError::InvalidFormat { message }) if message.contains("footer too short for version 1"))
+        );
+    }
+
+    /// Scenario: A footer declares version 2 but contains only the version 1 fields.
+    /// Guarantees: The reader rejects version 2 segments missing their idempotency key.
+    #[test]
+    fn footer_decode_rejects_buffer_too_short_for_v2() {
+        let mut buf = [0u8; FOOTER_V1_SIZE];
+        buf[0..2].copy_from_slice(&SEGMENT_VERSION_V2.to_le_bytes());
+
+        let result = Footer::decode(&buf);
+
+        assert!(
+            matches!(result, Err(SegmentError::InvalidFormat { message }) if message.contains("footer too short for version 2"))
         );
     }
 
@@ -1411,6 +1534,8 @@ mod tests {
         assert_eq!(dict_col.len(), 5);
     }
 
+    /// Scenario: A byte in the persisted UUIDv7 idempotency key is corrupted.
+    /// Guarantees: The segment CRC rejects the modified key.
     #[tokio::test]
     async fn reader_detects_checksum_mismatch() {
         let seg = TestSegment::new().await;
@@ -1433,9 +1558,10 @@ mod tests {
             std::fs::set_permissions(&seg.path, permissions).expect("set permissions");
         }
 
-        // Corrupt a byte in the footer
+        // Corrupt the final byte of the idempotency key without changing its
+        // version bits, so footer parsing reaches CRC validation.
         let mut bytes = std::fs::read(&seg.path).expect("read");
-        let footer_pos = bytes.len() - 20; // Somewhere in footer
+        let footer_pos = bytes.len() - TRAILER_SIZE - 1;
         bytes[footer_pos] ^= 0xFF;
         std::fs::write(&seg.path, &bytes).expect("write");
 

--- a/rust/otap-dataflow/crates/quiver/src/segment/test_utils.rs
+++ b/rust/otap-dataflow/crates/quiver/src/segment/test_utils.rs
@@ -92,6 +92,7 @@ pub fn slot_descriptors() -> Vec<SlotDescriptor> {
 pub struct TestBundle {
     descriptor: BundleDescriptor,
     payloads: HashMap<SlotId, (SchemaFingerprint, RecordBatch)>,
+    ingestion_time: SystemTime,
 }
 
 impl TestBundle {
@@ -101,7 +102,15 @@ impl TestBundle {
         Self {
             descriptor: BundleDescriptor::new(slots),
             payloads: HashMap::new(),
+            ingestion_time: SystemTime::now(),
         }
+    }
+
+    /// Sets the bundle ingestion timestamp.
+    #[must_use]
+    pub fn with_ingestion_time(mut self, ingestion_time: SystemTime) -> Self {
+        self.ingestion_time = ingestion_time;
+        self
     }
 
     /// Adds a payload to the bundle for the specified slot.
@@ -123,7 +132,7 @@ impl RecordBundle for TestBundle {
     }
 
     fn ingestion_time(&self) -> SystemTime {
-        SystemTime::now()
+        self.ingestion_time
     }
 
     fn payload(&self, slot: SlotId) -> Option<PayloadRef<'_>> {

--- a/rust/otap-dataflow/crates/quiver/src/segment/types.rs
+++ b/rust/otap-dataflow/crates/quiver/src/segment/types.rs
@@ -10,6 +10,7 @@
 use std::collections::HashMap;
 
 use arrow_array::types::UInt32Type;
+use uuid::{Uuid, Variant};
 
 use crate::record_bundle::{ArrowPrimitive, SchemaFingerprint, SlotId};
 
@@ -22,8 +23,14 @@ use super::error::SegmentError;
 /// Magic bytes identifying a Quiver segment file.
 pub(super) const SEGMENT_MAGIC: &[u8; 8] = b"QUIVER\0S";
 
+/// Segment file format version without a durable idempotency key.
+pub(super) const SEGMENT_VERSION_V1: u16 = 1;
+
+/// Segment file format version with a durable UUIDv7 idempotency key.
+pub(super) const SEGMENT_VERSION_V2: u16 = 2;
+
 /// Current segment file format version.
-pub(super) const SEGMENT_VERSION: u16 = 1;
+pub(super) const SEGMENT_VERSION: u16 = SEGMENT_VERSION_V2;
 
 /// Size of the fixed trailer at the end of the segment file.
 /// Layout: footer_size (4) + magic (8) + crc32 (4) = 16 bytes
@@ -34,6 +41,10 @@ pub(super) const TRAILER_SIZE: usize = 16;
 ///         directory_offset (8) + directory_length (4) +
 ///         manifest_offset (8) + manifest_length (4) = 34 bytes
 pub(super) const FOOTER_V1_SIZE: usize = 34;
+
+/// Size of the footer for version 2.
+/// Layout: version 1 fields (34) + idempotency_key (16) = 50 bytes
+pub(super) const FOOTER_V2_SIZE: usize = FOOTER_V1_SIZE + 16;
 
 // -----------------------------------------------------------------------------
 // Segment Limits
@@ -427,13 +438,13 @@ impl std::fmt::Display for SegmentSeq {
 // Footer
 // -----------------------------------------------------------------------------
 
-/// Segment file footer structure (version 1).
+/// Segment file footer structure.
 ///
 /// The footer contains metadata needed to locate and interpret the segment's
-/// stream directory and batch manifest. Future versions may add additional
-/// fields; the trailer's `footer_size` field allows readers to handle
-/// variable-sized footers.
-#[derive(Debug, Clone)]
+/// stream directory and batch manifest. Version 2 adds a durable UUIDv7
+/// idempotency key. Future versions may add fields; the trailer's `footer_size`
+/// field allows readers to handle variable-sized footers.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct Footer {
     pub version: u16,
     pub stream_count: u32,
@@ -442,12 +453,46 @@ pub(super) struct Footer {
     pub directory_length: u32,
     pub manifest_offset: u64,
     pub manifest_length: u32,
+    /// Durable segment idempotency key. Absent only for version 1 segments.
+    pub idempotency_key: Option<Uuid>,
 }
 
 impl Footer {
     /// Encodes the footer to bytes.
-    pub fn encode(&self) -> Vec<u8> {
-        let mut buf = vec![0u8; FOOTER_V1_SIZE];
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the version is unsupported or its idempotency key
+    /// does not satisfy the version contract.
+    pub fn encode(&self) -> Result<Vec<u8>, SegmentError> {
+        let footer_size = match (self.version, self.idempotency_key) {
+            (SEGMENT_VERSION_V1, None) => FOOTER_V1_SIZE,
+            (SEGMENT_VERSION_V1, Some(_)) => {
+                return Err(SegmentError::InvalidFormat {
+                    message: "version 1 footer cannot contain an idempotency key".to_string(),
+                });
+            }
+            (SEGMENT_VERSION_V2, Some(idempotency_key)) => {
+                if !is_uuid_v7(idempotency_key) {
+                    return Err(SegmentError::InvalidFormat {
+                        message: "version 2 footer idempotency key must be UUIDv7".to_string(),
+                    });
+                }
+                FOOTER_V2_SIZE
+            }
+            (SEGMENT_VERSION_V2, None) => {
+                return Err(SegmentError::InvalidFormat {
+                    message: "version 2 footer requires an idempotency key".to_string(),
+                });
+            }
+            (version, _) => {
+                return Err(SegmentError::InvalidFormat {
+                    message: format!("unsupported segment version: {}", version),
+                });
+            }
+        };
+
+        let mut buf = vec![0u8; footer_size];
         let mut pos = 0;
 
         // Version (2 bytes)
@@ -476,11 +521,16 @@ impl Footer {
 
         // Manifest length (4 bytes)
         buf[pos..pos + 4].copy_from_slice(&self.manifest_length.to_le_bytes());
+        pos += 4;
 
-        buf
+        if let Some(idempotency_key) = self.idempotency_key {
+            buf[pos..pos + 16].copy_from_slice(idempotency_key.as_bytes());
+        }
+
+        Ok(buf)
     }
 
-    /// Decodes a version 1 footer from bytes.
+    /// Decodes a supported footer from bytes.
     ///
     /// # Errors
     ///
@@ -493,17 +543,22 @@ impl Footer {
         }
 
         let version = u16::from_le_bytes([buf[0], buf[1]]);
-        if version != SEGMENT_VERSION {
-            return Err(SegmentError::InvalidFormat {
-                message: format!("unsupported segment version: {}", version),
-            });
-        }
+        let expected_size = match version {
+            SEGMENT_VERSION_V1 => FOOTER_V1_SIZE,
+            SEGMENT_VERSION_V2 => FOOTER_V2_SIZE,
+            _ => {
+                return Err(SegmentError::InvalidFormat {
+                    message: format!("unsupported segment version: {}", version),
+                });
+            }
+        };
 
-        if buf.len() < FOOTER_V1_SIZE {
+        if buf.len() < expected_size {
             return Err(SegmentError::InvalidFormat {
                 message: format!(
-                    "footer too short for version 1: expected {} bytes, got {}",
-                    FOOTER_V1_SIZE,
+                    "footer too short for version {}: expected {} bytes, got {}",
+                    version,
+                    expected_size,
                     buf.len()
                 ),
             });
@@ -553,6 +608,25 @@ impl Footer {
         // Manifest length (4 bytes)
         let manifest_length =
             u32::from_le_bytes([buf[pos], buf[pos + 1], buf[pos + 2], buf[pos + 3]]);
+        pos += 4;
+
+        let idempotency_key = if version == SEGMENT_VERSION_V2 {
+            let id_bytes: [u8; 16] =
+                buf[pos..pos + 16]
+                    .try_into()
+                    .map_err(|_| SegmentError::InvalidFormat {
+                        message: "version 2 footer has an invalid idempotency key".to_string(),
+                    })?;
+            let idempotency_key = Uuid::from_bytes(id_bytes);
+            if !is_uuid_v7(idempotency_key) {
+                return Err(SegmentError::InvalidFormat {
+                    message: "version 2 footer idempotency key must be UUIDv7".to_string(),
+                });
+            }
+            Some(idempotency_key)
+        } else {
+            None
+        };
 
         Ok(Footer {
             version,
@@ -562,8 +636,14 @@ impl Footer {
             directory_length,
             manifest_offset,
             manifest_length,
+            idempotency_key,
         })
     }
+}
+
+/// Returns whether a UUID satisfies the RFC 9562 UUIDv7 format contract.
+fn is_uuid_v7(value: Uuid) -> bool {
+    value.get_version_num() == 7 && value.get_variant() == Variant::RFC4122
 }
 
 // -----------------------------------------------------------------------------

--- a/rust/otap-dataflow/crates/quiver/src/segment/writer.rs
+++ b/rust/otap-dataflow/crates/quiver/src/segment/writer.rs
@@ -35,6 +35,7 @@
 //! |  - Directory length: u32                                                |
 //! |  - Manifest offset: u64                                                 |
 //! |  - Manifest length: u32                                                 |
+//! |  - Idempotency key: UUIDv7 (16 bytes, version 2+)                        |
 //! |  - (Future versions may add more fields here)                           |
 //! +-------------------------------------------------------------------------+
 //! |                         Trailer (fixed 16 bytes)                        |
@@ -81,6 +82,7 @@ use arrow_array::builder::{
 use arrow_ipc::writer::FileWriter;
 use arrow_schema::{DataType, Field, Fields, Schema};
 use crc32fast::Hasher;
+use uuid::Uuid;
 
 use super::error::SegmentError;
 use super::types::{
@@ -181,7 +183,7 @@ impl SegmentWriter {
         segment: super::OpenSegment,
     ) -> Result<(u64, u32), SegmentError> {
         let path = path.as_ref().to_path_buf();
-        let (accumulators, manifest) = segment.into_parts()?;
+        let (accumulators, manifest, idempotency_key) = segment.into_parts()?;
 
         // Create the file asynchronously, then convert to std::fs::File for Arrow IPC.
         let async_file = tokio::fs::File::create(&path)
@@ -198,7 +200,13 @@ impl SegmentWriter {
             move || -> Result<(File, (u64, u32)), SegmentError> {
                 let mut writer = BufWriter::new(std_file);
 
-                let result = Self::write_streaming(&mut writer, accumulators, manifest, &path)?;
+                let result = Self::write_streaming(
+                    &mut writer,
+                    accumulators,
+                    manifest,
+                    idempotency_key,
+                    &path,
+                )?;
 
                 // Extract the underlying file for fsync
                 let file = writer
@@ -266,6 +274,7 @@ impl SegmentWriter {
         writer: &mut W,
         accumulators: Vec<super::StreamAccumulator>,
         manifest: Vec<ManifestEntry>,
+        idempotency_key: Uuid,
         path: &Path,
     ) -> Result<(u64, u32), SegmentError> {
         // Validate limits before writing to prevent creating unreadable segments
@@ -351,9 +360,10 @@ impl SegmentWriter {
             directory_length,
             manifest_offset,
             manifest_length,
+            idempotency_key: Some(idempotency_key),
         };
 
-        let footer_bytes = footer.encode();
+        let footer_bytes = footer.encode()?;
         writer
             .write_all(&footer_bytes)
             .map_err(|e| SegmentError::io(path.to_path_buf(), e))?;
@@ -627,7 +637,10 @@ mod tests {
     use super::*;
     use crate::record_bundle::SlotId;
     use crate::segment::test_utils::{make_batch, test_schema};
-    use crate::segment::types::{ChunkIndex, FOOTER_V1_SIZE, SEGMENT_MAGIC, StreamId};
+    use crate::segment::types::{
+        ChunkIndex, FOOTER_V1_SIZE, FOOTER_V2_SIZE, SEGMENT_MAGIC, SEGMENT_VERSION_V1,
+        SEGMENT_VERSION_V2, StreamId,
+    };
 
     #[tokio::test]
     async fn write_empty_segment_fails() {
@@ -783,6 +796,8 @@ mod tests {
         }
     }
 
+    /// Scenario: A segment is written through the streaming finalization path.
+    /// Guarantees: The v2 result carries a UUIDv7 idempotency key into reconstructed bundles.
     #[tokio::test]
     async fn write_segment_streaming_produces_readable_file() {
         use crate::segment::test_utils::{TestBundle, slot_descriptors, test_fingerprint};
@@ -803,6 +818,9 @@ mod tests {
             batch.clone(),
         );
         let _ = open_segment.append(&bundle).unwrap();
+        let expected_idempotency_key = open_segment
+            .idempotency_key()
+            .expect("first append assigns key");
 
         // Write using the streaming API
         let writer = SegmentWriter::new(SegmentSeq::new(42), true);
@@ -815,38 +833,160 @@ mod tests {
         let reader = SegmentReader::open(&path).unwrap();
         assert_eq!(reader.bundle_count(), 1);
         assert_eq!(reader.stream_count(), 1);
+        let idempotency_key = reader
+            .idempotency_key()
+            .expect("version 2 segment has an idempotency key");
+        assert_eq!(idempotency_key.get_version_num(), 7);
+        assert_eq!(idempotency_key, expected_idempotency_key);
 
         // Read back the bundle
         let manifest = reader.manifest();
         let reconstructed = reader.read_bundle(&manifest[0]).unwrap();
+        assert_eq!(reconstructed.idempotency_key(), Some(idempotency_key));
         let payload = reconstructed.payload(SlotId::new(0)).unwrap();
         assert_eq!(payload.num_rows(), 3);
     }
 
+    /// Scenario: A version 2 footer contains its required UUIDv7 idempotency key.
+    /// Guarantees: Encoding and decoding preserve the exact durable key.
     #[test]
-    fn footer_encode_decode_roundtrip() {
+    fn footer_v2_encode_decode_roundtrip() {
+        let idempotency_key =
+            Uuid::parse_str("01890f12-3456-789a-8bcd-ef0123456789").expect("valid UUIDv7");
         let footer = Footer {
-            version: SEGMENT_VERSION,
+            version: SEGMENT_VERSION_V2,
             stream_count: 5,
             bundle_count: 100,
             directory_offset: 12345678,
             directory_length: 1024,
             manifest_offset: 12346702,
             manifest_length: 2048,
+            idempotency_key: Some(idempotency_key),
         };
 
-        let encoded = footer.encode();
-        assert_eq!(encoded.len(), FOOTER_V1_SIZE);
+        let encoded = footer.encode().expect("encode footer");
+        assert_eq!(encoded.len(), FOOTER_V2_SIZE);
 
         let decoded = Footer::decode(&encoded).unwrap();
 
-        assert_eq!(decoded.version, footer.version);
-        assert_eq!(decoded.stream_count, footer.stream_count);
-        assert_eq!(decoded.bundle_count, footer.bundle_count);
-        assert_eq!(decoded.directory_offset, footer.directory_offset);
-        assert_eq!(decoded.directory_length, footer.directory_length);
-        assert_eq!(decoded.manifest_offset, footer.manifest_offset);
-        assert_eq!(decoded.manifest_length, footer.manifest_length);
+        assert_eq!(decoded, footer);
+    }
+
+    /// Scenario: A version 1 footer predates durable idempotency keys.
+    /// Guarantees: Its 34-byte representation still decodes with no idempotency key.
+    #[test]
+    fn footer_v1_encode_decode_roundtrip() {
+        let footer = Footer {
+            version: SEGMENT_VERSION_V1,
+            stream_count: 5,
+            bundle_count: 100,
+            directory_offset: 12345678,
+            directory_length: 1024,
+            manifest_offset: 12346702,
+            manifest_length: 2048,
+            idempotency_key: None,
+        };
+
+        let encoded = footer.encode().expect("encode footer");
+        assert_eq!(encoded.len(), FOOTER_V1_SIZE);
+        assert_eq!(Footer::decode(&encoded).unwrap(), footer);
+    }
+
+    /// Scenario: Version 2 extends the version 1 footer with an idempotency key.
+    /// Guarantees: The common 34-byte metadata prefix is unchanged apart from the version field.
+    #[test]
+    fn footer_v2_preserves_v1_common_fields() {
+        let v1 = Footer {
+            version: SEGMENT_VERSION_V1,
+            stream_count: 5,
+            bundle_count: 100,
+            directory_offset: 12345678,
+            directory_length: 1024,
+            manifest_offset: 12346702,
+            manifest_length: 2048,
+            idempotency_key: None,
+        };
+        let v2 = Footer {
+            version: SEGMENT_VERSION_V2,
+            idempotency_key: Some(Uuid::parse_str("01890f12-3456-789a-8bcd-ef0123456789").unwrap()),
+            ..v1.clone()
+        };
+
+        let v1_bytes = v1.encode().expect("encode v1 footer");
+        let v2_bytes = v2.encode().expect("encode v2 footer");
+
+        assert_eq!(&v2_bytes[2..FOOTER_V1_SIZE], &v1_bytes[2..]);
+        assert_eq!(u16::from_le_bytes([v2_bytes[0], v2_bytes[1]]), 2);
+    }
+
+    /// Scenario: A version 2 footer is given a non-v7 idempotency key.
+    /// Guarantees: The writer rejects keys that violate the UUIDv7 format contract.
+    #[test]
+    fn footer_v2_rejects_non_v7_idempotency_key() {
+        let footer = Footer {
+            version: SEGMENT_VERSION_V2,
+            stream_count: 1,
+            bundle_count: 1,
+            directory_offset: 0,
+            directory_length: 0,
+            manifest_offset: 0,
+            manifest_length: 0,
+            idempotency_key: Some(Uuid::nil()),
+        };
+
+        let result = footer.encode();
+
+        assert!(
+            matches!(result, Err(SegmentError::InvalidFormat { message }) if message.contains("must be UUIDv7"))
+        );
+    }
+
+    /// Scenario: A key has version 7 bits but not the RFC 9562 UUID variant.
+    /// Guarantees: Version 2 rejects values that are not structurally valid UUIDv7 keys.
+    #[test]
+    fn footer_v2_rejects_non_rfc_uuid_variant() {
+        let mut key_bytes = *Uuid::parse_str("01890f12-3456-789a-8bcd-ef0123456789")
+            .expect("valid UUIDv7")
+            .as_bytes();
+        key_bytes[8] = 0x00;
+        let footer = Footer {
+            version: SEGMENT_VERSION_V2,
+            stream_count: 1,
+            bundle_count: 1,
+            directory_offset: 0,
+            directory_length: 0,
+            manifest_offset: 0,
+            manifest_length: 0,
+            idempotency_key: Some(Uuid::from_bytes(key_bytes)),
+        };
+
+        let result = footer.encode();
+
+        assert!(
+            matches!(result, Err(SegmentError::InvalidFormat { message }) if message.contains("must be UUIDv7"))
+        );
+    }
+
+    /// Scenario: A version 2 footer is encoded without an idempotency key.
+    /// Guarantees: Version 2 cannot produce a segment that lacks its required durable key.
+    #[test]
+    fn footer_v2_requires_idempotency_key() {
+        let footer = Footer {
+            version: SEGMENT_VERSION_V2,
+            stream_count: 1,
+            bundle_count: 1,
+            directory_offset: 0,
+            directory_length: 0,
+            manifest_offset: 0,
+            manifest_length: 0,
+            idempotency_key: None,
+        };
+
+        let result = footer.encode();
+
+        assert!(
+            matches!(result, Err(SegmentError::InvalidFormat { message }) if message.contains("requires an idempotency key"))
+        );
     }
 
     #[test]
@@ -960,11 +1100,14 @@ mod tests {
         assert_eq!(writer.segment_seq(), SegmentSeq::new(42));
     }
 
+    /// Scenario: Segment format constants define the on-disk v1 and v2 layouts.
+    /// Guarantees: Version, magic, trailer size, and both footer sizes remain stable.
     #[test]
     fn segment_constants_have_expected_values() {
         assert_eq!(SEGMENT_MAGIC, b"QUIVER\0S");
-        assert_eq!(SEGMENT_VERSION, 1);
+        assert_eq!(SEGMENT_VERSION, 2);
         assert_eq!(TRAILER_SIZE, 16);
         assert_eq!(FOOTER_V1_SIZE, 34);
+        assert_eq!(FOOTER_V2_SIZE, 50);
     }
 }


### PR DESCRIPTION
### Change Summary

Adds a UUIDv7 idempotency key to new Quiver segments and introduces the qseg v2 footer needed to persist it.

The key is created on the first successful append using the bundle's ingestion time, retained for the segment's lifetime, and exposed by readers and subscriber-delivered bundles. This gives downstream subscribers a stable, collision-resistant identity for retrying writes.

Readers remain compatible with qseg v1, where the key is absent. qseg v2 requires a valid UUIDv7. This does not provide deterministic identity when an unfinalized segment is reconstructed from its WAL.

Closes #3584

### Testing

- `cargo test -p otap-df-quiver --locked`
- `cargo xtask check`

### Changelog

- [x] Added a `.chloggen/*.yaml` entry
`