### PR TITLE
fix(query-engine): Prevent scalar predicate results from causing pipeline level fatal error

### DIFF
--- a/rust/otap-dataflow/.chloggen/query-engine-fix-attributes-all-scalar.yaml
+++ b/rust/otap-dataflow/.chloggen/query-engine-fix-attributes-all-scalar.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: query-engine
+note: Prevent scalar predicate results from terminating attribute filters.
+issues: [3605]

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/join.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/join.rs
@@ -1430,18 +1430,6 @@ impl JoinExec for AttributesAllSelectionVecJoin {
             });
         }
 
-        let selection_vec = match vals {
-            ColumnarValue::Array(arr) => arr.as_boolean(),
-            ColumnarValue::Scalar(_) => {
-                // In the future (if needed someday) we could handle by invoking scalar join
-                return Err(Error::ExecutionError {
-                    cause: "Invalid columnar value from AttributesAll eval. \
-                        expected Array got Scalar"
-                        .into(),
-                });
-            }
-        };
-
         let parent_ids = extract_u16_array(
             if self.all_attrs_left {
                 left.parent_ids.as_ref()
@@ -1451,7 +1439,25 @@ impl JoinExec for AttributesAllSelectionVecJoin {
             consts::PARENT_ID,
         )?;
 
-        let selected_parent_ids = filter(parent_ids, selection_vec)?;
+        let selection_vec = match vals {
+            ColumnarValue::Array(arr) => arr.as_boolean().clone(),
+            ColumnarValue::Scalar(ScalarValue::Boolean(Some(true))) => {
+                BooleanArray::new(BooleanBuffer::new_set(parent_ids.len()), None)
+            }
+            ColumnarValue::Scalar(ScalarValue::Boolean(Some(false) | None)) => {
+                BooleanArray::new(BooleanBuffer::new_unset(parent_ids.len()), None)
+            }
+            ColumnarValue::Scalar(other) => {
+                return Err(Error::ExecutionError {
+                    cause: format!(
+                        "Invalid scalar value from AttributesAll eval {:?}",
+                        other.data_type()
+                    ),
+                });
+            }
+        };
+
+        let selected_parent_ids = filter(parent_ids, &selection_vec)?;
         let mut selected_lookup = IdBitmap::new();
         selected_lookup.populate(
             selected_parent_ids

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
@@ -5888,4 +5888,29 @@ mod test {
             &expected
         );
     }
+
+    /// Scenario: A five-attribute traffic-generator-shaped log record joins two attribute predicates.
+    /// Guarantees: A scalar false result from fused attribute evaluation does not terminate filtering.
+    #[tokio::test]
+    async fn test_filter_attributes_all_scalar_result() {
+        let log_records = vec![
+            LogRecord::build()
+                .attributes([
+                    KeyValue::new("thread.id", AnyValue::new_int(0)),
+                    KeyValue::new("thread.name", AnyValue::new_string("worker")),
+                    KeyValue::new("code.function", AnyValue::new_string("run")),
+                    KeyValue::new("code.namespace", AnyValue::new_string("example")),
+                    KeyValue::new("code.filepath", AnyValue::new_string("main.rs")),
+                ])
+                .finish(),
+        ];
+
+        let result = exec_logs_pipeline::<OplParser>(
+            r#"logs | where (attributes["code.function"] == "foo") and not(contains(attributes["thread.name"], "bar"))"#,
+            to_logs_data(log_records),
+        )
+        .await;
+
+        assert!(result.resource_logs.is_empty());
+    }
 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
@@ -5890,7 +5890,7 @@ mod test {
     }
 
     /// Scenario: A five-attribute traffic-generator-shaped log record joins two attribute predicates.
-    /// Guarantees: A scalar false result from fused attribute evaluation does not terminate filtering.
+    /// Guarantees: Scalar false filters the record, while scalar true keeps it without terminating filtering.
     #[tokio::test]
     async fn test_filter_attributes_all_scalar_result() {
         let log_records = vec![

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
@@ -5907,10 +5907,22 @@ mod test {
 
         let result = exec_logs_pipeline::<OplParser>(
             r#"logs | where (attributes["code.function"] == "foo") and not(contains(attributes["thread.name"], "bar"))"#,
-            to_logs_data(log_records),
+            to_logs_data(log_records.clone()),
         )
         .await;
 
         assert!(result.resource_logs.is_empty());
+
+        let result = exec_logs_pipeline::<OplParser>(
+            r#"logs | where (attributes["code.function"] == "run") and not(contains(attributes["thread.name"], "bar"))"#,
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+
+        assert!(!result.resource_logs.is_empty());
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[log_records[0].clone()]
+        );
     }
 }


### PR DESCRIPTION
# Change Summary

Prevent valid attribute predicates from terminating OTAP pipeline cores when the query engine evaluates them to scalar Booleans.

See the linked issue for more details; TL;DR this is caused by a DataFusion optimization.

## What issue does this PR close?

* Closes #3605

## How are these changes tested?

Unit tests and local engine runs

## Are there any user-facing changes?

Yes, bugfix for crashes on certain queries

### Changelog

* [x] Added a `.chloggen/*.yaml` entry
* [ ] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
