### PR TITLE
fix: panic decoding KeyValue OTLP proto bytes with invalid length

### DIFF
--- a/rust/otap-dataflow/.chloggen/otlp-keyvalue-proto-decode-panic.yaml
+++ b/rust/otap-dataflow/.chloggen/otlp-keyvalue-proto-decode-panic.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: pdata
+note: fixes panic proto decoding `common::KeyValue` with invalid field lengths
+issues: [3672]

--- a/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/common.rs
+++ b/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/common.rs
@@ -259,7 +259,7 @@ impl AttributeView for RawKeyValue<'_> {
         loop {
             if let Some((start, end)) = from_option_nonzero_range_to_primitive(self.key_range.get())
             {
-                return &self.buf[start..end];
+                return &self.buf.get(start..end).unwrap_or_default();
             } else if self.pos.get() >= self.buf.len() {
                 break;
             } else {
@@ -277,7 +277,7 @@ impl AttributeView for RawKeyValue<'_> {
             if let Some((start, end)) =
                 from_option_nonzero_range_to_primitive(self.value_range.get())
             {
-                let slice = &self.buf[start..end];
+                let slice = &self.buf.get(start..end)?;
                 return Some(RawAnyValue {
                     buf: slice,
                     value_offset: Cell::new(None),
@@ -525,5 +525,52 @@ impl InstrumentationScopeView for RawInstrumentationScope<'_> {
             INSTRUMENTATION_SCOPE_ATTRIBUTES,
             wire_types::LEN,
         ))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use otap_df_config::ConversionOptions;
+    use otap_df_pdata_views::views::common::AttributeView;
+
+    use crate::{
+        otlp::{BoundedBuf, ProtoBuffer},
+        proto::consts::{
+            field_num::common::{KEY_VALUE_KEY, KEY_VALUE_VALUE},
+            wire_types,
+        },
+        views::otlp::bytes::common::RawKeyValue,
+    };
+
+    #[test]
+    fn test_kv_handles_invalid_key_range() {
+        let mut protobuf = ProtoBuffer::new(ConversionOptions::default());
+        protobuf
+            .encode_field_tag(KEY_VALUE_KEY, wire_types::LEN)
+            .unwrap();
+        // length is for some reason invalid - someone gave us a bad proto bytes
+        protobuf.encode_varint(5).unwrap();
+        protobuf.extend_from_slice("aaa".as_bytes()).unwrap();
+
+        let kv_view = RawKeyValue::new(protobuf.as_slice());
+        let key = kv_view.key();
+        assert!(key.is_empty());
+    }
+
+    #[test]
+    fn test_kv_handles_invalid_value_range() {
+        let mut protobuf = ProtoBuffer::new(ConversionOptions::default());
+        protobuf.encode_string(KEY_VALUE_KEY, "my-key").unwrap();
+
+        protobuf
+            .encode_field_tag(KEY_VALUE_VALUE, wire_types::LEN)
+            .unwrap();
+        // length is for some reason invalid - someone gave us bad proto bytes
+        protobuf.encode_varint(4).unwrap();
+        protobuf.extend_from_slice(&[0]).unwrap();
+
+        let kv_view = RawKeyValue::new(protobuf.as_slice());
+        let value = kv_view.value();
+        assert!(value.is_none());
     }
 }

--- a/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/common.rs
+++ b/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/common.rs
@@ -259,7 +259,7 @@ impl AttributeView for RawKeyValue<'_> {
         loop {
             if let Some((start, end)) = from_option_nonzero_range_to_primitive(self.key_range.get())
             {
-                return &self.buf.get(start..end).unwrap_or_default();
+                return self.buf.get(start..end).unwrap_or_default();
             } else if self.pos.get() >= self.buf.len() {
                 break;
             } else {


### PR DESCRIPTION
# Change Summary

<!--Replace with a brief summary of the change in this PR-->

Fixes a panic decoding OTLP proto bytes if for some reason the lengths specified of the key or value field in some proto KeyValue are invalid (e.g. greater than the length of the buffer containing the message).

## What issue does this PR close?

<!--We highly recommend correlation of every PR to an issue-->

* Closes https://github.com/open-telemetry/otel-arrow/issues/3672

## How are these changes tested?

## Are there any user-facing changes?

 <!-- If yes, provide further info below -->

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry
* [ ] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
