### PR TITLE
chore: [query-engine] Add lifetime decoration to ArrayValue & MapValue get_items APIs

### DIFF
--- a/rust/experimental/query_engine/engine-recordset/src/primitives/owned_value.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/primitives/owned_value.rs
@@ -116,10 +116,10 @@ impl From<Value<'_>> for OwnedValue {
             Value::Map(m) => {
                 let mut values: HashMap<Box<str>, OwnedValue> = HashMap::new();
 
-                m.get_items(&mut KeyValueClosureCallback::new(|k, v| {
+                m.get_items(&mut |k, v| {
                     values.insert(k.into(), v.into());
                     true
-                }));
+                });
 
                 OwnedValue::Map(MapValueStorage::new(values))
             }
@@ -135,10 +135,10 @@ impl From<&dyn ArrayValue> for ArrayValueStorage<OwnedValue> {
     fn from(value: &dyn ArrayValue) -> Self {
         let mut values = Vec::new();
 
-        value.get_items(&mut IndexValueClosureCallback::new(|_, v| {
+        value.get_items(&mut |_, v| {
             values.push(v.into());
             true
-        }));
+        });
 
         ArrayValueStorage::new(values)
     }
@@ -148,10 +148,10 @@ impl From<&dyn MapValue> for MapValueStorage<OwnedValue> {
     fn from(value: &dyn MapValue) -> Self {
         let mut values: HashMap<Box<str>, _> = HashMap::new();
 
-        value.get_items(&mut KeyValueClosureCallback::new(|k, v| {
+        value.get_items(&mut |k, v| {
             values.insert(k.into(), v.into());
             true
-        }));
+        });
 
         MapValueStorage::new(values)
     }

--- a/rust/experimental/query_engine/engine-recordset/src/primitives/resolved_value.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/primitives/resolved_value.rs
@@ -437,10 +437,10 @@ impl ArrayValue for List<'_> {
         Err("List does not support static access".to_string())
     }
 
-    fn get_item_range(
-        &self,
+    fn get_item_range<'a>(
+        &'a self,
         range: ArrayRange,
-        item_callback: &mut dyn IndexValueCallback,
+        item_callback: &mut dyn IndexValueCallback<'a>,
     ) -> bool {
         for (index, value) in range.get_slice(&self.values).iter().enumerate() {
             if !item_callback.next(index, value.to_value()) {
@@ -514,10 +514,10 @@ impl ArrayValue for ArraySlice<'_> {
             .get_static(self.range_start_inclusive + index)
     }
 
-    fn get_item_range(
-        &self,
+    fn get_item_range<'a>(
+        &'a self,
         range: ArrayRange,
-        item_callback: &mut dyn IndexValueCallback,
+        item_callback: &mut dyn IndexValueCallback<'a>,
     ) -> bool {
         let start = range
             .get_start_range_inclusize()
@@ -671,10 +671,10 @@ impl ArrayValue for Sequence<'_> {
         Err("Sequence does not support static access".to_string())
     }
 
-    fn get_item_range(
-        &self,
+    fn get_item_range<'a>(
+        &'a self,
         range: ArrayRange,
-        item_callback: &mut dyn IndexValueCallback,
+        item_callback: &mut dyn IndexValueCallback<'a>,
     ) -> bool {
         let len = self.len();
 
@@ -1042,10 +1042,10 @@ impl ArrayValue for ResolvedArrayValue<'_> {
         self.get_array().get_static(index)
     }
 
-    fn get_item_range(
-        &self,
+    fn get_item_range<'a>(
+        &'a self,
         range: ArrayRange,
-        item_callback: &mut dyn IndexValueCallback,
+        item_callback: &mut dyn IndexValueCallback<'a>,
     ) -> bool {
         self.get_array().get_item_range(range, item_callback)
     }
@@ -1205,7 +1205,7 @@ impl MapValue for ResolvedMapValue<'_> {
         self.get_map().get_static(key)
     }
 
-    fn get_items(&self, item_callback: &mut dyn KeyValueCallback) -> bool {
+    fn get_items<'a>(&'a self, item_callback: &mut dyn KeyValueCallback<'a>) -> bool {
         self.get_map().get_items(item_callback)
     }
 }

--- a/rust/experimental/query_engine/engine-recordset/src/primitives/resolved_value.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/primitives/resolved_value.rs
@@ -440,10 +440,10 @@ impl ArrayValue for List<'_> {
     fn get_item_range<'a>(
         &'a self,
         range: ArrayRange,
-        item_callback: &mut dyn IndexValueCallback<'a>,
+        item_callback: &mut dyn FnMut(usize, Value<'a>) -> bool,
     ) -> bool {
         for (index, value) in range.get_slice(&self.values).iter().enumerate() {
-            if !item_callback.next(index, value.to_value()) {
+            if !(item_callback)(index, value.to_value()) {
                 return false;
             }
         }
@@ -517,7 +517,7 @@ impl ArrayValue for ArraySlice<'_> {
     fn get_item_range<'a>(
         &'a self,
         range: ArrayRange,
-        item_callback: &mut dyn IndexValueCallback<'a>,
+        item_callback: &mut dyn FnMut(usize, Value<'a>) -> bool,
     ) -> bool {
         let start = range
             .get_start_range_inclusize()
@@ -674,13 +674,12 @@ impl ArrayValue for Sequence<'_> {
     fn get_item_range<'a>(
         &'a self,
         range: ArrayRange,
-        item_callback: &mut dyn IndexValueCallback<'a>,
+        item_callback: &mut dyn FnMut(usize, Value<'a>) -> bool,
     ) -> bool {
         let len = self.len();
 
         let mut start = range.get_start_range_inclusize().unwrap_or(0);
         let mut end = range.get_end_range_exclusive().unwrap_or(len);
-        let mut index = 0;
 
         if end > len {
             panic!(
@@ -689,6 +688,13 @@ impl ArrayValue for Sequence<'_> {
             )
         }
 
+        let mut index = 0;
+        let mut cb = move |_, v| {
+            let r = (item_callback)(index, v);
+            index += 1;
+            r
+        };
+
         for v in &self.values {
             let len = usize::min(end, v.len());
             if len == 0 {
@@ -696,14 +702,7 @@ impl ArrayValue for Sequence<'_> {
             }
             if start < len {
                 let range = (start..len).into();
-                if !v.get_item_range(
-                    range,
-                    &mut IndexValueClosureCallback::new(|_, v| {
-                        let r = item_callback.next(index, v);
-                        index += 1;
-                        r
-                    }),
-                ) {
+                if !v.get_item_range(range, &mut cb) {
                     return false;
                 }
                 start = 0;
@@ -1045,7 +1044,7 @@ impl ArrayValue for ResolvedArrayValue<'_> {
     fn get_item_range<'a>(
         &'a self,
         range: ArrayRange,
-        item_callback: &mut dyn IndexValueCallback<'a>,
+        item_callback: &mut dyn FnMut(usize, Value<'a>) -> bool,
     ) -> bool {
         self.get_array().get_item_range(range, item_callback)
     }
@@ -1205,7 +1204,7 @@ impl MapValue for ResolvedMapValue<'_> {
         self.get_map().get_static(key)
     }
 
-    fn get_items<'a>(&'a self, item_callback: &mut dyn KeyValueCallback<'a>) -> bool {
+    fn get_items<'a>(&'a self, item_callback: &mut dyn FnMut(&str, Value<'a>) -> bool) -> bool {
         self.get_map().get_items(item_callback)
     }
 }
@@ -1235,14 +1234,11 @@ mod tests {
         fn run_test(v: &Sequence, range: ArrayRange, expected: &[Value]) {
             let mut items = 0;
 
-            assert!(v.get_item_range(
-                range,
-                &mut IndexValueClosureCallback::new(|i, v| {
-                    assert_eq!(expected[i], v);
-                    items += 1;
-                    true
-                }),
-            ));
+            assert!(v.get_item_range(range, &mut |i, v| {
+                assert_eq!(expected[i], v);
+                items += 1;
+                true
+            },));
 
             assert_eq!(expected.len(), items);
         }
@@ -1326,13 +1322,10 @@ mod tests {
     #[should_panic]
     fn test_sequence_get_item_range_panic() {
         fn run_test(v: &Sequence, range: ArrayRange, expected: &[Value]) {
-            v.get_item_range(
-                range,
-                &mut IndexValueClosureCallback::new(|i, v| {
-                    assert_eq!(expected[i], v);
-                    true
-                }),
-            );
+            v.get_item_range(range, &mut |i, v| {
+                assert_eq!(expected[i], v);
+                true
+            });
         }
 
         let sequence = Sequence::new(vec![

--- a/rust/experimental/query_engine/engine-recordset/src/primitives/value_storage.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/primitives/value_storage.rs
@@ -328,10 +328,10 @@ impl<T: EnumerableValueSource<T>> ArrayValue for ArrayValueStorage<T> {
         Ok(self.values.get(index).map(|v| v as &dyn AsStaticValue))
     }
 
-    fn get_item_range(
-        &self,
+    fn get_item_range<'a>(
+        &'a self,
         range: ArrayRange,
-        item_callback: &mut dyn IndexValueCallback,
+        item_callback: &mut dyn IndexValueCallback<'a>,
     ) -> bool {
         for (index, value) in range.get_slice(&self.values).iter().enumerate() {
             if !item_callback.next(index, value.to_value()) {
@@ -460,7 +460,7 @@ impl<T: EnumerableValueSource<T>> MapValue for MapValueStorage<T> {
         Ok(self.values.get(key).map(|v| v as &dyn AsStaticValue))
     }
 
-    fn get_items(&self, item_callback: &mut dyn KeyValueCallback) -> bool {
+    fn get_items<'a>(&'a self, item_callback: &mut dyn KeyValueCallback<'a>) -> bool {
         for (key, value) in self.values.iter() {
             if !item_callback.next(key, value.to_value()) {
                 return false;

--- a/rust/experimental/query_engine/engine-recordset/src/primitives/value_storage.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/primitives/value_storage.rs
@@ -331,10 +331,10 @@ impl<T: EnumerableValueSource<T>> ArrayValue for ArrayValueStorage<T> {
     fn get_item_range<'a>(
         &'a self,
         range: ArrayRange,
-        item_callback: &mut dyn IndexValueCallback<'a>,
+        item_callback: &mut dyn FnMut(usize, Value<'a>) -> bool,
     ) -> bool {
         for (index, value) in range.get_slice(&self.values).iter().enumerate() {
-            if !item_callback.next(index, value.to_value()) {
+            if !(item_callback)(index, value.to_value()) {
                 return false;
             }
         }
@@ -460,9 +460,9 @@ impl<T: EnumerableValueSource<T>> MapValue for MapValueStorage<T> {
         Ok(self.values.get(key).map(|v| v as &dyn AsStaticValue))
     }
 
-    fn get_items<'a>(&'a self, item_callback: &mut dyn KeyValueCallback<'a>) -> bool {
+    fn get_items<'a>(&'a self, item_callback: &mut dyn FnMut(&str, Value<'a>) -> bool) -> bool {
         for (key, value) in self.values.iter() {
-            if !item_callback.next(key, value.to_value()) {
+            if !(item_callback)(key, value.to_value()) {
                 return false;
             }
         }

--- a/rust/experimental/query_engine/engine-recordset/src/test_helpers.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/test_helpers.rs
@@ -136,9 +136,9 @@ impl MapValue for TestRecord {
         Ok(self.values.get(key).map(|v| v as &dyn AsStaticValue))
     }
 
-    fn get_items<'a>(&'a self, item_callback: &mut dyn KeyValueCallback<'a>) -> bool {
+    fn get_items<'a>(&'a self, item_callback: &mut dyn FnMut(&str, Value<'a>) -> bool) -> bool {
         for (k, v) in &self.values {
-            if !item_callback.next(k, v.to_value()) {
+            if !(item_callback)(k, v.to_value()) {
                 return false;
             }
         }

--- a/rust/experimental/query_engine/engine-recordset/src/test_helpers.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/test_helpers.rs
@@ -136,7 +136,7 @@ impl MapValue for TestRecord {
         Ok(self.values.get(key).map(|v| v as &dyn AsStaticValue))
     }
 
-    fn get_items(&self, item_callback: &mut dyn KeyValueCallback) -> bool {
+    fn get_items<'a>(&'a self, item_callback: &mut dyn KeyValueCallback<'a>) -> bool {
         for (k, v) in &self.values {
             if !item_callback.next(k, v.to_value()) {
                 return false;

--- a/rust/experimental/query_engine/expressions/src/primitives/array_value.rs
+++ b/rust/experimental/query_engine/expressions/src/primitives/array_value.rs
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{fmt::Debug, ops::*};
+use std::{fmt::Debug, marker::PhantomData, ops::*};
 
 use crate::*;
 
@@ -18,12 +18,15 @@ pub trait ArrayValue: Debug {
     // of support for this method
     fn get_static(&self, index: usize) -> Result<Option<&(dyn AsStaticValue + 'static)>, String>;
 
-    fn get_items(&self, item_callback: &mut dyn IndexValueCallback) -> bool {
+    fn get_items<'a>(&'a self, item_callback: &mut dyn IndexValueCallback<'a>) -> bool {
         self.get_item_range((..).into(), item_callback)
     }
 
-    fn get_item_range(&self, range: ArrayRange, item_callback: &mut dyn IndexValueCallback)
-    -> bool;
+    fn get_item_range<'a>(
+        &'a self,
+        range: ArrayRange,
+        item_callback: &mut dyn IndexValueCallback<'a>,
+    ) -> bool;
 
     fn to_string(&self) -> ValueString<'_> {
         let mut values = Vec::new();
@@ -122,31 +125,35 @@ impl From<RangeInclusive<usize>> for ArrayRange {
     }
 }
 
-pub trait IndexValueCallback {
-    fn next(&mut self, index: usize, value: Value) -> bool;
+pub trait IndexValueCallback<'a> {
+    fn next(&mut self, index: usize, value: Value<'a>) -> bool;
 }
 
-pub struct IndexValueClosureCallback<F>
+pub struct IndexValueClosureCallback<'a, F>
 where
-    F: FnMut(usize, Value) -> bool,
+    F: FnMut(usize, Value<'a>) -> bool,
 {
     callback: F,
+    marker: PhantomData<&'a usize>,
 }
 
-impl<F> IndexValueClosureCallback<F>
+impl<'a, F> IndexValueClosureCallback<'a, F>
 where
-    F: FnMut(usize, Value) -> bool,
+    F: FnMut(usize, Value<'a>) -> bool,
 {
-    pub fn new(callback: F) -> IndexValueClosureCallback<F> {
-        Self { callback }
+    pub fn new(callback: F) -> IndexValueClosureCallback<'a, F> {
+        Self {
+            callback,
+            marker: Default::default(),
+        }
     }
 }
 
-impl<F> IndexValueCallback for IndexValueClosureCallback<F>
+impl<'a, F> IndexValueCallback<'a> for IndexValueClosureCallback<'a, F>
 where
-    F: FnMut(usize, Value) -> bool,
+    F: FnMut(usize, Value<'a>) -> bool,
 {
-    fn next(&mut self, index: usize, value: Value) -> bool {
+    fn next(&mut self, index: usize, value: Value<'a>) -> bool {
         (self.callback)(index, value)
     }
 }

--- a/rust/experimental/query_engine/expressions/src/primitives/array_value.rs
+++ b/rust/experimental/query_engine/expressions/src/primitives/array_value.rs
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{fmt::Debug, marker::PhantomData, ops::*};
+use std::{fmt::Debug, ops::*};
 
 use crate::*;
 
@@ -18,23 +18,23 @@ pub trait ArrayValue: Debug {
     // of support for this method
     fn get_static(&self, index: usize) -> Result<Option<&(dyn AsStaticValue + 'static)>, String>;
 
-    fn get_items<'a>(&'a self, item_callback: &mut dyn IndexValueCallback<'a>) -> bool {
+    fn get_items<'a>(&'a self, item_callback: &mut dyn FnMut(usize, Value<'a>) -> bool) -> bool {
         self.get_item_range((..).into(), item_callback)
     }
 
     fn get_item_range<'a>(
         &'a self,
         range: ArrayRange,
-        item_callback: &mut dyn IndexValueCallback<'a>,
+        item_callback: &mut dyn FnMut(usize, Value<'a>) -> bool,
     ) -> bool;
 
     fn to_string(&self) -> ValueString<'_> {
         let mut values = Vec::new();
 
-        self.get_items(&mut IndexValueClosureCallback::new(|_, value| {
+        self.get_items(&mut |_, value| {
             values.push(value.to_json_value());
             true
-        }));
+        });
 
         ValueString::Owned(serde_json::Value::Array(values).to_string())
     }
@@ -125,39 +125,6 @@ impl From<RangeInclusive<usize>> for ArrayRange {
     }
 }
 
-pub trait IndexValueCallback<'a> {
-    fn next(&mut self, index: usize, value: Value<'a>) -> bool;
-}
-
-pub struct IndexValueClosureCallback<'a, F>
-where
-    F: FnMut(usize, Value<'a>) -> bool,
-{
-    callback: F,
-    marker: PhantomData<&'a F>,
-}
-
-impl<'a, F> IndexValueClosureCallback<'a, F>
-where
-    F: FnMut(usize, Value<'a>) -> bool,
-{
-    pub fn new(callback: F) -> IndexValueClosureCallback<'a, F> {
-        Self {
-            callback,
-            marker: Default::default(),
-        }
-    }
-}
-
-impl<'a, F> IndexValueCallback<'a> for IndexValueClosureCallback<'a, F>
-where
-    F: FnMut(usize, Value<'a>) -> bool,
-{
-    fn next(&mut self, index: usize, value: Value<'a>) -> bool {
-        (self.callback)(index, value)
-    }
-}
-
 pub(crate) fn equal_to(
     query_location: &QueryLocation,
     left: &dyn ArrayValue,
@@ -170,26 +137,23 @@ pub(crate) fn equal_to(
 
     let mut e = None;
 
-    let completed =
-        left.get_items(&mut IndexValueClosureCallback::new(
-            |index, left_value| match right.get(index) {
-                Some(right_value) => {
-                    let r = Value::are_values_equal(
-                        query_location,
-                        &left_value,
-                        &right_value.to_value(),
-                        case_insensitive,
-                    );
-                    if let Err(exp_e) = r {
-                        e = Some(exp_e);
-                        false
-                    } else {
-                        r.unwrap()
-                    }
-                }
-                None => false,
-            },
-        ));
+    let completed = left.get_items(&mut |index, left_value| match right.get(index) {
+        Some(right_value) => {
+            let r = Value::are_values_equal(
+                query_location,
+                &left_value,
+                &right_value.to_value(),
+                case_insensitive,
+            );
+            if let Err(exp_e) = r {
+                e = Some(exp_e);
+                false
+            } else {
+                r.unwrap()
+            }
+        }
+        None => false,
+    });
 
     if let Some(exp_e) = e {
         Err(exp_e)

--- a/rust/experimental/query_engine/expressions/src/primitives/array_value.rs
+++ b/rust/experimental/query_engine/expressions/src/primitives/array_value.rs
@@ -134,7 +134,7 @@ where
     F: FnMut(usize, Value<'a>) -> bool,
 {
     callback: F,
-    marker: PhantomData<&'a usize>,
+    marker: PhantomData<&'a F>,
 }
 
 impl<'a, F> IndexValueClosureCallback<'a, F>

--- a/rust/experimental/query_engine/expressions/src/primitives/map_value.rs
+++ b/rust/experimental/query_engine/expressions/src/primitives/map_value.rs
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fmt::Debug;
+use std::{fmt::Debug, marker::PhantomData};
 
 use crate::*;
 
@@ -20,7 +20,7 @@ pub trait MapValue: Debug {
     // of support for this method
     fn get_static(&self, key: &str) -> Result<Option<&(dyn AsStaticValue + 'static)>, String>;
 
-    fn get_items(&self, item_callback: &mut dyn KeyValueCallback) -> bool;
+    fn get_items<'a>(&'a self, item_callback: &mut dyn KeyValueCallback<'a>) -> bool;
 
     fn to_string(&self) -> ValueString<'_> {
         let mut values = serde_json::Map::new();
@@ -34,31 +34,35 @@ pub trait MapValue: Debug {
     }
 }
 
-pub trait KeyValueCallback {
-    fn next(&mut self, key: &str, value: Value) -> bool;
+pub trait KeyValueCallback<'a> {
+    fn next(&mut self, key: &str, value: Value<'a>) -> bool;
 }
 
-pub struct KeyValueClosureCallback<F>
+pub struct KeyValueClosureCallback<'a, F>
 where
-    F: FnMut(&str, Value) -> bool,
+    F: FnMut(&str, Value<'a>) -> bool,
 {
     callback: F,
+    marker: PhantomData<&'a usize>,
 }
 
-impl<F> KeyValueClosureCallback<F>
+impl<'a, F> KeyValueClosureCallback<'a, F>
 where
-    F: FnMut(&str, Value) -> bool,
+    F: FnMut(&str, Value<'a>) -> bool,
 {
-    pub fn new(callback: F) -> KeyValueClosureCallback<F> {
-        Self { callback }
+    pub fn new(callback: F) -> KeyValueClosureCallback<'a, F> {
+        Self {
+            callback,
+            marker: Default::default(),
+        }
     }
 }
 
-impl<F> KeyValueCallback for KeyValueClosureCallback<F>
+impl<'a, F> KeyValueCallback<'a> for KeyValueClosureCallback<'a, F>
 where
-    F: FnMut(&str, Value) -> bool,
+    F: FnMut(&str, Value<'a>) -> bool,
 {
-    fn next(&mut self, key: &str, value: Value) -> bool {
+    fn next(&mut self, key: &str, value: Value<'a>) -> bool {
         (self.callback)(key, value)
     }
 }

--- a/rust/experimental/query_engine/expressions/src/primitives/map_value.rs
+++ b/rust/experimental/query_engine/expressions/src/primitives/map_value.rs
@@ -43,7 +43,7 @@ where
     F: FnMut(&str, Value<'a>) -> bool,
 {
     callback: F,
-    marker: PhantomData<&'a usize>,
+    marker: PhantomData<&'a F>,
 }
 
 impl<'a, F> KeyValueClosureCallback<'a, F>

--- a/rust/experimental/query_engine/expressions/src/primitives/map_value.rs
+++ b/rust/experimental/query_engine/expressions/src/primitives/map_value.rs
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{fmt::Debug, marker::PhantomData};
+use std::fmt::Debug;
 
 use crate::*;
 
@@ -20,50 +20,17 @@ pub trait MapValue: Debug {
     // of support for this method
     fn get_static(&self, key: &str) -> Result<Option<&(dyn AsStaticValue + 'static)>, String>;
 
-    fn get_items<'a>(&'a self, item_callback: &mut dyn KeyValueCallback<'a>) -> bool;
+    fn get_items<'a>(&'a self, item_callback: &mut dyn FnMut(&str, Value<'a>) -> bool) -> bool;
 
     fn to_string(&self) -> ValueString<'_> {
         let mut values = serde_json::Map::new();
 
-        self.get_items(&mut KeyValueClosureCallback::new(|key, value| {
+        self.get_items(&mut |key, value| {
             values.insert(key.into(), value.to_json_value());
             true
-        }));
+        });
 
         ValueString::Owned(serde_json::Value::Object(values).to_string())
-    }
-}
-
-pub trait KeyValueCallback<'a> {
-    fn next(&mut self, key: &str, value: Value<'a>) -> bool;
-}
-
-pub struct KeyValueClosureCallback<'a, F>
-where
-    F: FnMut(&str, Value<'a>) -> bool,
-{
-    callback: F,
-    marker: PhantomData<&'a F>,
-}
-
-impl<'a, F> KeyValueClosureCallback<'a, F>
-where
-    F: FnMut(&str, Value<'a>) -> bool,
-{
-    pub fn new(callback: F) -> KeyValueClosureCallback<'a, F> {
-        Self {
-            callback,
-            marker: Default::default(),
-        }
-    }
-}
-
-impl<'a, F> KeyValueCallback<'a> for KeyValueClosureCallback<'a, F>
-where
-    F: FnMut(&str, Value<'a>) -> bool,
-{
-    fn next(&mut self, key: &str, value: Value<'a>) -> bool {
-        (self.callback)(key, value)
     }
 }
 
@@ -79,25 +46,23 @@ pub(crate) fn equal_to(
 
     let mut e = None;
 
-    let completed = left.get_items(&mut KeyValueClosureCallback::new(
-        |k, left_value| match right.get(k) {
-            Some(right_value) => {
-                let r = Value::are_values_equal(
-                    query_location,
-                    &left_value,
-                    &right_value.to_value(),
-                    case_insensitive,
-                );
-                if let Err(exp_e) = r {
-                    e = Some(exp_e);
-                    false
-                } else {
-                    r.unwrap()
-                }
+    let completed = left.get_items(&mut |k, left_value| match right.get(k) {
+        Some(right_value) => {
+            let r = Value::are_values_equal(
+                query_location,
+                &left_value,
+                &right_value.to_value(),
+                case_insensitive,
+            );
+            if let Err(exp_e) = r {
+                e = Some(exp_e);
+                false
+            } else {
+                r.unwrap()
             }
-            None => false,
-        },
-    ));
+        }
+        None => false,
+    });
 
     if let Some(exp_e) = e {
         Err(exp_e)

--- a/rust/experimental/query_engine/expressions/src/primitives/value.rs
+++ b/rust/experimental/query_engine/expressions/src/primitives/value.rs
@@ -12,8 +12,8 @@ use regex::{Regex, RegexBuilder};
 use serde_json::json;
 
 use crate::{
-    ArrayValue, ExpressionError, IndexValueClosureCallback, KeyValueClosureCallback, MapValue,
-    QueryLocation, ValueType, array_value, date_utils, map_value,
+    ArrayValue, ExpressionError, MapValue, QueryLocation, ValueType, array_value, date_utils,
+    map_value,
 };
 
 #[derive(Debug, Clone)]
@@ -184,10 +184,10 @@ impl Value<'_> {
             Value::Array(a) => {
                 let mut values = Vec::new();
 
-                a.get_items(&mut IndexValueClosureCallback::new(|_, value| {
+                a.get_items(&mut |_, value| {
                     values.push(value.to_json_value());
                     true
-                }));
+                });
 
                 serde_json::Value::Array(values)
             }
@@ -198,10 +198,10 @@ impl Value<'_> {
             Value::Map(m) => {
                 let mut values = serde_json::Map::new();
 
-                m.get_items(&mut KeyValueClosureCallback::new(|key, value| {
+                m.get_items(&mut |key, value| {
                     values.insert(key.into(), value.to_json_value());
                     true
-                }));
+                });
 
                 serde_json::Value::Object(values)
             }
@@ -472,7 +472,7 @@ impl Value<'_> {
         match haystack {
             Value::Array(array) => {
                 let mut found = false;
-                array.get_items(&mut IndexValueClosureCallback::new(|_, item_value| {
+                array.get_items(&mut |_, item_value| {
                     match Self::are_values_equal(
                         query_location,
                         &item_value,
@@ -489,7 +489,7 @@ impl Value<'_> {
                         }
                         Err(_) => true, // Continue iteration on error
                     }
-                }));
+                });
                 Ok(found)
             }
             Value::String(string_val) => {

--- a/rust/experimental/query_engine/expressions/src/scalars/collection_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/collection_scalar_expression.rs
@@ -90,9 +90,7 @@ impl CombineScalarExpression {
             .map(|v| v.to_value())
         {
             Some(Value::Array(a)) => {
-                let completed = a.get_items(&mut IndexValueClosureCallback::new(|_, v| {
-                    v.get_value_type() == ValueType::Array
-                }));
+                let completed = a.get_items(&mut |_, v| v.get_value_type() == ValueType::Array);
 
                 if completed {
                     Ok(Some(ValueType::Array))

--- a/rust/experimental/query_engine/expressions/src/scalars/statics/array_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/statics/array_scalar_expression.rs
@@ -55,10 +55,10 @@ impl ArrayValue for ArrayScalarExpression {
     fn get_item_range<'a>(
         &'a self,
         range: ArrayRange,
-        item_callback: &mut dyn IndexValueCallback<'a>,
+        item_callback: &mut dyn FnMut(usize, Value<'a>) -> bool,
     ) -> bool {
         for (index, value) in range.get_slice(&self.values).iter().enumerate() {
-            if !item_callback.next(index, value.to_value()) {
+            if !(item_callback)(index, value.to_value()) {
                 return false;
             }
         }
@@ -102,15 +102,12 @@ mod tests {
 
             let mut indices = Vec::new();
 
-            array.get_item_range(
-                range,
-                &mut IndexValueClosureCallback::new(|_, v| {
-                    if let Value::Integer(i) = v {
-                        indices.push(i.get_value());
-                    }
-                    true
-                }),
-            );
+            array.get_item_range(range, &mut |_, v| {
+                if let Value::Integer(i) = v {
+                    indices.push(i.get_value());
+                }
+                true
+            });
 
             assert_eq!(expected, indices);
         };

--- a/rust/experimental/query_engine/expressions/src/scalars/statics/array_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/statics/array_scalar_expression.rs
@@ -52,10 +52,10 @@ impl ArrayValue for ArrayScalarExpression {
         Ok(self.values.get(index).map(|v| v as &dyn AsStaticValue))
     }
 
-    fn get_item_range(
-        &self,
+    fn get_item_range<'a>(
+        &'a self,
         range: ArrayRange,
-        item_callback: &mut dyn IndexValueCallback,
+        item_callback: &mut dyn IndexValueCallback<'a>,
     ) -> bool {
         for (index, value) in range.get_slice(&self.values).iter().enumerate() {
             if !item_callback.next(index, value.to_value()) {

--- a/rust/experimental/query_engine/expressions/src/scalars/statics/map_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/statics/map_scalar_expression.rs
@@ -58,9 +58,9 @@ impl MapValue for MapScalarExpression {
         Ok(self.values.get(key).map(|v| v as &dyn AsStaticValue))
     }
 
-    fn get_items<'a>(&'a self, item_callback: &mut dyn KeyValueCallback<'a>) -> bool {
+    fn get_items<'a>(&'a self, item_callback: &mut dyn FnMut(&str, Value<'a>) -> bool) -> bool {
         for (key, value) in &self.values {
-            if !item_callback.next(key, value.to_value()) {
+            if !(item_callback)(key, value.to_value()) {
                 return false;
             }
         }

--- a/rust/experimental/query_engine/expressions/src/scalars/statics/map_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/statics/map_scalar_expression.rs
@@ -58,7 +58,7 @@ impl MapValue for MapScalarExpression {
         Ok(self.values.get(key).map(|v| v as &dyn AsStaticValue))
     }
 
-    fn get_items(&self, item_callback: &mut dyn KeyValueCallback) -> bool {
+    fn get_items<'a>(&'a self, item_callback: &mut dyn KeyValueCallback<'a>) -> bool {
         for (key, value) in &self.values {
             if !item_callback.next(key, value.to_value()) {
                 return false;

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/attached_records.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/attached_records.rs
@@ -61,8 +61,8 @@ impl MapValue for Resource {
         Ok(None)
     }
 
-    fn get_items(&self, item_callback: &mut dyn KeyValueCallback) -> bool {
-        item_callback.next("Attributes", Value::Map(&self.attributes))
+    fn get_items<'a>(&'a self, item_callback: &mut dyn FnMut(&str, Value<'a>) -> bool) -> bool {
+        (item_callback)("Attributes", Value::Map(&self.attributes))
     }
 }
 
@@ -98,17 +98,17 @@ impl MapValue for InstrumentationScope {
         })
     }
 
-    fn get_items(&self, item_callback: &mut dyn KeyValueCallback) -> bool {
+    fn get_items<'a>(&'a self, item_callback: &mut dyn FnMut(&str, Value<'a>) -> bool) -> bool {
         if let Some(v) = &self.name {
-            if !item_callback.next("Name", Value::String(v)) {
+            if !(item_callback)("Name", Value::String(v)) {
                 return false;
             }
         }
         if let Some(v) = &self.version {
-            if !item_callback.next("Version", Value::String(v)) {
+            if !(item_callback)("Version", Value::String(v)) {
                 return false;
             }
         }
-        item_callback.next("Attributes", Value::Map(&self.attributes))
+        (item_callback)("Attributes", Value::Map(&self.attributes))
     }
 }

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/logs.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/logs.rs
@@ -107,52 +107,52 @@ impl MapValue for LogRecord {
         })
     }
 
-    fn get_items(&self, item_callback: &mut dyn KeyValueCallback) -> bool {
+    fn get_items<'a>(&'a self, item_callback: &mut dyn FnMut(&str, Value<'a>) -> bool) -> bool {
         if let Some(v) = &self.timestamp {
-            if !item_callback.next("time_unix_nano", Value::DateTime(v)) {
+            if !(item_callback)("time_unix_nano", Value::DateTime(v)) {
                 return false;
             }
         }
         if let Some(v) = &self.observed_timestamp {
-            if !item_callback.next("observed_time_unix_nano", Value::DateTime(v)) {
+            if !(item_callback)("observed_time_unix_nano", Value::DateTime(v)) {
                 return false;
             }
         }
         if let Some(v) = &self.severity_number {
-            if !item_callback.next("severity_number", Value::Integer(v)) {
+            if !(item_callback)("severity_number", Value::Integer(v)) {
                 return false;
             }
         }
         if let Some(v) = &self.severity_text {
-            if !item_callback.next("severity_text", Value::String(v)) {
+            if !(item_callback)("severity_text", Value::String(v)) {
                 return false;
             }
         }
         if let Some(v) = &self.body {
-            if !item_callback.next("body", v.to_value()) {
+            if !(item_callback)("body", v.to_value()) {
                 return false;
             }
         }
-        if !item_callback.next("attributes", Value::Map(&self.attributes)) {
+        if !(item_callback)("attributes", Value::Map(&self.attributes)) {
             return false;
         }
         if let Some(v) = &self.flags {
-            if !item_callback.next("flags", Value::Integer(v)) {
+            if !(item_callback)("flags", Value::Integer(v)) {
                 return false;
             }
         }
         if let Some(v) = &self.trace_id {
-            if !item_callback.next("trace_id", Value::Array(v)) {
+            if !(item_callback)("trace_id", Value::Array(v)) {
                 return false;
             }
         }
         if let Some(v) = &self.span_id {
-            if !item_callback.next("span_id", Value::Array(v)) {
+            if !(item_callback)("span_id", Value::Array(v)) {
                 return false;
             }
         }
         if let Some(v) = &self.event_name {
-            if !item_callback.next("event_name", Value::String(v)) {
+            if !(item_callback)("event_name", Value::String(v)) {
                 return false;
             }
         }

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/proto/common.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/proto/common.rs
@@ -99,7 +99,7 @@ impl From<OwnedValue> for AnyValue {
                 if a.len() > 0 {
                     let mut byte_values = Vec::new();
 
-                    let is_bytes = a.get_items(&mut IndexValueClosureCallback::new(|_, v| {
+                    let is_bytes = a.get_items(&mut |_, v| {
                         if let Value::Integer(i) = v {
                             let v = i.get_value();
                             if v >= u8::MIN as i64 && v <= u8::MAX as i64 {
@@ -109,7 +109,7 @@ impl From<OwnedValue> for AnyValue {
                         }
 
                         false
-                    }));
+                    });
 
                     if is_bytes {
                         return AnyValue::Native(OtlpAnyValue::BytesValue(
@@ -225,13 +225,13 @@ impl ArrayValue for ByteArrayValueStorage {
         Ok(self.values.get(index).map(|v| v as &dyn AsStaticValue))
     }
 
-    fn get_item_range(
-        &self,
+    fn get_item_range<'a>(
+        &'a self,
         range: ArrayRange,
-        item_callback: &mut dyn IndexValueCallback,
+        item_callback: &mut dyn FnMut(usize, Value<'a>) -> bool,
     ) -> bool {
         for (index, value) in range.get_slice(&self.values).iter().enumerate() {
-            if !item_callback.next(index, Value::Integer(value)) {
+            if !(item_callback)(index, Value::Integer(value)) {
                 return false;
             }
         }


### PR DESCRIPTION
# Changes

* Replace custom traits\structs on `ArrayValue` & `MapyValue` `get_item*` APIs with more vanilla `&mut dyn FnMut(...)` contracts
* Decorate `Value` argument on `ArrayValue` & `MapyValue` `get_item*` APIs with lifetime

# Details

The decoration makes it possible to use these "iterator"-like APIs to create mutable versions of arrays & maps sourced from something immutable (think static data provided in a query) with shallow cloning.

Example usage:

```rust
impl<'a> From<&'a (dyn ArrayValue + 'a)> for OwnedArrayValue<'a> {
    fn from(value: &'a (dyn ArrayValue + 'a)) -> Self {
        let mut array = OwnedArrayValue::with_capacity(value.len());

        let values = array.get_values_mut();

        value.get_items(&mut |_, value| {
            values.push(value.into()); // With change "value" here is Value<'a> without changes it is Value<'_>
            true
        });

        array
    }
}
```

What does RecordSet do? Deep clone.