### PR TITLE
fix: two OPL parser panics

### DIFF
--- a/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
+++ b/rust/experimental/query_engine/kql-parser/src/scalar_primitive_expressions.rs
@@ -236,9 +236,12 @@ fn parse_regex_expression(
 
     let mut inner_rules = regex_expression_rule.into_inner();
 
-    let pattern = parse_standard_string_literal(inner_rules.next().unwrap());
+    let pattern = parse_standard_string_literal(inner_rules.next().unwrap())?;
 
-    let options = inner_rules.next().map(|r| parse_standard_string_literal(r));
+    let options = inner_rules
+        .next()
+        .map(|r| parse_standard_string_literal(r))
+        .transpose()?;
 
     let regex = Value::parse_regex(
         &query_location,
@@ -288,7 +291,7 @@ fn parse_dynamic_expression(
 
                     let key = parse_standard_string_literal(
                         dynamic_map_item_expression_rules.next().unwrap(),
-                    );
+                    )?;
 
                     let value = parse_dynamic_inner_expression(
                         dynamic_map_item_expression_rules.next().unwrap(),

--- a/rust/experimental/query_engine/parser-abstractions/src/parser_abstractions.rs
+++ b/rust/experimental/query_engine/parser-abstractions/src/parser_abstractions.rs
@@ -112,7 +112,8 @@ pub fn parse_standard_string_literal<R: RuleType>(
     let mut chars = raw_string.chars();
     let mut s = String::with_capacity(raw_string.len());
     let mut position = 1;
-    let mut last_char = '\0';
+    // let mut last_char = '\0';
+    let mut parsing_escape_sequence = false;
 
     let mut c = chars.next();
     loop {
@@ -123,12 +124,20 @@ pub fn parse_standard_string_literal<R: RuleType>(
         let mut current_char = c.unwrap();
         let mut skip_push = false;
 
-        if position == 1 || current_char == '\\' {
+        if position == 1 {
             skip_push = true;
-        } else if last_char == '\\' {
+            parsing_escape_sequence = false;
+        } else if current_char == '\\' {
+            if !parsing_escape_sequence {
+                skip_push = true;
+                parsing_escape_sequence = true;
+            } else {
+                parsing_escape_sequence = false;
+            }
+        } else if parsing_escape_sequence {
+            parsing_escape_sequence = false;
             match current_char {
                 '"' => current_char = '"',
-                '\\' => current_char = '\\',
                 'n' => current_char = '\n',
                 'r' => current_char = '\r',
                 't' => current_char = '\t',
@@ -141,7 +150,26 @@ pub fn parse_standard_string_literal<R: RuleType>(
             }
         }
 
-        last_char = current_char;
+
+        // if position == 1 || current_char == '\\' {
+        //     skip_push = true;
+        // } else if last_char == '\\' {
+        //     match current_char {
+        //         '"' => current_char = '"',
+        //         '\\' => current_char = '\\',
+        //         'n' => current_char = '\n',
+        //         'r' => current_char = '\r',
+        //         't' => current_char = '\t',
+        //         other => {
+        //             return Err(ParserError::SyntaxError(
+        //                 query_location,
+        //                 format!("Unexpected escape sequence character '{other}'"),
+        //             ));
+        //         }
+        //     }
+        // }
+
+        // last_char = current_char;
         position += 1;
 
         c = chars.next();

--- a/rust/experimental/query_engine/parser-abstractions/src/parser_abstractions.rs
+++ b/rust/experimental/query_engine/parser-abstractions/src/parser_abstractions.rs
@@ -105,7 +105,7 @@ pub fn parse_standard_double_literal<R: RuleType>(
 /// Handles basic escape sequences: \", \\, \n, \r, \t
 pub fn parse_standard_string_literal<R: RuleType>(
     string_literal_rule: Pair<R>,
-) -> StaticScalarExpression {
+) -> Result<StaticScalarExpression, ParserError> {
     let query_location = to_query_location(&string_literal_rule);
 
     let raw_string = string_literal_rule.as_str();
@@ -132,7 +132,12 @@ pub fn parse_standard_string_literal<R: RuleType>(
                 'n' => current_char = '\n',
                 'r' => current_char = '\r',
                 't' => current_char = '\t',
-                _ => panic!("Unexpected escape character"),
+                other => {
+                    return Err(ParserError::SyntaxError(
+                        query_location,
+                        format!("Unexpected escape sequence character '{other}'"),
+                    ));
+                }
             }
         }
 
@@ -149,5 +154,8 @@ pub fn parse_standard_string_literal<R: RuleType>(
         }
     }
 
-    StaticScalarExpression::String(StringScalarExpression::new(query_location, s.as_str()))
+    Ok(StaticScalarExpression::String(StringScalarExpression::new(
+        query_location,
+        s.as_str(),
+    )))
 }

--- a/rust/experimental/query_engine/parser-abstractions/src/parser_abstractions.rs
+++ b/rust/experimental/query_engine/parser-abstractions/src/parser_abstractions.rs
@@ -112,7 +112,6 @@ pub fn parse_standard_string_literal<R: RuleType>(
     let mut chars = raw_string.chars();
     let mut s = String::with_capacity(raw_string.len());
     let mut position = 1;
-    // let mut last_char = '\0';
     let mut parsing_escape_sequence = false;
 
     let mut c = chars.next();
@@ -150,26 +149,6 @@ pub fn parse_standard_string_literal<R: RuleType>(
             }
         }
 
-
-        // if position == 1 || current_char == '\\' {
-        //     skip_push = true;
-        // } else if last_char == '\\' {
-        //     match current_char {
-        //         '"' => current_char = '"',
-        //         '\\' => current_char = '\\',
-        //         'n' => current_char = '\n',
-        //         'r' => current_char = '\r',
-        //         't' => current_char = '\t',
-        //         other => {
-        //             return Err(ParserError::SyntaxError(
-        //                 query_location,
-        //                 format!("Unexpected escape sequence character '{other}'"),
-        //             ));
-        //         }
-        //     }
-        // }
-
-        // last_char = current_char;
         position += 1;
 
         c = chars.next();

--- a/rust/experimental/query_engine/parser-abstractions/src/parser_error.rs
+++ b/rust/experimental/query_engine/parser-abstractions/src/parser_error.rs
@@ -37,6 +37,8 @@ impl From<&ExpressionError> for ParserError {
 }
 
 impl ParserError {
+    /// Converts the pest error to a syntax error, identifying the invalid content from the error
+    /// location information.
     pub fn from_pest_error(query: &str, pest_error: Error<impl pest::RuleType>) -> Self {
         let (start, end) = match pest_error.location {
             pest::error::InputLocation::Pos(p) => (0, p),
@@ -48,14 +50,66 @@ impl ParserError {
             pest::error::LineColLocation::Span(l, _) => l,
         };
 
-        let content = query.lines().nth(line - 1)
-            .or(query.get(start..end))
-            .unwrap_or(query);
+        // try to identify invalid syntax on the line that contains it.
+        let invalid_line = query.lines().nth(line - 1);
+
+        // if for some reason the error's line isn't in the query (which can happen for empty
+        // queries, e.g. "", or if we're simply passed an error with a bad line), fall back to
+        // identifying the invalid content by start..end range. If the range is also not valid
+        // for the query, just fall back to using the query contents.
+        let invalid_content = invalid_line.or(query.get(start..end)).unwrap_or(query);
 
         Self::SyntaxNotSupported(
             QueryLocation::new(start, end, line, column)
                 .expect("QueryLocation could not be constructed"),
-            format!("Syntax '{content}' supplied in query is not supported"),
+            format!("Syntax '{invalid_content}' supplied in query is not supported"),
         )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use pest::Position;
+    use pest::error::{ErrorVariant, LineColLocation};
+
+    use super::*;
+
+    /// test to ensure we don't panic when receiving a pest error with an invalid location
+    #[test]
+    fn test_from_pest_error_invalid_location() {
+        let pest_error = Error::<()>::new_from_pos(
+            ErrorVariant::CustomError {
+                message: "test".into(),
+            },
+            Position::new("a\na", 2).unwrap(),
+        );
+
+        // ensure we don't panic when the line doesn't exist
+        let (line, _) = match pest_error.line_col {
+            LineColLocation::Pos(p) => p,
+            _ => {
+                panic!("invalid pos")
+            }
+        };
+        assert!(line > 0);
+        let error = ParserError::from_pest_error("abc", pest_error.clone());
+        assert!(
+            error
+                .to_string()
+                .contains("Syntax 'ab' supplied in query is not supported"),
+        );
+
+        // ensure we don't panic when the position doesn't exist:
+        let (_, end) = match pest_error.location {
+            pest::error::InputLocation::Pos(p) => (0, p),
+            pest::error::InputLocation::Span(s) => s,
+        };
+        assert!(end > 1);
+        let error = ParserError::from_pest_error("a", pest_error);
+        assert!(
+            error
+                .to_string()
+                .contains("Syntax 'a' supplied in query is not supported"),
+        );
     }
 }

--- a/rust/experimental/query_engine/parser-abstractions/src/parser_error.rs
+++ b/rust/experimental/query_engine/parser-abstractions/src/parser_error.rs
@@ -77,9 +77,9 @@ mod test {
 
     use super::*;
 
-/// Scenario: Converting a pest error whose line/column does not exist in the provided query.
-/// Guarantees: `ParserError::from_pest_error` does not panic and falls back to a safe content slice.
-#[test]
+    /// Scenario: Converting a pest error whose line/column does not exist in the provided query.
+    /// Guarantees: `ParserError::from_pest_error` does not panic and falls back to a safe content slice.
+    #[test]
     fn test_from_pest_error_invalid_location() {
         let pest_error = Error::<()>::new_from_pos(
             ErrorVariant::CustomError {

--- a/rust/experimental/query_engine/parser-abstractions/src/parser_error.rs
+++ b/rust/experimental/query_engine/parser-abstractions/src/parser_error.rs
@@ -77,8 +77,9 @@ mod test {
 
     use super::*;
 
-    /// test to ensure we don't panic when receiving a pest error with an invalid location
-    #[test]
+/// Scenario: Converting a pest error whose line/column does not exist in the provided query.
+/// Guarantees: `ParserError::from_pest_error` does not panic and falls back to a safe content slice.
+#[test]
     fn test_from_pest_error_invalid_location() {
         let pest_error = Error::<()>::new_from_pos(
             ErrorVariant::CustomError {

--- a/rust/experimental/query_engine/parser-abstractions/src/parser_error.rs
+++ b/rust/experimental/query_engine/parser-abstractions/src/parser_error.rs
@@ -50,19 +50,22 @@ impl ParserError {
             pest::error::LineColLocation::Span(l, _) => l,
         };
 
-        // try to identify invalid syntax on the line that contains it.
-        let invalid_line = query.lines().nth(line - 1);
+        // try to identify invalid syntax on the line/column that contains it.
+        let invalid_line = query
+            .lines()
+            .nth(line - 1)
+            .and_then(|line| line.get(column - 1..));
 
         // if for some reason the error's line isn't in the query (which can happen for empty
         // queries, e.g. "", or if we're simply passed an error with a bad line), fall back to
         // identifying the invalid content by start..end range. If the range is also not valid
         // for the query, just fall back to using the query contents.
-        let invalid_content = invalid_line.or(query.get(start..end)).unwrap_or(query);
+        let content = invalid_line.or(query.get(start..end)).unwrap_or(query);
 
         Self::SyntaxNotSupported(
             QueryLocation::new(start, end, line, column)
                 .expect("QueryLocation could not be constructed"),
-            format!("Syntax '{invalid_content}' supplied in query is not supported"),
+            format!("Syntax '{content}' supplied in query is not supported"),
         )
     }
 }
@@ -81,22 +84,30 @@ mod test {
             ErrorVariant::CustomError {
                 message: "test".into(),
             },
-            Position::new("a\na", 2).unwrap(),
+            Position::new("a\nabc", 4).unwrap(),
         );
 
         // ensure we don't panic when the line doesn't exist
-        let (line, _) = match pest_error.line_col {
+        let (line, col) = match pest_error.line_col {
             LineColLocation::Pos(p) => p,
             _ => {
                 panic!("invalid pos")
             }
         };
         assert!(line > 0);
-        let error = ParserError::from_pest_error("abc", pest_error.clone());
+        assert!(col > 0);
+        let error = ParserError::from_pest_error("abcde", pest_error.clone());
         assert!(
             error
                 .to_string()
-                .contains("Syntax 'ab' supplied in query is not supported"),
+                .contains("Syntax 'abcd' supplied in query is not supported"),
+        );
+
+        let error = ParserError::from_pest_error("ab\nc", pest_error.clone());
+        assert!(
+            error
+                .to_string()
+                .contains("Syntax 'ab\nc' supplied in query is not supported"),
         );
 
         // ensure we don't panic when the position doesn't exist:
@@ -105,11 +116,11 @@ mod test {
             pest::error::InputLocation::Span(s) => s,
         };
         assert!(end > 1);
-        let error = ParserError::from_pest_error("a", pest_error);
+        let error = ParserError::from_pest_error("ab", pest_error);
         assert!(
             error
                 .to_string()
-                .contains("Syntax 'a' supplied in query is not supported"),
+                .contains("Syntax 'ab' supplied in query is not supported"),
         );
     }
 }

--- a/rust/experimental/query_engine/parser-abstractions/src/parser_error.rs
+++ b/rust/experimental/query_engine/parser-abstractions/src/parser_error.rs
@@ -48,14 +48,9 @@ impl ParserError {
             pest::error::LineColLocation::Span(l, _) => l,
         };
 
-        let content = if line > 0 && column > 0 {
-            &query
-                .lines()
-                .nth(line - 1)
-                .expect("Query line did not exist")[column - 1..]
-        } else {
-            &query[start..end]
-        };
+        let content = query.lines().nth(line - 1)
+            .or(query.get(start..end))
+            .unwrap_or(query);
 
         Self::SyntaxNotSupported(
             QueryLocation::new(start, end, line, column)

--- a/rust/experimental/query_engine/parser-abstractions/src/test_helpers.rs
+++ b/rust/experimental/query_engine/parser-abstractions/src/test_helpers.rs
@@ -140,7 +140,7 @@ pub mod parse_test_helpers {
         for (input, expected) in inputs {
             let mut result = P::parse(parser_rule, input).unwrap();
             let pair = result.next().unwrap();
-            let expr = parse_standard_string_literal(pair);
+            let expr = parse_standard_string_literal(pair).unwrap();
 
             match expr {
                 StaticScalarExpression::String(v) => assert_eq!(*expected, v.get_value()),

--- a/rust/otap-dataflow/.chloggen/opl-parser-panic-fixes.yaml
+++ b/rust/otap-dataflow/.chloggen/opl-parser-panic-fixes.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: query-engine
+note: Fix panics parsing OPL empty query and escape sequences
+issues: [3658]

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser.rs
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser.rs
@@ -174,6 +174,39 @@ mod test {
     }
 
     #[test]
+    fn test_parse_empty_string() {
+        let result = OplParser::parse("");
+        assert!(result.is_err());
+
+        let errors = result.err().unwrap();
+        assert_eq!(errors.len(), 1);
+
+        let error = &errors[0];
+        assert!(
+            error
+                .to_string()
+                .contains("Syntax '' supplied in query is not supported")
+        )
+    }
+
+    #[test]
+    fn test_parse_unexpected_escape_sequence() {
+        let result = OplParser::parse(r#"logs | where (matches(attributes["code"], regexp"\\d+"))"#);
+        assert!(result.is_err());
+
+        let errors = result.err().unwrap();
+        assert_eq!(errors.len(), 1);
+
+        let error = &errors[0];
+        println!("ERROR={error}");
+        assert!(
+            error
+                .to_string()
+                .contains("Unexpected escape sequence character 'd'")
+        )
+    }
+
+    #[test]
     fn test_parse_comments() {
         let programs = [
             // simple with inline comment

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser.rs
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser.rs
@@ -144,10 +144,12 @@ pub(crate) fn invalid_child_rule_error(
 mod test {
     use data_engine_expressions::{
         DataExpression, DiscardDataExpression, EqualToLogicalExpression, LogicalExpression,
-        NotLogicalExpression, QueryLocation, ScalarExpression, SourceScalarExpression,
-        StaticScalarExpression, StringScalarExpression, ValueAccessor,
+        MatchesLogicalExpression, NotLogicalExpression, QueryLocation, RegexScalarExpression,
+        ScalarExpression, SourceScalarExpression, StaticScalarExpression, StringScalarExpression,
+        ValueAccessor,
     };
     use data_engine_parser_abstractions::Parser;
+    use regex::Regex;
 
     use super::OplParser;
 
@@ -190,20 +192,47 @@ mod test {
     }
 
     #[test]
-    fn test_parse_unexpected_escape_sequence() {
-        let result = OplParser::parse(r#"logs | where (matches(attributes["code"], regexp"\\d+"))"#);
-        assert!(result.is_err());
-
-        let errors = result.err().unwrap();
-        assert_eq!(errors.len(), 1);
-
-        let error = &errors[0];
-        println!("ERROR={error}");
-        assert!(
-            error
-                .to_string()
-                .contains("Unexpected escape sequence character 'd'")
-        )
+    fn test_parse_escape_sequence_double_backslash() {
+        let result =
+            OplParser::parse(r#"logs | where (matches(attributes["code"], "\\d+"))"#).unwrap();
+        let data_exprs = result.pipeline.get_expressions();
+        assert_eq!(data_exprs.len(), 1);
+        pretty_assertions::assert_eq!(
+            &data_exprs[0],
+            &DataExpression::Discard(
+                DiscardDataExpression::new(QueryLocation::new_fake()).with_predicate(
+                    LogicalExpression::Not(NotLogicalExpression::new(
+                        QueryLocation::new_fake(),
+                        LogicalExpression::Matches(MatchesLogicalExpression::new(
+                            QueryLocation::new_fake(),
+                            ScalarExpression::Source(SourceScalarExpression::new(
+                                QueryLocation::new_fake(),
+                                ValueAccessor::new_with_selectors(vec![
+                                    ScalarExpression::Static(
+                                        StaticScalarExpression::String(StringScalarExpression::new(
+                                            QueryLocation::new_fake(),
+                                            "attributes",
+                                        )),
+                                    ),
+                                    ScalarExpression::Static(
+                                        StaticScalarExpression::String(StringScalarExpression::new(
+                                            QueryLocation::new_fake(),
+                                            "code",
+                                        )),
+                                    )
+                                ]),
+                            )),
+                            ScalarExpression::Static(StaticScalarExpression::Regex(
+                                RegexScalarExpression::new(
+                                    QueryLocation::new_fake(),
+                                    Regex::new("\\d+").unwrap()
+                                ),
+                            )),
+                        )),
+                    )),
+                ),
+            )
+        );
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser.rs
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser.rs
@@ -208,18 +208,18 @@ mod test {
                             ScalarExpression::Source(SourceScalarExpression::new(
                                 QueryLocation::new_fake(),
                                 ValueAccessor::new_with_selectors(vec![
-                                    ScalarExpression::Static(
-                                        StaticScalarExpression::String(StringScalarExpression::new(
+                                    ScalarExpression::Static(StaticScalarExpression::String(
+                                        StringScalarExpression::new(
                                             QueryLocation::new_fake(),
                                             "attributes",
-                                        )),
-                                    ),
-                                    ScalarExpression::Static(
-                                        StaticScalarExpression::String(StringScalarExpression::new(
+                                        )
+                                    ),),
+                                    ScalarExpression::Static(StaticScalarExpression::String(
+                                        StringScalarExpression::new(
                                             QueryLocation::new_fake(),
                                             "code",
-                                        )),
-                                    )
+                                        )
+                                    ),)
                                 ]),
                             )),
                             ScalarExpression::Static(StaticScalarExpression::Regex(

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser/expression.rs
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser/expression.rs
@@ -741,7 +741,7 @@ fn parse_primitive_expression(
             .into())
         }
         Rule::string_literal => {
-            Ok(ScalarExpression::Static(parse_standard_string_literal(rule)).into())
+            Ok(ScalarExpression::Static(parse_standard_string_literal(rule)?).into())
         }
         Rule::tagged_literal => Ok(parse_tagged_literal(rule, query_location)?.into()),
         Rule::bool_true_token => Ok(ScalarExpression::Static(StaticScalarExpression::Boolean(
@@ -777,7 +777,7 @@ pub(crate) fn parse_tagged_literal(
         .next()
         .ok_or_else(|| no_inner_rule_error(query_location.clone()))?;
 
-    let tagged_str = match parse_standard_string_literal(tagged_string_literal_rule) {
+    let tagged_str = match parse_standard_string_literal(tagged_string_literal_rule)? {
         StaticScalarExpression::String(str) => str,
         invalid_expr => {
             return Err(ParserError::SyntaxError(

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser/operator.rs
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser/operator.rs
@@ -65,7 +65,7 @@ pub(crate) fn parse_route_to_operator_call(
     if let Some(rule) = operator_call_rule.into_inner().next() {
         let rule_query_location = to_query_location(&rule);
         let dest = match rule.as_rule() {
-            Rule::string_literal => match parse_standard_string_literal(rule) {
+            Rule::string_literal => match parse_standard_string_literal(rule)? {
                 StaticScalarExpression::String(string) => string,
                 invalid_expr => {
                     return Err(ParserError::SyntaxError(
@@ -187,7 +187,7 @@ pub(crate) fn parse_rename_operator_call(
             )
         })?;
 
-        let source_key = match parse_standard_string_literal(source_key_rule) {
+        let source_key = match parse_standard_string_literal(source_key_rule)? {
             StaticScalarExpression::String(s) => s,
             other => {
                 return Err(ParserError::SyntaxError(
@@ -196,7 +196,7 @@ pub(crate) fn parse_rename_operator_call(
                 ));
             }
         };
-        let dest_key = match parse_standard_string_literal(dest_key_rule) {
+        let dest_key = match parse_standard_string_literal(dest_key_rule)? {
             StaticScalarExpression::String(s) => s,
             other => {
                 return Err(ParserError::SyntaxError(

--- a/rust/otap-dataflow/crates/query-engine-languages/src/ottl/scalar_expression.rs
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/ottl/scalar_expression.rs
@@ -28,7 +28,7 @@ pub(crate) fn parse_scalar_expression(
             ScalarExpression::Static(parse_standard_integer_literal(scalar_rule)?)
         }
         Rule::string_literal => {
-            ScalarExpression::Static(parse_standard_string_literal(scalar_rule))
+            ScalarExpression::Static(parse_standard_string_literal(scalar_rule)?)
         }
         Rule::null_literal => ScalarExpression::Static(parse_standard_null_literal(scalar_rule)),
         Rule::scalar_expression => parse_scalar_expression(scalar_rule, _state)?,

--- a/rust/otap-dataflow/crates/query-engine-languages/src/ottl/scalar_primitive_expression.rs
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/ottl/scalar_primitive_expression.rs
@@ -80,6 +80,7 @@ mod parse_tests {
                 ("\"hello\"", "hello"),
                 ("\"\"", ""),
                 ("\"hello world\"", "hello world"),
+                ("\"he\\\\llo\"", "he\\llo"),
                 ("\"he\\\"llo\"", "he\"llo"),
                 ("\"he\\nllo\"", "he\nllo"),
             ],

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
@@ -802,6 +802,44 @@ mod test {
     }
 
     #[tokio::test]
+    async fn test_filter_logs_body_using_matches_with_escape_sequences() {
+        let input = vec![
+            LogRecord::build()
+                .body(AnyValue::new_string("hello 1"))
+                .event_name("1")
+                .finish(),
+            LogRecord::build()
+                .body(AnyValue::new_string("hello 12"))
+                .event_name("2")
+                .finish(),
+            LogRecord::build()
+                .body(AnyValue::new_string("hello world"))
+                .event_name("3")
+                .finish(),
+            LogRecord::build()
+                .body(AnyValue::new_string("hello"))
+                .event_name("6")
+                .finish(),
+        ];
+
+        let query = r#"logs | where matches(body, "hello \\d$")"#;
+        let result = exec_logs_pipeline::<OplParser>(query, to_logs_data(input.clone())).await;
+
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[input[0].clone()]
+        );
+
+        let query = r#"logs | where matches(body, "hello \\d+")"#;
+        let result = exec_logs_pipeline::<OplParser>(query, to_logs_data(input.clone())).await;
+
+        assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[input[0].clone(), input[1].clone()]
+        );
+    }
+
+    #[tokio::test]
     async fn test_filter_logs_body_using_contains() {
         let input = vec![
             LogRecord::build()


### PR DESCRIPTION
# Change Summary

<!--Replace with a brief summary of the change in this PR-->

Fixes a few panics that occured when parsing OPL.

**Parsing empty string `""`**

```rs
OplParser::parse(""); // This panics with "Query line did not exist"
```

Root cause: Pest would identify the position of the error as line `1`. When we take this line to produce the error content, we take it from an empyt iterator and panic when we don't fine the line:
https://github.com/open-telemetry/otel-arrow/blob/4c05b596db372a0ca5249a4698f9a65f1a0d6840/rust/experimental/query_engine/parser-abstractions/src/parser_error.rs#L46-L58

> An empty string returns an empty iterator.
 - https://doc.rust-lang.org/std/primitive.str.html#method.lines
 
 Solution: make `ParserError::from_pest_error` robust over invalid error positions.
 
 **Parsing escape double backslash escape sequences (in regexps)**:

```rs
OplParser::parse(r#"logs | where (matches(attributes["code"], "\\d+"))"#); // // This panics with "Unexpected escape character"
```

Root case: when parsing the string literal, we look back a single character. and if the previous character is `\`, we assume we're parsing an escape sequence:
https://github.com/open-telemetry/otel-arrow/blob/4c05b596db372a0ca5249a4698f9a65f1a0d6840/rust/experimental/query_engine/parser-abstractions/src/parser_abstractions.rs#L117-L150

Solution: if it the previous character was `\` but was already escaped by a previous `\`, we are not parsing an escape sequence and should take the current character.

## What issue does this PR close?

<!--We highly recommend correlation of every PR to an issue-->

* Closes https://github.com/open-telemetry/otel-arrow/issues/3658

## How are these changes tested?

## Are there any user-facing changes?

 <!-- If yes, provide further info below -->
 
 No

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [ ] Added a `.chloggen/*.yaml` entry
* [ ] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
