### PR TITLE
doc: make auth extension READMEs the full config reference

### DIFF
--- a/rust/otap-dataflow/crates/contrib-extensions/README.md
+++ b/rust/otap-dataflow/crates/contrib-extensions/README.md
@@ -16,8 +16,12 @@ configuration semantics, see
 
 | Extension | URN | Feature gate | Capability | Docs |
 | --- | --- | --- | --- | --- |
-| Azure Identity Auth | `urn:microsoft:extension:azure_identity_auth` | `azure-identity-auth-extension` | `bearer_token_provider` | [`design.md`](./src/azure_identity_auth/design.md) |
-| OAuth 2.0 Client Auth | `urn:otel:extension:oauth2_client_auth` | `oauth2-client-auth-extension` | `bearer_token_provider` | [`design.md`](./src/oauth2_client_auth/design.md) |
+| Azure Identity Auth | `urn:microsoft:extension:azure_identity_auth` | `azure-identity-auth-extension` | `bearer_token_provider` | [usage](./src/azure_identity_auth/README.md), [design](./src/azure_identity_auth/design.md) |
+| OAuth 2.0 Client Auth | `urn:otel:extension:oauth2_client_auth` | `oauth2-client-auth-extension` | `bearer_token_provider` | [usage](./src/oauth2_client_auth/README.md), [design](./src/oauth2_client_auth/design.md) |
+
+Each extension's README is the authoritative configuration reference for that
+extension. Nodes that bind an extension document only the binding and how they
+use the capability, and link here for the provider's own options.
 
 Extensions are enabled through individual feature gates or the aggregate
 `contrib-extensions` feature gate. An extension documented as `Experimental`,

--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/README.md
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/README.md
@@ -2,32 +2,187 @@
 
 # Azure Identity Auth Extension
 
-**Status:** Draft
+## Metadata
 
-| | |
+- URN: `urn:microsoft:extension:azure_identity_auth`
+- Feature gate: `azure-identity-auth-extension` (or the aggregate `contrib-extensions`)
+- Capability provided: `bearer_token_provider`
+- Execution model: Active + Shared
+- Stability: Draft
+
+## Overview
+
+Acquires and refreshes Azure OAuth access tokens via the `azure_identity` SDK and
+exposes them to data-path nodes through the `bearer_token_provider` capability,
+so nodes never construct credentials or manage token refresh themselves. Three
+authentication flows are supported: Managed Identity, local developer tooling,
+and Workload Identity Federation.
+
+Tokens are cached and refreshed ahead of expiry in a background task, concurrent
+cache misses are coalesced onto a single credential call, and pipeline startup is
+held until the first token is published.
+
+This README is the configuration reference for the extension. Nodes that consume
+the capability (for example the
+[Azure Monitor exporter](../../../contrib-nodes/src/exporters/azure_monitor_exporter/README.md)
+and the
+[OTLP HTTP exporter](../../../core-nodes/src/exporters/otlp_http_exporter/README.md))
+document only how they *use* a bearer token, not how to configure a provider.
+
+For the design -- lifecycle, refresh and retry behavior, and the rationale behind
+the defaults -- see [`design.md`](./design.md).
+
+## Getting Started
+
+Declare the extension in the pipeline's `extensions:` section and bind it on a
+consumer node via the node's `capabilities:` map:
+
+```yaml
+groups:
+  default:
+    pipelines:
+      main:
+        extensions:
+          azure_identity:
+            type: "urn:microsoft:extension:azure_identity_auth"
+            config:
+              method: managed_identity
+              scope: "https://monitor.azure.com/.default"
+
+        nodes:
+          azure-monitor-exporter:
+            type: "urn:microsoft:exporter:azure_monitor"
+            # Bind the capability to the extension instance declared above.
+            capabilities:
+              bearer_token_provider: azure_identity
+            config:
+              api:
+                dcr_endpoint: "https://my-workspace.eastus-1.ingest.monitor.azure.com"
+                stream_name: "Custom-MyLogTable_CL"
+                dcr: "dcr-abc123def456"
+```
+
+One extension instance serves one identity and one scope. Consumers that need a
+different Azure resource need their own instance -- for example
+`https://monitor.azure.com/.default` for Azure Monitor and
+`https://storage.azure.com/.default` for Blob Storage. Declare each under its own
+name and bind consumers accordingly.
+
+## Building
+
+Enable the extension's feature gate together with the nodes that consume it.
+From the `otap-dataflow` directory:
+
+```bash
+cargo build --release \
+  --features azure-identity-auth-extension,azure-monitor-exporter
+```
+
+The extension talks to Azure over TLS through the Azure SDK's `reqwest`/`rustls`
+client, which requires a process-wide `rustls` crypto provider. The deployed
+binary **must** enable exactly one `crypto-*` feature (`crypto-ring`,
+`crypto-aws-lc`, `crypto-openssl`, or `crypto-symcrypt`, forwarded to
+`otap-df-otap`); the workspace binary's default build includes `crypto-ring`. A
+build that enables `azure-identity-auth-extension` without any `crypto-*` feature
+installs no provider, and token acquisition panics at runtime with "No provider
+set".
+
+Verify registration with `./target/release/df_engine --help`;
+`urn:microsoft:extension:azure_identity_auth` appears in the Extensions list.
+
+## Configuration
+
+Unknown fields are rejected, and the whole config is validated before the
+pipeline starts, so a mistake fails at startup rather than on the first export.
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `method` | enum | `managed_identity` | Authentication flow. See [Authentication methods](#authentication-methods). |
+| `client_id` | string | *none* | Entra client ID. For `managed_identity`, the user-assigned identity's client ID (omit for the system-assigned identity). For `workload_identity`, the application client ID; falls back to `AZURE_CLIENT_ID`. Not valid for `development`. |
+| `tenant_id` | string | *none* | Entra tenant ID. Only valid for `workload_identity`; falls back to `AZURE_TENANT_ID`. |
+| `token_file_path` | path | *none* | Projected federated token file. Only valid for `workload_identity`; falls back to `AZURE_FEDERATED_TOKEN_FILE`. |
+| `scope` | string | `https://monitor.azure.com/.default` | OAuth scope to request tokens for. Must be non-empty. |
+| `startup_timeout` | duration | `30s` | How long the engine holds data-path node startup waiting for the first token publish before aborting startup. Must be non-zero. |
+
+`startup_timeout` accepts human-readable durations such as `30s` or `1m`.
+
+### Authentication methods
+
+| `method` | Aliases | Credential | Notes |
+| --- | --- | --- | --- |
+| `managed_identity` | `msi`, `managedidentity` | `ManagedIdentityCredential` | System-assigned by default; set `client_id` for a user-assigned identity. Requires no secrets in the pipeline config. |
+| `development` | `dev`, `developer`, `cli` | `DeveloperToolsCredential` | Uses the operator's local Azure CLI / `azd` session. Local development only. |
+| `workload_identity` | `wif`, `workloadidentity` | `WorkloadIdentityCredential` | Exchanges a projected federated ServiceAccount token for an Entra ID access token. For Kubernetes workloads without a managed identity (self-hosted or non-AKS). |
+
+Workload Identity Federation reads `client_id`, `tenant_id`, and
+`token_file_path`, each falling back to the `AZURE_CLIENT_ID` /
+`AZURE_TENANT_ID` / `AZURE_FEDERATED_TOKEN_FILE` environment variables injected
+by the Azure Workload Identity webhook, so all three may be omitted from the
+config:
+
+```yaml
+type: "urn:microsoft:extension:azure_identity_auth"
+config:
+  method: workload_identity
+  scope: "https://monitor.azure.com/.default"
+  # All three are optional; they fall back to the standard AZURE_* env vars.
+  client_id: "00000000-0000-0000-0000-000000000000"
+  tenant_id: "11111111-1111-1111-1111-111111111111"
+  token_file_path: "/var/run/secrets/azure/tokens/azure-identity-token"
+```
+
+### Validation rules
+
+Config validation rejects:
+
+- an empty or whitespace-only `scope`;
+- a zero `startup_timeout`;
+- `tenant_id` or `token_file_path` with a method other than `workload_identity`;
+- `client_id` with the `development` method;
+- unknown fields.
+
+## Security Notes
+
+- Token secrets are held only in memory and are never logged; log and telemetry
+  sites emit credential type, scope, and timing only.
+- `managed_identity` and `workload_identity` require no secrets in the pipeline
+  config, which is the recommended posture for production.
+- `development` relies on the operator's local Azure CLI session and is intended
+  for local development only.
+- The extension requests exactly the configured `scope`; scope it to the least
+  privilege the consumer needs.
+
+## Telemetry
+
+Metric set: `extension.azure_identity_auth`.
+
+| Metric | Type | Unit | Description |
+| --- | --- | --- | --- |
+| `auth_successes` | Counter | `{acquisition}` | Successful credential acquisitions. |
+| `auth_failures` | Counter | `{acquisition}` | Failed credential acquisitions. |
+| `auth_token_publish` | Counter | `{token}` | Tokens published to consumers. |
+| `auth_success_latency` | Mmsc | `ms` | Latency of successful acquisitions (min/max/sum/count). |
+
+Events:
+
+| Event | Severity | Description |
+| --- | --- | --- |
+| `azure_identity_auth.token_refresh_failed` | `warn` | A credential acquisition failed; the loop retries with backoff. |
+
+## Troubleshooting
+
+| Symptom | Likely cause |
 | --- | --- |
-| **URN** | `urn:microsoft:extension:azure_identity_auth` |
-| **Feature gate** | `azure-identity-auth-extension` |
-| **Capability** | `bearer_token_provider` |
-| **Execution model** | Active + Shared |
+| Panic at runtime with "No provider set" | The binary was built without a `crypto-*` feature. See [Building](#building). |
+| Startup aborts with a readiness timeout | The first token was not acquired within `startup_timeout`. Check identity assignment, network reachability of IMDS or Entra ID, and the `azure_identity_auth.token_refresh_failed` event. |
+| Config rejected at startup | See [Validation rules](#validation-rules); the error names the offending field. |
+| `403` from the Azure service despite successful acquisition | The identity lacks a role assignment on the target resource, or `scope` targets the wrong resource. |
+| Exporter stops accepting data mid-run | Refresh is failing and the cached token lapsed. Check `auth_failures` and the refresh-failure event. |
 
-Acquires and refreshes Azure OAuth access tokens via the `azure_identity` SDK
-and exposes them to data-path nodes through the `BearerTokenProvider`
-capability, so nodes never construct credentials or manage token refresh
-themselves. Supported flows: Managed Identity, developer tooling, and Workload
-Identity Federation.
+## Related Docs
 
-For the full design -- problem, goals, lifecycle, configuration reference, and
-security considerations -- see
-[`design.md`](./design.md).
-
-## Crypto provider requirement
-
-The Azure Identity Auth extension talks to Azure over TLS via the Azure SDK's
-`reqwest`/`rustls` client, which requires a process-wide `rustls` crypto
-provider to be installed. The deployed binary **must** enable exactly one
-`crypto-*` feature (`crypto-ring`, `crypto-aws-lc`, `crypto-openssl`, or
-`crypto-symcrypt`, forwarded to `otap-df-otap`); the workspace binary's default
-build includes `crypto-ring`. A build that enables
-`azure-identity-auth-extension` without any `crypto-*` feature installs no
-provider, and token acquisition panics at runtime with "No provider set".
+- [Design](./design.md)
+- [Contrib extension catalog](../../README.md)
+- [Writing pipeline configuration](../../../../docs/configuration.md)
+- [Configuration model](../../../../docs/configuration-model.md)
+- [Extension system architecture](../../../../docs/extension-system-architecture.md)

--- a/rust/otap-dataflow/crates/contrib-extensions/src/oauth2_client_auth/README.md
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/oauth2_client_auth/README.md
@@ -2,38 +2,270 @@
 
 # OAuth 2.0 Client Auth Extension
 
-**Status:** Draft
+## Metadata
 
-| | |
-| --- | --- |
-| **URN** | `urn:otel:extension:oauth2_client_auth` |
-| **Feature gate** | `oauth2-client-auth-extension` |
-| **Capability** | `bearer_token_provider` |
-| **Execution model** | Active + Shared |
+- URN: `urn:otel:extension:oauth2_client_auth`
+- Feature gate: `oauth2-client-auth-extension` (or the aggregate `contrib-extensions`)
+- Capability provided: `bearer_token_provider`
+- Execution model: Active + Shared
+- Stability: Draft
+
+## Overview
 
 Acquires and refreshes OAuth 2.0 access tokens and exposes them to data-path
-nodes through the `BearerTokenProvider` capability, so nodes never construct
-credentials or manage token refresh themselves. Two grants are supported: the
-client-credentials grant (RFC 6749 section 4.4, client id + secret) and the
-JWT-bearer grant (RFC 7523 section 2.1, a signed JWT assertion). The token
-endpoint is reached over TLS via the engine's shared `TlsClientConfig`, and the
-`client_id` / `client_secret` / signing-key material may be supplied inline or
-via files that are re-read on each acquisition for rotation without a restart.
+nodes through the `bearer_token_provider` capability, so nodes never construct
+credentials or manage token refresh themselves. Two grants are supported:
+
+- **client credentials** (RFC 6749 section 4.4) -- authenticate with a client id
+  and secret.
+- **JWT bearer** (RFC 7523 section 2.1) -- sign a JWT and send it as the
+  `assertion` parameter instead of a secret.
+
 Tokens are cached and refreshed ahead of expiry in a background task, concurrent
-cache misses are coalesced onto a single token request, and startup is gated on
-the first successful token publish.
+cache misses are coalesced onto a single token request, and pipeline startup is
+held until the first token is published. Credential material may be supplied
+inline or via files that are re-read on each acquisition, so secrets can rotate
+without a restart.
 
-For the full design -- problem, goals, lifecycle, configuration reference, and
-security considerations -- see
-[`design.md`](./design.md).
+This README is the configuration reference for the extension. Nodes that consume
+the capability (for example the
+[OTLP HTTP exporter](../../../core-nodes/src/exporters/otlp_http_exporter/README.md))
+document only how they *use* a bearer token, not how to configure a provider.
 
-## Crypto provider requirement
+For the design -- lifecycle, refresh and retry behavior, and the rationale behind
+the defaults -- see [`design.md`](./design.md).
 
-The OAuth 2.0 Client Auth extension talks to the token endpoint over TLS via a
-`reqwest`/`rustls` client, which requires a process-wide `rustls` crypto
-provider to be installed. The deployed binary **must** enable exactly one
-`crypto-*` feature (`crypto-ring`, `crypto-aws-lc`, `crypto-openssl`, or
-`crypto-symcrypt`, forwarded to `otap-df-otap`); the workspace binary's default
-build includes `crypto-ring`. A build that enables
-`oauth2-client-auth-extension` without any `crypto-*` feature installs no
-provider, and token acquisition panics at runtime with "No provider set".
+## Getting Started
+
+Declare the extension in the pipeline's `extensions:` section and bind it on a
+consumer node via the node's `capabilities:` map:
+
+```yaml
+groups:
+  default:
+    pipelines:
+      main:
+        extensions:
+          oauth2:
+            type: "urn:otel:extension:oauth2_client_auth"
+            config:
+              token_url: "https://idp.example.com/oauth2/v1/token"
+              client_id: "someclientid"
+              client_secret_file: "/etc/secrets/oauth2_client_secret"
+              scopes: ["telemetry.write"]
+
+        nodes:
+          otlp-http-exporter:
+            type: "urn:otel:exporter:otlp_http"
+            # Bind the capability to the extension instance declared above.
+            capabilities:
+              bearer_token_provider: oauth2
+            config:
+              endpoint: "https://otlp.example.com:4318"
+              client_pool_size: 1
+              http: {}
+```
+
+One extension instance serves one client identity and scope set. Declare several
+instances (under different names) when different consumers need different
+credentials, and bind each consumer to the instance it needs.
+
+## Building
+
+Enable the extension's feature gate together with the nodes that consume it.
+From the `otap-dataflow` directory:
+
+```bash
+cargo build --release --features oauth2-client-auth-extension
+```
+
+The extension reaches the token endpoint over TLS through a `reqwest`/`rustls`
+client, which requires a process-wide `rustls` crypto provider. The deployed
+binary **must** enable exactly one `crypto-*` feature (`crypto-ring`,
+`crypto-aws-lc`, `crypto-openssl`, or `crypto-symcrypt`, forwarded to
+`otap-df-otap`); the workspace binary's default build includes `crypto-ring`. A
+build that enables `oauth2-client-auth-extension` without any `crypto-*` feature
+installs no provider, and token acquisition panics at runtime with "No provider
+set".
+
+Verify registration with `./target/release/df_engine --help`;
+`urn:otel:extension:oauth2_client_auth` appears in the Extensions list.
+
+## Configuration
+
+Unknown fields are rejected, and the whole config is validated before the
+pipeline starts, so a mistake fails at startup rather than on the first export.
+
+### Common fields
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `grant_type` | enum | `client_credentials` | Grant used to acquire tokens: `client_credentials` or `jwt-bearer`. |
+| `token_url` | string | *required* | Token endpoint URL (RFC 6749 section 3.2). Must be non-empty. Use `https://` in production; `http://` is accepted but logs the `oauth2_client_auth.insecure_token_url` warning. |
+| `client_id` | string | *none* | Client identifier. Required unless `client_id_file` is set. |
+| `client_id_file` | path | *none* | File holding the client identifier. Re-read on each acquisition; takes precedence over `client_id`. |
+| `scopes` | list of string | `[]` | Scopes requested from the token endpoint, sent as the `scope` parameter. |
+| `endpoint_params` | map of string to string | `{}` | Extra parameters sent to the token endpoint (for example `audience`). |
+| `expiry_buffer` | duration | `5m` | Refresh this far ahead of the token's expiry. Must be non-zero. |
+| `default_token_lifetime` | duration | `24h` | Lifetime assumed when the token response omits `expires_in`. Must be non-zero and greater than `expiry_buffer`. |
+| `timeout` | duration | `30s` | Per-request timeout on the token client, covering the whole request. Must be non-zero. |
+| `connect_timeout` | duration | `10s` | Connection-establishment timeout on the token client. Must be non-zero. |
+| `tls` | object | *none* | Client TLS for the token endpoint. See [Token-endpoint TLS](#token-endpoint-tls). |
+| `startup_timeout` | duration | `30s` | How long the engine holds data-path node startup waiting for the first token publish before aborting startup. Must be non-zero. |
+
+Duration fields accept human-readable values such as `30s`, `5m`, or `1h`.
+
+### Client credentials grant
+
+`grant_type: client_credentials` (the default) authenticates with a client id
+and secret. At least one of the secret fields must be set:
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `client_secret` | string | *none* | Client secret. Required unless `client_secret_file` is set. Redacted from logs, but the rendered pipeline config still holds it in cleartext -- prefer `client_secret_file`. |
+| `client_secret_file` | path | *none* | File holding the client secret. Re-read on each acquisition; takes precedence over `client_secret`. |
+
+```yaml
+type: "urn:otel:extension:oauth2_client_auth"
+config:
+  grant_type: client_credentials
+  token_url: "https://idp.example.com/oauth2/v1/token"
+  client_id: "someclientid"
+  client_secret_file: "/etc/secrets/oauth2_client_secret"
+  scopes: ["telemetry.write"]
+  endpoint_params:
+    audience: "https://otlp.example.com"
+  expiry_buffer: 5m
+  timeout: 2s
+```
+
+The request sends `grant_type=client_credentials` with the client id and secret.
+
+### JWT bearer grant
+
+`grant_type: jwt-bearer` signs a JWT and sends it as the `assertion` parameter;
+the signed JWT is itself the authorization grant, so no client secret is used.
+The following fields apply only to this grant and are **rejected** for
+`client_credentials` (and, conversely, `client_secret` / `client_secret_file` are
+rejected here):
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `client_certificate_key` | string | *none* | PEM private key used to sign the assertion. Required unless `client_certificate_key_file` is set. Redacted from logs; prefer the file form. |
+| `client_certificate_key_file` | path | *none* | File holding the signing key. Re-read on each acquisition; takes precedence over `client_certificate_key`. |
+| `signature_algorithm` | enum | `RS256` | RSA algorithm used to sign the assertion: `RS256`, `RS384`, or `RS512`. |
+| `client_certificate_key_id` | string | *none* | Optional `kid` header placed on the assertion. |
+| `iss` | string | value of `client_id` | Assertion issuer (`iss` claim). |
+| `audience` | string | value of `token_url` | Assertion audience (`aud` claim). |
+| `claims` | map of string to string | `{}` | Extra claims added to the assertion. |
+
+```yaml
+type: "urn:otel:extension:oauth2_client_auth"
+config:
+  grant_type: jwt-bearer
+  token_url: "https://idp.example.com/oauth2/v1/token"
+  client_id: "someclientid"
+  client_certificate_key_file: "/etc/secrets/oauth2_signing_key.pem"
+  signature_algorithm: RS512
+  client_certificate_key_id: "key-1"
+  audience: "https://idp.example.com/oauth2/v1/token"
+  claims:
+    tenant: "acme"
+  scopes: ["telemetry.write"]
+```
+
+The request sends `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer` and
+`assertion=<signed JWT>`. The assertion carries `iss` / `sub` (default
+`client_id`), `aud` (default `token_url`), plus `exp`, `iat`, and `jti`.
+
+### Credential rotation
+
+Every credential field has a `_file` counterpart (`client_id_file`,
+`client_secret_file`, `client_certificate_key_file`). The file is re-read on each
+token acquisition, so rewriting it rotates the credential without restarting the
+collector, and the secret never appears in the rendered pipeline config. When
+both forms are set, the `_file` form wins. Prefer the file form in production.
+
+### Token-endpoint TLS
+
+The token endpoint carries the client secret (or signed assertion) and returns
+bearer tokens, so it must be reached over TLS in production. Transport is decided
+by the `token_url` scheme: `https://` uses TLS configured by the `tls` block,
+while `http://` is plaintext and intended only for local development.
+
+`tls` is the engine's shared `TlsClientConfig` -- the same type the OTLP/HTTP
+exporter uses -- so the settings and their validation match the rest of the
+collector. The most relevant fields:
+
+| Field | Description |
+| --- | --- |
+| `ca_file` / `ca_pem` | Trust a private or enterprise CA. |
+| `include_system_ca_certs_pool` | Also trust the system store (default `true`). |
+| `cert_file` / `key_file` | Present a client certificate for mutual TLS (RFC 8705), in addition to or instead of a client secret. |
+| `insecure_skip_verify` | Skip certificate verification. Development and testing only -- it disables verification on the connection that carries the client secret. |
+
+```yaml
+tls:
+  ca_file: "/etc/ssl/idp-ca.pem"
+  cert_file: "/etc/ssl/client.pem"
+  key_file: "/etc/ssl/client-key.pem"
+```
+
+Two `TlsClientConfig` knobs are rejected at config validation rather than
+silently ignored, so a config that relies on them fails at startup:
+
+- **`server_name_override`** (SNI override) is not supported by the
+  reqwest/rustls token client, matching the OTLP/HTTP exporter.
+- **`insecure`** (disable TLS) is rejected alongside an `https://` `token_url`,
+  because the scheme mandates a TLS handshake. Use an `http://` `token_url` for a
+  plaintext endpoint; setting `insecure` alongside one is accepted as a no-op.
+
+### Validation rules
+
+Config validation rejects:
+
+- an empty `token_url`;
+- a zero `expiry_buffer`, `timeout`, `connect_timeout`, or `startup_timeout`;
+- a `default_token_lifetime` at or below `expiry_buffer` (every refresh would be
+  scheduled in the past);
+- a missing client identifier (`client_id` and `client_id_file` both unset);
+- a missing secret for `client_credentials`, or a missing signing key for
+  `jwt-bearer`;
+- fields belonging to the other grant;
+- unknown fields.
+
+## Telemetry
+
+Metric set: `extension.oauth2_client_auth`.
+
+| Metric | Type | Unit | Description |
+| --- | --- | --- | --- |
+| `auth_successes` | Counter | `{acquisition}` | Successful token acquisitions. |
+| `auth_failures` | Counter | `{acquisition}` | Failed token acquisitions. |
+| `auth_token_publish` | Counter | `{token}` | Tokens published to consumers. |
+| `auth_success_latency` | Mmsc | `ms` | Latency of successful acquisitions (min/max/sum/count). |
+
+Events:
+
+| Event | Severity | Description |
+| --- | --- | --- |
+| `oauth2_client_auth.insecure_token_url` | `warn` | The configured `token_url` uses plaintext `http://`. |
+| `oauth2_client_auth.token_refresh_failed` | `warn` | A token acquisition failed; the loop retries with backoff. |
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+| --- | --- |
+| Panic at runtime with "No provider set" | The binary was built without a `crypto-*` feature. See [Building](#building). |
+| Startup aborts with a readiness timeout | The first token was not acquired within `startup_timeout`. Check `token_url` reachability, credentials, and the `oauth2_client_auth.token_refresh_failed` event. |
+| Config rejected at startup | See [Validation rules](#validation-rules); the error names the offending field. |
+| Exporter stops accepting data mid-run | Refresh is failing and the cached token lapsed. Check `auth_failures` and the refresh-failure event. |
+| Signing key errors on `jwt-bearer` | The build has no JWT signing backend, or the key is not a supported PEM RSA key. |
+
+## Related Docs
+
+- [Design](./design.md)
+- [Contrib extension catalog](../../README.md)
+- [Writing pipeline configuration](../../../../docs/configuration.md)
+- [Configuration model](../../../../docs/configuration-model.md)
+- [Extension system architecture](../../../../docs/extension-system-architecture.md)

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/README.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/README.md
@@ -65,14 +65,9 @@ cargo build --release \
   --features azure-monitor-exporter,azure-identity-auth-extension
 ```
 
-The `azure_identity_auth` extension talks to Azure over TLS and needs a
-process-wide `rustls` crypto provider. The workspace binary's default build
-already enables `crypto-ring`; if you build a custom binary, enable exactly one
-`crypto-*` feature (`crypto-ring`, `crypto-aws-lc`, `crypto-openssl`, or
-`crypto-symcrypt`), otherwise token acquisition panics at runtime with "No
-provider set". See the
-[extension README](../../../../contrib-extensions/src/azure_identity_auth/README.md)
-for details.
+The extension also requires a `rustls` crypto provider feature; see
+[Building](../../../../contrib-extensions/src/azure_identity_auth/README.md#building)
+in the extension README.
 
 ## Verify the exporter is registered
 
@@ -140,57 +135,21 @@ The exporter obtains OAuth bearer tokens from the
 [`azure_identity_auth`](../../../../contrib-extensions/src/azure_identity_auth/README.md)
 extension through the `bearer_token_provider` capability. Wiring has two parts:
 
-1. Declare the extension instance in the pipeline's `extensions:` section.
+1. Declare the extension instance in the pipeline's `extensions:` section, with
+   `scope: "https://monitor.azure.com/.default"`.
 2. Bind it on the exporter node via the node's `capabilities:` map, e.g.
-   `bearer_token_provider: <instance-name>`.
+   `bearer_token_provider: <instance-name>`, as shown under
+   [Getting Started](#getting-started).
 
-The authentication flow is chosen by the extension's `method` field:
+The authentication flow, identity, scope, and startup behavior are configured on
+the extension. See the
+[extension README](../../../../contrib-extensions/src/azure_identity_auth/README.md)
+for the full configuration reference, the supported methods
+(`managed_identity`, `development`, `workload_identity`), and its telemetry.
 
-- `managed_identity` (aliases: `msi`, `managedidentity`) - Azure Managed
-  Identity. Set `client_id` for a user-assigned identity; omit it for the
-  system-assigned identity.
-- `development` (aliases: `dev`, `developer`, `cli`) - local Azure developer
-  credentials (Azure CLI / Azure Developer CLI).
-- `workload_identity` (aliases: `wif`, `workloadidentity`) - Workload Identity
-  Federation. Reads a projected federated ServiceAccount token and exchanges it
-  with Entra ID for an access token. Useful for Kubernetes workloads without a
-  managed identity (e.g. self-hosted or non-AKS clusters). Uses `client_id`,
-  `tenant_id`, and `token_file_path`, each falling back to the standard
-  `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_FEDERATED_TOKEN_FILE`
-  environment variables injected by the Azure Workload Identity webhook.
-
-```yaml
-groups:
-  default:
-    pipelines:
-      main:
-        extensions:
-          azure_identity:
-            type: "urn:microsoft:extension:azure_identity_auth"
-            config:
-              method: workload_identity
-              scope: "https://monitor.azure.com/.default"
-              # All fields below are optional; fall back to the standard AZURE_* env vars.
-              client_id: "00000000-0000-0000-0000-000000000000"
-              tenant_id: "11111111-1111-1111-1111-111111111111"
-              token_file_path: "/var/run/secrets/azure/tokens/azure-identity-token"
-
-        nodes:
-          azure-monitor-exporter:
-            type: "urn:microsoft:exporter:azure_monitor"
-            capabilities:
-              bearer_token_provider: azure_identity
-            config:
-              api:
-                dcr_endpoint: "https://my-workspace.eastus-1.ingest.monitor.azure.com"
-                stream_name: "Custom-MyLogTable_CL"
-                dcr: "dcr-abc123def456"
-```
-
-For the full extension configuration reference (including `scope` and
-`startup_timeout`), see the
-[`azure_identity_auth` extension README](../../../../contrib-extensions/src/azure_identity_auth/README.md)
-and its [design doc](../../../../contrib-extensions/src/azure_identity_auth/design.md).
+Until the extension publishes a usable token, the exporter stops accepting new
+batches and applies backpressure upstream rather than exporting unauthenticated;
+it resumes as soon as a token arrives, and nothing is dropped.
 
 ## Usage
 

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/README.md
@@ -97,10 +97,14 @@ optional and additive: without it the exporter sends no `authorization` header
 (the default); with it, the bound extension acquires and refreshes the token in
 the background so credentials rotate without restarting the exporter.
 
-Declare a provider extension (e.g.
-[`azure_identity_auth`](../../../../contrib-extensions/src/azure_identity_auth/README.md))
-in the pipeline's `extensions:` section and bind it on the exporter node via the
-node's `capabilities:` map:
+Declare a provider extension in the pipeline's `extensions:` section and bind it
+on the exporter node via the node's `capabilities:` map. Any provider works and
+the exporter cannot tell them apart; today the available ones are
+[`oauth2_client_auth`](../../../../contrib-extensions/src/oauth2_client_auth/README.md)
+(any OAuth 2.0 token endpoint) and
+[`azure_identity_auth`](../../../../contrib-extensions/src/azure_identity_auth/README.md)
+(Azure identities). See the chosen extension's README for its configuration
+reference; only the binding is documented here.
 
 ```yaml
 groups:
@@ -108,18 +112,19 @@ groups:
     pipelines:
       main:
         extensions:
-          azure_identity:
-            type: "urn:microsoft:extension:azure_identity_auth"
+          token_provider:
+            type: "urn:otel:extension:oauth2_client_auth"
             config:
-              method: managed_identity
-              scope: "https://monitor.azure.com/.default"
+              token_url: "https://idp.example.com/oauth2/v1/token"
+              client_id: "someclientid"
+              client_secret_file: "/etc/secrets/oauth2_client_secret"
 
         nodes:
           otlp-http-exporter:
             type: "urn:otel:exporter:otlp_http"
             # Bind the bearer token provider to the extension declared above.
             capabilities:
-              bearer_token_provider: azure_identity
+              bearer_token_provider: token_provider
             config:
               endpoint: "https://my-endpoint:4318"
               client_pool_size: 1
@@ -137,8 +142,8 @@ small safety margin of expiring -- the exporter **stops accepting new batches**
 request. It resumes as soon as a usable token arrives; nothing is dropped. (If
 buffered batches are force-drained during shutdown while no token is available,
 they are NACK'd as **retryable**.) A token is guaranteed to eventually arrive:
-the `azure_identity_auth` extension holds data-path startup until its first token
-publish, and its token stream stays live for the exporter's lifetime.
+the bound extension holds data-path startup until its first token publish, and
+its token stream stays live for the exporter's lifetime.
 
 ## Examples
 


### PR DESCRIPTION
# Change Summary

The oauth2_client_auth and azure_identity_auth READMEs only summarized the extensions and deferred to design.md, so operators had to read design docs or consumer exporter READMEs to find configuration options. Consumer READMEs in turn duplicated provider details that drift out of sync.

Rewrite both extension READMEs as standalone usage guides: metadata, getting started, build/feature gates, complete config field tables (including grant-specific and method-specific fields), validation rules, telemetry, and troubleshooting. Design rationale and lifecycle detail stay in design.md.

Remove the duplicated provider configuration from the Azure Monitor and OTLP HTTP exporter READMEs, which now document only the capability binding and link to the extension. Update the contrib-extensions catalog to link usage and design docs and state the ownership rule.

## What issue does this PR close?

* Related to #3479 
* Related to #3356

## How are these changes tested?

n/a

## Are there any user-facing changes?

n/a

### Changelog

* [ ] Added a `.chloggen/*.yaml` entry
* [ ] This PR is a `chore` (indicated in title)
* [x] This is a documentation-only PR.
