### PR TITLE
feat(admin): add debug endpoint to retrieve CPU profile as pprof format from admin server

### DIFF
--- a/rust/otap-dataflow/.chloggen/admin-cpu-profile-endpoint.yaml
+++ b/rust/otap-dataflow/.chloggen/admin-cpu-profile-endpoint.yaml
@@ -1,6 +1,6 @@
 change_type: enhancement
 component: engine
 note: >-
-  Add heap profiling endpoint at `/api/v1/debug/pprof/profile` that dumps
-  profile in pprof format
+  Add CPU profiling endpoint at `/api/v1/debug/pprof/profile` that collects
+  a CPU profile in pprof format.
 issues: [3692]

--- a/rust/otap-dataflow/.chloggen/admin-cpu-profile-endpoint.yaml
+++ b/rust/otap-dataflow/.chloggen/admin-cpu-profile-endpoint.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: engine
+note: >-
+  Add heap profiling endpoint at `/api/v1/debug/pprof/profile` that dumps
+  profile in pprof format
+issues: [3692]

--- a/rust/otap-dataflow/Cargo.lock
+++ b/rust/otap-dataflow/Cargo.lock
@@ -73,6 +73,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "alloca"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1254,7 +1263,7 @@ dependencies = [
  "otap-df-telemetry",
  "otap-df-telemetry-macros",
  "otap-df-test-net",
- "prost",
+ "prost 0.14.4",
  "roaring",
  "serde_json",
  "tikv-jemallocator",
@@ -1468,8 +1477,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85a885520bf6249ab931a764ffdb87b0ceef48e6e7d807cfdb21b751e086e1ad"
 dependencies = [
- "prost",
- "prost-types",
+ "prost 0.14.4",
+ "prost-types 0.14.4",
  "tonic",
  "tonic-prost",
  "ureq",
@@ -1484,7 +1493,7 @@ dependencies = [
  "base64",
  "bollard-buildkit-proto",
  "bytes",
- "prost",
+ "prost 0.14.4",
  "serde",
  "serde_json",
  "serde_repr",
@@ -3126,7 +3135,7 @@ dependencies = [
  "itertools 0.14.0",
  "parking_lot",
  "paste",
- "petgraph",
+ "petgraph 0.8.3",
  "tokio",
 ]
 
@@ -3278,6 +3287,15 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
 
 [[package]]
 name = "deflate64"
@@ -3592,6 +3610,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3754,6 +3792,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "finl_unicode"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3826,7 +3876,7 @@ checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -5595,6 +5645,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -6583,6 +6642,17 @@ checksum = "cf5a574dadd7941adeaa71823ecba5e28331b8313fb2e1c6a5c7e5981ea53ad6"
 
 [[package]]
 name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
@@ -7053,7 +7123,7 @@ checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.14.4",
 ]
 
 [[package]]
@@ -7154,6 +7224,7 @@ dependencies = [
  "otap-df-state",
  "otap-df-telemetry",
  "otap-df-telemetry-macros",
+ "pprof",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
@@ -7314,7 +7385,7 @@ dependencies = [
  "otap-df-telemetry-macros",
  "paste",
  "pretty_assertions",
- "prost",
+ "prost 0.14.4",
  "rand 0.10.2",
  "rdkafka",
  "regex",
@@ -7373,7 +7444,7 @@ dependencies = [
  "otap-df-telemetry",
  "otap-df-telemetry-macros",
  "otap-df-test-net",
- "prost",
+ "prost 0.14.4",
  "serde",
  "serde_json",
  "smallvec",
@@ -7435,8 +7506,8 @@ dependencies = [
  "parking_lot",
  "parquet",
  "pretty_assertions",
- "prost",
- "prost-types",
+ "prost 0.14.4",
+ "prost-types 0.14.4",
  "rand 0.10.2",
  "regex",
  "reqwest 0.13.4",
@@ -7512,7 +7583,7 @@ dependencies = [
  "otap-df-telemetry",
  "otap-df-telemetry-macros",
  "parking_lot",
- "prost",
+ "prost 0.14.4",
  "secrecy",
  "serde_json",
  "serde_yaml",
@@ -7581,8 +7652,8 @@ dependencies = [
  "otap-df-test-tls-certs",
  "parking_lot",
  "pretty_assertions",
- "prost",
- "prost-types",
+ "prost 0.14.4",
+ "prost-types 0.14.4",
  "reqwest 0.13.4",
  "rustls",
  "rustls-native-certs",
@@ -7635,7 +7706,7 @@ dependencies = [
  "otap-df-test-net",
  "paste",
  "pretty_assertions",
- "prost",
+ "prost 0.14.4",
  "rand 0.10.2",
  "replace_with",
  "roaring",
@@ -7690,7 +7761,7 @@ dependencies = [
  "otap-df-query-engine-languages",
  "parking_lot",
  "pretty_assertions",
- "prost",
+ "prost 0.14.4",
  "sha1 0.11.0",
  "smallvec",
  "thiserror 2.0.19",
@@ -7726,7 +7797,7 @@ dependencies = [
  "otap-df-pdata",
  "otap-df-query-engine",
  "otap-df-query-engine-languages",
- "prost",
+ "prost 0.14.4",
  "serde",
  "tokio",
 ]
@@ -7809,7 +7880,7 @@ dependencies = [
  "otap-df-pdata-views",
  "otap-df-telemetry-macros",
  "parking_lot",
- "prost",
+ "prost 0.14.4",
  "serde",
  "serde_yaml",
  "slotmap",
@@ -7862,7 +7933,7 @@ dependencies = [
  "otap-df-telemetry-macros",
  "otap-df-test-net",
  "otap-df-test-tls-certs",
- "prost",
+ "prost 0.14.4",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -8142,6 +8213,16 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset 0.4.2",
+ "indexmap 2.14.0",
+]
+
+[[package]]
+name = "petgraph"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
@@ -8398,6 +8479,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efca4c95a19a79d1c98f791f10aebd5c1363b473244630bb7dbde1dc98455a24"
 
 [[package]]
+name = "pprof"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a01da47675efa7673b032bf8efd8214f1917d89685e07e395ab125ea42b187"
+dependencies = [
+ "aligned-vec",
+ "backtrace",
+ "cfg-if",
+ "findshlibs",
+ "libc",
+ "log",
+ "nix 0.26.4",
+ "once_cell",
+ "prost 0.12.6",
+ "prost-build 0.12.6",
+ "prost-derive 0.12.6",
+ "sha2 0.10.9",
+ "smallvec",
+ "spin 0.10.1",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "pprof_util"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8408,7 +8514,7 @@ dependencies = [
  "flate2",
  "num",
  "paste",
- "prost",
+ "prost 0.14.4",
 ]
 
 [[package]]
@@ -8471,12 +8577,43 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+dependencies = [
+ "bytes",
+ "prost-derive 0.12.6",
+]
+
+[[package]]
+name = "prost"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.14.4",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
+dependencies = [
+ "bytes",
+ "heck",
+ "itertools 0.12.1",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph 0.6.5",
+ "prettyplease",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
+ "regex",
+ "syn 2.0.119",
+ "tempfile",
 ]
 
 [[package]]
@@ -8489,15 +8626,28 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "multimap",
- "petgraph",
+ "petgraph 0.8.3",
  "prettyplease",
- "prost",
- "prost-types",
+ "prost 0.14.4",
+ "prost-types 0.14.4",
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
  "syn 2.0.119",
  "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+dependencies = [
+ "anyhow",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8515,11 +8665,20 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
+dependencies = [
+ "prost 0.12.6",
+]
+
+[[package]]
+name = "prost-types"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
- "prost",
+ "prost 0.14.4",
 ]
 
 [[package]]
@@ -10051,6 +10210,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10169,6 +10337,29 @@ name = "supports-unicode"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
+
+[[package]]
+name = "symbolic-common"
+version = "12.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "332615d90111d8eeaf86a84dc9bbe9f65d0d8c5cf11b4caccedc37754eb0dcfd"
+dependencies = [
+ "debugid",
+ "memmap2",
+ "stable_deref_trait",
+ "uuid",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "12.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "912017718eb4d21930546245af9a3475c9dccf15675a5c215664e76621afc471"
+dependencies = [
+ "cpp_demangle 0.4.5",
+ "rustc-demangle",
+ "symbolic-common",
+]
 
 [[package]]
 name = "symcrypt"
@@ -10843,7 +11034,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.14.4",
  "tonic",
 ]
 
@@ -10855,8 +11046,8 @@ checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build",
- "prost-types",
+ "prost-build 0.14.4",
+ "prost-types 0.14.4",
  "quote",
  "syn 2.0.119",
  "tempfile",
@@ -12519,7 +12710,7 @@ dependencies = [
  "otap-df-component-inventory-syntax",
  "otap-df-pdata-otlp-model",
  "proc-macro2",
- "prost-build",
+ "prost-build 0.14.4",
  "serde",
  "serde_json",
  "syn 2.0.119",

--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -166,6 +166,7 @@ parquet = { version = "58.3", default-features = false, features = ["arrow", "as
 pest = "2.8"
 pest_derive = "2.8"
 pretty_assertions = "1.4.1"
+pprof = { version = "0.15", features = ["prost-codec"] }
 proc-macro2 = "1.0"
 prometheus = "0.14.0"
 prost = "0.14"

--- a/rust/otap-dataflow/PROFILING.md
+++ b/rust/otap-dataflow/PROFILING.md
@@ -84,3 +84,26 @@ curl http://localhost:8080/api/v1/debug/pprof/heap -o heap.pprof
 ```bash
 go tool pprof -http=:18080 ./target/debug/df_engine ./heap.pprof
 ```
+
+## Live CPU profiling (pprof)
+
+The admin server exposes a CPU profiling endpoint at
+`/api/v1/debug/pprof/profile` that collects a CPU profile and returns it
+in pprof format. Not available on Windows.
+
+Optional query parameters:
+
+- `seconds` -- sampling duration in seconds (default 30).
+- `frequency` -- sampling frequency in Hz (default 100).
+
+**Fetch** a 10-second CPU profile:
+
+```bash
+curl "http://localhost:8080/api/v1/debug/pprof/profile?seconds=10" -o cpu.pprof
+```
+
+**View** with `go tool pprof`:
+
+```bash
+go tool pprof -http=:18080 ./target/debug/df_engine ./cpu.pprof
+```

--- a/rust/otap-dataflow/crates/admin/Cargo.toml
+++ b/rust/otap-dataflow/crates/admin/Cargo.toml
@@ -24,7 +24,6 @@ otap-df-state = { workspace = true }
 otap-df-telemetry = { workspace = true }
 otap-df-engine = { workspace = true }
 
-pprof = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -37,6 +36,7 @@ include_dir = { workspace = true }
 mime_guess = { workspace = true }
 
 [target.'cfg(not(windows))'.dependencies]
+pprof = { workspace = true }
 jemalloc_pprof = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/rust/otap-dataflow/crates/admin/Cargo.toml
+++ b/rust/otap-dataflow/crates/admin/Cargo.toml
@@ -24,6 +24,7 @@ otap-df-state = { workspace = true }
 otap-df-telemetry = { workspace = true }
 otap-df-engine = { workspace = true }
 
+pprof = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/rust/otap-dataflow/crates/admin/README.md
+++ b/rust/otap-dataflow/crates/admin/README.md
@@ -55,6 +55,10 @@ For the operator guide to live pipeline mutation, see
   (e.g. `_RJEM_MALLOC_CONF="prof:true,prof_active:true,lg_prof_sample:19"`
   on macOS, or `MALLOC_CONF` on Linux). Returns `application/x-protobuf`.
   Returns HTTP 500 if profiling is unavailable or not activated.
+- `GET /api/v1/debug/pprof/profile`: collect a CPU profile in pprof format.
+  Optional query parameters: `seconds` (sampling duration, default 30) and
+  `frequency` (sampling frequency in Hz, default 100). Returns
+  `application/x-protobuf`. Not available on Windows.
 
 ## Embedded UI layout (crate-relative)
 

--- a/rust/otap-dataflow/crates/admin/src/debug.rs
+++ b/rust/otap-dataflow/crates/admin/src/debug.rs
@@ -132,9 +132,20 @@ struct CpuProfileParams {
 }
 
 async fn get_cpu_profile(
-    State(_state): State<AppState>,
+    State(state): State<AppState>,
     Query(params): Query<CpuProfileParams>,
 ) -> Result<Response, (StatusCode, String)> {
+    let permit = state
+        .cpu_profile_permits
+        .clone()
+        .try_acquire_owned()
+        .map_err(|_| {
+            (
+                StatusCode::TOO_MANY_REQUESTS,
+                "A heap profile dump is already in progress".into(),
+            )
+        })?;
+
     // start profile
     let profile_builder =
         pprof::ProfilerGuardBuilder::default().frequency(params.frequency.unwrap_or(100) as i32);
@@ -152,6 +163,7 @@ async fn get_cpu_profile(
     // offload the blocking generation of the profile to a dedicate thread so that the
     // admin server's async runtime stays responsive.
     let pprof = tokio::task::spawn_blocking(move || {
+        let _permit = permit;
         // finish profiling
         let report = guard.report().build().map_err(|e| {
             (

--- a/rust/otap-dataflow/crates/admin/src/debug.rs
+++ b/rust/otap-dataflow/crates/admin/src/debug.rs
@@ -10,16 +10,16 @@
 //!   shutdown responsive.
 
 use axum::Router;
-use axum::body::Body;
 use axum::extract::{Query, State};
-use axum::http::{StatusCode, header};
+use axum::http::StatusCode;
 use axum::response::Response;
 use axum::routing::get;
-use serde::Deserialize;
 
 #[cfg(all(feature = "jemalloc-pprof", not(windows)))]
 use std::panic::AssertUnwindSafe;
-use std::time::Duration;
+
+#[cfg(not(windows))]
+use axum::{body::Body, http::header};
 
 use crate::AppState;
 
@@ -120,7 +120,7 @@ async fn get_heap_profile(State(state): State<AppState>) -> Result<Response, (St
 }
 
 /// Querystring parameters for /profile endpoint
-#[derive(Deserialize)]
+#[derive(serde::Deserialize)]
 struct CpuProfileParams {
     /// How long (in seconds) to sample CPU. If the parameter is not specified, the default will
     /// be 30 seconds
@@ -136,6 +136,8 @@ async fn get_cpu_profile(
 ) -> Result<Response, (StatusCode, String)> {
     #[cfg(not(windows))]
     {
+        
+        use std::time::Duration;
         use pprof::protos::Message;
         let permit = state
             .cpu_profile_permits
@@ -213,9 +215,10 @@ async fn get_cpu_profile(
 
     #[cfg(not(not(windows)))]
     {
-        // Suppress dead-code warning for the semaphore field when the
-        // jemalloc-pprof feature is not compiled in.
-        let _ = &state.heap_profile_permits;
+        // Suppress dead-code warning for the unused fields when the feature is not compiled in.
+        let _ = &state.cpu_profile_permits;
+        let _ = params.seconds;
+        let _ = params.frequency;
         Err((
             StatusCode::INTERNAL_SERVER_ERROR,
             "CPU profiling is not available in this build".into(),

--- a/rust/otap-dataflow/crates/admin/src/debug.rs
+++ b/rust/otap-dataflow/crates/admin/src/debug.rs
@@ -10,20 +10,25 @@
 //!   shutdown responsive.
 
 use axum::Router;
-use axum::extract::State;
+use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::Response;
 use axum::routing::get;
+use pprof::protos::Message;
+use serde::Deserialize;
 
 #[cfg(all(feature = "jemalloc-pprof", not(windows)))]
 use axum::{body::Body, http::header};
 #[cfg(all(feature = "jemalloc-pprof", not(windows)))]
 use std::panic::AssertUnwindSafe;
+use std::time::Duration;
 
 use crate::AppState;
 
 pub(crate) fn routes() -> Router<AppState> {
-    Router::new().route("/debug/pprof/heap", get(get_heap_profile))
+    Router::new()
+    .route("/debug/pprof/heap", get(get_heap_profile))
+    .route("/debug/pprof/profile", get(get_cpu_profile))
 }
 
 async fn get_heap_profile(State(state): State<AppState>) -> Result<Response, (StatusCode, String)> {
@@ -114,4 +119,68 @@ async fn get_heap_profile(State(state): State<AppState>) -> Result<Response, (St
             "Heap profiling is not available in this build".into(),
         ))
     }
+}
+
+/// Querystring parameters for /profile endpoint
+#[derive(Deserialize)]
+struct CpuProfileParams {
+    /// How long (in seconds) to sample CPU. If the parameter is not specified, the default will
+    /// be 30 seconds
+    seconds: Option<u16>,
+
+    /// profile sampling frequency. Default = 100 (sample each 10ms)
+    frequency: Option<u16>,
+}
+
+async fn get_cpu_profile(
+    State(_state): State<AppState>,
+    Query(params): Query<CpuProfileParams>,
+) -> Result<Response, (StatusCode, String)> {
+    // start profile
+    let profile_builder =
+        pprof::ProfilerGuardBuilder::default().frequency(params.frequency.unwrap_or(100) as i32);
+    let guard = profile_builder.build().map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Could not build profiler: {e}"),
+        )
+    })?;
+
+    // sleep for profile duration
+    let profile_time = Duration::from_secs(params.seconds.unwrap_or(30) as u64);
+    tokio::time::sleep(profile_time).await;
+
+    // finish profiling
+    let report = guard.report().build().map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Could not build profile report: {e}"),
+        )
+    })?;
+
+    // encode profile as proto-encoded pprof
+    let pprof = match report.pprof() {
+        Ok(pprof) => pprof.encode_to_vec(),
+        Err(e) => {
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Could not proto-encode profile report: {e}"),
+            ));
+        }
+    };
+
+    // return response
+    let body = Body::from(pprof);
+    let resp = Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "application/x-protobuf")
+        .body(body)
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Could not dump profile pprof: {e}"),
+            )
+        })?;
+
+    Ok(resp)
 }

--- a/rust/otap-dataflow/crates/admin/src/debug.rs
+++ b/rust/otap-dataflow/crates/admin/src/debug.rs
@@ -136,9 +136,8 @@ async fn get_cpu_profile(
 ) -> Result<Response, (StatusCode, String)> {
     #[cfg(not(windows))]
     {
-        
-        use std::time::Duration;
         use pprof::protos::Message;
+        use std::time::Duration;
         let permit = state
             .cpu_profile_permits
             .clone()

--- a/rust/otap-dataflow/crates/admin/src/debug.rs
+++ b/rust/otap-dataflow/crates/admin/src/debug.rs
@@ -138,6 +138,22 @@ async fn get_cpu_profile(
     {
         use pprof::protos::Message;
         use std::time::Duration;
+
+        let seconds = params.seconds.unwrap_or(30);
+        if seconds == 0 {
+            return Err((
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "seconds must be greater than 0".into(),
+            ));
+        }
+        let frequency = params.frequency.unwrap_or(100);
+        if frequency == 0 {
+            return Err((
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "frequency must be greater than 0".into(),
+            ));
+        }
+
         let permit = state
             .cpu_profile_permits
             .clone()
@@ -145,13 +161,12 @@ async fn get_cpu_profile(
             .map_err(|_| {
                 (
                     StatusCode::TOO_MANY_REQUESTS,
-                    "A heap profile dump is already in progress".into(),
+                    "A cpu profile dump is already in progress".into(),
                 )
             })?;
 
         // start profile
-        let profile_builder = pprof::ProfilerGuardBuilder::default()
-            .frequency(params.frequency.unwrap_or(100) as i32);
+        let profile_builder = pprof::ProfilerGuardBuilder::default().frequency(frequency as i32);
         let guard = profile_builder.build().map_err(|e| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -160,10 +175,10 @@ async fn get_cpu_profile(
         })?;
 
         // sleep for profile duration
-        let profile_time = Duration::from_secs(params.seconds.unwrap_or(30) as u64);
+        let profile_time = Duration::from_secs(seconds as u64);
         tokio::time::sleep(profile_time).await;
 
-        // offload the blocking generation of the profile to a dedicate thread so that the
+        // offload the blocking generation of the profile to a dedicated thread so that the
         // admin server's async runtime stays responsive.
         let pprof = tokio::task::spawn_blocking(move || {
             let _permit = permit;

--- a/rust/otap-dataflow/crates/admin/src/debug.rs
+++ b/rust/otap-dataflow/crates/admin/src/debug.rs
@@ -10,15 +10,14 @@
 //!   shutdown responsive.
 
 use axum::Router;
+use axum::body::Body;
 use axum::extract::{Query, State};
-use axum::http::StatusCode;
+use axum::http::{StatusCode, header};
 use axum::response::Response;
 use axum::routing::get;
 use pprof::protos::Message;
 use serde::Deserialize;
 
-#[cfg(all(feature = "jemalloc-pprof", not(windows)))]
-use axum::{body::Body, http::header};
 #[cfg(all(feature = "jemalloc-pprof", not(windows)))]
 use std::panic::AssertUnwindSafe;
 use std::time::Duration;
@@ -27,8 +26,8 @@ use crate::AppState;
 
 pub(crate) fn routes() -> Router<AppState> {
     Router::new()
-    .route("/debug/pprof/heap", get(get_heap_profile))
-    .route("/debug/pprof/profile", get(get_cpu_profile))
+        .route("/debug/pprof/heap", get(get_heap_profile))
+        .route("/debug/pprof/profile", get(get_cpu_profile))
 }
 
 async fn get_heap_profile(State(state): State<AppState>) -> Result<Response, (StatusCode, String)> {
@@ -150,24 +149,37 @@ async fn get_cpu_profile(
     let profile_time = Duration::from_secs(params.seconds.unwrap_or(30) as u64);
     tokio::time::sleep(profile_time).await;
 
-    // finish profiling
-    let report = guard.report().build().map_err(|e| {
+    // offload the blocking generation of the profile to a dedicate thread so that the
+    // admin server's async runtime stays responsive.
+    let pprof = tokio::task::spawn_blocking(move || {
+        // finish profiling
+        let report = guard.report().build().map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Could not build profile report: {e}"),
+            )
+        })?;
+
+        // encode profile as proto-encoded pprof
+        let pprof = match report.pprof() {
+            Ok(pprof) => pprof.encode_to_vec(),
+            Err(e) => {
+                return Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Could not proto-encode profile report: {e}"),
+                ));
+            }
+        };
+
+        Ok(pprof)
+    })
+    .await
+    .map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Could not build profile report: {e}"),
+            format!("Heap profile task failed to join: {e}"),
         )
-    })?;
-
-    // encode profile as proto-encoded pprof
-    let pprof = match report.pprof() {
-        Ok(pprof) => pprof.encode_to_vec(),
-        Err(e) => {
-            return Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Could not proto-encode profile report: {e}"),
-            ));
-        }
-    };
+    })??;
 
     // return response
     let body = Body::from(pprof);

--- a/rust/otap-dataflow/crates/admin/src/debug.rs
+++ b/rust/otap-dataflow/crates/admin/src/debug.rs
@@ -15,7 +15,6 @@ use axum::extract::{Query, State};
 use axum::http::{StatusCode, header};
 use axum::response::Response;
 use axum::routing::get;
-use pprof::protos::Message;
 use serde::Deserialize;
 
 #[cfg(all(feature = "jemalloc-pprof", not(windows)))]
@@ -135,76 +134,91 @@ async fn get_cpu_profile(
     State(state): State<AppState>,
     Query(params): Query<CpuProfileParams>,
 ) -> Result<Response, (StatusCode, String)> {
-    let permit = state
-        .cpu_profile_permits
-        .clone()
-        .try_acquire_owned()
-        .map_err(|_| {
-            (
-                StatusCode::TOO_MANY_REQUESTS,
-                "A heap profile dump is already in progress".into(),
-            )
-        })?;
+    #[cfg(not(windows))]
+    {
+        use pprof::protos::Message;
+        let permit = state
+            .cpu_profile_permits
+            .clone()
+            .try_acquire_owned()
+            .map_err(|_| {
+                (
+                    StatusCode::TOO_MANY_REQUESTS,
+                    "A heap profile dump is already in progress".into(),
+                )
+            })?;
 
-    // start profile
-    let profile_builder =
-        pprof::ProfilerGuardBuilder::default().frequency(params.frequency.unwrap_or(100) as i32);
-    let guard = profile_builder.build().map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Could not build profiler: {e}"),
-        )
-    })?;
-
-    // sleep for profile duration
-    let profile_time = Duration::from_secs(params.seconds.unwrap_or(30) as u64);
-    tokio::time::sleep(profile_time).await;
-
-    // offload the blocking generation of the profile to a dedicate thread so that the
-    // admin server's async runtime stays responsive.
-    let pprof = tokio::task::spawn_blocking(move || {
-        let _permit = permit;
-        // finish profiling
-        let report = guard.report().build().map_err(|e| {
+        // start profile
+        let profile_builder = pprof::ProfilerGuardBuilder::default()
+            .frequency(params.frequency.unwrap_or(100) as i32);
+        let guard = profile_builder.build().map_err(|e| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Could not build profile report: {e}"),
+                format!("Could not build profiler: {e}"),
             )
         })?;
 
-        // encode profile as proto-encoded pprof
-        let pprof = match report.pprof() {
-            Ok(pprof) => pprof.encode_to_vec(),
-            Err(e) => {
-                return Err((
+        // sleep for profile duration
+        let profile_time = Duration::from_secs(params.seconds.unwrap_or(30) as u64);
+        tokio::time::sleep(profile_time).await;
+
+        // offload the blocking generation of the profile to a dedicate thread so that the
+        // admin server's async runtime stays responsive.
+        let pprof = tokio::task::spawn_blocking(move || {
+            let _permit = permit;
+            // finish profiling
+            let report = guard.report().build().map_err(|e| {
+                (
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Could not proto-encode profile report: {e}"),
-                ));
-            }
-        };
+                    format!("Could not build profile report: {e}"),
+                )
+            })?;
 
-        Ok(pprof)
-    })
-    .await
-    .map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Heap profile task failed to join: {e}"),
-        )
-    })??;
+            // encode profile as proto-encoded pprof
+            let pprof = match report.pprof() {
+                Ok(pprof) => pprof.encode_to_vec(),
+                Err(e) => {
+                    return Err((
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("Could not proto-encode profile report: {e}"),
+                    ));
+                }
+            };
 
-    // return response
-    let body = Body::from(pprof);
-    let resp = Response::builder()
-        .status(StatusCode::OK)
-        .header(header::CONTENT_TYPE, "application/x-protobuf")
-        .body(body)
+            Ok(pprof)
+        })
+        .await
         .map_err(|e| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Could not dump profile pprof: {e}"),
+                format!("Heap profile task failed to join: {e}"),
             )
-        })?;
+        })??;
 
-    Ok(resp)
+        // return response
+        let body = Body::from(pprof);
+        let resp = Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, "application/x-protobuf")
+            .body(body)
+            .map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Could not dump profile pprof: {e}"),
+                )
+            })?;
+
+        Ok(resp)
+    }
+
+    #[cfg(not(not(windows)))]
+    {
+        // Suppress dead-code warning for the semaphore field when the
+        // jemalloc-pprof feature is not compiled in.
+        let _ = &state.heap_profile_permits;
+        Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "CPU profiling is not available in this build".into(),
+        ))
+    }
 }

--- a/rust/otap-dataflow/crates/admin/src/engine_config.rs
+++ b/rust/otap-dataflow/crates/admin/src/engine_config.rs
@@ -213,6 +213,7 @@ mod tests {
             controller,
             terminal_control_plane_permits: Arc::new(tokio::sync::Semaphore::new(1)),
             heap_profile_permits: Arc::new(tokio::sync::Semaphore::new(1)),
+            cpu_profile_permits: Arc::new(tokio::sync::Semaphore::new(1)),
             log_tap: None,
             memory_pressure_state: MemoryPressureState::default(),
             target_info: Arc::from(""),

--- a/rust/otap-dataflow/crates/admin/src/lib.rs
+++ b/rust/otap-dataflow/crates/admin/src/lib.rs
@@ -45,6 +45,7 @@ use otap_df_telemetry::registry::TelemetryRegistryHandle;
 use otap_df_telemetry::{otel_info, otel_warn};
 
 const TERMINAL_CONTROL_PLANE_PERMITS: usize = 1;
+const CPU_PROFILE_PERMITS: usize = 1;
 const HEAP_PROFILE_PERMITS: usize = 1;
 
 /// Control-plane error surfaced to admin handlers.
@@ -230,6 +231,9 @@ struct AppState {
     /// requests are rejected immediately with HTTP 429.
     heap_profile_permits: Arc<Semaphore>,
 
+    /// Limits concurrent CPU profile dumps. Excess requests are rejected immediately with HTTP 429
+    cpu_profile_permits: Arc<Semaphore>,
+
     /// Optional internal log tap for querying retained internal logs.
     log_tap: Option<InternalLogTapHandle>,
 
@@ -331,6 +335,7 @@ pub async fn run(
         controller,
         terminal_control_plane_permits: Arc::new(Semaphore::new(TERMINAL_CONTROL_PLANE_PERMITS)),
         heap_profile_permits: Arc::new(Semaphore::new(HEAP_PROFILE_PERMITS)),
+        cpu_profile_permits: Arc::new(Semaphore::new(CPU_PROFILE_PERMITS)),
         log_tap,
         memory_pressure_state,
         target_info,

--- a/rust/otap-dataflow/crates/admin/src/pipeline.rs
+++ b/rust/otap-dataflow/crates/admin/src/pipeline.rs
@@ -573,6 +573,7 @@ mod tests {
             controller,
             terminal_control_plane_permits: Arc::new(tokio::sync::Semaphore::new(1)),
             heap_profile_permits: Arc::new(tokio::sync::Semaphore::new(1)),
+            cpu_profile_permits: Arc::new(tokio::sync::Semaphore::new(1)),
             log_tap: None,
             memory_pressure_state: MemoryPressureState::default(),
             target_info: Arc::from(""),

--- a/rust/otap-dataflow/crates/admin/src/pipeline_group.rs
+++ b/rust/otap-dataflow/crates/admin/src/pipeline_group.rs
@@ -344,6 +344,7 @@ mod tests {
             controller,
             terminal_control_plane_permits: Arc::new(tokio::sync::Semaphore::new(1)),
             heap_profile_permits: Arc::new(tokio::sync::Semaphore::new(1)),
+            cpu_profile_permits: Arc::new(tokio::sync::Semaphore::new(1)),
             log_tap: None,
             memory_pressure_state: MemoryPressureState::default(),
             target_info: Arc::from(""),

--- a/rust/otap-dataflow/crates/admin/src/telemetry.rs
+++ b/rust/otap-dataflow/crates/admin/src/telemetry.rs
@@ -2651,6 +2651,7 @@ mod tests {
             controller: Arc::new(NoopControlPlane),
             terminal_control_plane_permits: Arc::new(tokio::sync::Semaphore::new(1)),
             heap_profile_permits: Arc::new(tokio::sync::Semaphore::new(1)),
+            cpu_profile_permits: Arc::new(tokio::sync::Semaphore::new(1)),
             log_tap: None,
             memory_pressure_state: MemoryPressureState::default(),
             target_info: Arc::from(""),


### PR DESCRIPTION
# Change Summary

<!--Replace with a brief summary of the change in this PR-->

Similar to what was done in #3497, this PR adds an endpoint that can dumb a CPU profile in pprof format.

```
curl -XGET "http://localhost:8080/api/v1/debug/pprof/profile?seconds=10"
```

## What issue does this PR close?

<!--We highly recommend correlation of every PR to an issue-->

* Closes #3692 

## How are these changes tested?

manually

## Are there any user-facing changes?

Yes - new endpoint in admin server

 <!-- If yes, provide further info below -->

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry
* [ ] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
