### PR TITLE
RFC 0003: Simplified tenant context design

### DIFF
--- a/rust/otap-dataflow/rfcs/0003-tenant-context.md
+++ b/rust/otap-dataflow/rfcs/0003-tenant-context.md
@@ -23,10 +23,9 @@ of tenant context:
 
 Multitenant features are implemented by a **tenant compiler** which is
 computed from the whole engine configuration. The tenant compiler
-internalizes strings and match conditions and computes hash codes for
-distinct token signatures. The goal of this design is to enable `O(1)`
-match operations; the initial implementation does not support
-conditional matching, as described in the implementation plan below.
+internalizes strings and match conditions and builds one literal
+dictionary per value-matched key. At runtime, new tenant contexts
+include packed symbol words used for fast condition lookup.
 
 ## Configuration model
 
@@ -191,14 +190,19 @@ nodes:
 
 ### Matching
 
-The tenant compiler computes hash codes enabling a fast lookup and
-equality mechanism. The tenant compiler determines a **token
-signature** which is the set of tenant tokens used in a condition. For
-each signature it computes:
+The tenant compiler computes packed symbol words enabling a fast
+lookup and equality mechanism. The tenant compiler determines a
+**token signature** which is the set of tenant keys used in a
+condition; conditions testing the same keys share a signature.
 
-- Hashcode: a hashcode joined from the set of values in the signature
-- Indices: the offset in the tenant context for the interned value 
-  identity or encoded literal value.
+The compiler allocates a **token-signature pair** for each distinct
+combination of a token and a compatible signature needed by a
+configured consumer. If there are `T` tokens, `S` distinct signatures,
+and `C` conditions, the number of allocated pairs is `P <= T * S <=
+T * C`.  The tenant compiler state is primarily a matrix of `S` by `T`
+with up to `C` non-empty cells, plus dictionaries.
+
+![Tenant compiler state](images/tenant-compiler-state.svg)
 
 Nodes will resolve tenant conditions at startup or whenever their
 configuration changes.
@@ -238,7 +242,7 @@ policy configuration to avoid empty tenant contexts. This requires the
 nodes to call tenant-context construction utility functions in the
 engine, that will take several forms:
 
-- For receiver nodes, call the utility function providing borrowed 
+- For receiver nodes, call the utility function providing borrowed
   transport headers, peer network address, and authorized identity.
 - For processor nodes that extend a single tenant context, call the
   utility function providing the original and the derived values.
@@ -295,7 +299,7 @@ include in the tenant context, for example:
 - Transport headers that are not referenced or bagged will be dropped
 - Static configuration strings are replaced by numeric identifiers
 - Tenant key names are compiled out, used only when bagged
-- Tenant key values are hashed and/or canonicalized
+- Value-matched tenant keys are dictionary-encoded
 
 The topic exporter and receiver will be extended with dedicated
 configuration for controlling the propagation of tenant context across
@@ -331,10 +335,44 @@ tenant context producer and two consumers illustrating the process.
 
 ![Tenant context with only transport headers](images/tenant-context-only-transport-headers.svg)
 
-Conditional matching is not supported in the initial step. Moving
-forward, the ability to match based on tenant token values will
-introduce new fields in the encoded tenant context implementing a
-`O(1)` hash-function-based lookup.
+## Performance invariants
+
+To state requirements for tenant context impact on pipeline
+performance, let `P` be the number of allocated token-signature pairs
+as defined above. This number is pruned in cases where signatures are
+shared or token keys are incompatible with a condition. For one
+condition set, let `Q <= P` be the pairs bound to that set and let `R
+<= Q` be the number whose tokens resolved for a particular tenant context.
+
+### Space
+
+- Zero memory allocations when tenant context is not used
+- Max one memory allocation with packed encoding per new context
+- General size limits over scratch space, dictionary sizes, and encoded context size
+- `O(P + sizeof(compiled literal values))` compiled space
+- Exactly `P` packed 64-bit symbol words per non-empty tenant context,
+  plus retained encoded values
+- Compiled epoch state is immutable, no locking for lookup and match.
+
+### Time
+
+At compile time:
+
+- `O(#value-matched keys + sizeof(condition values))` for dictionary
+  encoding
+- `O(P + sum(#signature_keys) + #conditions)` to build signature
+  layouts, pair indices, and condition probe tables
+
+Per request:
+
+- `O(#value-matched keys + sizeof(value-matched input values))` to
+  dictionary-encode extracted values
+- `O(P + sum(#signature_keys per resolved pair))` to initialize and pack
+  the context's symbol words
+- Expected `O(Q)` to evaluate a condition set: one resolved-token bit
+  test per bound pair and, for each of the `R` resolved pairs, at most
+  one hash-table probe keyed by one packed `u64`. The `u64` equality
+  test occurs inside that probe rather than as a separate pass.
 
 ## PR series
 
@@ -348,7 +386,7 @@ Tenant context will be implemented in approximately 10 PRs.
 | 4  | Carriers                    | Tenant consumers can extract key values                         |
 | 5  | Remove transport headers    | Net-negative cost compared with starting point                  |
 | 6  | Authorization               | New extractors for authorization subject/audience/claims        |
-| 7  | Matchers                    | Compiler computes hash-join value array, adds tenant_router     |
+| 7  | Matchers                    | Compiler computes packed symbol words, adds tenant_router       |
 | 8  | Topics                      | Topic exporter and receiver use special extractors              |
 | 9  | Batch processor             | Batch processor gains partition keys                            |
 | 10 | Ingress rules               | Required token checking, idempotency key support                |

--- a/rust/otap-dataflow/rfcs/0003-tenant-context.md
+++ b/rust/otap-dataflow/rfcs/0003-tenant-context.md
@@ -1,0 +1,270 @@
+# Tenant Context
+
+**Status:** Draft
+
+## Overview
+
+This document defines **tenant context** as the defining property of
+the OTAP DFE request carrying request-specific metadata including:
+
+- Peer network address
+- Transport headers
+- Authorized identity information
+- Idempotency keys
+
+Tenant contexts are efficiently encoded and carried by reference-counted
+bytes.  Multitenant features are provided for producers and consumers
+of tenant context:
+
+- Producers use standard engine methods to enter metadata associated
+  with a new request, yielding a new tenant context.
+- Consumers use standard engine methods to match by or retrieve tenant
+  variables.
+
+Multitenant features are implemented by a **tenant compiler** which is
+computed from the whole engine configuration. The tenant compiler
+internalizes strings and match conditions and computes hash codes for
+distinct token signatures, enabling `O(1)` match operations.
+
+## Configuration model
+
+Taken alongside a DFE pipeline configuration, the tenant context
+defines a parallel metadata pipeline where extraction and application
+of key metadata are configured and controlled by the user. Metadata
+variables are each an aspect of the tenant context belonging to one or
+more tenant tokens that are used for matching and propagating metadata
+in the pipeline.
+
+A **tenant key** is one key and value belonging to a tenant context.
+
+An **extractor** produces one tenant key. Extractors are conditional, they
+can fail to match.
+
+A **tenant token** is one set of tenant keys, defined when a list of
+extractors all match.
+
+In most case, tenant context behavior will be specified entirely
+through policies, where tenant extractors and ingress rules are
+expressed. Policies inform the engine that a combination of tenant
+keys translates into a per-tenant configuration, generally, so that
+`batch_processor` does not need to know how it is being used with
+multiple tenants. In a few cases, such as the topic exporter and
+receiver, and a new processor named `tenant_router`, will the
+configuration directly refer to tenant values by key.
+
+### Producers
+
+Receivers and processor nodes that create new contexts will use engine
+methods configured through `tenant` policies, listing tokens and
+extractors, defining the keys:
+
+```yaml
+policies:
+  tenant:
+    tokens:
+      edge:
+        extractors:
+          - key: tenant_id
+            transport_header: x-tenant-id
+          - key: project_id
+            transport_header: x-project-id
+
+```
+
+We emphasize transport header in this document because at the time of
+writing, transport headers are encoded using
+`Option<Arc<Vec<TransportHeader>>>`. This design will replace the
+implementation of transport headers with tenant context, a
+reference-counted `Bytes`. Then, using scratch space to construct
+tenant tokens, we will reduce the number of allocations to one per
+tenant context.
+
+Receivers evaluate their required and optional tenant tokens, optional
+when they may be present and required when they must be present.
+
+```yaml
+nodes:
+  ingest:
+    type: receiver:otlp
+    policies:
+      ingress:
+        optional_tokens: [edge]
+    config:
+      ...
+```
+
+### Consumers
+
+Consumers of the tenant context fall into two categories:
+
+- Carriers: Consumers have the general ability to extract values from
+  tenant context by key.
+- Matchers: Consumers have the general ability to form conditions on
+  tenant context, either in configuration or in runtime data structures.
+
+As an example of the carrier pattern, the gRPC OTLP exporter can be
+configured to export specific tenant keys:
+
+```yaml
+nodes:
+  backend:
+    type: exporter:otlp_grpc
+    config:
+      grpc_endpoint: http://backend:4317
+      tenant_headers:
+        - key: tenant_id
+          header: x-customer-id
+        - key: project_id
+          header: x-workspace-id
+```
+
+In this example, the tenant compiler knows that tenant headers must be
+carried in the tenant context, so that callers are able to reproduce
+the values of `tenant_id` and `project_id`. In the example above, the
+tenant token is not required, so the `x-customer-id` header will be
+absent when the tenant key is undefined.
+
+As an example of the matcher pattern, a new `tenant_router` processor
+will be introduced to route by tenant context variables. The first
+branch ("priority") is taken when the `tenant_id` equals "acme". The
+second branch is taken when there is any `tenant_id` defined.
+
+```yaml
+nodes:
+  route:
+    type: processor:tenant_router
+    policies:
+      ingress:
+        required_tokens: [edge]
+    outputs:
+      - priority
+      - shared
+    config:
+      routes:
+        - entries:
+            - key: tenant_id
+              value: acme
+          port: priority
+        - entries:
+            - key: tenant_id
+          port: shared
+```
+
+### Propagation
+
+Tenant context propagates with each request. Like the associated
+request data, tenant context can be cheaply cloned. Some nodes will
+implement specific translation of tenant context. This may be done
+however they see fit, for example, the batch processor can be
+configured using tenant context, first by listing required tenant
+tokens, then the set of metadata keys it partitions by.
+
+```yaml
+nodes:
+  batch:
+    type: processor:batch
+    policies:
+      ingress:
+        required_tokens: [edge]
+        partition_keys: [tenant_id, project_id]
+        max_cardinality: 100
+    config:
+      ...
+```
+
+Nodes may require tenant tokens even when they do not use them,
+for example to declare that an idempotency key,
+
+```yaml
+policies:
+  tenant:
+    tokens:
+      idempotent:
+        extractors:
+          - key: idem
+            idempotency: uuid7
+```
+
+can be required by the recipient.
+
+```yaml
+nodes:
+  buffer:
+    type: processor:durable_buffer
+    policies:
+      ingress:
+        required_tokens: [edge, idempotent]
+    config:
+      ...
+```
+
+## Tenant compiler
+
+The tenant compiler hides the details involved in evaluating and
+applying tenant contexts. The engine uses the graph of nodes and
+policies defined for each, then it precomputes all the necessary
+information for fast evaluation:
+
+- Compute a tenant context from the inputs
+- Match a condition over tenant context variables
+- Extract a value from a tenant context variable.
+
+Tenant contexts are computed for the set of reachable nodes in a
+pipeline. The compiler knows which variables are extracted and which
+are only matched. Tenant variables can be "bagged" for extraction as a
+list of key:values, encoding using OTLP bytes. The bagged section of
+the tenant context can be borrowed as `&[u8]` for use encoding
+OpenTelemetry attributes directly from the tenant context.
+
+The topic exporter and receiver will be extended with dedicated
+configuration for controlling the propagation of tenant context across
+pipeline group boundaries.
+
+### Live reconfiguration
+
+Live reconfiguration of the tenant compiler will be supported. Tenant
+producer and consumer configuration are paired, when either changes
+both sides will be recompiled and reconfigured. Consumer
+reconfiguration events will be distributed ahead of producer
+reconfiguration events. The tenant context carries state to indicate
+which version of the compiler was used as an epoch number.
+
+In some cases, live reconfiguration will be possible without
+restarting a pipeline. Multiple tenant-compiler epochs can run
+concurrently.  In some cases, it will require a draining or flushing
+procedure to remove an old tenant configuration from memory.
+
+## Transport headers
+
+The first deliverable in the timeline below, where tenant context is
+used in the pipeline, will be a re-implementation of transport headers
+in the DFE. The diagram explains how the tenant compiler works, with a
+tenant context producer and two consumers illustrating the process.
+
+![Tenant context with only transport headers](images/tenant-context-only-transport-headers.svg)
+
+Conditional matching is not supported in the initial step. Moving
+forward, the ability to match based on tenant token values will
+introduce new fields in the encoded tenant context implementing a
+`O(1)` hash-function-based lookup.
+
+## PR series
+
+Tenant context will be implemented in approximately 10 PRs.
+
+| PR | Main feature                | Main development                                                |
+|----|-----------------------------|-----------------------------------------------------------------|
+| 1  | Tenant Compiler             | Intern strings, index values, compute bagged encoding           |
+| 2  | Transport header extractors | Map request context, transport header policy into tenant tokens |
+| 3  | Propagation                 | Tenant context travels with request context                     |
+| 4  | Carriers                    | Tenant consumers can extract key values                         |
+| 5  | Remove transport headers    | Net-negative cost compared with starting point                  |
+| 6  | Authorization               | New extractors for authorization subject/audience/claims        |
+| 7  | Matchers                    | Compiler computes hash-join value array, adds tenant_router     |
+| 8  | Topics                      | Topic exporter and receiver use special extractors              |
+| 9  | Batch processor             | Batch processor gains partition keys                            |
+| 10 | Ingress rules               | Required token checking, idempotency key support                |
+
+At this point, many more nodes will come up for review, and how we
+design the use of tenant tokens for matching and propagation will
+be extended to most of the remaining components as separate issues.

--- a/rust/otap-dataflow/rfcs/0003-tenant-context.md
+++ b/rust/otap-dataflow/rfcs/0003-tenant-context.md
@@ -221,6 +221,7 @@ policies:
 nodes:
   batch:
     type: processor:batch
+    policies:
       ingress:
         required_tokens: [edge]
         partition_keys: [tenant_id, project_id]

--- a/rust/otap-dataflow/rfcs/0003-tenant-context.md
+++ b/rust/otap-dataflow/rfcs/0003-tenant-context.md
@@ -25,7 +25,7 @@ Multitenant features are implemented by a **tenant compiler** which is
 computed from the whole engine configuration. The tenant compiler
 internalizes strings and match conditions and builds one literal
 dictionary per value-matched key. At runtime, new tenant contexts
-include packed symbol words used for fast condition lookup.
+include precomputed results for every configured condition set.
 
 ## Configuration model
 
@@ -131,14 +131,23 @@ components to maintain type safety. Consumers will be able to extract
 authorized key information separately from transport headers, peer
 address, and other attributes.
 
+## Transport headers
+
+The first deliverable in the timeline below, where tenant context is
+used in the pipeline, will be a re-implementation of transport headers
+in the DFE. The diagram explains how the tenant compiler works, with a
+tenant context producer and two consumers illustrating the process.
+
+![Tenant context with only transport headers](images/tenant-context-only-transport-headers.svg)
+
 ### Consumers
 
 Consumers of the tenant context fall into two categories:
 
 - Carriers: Consumers have the general ability to extract values from
   tenant context by key.
-- Matchers: Consumers have the general ability to form conditions on
-  tenant context, either in configuration or in runtime data structures.
+- Matchers: Consumers declare condition sets before a compiler epoch is
+  activated. Condition sets remain static for that epoch.
 
 As an example of the carrier pattern, the gRPC OTLP exporter can be
 configured to export specific tenant keys:
@@ -190,22 +199,19 @@ nodes:
 
 ### Matching
 
-The tenant compiler computes packed symbol words enabling a fast
-lookup and equality mechanism. The tenant compiler determines a
-**token signature** which is the set of tenant keys used in a
-condition; conditions testing the same keys share a signature.
-
-The compiler allocates a **token-signature pair** for each distinct
-combination of a token and a compatible signature needed by a
-configured consumer. If there are `T` tokens, `S` distinct signatures,
-and `C` conditions, the number of allocated pairs is `P <= T * S <=
-T * C`.  The tenant compiler state is primarily a matrix of `S` by `T`
-with up to `C` non-empty cells, plus dictionaries.
+Condition sets are static within a compiler epoch. Conditions testing
+the same key shape share a **signature**, and each compatible
+token-signature pair has one construction-time PairSlot. The number of
+PairSlots is bounded by `#tokens x #signatures`.
 
 ![Tenant compiler state](images/tenant-compiler-state.svg)
 
-Nodes will resolve tenant conditions at startup or whenever their
-configuration changes.
+When constructing tenant context, the engine dictionary-encodes
+value-matched keys, computes PairSlot words in scratch, and evaluates
+every condition set. Only the winning condition index or no-match
+result for each set is packed into tenant context. Consumers retrieve
+that result directly by condition-set identifier. Configuration
+changes compile a new epoch with a new immutable layout.
 
 ### Propagation
 
@@ -326,53 +332,28 @@ be required to achieve. Components that use tenant conditions are
 expected to fail requests that refer to an unknown tenant compiler
 epoch. A coarse epoch timeout mechanism may be sufficient.
 
-## Transport headers
-
-The first deliverable in the timeline below, where tenant context is
-used in the pipeline, will be a re-implementation of transport headers
-in the DFE. The diagram explains how the tenant compiler works, with a
-tenant context producer and two consumers illustrating the process.
-
-![Tenant context with only transport headers](images/tenant-context-only-transport-headers.svg)
-
 ## Performance invariants
 
-To state requirements for tenant context impact on pipeline
-performance, let `P` be the number of allocated token-signature pairs
-as defined above. This number is pruned in cases where signatures are
-shared or token keys are incompatible with a condition. For one
-condition set, let `Q <= P` be the pairs bound to that set and let `R
-<= Q` be the number whose tokens resolved for a particular tenant context.
+All dimensions are explicitly limited: tokens, keys per token,
+signatures, condition sets and branches, literal dictionaries, scratch
+space, retained values, field sizes, and total encoded context size.
+Configurations or inputs exceeding a limit fail rather than growing
+state without bound.
 
-### Space
-
-- Zero memory allocations when tenant context is not used
-- Max one memory allocation with packed encoding per new context
-- General size limits over scratch space, dictionary sizes, and encoded context size
-- `O(P + sizeof(compiled literal values))` compiled space
-- Exactly `P` packed 64-bit symbol words per non-empty tenant context,
-  plus retained encoded values
-- Compiled epoch state is immutable, no locking for lookup and match.
-
-### Time
-
-At compile time:
-
-- `O(#value-matched keys + sizeof(condition values))` for dictionary
-  encoding
-- `O(P + sum(#signature_keys) + #conditions)` to build signature
-  layouts, pair indices, and condition probe tables
-
-Per request:
-
-- `O(#value-matched keys + sizeof(value-matched input values))` to
-  dictionary-encode extracted values
-- `O(P + sum(#signature_keys per resolved pair))` to initialize and pack
-  the context's symbol words
-- Expected `O(Q)` to evaluate a condition set: one resolved-token bit
-  test per bound pair and, for each of the `R` resolved pairs, at most
-  one hash-table probe keyed by one packed `u64`. The `u64` equality
-  test occurs inside that probe rather than as a separate pass.
+- Conditions with the same key shape share a signature. Compatible
+  token-signature pairs are bounded by
+  `#tokens x #signatures` and exist only in construction scratch.
+- Tenant-context construction evaluates extractors, resolves tokens,
+  dictionary-encodes value-matched keys, and precomputes every
+  reachable condition-set result.
+- Consumers read a condition result in `O(1)` by its condition-set
+  identifier. Retained values are likewise addressed by precomputed
+  slots rather than searched by name.
+- Tenant context costs no allocation when unused and one allocation
+  when packed; reusable scratch does not allocate at steady state
+  within configured limits.
+- Compiler state is immutable within an epoch, so request-time
+  construction and consumer lookups require no locks.
 
 ## PR series
 
@@ -386,7 +367,7 @@ Tenant context will be implemented in approximately 10 PRs.
 | 4  | Carriers                    | Tenant consumers can extract key values                         |
 | 5  | Remove transport headers    | Net-negative cost compared with starting point                  |
 | 6  | Authorization               | New extractors for authorization subject/audience/claims        |
-| 7  | Matchers                    | Compiler computes packed symbol words, adds tenant_router       |
+| 7  | Matchers                    | Compiler precomputes condition-set results, adds tenant_router  |
 | 8  | Topics                      | Topic exporter and receiver use special extractors              |
 | 9  | Batch processor             | Batch processor gains partition keys                            |
 | 10 | Ingress rules               | Required token checking, idempotency key support                |

--- a/rust/otap-dataflow/rfcs/0003-tenant-context.md
+++ b/rust/otap-dataflow/rfcs/0003-tenant-context.md
@@ -94,6 +94,12 @@ nodes:
       ...
 ```
 
+Receivers are expected to handle missing required tokens in a protocol
+specific way, for example the gRPC code `FAILED_PRECONDITION` or HTTP
+403 `Forbidden`. Other nodes with missing required tokens will
+automatically Nack requests, and other configurations can be added
+through policies.
+
 ### Consumers
 
 Consumers of the tenant context fall into two categories:
@@ -284,6 +290,10 @@ Tenant context will be implemented in approximately 10 PRs.
 | 8  | Topics                      | Topic exporter and receiver use special extractors              |
 | 9  | Batch processor             | Batch processor gains partition keys                            |
 | 10 | Ingress rules               | Required token checking, idempotency key support                |
+
+Note that a PR5, when transport headers are removed, we will have
+implemented the complete equivalent functionality compared with the
+existing mechanism.
 
 At this point, many more nodes will come up for review, and how we
 design the use of tenant tokens for matching and propagation will

--- a/rust/otap-dataflow/rfcs/0003-tenant-context.md
+++ b/rust/otap-dataflow/rfcs/0003-tenant-context.md
@@ -45,6 +45,10 @@ they can fail to match.
 A **tenant token** is one set of tenant keys, defined when a list of
 extractors all match.
 
+A **tenant condition** is a precomputed matcher for a set of keys and
+optional values that callers can quickly evaluate over a tenant
+context.
+
 In most cases, tenant context behavior will be specified entirely
 through policies, where tenant extractors and ingress rules are
 expressed. Policies inform the engine that a combination of tenant
@@ -99,6 +103,34 @@ specific way, for example the gRPC code `FAILED_PRECONDITION` or HTTP
 403 `Forbidden`. Other nodes with missing required tokens will
 automatically Nack requests, and other configurations can be added
 through policies.
+
+### Trust boundary
+
+The engine governs the use of tenant context to enforce type-correct
+use of extractors. Authorization extensions that implement recognized
+authorization capabilities are able to produce the
+`AuthorizedIdentity` struct used in authorization
+extractors. Authorization claims will not be able to be produced from
+transport headers directly, they must be produced by authorization
+extensions.
+
+```yaml
+policies:
+  tenant:
+    tokens:
+      auth_subject:
+        extractors:
+          - key: user_id
+            authorized_key: sub
+            retain: false
+```
+
+Specific `authorized_key` extractor semantics are out of scope in this
+document. While the tenant context uses a packed `Bytes`
+representation, it retains logical separation of its independent
+components to maintain type safety. Consumers will be able to extract
+authorized key information separately from transport headers, peer
+address, and other attributes.
 
 ### Consumers
 
@@ -156,6 +188,20 @@ nodes:
             - key: tenant_id
           port: shared
 ```
+
+### Matching
+
+The tenant compiler computes hash codes enabling a fast lookup and
+equality mechanism. The tenant compiler determines a **token
+signature** which is the set of tenant tokens used in a condition. For
+each signature it computes:
+
+- Hashcode: a hashcode joined from the set of values in the signature
+- Indices: the offset in the tenant context for the interned value 
+  identity or encoded literal value.
+
+Nodes will resolve tenant conditions at startup or whenever their
+configuration changes.
 
 ### Propagation
 
@@ -242,6 +288,14 @@ list of key:values, encoding using OTLP bytes. The bagged section of
 the tenant context can be borrowed as `&[u8]` for encoding
 OpenTelemetry attributes directly from the tenant context.
 
+The tenant compiler determines what information is necessary to
+include in the tenant context, for example:
+
+- Transport headers that are not referenced or bagged will be dropped
+- Static configuration strings are replaced by numeric identifiers
+- Tenant key names are compiled out, used only when bagged
+- Tenant key values are hashed and/or canonicalized
+
 The topic exporter and receiver will be extended with dedicated
 configuration for controlling the propagation of tenant context across
 pipeline group boundaries.
@@ -256,9 +310,16 @@ reconfiguration events. The tenant context carries state to indicate
 which version of the compiler was used as an epoch number.
 
 In some cases, live reconfiguration will be possible without
-restarting a pipeline. Multiple tenant-compiler epochs can run
-concurrently.  In some cases, it will require a draining or flushing
-procedure to remove an old tenant configuration from memory.
+restarting a pipeline, for example to add a new tenant condition.  In
+other cases, it will require a draining or flushing procedure to
+remove tenant epochs from memory.
+
+Components that use tenant conditions will require changes to support
+this mode of live reconfiguration, as it means multiple
+tenant-compiler epochs can be in-use concurrently. Orchestration may
+be required to achieve. Components that use tenant conditions are
+expected to fail requests that refer to an unknown tenant compiler
+epoch. A coarse epoch timeout mechanism may be sufficient.
 
 ## Transport headers
 

--- a/rust/otap-dataflow/rfcs/0003-tenant-context.md
+++ b/rust/otap-dataflow/rfcs/0003-tenant-context.md
@@ -70,7 +70,6 @@ policies:
             transport_header: x-tenant-id
           - key: project_id
             transport_header: x-project-id
-
 ```
 
 We emphasize transport headers in this document because at the time of
@@ -162,17 +161,37 @@ configured using tenant context, first by listing required tenant
 tokens, then the set of metadata keys it partitions by.
 
 ```yaml
+policies:
+  tenant:
+    tokens:
+      batched:
+        propagate_keys: [tenant_id, project_id]
 nodes:
   batch:
     type: processor:batch
-    policies:
       ingress:
         required_tokens: [edge]
         partition_keys: [tenant_id, project_id]
         max_cardinality: 100
+      egress:
+        required_tokens: [batched]
     config:
       ...
 ```
+
+In general, nodes that combine many tenant contexts into one will be
+forced to reset the tenant context. These nodes will require explicit
+policy configuration to avoid empty tenant contexts. This requires the
+nodes to call tenant-context construction utility functions in the
+engine, that will take several forms:
+
+- For receiver nodes, call the utility function providing borrowed 
+  transport headers, peer network address, and authorized identity.
+- For processor nodes that extend a single tenant context, call the
+  utility function providing the original and the derived values.
+- Processor nodes that combine multiple tenant contexts must use the
+  `partition_keys` mechanism, the engine automatically constructs
+  egress tokens from the projection of the partition keys.
 
 Nodes may require tenant tokens even when they do not use them, for
 example to declare an idempotency key that can be required by the

--- a/rust/otap-dataflow/rfcs/0003-tenant-context.md
+++ b/rust/otap-dataflow/rfcs/0003-tenant-context.md
@@ -24,7 +24,9 @@ of tenant context:
 Multitenant features are implemented by a **tenant compiler** which is
 computed from the whole engine configuration. The tenant compiler
 internalizes strings and match conditions and computes hash codes for
-distinct token signatures, enabling `O(1)` match operations.
+distinct token signatures. The goal of this design is to enable `O(1)`
+match operations; the initial implementation does not support
+conditional matching, as described in the implementation plan below.
 
 ## Configuration model
 
@@ -37,19 +39,19 @@ in the pipeline.
 
 A **tenant key** is one key and value belonging to a tenant context.
 
-An **extractor** produces one tenant key. Extractors are conditional, they
-can fail to match.
+An **extractor** produces one tenant key. Extractors are conditional;
+they can fail to match.
 
 A **tenant token** is one set of tenant keys, defined when a list of
 extractors all match.
 
-In most case, tenant context behavior will be specified entirely
+In most cases, tenant context behavior will be specified entirely
 through policies, where tenant extractors and ingress rules are
 expressed. Policies inform the engine that a combination of tenant
 keys translates into a per-tenant configuration, generally, so that
 `batch_processor` does not need to know how it is being used with
-multiple tenants. In a few cases, such as the topic exporter and
-receiver, and a new processor named `tenant_router`, will the
+multiple tenants. Only in a few cases, such as the topic exporter and
+receiver, and a new processor named `tenant_router`, does the
 configuration directly refer to tenant values by key.
 
 ### Producers
@@ -71,7 +73,7 @@ policies:
 
 ```
 
-We emphasize transport header in this document because at the time of
+We emphasize transport headers in this document because at the time of
 writing, transport headers are encoded using
 `Option<Arc<Vec<TransportHeader>>>`. This design will replace the
 implementation of transport headers with tenant context, a
@@ -172,8 +174,9 @@ nodes:
       ...
 ```
 
-Nodes may require tenant tokens even when they do not use them,
-for example to declare that an idempotency key,
+Nodes may require tenant tokens even when they do not use them, for
+example to declare an idempotency key that can be required by the
+recipient:
 
 ```yaml
 policies:
@@ -184,8 +187,6 @@ policies:
           - key: idem
             idempotency: uuid7
 ```
-
-can be required by the recipient.
 
 ```yaml
 nodes:
@@ -213,7 +214,7 @@ Tenant contexts are computed for the set of reachable nodes in a
 pipeline. The compiler knows which variables are extracted and which
 are only matched. Tenant variables can be "bagged" for extraction as a
 list of key:values, encoding using OTLP bytes. The bagged section of
-the tenant context can be borrowed as `&[u8]` for use encoding
+the tenant context can be borrowed as `&[u8]` for encoding
 OpenTelemetry attributes directly from the tenant context.
 
 The topic exporter and receiver will be extended with dedicated

--- a/rust/otap-dataflow/rfcs/images/tenant-compiler-state.svg
+++ b/rust/otap-dataflow/rfcs/images/tenant-compiler-state.svg
@@ -1,0 +1,239 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="1090" viewBox="0 0 960 1090" font-family="Helvetica, Arial, sans-serif">
+  <title>Tenant compiler state as a token by signature matrix over per-key dictionaries</title>
+  <desc>Compatible token and signature intersections allocate PairSlots used as construction scratch. Per-key dictionaries map request values to symbols, static condition sets are evaluated once during context construction, and consumers read precomputed results by condition-set identifier.</desc>
+
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#8a94a0"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="960" height="1090" fill="#ffffff"/>
+
+  <text x="24" y="30" font-size="16" font-weight="bold" fill="#1f2933">Tenant compiler state</text>
+
+  <!-- Token by signature compatibility matrix. -->
+  <text x="24" y="82" font-size="11" font-weight="bold" fill="#6b7784" letter-spacing="0.6">TOKENS</text>
+  <text x="194" y="82" font-size="11" font-weight="bold" fill="#6b7784" letter-spacing="0.6">SIGNATURES (SETS OF CONDITION KEYS)</text>
+
+  <rect x="24" y="168" width="154" height="68" rx="4" fill="#eef1f4" stroke="#8a94a0"/>
+  <text x="36" y="190" font-size="12" font-weight="bold" fill="#1f2933">edge</text>
+  <text x="36" y="210" font-size="10" font-family="monospace" fill="#3a414a">tenant_id</text>
+  <text x="36" y="225" font-size="10" font-family="monospace" fill="#3a414a">project_id</text>
+
+  <rect x="24" y="242" width="154" height="68" rx="4" fill="#eef1f4" stroke="#8a94a0"/>
+  <text x="36" y="264" font-size="12" font-weight="bold" fill="#1f2933">auth</text>
+  <text x="36" y="284" font-size="10" font-family="monospace" fill="#3a414a">user_id</text>
+  <text x="36" y="299" font-size="10" font-family="monospace" fill="#3a414a">role</text>
+
+  <rect x="24" y="316" width="154" height="68" rx="4" fill="#eef1f4" stroke="#8a94a0"/>
+  <text x="36" y="338" font-size="12" font-weight="bold" fill="#1f2933">combined</text>
+  <text x="36" y="358" font-size="10" font-family="monospace" fill="#3a414a">tenant_id, project_id</text>
+  <text x="36" y="373" font-size="10" font-family="monospace" fill="#3a414a">role</text>
+
+  <rect x="194" y="68" width="230" height="94" rx="4" fill="#d7e3ee" stroke="#6f879b"/>
+  <text x="309" y="94" font-size="13" font-weight="bold" fill="#1f2933" text-anchor="middle">S0</text>
+  <text x="309" y="116" font-size="11" font-family="monospace" fill="#3a414a" text-anchor="middle">{ project_id? }</text>
+  <text x="309" y="138" font-size="10" fill="#6b7784" text-anchor="middle">1 presence key: 1 bit</text>
+
+  <rect x="430" y="68" width="280" height="94" rx="4" fill="#d7e3ee" stroke="#6f879b"/>
+  <text x="570" y="94" font-size="13" font-weight="bold" fill="#1f2933" text-anchor="middle">S1</text>
+  <text x="570" y="116" font-size="11" font-family="monospace" fill="#3a414a" text-anchor="middle">{ tenant_id = ..., project_id? }</text>
+  <text x="570" y="138" font-size="10" fill="#6b7784" text-anchor="middle">1 value-matched + 1 presence key: 4 bits</text>
+
+  <rect x="716" y="68" width="220" height="94" rx="4" fill="#d7e3ee" stroke="#6f879b"/>
+  <text x="826" y="94" font-size="13" font-weight="bold" fill="#1f2933" text-anchor="middle">S2</text>
+  <text x="826" y="116" font-size="11" font-family="monospace" fill="#3a414a" text-anchor="middle">{ role = ... }</text>
+  <text x="826" y="138" font-size="10" fill="#6b7784" text-anchor="middle">1 value-matched key: 3 symbol bits</text>
+
+  <!-- Matrix row: edge. -->
+  <rect x="194" y="168" width="230" height="68" rx="4" fill="#ffffff" stroke="#6b9b78" stroke-width="1.5"/>
+  <text x="309" y="190" font-size="12" font-weight="bold" fill="#315c3d" text-anchor="middle">P0: u64</text>
+  <rect x="204" y="199" width="24" height="24" fill="#d9822b"/>
+  <rect x="228" y="199" width="186" height="24" fill="#e5e8eb"/>
+  <text x="216" y="215" font-size="9" font-weight="bold" fill="#ffffff" text-anchor="middle">1</text>
+  <text x="321" y="215" font-size="9" fill="#6b7784" text-anchor="middle">unused 63</text>
+
+  <rect x="430" y="168" width="280" height="68" rx="4" fill="#ffffff" stroke="#6b9b78" stroke-width="1.5"/>
+  <text x="570" y="190" font-size="12" font-weight="bold" fill="#315c3d" text-anchor="middle">P1: u64</text>
+  <rect x="440" y="199" width="72" height="24" fill="#4f81bd"/>
+  <rect x="512" y="199" width="24" height="24" fill="#d9822b"/>
+  <rect x="536" y="199" width="164" height="24" fill="#e5e8eb"/>
+  <text x="476" y="215" font-size="9" font-weight="bold" fill="#ffffff" text-anchor="middle">tenant 3</text>
+  <text x="524" y="215" font-size="9" font-weight="bold" fill="#ffffff" text-anchor="middle">1</text>
+  <text x="618" y="215" font-size="9" fill="#6b7784" text-anchor="middle">unused 60</text>
+
+  <rect x="716" y="168" width="220" height="68" rx="4" fill="#f4f5f6" stroke="#c9ced3"/>
+  <text x="826" y="207" font-size="18" fill="#aab2bb" text-anchor="middle">-</text>
+
+  <!-- Matrix row: auth. -->
+  <rect x="194" y="242" width="230" height="68" rx="4" fill="#f4f5f6" stroke="#c9ced3"/>
+  <text x="309" y="281" font-size="18" fill="#aab2bb" text-anchor="middle">-</text>
+
+  <rect x="430" y="242" width="280" height="68" rx="4" fill="#f4f5f6" stroke="#c9ced3"/>
+  <text x="570" y="281" font-size="18" fill="#aab2bb" text-anchor="middle">-</text>
+
+  <rect x="716" y="242" width="220" height="68" rx="4" fill="#ffffff" stroke="#6b9b78" stroke-width="1.5"/>
+  <text x="826" y="264" font-size="12" font-weight="bold" fill="#315c3d" text-anchor="middle">P2: u64</text>
+  <rect x="726" y="273" width="72" height="24" fill="#8b67a8"/>
+  <rect x="798" y="273" width="128" height="24" fill="#e5e8eb"/>
+  <text x="762" y="289" font-size="9" font-weight="bold" fill="#ffffff" text-anchor="middle">role 3</text>
+  <text x="862" y="289" font-size="9" fill="#6b7784" text-anchor="middle">unused 61</text>
+
+  <!-- Matrix row: combined. -->
+  <rect x="194" y="316" width="230" height="68" rx="4" fill="#ffffff" stroke="#6b9b78" stroke-width="1.5"/>
+  <text x="309" y="338" font-size="12" font-weight="bold" fill="#315c3d" text-anchor="middle">P3: u64</text>
+  <rect x="204" y="347" width="24" height="24" fill="#d9822b"/>
+  <rect x="228" y="347" width="186" height="24" fill="#e5e8eb"/>
+  <text x="216" y="363" font-size="9" font-weight="bold" fill="#ffffff" text-anchor="middle">1</text>
+  <text x="321" y="363" font-size="9" fill="#6b7784" text-anchor="middle">unused 63</text>
+
+  <rect x="430" y="316" width="280" height="68" rx="4" fill="#ffffff" stroke="#6b9b78" stroke-width="1.5"/>
+  <text x="570" y="338" font-size="12" font-weight="bold" fill="#315c3d" text-anchor="middle">P4: u64</text>
+  <rect x="440" y="347" width="72" height="24" fill="#4f81bd"/>
+  <rect x="512" y="347" width="24" height="24" fill="#d9822b"/>
+  <rect x="536" y="347" width="164" height="24" fill="#e5e8eb"/>
+  <text x="476" y="363" font-size="9" font-weight="bold" fill="#ffffff" text-anchor="middle">tenant 3</text>
+  <text x="524" y="363" font-size="9" font-weight="bold" fill="#ffffff" text-anchor="middle">1</text>
+  <text x="618" y="363" font-size="9" fill="#6b7784" text-anchor="middle">unused 60</text>
+
+  <rect x="716" y="316" width="220" height="68" rx="4" fill="#ffffff" stroke="#6b9b78" stroke-width="1.5"/>
+  <text x="826" y="338" font-size="12" font-weight="bold" fill="#315c3d" text-anchor="middle">P5: u64</text>
+  <rect x="726" y="347" width="72" height="24" fill="#8b67a8"/>
+  <rect x="798" y="347" width="128" height="24" fill="#e5e8eb"/>
+  <text x="762" y="363" font-size="9" font-weight="bold" fill="#ffffff" text-anchor="middle">role 3</text>
+  <text x="862" y="363" font-size="9" fill="#6b7784" text-anchor="middle">unused 61</text>
+
+  <line x1="24" y1="420" x2="936" y2="420" stroke="#dde1e6"/>
+
+  <!-- Compiled dictionaries and condition sets below the matrix. -->
+  <text x="24" y="438" font-size="11" font-weight="bold" fill="#6b7784" letter-spacing="0.6">COMPILED LOOKUP STATE</text>
+
+  <rect x="24" y="450" width="280" height="92" rx="5" fill="#f3f7fc" stroke="#4f81bd" stroke-width="2"/>
+  <rect x="24" y="450" width="280" height="28" rx="5" fill="#4f81bd"/>
+  <text x="38" y="469" font-size="11" font-weight="bold" font-family="monospace" fill="#ffffff">tenant_id dictionary</text>
+  <line x1="124" y1="478" x2="124" y2="542" stroke="#9ab7d6"/>
+  <line x1="164" y1="478" x2="164" y2="542" stroke="#9ab7d6"/>
+  <line x1="264" y1="478" x2="264" y2="542" stroke="#9ab7d6"/>
+  <line x1="24" y1="499" x2="304" y2="499" stroke="#9ab7d6"/>
+  <line x1="24" y1="520" x2="304" y2="520" stroke="#9ab7d6"/>
+  <text x="74" y="493" font-size="10" font-family="monospace" fill="#3a414a" text-anchor="middle">absent</text>
+  <text x="144" y="493" font-size="10" font-family="monospace" fill="#3a414a" text-anchor="middle">0</text>
+  <text x="214" y="493" font-size="10" font-family="monospace" fill="#3a414a" text-anchor="middle">unknown</text>
+  <text x="284" y="493" font-size="10" font-family="monospace" fill="#3a414a" text-anchor="middle">1</text>
+  <text x="74" y="514" font-size="10" font-family="monospace" fill="#3a414a" text-anchor="middle">"acme"</text>
+  <text x="144" y="514" font-size="10" font-family="monospace" fill="#3a414a" text-anchor="middle">2</text>
+  <text x="214" y="514" font-size="10" font-family="monospace" fill="#3a414a" text-anchor="middle">"globex"</text>
+  <text x="284" y="514" font-size="10" font-family="monospace" fill="#3a414a" text-anchor="middle">3</text>
+  <text x="74" y="536" font-size="10" font-family="monospace" fill="#3a414a" text-anchor="middle">"initech"</text>
+  <text x="144" y="536" font-size="10" font-family="monospace" fill="#3a414a" text-anchor="middle">4</text>
+  <text x="214" y="536" font-size="10" font-family="monospace" fill="#3a414a" text-anchor="middle">"umbrella"</text>
+  <text x="284" y="536" font-size="10" font-family="monospace" fill="#3a414a" text-anchor="middle">5</text>
+
+  <rect x="340" y="450" width="280" height="92" rx="5" fill="#f8f4fa" stroke="#8b67a8" stroke-width="2"/>
+  <rect x="340" y="450" width="280" height="28" rx="5" fill="#8b67a8"/>
+  <text x="354" y="469" font-size="11" font-weight="bold" font-family="monospace" fill="#ffffff">role dictionary</text>
+  <line x1="440" y1="478" x2="440" y2="542" stroke="#bda9ce"/>
+  <line x1="480" y1="478" x2="480" y2="542" stroke="#bda9ce"/>
+  <line x1="580" y1="478" x2="580" y2="542" stroke="#bda9ce"/>
+  <line x1="340" y1="499" x2="620" y2="499" stroke="#bda9ce"/>
+  <line x1="340" y1="520" x2="620" y2="520" stroke="#bda9ce"/>
+  <text x="390" y="493" font-size="10" font-family="monospace" fill="#3a414a" text-anchor="middle">absent</text>
+  <text x="460" y="493" font-size="10" font-family="monospace" fill="#3a414a" text-anchor="middle">0</text>
+  <text x="530" y="493" font-size="10" font-family="monospace" fill="#3a414a" text-anchor="middle">unknown</text>
+  <text x="600" y="493" font-size="10" font-family="monospace" fill="#3a414a" text-anchor="middle">1</text>
+  <text x="390" y="514" font-size="10" font-family="monospace" fill="#3a414a" text-anchor="middle">"admin"</text>
+  <text x="460" y="514" font-size="10" font-family="monospace" fill="#3a414a" text-anchor="middle">2</text>
+  <text x="530" y="514" font-size="10" font-family="monospace" fill="#3a414a" text-anchor="middle">"reader"</text>
+  <text x="600" y="514" font-size="10" font-family="monospace" fill="#3a414a" text-anchor="middle">3</text>
+  <text x="390" y="536" font-size="10" font-family="monospace" fill="#3a414a" text-anchor="middle">"writer"</text>
+  <text x="460" y="536" font-size="10" font-family="monospace" fill="#3a414a" text-anchor="middle">4</text>
+  <text x="530" y="536" font-size="10" font-family="monospace" fill="#3a414a" text-anchor="middle">"owner"</text>
+  <text x="600" y="536" font-size="10" font-family="monospace" fill="#3a414a" text-anchor="middle">5</text>
+
+  <rect x="656" y="450" width="280" height="92" rx="5" fill="#f3f8f4" stroke="#6b9b78" stroke-width="2"/>
+  <rect x="656" y="450" width="280" height="28" rx="5" fill="#6b9b78"/>
+  <text x="670" y="469" font-size="11" font-weight="bold" font-family="monospace" fill="#ffffff">condition sets</text>
+  <line x1="700" y1="478" x2="700" y2="542" stroke="#a6c2ad"/>
+  <line x1="810" y1="478" x2="810" y2="542" stroke="#a6c2ad"/>
+  <line x1="860" y1="478" x2="860" y2="542" stroke="#a6c2ad"/>
+  <line x1="656" y1="510" x2="936" y2="510" stroke="#a6c2ad"/>
+  <text x="678" y="499" font-size="10" font-family="monospace" fill="#315c3d" text-anchor="middle">C0</text>
+  <text x="755" y="499" font-size="9" font-family="monospace" fill="#315c3d" text-anchor="middle">edge+combined</text>
+  <text x="835" y="499" font-size="9.5" font-family="monospace" fill="#315c3d" text-anchor="middle">S0,S1</text>
+  <text x="898" y="499" font-size="9.5" font-family="monospace" fill="#315c3d" text-anchor="middle">b0..b2</text>
+  <text x="678" y="531" font-size="10" font-family="monospace" fill="#315c3d" text-anchor="middle">C1</text>
+  <text x="755" y="531" font-size="9.5" font-family="monospace" fill="#315c3d" text-anchor="middle">auth</text>
+  <text x="835" y="531" font-size="9.5" font-family="monospace" fill="#315c3d" text-anchor="middle">S2</text>
+  <text x="898" y="531" font-size="9.5" font-family="monospace" fill="#315c3d" text-anchor="middle">b0..b3</text>
+
+  <line x1="24" y1="560" x2="936" y2="560" stroke="#dde1e6"/>
+
+  <!-- Runtime construction of the complete tenant context. -->
+  <text x="24" y="584" font-size="11" font-weight="bold" fill="#6b7784" letter-spacing="0.6">ONCE PER REQUEST</text>
+
+  <rect x="24" y="610" width="176" height="112" rx="5" fill="#eef1f4" stroke="#8a94a0"/>
+  <text x="112" y="634" font-size="12" font-weight="bold" fill="#1f2933" text-anchor="middle">request</text>
+  <text x="40" y="658" font-size="10" font-family="monospace" fill="#3a414a">transport headers</text>
+  <text x="40" y="680" font-size="10" font-family="monospace" fill="#3a414a">authorized identity</text>
+  <text x="40" y="702" font-size="10" font-family="monospace" fill="#3a414a">peer address</text>
+
+  <path d="M 204 666 L 244 666" stroke="#3a414a" fill="none" marker-end="url(#arrow)"/>
+
+  <rect x="248" y="618" width="160" height="96" rx="5" fill="#d7e3ee" stroke="#6f879b" stroke-width="1.5"/>
+  <text x="328" y="643" font-size="12" font-weight="bold" fill="#1f2933" text-anchor="middle">receiver</text>
+  <text x="328" y="665" font-size="10" fill="#3a414a" text-anchor="middle">evaluate tokens</text>
+  <text x="328" y="683" font-size="10" fill="#3a414a" text-anchor="middle">evaluate condition sets</text>
+  <text x="328" y="701" font-size="10" fill="#3a414a" text-anchor="middle">encode context</text>
+
+  <path d="M 412 666 L 440 666" stroke="#3a414a" fill="none" marker-end="url(#arrow)"/>
+
+  <rect x="444" y="596" width="492" height="198" rx="6" fill="#f7f0e6" stroke="#a1836a" stroke-width="1.5"/>
+  <text x="460" y="619" font-size="12" font-weight="bold" fill="#6b4f36">tenant context</text>
+
+  <rect x="460" y="630" width="460" height="28" fill="#efe3d2" stroke="#c3ab90"/>
+  <line x1="690" y1="630" x2="690" y2="658" stroke="#c3ab90"/>
+  <text x="575" y="648" font-size="9.5" font-family="monospace" fill="#6b4f36" text-anchor="middle">epoch + counts</text>
+  <text x="805" y="648" font-size="9.5" font-family="monospace" fill="#6b4f36" text-anchor="middle">resolved token mask</text>
+
+  <rect x="460" y="666" width="115" height="28" fill="#dcefe2" stroke="#6b9b78"/>
+  <rect x="575" y="666" width="115" height="28" fill="#dcefe2" stroke="#6b9b78"/>
+  <rect x="690" y="666" width="115" height="28" fill="#dcefe2" stroke="#6b9b78"/>
+  <rect x="805" y="666" width="115" height="28" fill="#dcefe2" stroke="#6b9b78"/>
+  <text x="517" y="684" font-size="9.5" font-family="monospace" fill="#315c3d" text-anchor="middle">C0: branch0</text>
+  <text x="632" y="684" font-size="9.5" font-family="monospace" fill="#315c3d" text-anchor="middle">C1: no match</text>
+  <text x="747" y="684" font-size="9.5" font-family="monospace" fill="#315c3d" text-anchor="middle">C2: branch3</text>
+  <text x="862" y="684" font-size="9.5" font-family="monospace" fill="#315c3d" text-anchor="middle">...</text>
+
+  <rect x="460" y="702" width="460" height="28" fill="#ffffff" stroke="#c3ab90"/>
+  <text x="690" y="720" font-size="9.5" font-family="monospace" fill="#6b4f36" text-anchor="middle">value index: offset[0] ... offset[n]</text>
+
+  <rect x="460" y="738" width="230" height="40" fill="#ffffff" stroke="#c3ab90"/>
+  <rect x="690" y="738" width="230" height="40" fill="#ffffff" stroke="#c3ab90"/>
+  <text x="575" y="762" font-size="9.5" font-family="monospace" fill="#6b4f36" text-anchor="middle">bagged OTLP content</text>
+  <text x="805" y="762" font-size="9.5" font-family="monospace" fill="#6b4f36" text-anchor="middle">retained values</text>
+
+  <line x1="24" y1="820" x2="936" y2="820" stroke="#dde1e6"/>
+
+  <!-- Precomputed condition result lookup by a consumer. -->
+  <text x="24" y="844" font-size="11" font-weight="bold" fill="#6b7784" letter-spacing="0.6">ONCE PER CONDITION-SET ENCOUNTER</text>
+
+  <rect x="82" y="866" width="260" height="72" rx="5" fill="#f7f0e6" stroke="#a1836a"/>
+  <text x="212" y="889" font-size="12" font-weight="bold" fill="#6b4f36" text-anchor="middle">tenant context</text>
+  <text x="212" y="920" font-size="10" font-family="monospace" fill="#6b4f36" text-anchor="middle">C0=branch0, C1=none, ...</text>
+
+  <rect x="82" y="950" width="260" height="72" rx="5" fill="#f3f8f4" stroke="#6b9b78"/>
+  <text x="212" y="973" font-size="12" font-weight="bold" fill="#315c3d" text-anchor="middle">condition set</text>
+  <text x="212" y="1004" font-size="10" font-family="monospace" fill="#315c3d" text-anchor="middle">C0</text>
+
+  <path d="M 346 902 L 370 902 L 370 914 L 394 914" stroke="#3a414a" fill="none" marker-end="url(#arrow)"/>
+  <path d="M 346 986 L 370 986 L 370 960 L 394 960" stroke="#3a414a" fill="none" marker-end="url(#arrow)"/>
+
+  <rect x="398" y="900" width="276" height="80" rx="5" fill="#dcefe2" stroke="#6b9b78"/>
+  <text x="536" y="929" font-size="12" font-weight="bold" fill="#315c3d" text-anchor="middle">match</text>
+  <text x="536" y="958" font-size="10" font-family="monospace" fill="#315c3d" text-anchor="middle">results[C0]</text>
+
+  <path d="M 678 940 L 750 940" stroke="#3a414a" fill="none" marker-end="url(#arrow)"/>
+  <text x="802" y="944" font-size="12" font-weight="bold" fill="#1f2933" text-anchor="middle">branch0</text>
+
+</svg>

--- a/rust/otap-dataflow/rfcs/images/tenant-context-only-transport-headers.svg
+++ b/rust/otap-dataflow/rfcs/images/tenant-context-only-transport-headers.svg
@@ -1,0 +1,123 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="860" height="596" viewBox="0 0 860 596" font-family="Helvetica, Arial, sans-serif">
+  <title>Tenant context, first cut: every node's tenant configuration is compiled once, then each node uses only its own part of the result</title>
+
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#3a414a"/>
+    </marker>
+    <marker id="arrowlight" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#8a94a0"/>
+    </marker>
+    <marker id="arrowctx" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#a1836a"/>
+    </marker>
+    <marker id="arrowtiny" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#a1836a"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="860" height="596" fill="#ffffff"/>
+
+  <!-- ============ compiled once ============ -->
+  <text x="24" y="26" font-size="11" font-weight="bold" fill="#6b7784" letter-spacing="0.6">COMPILED ONCE</text>
+
+  <rect x="24" y="38" width="260" height="68" rx="5" fill="#eef1f4" stroke="#8a94a0"/>
+  <text x="36" y="57" font-size="11" font-weight="bold" fill="#3a414a">policies.tenant</text>
+  <text x="36" y="77" font-size="11" font-family="monospace" fill="#3a414a">tenant_id  &lt;- x-tenant-id</text>
+  <text x="36" y="93" font-size="11" font-family="monospace" fill="#3a414a">project_id &lt;- x-project-id</text>
+
+  <rect x="300" y="38" width="260" height="68" rx="5" fill="#eef1f4" stroke="#8a94a0"/>
+  <text x="312" y="57" font-size="11" font-weight="bold" fill="#3a414a">batch policies</text>
+  <text x="312" y="77" font-size="11" font-family="monospace" fill="#3a414a">metadata_keys:</text>
+  <text x="312" y="93" font-size="11" font-family="monospace" fill="#3a414a">  [tenant_id, project_id]</text>
+
+  <rect x="576" y="38" width="260" height="68" rx="5" fill="#eef1f4" stroke="#8a94a0"/>
+  <text x="588" y="57" font-size="11" font-weight="bold" fill="#3a414a">exporter config</text>
+  <text x="588" y="77" font-size="11" font-family="monospace" fill="#3a414a">tenant_id  -&gt; x-customer-id</text>
+  <text x="588" y="93" font-size="11" font-family="monospace" fill="#3a414a">project_id -&gt; x-workspace-id</text>
+
+  <path d="M 154 110 L 154 120 L 390 120 L 390 128" stroke="#3a414a" fill="none" marker-end="url(#arrow)"/>
+  <path d="M 430 110 L 430 128" stroke="#3a414a" fill="none" marker-end="url(#arrow)"/>
+  <path d="M 706 110 L 706 120 L 470 120 L 470 128" stroke="#3a414a" fill="none" marker-end="url(#arrow)"/>
+
+  <rect x="340" y="132" width="180" height="44" rx="5" fill="#d7e3ee" stroke="#3a414a" stroke-width="1.5"/>
+  <text x="430" y="159" font-size="13" font-weight="bold" fill="#1f2933" text-anchor="middle">tenant compiler</text>
+
+  <path d="M 390 176 L 390 202 L 258 202 L 258 246" stroke="#8a94a0" fill="none" marker-end="url(#arrowlight)"/>
+  <path d="M 430 176 L 430 246" stroke="#8a94a0" fill="none" marker-end="url(#arrowlight)"/>
+  <path d="M 470 176 L 470 202 L 602 202 L 602 246" stroke="#8a94a0" fill="none" marker-end="url(#arrowlight)"/>
+  <text x="266" y="224" font-size="10" fill="#6b7784">extractor plan</text>
+  <text x="438" y="224" font-size="10" fill="#6b7784">partition keys</text>
+  <text x="610" y="224" font-size="10" fill="#6b7784">value lookups</text>
+
+  <line x1="24" y1="190" x2="836" y2="190" stroke="#dde1e6"/>
+
+  <!-- ============ once per request ============ -->
+  <text x="24" y="212" font-size="11" font-weight="bold" fill="#6b7784" letter-spacing="0.6">ONCE PER REQUEST</text>
+
+  <text x="54" y="248" font-size="10" fill="#6b7784">inbound</text>
+  <text x="54" y="266" font-size="11" font-family="monospace" fill="#3a414a">x-tenant-id: acme</text>
+  <text x="54" y="283" font-size="11" font-family="monospace" fill="#3a414a">x-project-id: p1</text>
+  <text x="54" y="300" font-size="11" font-family="monospace" fill="#aab2bb">authorization: ...</text>
+  <line x1="54" y1="296" x2="162" y2="296" stroke="#aab2bb"/>
+
+  <path d="M 168 272 L 192 272" stroke="#3a414a" fill="none" marker-end="url(#arrow)"/>
+
+  <rect x="196" y="246" width="124" height="52" rx="5" fill="#ffffff" stroke="#3a414a" stroke-width="1.5"/>
+  <text x="258" y="268" font-size="12" font-weight="bold" fill="#1f2933" text-anchor="middle">receiver</text>
+  <text x="258" y="285" font-size="10" fill="#6b7784" text-anchor="middle">compiles context</text>
+
+  <rect x="368" y="246" width="124" height="52" rx="5" fill="#ffffff" stroke="#3a414a" stroke-width="1.5"/>
+  <text x="430" y="268" font-size="12" font-weight="bold" fill="#1f2933" text-anchor="middle">batch</text>
+  <text x="430" y="285" font-size="10" fill="#6b7784" text-anchor="middle">batch by project</text>
+
+  <rect x="540" y="246" width="124" height="52" rx="5" fill="#ffffff" stroke="#3a414a" stroke-width="1.5"/>
+  <text x="602" y="268" font-size="12" font-weight="bold" fill="#1f2933" text-anchor="middle">exporter</text>
+  <text x="602" y="285" font-size="10" fill="#6b7784" text-anchor="middle">reads both keys</text>
+
+  <path d="M 324 272 L 364 272" stroke="#3a414a" fill="none" marker-end="url(#arrow)"/>
+  <path d="M 496 272 L 536 272" stroke="#3a414a" fill="none" marker-end="url(#arrow)"/>
+  <path d="M 668 272 L 692 272" stroke="#3a414a" fill="none" marker-end="url(#arrow)"/>
+
+  <text x="696" y="252" font-size="10" fill="#6b7784">outbound</text>
+  <text x="696" y="270" font-size="11" font-family="monospace" fill="#3a414a">x-customer-id: acme</text>
+  <text x="696" y="288" font-size="11" font-family="monospace" fill="#3a414a">x-workspace-id: p1</text>
+
+  <!-- the carried context -->
+  <path d="M 258 302 L 258 336" stroke="#a1836a" fill="none" marker-end="url(#arrowctx)"/>
+  <path d="M 430 336 L 430 302" stroke="#a1836a" fill="none" marker-end="url(#arrowctx)"/>
+  <path d="M 602 336 L 602 302" stroke="#a1836a" fill="none" marker-end="url(#arrowctx)"/>
+
+  <rect x="196" y="338" width="468" height="128" rx="6" fill="#f7f0e6" stroke="#a1836a" stroke-width="1.5"/>
+  <text x="212" y="360" font-size="12" font-weight="bold" fill="#6b4f36">tenant context</text>
+  <text x="314" y="360" font-size="10" fill="#8a6f52">one allocation, refcounted</text>
+
+  <rect x="212" y="368" width="436" height="24" rx="3" fill="#efe3d2" stroke="#c3ab90"/>
+  <line x1="274" y1="368" x2="274" y2="392" stroke="#c3ab90"/>
+  <line x1="336" y1="368" x2="336" y2="392" stroke="#c3ab90"/>
+  <line x1="410" y1="368" x2="410" y2="392" stroke="#c3ab90"/>
+  <text x="243" y="384" font-size="10" font-family="monospace" fill="#6b4f36" text-anchor="middle">epoch</text>
+  <text x="305" y="384" font-size="10" font-family="monospace" fill="#6b4f36" text-anchor="middle">tokens</text>
+  <text x="373" y="384" font-size="10" font-family="monospace" fill="#6b4f36" text-anchor="middle">index</text>
+  <text x="529" y="384" font-size="10" font-family="monospace" fill="#6b4f36" text-anchor="middle">data</text>
+
+  <rect x="348" y="402" width="18" height="15" rx="2" fill="#ffffff" stroke="#c3ab90"/>
+  <rect x="374" y="402" width="18" height="15" rx="2" fill="#ffffff" stroke="#c3ab90"/>
+  <path d="M 357 419 L 357 433 L 410 433" stroke="#a1836a" fill="none" marker-end="url(#arrowtiny)"/>
+  <path d="M 383 419 L 383 455 L 584 455 L 584 447" stroke="#a1836a" fill="none" marker-end="url(#arrowtiny)"/>
+
+  <rect x="416" y="424" width="108" height="19" rx="2" fill="#ffffff" stroke="#c3ab90"/>
+  <text x="422" y="437" font-size="9.5" font-family="monospace" fill="#3a414a">tenant_id="acme"</text>
+  <rect x="530" y="424" width="108" height="19" rx="2" fill="#ffffff" stroke="#c3ab90"/>
+  <text x="536" y="437" font-size="9.5" font-family="monospace" fill="#3a414a">project_id="p1"</text>
+
+  <!-- ============ sampled ============ -->
+  <path d="M 529 466 L 529 542" stroke="#8a94a0" fill="none" stroke-dasharray="4 3" marker-end="url(#arrowlight)"/>
+
+  <line x1="24" y1="486" x2="836" y2="486" stroke="#dde1e6"/>
+  <text x="24" y="508" font-size="11" font-weight="bold" fill="#6b7784" letter-spacing="0.6">SAMPLED</text>
+  <text x="543" y="520" font-size="10" fill="#6b7784">span attributes</text>
+
+  <rect x="429" y="542" width="200" height="38" rx="5" fill="#ffffff" stroke="#3a414a" stroke-width="1.5"/>
+  <text x="529" y="566" font-size="12" font-weight="bold" fill="#1f2933" text-anchor="middle">observability pipeline</text>
+</svg>


### PR DESCRIPTION
# Change Summary

RFC 0003: Simplified tenant context design.

Replaces #3389, #3583, #3635, #3636.

## What issue does this PR close?

* Part of #1245, 
* Part of #3272 

## How are these changes tested?

Prototype in #3636.

## Are there any user-facing changes?

New configuration.

* [x] This is a documentation-only PR.
