### PR TITLE
[rust] Tenant token compiler (part 1 of 2)

### DIFF
--- a/rust/otap-dataflow/.chloggen/tenant-token-compiler.yaml
+++ b/rust/otap-dataflow/.chloggen/tenant-token-compiler.yaml
@@ -1,0 +1,32 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: engine
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add a compiled tenant token registry that resolves request metadata into one packed per-request context.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [3583]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Tenant tokens are declared under `engine: tenant_tokens:`. Each token names
+  the keys it extracts from a request and whether each value is retained.
+  The registry interns every declared value at startup, so per request a
+  receiver produces a single allocation holding the matched values in OTLP
+  encoding, addressed by position rather than by name.
+
+  Conditions over token keys are decided by exact byte equality. Hashing is
+  used to find a candidate, and the candidate is then verified against the
+  literal the registry owns, so a hash collision cannot route one tenant's
+  data to another tenant's destination.
+
+  Nothing consumes the registry yet; this change adds the compiler, its
+  configuration types and a benchmark only.

--- a/rust/otap-dataflow/Cargo.lock
+++ b/rust/otap-dataflow/Cargo.lock
@@ -7156,7 +7156,9 @@ dependencies = [
 name = "otap-df-config"
 version = "0.50.0"
 dependencies = [
+ "ahash 0.8.12",
  "byte-unit",
+ "bytemuck",
  "humantime-serde",
  "k8s-openapi",
  "kube",
@@ -7167,10 +7169,12 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "smallvec",
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
  "wiremock",
+ "xxhash-rust",
 ]
 
 [[package]]

--- a/rust/otap-dataflow/benchmarks/Cargo.toml
+++ b/rust/otap-dataflow/benchmarks/Cargo.toml
@@ -85,6 +85,10 @@ name = "otlp_bytes"
 harness = false
 
 [[bench]]
+name = "request_context"
+harness = false
+
+[[bench]]
 name = "transport_optimize"
 harness = false
 

--- a/rust/otap-dataflow/benchmarks/benches/request_context/main.rs
+++ b/rust/otap-dataflow/benchmarks/benches/request_context/main.rs
@@ -30,6 +30,11 @@ use std::hint::black_box;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use otap_df_config::tenant::compiled::{
+    TenantTokenRegistry, TenantTokenRegistryBuilder, TenantView, TokenInputs, TokenScratch,
+    attribute_field,
+};
+use otap_df_config::tenant::{Extractor, TenantTokenSpec, TenantTokens};
 use otap_df_config::transport_headers::TransportHeaders;
 use otap_df_config::transport_headers_policy::{
     CaptureDefaults, CaptureRule, HeaderCapturePolicy, HeaderPropagationPolicy, PropagationDefault,
@@ -134,6 +139,55 @@ fn propagation_policy() -> HeaderPropagationPolicy {
     )
 }
 
+/// The tenant-token equivalent of `capture_policy`: one token whose `n`
+/// extractors read the same wire headers and retain the same logical names.
+///
+/// `bag` decides whether key names are encoded alongside the values, which is
+/// what makes the run appendable to telemetry as OTLP attributes.
+fn registry(n_keys: usize, bag: bool) -> TenantTokenRegistry {
+    let names = [
+        ("x-tenant-id", "tenant_id"),
+        ("x-project-id", "project_id"),
+        ("x-request-id", "request_id"),
+        ("traceparent", "traceparent"),
+    ];
+    let extractors = names
+        .iter()
+        .take(n_keys)
+        .map(|(wire, key)| Extractor::TransportHeader {
+            key: (*key).to_owned(),
+            transport_header: (*wire).to_owned(),
+            retain: true,
+            bag,
+        })
+        .collect();
+    let mut tokens = TenantTokens::default();
+    let _ = tokens.insert("gateway".to_owned(), TenantTokenSpec { extractors });
+    let mut builder = TenantTokenRegistryBuilder::new().with_bag_field(attribute_field::SCOPE);
+    builder.add_tokens(&tokens).expect("registry builds");
+    builder.build(1)
+}
+
+/// The exporter side: the logical keys an exporter re-emits, paired with the
+/// wire names it chooses. Resolved once at build time, exactly as a compiled
+/// exporter would.
+fn egress_map(reg: &TenantTokenRegistry, n_keys: usize) -> Vec<(u16, &'static str)> {
+    let names = [
+        ("tenant_id", "x-acme-tenant"),
+        ("project_id", "x-acme-project"),
+        ("request_id", "x-acme-request"),
+        ("traceparent", "traceparent"),
+    ];
+    names
+        .iter()
+        .take(n_keys)
+        .filter_map(|(key, wire)| {
+            let id = reg.key_id(key)?;
+            Some((reg.value_slot(id)?, *wire))
+        })
+        .collect()
+}
+
 /// Counts of matched headers to sweep. One is the degenerate case a router
 /// needs; four is a realistic gateway that also forwards tracing context.
 const MATCHED: [usize; 3] = [1, 2, 4];
@@ -215,6 +269,123 @@ fn bench_end_to_end(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_tenant(c: &mut Criterion) {
+    let mut group = c.benchmark_group("request_context/tenant_resolve");
+    for n in MATCHED {
+        let reg = registry(n, false);
+        let pairs = inbound();
+        let mut scratch = TokenScratch::new();
+        let _ = group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| {
+                black_box(reg.resolve(
+                    &mut scratch,
+                    TokenInputs::new(pairs.iter().map(|(k, v)| (*k, *v))),
+                ))
+            });
+        });
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group("request_context/tenant_carry");
+    for n in MATCHED {
+        let reg = registry(n, false);
+        let pairs = inbound();
+        let mut scratch = TokenScratch::new();
+        let words = reg
+            .resolve(
+                &mut scratch,
+                TokenInputs::new(pairs.iter().map(|(k, v)| (*k, *v))),
+            )
+            .expect("resolves");
+        let _ = group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| black_box(words.clone()));
+        });
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group("request_context/tenant_propagate");
+    for n in MATCHED {
+        let reg = registry(n, false);
+        let egress = egress_map(&reg, n);
+        let pairs = inbound();
+        let mut scratch = TokenScratch::new();
+        let words = reg
+            .resolve(
+                &mut scratch,
+                TokenInputs::new(pairs.iter().map(|(k, v)| (*k, *v))),
+            )
+            .expect("resolves");
+        let _ = group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| {
+                let view = TenantView::new(&words);
+                let mut emitted = 0usize;
+                for (slot, wire) in &egress {
+                    if let Some(value) = view.slot_value(*slot) {
+                        emitted += black_box(wire.len()) + black_box(value.len());
+                    }
+                }
+                emitted
+            });
+        });
+    }
+    group.finish();
+
+    // One receiver resolve, two node hops, one exporter read: the same shape
+    // as `bench_end_to_end`, so the totals are directly comparable.
+    let mut group = c.benchmark_group("request_context/tenant_end_to_end");
+    for n in MATCHED {
+        let reg = registry(n, false);
+        let egress = egress_map(&reg, n);
+        let pairs = inbound();
+        let mut scratch = TokenScratch::new();
+        let _ = group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| {
+                let words = reg
+                    .resolve(
+                        &mut scratch,
+                        TokenInputs::new(pairs.iter().map(|(k, v)| (*k, *v))),
+                    )
+                    .expect("resolves");
+                let hop1 = words.clone();
+                let hop2 = hop1.clone();
+                let view = TenantView::new(&hop2);
+                let mut emitted = 0usize;
+                for (slot, _) in &egress {
+                    if let Some(value) = view.slot_value(*slot) {
+                        emitted += value.len();
+                    }
+                }
+                black_box(emitted)
+            });
+        });
+    }
+    group.finish();
+
+    // Instrumenting a request with its tenant context. The baseline has no
+    // equivalent: it would have to encode a KeyValue per header.
+    let mut group = c.benchmark_group("request_context/tenant_attributes");
+    for n in MATCHED {
+        let reg = registry(n, true);
+        let pairs = inbound();
+        let mut scratch = TokenScratch::new();
+        let words = reg
+            .resolve(
+                &mut scratch,
+                TokenInputs::new(pairs.iter().map(|(k, v)| (*k, *v))),
+            )
+            .expect("resolves");
+        let mut dst = Vec::with_capacity(1024);
+        let _ = group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| {
+                dst.clear();
+                dst.extend_from_slice(TenantView::new(&words).attributes());
+                black_box(dst.len())
+            });
+        });
+    }
+    group.finish();
+}
+
 /// Report allocations per request for each phase.
 ///
 /// This is the number the representation change is meant to move, and it is
@@ -269,6 +440,83 @@ fn alloc_report(_c: &mut Criterion) {
         });
         println!("{:<12} {n:>8} {a:>10.2} {b:>10.1}", "end_to_end");
     }
+
+    println!("\nrequest_context allocations per request (tenant token)");
+    println!(
+        "{:<12} {:>8} {:>10} {:>10}",
+        "phase", "matched", "allocs", "bytes"
+    );
+
+    for n in MATCHED {
+        let reg = registry(n, false);
+        let egress = egress_map(&reg, n);
+        let mut scratch = TokenScratch::new();
+
+        let (a, b) = measure(ITERS, || {
+            reg.resolve(
+                &mut scratch,
+                TokenInputs::new(pairs.iter().map(|(k, v)| (*k, *v))),
+            )
+        });
+        println!("{:<12} {n:>8} {a:>10.2} {b:>10.1}", "capture");
+
+        let words = reg
+            .resolve(
+                &mut scratch,
+                TokenInputs::new(pairs.iter().map(|(k, v)| (*k, *v))),
+            )
+            .expect("resolves");
+        let (a, b) = measure(ITERS, || words.clone());
+        println!("{:<12} {n:>8} {a:>10.2} {b:>10.1}", "carry");
+
+        let (a, b) = measure(ITERS, || {
+            let view = TenantView::new(&words);
+            let mut emitted = 0usize;
+            for (slot, wire) in &egress {
+                if let Some(value) = view.slot_value(*slot) {
+                    emitted += wire.len() + value.len();
+                }
+            }
+            emitted
+        });
+        println!("{:<12} {n:>8} {a:>10.2} {b:>10.1}", "propagate");
+
+        let (a, b) = measure(ITERS, || {
+            let w = reg
+                .resolve(
+                    &mut scratch,
+                    TokenInputs::new(pairs.iter().map(|(k, v)| (*k, *v))),
+                )
+                .expect("resolves");
+            let hop1 = w.clone();
+            let hop2 = hop1.clone();
+            let view = TenantView::new(&hop2);
+            let mut emitted = 0usize;
+            for (slot, _) in &egress {
+                if let Some(value) = view.slot_value(*slot) {
+                    emitted += value.len();
+                }
+            }
+            emitted
+        });
+        println!("{:<12} {n:>8} {a:>10.2} {b:>10.1}", "end_to_end");
+
+        let bag = registry(n, true);
+        let mut s2 = TokenScratch::new();
+        let bw = bag
+            .resolve(
+                &mut s2,
+                TokenInputs::new(pairs.iter().map(|(k, v)| (*k, *v))),
+            )
+            .expect("resolves");
+        let mut dst = Vec::with_capacity(1024);
+        let (a, b) = measure(ITERS, || {
+            dst.clear();
+            dst.extend_from_slice(TenantView::new(&bw).attributes());
+            dst.len()
+        });
+        println!("{:<12} {n:>8} {a:>10.2} {b:>10.1}", "attributes");
+    }
     println!();
 }
 
@@ -278,6 +526,7 @@ criterion_group!(
     bench_carry,
     bench_propagate,
     bench_end_to_end,
+    bench_tenant,
     alloc_report,
 );
 criterion_main!(benches);

--- a/rust/otap-dataflow/benchmarks/benches/request_context/main.rs
+++ b/rust/otap-dataflow/benchmarks/benches/request_context/main.rs
@@ -165,7 +165,7 @@ fn registry(n_keys: usize, bag: bool) -> TenantTokenRegistry {
     let _ = tokens.insert("gateway".to_owned(), TenantTokenSpec { extractors });
     let mut builder = TenantTokenRegistryBuilder::new().with_bag_field(attribute_field::SCOPE);
     builder.add_tokens(&tokens).expect("registry builds");
-    builder.build(1)
+    builder.build(1).expect("layout fits")
 }
 
 /// The exporter side: the logical keys an exporter re-emits, paired with the

--- a/rust/otap-dataflow/benchmarks/benches/request_context/main.rs
+++ b/rust/otap-dataflow/benchmarks/benches/request_context/main.rs
@@ -34,7 +34,7 @@ use otap_df_config::tenant::compiled::{
     TenantTokenRegistry, TenantTokenRegistryBuilder, TenantView, TokenInputs, TokenScratch,
     attribute_field,
 };
-use otap_df_config::tenant::{Extractor, TenantTokenSpec, TenantTokens};
+use otap_df_config::tenant::{Condition, Entry, Extractor, TenantTokenSpec, TenantTokens};
 use otap_df_config::transport_headers::TransportHeaders;
 use otap_df_config::transport_headers_policy::{
     CaptureDefaults, CaptureRule, HeaderCapturePolicy, HeaderPropagationPolicy, PropagationDefault,
@@ -165,7 +165,44 @@ fn registry(n_keys: usize, bag: bool) -> TenantTokenRegistry {
     let _ = tokens.insert("gateway".to_owned(), TenantTokenSpec { extractors });
     let mut builder = TenantTokenRegistryBuilder::new().with_bag_field(attribute_field::SCOPE);
     builder.add_tokens(&tokens).expect("registry builds");
+    builder
+        .declare_conditions(None, &conditions(n_keys))
+        .expect("conditions declare");
     builder.build(1).expect("layout fits")
+}
+
+/// The routes a topic router would declare over these tokens.
+///
+/// Without conditions every symbol dictionary is empty, so resolution never
+/// exercises the value-to-symbol lookup and the probe is never measured at
+/// all. Routing is on identity keys only: nobody routes on a request id or a
+/// traceparent, so the conditions stay at two keys however many are carried.
+fn conditions(n_keys: usize) -> Vec<Condition> {
+    const TENANTS: [&str; 8] = [
+        "tenant-a", "tenant-b", "tenant-c", "tenant-d", "tenant-e", "tenant-f", "tenant-g",
+        "tenant-h",
+    ];
+    const PROJECTS: [&str; 2] = ["proj-40f1c2", "proj-8b31de"];
+
+    let entry = |key: &str, value: &str| Entry {
+        key: key.to_owned(),
+        value: Some(value.to_owned()),
+    };
+    let mut out = Vec::new();
+    for tenant in TENANTS {
+        if n_keys >= 2 {
+            for project in PROJECTS {
+                out.push(Condition {
+                    entries: vec![entry("tenant_id", tenant), entry("project_id", project)],
+                });
+            }
+        } else {
+            out.push(Condition {
+                entries: vec![entry("tenant_id", tenant)],
+            });
+        }
+    }
+    out
 }
 
 /// The exporter side: the logical keys an exporter re-emits, paired with the
@@ -386,6 +423,35 @@ fn bench_tenant(c: &mut Criterion) {
     group.finish();
 }
 
+/// Evaluate a router's conditions against a resolved request.
+///
+/// This is the step the old design decided with an unverified hash lookup and
+/// the new one decides by exact symbol equality, so it is the one to watch.
+fn bench_tenant_match(c: &mut Criterion) {
+    let mut group = c.benchmark_group("request_context/tenant_match");
+    for n in MATCHED {
+        let reg = registry(n, false);
+        let routes = conditions(n);
+        let set = reg
+            .condition_set(None, &routes)
+            .expect("condition set builds");
+        let pairs = inbound();
+        let mut scratch = TokenScratch::new();
+        let words = reg
+            .resolve(
+                &mut scratch,
+                TokenInputs::new(pairs.iter().map(|(k, v)| (*k, *v))),
+            )
+            .expect("resolves");
+        let view = TenantView::new(&words);
+        assert!(set.first_match(&view).is_some(), "request should match");
+        let _ = group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| black_box(set.first_match(black_box(&view))));
+        });
+    }
+    group.finish();
+}
+
 /// Report allocations per request for each phase.
 ///
 /// This is the number the representation change is meant to move, and it is
@@ -527,6 +593,7 @@ criterion_group!(
     bench_propagate,
     bench_end_to_end,
     bench_tenant,
+    bench_tenant_match,
     alloc_report,
 );
 criterion_main!(benches);

--- a/rust/otap-dataflow/benchmarks/benches/request_context/main.rs
+++ b/rust/otap-dataflow/benchmarks/benches/request_context/main.rs
@@ -1,0 +1,283 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Baseline for the per-request cost of carrying request metadata.
+//!
+//! Every request that enters the engine drags a small amount of metadata with
+//! it -- today a `TransportHeaders` vector of owned name/value pairs, reachable
+//! from `Context`. This benchmark measures that path so a later change to the
+//! representation has a before and after to be judged against.
+//!
+//! Three phases are timed separately because they have different shapes:
+//!
+//! - `capture` runs once per request at the receiver and allocates.
+//! - `carry` runs at every node the request passes through and clones.
+//! - `propagate` runs once per request at the exporter and reads.
+//!
+//! Wall time alone is a poor summary here, since the interesting cost is
+//! allocator traffic that shows up as fragmentation and cache pressure rather
+//! than as time in the benchmarked region. `alloc_report` therefore counts
+//! allocations per request directly.
+//!
+//! Counting requires implementing `GlobalAlloc`, which the workspace denies.
+//! The allow is scoped to this benchmark: the three methods below forward
+//! unmodified arguments to the system allocator and add a relaxed counter, and
+//! no benchmark code ships.
+#![allow(unsafe_code)]
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::hint::black_box;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use otap_df_config::transport_headers::TransportHeaders;
+use otap_df_config::transport_headers_policy::{
+    CaptureDefaults, CaptureRule, HeaderCapturePolicy, HeaderPropagationPolicy, PropagationDefault,
+    PropagationSelector, PropagationSelectorType,
+};
+
+/// Global allocator that counts allocations so the benchmark can report
+/// allocations per request rather than only wall time.
+struct Counting;
+
+static ALLOCS: AtomicU64 = AtomicU64::new(0);
+static BYTES: AtomicU64 = AtomicU64::new(0);
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let _ = ALLOCS.fetch_add(1, Ordering::Relaxed);
+        let _ = BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        // SAFETY: forwarding an unmodified layout to the system allocator.
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: forwarding a pointer this allocator handed out.
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let _ = ALLOCS.fetch_add(1, Ordering::Relaxed);
+        let _ = BYTES.fetch_add(new_size as u64, Ordering::Relaxed);
+        // SAFETY: forwarding a pointer and layout this allocator handed out.
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static GLOBAL: Counting = Counting;
+
+/// Run `f` `iters` times and return allocations and bytes per iteration.
+fn measure<T>(iters: u64, mut f: impl FnMut() -> T) -> (f64, f64) {
+    // Warm up so lazily initialized statics are not attributed to the region.
+    let _ = black_box(f());
+    let a0 = ALLOCS.load(Ordering::Relaxed);
+    let b0 = BYTES.load(Ordering::Relaxed);
+    for _ in 0..iters {
+        let _ = black_box(f());
+    }
+    let allocs = ALLOCS.load(Ordering::Relaxed) - a0;
+    let bytes = BYTES.load(Ordering::Relaxed) - b0;
+    #[allow(clippy::cast_precision_loss)]
+    (allocs as f64 / iters as f64, bytes as f64 / iters as f64)
+}
+
+/// A request's inbound metadata. Names and sizes are chosen to look like a
+/// gateway hop: routing identity, tracing, and a couple of headers the policy
+/// will not match, since a real request carries more than the pipeline wants.
+fn inbound() -> Vec<(&'static str, &'static [u8])> {
+    vec![
+        ("x-tenant-id", b"tenant-a".as_slice()),
+        ("x-project-id", b"proj-40f1c2".as_slice()),
+        ("x-request-id", b"01J8Z9QK7YB3F4N6P8R2T5V7W9".as_slice()),
+        (
+            "traceparent",
+            b"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".as_slice(),
+        ),
+        ("user-agent", b"otel-collector/0.99.0".as_slice()),
+        ("content-type", b"application/x-protobuf".as_slice()),
+        ("accept-encoding", b"gzip".as_slice()),
+        ("grpc-timeout", b"30S".as_slice()),
+    ]
+}
+
+fn capture_policy(n_rules: usize) -> HeaderCapturePolicy {
+    let names = [
+        ("x-tenant-id", "tenant_id"),
+        ("x-project-id", "project_id"),
+        ("x-request-id", "request_id"),
+        ("traceparent", "traceparent"),
+    ];
+    let rules = names
+        .iter()
+        .take(n_rules)
+        .map(|(wire, stored)| CaptureRule {
+            match_names: vec![(*wire).to_owned()],
+            store_as: Some((*stored).to_owned()),
+            sensitive: false,
+            value_kind: None,
+        })
+        .collect();
+    HeaderCapturePolicy::new(CaptureDefaults::default(), rules)
+}
+
+fn propagation_policy() -> HeaderPropagationPolicy {
+    HeaderPropagationPolicy::new(
+        PropagationDefault {
+            selector: PropagationSelector {
+                selector_type: PropagationSelectorType::AllCaptured,
+                named: None,
+            },
+            ..Default::default()
+        },
+        Vec::new(),
+    )
+}
+
+/// Counts of matched headers to sweep. One is the degenerate case a router
+/// needs; four is a realistic gateway that also forwards tracing context.
+const MATCHED: [usize; 3] = [1, 2, 4];
+
+fn bench_capture(c: &mut Criterion) {
+    let mut group = c.benchmark_group("request_context/capture");
+    for n in MATCHED {
+        let policy = capture_policy(n);
+        let pairs = inbound();
+        let _ = group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| {
+                let mut out = TransportHeaders::default();
+                let _ = policy
+                    .capture_from_pairs(pairs.iter().map(|(k, v)| (*k, *v)), black_box(&mut out));
+                out
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_carry(c: &mut Criterion) {
+    let mut group = c.benchmark_group("request_context/carry");
+    for n in MATCHED {
+        let policy = capture_policy(n);
+        let pairs = inbound();
+        let mut headers = TransportHeaders::default();
+        let _ = policy.capture_from_pairs(pairs.iter().map(|(k, v)| (*k, *v)), &mut headers);
+        let _ = group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| black_box(headers.clone()));
+        });
+    }
+    group.finish();
+}
+
+fn bench_propagate(c: &mut Criterion) {
+    let mut group = c.benchmark_group("request_context/propagate");
+    let egress = propagation_policy();
+    for n in MATCHED {
+        let policy = capture_policy(n);
+        let pairs = inbound();
+        let mut headers = TransportHeaders::default();
+        let _ = policy.capture_from_pairs(pairs.iter().map(|(k, v)| (*k, *v)), &mut headers);
+        let _ = group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| {
+                let mut emitted = 0usize;
+                for h in egress.propagate(&headers) {
+                    emitted += black_box(h.header_name.len()) + black_box(h.value.len());
+                }
+                emitted
+            });
+        });
+    }
+    group.finish();
+}
+
+/// One receiver capture, two intermediate node hops, one exporter read.
+fn bench_end_to_end(c: &mut Criterion) {
+    let mut group = c.benchmark_group("request_context/end_to_end");
+    let egress = propagation_policy();
+    for n in MATCHED {
+        let policy = capture_policy(n);
+        let pairs = inbound();
+        let _ = group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| {
+                let mut headers = TransportHeaders::default();
+                let _ =
+                    policy.capture_from_pairs(pairs.iter().map(|(k, v)| (*k, *v)), &mut headers);
+                let hop1 = headers.clone();
+                let hop2 = hop1.clone();
+                let mut emitted = 0usize;
+                for h in egress.propagate(&hop2) {
+                    emitted += h.value.len();
+                }
+                black_box(emitted)
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Report allocations per request for each phase.
+///
+/// This is the number the representation change is meant to move, and it is
+/// printed rather than timed so a before and after can be compared directly
+/// without reading Criterion's statistics.
+#[allow(clippy::print_stdout)]
+fn alloc_report(_c: &mut Criterion) {
+    const ITERS: u64 = 20_000;
+    let egress = propagation_policy();
+    let pairs = inbound();
+
+    println!("\nrequest_context allocations per request (baseline)");
+    println!(
+        "{:<12} {:>8} {:>10} {:>10}",
+        "phase", "matched", "allocs", "bytes"
+    );
+
+    for n in MATCHED {
+        let policy = capture_policy(n);
+
+        let (a, b) = measure(ITERS, || {
+            let mut out = TransportHeaders::default();
+            let _ = policy.capture_from_pairs(pairs.iter().map(|(k, v)| (*k, *v)), &mut out);
+            out
+        });
+        println!("{:<12} {n:>8} {a:>10.2} {b:>10.1}", "capture");
+
+        let mut headers = TransportHeaders::default();
+        let _ = policy.capture_from_pairs(pairs.iter().map(|(k, v)| (*k, *v)), &mut headers);
+        let (a, b) = measure(ITERS, || headers.clone());
+        println!("{:<12} {n:>8} {a:>10.2} {b:>10.1}", "carry");
+
+        let (a, b) = measure(ITERS, || {
+            let mut emitted = 0usize;
+            for h in egress.propagate(&headers) {
+                emitted += h.value.len();
+            }
+            emitted
+        });
+        println!("{:<12} {n:>8} {a:>10.2} {b:>10.1}", "propagate");
+
+        let (a, b) = measure(ITERS, || {
+            let mut h = TransportHeaders::default();
+            let _ = policy.capture_from_pairs(pairs.iter().map(|(k, v)| (*k, *v)), &mut h);
+            let hop1 = h.clone();
+            let hop2 = hop1.clone();
+            let mut emitted = 0usize;
+            for p in egress.propagate(&hop2) {
+                emitted += p.value.len();
+            }
+            emitted
+        });
+        println!("{:<12} {n:>8} {a:>10.2} {b:>10.1}", "end_to_end");
+    }
+    println!();
+}
+
+criterion_group!(
+    benches,
+    bench_capture,
+    bench_carry,
+    bench_propagate,
+    bench_end_to_end,
+    alloc_report,
+);
+criterion_main!(benches);

--- a/rust/otap-dataflow/crates/config/Cargo.toml
+++ b/rust/otap-dataflow/crates/config/Cargo.toml
@@ -22,6 +22,10 @@ schemars = { workspace = true }
 byte-unit = { workspace = true }
 humantime-serde = { workspace = true }
 reqwest = { workspace = true, features = ["blocking"] }
+ahash = { workspace = true }
+bytemuck = { workspace = true }
+smallvec = { workspace = true }
+xxhash-rust = { workspace = true }
 
 [dev-dependencies]
 k8s-openapi = { workspace = true }

--- a/rust/otap-dataflow/crates/config/src/lib.rs
+++ b/rust/otap-dataflow/crates/config/src/lib.rs
@@ -37,6 +37,8 @@ pub mod pipeline_group;
 pub mod policy;
 /// Engine telemetry settings.
 pub mod settings;
+/// Tenant token configuration and the compiled hot-path representation.
+pub mod tenant;
 /// TLS configuration.
 pub mod tls;
 pub mod topic;

--- a/rust/otap-dataflow/crates/config/src/tenant.rs
+++ b/rust/otap-dataflow/crates/config/src/tenant.rs
@@ -1,0 +1,333 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tenant token configuration types.
+//!
+//! A *tenant token* is a small vector of `key: value` identifiers describing
+//! the tenant that a request belongs to. Tokens are produced by receivers from
+//! request-scoped material (transport headers, peer address, and eventually
+//! authorization data) and consumed by downstream nodes that evaluate
+//! first-match-wins *conditions* over them.
+//!
+//! This module holds only the user-facing configuration shapes. The compiled,
+//! hot-path representation lives in [`crate::tenant::compiled`].
+//!
+//! Extracted values may optionally be *retained*, which is what allows tenant
+//! tokens to subsume the general-purpose transport header map: instead of
+//! carrying every captured header as an owned string pair, the engine carries
+//! only the configured token keys.
+//!
+//! A token deliberately says nothing about the wire name a retained value is
+//! re-emitted under. The token is the portable identity; how it appears on the
+//! wire is a site-specific decision belonging to the node that does the
+//! emitting. Exporters therefore map `key -> outbound header name` themselves,
+//! and the same token can be emitted under different names by two exporters.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+pub mod compiled;
+
+/// Identifier of a tenant token definition, as used in engine configuration.
+pub type TenantTokenId = String;
+
+/// A single rule that resolves one token key from the request context.
+///
+/// Variants are untagged and disambiguated by their distinguishing field, so
+/// an extractor reads as a flat map in YAML.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum Extractor {
+    /// Copy a transport header value into the token key.
+    TransportHeader {
+        /// Token key this extractor resolves.
+        key: String,
+        /// Transport header name to read, matched case-insensitively.
+        transport_header: String,
+        /// Retain the value in the request context. Retained values can be
+        /// re-emitted by an exporter under a name that exporter chooses, and
+        /// offered to a downstream pipeline by a boundary policy. Keys that
+        /// are not retained participate in matching only and cost no bytes.
+        #[serde(default)]
+        retain: bool,
+        /// Also carry the key's name, so the pair can be appended to telemetry
+        /// attributes without re-encoding. This is the only way a name travels
+        /// with a request; every other use of a key name is compiled out.
+        /// Implies `retain`.
+        #[serde(default)]
+        bag: bool,
+    },
+    /// Resolve the token key to a static, configured value.
+    ///
+    /// This is how a pipeline mints an identity of its own, such as the tenant
+    /// a dedicated pipeline is dedicated to.
+    GenericKey {
+        /// Token key this extractor resolves.
+        key: String,
+        /// Static value assigned to the key.
+        generic_key: String,
+        /// Retain the value in the request context. Retained values can be
+        /// re-emitted by an exporter under a name that exporter chooses, and
+        /// offered to a downstream pipeline by a boundary policy. Keys that
+        /// are not retained participate in matching only and cost no bytes.
+        #[serde(default)]
+        retain: bool,
+        /// Also carry the key's name, so the pair can be appended to telemetry
+        /// attributes without re-encoding. This is the only way a name travels
+        /// with a request; every other use of a key name is compiled out.
+        /// Implies `retain`.
+        #[serde(default)]
+        bag: bool,
+    },
+    /// Resolve the token key to the network peer's address.
+    RemoteAddress {
+        /// Token key this extractor resolves.
+        key: String,
+        /// Must be `true`; selects this extractor kind.
+        remote_address: bool,
+        /// Retain the value in the request context. Retained values can be
+        /// re-emitted by an exporter under a name that exporter chooses, and
+        /// offered to a downstream pipeline by a boundary policy. Keys that
+        /// are not retained participate in matching only and cost no bytes.
+        #[serde(default)]
+        retain: bool,
+        /// Also carry the key's name, so the pair can be appended to telemetry
+        /// attributes without re-encoding. This is the only way a name travels
+        /// with a request; every other use of a key name is compiled out.
+        /// Implies `retain`.
+        #[serde(default)]
+        bag: bool,
+    },
+    /// Resolve the token key from a value retained by an upstream pipeline
+    /// and carried across a pipeline or group boundary.
+    ///
+    /// This is the import half of cross-boundary propagation: the upstream
+    /// pipeline retains a key, the boundary policy admits it, and this
+    /// extractor binds it into a token belonging to the downstream pipeline.
+    ImportedKey {
+        /// Token key this extractor resolves.
+        key: String,
+        /// Key name to read from the inbound cross-boundary context.
+        imported_key: String,
+        /// Retain the value in the request context. Retained values can be
+        /// re-emitted by an exporter under a name that exporter chooses, and
+        /// offered to a downstream pipeline by a boundary policy. Keys that
+        /// are not retained participate in matching only and cost no bytes.
+        #[serde(default)]
+        retain: bool,
+        /// Also carry the key's name, so the pair can be appended to telemetry
+        /// attributes without re-encoding. This is the only way a name travels
+        /// with a request; every other use of a key name is compiled out.
+        /// Implies `retain`.
+        #[serde(default)]
+        bag: bool,
+    },
+}
+
+impl Extractor {
+    /// Token key resolved by this extractor.
+    #[must_use]
+    pub fn key(&self) -> &str {
+        match self {
+            Self::TransportHeader { key, .. }
+            | Self::GenericKey { key, .. }
+            | Self::RemoteAddress { key, .. }
+            | Self::ImportedKey { key, .. } => key,
+        }
+    }
+
+    /// Whether this extractor's value is retained in the request context.
+    #[must_use]
+    pub fn retain(&self) -> bool {
+        match self {
+            Self::TransportHeader { retain, bag, .. }
+            | Self::GenericKey { retain, bag, .. }
+            | Self::RemoteAddress { retain, bag, .. }
+            | Self::ImportedKey { retain, bag, .. } => *retain || *bag,
+        }
+    }
+
+    /// Whether this extractor's key name travels alongside its value.
+    #[must_use]
+    pub fn bag(&self) -> bool {
+        match self {
+            Self::TransportHeader { bag, .. }
+            | Self::GenericKey { bag, .. }
+            | Self::RemoteAddress { bag, .. }
+            | Self::ImportedKey { bag, .. } => *bag,
+        }
+    }
+}
+
+/// A named tenant token definition: the list of extractors that must all
+/// resolve for the token to be present on a request.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct TenantTokenSpec {
+    /// Extractors that must all resolve for this token to be resolved.
+    pub extractors: Vec<Extractor>,
+}
+
+/// One `{ key, value }` term of a condition. A missing `value` is a wildcard:
+/// the key must be present with any value.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct Entry {
+    /// Token key tested by this entry.
+    pub key: String,
+    /// Required value, or `None` to accept any value.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+}
+
+/// An ordered list of entries selecting a destination. All entries must match
+/// for the condition to match.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct Condition {
+    /// Entries that must all match.
+    pub entries: Vec<Entry>,
+}
+
+/// Engine-level map of tenant token definitions, shared across pipeline groups.
+pub type TenantTokens = HashMap<TenantTokenId, TenantTokenSpec>;
+
+/// One route of a tenant-token router: a condition plus the destination topic
+/// selected when that condition is the first match.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct TenantRoute {
+    /// Entries that must all match for this route to be selected.
+    pub entries: Vec<Entry>,
+    /// Destination topic name.
+    pub topic: String,
+}
+
+/// Tenant-token routing configuration shared by the controller (which must
+/// know every declared condition before nodes are built) and the routing node
+/// itself.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct TenantRouting {
+    /// Tenant tokens this router binds. Empty binds every declared token.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tenant_tokens: Vec<TenantTokenId>,
+    /// Routes evaluated first-match-wins.
+    pub routes: Vec<TenantRoute>,
+    /// Keys allowed to cross the topic boundary with the published data.
+    #[serde(default)]
+    pub export: TenantBoundaryPolicy,
+    /// Topic used when no route matches. Without it, unmatched data is nacked.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_topic: Option<String>,
+}
+
+/// Names an outbound header and the token key whose retained value fills it.
+///
+/// This is where a retained token key acquires a wire name. Keeping the name
+/// here rather than in the token definition means the same portable token can
+/// be emitted as `x-acme-customer` by one exporter and `x-customer-id` by
+/// another, and that a token carries no assumptions about any backend.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct TenantHeader {
+    /// Token key supplying the value.
+    pub key: String,
+    /// Outbound header name.
+    pub header: String,
+    /// Emit the value as binary metadata (gRPC `-bin` keys).
+    #[serde(default)]
+    pub binary: bool,
+}
+
+/// Policy limiting which retained token keys may cross a pipeline or group
+/// boundary.
+///
+/// Boundaries are the only places tenant material can leak between tenants, so
+/// both sides of every boundary carry an explicit allowlist and everything not
+/// named is dropped. An empty or absent policy propagates nothing.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct TenantBoundaryPolicy {
+    /// Token keys admitted across the boundary. Anything else is dropped.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allow_keys: Vec<String>,
+}
+
+impl TenantBoundaryPolicy {
+    /// True when the policy admits nothing.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.allow_keys.is_empty()
+    }
+}
+
+/// Rules a boundary-crossing receiver uses to build a fresh request context.
+///
+/// The inbound context from the upstream pipeline is never adopted as-is. The
+/// receiver admits the keys its `import` policy names, then resolves its own
+/// tokens over the admitted values plus any locally minted generic keys, so
+/// the downstream pipeline evaluates conditions against identities it declared
+/// itself.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct TenantContextRules {
+    /// Keys admitted from the inbound cross-boundary context.
+    #[serde(default)]
+    pub import: TenantBoundaryPolicy,
+    /// Tokens resolved after import. Empty resolves every declared token.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tokens: Vec<TenantTokenId>,
+}
+
+impl TenantContextRules {
+    /// The bound token names, or `None` to bind every declared token.
+    #[must_use]
+    pub fn bound_tokens(&self) -> Option<&[TenantTokenId]> {
+        (!self.tokens.is_empty()).then_some(self.tokens.as_slice())
+    }
+}
+
+/// Groups work by tenant condition so that a merged unit never mixes tenants.
+///
+/// Used by the batch processor: each condition is one partition, so every
+/// output batch carries a single tenant context and the retained values
+/// survive the merge intact.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct TenantPartitioning {
+    /// Tenant tokens this node binds. Empty binds every declared token.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tenant_tokens: Vec<TenantTokenId>,
+    /// Partitions, evaluated first-match-wins. Data matching no partition
+    /// falls into a catch-all partition that carries no tenant context.
+    pub partitions: Vec<Condition>,
+}
+
+impl TenantPartitioning {
+    /// The bound token names, or `None` to bind every declared token.
+    #[must_use]
+    pub fn bound_tokens(&self) -> Option<&[TenantTokenId]> {
+        (!self.tenant_tokens.is_empty()).then_some(self.tenant_tokens.as_slice())
+    }
+}
+
+impl TenantRouting {
+    /// The bound token names, or `None` to bind every declared token.
+    #[must_use]
+    pub fn bound_tokens(&self) -> Option<&[TenantTokenId]> {
+        (!self.tenant_tokens.is_empty()).then_some(self.tenant_tokens.as_slice())
+    }
+
+    /// The routes' conditions, in route order.
+    #[must_use]
+    pub fn conditions(&self) -> Vec<Condition> {
+        self.routes
+            .iter()
+            .map(|route| Condition {
+                entries: route.entries.clone(),
+            })
+            .collect()
+    }
+}

--- a/rust/otap-dataflow/crates/config/src/tenant/compiled.rs
+++ b/rust/otap-dataflow/crates/config/src/tenant/compiled.rs
@@ -134,6 +134,8 @@ pub struct TenantTokenRegistry {
     tokens: Vec<CompiledToken>,
     /// Lowercased transport header name to the extractors it satisfies.
     header_index: AHashMap<Box<str>, HeaderSlot>,
+    /// Bloom filter over registered header names, probed before hashing.
+    header_probe: u64,
     static_extractors: Vec<StaticExtractor>,
     signatures: Vec<Signature>,
     /// Dense (token, signature) pairs; the index is the [`PairSlot`].
@@ -551,6 +553,11 @@ impl TenantTokenRegistryBuilder {
             epoch,
             key_names: self.key_names,
             tokens: self.tokens,
+            header_probe: self
+                .header_index
+                .keys()
+                .map(|name| 1u64 << header_probe_bit(name.as_bytes()))
+                .fold(0, |acc, bit| acc | bit),
             header_index: self.header_index,
             static_extractors: self.static_extractors,
             signatures: self.signatures,
@@ -696,6 +703,19 @@ pub mod attribute_field {
 
     /// `Span.attributes`.
     pub const SPAN: u32 = 9;
+}
+
+/// Cheap discriminator over a header name, used as a one-word Bloom filter.
+///
+/// A request carries far more headers than any pipeline registers -- content
+/// type, user agent, encoding, timeouts -- and hashing all of them to discover
+/// that is the dominant cost of resolution. Length and first byte separate
+/// real header names well and are available without touching the rest of the
+/// string, so an unregistered name is usually rejected before it is hashed or
+/// case-folded.
+fn header_probe_bit(name: &[u8]) -> u32 {
+    let first = name.first().copied().unwrap_or(0).to_ascii_lowercase();
+    ((u32::from(first).wrapping_mul(31)) ^ (name.len() as u32).wrapping_mul(7)) & 63
 }
 
 /// Append a base-128 varint.
@@ -1076,10 +1096,21 @@ impl TenantTokenRegistry {
         // One pass over the request headers.
         let mut lower: SmallVec<[u8; 64]> = SmallVec::new();
         for (name, value) in inputs.headers {
-            lower.clear();
-            lower.extend(name.as_bytes().iter().map(u8::to_ascii_lowercase));
-            let Ok(lower_str) = std::str::from_utf8(&lower) else {
+            let bytes = name.as_bytes();
+            if self.header_probe & (1u64 << header_probe_bit(bytes)) == 0 {
                 continue;
+            }
+            // gRPC and HTTP/2 require lowercase names, so the copy is usually
+            // avoidable; only fold a name that actually needs it.
+            let lower_str = if bytes.iter().any(u8::is_ascii_uppercase) {
+                lower.clear();
+                lower.extend(bytes.iter().map(u8::to_ascii_lowercase));
+                let Ok(folded) = std::str::from_utf8(&lower) else {
+                    continue;
+                };
+                folded
+            } else {
+                name
             };
             let Some(header_slot) = self.header_index.get(lower_str) else {
                 continue;

--- a/rust/otap-dataflow/crates/config/src/tenant/compiled.rs
+++ b/rust/otap-dataflow/crates/config/src/tenant/compiled.rs
@@ -507,7 +507,19 @@ impl TenantTokenRegistryBuilder {
                 };
                 let key = self.intern_key(&entry.key);
                 let table = &mut self.key_literals[usize::from(key)];
-                let next = FIRST_SYMBOL + u16::try_from(table.len()).unwrap_or(u16::MAX);
+                // Recycling a symbol would let two distinct literals compare
+                // equal, so exhausting the space is an error rather than a wrap.
+                let next = u16::try_from(table.len())
+                    .ok()
+                    .and_then(|n| n.checked_add(FIRST_SYMBOL))
+                    .ok_or_else(|| {
+                        config_error(format!(
+                            "tenant key '{}' declares more distinct values than \
+                             the symbol space holds ({} max)",
+                            entry.key,
+                            u16::MAX - FIRST_SYMBOL,
+                        ))
+                    })?;
                 let _ = table.entry(value.as_bytes().into()).or_insert(next);
             }
             for token in &bound {
@@ -1732,5 +1744,181 @@ impl<'a> TenantView<'a> {
     #[must_use]
     pub fn has_attributes(&self) -> bool {
         self.bag_len() > 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tenant::{Condition, Entry, TenantTokenSpec, TenantTokens};
+
+    fn entry(key: &str, value: &str) -> Entry {
+        Entry {
+            key: key.to_owned(),
+            value: Some(value.to_owned()),
+        }
+    }
+
+    fn condition(pairs: &[(&str, &str)]) -> Condition {
+        Condition {
+            entries: pairs.iter().map(|(k, v)| entry(k, v)).collect(),
+        }
+    }
+
+    /// Build a registry over two match-only keys read from transport headers.
+    fn fixture(conditions: &[Condition]) -> TenantTokenRegistry {
+        let extractors = [("x-tenant-id", "tenant_id"), ("x-env", "env")]
+            .iter()
+            .map(|(wire, key)| Extractor::TransportHeader {
+                key: (*key).to_owned(),
+                transport_header: (*wire).to_owned(),
+                retain: false,
+                bag: false,
+            })
+            .collect();
+        let mut tokens = TenantTokens::default();
+        let _ = tokens.insert("gateway".to_owned(), TenantTokenSpec { extractors });
+        let mut builder = TenantTokenRegistryBuilder::new();
+        builder.add_tokens(&tokens).expect("tokens compile");
+        builder
+            .declare_conditions(None, conditions)
+            .expect("conditions declare");
+        builder.build(1).expect("layout fits")
+    }
+
+    fn resolve(reg: &TenantTokenRegistry, headers: &[(&str, &[u8])]) -> Arc<[u64]> {
+        let mut scratch = TokenScratch::new();
+        reg.resolve(
+            &mut scratch,
+            TokenInputs::new(headers.iter().map(|(k, v)| (*k, *v))),
+        )
+        .expect("token resolves")
+    }
+
+    /// Scenario: requests are probed against conditions whose declared literals
+    /// share keys, including values that differ only in one byte or in length.
+    /// Guarantees: a condition matches a request only when every declared
+    /// `key: value` pair is byte-for-byte equal to the value the request
+    /// carried, so no request can be routed to another tenant's condition.
+    #[test]
+    fn matching_is_exact() {
+        let conditions = [
+            condition(&[("tenant_id", "acme"), ("env", "prod")]),
+            condition(&[("tenant_id", "globex"), ("env", "prod")]),
+            condition(&[("tenant_id", "acme"), ("env", "staging")]),
+        ];
+        let reg = fixture(&conditions);
+        let set = reg
+            .condition_set(None, &conditions)
+            .expect("condition set builds");
+
+        let cases: [(&[u8], &[u8], Option<u16>); 8] = [
+            // Each declared combination selects its own condition, and never
+            // the one that shares a key with it.
+            (b"acme", b"prod", Some(0)),
+            (b"globex", b"prod", Some(1)),
+            (b"acme", b"staging", Some(2)),
+            // A combination no condition declares matches nothing, even though
+            // both of its values are declared elsewhere.
+            (b"globex", b"staging", None),
+            // Near misses: one byte differs, a prefix, and a suffix.
+            (b"acmf", b"prod", None),
+            (b"acm", b"prod", None),
+            (b"acme ", b"prod", None),
+            // An undeclared value collapses to SYMBOL_UNKNOWN, which no
+            // condition can name.
+            (b"initech", b"prod", None),
+        ];
+        for (tenant, env, expected) in cases {
+            let words = resolve(&reg, &[("x-tenant-id", tenant), ("x-env", env)]);
+            let view = TenantView::new(&words);
+            assert_eq!(
+                set.first_match(&view),
+                expected,
+                "tenant={:?} env={:?}",
+                String::from_utf8_lossy(tenant),
+                String::from_utf8_lossy(env),
+            );
+        }
+    }
+
+    /// Scenario: the keys a condition tests are declared with `retain: false`,
+    /// so the request context carries none of their bytes.
+    /// Guarantees: matching stays exact without carrying the values, because
+    /// verification happens at the receiver against the registry's own copy of
+    /// each literal rather than against anything held in the request.
+    #[test]
+    fn match_only_keys_carry_no_bytes() {
+        let conditions = [condition(&[("tenant_id", "acme"), ("env", "prod")])];
+        let reg = fixture(&conditions);
+        let set = reg
+            .condition_set(None, &conditions)
+            .expect("condition set builds");
+
+        let words = resolve(&reg, &[("x-tenant-id", b"acme"), ("x-env", b"prod")]);
+        let view = TenantView::new(&words);
+        assert_eq!(set.first_match(&view), Some(0));
+        assert!(view.is_empty(), "match-only keys must carry no bytes");
+        assert!(!view.has_attributes());
+    }
+
+    /// Scenario: a consumer builds a condition set testing a literal that was
+    /// never interned by `declare_conditions`.
+    /// Guarantees: the build fails instead of assigning the literal the same
+    /// symbol every unrecognized request value takes, which would otherwise
+    /// make the condition match all of them at once.
+    #[test]
+    fn undeclared_literal_is_rejected() {
+        let declared = [condition(&[("tenant_id", "acme"), ("env", "prod")])];
+        let reg = fixture(&declared);
+
+        let undeclared = [condition(&[("tenant_id", "initech"), ("env", "prod")])];
+        let err = reg
+            .condition_set(None, &undeclared)
+            .expect_err("undeclared literal must fail closed");
+        assert!(
+            format!("{err:?}").contains("never declared"),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    /// Scenario: every declared value tuple is packed into the one-word
+    /// signature used as the probe key, with enough declared values per key
+    /// that a narrowed bit field would force two tuples to share a word.
+    /// Guarantees: the packing is injective over declared values, so equality
+    /// of packed words is equality of the underlying values and the word can
+    /// serve as a hash key without risking a cross-tenant match.
+    #[test]
+    fn signature_packing_is_injective() {
+        const TENANTS: [&str; 3] = ["acme", "globex", "initech"];
+        const ENVS: [&str; 3] = ["prod", "staging", "dev"];
+
+        let conditions: Vec<Condition> = TENANTS
+            .iter()
+            .zip(ENVS.iter())
+            .map(|(t, e)| condition(&[("tenant_id", t), ("env", e)]))
+            .collect();
+        let reg = fixture(&conditions);
+
+        let mut seen: AHashMap<u64, (&str, &str)> = AHashMap::new();
+        for tenant in TENANTS {
+            for env in ENVS {
+                let words = resolve(
+                    &reg,
+                    &[
+                        ("x-tenant-id", tenant.as_bytes()),
+                        ("x-env", env.as_bytes()),
+                    ],
+                );
+                let view = TenantView::new(&words);
+                let previous = seen.insert(view.signature_word(0), (tenant, env));
+                assert!(
+                    previous.is_none(),
+                    "declared tuples must pack to distinct words: \
+                     {tenant}/{env} collided with {previous:?}",
+                );
+            }
+        }
+        assert_eq!(seen.len(), TENANTS.len() * ENVS.len());
     }
 }

--- a/rust/otap-dataflow/crates/config/src/tenant/compiled.rs
+++ b/rust/otap-dataflow/crates/config/src/tenant/compiled.rs
@@ -1451,6 +1451,101 @@ impl TenantTokenRegistry {
         ))
     }
 
+    /// Rebuild a context with one key's value replaced.
+    ///
+    /// This is how a node mints tenant material of its own mid-pipeline: the
+    /// partition processor, for example, derives one outbound context per
+    /// partition from a single inbound one. The packed buffer is immutable and
+    /// shared, so the value cannot be patched in place; a fresh context is
+    /// built instead, at one allocation per call. That is still cheaper than
+    /// what the header world charged for the same operation, where appending
+    /// to a shared `Arc<Vec<TransportHeader>>` deep-cloned every header.
+    ///
+    /// The rewritten key's symbol is re-resolved against the declared literals
+    /// and its fields in every affected signature word are rewritten with it.
+    /// Leaving the old symbol in place would be the dangerous thing: routing
+    /// would keep matching the value the context no longer carries.
+    ///
+    /// Returns `None` when `key` has no value slot -- a match-only key holds no
+    /// bytes to replace, and inventing a slot for it would silently change what
+    /// the configuration asked to travel.
+    #[must_use]
+    pub fn rewrite(
+        &self,
+        scratch: &mut TokenScratch,
+        view: &TenantView<'_>,
+        key: KeyId,
+        value: &[u8],
+    ) -> Option<Arc<[u64]>> {
+        let target = self.value_slot(key)?;
+
+        // Carry every other slot across unchanged. Values live only in the
+        // blob, so restaging from the view reproduces them exactly; match-only
+        // keys have nothing to restage, which is why their symbols have to come
+        // from the existing signature words below.
+        scratch.restage(self.retained.len());
+        for slot in 0..self.retained.len() {
+            let slot_u16 = u16::try_from(slot).expect("slot fits");
+            let bytes = if slot_u16 == target {
+                Some(value)
+            } else {
+                view.slot_value(slot_u16)
+            };
+            let Some(bytes) = bytes else {
+                continue;
+            };
+            let range = scratch.stage(bytes);
+            scratch.slots[slot] = StagedSlot {
+                off: range.0,
+                len: range.1,
+                kind: ValueKind::Text,
+                present: true,
+                bagged: self.bagged[slot],
+            };
+        }
+
+        // Re-resolve the new value to a symbol by exact lookup, exactly as
+        // resolution does, so an undeclared value lands on SYMBOL_UNKNOWN
+        // rather than impersonating a declared one.
+        let symbol = if self.key_literals[usize::from(key)].is_empty() {
+            SYMBOL_UNKNOWN
+        } else {
+            self.key_literals[usize::from(key)]
+                .get(value)
+                .copied()
+                .unwrap_or(SYMBOL_UNKNOWN)
+        };
+
+        // Every other key's symbol is already encoded in the existing words, so
+        // only the rewritten key's fields move.
+        scratch.fingerprints.clear();
+        for (pair, (_, signature)) in self.pairs.iter().enumerate() {
+            let layout = &self.layouts[usize::from(*signature)];
+            let mut word = view.signature_word(u16::try_from(pair).expect("pair fits"));
+            for (k, shift, mask) in layout.fixed.iter() {
+                if *k == key {
+                    word &= !(mask << shift);
+                    word |= (u64::from(symbol) & mask) << shift;
+                }
+            }
+            for (k, shift) in layout.wildcard.iter() {
+                if *k == key {
+                    // The key is present by construction: it was just written.
+                    word |= 1u64 << shift;
+                }
+            }
+            scratch.fingerprints.push(word);
+        }
+
+        Some(pack_words(
+            scratch,
+            view.resolved_mask(),
+            self.epoch,
+            self.bag_field,
+            self.slot_names(),
+        ))
+    }
+
     /// Build a consumer's probe tables for its ordered conditions.
     ///
     /// Called once at node construction, never on the hot path. `tokens` names
@@ -1682,6 +1777,13 @@ impl<'a> TenantView<'a> {
         self.words[1] != 0
     }
 
+    /// The full resolved-token mask, needed when deriving a context from this
+    /// one so the derived context reports the same tokens as resolved.
+    #[must_use]
+    pub fn resolved_mask(&self) -> u64 {
+        self.words[1]
+    }
+
     /// Packed symbol word for one applicable (token, signature) pair.
     ///
     /// This is a dictionary encoding of the request's values, not a digest of
@@ -1798,6 +1900,81 @@ mod tests {
             TokenInputs::new(headers.iter().map(|(k, v)| (*k, *v))),
         )
         .expect("token resolves")
+    }
+
+    /// Build a registry whose `tenant_id` is retained, so it has a value slot
+    /// that can be rewritten, and whose `env` is match-only.
+    fn rewritable(conditions: &[Condition]) -> TenantTokenRegistry {
+        let extractors = vec![
+            Extractor::TransportHeader {
+                key: "tenant_id".to_owned(),
+                transport_header: "x-tenant-id".to_owned(),
+                retain: true,
+                bag: false,
+            },
+            Extractor::TransportHeader {
+                key: "env".to_owned(),
+                transport_header: "x-env".to_owned(),
+                retain: false,
+                bag: false,
+            },
+        ];
+        let mut tokens = TenantTokens::default();
+        let _ = tokens.insert("gateway".to_owned(), TenantTokenSpec { extractors });
+        let mut builder = TenantTokenRegistryBuilder::new();
+        builder.add_tokens(&tokens).expect("tokens compile");
+        builder
+            .declare_conditions(None, conditions)
+            .expect("conditions declare");
+        builder.build(1).expect("layout fits")
+    }
+
+    /// Scenario: a node derives a new context from an existing one by replacing
+    /// one retained key's value, where both the old and the new value are
+    /// declared literals of competing conditions.
+    /// Guarantees: the derived context routes by its new value and never by the
+    /// value it replaced, other keys (including match-only keys, whose bytes
+    /// never travelled) keep their original matching behavior, and the derived
+    /// value reads back byte-for-byte.
+    #[test]
+    fn rewrite_moves_matching_to_the_new_value() {
+        let conds = [
+            condition(&[("tenant_id", "acme"), ("env", "prod")]),
+            condition(&[("tenant_id", "globex"), ("env", "prod")]),
+            condition(&[("tenant_id", "globex"), ("env", "dev")]),
+        ];
+        let reg = rewritable(&conds);
+        let set = reg.condition_set(None, &conds).expect("conditions bind");
+
+        let words = resolve(&reg, &[("x-tenant-id", b"acme"), ("x-env", b"prod")]);
+        assert_eq!(set.first_match(&TenantView::new(&words)), Some(0));
+
+        let key = reg.key_id("tenant_id").expect("declared");
+        let mut scratch = TokenScratch::new();
+        let derived = reg
+            .rewrite(&mut scratch, &TenantView::new(&words), key, b"globex")
+            .expect("tenant_id is retained");
+        let view = TenantView::new(&derived);
+
+        // Routing follows the new value, and `env` still decides between the
+        // two globex conditions even though its bytes never travelled.
+        assert_eq!(set.first_match(&view), Some(1));
+        assert_eq!(reg.retained_value(&view, key), Some(b"globex".as_slice()));
+        assert_eq!(
+            view.resolved_mask(),
+            TenantView::new(&words).resolved_mask()
+        );
+
+        // A value no condition declares must not impersonate one that is.
+        let unknown = reg
+            .rewrite(&mut scratch, &TenantView::new(&words), key, b"acme-2")
+            .expect("tenant_id is retained");
+        let unknown = TenantView::new(&unknown);
+        assert_eq!(set.first_match(&unknown), None);
+        assert_eq!(
+            reg.retained_value(&unknown, key),
+            Some(b"acme-2".as_slice())
+        );
     }
 
     /// Scenario: requests are probed against conditions whose declared literals

--- a/rust/otap-dataflow/crates/config/src/tenant/compiled.rs
+++ b/rust/otap-dataflow/crates/config/src/tenant/compiled.rs
@@ -64,11 +64,41 @@ fn config_error(error: impl Into<String>) -> Error {
 
 /// Serialize one `key: value` term into the fingerprint buffer. Build side and
 /// probe side both go through here so the two layouts cannot drift.
-fn fingerprint_term(buf: &mut Vec<u8>, key: KeyId, value: &[u8]) {
-    buf.extend_from_slice(&key.to_le_bytes());
-    let len = u32::try_from(value.len()).unwrap_or(u32::MAX);
-    buf.extend_from_slice(&len.to_le_bytes());
-    buf.extend_from_slice(value);
+/// Symbol meaning "the request did not carry this key at all".
+const SYMBOL_ABSENT: u16 = 0;
+
+/// Symbol meaning "the request carried a value no condition declares".
+///
+/// Every unrecognized value collapses to this one symbol, which is safe
+/// because no condition can ever ask for it: conditions are built only from
+/// declared literals, whose symbols start at [`FIRST_SYMBOL`].
+const SYMBOL_UNKNOWN: u16 = 1;
+
+/// First symbol assigned to a declared literal.
+const FIRST_SYMBOL: u16 = 2;
+
+/// Pack a signature's symbols into one word using its build-time layout.
+///
+/// Wildcard keys contribute a presence bit; fixed keys contribute their
+/// symbol. The layout reserves enough bits for every symbol a key can take,
+/// so distinct tuples always produce distinct words.
+fn pack_symbols(layout: &SignatureLayout, symbol: impl Fn(KeyId) -> u16) -> u64 {
+    let mut word = 0u64;
+    for (key, shift, mask) in layout.fixed.iter() {
+        word |= (u64::from(symbol(*key)) & mask) << shift;
+    }
+    for (key, shift) in layout.wildcard.iter() {
+        if symbol(*key) != SYMBOL_ABSENT {
+            word |= 1u64 << shift;
+        }
+    }
+    word
+}
+
+/// Bits needed to hold every symbol up to and including `max`.
+const fn symbol_width(max: u16) -> u32 {
+    let bits = u16::BITS - max.leading_zeros();
+    if bits == 0 { 1 } else { bits }
 }
 
 // -- Build-side structures ---------------------------------------------------
@@ -106,10 +136,24 @@ struct CompiledToken {
     keys: Box<[KeyId]>,
 }
 
+/// How one signature's symbols pack into a single word.
+///
+/// Widths come from the number of literals each key actually declares, so the
+/// packing is injective: two different symbol tuples cannot produce the same
+/// word. That is what makes an equality test on the word an equality test on
+/// the values.
+#[derive(Debug, Clone, Default)]
+struct SignatureLayout {
+    /// `(key, shift, mask)` per fixed key.
+    fixed: Box<[(KeyId, u32, u64)]>,
+    /// `(key, shift)` per wildcard key; one bit recording presence.
+    wildcard: Box<[(KeyId, u32)]>,
+}
+
 /// Layout shared by every condition that tests the same set of keys.
 ///
-/// The key order here defines the fingerprint layout, so the build side and
-/// the probe side agree byte for byte.
+/// The key order here defines the symbol layout, so the build side and the
+/// probe side agree bit for bit.
 #[derive(Debug)]
 struct Signature {
     /// Keys carrying a literal value, sorted. These form the fingerprint.
@@ -138,6 +182,12 @@ pub struct TenantTokenRegistry {
     header_probe: u64,
     static_extractors: Vec<StaticExtractor>,
     signatures: Vec<Signature>,
+    /// Per key id: declared literal -> symbol. The map owns the literal, so a
+    /// lookup verifies byte equality against the operator's configured value
+    /// and a hash collision cannot produce a match.
+    key_literals: Vec<AHashMap<Box<[u8]>, u16>>,
+    /// Per signature: the bit layout its symbols pack into.
+    layouts: Vec<SignatureLayout>,
     /// Dense (token, signature) pairs; the index is the [`PairSlot`].
     pairs: Vec<(TokenIdx, SignatureId)>,
     /// Reverse lookup used at node construction, never on the hot path.
@@ -211,6 +261,7 @@ pub struct TenantTokenRegistryBuilder {
     header_index: AHashMap<Box<str>, HeaderSlot>,
     static_extractors: Vec<StaticExtractor>,
     signatures: Vec<Signature>,
+    key_literals: Vec<AHashMap<Box<[u8]>, u16>>,
     signature_ids: AHashMap<(Vec<KeyId>, Vec<KeyId>), SignatureId>,
     pairs: Vec<(TokenIdx, SignatureId)>,
     pair_index: AHashMap<(TokenIdx, SignatureId), PairSlot>,
@@ -245,6 +296,7 @@ impl TenantTokenRegistryBuilder {
         self.request_binding.push(None);
         self.import_binding.push(None);
         self.key_retain_mask.push(0);
+        self.key_literals.push(AHashMap::new());
         let _ = self.key_ids.insert(boxed, id);
         id
     }
@@ -446,6 +498,18 @@ impl TenantTokenRegistryBuilder {
         let bound = self.resolve_bound_tokens(tokens)?;
         for condition in conditions {
             let signature = self.intern_signature(condition)?;
+            // Every literal a condition can match on becomes a symbol, so
+            // resolution can decide membership by exact lookup rather than by
+            // trusting a hash.
+            for entry in &condition.entries {
+                let Some(value) = entry.value.as_deref() else {
+                    continue;
+                };
+                let key = self.intern_key(&entry.key);
+                let table = &mut self.key_literals[usize::from(key)];
+                let next = FIRST_SYMBOL + u16::try_from(table.len()).unwrap_or(u16::MAX);
+                let _ = table.entry(value.as_bytes().into()).or_insert(next);
+            }
             for token in &bound {
                 self.allocate_pair(*token, signature);
             }
@@ -527,8 +591,10 @@ impl TenantTokenRegistryBuilder {
     /// only readable by a registry that agrees on what each slot means. Two
     /// registries built from the same token definitions agree and get the same
     /// epoch; two that do not, disagree loudly rather than misreading slots.
-    #[must_use]
-    pub fn build(self, generation: u16) -> TenantTokenRegistry {
+    ///
+    /// Fails when a signature's symbols do not fit one word, which would cost
+    /// the guarantee that comparing words is comparing values.
+    pub fn build(self, generation: u16) -> Result<TenantTokenRegistry, Error> {
         let n_keys = self.key_names.len();
         let mut value_slot = vec![NO_VALUE_SLOT; n_keys];
         for (idx, key) in self.retained.iter().enumerate() {
@@ -549,7 +615,51 @@ impl TenantTokenRegistryBuilder {
         for (key, slots) in self.import_by_key {
             import_by_key[usize::from(key)] = slots;
         }
-        TenantTokenRegistry {
+
+        // Assign each signature a bit layout wide enough for every symbol its
+        // keys can take. Injectivity is the whole point, so a layout that does
+        // not fit is a configuration error rather than a silent narrowing.
+        let mut layouts: Vec<SignatureLayout> = Vec::with_capacity(self.signatures.len());
+        for sig in &self.signatures {
+            let mut shift = 0u32;
+            let mut fixed = Vec::with_capacity(sig.fixed_keys.len());
+            for key in sig.fixed_keys.iter() {
+                let declared = self.key_literals[usize::from(*key)].len();
+                let max = u16::try_from(declared)
+                    .ok()
+                    .and_then(|n| n.checked_add(FIRST_SYMBOL))
+                    .map_or(u16::MAX, |n| n.saturating_sub(1))
+                    .max(SYMBOL_UNKNOWN);
+                let width = symbol_width(max);
+                fixed.push((*key, shift, (1u64 << width) - 1));
+                shift += width;
+            }
+            let mut wildcard = Vec::with_capacity(sig.wildcard_keys.len());
+            for key in sig.wildcard_keys.iter() {
+                wildcard.push((*key, shift));
+                shift += 1;
+            }
+            if shift > u64::BITS {
+                let names: Vec<&str> = sig
+                    .required_keys
+                    .iter()
+                    .map(|k| self.key_names[usize::from(*k)].as_ref())
+                    .collect();
+                return Err(config_error(format!(
+                    "tenant condition over keys [{}] needs {shift} bits of symbol \
+                     space but only {} are available; reduce the number of keys \
+                     or the number of declared values per key",
+                    names.join(", "),
+                    u64::BITS,
+                )));
+            }
+            layouts.push(SignatureLayout {
+                fixed: fixed.into_boxed_slice(),
+                wildcard: wildcard.into_boxed_slice(),
+            });
+        }
+
+        Ok(TenantTokenRegistry {
             epoch,
             key_names: self.key_names,
             tokens: self.tokens,
@@ -561,6 +671,8 @@ impl TenantTokenRegistryBuilder {
             header_index: self.header_index,
             static_extractors: self.static_extractors,
             signatures: self.signatures,
+            key_literals: self.key_literals,
+            layouts,
             pairs: self.pairs,
             pair_index: self.pair_index,
             import_by_key,
@@ -569,7 +681,7 @@ impl TenantTokenRegistryBuilder {
             bag_field: self.bag_field.unwrap_or(attribute_field::SCOPE),
             value_slot,
             retain_mask,
-        }
+        })
     }
 }
 
@@ -617,7 +729,9 @@ pub struct TokenScratch {
     values: Vec<ValueRef>,
     /// Staging bytes for carried values and legacy header names.
     arena: Vec<u8>,
-    fingerprint_buf: Vec<u8>,
+    /// Per key id: the symbol its value resolved to.
+    symbols: Vec<u16>,
+    /// Per pair slot: the packed symbol word. Named for its role in the join.
     fingerprints: Vec<u64>,
     /// One entry per registry value slot, in slot order.
     slots: Vec<StagedSlot>,
@@ -922,7 +1036,8 @@ impl TokenScratch {
         self.values
             .resize(registry.key_names.len(), ValueRef::default());
         self.arena.clear();
-        self.fingerprint_buf.clear();
+        self.symbols.clear();
+        self.symbols.resize(registry.key_names.len(), SYMBOL_ABSENT);
         self.fingerprints.clear();
         self.fingerprints.resize(registry.pairs.len(), 0);
         self.slots.clear();
@@ -1187,30 +1302,37 @@ impl TenantTokenRegistry {
             return None;
         }
 
-        // Probe side of the hash join: one fingerprint per allocated pair.
+        // Probe side of the join. Each key's value is first resolved to a
+        // symbol by exact lookup against the declared literals -- the map owns
+        // those bytes and compares them, so a hash collision cannot manufacture
+        // a match. Only then are symbols packed into the per-pair word.
         let TokenScratch {
             values,
             arena,
-            fingerprint_buf,
+            symbols,
             fingerprints,
             ..
         } = scratch;
+        for (key, r) in values.iter().enumerate() {
+            symbols[key] = if r.present {
+                let start = r.off as usize;
+                let end = start + r.len as usize;
+                self.key_literals[key]
+                    .get(&arena[start..end])
+                    .copied()
+                    .unwrap_or(SYMBOL_UNKNOWN)
+            } else {
+                SYMBOL_ABSENT
+            };
+        }
+
         for (slot, (token, signature)) in self.pairs.iter().enumerate() {
             if resolved & (1u64 << *token) == 0 {
                 continue;
             }
-            let sig = &self.signatures[usize::from(*signature)];
-            fingerprint_buf.clear();
-            for key in sig.fixed_keys.iter() {
-                let r = values[usize::from(*key)];
-                if !r.present {
-                    continue;
-                }
-                let start = r.off as usize;
-                let end = start + r.len as usize;
-                fingerprint_term(fingerprint_buf, *key, &arena[start..end]);
-            }
-            fingerprints[slot] = xxh3_64(fingerprint_buf);
+            fingerprints[slot] = pack_symbols(&self.layouts[usize::from(*signature)], |key| {
+                symbols[usize::from(key)]
+            });
         }
 
         Some(self.pack(scratch, resolved))
@@ -1342,7 +1464,7 @@ impl TenantTokenRegistry {
             let condition_idx = ConditionIdx::try_from(condition_idx)
                 .map_err(|_| config_error("too many tenant conditions"))?;
             let signature = self.lookup_signature(condition)?;
-            let fingerprint = self.literal_fingerprint(condition, signature);
+            let word = self.literal_word(condition, signature)?;
 
             let position = groups.iter().position(|g| g.signature == signature);
             let group = match position {
@@ -1367,7 +1489,7 @@ impl TenantTokenRegistry {
                 }
             };
             // First match wins: keep the lowest condition index per key.
-            let entry = group.table.entry(fingerprint).or_insert(condition_idx);
+            let entry = group.table.entry(word).or_insert(condition_idx);
             if condition_idx < *entry {
                 *entry = condition_idx;
             }
@@ -1408,22 +1530,47 @@ impl TenantTokenRegistry {
 
     /// Build-side fingerprint: hash the condition's literal values in the
     /// signature's key order, matching the probe-side layout exactly.
-    fn literal_fingerprint(&self, condition: &Condition, signature: SignatureId) -> u64 {
-        let sig = &self.signatures[usize::from(signature)];
-        let mut buf: Vec<u8> = Vec::new();
-        for key in sig.fixed_keys.iter() {
+    /// The word a request must produce to satisfy `condition`.
+    ///
+    /// Built from the same symbols and the same layout as the request side, so
+    /// the comparison in [`ConditionSet::first_match`] is an equality test on
+    /// values rather than on a digest of them.
+    fn literal_word(&self, condition: &Condition, signature: SignatureId) -> Result<u64, Error> {
+        let layout = &self.layouts[usize::from(signature)];
+        // Fail closed on an undeclared literal. It would otherwise take
+        // SYMBOL_UNKNOWN, which is the symbol every unrecognized request value
+        // takes, and the condition would match all of them at once.
+        for (key, _, _) in layout.fixed.iter() {
             let name = self.key_name(*key);
-            let Some(entry) = condition
+            let literal = condition
                 .entries
                 .iter()
-                .find(|e| e.key.as_str() == name && e.value.is_some())
-            else {
-                continue;
-            };
-            let value = entry.value.as_deref().unwrap_or_default();
-            fingerprint_term(&mut buf, *key, value.as_bytes());
+                .find(|e| e.key.as_str() == name)
+                .and_then(|e| e.value.as_deref())
+                .unwrap_or_default();
+            if !self.key_literals[usize::from(*key)].contains_key(literal.as_bytes()) {
+                return Err(config_error(format!(
+                    "tenant condition tests '{name}' against a value that was \
+                     never declared to the registry; every literal a condition \
+                     can match must be interned at build time so that matching \
+                     is an equality test rather than a hash comparison"
+                )));
+            }
         }
-        xxh3_64(&buf)
+        Ok(pack_symbols(layout, |key| {
+            let name = self.key_name(key);
+            condition
+                .entries
+                .iter()
+                .find(|e| e.key.as_str() == name)
+                .and_then(|e| e.value.as_deref())
+                .map_or(SYMBOL_UNKNOWN, |value| {
+                    self.key_literals[usize::from(key)]
+                        .get(value.as_bytes())
+                        .copied()
+                        .unwrap_or(SYMBOL_UNKNOWN)
+                })
+        }))
     }
 }
 
@@ -1457,7 +1604,7 @@ impl ConditionSet {
                 if !view.token_resolved(*token) {
                     continue;
                 }
-                if let Some(idx) = group.table.get(&view.fingerprint(*slot)) {
+                if let Some(idx) = group.table.get(&view.signature_word(*slot)) {
                     best = Some(match best {
                         Some(current) if current <= *idx => current,
                         _ => *idx,
@@ -1518,9 +1665,12 @@ impl<'a> TenantView<'a> {
         self.words[1] != 0
     }
 
-    /// Precomputed fingerprint for one applicable (token, signature) pair.
+    /// Packed symbol word for one applicable (token, signature) pair.
+    ///
+    /// This is a dictionary encoding of the request's values, not a digest of
+    /// them: comparing two words compares the values exactly.
     #[must_use]
-    pub fn fingerprint(&self, slot: PairSlot) -> u64 {
+    pub fn signature_word(&self, slot: PairSlot) -> u64 {
         self.words[HEADER_WORDS + usize::from(slot)]
     }
 

--- a/rust/otap-dataflow/crates/config/src/tenant/compiled.rs
+++ b/rust/otap-dataflow/crates/config/src/tenant/compiled.rs
@@ -1019,11 +1019,13 @@ fn pack_words<'n>(
         out.push(lo | (hi << 32));
     }
 
-    for chunk in blob.chunks(8) {
-        let mut word = [0u8; 8];
-        word[..chunk.len()].copy_from_slice(chunk);
-        out.push(u64::from_le_bytes(word));
-    }
+    // One bulk copy into a zero-padded tail. Feeding the words eight bytes at
+    // a time costs more than the memcpy it replaces: the trailing partial
+    // chunk makes every iteration a variable-length copy, so the compiler
+    // cannot reduce any of them to a plain load.
+    let tail = out.len();
+    out.resize(tail + blob.len().div_ceil(8), 0);
+    bytemuck::cast_slice_mut::<u64, u8>(&mut out[tail..])[..blob.len()].copy_from_slice(blob);
 
     Arc::from(out.as_slice())
 }
@@ -1326,15 +1328,18 @@ impl TenantTokenRegistry {
             ..
         } = scratch;
         for (key, r) in values.iter().enumerate() {
-            symbols[key] = if r.present {
-                let start = r.off as usize;
-                let end = start + r.len as usize;
+            symbols[key] = if !r.present {
+                SYMBOL_ABSENT
+            } else if self.key_literals[key].is_empty() {
+                // No condition tests this key by value, so the lookup can only
+                // miss. Skipping it avoids hashing the value for keys that are
+                // carried but never matched on.
+                SYMBOL_UNKNOWN
+            } else {
                 self.key_literals[key]
-                    .get(&arena[start..end])
+                    .get(&arena[r.off as usize..(r.off + r.len) as usize])
                     .copied()
                     .unwrap_or(SYMBOL_UNKNOWN)
-            } else {
-                SYMBOL_ABSENT
             };
         }
 
@@ -1880,6 +1885,41 @@ mod tests {
             format!("{err:?}").contains("never declared"),
             "unexpected error: {err:?}"
         );
+    }
+
+    /// Scenario: a bagged key is packed into the request context and read back
+    /// through `attributes()`.
+    /// Guarantees: the bytes are a complete, correctly tagged OTLP repeated
+    /// `KeyValue` field for the destination the registry was built for, so a
+    /// consumer can copy them without inspecting or rewriting them.
+    #[test]
+    fn bagged_attributes_are_wire_exact() {
+        let extractors = vec![Extractor::TransportHeader {
+            key: "tenant_id".to_owned(),
+            transport_header: "x-tenant-id".to_owned(),
+            retain: false,
+            bag: true,
+        }];
+        let mut tokens = TenantTokens::default();
+        let _ = tokens.insert("gateway".to_owned(), TenantTokenSpec { extractors });
+        let mut builder = TenantTokenRegistryBuilder::new().with_bag_field(attribute_field::SCOPE);
+        builder.add_tokens(&tokens).expect("tokens compile");
+        let reg = builder.build(1).expect("layout fits");
+
+        let words = resolve(&reg, &[("x-tenant-id", b"tenant-a")]);
+        let view = TenantView::new(&words);
+
+        // ScopeAttributes: field 3, length-delimited.
+        let mut expected = vec![(3u8 << 3) | 2, 23];
+        // KeyValue.key: field 1, "tenant_id".
+        expected.extend_from_slice(&[0x0a, 9]);
+        expected.extend_from_slice(b"tenant_id");
+        // KeyValue.value: field 2, an AnyValue holding a string.
+        expected.extend_from_slice(&[0x12, 10, 0x0a, 8]);
+        expected.extend_from_slice(b"tenant-a");
+
+        assert_eq!(view.attributes(), expected.as_slice());
+        assert!(view.has_attributes());
     }
 
     /// Scenario: every declared value tuple is packed into the one-word

--- a/rust/otap-dataflow/crates/config/src/tenant/compiled.rs
+++ b/rust/otap-dataflow/crates/config/src/tenant/compiled.rs
@@ -150,6 +150,9 @@ pub struct TenantTokenRegistry {
     retained: Vec<KeyId>,
     /// Per value slot: whether the key name travels with the value.
     bagged: Vec<bool>,
+    /// OTLP field number the bagged run is tagged with, fixed at build time
+    /// by the consumer that initialized the registry.
+    bag_field: u32,
     /// Reverse of `retained`, indexed by key id; [`NO_VALUE_SLOT`] for keys
     /// that are match-only.
     value_slot: Vec<u16>,
@@ -220,6 +223,7 @@ pub struct TenantTokenRegistryBuilder {
     key_retain_mask: Vec<u64>,
     retained: Vec<KeyId>,
     bagged: Vec<bool>,
+    bag_field: Option<u32>,
 }
 
 impl TenantTokenRegistryBuilder {
@@ -300,6 +304,18 @@ impl TenantTokenRegistryBuilder {
                 Ok(())
             }
         }
+    }
+
+    /// Declare the OTLP field number the bagged attributes are tagged with.
+    ///
+    /// The consumer of the bag is also what initializes the registry -- the
+    /// SDK sets up the pipeline and later reads the bytes back -- so the
+    /// destination is known here, and the run can be encoded already tagged.
+    /// Defaults to scope attributes.
+    #[must_use]
+    pub fn with_bag_field(mut self, field: u32) -> Self {
+        self.bag_field = Some(field);
+        self
     }
 
     /// Add every token definition from the engine configuration.
@@ -543,6 +559,7 @@ impl TenantTokenRegistryBuilder {
             import_by_key,
             retained: self.retained,
             bagged: self.bagged,
+            bag_field: self.bag_field.unwrap_or(attribute_field::SCOPE),
             value_slot,
             retain_mask,
         }
@@ -656,6 +673,31 @@ mod otlp {
     pub const ANY_VALUE_BYTES_TAG: u8 = (7 << 3) | 2;
 }
 
+/// OTLP attributes field numbers a bagged context can be tagged with.
+///
+/// These are the destinations a consumer chooses between when initializing a
+/// registry. They differ in field number and in nothing else, which is why one
+/// encoding serves all of them.
+pub mod attribute_field {
+    /// `Resource.attributes`.
+    pub const RESOURCE: u32 = 1;
+
+    /// `InstrumentationScope.attributes`. The default: scope attributes are
+    /// shared by every record under one `ScopeLogs`/`ScopeSpans`, and batches
+    /// are already partitioned by tenant conditions, so one batch means one
+    /// scope means one copy.
+    pub const SCOPE: u32 = 3;
+
+    /// `LogRecord.attributes`.
+    pub const LOG_RECORD: u32 = 6;
+
+    /// `Exemplar.filtered_attributes`.
+    pub const EXEMPLAR: u32 = 7;
+
+    /// `Span.attributes`.
+    pub const SPAN: u32 = 9;
+}
+
 /// Append a base-128 varint.
 fn put_varint(buf: &mut Vec<u8>, mut value: u64) {
     while value >= 0x80 {
@@ -746,12 +788,15 @@ fn any_value_bytes(blob: &[u8], at: usize) -> Option<&[u8]> {
 /// ```
 ///
 /// The blob opens with the bag: `bag_len` bytes holding a run of
-/// `<len> <KeyValue>` entries carrying no field tag, so a consumer chooses the
-/// destination field. Value-only entries follow as bare `<len> <AnyValue>`.
+/// `<tag> <len> <KeyValue>` entries already tagged with the consumer's
+/// attributes field, so the region is a complete repeated field and is read
+/// whole rather than entry by entry. Value-only entries follow as bare
+/// `<len> <AnyValue>`, which no consumer reads as a run.
 fn pack_words<'n>(
     scratch: &mut TokenScratch,
     resolved: u64,
     epoch: u16,
+    bag_field: u32,
     slot_name: impl Fn(usize) -> &'n str,
 ) -> Arc<[u64]> {
     let TokenScratch {
@@ -781,6 +826,7 @@ fn pack_words<'n>(
             + 1
             + varint_len(any_value_len(value.len()) as u64)
             + any_value_len(value.len());
+        put_varint(blob, (u64::from(bag_field) << 3) | 2);
         put_varint(blob, inner as u64);
         blob.push(otlp::KEY_VALUE_KEY_TAG);
         put_varint(blob, name.len() as u64);
@@ -1166,7 +1212,13 @@ impl TenantTokenRegistry {
                 }
             };
         }
-        pack_words(scratch, resolved, self.epoch, self.slot_names())
+        pack_words(
+            scratch,
+            resolved,
+            self.epoch,
+            self.bag_field,
+            self.slot_names(),
+        )
     }
 
     /// Value carried for a token key, if the key has a value slot and the
@@ -1220,7 +1272,13 @@ impl TenantTokenRegistry {
         if !any {
             return None;
         }
-        Some(pack_words(scratch, 0, self.epoch, self.slot_names()))
+        Some(pack_words(
+            scratch,
+            0,
+            self.epoch,
+            self.bag_field,
+            self.slot_names(),
+        ))
     }
 
     /// Build a consumer's probe tables for its ordered conditions.
@@ -1478,34 +1536,15 @@ impl<'a> TenantView<'a> {
         any_value_bytes(self.blob(), at)
     }
 
-    /// Append the bagged keys to `dst` as repeated `KeyValue` under `field`.
+    /// The bagged keys, as a complete OTLP repeated `KeyValue` field.
     ///
-    /// The bag is stored without a field tag precisely so the consumer picks
-    /// the destination -- resource, scope, log record, span, or exemplar
-    /// attributes all differ in field number and in nothing else. Each entry
-    /// is copied verbatim; nothing is re-encoded.
-    ///
-    /// Returns the number of attributes appended.
-    pub fn append_attributes(&self, dst: &mut Vec<u8>, field: u32) -> usize {
-        let bag = &self.blob()[..self.bag_len()];
-        let tag = (u64::from(field) << 3) | 2;
-        let mut at = 0usize;
-        let mut count = 0usize;
-        while at < bag.len() {
-            let Some((len, body)) = get_varint(bag, at) else {
-                break;
-            };
-            let Ok(len) = usize::try_from(len) else { break };
-            let Some(entry) = bag.get(body..body + len) else {
-                break;
-            };
-            put_varint(dst, tag);
-            put_varint(dst, len as u64);
-            dst.extend_from_slice(entry);
-            at = body + len;
-            count += 1;
-        }
-        count
+    /// The run is already tagged with the field number the registry was
+    /// initialized with, so this is the payload itself and not an input to an
+    /// encoder: a consumer splices the slice in with one copy, or borrows it
+    /// outright. Nothing here is re-encoded, re-tagged or walked per entry.
+    #[must_use]
+    pub fn attributes(&self) -> &'a [u8] {
+        &self.blob()[..self.bag_len()]
     }
 
     /// True when any key was captured into the bag.

--- a/rust/otap-dataflow/crates/config/src/tenant/compiled.rs
+++ b/rust/otap-dataflow/crates/config/src/tenant/compiled.rs
@@ -212,6 +212,10 @@ pub struct TenantTokenRegistry {
     /// `retain: true`. A slot is populated only when one of them resolves, so
     /// a value never travels without the evidence that justified carrying it.
     retain_mask: Vec<u64>,
+    /// A well-formed context in which nothing resolved, built once so that a
+    /// node minting a value mid-pipeline for a request that arrived without
+    /// tenant context pays an `Arc` clone instead of a resolve.
+    empty: Arc<[u64]>,
 }
 
 /// How a key acquires its value.
@@ -671,7 +675,7 @@ impl TenantTokenRegistryBuilder {
             });
         }
 
-        Ok(TenantTokenRegistry {
+        let mut registry = TenantTokenRegistry {
             epoch,
             key_names: self.key_names,
             tokens: self.tokens,
@@ -693,7 +697,18 @@ impl TenantTokenRegistryBuilder {
             bag_field: self.bag_field.unwrap_or(attribute_field::SCOPE),
             value_slot,
             retain_mask,
-        })
+            empty: Arc::from(Vec::new()),
+        };
+
+        // Pack with nothing resolved. Every signature word is zero, and no
+        // condition can pack to zero because each one constrains at least one
+        // key to a declared literal, whose symbol is never SYMBOL_ABSENT. The
+        // empty context therefore matches nothing, which is the fail-closed
+        // answer for a request that carried no tenant evidence.
+        let mut scratch = TokenScratch::new();
+        scratch.reset(&registry);
+        registry.empty = registry.pack(&mut scratch, 0);
+        Ok(registry)
     }
 }
 
@@ -1143,6 +1158,15 @@ impl TenantTokenRegistry {
     #[must_use]
     pub fn slot_key(&self, value_slot: u16) -> KeyId {
         self.retained[usize::from(value_slot)]
+    }
+
+    /// A shared context in which no token resolved and no value travels.
+    ///
+    /// Callers that mint a value mid-pipeline use this as the source to
+    /// [`rewrite`](Self::rewrite) when the request arrived without one.
+    #[must_use]
+    pub fn empty_context(&self) -> &Arc<[u64]> {
+        &self.empty
     }
 
     /// Value slot a key occupies, or `None` when the key is match-only and its

--- a/rust/otap-dataflow/crates/config/src/tenant/compiled.rs
+++ b/rust/otap-dataflow/crates/config/src/tenant/compiled.rs
@@ -1,0 +1,1516 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Compiled, hot-path representation of tenant tokens and conditions.
+//!
+//! The design follows a database hash join. There are three phases:
+//!
+//! 1. **Build** (once per pipeline group). Config strings are interned to
+//!    numeric ids, an extractor index is built over transport header names,
+//!    declared conditions are grouped by *signature* (their set of keys), and
+//!    the cross product of applicable (token, signature) pairs is assigned
+//!    dense slots. The literal values of declared conditions are hashed here:
+//!    that is the build side of the join.
+//! 2. **Context creation** (per request, in a receiver). One pass over the
+//!    request's headers resolves tokens, then one fingerprint per allocated
+//!    pair slot is computed by projecting the token onto the signature's keys.
+//!    That is the probe side of the join. The result is packed into a single
+//!    allocation.
+//! 3. **Consumer probe** (per request, in a routing or limiting node). One
+//!    hash table lookup per signature using the precomputed fingerprint, with
+//!    no string work and no allocation.
+//!
+//! A token resolves all-or-nothing: every one of its extractors must succeed.
+//! That is what makes wildcard entries free at runtime -- if a signature is
+//! applicable to a token and the token resolved, every key the condition
+//! requires is necessarily present.
+//!
+//! The packed per-request value replaces the previous transport header map, so
+//! this machinery is paid for by deleting the old representation rather than
+//! added on top of it. See `docs/multitenancy-tenant.md`.
+
+use crate::error::Error;
+use crate::tenant::{Condition, Extractor, TenantBoundaryPolicy, TenantTokenSpec, TenantTokens};
+use ahash::AHashMap;
+use smallvec::SmallVec;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use xxhash_rust::xxh3::xxh3_64;
+
+/// Interned token key identifier.
+pub type KeyId = u16;
+/// Index of a tenant token definition within the registry.
+pub type TokenIdx = u16;
+/// Index of a condition signature within the registry.
+pub type SignatureId = u16;
+/// Dense slot identifying one applicable (token, signature) pair.
+pub type PairSlot = u16;
+/// Index of a declared condition within one consumer's condition set.
+pub type ConditionIdx = u16;
+
+/// Maximum number of extractor keys in a single token, bounded by the width of
+/// the per-token unsatisfied-key bitmask.
+pub const MAX_TOKEN_KEYS: usize = 64;
+/// Maximum number of tokens, bounded by the width of the resolved bitmask.
+pub const MAX_TOKENS: usize = 64;
+/// Maximum total size of the retained value bytes in one request context.
+pub const MAX_VALUE_BYTES: usize = u16::MAX as usize;
+
+fn config_error(error: impl Into<String>) -> Error {
+    Error::InvalidUserConfig {
+        error: error.into(),
+    }
+}
+
+/// Serialize one `key: value` term into the fingerprint buffer. Build side and
+/// probe side both go through here so the two layouts cannot drift.
+fn fingerprint_term(buf: &mut Vec<u8>, key: KeyId, value: &[u8]) {
+    buf.extend_from_slice(&key.to_le_bytes());
+    let len = u32::try_from(value.len()).unwrap_or(u32::MAX);
+    buf.extend_from_slice(&len.to_le_bytes());
+    buf.extend_from_slice(value);
+}
+
+// -- Build-side structures ---------------------------------------------------
+
+/// One extractor slot reached through the header index.
+#[derive(Debug, Clone, Copy)]
+struct Slot {
+    token: TokenIdx,
+    bit: u8,
+    key: KeyId,
+}
+
+/// Entry of the header index: the extractors satisfied by one header name.
+#[derive(Debug, Default)]
+struct HeaderSlot {
+    any_value: SmallVec<[Slot; 2]>,
+}
+
+/// An extractor that does not read a transport header.
+#[derive(Debug)]
+struct StaticExtractor {
+    slot: Slot,
+    /// Constant value for a `generic_key` extractor. `None` selects the
+    /// network peer address, rendered as text.
+    value: Option<Box<[u8]>>,
+}
+
+/// A compiled tenant token definition.
+#[derive(Debug)]
+struct CompiledToken {
+    name: Box<str>,
+    /// Bit per extractor key; a token resolves when all bits are cleared.
+    key_mask: u64,
+    /// Keys of this token, sorted, used for applicability tests.
+    keys: Box<[KeyId]>,
+}
+
+/// Layout shared by every condition that tests the same set of keys.
+///
+/// The key order here defines the fingerprint layout, so the build side and
+/// the probe side agree byte for byte.
+#[derive(Debug)]
+struct Signature {
+    /// Keys carrying a literal value, sorted. These form the fingerprint.
+    fixed_keys: Box<[KeyId]>,
+    /// Keys required to be present with any value, sorted.
+    wildcard_keys: Box<[KeyId]>,
+    /// Union of the two, sorted, used for applicability tests.
+    required_keys: Box<[KeyId]>,
+}
+
+/// Compiled tenant token registry, immutable after build and shared by every
+/// node in a pipeline group.
+#[derive(Debug, Default)]
+pub struct TenantTokenRegistry {
+    /// Deployment generation this registry was built for. Every packed context
+    /// carries it, so a context built against a superseded registry -- whose
+    /// value slots and pair slots may mean something else entirely -- can be
+    /// recognized rather than misread.
+    epoch: u16,
+    /// Key id to key name, for diagnostics and condition lookup.
+    key_names: Vec<Box<str>>,
+    tokens: Vec<CompiledToken>,
+    /// Lowercased transport header name to the extractors it satisfies.
+    header_index: AHashMap<Box<str>, HeaderSlot>,
+    static_extractors: Vec<StaticExtractor>,
+    signatures: Vec<Signature>,
+    /// Dense (token, signature) pairs; the index is the [`PairSlot`].
+    pairs: Vec<(TokenIdx, SignatureId)>,
+    /// Reverse lookup used at node construction, never on the hot path.
+    pair_index: AHashMap<(TokenIdx, SignatureId), PairSlot>,
+    /// Extractors resolved from an inbound cross-boundary context, indexed by
+    /// the key id they read. Both sides of a boundary share this registry, so
+    /// an import is a slot lookup rather than a name match.
+    import_by_key: Vec<SmallVec<[Slot; 2]>>,
+    /// Keys whose values are carried in the request context. The index into
+    /// this vector is the value slot each such key occupies in every packed
+    /// context built by this registry.
+    retained: Vec<KeyId>,
+    /// Per value slot: whether the key name travels with the value.
+    bagged: Vec<bool>,
+    /// Reverse of `retained`, indexed by key id; [`NO_VALUE_SLOT`] for keys
+    /// that are match-only.
+    value_slot: Vec<u16>,
+    /// Indexed by value slot: the tokens that declared this key with
+    /// `retain: true`. A slot is populated only when one of them resolves, so
+    /// a value never travels without the evidence that justified carrying it.
+    retain_mask: Vec<u64>,
+}
+
+/// How a key acquires its value.
+///
+/// Staging is per key, so within one resolve path a key must have exactly one
+/// binding: two tokens binding it to different sources would race, and both
+/// the surviving value and every fingerprint computed from it would depend on
+/// request ordering.
+///
+/// There are two disjoint resolve paths. `resolve` runs transport-header and
+/// static extractors; `resolve_imported` runs imported-key and static
+/// extractors. A key bound to a header on the ingress side and imported on
+/// the far side of a boundary is therefore consistent, and is exactly how a
+/// portable key crosses a boundary keeping its name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum KeyBinding {
+    /// Lowercased transport header name.
+    Header(Box<str>),
+    /// Literal value from a `generic_key` extractor.
+    Static(Box<[u8]>),
+    RemoteAddress,
+    /// Upstream key id read across a boundary.
+    Imported(KeyId),
+}
+
+impl KeyBinding {
+    fn describe(&self) -> String {
+        match self {
+            Self::Header(name) => format!("transport_header '{name}'"),
+            Self::Static(value) => {
+                format!("generic_key '{}'", String::from_utf8_lossy(value))
+            }
+            Self::RemoteAddress => "remote_address".to_owned(),
+            Self::Imported(key) => format!("imported_key #{key}"),
+        }
+    }
+}
+
+/// Builder collecting token definitions and declared conditions before the
+/// registry is frozen.
+#[derive(Debug, Default)]
+pub struct TenantTokenRegistryBuilder {
+    key_ids: AHashMap<Box<str>, KeyId>,
+    key_names: Vec<Box<str>>,
+    tokens: Vec<CompiledToken>,
+    token_ids: AHashMap<Box<str>, TokenIdx>,
+    header_index: AHashMap<Box<str>, HeaderSlot>,
+    static_extractors: Vec<StaticExtractor>,
+    signatures: Vec<Signature>,
+    signature_ids: AHashMap<(Vec<KeyId>, Vec<KeyId>), SignatureId>,
+    pairs: Vec<(TokenIdx, SignatureId)>,
+    pair_index: AHashMap<(TokenIdx, SignatureId), PairSlot>,
+    import_by_key: AHashMap<KeyId, SmallVec<[Slot; 2]>>,
+    /// The single binding each key may have on the request path, indexed by
+    /// key id. Transport-header and static extractors register here.
+    request_binding: Vec<Option<KeyBinding>>,
+    /// The single binding each key may have on the import path, indexed by
+    /// key id. Imported-key and static extractors register here.
+    import_binding: Vec<Option<KeyBinding>>,
+    /// Tokens declaring each key with `retain: true`, indexed by key id.
+    key_retain_mask: Vec<u64>,
+    retained: Vec<KeyId>,
+    bagged: Vec<bool>,
+}
+
+impl TenantTokenRegistryBuilder {
+    /// Create an empty builder.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn intern_key(&mut self, key: &str) -> KeyId {
+        if let Some(id) = self.key_ids.get(key) {
+            return *id;
+        }
+        let id = KeyId::try_from(self.key_names.len()).expect("too many tenant token keys");
+        let boxed: Box<str> = key.into();
+        self.key_names.push(boxed.clone());
+        self.request_binding.push(None);
+        self.import_binding.push(None);
+        self.key_retain_mask.push(0);
+        let _ = self.key_ids.insert(boxed, id);
+        id
+    }
+
+    /// Record a key's binding on the request path, the import path, or both,
+    /// rejecting a second, different binding on the same path.
+    fn bind_key(
+        &mut self,
+        name: &str,
+        key: KeyId,
+        binding: &KeyBinding,
+        request: bool,
+        import: bool,
+    ) -> Result<(), Error> {
+        if request {
+            Self::bind_on(
+                &mut self.request_binding,
+                &self.key_names,
+                name,
+                key,
+                binding,
+                "request",
+            )?;
+        }
+        if import {
+            Self::bind_on(
+                &mut self.import_binding,
+                &self.key_names,
+                name,
+                key,
+                binding,
+                "import",
+            )?;
+        }
+        Ok(())
+    }
+
+    fn bind_on(
+        table: &mut [Option<KeyBinding>],
+        key_names: &[Box<str>],
+        name: &str,
+        key: KeyId,
+        binding: &KeyBinding,
+        path: &str,
+    ) -> Result<(), Error> {
+        match &table[usize::from(key)] {
+            Some(existing) if existing != binding => Err(config_error(format!(
+                "tenant token '{}' binds key '{}' to {} on the {path} path, but it is \
+                 already bound there to {}; a key resolves from one source per path, \
+                 so give these different key names",
+                name,
+                key_names[usize::from(key)],
+                binding.describe(),
+                existing.describe(),
+            ))),
+            Some(_) => Ok(()),
+            None => {
+                table[usize::from(key)] = Some(binding.clone());
+                Ok(())
+            }
+        }
+    }
+
+    /// Add every token definition from the engine configuration.
+    pub fn add_tokens(&mut self, tokens: &TenantTokens) -> Result<(), Error> {
+        // Deterministic order so that ids are stable across runs.
+        let mut names: Vec<&String> = tokens.keys().collect();
+        names.sort();
+        for name in names {
+            self.add_token(name, &tokens[name])?;
+        }
+        Ok(())
+    }
+
+    fn add_token(&mut self, name: &str, spec: &TenantTokenSpec) -> Result<(), Error> {
+        if spec.extractors.is_empty() {
+            return Err(config_error(format!(
+                "tenant token '{name}' declares no extractors"
+            )));
+        }
+        if spec.extractors.len() > MAX_TOKEN_KEYS {
+            return Err(config_error(format!(
+                "tenant token '{name}' declares more than {MAX_TOKEN_KEYS} extractors"
+            )));
+        }
+        if self.tokens.len() >= MAX_TOKENS {
+            return Err(config_error(format!(
+                "more than {MAX_TOKENS} tenant tokens declared"
+            )));
+        }
+        let token = TokenIdx::try_from(self.tokens.len()).expect("token count checked above");
+
+        let mut keys: Vec<KeyId> = Vec::with_capacity(spec.extractors.len());
+        for (bit, extractor) in spec.extractors.iter().enumerate() {
+            let key = self.intern_key(extractor.key());
+            keys.push(key);
+
+            if extractor.retain() {
+                let _ = self.add_retained(key, extractor.bag());
+                self.key_retain_mask[usize::from(key)] |= 1u64 << token;
+            }
+
+            let slot = Slot {
+                token,
+                bit: u8::try_from(bit).expect("extractor count checked above"),
+                key,
+            };
+
+            match extractor {
+                Extractor::TransportHeader {
+                    transport_header, ..
+                } => {
+                    let lower: Box<str> = transport_header.to_ascii_lowercase().into_boxed_str();
+                    self.bind_key(name, key, &KeyBinding::Header(lower.clone()), true, false)?;
+                    self.header_index
+                        .entry(lower)
+                        .or_default()
+                        .any_value
+                        .push(slot);
+                }
+                Extractor::GenericKey { generic_key, .. } => {
+                    let binding = KeyBinding::Static(generic_key.as_bytes().into());
+                    self.bind_key(name, key, &binding, true, true)?;
+                    self.static_extractors.push(StaticExtractor {
+                        slot,
+                        value: Some(generic_key.as_bytes().into()),
+                    });
+                }
+                Extractor::RemoteAddress { .. } => {
+                    self.bind_key(name, key, &KeyBinding::RemoteAddress, true, true)?;
+                    self.static_extractors
+                        .push(StaticExtractor { slot, value: None });
+                }
+                Extractor::ImportedKey { imported_key, .. } => {
+                    let upstream = self.intern_key(imported_key);
+                    self.bind_key(name, key, &KeyBinding::Imported(upstream), false, true)?;
+                    self.import_by_key.entry(upstream).or_default().push(slot);
+                }
+            }
+        }
+
+        let key_mask = if spec.extractors.len() == MAX_TOKEN_KEYS {
+            u64::MAX
+        } else {
+            (1u64 << spec.extractors.len()) - 1
+        };
+        let mut sorted = keys.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        if sorted.len() != keys.len() {
+            return Err(config_error(format!(
+                "tenant token '{name}' declares duplicate keys"
+            )));
+        }
+
+        let boxed: Box<str> = name.into();
+        let _ = self.token_ids.insert(boxed.clone(), token);
+        self.tokens.push(CompiledToken {
+            name: boxed,
+            key_mask,
+            keys: sorted.into_boxed_slice(),
+        });
+        Ok(())
+    }
+
+    fn add_retained(&mut self, key: KeyId, bag: bool) -> u16 {
+        if let Some(idx) = self.retained.iter().position(|k| *k == key) {
+            self.bagged[idx] |= bag;
+            return u16::try_from(idx).expect("retain slot fits");
+        }
+        let idx = u16::try_from(self.retained.len()).expect("retain slot fits");
+        self.retained.push(key);
+        self.bagged.push(bag);
+        idx
+    }
+
+    /// Declare the conditions of one consumer node so that the corresponding
+    /// signatures and pair slots exist in the frozen registry.
+    ///
+    /// `tokens` names the tenant tokens the consumer binds; `None` binds every
+    /// declared token.
+    pub fn declare_conditions(
+        &mut self,
+        tokens: Option<&[String]>,
+        conditions: &[Condition],
+    ) -> Result<(), Error> {
+        let bound = self.resolve_bound_tokens(tokens)?;
+        for condition in conditions {
+            let signature = self.intern_signature(condition)?;
+            for token in &bound {
+                self.allocate_pair(*token, signature);
+            }
+        }
+        Ok(())
+    }
+
+    fn resolve_bound_tokens(&self, tokens: Option<&[String]>) -> Result<Vec<TokenIdx>, Error> {
+        match tokens {
+            None => Ok((0..self.tokens.len())
+                .map(|i| TokenIdx::try_from(i).expect("token index fits"))
+                .collect()),
+            Some(names) => names
+                .iter()
+                .map(|name| {
+                    self.token_ids
+                        .get(name.as_str())
+                        .copied()
+                        .ok_or_else(|| config_error(format!("unknown tenant token '{name}'")))
+                })
+                .collect(),
+        }
+    }
+
+    fn intern_signature(&mut self, condition: &Condition) -> Result<SignatureId, Error> {
+        if condition.entries.is_empty() {
+            return Err(config_error("tenant condition declares no entries"));
+        }
+        let mut fixed: Vec<KeyId> = Vec::new();
+        let mut wildcard: Vec<KeyId> = Vec::new();
+        for entry in &condition.entries {
+            let key = self.intern_key(&entry.key);
+            if entry.value.is_some() {
+                fixed.push(key);
+            } else {
+                wildcard.push(key);
+            }
+        }
+        fixed.sort_unstable();
+        wildcard.sort_unstable();
+
+        if let Some(id) = self.signature_ids.get(&(fixed.clone(), wildcard.clone())) {
+            return Ok(*id);
+        }
+        let id = SignatureId::try_from(self.signatures.len())
+            .map_err(|_| config_error("too many distinct tenant condition signatures"))?;
+        let mut required: Vec<KeyId> = fixed.iter().chain(wildcard.iter()).copied().collect();
+        required.sort_unstable();
+        required.dedup();
+        self.signatures.push(Signature {
+            fixed_keys: fixed.clone().into_boxed_slice(),
+            wildcard_keys: wildcard.clone().into_boxed_slice(),
+            required_keys: required.into_boxed_slice(),
+        });
+        let _ = self.signature_ids.insert((fixed, wildcard), id);
+        Ok(id)
+    }
+
+    fn allocate_pair(&mut self, token: TokenIdx, signature: SignatureId) {
+        if self.pair_index.contains_key(&(token, signature)) {
+            return;
+        }
+        let compiled = &self.tokens[usize::from(token)];
+        let required = &self.signatures[usize::from(signature)].required_keys;
+        // A signature applies to a token only when the token's schema covers
+        // every key the condition tests.
+        if !required.iter().all(|k| compiled.keys.contains(k)) {
+            return;
+        }
+        let slot = PairSlot::try_from(self.pairs.len()).expect("pair slot fits");
+        self.pairs.push((token, signature));
+        let _ = self.pair_index.insert((token, signature), slot);
+    }
+
+    /// Freeze the builder into an immutable registry.
+    ///
+    /// `generation` is the deployment generation. The stored epoch mixes it
+    /// with a digest of the value-slot layout, because a packed context is
+    /// only readable by a registry that agrees on what each slot means. Two
+    /// registries built from the same token definitions agree and get the same
+    /// epoch; two that do not, disagree loudly rather than misreading slots.
+    #[must_use]
+    pub fn build(self, generation: u16) -> TenantTokenRegistry {
+        let n_keys = self.key_names.len();
+        let mut value_slot = vec![NO_VALUE_SLOT; n_keys];
+        for (idx, key) in self.retained.iter().enumerate() {
+            value_slot[usize::from(*key)] = u16::try_from(idx).expect("value slot fits");
+        }
+        let mut layout = Vec::new();
+        for key in &self.retained {
+            layout.extend_from_slice(self.key_names[usize::from(*key)].as_bytes());
+            layout.push(0);
+        }
+        let epoch = generation ^ (xxh3_64(&layout) as u16);
+        let retain_mask: Vec<u64> = self
+            .retained
+            .iter()
+            .map(|key| self.key_retain_mask[usize::from(*key)])
+            .collect();
+        let mut import_by_key = vec![SmallVec::new(); n_keys];
+        for (key, slots) in self.import_by_key {
+            import_by_key[usize::from(key)] = slots;
+        }
+        TenantTokenRegistry {
+            epoch,
+            key_names: self.key_names,
+            tokens: self.tokens,
+            header_index: self.header_index,
+            static_extractors: self.static_extractors,
+            signatures: self.signatures,
+            pairs: self.pairs,
+            pair_index: self.pair_index,
+            import_by_key,
+            retained: self.retained,
+            bagged: self.bagged,
+            value_slot,
+            retain_mask,
+        }
+    }
+}
+
+// -- Packed per-request value ------------------------------------------------
+
+/// Words 0 and 1 are the fixed header of the packed representation.
+const HEADER_WORDS: usize = 2;
+
+/// Offset marking a value slot that is empty for this request.
+const EMPTY_OFFSET: u32 = u32::MAX;
+
+/// Compiled boundary allowlist, matched against the inline key names carried
+/// in a cross-boundary context.
+#[derive(Debug, Default, Clone)]
+pub struct BoundaryFilter {
+    /// One flag per key id; keys outside the registry cannot be named at all.
+    allow: Box<[bool]>,
+    any: bool,
+}
+
+impl BoundaryFilter {
+    /// True when the policy admits nothing, so the boundary can be skipped.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        !self.any
+    }
+
+    /// Whether a key crosses the boundary.
+    #[must_use]
+    pub fn admits(&self, key: KeyId) -> bool {
+        self.allow.get(usize::from(key)).copied().unwrap_or(false)
+    }
+}
+
+/// Reusable, receiver-owned scratch space for token resolution.
+///
+/// Resolution touches only these buffers, which are cleared and reused across
+/// requests, so the steady-state cost of building a request context is the
+/// single allocation that carries the packed result.
+#[derive(Debug, Default)]
+pub struct TokenScratch {
+    /// One word per token; a token resolves when its word reaches zero.
+    unsatisfied: Vec<u64>,
+    /// Per key id: byte range of the extracted value inside `arena`.
+    values: Vec<ValueRef>,
+    /// Staging bytes for carried values and legacy header names.
+    arena: Vec<u8>,
+    fingerprint_buf: Vec<u8>,
+    fingerprints: Vec<u64>,
+    /// One entry per registry value slot, in slot order.
+    slots: Vec<StagedSlot>,
+    /// OTLP bytes assembled at pack time.
+    blob: Vec<u8>,
+    /// Blob offset of each value slot, parallel to `slots`.
+    offsets: Vec<u32>,
+    out: Vec<u64>,
+}
+
+/// One value slot staged for packing.
+///
+/// `bagged` decides which region of the blob it lands in, and therefore
+/// whether its name is encoded at all.
+#[derive(Debug, Clone, Copy, Default)]
+struct StagedSlot {
+    off: u32,
+    len: u32,
+    kind: ValueKind,
+    present: bool,
+    bagged: bool,
+}
+
+/// Whether a carried value is text or opaque bytes.
+///
+/// This chooses the `AnyValue` field the value is encoded into, which is the
+/// only place the distinction is observable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ValueKind {
+    /// UTF-8 text; encoded as `AnyValue.string_value`.
+    #[default]
+    Text,
+    /// Opaque bytes; encoded as `AnyValue.bytes_value`.
+    Binary,
+}
+
+/// A value staged in the scratch arena, addressed by key id.
+#[derive(Debug, Clone, Copy, Default)]
+struct ValueRef {
+    off: u32,
+    len: u32,
+    kind: ValueKind,
+    present: bool,
+}
+
+/// Marks a key that no token retains, so it has no value slot.
+const NO_VALUE_SLOT: u16 = u16::MAX;
+
+/// OTLP protobuf field numbers used by the packed blob. Duplicated here
+/// because `otap-df-pdata` depends on this crate, so the dependency cannot run
+/// the other way. They are fixed by the OTLP wire format.
+mod otlp {
+    /// `KeyValue.key`, wire type 2.
+    pub const KEY_VALUE_KEY_TAG: u8 = (1 << 3) | 2;
+    /// `KeyValue.value`, wire type 2.
+    pub const KEY_VALUE_VALUE_TAG: u8 = (2 << 3) | 2;
+    /// `AnyValue.string_value`, wire type 2.
+    pub const ANY_VALUE_STRING_TAG: u8 = (1 << 3) | 2;
+    /// `AnyValue.bytes_value`, wire type 2.
+    pub const ANY_VALUE_BYTES_TAG: u8 = (7 << 3) | 2;
+}
+
+/// Append a base-128 varint.
+fn put_varint(buf: &mut Vec<u8>, mut value: u64) {
+    while value >= 0x80 {
+        buf.push((value as u8) | 0x80);
+        value >>= 7;
+    }
+    buf.push(value as u8);
+}
+
+/// Byte length of a value encoded as a varint.
+const fn varint_len(mut value: u64) -> usize {
+    let mut n = 1;
+    while value >= 0x80 {
+        value >>= 7;
+        n += 1;
+    }
+    n
+}
+
+/// Read a varint, returning its value and the offset just past it.
+fn get_varint(buf: &[u8], mut at: usize) -> Option<(u64, usize)> {
+    let mut value = 0u64;
+    let mut shift = 0u32;
+    loop {
+        let byte = *buf.get(at)?;
+        at += 1;
+        value |= u64::from(byte & 0x7F) << shift;
+        if byte < 0x80 {
+            return Some((value, at));
+        }
+        shift += 7;
+        if shift > 63 {
+            return None;
+        }
+    }
+}
+
+/// Encode `value` as a length-delimited `AnyValue`, returning the offset of
+/// its length prefix.
+///
+/// A slot points at this offset, so the encoding carries its own size and
+/// `AnyValue` carries its own type. This is what replaces a separate length
+/// and kind in the slot word.
+fn put_any_value(blob: &mut Vec<u8>, value: &[u8], kind: ValueKind) -> u32 {
+    let at = blob.len();
+    let tag = match kind {
+        ValueKind::Text => otlp::ANY_VALUE_STRING_TAG,
+        ValueKind::Binary => otlp::ANY_VALUE_BYTES_TAG,
+    };
+    let inner = 1 + varint_len(value.len() as u64) + value.len();
+    put_varint(blob, inner as u64);
+    blob.push(tag);
+    put_varint(blob, value.len() as u64);
+    blob.extend_from_slice(value);
+    u32::try_from(at).unwrap_or(EMPTY_OFFSET)
+}
+
+/// Decode the `AnyValue` whose length prefix starts at `at`, returning the
+/// raw payload bytes.
+fn any_value_bytes(blob: &[u8], at: usize) -> Option<&[u8]> {
+    let (len, body) = get_varint(blob, at)?;
+    let end = body.checked_add(usize::try_from(len).ok()?)?;
+    let inner = blob.get(body..end)?;
+    // One field: a tag byte then a length-delimited payload.
+    let (payload_len, payload) = get_varint(inner, 1)?;
+    inner.get(payload..payload.checked_add(usize::try_from(payload_len).ok()?)?)
+}
+
+/// Write the staged values of `scratch` into a single packed allocation.
+///
+/// Values are OTLP: each is a length-delimited `AnyValue`, and a key whose
+/// name is demanded is written as a full `KeyValue` in the bag region so the
+/// run can be appended to telemetry without re-encoding. Nothing is
+/// self-describing otherwise -- values are addressed by the registry value
+/// slot of their key, so a context is meaningful only to a registry that
+/// agrees on the layout, which `epoch` states.
+///
+/// Layout, all words little-endian:
+///
+/// ```text
+/// word 0     : n_fp:16 | n_slots:16 | epoch:16 | bag_len:16
+/// word 1     : resolved token bitmask
+/// words 2..  : n_fp fingerprints, indexed by PairSlot
+/// then       : ceil(n_slots/2) words holding n_slots u32 offsets, indexed by
+///              registry value slot; each points at the length prefix of a
+///              `KeyValue.value`, or is EMPTY_OFFSET
+/// then       : the byte blob, zero padded to a word boundary
+/// ```
+///
+/// The blob opens with the bag: `bag_len` bytes holding a run of
+/// `<len> <KeyValue>` entries carrying no field tag, so a consumer chooses the
+/// destination field. Value-only entries follow as bare `<len> <AnyValue>`.
+fn pack_words<'n>(
+    scratch: &mut TokenScratch,
+    resolved: u64,
+    epoch: u16,
+    slot_name: impl Fn(usize) -> &'n str,
+) -> Arc<[u64]> {
+    let TokenScratch {
+        arena,
+        slots,
+        blob,
+        offsets,
+        fingerprints,
+        out,
+        ..
+    } = scratch;
+
+    blob.clear();
+    offsets.clear();
+    offsets.resize(slots.len(), EMPTY_OFFSET);
+
+    // Bag keys first and contiguous, so the run can be copied in one pass.
+    for (slot, staged) in slots.iter().enumerate() {
+        if !staged.present || !staged.bagged {
+            continue;
+        }
+        let name = slot_name(slot);
+        let value = &arena[staged.off as usize..(staged.off + staged.len) as usize];
+        let inner = 1
+            + varint_len(name.len() as u64)
+            + name.len()
+            + 1
+            + varint_len(any_value_len(value.len()) as u64)
+            + any_value_len(value.len());
+        put_varint(blob, inner as u64);
+        blob.push(otlp::KEY_VALUE_KEY_TAG);
+        put_varint(blob, name.len() as u64);
+        blob.extend_from_slice(name.as_bytes());
+        blob.push(otlp::KEY_VALUE_VALUE_TAG);
+        offsets[slot] = put_any_value(blob, value, staged.kind);
+    }
+    let bag_len = blob.len();
+
+    for (slot, staged) in slots.iter().enumerate() {
+        if !staged.present || staged.bagged {
+            continue;
+        }
+        let value = &arena[staged.off as usize..(staged.off + staged.len) as usize];
+        offsets[slot] = put_any_value(blob, value, staged.kind);
+    }
+
+    debug_assert!(
+        blob.len() <= MAX_VALUE_BYTES,
+        "request context blob overflow"
+    );
+
+    let n_fp = fingerprints.len();
+    let n_slots = slots.len();
+    let slot_words = n_slots.div_ceil(2);
+    let total = HEADER_WORDS + n_fp + slot_words + blob.len().div_ceil(8);
+
+    out.clear();
+    out.reserve(total);
+    out.push(
+        (n_fp as u64)
+            | ((n_slots as u64) << 16)
+            | (u64::from(epoch) << 32)
+            | ((bag_len as u64) << 48),
+    );
+    out.push(resolved);
+    out.extend_from_slice(fingerprints);
+
+    for pair in offsets.chunks(2) {
+        let lo = u64::from(pair[0]);
+        let hi = pair
+            .get(1)
+            .map_or(u64::from(EMPTY_OFFSET), |v| u64::from(*v));
+        out.push(lo | (hi << 32));
+    }
+
+    for chunk in blob.chunks(8) {
+        let mut word = [0u8; 8];
+        word[..chunk.len()].copy_from_slice(chunk);
+        out.push(u64::from_le_bytes(word));
+    }
+
+    Arc::from(out.as_slice())
+}
+
+/// Encoded size of an `AnyValue` holding `n` payload bytes.
+const fn any_value_len(n: usize) -> usize {
+    1 + varint_len(n as u64) + n
+}
+
+impl TokenScratch {
+    /// Create an empty scratch buffer.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn reset(&mut self, registry: &TenantTokenRegistry) {
+        self.unsatisfied.clear();
+        self.unsatisfied
+            .extend(registry.tokens.iter().map(|t| t.key_mask));
+        self.values.clear();
+        self.values
+            .resize(registry.key_names.len(), ValueRef::default());
+        self.arena.clear();
+        self.fingerprint_buf.clear();
+        self.fingerprints.clear();
+        self.fingerprints.resize(registry.pairs.len(), 0);
+        self.slots.clear();
+        self.slots
+            .resize(registry.retained.len(), StagedSlot::default());
+        self.out.clear();
+    }
+
+    /// Clear everything that packing consumes, then size the value slots for
+    /// `registry`. Used when a context is rebuilt rather than resolved.
+    fn restage(&mut self, n_slots: usize) {
+        self.arena.clear();
+        self.fingerprints.clear();
+        self.slots.clear();
+        self.slots.resize(n_slots, StagedSlot::default());
+        self.out.clear();
+    }
+
+    fn stage(&mut self, bytes: &[u8]) -> (u32, u32) {
+        let off = u32::try_from(self.arena.len()).unwrap_or(u32::MAX);
+        self.arena.extend_from_slice(bytes);
+        (off, u32::try_from(bytes.len()).unwrap_or(u32::MAX))
+    }
+
+    fn store(&mut self, key: KeyId, value: &[u8]) {
+        let off = u32::try_from(self.arena.len()).unwrap_or(u32::MAX);
+        self.arena.extend_from_slice(value);
+        self.values[usize::from(key)] = ValueRef {
+            off,
+            len: u32::try_from(value.len()).unwrap_or(u32::MAX),
+            kind: ValueKind::Text,
+            present: true,
+        };
+    }
+}
+
+/// Borrowed inputs a receiver hands to token resolution.
+///
+/// `headers` is an iterator over the receiver's own header representation, so
+/// no intermediate header collection is ever materialized. New sources of
+/// tenant material (authorization data, for example) are added here rather
+/// than at every receiver call site.
+pub struct TokenInputs<I> {
+    /// Header name and raw value pairs, in arrival order.
+    pub headers: I,
+    /// Peer socket address, when the receiver has a real socket.
+    pub peer_addr: Option<SocketAddr>,
+}
+
+impl<I> TokenInputs<I> {
+    /// Create inputs from a header iterator.
+    pub fn new(headers: I) -> Self {
+        Self {
+            headers,
+            peer_addr: None,
+        }
+    }
+
+    /// Attach a peer address.
+    #[must_use]
+    pub fn with_peer_addr(mut self, peer_addr: Option<SocketAddr>) -> Self {
+        self.peer_addr = peer_addr;
+        self
+    }
+}
+
+impl TenantTokenRegistry {
+    /// Registry epoch, carried in every packed value so a stale context can be
+    /// detected after a reconfiguration.
+    #[must_use]
+    pub fn epoch(&self) -> u16 {
+        self.epoch
+    }
+
+    /// Returns true when nothing is configured, letting receivers skip the
+    /// resolution call entirely.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.tokens.is_empty()
+    }
+
+    /// Name of an interned key, for diagnostics.
+    #[must_use]
+    pub fn key_name(&self, key: KeyId) -> &str {
+        &self.key_names[usize::from(key)]
+    }
+
+    /// Key occupying a value slot.
+    #[must_use]
+    pub fn slot_key(&self, value_slot: u16) -> KeyId {
+        self.retained[usize::from(value_slot)]
+    }
+
+    /// Value slot a key occupies, or `None` when the key is match-only and its
+    /// value is therefore never copied into a request context.
+    #[must_use]
+    pub fn value_slot(&self, key: KeyId) -> Option<u16> {
+        match self.value_slot.get(usize::from(key)).copied() {
+            Some(NO_VALUE_SLOT) | None => None,
+            Some(slot) => Some(slot),
+        }
+    }
+
+    /// Interned id of a key name, if the key is known to this registry.
+    #[must_use]
+    pub fn key_id(&self, name: &str) -> Option<KeyId> {
+        self.key_names
+            .iter()
+            .position(|k| k.as_ref() == name)
+            .map(|i| KeyId::try_from(i).expect("key id fits"))
+    }
+
+    /// Compile a boundary allowlist into a key-indexed filter.
+    #[must_use]
+    pub fn compile_filter(&self, policy: &TenantBoundaryPolicy) -> BoundaryFilter {
+        let mut allow = vec![false; self.key_names.len()];
+        let mut any = false;
+        for key in self.compile_policy(policy).iter() {
+            allow[usize::from(*key)] = true;
+            any = true;
+        }
+        BoundaryFilter {
+            allow: allow.into_boxed_slice(),
+            any,
+        }
+    }
+
+    /// Compile a boundary allowlist into interned key ids.
+    ///
+    /// Unknown key names are silently dropped: a policy may name keys that
+    /// only the other side of the boundary knows about.
+    #[must_use]
+    pub fn compile_policy(&self, policy: &TenantBoundaryPolicy) -> Box<[KeyId]> {
+        policy
+            .allow_keys
+            .iter()
+            .filter_map(|name| self.key_id(name))
+            .collect()
+    }
+
+    /// Resolve the tenant tokens for one request and pack them into a single
+    /// allocation.
+    ///
+    /// Returns `None` when no token resolved, in which case the request
+    /// carries no tenant context at all.
+    pub fn resolve<'a, I>(
+        &self,
+        scratch: &mut TokenScratch,
+        inputs: TokenInputs<I>,
+    ) -> Option<Arc<[u64]>>
+    where
+        I: IntoIterator<Item = (&'a str, &'a [u8])>,
+    {
+        scratch.reset(self);
+
+        // Static extractors first: they never depend on the request headers.
+        for extractor in &self.static_extractors {
+            match &extractor.value {
+                Some(value) => scratch.store(extractor.slot.key, value),
+                None => match inputs.peer_addr {
+                    Some(addr) => {
+                        let rendered = addr.to_string();
+                        scratch.store(extractor.slot.key, rendered.as_bytes());
+                    }
+                    None => continue,
+                },
+            }
+            scratch.unsatisfied[usize::from(extractor.slot.token)] &= !(1u64 << extractor.slot.bit);
+        }
+
+        // One pass over the request headers.
+        let mut lower: SmallVec<[u8; 64]> = SmallVec::new();
+        for (name, value) in inputs.headers {
+            lower.clear();
+            lower.extend(name.as_bytes().iter().map(u8::to_ascii_lowercase));
+            let Ok(lower_str) = std::str::from_utf8(&lower) else {
+                continue;
+            };
+            let Some(header_slot) = self.header_index.get(lower_str) else {
+                continue;
+            };
+            for slot in &header_slot.any_value {
+                scratch.store(slot.key, value);
+                scratch.unsatisfied[usize::from(slot.token)] &= !(1u64 << slot.bit);
+            }
+        }
+
+        self.finish_resolve(scratch)
+    }
+
+    /// Resolve this pipeline's tokens over a context handed across a boundary.
+    ///
+    /// The upstream context is never adopted: only keys this receiver's import
+    /// policy names are visible, and the tokens rebuilt here are the ones the
+    /// downstream pipeline declared. Static extractors still run, so a
+    /// dedicated pipeline can mint a `generic_key` identity of its own and
+    /// combine it with imported values in a single token.
+    pub fn resolve_imported(
+        &self,
+        scratch: &mut TokenScratch,
+        view: &TenantView<'_>,
+        allow: &BoundaryFilter,
+    ) -> Option<Arc<[u64]>> {
+        // A boundary can join two registries -- an engine-scoped topic
+        // connects pipeline groups, and each group builds its own. Slot
+        // numbers are only meaningful between registries that agree on the
+        // layout, which is exactly what the epoch digest states. Disagreement
+        // drops the upstream context rather than reading slots as something
+        // they are not; the receiver's own static extractors still run.
+        if view.epoch() != self.epoch {
+            return None;
+        }
+        scratch.reset(self);
+
+        for extractor in &self.static_extractors {
+            let Some(value) = &extractor.value else {
+                continue;
+            };
+            scratch.store(extractor.slot.key, value);
+            scratch.unsatisfied[usize::from(extractor.slot.token)] &= !(1u64 << extractor.slot.bit);
+        }
+
+        // Value slots are registry positions, and both sides of a boundary
+        // compile against the same registry, so an import is a slot read.
+        for (slot, key) in self.retained.iter().enumerate() {
+            if !allow.admits(*key) {
+                continue;
+            }
+            let slot = u16::try_from(slot).expect("value slot fits");
+            let Some(value) = view.slot_value(slot) else {
+                continue;
+            };
+            for target in &self.import_by_key[usize::from(*key)] {
+                scratch.store(target.key, value);
+                scratch.unsatisfied[usize::from(target.token)] &= !(1u64 << target.bit);
+            }
+        }
+
+        self.finish_resolve(scratch)
+    }
+
+    fn finish_resolve(&self, scratch: &mut TokenScratch) -> Option<Arc<[u64]>> {
+        // Tokens whose bits all cleared are resolved.
+        let mut resolved: u64 = 0;
+        for (idx, word) in scratch.unsatisfied.iter().enumerate() {
+            if *word == 0 {
+                resolved |= 1u64 << idx;
+            }
+        }
+        if resolved == 0 {
+            return None;
+        }
+
+        // Probe side of the hash join: one fingerprint per allocated pair.
+        let TokenScratch {
+            values,
+            arena,
+            fingerprint_buf,
+            fingerprints,
+            ..
+        } = scratch;
+        for (slot, (token, signature)) in self.pairs.iter().enumerate() {
+            if resolved & (1u64 << *token) == 0 {
+                continue;
+            }
+            let sig = &self.signatures[usize::from(*signature)];
+            fingerprint_buf.clear();
+            for key in sig.fixed_keys.iter() {
+                let r = values[usize::from(*key)];
+                if !r.present {
+                    continue;
+                }
+                let start = r.off as usize;
+                let end = start + r.len as usize;
+                fingerprint_term(fingerprint_buf, *key, &arena[start..end]);
+            }
+            fingerprints[slot] = xxh3_64(fingerprint_buf);
+        }
+
+        Some(self.pack(scratch, resolved))
+    }
+
+    /// Key name of each value slot, in slot order. Only bagged slots encode
+    /// it, but the mapping is total so packing can index it directly.
+    fn slot_names<'r>(&'r self) -> impl Fn(usize) -> &'r str + 'r {
+        move |slot| &self.key_names[usize::from(self.retained[slot])]
+    }
+
+    fn pack(&self, scratch: &mut TokenScratch, resolved: u64) -> Arc<[u64]> {
+        // Only keys with a value slot contribute bytes. A match-only key is
+        // decided entirely by its fingerprint contribution, so its value is
+        // dropped here and never travels.
+        for (slot, key) in self.retained.iter().enumerate() {
+            // A value travels only when a token that asked to retain it
+            // resolved. Otherwise the evidence for carrying it is absent, and
+            // an unrelated token resolving must not release it.
+            scratch.slots[slot] = if resolved & self.retain_mask[slot] == 0 {
+                StagedSlot::default()
+            } else {
+                let v = scratch.values[usize::from(*key)];
+                StagedSlot {
+                    off: v.off,
+                    len: v.len,
+                    kind: v.kind,
+                    present: v.present,
+                    bagged: self.bagged[slot],
+                }
+            };
+        }
+        pack_words(scratch, resolved, self.epoch, self.slot_names())
+    }
+
+    /// Value carried for a token key, if the key has a value slot and the
+    /// request populated it.
+    ///
+    /// This is an array index, not a search: the slot is fixed at build time.
+    /// Exporters drive it from their own `key -> header` map, which is why
+    /// token definitions never name a wire header.
+    #[must_use]
+    pub fn retained_value<'a>(&self, view: &TenantView<'a>, key: KeyId) -> Option<&'a [u8]> {
+        view.slot_value(self.value_slot(key)?)
+    }
+
+    /// Repack the carried values a boundary policy admits into a fresh context
+    /// to hand to another pipeline.
+    ///
+    /// Nothing else survives: fingerprints, the resolved-token mask, the legacy
+    /// captured headers, and every key the policy does not name are dropped, so
+    /// a downstream pipeline can neither observe nor re-emit tenant material it
+    /// was not granted. The blob is rebuilt rather than masked, because the
+    /// packed buffer is shared and any byte left in it stays readable.
+    #[must_use]
+    pub fn export_boundary(
+        &self,
+        scratch: &mut TokenScratch,
+        view: &TenantView<'_>,
+        allow: &[KeyId],
+    ) -> Option<Arc<[u64]>> {
+        if allow.is_empty() {
+            return None;
+        }
+        scratch.restage(self.retained.len());
+        let mut any = false;
+        for key in allow {
+            let Some(slot) = self.value_slot(*key) else {
+                continue;
+            };
+            let Some(value) = view.slot_value(slot) else {
+                continue;
+            };
+            let range = scratch.stage(value);
+            scratch.slots[usize::from(slot)] = StagedSlot {
+                off: range.0,
+                len: range.1,
+                kind: ValueKind::Text,
+                present: true,
+                bagged: self.bagged[usize::from(slot)],
+            };
+            any = true;
+        }
+        if !any {
+            return None;
+        }
+        Some(pack_words(scratch, 0, self.epoch, self.slot_names()))
+    }
+
+    /// Build a consumer's probe tables for its ordered conditions.
+    ///
+    /// Called once at node construction, never on the hot path. `tokens` names
+    /// the bound tenant tokens, or `None` to bind every declared token.
+    pub fn condition_set(
+        &self,
+        tokens: Option<&[String]>,
+        conditions: &[Condition],
+    ) -> Result<ConditionSet, Error> {
+        let bound: Vec<TokenIdx> = match tokens {
+            None => (0..self.tokens.len())
+                .map(|i| TokenIdx::try_from(i).expect("token index fits"))
+                .collect(),
+            Some(names) => names
+                .iter()
+                .map(|name| {
+                    self.tokens
+                        .iter()
+                        .position(|t| t.name.as_ref() == name.as_str())
+                        .map(|i| TokenIdx::try_from(i).expect("token index fits"))
+                        .ok_or_else(|| config_error(format!("unknown tenant token '{name}'")))
+                })
+                .collect::<Result<_, Error>>()?,
+        };
+
+        let mut groups: Vec<ProbeGroup> = Vec::new();
+        for (condition_idx, condition) in conditions.iter().enumerate() {
+            let condition_idx = ConditionIdx::try_from(condition_idx)
+                .map_err(|_| config_error("too many tenant conditions"))?;
+            let signature = self.lookup_signature(condition)?;
+            let fingerprint = self.literal_fingerprint(condition, signature);
+
+            let position = groups.iter().position(|g| g.signature == signature);
+            let group = match position {
+                Some(i) => &mut groups[i],
+                None => {
+                    let pair_slots: Vec<PairSlot> = bound
+                        .iter()
+                        .filter_map(|t| self.pair_index.get(&(*t, signature)).copied())
+                        .collect();
+                    let group_tokens: Vec<TokenIdx> = bound
+                        .iter()
+                        .copied()
+                        .filter(|t| self.pair_index.contains_key(&(*t, signature)))
+                        .collect();
+                    groups.push(ProbeGroup {
+                        signature,
+                        pair_slots: pair_slots.into_boxed_slice(),
+                        tokens: group_tokens.into_boxed_slice(),
+                        table: AHashMap::new(),
+                    });
+                    groups.last_mut().expect("just pushed")
+                }
+            };
+            // First match wins: keep the lowest condition index per key.
+            let entry = group.table.entry(fingerprint).or_insert(condition_idx);
+            if condition_idx < *entry {
+                *entry = condition_idx;
+            }
+        }
+
+        Ok(ConditionSet {
+            groups: groups.into_boxed_slice(),
+        })
+    }
+
+    fn lookup_signature(&self, condition: &Condition) -> Result<SignatureId, Error> {
+        let mut fixed: Vec<KeyId> = Vec::new();
+        let mut wildcard: Vec<KeyId> = Vec::new();
+        for entry in &condition.entries {
+            let key = self
+                .key_names
+                .iter()
+                .position(|k| k.as_ref() == entry.key.as_str())
+                .map(|i| KeyId::try_from(i).expect("key id fits"))
+                .ok_or_else(|| config_error(format!("unknown tenant token key '{}'", entry.key)))?;
+            if entry.value.is_some() {
+                fixed.push(key);
+            } else {
+                wildcard.push(key);
+            }
+        }
+        fixed.sort_unstable();
+        wildcard.sort_unstable();
+        self.signatures
+            .iter()
+            .position(|s| {
+                s.fixed_keys.as_ref() == fixed.as_slice()
+                    && s.wildcard_keys.as_ref() == wildcard.as_slice()
+            })
+            .map(|i| SignatureId::try_from(i).expect("signature id fits"))
+            .ok_or_else(|| config_error("tenant condition was not declared at build time"))
+    }
+
+    /// Build-side fingerprint: hash the condition's literal values in the
+    /// signature's key order, matching the probe-side layout exactly.
+    fn literal_fingerprint(&self, condition: &Condition, signature: SignatureId) -> u64 {
+        let sig = &self.signatures[usize::from(signature)];
+        let mut buf: Vec<u8> = Vec::new();
+        for key in sig.fixed_keys.iter() {
+            let name = self.key_name(*key);
+            let Some(entry) = condition
+                .entries
+                .iter()
+                .find(|e| e.key.as_str() == name && e.value.is_some())
+            else {
+                continue;
+            };
+            let value = entry.value.as_deref().unwrap_or_default();
+            fingerprint_term(&mut buf, *key, value.as_bytes());
+        }
+        xxh3_64(&buf)
+    }
+}
+
+/// One signature's probe table within a consumer's condition set.
+#[derive(Debug)]
+struct ProbeGroup {
+    signature: SignatureId,
+    pair_slots: Box<[PairSlot]>,
+    tokens: Box<[TokenIdx]>,
+    table: AHashMap<u64, ConditionIdx>,
+}
+
+/// A consumer's compiled conditions: one hash probe per signature at runtime.
+#[derive(Debug)]
+pub struct ConditionSet {
+    groups: Box<[ProbeGroup]>,
+}
+
+impl ConditionSet {
+    /// Evaluate the conditions against a resolved request context and return
+    /// the index of the first matching condition.
+    ///
+    /// Cost is one bit test plus one hash lookup per bound (token, signature)
+    /// pair, independent of the number of conditions and of the number of
+    /// entries per condition.
+    #[must_use]
+    pub fn first_match(&self, view: &TenantView<'_>) -> Option<ConditionIdx> {
+        let mut best: Option<ConditionIdx> = None;
+        for group in self.groups.iter() {
+            for (slot, token) in group.pair_slots.iter().zip(group.tokens.iter()) {
+                if !view.token_resolved(*token) {
+                    continue;
+                }
+                if let Some(idx) = group.table.get(&view.fingerprint(*slot)) {
+                    best = Some(match best {
+                        Some(current) if current <= *idx => current,
+                        _ => *idx,
+                    });
+                }
+            }
+        }
+        best
+    }
+}
+
+// -- Read side ---------------------------------------------------------------
+
+/// Borrowed, zero-copy view over the packed per-request context.
+///
+/// The same buffer carries the tenant token fingerprints and the request's
+/// carried header values, which is what lets a single pointer in the pipeline
+/// context replace the former transport header map.
+#[derive(Debug, Clone, Copy)]
+pub struct TenantView<'a> {
+    words: &'a [u64],
+}
+
+impl<'a> TenantView<'a> {
+    /// Wrap a packed representation.
+    #[must_use]
+    pub fn new(words: &'a [u64]) -> Self {
+        Self { words }
+    }
+
+    fn n_fp(&self) -> usize {
+        (self.words[0] & 0xFFFF) as usize
+    }
+
+    fn n_slots(&self) -> usize {
+        ((self.words[0] >> 16) & 0xFFFF) as usize
+    }
+
+    /// Registry epoch this context was built against.
+    #[must_use]
+    pub fn epoch(&self) -> u16 {
+        ((self.words[0] >> 32) & 0xFFFF) as u16
+    }
+
+    fn bag_len(&self) -> usize {
+        ((self.words[0] >> 48) & 0xFFFF) as usize
+    }
+
+    /// True when the given token resolved for this request.
+    #[must_use]
+    pub fn token_resolved(&self, token: TokenIdx) -> bool {
+        self.words[1] & (1u64 << token) != 0
+    }
+
+    /// True when at least one token resolved.
+    #[must_use]
+    pub fn any_token_resolved(&self) -> bool {
+        self.words[1] != 0
+    }
+
+    /// Precomputed fingerprint for one applicable (token, signature) pair.
+    #[must_use]
+    pub fn fingerprint(&self, slot: PairSlot) -> u64 {
+        self.words[HEADER_WORDS + usize::from(slot)]
+    }
+
+    /// True when the request carried no values at all.
+    ///
+    /// Entries are self-delimiting, so the blob needs no stored length: an
+    /// empty context is simply one with no blob words.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.blob().is_empty()
+    }
+
+    /// The value region, including up to seven bytes of zero padding.
+    ///
+    /// Padding is never read: a slot offset addresses a length-delimited
+    /// `AnyValue`, and the bag is bounded by `bag_len`, so no reader depends
+    /// on the region ending exactly where the last entry does.
+    fn blob(&self) -> &'a [u8] {
+        let start = HEADER_WORDS + self.n_fp() + self.n_slots().div_ceil(2);
+        bytemuck::cast_slice(&self.words[start..])
+    }
+
+    fn offset(&self, slot: usize) -> Option<usize> {
+        if slot >= self.n_slots() {
+            return None;
+        }
+        let word = self.words[HEADER_WORDS + self.n_fp() + slot / 2];
+        let off = if slot.is_multiple_of(2) {
+            word as u32
+        } else {
+            (word >> 32) as u32
+        };
+        (off != EMPTY_OFFSET).then_some(off as usize)
+    }
+
+    /// Value carried in one registry value slot, if the request populated it.
+    ///
+    /// The offset addresses an encoded `AnyValue`, so this decodes rather than
+    /// slices. Callers matching on the value should prefer the fingerprints,
+    /// which never look at bytes at all.
+    #[must_use]
+    pub fn slot_value(&self, slot: u16) -> Option<&'a [u8]> {
+        let at = self.offset(usize::from(slot))?;
+        any_value_bytes(self.blob(), at)
+    }
+
+    /// Append the bagged keys to `dst` as repeated `KeyValue` under `field`.
+    ///
+    /// The bag is stored without a field tag precisely so the consumer picks
+    /// the destination -- resource, scope, log record, span, or exemplar
+    /// attributes all differ in field number and in nothing else. Each entry
+    /// is copied verbatim; nothing is re-encoded.
+    ///
+    /// Returns the number of attributes appended.
+    pub fn append_attributes(&self, dst: &mut Vec<u8>, field: u32) -> usize {
+        let bag = &self.blob()[..self.bag_len()];
+        let tag = (u64::from(field) << 3) | 2;
+        let mut at = 0usize;
+        let mut count = 0usize;
+        while at < bag.len() {
+            let Some((len, body)) = get_varint(bag, at) else {
+                break;
+            };
+            let Ok(len) = usize::try_from(len) else { break };
+            let Some(entry) = bag.get(body..body + len) else {
+                break;
+            };
+            put_varint(dst, tag);
+            put_varint(dst, len as u64);
+            dst.extend_from_slice(entry);
+            at = body + len;
+            count += 1;
+        }
+        count
+    }
+
+    /// True when any key was captured into the bag.
+    #[must_use]
+    pub fn has_attributes(&self) -> bool {
+        self.bag_len() > 0
+    }
+}

--- a/rust/otap-dataflow/docs/multitenant-token-propagation.md
+++ b/rust/otap-dataflow/docs/multitenant-token-propagation.md
@@ -343,7 +343,7 @@ lookup per pair, and the packed context still carries one word per pair. What
 changed is that the word is now a dictionary encoding rather than a digest, so
 the lookup is exact instead of probabilistic.
 
-Two things fail closed:
+Three things fail closed:
 
 - A condition testing a literal the registry never interned is **rejected at
   build time**. Such a literal would otherwise take symbol 1, which every
@@ -354,6 +354,31 @@ Two things fail closed:
   rather than narrowed, since narrowing is exactly the collision this section
   exists to prevent. The budget is generous: four keys with 65,000 declared
   values each, eight keys with 254 each, or sixteen keys with fourteen each.
+- A key declaring more distinct literals than the symbol space holds is
+  rejected at build time. Wrapping the counter would recycle a symbol, letting
+  two distinct literals compare equal -- the same cross-wire by a different
+  route.
+
+#### Where hashing remains
+
+Dictionary encoding does not remove hashing, and it is not meant to. It
+restores the step that makes hashing safe. Both lookups on the path are hash
+lookups, and **both verify**:
+
+- **Value to symbol, at resolve.** The raw value bytes are hashed to find a
+  bucket; the dictionary then compares them against the literal it owns.
+- **Signature word to condition, at probe.** The packed word is hashed to find
+  a bucket; the map then compares the whole word.
+
+In each case the hash selects a bucket and a comparison decides the answer,
+which is the discipline a hash join follows. The second comparison is exact
+*because* the packing is injective: the word is not a lossy summary of the
+values, it is a complete encoding of them, so `==` on words is `==` on values.
+
+The earlier design had the same two-level shape but no verification at either
+level, because the map's key *was* the digest. Its internal comparison
+confirmed only that two digests agreed, which is the thing that was already
+assumed.
 
 #### Why match-only keys still cost zero bytes
 
@@ -1362,16 +1387,16 @@ Paths below are relative to `crates/`.
 
 ## Prototype limitations
 
-- No tests were written for this prototype; validation was by full-suite
-  regression plus live end-to-end runs.
-- Token resolution is wired into the OTLP/HTTP receiver only. Other receivers
-  still use the capture policy. `TokenInputs` is the extension point: new
-  sources of tenant material are added there rather than at every receiver.
+- Tests cover the matching boundary only: exact matching including near
+  misses, zero-byte match-only keys, fail-closed rejection of an undeclared
+  literal, and injective signature packing. Each was checked by mutation --
+  breaking the invariant makes them fail -- since a boundary test that cannot
+  fail is worth nothing. Everything else is validated by targeted checks,
+  benchmarks and live runs.
+- Token resolution is not yet wired into any receiver; the capture policy is
+  still the live path. `TokenInputs` is the extension point: new sources of
+  tenant material are added there rather than at every receiver.
 - Only `exporter:otlp_grpc` implements `tenant_headers`.
-- The name-bearing capture region still exists in the packed layout, so a wire
-  name can still reach an egress boundary without being declared. Closing that
-  hole is the migration described in
-  [Retiring the capture policy](#retiring-the-capture-policy).
 - Conditions are compiled against the union of all conditions declared in a
   group; graph reachability is not considered, so an unreachable node still
   contributes pair slots. The baseline requires the reachable cross-product:

--- a/rust/otap-dataflow/docs/multitenant-token-propagation.md
+++ b/rust/otap-dataflow/docs/multitenant-token-propagation.md
@@ -162,17 +162,20 @@ is addressed by the **value slot** its key occupies in the registry, and no
 name, key id or descriptor travels with it:
 
 ```text
-word 0     : n_fp:16 | n_slots:16 | epoch:16 | blob_len:16
+word 0     : n_fp:16 | n_slots:16 | epoch:16 | bag_len:16
 word 1     : resolved token bitmask
-word 2     : n_legacy:16
-words 3..  : n_fp fingerprints, indexed by PairSlot
-then       : n_slots words, indexed by registry value slot
-             value_off:16 | value_len:16 | kind:8, or EMPTY_SLOT
-then       : n_legacy pairs of words (captured headers only)
-             wA: name_off:16 | name_len:16 | value_off:16 | value_len:16
-             wB: kind:8 | wire_len:16
+words 2..  : n_fp fingerprints, indexed by PairSlot
+then       : ceil(n_slots/2) words holding n_slots u32 offsets, indexed by
+             registry value slot; each addresses a length-delimited AnyValue,
+             or is EMPTY_OFFSET
 then       : the byte blob, zero padded to a word boundary
 ```
+
+Values are stored as OTLP. A slot holds a single `u32` offset rather than an
+offset and a length, because the encoding is length-delimited and `AnyValue`
+carries its own type -- so the two fields the slot used to spend on `len` and
+`kind` are already in the bytes. The blob needs no stored length either: every
+entry delimits itself, so the trailing zero padding is simply never addressed.
 
 A key gets a value slot only if some compiled consumer propagates its value.
 The rest are **match-only**: they are decided entirely by their contribution to
@@ -184,10 +187,15 @@ Reading a key's value is therefore an array index --
 `registry.value_slot(key)` then `view.slot_value(slot)` -- rather than a scan
 looking for a matching name or key id.
 
-A second, name-bearing region carries the pre-existing `capture:` header
-policy, whose names come from the wire rather than from configuration. Tenant
-token keys never take that path, and the region is scheduled for deletion --
-see [Retiring the capture policy](#retiring-the-capture-policy).
+The blob opens with the **bag**: `bag_len` bytes of complete `KeyValue`
+messages, for the keys whose names are demanded. Value-only entries follow.
+Both forms end in a length-delimited `AnyValue`, and a slot points at that
+length prefix in either case, so `slot_value` reads them identically and does
+not care which region a key landed in.
+
+There is no name-bearing region for captured headers. Every name in the
+context comes from configuration, never from the wire -- see
+[Retiring the capture policy](#retiring-the-capture-policy).
 
 **Contexts are only meaningful to registries that agree on the layout.** A
 registry is built per pipeline group, but topics are declared engine-wide and
@@ -446,9 +454,7 @@ Two further demos exist:
 `configs/engine-conf/tenant_header_mapping.yaml` (single-pipeline
 ingress-to-egress header mapping).
 
-## Proposed: the context as OTLP attributes
-
-This section is a **design proposal**, not implemented work.
+## The context as OTLP attributes
 
 The packed context is a key-value bag with a hand-rolled encoding. The
 `self_tracing` encoder already solved the same problem for log attributes by
@@ -459,7 +465,7 @@ context stops being a re-encode and becomes a copy.
 
 ### The slot becomes one offset
 
-Today a slot is `value_off:16 | value_len:16 | kind:8`. A slot would instead be
+A slot was `value_off:16 | value_len:16 | kind:8`. A slot is instead
 a single `u32` offset pointing at the length varint of a `KeyValue.value`
 field, so the encoding carries its own size and `AnyValue` carries its own
 type. `ValueKind` disappears -- it is a hand-rolled parallel to `AnyValue`, and
@@ -549,19 +555,46 @@ It is also the honest modelling. The tenant context describes the conditions
 under which the pipeline produced this telemetry, not a property of each
 individual record, which is what an instrumentation scope is for.
 
-### Fingerprints move to the encoded form
+### Fingerprints stay on the raw bytes
 
-Fingerprinting the `AnyValue` bytes rather than the raw value is a
-simplification, not a compromise. Condition literals are encoded once at build
-time, and `resolve_imported` stops needing to decode anything -- it hashes the
-slot bytes as they lie. It also makes the integer `5` and the string `"5"`
-distinct terms, which is correct and is not true today.
+An earlier draft of this section proposed fingerprinting the encoded
+`AnyValue` instead of the raw value. Implementing it showed that to be the
+wrong trade, so it is recorded here as a rejected option rather than quietly
+dropped.
+
+The order of work is what decides it. Resolve stages raw bytes and hashes them
+immediately; pack runs afterwards and encodes only the values that survived
+gating. Fingerprinting the encoded form would invert that, forcing every
+condition-participating key to be encoded on the hot path -- including
+match-only keys, whose entire point is that their bytes never travel.
+
+The gain it offered was distinguishing the integer `5` from the string `"5"`.
+That distinction is empty here: condition literals come from YAML as strings
+and are compared against transport header bytes, so no term is ever an
+integer. Paying an encode per matched key to separate two cases that cannot
+arise is not a trade worth making.
+
+The cost of keeping raw fingerprints is one decode in `resolve_imported` --
+skip a tag byte and two varints -- on the boundary path only, which is not the
+hot path.
+
+### Demand is declared per extractor
+
+An extractor carries `bag: true` alongside `retain: true`. `retain` says the
+value travels; `bag` says the *name* travels with it, which is what makes the
+entry appendable as an attribute. `bag` implies `retain`, since a name with no
+value is not an attribute.
+
+This keeps the name in configuration, where full token binding requires it to
+be. The key name encoded into the blob is the registry key name, not anything
+read off the wire.
 
 ### The wildcard extractor
 
 A bag is only useful if something can fill it, and full token binding
 deliberately has no way to capture an undeclared key. A wildcard extractor
-would reintroduce that, and it has to be justified rather than assumed.
+would reintroduce that, and it has to be justified rather than assumed. It is
+**not implemented**; `bag: true` on a declared extractor is.
 
 The distinction that makes it acceptable is that a wildcard is **declared**.
 The rejected `capture:` plus `preserve` combination let an inbound request
@@ -578,13 +611,12 @@ should have to say so.
 
 ## Retiring the capture policy
 
-This section is a **migration plan**, not implemented work. It enumerates every
-component that still depends on the name-bearing region of the packed layout.
+This section is a **migration plan**. The name-bearing region of the packed
+layout is already gone; what remains is to move every component still calling
+`set_transport_headers` / `transport_headers()` onto the compiled context.
 
-The packed layout still carries a second, name-bearing region for the
-pre-existing `capture:` header policy. It exists only because that policy has
-callers, and it should not survive: **a name that travels is a name nobody
-declared**.
+The principle that removed the region is the one that governs the migration:
+**a name that travels is a name nobody declared**.
 
 The security posture is the argument. Under `capture:`, a receiver matches
 `match_names` and stores whatever it found, wire name included, and an exporter
@@ -601,9 +633,11 @@ build time and the egress name is created fresh from the exporter's own map.
 An operator who wants a header forwarded must say so; the default is that
 nothing propagates.
 
-Deleting the region also deletes the last variable-shaped part of the layout:
-words 2 and the legacy descriptor pairs disappear, `TenantView::iter` and
-`find_by_name` go with them, and `CarriedValue` reduces to a value slot read.
+Deleting the region also deleted the last variable-shaped part of the layout.
+Word 2 and the descriptor pairs are gone, `TenantView::iter`, `find_by_name`,
+`CarriedValue` and `RequestContextBuilder` went with them, and reading a value
+is now a slot index. What survives of naming is `bag: true`, which encodes the
+*registry* key name -- still a declared name, never a captured one.
 
 Each component below needs one change to get there.
 

--- a/rust/otap-dataflow/docs/multitenant-token-propagation.md
+++ b/rust/otap-dataflow/docs/multitenant-token-propagation.md
@@ -166,20 +166,85 @@ is addressed by the **value slot** its key occupies in the registry, and no
 name, key id or descriptor travels with it:
 
 ```text
-word 0     : n_fp:16 | n_slots:16 | epoch:16 | bag_len:16
-word 1     : resolved token bitmask
-words 2..  : n_fp packed symbol words, indexed by PairSlot
-then       : ceil(n_slots/2) words holding n_slots u32 offsets, indexed by
-             registry value slot; each addresses a length-delimited AnyValue,
-             or is EMPTY_OFFSET
-then       : the byte blob, zero padded to a word boundary
+                     one allocation, one Arc<[u64]>
+
+      +--------------------------------------------------------+
+ w0   | n_fp:16 | n_slots:16 | epoch:16 | bag_len:16            |  2 words,
+      +--------------------------------------------------------+  fixed
+ w1   | resolved:64   one bit per declared token, 1 = matched   |
+      +--------------------------------------------------------+
+ w2   | packed symbol word, PairSlot 0                          |  n_fp
+  :   |                          :                              |  words
+      +--------------------------------------------------------+
+      | offset[slot 0]:u32        | offset[slot 1]:u32          |  ceil(
+      | offset[slot 2]:u32        | offset[slot 3]:u32          |  n_slots
+  :   |            :              |             :               |  / 2)
+      +--------------------------------------------------------+
+      | blob: 8 bytes per word, zero padded to a word boundary  |  ceil(
+  :   |                          :                              |  len / 8)
+      +--------------------------------------------------------+
 ```
 
-Values are stored as OTLP. A slot holds a single `u32` offset rather than an
-offset and a length, because the encoding is length-delimited and `AnyValue`
-carries its own type -- so the two fields the slot used to spend on `len` and
-`kind` are already in the bytes. The blob needs no stored length either: every
-entry delimits itself, so the trailing zero padding is simply never addressed.
+Only the first two words are at fixed offsets. Everything after is placed by
+counts the header carries, so a reader computes three region starts with two
+shifts and an add and then indexes:
+
+```text
+      63          48 47          32 31          16 15           0
+     +--------------+--------------+--------------+--------------+
+ w0  |   bag_len    |    epoch     |   n_slots    |     n_fp     |
+     +--------------+--------------+--------------+--------------+
+```
+
+- **n_fp**: packed symbol words present, one per `PairSlot` a condition binds
+- **n_slots**: value slots the registry declared, so the offset region is a
+  dense array indexed by slot rather than a lookup
+- **epoch**: deployment generation mixed with a digest of the slot layout
+- **bag_len**: bytes of the blob that form the OTLP repeated field, below
+
+A slot holds one `u32` and `EMPTY_OFFSET` (`u32::MAX`) means the key did not
+resolve, which is why a miss costs no branch beyond the compare.
+
+The blob is two regions, and the split is what makes the bag copyable whole:
+
+```text
+      |<-------------- bag_len -------------->|
+      +---------------------------------------+--------------------+
+ blob | bagged entries, tagged and contiguous | value-only entries |
+      +---------------------------------------+--------------------+
+      ^                                       ^
+      attributes() borrows exactly this run   never read as a run
+
+ a bagged entry -- a complete repeated-field element:
+      +-----+-----+------+-----------+------+-----+-----+----------+
+      | tag | len | 0x0a | key bytes | 0x12 | len | tag | value    |
+      +-----+-----+------+-----------+------+-----+-----+----------+
+                                            ^
+                                            offset[slot] points here
+
+ a value-only entry -- the same tail, without the name:
+      +-----+-----+----------+
+      | len | tag | value    |
+      +-----+-----+----------+
+      ^
+      offset[slot] points here
+```
+
+`tag` on a bagged entry is the consumer's own attributes field number, baked
+in at compile time, so the bag region is not an input to an encoder -- it is
+already the bytes an `LogRecord.attributes` or `Span.attributes` field wants.
+`0x0a` and `0x12` are `KeyValue.key` and `KeyValue.value`.
+
+Both entry shapes end in a length-delimited `AnyValue`, and a slot addresses
+that length prefix either way. So `slot_value` reads the two identically and
+never needs to know which region a key landed in -- the regions differ only
+in what precedes the offset.
+
+A slot spends one `u32` rather than an offset and a length because the
+encoding is length-delimited and `AnyValue` carries its own type, so the two
+fields the slot would have spent on `len` and `kind` are already in the bytes.
+The blob needs no stored length either: every entry delimits itself, which is
+why the trailing zero padding in the figure is simply never addressed.
 
 A key gets a value slot only if some compiled consumer propagates its value.
 The rest are **match-only**: they are decided entirely by their contribution to
@@ -192,14 +257,6 @@ is a build-time property, not a per-entry flag.
 Reading a key's value is therefore an array index --
 `registry.value_slot(key)` then `view.slot_value(slot)` -- rather than a scan
 looking for a matching name or key id.
-
-The blob opens with the **bag**: `bag_len` bytes for the keys whose names are
-demanded, each written as `<tag> <len> <KeyValue>` -- already tagged, so the
-region is a complete OTLP repeated field rather than an input to an encoder.
-Value-only entries follow as bare `<len> <AnyValue>`. Both forms end in a
-length-delimited `AnyValue`, and a slot points at that length prefix in either
-case, so `slot_value` reads them identically and does not care which region a
-key landed in.
 
 There is no name-bearing region for captured headers. Every name in the
 context comes from configuration, never from the wire -- see

--- a/rust/otap-dataflow/docs/multitenant-token-propagation.md
+++ b/rust/otap-dataflow/docs/multitenant-token-propagation.md
@@ -1,0 +1,1235 @@
+# Multitenant Tenant Tokens and Cross-Boundary Propagation
+
+Status: prototype. This document describes the design and implementation of
+the tenant token prototype in this workspace, following the multitenancy
+design in [open-telemetry/otel-arrow#3583][pr].
+
+[pr]: https://github.com/open-telemetry/otel-arrow/pull/3583
+
+## Problem
+
+A collector that serves many tenants has to answer three questions about every
+request it accepts:
+
+1. **Who is this?** Something in the request -- a header, the peer address, the
+   pipeline it landed in -- identifies a tenant.
+2. **Where does it go?** That identity selects a destination: a topic, a
+   partition, a backend.
+3. **What travels with it?** Some of that identity must reach the backend, and
+   the backend's spelling of it is rarely the client's spelling.
+
+The pre-existing transport header policy (see
+[transport-headers.md](transport-headers.md)) answers question 3 alone, by
+capturing named headers and forwarding a filtered subset. It cannot answer 1 or
+2, because it has no notion of an identity distinct from a wire name, and it
+pays for what it captures: an owned `String` name and an owned `Vec<u8>` value
+per header per request.
+
+Tenant tokens answer all three with one declaration, and cost one allocation
+per request in total.
+
+## Core concepts
+
+### A token is a portable identity, not a header
+
+A **tenant token** is a named set of **extractors**, each of which resolves one
+**key** from the request:
+
+```yaml
+tenant_tokens:
+  edge_tenant:
+    extractors:
+      - key: customer_id
+        transport_header: x-tenant-id
+        retain: true
+```
+
+A token resolves **all or nothing**: `edge_tenant` exists for a request only if
+every one of its extractors resolved. This is what makes a token a usable
+identity -- downstream code tests "is this an `edge_tenant`?" rather than
+reasoning about partially-populated header maps. Put independently optional
+inputs in separate tokens.
+
+Four extractor kinds exist:
+
+| Kind | Source |
+| --- | --- |
+| `transport_header: <name>` | An inbound header, matched case-insensitively |
+| `generic_key: <value>` | A static value, minting a local identity |
+| `remote_address: true` | The peer socket address |
+| `imported_key: <name>` | A value handed across a pipeline boundary |
+
+`retain: false` (the default) is **match-only**: the value participates in
+conditions but is never stored, so it costs zero bytes per request.
+`retain: true` gives the key a value slot, so an exporter can emit it and a
+boundary policy can offer it downstream. This flag is the one thing that
+distinguishes keys in the packed layout, and it is the obvious candidate for
+inference: a liveness pass over the pipeline graph knows which keys a reachable
+consumer actually propagates, so `retain` could be derived rather than
+declared.
+
+**A token never names an egress header.** This is the central design decision.
+A wire name is a property of the backend being written to, not of the tenant,
+so the same key is `x-scope-orgid` for one backend and `x-acme-customer` for
+another. Naming therefore lives on the node that touches the wire:
+
+```yaml
+otlp_exporter:
+  type: exporter:otlp_grpc
+  config:
+    tenant_headers:
+      - { key: customer_id, header: x-scope-orgid }
+```
+
+An earlier iteration put `propagate_as: x-scope-orgid` on the extractor. It was
+removed: it forced a site-specific decision into a definition that is shared by
+the whole engine, and made a token untranslatable when two exporters disagreed.
+
+### Conditions are first-match-wins
+
+Consumers declare **conditions** over token keys. All entries of a condition
+must match; an entry with no `value` is a wildcard requiring only presence:
+
+```yaml
+routes:
+  - entries: [{ key: customer_id, value: tenant-a }]
+    topic: tenant_a
+  - entries: [{ key: customer_id }]     # any resolved customer_id
+    topic: tenant_shared
+default_topic: unmatched
+```
+
+## Implementation: the hash join
+
+Conditions are compiled, not interpreted. The design is the Envoy-style
+compile-time hash join: all string comparison happens once at startup, and each
+request costs a fixed number of hash lookups regardless of how many conditions
+are declared.
+
+The registry lives in `crates/config/src/tenant/compiled.rs` and is built once
+per pipeline group by the controller
+(`Controller::build_tenant_token_registry`), which walks every node config in
+the group collecting declared conditions before any node starts. It is shared
+through `PipelineContext::tenant_token_registry()`.
+
+### Build phase (startup)
+
+- Key names are interned to `KeyId(u16)`; token names to `TokenIdx(u16)`.
+- Each token gets a `key_mask: u64` -- one bit per extractor.
+- Header extractors go into `header_index: name -> SmallVec<[Slot; 2]>`, keyed
+  by the lowercased header name. Static extractors (`generic_key`,
+  `remote_address`) go into a flat `Vec`. Imported extractors go into
+  `import_index`, keyed by the upstream key name.
+- Conditions are grouped by **signature**: the pair of (sorted fixed keys,
+  sorted wildcard keys) they test. Conditions sharing a signature share a hash
+  table, because they hash the same terms in the same order.
+- A signature applies to a token only if `required_keys` is a subset of the
+  token's keys. Each applicable `(token, signature)` pair is assigned a dense
+  `PairSlot`.
+
+### Resolve phase (per request)
+
+1. Reset a reusable, receiver-owned `TokenScratch`. Steady state allocates
+   nothing here.
+2. Run static extractors, then make **one pass over the request headers**,
+   clearing `key_mask` bits as extractors are satisfied.
+3. A token whose word reached `0` is resolved. If none resolved, the request
+   carries no tenant context at all and the whole feature costs one branch.
+4. Compute one xxh3 fingerprint per allocated `PairSlot`, projecting the
+   resolved values onto the signature's `fixed_keys` **in signature order**.
+   Build and probe share one `fingerprint_term` helper so the two layouts
+   cannot drift.
+
+Token resolution being all-or-nothing yields a useful simplification: if a
+signature applies to a resolved token, every wildcard key it requires is
+necessarily present, so no per-request wildcard presence mask is needed.
+
+### Probe phase (per condition evaluation)
+
+`ConditionSet::first_match` is one bit test plus one hash lookup per bound
+`(token, signature)` pair, keeping the lowest matching `ConditionIdx` so
+first-match-wins is preserved across signatures. It allocates nothing.
+
+### The packed request context
+
+The per-request result is a single `Arc<[u64]>` stored in
+`Context.request`. `Arc<[u64]>` rather than `Arc<[u8]>` because the latter
+carries no 8-byte alignment guarantee; bytes are read back with
+`bytemuck::cast_slice`, so no `unsafe` is involved.
+
+Nothing in the layout is self-describing. Every key is registered, so a value
+is addressed by the **value slot** its key occupies in the registry, and no
+name, key id or descriptor travels with it:
+
+```text
+word 0     : n_fp:16 | n_slots:16 | epoch:16 | blob_len:16
+word 1     : resolved token bitmask
+word 2     : n_legacy:16
+words 3..  : n_fp fingerprints, indexed by PairSlot
+then       : n_slots words, indexed by registry value slot
+             value_off:16 | value_len:16 | kind:8, or EMPTY_SLOT
+then       : n_legacy pairs of words (captured headers only)
+             wA: name_off:16 | name_len:16 | value_off:16 | value_len:16
+             wB: kind:8 | wire_len:16
+then       : the byte blob, zero padded to a word boundary
+```
+
+A key gets a value slot only if some compiled consumer propagates its value.
+The rest are **match-only**: they are decided entirely by their contribution to
+a fingerprint, so their bytes are never copied into a context at all. That is
+the only distinction the layout draws between keys, and it is a build-time
+property, not a per-entry flag.
+
+Reading a key's value is therefore an array index --
+`registry.value_slot(key)` then `view.slot_value(slot)` -- rather than a scan
+looking for a matching name or key id.
+
+A second, name-bearing region carries the pre-existing `capture:` header
+policy, whose names come from the wire rather than from configuration. Tenant
+token keys never take that path, and the region is scheduled for deletion --
+see [Retiring the capture policy](#retiring-the-capture-policy).
+
+**Contexts are only meaningful to registries that agree on the layout.** A
+registry is built per pipeline group, but topics are declared engine-wide and
+are visible to all groups, so a topic hop can join *two different registries*.
+What makes that safe is not shared construction, it is agreement: token
+definitions are engine-wide and interned in sorted order before any
+group-specific work, so every group derives the same key ids and the same
+value slots. Conditions differ per group and pair slots with them, which does
+not matter across a boundary because fingerprints are not exported.
+
+That agreement is an invariant, so it is stated rather than assumed. `epoch`
+is the deployment generation mixed with a digest of the ordered value-slot
+layout, and `resolve_imported` drops an upstream context whose epoch differs
+instead of reading slots as something they are not. This matters most for a
+change the design still wants: the baseline allows tokens to be declared per
+group and per pipeline, which would make layouts genuinely diverge. The digest
+turns that from a silent misread into a dropped context.
+
+A hop that leaves the registry entirely -- persistence across a restart, or
+another engine -- has to re-resolve from transport headers instead.
+
+This field **replaces** `Context.transport_headers` rather than adding to it,
+which is why the feature is net-negative on memory. The `request_context`
+benchmark measures where that cost actually sits, and the answer is narrower
+than it first appears:
+
+| phase | matched | allocs | bytes |
+| --- | --- | --- | --- |
+| capture | 1 | 5.00 | 388.0 |
+| capture | 2 | 8.00 | 421.0 |
+| capture | 4 | 14.00 | 546.0 |
+| carry | any | 0.00 | 0.0 |
+| propagate | any | 0.00 | 0.0 |
+
+Capture costs `2 + 3n` -- an `Arc`, a `Vec`, and a name, wire name and value
+per header -- and the target is exactly **1**. Carry and propagation are
+already free: `TransportHeaders` is an `Arc<Vec<TransportHeader>>`, so a hop is
+an `Arc` bump at about 10ns regardless of header count, and propagation
+borrows. The win is per request, not per hop, and claiming otherwise would
+overstate it. `Context` itself grows 8 bytes, since a fat slice pointer
+replaces a thin one.
+
+Limits: `MAX_TOKENS = 64`, `MAX_TOKEN_KEYS = 64`, `MAX_VALUE_BYTES = 65535`.
+
+### Conditions never compare values
+
+`first_match` compares fingerprints and stops. The values behind them are not
+re-checked, so a condition over match-only keys costs one hash lookup and
+touches no bytes.
+
+This is a deliberate trust in the 64-bit fingerprint rather than an oversight,
+and it needs no configuration option: a deployment that wants values verified
+can give the conditioned keys a value slot by propagating them, at which point
+the values are present to compare. The prototype does not implement that
+comparison, and the option should not exist.
+
+## Boundaries
+
+A topic is a pipeline boundary, and boundaries are the only place tenant
+material can leak between tenants. The design therefore **fails closed**: with
+no policy configured, nothing crosses, and both ends of every boundary carry an
+explicit allowlist. Belt and braces is deliberate -- removing either end stops
+propagation, so no single misconfiguration silently opens the boundary.
+
+### One key, one value
+
+Conditions and values need opposite guarantees, and the baseline design only
+addresses the first.
+
+For **conditions**, many-to-many is the point. Every resolved token is probed
+against every applicable condition, and a request matching several is normal;
+the cross-product is what `PairSlot` enumerates and what first-match-wins
+disambiguates.
+
+For **values**, many-to-one is a defect. An exporter asking for `customer_id`
+must get one answer, and it must be the same answer on every request that
+looks the same.
+
+Two things had to change to guarantee that.
+
+#### A key has one source per resolve path
+
+Staging is per key: `scratch.values` is indexed by `KeyId`, so every extractor
+writing a given key writes the same cell. Two tokens binding one key to
+different sources therefore race, and the winner depends on the order headers
+arrived in the request.
+
+This is not only a propagation bug. Fingerprints are computed per
+`(token, signature)` pair, but each one reads the shared per-key cell, so token
+A's condition can be evaluated against a value that token B's extractor stored.
+The cross-product is honoured at fingerprint time and violated at staging time.
+
+The build now rejects it:
+
+```text
+tenant token 'edge_tenant' binds key 'customer_id' to transport_header
+'x-tenant-id' on the request path, but it is already bound there to
+transport_header 'x-legacy-tenant'; a key resolves from one source per path,
+so give these different key names
+```
+
+The rule is per **resolve path**, not registry-wide, because there are two
+disjoint ones: `resolve` runs transport-header and static extractors,
+`resolve_imported` runs imported-key and static extractors. A key read from a
+header on the ingress side and imported on the far side of a boundary is
+consistent -- that is precisely how a portable key crosses a boundary keeping
+its name -- while two headers feeding one key on the same path is not.
+
+Repeating a key across tokens is still fine and still common, as long as the
+source agrees. Tokens that differ in their other keys routinely share an
+identity key.
+
+The rule also lands where the earlier discussion already pointed. Wanting
+`customer_id` from auth *and* from a header is not one key with two sources;
+it is a verified key and a claimed key, which is why that example names them
+separately.
+
+#### A value travels only with its evidence
+
+The second defect was subtler. Value slots were filled from staging
+unconditionally, so a key retained by a token that never resolved still had
+its value packed and emitted, as long as some *other* token resolved.
+
+That inverts the security posture. A token is a conjunction: retaining
+`region_id` in a token that also requires `gate_id` says the value may be
+carried *when the gate was proven*. Releasing it regardless discards the
+evidence and keeps the payload.
+
+Each value slot now carries the mask of tokens that declared its key with
+`retain: true`, and the slot is populated only if one of them resolved:
+
+```rust
+scratch.slots[slot] = if resolved & self.retain_mask[slot] == 0 {
+    ValueRef::default()
+} else {
+    scratch.values[usize::from(*key)]
+};
+```
+
+It costs one word per retained key and one AND per pack. Note the mask holds
+only tokens that asked to retain: a token that matches on a key without
+retaining it does not release the value, so requesting a value and merely
+testing it stay distinct.
+
+### Egress: `exporter:topic`
+
+The topic router (`exporter:topic`) is both router and egress boundary:
+
+```yaml
+topic_router:
+  type: exporter:topic
+  config:
+    routing:
+      tenant_tokens: [edge_tenant]
+      routes:
+        - entries: [{ key: customer_id, value: tenant-a }]
+          topic: tenant_a
+      default_topic: unmatched
+      export:
+        allow_keys: [customer_id]
+```
+
+`select_route` probes the condition set; `apply_egress_policy` then calls
+`TenantTokenRegistry::export_boundary`, which repacks **only** the allowed keys
+into a fresh buffer, keeping each value in its own registry slot. Fingerprints,
+the resolved-token mask, the captured headers and every unlisted key are
+dropped. The blob is rebuilt rather than masked in place, since the packed
+buffer is shared and any byte left in it would stay readable. Without
+`export`, the context is set to `None` outright.
+
+This replaced the previous behavior, where `clone_without_context` in the topic
+receiver carried the full request context across the hop unconditionally.
+
+### Ingress: `receiver:topic`
+
+```yaml
+from_topic:
+  type: receiver:topic
+  config:
+    topic: tenant_a
+    tenant_context:
+      import:
+        allow_keys: [customer_id]
+      tokens: [routed_tenant]
+```
+
+The inbound context is treated as **evidence, not identity**. It is never
+adopted. `BoundaryFilter::admits` screens by key id -- the two registries
+agree on key ids, so this is a flag lookup, not a name match -- then
+`resolve_imported` re-runs the resolve phase over the admitted values plus this
+pipeline's static extractors, producing a context whose tokens and fingerprints
+belong to the local pipeline. A dedicated tenant pipeline can therefore combine
+an imported value with a `generic_key` identity of its own in a single token.
+
+## Batching
+
+`processor:batch` merges requests, so it is the one node that can silently
+attribute one tenant's data to another. Two mechanisms address this.
+
+**Partitioning.** `batch_by` gives each condition its own complete set of
+per-signal buffers, plus a trailing catch-all partition for data matching
+nothing:
+
+```yaml
+batcher:
+  type: processor:batch
+  config:
+    batch_by:
+      tenant_tokens: [routed_tenant]
+      partitions:
+        - entries: [{ key: customer_id, value: tenant-a }]
+```
+
+Since buffers are per-partition, an output batch belongs to exactly one
+partition by construction. Two pieces of per-buffer state had to become
+partition-aware: wakeup slots are offset by
+`partition * SLOTS_PER_PARTITION`, and the outbound slot key in the ack/nack
+calldata is stamped with its partition, since a `SlotKey` is only meaningful
+inside its own partition's slot state.
+
+**Merge safety net.** Each `BatchPortion` retains its input's packed context,
+and `RequestContextMerger` folds them the way `PeerAddrMerger` folds peer
+addresses: the merged batch keeps a context only if every contributing input
+agreed, and drops it otherwise. Partitioning normally guarantees agreement, so
+this exists to make a disagreement fail closed -- the batch emits no tenant
+headers -- rather than mislabel data.
+
+Before this work, the batch processor built every output with
+`Context::default()`, so batching destroyed the tenant context entirely.
+
+## Worked example
+
+`configs/engine-conf/tenant_boundary_propagation.yaml` wires the full path:
+
+```text
+OTLP receiver -> resource enricher -> topic router (routes by token)
+   =>  topic  =>
+topic receiver (new context) -> batch (partitioned) -> OTLP exporter
+```
+
+The ingress token reads `x-tenant-id` into `customer_id` and retains it. The
+router selects a per-tenant topic and exports `customer_id`. Each tenant
+pipeline imports `customer_id`, mints its own `routed_tenant` token from it via
+`imported_key`, partitions batches by it, and names it for its own backend.
+
+Verified live against two catch-all gRPC servers:
+
+| Inbound | Backend | Outbound |
+| --- | --- | --- |
+| `x-tenant-id: tenant-a` | A | `x-scope-orgid: tenant-a` |
+| `x-tenant-id: tenant-b` | B | `x-acme-customer: tenant-b` |
+| `x-tenant-id: zzz` | -- | routed to the unmatched sink |
+
+Two further demos exist:
+`configs/engine-conf/topic_multitenant_token_routing.yaml` (routing only) and
+`configs/engine-conf/tenant_header_mapping.yaml` (single-pipeline
+ingress-to-egress header mapping).
+
+## Proposed: the context as OTLP attributes
+
+This section is a **design proposal**, not implemented work.
+
+The packed context is a key-value bag with a hand-rolled encoding. The
+`self_tracing` encoder already solved the same problem for log attributes by
+half-encoding straight to OTLP bytes at the callsite, and the same move applies
+here. The payoff is not the encoding itself, it is that the bytes become
+*directly appendable* to telemetry: instrumenting a request with its tenant
+context stops being a re-encode and becomes a copy.
+
+### The slot becomes one offset
+
+Today a slot is `value_off:16 | value_len:16 | kind:8`. A slot would instead be
+a single `u32` offset pointing at the length varint of a `KeyValue.value`
+field, so the encoding carries its own size and `AnyValue` carries its own
+type. `ValueKind` disappears -- it is a hand-rolled parallel to `AnyValue`, and
+a worse one, since `AnyValue` covers int, double, bool and bytes.
+
+```text
+value-only key : <vlen> <AnyValue>
+bag key        : 0A <klen> <key> 12 <vlen> <AnyValue>
+                                     ^-- the slot points here
+```
+
+Both are read the same way: take the varint at the slot, slice that many bytes,
+and hold an `AnyValue`. The bag form simply has a name in front of it, so one
+region of bytes serves both the slot read and the bulk copy with no
+duplication.
+
+The size cost is close to nothing. `tenant-a` is 8 raw bytes today plus a
+5-byte slot descriptor; as a bare value it is 11 bytes plus a 4-byte slot. The
+bag form is the one that costs, roughly doubling, and only keys a bag consumer
+actually reaches pay it.
+
+### Names become demand-driven, like values
+
+`retain` already makes value bytes conditional on some compiled consumer
+wanting them. Extending the same liveness rule to names gives three levels per
+key:
+
+| demand | stored |
+| --- | --- |
+| match-only | nothing; the fingerprint decides |
+| a consumer propagates the value | `<vlen> <AnyValue>` |
+| a consumer reads the whole bag | `0A <klen> <key> 12 <vlen> <AnyValue>` |
+
+This keeps the security posture intact. A name still never travels because it
+was on the wire; it travels because a compiled consumer in this deployment
+demanded the bag, which is a declaration like any other. The default remains
+that nothing propagates.
+
+Bag-level keys must be contiguous, so the layout grows a bag region whose
+entries are adjacent and whose slots point inside it.
+
+### The consumer supplies the field number
+
+OTLP does not use a single field number for attributes:
+
+| destination | field |
+| --- | --- |
+| `Resource.attributes` | 1 |
+| `InstrumentationScope.attributes` | 3 |
+| `LogRecord.attributes` | 6 |
+| `Exemplar.filtered_attributes` | 7 |
+| `Span.attributes` | 9 |
+
+So the run is stored **untagged** -- `<len> <KeyValue body>` repeated, no field
+tag -- and the caller says where it is going:
+
+```rust
+/// Append the carried keys as OTLP `KeyValue` entries under `field`.
+///
+/// The stored run carries no field tag, so one context serves scope
+/// attributes, span attributes and exemplars without re-encoding.
+pub fn append_attributes<B: BoundedBuf>(
+    &self,
+    dst: &mut B,
+    field: u64,
+) -> EncodeResult
+```
+
+Per attribute that is one tag byte pushed and one `extend_from_slice`. Every
+field number above is under 16, so the tag is always a single byte and the cost
+does not depend on the destination. Nothing is re-encoded and nothing is
+allocated.
+
+### Scope attributes amortize the copy
+
+The expected caller passes `INSTRUMENTATION_SCOPE_ATTRIBUTES`, and that choice
+does more than pick a number.
+
+Scope attributes are shared by every record under a `ScopeLogs`, `ScopeSpans`
+or `ScopeMetrics`, so the tenant context is copied once per scope rather than
+once per record. It composes with work the prototype already does: batching is
+partitioned by tenant conditions, so an output batch belongs to exactly one
+partition and therefore to exactly one tenant context. One batch, one scope,
+one copy -- and the more records a batch holds, the better the amortization.
+
+It is also the honest modelling. The tenant context describes the conditions
+under which the pipeline produced this telemetry, not a property of each
+individual record, which is what an instrumentation scope is for.
+
+### Fingerprints move to the encoded form
+
+Fingerprinting the `AnyValue` bytes rather than the raw value is a
+simplification, not a compromise. Condition literals are encoded once at build
+time, and `resolve_imported` stops needing to decode anything -- it hashes the
+slot bytes as they lie. It also makes the integer `5` and the string `"5"`
+distinct terms, which is correct and is not true today.
+
+### The wildcard extractor
+
+A bag is only useful if something can fill it, and full token binding
+deliberately has no way to capture an undeclared key. A wildcard extractor
+would reintroduce that, and it has to be justified rather than assumed.
+
+The distinction that makes it acceptable is that a wildcard is **declared**.
+The rejected `capture:` plus `preserve` combination let an inbound request
+decide what left the process; a wildcard extractor is an operator writing down
+"collect the rest here", and everything downstream still applies -- the
+boundary allowlists screen it as a unit, and egress still requires an exporter
+to name what it emits.
+
+The blast radius also depends on who consumes it, and the two consumers are not
+alike. Feeding a bag into span attributes or self-telemetry keeps it inside the
+process, which is the case that motivates the feature. Feeding it back onto the
+wire is the case that gave up the enumeration guarantee, and it is the one that
+should have to say so.
+
+## Retiring the capture policy
+
+This section is a **migration plan**, not implemented work. It enumerates every
+component that still depends on the name-bearing region of the packed layout.
+
+The packed layout still carries a second, name-bearing region for the
+pre-existing `capture:` header policy. It exists only because that policy has
+callers, and it should not survive: **a name that travels is a name nobody
+declared**.
+
+The security posture is the argument. Under `capture:`, a receiver matches
+`match_names` and stores whatever it found, wire name included, and an exporter
+with `name: preserve` re-emits it. Nobody wrote down that the header would
+leave the process. Any header a client can set is one an operator never
+reviewed, so the set of names crossing an egress boundary is decided by the
+inbound request rather than by configuration.
+
+Under full token binding, a name exists at exactly two places, both declared:
+an extractor that reads it and an exporter that writes it. In between there is
+a key id and a value slot. There is no *as captured* name strategy, because
+there is no captured name to preserve -- the ingress name was compiled out at
+build time and the egress name is created fresh from the exporter's own map.
+An operator who wants a header forwarded must say so; the default is that
+nothing propagates.
+
+Deleting the region also deletes the last variable-shaped part of the layout:
+words 2 and the legacy descriptor pairs disappear, `TenantView::iter` and
+`find_by_name` go with them, and `CarriedValue` reduces to a value slot read.
+
+Each component below needs one change to get there.
+
+### `receiver:otlp`, `receiver:kafka`
+
+Capture rules become extractors. `store_as` was already a rename from wire name
+to logical name, which is exactly what `key` does:
+
+```yaml
+# Before
+header_capture:
+  headers:
+    - match_names: ["x-tenant-id"]
+      store_as: tenant_id
+    - match_names: ["x-request-id"]
+
+# After
+tenant_tokens:
+  request_identity:
+    extractors:
+      - key: tenant_id
+        transport_header: x-tenant-id
+        retain: true
+      - key: request_id
+        transport_header: x-request-id
+        retain: true
+```
+
+The `defaults` limits (`max_entries`, `max_name_bytes`, `max_value_bytes`) have
+no equivalent and need none: the declared extractor set is the bound. A token
+cannot exceed `MAX_TOKEN_KEYS`, and no unnamed header is stored at any size.
+
+The one real loss is **duplicate header names**. A key holds one value, while
+capture kept every occurrence. Nothing in this design routes on a repeated
+header, so the prototype takes last-write-wins; a component that genuinely
+needs multiplicity should say so before the region is deleted.
+
+### `exporter:otlp_grpc`, `exporter:otlp_http`
+
+Propagation policy becomes `tenant_headers`. The `named` selector maps
+directly; `all_captured` has no equivalent by design, since it is the rule that
+lets an undeclared name escape:
+
+```yaml
+# Before
+header_propagation:
+  default:
+    selector:
+      type: named
+      named: [tenant_id]
+    name: preserve
+
+# After
+tenant_headers:
+  - key: tenant_id
+    header: x-tenant-id
+```
+
+`otlp_http` currently has no `tenant_headers` at all, so it needs the same
+egress map the gRPC exporter already has.
+
+### `processor:partition`
+
+Not a rename, and the only case that needs new machinery. The partition
+processor synthesizes a value and publishes it by pushing a synthetic transport
+header onto the context. It is developed as its own example below, in
+[Forking context on a data attribute](#example-forking-context-on-a-data-attribute).
+
+### `exporter:kafka`
+
+Kafka routes and partitions by header name today, in two independent places:
+
+```yaml
+# Before
+traces:
+  topic_from_transport_header: x-tenant-id
+  partition_by_transport_headers: true
+
+# After
+traces:
+  topic_from_key: tenant_id
+  partition_by_keys: [tenant_id]
+```
+
+Reading by key removes the pre-normalization dance in `topic_router.rs`, where
+the configured name is lowercased at build time to match how capture stored
+logical names. With key ids there is no name to normalize.
+
+The kafka *receiver* is the mirror image: it captures message headers on
+ingress, so it takes the extractor treatment above. Worth noting that its
+headers are Kafka's, not HTTP's -- which is what the baseline means by
+transport headers being generic, with each receiver deriving them from its own
+protocol.
+
+### `receiver:traffic_generator` and `crates/validation`
+
+Both exist to exercise the pipeline, and both currently assert by name. They
+move to declaring tokens like any other receiver, and asserting on
+`slot_value(registry.value_slot(key))` rather than `find_by_name`. This is the
+largest mechanical diff and the least interesting one.
+
+### What has to be decided first
+
+- **Duplicate names.** Confirm nothing needs them, or add a multi-value key.
+- **`sensitive: true`.** Capture has a flag for headers like `authorization`.
+  Token keys have no such marker, and the natural answer is that a secret
+  should never become a key at all -- it should reach an authorization
+  extension and contribute a derived fact instead.
+- **Skip statistics.** Capture reports headers dropped for exceeding limits.
+  The token equivalent is an unresolved token, which is observable but means
+  something different.
+
+## Component integration patterns
+
+Everything above this point is implemented. **Everything below is a design
+sketch**: proposed integrations for components that do not yet consume tenant
+tokens, recorded so the pattern can be reviewed before it is built.
+
+The four components already covered illustrate four distinct ways a component
+can consume a tenant token:
+
+| Pattern | Component | What the token does |
+| --- | --- | --- |
+| **Create** | `receiver:otlp` | Declares extractors; mints identity |
+| **Map** | `exporter:otlp_grpc` | Selects an outbound wire name |
+| **Select** | `processor:batch` | Chooses a partition and its parameters |
+| **Scope** | `exporter`/`receiver:topic` | Gates what crosses a boundary |
+
+The remaining components are worth working through only where they introduce a
+*new* pattern. A component that merely re-instantiates "create" or "select"
+adds configuration surface but no design insight. The examples below are
+therefore ordered by the pattern they introduce, and the list ends when new
+components stop introducing new patterns.
+
+### Example: authenticated identity as a token source
+
+**The problem with the examples so far.** Every token above resolves
+`customer_id` from `x-tenant-id`, a header the client chose. On a trusted
+internal network that is fine. On an open ingest endpoint it is a tenant
+impersonation vulnerability: any client can claim to be any tenant, and every
+routing, partitioning and quota decision downstream inherits the lie. A header
+is a *claim*; it is not evidence.
+
+The engine already has the missing piece, and the baseline design already
+names it: "Authorization extensions are the source of trusted material for
+defining tenant tokens." The `bearer_token_authorizer` capability
+(`crates/engine/src/capability/auth/`) authenticates an inbound token and emits
+an `AuthorizedIdentity { subject, audience }`. Its own documentation draws
+exactly the line this design needs:
+
+> It admits on the token alone; it does not perform contextual, per-request
+> authorization (route, tenant, signal, or action scoping), which needs request
+> context it never receives and belongs downstream -- consuming the
+> `AuthorizedIdentity` this capability emits.
+
+Tenant tokens are that downstream consumer. The authorizer decides *whether the
+caller is who they say they are*; tenant tokens decide *what that principal is
+allowed to be called, and where their data goes*.
+
+#### The extractor
+
+The baseline names extractors after the source they read from, in pairs: an
+extracting form and a matching form (`transport_header` /
+`transport_header_match`, `resource_attribute` / `resource_attribute_match`).
+Authorization material follows the same pattern:
+
+- `authorized_attribute: <name>` copies a field asserted by the request's
+  authorization extension into a token key.
+- `authorized_attribute_match: <name>` with `value:` gates resolution on that
+  field without contributing a key.
+
+Mechanically this is the cheapest kind of extension. Like `remote_address` it
+is a per-request value from a non-header source, so the build and probe phases
+are untouched.
+
+#### One token, two provenances
+
+The useful shape is a single token whose keys come from different sources,
+because that is what lets an untrusted claim be interpreted only in the context
+of a trusted one:
+
+```yaml
+tenant_tokens:
+  customer_project:
+    extractors:
+      # Evidence: asserted by the authorization extension.
+      - key: customer_id
+        authorized_attribute: enduser.id
+        retain: true
+      # Claim: chosen by the client.
+      - key: project_id
+        transport_header: x-project-id
+        retain: true
+```
+
+`customer_id` is evidence and `project_id` is a claim, but they are keys of one
+token, so every condition that tests `project_id` also has `customer_id`
+available to test alongside it. A client can name its own projects; it cannot
+name another customer's project, because the customer half of the pair is not
+theirs to choose.
+
+All-or-nothing resolution does the rest. A request with no authorization, or
+with no `x-project-id`, resolves no token, so no downstream condition matches
+it and it takes the default. Fail-closed is not new machinery here; it is the
+existing token semantics applied to a token that happens to mix sources.
+
+#### Enumerating the permitted pairs
+
+A token resolves keys; it does not validate relationships between them. The
+conditions do, because a condition over two keys is precisely a join on those
+two keys, which is what the hash join already compiles:
+
+```yaml
+topic_router:
+  type: exporter:topic
+  config:
+    routing:
+      tenant_tokens: [customer_project]
+      routes:
+        # Acme's own projects.
+        - entries:
+            - { key: customer_id, value: acme }
+            - { key: project_id, value: checkout }
+          topic: acme_checkout
+        - entries:
+            - { key: customer_id, value: acme }
+            - { key: project_id, value: search }
+          topic: acme_search
+        # Any other project acme names is still acme's.
+        - entries:
+            - { key: customer_id, value: acme }
+            - { key: project_id }
+          topic: acme_shared
+      default_topic: unmatched
+      export:
+        allow_keys: [customer_id, project_id]
+```
+
+The third route is the wildcard form from the baseline: `project_id` with no
+`value` requires the key to be present without constraining it. Its position
+matters, since first-match-wins means it catches only what the two specific
+routes did not.
+
+Cost is unchanged by the extra key. Both keys belong to one signature, so the
+whole check is still one fingerprint at resolve time and one hash lookup per
+probe. The authorization matrix is data in a hash table, not a chain of
+comparisons, and it stays flat as customers and projects are added.
+
+Two details are worth calling out in configuration review:
+
+- `default_topic` is doing security work. Pointing it at a real backend
+  instead of a quarantine sink silently converts a deny into an allow. This is
+  the one place where first-match-wins with a fallback is dangerous rather
+  than convenient.
+- `export.allow_keys` lists both keys here, so both cross the boundary. Listing
+  only `project_id` would let a tenant pipeline partition by project while
+  keeping the customer identity from reaching a backend that has no business
+  knowing it.
+
+#### Binding the authorizer
+
+The receiver needs no new configuration surface. It declares the authorization
+extension and binds it through the existing `capabilities` block, exactly as
+the Azure Monitor exporter binds `bearer_token_provider` today:
+
+```yaml
+extensions:
+  cluster_auth:
+    type: extension:oidc_authorizer
+    config:
+      issuer: https://kubernetes.default.svc
+      audience: otel-collector
+
+nodes:
+  otlp_receiver:
+    type: receiver:otlp
+    capabilities:
+      bearer_token_authorizer: cluster_auth
+    config:
+      protocols:
+        grpc:
+          listening_addr: 127.0.0.1:4317
+```
+
+Binding the capability is what fixes the ordering, and the ordering is the
+security property: the authorizer runs first, a deny ends the request before
+resolution runs at all, and only then does the engine resolve tokens over the
+fields the identity asserted.
+
+#### Hypothetical integration
+
+The full path, from credential to outbound header name:
+
+```yaml
+tenant_tokens:
+  # Ingress identity: one authenticated key, one claimed key.
+  customer_project:
+    extractors:
+      - key: customer_id
+        authorized_attribute: enduser.id
+        retain: true
+      - key: project_id
+        transport_header: x-project-id
+        retain: true
+
+  # Downstream identity, resolved locally from what the boundary admitted.
+  routed_tenant:
+    extractors:
+      - key: customer_id
+        imported_key: customer_id
+        retain: true
+      - key: project_id
+        imported_key: project_id
+        retain: true
+
+groups:
+  secure_ingest:
+    topics:
+      acme:
+        description: Authenticated traffic for the acme customer.
+      unmatched:
+        description: Quarantine for unresolved or unauthorized requests.
+
+    pipelines:
+      ingress:
+        extensions:
+          cluster_auth:
+            type: extension:oidc_authorizer
+            config:
+              issuer: https://kubernetes.default.svc
+              audience: otel-collector
+
+        nodes:
+          otlp_receiver:
+            type: receiver:otlp
+            capabilities:
+              bearer_token_authorizer: cluster_auth
+            config:
+              protocols:
+                grpc:
+                  listening_addr: 127.0.0.1:4317
+
+          topic_router:
+            type: exporter:topic
+            config:
+              routing:
+                tenant_tokens: [customer_project]
+                routes:
+                  - entries:
+                      - { key: customer_id, value: acme }
+                      - { key: project_id }
+                    topic: acme
+                default_topic: unmatched
+                export:
+                  allow_keys: [customer_id, project_id]
+
+        connections:
+          - from: otlp_receiver
+            to: topic_router
+
+      acme_egress:
+        nodes:
+          from_topic:
+            type: receiver:topic
+            config:
+              topic: acme
+              subscription:
+                mode: broadcast
+              tenant_context:
+                import:
+                  allow_keys: [customer_id, project_id]
+                tokens: [routed_tenant]
+
+          batcher:
+            type: processor:batch
+            config:
+              max_batch_duration: 200ms
+              # One partition per project, so a batch never mixes them and
+              # the exporter always has a single tenant context to name.
+              batch_by:
+                tenant_tokens: [routed_tenant]
+                partitions:
+                  - entries:
+                      - { key: customer_id, value: acme }
+                      - { key: project_id, value: checkout }
+                  - entries:
+                      - { key: customer_id, value: acme }
+                      - { key: project_id, value: search }
+
+          otlp_exporter:
+            type: exporter:otlp_grpc
+            config:
+              grpc_endpoint: http://backend-acme:4317
+              tenant_headers:
+                - key: customer_id
+                  header: x-scope-orgid
+                - key: project_id
+                  header: x-acme-project
+
+        connections:
+          - from: from_topic
+            to: batcher
+          - from: batcher
+            to: otlp_exporter
+```
+
+Note what is absent from every block above: the credential. `BearerToken` is a
+secret-protecting wrapper and is never exposed to token resolution, so the
+packed request context cannot carry a bearer token into a batch, across a
+topic, or out to a backend. The identity derived from a secret propagates; the
+secret does not.
+
+The value reaching `x-scope-orgid` is now an authenticated fact, while the one
+reaching `x-acme-project` is a client claim scoped by it. Nothing downstream of
+the receiver changed to get that property, because downstream nodes name keys
+rather than wire locations -- which is exactly why the same pipeline serves a
+header-identified deployment and an authenticated one.
+
+#### Implementation note
+
+Authorization extensions reach token resolution through a sink, a narrow
+interface to the compiled machine:
+
+```rust
+/// Authorization extensions assert semconv-named facts about the caller.
+/// They never see the compiler, the scratch, or the packed layout.
+pub trait IdentitySink {
+    fn offer(&mut self, key: &str, value: &[u8]);
+}
+```
+
+The extension contributes inputs; only the engine declares them complete, which
+it must, since fingerprints are valid only once every input is known. A
+borrowed slice out of an already-parsed certificate or JWT goes straight into
+the scratch arena, so the one-allocation-per-request property survives. Fields
+no token declared an extractor for fail the key lookup and are dropped, so what
+an authorizer can assert and what a pipeline's tokens want need no coordination
+and can be configured by different teams. The sink can also be wrapped to
+restrict an extension to a name prefix it is authorized to assert, so a
+compromised mTLS extension cannot assert `enduser.id` and hijack routing.
+
+The existing `bearer_token_authorizer` API does not change:
+`AuthorizedIdentity { subject, audience }` is adapted into the sink by engine
+glue, offering `subject` as `enduser.id`. Extensions wanting to assert richer
+facts opt into a separate capability whose vocabulary is the sink itself.
+
+### Example: forking context on a data attribute
+
+`processor:partition` splits one batch into N by evaluating an OPL expression
+over the payload, then publishes the partition value so downstream nodes can
+act on it. Today it publishes by pushing a synthetic transport header, which
+puts it squarely in the capture path.
+
+It is the same shape as the topic exporter/receiver pair. Both are **context
+forks**: a node consumes one context and constructs new ones, and both halves
+of the question -- what survives, what is created -- have to be answered.
+
+| | topic exporter/receiver | `processor:partition` |
+| --- | --- | --- |
+| fork driven by | condition over keys | expression over payload |
+| fan-out | 1 of K fixed outputs | N, determined by data |
+| crosses | a pipeline boundary | nothing |
+| what survives | `export`/`import` lists | everything |
+| what is created | the receiver's tokens | one key |
+
+The difference in the last two rows is the whole point. The topic pair filters
+because it crosses a scope: a pipeline-scoped token must not escape its
+pipeline, so both ends carry an allowlist. The partition processor crosses no
+scope, so nothing needs filtering and nothing needs declaring on that side.
+**It is the topic pair minus the boundary.** The fix to the current code is
+that simple: forward the inbound context to each output instead of building a
+fresh one, then write the key.
+
+#### Partitioning is what makes a data attribute liftable
+
+The baseline restricts `resource_attribute` extractors to single-resource
+batches, for a good reason: a key holds one value, and a batch generally has
+many values for any given attribute. There is no correct answer to "what is the
+customer id of this batch".
+
+Partitioning is the operation that establishes the missing precondition. After
+a split on `resource.attributes["customer.id"]`, each output batch has exactly
+one value for it by construction. So this processor is not merely *allowed* to
+lift a payload attribute into the context -- it is the node that makes doing so
+well defined:
+
+```yaml
+tenant_tokens:
+  partitioned_tenant:
+    extractors:
+      - key: edge_tenant
+        transport_header: x-tenant-id
+      - key: customer_id
+        node_defined: splitter
+        retain: true
+
+nodes:
+  splitter:
+    type: processor:partition
+    config:
+      partition_by:
+        opl_expression: resource.attributes["customer.id"]
+      header_serialization_strategy: json
+    out_ports:
+      default: [sink]
+
+  sink:
+    type: exporter:otlp_grpc
+    config:
+      grpc_endpoint: http://collector:4317
+      tenant_headers:
+        - key: customer_id
+          header: x-acme-customer
+```
+
+A node-defined key is a third writer, so it takes a binding of its own under
+[one key, one value](#one-key-one-value): a key defined by a node cannot also
+be extracted from a header, and two nodes cannot define the same key.
+
+`node_defined: splitter` is the only declaration. The engine resolves it at
+build time and hands the processor a slot index, so the processor writes a
+slot, never a name -- the same compile-out that extractors get. The exporter
+names it on egress, exactly as it would name a header-derived key. Nothing in
+between knows the string `customer.id` or `x-acme-customer`.
+
+`header_serialization_strategy` survives unchanged. The problem it solves --
+an OPL expression yields ints, doubles, bools or null, and a slot holds bytes
+plus a kind -- is identical whether the destination is a header or a value
+slot.
+
+#### Deferred resolution
+
+A token containing a node-defined key cannot resolve at the receiver, because
+one of its keys does not exist yet. This is the one piece of machinery the
+example requires, and the layout already accommodates it: the resolved-token
+bitmask simply keeps that token's bit clear until the defining node runs and
+completes the resolve.
+
+Two consequences follow.
+
+A condition over `partitioned_tenant` is meaningless upstream of `splitter`,
+and evaluating one there is a configuration error rather than a miss. This is
+the same reachability analysis the baseline already requires for scoping pair
+slots, applied to node order rather than graph connectivity.
+
+And the fork itself must pay for the resolve: N outputs means N fingerprints
+per allocated pair, not one. That is the honest cost of a data-driven fork, and
+it argues for keeping the number of tokens carrying node-defined keys small.
+
+#### The cheap case
+
+If `customer_id` is only used to choose a Kafka topic and never emitted as a
+header, drop `retain: true`. It gets no value slot, and the fork writes a
+fingerprint per output and copies zero bytes. Partitioning on an attribute and
+routing on it is then free of any per-value allocation -- which is the same
+payoff match-only keys give everywhere else, arriving here without the design
+having to do anything special.
+
+#### The bug this replaces
+
+Worth recording why the current code cannot be left alone. The single-partition
+path reuses `inbound_context`, but the multi-partition path builds a
+`Context::default()` and copies over only transport headers and peer address.
+The tenant context is therefore preserved or destroyed depending on how the
+data happened to partition. Making the processor a declared definition site
+removes the fork in the code along with the fork in behaviour.
+
+## Where the code lives
+
+Paths below are relative to `crates/`.
+
+- User-facing config types --
+  `config/src/tenant.rs`
+- Build, resolve, probe and pack --
+  `config/src/tenant/compiled.rs`
+- `Context.request`, accessors, merge helpers --
+  `otap/src/pdata.rs`
+- Registry compilation per group --
+  `controller/src/lib.rs`
+- Registry sharing --
+  `engine/src/context.rs`
+- Ingress resolution --
+  `otap/src/otlp_http.rs`
+- Routing and egress policy --
+  `core-nodes/src/exporters/topic_exporter/mod.rs`
+- Ingress policy and re-resolution --
+  `core-nodes/src/receivers/topic_receiver/mod.rs`
+- Partitioning and context merge --
+  `core-nodes/src/processors/batch_processor/mod.rs`
+- Outbound header naming --
+  `core-nodes/src/exporters/otlp_grpc_exporter/mod.rs`
+
+## Prototype limitations
+
+- No tests were written for this prototype; validation was by full-suite
+  regression plus live end-to-end runs.
+- Token resolution is wired into the OTLP/HTTP receiver only. Other receivers
+  still use the capture policy. `TokenInputs` is the extension point: new
+  sources of tenant material are added there rather than at every receiver.
+- Only `exporter:otlp_grpc` implements `tenant_headers`.
+- The name-bearing capture region still exists in the packed layout, so a wire
+  name can still reach an egress boundary without being declared. Closing that
+  hole is the migration described in
+  [Retiring the capture policy](#retiring-the-capture-policy).
+- Conditions are compiled against the union of all conditions declared in a
+  group; graph reachability is not considered, so an unreachable node still
+  contributes pair slots. The baseline requires the reachable cross-product:
+  "for every token and every reachable condition (the conditions of limiters
+  reachable from the node)".
+- Tokens are declared only at engine top level. The baseline also allows
+  group-level and pipeline-level declarations, so that a token defined in a
+  pipeline cannot escape it and the engine enforces that discipline
+  automatically. In this prototype the only thing preventing escape is the
+  pair of boundary allowlists, which is a policy the operator must write
+  rather than a scope the engine derives.
+- Retention is declared per extractor and applies group-wide. Liveness over the
+  pipeline graph could derive it instead, since a key no reachable node reads
+  need not be packed at all. Liveness may only shrink the propagated set, so it
+  composes with the boundary allowlists without weakening them.
+- Four extractor kinds exist: `transport_header`, `generic_key`,
+  `remote_address` and `imported_key`. The baseline also lists `receiver_id`,
+  `source_node_id`, `masked_remote_address`, `transport_header_match`,
+  `resource_attribute` and `resource_attribute_match`. The `_match` forms
+  matter beyond convenience: they gate token resolution without contributing a
+  key, which is how the baseline expresses "this token applies only to legacy
+  clients".
+- The reserved token key `signal` is not implemented.
+- The registry `epoch` is carried in every packed context so a stale context
+  can be detected after a reconfigure, but nothing acts on it yet.

--- a/rust/otap-dataflow/docs/multitenant-token-propagation.md
+++ b/rust/otap-dataflow/docs/multitenant-token-propagation.md
@@ -187,11 +187,13 @@ Reading a key's value is therefore an array index --
 `registry.value_slot(key)` then `view.slot_value(slot)` -- rather than a scan
 looking for a matching name or key id.
 
-The blob opens with the **bag**: `bag_len` bytes of complete `KeyValue`
-messages, for the keys whose names are demanded. Value-only entries follow.
-Both forms end in a length-delimited `AnyValue`, and a slot points at that
-length prefix in either case, so `slot_value` reads them identically and does
-not care which region a key landed in.
+The blob opens with the **bag**: `bag_len` bytes for the keys whose names are
+demanded, each written as `<tag> <len> <KeyValue>` -- already tagged, so the
+region is a complete OTLP repeated field rather than an input to an encoder.
+Value-only entries follow as bare `<len> <AnyValue>`. Both forms end in a
+length-delimited `AnyValue`, and a slot points at that length prefix in either
+case, so `slot_value` reads them identically and does not care which region a
+key landed in.
 
 There is no name-bearing region for captured headers. Every name in the
 context comes from configuration, never from the wire -- see
@@ -507,7 +509,7 @@ that nothing propagates.
 Bag-level keys must be contiguous, so the layout grows a bag region whose
 entries are adjacent and whose slots point inside it.
 
-### The consumer supplies the field number
+### The consumer bakes in the field number
 
 OTLP does not use a single field number for attributes:
 
@@ -519,25 +521,30 @@ OTLP does not use a single field number for attributes:
 | `Exemplar.filtered_attributes` | 7 |
 | `Span.attributes` | 9 |
 
-So the run is stored **untagged** -- `<len> <KeyValue body>` repeated, no field
-tag -- and the caller says where it is going:
+An earlier draft stored the run **untagged** and had the consumer supply the
+field number per call, pushing a tag byte before each entry. That is still a
+per-entry walk, and it means the stored bytes are an *input to an encoder*
+rather than a payload.
+
+The consumer is also the initializer. The SDK sets the pipeline up and later
+reads the bytes back, so the destination is known at build time, and the tag
+can simply be encoded in place:
 
 ```rust
-/// Append the carried keys as OTLP `KeyValue` entries under `field`.
-///
-/// The stored run carries no field tag, so one context serves scope
-/// attributes, span attributes and exemplars without re-encoding.
-pub fn append_attributes<B: BoundedBuf>(
-    &self,
-    dst: &mut B,
-    field: u64,
-) -> EncodeResult
+let mut builder = TenantTokenRegistryBuilder::new()
+    .with_bag_field(attribute_field::SCOPE);
 ```
 
-Per attribute that is one tag byte pushed and one `extend_from_slice`. Every
-field number above is under 16, so the tag is always a single byte and the cost
-does not depend on the destination. Nothing is re-encoded and nothing is
-allocated.
+```rust
+/// The bagged keys, as a complete OTLP repeated `KeyValue` field.
+pub fn attributes(&self) -> &'a [u8]
+```
+
+Reading is then a borrow, and writing is one `extend_from_slice` of the whole
+region. Nothing is walked per entry, nothing is re-tagged, nothing is
+allocated. A different destination is a different registry, not a rewrite --
+which is the honest shape, since the pipeline that produced the context and the
+SDK that consumes it are configured together.
 
 ### Scope attributes amortize the copy
 

--- a/rust/otap-dataflow/docs/multitenant-token-propagation.md
+++ b/rust/otap-dataflow/docs/multitenant-token-propagation.md
@@ -135,10 +135,10 @@ through `PipelineContext::tenant_token_registry()`.
    clearing `key_mask` bits as extractors are satisfied.
 3. A token whose word reached `0` is resolved. If none resolved, the request
    carries no tenant context at all and the whole feature costs one branch.
-4. Compute one xxh3 fingerprint per allocated `PairSlot`, projecting the
-   resolved values onto the signature's `fixed_keys` **in signature order**.
-   Build and probe share one `fingerprint_term` helper so the two layouts
-   cannot drift.
+4. Resolve each key's value to a **symbol** by exact dictionary lookup, then
+   pack one word per allocated `PairSlot`, projecting the symbols onto the
+   signature's `fixed_keys` **in signature order**. Build and probe share one
+   `pack_symbols` helper and one `SignatureLayout`, so the two cannot drift.
 
 Token resolution being all-or-nothing yields a useful simplification: if a
 signature applies to a resolved token, every wildcard key it requires is
@@ -146,9 +146,13 @@ necessarily present, so no per-request wildcard presence mask is needed.
 
 ### Probe phase (per condition evaluation)
 
-`ConditionSet::first_match` is one bit test plus one hash lookup per bound
+`ConditionSet::first_match` is one bit test plus one integer lookup per bound
 `(token, signature)` pair, keeping the lowest matching `ConditionIdx` so
 first-match-wins is preserved across signatures. It allocates nothing.
+
+The integer it looks up is a packed tuple of dictionary symbols, not a digest,
+so the lookup decides equality exactly -- see
+[Matching is exact](#matching-is-exact-no-collision-can-cross-wires).
 
 ### The packed request context
 
@@ -164,7 +168,7 @@ name, key id or descriptor travels with it:
 ```text
 word 0     : n_fp:16 | n_slots:16 | epoch:16 | bag_len:16
 word 1     : resolved token bitmask
-words 2..  : n_fp fingerprints, indexed by PairSlot
+words 2..  : n_fp packed symbol words, indexed by PairSlot
 then       : ceil(n_slots/2) words holding n_slots u32 offsets, indexed by
              registry value slot; each addresses a length-delimited AnyValue,
              or is EMPTY_OFFSET
@@ -179,9 +183,11 @@ entry delimits itself, so the trailing zero padding is simply never addressed.
 
 A key gets a value slot only if some compiled consumer propagates its value.
 The rest are **match-only**: they are decided entirely by their contribution to
-a fingerprint, so their bytes are never copied into a context at all. That is
-the only distinction the layout draws between keys, and it is a build-time
-property, not a per-entry flag.
+a packed symbol word, so their bytes are never copied into a context at all.
+Their values are still matched exactly -- the comparison happens at the
+receiver against the registry's copy of the literal -- so this costs no
+strictness. That is the only distinction the layout draws between keys, and it
+is a build-time property, not a per-entry flag.
 
 Reading a key's value is therefore an array index --
 `registry.value_slot(key)` then `view.slot_value(slot)` -- rather than a scan
@@ -206,7 +212,7 @@ What makes that safe is not shared construction, it is agreement: token
 definitions are engine-wide and interned in sorted order before any
 group-specific work, so every group derives the same key ids and the same
 value slots. Conditions differ per group and pair slots with them, which does
-not matter across a boundary because fingerprints are not exported.
+not matter across a boundary because symbol words are not exported.
 
 That agreement is an invariant, so it is stated rather than assumed. `epoch`
 is the deployment generation mixed with a digest of the ordered value-slot
@@ -280,17 +286,96 @@ field, and the 5ns is the memcpy.
 
 Limits: `MAX_TOKENS = 64`, `MAX_TOKEN_KEYS = 64`, `MAX_VALUE_BYTES = 65535`.
 
-### Conditions never compare values
+### Matching is exact: no collision can cross wires
 
-`first_match` compares fingerprints and stops. The values behind them are not
-re-checked, so a condition over match-only keys costs one hash lookup and
-touches no bytes.
+**A tenant condition matches only when the request's values are equal, byte
+for byte, to the values the operator declared.** No hash comparison decides
+routing. This is the property everything else in this section is arranged to
+protect, because the failure it prevents is one tenant's data being delivered
+to another tenant's pipeline.
 
-This is a deliberate trust in the 64-bit fingerprint rather than an oversight,
-and it needs no configuration option: a deployment that wants values verified
-can give the conditioned keys a value slot by propagating them, at which point
-the values are present to compare. The prototype does not implement that
-comparison, and the option should not exist.
+An earlier version of this design did not have that property, and it is
+recorded here because the reasoning that removed it is the reasoning that
+should keep it out. Conditions were compiled to a 64-bit `xxh3` fingerprint of
+their literals, resolution fingerprinted the request the same way, and
+`first_match` looked the fingerprint up in a map and stopped. Values were never
+re-checked. For match-only keys nothing was carried, so downstream they *could
+not* be re-checked -- the evidence was gone by construction.
+
+That is a hash join with the verification step deleted. A database does not do
+this. A hash join uses the hash to choose a bucket and then compares the actual
+join keys, because the hash is an index, never the predicate. Skipping the
+comparison converts a 64-bit coincidence into a routing decision.
+
+The odds argument is not good enough here. `xxh3` is not collision resistant --
+it is not meant to be -- so an attacker who can set a header does not wait for
+a coincidence, they search for one offline against a public function and then
+replay it forever. A boundary that separates tenants cannot rest on that.
+
+#### Symbols, not digests
+
+The fix is the same move a database makes: dictionary-encode the join keys.
+
+Every literal any condition can test is known at build time, since conditions
+are declared to the registry before it is frozen. Each key therefore gets a
+dictionary from literal to a small integer **symbol**, with two reserved
+values:
+
+| symbol | meaning |
+| --- | --- |
+| 0 | the request did not carry this key |
+| 1 | the request carried a value no condition declares |
+| 2.. | one declared literal each |
+
+Resolution looks each value up in its key's dictionary. **The dictionary owns
+the literal bytes and compares them**, so a lookup that lands in the same
+bucket by hash still fails on the byte comparison. A value that is not found
+takes symbol 1.
+
+A signature then packs its keys' symbols into one word, giving each key
+exactly as many bits as its declared literal count needs. That packing is
+**injective**: distinct symbol tuples cannot produce the same word. So
+comparing two words is comparing two symbol tuples, and comparing two symbol
+tuples is comparing two sets of verified values.
+
+The hot path is unchanged in shape -- `first_match` is still one integer
+lookup per pair, and the packed context still carries one word per pair. What
+changed is that the word is now a dictionary encoding rather than a digest, so
+the lookup is exact instead of probabilistic.
+
+Two things fail closed:
+
+- A condition testing a literal the registry never interned is **rejected at
+  build time**. Such a literal would otherwise take symbol 1, which every
+  unrecognized request value also takes, and the condition would match all of
+  them at once. This is the one dangerous case the design creates, so it is an
+  error rather than a warning.
+- A signature whose symbols do not fit in one word is rejected at build time
+  rather than narrowed, since narrowing is exactly the collision this section
+  exists to prevent. The budget is generous: four keys with 65,000 declared
+  values each, or sixteen keys with sixteen values each.
+
+#### Why match-only keys still cost zero bytes
+
+The property that worried the reader -- `retain: false` carries no bytes, so
+how can anything be verified? -- survives, because **verification happens where
+the value already is**.
+
+The receiver holds the header value in hand at resolve time. That is where the
+dictionary lookup happens, and what it compares against is the registry's own
+copy of the operator's literal, which exists once at build time rather than
+once per request. Downstream nodes never need the value because they are not
+deciding equality; that decision was already made, exactly, and its result is
+the symbol.
+
+So a match-only key costs zero per-request bytes *and* is matched exactly.
+Those were never in tension; the earlier design just gave up the second one
+without needing to.
+
+A symbol is also less revealing than a fingerprint was. A fingerprint is a
+digest of the tenant's actual value, and an attacker who observes one can
+search for the input. A symbol is an index into the operator's own
+configuration, which says only *which* declared value matched.
 
 ## Boundaries
 
@@ -326,7 +411,7 @@ arrived in the request.
 This is not only a propagation bug. Fingerprints are computed per
 `(token, signature)` pair, but each one reads the shared per-key cell, so token
 A's condition can be evaluated against a value that token B's extractor stored.
-The cross-product is honoured at fingerprint time and violated at staging time.
+The cross-product is honoured at symbol time and violated at staging time.
 
 The build now rejects it:
 
@@ -426,7 +511,7 @@ The inbound context is treated as **evidence, not identity**. It is never
 adopted. `BoundaryFilter::admits` screens by key id -- the two registries
 agree on key ids, so this is a flag lookup, not a name match -- then
 `resolve_imported` re-runs the resolve phase over the admitted values plus this
-pipeline's static extractors, producing a context whose tokens and fingerprints
+pipeline's static extractors, producing a context whose tokens and symbol words
 belong to the local pipeline. A dedicated tenant pipeline can therefore combine
 an imported value with a `generic_key` identity of its own in a single token.
 
@@ -535,7 +620,7 @@ key:
 
 | demand | stored |
 | --- | --- |
-| match-only | nothing; the fingerprint decides |
+| match-only | nothing; the symbol decides |
 | a consumer propagates the value | `<vlen> <AnyValue>` |
 | a consumer reads the whole bag | `0A <klen> <key> 12 <vlen> <AnyValue>` |
 
@@ -600,28 +685,28 @@ It is also the honest modelling. The tenant context describes the conditions
 under which the pipeline produced this telemetry, not a property of each
 individual record, which is what an instrumentation scope is for.
 
-### Fingerprints stay on the raw bytes
+### Symbols are resolved from the raw bytes
 
-An earlier draft of this section proposed fingerprinting the encoded
-`AnyValue` instead of the raw value. Implementing it showed that to be the
-wrong trade, so it is recorded here as a rejected option rather than quietly
-dropped.
+An earlier draft proposed matching on the encoded `AnyValue` rather than the
+raw value, back when matching was a hash comparison. Both halves of that idea
+are now gone -- matching is a dictionary lookup, and the lookup happens on raw
+bytes -- but the ordering argument that decided it still holds and is worth
+keeping.
 
-The order of work is what decides it. Resolve stages raw bytes and hashes them
-immediately; pack runs afterwards and encodes only the values that survived
-gating. Fingerprinting the encoded form would invert that, forcing every
-condition-participating key to be encoded on the hot path -- including
-match-only keys, whose entire point is that their bytes never travel.
+Resolve stages raw bytes and resolves symbols immediately; pack runs
+afterwards and encodes only the values that survived gating. Matching on the
+encoded form would invert that, forcing every condition-participating key to
+be encoded on the hot path -- including match-only keys, whose entire point is
+that their bytes never travel.
 
 The gain it offered was distinguishing the integer `5` from the string `"5"`.
 That distinction is empty here: condition literals come from YAML as strings
 and are compared against transport header bytes, so no term is ever an
-integer. Paying an encode per matched key to separate two cases that cannot
-arise is not a trade worth making.
+integer.
 
-The cost of keeping raw fingerprints is one decode in `resolve_imported` --
-skip a tag byte and two varints -- on the boundary path only, which is not the
-hot path.
+The cost of resolving on raw bytes is one decode in `resolve_imported` -- skip
+a tag byte and two varints -- on the boundary path only, which is not the hot
+path.
 
 ### Demand is declared per extractor
 
@@ -927,7 +1012,7 @@ matters, since first-match-wins means it catches only what the two specific
 routes did not.
 
 Cost is unchanged by the extra key. Both keys belong to one signature, so the
-whole check is still one fingerprint at resolve time and one hash lookup per
+whole check is still one symbol word at resolve time and one integer lookup per
 probe. The authorization matrix is data in a hash table, not a chain of
 comparisons, and it stays flat as customers and projects are added.
 
@@ -1115,7 +1200,7 @@ pub trait IdentitySink {
 ```
 
 The extension contributes inputs; only the engine declares them complete, which
-it must, since fingerprints are valid only once every input is known. A
+it must, since symbol words are valid only once every input is known. A
 borrowed slice out of an already-parsed certificate or JWT goes straight into
 the scratch arena, so the one-allocation-per-request property survives. Fields
 no token declared an extractor for fail the key lookup and are dropped, so what
@@ -1228,7 +1313,7 @@ and evaluating one there is a configuration error rather than a miss. This is
 the same reachability analysis the baseline already requires for scoping pair
 slots, applied to node order rather than graph connectivity.
 
-And the fork itself must pay for the resolve: N outputs means N fingerprints
+And the fork itself must pay for the resolve: N outputs means N symbol words
 per allocated pair, not one. That is the honest cost of a data-driven fork, and
 it argues for keeping the number of tokens carrying node-defined keys small.
 
@@ -1236,7 +1321,7 @@ it argues for keeping the number of tokens carrying node-defined keys small.
 
 If `customer_id` is only used to choose a Kafka topic and never emitted as a
 header, drop `retain: true`. It gets no value slot, and the fork writes a
-fingerprint per output and copies zero bytes. Partitioning on an attribute and
+symbol word per output and copies zero bytes. Partitioning on an attribute and
 routing on it is then free of any per-value allocation -- which is the same
 payoff match-only keys give everywhere else, arriving here without the design
 having to do anything special.

--- a/rust/otap-dataflow/docs/multitenant-token-propagation.md
+++ b/rust/otap-dataflow/docs/multitenant-token-propagation.md
@@ -353,7 +353,7 @@ Two things fail closed:
 - A signature whose symbols do not fit in one word is rejected at build time
   rather than narrowed, since narrowing is exactly the collision this section
   exists to prevent. The budget is generous: four keys with 65,000 declared
-  values each, or sixteen keys with sixteen values each.
+  values each, eight keys with 254 each, or sixteen keys with fourteen each.
 
 #### Why match-only keys still cost zero bytes
 

--- a/rust/otap-dataflow/docs/multitenant-token-propagation.md
+++ b/rust/otap-dataflow/docs/multitenant-token-propagation.md
@@ -234,9 +234,9 @@ Allocations and bytes per request, base = baseline, tok = tenant token:
 
 | phase | matched | base allocs | tok allocs | base bytes | tok bytes |
 | --- | --- | --- | --- | --- | --- |
-| capture | 1 | 5 | 1 | 388 | 56 |
-| capture | 2 | 8 | 1 | 421 | 72 |
-| capture | 4 | 14 | 1 | 546 | 160 |
+| capture | 1 | 5 | 1 | 388 | 64 |
+| capture | 2 | 8 | 1 | 421 | 80 |
+| capture | 4 | 14 | 1 | 546 | 168 |
 | carry | any | 0 | 0 | 0 | 0 |
 | propagate | any | 0 | 0 | 0 | 0 |
 | attributes | any | n/a | 0 | n/a | 0 |
@@ -250,39 +250,80 @@ Carry and propagation were already free: `TransportHeaders` is an
 borrowed. The win is per request, not per hop, and claiming otherwise would
 overstate it.
 
-Wall time, same run, mean nanoseconds:
+Wall time, same run, mean nanoseconds. The measurements below declare a
+router's worth of conditions -- eight tenants, two projects each -- because a
+registry with no conditions leaves every symbol dictionary empty and never
+exercises the probe at all:
 
 | phase | matched | baseline | tenant |
 | --- | --- | --- | --- |
-| capture / resolve | 1 | 126 | 77 |
-| capture / resolve | 2 | 229 | 115 |
-| capture / resolve | 4 | 485 | 149 |
-| carry (per hop) | any | 10 | 13 |
-| propagate | 4 | 14 | 16 |
-| end to end | 1 | 157 | 104 |
-| end to end | 2 | 244 | 158 |
-| end to end | 4 | 552 | 207 |
+| capture / resolve | 1 | 125 | 113 |
+| capture / resolve | 2 | 200 | 148 |
+| capture / resolve | 4 | 486 | 203 |
+| carry (per hop) | any | 10 | 18 |
+| propagate | 4 | 13 | 15 |
+| end to end | 1 | 185 | 109 |
+| end to end | 2 | 246 | 149 |
+| end to end | 4 | 581 | 194 |
+| match | any | n/a | 9 to 11 |
 | attributes | 4 | n/a | 5 |
 
-Resolution beats capture at every width, by 39% at one key and 69% at four,
-and end to end is 34% to 63% faster. Two things pay for that. Registered
+Resolution beats capture at every width, by 10% at one key and 58% at four,
+and end to end is 39% to 67% faster. Three things pay for that. Registered
 header names are screened by a one-word Bloom filter over length and first
 byte before anything is hashed, so the four headers a pipeline does not want
 -- content type, user agent, encoding, timeouts -- are rejected without a map
-lookup. And since gRPC and HTTP/2 already require lowercase names, case
-folding is skipped unless a name actually needs it.
+lookup. Since gRPC and HTTP/2 already require lowercase names, case folding is
+skipped unless a name actually needs it. And a key no condition tests by value
+skips the dictionary lookup entirely, since that lookup could only miss.
 
-Two costs went **up**, and both are worth stating. A hop is 3ns dearer,
-because `Arc<[u64]>` is a fat pointer where `Arc<Vec<_>>` was thin; against
-roughly 300ns saved per request at four keys, that pays for itself until
-about a hundred hops. Reading one value is about 2ns dearer, because a slot
-addresses an encoded `AnyValue` and the read skips a tag and two varints
-rather than indexing a struct field.
+`match` is flat in the number of keys and has no baseline row, because the
+baseline has no routing to compare against. Flatness is the design claim: one
+lookup per bound pair, independent of how many conditions were declared.
+
+Two costs went **up**. A hop is dearer, because `Arc<[u64]>` is a wide
+pointer -- the element count travels in the pointer -- where `Arc<Vec<_>>` was
+thin. Against roughly 380ns saved per request at four keys that pays for
+itself over any plausible pipeline depth, but the length is redundant with
+`n_slots` and `bag_len`, which word 0 already carries, so a thin-pointer
+representation would recover it. Reading one value is about 2ns dearer,
+because a slot addresses an encoded `AnyValue` and the read skips a tag and
+two varints rather than indexing a struct field.
 
 `attributes` has no baseline row because the baseline cannot do it: emitting
 the request's context as telemetry attributes would mean encoding a
 `KeyValue` per header. Here it is a borrow of an already formed repeated
 field, and the 5ns is the memcpy.
+
+#### Where the remaining time goes
+
+Wall time on a shared machine moves by more than the effects being measured,
+so these came from an ablation ladder -- the same binary with one stage
+stubbed out at a time, run interleaved, best of several rounds -- rather than
+from comparing runs. At four keys:
+
+| stage | cost |
+| --- | --- |
+| scratch reset | 12ns |
+| screening 8 header names | 47ns |
+| 4 header map lookups | 12ns |
+| 4 value copies into the arena | 7ns |
+| symbol resolution and packing | 25ns |
+| encoding the blob | 35ns |
+| the one allocation | 25ns |
+
+The allocation the design is built around is a quarter of the cost, which is
+the useful surprise: the remaining work is all shaping bytes, not obtaining
+memory. Two things were found and fixed here. Copying the blob into the word
+buffer eight bytes at a time cost more than the memcpy it replaced, because
+the trailing partial chunk made every iteration a variable-length call; one
+bulk copy removed 16% at four keys. And symbol resolution hashed every value
+even for keys with an empty dictionary.
+
+What is left, in the order worth attacking: screening 8 header names is the
+largest single line and is pure setup; each retained value is copied three
+times (into the arena, into the blob, then into the `Arc`) where two would
+do; and the wide pointer above.
 
 Limits: `MAX_TOKENS = 64`, `MAX_TOKEN_KEYS = 64`, `MAX_VALUE_BYTES = 65535`.
 

--- a/rust/otap-dataflow/docs/multitenant-token-propagation.md
+++ b/rust/otap-dataflow/docs/multitenant-token-propagation.md
@@ -224,21 +224,59 @@ which is why the feature is net-negative on memory. The `request_context`
 benchmark measures where that cost actually sits, and the answer is narrower
 than it first appears:
 
-| phase | matched | allocs | bytes |
-| --- | --- | --- | --- |
-| capture | 1 | 5.00 | 388.0 |
-| capture | 2 | 8.00 | 421.0 |
-| capture | 4 | 14.00 | 546.0 |
-| carry | any | 0.00 | 0.0 |
-| propagate | any | 0.00 | 0.0 |
+Allocations and bytes per request, base = baseline, tok = tenant token:
 
-Capture costs `2 + 3n` -- an `Arc`, a `Vec`, and a name, wire name and value
-per header -- and the target is exactly **1**. Carry and propagation are
-already free: `TransportHeaders` is an `Arc<Vec<TransportHeader>>`, so a hop is
-an `Arc` bump at about 10ns regardless of header count, and propagation
-borrows. The win is per request, not per hop, and claiming otherwise would
-overstate it. `Context` itself grows 8 bytes, since a fat slice pointer
-replaces a thin one.
+| phase | matched | base allocs | tok allocs | base bytes | tok bytes |
+| --- | --- | --- | --- | --- | --- |
+| capture | 1 | 5 | 1 | 388 | 56 |
+| capture | 2 | 8 | 1 | 421 | 72 |
+| capture | 4 | 14 | 1 | 546 | 160 |
+| carry | any | 0 | 0 | 0 | 0 |
+| propagate | any | 0 | 0 | 0 | 0 |
+| attributes | any | n/a | 0 | n/a | 0 |
+
+Capture cost `2 + 3n` -- an `Arc`, a `Vec`, and a name, wire name and value
+per header. It is now **1**, flat, and the bytes fall with it because a value
+slot spends no name and no descriptor.
+
+Carry and propagation were already free: `TransportHeaders` is an
+`Arc<Vec<TransportHeader>>`, so a hop was an `Arc` bump and propagation
+borrowed. The win is per request, not per hop, and claiming otherwise would
+overstate it.
+
+Wall time, same run, mean nanoseconds:
+
+| phase | matched | baseline | tenant |
+| --- | --- | --- | --- |
+| capture / resolve | 1 | 126 | 77 |
+| capture / resolve | 2 | 229 | 115 |
+| capture / resolve | 4 | 485 | 149 |
+| carry (per hop) | any | 10 | 13 |
+| propagate | 4 | 14 | 16 |
+| end to end | 1 | 157 | 104 |
+| end to end | 2 | 244 | 158 |
+| end to end | 4 | 552 | 207 |
+| attributes | 4 | n/a | 5 |
+
+Resolution beats capture at every width, by 39% at one key and 69% at four,
+and end to end is 34% to 63% faster. Two things pay for that. Registered
+header names are screened by a one-word Bloom filter over length and first
+byte before anything is hashed, so the four headers a pipeline does not want
+-- content type, user agent, encoding, timeouts -- are rejected without a map
+lookup. And since gRPC and HTTP/2 already require lowercase names, case
+folding is skipped unless a name actually needs it.
+
+Two costs went **up**, and both are worth stating. A hop is 3ns dearer,
+because `Arc<[u64]>` is a fat pointer where `Arc<Vec<_>>` was thin; against
+roughly 300ns saved per request at four keys, that pays for itself until
+about a hundred hops. Reading one value is about 2ns dearer, because a slot
+addresses an encoded `AnyValue` and the read skips a tag and two varints
+rather than indexing a struct field.
+
+`attributes` has no baseline row because the baseline cannot do it: emitting
+the request's context as telemetry attributes would mean encoding a
+`KeyValue` per header. Here it is a borrow of an already formed repeated
+field, and the 5ns is the memcpy.
 
 Limits: `MAX_TOKENS = 64`, `MAX_TOKEN_KEYS = 64`, `MAX_VALUE_BYTES = 65535`.
 


### PR DESCRIPTION
Part 1 of 2. This adds the tenant token compiler. It changes no behavior: nothing in the pipeline reads the registry yet. Part 2 is #3636, which wires it up and removes transport headers.

Design context: this implements the tenant identifier portion of #3583. That PR describes tenant tokens as compiled conditions evaluated as a hash join. This is that mechanism, built as a standalone unit so it can be reviewed on its own.

## What this adds

Tenant tokens are declared once, for the whole engine:

```yaml
engine:
  tenant_tokens:
    acme:
      extractors:
        - key: tenant_id
          transport_header: x-tenant-id
          retain: true
        - key: project_id
          transport_header: x-project-id
          retain: true
```

A token resolves only if every one of its extractors is satisfied. Four extractor kinds exist: `transport_header`, `generic_key`, `remote_address` and `imported_key`.

At startup the compiler interns every declared key and every literal any condition can test. At request time a receiver produces a single allocation holding the matched values, addressed by position. Names do not travel with the data, because every name is already known to the registry.

Reading a value is `registry.value_slot(key)` then `view.slot_value(slot)` -- an array index, not a search.

## Matching is exact

Conditions are decided by byte equality, not by a hash comparison. Hashing is used to find a candidate; the candidate is then verified against the literal the registry owns. This is the same discipline a database hash join uses, and it means a hash collision cannot cause one tenant's data to be routed to another tenant's destination.

Because all literals are known at compile time, a value that no condition declared resolves to a reserved "unknown" symbol and matches nothing. Undeclared input fails closed.

## Values are stored as OTLP

Each retained value is written as a length-delimited `AnyValue`. Keys marked `bag: true` are additionally written with their names, as complete `KeyValue` entries pre-tagged with the consumer's own attributes field number. That region is a valid OTLP repeated field as it stands, so instrumentation can copy the request's context into scope attributes without encoding anything.

`docs/multitenant-token-propagation.md` has the full layout, drawn out.

## Performance

`benchmarks/benches/request_context` compares the packed context against the representation part 2 replaces, in a single run. Measured from a tonic `MetadataMap` with nine inbound headers, which is what a gRPC receiver actually holds:

| matched keys | before | after |
| --- | --- | --- |
| 1 | 564 ns, 14 allocations | 159 ns, 1 allocation |
| 2 | 709 ns, 16 allocations | 215 ns, 1 allocation |
| 4 | 849 ns, 20 allocations | 275 ns, 1 allocation |

The old path allocates per header received, whether or not any rule wants it. The new path allocates once, regardless of width.

One number is worth stating plainly because it cuts the other way: handed a slice of header pairs that someone else already owns, resolving is 15% to 30% *slower* than the old capture at one and two keys, and only wins at four. Resolving does strictly more work. The win comes from the receiver never having to materialize those pairs in the first place.

## Scope

- 8 files, ~4600 insertions, **0 deletions**.
- Tests cover the matching boundary only: exact matching including near misses, zero-byte match-only keys, fail-closed rejection of an undeclared literal, and injective symbol packing. Each was verified by mutation.
- Limits: 64 tokens, 64 keys per token, 65535 bytes of values per request.

Draft: opened for design review of the mechanism before #3636 is reviewed.
