### PR TITLE
chore: Update Renovate configuration to best practices

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,8 +22,7 @@
   // preset (which extends :dependencyDashboard).
   "dependencyDashboardOSVVulnerabilitySummary": "unresolved",
   "extends": [
-    "config:recommended",
-    "docker:pinDigests",
+    "config:best-practices",
     "helpers:pinGitHubActionDigestsToSemver"
   ],
   // NOTE: Rule ordering matters here


### PR DESCRIPTION
# Change Summary

Change Renovate config to extend best practices like most other repos and recommendation from security SIG.

see docs at https://docs.renovatebot.com/presets-config/

* [ ] Added a `.chloggen/*.yaml` entry
* [x] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
