### PR TITLE
docs(changelog): require end-user-focused entries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,11 @@ compatibility. The project does not publish crates or make an API stability
 promise, so an API change alone is not a `breaking` change. Choose the entry
 type that describes the user-facing impact instead.
 
+Changelog entries are release notes for end users. Write `note` and `subtext`
+in terms of observable behavior, configuration changes, and actions users must
+take. Avoid implementation details such as internal refactors, type names, or
+instrumentation mechanisms unless they directly affect users.
+
 Changelog entries must use ASCII characters only. Replace typographic punctuation
 and other non-ASCII characters with ASCII equivalents.
 

--- a/rust/otap-dataflow/AGENTS.md
+++ b/rust/otap-dataflow/AGENTS.md
@@ -153,6 +153,11 @@ compatibility. The project does not publish crates or make an API stability
 promise, so an API change alone is not a `breaking` change. Choose the entry
 type that describes the user-facing impact instead.
 
+Changelog entries are release notes for end users. Write `note` and `subtext`
+in terms of observable behavior, configuration changes, and actions users must
+take. Avoid implementation details such as internal refactors, type names, or
+instrumentation mechanisms unless they directly affect users.
+
 Changelog entries must use ASCII characters only. Replace typographic punctuation
 and other non-ASCII characters with ASCII equivalents.
 


### PR DESCRIPTION
# Change Summary

Clarify in the repository and Rust-specific `AGENTS.md` files that changelog entries are release notes for end users. Entries should describe observable behavior, configuration changes, and required user actions while avoiding irrelevant implementation details.

This follows up on the changelog guidance discussion in #3612.

## Are there any user-facing changes?

No. This updates contributor and agent guidance only.

### Changelog

- [ ] Added a `.chloggen/*.yaml` entry
- [ ] This PR is a `chore` (indicated in title)
- [x] This is a documentation-only PR.