### PR TITLE
chore(ci): track df_engine .text size and per-crate bloat on merges to main

### DIFF
--- a/.github/workflows/dataflow-engine-binary-size.yml
+++ b/.github/workflows/dataflow-engine-binary-size.yml
@@ -7,6 +7,12 @@ on:
   schedule:
     # Run daily at 00:00 UTC
     - cron: "0 0 * * *"
+  push:
+    branches: [main]
+    paths:
+      - 'rust/**'
+      - 'proto/**'
+      - '.github/workflows/dataflow-engine-binary-size.yml'
 
 jobs:
   build-multiarch:
@@ -75,9 +81,73 @@ jobs:
           name: size-report-${{ matrix.platform.name }}
           path: size-reports/${{ matrix.platform.name }}.json
 
+  bloat-multiarch:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - name: linux-amd64
+            runner: ubuntu-24.04
+            # target-cpu matches the docker build above, but without
+            # strip=symbols: cargo-bloat needs symbols to attribute crates
+            rustflags: "-C target-cpu=x86-64"
+          - name: linux-arm64
+            runner: ubuntu-24.04-arm
+            rustflags: "-C target-cpu=generic"
+    runs-on: ${{ matrix.platform.runner }}
+    env:
+      RUSTFLAGS: ${{ matrix.platform.rustflags }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          submodules: true
+
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        with:
+          toolchain: stable
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: ./rust/otap-dataflow
+          cache-bin: false
+
+      - name: Install protobuf compiler
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Install cargo-bloat
+        run: cargo install cargo-bloat --locked --version 0.12.1
+
+      - name: Measure .text size and top crate contributions
+        run: |
+          cd rust/otap-dataflow
+          cargo bloat --locked --release --bin df_engine --crates -n 10 \
+            --message-format json > "$RUNNER_TEMP/bloat.json"
+          cd ../..
+
+          mkdir -p size-reports
+          jq --arg platform "${{ matrix.platform.name }}" '
+            [{name: ($platform + "-text-size"), unit: "MB",
+              value: ((."text-section-size" / 1048576 * 100 | round) / 100)}]
+            + [.crates[] | {name: ($platform + "-crate-" + .name), unit: "MB",
+                value: ((.size / 1048576 * 100 | round) / 100)}]
+          ' "$RUNNER_TEMP/bloat.json" > size-reports/bloat-${{ matrix.platform.name }}.json
+
+          jq -r '.[] | "\(.name): \(.value) MB"' size-reports/bloat-${{ matrix.platform.name }}.json
+
+      - name: Upload bloat report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: size-report-bloat-${{ matrix.platform.name }}
+          path: size-reports/bloat-${{ matrix.platform.name }}.json
+
   summary:
     runs-on: ubuntu-24.04
-    needs: build-multiarch
+    needs: [build-multiarch, bloat-multiarch]
     if: always()
     permissions:
       # contents permission to update benchmark contents in gh-pages branch
@@ -95,16 +165,12 @@ jobs:
       - name: Consolidate and display results
         run: |
           # Merge all JSON files into a single array using jq
-          jq -s 'map(.[0])' all-reports/*.json > consolidated-sizes.json
+          jq -s 'add' all-reports/*.json > consolidated-sizes.json
 
           echo "## Dataflow Engine Binary Size"
-          echo "| Platform | Size |"
-          echo "|----------|------|"
-          for json in all-reports/*.json; do
-            PLATFORM=$(jq -r '.[0].name' "$json" | sed 's/-binary-size//')
-            SIZE_MB=$(jq -r '.[0].value' "$json")
-            echo "| $PLATFORM | ${SIZE_MB} MB |"
-          done
+          echo "| Metric | Size |"
+          echo "|--------|------|"
+          jq -r '.[] | "| \(.name) | \(.value) MB |"' consolidated-sizes.json
 
       - name: Update binary size benchmarks
         uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
@@ -114,6 +180,6 @@ jobs:
           gh-pages-branch: benchmarks
           github-token: ${{ secrets.GITHUB_TOKEN }}
           benchmark-data-dir-path: "docs/benchmarks/binary-size"
-          auto-push: ${{ github.event_name == 'schedule' }}
+          auto-push: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
           comment-on-alert: true
           alert-threshold: "110%"

--- a/.github/workflows/dataflow-engine-binary-size.yml
+++ b/.github/workflows/dataflow-engine-binary-size.yml
@@ -14,6 +14,12 @@ on:
       - 'proto/**'
       - '.github/workflows/dataflow-engine-binary-size.yml'
 
+# serialize runs so two merges landing close together do not race on the
+# push to the benchmarks branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build-multiarch:
     strategy:
@@ -173,6 +179,11 @@ jobs:
           jq -r '.[] | "| \(.name) | \(.value) MB |"' consolidated-sizes.json
 
       - name: Update binary size benchmarks
+        # the table above still renders from whatever landed, but a partial
+        # matrix must not become a benchmark data point
+        if: >-
+          needs.build-multiarch.result == 'success' &&
+          needs.bloat-multiarch.result == 'success'
         uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
           tool: "customSmallerIsBetter"


### PR DESCRIPTION
# Change Summary

adds the missing pieces from #2673 to the binary size workflow: a push-to-main trigger so metrics land per merge (was daily cron only), and a native cargo-bloat job on amd64 + arm64 that builds with symbols and records the `.text` section size plus the top 10 crate contributions per arch (tracked separately per arch, as preferred in the issue discussion). the docker job is untouched, it keeps measuring the shipped stripped size.

also fixed the summary merge: `jq -s 'map(.[0])'` only kept the first entry of each report file, which would have dropped the new multi-entry bloat reports. switched to `add`, and the results table now prints every metric.

one thing to watch: the 110% alert threshold now also applies to the per-crate series. crate attribution can shift when inlining changes, so if that alerts too often the crate series could move to a separate benchmark step with a higher threshold.

## What issue does this PR close?

* Closes #2673

## How are these changes tested?

ran the full workflow end to end via workflow_dispatch on my fork (both arches, docker + bloat jobs + summary): https://github.com/mateenali66/otel-arrow/actions/runs/30155340424. cargo-bloat's json schema (`file-size`, `text-section-size`, `crates[]`) and the jq transform were also verified locally against captured output.

## Are there any user-facing changes?

no, CI only.

### Changelog

* [ ] Added a `.chloggen/*.yaml` entry
* [x] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
