### PR TITLE
feat(metrics): Migrate filter_processor telemetry to enum attributes

### DIFF
--- a/rust/otap-dataflow/.chloggen/filter-processor-metrics.yaml
+++ b/rust/otap-dataflow/.chloggen/filter-processor-metrics.yaml
@@ -2,3 +2,5 @@ change_type: breaking
 component: pipeline
 note: "Migrate filter_processor metrics to use enum attributes."
 issues: [3530]
+subtext: |
+  Migration: The `signals_consumed` and `signals_filtered` metrics for `filter_processor` have been removed. Use the `dropped.items` metric and engine-level consumed metrics instead.

--- a/rust/otap-dataflow/.chloggen/filter-processor-metrics.yaml
+++ b/rust/otap-dataflow/.chloggen/filter-processor-metrics.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: pipeline
+note: "Migrate filter_processor metrics to use enum attributes."
+issues: [3530]

--- a/rust/otap-dataflow/.chloggen/filter-processor-metrics.yaml
+++ b/rust/otap-dataflow/.chloggen/filter-processor-metrics.yaml
@@ -1,4 +1,4 @@
-change_type: enhancement
+change_type: breaking
 component: pipeline
 note: "Migrate filter_processor metrics to use enum attributes."
 issues: [3530]

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/README.md
@@ -156,10 +156,8 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
 
 | Metric | Unit | Description |
 | --- | --- | --- |
-| `processor.filter.pdata.log_signals_consumed` | `{log}` | Number of log signals consumed. |
-| `processor.filter.pdata.span_signals_consumed` | `{span}` | Number of span signals consumed. |
-| `processor.filter.pdata.log_signals_filtered` | `{log}` | Number of log signals filtered. |
-| `processor.filter.pdata.span_signals_filtered` | `{span}` | Number of span signals filtered. |
+| `processor.filter.pdata.signals_consumed` | `{signal}` | Number of signals consumed, partitioned by `signal` type. |
+| `processor.filter.pdata.signals_filtered` | `{signal}` | Number of signals filtered, partitioned by `signal` type. |
 
 ### Events
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/README.md
@@ -156,8 +156,7 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
 
 | Metric | Unit | Description |
 | --- | --- | --- |
-| `processor.filter.pdata.signals_consumed` | `{signal}` | Number of signals consumed, partitioned by `signal` type. |
-| `processor.filter.pdata.signals_filtered` | `{signal}` | Number of signals filtered, partitioned by `signal` type. |
+| `processor.filter.pdata.dropped.items` | `{item}` | Number of signal items (log records, spans, or metric data points) a decision node chose to drop. |
 
 ### Events
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/metrics.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/metrics.rs
@@ -13,11 +13,8 @@ use otap_df_telemetry_macros::metric_set;
 )]
 #[derive(Debug, Default, Clone)]
 pub struct FilterPdataMetrics {
-    /// Number of signals consumed
-    #[metric(unit = "{signal}")]
-    pub signals_consumed: Counter<u64>,
-
-    /// Number of signals filtered
-    #[metric(unit = "{signal}")]
-    pub signals_filtered: Counter<u64>,
+    /// Number of signal items (log records, spans, or metric data points) a
+    /// decision node chose to drop.
+    #[metric(name = "dropped.items", unit = "{item}")]
+    pub dropped_items: Counter<u64>,
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/metrics.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/metrics.rs
@@ -2,30 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Metrics for the OTAP FilterProcessor node.
+use otap_df_telemetry::common_attributes::SignalAttributes;
 use otap_df_telemetry::instrument::Counter;
 use otap_df_telemetry_macros::metric_set;
 
 /// Pdata-oriented metrics for the OTAP FilterProcessor
-#[metric_set(name = "processor.filter.pdata")]
+#[metric_set(
+    name = "processor.filter.pdata",
+    measurement_attributes = SignalAttributes
+)]
 #[derive(Debug, Default, Clone)]
 pub struct FilterPdataMetrics {
-    /// Number of log signals consumed
-    #[metric(unit = "{log}")]
-    pub log_signals_consumed: Counter<u64>,
-    /// Number of metric signals consumed
-    #[metric(unit = "{metric}")]
-    pub metric_signals_consumed: Counter<u64>,
-    /// Number of span signals consumed
-    #[metric(unit = "{span}")]
-    pub span_signals_consumed: Counter<u64>,
+    /// Number of signals consumed
+    #[metric(unit = "{signal}")]
+    pub signals_consumed: Counter<u64>,
 
-    /// Number of log signals filtered
-    #[metric(unit = "{log}")]
-    pub log_signals_filtered: Counter<u64>,
-    /// Number of metric signals filtered
-    #[metric(unit = "{metric}")]
-    pub metric_signals_filtered: Counter<u64>,
-    /// Number of span signals filtered
-    #[metric(unit = "{span}")]
-    pub span_signals_filtered: Counter<u64>,
+    /// Number of signals filtered
+    #[metric(unit = "{signal}")]
+    pub signals_filtered: Counter<u64>,
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/mod.rs
@@ -91,7 +91,7 @@ impl FilterProcessor {
     #[must_use]
     #[allow(dead_code)]
     pub fn new(config: Config, pipeline_ctx: PipelineContext) -> Self {
-        let metrics = pipeline_ctx.register_metrics::<FilterPdataMetrics>();
+        let metrics = FilterPdataMetrics::register(&pipeline_ctx);
         let compute_duration = ComputeDuration::new(&pipeline_ctx);
         FilterProcessor {
             config,
@@ -103,7 +103,7 @@ impl FilterProcessor {
 
     /// Creates a new FilterProcessor from a configuration object
     pub fn from_config(pipeline_ctx: PipelineContext, config: &Value) -> Result<Self, ConfigError> {
-        let metrics = pipeline_ctx.register_metrics::<FilterPdataMetrics>();
+        let metrics = FilterPdataMetrics::register(&pipeline_ctx);
         let compute_duration = ComputeDuration::new(&pipeline_ctx);
         let config: Config =
             serde_json::from_value(config.clone()).map_err(|e| ConfigError::InvalidUserConfig {
@@ -137,7 +137,7 @@ impl local::Processor<OtapPdata> for FilterProcessor {
                     mut metrics_reporter,
                 } = control
                 {
-                    _ = metrics_reporter.report(&mut self.metrics);
+                    _ = metrics_reporter.report_measurement(&mut self.metrics);
                     self.compute_duration.report(&mut metrics_reporter);
                 }
                 Ok(())

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/mod.rs
@@ -29,7 +29,8 @@ use otap_df_otap::{OTAP_PROCESSOR_FACTORIES, pdata::OtapPdata};
 use otap_df_pdata::TryIntoWithOptions;
 use otap_df_pdata::otap::OtapArrowRecords;
 use otap_df_pdata::otap::filter::IdBitmapPool;
-use otap_df_telemetry::metrics::MetricSet;
+use otap_df_telemetry::common_attributes::SignalAttributes;
+use otap_df_telemetry::metrics::MeasurementMetricSet;
 use serde_json::Value;
 use std::sync::Arc;
 
@@ -41,7 +42,7 @@ pub const FILTER_PROCESSOR_URN: &str = "urn:otel:processor:filter";
 /// processor that outputs all data received to stdout
 pub struct FilterProcessor {
     config: Config,
-    metrics: MetricSet<FilterPdataMetrics>,
+    metrics: MeasurementMetricSet<FilterPdataMetrics>,
     compute_duration: ComputeDuration,
     /// Reusable paged-bitmap pool for filtering metric child batches across
     /// successive `Message::PData` calls. Storing the pool on the processor
@@ -205,20 +206,9 @@ impl local::Processor<OtapPdata> for FilterProcessor {
                         }
                     })?;
 
-                match signal {
-                    SignalType::Metrics => {
-                        self.metrics.metric_signals_consumed.add(signals_consumed);
-                        self.metrics.metric_signals_filtered.add(signals_filtered);
-                    }
-                    SignalType::Logs => {
-                        self.metrics.log_signals_consumed.add(signals_consumed);
-                        self.metrics.log_signals_filtered.add(signals_filtered);
-                    }
-                    SignalType::Traces => {
-                        self.metrics.span_signals_consumed.add(signals_consumed);
-                        self.metrics.span_signals_filtered.add(signals_filtered);
-                    }
-                }
+                let metric = self.metrics.with(SignalAttributes { signal });
+                metric.signals_consumed.add(signals_consumed);
+                metric.signals_filtered.add(signals_filtered);
 
                 // Record the drop flow-metric. A no-op unless this node is
                 // a decision node in a flow that enables `dropped.items`.

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/mod.rs
@@ -150,7 +150,7 @@ impl local::Processor<OtapPdata> for FilterProcessor {
                 let mut arrow_records: OtapArrowRecords = payload.try_into_with_default()?;
                 arrow_records.decode_transport_optimized_ids()?;
 
-                let (filtered_arrow_records, signals_consumed, signals_filtered): (
+                let (filtered_arrow_records, _signals_consumed, dropped_items): (
                     OtapArrowRecords,
                     u64,
                     u64,
@@ -207,13 +207,12 @@ impl local::Processor<OtapPdata> for FilterProcessor {
                     })?;
 
                 let metric = self.metrics.with(SignalAttributes { signal });
-                metric.signals_consumed.add(signals_consumed);
-                metric.signals_filtered.add(signals_filtered);
+                metric.dropped_items.add(dropped_items);
 
                 // Record the drop flow-metric. A no-op unless this node is
                 // a decision node in a flow that enables `dropped.items`.
-                // `signals_filtered` is the dropped count.
-                effect_handler.record_flow_dropped_items(signal, signals_filtered);
+                // `dropped_items` is the dropped count.
+                effect_handler.record_flow_dropped_items(signal, dropped_items);
 
                 effect_handler
                     .send_message_with_source_node(OtapPdata::new(


### PR DESCRIPTION
Related to #3530

This PR updates the `filter_processor` telemetry to use enum attributes, following the exact migration blueprint established for other components.

### Changes
* **Consolidated Metrics:** Replaced the individual per-signal counters (`log_signals_consumed`, `metric_signals_consumed`, etc.) with unified `signals_consumed` and `signals_filtered` metrics to prevent metric explosion.
* **Enum Attributes:** Leveraged `SignalAttributes` to cleanly partition these new unified counters by the `SignalType` enum.
* **Documentation:** Updated `README.md` to accurately reflect the new metric sets and their dimensions.
* **Changelog:** Added the corresponding `.chloggen` entry.

### References
* **Tracking Issue:** #3530 (Enum-attribute instrumentation migration)
* **Prior Art / Blueprint:** #3519 (`azure_monitor_exporter` migration)

Reviewers: @drewrelmas