### PR TITLE
fix(azure_monitor_exporter): clarify metric descriptions

### DIFF
--- a/rust/otap-dataflow/.chloggen/azure-monitor-metric-description-clarity.yaml
+++ b/rust/otap-dataflow/.chloggen/azure-monitor-metric-description-clarity.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: pipeline
+note: Clarify Azure Monitor exporter metric descriptions for completed export attempts.
+issues: [3625]

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/metrics.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/metrics.rs
@@ -59,16 +59,16 @@ pub struct AzureMonitorExporterOperationalMetrics {
 )]
 #[derive(Debug, Default, Clone)]
 pub struct AzureMonitorExporterExportMetrics {
-    /// Number of items resolved by export outcome.
+    /// Number of items in completed export attempts.
     #[metric(unit = "{item}")]
     pub items: Counter<u64>,
-    /// Number of batches resolved by export outcome.
+    /// Number of completed export batches.
     #[metric(unit = "{batch}")]
     pub batches: Counter<u64>,
-    /// Number of messages resolved by export outcome.
+    /// Number of messages in completed export attempts.
     #[metric(unit = "{message}")]
     pub messages: Counter<u64>,
-    /// Compressed request-body bytes resolved by export outcome.
+    /// Compressed request-body bytes in completed export attempts.
     #[metric(unit = "By")]
     pub bytes: Counter<u64>,
 }
@@ -120,7 +120,7 @@ struct AzureMonitorExporterStateMetrics {
 )]
 #[derive(Debug, Default, Clone)]
 pub struct AzureMonitorExporterHeartbeatMetrics {
-    /// Number of heartbeat sends resolved by outcome.
+    /// Number of completed heartbeat send attempts.
     #[metric(unit = "{heartbeat}")]
     pub sends: Counter<u64>,
 }

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/telemetry.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/telemetry.md
@@ -8,10 +8,10 @@ by the crate and log events emitted via `otel_*` log macros.
 
 | Metric name | Description | Produced in file |
 | --- | --- | --- |
-| `exporter.azure_monitor.exports.items` | Number of log items (Azure Monitor rows) resolved by `signal="logs"` and `outcome` (`success` or `failure`). | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
-| `exporter.azure_monitor.exports.batches` | Number of log batches resolved by `signal="logs"` and `outcome` (`success` or `failure`). | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
-| `exporter.azure_monitor.exports.messages` | Number of log messages resolved by `signal="logs"` and `outcome` (`success` or `failure`). | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
-| `exporter.azure_monitor.exports.bytes` | Compressed request-body bytes resolved by `signal="logs"` and `outcome` (`success` or `failure`). | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
+| `exporter.azure_monitor.exports.items` | Number of log items (Azure Monitor rows) in completed export attempts. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
+| `exporter.azure_monitor.exports.batches` | Number of completed log export batches. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
+| `exporter.azure_monitor.exports.messages` | Number of log messages in completed export attempts. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
+| `exporter.azure_monitor.exports.bytes` | Compressed request-body bytes in completed export attempts. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
 | `exporter.azure_monitor.http.responses` | Number of HTTP export attempts by `response` (`http_2xx`, `http_400`, `http_401`, `http_403`, `http_404`, `http_413`, `http_429`, `http_5xx`, `network_error`, or `other`). | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs` |
 | `exporter.azure_monitor.http.latency` | HTTP export attempt latency in milliseconds (min/max/sum/count), partitioned by `response`. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs` |
 | `exporter.azure_monitor.batch_size` | Compressed batch size in bytes (min/max/sum/count). | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs` |
@@ -20,7 +20,7 @@ by the crate and log events emitted via `otel_*` log macros.
 | `exporter.azure_monitor.in_flight_log_records` | Current number of log records in-flight at the exporter (enqueued export requests awaiting completion, including records being retried). | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
 | `exporter.azure_monitor.state.mappings` | Current number of exporter state-map entries, partitioned by `mapping` (`batch_to_message`, `message_to_batch`, or `message_to_data`). | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
 | `exporter.azure_monitor.log_entries_too_large` | Number of log entries rejected for exceeding batch size limit. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
-| `exporter.azure_monitor.heartbeats.sends` | Number of heartbeat sends resolved by `outcome` (`success` or `failure`). | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
+| `exporter.azure_monitor.heartbeats.sends` | Number of completed heartbeat send attempts. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
 
 ## Logs
 


### PR DESCRIPTION
# Change Summary

Clarify Azure Monitor exporter metric descriptions by replacing ambiguous "resolved by outcome" wording with descriptions of completed export attempts. This keeps `outcome` as an attribute rather than describing bytes, items, or messages as being resolved.

## What issue does this PR close?

Related to #3625.

## Are there any user-facing changes?

Yes. Azure Monitor exporter metric descriptions are clearer; metric names, values, and attributes are unchanged.

### Changelog

- [x] Added a `.chloggen/*.yaml` entry
- [ ] This PR is a `chore` (indicated in title)
- [ ] This is a documentation-only PR.