### PR TITLE
fix(logs): Preserve runtime error details in internal logs

### DIFF
--- a/rust/otap-dataflow/.chloggen/preserve-runtime-error-details.yaml
+++ b/rust/otap-dataflow/.chloggen/preserve-runtime-error-details.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: engine
+note: Preserve actionable runtime error details in bounded internal logs.
+issues: [3598]

--- a/rust/otap-dataflow/crates/state/src/store.rs
+++ b/rust/otap-dataflow/crates/state/src/store.rs
@@ -11,7 +11,9 @@ use crate::pipeline_status::{PipelineRolloutSummary, PipelineStatus, RuntimeInst
 use otap_df_config::PipelineKey;
 use otap_df_config::health::HealthPolicy;
 use otap_df_config::observed_state::{ObservedStateSettings, SendPolicy};
-use otap_df_telemetry::event::{EngineEvent, EventType, ObservedEvent, ObservedEventReporter};
+use otap_df_telemetry::event::{
+    EngineEvent, ErrorEvent, ErrorSummary, EventType, ObservedEvent, ObservedEventReporter,
+};
 use otap_df_telemetry::log_tap::InternalLogTapHandle;
 use otap_df_telemetry::registry::TelemetryRegistryHandle;
 use otap_df_telemetry::self_tracing::{AnsiCode, ConsoleWriter, LogContext, StyledBufWriter};
@@ -23,6 +25,19 @@ use std::sync::{Arc, Mutex};
 use tokio_util::sync::CancellationToken;
 
 const RECENT_EVENTS_CAPACITY: usize = 10;
+
+fn error_event_details(error: &ErrorEvent) -> (&'static str, Option<&ErrorSummary>) {
+    match error {
+        ErrorEvent::AdmissionError(summary) => ("admission_error", Some(summary)),
+        ErrorEvent::ConfigRejected(summary) => ("config_rejected", Some(summary)),
+        ErrorEvent::UpdateFailed(summary) => ("update_failed", Some(summary)),
+        ErrorEvent::RollbackFailed(summary) => ("rollback_failed", Some(summary)),
+        ErrorEvent::DrainError(summary) => ("drain_error", Some(summary)),
+        ErrorEvent::DrainDeadlineReached => ("drain_deadline_reached", None),
+        ErrorEvent::RuntimeError(summary) => ("runtime_error", Some(summary)),
+        ErrorEvent::DeleteError(summary) => ("delete_error", Some(summary)),
+    }
+}
 
 /// Event-driven observed state store representing what we know about the state of the
 /// pipelines (DAG executors) controlled by the controller.
@@ -399,13 +414,53 @@ impl ObservedStateStore {
                 );
             }
             EventType::Error(err) => {
-                otel_error!("state.observed_error",
-                    pipeline_group_id = %observed_event.key.pipeline_group_id,
-                    pipeline_id = %observed_event.key.pipeline_id,
-                    core_id = observed_event.key.core_id,
-                    event_type = ?err,
-                    message = observed_event.message.as_deref().unwrap_or(""),
-                );
+                let (event_type, summary) = error_event_details(err);
+                if let Some(summary) = summary {
+                    match summary {
+                        ErrorSummary::Pipeline {
+                            error_kind,
+                            message: error,
+                            ..
+                        } => {
+                            otel_error!("state.observed_error",
+                                error = error,
+                                error_kind = error_kind,
+                                event_type = event_type,
+                                pipeline_group_id = %observed_event.key.pipeline_group_id,
+                                pipeline_id = %observed_event.key.pipeline_id,
+                                core_id = observed_event.key.core_id,
+                                message = observed_event.message.as_deref().unwrap_or(""),
+                            );
+                        }
+                        ErrorSummary::Node {
+                            node,
+                            node_kind,
+                            error_kind,
+                            message: error,
+                            ..
+                        } => {
+                            otel_error!("state.observed_error",
+                                error = error,
+                                error_kind = error_kind,
+                                event_type = event_type,
+                                node = %node,
+                                node_kind = ?node_kind,
+                                pipeline_group_id = %observed_event.key.pipeline_group_id,
+                                pipeline_id = %observed_event.key.pipeline_id,
+                                core_id = observed_event.key.core_id,
+                                message = observed_event.message.as_deref().unwrap_or(""),
+                            );
+                        }
+                    }
+                } else {
+                    otel_error!("state.observed_error",
+                        event_type = event_type,
+                        pipeline_group_id = %observed_event.key.pipeline_group_id,
+                        pipeline_id = %observed_event.key.pipeline_id,
+                        core_id = observed_event.key.core_id,
+                        message = observed_event.message.as_deref().unwrap_or(""),
+                    );
+                }
             }
             EventType::Success(_) => {}
         };
@@ -621,6 +676,21 @@ mod tests {
         }
     }
 
+    struct LogCaptureLayer {
+        sender: flume::Sender<LogRecord>,
+    }
+
+    impl<S> Layer<S> for LogCaptureLayer
+    where
+        S: Subscriber + for<'a> LookupSpan<'a>,
+    {
+        fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+            self.sender
+                .send(LogRecord::new(event, LogContext::default()))
+                .expect("log capture receiver should be connected");
+        }
+    }
+
     fn emit_log_via_async_reporter(reporter: ObservedEventReporter, message: &str) {
         let dispatch = tracing::Dispatch::new(
             tracing_subscriber::Registry::default().with(ReporterLayer { reporter }),
@@ -628,6 +698,92 @@ mod tests {
         tracing::dispatcher::with_default(&dispatch, || {
             otel_info!("state.test.log", message = message);
         });
+    }
+
+    /// Scenario: pipeline-level and node-level runtime errors reach observed state.
+    /// Guarantees: rendered state errors retain compact diagnostics and required identity fields.
+    #[test]
+    fn observed_runtime_errors_log_compact_error_summaries() {
+        let store = ObservedStateStore::new(
+            &ObservedStateSettings::default(),
+            TelemetryRegistryHandle::new(),
+        );
+        let (sender, receiver) = flume::bounded(2);
+        let dispatch = tracing::Dispatch::new(
+            tracing_subscriber::Registry::default().with(LogCaptureLayer { sender }),
+        );
+        let error = "Pipeline runtime error: A processor error occurred in node debug \
+            (transport): Write error: No space left on device (os error 28)";
+
+        tracing::dispatcher::with_default(&dispatch, || {
+            let result = store
+                .report_engine(EngineEvent::pipeline_runtime_error(
+                    make_key(0),
+                    "Pipeline encountered a runtime error.",
+                    ErrorSummary::Pipeline {
+                        error_kind: "runtime".into(),
+                        message: error.into(),
+                        source: None,
+                    },
+                ))
+                .expect_err("runtime error from Pending should be rejected after logging");
+            assert!(matches!(result, Error::InvalidTransition { .. }));
+
+            let result = store
+                .report_engine(EngineEvent::node_runtime_error(
+                    make_key(0),
+                    "debug".into(),
+                    otap_df_config::node::NodeKind::Processor,
+                    Some("Node encountered a runtime error.".into()),
+                    ErrorSummary::Node {
+                        node: "debug".into(),
+                        node_kind: otap_df_config::node::NodeKind::Processor,
+                        error_kind: "transport".into(),
+                        message: "Write error: No space left on device (os error 28)".into(),
+                        source: None,
+                    },
+                ))
+                .expect_err("runtime error from Pending should be rejected after logging");
+            assert!(matches!(result, Error::InvalidTransition { .. }));
+        });
+
+        let rendered_pipeline = receiver
+            .recv()
+            .expect("pipeline error log should be captured")
+            .to_string();
+        assert!(
+            rendered_pipeline.contains(error),
+            "rendered log: {rendered_pipeline}"
+        );
+        assert!(
+            rendered_pipeline.contains("error_kind=runtime"),
+            "rendered log: {rendered_pipeline}"
+        );
+        assert!(
+            rendered_pipeline.contains("pipeline_group_id=group"),
+            "rendered log: {rendered_pipeline}"
+        );
+        assert!(
+            !rendered_pipeline.contains("dropped"),
+            "rendered log: {rendered_pipeline}"
+        );
+
+        let rendered_node = receiver
+            .recv()
+            .expect("node error log should be captured")
+            .to_string();
+        assert!(
+            rendered_node.contains("node=debug"),
+            "rendered log: {rendered_node}"
+        );
+        assert!(
+            rendered_node.contains("node_kind=Processor"),
+            "rendered log: {rendered_node}"
+        );
+        assert!(
+            rendered_node.contains("error_kind=transport"),
+            "rendered log: {rendered_node}"
+        );
     }
 
     /// Validates that `send_timeout(1ms)` on a full bounded channel drops

--- a/rust/otap-dataflow/crates/telemetry/src/self_tracing.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/self_tracing.rs
@@ -33,12 +33,13 @@ pub use formatter::{
 /// During encoding, `ProtoBuffer<LOG_ARGUMENTS_ENCODE_INLINE>` keeps data on the
 /// stack.  After encoding the result is converted to `Bytes` for
 /// cheap reference-counted storage.
-pub const LOG_ARGUMENTS_ENCODE_INLINE: usize = 256;
+pub const LOG_ARGUMENTS_ENCODE_INLINE: usize = 512;
 
-/// Default buffer size for log formatting. Note that we truncate and
-/// recognize dropped_attributes_count at the top-level of each log
-/// record.
-pub const LOG_BUFFER_SIZE: usize = 512;
+/// Default buffer size for log formatting. This exceeds the encoded log
+/// payload budget to leave room for timestamps, callsite metadata, and entity
+/// context. Note that we truncate and recognize dropped_attributes_count at
+/// the top-level of each log record.
+pub const LOG_BUFFER_SIZE: usize = 1024;
 
 /// A log record with structural metadata and pre-encoded body/attributes.
 /// A SystemTime value for the event is presumed to be external.

--- a/rust/otap-dataflow/crates/telemetry/src/self_tracing/encoder.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/self_tracing/encoder.rs
@@ -11,7 +11,9 @@ use bytes::Bytes;
 use otap_df_config::pipeline::telemetry::{
     AttributeValue as ConfigAttributeValue, AttributeValueArray as ConfigAttributeValueArray,
 };
-use otap_df_pdata::otlp::common::{BoundedBuf, Dropped, EncodeResult, ProtoBuffer};
+use otap_df_pdata::otlp::common::{
+    BoundedBuf, Dropped, EncodeResult, ProtoBuffer, TRUNCATION_SUFFIX,
+};
 use otap_df_pdata::proto::consts::{
     field_num::common::*, field_num::logs::*, field_num::resource::*, wire_types,
 };
@@ -103,6 +105,9 @@ pub struct DirectFieldVisitor<'buf, B: BoundedBuf> {
     buf: &'buf mut B,
     dropped_count: u32,
 }
+
+/// Reserve 64 bytes for the generic message body plus protobuf wire overhead.
+const ERROR_ATTRIBUTE_BODY_RESERVE: usize = 72;
 
 impl<'buf, B: BoundedBuf> DirectFieldVisitor<'buf, B> {
     /// Create a new DirectFieldVisitor that writes to the provided buffer.
@@ -202,6 +207,31 @@ impl<'buf, B: BoundedBuf> DirectFieldVisitor<'buf, B> {
         })
     }
 
+    /// Encode a Debug attribute with bounded formatting and string truncation.
+    ///
+    /// This is used only for diagnostic-priority fields. It prevents a large
+    /// Debug implementation from allocating an unbounded intermediate string
+    /// while preserving a marked prefix in the encoded attribute.
+    #[inline]
+    fn encode_debug_attribute_truncating_to(
+        buf: &mut B,
+        key: &str,
+        value: &dyn std::fmt::Debug,
+    ) -> Result<bool, Dropped> {
+        let mut truncated = false;
+        buf.encode_len_delimited_partial(LOG_RECORD_ATTRIBUTES, |buf| {
+            buf.encode_string(KEY_VALUE_KEY, key)?;
+            buf.encode_len_delimited_partial(KEY_VALUE_VALUE, |buf| {
+                buf.encode_len_delimited_partial(ANY_VALUE_STRING_VALUE, |buf| {
+                    truncated = encode_debug_string_truncating(buf, value)?;
+                    Ok(())
+                })?;
+                Ok(())
+            })
+        })?;
+        Ok(truncated)
+    }
+
     /// Encode the body as a string. Empty strings are skipped.
     ///
     /// Wrapped in `try_encode` so that any partial wire bytes written before
@@ -245,6 +275,66 @@ impl<B: BoundedBuf> std::fmt::Write for BoundedBufFmt<'_, B> {
     }
 }
 
+/// Direct formatter for diagnostic-priority Debug attributes.
+///
+/// Reserves the existing truncation suffix while writing to the bounded
+/// protobuf buffer, avoiding an intermediate allocation and copy.
+struct TruncatingBoundedBufFmt<'a, B: BoundedBuf> {
+    buf: &'a mut B,
+    truncated: bool,
+}
+
+impl<B: BoundedBuf> std::fmt::Write for TruncatingBoundedBufFmt<'_, B> {
+    fn write_str(&mut self, value: &str) -> std::fmt::Result {
+        if self.truncated {
+            return Err(std::fmt::Error);
+        }
+
+        let suffix_len = TRUNCATION_SUFFIX.len();
+        if value.len() <= self.buf.remaining().saturating_sub(suffix_len) {
+            self.buf
+                .try_extend(value.as_bytes())
+                .map_err(|_| std::fmt::Error)?;
+            return Ok(());
+        }
+
+        let prefix_len = self.buf.remaining().saturating_sub(suffix_len);
+        let mut end = prefix_len.min(value.len());
+        while end > 0 && !value.is_char_boundary(end) {
+            end -= 1;
+        }
+        if end > 0 {
+            self.buf
+                .try_extend(&value.as_bytes()[..end])
+                .map_err(|_| std::fmt::Error)?;
+        }
+        self.buf
+            .try_extend(TRUNCATION_SUFFIX)
+            .map_err(|_| std::fmt::Error)?;
+        self.truncated = true;
+        Err(std::fmt::Error)
+    }
+}
+
+/// Encode a Debug value directly into a bounded buffer with a truncation suffix.
+#[inline]
+fn encode_debug_string_truncating<B: BoundedBuf>(
+    buf: &mut B,
+    value: &dyn std::fmt::Debug,
+) -> Result<bool, Dropped> {
+    use std::fmt::Write as _;
+
+    let mut adapter = TruncatingBoundedBufFmt {
+        buf,
+        truncated: false,
+    };
+    match write!(adapter, "{value:?}") {
+        Ok(()) => Ok(false),
+        Err(_) if adapter.truncated => Ok(true),
+        Err(_) => Err(Dropped),
+    }
+}
+
 /// Helper to encode a Debug value as a protobuf string field.
 /// This is separate from DirectFieldVisitor to avoid borrow conflicts with the macro.
 #[inline]
@@ -270,6 +360,14 @@ fn encode_debug_string<B: BoundedBuf>(buf: &mut B, value: &dyn std::fmt::Debug) 
 #[inline]
 fn attr_budget<B: BoundedBuf>(buf: &B) -> usize {
     buf.remaining().div_ceil(2)
+}
+
+/// Compute the error-field budget while reserving space for the log body.
+#[inline]
+fn error_attr_budget<B: BoundedBuf>(buf: &B) -> usize {
+    buf.remaining()
+        .saturating_sub(ERROR_ATTRIBUTE_BODY_RESERVE)
+        .max(1)
 }
 
 impl<B: BoundedBuf> tracing::field::Visit for DirectFieldVisitor<'_, B> {
@@ -334,8 +432,12 @@ impl<B: BoundedBuf> tracing::field::Visit for DirectFieldVisitor<'_, B> {
             self.encode_body_string(value);
             return;
         }
-        let budget = attr_budget(self.buf);
         let key = field.name();
+        let budget = if key == "error" {
+            error_attr_budget(self.buf)
+        } else {
+            attr_budget(self.buf)
+        };
         let mut truncated = false;
         // Attempt the encoding (with truncation as needed) within the scoped
         // budget, transactionally so a hard failure rolls back any partial
@@ -366,13 +468,28 @@ impl<B: BoundedBuf> tracing::field::Visit for DirectFieldVisitor<'_, B> {
             self.encode_body_debug(value);
             return;
         }
-        let budget = attr_budget(self.buf);
+        let is_error = field.name() == "error";
+        let budget = if is_error {
+            error_attr_budget(self.buf)
+        } else {
+            attr_budget(self.buf)
+        };
+        let mut truncated = false;
         let fit = self.buf.with_max_remaining(budget, |buf| {
             buf.try_encode(|b| {
-                DirectFieldVisitor::encode_debug_attribute_to(b, field.name(), value)
+                if is_error {
+                    truncated = DirectFieldVisitor::encode_debug_attribute_truncating_to(
+                        b,
+                        field.name(),
+                        value,
+                    )?;
+                    Ok(())
+                } else {
+                    DirectFieldVisitor::encode_debug_attribute_to(b, field.name(), value)
+                }
             })
         });
-        if fit.is_err() {
+        if fit.is_err() || truncated {
             self.dropped_count += 1;
         }
     }
@@ -1208,6 +1325,82 @@ mod tests {
         );
     }
 
+    /// Scenario: a direct error attribute exceeds its bounded encoding budget.
+    /// Guarantees: the error retains a marked prefix instead of being dropped entirely.
+    #[test]
+    fn record_error_overflow_preserves_truncated_prefix() {
+        use otap_df_pdata::otlp::common::StackProtoBuffer;
+        use otap_df_pdata::proto::opentelemetry::common::v1::KeyValue as ProtoKeyValue;
+        use otap_df_pdata::views::otlp::bytes::logs::RawLogRecord;
+        use otap_df_pdata_views::views::common::AnyValueView;
+        use otap_df_pdata_views::views::logs::LogRecordView;
+        use prost::Message;
+        use tracing::field::Visit;
+
+        struct HugeError;
+        impl std::fmt::Debug for HugeError {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("root cause: ")?;
+                for _ in 0..512 {
+                    f.write_str("xxxxxxxx")?;
+                }
+                Ok(())
+            }
+        }
+
+        let fields = DEBUG_TEST_METADATA.fields();
+        let error = fields.field("error").expect("error field should exist");
+        let message = fields.field("message").expect("message field should exist");
+        let mut buf = StackProtoBuffer::<256>::default();
+        let mut visitor = DirectFieldVisitor::new(&mut buf);
+        visitor.record_debug(&error, &HugeError);
+        let body = "m".repeat(64);
+        visitor.record_str(&message, &body);
+
+        assert_eq!(
+            visitor.dropped_count(),
+            1,
+            "the error prefix should report truncation"
+        );
+        let bytes = buf.as_ref().to_vec();
+        let mut cursor = bytes.as_slice();
+        let (_, tag_len) = read_varint(cursor);
+        cursor = &cursor[tag_len..];
+        let (len, len_len) = read_varint(cursor);
+        cursor = &cursor[len_len..];
+        let key_value = ProtoKeyValue::decode(&cursor[..len as usize])
+            .expect("truncated error should remain decodable");
+        let value = match key_value
+            .value
+            .as_ref()
+            .and_then(|value| value.value.as_ref())
+        {
+            Some(
+                otap_df_pdata::proto::opentelemetry::common::v1::any_value::Value::StringValue(
+                    value,
+                ),
+            ) => value,
+            other => panic!("expected StringValue, got {other:?}"),
+        };
+
+        assert_eq!(key_value.key, "error");
+        assert!(value.starts_with("root cause: "), "error value: {value}");
+        assert!(
+            value.ends_with(std::str::from_utf8(TRUNCATION_SUFFIX).unwrap()),
+            "error value: {value}"
+        );
+
+        let record = RawLogRecord::new(buf.as_ref());
+        let actual_body = record
+            .body()
+            .and_then(|body| body.as_string().map(|value| value.to_vec()));
+        assert_eq!(
+            actual_body.as_deref(),
+            Some(body.as_bytes()),
+            "body should fit in the space reserved after the error"
+        );
+    }
+
     static DEBUG_TEST_CALLSITE: DebugTestCallsite = DebugTestCallsite;
 
     struct DebugTestCallsite;
@@ -1227,7 +1420,7 @@ mod tests {
         Some(line!()),
         Some(module_path!()),
         tracing::field::FieldSet::new(
-            &["dbg"],
+            &["dbg", "error", "message"],
             tracing::callsite::Identifier(&DEBUG_TEST_CALLSITE),
         ),
         tracing::metadata::Kind::EVENT,

--- a/rust/otap-dataflow/crates/telemetry/src/self_tracing/encoder.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/self_tracing/encoder.rs
@@ -107,7 +107,9 @@ pub struct DirectFieldVisitor<'buf, B: BoundedBuf> {
 }
 
 /// Reserve 64 bytes for the generic message body plus protobuf wire overhead.
-const ERROR_ATTRIBUTE_BODY_RESERVE: usize = 72;
+const MESSAGE_BODY_ENCODED_RESERVE: usize = 72;
+/// Smallest budget that retains a meaningful error prefix with a truncation suffix.
+const MIN_ERROR_DIAGNOSTIC_BUDGET: usize = 72;
 
 impl<'buf, B: BoundedBuf> DirectFieldVisitor<'buf, B> {
     /// Create a new DirectFieldVisitor that writes to the provided buffer.
@@ -365,9 +367,13 @@ fn attr_budget<B: BoundedBuf>(buf: &B) -> usize {
 /// Compute the error-field budget while reserving space for the log body.
 #[inline]
 fn error_attr_budget<B: BoundedBuf>(buf: &B) -> usize {
-    buf.remaining()
-        .saturating_sub(ERROR_ATTRIBUTE_BODY_RESERVE)
-        .max(1)
+    let remaining = buf.remaining();
+    let budget_after_body_reserve = remaining.saturating_sub(MESSAGE_BODY_ENCODED_RESERVE);
+    if budget_after_body_reserve < MIN_ERROR_DIAGNOSTIC_BUDGET {
+        remaining
+    } else {
+        budget_after_body_reserve
+    }
 }
 
 impl<B: BoundedBuf> tracing::field::Visit for DirectFieldVisitor<'_, B> {
@@ -1398,6 +1404,49 @@ mod tests {
             actual_body.as_deref(),
             Some(body.as_bytes()),
             "body should fit in the space reserved after the error"
+        );
+    }
+
+    /// Scenario: a record has sufficient capacity for both an error and its body.
+    /// Guarantees: the error budget reserves encoded space for the generic message body.
+    #[test]
+    fn error_budget_reserves_body_when_capacity_is_abundant() {
+        use otap_df_pdata::otlp::common::{BoundedBuf, StackProtoBuffer};
+
+        let mut buf = StackProtoBuffer::<512>::default();
+        assert_eq!(error_attr_budget(&buf), 512 - MESSAGE_BODY_ENCODED_RESERVE);
+
+        buf.try_extend(&[0; 100])
+            .expect("prefix should fit in test buffer");
+        assert_eq!(
+            error_attr_budget(&buf),
+            512 - 100 - MESSAGE_BODY_ENCODED_RESERVE
+        );
+    }
+
+    /// Scenario: reserving the body leaves exactly the minimum useful error budget.
+    /// Guarantees: the error budget retains both the body reserve and a meaningful error prefix.
+    #[test]
+    fn error_budget_reserves_body_at_minimum_error_threshold() {
+        use otap_df_pdata::otlp::common::StackProtoBuffer;
+
+        let buf =
+            StackProtoBuffer::<{ MESSAGE_BODY_ENCODED_RESERVE + MIN_ERROR_DIAGNOSTIC_BUDGET }>::default();
+        assert_eq!(error_attr_budget(&buf), MIN_ERROR_DIAGNOSTIC_BUDGET);
+    }
+
+    /// Scenario: reserving the body would leave too little space for an error attribute.
+    /// Guarantees: the error budget falls back to all remaining record space.
+    #[test]
+    fn error_budget_prioritizes_error_when_body_reserve_is_unaffordable() {
+        use otap_df_pdata::otlp::common::StackProtoBuffer;
+
+        let buf = StackProtoBuffer::<
+            { MESSAGE_BODY_ENCODED_RESERVE + MIN_ERROR_DIAGNOSTIC_BUDGET - 1 },
+        >::default();
+        assert_eq!(
+            error_attr_budget(&buf),
+            MESSAGE_BODY_ENCODED_RESERVE + MIN_ERROR_DIAGNOSTIC_BUDGET - 1
         );
     }
 

--- a/rust/otap-dataflow/crates/telemetry/src/tracing_init.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/tracing_init.rs
@@ -482,9 +482,11 @@ mod tests {
             let (reporter, receiver) = test_reporter();
             let setup = test_setup(internal_async_provider(reporter), level("info"));
 
-            // Use enough long-string attributes to overflow any reasonable
-            // LOG_ARGUMENTS_ENCODE_INLINE (well above 256 bytes worth of payload).
+            // Keep the regular fields below the limit, then add one field that
+            // exceeds the current inline budget so this test remains valid if
+            // the configured buffer size changes.
             setup.with_subscriber_ignoring_env(|| {
+                let oversized_value = "x".repeat(crate::self_tracing::LOG_ARGUMENTS_ENCODE_INLINE);
                 otel_info!(
                     "overflow.test",
                     a = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -494,6 +496,7 @@ mod tests {
                     e = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
                     f = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
                     g = "gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg",
+                    oversized = oversized_value.as_str(),
                     message = "Body that itself is fairly long and may not fit alongside the attributes above"
                 );
             });


### PR DESCRIPTION
# Change Summary

Preserve runtime error details in compact observed-state fields and retain a bounded, marked prefix for oversized direct error fields.

Use the smallest validated internal log buffer increase.

### Approach

- Replace verbose observed-state error rendering with compact error, category, type, and identity fields.
- Prioritize `error` fields within the existing bounded record budget.
- Preserve an explicit `[...]`-marked prefix when an error exceeds that budget.
- Reserve 72 B for the message body only when at least 72 B remains for meaningful error diagnostics.
- Keep other attributes subject to the existing bounded truncation and drop behavior.

```text
available record budget
         |
         +-- after 72 B body reserve, >= 72 B remains for error
         |      -> error uses remaining budget after reservation
         |      -> body is retained
         |
         +-- body reservation leaves < 72 B for error
                -> error uses all remaining budget
                -> body may be dropped
```

Before:

```text
ERROR state.observed_error: Pipeline encountered a runtime error. [pipeline_group_id=runtime_error_reproduction_pipeline_group, pipeline_id=runtime_error_reproduction_pipeline, core_id=0] (1 dropped)
ERROR controller.pipeline_runtime_failed: Pipeline terminated with a runtime error [core_id=0] (1 dropped)
```

After:

```text
ERROR state.observed_error: Pipeline encountered a runtime error. [error=Pipeline runtime error: A processor error occurred in node debug (transport): Write error: No space left on device (os error 28), error_kind=runtime, event_type=runtime_error, pipeline_group_id=runtime_error_reproduction_pipeline_group, pipeline_id=runtime_error_reproduction_pipeline, core_id=0]
ERROR controller.pipeline_runtime_failed: Pipeline terminated with a runtime error [core_id=0, error=<full error or bounded prefix ending in [...]>]
```

## What issue does this PR close?

* Closes #3598

## How are these changes tested?

Unit tests and local pipeline runs

## Are there any user-facing changes?

Error attributes on internal logs should be more visible.

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry
* [ ] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
