### PR TITLE
Introduce `max_in_flight`  in the ClickHouse exporter

### DIFF
--- a/rust/otap-dataflow/.chloggen/clickhouse-exporter-concurrent-inserts.yaml
+++ b/rust/otap-dataflow/.chloggen/clickhouse-exporter-concurrent-inserts.yaml
@@ -3,7 +3,7 @@
 
 change_type: enhancement
 component: pipeline
-note: "Allow the ClickHouse exporter to run concurrent inserts with the configurable max_in_flight setting."
+note: "Run up to 10 ClickHouse inserts concurrently by default and allow max_in_flight to tune the limit."
 issues: [3512]
 subtext: |
-  The default remains 1. Increase max_in_flight to overlap synchronous ClickHouse HTTP insert requests.
+  Set max_in_flight to 1 to retain serialized inserts. Values greater than 1 overlap synchronous HTTP inserts and may complete out of order.

--- a/rust/otap-dataflow/.chloggen/clickhouse-exporter-concurrent-inserts.yaml
+++ b/rust/otap-dataflow/.chloggen/clickhouse-exporter-concurrent-inserts.yaml
@@ -1,0 +1,9 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+change_type: enhancement
+component: pipeline
+note: "Allow the ClickHouse exporter to run concurrent inserts with the configurable max_in_flight setting."
+issues: [3512]
+subtext: |
+  The default remains 1. Increase max_in_flight to overlap synchronous ClickHouse HTTP insert requests.

--- a/rust/otap-dataflow/.chloggen/clickhouse-exporter-concurrent-inserts.yaml
+++ b/rust/otap-dataflow/.chloggen/clickhouse-exporter-concurrent-inserts.yaml
@@ -6,4 +6,4 @@ component: pipeline
 note: "Run up to 10 ClickHouse inserts concurrently by default and allow max_in_flight to tune the limit."
 issues: [3512]
 subtext: |
-  Set max_in_flight to 1 to retain serialized inserts. Values greater than 1 overlap synchronous HTTP inserts and may complete out of order.
+  Set max_in_flight to 1 to retain serialized inserts. Values greater than 1 overlap synchronous HTTP inserts and may complete out of order. Shutdown drains accepted inserts only until the engine deadline.

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/README.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/README.md
@@ -109,15 +109,16 @@ Top-level config fields:
 - `username`
 - `password` (supports `${env:VAR}` / `${env:VAR:-default}` substitution, e.g. `"${env:CLICKHOUSE_PASSWORD}"`)
 - `async_insert`
-- `max_in_flight` (positive integer, defaults to `1`)
+- `max_in_flight` (positive integer, defaults to `10`)
 - `table_defaults`
 - `tables`
 
 `max_in_flight` bounds the number of ClickHouse HTTP insert requests that can
 run concurrently. Values greater than one overlap synchronous inserts and may
 complete them out of order. When the limit is reached, the exporter applies
-backpressure until an insert completes. Set it to `10` for the same insert
-concurrency used by the benchmark Collector configuration.
+backpressure until an insert completes. The default of `10` matches the insert
+concurrency used by the benchmark Collector configuration. Set it to `1` to
+retain serialized insert behavior.
 
 Inline attributes are always stored as `Map(LowCardinality(String), String)`;
 there is no per-group representation configuration.

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/README.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/README.md
@@ -207,7 +207,10 @@ payloads remain internal to the transform process.
 - writes only signal payloads
 - maps `Logs -> logs table` and `Spans -> traces table`
 - runs at most `max_in_flight` insert requests concurrently
-- drains accepted insert requests during shutdown
+- drains accepted insert requests until the shutdown deadline
+
+If the shutdown deadline expires, the exporter stops waiting for active
+inserts and drops queued inserts that have not started.
 
 There is no longer any special write ordering for attribute tables because
 attribute tables do not exist.

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/README.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/README.md
@@ -109,8 +109,15 @@ Top-level config fields:
 - `username`
 - `password` (supports `${env:VAR}` / `${env:VAR:-default}` substitution, e.g. `"${env:CLICKHOUSE_PASSWORD}"`)
 - `async_insert`
+- `max_in_flight` (positive integer, defaults to `1`)
 - `table_defaults`
 - `tables`
+
+`max_in_flight` bounds the number of ClickHouse HTTP insert requests that can
+run concurrently. Values greater than one overlap synchronous inserts and may
+complete them out of order. When the limit is reached, the exporter applies
+backpressure until an insert completes. Set it to `10` for the same insert
+concurrency used by the benchmark Collector configuration.
 
 Inline attributes are always stored as `Map(LowCardinality(String), String)`;
 there is no per-group representation configuration.
@@ -198,6 +205,8 @@ payloads remain internal to the transform process.
 - initializes configured tables
 - writes only signal payloads
 - maps `Logs -> logs table` and `Spans -> traces table`
+- runs at most `max_in_flight` insert requests concurrently
+- drains accepted insert requests during shutdown
 
 There is no longer any special write ordering for attribute tables because
 attribute tables do not exist.

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/config.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/config.rs
@@ -30,7 +30,7 @@ use secrecy::SecretString;
 use serde::Deserialize;
 use std::num::NonZeroUsize;
 
-const DEFAULT_MAX_IN_FLIGHT: usize = 1;
+const DEFAULT_MAX_IN_FLIGHT: usize = 10;
 
 #[derive(Debug, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
@@ -298,9 +298,9 @@ mod tests {
     use secrecy::ExposeSecret;
 
     /// Scenario: a ClickHouse exporter config omits the concurrency setting.
-    /// Guarantees: inserts remain serialized by default for backward compatibility.
+    /// Guarantees: the runtime configuration permits ten concurrent inserts by default.
     #[test]
-    fn max_in_flight_defaults_to_one() {
+    fn max_in_flight_defaults_to_ten() {
         let patch: ConfigPatch = serde_json::from_value(serde_json::json!({
             "endpoint": "http://localhost:8123",
             "database": "otap",
@@ -309,7 +309,7 @@ mod tests {
         }))
         .unwrap();
 
-        assert_eq!(Config::from_patch(patch).max_in_flight, 1);
+        assert_eq!(Config::from_patch(patch).max_in_flight, 10);
     }
 
     /// Scenario: a ClickHouse exporter config requests OTC-equivalent concurrency.

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/config.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/config.rs
@@ -30,7 +30,8 @@ use secrecy::SecretString;
 use serde::Deserialize;
 use std::num::NonZeroUsize;
 
-const DEFAULT_MAX_IN_FLIGHT: usize = 10;
+const DEFAULT_MAX_IN_FLIGHT: NonZeroUsize =
+    NonZeroUsize::new(10).expect("default max_in_flight must be non-zero");
 
 #[derive(Debug, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
@@ -66,7 +67,7 @@ pub struct Config {
     /// Use async insert
     pub async_insert: bool,
     /// Maximum number of ClickHouse insert requests allowed to run concurrently.
-    pub max_in_flight: usize,
+    pub max_in_flight: NonZeroUsize,
     pub table_defaults: DefaultTableConfig,
     pub tables: TablesConfig,
 }
@@ -74,10 +75,7 @@ pub struct Config {
 impl Config {
     pub fn from_patch(p: ConfigPatch) -> Self {
         let async_insert = p.async_insert.unwrap_or(true);
-        let max_in_flight = p
-            .max_in_flight
-            .map(NonZeroUsize::get)
-            .unwrap_or(DEFAULT_MAX_IN_FLIGHT);
+        let max_in_flight = p.max_in_flight.unwrap_or(DEFAULT_MAX_IN_FLIGHT);
 
         let tables = TablesConfig::from_patch(p.tables);
 
@@ -309,7 +307,7 @@ mod tests {
         }))
         .unwrap();
 
-        assert_eq!(Config::from_patch(patch).max_in_flight, 10);
+        assert_eq!(Config::from_patch(patch).max_in_flight.get(), 10);
     }
 
     /// Scenario: a ClickHouse exporter config requests OTC-equivalent concurrency.
@@ -325,7 +323,7 @@ mod tests {
         }))
         .unwrap();
 
-        assert_eq!(Config::from_patch(patch).max_in_flight, 10);
+        assert_eq!(Config::from_patch(patch).max_in_flight.get(), 10);
     }
 
     /// Scenario: a ClickHouse exporter config sets the concurrency limit to zero.

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/config.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/config.rs
@@ -28,6 +28,9 @@
 //! configuration fields.
 use secrecy::SecretString;
 use serde::Deserialize;
+use std::num::NonZeroUsize;
+
+const DEFAULT_MAX_IN_FLIGHT: usize = 1;
 
 #[derive(Debug, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
@@ -38,6 +41,9 @@ pub struct ConfigPatch {
     pub password: SecretString,
 
     pub async_insert: Option<bool>,
+
+    /// Maximum number of ClickHouse insert requests allowed to run concurrently.
+    pub max_in_flight: Option<NonZeroUsize>,
 
     #[serde(default)]
     pub table_defaults: DefaultTableConfig,
@@ -59,6 +65,8 @@ pub struct Config {
     pub password: SecretString,
     /// Use async insert
     pub async_insert: bool,
+    /// Maximum number of ClickHouse insert requests allowed to run concurrently.
+    pub max_in_flight: usize,
     pub table_defaults: DefaultTableConfig,
     pub tables: TablesConfig,
 }
@@ -66,6 +74,10 @@ pub struct Config {
 impl Config {
     pub fn from_patch(p: ConfigPatch) -> Self {
         let async_insert = p.async_insert.unwrap_or(true);
+        let max_in_flight = p
+            .max_in_flight
+            .map(NonZeroUsize::get)
+            .unwrap_or(DEFAULT_MAX_IN_FLIGHT);
 
         let tables = TablesConfig::from_patch(p.tables);
 
@@ -75,6 +87,7 @@ impl Config {
             username: p.username,
             password: p.password,
             async_insert,
+            max_in_flight,
             table_defaults: p.table_defaults,
             tables,
         }
@@ -284,6 +297,55 @@ mod tests {
     use super::*;
     use secrecy::ExposeSecret;
 
+    /// Scenario: a ClickHouse exporter config omits the concurrency setting.
+    /// Guarantees: inserts remain serialized by default for backward compatibility.
+    #[test]
+    fn max_in_flight_defaults_to_one() {
+        let patch: ConfigPatch = serde_json::from_value(serde_json::json!({
+            "endpoint": "http://localhost:8123",
+            "database": "otap",
+            "username": "clickhouse",
+            "password": "secret"
+        }))
+        .unwrap();
+
+        assert_eq!(Config::from_patch(patch).max_in_flight, 1);
+    }
+
+    /// Scenario: a ClickHouse exporter config requests OTC-equivalent concurrency.
+    /// Guarantees: the configured maximum is preserved in the runtime configuration.
+    #[test]
+    fn max_in_flight_accepts_configured_value() {
+        let patch: ConfigPatch = serde_json::from_value(serde_json::json!({
+            "endpoint": "http://localhost:8123",
+            "database": "otap",
+            "username": "clickhouse",
+            "password": "secret",
+            "max_in_flight": 10
+        }))
+        .unwrap();
+
+        assert_eq!(Config::from_patch(patch).max_in_flight, 10);
+    }
+
+    /// Scenario: a ClickHouse exporter config sets the concurrency limit to zero.
+    /// Guarantees: invalid zero-capacity configurations are rejected during deserialization.
+    #[test]
+    fn max_in_flight_rejects_zero() {
+        let error = serde_json::from_value::<ConfigPatch>(serde_json::json!({
+            "endpoint": "http://localhost:8123",
+            "database": "otap",
+            "username": "clickhouse",
+            "password": "secret",
+            "max_in_flight": 0
+        }))
+        .unwrap_err();
+
+        assert!(error.to_string().contains("nonzero usize"));
+    }
+
+    /// Scenario: all supported top-level and nested exporter fields are configured.
+    /// Guarantees: explicit values are retained and unspecified table values use defaults.
     #[test]
     fn test_config_deserialization() {
         let json = serde_json::json!({
@@ -343,6 +405,8 @@ mod tests {
         assert_eq!(config.tables.metrics.sum.name, "otel_metrics_sum");
     }
 
+    /// Scenario: a ClickHouse exporter config contains an unsupported top-level field.
+    /// Guarantees: deserialization rejects the typo instead of silently ignoring it.
     #[test]
     fn test_config_patch_rejects_unknown_fields() {
         let json = serde_json::json!({
@@ -357,6 +421,8 @@ mod tests {
         assert!(err.to_string().contains("unknown field `unknown_field`"));
     }
 
+    /// Scenario: only the required connection fields are configured.
+    /// Guarantees: runtime table names and table settings match the documented defaults.
     #[test]
     fn test_config_defaults_match_spec() {
         let json = serde_json::json!({

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/in_flight.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/in_flight.rs
@@ -1,0 +1,150 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Bounded tracking for concurrent ClickHouse insert requests.
+
+use futures::StreamExt;
+use futures::future::LocalBoxFuture;
+use futures::stream::FuturesUnordered;
+use otap_df_config::SignalType;
+use otap_df_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
+
+use super::error::ClickhouseExporterError;
+
+pub(super) type WrittenRows = Vec<(ArrowPayloadType, u64)>;
+
+/// Result of one fully transformed pdata message sent to ClickHouse.
+pub(super) struct CompletedWrite {
+    pub signal_type: SignalType,
+    pub result: Result<WrittenRows, ClickhouseExporterError>,
+}
+
+/// Tracks insert futures and enforces the configured concurrency bound.
+pub(super) struct InFlightWrites {
+    futures: FuturesUnordered<LocalBoxFuture<'static, CompletedWrite>>,
+    limit: usize,
+}
+
+impl InFlightWrites {
+    pub(super) fn new(limit: usize) -> Self {
+        Self {
+            futures: FuturesUnordered::new(),
+            limit: limit.max(1),
+        }
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.futures.is_empty()
+    }
+
+    pub(super) fn is_at_capacity(&self) -> bool {
+        self.futures.len() >= self.limit
+    }
+
+    pub(super) async fn push(
+        &mut self,
+        future: LocalBoxFuture<'static, CompletedWrite>,
+    ) -> Option<CompletedWrite> {
+        let completed = if self.is_at_capacity() {
+            self.futures.next().await
+        } else {
+            None
+        };
+        self.futures.push(future);
+        completed
+    }
+
+    pub(super) async fn next_completion(&mut self) -> Option<CompletedWrite> {
+        self.futures.next().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn completed_write(rows: u64) -> CompletedWrite {
+        CompletedWrite {
+            signal_type: SignalType::Logs,
+            result: Ok(vec![(ArrowPayloadType::Logs, rows)]),
+        }
+    }
+
+    /// Scenario: a third insert is submitted to a queue limited to two concurrent requests.
+    /// Guarantees: one request completes before the third is admitted and the queue stays bounded.
+    #[tokio::test]
+    async fn push_at_capacity_waits_for_a_completion() {
+        let mut writes = InFlightWrites::new(2);
+        assert!(
+            writes
+                .push(Box::pin(async { completed_write(1) }))
+                .await
+                .is_none()
+        );
+        assert!(
+            writes
+                .push(Box::pin(async { completed_write(2) }))
+                .await
+                .is_none()
+        );
+        assert!(writes.is_at_capacity());
+
+        let completed = writes
+            .push(Box::pin(async { completed_write(3) }))
+            .await
+            .expect("one insert should finish before admitting another");
+
+        assert!(matches!(completed.result.unwrap()[0].1, 1 | 2));
+        assert!(writes.is_at_capacity());
+    }
+
+    /// Scenario: an internal caller constructs a queue with a zero concurrency limit.
+    /// Guarantees: the defensive lower bound still permits exactly one in-flight request.
+    #[tokio::test]
+    async fn zero_limit_is_clamped_to_one() {
+        let mut writes = InFlightWrites::new(0);
+        assert!(
+            writes
+                .push(Box::pin(async { completed_write(1) }))
+                .await
+                .is_none()
+        );
+        assert!(writes.is_at_capacity());
+
+        let completed = writes
+            .push(Box::pin(async { completed_write(2) }))
+            .await
+            .expect("the first insert should complete before admitting the second");
+
+        assert_eq!(completed.result.unwrap()[0].1, 1);
+        assert!(writes.is_at_capacity());
+    }
+
+    /// Scenario: shutdown begins while two accepted insert requests are still in flight.
+    /// Guarantees: callers can drain every accepted request and observe all written row counts.
+    #[tokio::test]
+    async fn accepted_writes_can_be_drained() {
+        let mut writes = InFlightWrites::new(2);
+        assert!(
+            writes
+                .push(Box::pin(async { completed_write(3) }))
+                .await
+                .is_none()
+        );
+        assert!(
+            writes
+                .push(Box::pin(async { completed_write(5) }))
+                .await
+                .is_none()
+        );
+
+        let mut rows = Vec::new();
+        while let Some(completed) = writes.next_completion().await {
+            rows.push(completed.result.unwrap()[0].1);
+        }
+        rows.sort_unstable();
+
+        assert_eq!(rows, vec![3, 5]);
+        assert!(writes.is_empty());
+    }
+}

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/in_flight.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/in_flight.rs
@@ -3,6 +3,9 @@
 
 //! Bounded tracking for concurrent ClickHouse insert requests.
 
+use std::collections::VecDeque;
+use std::num::NonZeroUsize;
+
 use futures::StreamExt;
 use futures::future::LocalBoxFuture;
 use futures::stream::FuturesUnordered;
@@ -22,46 +25,97 @@ pub(super) struct CompletedWrite {
 /// Tracks insert futures and enforces the configured concurrency bound.
 pub(super) struct InFlightWrites {
     futures: FuturesUnordered<LocalBoxFuture<'static, CompletedWrite>>,
-    limit: usize,
+    queued: VecDeque<LocalBoxFuture<'static, CompletedWrite>>,
+    limit: NonZeroUsize,
 }
 
 impl InFlightWrites {
-    pub(super) fn new(limit: usize) -> Self {
+    pub(super) fn new(limit: NonZeroUsize) -> Self {
         Self {
             futures: FuturesUnordered::new(),
-            limit: limit.max(1),
+            queued: VecDeque::new(),
+            limit,
         }
     }
 
     pub(super) fn is_empty(&self) -> bool {
-        self.futures.is_empty()
+        self.futures.is_empty() && self.queued.is_empty()
     }
 
     pub(super) fn is_at_capacity(&self) -> bool {
-        self.futures.len() >= self.limit
+        self.futures.len() >= self.limit.get()
     }
 
-    pub(super) async fn push(
-        &mut self,
-        future: LocalBoxFuture<'static, CompletedWrite>,
-    ) -> Option<CompletedWrite> {
-        let completed = if self.is_at_capacity() {
-            self.futures.next().await
-        } else {
-            None
-        };
-        self.futures.push(future);
-        completed
+    pub(super) fn len(&self) -> usize {
+        self.futures.len() + self.queued.len()
+    }
+
+    /// Adds a write without blocking the exporter's control-message loop.
+    ///
+    /// Normal pdata admission stops when the active set reaches `limit`. The
+    /// queue is used only when `ExporterInbox` force-drains buffered pdata
+    /// during shutdown. Queued futures remain unpolled until an active slot is
+    /// available, so the configured concurrency bound still applies.
+    pub(super) fn push(&mut self, future: LocalBoxFuture<'static, CompletedWrite>) {
+        self.queued.push_back(future);
+        self.fill_capacity();
     }
 
     pub(super) async fn next_completion(&mut self) -> Option<CompletedWrite> {
-        self.futures.next().await
+        self.fill_capacity();
+        let completed = self.futures.next().await;
+        if completed.is_some() {
+            self.fill_capacity();
+        }
+        completed
+    }
+
+    /// Drains accepted writes until they complete or the shutdown deadline expires.
+    ///
+    /// Returns the number of active and queued writes left when the deadline
+    /// expires. Those futures are cancelled when this tracker is dropped.
+    pub(super) async fn drain_until(
+        &mut self,
+        deadline: tokio::time::Instant,
+        mut on_completion: impl FnMut(CompletedWrite),
+    ) -> usize {
+        while !self.is_empty() {
+            match tokio::time::timeout_at(deadline, self.next_completion()).await {
+                Ok(Some(completed)) => on_completion(completed),
+                Ok(None) => break,
+                Err(_) => return self.len(),
+            }
+        }
+        0
+    }
+
+    fn fill_capacity(&mut self) {
+        while !self.is_at_capacity() {
+            let Some(future) = self.queued.pop_front() else {
+                break;
+            };
+            self.futures.push(future);
+        }
+    }
+
+    #[cfg(test)]
+    fn active_len(&self) -> usize {
+        self.futures.len()
+    }
+
+    #[cfg(test)]
+    fn queued_len(&self) -> usize {
+        self.queued.len()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn limit(value: usize) -> NonZeroUsize {
+        NonZeroUsize::new(value).expect("test limit must be non-zero")
+    }
 
     fn completed_write(rows: u64) -> CompletedWrite {
         CompletedWrite {
@@ -70,81 +124,69 @@ mod tests {
         }
     }
 
-    /// Scenario: a third insert is submitted to a queue limited to two concurrent requests.
-    /// Guarantees: one request completes before the third is admitted and the queue stays bounded.
+    /// Scenario: forced shutdown draining submits a third write while two writes are active.
+    /// Guarantees: submission does not block and the third future remains unpolled until a slot opens.
     #[tokio::test]
-    async fn push_at_capacity_waits_for_a_completion() {
-        let mut writes = InFlightWrites::new(2);
-        assert!(
-            writes
-                .push(Box::pin(async { completed_write(1) }))
-                .await
-                .is_none()
-        );
-        assert!(
-            writes
-                .push(Box::pin(async { completed_write(2) }))
-                .await
-                .is_none()
-        );
+    async fn push_at_capacity_queues_without_blocking() {
+        let mut writes = InFlightWrites::new(limit(2));
+        writes.push(Box::pin(async { completed_write(1) }));
+        writes.push(Box::pin(futures::future::pending()));
         assert!(writes.is_at_capacity());
+
+        writes.push(Box::pin(async { completed_write(3) }));
+        assert_eq!(writes.active_len(), 2);
+        assert_eq!(writes.queued_len(), 1);
+        assert_eq!(writes.len(), 3);
 
         let completed = writes
-            .push(Box::pin(async { completed_write(3) }))
+            .next_completion()
             .await
-            .expect("one insert should finish before admitting another");
-
-        assert!(matches!(completed.result.unwrap()[0].1, 1 | 2));
-        assert!(writes.is_at_capacity());
-    }
-
-    /// Scenario: an internal caller constructs a queue with a zero concurrency limit.
-    /// Guarantees: the defensive lower bound still permits exactly one in-flight request.
-    #[tokio::test]
-    async fn zero_limit_is_clamped_to_one() {
-        let mut writes = InFlightWrites::new(0);
-        assert!(
-            writes
-                .push(Box::pin(async { completed_write(1) }))
-                .await
-                .is_none()
-        );
-        assert!(writes.is_at_capacity());
-
-        let completed = writes
-            .push(Box::pin(async { completed_write(2) }))
-            .await
-            .expect("the first insert should complete before admitting the second");
-
+            .expect("the ready active write should complete");
         assert_eq!(completed.result.unwrap()[0].1, 1);
         assert!(writes.is_at_capacity());
+        assert_eq!(writes.active_len(), 2);
+        assert_eq!(writes.queued_len(), 0);
     }
 
     /// Scenario: shutdown begins while two accepted insert requests are still in flight.
     /// Guarantees: callers can drain every accepted request and observe all written row counts.
     #[tokio::test]
     async fn accepted_writes_can_be_drained() {
-        let mut writes = InFlightWrites::new(2);
-        assert!(
-            writes
-                .push(Box::pin(async { completed_write(3) }))
-                .await
-                .is_none()
-        );
-        assert!(
-            writes
-                .push(Box::pin(async { completed_write(5) }))
-                .await
-                .is_none()
-        );
+        let mut writes = InFlightWrites::new(limit(2));
+        writes.push(Box::pin(async { completed_write(3) }));
+        writes.push(Box::pin(async { completed_write(5) }));
 
         let mut rows = Vec::new();
-        while let Some(completed) = writes.next_completion().await {
-            rows.push(completed.result.unwrap()[0].1);
-        }
+        let abandoned = writes
+            .drain_until(
+                tokio::time::Instant::now() + std::time::Duration::from_secs(1),
+                |completed| {
+                    rows.push(completed.result.unwrap()[0].1);
+                },
+            )
+            .await;
         rows.sort_unstable();
 
+        assert_eq!(abandoned, 0);
         assert_eq!(rows, vec![3, 5]);
         assert!(writes.is_empty());
+    }
+
+    /// Scenario: shutdown reaches its deadline with one active and one queued write stalled.
+    /// Guarantees: draining returns at the deadline and reports every write that will be abandoned.
+    #[tokio::test(start_paused = true)]
+    async fn drain_stops_at_deadline() {
+        let mut writes = InFlightWrites::new(limit(1));
+        writes.push(Box::pin(futures::future::pending()));
+        writes.push(Box::pin(async { completed_write(2) }));
+
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        let abandoned = writes
+            .drain_until(deadline, |_| panic!("stalled writes must not complete"))
+            .await;
+
+        assert_eq!(abandoned, 2);
+        assert_eq!(writes.active_len(), 1);
+        assert_eq!(writes.queued_len(), 1);
     }
 }

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/mod.rs
@@ -51,6 +51,7 @@ use otap_df_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
 use otap_df_telemetry::common_attributes::{Outcome, SignalOutcomeAttributes};
 use otap_df_telemetry::metrics::MetricSetHandler;
 use otap_df_telemetry::metrics::{MeasurementMetricSet, MetricSet};
+use std::rc::Rc;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -217,19 +218,19 @@ impl Exporter<OtapPdata> for ClickhouseExporter {
             endpoint = self.config.endpoint,
             database = self.config.database,
             username = self.config.username,
-            max_in_flight = self.config.max_in_flight
+            max_in_flight = self.config.max_in_flight.get()
         );
 
         let mut batch_transformer = BatchTransformer::new();
         let clickhouse_writer =
-            ClickHouseWriter::new(&self.config)
-                .await
-                .map_err(|e| Error::ExporterError {
+            Rc::new(ClickHouseWriter::new(&self.config).await.map_err(|e| {
+                Error::ExporterError {
                     exporter: exporter_id.clone(),
                     kind: ExporterErrorKind::Connect,
                     error: format!("clickhouse writer initialization error: {e}"),
                     source_detail: format_error_sources(&e),
-                })?;
+                }
+            })?);
         let mut in_flight_writes = InFlightWrites::new(self.config.max_in_flight);
 
         // Start periodic telemetry collection (internal metrics)
@@ -258,8 +259,17 @@ impl Exporter<OtapPdata> for ClickhouseExporter {
                         "clickhouse.exporter.shutdown",
                         message = "Clickhouse exporter shutting down",
                     );
-                    while let Some(completed) = in_flight_writes.next_completion().await {
-                        self.finalize_write(completed);
+                    let abandoned = in_flight_writes
+                        .drain_until(tokio::time::Instant::from_std(deadline), |completed| {
+                            self.finalize_write(completed);
+                        })
+                        .await;
+                    if abandoned > 0 {
+                        otap_df_telemetry::otel_warn!(
+                            "clickhouse.exporter.shutdown.deadline_exceeded",
+                            message = "ClickHouse writes abandoned at the shutdown deadline",
+                            abandoned_writes = abandoned,
+                        );
                     }
                     let _ = telemetry_cancel_handle.cancel().await;
                     return Ok(Self::terminal_state(
@@ -339,7 +349,7 @@ impl Exporter<OtapPdata> for ClickhouseExporter {
                             continue;
                         }
                     };
-                    let writer = clickhouse_writer.clone();
+                    let writer = Rc::clone(&clickhouse_writer);
                     let write_future: LocalBoxFuture<'static, CompletedWrite> =
                         Box::pin(async move {
                             CompletedWrite {
@@ -347,9 +357,7 @@ impl Exporter<OtapPdata> for ClickhouseExporter {
                                 result: writer.write_batches(&write_batches).await,
                             }
                         });
-                    if let Some(completed) = in_flight_writes.push(write_future).await {
-                        self.finalize_write(completed);
-                    }
+                    in_flight_writes.push(write_future);
                 }
                 _ => {
                     // Ignore other messages

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/mod.rs
@@ -28,6 +28,7 @@
 //! ```
 
 use async_trait::async_trait;
+use futures::future::LocalBoxFuture;
 use linkme::distributed_slice;
 use otap_df_config::node::NodeUserConfig;
 use otap_df_config::validation::validate_typed_config;
@@ -54,6 +55,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use crate::exporters::clickhouse_exporter::config::{Config, ConfigPatch};
+use crate::exporters::clickhouse_exporter::in_flight::{CompletedWrite, InFlightWrites};
 use crate::exporters::clickhouse_exporter::metrics::ClickhouseExporterMetrics;
 use crate::exporters::clickhouse_exporter::transform::transform_batch::BatchTransformer;
 use crate::exporters::clickhouse_exporter::writer::ClickHouseWriter;
@@ -62,6 +64,7 @@ mod arrays;
 mod config;
 mod consts;
 mod error;
+mod in_flight;
 mod metrics;
 mod schema;
 mod tables;
@@ -137,6 +140,42 @@ impl ClickhouseExporter {
 
         TerminalState::new(deadline, snapshots)
     }
+
+    fn finalize_write(&mut self, completed: CompletedWrite) {
+        let CompletedWrite {
+            signal_type,
+            result,
+        } = completed;
+
+        match result {
+            Ok(written_rows) => {
+                for (payload_type, rows) in written_rows {
+                    self.ch_metrics.add(rows, payload_type);
+                }
+                self.pdata_metrics
+                    .with(SignalOutcomeAttributes {
+                        signal: signal_type,
+                        outcome: Outcome::Success,
+                    })
+                    .messages
+                    .inc();
+            }
+            Err(error) => {
+                self.pdata_metrics
+                    .with(SignalOutcomeAttributes {
+                        signal: signal_type,
+                        outcome: Outcome::Failure,
+                    })
+                    .messages
+                    .inc();
+                otap_df_telemetry::otel_warn!(
+                    "clickhouse.exporter.write.error",
+                    message = format!("Error writing batch to clickhouse: {error}"),
+                    signal_type = format!("{signal_type:?}"),
+                );
+            }
+        }
+    }
 }
 
 /// Register Clickhouse exporter with the OTAP exporter factory
@@ -177,7 +216,8 @@ impl Exporter<OtapPdata> for ClickhouseExporter {
             message = "Clickhouse exporter starting",
             endpoint = self.config.endpoint,
             database = self.config.database,
-            username = self.config.username
+            username = self.config.username,
+            max_in_flight = self.config.max_in_flight
         );
 
         let mut batch_transformer = BatchTransformer::new();
@@ -190,6 +230,7 @@ impl Exporter<OtapPdata> for ClickhouseExporter {
                     error: format!("clickhouse writer initialization error: {e}"),
                     source_detail: format_error_sources(&e),
                 })?;
+        let mut in_flight_writes = InFlightWrites::new(self.config.max_in_flight);
 
         // Start periodic telemetry collection (internal metrics)
         let telemetry_cancel_handle = effect_handler
@@ -198,12 +239,28 @@ impl Exporter<OtapPdata> for ClickhouseExporter {
 
         // Message loop
         loop {
-            match inbox.recv().await? {
+            let accepting_pdata = !in_flight_writes.is_at_capacity();
+            let message = tokio::select! {
+                biased;
+
+                completed = in_flight_writes.next_completion(), if !in_flight_writes.is_empty() => {
+                    if let Some(completed) = completed {
+                        self.finalize_write(completed);
+                    }
+                    continue;
+                }
+                message = inbox.recv_when(accepting_pdata) => message?,
+            };
+
+            match message {
                 Message::Control(NodeControlMsg::Shutdown { deadline, .. }) => {
                     otap_df_telemetry::otel_info!(
                         "clickhouse.exporter.shutdown",
                         message = "Clickhouse exporter shutting down",
                     );
+                    while let Some(completed) = in_flight_writes.next_completion().await {
+                        self.finalize_write(completed);
+                    }
                     let _ = telemetry_cancel_handle.cancel().await;
                     return Ok(Self::terminal_state(
                         deadline,
@@ -282,33 +339,16 @@ impl Exporter<OtapPdata> for ClickhouseExporter {
                             continue;
                         }
                     };
-                    match clickhouse_writer
-                        .write_batches(&write_batches, &mut self.ch_metrics)
-                        .await
-                    {
-                        Ok(_) => {
-                            self.pdata_metrics
-                                .with(SignalOutcomeAttributes {
-                                    signal: signal_type,
-                                    outcome: Outcome::Success,
-                                })
-                                .messages
-                                .inc();
-                        }
-                        Err(e) => {
-                            self.pdata_metrics
-                                .with(SignalOutcomeAttributes {
-                                    signal: signal_type,
-                                    outcome: Outcome::Failure,
-                                })
-                                .messages
-                                .inc();
-                            otap_df_telemetry::otel_warn!(
-                                "clickhouse.exporter.write.error",
-                                message = format!("Error writing batch to clickhouse: {}", e),
-                                signal_type = format!("{:?}", signal_type),
-                            );
-                        }
+                    let writer = clickhouse_writer.clone();
+                    let write_future: LocalBoxFuture<'static, CompletedWrite> =
+                        Box::pin(async move {
+                            CompletedWrite {
+                                signal_type,
+                                result: writer.write_batches(&write_batches).await,
+                            }
+                        });
+                    if let Some(completed) = in_flight_writes.push(write_future).await {
+                        self.finalize_write(completed);
                     }
                 }
                 _ => {
@@ -323,6 +363,8 @@ impl Exporter<OtapPdata> for ClickhouseExporter {
 mod tests {
     use super::*;
 
+    /// Scenario: the ClickHouse exporter is registered with its public component URN.
+    /// Guarantees: configuration references continue to resolve to the exporter factory.
     #[test]
     fn test_urn_constant() {
         assert_eq!(CLICKHOUSE_EXPORTER_URN, "urn:otel:exporter:clickhouse");

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/transform_batch.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/transform_batch.rs
@@ -1610,7 +1610,6 @@ mod realistic_otap_tests {
         use clickhouse_ext_arrow::ArrowClientExt;
 
         use crate::exporters::clickhouse_exporter::config::Config;
-        use crate::exporters::clickhouse_exporter::metrics::ClickhouseExporterMetrics;
         use crate::exporters::clickhouse_exporter::transform::transform_batch::BatchTransformer;
         use crate::exporters::clickhouse_exporter::writer::{ClickHouseWriter, build_client};
 
@@ -1643,12 +1642,6 @@ mod realistic_otap_tests {
                 .execute()
                 .await
                 .expect("drop pre-existing test database");
-        }
-
-        /// Register a throwaway metric set so we can call the real `write_batches` path.
-        fn fresh_metrics() -> otap_df_telemetry::metrics::MetricSet<ClickhouseExporterMetrics> {
-            let (pipeline_ctx, _registry) = otap_df_engine::testing::test_pipeline_ctx();
-            pipeline_ctx.register_metrics::<ClickhouseExporterMetrics>()
         }
 
         /// Return a copy of `batch` with the field named `from` renamed to `to` (arrays untouched).
@@ -1687,6 +1680,8 @@ mod realistic_otap_tests {
             span_id: String,
         }
 
+        /// Scenario: transformed OTAP logs are inserted into a live ClickHouse schema.
+        /// Guarantees: every fixture row and representative field round-trips without coercion loss.
         #[tokio::test]
         #[ignore = "requires a live ClickHouse; run with --ignored e2e"]
         async fn e2e_logs_insert_roundtrips_through_clickhouse_schema() {
@@ -1710,9 +1705,8 @@ mod realistic_otap_tests {
             let writer = ClickHouseWriter::new(&config)
                 .await
                 .expect("writer init creates db + tables");
-            let mut metrics = fresh_metrics();
             writer
-                .write_batches(&batches, &mut metrics)
+                .write_batches(&batches)
                 .await
                 .expect("insert logs batch over FORMAT ArrowStream");
 
@@ -1810,6 +1804,8 @@ mod realistic_otap_tests {
             link0_kind: String,
         }
 
+        /// Scenario: transformed OTAP spans with events and links are inserted into ClickHouse.
+        /// Guarantees: nested span data and attributes round-trip through the production schema.
         #[tokio::test]
         #[ignore = "requires a live ClickHouse; run with --ignored e2e"]
         async fn e2e_traces_insert_roundtrips_through_clickhouse_schema() {
@@ -1851,11 +1847,10 @@ mod realistic_otap_tests {
             let writer = ClickHouseWriter::new(&config)
                 .await
                 .expect("writer init creates db + tables");
-            let mut metrics = fresh_metrics();
             let mut write_batches = HashMap::new();
             _ = write_batches.insert(ArrowPayloadType::Spans, spans_batch.clone());
             writer
-                .write_batches(&write_batches, &mut metrics)
+                .write_batches(&write_batches)
                 .await
                 .expect("insert spans batch over FORMAT ArrowStream");
 

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/writer.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/writer.rs
@@ -37,7 +37,6 @@ use crate::exporters::clickhouse_exporter::{
     tables::{build_payload_destination_table_map, init_table, validate_identifier},
 };
 
-#[derive(Clone)]
 pub struct ClickHouseWriter {
     client: Client,
     payload_destination_tables: HashMap<ArrowPayloadType, String>,

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/writer.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/writer.rs
@@ -11,8 +11,8 @@
 //! - **Writer abstraction**
 //!   - [`ClickHouseWriter`] maintains a ClickHouse client, the target database name, and a
 //!     precomputed map from `ArrowPayloadType` to destination table name.
-//!   - `write_batches` accepts a set of per-payload `RecordBatch`es and dispatches inserts,
-//!     updating metrics inline.
+//!   - `write_batches` accepts a set of per-payload `RecordBatch`es, dispatches inserts, and
+//!     returns the successfully written row counts for metrics accounting by the caller.
 //!   - `write_batch` performs a single `INSERT ... FORMAT ArrowStream` over HTTP using the official
 //!     client's Arrow extension, surfacing any server-side errors on `end()`.
 //!
@@ -29,16 +29,15 @@ use arrow_array::RecordBatch;
 use clickhouse::Client;
 use clickhouse_ext_arrow::ArrowClientExt;
 use otap_df_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
-use otap_df_telemetry::metrics::MetricSet;
 use secrecy::ExposeSecret;
 
 use crate::exporters::clickhouse_exporter::{
     config::Config,
     error::ClickhouseExporterError,
-    metrics::ClickhouseExporterMetrics,
     tables::{build_payload_destination_table_map, init_table, validate_identifier},
 };
 
+#[derive(Clone)]
 pub struct ClickHouseWriter {
     client: Client,
     payload_destination_tables: HashMap<ArrowPayloadType, String>,
@@ -103,16 +102,16 @@ impl ClickHouseWriter {
     pub async fn write_batches(
         &self,
         write_batches: &HashMap<ArrowPayloadType, RecordBatch>,
-        ch_metrics: &mut MetricSet<ClickhouseExporterMetrics>,
-    ) -> Result<(), ClickhouseExporterError> {
+    ) -> Result<Vec<(ArrowPayloadType, u64)>, ClickhouseExporterError> {
+        let mut written_rows = Vec::with_capacity(write_batches.len());
         for (payload_type, batch) in write_batches {
             let Some(table_name) = self.payload_destination_tables.get(payload_type) else {
                 continue;
             };
             self.write_batch(table_name, batch).await?;
-            ch_metrics.add(batch.num_rows() as u64, *payload_type);
+            written_rows.push((*payload_type, batch.num_rows() as u64));
         }
-        Ok(())
+        Ok(written_rows)
     }
 }
 
@@ -226,6 +225,8 @@ mod tests {
         }
     }
 
+    /// Scenario: a batch set contains mapped signal payloads and an unmapped attribute payload.
+    /// Guarantees: mapped batches are written once and their exact row counts are returned.
     #[tokio::test]
     async fn writes_all_mapped_payloads_and_reports_rows() {
         // Arrange: only signal tables have mappings (no attribute table mappings)
@@ -279,6 +280,8 @@ mod tests {
         assert!(!stat_map.contains_key(&ArrowPayloadType::ResourceAttrs));
     }
 
+    /// Scenario: a batch is supplied for a payload without a destination table mapping.
+    /// Guarantees: the unmapped batch is skipped and only mapped rows are reported as written.
     #[tokio::test]
     async fn skips_when_batch_present_but_no_table_mapping() {
         // Arrange: only Logs has a table mapping
@@ -309,6 +312,8 @@ mod tests {
         assert_eq!(stats[0].1, 1);
     }
 
+    /// Scenario: the writer receives an empty collection of transformed batches.
+    /// Guarantees: no inserts occur and no written-row metrics are returned.
     #[tokio::test]
     async fn empty_input_writes_nothing() {
         let writer = TestWriter::default();


### PR DESCRIPTION
# Change Summary

Adds configurable, bounded concurrency to the df_engine ClickHouse exporter.

The new `max_in_flight` setting controls how many ClickHouse HTTP insert requests may execute concurrently. It defaults to 10, enabling concurrent inserts without requiring additional configuration.

The exporter applies backpressure when the configured limit is reached and drains accepted requests during shutdown. Concurrent requests may complete out of order.

Users who require serialized insertion behavior can set:

```yaml
exporter:
  type: urn:otel:exporter:clickhouse
  config:
    endpoint: http://clickhouse:8123
    max_in_flight: 1
```

## Performance impact

The change was benchmarked against the serialized implementation using:

- 8,192-log input batches
- synchronous ClickHouse inserts
- `max_in_flight: 1` for the baseline
- `max_in_flight: 10` for this change and the new default
- one df_engine core
- six ClickHouse cores
- twelve traffic-generator cores
- ClickHouse 25.6
- three 60-second repetitions per scenario

Median ClickHouse written throughput under maximum offered load:

| Input path | Serialized baseline | New default | Gain |
| --- | --- | --- | --- |
| DFE OTAP | 180,271 logs/s | 682,597 logs/s | +278.6% / 3.79x |
| DFE OTLP | 179,810 logs/s | 437,543 logs/s | +143.3% / 2.43x |

At a fixed offered load of approximately 100,000 logs/s, written throughput remained unchanged, as expected. DFE CPU usage decreased by approximately 1.0% for OTAP and 9.8% for OTLP.

These results indicate that the new default can provide up to approximately 3.8x OTAP throughput and 2.4x OTLP throughput when serialized synchronous inserts are the bottleneck. The actual gain depends on the workload, ClickHouse capacity, and insertion latency.

Concurrent inserts drive ClickHouse harder and increased memory consumption during the saturation runs. Operators can reduce `max_in_flight` when ClickHouse resource consumption or insertion ordering is more important than maximum throughput.

## What issue does this PR close?

- Related to #3512
- Implements the bounded-concurrency follow-up identified by the ClickHouse exporter benchmarks in #3512

## How are these changes tested?

Automated tests cover:

- defaulting `max_in_flight` to 10
- accepting an explicitly configured concurrency limit
- rejecting a zero concurrency limit
- enforcing the configured bound
- applying backpressure before admitting another request
- draining all accepted writes during shutdown
- preserving completed row counts

The full workspace check passed.

## Are there any user-facing changes?

Yes. The ClickHouse exporter now allows up to ten concurrent inserts by default.

The new `max_in_flight` positive integer setting can be used to tune this limit. Values greater than one improve throughput by overlapping synchronous HTTP inserts, but inserts may complete out of order and can place more load on ClickHouse.

Set `max_in_flight: 1` to retain serialized insertion behavior.

### Changelog

- [x] Added a `.chloggen/*.yaml` entry
- [ ] This PR is a chore (indicated in title)
- [ ] This is a documentation-only PR.