### PR TITLE
chore: wire OTAP review guide into Copilot code review

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,22 @@
+# Copilot Instructions for otel-arrow
+
+See [AGENTS.md](../AGENTS.md) for build, test, and contribution conventions,
+including changelog entries, ASCII-only Rust source, and test documentation.
+
+## Reviewing pull requests
+
+When reviewing changes under `rust/`, follow the project's review guide,
+[AI-Assisted Pull Request Review][review-guide]. It defines what matters in an
+OTAP Dataflow review: architectural invariants, runtime and performance
+characteristics, bounded resources, backpressure, correctness, semantic
+fidelity, test adequacy, and security.
+
+The highest-signal rules are restated as path-specific instructions in
+[.github/instructions](instructions/), which apply automatically to matching
+files.
+
+Report only risks supported by the diff, nearby code, or project guidance, and
+avoid stylistic nitpicks unless they affect correctness, readability, or
+maintainability.
+
+[review-guide]: ../rust/otap-dataflow/docs/ai/ai-assisted-pr-review.md

--- a/.github/instructions/rust-review.instructions.md
+++ b/.github/instructions/rust-review.instructions.md
@@ -1,0 +1,49 @@
+---
+applyTo: "rust/**/*.rs"
+---
+
+# Rust review rules (OTAP Dataflow)
+
+These restate the highest-signal rules from the project's review guide,
+[AI-Assisted Pull Request Review][review-guide]. Consult that guide for the
+full review criteria; it remains the source of truth.
+
+## 1. Prefer `!Send` futures
+
+The engine is share-nothing and thread-per-core, so work stays local to a core
+by default. Prefer `!Send` futures and `?Send`-friendly traits.
+
+Flag a newly introduced `Send` bound, or a change that forces one on an
+existing trait or future, unless the pull request explains why it is required.
+
+## 2. Justify shared-state and cross-thread primitives
+
+`Arc<Mutex<_>>`, `RwLock`, atomics, and `tokio::spawn` are not banned, but each
+use must be justified in a code comment or the pull request description.
+Prefer pipeline-local `spawn_local` / `LocalSet` work instead.
+
+Flag any new use that arrives without a justification, and say what is missing
+rather than simply objecting to the primitive. Hidden cross-core
+synchronization breaks the runtime model even when the code compiles and the
+tests pass.
+
+## 3. Document every test
+
+Every test carries doc comments immediately above its declaration:
+
+```rust
+/// Scenario: <the behavior or condition under test>
+/// Guarantees: <the observable invariant protected by the test>
+```
+
+Both statements must be specific enough for a reviewer to understand the test's
+intent, and what must not regress, without reading its implementation. Flag new
+tests that omit them or that restate the test name.
+
+## Out of scope for review comments
+
+Do not comment on non-ASCII characters in Rust source, or on missing changelog
+entries. Continuous integration already enforces both and fails the build, so
+review comments about them add noise without adding signal.
+
+[review-guide]: ../../rust/otap-dataflow/docs/ai/ai-assisted-pr-review.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,15 @@
 If working on Rust code (i.e., the `rust/` directory), read and follow all
 instructions in [rust/otap-dataflow/AGENTS.md](rust/otap-dataflow/AGENTS.md).
 
+## Reviewing changes
+
+When reviewing a pull request, follow
+[rust/otap-dataflow/docs/ai/ai-assisted-pr-review.md](rust/otap-dataflow/docs/ai/ai-assisted-pr-review.md).
+It describes what matters in an OTAP Dataflow review for both human and agent
+reviewers: architectural invariants, runtime and performance characteristics,
+bounded resources, backpressure, correctness, semantic fidelity, test adequacy,
+and security.
+
 ## ASCII-only source
 
 Rust source under `rust/otap-dataflow` must be ASCII-only; CI


### PR DESCRIPTION
## Change Summary

Copilot code review currently falls back to generic, language-level heuristics
on this repository, so it does not check the things that actually matter in
OTAP Dataflow reviews.

The standards for that already exist. @lquerel wrote
[`rust/otap-dataflow/docs/ai/ai-assisted-pr-review.md`](https://github.com/open-telemetry/otel-arrow/blob/main/rust/otap-dataflow/docs/ai/ai-assisted-pr-review.md),
which covers the OTAP runtime model in depth. The problem is purely one of
distribution: Copilot code review never loads it. There is no
`.github/copilot-instructions.md`, no `.github/instructions/` directory, and
`AGENTS.md` does not link to it.

**This PR adds the missing wiring and introduces no new standards.**

- `.github/copilot-instructions.md` - thin, repo-wide pointer to `AGENTS.md`
  and the review guide.
- `.github/instructions/rust-review.instructions.md` - restates the three
  highest-signal rules, scoped to `rust/**/*.rs` with `applyTo` frontmatter.
  The guide remains the source of truth; everything else links out to it.
- `AGENTS.md` - links the review guide under a new "Reviewing changes"
  section, so Claude, Codex, and other agents reach the same source of truth
  instead of each vendor accumulating its own drifting copy.

## The three rules

All three are already documented in this repository, and none are enforced by
CI today:

1. **Prefer `!Send` futures** - a newly introduced `Send` bound needs
   justification (share-nothing, thread-per-core).
2. **Justify `Arc<Mutex<_>>`, `RwLock`, atomics, and `tokio::spawn`** - not
   banned, but each use needs a stated reason; prefer `spawn_local` /
   `LocalSet`.
3. **Document every test** with `Scenario:` / `Guarantees:` doc comments.

Rules that CI already fails the build on are **explicitly excluded** so review
comments stay signal rather than noise:

- non-ASCII Rust source (`repo-lint.yaml` runs `tools/sanitycheck.py`)
- missing changelog entries (`changelog.yml`)

## Why start with only three

Starting with a small set of rules that are already documented in this
repository keeps the focus on the mechanism rather than the rule list. Once
this is in, the natural follow-up is to grow the rule set
from recurring review feedback, which the guide already anticipates:

> "This guideline is expected to evolve. Update it when recurring PR comments,
> issues, incidents, or maintainer feedback reveal review gaps that should
> become shared guidance."

## How are these changes tested?

- `npx markdownlint-cli2` on all three changed files: **0 issues**.
- `tools/sanitycheck.py`: the changed files are ASCII-only and stored with LF
  line endings. (Local runs show pre-existing CRLF failures across many
  untouched files due to a Windows `core.autocrlf=true` checkout; the committed
  blobs for these three files contain zero CR bytes.)
- All relative links verified to resolve.
- Instruction files are read from the PR head branch, so Copilot's review of
  this PR exercises the new configuration directly.

## Are there any user-facing changes?

No. Documentation and repository configuration only.

### Changelog

- [x] This PR is a `chore` (indicated in title)
- [x] This is a documentation-only PR.
