### PR TITLE
fix(transform_processor): retain request metadata on split transform batches

### DIFF
--- a/rust/otap-dataflow/.chloggen/transform-split-context-metadata.yaml
+++ b/rust/otap-dataflow/.chloggen/transform-split-context-metadata.yaml
@@ -1,0 +1,24 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: pipeline
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Retain transport headers and peer address on outbound batches when the transform processor splits a batch
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [3501]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries. Breaking entries must include a `Migration:`
+# section with the specific action consumers must take. Keep notes to 200
+# characters and subtext to 300 characters.
+subtext: |
+  Batches sent to a `route_to` port, and the batch sent to the default port alongside them, were
+  given an empty context. Downstream components lost request metadata such as tenant ID, auth and
+  originating peer whenever a query split the batch.

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/partition_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/partition_processor/mod.rs
@@ -28,7 +28,7 @@ use otap_df_engine::{
 use otap_df_otap::OTAP_PROCESSOR_FACTORIES;
 use otap_df_otap::accessory::context::split_contexts::Contexts;
 use otap_df_otap::accessory::slots::Key;
-use otap_df_otap::pdata::{Context, OtapPdata};
+use otap_df_otap::pdata::OtapPdata;
 use otap_df_otap::transport_headers::{TransportHeader, ValueKind};
 use otap_df_pdata::{OtapArrowRecords, OtapPayload, TryIntoWithOptions};
 use otap_df_query_engine::parser::default_parser_options;
@@ -339,20 +339,15 @@ impl Processor<OtapPdata> for PartitionProcessor {
                             })?;
 
                             // set the transport header
-                            let mut pdata_context = Context::default();
-                            let mut headers = inbound_context
-                                .transport_headers()
-                                .cloned()
-                                .unwrap_or_default();
+                            let mut pdata_context = inbound_context.clone_detached();
+                            let mut headers =
+                                pdata_context.take_transport_headers().unwrap_or_default();
                             headers.push(partition_value_to_transport_header(
                                 self.header_name.clone(),
                                 &self.serialization_strategy,
                                 partition.value,
                             ));
                             pdata_context.set_transport_headers(headers);
-                            if let Some(peer_addr) = inbound_context.peer_addr() {
-                                pdata_context.set_peer_addr(peer_addr);
-                            }
 
                             let outbound_batch_num_items = partition.batch.num_items();
                             let mut pdata = OtapPdata::new(pdata_context, partition.batch.into());

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
@@ -275,6 +275,10 @@ impl TransformProcessor {
             return Ok(());
         }
 
+        // Must be built before the context is moved into the slot map below. Holds no
+        // frames, so cloning it per outbound batch is cheap.
+        let outbound_context = inbound_context.clone_detached();
+
         // keep error reason if there was an error, so we can send it to upstream in Nack once
         // all routed outbound batches have been Ack/Nack'd
         let inbound_ctx_key = self
@@ -296,7 +300,7 @@ impl TransformProcessor {
         // the output of the pipeline. We need to do this b/c we'll be emitting this batch, plus
         // any routed batches, and we don't want to Ack the inbound context until we receive Acks
         // from all downstream batches (including this result)
-        let mut pdata = OtapPdata::new(Context::default(), default_otap_batch.into());
+        let mut pdata = OtapPdata::new(outbound_context.clone(), default_otap_batch.into());
         let outbound_key = self
             .contexts
             .insert_outbound(inbound_ctx_key)
@@ -364,8 +368,7 @@ impl TransformProcessor {
 
             // setup the pdata with the new outbound context
             let payload = OtapPayload::OtapArrowRecords(otap_batch);
-            let context = Context::default();
-            let mut pdata = OtapPdata::new(context, payload);
+            let mut pdata = OtapPdata::new(outbound_context.clone(), payload);
             let outbound_key = self
                 .contexts
                 .insert_outbound(inbound_ctx_key)
@@ -701,8 +704,10 @@ mod test {
     use otap_df_otap::{
         pdata::{Context, OtapPdata},
         testing::{TestCallData, next_ack, next_nack},
+        transport_headers::{TransportHeader, TransportHeaders},
     };
     use otap_df_telemetry::registry::TelemetryRegistryHandle;
+    use std::net::SocketAddr;
 
     #[derive(Debug, PartialEq, Eq)]
     struct TransformMetricPoint {
@@ -2127,6 +2132,101 @@ mod test {
                         panic!("got unexpected pipeline ctrl message {other:?}")
                     }
                 };
+            })
+            .validate(|_ctx| async move {})
+    }
+
+    /// Scenario: an inbound batch carrying transport headers and a peer address is
+    /// split across the default output port and two routed output ports.
+    /// Guarantees: every outbound batch carries the originating request's transport
+    /// headers and peer address, while the inbound Ack frames stay behind so the
+    /// upstream node is still Ack'd exactly once after all outbound batches settle.
+    #[test]
+    fn test_split_batch_retains_inbound_request_metadata() {
+        let runtime = TestRuntime::<OtapPdata>::new();
+        let query = r#"logs
+            | if (severity_text == "ERROR") {
+                route_to "error_port"
+            } else if (severity_text == "INFO") {
+                route_to "info_port"
+            }"#;
+        let mut processor = try_create_with_opl_query(query, &runtime).expect("created processor");
+
+        let error_port_rx = set_pdata_sender("error_port", &mut processor);
+        let info_port_rx = set_pdata_sender("info_port", &mut processor);
+
+        runtime
+            .set_processor(processor)
+            .run_test(|mut ctx| async move {
+                let peer_addr: SocketAddr = "10.0.0.1:5005".parse().unwrap();
+                let mut headers = TransportHeaders::new();
+                headers.push(TransportHeader::text("tenant", "x-tenant", "acme"));
+
+                let upstream_node_id = 999;
+                let pdata = create_pdata_with_subscriber(
+                    to_otap_logs(create_log_records(&["ERROR", "INFO", "DEBUG"])),
+                    Interests::ACKS,
+                    1,
+                    upstream_node_id,
+                )
+                .with_transport_headers(headers.clone())
+                .with_peer_addr(peer_addr);
+
+                ctx.process(Message::PData(pdata))
+                    .await
+                    .expect("no process error");
+
+                // DEBUG stays on the default port, ERROR and INFO are routed
+                let (default_ctx, _) = ctx.drain_pdata().await.pop().unwrap().into_parts();
+                let (error_ctx, _) = error_port_rx.recv().await.unwrap().into_parts();
+                let (info_ctx, _) = info_port_rx.recv().await.unwrap().into_parts();
+
+                for (port, context) in [
+                    ("default", &default_ctx),
+                    ("error_port", &error_ctx),
+                    ("info_port", &info_ctx),
+                ] {
+                    assert_eq!(
+                        context.transport_headers(),
+                        Some(&headers),
+                        "{port} lost the inbound transport headers"
+                    );
+                    assert_eq!(
+                        context.peer_addr(),
+                        Some(peer_addr),
+                        "{port} lost the inbound peer address"
+                    );
+                }
+
+                let (runtime_ctrl_tx, _runtime_ctrl_rx) = runtime_ctrl_msg_channel(10);
+                let (pipeline_completion_tx, mut pipeline_completion_rx) =
+                    pipeline_completion_msg_channel(10);
+                ctx.set_runtime_ctrl_sender(runtime_ctrl_tx);
+                ctx.set_pipeline_completion_sender(pipeline_completion_tx);
+
+                send_ack(&mut ctx, default_ctx, SignalType::Logs)
+                    .await
+                    .unwrap();
+                assert!(pipeline_completion_rx.is_empty());
+                send_ack(&mut ctx, error_ctx, SignalType::Logs)
+                    .await
+                    .unwrap();
+                assert!(pipeline_completion_rx.is_empty());
+                send_ack(&mut ctx, info_ctx, SignalType::Logs)
+                    .await
+                    .unwrap();
+
+                match pipeline_completion_rx.recv().await.unwrap() {
+                    PipelineCompletionMsg::DeliverAck { ack } => {
+                        let (node_id, _ack) = next_ack(ack).expect("expected ack subscriber");
+                        assert_eq!(node_id, upstream_node_id);
+                    }
+                    other => panic!("got unexpected pipeline ctrl message {other:?}"),
+                };
+                assert!(
+                    pipeline_completion_rx.is_empty(),
+                    "upstream must be Ack'd once, not once per outbound batch"
+                );
             })
             .validate(|_ctx| async move {})
     }

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -424,6 +424,26 @@ impl Context {
     pub fn frames(&self) -> &[Frame] {
         &self.stack
     }
+
+    /// Clone the request-scoped metadata (transport headers, peer address) and
+    /// leave the Ack/Nack routing state behind.
+    ///
+    /// Frames are not copied: a processor that splits a batch parks the inbound
+    /// context and subscribes each outbound batch separately, so copied frames
+    /// would Ack the upstream node once per outbound batch. The flow_metric
+    /// accumulator is dropped for the same reason and must be redistributed by
+    /// the caller. The signal is left unset; the engine recaptures it from the
+    /// payload on the next metrics stamp.
+    #[must_use]
+    pub fn clone_detached(&self) -> Self {
+        Self {
+            stack: Vec::new(),
+            transport_headers: self.transport_headers.clone(),
+            peer_addr: self.peer_addr,
+            flow_compute_ns: None,
+            signal: None,
+        }
+    }
 }
 
 // Frame is defined in otap_df_engine::control (imported above).
@@ -637,13 +657,7 @@ impl OtapPdata {
     #[must_use]
     pub fn clone_without_context(&self) -> Self {
         Self {
-            context: Context {
-                stack: Vec::new(),
-                transport_headers: self.context.transport_headers.clone(),
-                peer_addr: self.context.peer_addr,
-                flow_compute_ns: None,
-                signal: None,
-            },
+            context: self.context.clone_detached(),
             payload: self.payload.clone(),
         }
     }
@@ -1059,6 +1073,7 @@ mod test {
     use crate::testing::{
         TestCallData, create_empty_test_pdata, create_test_pdata, next_ack, next_nack,
     };
+    use crate::transport_headers::TransportHeader;
     use otap_df_channel::mpsc::Channel as LocalChannel;
     use otap_df_engine::ConsumerEffectHandlerExtension;
     use otap_df_engine::control::{
@@ -2134,6 +2149,51 @@ mod test {
             next_nack(nack).is_none(),
             "reset context must not route nacks"
         );
+    }
+
+    /// Scenario: a context carrying transport headers, a peer address, Ack/Nack
+    /// subscribers, an active flow_metric accumulator and a captured signal is
+    /// detached to seed an outbound batch produced by splitting the inbound one.
+    /// Guarantees: the request-scoped metadata is copied while the frame stack,
+    /// flow accumulator and signal are left behind, so each outbound batch keeps
+    /// the originating request's metadata without re-Acking the upstream node.
+    #[test]
+    fn clone_detached_keeps_request_metadata_and_drops_routing_state() {
+        let addr: SocketAddr = "10.0.0.1:5005".parse().unwrap();
+        let mut headers = TransportHeaders::new();
+        headers.push(TransportHeader::text("tenant", "x-tenant", "acme"));
+
+        let (test_data, pdata) = create_test();
+        let mut pdata = pdata
+            .test_subscribe_to(Interests::ACKS | Interests::NACKS, test_data.into(), 101)
+            .with_peer_addr(addr)
+            .with_transport_headers(headers.clone());
+        pdata.start_flow_metric();
+        pdata.add_flow_compute(42);
+
+        let (mut context, _payload) = pdata.into_parts();
+        context.capture_signal(SignalType::Logs);
+        assert!(context.has_subscribers(), "precondition: has subscribers");
+
+        let detached = context.clone_detached();
+
+        assert_eq!(detached.transport_headers(), Some(&headers));
+        assert_eq!(detached.peer_addr(), Some(addr));
+        assert!(
+            !detached.has_subscribers(),
+            "detached context must not inherit the inbound subscribers"
+        );
+        assert_eq!(detached.source_node(), None);
+        assert_eq!(
+            detached.flow_compute_ns, None,
+            "flow accumulation is distributed by the caller, not copied"
+        );
+        assert_eq!(detached.signal(), None);
+
+        // The source context is untouched: it stays parked in the split
+        // processor's slot map and Acks upstream once its outbounds settle.
+        assert!(context.has_subscribers());
+        assert_eq!(context.signal(), Some(SignalType::Logs));
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
# Change Summary

When a query routed part of a batch, the transform processor built each outbound batch on `Context::default()`, dropping the inbound transport headers and peer address.

This PR introduces a new helper, `Context::clone_detached`, which copies the request metadata without the frames to be used by batch-splitting processors and updates the transform processor and partition processor to use it.

## What issue does this PR close?

* Closes #3501

## How are these changes tested?

New unit tests.

## Are there any user-facing changes?

Yes. Batches split by the transform processor keep the originating request's transport headers and peer address.

### Changelog

* [x] Added a `.chloggen/*.yaml` entry
* [ ] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.