### PR TITLE
fix(journald): bound filtered follow waits

### DIFF
--- a/rust/otap-dataflow/.chloggen/journald-bound-filtered-follow-waits.yaml
+++ b/rust/otap-dataflow/.chloggen/journald-bound-filtered-follow-waits.yaml
@@ -1,0 +1,5 @@
+change_type: bug_fix
+component: pipeline
+note: "Bound journald filtered follow waits so unrelated journal activity cannot indefinitely delay batch flushes or shutdown."
+issues: [3399]
+subtext: "Adds behavior-level regression coverage for start_at: end follow startup, idle timeouts, non-matching wakeups, and systemd errors."

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/README.md
@@ -138,7 +138,7 @@ config:
 | `identifiers` | list | `[]` | Exact `SYSLOG_IDENTIFIER` matches. An empty list installs no identifier filter. |
 | `priorities` | list | unset | Exact journald `PRIORITY` values to include. When unset, no priority filter is installed. |
 | `max_priority` | enum | unset | Shorthand for all priorities up to the selected level. Mutually exclusive with `priorities`. |
-| `start_at` | enum | `end` | `end` reads new entries only when no checkpoint exists; `beginning` reads existing entries. |
+| `start_at` | enum | `end` | `end` skips currently visible matching history when no checkpoint exists; see Limits for the head-recovery boundary risk. `beginning` reads existing entries. |
 | `batch.max_records` | integer | `1024` | Maximum log records per emitted batch. |
 | `batch.max_flush_period` | duration | `200ms` | Maximum time to hold a partial batch. |
 | `extraction.max_entry_bytes` | byte size | `1MiB` | Maximum copied bytes per journal entry. |
@@ -172,6 +172,7 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
 | Event | Severity | Description |
 | --- | --- | --- |
 | `journald_receiver.start` | `info` | Receiver started for the configured `source_id` and journal root path. |
+| `journald_receiver.start_at_end_head_recovery` | `warn` | `start_at: end` found no matching tail anchor and repositioned to the journal head. |
 | `journald_receiver.drain_ingress` | `info` | Receiver ingress drain started for the configured `source_id`. |
 | `journald_receiver.shutdown` | `info` | Receiver shutdown completed for the configured `source_id`. |
 
@@ -201,6 +202,12 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
   first implementation. Array coalescing is planned as a follow-up.
 - With `start_at: end`, a process crash before the first successful checkpoint
   can skip entries already read from journald but not yet durably committed.
+- With `start_at: end`, if no matching entry exists at startup, the receiver
+  repositions to the journal head so future matching appends remain followable.
+  A later journal invalidation (for example rotation, persistent-journal flush,
+  or a newly mounted journal root) can expose pre-startup matching history.
+  The receiver emits `journald_receiver.start_at_end_head_recovery` when this
+  fallback is taken. A durable boundary guard remains tracked in issue #3399.
 - Extraction limits are per entry and per field. There is no aggregate batch
   byte cap in v1, so tune `batch.max_records` and extraction limits for the
   expected host log volume and memory budget.

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/journal.rs
@@ -6,7 +6,7 @@
 #[cfg(any(target_os = "linux", test))]
 use crate::receivers::journald_receiver::config::StartAt;
 #[cfg(any(target_os = "linux", test))]
-use std::ffi::c_int;
+use std::{ffi::c_int, time::Duration};
 
 /// Minimal seam over the `sd-journal` seek/step calls used to position a freshly
 /// opened journal when no checkpoint cursor exists. Abstracting the three raw
@@ -22,6 +22,64 @@ trait JournalSeek {
     /// `sd_journal_previous`: step to the previous entry. Returns `1` when an
     /// entry is now current, `0` when there is none, `< 0` on error.
     fn previous(&mut self) -> c_int;
+}
+
+/// Minimal seam over the `sd-journal` calls used by the follow loop.
+#[cfg(any(target_os = "linux", test))]
+trait JournalFollow {
+    /// `sd_journal_next`: advance to the next matching entry.
+    fn next(&mut self) -> c_int;
+    /// `sd_journal_wait`: wait for a journal change or timeout.
+    fn wait(&mut self, wait_timeout: Duration) -> c_int;
+}
+
+#[cfg(any(target_os = "linux", test))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum FreshStartPosition {
+    Beginning,
+    EndAnchored,
+    EndHeadRecovery,
+}
+
+/// Advances through at most one blocking `next()`/`wait()` cycle and returns
+/// the next current entry.
+///
+/// A positive wait result may be caused by an append that does not match the
+/// configured filters. If the retrying `next()` still finds no matching entry,
+/// this returns `None` so the worker can poll control commands and recompute its
+/// batch flush deadline instead of re-arming the full timeout indefinitely.
+#[cfg(any(target_os = "linux", test))]
+fn follow_next_entry<J, T, E>(
+    journal: &mut J,
+    wait_timeout: Duration,
+    mut current_entry: impl FnMut(&mut J) -> Result<T, E>,
+    mut systemd_error: impl FnMut(&'static str, c_int) -> E,
+) -> Result<Option<T>, E>
+where
+    J: JournalFollow,
+{
+    let mut has_waited = false;
+    loop {
+        let next = journal.next();
+        if next < 0 {
+            return Err(systemd_error("sd_journal_next", next));
+        }
+        if next > 0 {
+            return current_entry(journal).map(Some);
+        }
+        if has_waited {
+            return Ok(None);
+        }
+
+        let waited = journal.wait(wait_timeout);
+        if waited < 0 {
+            return Err(systemd_error("sd_journal_wait", waited));
+        }
+        if waited == 0 {
+            return Ok(None);
+        }
+        has_waited = true;
+    }
 }
 
 /// Positions a freshly opened journal (no checkpoint cursor) for `start_at`.
@@ -55,9 +113,11 @@ trait JournalSeek {
 /// would require `seek_tail()` + `previous()` to spuriously report `0` while
 /// matching entries actually exist (the multi-file positioning bug of the
 /// systemd#17662 class noted below); on such an old/buggy libsystemd it would
-/// replay that history once at startup (not observed on modern systemd). Bounding
-/// replay even under that bug would need a durable tail-boundary guard, which
-/// `start_at: end` deliberately omits (see the resume-anchor note below).
+/// replay that history once at startup (not observed on modern systemd). A later
+/// `SD_JOURNAL_INVALIDATE` can likewise make older matching entries visible after
+/// the head seek. Bounding replay across either case needs a durable tail-boundary
+/// guard, which `start_at: end` deliberately omits (see the resume-anchor note
+/// below and issue #3399).
 ///
 /// Returns `Err((operation, rc))` with the failing call's name and its negative
 /// return code. `seek_tail`/`seek_head` return `0` on success; `previous`
@@ -73,30 +133,37 @@ trait JournalSeek {
 fn position_for_fresh_start<J: JournalSeek>(
     seek: &mut J,
     start_at: StartAt,
-) -> Result<(), (&'static str, c_int)> {
+) -> Result<FreshStartPosition, (&'static str, c_int)> {
     fn require_nonneg(rc: c_int, operation: &'static str) -> Result<(), (&'static str, c_int)> {
         if rc < 0 { Err((operation, rc)) } else { Ok(()) }
     }
 
     match start_at {
-        StartAt::Beginning => require_nonneg(seek.seek_head(), "sd_journal_seek_head"),
+        StartAt::Beginning => {
+            require_nonneg(seek.seek_head(), "sd_journal_seek_head")?;
+            Ok(FreshStartPosition::Beginning)
+        }
         StartAt::End => {
             require_nonneg(seek.seek_tail(), "sd_journal_seek_tail")?;
             let anchored = seek.previous();
             require_nonneg(anchored, "sd_journal_previous")?;
             if anchored == 0 {
                 require_nonneg(seek.seek_head(), "sd_journal_seek_head")?;
+                return Ok(FreshStartPosition::EndHeadRecovery);
             }
-            Ok(())
+            Ok(FreshStartPosition::EndAnchored)
         }
     }
 }
 
 #[cfg(test)]
 mod fresh_start_tests {
-    use super::{JournalSeek, position_for_fresh_start};
+    use super::{
+        FreshStartPosition, JournalFollow, JournalSeek, follow_next_entry, position_for_fresh_start,
+    };
     use crate::receivers::journald_receiver::config::StartAt;
     use std::ffi::c_int;
+    use std::time::Duration;
 
     #[derive(Default)]
     struct RecordingSeek {
@@ -121,10 +188,147 @@ mod fresh_start_tests {
         }
     }
 
+    #[derive(Clone, Copy)]
+    struct FakeEntry {
+        cursor: &'static str,
+        matches: bool,
+    }
+
+    #[derive(Clone, Copy)]
+    enum FakePosition {
+        BeforeHead,
+        At(usize),
+        After(usize),
+        RawTail,
+    }
+
+    struct FakeJournal {
+        entries: Vec<FakeEntry>,
+        position: FakePosition,
+        append_on_wait: Option<FakeEntry>,
+        current_error: Option<String>,
+        next_error: Option<c_int>,
+        wait_error: Option<c_int>,
+        wait_change_rc: c_int,
+        wait_timeouts: Vec<Duration>,
+        calls: Vec<&'static str>,
+    }
+
+    impl FakeJournal {
+        fn new(entries: Vec<FakeEntry>, append_on_wait: Option<FakeEntry>) -> Self {
+            Self {
+                entries,
+                position: FakePosition::BeforeHead,
+                append_on_wait,
+                current_error: None,
+                next_error: None,
+                wait_error: None,
+                wait_change_rc: 1,
+                wait_timeouts: Vec::new(),
+                calls: Vec::new(),
+            }
+        }
+
+        fn current_cursor(&mut self) -> Result<&'static str, String> {
+            if let Some(error) = self.current_error.take() {
+                return Err(error);
+            }
+            let FakePosition::At(index) = self.position else {
+                return Err("no current entry".to_owned());
+            };
+            Ok(self.entries[index].cursor)
+        }
+    }
+
+    fn follow(
+        journal: &mut FakeJournal,
+        wait_timeout: Duration,
+    ) -> Result<Option<&'static str>, String> {
+        follow_next_entry(
+            journal,
+            wait_timeout,
+            FakeJournal::current_cursor,
+            |operation, rc| format!("{operation} failed with {rc}"),
+        )
+    }
+
+    impl JournalSeek for FakeJournal {
+        fn seek_head(&mut self) -> c_int {
+            self.calls.push("seek_head");
+            self.position = FakePosition::BeforeHead;
+            0
+        }
+
+        fn seek_tail(&mut self) -> c_int {
+            self.calls.push("seek_tail");
+            self.position = FakePosition::RawTail;
+            0
+        }
+
+        fn previous(&mut self) -> c_int {
+            self.calls.push("previous");
+            let end = match self.position {
+                FakePosition::BeforeHead => 0,
+                FakePosition::At(index) => index,
+                FakePosition::After(index) => index,
+                FakePosition::RawTail => self.entries.len(),
+            };
+            if let Some(index) = (0..end).rev().find(|index| self.entries[*index].matches) {
+                self.position = FakePosition::At(index);
+                1
+            } else {
+                0
+            }
+        }
+    }
+
+    impl JournalFollow for FakeJournal {
+        fn next(&mut self) -> c_int {
+            self.calls.push("next");
+            if let Some(rc) = self.next_error.take() {
+                return rc;
+            }
+            let start = match self.position {
+                FakePosition::BeforeHead => 0,
+                FakePosition::At(index) => index.saturating_add(1),
+                FakePosition::After(index) => index,
+                // Model libsystemd's raw-tail behavior: without an anchor or
+                // seek_head recovery, appends remain invisible to bare next().
+                FakePosition::RawTail => return 0,
+            };
+            if let Some(index) =
+                (start..self.entries.len()).find(|index| self.entries[*index].matches)
+            {
+                self.position = FakePosition::At(index);
+                1
+            } else {
+                self.position = FakePosition::After(self.entries.len());
+                0
+            }
+        }
+
+        fn wait(&mut self, wait_timeout: Duration) -> c_int {
+            self.calls.push("wait");
+            self.wait_timeouts.push(wait_timeout);
+            if let Some(rc) = self.wait_error.take() {
+                return rc;
+            }
+            if let Some(entry) = self.append_on_wait.take() {
+                self.entries.push(entry);
+                self.wait_change_rc
+            } else {
+                0
+            }
+        }
+    }
+
     #[test]
     fn beginning_seeks_head_only() {
         let mut seek = RecordingSeek::default();
-        assert!(position_for_fresh_start(&mut seek, StartAt::Beginning).is_ok());
+        assert_eq!(
+            position_for_fresh_start(&mut seek, StartAt::Beginning),
+            Ok(FreshStartPosition::Beginning)
+        );
         assert_eq!(seek.calls, ["seek_head"]);
     }
 
@@ -136,7 +340,10 @@ mod fresh_start_tests {
             previous_rc: 1,
             ..Default::default()
         };
-        assert!(position_for_fresh_start(&mut seek, StartAt::End).is_ok());
+        assert_eq!(
+            position_for_fresh_start(&mut seek, StartAt::End),
+            Ok(FreshStartPosition::EndAnchored)
+        );
         assert_eq!(seek.calls, ["seek_tail", "previous"]);
     }
 
@@ -149,8 +356,248 @@ mod fresh_start_tests {
             previous_rc: 0,
             ..Default::default()
         };
-        assert!(position_for_fresh_start(&mut seek, StartAt::End).is_ok());
+        assert_eq!(
+            position_for_fresh_start(&mut seek, StartAt::End),
+            Ok(FreshStartPosition::EndHeadRecovery)
+        );
         assert_eq!(seek.calls, ["seek_tail", "previous", "seek_head"]);
+    }
+
+    /// Scenario: `start_at: end` starts with historical entries that do not
+    /// match the configured filters, then a matching entry is appended.
+    /// Guarantees: the follow loop delivers the first matching append instead
+    /// of remaining parked at the raw tail when existing history has no match.
+    #[test]
+    fn end_with_no_existing_match_follows_first_matching_append() {
+        let mut journal = FakeJournal::new(
+            vec![FakeEntry {
+                cursor: "historical-unmatched",
+                matches: false,
+            }],
+            Some(FakeEntry {
+                cursor: "new-matching",
+                matches: true,
+            }),
+        );
+
+        assert_eq!(
+            position_for_fresh_start(&mut journal, StartAt::End),
+            Ok(FreshStartPosition::EndHeadRecovery)
+        );
+        let delivered =
+            follow(&mut journal, Duration::from_millis(1)).expect("follow newly appended entry");
+
+        assert_eq!(delivered, Some("new-matching"));
+        assert_eq!(
+            journal.calls,
+            ["seek_tail", "previous", "seek_head", "next", "wait", "next"]
+        );
+    }
+
+    /// Scenario: `start_at: end` starts with an existing matching entry, then
+    /// another matching entry is appended after startup positioning.
+    /// Guarantees: the existing entry is used only as the tail anchor and the
+    /// follow loop delivers the newly appended entry without replay.
+    #[test]
+    fn end_with_existing_match_follows_append_without_replay() {
+        let mut journal = FakeJournal::new(
+            vec![FakeEntry {
+                cursor: "historical-matching",
+                matches: true,
+            }],
+            Some(FakeEntry {
+                cursor: "new-matching",
+                matches: true,
+            }),
+        );
+
+        assert_eq!(
+            position_for_fresh_start(&mut journal, StartAt::End),
+            Ok(FreshStartPosition::EndAnchored)
+        );
+        let delivered =
+            follow(&mut journal, Duration::from_millis(1)).expect("follow newly appended entry");
+
+        assert_eq!(delivered, Some("new-matching"));
+        assert_eq!(
+            journal.calls,
+            ["seek_tail", "previous", "next", "wait", "next"]
+        );
+
+        let exhausted = follow(&mut journal, Duration::from_millis(1))
+            .expect("observe end after delivered entry");
+        assert_eq!(exhausted, None);
+        assert_eq!(
+            journal.calls,
+            [
+                "seek_tail",
+                "previous",
+                "next",
+                "wait",
+                "next",
+                "next",
+                "wait"
+            ]
+        );
+    }
+
+    /// Scenario: `start_at: beginning` has an existing matching entry.
+    /// Guarantees: the follow loop returns the current entry immediately without
+    /// waiting when `next()` succeeds on its first attempt.
+    #[test]
+    fn beginning_with_existing_match_delivers_immediately() {
+        let mut journal = FakeJournal::new(
+            vec![FakeEntry {
+                cursor: "historical-matching",
+                matches: true,
+            }],
+            None,
+        );
+
+        assert_eq!(
+            position_for_fresh_start(&mut journal, StartAt::Beginning),
+            Ok(FreshStartPosition::Beginning)
+        );
+        let delivered =
+            follow(&mut journal, Duration::from_millis(17)).expect("read existing entry");
+
+        assert_eq!(delivered, Some("historical-matching"));
+        assert_eq!(journal.calls, ["seek_head", "next"]);
+        assert!(journal.wait_timeouts.is_empty());
+    }
+
+    /// Scenario: the raw-tail position receives an append without the
+    /// `previous()` or `seek_head()` recovery used by the production fix.
+    /// Guarantees: the fake preserves the pre-fix stall and the follow helper
+    /// yields after one wake instead of re-arming the timeout indefinitely.
+    #[test]
+    fn raw_tail_without_recovery_stays_stalled_after_append() {
+        let mut journal = FakeJournal::new(
+            Vec::new(),
+            Some(FakeEntry {
+                cursor: "new-matching",
+                matches: true,
+            }),
+        );
+        assert_eq!(journal.seek_tail(), 0);
+
+        let delivered = follow(&mut journal, Duration::from_millis(1)).expect("follow raw tail");
+
+        assert_eq!(delivered, None);
+        assert_eq!(journal.calls, ["seek_tail", "next", "wait", "next"]);
+    }
+
+    /// Scenario: a journal change contains no entry matching the configured
+    /// filters.
+    /// Guarantees: one non-matching wake yields to the worker command loop
+    /// instead of restarting the full blocking timeout.
+    #[test]
+    fn follow_yields_after_nonmatching_append() {
+        let mut journal = FakeJournal::new(
+            Vec::new(),
+            Some(FakeEntry {
+                cursor: "new-unmatched",
+                matches: false,
+            }),
+        );
+
+        let delivered =
+            follow(&mut journal, Duration::from_millis(3)).expect("follow non-matching append");
+
+        assert_eq!(delivered, None);
+        assert_eq!(journal.calls, ["next", "wait", "next"]);
+        assert_eq!(journal.wait_timeouts, [Duration::from_millis(3)]);
+        assert_eq!(journal.current_cursor(), Err("no current entry".to_owned()));
+    }
+
+    /// Scenario: journal rotation invalidates the file set without exposing a
+    /// new matching entry at the current cursor.
+    /// Guarantees: `SD_JOURNAL_INVALIDATE` is treated as a wakeup, followed by
+    /// one `next()` retry and a yield to the worker command loop.
+    #[test]
+    fn follow_yields_after_invalidation_without_match() {
+        let mut journal = FakeJournal::new(
+            Vec::new(),
+            Some(FakeEntry {
+                cursor: "rotated-unmatched",
+                matches: false,
+            }),
+        );
+        journal.wait_change_rc = 2;
+
+        let delivered =
+            follow(&mut journal, Duration::from_millis(5)).expect("follow invalidation");
+
+        assert_eq!(delivered, None);
+        assert_eq!(journal.calls, ["next", "wait", "next"]);
+        assert_eq!(journal.wait_timeouts, [Duration::from_millis(5)]);
+    }
+
+    /// Scenario: the journal remains idle until the configured wait expires.
+    /// Guarantees: the follow helper returns `None` and forwards the exact
+    /// timeout to the underlying journal wait call.
+    #[test]
+    fn follow_returns_none_when_wait_times_out() {
+        let mut journal = FakeJournal::new(Vec::new(), None);
+
+        let delivered =
+            follow(&mut journal, Duration::from_millis(17)).expect("observe wait timeout");
+
+        assert_eq!(delivered, None);
+        assert_eq!(journal.calls, ["next", "wait"]);
+        assert_eq!(journal.wait_timeouts, [Duration::from_millis(17)]);
+    }
+
+    /// Scenario: `sd_journal_next` returns a negative systemd error.
+    /// Guarantees: the follow helper preserves the operation name and return
+    /// code without calling `wait()`.
+    #[test]
+    fn follow_propagates_next_error() {
+        let mut journal = FakeJournal::new(Vec::new(), None);
+        journal.next_error = Some(-5);
+
+        let error = follow(&mut journal, Duration::from_millis(1))
+            .expect_err("next error should propagate");
+
+        assert_eq!(error, "sd_journal_next failed with -5");
+        assert_eq!(journal.calls, ["next"]);
+    }
+
+    /// Scenario: `sd_journal_wait` returns a negative systemd error after EOF.
+    /// Guarantees: the follow helper preserves the operation name and return
+    /// code after exactly one `next()` attempt.
+    #[test]
+    fn follow_propagates_wait_error() {
+        let mut journal = FakeJournal::new(Vec::new(), None);
+        journal.wait_error = Some(-22);
+
+        let error = follow(&mut journal, Duration::from_millis(1))
+            .expect_err("wait error should propagate");
+
+        assert_eq!(error, "sd_journal_wait failed with -22");
+        assert_eq!(journal.calls, ["next", "wait"]);
+    }
+
+    /// Scenario: reading the current entry fails after `sd_journal_next`
+    /// successfully advances.
+    /// Guarantees: current-entry decoding errors are propagated rather than
+    /// converted into an idle result that would silently drop the entry.
+    #[test]
+    fn follow_propagates_current_entry_error() {
+        let mut journal = FakeJournal::new(
+            vec![FakeEntry {
+                cursor: "matching",
+                matches: true,
+            }],
+            None,
+        );
+        journal.current_error = Some("decode failed".to_owned());
+
+        let error = follow(&mut journal, Duration::from_millis(1))
+            .expect_err("current-entry error should propagate");
+
+        assert_eq!(error, "decode failed");
+        assert_eq!(journal.calls, ["next"]);
     }
 
     #[test]
@@ -356,6 +803,7 @@ mod imp {
         lib: &'static LibSystemd,
         journal: NonNull<SdJournal>,
         extraction: ExtractionConfig,
+        fresh_start_position: Option<super::FreshStartPosition>,
     }
 
     impl SdJournalReader {
@@ -405,6 +853,7 @@ mod imp {
                 lib,
                 journal,
                 extraction: config.extraction.clone(),
+                fresh_start_position: None,
             };
             let data_threshold = extraction_data_threshold(&reader.extraction);
             check(
@@ -437,8 +886,14 @@ mod imp {
             // `StartAt::End` this anchors past existing entries (and unparks an
             // empty journal from the tail) so the worker's next()/wait() loop
             // follows only newly appended records; see `position_for_fresh_start`.
-            super::position_for_fresh_start(self, config.start_at)
-                .map_err(|(operation, rc)| JournalError::SystemdCall { operation, rc })
+            let position = super::position_for_fresh_start(self, config.start_at)
+                .map_err(|(operation, rc)| JournalError::SystemdCall { operation, rc })?;
+            self.fresh_start_position = Some(position);
+            Ok(())
+        }
+
+        pub(crate) fn took_end_head_recovery(&self) -> bool {
+            self.fresh_start_position == Some(super::FreshStartPosition::EndHeadRecovery)
         }
 
         fn configure_matches(&mut self, config: &RuntimeConfig) -> Result<(), JournalError> {
@@ -542,29 +997,9 @@ mod imp {
             &mut self,
             wait_timeout: Duration,
         ) -> Result<Option<JournalEntry>, JournalError> {
-            loop {
-                let next = unsafe { (self.lib.next)(self.journal.as_ptr()) };
-                if next < 0 {
-                    return Err(JournalError::SystemdCall {
-                        operation: "sd_journal_next",
-                        rc: next,
-                    });
-                }
-                if next > 0 {
-                    return self.current_entry().map(Some);
-                }
-                let timeout = duration_to_usec(wait_timeout);
-                let waited = unsafe { (self.lib.wait)(self.journal.as_ptr(), timeout) };
-                if waited < 0 {
-                    return Err(JournalError::SystemdCall {
-                        operation: "sd_journal_wait",
-                        rc: waited,
-                    });
-                }
-                if waited == 0 {
-                    return Ok(None);
-                }
-            }
+            super::follow_next_entry(self, wait_timeout, Self::current_entry, |operation, rc| {
+                JournalError::SystemdCall { operation, rc }
+            })
         }
 
         fn current_entry(&mut self) -> Result<JournalEntry, JournalError> {
@@ -677,7 +1112,9 @@ mod imp {
         if duration.is_zero() {
             return 0;
         }
-        let usec = duration.as_micros().min(u64::MAX as u128) as u64;
+        // `u64::MAX` is libsystemd's "wait indefinitely" sentinel, so a
+        // saturating conversion must stop one microsecond below it.
+        let usec = duration.as_micros().min((u64::MAX - 1) as u128) as u64;
         usec.max(1)
     }
 
@@ -694,6 +1131,17 @@ mod imp {
         }
         fn previous(&mut self) -> c_int {
             unsafe { (self.lib.previous)(self.journal.as_ptr()) }
+        }
+    }
+
+    impl super::JournalFollow for SdJournalReader {
+        fn next(&mut self) -> c_int {
+            unsafe { (self.lib.next)(self.journal.as_ptr()) }
+        }
+
+        fn wait(&mut self, wait_timeout: Duration) -> c_int {
+            let timeout = duration_to_usec(wait_timeout);
+            unsafe { (self.lib.wait)(self.journal.as_ptr(), timeout) }
         }
     }
 
@@ -847,6 +1295,17 @@ mod imp {
     mod tests {
         use super::*;
         use std::os::unix::fs::PermissionsExt;
+
+        /// Scenario: wait durations exercise zero, sub-microsecond, and
+        /// saturating conversions at the libsystemd boundary.
+        /// Guarantees: finite durations never map to libsystemd's `u64::MAX`
+        /// sentinel for an infinite wait.
+        #[test]
+        fn duration_conversion_avoids_infinite_wait_sentinel() {
+            assert_eq!(duration_to_usec(Duration::ZERO), 0);
+            assert_eq!(duration_to_usec(Duration::from_nanos(1)), 1);
+            assert_eq!(duration_to_usec(Duration::MAX), u64::MAX - 1);
+        }
 
         #[test]
         fn preflight_reports_access_when_journal_parent_is_not_traversable() {

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/mod.rs
@@ -264,6 +264,7 @@ struct WorkerBatch {
 
 #[cfg(target_os = "linux")]
 enum WorkerEvent {
+    HeadRecovery,
     Batch(WorkerBatch),
     CommitResult {
         batch_id: u64,
@@ -516,6 +517,11 @@ fn worker_loop_inner(
 ) -> Result<(), WorkerError> {
     let mut committed_cursor = checkpoint::read_cursor(&checkpoint_path)?;
     let mut reader = journal::SdJournalReader::open(&config, committed_cursor.as_deref())?;
+    if reader.took_end_head_recovery() {
+        event_tx
+            .blocking_send(WorkerEvent::HeadRecovery)
+            .map_err(|_| WorkerError::EventChannelClosed)?;
+    }
     let mut next_batch_id = 1u64;
     let mut builder = arrow_records_encoder::JournaldArrowRecordsBuilder::new();
     let mut first_cursor = String::new();
@@ -630,9 +636,9 @@ fn worker_loop_inner(
                         first_cursor = entry.cursor.clone();
                         first_record_at = StdInstant::now();
                     }
-                    last_cursor = entry.cursor.clone();
                     dropped_fields = dropped_fields.saturating_add(entry.dropped_fields);
                     builder.append(&entry);
+                    last_cursor = entry.cursor;
                 }
             }
         }
@@ -867,6 +873,13 @@ impl local::Receiver<OtapPdata> for JournaldReceiver {
 
                 event = event_rx.recv() => {
                     match event {
+                        Some(WorkerEvent::HeadRecovery) => {
+                            otel_warn!(
+                                "journald_receiver.start_at_end_head_recovery",
+                                source_id = config.source_id.as_str(),
+                                journal_root_path = config.journal.root_path.display().to_string()
+                            );
+                        }
                         Some(WorkerEvent::Batch(batch)) => {
                             if pending.len() >= max_in_flight {
                                 let _ =

--- a/rust/otap-dataflow/docs/journald-receiver.md
+++ b/rust/otap-dataflow/docs/journald-receiver.md
@@ -314,8 +314,16 @@ resume anchor. If the process crashes after entries are read from journald but
 before the first cursor commit succeeds, restart applies `start_at` again and
 may skip those uncommitted entries. While the process stays alive, a Nack before
 the first checkpoint replays the retained in-flight batch instead of reopening
-at the live tail. A production follow-up should add an initial durable anchor or
-document an operator policy for first-start loss tolerance.
+at the live tail.
+
+If no matching entry exists when `start_at: end` is positioned, the reader
+repositions to the journal head so it can follow the first future matching
+append. A later `SD_JOURNAL_INVALIDATE` (for example rotation, persistent
+journal flush, or a newly mounted journal root) can make older matching entries
+visible before that position. The receiver emits
+`journald_receiver.start_at_end_head_recovery` when it takes this fallback. A
+production follow-up must add a durable startup boundary; issue #3399 remains
+open for that work.
 
 Each emitted batch carries:
 
@@ -621,8 +629,8 @@ Deferred follow-ups include:
 - expanding receiver self-telemetry for stale cursors, permission warnings,
   worker restarts, last-entry timestamp, and backpressure duration
 - failing closed or warning clearly on partially readable journal trees
-- an initial durable resume anchor for `start_at: end` before the first
-  checkpoint commit
+- an initial durable resume anchor and replay boundary for `start_at: end`
+  before the first checkpoint commit, including journal invalidation handling
 - configurable recovery for corrupt or unsupported checkpoint envelopes, such
   as falling back to `start_at` and writing a fresh cursor when the operator
   opts in


### PR DESCRIPTION
## Summary

- bound each journald follow call to one blocking wait so non-matching journal activity cannot indefinitely delay batch flushes, checkpoint commands, drain, or shutdown
- exercise the production `next()` / `wait()` control flow with behavior-level tests for `start_at: end`, idle timeouts, non-matching wakes, invalidation, errors, immediate reads, raw-tail stalls, cursor advancement, and current-entry failures
- emit and document `journald_receiver.start_at_end_head_recovery` from the pipeline thread when fresh `start_at: end` cannot establish a matching tail anchor
- avoid the libsystemd infinite-wait sentinel and remove one per-record cursor clone

Refs #3399.

## Scope

This PR addresses the behavior-level follow-test work in #3399 and the closely coupled wait-budget defect found by the mandatory review panel.

It deliberately does **not** close #3399. We are knowingly retaining the current best-effort head recovery for fresh `start_at: end`: buggy libsystemd behavior or a later `SD_JOURNAL_INVALIDATE` can expose pre-startup matching history. The warning and operator documentation make that risk explicit, while #3399 remains open for the dedicated monotonic/boot-aware durable boundary guard. This PR does not claim that `start_at: end` is fully replay-safe.

The diff is larger than a typical test-only change because the production follow seam, faithful fake state machine, branch/error coverage, operator telemetry, documentation, and changelog form one reviewable behavior contract.

## Validation

- `cargo test -p otap-df-core-nodes --lib` (850 tests: 846 passed, 4 ignored)
- `cargo clippy -p otap-df-core-nodes --lib --tests -- -D warnings`
- Linux target `cargo-zigbuild check`
- Linux target test compilation with `cargo-zigbuild test --no-run`
- `cargo xtask check` with constrained build parallelism
- `markdownlint-cli2` on both changed Markdown files
- pinned `chloggen v0.30.0` validation for Go and Rust entries
- ASCII/LF checks for changed Rust, YAML, and Markdown files

## Review panel

Twenty independent reviews ran across SRE, SDET, Security, Performance Architect, and Adversarial personas using Claude Opus 5, GPT-5.6 Sol, Gemini 3.1 Pro, and MAI Code Flash. Material findings were deduplicated and resolved; MAI findings were advisory and independently verified by frontier models. Resolution re-reviews found no remaining defect in this PR's stated scope.
