### PR TITLE
fix(admin): Expose per-data-point metric attributes in JSON endpoint responses

### DIFF
--- a/rust/otap-dataflow/.chloggen/admin-metrics-data-point-attributes.yaml
+++ b/rust/otap-dataflow/.chloggen/admin-metrics-data-point-attributes.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: observability
+note: "Expose metric data point attributes from the admin metrics JSON endpoint."
+issues:
+  - 3300
+subtext: The admin metrics JSON endpoint now properly includes data point attributes, matching the existing prometheus endpoint behavior.

--- a/rust/otap-dataflow/crates/admin-types/src/telemetry.rs
+++ b/rust/otap-dataflow/crates/admin-types/src/telemetry.rs
@@ -69,6 +69,9 @@ pub struct MetricSet {
     pub name: String,
     /// Attributes.
     pub attributes: BTreeMap<String, AttributeValue>,
+    /// Attributes that identify the metric data point bucket.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub data_point_attributes: BTreeMap<String, AttributeValue>,
     /// Metric values keyed by field name.
     pub metrics: BTreeMap<String, MetricValue>,
 }
@@ -79,6 +82,9 @@ pub struct MetricDataPoint {
     /// Metric descriptor fields.
     #[serde(flatten)]
     pub metadata: MetricsField,
+    /// Attributes that identify this metric data point.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub attributes: BTreeMap<String, AttributeValue>,
     /// Metric value.
     pub value: MetricValue,
 }
@@ -332,6 +338,9 @@ mod tests {
                             "instrument": "counter",
                             "temporality": "cumulative",
                             "value_type": "u64",
+                            "attributes": {
+                                "signal": { "String": "logs" }
+                            },
                             "value": 5
                         }
                     ]
@@ -349,6 +358,9 @@ mod tests {
                     "name": "engine",
                     "attributes": {
                         "node.id": { "String": "receiver" }
+                    },
+                    "data_point_attributes": {
+                        "signal": { "String": "logs" }
                     },
                     "metrics": {
                         "items": 5

--- a/rust/otap-dataflow/crates/admin/src/telemetry.rs
+++ b/rust/otap-dataflow/crates/admin/src/telemetry.rs
@@ -80,6 +80,9 @@ struct MetricDataPointWithMetadata {
     /// Descriptor for retrieving metric metadata
     #[serde(flatten)]
     metadata: MetricsField,
+    /// Attributes that identify this metric data point.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    attributes: HashMap<String, AttributeValue>,
     /// Current value.
     value: MetricValue,
 }
@@ -95,6 +98,8 @@ struct AllMetrics {
 struct MetricSet {
     name: String,
     attributes: HashMap<String, AttributeValue>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    data_point_attributes: HashMap<String, AttributeValue>,
     metrics: HashMap<String, MetricValue>,
 }
 
@@ -545,6 +550,7 @@ fn groups_with_metadata(groups: &[AggregateGroup]) -> Vec<MetricSetWithMetadata>
             if let Some(val) = g.metrics.get(field.name) {
                 metrics.push(MetricDataPointWithMetadata {
                     metadata: *field,
+                    attributes: HashMap::new(),
                     value: *val,
                 });
             }
@@ -567,6 +573,7 @@ fn groups_without_metadata(groups: &[AggregateGroup]) -> Vec<MetricSet> {
         out.push(MetricSet {
             name: g.name.clone(),
             attributes: g.attributes.clone(),
+            data_point_attributes: HashMap::new(),
             metrics: g.metrics.clone(),
         });
     }
@@ -1040,13 +1047,15 @@ fn collect_metrics_snapshot(
 ) -> Vec<MetricSetWithMetadata> {
     let mut metric_sets = Vec::new();
 
-    telemetry_registry.visit_current_metrics_with_zeroes(
-        |descriptor, attributes, metrics_iter| {
+    telemetry_registry.visit_current_metrics_with_item_attrs(
+        |descriptor, attributes, item_attributes, metrics_iter| {
+            let data_point_attributes = data_point_attributes(item_attributes);
             let mut metrics = Vec::new();
 
             for (field, value) in metrics_iter {
                 metrics.push(MetricDataPointWithMetadata {
                     metadata: *field,
+                    attributes: data_point_attributes.clone(),
                     value,
                 });
             }
@@ -1079,13 +1088,15 @@ fn collect_metrics_snapshot_and_reset(
 ) -> Vec<MetricSetWithMetadata> {
     let mut metric_sets = Vec::new();
 
-    telemetry_registry.visit_admin_metrics_and_reset_with_zeroes(
-        |descriptor, attributes, metrics_iter| {
+    telemetry_registry.visit_admin_metrics_and_reset_with_item_attrs(
+        |descriptor, attributes, item_attributes, metrics_iter| {
+            let data_point_attributes = data_point_attributes(item_attributes);
             let mut metrics = Vec::new();
 
             for (field, value) in metrics_iter {
                 metrics.push(MetricDataPointWithMetadata {
                     metadata: *field,
+                    attributes: data_point_attributes.clone(),
                     value,
                 });
             }
@@ -1114,26 +1125,30 @@ fn collect_metrics_snapshot_and_reset(
 fn collect_compact_snapshot(telemetry_registry: &TelemetryRegistryHandle) -> Vec<MetricSet> {
     let mut metric_sets = Vec::new();
 
-    telemetry_registry.visit_current_metrics(|descriptor, attributes, metrics_iter| {
-        let mut metrics = HashMap::new();
-        for (field, value) in metrics_iter {
-            let _ = metrics.insert(field.name.to_string(), value);
-        }
-
-        if !metrics.is_empty() {
-            // include attributes in compact format
-            let mut attrs_map = HashMap::new();
-            for (key, value) in attributes.iter_attributes() {
-                let _ = attrs_map.insert(key.to_string(), value.clone());
+    telemetry_registry.visit_current_metrics_with_item_attrs(
+        |descriptor, attributes, item_attributes, metrics_iter| {
+            let mut metrics = HashMap::new();
+            for (field, value) in metrics_iter {
+                let _ = metrics.insert(field.name.to_string(), value);
             }
 
-            metric_sets.push(MetricSet {
-                name: descriptor.name.to_string(),
-                attributes: attrs_map,
-                metrics,
-            });
-        }
-    });
+            if !metrics.is_empty() {
+                // include attributes in compact format
+                let mut attrs_map = HashMap::new();
+                for (key, value) in attributes.iter_attributes() {
+                    let _ = attrs_map.insert(key.to_string(), value.clone());
+                }
+
+                metric_sets.push(MetricSet {
+                    name: descriptor.name.to_string(),
+                    attributes: attrs_map,
+                    data_point_attributes: data_point_attributes(item_attributes),
+                    metrics,
+                });
+            }
+        },
+        false,
+    );
 
     metric_sets
 }
@@ -1144,27 +1159,43 @@ fn collect_compact_snapshot_and_reset(
 ) -> Vec<MetricSet> {
     let mut metric_sets = Vec::new();
 
-    telemetry_registry.visit_admin_metrics_and_reset(|descriptor, attributes, metrics_iter| {
-        let mut metrics = HashMap::new();
-        for (field, value) in metrics_iter {
-            let _ = metrics.insert(field.name.to_string(), value);
-        }
-
-        if !metrics.is_empty() {
-            let mut attrs_map = HashMap::new();
-            for (key, value) in attributes.iter_attributes() {
-                let _ = attrs_map.insert(key.to_string(), value.clone());
+    telemetry_registry.visit_admin_metrics_and_reset_with_item_attrs(
+        |descriptor, attributes, item_attributes, metrics_iter| {
+            let mut metrics = HashMap::new();
+            for (field, value) in metrics_iter {
+                let _ = metrics.insert(field.name.to_string(), value);
             }
 
-            metric_sets.push(MetricSet {
-                name: descriptor.name.to_string(),
-                attributes: attrs_map,
-                metrics,
-            });
-        }
-    });
+            if !metrics.is_empty() {
+                let mut attrs_map = HashMap::new();
+                for (key, value) in attributes.iter_attributes() {
+                    let _ = attrs_map.insert(key.to_string(), value.clone());
+                }
+
+                metric_sets.push(MetricSet {
+                    name: descriptor.name.to_string(),
+                    attributes: attrs_map,
+                    data_point_attributes: data_point_attributes(item_attributes),
+                    metrics,
+                });
+            }
+        },
+        false,
+    );
 
     metric_sets
+}
+
+fn data_point_attributes(item_attributes: &[(&str, &str)]) -> HashMap<String, AttributeValue> {
+    item_attributes
+        .iter()
+        .map(|(key, value)| {
+            (
+                (*key).to_string(),
+                AttributeValue::String((*value).to_string()),
+            )
+        })
+        .collect()
 }
 
 fn format_line_protocol(
@@ -3672,6 +3703,135 @@ mod tests {
             output.matches(r#"otel_scope_foo="scope;value""#).count(),
             2,
             "scope and item collisions should merge values:\n{output}"
+        );
+    }
+
+    /// Scenario: a metric data point has measurement attributes in an admin JSON response.
+    /// Guarantees: verbose JSON preserves data point attributes separately from scope attributes.
+    #[tokio::test]
+    async fn metrics_handler_json_preserves_measurement_item_attributes() {
+        let state = test_app_state();
+        let registry = state.metrics_registry.clone();
+        let (receiver, mut reporter) = MetricsReporter::create_new_and_receiver(1);
+        let mut metrics = registry
+            .register_metric_set_with_measurement_attributes::<DatapointSignalMetrics>(
+                PrometheusScopeAttributes {
+                    foo: "scope".to_string(),
+                },
+            );
+        metrics
+            .with(DatapointSignalAttributes {
+                signal: SignalType::Logs,
+                scope_foo: DatapointCollision::Value,
+            })
+            .events
+            .add(7);
+        reporter
+            .report_measurement(&mut metrics)
+            .expect("measurement metrics should report");
+
+        while let Ok(snapshot) = receiver.try_recv() {
+            registry.accumulate_metric_set_snapshot(
+                snapshot.key(),
+                snapshot.bucket(),
+                snapshot.get_metrics(),
+            );
+        }
+
+        let response = get_metrics(
+            State(state),
+            Query(MetricsQuery {
+                format: Some(OutputFormat::Json),
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("JSON metrics should render");
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("JSON metrics body should collect");
+        let metrics: api::MetricsResponse =
+            serde_json::from_slice(&body).expect("JSON metrics response should deserialize");
+
+        assert_eq!(metrics.metric_sets.len(), 1);
+        assert_eq!(
+            metrics.metric_sets[0].attributes.get("foo"),
+            Some(&api::AttributeValue::String("scope".to_string()))
+        );
+        assert_eq!(metrics.metric_sets[0].metrics.len(), 1);
+        assert_eq!(
+            metrics.metric_sets[0].metrics[0].attributes.get("signal"),
+            Some(&api::AttributeValue::String("logs".to_string()))
+        );
+        assert_eq!(
+            metrics.metric_sets[0].metrics[0]
+                .attributes
+                .get("otel.scope.foo"),
+            Some(&api::AttributeValue::String("value".to_string()))
+        );
+    }
+
+    /// Scenario: a metric data point has measurement attributes in compact admin JSON.
+    /// Guarantees: compact JSON preserves data point attributes separately from scope attributes.
+    #[tokio::test]
+    async fn metrics_handler_compact_json_preserves_measurement_item_attributes() {
+        let state = test_app_state();
+        let registry = state.metrics_registry.clone();
+        let (receiver, mut reporter) = MetricsReporter::create_new_and_receiver(1);
+        let mut metrics = registry
+            .register_metric_set_with_measurement_attributes::<DatapointSignalMetrics>(
+                PrometheusScopeAttributes {
+                    foo: "scope".to_string(),
+                },
+            );
+        metrics
+            .with(DatapointSignalAttributes {
+                signal: SignalType::Logs,
+                scope_foo: DatapointCollision::Value,
+            })
+            .events
+            .add(7);
+        reporter
+            .report_measurement(&mut metrics)
+            .expect("measurement metrics should report");
+
+        while let Ok(snapshot) = receiver.try_recv() {
+            registry.accumulate_metric_set_snapshot(
+                snapshot.key(),
+                snapshot.bucket(),
+                snapshot.get_metrics(),
+            );
+        }
+
+        let response = get_metrics(
+            State(state),
+            Query(MetricsQuery {
+                format: Some(OutputFormat::JsonCompact),
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("compact JSON metrics should render");
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("compact JSON metrics body should collect");
+        let metrics: api::CompactMetricsResponse = serde_json::from_slice(&body)
+            .expect("compact JSON metrics response should deserialize");
+
+        assert_eq!(metrics.metric_sets.len(), 1);
+        assert_eq!(
+            metrics.metric_sets[0].attributes.get("foo"),
+            Some(&api::AttributeValue::String("scope".to_string()))
+        );
+        assert_eq!(
+            metrics.metric_sets[0].data_point_attributes.get("signal"),
+            Some(&api::AttributeValue::String("logs".to_string()))
+        );
+        assert_eq!(
+            metrics.metric_sets[0]
+                .data_point_attributes
+                .get("otel.scope.foo"),
+            Some(&api::AttributeValue::String("value".to_string()))
         );
     }
 

--- a/rust/otap-dataflow/crates/admin/src/telemetry.rs
+++ b/rust/otap-dataflow/crates/admin/src/telemetry.rs
@@ -291,6 +291,7 @@ pub async fn get_logs(
 /// Query parameters:
 /// - `reset` (bool, default false): whether to reset metrics after reading.
 /// - `format` (string, default "prometheus"): output format, one of "json", "json_compact", "line_protocol", "prometheus".
+/// - `keep_all_zeroes` (bool, default false): whether JSON formats include all-zero metric sets.
 async fn get_metrics(
     State(state): State<AppState>,
     Query(q): Query<MetricsQuery>,
@@ -318,9 +319,9 @@ async fn get_metrics(
         }
         OutputFormat::JsonCompact => {
             let metric_sets = if q.reset {
-                collect_compact_snapshot_and_reset(&state.metrics_registry)
+                collect_compact_snapshot_and_reset(&state.metrics_registry, q.keep_all_zeroes)
             } else {
-                collect_compact_snapshot(&state.metrics_registry)
+                collect_compact_snapshot(&state.metrics_registry, q.keep_all_zeroes)
             };
 
             let response = AllMetrics {
@@ -1122,7 +1123,10 @@ fn collect_metrics_snapshot_and_reset(
 }
 
 /// Compact snapshot without resetting.
-fn collect_compact_snapshot(telemetry_registry: &TelemetryRegistryHandle) -> Vec<MetricSet> {
+fn collect_compact_snapshot(
+    telemetry_registry: &TelemetryRegistryHandle,
+    keep_all_zeroes: bool,
+) -> Vec<MetricSet> {
     let mut metric_sets = Vec::new();
 
     telemetry_registry.visit_current_metrics_with_item_attrs(
@@ -1147,7 +1151,7 @@ fn collect_compact_snapshot(telemetry_registry: &TelemetryRegistryHandle) -> Vec
                 });
             }
         },
-        false,
+        keep_all_zeroes,
     );
 
     metric_sets
@@ -1156,6 +1160,7 @@ fn collect_compact_snapshot(telemetry_registry: &TelemetryRegistryHandle) -> Vec
 /// Compact snapshot with resetting.
 fn collect_compact_snapshot_and_reset(
     telemetry_registry: &TelemetryRegistryHandle,
+    keep_all_zeroes: bool,
 ) -> Vec<MetricSet> {
     let mut metric_sets = Vec::new();
 
@@ -1180,7 +1185,7 @@ fn collect_compact_snapshot_and_reset(
                 });
             }
         },
-        false,
+        keep_all_zeroes,
     );
 
     metric_sets
@@ -2370,6 +2375,7 @@ mod tests {
     };
     use otap_df_telemetry::instrument::MmscSnapshot;
     use otap_df_telemetry::metrics::MetricSetHandler;
+    use std::collections::BTreeMap;
     use std::sync::Arc;
     use tower::ServiceExt;
 
@@ -3599,6 +3605,51 @@ mod tests {
 
         fn attribute_values(&self) -> &[AttributeValue] {
             &self.values
+        }
+    }
+
+    /// Scenario: compact JSON requests retain an unobserved all-zero metric set.
+    /// Guarantees: `keep_all_zeroes` is honored with and without resetting metrics.
+    #[tokio::test]
+    async fn metrics_handler_compact_json_honors_keep_all_zeroes() {
+        for reset in [false, true] {
+            let state = test_app_state();
+            let _metric_set =
+                state
+                    .metrics_registry
+                    .register_metric_set::<E2eMetricSet>(E2eAttributeSet {
+                        values: vec![AttributeValue::String("GET".to_string())],
+                    });
+
+            let response = get_metrics(
+                State(state),
+                Query(MetricsQuery {
+                    reset,
+                    format: Some(OutputFormat::JsonCompact),
+                    keep_all_zeroes: true,
+                }),
+            )
+            .await
+            .expect("compact JSON metrics should render");
+            let body = to_bytes(response.into_body(), usize::MAX)
+                .await
+                .expect("compact JSON metrics body should collect");
+            let metrics: api::CompactMetricsResponse = serde_json::from_slice(&body)
+                .expect("compact JSON metrics response should deserialize");
+
+            assert_eq!(metrics.metric_sets.len(), 1);
+            assert_eq!(metrics.metric_sets[0].name, "http_server");
+            assert_eq!(
+                metrics.metric_sets[0].metrics,
+                BTreeMap::from([
+                    (
+                        "http_request_duration".to_string(),
+                        api::MetricValue::F64(0.0)
+                    ),
+                    ("http_requests".to_string(), api::MetricValue::U64(0)),
+                    ("memory_usage".to_string(), api::MetricValue::U64(0)),
+                ])
+            );
         }
     }
 

--- a/rust/otap-dataflow/crates/ctl/src/troubleshoot/filter.rs
+++ b/rust/otap-dataflow/crates/ctl/src/troubleshoot/filter.rs
@@ -178,6 +178,7 @@ fn filter_compact_metric_set(
     Some(telemetry::MetricSet {
         name: metric_set.name.clone(),
         attributes: metric_set.attributes.clone(),
+        data_point_attributes: metric_set.data_point_attributes.clone(),
         metrics,
     })
 }

--- a/rust/otap-dataflow/crates/ctl/src/troubleshoot/tests.rs
+++ b/rust/otap-dataflow/crates/ctl/src/troubleshoot/tests.rs
@@ -133,6 +133,10 @@ fn metrics_filters_prune_sets_and_metric_names() {
                     otap_df_admin_api::telemetry::AttributeValue::String("receiver".to_string()),
                 ),
             ]),
+            data_point_attributes: BTreeMap::from([(
+                "signal".to_string(),
+                otap_df_admin_api::telemetry::AttributeValue::String("logs".to_string()),
+            )]),
             metrics: BTreeMap::from([
                 (
                     "pending.sends".to_string(),
@@ -160,6 +164,13 @@ fn metrics_filters_prune_sets_and_metric_names() {
 
     assert_eq!(filtered.metric_sets.len(), 1);
     assert_eq!(filtered.metric_sets[0].metrics.len(), 1);
+    assert_eq!(
+        filtered.metric_sets[0].data_point_attributes,
+        BTreeMap::from([(
+            "signal".to_string(),
+            otap_df_admin_api::telemetry::AttributeValue::String("logs".to_string()),
+        )])
+    );
     assert!(
         filtered.metric_sets[0]
             .metrics
@@ -203,6 +214,7 @@ fn diagnosis_surfaces_drain_deadline_and_drop_signatures() {
             metric_sets: vec![otap_df_admin_api::telemetry::MetricSet {
                 name: "engine.pipeline".to_string(),
                 attributes: BTreeMap::new(),
+                data_point_attributes: BTreeMap::new(),
                 metrics: BTreeMap::from([(
                     "pending.sends".to_string(),
                     otap_df_admin_api::telemetry::MetricValue::U64(1),

--- a/rust/otap-dataflow/crates/ctl/src/ui/tests.rs
+++ b/rust/otap-dataflow/crates/ctl/src/ui/tests.rs
@@ -568,6 +568,7 @@ fn extract_engine_vitals_maps_cpu_rss_and_pressure() {
         metric_sets: vec![telemetry::MetricSet {
             name: "engine".to_string(),
             attributes: BTreeMap::new(),
+            data_point_attributes: BTreeMap::new(),
             metrics: BTreeMap::from([
                 (
                     "cpu.utilization".to_string(),
@@ -623,6 +624,7 @@ fn extract_engine_vitals_accepts_legacy_underscore_names() {
         metric_sets: vec![telemetry::MetricSet {
             name: "engine".to_string(),
             attributes: BTreeMap::new(),
+            data_point_attributes: BTreeMap::new(),
             metrics: BTreeMap::from([
                 (
                     "cpu_utilization".to_string(),


### PR DESCRIPTION
# Change Summary

Expose per-data-point metric attributes in the admin metrics JSON response so JSON and Prometheus formats identify the same metric series.

### Validation

After sending 10 syslog records through a test pipeline config, Prometheus -- which already exposed data point attributes as labels -- reports the successful Azure Monitor export.

```text
items_total{otel_scope_name="exporter.azure_monitor.exports",otel_scope_node_id="azure-monitor-exporter",signal="logs",outcome="success"} 10
```

The new verbose JSON `attributes` field is highlighted below.

```diff
{
  "name": "exporter.azure_monitor.exports",
  "scope_attributes": {
    "node.id": {
      "String": "azure-monitor-exporter"
    }
  },
  "metrics": [
    {
      "name": "items",
+      "attributes": {
+        "outcome": {
+          "String": "success"
+        },
+        "signal": {
+          "String": "logs"
+        }
+      },
      "value": 10
    }
  ]
}
```

The new compact JSON `data_point_attributes` field is highlighted below; it keeps the dimensions without repeating them for every metric.

```diff
{
  "name": "exporter.azure_monitor.exports",
  "scope_attributes": {
    "node.id": {
      "String": "azure-monitor-exporter"
    }
  },
+  "data_point_attributes": {
+    "outcome": {
+      "String": "success"
+    },
+    "signal": {
+      "String": "logs"
+    }
+  },
  "metrics": {
    "batches": 1,
    "items": 10,
    "messages": 1
  }
}
```


## What issue does this PR close?

<!--We highly recommend correlation of every PR to an issue-->

* Related to #3300

## How are these changes tested?

Local engine runs

## Are there any user-facing changes?

Yes, JSON metrics endpoint now matches Prometheus endpoint behavior.

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry
* [ ] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
