### PR TITLE
chore(changelog): Adjust checked-in chlog entries for new enforcement

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -14,18 +14,27 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled, edited]
     branches:
       - main
+  merge_group:
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  changelog:
+  changelog-merge-group:
+    name: changelog
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && github.actor != 'otelbot' }}
+    if: ${{ github.event_name == 'merge_group' }}
+    steps:
+      - run: echo "Changelog validation passed on the pull request."
+
+  changelog-validation:
+    name: changelog
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && github.actor != 'otelbot' }}
     env:
       PR_HEAD: ${{ github.event.pull_request.head.sha }}
 

--- a/go/.chloggen/fix-uint16-batch-overflow-panic.yaml
+++ b/go/.chloggen/fix-uint16-batch-overflow-panic.yaml
@@ -19,7 +19,5 @@ issues: [1883]
 subtext: |
   The uint16 record-ID counters used by the metrics, logs, and traces producers
   previously wrapped past their maximum value, causing the delta ID builder to
-  panic with "value is less than previous value". These builders now return
-  ErrTooManyRecords ("OTel Arrow components do not currently support batch sizes
-  larger than 65535"), and the delta builders return errors rather than
-  panicking.
+  panic. These builders now return ErrTooManyRecords ("OTel Arrow components do 
+  not currently support batch sizes larger than 65535").

--- a/rust/otap-dataflow/.chloggen/kafka-receiver-consumer-group-observability.yaml
+++ b/rust/otap-dataflow/.chloggen/kafka-receiver-consumer-group-observability.yaml
@@ -17,13 +17,8 @@ issues: [3535] #PR
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  New `receiver.kafka` metrics: `rebalances_total`, `partition_assignments`,
-  and `consumer_lag` (average per-partition lag, opt-in via the new
-  `lag_refresh_interval_ms` config; off by default). New structured log events:
-  `kafka.rebalance.partitions_assigned`, `kafka.rebalance.partitions_revoked`,
-  `kafka.consumer_group.joined`, and `kafka.consumer_group.left`.
-
-  Breaking metric-contract changes: `partitions_assigned` changed from a
-  cumulative counter to a point-in-time gauge of current partition ownership;
-  its former cumulative-acquisition semantic is now `partition_assignments`.
-  The `partitions_revoked` counter was renamed to `partition_revocations`.
+  Adds `rebalances_total`, `partition_assignments`, optional `consumer_lag`, and
+  consumer-group lifecycle logs. Breaking: `partitions_assigned` is now a
+  current-ownership gauge; cumulative assignments moved to
+  `partition_assignments`; `partitions_revoked` was renamed
+  `partition_revocations`.


### PR DESCRIPTION
# Change Summary

Caused unrelated failure in https://github.com/open-telemetry/otel-arrow/actions/runs/30647447237/job/91212225328?pr=3625

## What issue does this PR close?

N/A

## How are these changes tested?

N/A

## Are there any user-facing changes?

N/A

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [ ] Added a `.chloggen/*.yaml` entry
* [x] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
