### PR TITLE
  chore: fix non-jemalloc test feature guard

### DIFF
--- a/rust/otap-dataflow/crates/engine/src/pipeline_metrics.rs
+++ b/rust/otap-dataflow/crates/engine/src/pipeline_metrics.rs
@@ -853,7 +853,7 @@ mod jemalloc_tests {
     }
 }
 
-#[cfg(all(test, not(feature = "jemalloc-testing")))]
+#[cfg(all(test, any(windows, not(feature = "jemalloc"))))]
 mod non_jemalloc_tests {
     use super::*;
     use crate::context::ControllerContext;
@@ -861,6 +861,8 @@ mod non_jemalloc_tests {
     use std::hint::black_box;
     use std::time::{Duration, Instant};
 
+    /// Scenario: Pipeline metrics are sampled when jemalloc accounting is unavailable.
+    /// Guarantees: CPU and OS metrics update while all allocator metrics remain zero.
     #[test]
     fn pipeline_metrics_monitor_does_not_update_memory_without_jemalloc() {
         let telemetry_registry = TelemetryRegistryHandle::new();


### PR DESCRIPTION
 # Change Summary

  Fix the non-jemalloc pipeline metrics test gate so the test only runs when jemalloc accounting is unavailable.

  The issue was exposed by #3497 enabling jemalloc's `unprefixed_malloc_on_supported_platforms` feature. The test then observed real jemalloc allocations while incorrectly expecting zero.

  ## What issue does this PR close?

  * Follow-up to #3497

  ## How are these changes tested?

  - `cargo fmt --all -- --check`
  - `python3 tools/sanitycheck.py`
  - `cargo check -p otap-df-engine`
  - Full configuration coverage will run in CI.

  ## Are there any user-facing changes?

  No. This only corrects test selection.

  ### Changelog

  * [ ] Added a `.chloggen/*.yaml` entry
  * [x] This PR is a `chore` (indicated in title)
  * [ ] This is a documentation-only PR.
