### PR TITLE
chore(ci): Update otap-dataflow deny.toml to unblock CI

### DIFF
--- a/rust/otap-dataflow/Cargo.lock
+++ b/rust/otap-dataflow/Cargo.lock
@@ -3667,11 +3667,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]

--- a/rust/otap-dataflow/deny.toml
+++ b/rust/otap-dataflow/deny.toml
@@ -76,9 +76,9 @@ ignore = [
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
     { id="RUSTSEC-2024-0436", reason="unmaintained `paste` crate is a dependency of parquet"},
     { id="RUSTSEC-2021-0127", reason="`serde_cbor` is archived, but current implementation meets needs" },
-    { id="RUSTSEC-2026-0194", reason="`quick-xml` <0.41 DoS via crafted untrusted XML; pulled transitively via datafusion → object_store. Fix merged upstream (apache/arrow-rs-object-store#785, 2026-07-02) but not yet in a released version. Remove once a new `object_store` (>0.14.0) is available."},
+    { id="RUSTSEC-2026-0194", reason="`quick-xml` <0.41 DoS via crafted untrusted XML; pulled transitively via datafusion -> object_store. Fix merged upstream (apache/arrow-rs-object-store#785, 2026-07-02) but not yet in a released version. Remove once a new `object_store` (>0.14.0) is available."},
     { id="RUSTSEC-2026-0195", reason="`quick-xml` <0.41 DoS via unbounded namespace-declaration allocation in `NsReader`. Same transitive path and fix as RUSTSEC-2026-0194."},
-    { id="RUSTSEC-2026-0204", reason="`crossbeam` (transitive dependency of criterion and weaver-forge) dereferences pointer in fmt::Display. See https://github.com/crossbeam-rs/crossbeam/pull/1276. Remove when dependency updated in these crates." }
+    { id="RUSTSEC-2026-0249", reason="`smartstring` is unmaintained and is pulled transitively by `one_collect` through `rhai`; no maintained replacement is currently available in that dependency chain. Remove when `rhai` replaces `smartstring`." }
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.


### PR DESCRIPTION
# Change Summary

- Add unmaintained `smartstring` dependency to ignore list.
- Upgrade `event-listener` to the patched release.

Observed in https://github.com/open-telemetry/otel-arrow/actions/runs/31429644287/job/93589839010?pr=3705

On local run with `--all-features`, got:
```text
error[unsound]: `event-listener` allows `!Send` tags to cross thread boundaries via `StackSlot`
    ┌─ /home/drewrelmas/src/gh/otel-arrow/rust/otap-dataflow/Cargo.lock:245:1
    │
245 │ event-listener 5.4.1 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unsound advisory **detected**

error[unmaintained]: smartstring is unmaintained
    ┌─ /home/drewrelmas/src/gh/otel-arrow/rust/otap-dataflow/Cargo.lock:718:1
    │
718 │ smartstring 1.0.1 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unmaintained advisory detected
```

## What issue does this PR close?

<!--We highly recommend correlation of every PR to an issue-->

* Closes #NNN

## How are these changes tested?

## Are there any user-facing changes?

 <!-- If yes, provide further info below -->

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [ ] Added a `.chloggen/*.yaml` entry
* [x] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
