### PR TITLE
fix(metrics): Consolidate `durable_buffer` loss metrics

### DIFF
--- a/rust/otap-dataflow/.chloggen/durable-buffer-loss-counter-temporality.yaml
+++ b/rust/otap-dataflow/.chloggen/durable-buffer-loss-counter-temporality.yaml
@@ -1,0 +1,6 @@
+change_type: breaking
+component: pipeline
+note: Consolidate durable buffer retention loss as delta counters under one metric family.
+issues: [3397]
+subtext: |
+  Migration: Rename `item_loss.items{signal,reason}` to `loss.items{signal,reason}`. Sum across signal to replace former aggregate item queries.

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/README.md
@@ -110,8 +110,8 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
 | `processor.durable_buffer.bundles` | `resolved` | `outcome=acked\|deferred\|permanently_rejected` |
 | `processor.durable_buffer.ingest` | `failures` | `failure=error\|backpressure` |
 | `processor.durable_buffer.items` | `rejected`, `consumed`, `produced`, `requeued`, `queued` | `signal=traces\|metrics\|logs` |
-| `processor.durable_buffer.loss` | `segments`, `bundles`, `items` | `reason=drop_oldest\|expired` |
-| `processor.durable_buffer.item_loss` | `items` | `signal=traces\|metrics\|logs`, `reason=drop_oldest\|expired` |
+| `processor.durable_buffer.loss` | `segments`, `bundles` | `reason=drop_oldest\|expired` |
+| `processor.durable_buffer.loss` | `items` | `signal=traces\|metrics\|logs`, `reason=drop_oldest\|expired` |
 
 ### Events
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/metrics.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/metrics.rs
@@ -7,7 +7,7 @@ use otap_df_config::SignalType;
 use otap_df_engine::context::PipelineContext;
 use otap_df_telemetry::common_attributes::SignalAttributes;
 use otap_df_telemetry::error::Error;
-use otap_df_telemetry::instrument::{Counter, Gauge, ObserveCounter};
+use otap_df_telemetry::instrument::{Counter, Gauge};
 use otap_df_telemetry::metrics::{MeasurementMetricSet, MetricSet};
 use otap_df_telemetry::reporter::MetricsReporter;
 use otap_df_telemetry_macros::{AttributeEnum, attribute_set, metric_set};
@@ -124,7 +124,7 @@ pub(super) struct LossAttributes {
     pub(super) reason: LossReason,
 }
 
-/// Aggregate storage loss metrics partitioned by retention reason.
+/// Segment and bundle loss metrics partitioned by retention reason.
 #[metric_set(
     name = "processor.durable_buffer.loss",
     measurement_attributes = LossAttributes
@@ -133,13 +133,10 @@ pub(super) struct LossAttributes {
 pub(super) struct DurableBufferLossMetrics {
     /// Number of segments lost.
     #[metric(unit = "{segment}")]
-    pub(super) segments: ObserveCounter<u64>,
+    pub(super) segments: Counter<u64>,
     /// Number of bundles lost.
     #[metric(unit = "{bundle}")]
-    pub(super) bundles: ObserveCounter<u64>,
-    /// Number of items lost.
-    #[metric(unit = "{item}")]
-    pub(super) items: ObserveCounter<u64>,
+    pub(super) bundles: Counter<u64>,
 }
 
 #[attribute_set(item, measurement)]
@@ -151,11 +148,11 @@ pub(super) struct SignalLossAttributes {
 
 /// Item loss metrics partitioned by signal and retention reason.
 #[metric_set(
-    name = "processor.durable_buffer.item_loss",
+    name = "processor.durable_buffer.loss",
     measurement_attributes = SignalLossAttributes
 )]
 #[derive(Debug, Default, Clone)]
-pub(super) struct DurableBufferItemLossMetrics {
+pub(super) struct DurableBufferLossItemMetrics {
     /// Number of items lost.
     #[metric(unit = "{item}")]
     pub(super) items: Counter<u64>,
@@ -168,7 +165,7 @@ pub(super) struct DurableBufferMetrics {
     pub(super) ingest_metrics: MeasurementMetricSet<DurableBufferIngestMetrics>,
     pub(super) item_metrics: MeasurementMetricSet<DurableBufferItemMetrics>,
     pub(super) loss_metrics: MeasurementMetricSet<DurableBufferLossMetrics>,
-    pub(super) item_loss_metrics: MeasurementMetricSet<DurableBufferItemLossMetrics>,
+    pub(super) loss_item_metrics: MeasurementMetricSet<DurableBufferLossItemMetrics>,
 }
 
 impl DurableBufferMetrics {
@@ -179,7 +176,7 @@ impl DurableBufferMetrics {
             ingest_metrics: DurableBufferIngestMetrics::register(pipeline_ctx),
             item_metrics: DurableBufferItemMetrics::register(pipeline_ctx),
             loss_metrics: DurableBufferLossMetrics::register(pipeline_ctx),
-            item_loss_metrics: DurableBufferItemLossMetrics::register(pipeline_ctx),
+            loss_item_metrics: DurableBufferLossItemMetrics::register(pipeline_ctx),
         }
     }
 
@@ -190,7 +187,7 @@ impl DurableBufferMetrics {
             .and_then(|()| reporter.report_measurement(&mut self.ingest_metrics))
             .and_then(|()| reporter.report_measurement(&mut self.item_metrics))
             .and_then(|()| reporter.report_measurement(&mut self.loss_metrics))
-            .and_then(|()| reporter.report_measurement(&mut self.item_loss_metrics))
+            .and_then(|()| reporter.report_measurement(&mut self.loss_item_metrics))
     }
 
     pub(super) fn bundles_for(
@@ -214,12 +211,12 @@ impl DurableBufferMetrics {
         self.loss_metrics.with(LossAttributes { reason })
     }
 
-    pub(super) fn item_loss_for(
+    pub(super) fn loss_items_for(
         &mut self,
         signal: SignalType,
         reason: LossReason,
-    ) -> &mut DurableBufferItemLossMetrics {
-        self.item_loss_metrics
+    ) -> &mut DurableBufferLossItemMetrics {
+        self.loss_item_metrics
             .with(SignalLossAttributes { signal, reason })
     }
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
@@ -333,7 +333,7 @@ pub struct DurableBuffer {
     /// same segment across telemetry ticks.
     metadata_load_warned_segments: HashSet<u64>,
 
-    /// Last cumulative Quiver loss values folded into delta counters.
+    /// Last cumulative Quiver retention-loss totals used to compute segment/bundle deltas.
     last_loss_snapshot: RetentionLossSnapshot,
 }
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
@@ -89,7 +89,7 @@ use quiver::segment_store::SegmentStore;
 use quiver::subscriber::{
     BundleHandle, BundleIndex, BundleRef, RegistryCallback, SegmentProvider, SubscriberId,
 };
-use quiver::{QuiverConfig, QuiverEngine};
+use quiver::{QuiverConfig, QuiverEngine, RetentionLossCounts, RetentionLossSnapshot};
 use smallvec::smallvec;
 
 use otap_df_telemetry::{otel_debug, otel_error, otel_info, otel_warn};
@@ -252,6 +252,27 @@ struct CachedSegmentMetrics {
     last_seen_generation: u64,
 }
 
+fn retention_loss_delta(
+    current: RetentionLossSnapshot,
+    previous: RetentionLossSnapshot,
+) -> RetentionLossSnapshot {
+    fn counts_delta(
+        current: RetentionLossCounts,
+        previous: RetentionLossCounts,
+    ) -> RetentionLossCounts {
+        RetentionLossCounts {
+            segments: current.segments.saturating_sub(previous.segments),
+            bundles: current.bundles.saturating_sub(previous.bundles),
+            items: current.items.saturating_sub(previous.items),
+        }
+    }
+
+    RetentionLossSnapshot {
+        drop_oldest: counts_delta(current.drop_oldest, previous.drop_oldest),
+        expired: counts_delta(current.expired, previous.expired),
+    }
+}
+
 /// Durable buffer that provides crash-resilient buffering via Quiver.
 ///
 /// # Segment Metrics Cache
@@ -311,6 +332,9 @@ pub struct DurableBuffer {
     /// Prevents warning spam when `bundle_metadata` repeatedly fails for the
     /// same segment across telemetry ticks.
     metadata_load_warned_segments: HashSet<u64>,
+
+    /// Last cumulative Quiver loss values folded into delta counters.
+    last_loss_snapshot: RetentionLossSnapshot,
 }
 
 impl DurableBuffer {
@@ -376,6 +400,7 @@ impl DurableBuffer {
             segment_cache: HashMap::new(),
             segment_cache_generation: 0,
             metadata_load_warned_segments: HashSet::new(),
+            last_loss_snapshot: RetentionLossSnapshot::default(),
         })
     }
 
@@ -766,58 +791,35 @@ impl DurableBuffer {
         self.segment_cache
             .retain(|seq, _| progress_snapshot.contains_key(&SegmentSeq::new(*seq)));
 
-        // NOTE (temporality inconsistency): these aggregate loss metrics are
-        // still cumulative ObserveCounters sourced from monotonic engine atomics
-        // via .observe(), so the dispatcher exports them as gauges regardless of
-        // reader temporality. Their per-signal breakdowns below are now delta
-        // Counters, so `dropped_items` will NOT equal the sum of the per-signal
-        // `dropped_*` across intervals. Making these delta-native (and every other
-        // ObserveCounter temporality-aware) is tracked as a follow-up; it needs
-        // either engine-side drain methods or a dispatcher-level fix rather than
-        // reintroducing per-metric last-value bookkeeping here.
-        self.metrics
-            .loss_for(LossReason::DropOldest)
-            .segments
-            .observe(engine.force_dropped_segments());
-        self.metrics
-            .loss_for(LossReason::DropOldest)
-            .bundles
-            .observe(engine.force_dropped_bundles());
-        self.metrics
-            .loss_for(LossReason::DropOldest)
-            .items
-            .observe(engine.force_dropped_items());
-        self.metrics
-            .loss_for(LossReason::Expired)
-            .segments
-            .observe(engine.expired_segments());
-        self.metrics
-            .loss_for(LossReason::Expired)
-            .bundles
-            .observe(engine.expired_bundles());
-        self.metrics
-            .loss_for(LossReason::Expired)
-            .items
-            .observe(engine.expired_items());
+        let current_loss_snapshot = engine.retention_loss_snapshot();
+        let loss_delta = retention_loss_delta(current_loss_snapshot, self.last_loss_snapshot);
+        self.last_loss_snapshot = current_loss_snapshot;
 
-        // Update dropped and expired metrics by draining the engine's pending bundles
-        // and aggregating by signal type via signal_type_from_slot_id(). This handles all
-        // slot ranges (Arrow 10-45 and OTLP 60-62) without hardcoding any slot IDs here.
-        for (slot_ids, count) in engine.drain_dropped_bundles_pending() {
+        let dropped = self.metrics.loss_for(LossReason::DropOldest);
+        dropped.segments.add(loss_delta.drop_oldest.segments);
+        dropped.bundles.add(loss_delta.drop_oldest.bundles);
+
+        let expired = self.metrics.loss_for(LossReason::Expired);
+        expired.segments.add(loss_delta.expired.segments);
+        expired.bundles.add(loss_delta.expired.bundles);
+
+        // Classify Quiver's opaque slot shapes in the OTAP layer, where signal
+        // semantics are known.
+        for (slot_ids, item_count) in engine.drain_dropped_items_by_shape() {
             if let Some(signal) = slot_ids.iter().copied().find_map(signal_type_from_slot_id) {
                 self.metrics
-                    .item_loss_for(signal, LossReason::DropOldest)
+                    .loss_items_for(signal, LossReason::DropOldest)
                     .items
-                    .add(count);
+                    .add(item_count);
             }
         }
 
-        for (slot_ids, count) in engine.drain_expired_bundles_pending() {
+        for (slot_ids, item_count) in engine.drain_expired_items_by_shape() {
             if let Some(signal) = slot_ids.iter().copied().find_map(signal_type_from_slot_id) {
                 self.metrics
-                    .item_loss_for(signal, LossReason::Expired)
+                    .loss_items_for(signal, LossReason::Expired)
                     .items
-                    .add(count);
+                    .add(item_count);
             }
         }
 
@@ -1770,12 +1772,6 @@ impl otap_df_engine::local::processor::Processor<OtapPdata> for DurableBuffer {
                         Some((
                             budget.used(),
                             budget.hard_cap(),
-                            engine.force_dropped_segments(),
-                            engine.force_dropped_bundles(),
-                            engine.force_dropped_items(),
-                            engine.expired_segments(),
-                            engine.expired_bundles(),
-                            engine.expired_items(),
                             engine.clone(),
                             subscriber_id.clone(),
                         ))
@@ -1783,19 +1779,7 @@ impl otap_df_engine::local::processor::Processor<OtapPdata> for DurableBuffer {
                         None
                     };
 
-                    if let Some((
-                        used,
-                        cap,
-                        dropped_segs,
-                        dropped_buns,
-                        dropped_items,
-                        expired_segs,
-                        expired_buns,
-                        expired_items,
-                        engine,
-                        subscriber_id,
-                    )) = quiver_metrics
-                    {
+                    if let Some((used, cap, engine, subscriber_id)) = quiver_metrics {
                         self.metrics
                             .operational_metrics
                             .storage_bytes_used
@@ -1811,31 +1795,6 @@ impl otap_df_engine::local::processor::Processor<OtapPdata> for DurableBuffer {
                             .operational_metrics
                             .storage_utilization
                             .set(utilization);
-
-                        self.metrics
-                            .loss_for(LossReason::DropOldest)
-                            .segments
-                            .observe(dropped_segs);
-                        self.metrics
-                            .loss_for(LossReason::DropOldest)
-                            .bundles
-                            .observe(dropped_buns);
-                        self.metrics
-                            .loss_for(LossReason::DropOldest)
-                            .items
-                            .observe(dropped_items);
-                        self.metrics
-                            .loss_for(LossReason::Expired)
-                            .segments
-                            .observe(expired_segs);
-                        self.metrics
-                            .loss_for(LossReason::Expired)
-                            .bundles
-                            .observe(expired_buns);
-                        self.metrics
-                            .loss_for(LossReason::Expired)
-                            .items
-                            .observe(expired_items);
 
                         // Recompute queued item gauges from the subscriber
                         // registry. This is the single source of truth for
@@ -2860,8 +2819,8 @@ mod tests {
             .validate(|_| async {});
     }
 
-    /// Scenario: DropOldest and max_age retention each remove log segments.
-    /// Guarantees: Per-signal item loss stays interval-scoped and aggregate expiry loss includes the expired segment count.
+    /// Scenario: DropOldest and max_age retention each remove log items.
+    /// Guarantees: Signal-partitioned item loss stays interval-scoped.
     #[tokio::test]
     async fn test_per_signal_dropped_expired_metrics() {
         let (mut processor, engine, subscriber_id, _temp_dir) =
@@ -2875,7 +2834,7 @@ mod tests {
             p.recompute_metrics(&engine, &subscriber_id);
             let sample = (
                 p.metrics
-                    .item_loss_metrics
+                    .loss_item_metrics
                     .get(SignalLossAttributes {
                         signal: SignalType::Logs,
                         reason: LossReason::DropOldest,
@@ -2883,7 +2842,7 @@ mod tests {
                     .items
                     .get(),
                 p.metrics
-                    .item_loss_metrics
+                    .loss_item_metrics
                     .get(SignalLossAttributes {
                         signal: SignalType::Logs,
                         reason: LossReason::Expired,
@@ -2892,7 +2851,7 @@ mod tests {
                     .get(),
             );
             reporter
-                .report_measurement(&mut p.metrics.item_loss_metrics)
+                .report_measurement(&mut p.metrics.loss_item_metrics)
                 .unwrap();
             while metrics_rx.try_recv().is_ok() {}
             sample
@@ -2941,6 +2900,58 @@ mod tests {
         assert_eq!(sample(&mut processor), (4, 0));
     }
 
+    /// Scenario: Segment and bundle loss occur in separate reporting intervals.
+    /// Guarantees: Each reason-only aggregate counter reports its delta and resets after export.
+    #[tokio::test]
+    async fn test_aggregate_loss_metrics_are_delta_counters() {
+        let (mut processor, engine, subscriber_id, _temp_dir) =
+            setup_test_processor(Some(Duration::from_millis(5))).await;
+        let (metrics_rx, mut reporter) = MetricsReporter::create_new_and_receiver(4);
+
+        let mut sample = |processor: &mut DurableBuffer| {
+            processor.recompute_metrics(&engine, &subscriber_id);
+            let dropped = processor.metrics.loss_metrics.get(LossAttributes {
+                reason: LossReason::DropOldest,
+            });
+            let dropped_values = (dropped.segments.get(), dropped.bundles.get());
+            let expired = processor.metrics.loss_metrics.get(LossAttributes {
+                reason: LossReason::Expired,
+            });
+            let expired_values = (expired.segments.get(), expired.bundles.get());
+
+            reporter
+                .report_measurement(&mut processor.metrics.loss_metrics)
+                .expect("report loss metrics");
+            while metrics_rx.try_recv().is_ok() {}
+
+            (dropped_values, expired_values)
+        };
+
+        engine
+            .ingest(&make_simple_bundle(SlotId::new(30), 5))
+            .await
+            .expect("ingest dropped bundle");
+        engine.flush().await.expect("flush dropped bundle");
+        assert_eq!(engine.force_drop_oldest_pending_segments(), 1);
+        assert_eq!(sample(&mut processor), ((1, 1), (0, 0)));
+
+        engine
+            .ingest(&make_simple_bundle(SlotId::new(30), 3))
+            .await
+            .expect("ingest expired bundle");
+        engine.flush().await.expect("flush expired bundle");
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert_eq!(
+            engine.cleanup_expired_segments().expect("expire segment"),
+            1
+        );
+        assert_eq!(sample(&mut processor), ((0, 0), (1, 1)));
+
+        assert_eq!(sample(&mut processor), ((0, 0), (0, 0)));
+    }
+
+    /// Scenario: DropOldest removes a metrics bundle containing 42 items.
+    /// Guarantees: Item loss is attributed to the metrics signal.
     #[tokio::test]
     async fn test_dropped_metrics_item_count() {
         let (mut processor, engine, subscriber_id, _temp_dir) = setup_test_processor(None).await;
@@ -2960,7 +2971,7 @@ mod tests {
         assert_eq!(
             processor
                 .metrics
-                .item_loss_metrics
+                .loss_item_metrics
                 .get(SignalLossAttributes {
                     signal: SignalType::Metrics,
                     reason: LossReason::DropOldest,
@@ -2969,19 +2980,10 @@ mod tests {
                 .get(),
             42
         );
-        assert_eq!(
-            processor
-                .metrics
-                .loss_metrics
-                .get(LossAttributes {
-                    reason: LossReason::DropOldest,
-                })
-                .items
-                .get(),
-            42
-        );
     }
 
+    /// Scenario: DropOldest removes a trace bundle containing 55 spans.
+    /// Guarantees: Item loss is attributed to the traces signal.
     #[tokio::test]
     async fn test_dropped_spans_item_count() {
         let (mut processor, engine, subscriber_id, _temp_dir) = setup_test_processor(None).await;
@@ -3001,7 +3003,7 @@ mod tests {
         assert_eq!(
             processor
                 .metrics
-                .item_loss_metrics
+                .loss_item_metrics
                 .get(SignalLossAttributes {
                     signal: SignalType::Traces,
                     reason: LossReason::DropOldest,
@@ -3012,6 +3014,8 @@ mod tests {
         );
     }
 
+    /// Scenario: DropOldest removes an OTLP pass-through log bundle.
+    /// Guarantees: Logical log loss uses the adapter item count.
     #[tokio::test]
     async fn test_dropped_otlp_passthrough_item_count() {
         let (mut processor, engine, subscriber_id, _temp_dir) = setup_test_processor(None).await;
@@ -3032,7 +3036,7 @@ mod tests {
         assert_eq!(
             processor
                 .metrics
-                .item_loss_metrics
+                .loss_item_metrics
                 .get(SignalLossAttributes {
                     signal: SignalType::Logs,
                     reason: LossReason::DropOldest,
@@ -3043,6 +3047,8 @@ mod tests {
         );
     }
 
+    /// Scenario: DropOldest and expiry remove items for all three signals.
+    /// Guarantees: Item totals reconcile across signal and reason dimensions.
     #[tokio::test]
     async fn test_reconciliation() {
         let (mut processor, engine, subscriber_id, _temp_dir) =
@@ -3098,7 +3104,7 @@ mod tests {
         let item_loss = |signal, reason| {
             processor
                 .metrics
-                .item_loss_metrics
+                .loss_item_metrics
                 .get(SignalLossAttributes { signal, reason })
                 .items
                 .get()
@@ -3109,39 +3115,16 @@ mod tests {
         let expired_logs = item_loss(SignalType::Logs, LossReason::Expired);
         let expired_spans = item_loss(SignalType::Traces, LossReason::Expired);
         let expired_metrics = item_loss(SignalType::Metrics, LossReason::Expired);
-        let dropped_items = processor
-            .metrics
-            .loss_metrics
-            .get(LossAttributes {
-                reason: LossReason::DropOldest,
-            })
-            .items
-            .get();
-        let expired_items = processor
-            .metrics
-            .loss_metrics
-            .get(LossAttributes {
-                reason: LossReason::Expired,
-            })
-            .items
-            .get();
-
-        // Assert dropped reconciliation
+        // Assert dropped signal breakdown.
         assert_eq!(dropped_logs, 10);
         assert_eq!(dropped_spans, 20);
         assert_eq!(dropped_metrics, 30);
-        assert_eq!(
-            dropped_logs + dropped_spans + dropped_metrics,
-            dropped_items
-        );
+        assert_eq!(dropped_logs + dropped_spans + dropped_metrics, 60);
 
-        // Assert expired reconciliation
+        // Assert expired signal breakdown.
         assert_eq!(expired_logs, 5);
         assert_eq!(expired_spans, 15);
         assert_eq!(expired_metrics, 25);
-        assert_eq!(
-            expired_logs + expired_spans + expired_metrics,
-            expired_items
-        );
+        assert_eq!(expired_logs + expired_spans + expired_metrics, 45);
     }
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/telemetry.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/telemetry.md
@@ -16,8 +16,8 @@ OpenTelemetry attributes rather than encoded in instrument names.
 | `processor.durable_buffer.bundles` | `resolved` | `outcome=acked\|deferred\|permanently_rejected` | Bundle resolution by downstream outcome. |
 | `processor.durable_buffer.ingest` | `failures` | `failure=error\|backpressure` | Failed ingest attempts by failure kind. |
 | `processor.durable_buffer.items` | `rejected`, `consumed`, `produced`, `requeued`, `queued` | `signal=traces\|metrics\|logs` | Item operations and queued gauges by OpenTelemetry signal. |
-| `processor.durable_buffer.loss` | `segments`, `bundles`, `items` | `reason=drop_oldest\|expired` | Aggregate retention loss by reason. |
-| `processor.durable_buffer.item_loss` | `items` | `signal=traces\|metrics\|logs`, `reason=drop_oldest\|expired` | Item loss by signal and retention reason. |
+| `processor.durable_buffer.loss` | `segments`, `bundles` | `reason=drop_oldest\|expired` | Segment and bundle retention loss. |
+| `processor.durable_buffer.loss` | `items` | `signal=traces\|metrics\|logs`, `reason=drop_oldest\|expired` | Item retention loss. |
 
 ## Logs
 

--- a/rust/otap-dataflow/crates/quiver/src/engine.rs
+++ b/rust/otap-dataflow/crates/quiver/src/engine.rs
@@ -67,6 +67,30 @@ pub struct MaintenanceStats {
     pub pending_deletes_cleared: usize,
 }
 
+/// Cumulative loss totals for one retention reason.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RetentionLossCounts {
+    /// Number of segments removed by retention.
+    pub segments: u64,
+    /// Number of bundles stored in the removed segments.
+    pub bundles: u64,
+    /// Number of logical items stored in the removed segments.
+    pub items: u64,
+}
+
+/// Cumulative retention-loss totals for the current engine lifetime.
+///
+/// The fields are loaded independently from monotonic atomics. A snapshot may
+/// briefly span one retention update, but later snapshots converge to the full
+/// totals and consumers can safely compute per-field deltas.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RetentionLossSnapshot {
+    /// Loss caused by the DropOldest size-cap policy.
+    pub drop_oldest: RetentionLossCounts,
+    /// Loss caused by max-age expiry.
+    pub expired: RetentionLossCounts,
+}
+
 /// Primary entry point for the persistence engine.
 ///
 /// The engine coordinates:
@@ -109,7 +133,7 @@ pub struct QuiverEngine {
     force_dropped_bundles: AtomicU64,
     /// Count of individual data items lost due to force-dropped segments.
     force_dropped_items: AtomicU64,
-    /// Pending dropped bundles grouped by slot shape, for per-signal tracking.
+    /// Pending dropped items grouped by slot shape, for per-signal tracking.
     /// Keyed by sorted slot_ids to bound memory by unique bundle shapes.
     dropped_items_by_shape: RwLock<HashMap<Vec<crate::record_bundle::SlotId>, u64>>,
     /// Count of segments lost due to max_age retention.
@@ -118,7 +142,7 @@ pub struct QuiverEngine {
     expired_bundles: AtomicU64,
     /// Count of individual data items lost due to expired segments.
     expired_items: AtomicU64,
-    /// Pending expired bundles grouped by slot shape, for per-signal tracking.
+    /// Pending expired items grouped by slot shape, for per-signal tracking.
     /// Keyed by sorted slot_ids to bound memory by unique bundle shapes.
     expired_items_by_shape: RwLock<HashMap<Vec<crate::record_bundle::SlotId>, u64>>,
     /// Segment store for finalized segment files.
@@ -510,8 +534,24 @@ impl QuiverEngine {
         self.force_dropped_items.load(Ordering::Relaxed)
     }
 
-    /// Drains and returns pending dropped bundles (grouped by slot shape) for per-signal classification.
-    pub fn drain_dropped_bundles_pending(&self) -> Vec<(Vec<crate::record_bundle::SlotId>, u64)> {
+    /// Returns cumulative retention-loss totals for this engine lifetime.
+    pub fn retention_loss_snapshot(&self) -> RetentionLossSnapshot {
+        RetentionLossSnapshot {
+            drop_oldest: RetentionLossCounts {
+                segments: self.force_dropped_segments(),
+                bundles: self.force_dropped_bundles(),
+                items: self.force_dropped_items(),
+            },
+            expired: RetentionLossCounts {
+                segments: self.expired_segments(),
+                bundles: self.expired_bundles(),
+                items: self.expired_items(),
+            },
+        }
+    }
+
+    /// Drains pending dropped items grouped by slot shape for signal classification.
+    pub fn drain_dropped_items_by_shape(&self) -> Vec<(Vec<crate::record_bundle::SlotId>, u64)> {
         let map = std::mem::take(&mut *self.dropped_items_by_shape.write());
         map.into_iter().collect()
     }
@@ -544,8 +584,8 @@ impl QuiverEngine {
         self.expired_items.load(Ordering::Relaxed)
     }
 
-    /// Drains and returns pending expired bundles (grouped by slot shape) for per-signal classification.
-    pub fn drain_expired_bundles_pending(&self) -> Vec<(Vec<crate::record_bundle::SlotId>, u64)> {
+    /// Drains pending expired items grouped by slot shape for signal classification.
+    pub fn drain_expired_items_by_shape(&self) -> Vec<(Vec<crate::record_bundle::SlotId>, u64)> {
         let map = std::mem::take(&mut *self.expired_items_by_shape.write());
         map.into_iter().collect()
     }
@@ -3463,6 +3503,8 @@ mod tests {
         // when the soft cap is exceeded -- this test verifies the mechanism works.)
     }
 
+    /// Scenario: DropOldest removes one pending segment without active readers.
+    /// Guarantees: The typed loss snapshot reports the cumulative segment and bundle loss.
     #[tokio::test]
     async fn force_drop_oldest_drops_pending_segments_without_readers() {
         let temp_dir = tempdir().expect("tempdir");
@@ -3516,6 +3558,10 @@ mod tests {
 
         // Counter should be incremented
         assert_eq!(engine.force_dropped_segments(), 1);
+        let loss = engine.retention_loss_snapshot();
+        assert_eq!(loss.drop_oldest.segments, 1);
+        assert!(loss.drop_oldest.bundles > 0);
+        assert_eq!(loss.expired, RetentionLossCounts::default());
 
         // Segment count should decrease
         let new_count = engine.segment_store.segment_count();
@@ -4266,12 +4312,8 @@ mod tests {
         }
     }
 
-    /// Test that cleanup_expired_segments deletes segments older than max_age.
-    ///
-    /// This test verifies:
-    /// 1. Segments with finalization time older than max_age are deleted
-    /// 2. Segments newer than max_age are preserved
-    /// 3. The method returns the correct count of deleted segments
+    /// Scenario: All finalized segments are older than the configured max_age.
+    /// Guarantees: Expiry removes them and the typed loss snapshot reports their totals.
     #[tokio::test]
     async fn cleanup_expired_segments_deletes_old_segments() {
         let dir = tempdir().expect("tempdir");
@@ -4325,6 +4367,10 @@ mod tests {
             0,
             "no segments should remain after cleanup"
         );
+        let loss = engine.retention_loss_snapshot();
+        assert_eq!(loss.expired.segments, initial_segment_count as u64);
+        assert_eq!(loss.expired.bundles, 5);
+        assert_eq!(loss.drop_oldest, RetentionLossCounts::default());
     }
 
     /// Test that cleanup_expired_segments force-completes segments with claimed bundles.

--- a/rust/otap-dataflow/crates/quiver/src/lib.rs
+++ b/rust/otap-dataflow/crates/quiver/src/lib.rs
@@ -132,7 +132,9 @@ pub use budget::{BudgetConfigError, DiskBudget};
 pub use config::{
     DurabilityMode, QuiverConfig, RetentionConfig, RetentionPolicy, SegmentConfig, WalConfig,
 };
-pub use engine::{MaintenanceStats, QuiverEngine, QuiverEngineBuilder};
+pub use engine::{
+    MaintenanceStats, QuiverEngine, QuiverEngineBuilder, RetentionLossCounts, RetentionLossSnapshot,
+};
 pub use error::{QuiverError, Result};
 
 pub use segment::SegmentError;


### PR DESCRIPTION
# Change Summary

Make durable-buffer retention loss delta-native and consolidate it under one public metric namespace:
```text
processor.durable_buffer.loss.segments{reason}
processor.durable_buffer.loss.bundles{reason}
processor.durable_buffer.loss.items{reason,signal}
```
This replaces the cumulative `ObserveCounter` instruments and the separate `processor.durable_buffer.item_loss` namespace.

### Context

The former OpenTelemetry SDK path exported `ObserveCounter` values as gauges, causing the temporality problem reported in #3397. The native ITS path introduced by #3523 removed that dispatcher and correctly maps instruments according to their source semantics:

```text
Counter.add(delta)             -> delta monotonic sum
ObserveCounter.observe(total)  -> cumulative monotonic sum
```

https://github.com/open-telemetry/otel-arrow/blob/f507031c5004de0c6269d0f8522b4e5f8821d48a/rust/otap-dataflow/crates/telemetry-macros/src/lib.rs#L202-L215

This fixes the gauge bug, but there is no longer an SDK reader that can convert cumulative observations according to a configured preference. Durable-buffer aggregate loss therefore remained cumulative while its signal-specific item loss was delta, even though both describe the same retention events.

Retention loss is event-like data, so this change makes all of its source metrics delta. Consumer-selected conversion after pipeline fan-out remains a separate concern tracked by #3543.

### Approach

Quiver owns retention events and continues tracking engine-lifetime totals. It now exposes those totals through a typed snapshot. The durable-buffer processor retains the previous snapshot, calculates interval differences, and records them into ITS `Counter`s:

```text
Quiver lifetime totals -> typed snapshot -> current - previous -> ITS delta counters
```

This keeps storage accounting in Quiver without coupling it to pipeline telemetry, while the processor owns the public metric contract.

Segments and bundles are partitioned by retention `reason`. Segments may contain multiple signals, and bundles are an internal Quiver representation that does not need a public signal dimension. Items retain both `reason` and `signal`; the processor maps Quiver's opaque slot shapes to OTAP signals.

## What issue does this PR close?

<!--We highly recommend correlation of every PR to an issue-->

* Related to #3397

## How are these changes tested?

Unit tests

## Are there any user-facing changes?

Yes, rename `item_loss.items{signal,reason}` to `loss.items{signal,reason}`. Sum across signal to replace former aggregate item queries.

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry
* [ ] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
