### PR TITLE
chore(ci): align Weaver live-check versions

### DIFF
--- a/.github/workflows/df-engine-internal-observability.yml
+++ b/.github/workflows/df-engine-internal-observability.yml
@@ -32,7 +32,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  WEAVER_VERSION: v0.24.0
+  WEAVER_VERSION: v0.25.1
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -73,8 +73,8 @@ jobs:
         working-directory: ./rust/otap-dataflow
       # Weaver listener lifecycle (start, readiness probe, /stop, report
       # capture, artifact upload) is owned by the upstream composite
-      # actions below. Pinned to the published v0.24.0 release, which is
-      # the first tag to ship these actions.
+      # actions below. Keep the actions and installed Weaver binary pinned
+      # to the same release so their live-check lifecycle stays compatible.
       - name: Start weaver live-check listener
         id: weaver-start
         uses: open-telemetry/weaver/.github/actions/weaver-live-check-start@26c685ff52b925056ff1d53476c6022638c01220 # v0.25.1
@@ -175,6 +175,10 @@ jobs:
           REPORT="${REPORT_PATH:-}"
           if [ -z "$REPORT" ] || [ ! -s "$REPORT" ]; then
             echo "::error::No live-check report found (path='$REPORT')"
+            exit 1
+          fi
+          if ! jq empty "$REPORT"; then
+            echo "::error::Weaver returned a truncated or invalid live-check report"
             exit 1
           fi
 


### PR DESCRIPTION
  Description:

  Align the Weaver binary with the v0.25.1 live-check actions and report truncated JSON explicitly.

  Validation: `tools/sanitycheck.py`, `git diff --check`.


Fix for error- https://github.com/open-telemetry/otel-arrow/actions/runs/31190748059/job/92906623927?pr=3471