### PR TITLE
chore(opamp): improve reconciliation diagnostics and example

### DIFF
--- a/rust/otap-dataflow/configs/opamp-controller-extension.yaml
+++ b/rust/otap-dataflow/configs/opamp-controller-extension.yaml
@@ -14,4 +14,37 @@ engine:
           agent_description:
             identifying_attributes:
               service.name: "otap-df-engine"
-groups: {}
+groups:
+  default:
+    pipelines:
+      light_traffic:
+        nodes:
+          generator:
+            type: receiver:traffic_generator
+            config:
+              data_source: synthetic
+              traffic_config:
+                max_batch_size: 10
+                signals_per_second: 10
+                log_weight: 100
+          sink:
+            type: exporter:otlp_grpc
+            config:
+              grpc_endpoint: "http://127.0.0.1:4317"
+        connections:
+          - from: generator
+            to: sink
+      local_backend:
+        nodes:
+          receiver:
+            type: receiver:otlp
+            config:
+              protocols:
+                grpc:
+                  listening_addr: "127.0.0.1:4317"
+          sink:
+            type: exporter:noop
+            config: {}
+        connections:
+          - from: receiver
+            to: sink

--- a/rust/otap-dataflow/crates/controller/src/extension/opamp/README.md
+++ b/rust/otap-dataflow/crates/controller/src/extension/opamp/README.md
@@ -37,18 +37,60 @@ agent page.
 ### 3. Push an engine config from the server
 
 Open the agent page, paste the following into the *Additional Configuration*
-box, and hit Save:
+box, and hit Save. Remote configuration is complete desired state, not a patch,
+so this payload preserves both pipelines from the startup config while changing
+`signals_per_second` from `10` to `20`:
 
 ```json
 {
   "version": "otel_dataflow/v1",
-  "engine": {},
+  "engine": {
+    "controller": {
+      "extensions": {
+        "opamp": {
+          "type": "urn:otel:extension:opamp",
+          "config": {
+            "endpoint": "ws://127.0.0.1:4320/v1/opamp",
+            "instance_uid": "8be4df61-93ca-11d2-aa0d-00e098032b8c",
+            "heartbeat_interval": "5s",
+            "agent_description": {
+              "identifying_attributes": {
+                "service.name": "otap-df-engine"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
   "groups": {
     "default": {
       "pipelines": {
-        "remote_pipeline": {
+        "light_traffic": {
           "nodes": {
-            "otlp_receiver": {
+            "generator": {
+              "type": "receiver:traffic_generator",
+              "config": {
+                "data_source": "synthetic",
+                "traffic_config": {
+                  "max_batch_size": 10,
+                  "signals_per_second": 20,
+                  "log_weight": 100
+                }
+              }
+            },
+            "sink": {
+              "type": "exporter:otlp_grpc",
+              "config": {
+                "grpc_endpoint": "http://127.0.0.1:4317"
+              }
+            }
+          },
+          "connections": [{ "from": "generator", "to": "sink" }]
+        },
+        "local_backend": {
+          "nodes": {
+            "receiver": {
               "type": "receiver:otlp",
               "config": {
                 "protocols": {
@@ -58,7 +100,7 @@ box, and hit Save:
             },
             "sink": { "type": "exporter:noop", "config": {} }
           },
-          "connections": [{ "from": "otlp_receiver", "to": "sink" }]
+          "connections": [{ "from": "receiver", "to": "sink" }]
         }
       }
     }
@@ -69,8 +111,8 @@ box, and hit Save:
 Expected sequence, visible in the server log and the engine log:
 
 1. The engine replies with `RemoteConfigStatus=APPLYING`.
-2. The engine reconciles the config and starts the pipeline (an OTLP gRPC
-   receiver comes up on `127.0.0.1:4317`).
+2. The engine reconciles the config, preserves the local OTLP loopback, and
+   updates the traffic generator to 20 signals per second.
 3. The next reply reports `RemoteConfigStatus=APPLIED` and `Healthy=true`.
 
 Pushing an invalid config (for example malformed JSON) is reported back as

--- a/rust/otap-dataflow/crates/controller/src/extension/opamp/mod.rs
+++ b/rust/otap-dataflow/crates/controller/src/extension/opamp/mod.rs
@@ -278,10 +278,7 @@ async fn connect_websocket(
 
         match connect_result {
             Ok((stream, _response)) => {
-                otel_info!(
-                    "opamp.controller_extension.ws_connect.success",
-                    message = "Connected to OpAMP server"
-                );
+                otel_info!("opamp.controller_extension.ws_connect.success");
                 return Some(stream);
             }
 
@@ -928,7 +925,6 @@ fn handle_server_to_agent_message(
         } else {
             otel_debug!(
                 "opamp.controller_extension.remote_config.missing",
-                message = "Remote configuration did not contain a config map",
                 config_hash_bytes
             );
         }
@@ -1046,10 +1042,9 @@ where
                         );
                     }
                     Ok(status) => {
-                        let failure_reason = status
-                            .failure_reason
-                            .as_deref()
-                            .unwrap_or("Remote configuration reconciliation failed");
+                        let failure_reason = status.failure_reason.as_deref().unwrap_or(
+                            "Controller returned a non-success status without a failure reason",
+                        );
                         otel_error!(
                             "opamp.controller_extension.remote_config.reconcile_failed",
                             message = failure_reason,
@@ -1060,8 +1055,7 @@ where
                     Err(error) => {
                         otel_error!(
                             "opamp.controller_extension.remote_config.reconcile_failed",
-                            message =
-                                format!("Remote configuration reconciliation failed: {error:?}")
+                            message =? error
                         );
                     }
                 }

--- a/rust/otap-dataflow/crates/controller/src/extension/opamp/mod.rs
+++ b/rust/otap-dataflow/crates/controller/src/extension/opamp/mod.rs
@@ -1046,7 +1046,8 @@ where
                     Err(error) => {
                         otel_error!(
                             "opamp.controller_extension.remote_config.reconcile_failed",
-                            message =? error
+                            message = "Remote configuration was not committed",
+                            error =? error
                         );
                     }
                 }
@@ -1872,6 +1873,8 @@ mod test {
         assert!(status.error_message.contains("error happen"));
     }
 
+    /// Scenario: the OpAMP server sends a remote configuration containing malformed JSON.
+    /// Guarantees: the agent reports the configuration as failed without reconciling it.
     #[tokio::test]
     async fn test_unparsable_config() {
         let control_plane = Arc::new(MockControlPlane::new(empty_engine_config()));
@@ -1913,6 +1916,8 @@ mod test {
         );
     }
 
+    /// Scenario: the agent has successfully applied a remote configuration.
+    /// Guarantees: a later heartbeat reports health and pipeline status with a new sequence number.
     #[tokio::test]
     async fn test_heartbeat_sent_after_applied_config() {
         let control_plane = Arc::new(MockControlPlane::new(empty_engine_config()));

--- a/rust/otap-dataflow/crates/controller/src/extension/opamp/mod.rs
+++ b/rust/otap-dataflow/crates/controller/src/extension/opamp/mod.rs
@@ -278,6 +278,10 @@ async fn connect_websocket(
 
         match connect_result {
             Ok((stream, _response)) => {
+                otel_info!(
+                    "opamp.controller_extension.ws_connect.success",
+                    message = "Connected to OpAMP server"
+                );
                 return Some(stream);
             }
 
@@ -836,6 +840,7 @@ fn handle_server_to_agent_message(
     }
 
     if let Some(remote_config) = message.remote_config {
+        let config_hash_bytes = remote_config.config_hash.len();
         if let Some(remote_config_config) = remote_config.config {
             if Some(&remote_config.config_hash) != session_state.last_config_hash.as_ref() {
                 if let Some(config_file) = remote_config_config
@@ -849,6 +854,10 @@ fn handle_server_to_agent_message(
                         if !config_file.body.is_empty() {
                             match serde_json::from_slice::<OtelDataflowSpec>(&config_file.body) {
                                 Ok(engine_config) => {
+                                    otel_debug!(
+                                        "opamp.controller_extension.remote_config.accepted",
+                                        config_hash_bytes
+                                    );
                                     updates.engine_config = Some(EngineConfigUpdate {
                                         engine_config,
                                         config_hash: remote_config.config_hash,
@@ -869,6 +878,12 @@ fn handle_server_to_agent_message(
                                     })
                                 }
                             }
+                        } else {
+                            otel_debug!(
+                                "opamp.controller_extension.remote_config.empty",
+                                message = "Ignoring empty remote configuration body",
+                                config_hash_bytes
+                            );
                         }
                     } else {
                         let message = "Invalid content type. expected application/json".to_string();
@@ -910,6 +925,12 @@ fn handle_server_to_agent_message(
                     )
                 }
             }
+        } else {
+            otel_debug!(
+                "opamp.controller_extension.remote_config.missing",
+                message = "Remote configuration did not contain a config map",
+                config_hash_bytes
+            );
         }
     }
 
@@ -985,6 +1006,11 @@ where
 
             // update engine config & report results to server
             if let Some(engine_config) = updates.engine_config {
+                otel_info!(
+                    "opamp.controller_extension.remote_config.reconcile_start",
+                    config_hash_bytes = engine_config.config_hash.len(),
+                    delete_missing = config.reconcile.delete_missing
+                );
                 // Send message to let the server we're applying the config
                 session_state.sequence_num += 1;
                 let message = applying_message(
@@ -1011,6 +1037,34 @@ where
                             delete_timeout_secs: config.reconcile.delete_timeout_secs,
                             delete_missing: config.reconcile.delete_missing,
                         });
+
+                match &reconcile_result {
+                    Ok(status) if status.state == EngineConfigReconcileState::Succeeded => {
+                        otel_info!(
+                            "opamp.controller_extension.remote_config.reconcile_succeeded",
+                            changes = status.changes.len()
+                        );
+                    }
+                    Ok(status) => {
+                        let failure_reason = status
+                            .failure_reason
+                            .as_deref()
+                            .unwrap_or("Remote configuration reconciliation failed");
+                        otel_error!(
+                            "opamp.controller_extension.remote_config.reconcile_failed",
+                            message = failure_reason,
+                            state =? status.state,
+                            changes = status.changes.len()
+                        );
+                    }
+                    Err(error) => {
+                        otel_error!(
+                            "opamp.controller_extension.remote_config.reconcile_failed",
+                            message =
+                                format!("Remote configuration reconciliation failed: {error:?}")
+                        );
+                    }
+                }
 
                 session_state.sequence_num += 1;
                 let reconcile_result_message = applied_result_message(

--- a/rust/otap-dataflow/crates/controller/src/extension/opamp/mod.rs
+++ b/rust/otap-dataflow/crates/controller/src/extension/opamp/mod.rs
@@ -837,7 +837,6 @@ fn handle_server_to_agent_message(
     }
 
     if let Some(remote_config) = message.remote_config {
-        let config_hash_bytes = remote_config.config_hash.len();
         if let Some(remote_config_config) = remote_config.config {
             if Some(&remote_config.config_hash) != session_state.last_config_hash.as_ref() {
                 if let Some(config_file) = remote_config_config
@@ -852,8 +851,7 @@ fn handle_server_to_agent_message(
                             match serde_json::from_slice::<OtelDataflowSpec>(&config_file.body) {
                                 Ok(engine_config) => {
                                     otel_debug!(
-                                        "opamp.controller_extension.remote_config.accepted",
-                                        config_hash_bytes
+                                        "opamp.controller_extension.remote_config.accepted"
                                     );
                                     updates.engine_config = Some(EngineConfigUpdate {
                                         engine_config,
@@ -861,9 +859,7 @@ fn handle_server_to_agent_message(
                                     })
                                 }
                                 Err(e) => {
-                                    let message =
-                                        "Could not deserialize JSON encoded engine config"
-                                            .to_string();
+                                    let message = "Remote configuration was rejected; the current engine configuration remains active".to_string();
                                     otel_error!(
                                         "opamp.controller_extension.message.invalid_config_json",
                                         message = message,
@@ -878,8 +874,7 @@ fn handle_server_to_agent_message(
                         } else {
                             otel_debug!(
                                 "opamp.controller_extension.remote_config.empty",
-                                message = "Ignoring empty remote configuration body",
-                                config_hash_bytes
+                                message = "Ignoring empty remote configuration body"
                             );
                         }
                     } else {
@@ -923,10 +918,7 @@ fn handle_server_to_agent_message(
                 }
             }
         } else {
-            otel_debug!(
-                "opamp.controller_extension.remote_config.missing",
-                config_hash_bytes
-            );
+            otel_debug!("opamp.controller_extension.remote_config.missing");
         }
     }
 
@@ -1004,7 +996,6 @@ where
             if let Some(engine_config) = updates.engine_config {
                 otel_info!(
                     "opamp.controller_extension.remote_config.reconcile_start",
-                    config_hash_bytes = engine_config.config_hash.len(),
                     delete_missing = config.reconcile.delete_missing
                 );
                 // Send message to let the server we're applying the config
@@ -1916,7 +1907,10 @@ mod test {
         let applied = &requests[1];
         let status = applied.remote_config_status.as_ref().unwrap();
         assert_eq!(status.status, RemoteConfigStatuses::Failed as i32);
-        assert!(status.error_message.contains("Could not deserialize JSON"));
+        assert_eq!(
+            status.error_message,
+            "Remote configuration was rejected; the current engine configuration remains active"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Add local OpAMP lifecycle logs for WebSocket connection and remote configuration reconciliation, including complete failure reasons.

Make the OpAMP controller example self-contained by generating lightweight log traffic and forwarding it through a local OTLP loopback pipeline. This makes it relatively easy to test.