### PR TITLE
chore(ci): exempt rust/experimental from the changelog check

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -5,6 +5,9 @@
 # refactors, dev-dependency bumps), include "chore" in the PR title,
 # apply the "chore" label, or apply the "skipchangelog" label.
 #
+# PRs confined to paths that have no changelog to write into -- any `docs/`
+# or `rfcs/` directory, or `rust/experimental/` -- are exempt automatically.
+#
 # Modeled on opentelemetry-collector-contrib/.github/workflows/changelog.yml.
 
 name: changelog
@@ -72,24 +75,30 @@ jobs:
           go-version: stable
           cache-dependency-path: "**/*.sum"
 
-      - name: Check if documentation-only PR
-        id: check_docs_only
+      - name: Check if PR only touches changelog-exempt paths
+        id: check_exempt_paths
         if: ${{ steps.detect_bypass.outputs.skip != 'true' }}
         run: |
           # Get all changed files
           all_changed=$(git diff --name-only "$(git merge-base origin/main "$PR_HEAD")" "$PR_HEAD")
 
-          # Treat PR as docs-only when all changed files are under any docs/ or rfcs/ directory.
-          non_doc_files=$(printf '%s\n' "$all_changed" | grep -v '^$' | grep -v -E '(^|.*/)(docs|rfcs)/' || true)
+          # Treat PR as exempt when every changed file is under a path with no
+          # user-facing changelog:
+          #   - any docs/ or rfcs/ directory
+          #   - rust/experimental/, whose crates ship no CHANGELOG.md
+          non_exempt_files=$(printf '%s\n' "$all_changed" | grep -v '^$' \
+            | grep -v -E '(^|.*/)(docs|rfcs)/' \
+            | grep -v -E '^rust/experimental/' \
+            || true)
 
-          if [ -z "$non_doc_files" ]; then
-            echo "is_doc_only=true" >> "$GITHUB_OUTPUT"
+          if [ -z "$non_exempt_files" ]; then
+            echo "is_exempt=true" >> "$GITHUB_OUTPUT"
           else
-            echo "is_doc_only=false" >> "$GITHUB_OUTPUT"
+            echo "is_exempt=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Ensure no direct edits to CHANGELOG files
-        if: ${{ steps.detect_bypass.outputs.skip != 'true' && steps.check_docs_only.outputs.is_doc_only != 'true' }}
+        if: ${{ steps.detect_bypass.outputs.skip != 'true' && steps.check_exempt_paths.outputs.is_exempt != 'true' }}
         run: |
           changed=$(git diff --name-only "$(git merge-base origin/main "$PR_HEAD")" "$PR_HEAD" \
             -- go/CHANGELOG.md rust/otap-dataflow/CHANGELOG.md)
@@ -105,7 +114,7 @@ jobs:
           fi
 
       - name: Ensure a .chloggen/*.yaml entry was added or edited
-        if: ${{ steps.detect_bypass.outputs.skip != 'true' && steps.check_docs_only.outputs.is_doc_only != 'true' }}
+        if: ${{ steps.detect_bypass.outputs.skip != 'true' && steps.check_exempt_paths.outputs.is_exempt != 'true' }}
         run: |
           touched=$(git diff --diff-filter=AM --name-only "$(git merge-base origin/main "$PR_HEAD")" "$PR_HEAD" \
             -- 'go/.chloggen/' 'rust/otap-dataflow/.chloggen/' \
@@ -144,7 +153,7 @@ jobs:
           fi
 
       - name: Validate .chloggen/*.yaml entries
-        if: ${{ steps.detect_bypass.outputs.skip != 'true' && steps.check_docs_only.outputs.is_doc_only != 'true' }}
+        if: ${{ steps.detect_bypass.outputs.skip != 'true' && steps.check_exempt_paths.outputs.is_exempt != 'true' }}
         run: |
           make chlog-install
           make chlog-validate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,6 +128,10 @@ dependency bumps):
 - Apply the `skipchangelog` label (for maintainers).
 - Documentation-only PRs (all changed files are under a `docs/` or `rfcs/`
   directory).
+- PRs confined to `rust/experimental/` -- those crates are not released and
+  ship no `CHANGELOG.md`, so there is no changelog to write an entry into. A
+  PR that also touches a released module (for example `rust/otap-dataflow/`)
+  is *not* exempt, even if the bulk of the change is experimental.
 - For dependency-update PRs: Renovate auto-applies the `dependencies` label
   and bot-authored PRs are exempt.
 


### PR DESCRIPTION
# Change Summary

Exempt PRs from the changelog-entry requirement when all changed files are confined to documentation, RFC, or rust/experimental/ paths.

Mixed PRs that also modify released modules remain subject to the changelog requirement.

## What issue does this PR close?

  - Related to #3608

## How are these changes tested?

  Source review of the path-filtering logic. The changelog workflow will exercise the change when this PR runs in CI.

## Are there any user-facing changes?

  No. This only updates the changelog CI policy and contributor documentation.

### Changelog

* [ ] Added a `.chloggen/*.yaml` entry
* [x] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
