### PR TITLE
wip: fix batching processor ignoring max_size on large single resources

### DIFF
--- a/rust/otap-dataflow/.chloggen/batch_max_size_fix.yaml
+++ b/rust/otap-dataflow/.chloggen/batch_max_size_fix.yaml
@@ -1,0 +1,5 @@
+change_type: bug_fix
+component: pdata
+note: >-
+  Track fixing the zero-copy bytes batch processor ignoring max_size for oversize single resources.
+issues: [3661]

--- a/rust/otap-dataflow/crates/pdata/src/otlp/batching.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/batching.rs
@@ -209,3 +209,5 @@ pub fn make_bytes_batches(
         }
     }
 }
+
+// TODO: Implement recursive protobuf splitting for Issue #3661 to handle oversize ResourceLogs


### PR DESCRIPTION
fixes #3661 

opening this to track some work on the `max_size` bug in the batch processor. 

right now, if a client dumps a massive payload into a single `ResourceLogs` (like 10k logs in one go), `make_bytes_batches` in `crates/pdata/src/otlp/batching.rs` just completely ignores the `max_size` limit. 

the zero-copy parser only slices at the top-level boundaries. because there's only one top-level resource tag in this scenario, it just uses `read_len_delim` to skip the whole thing and forwards it as one huge chunk.

i pushed an initial branch just to get this started. currently working on adding some recursive splitting logic so we can actually step down into `ScopeLogs` / `LogRecords` and cut the payload properly when the top-level field gets too big. 

will update once I have the recursive parsing wired up. lmk if anyone has already started looking into this or has ideas on a simpler approach.