### PR TITLE
Optimize OTAP log transformation in the ClickHouse exporter

### DIFF
--- a/rust/otap-dataflow/.chloggen/clickhouse-exporter-optimize-otap-logs.yaml
+++ b/rust/otap-dataflow/.chloggen/clickhouse-exporter-optimize-otap-logs.yaml
@@ -1,0 +1,9 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+change_type: enhancement
+component: pipeline
+note: "Reduce CPU used to transform OTAP logs in the ClickHouse exporter."
+issues: [3512]
+subtext: |
+  Canonical OTAP log batches use a specialized shape-preserving path. Unsupported layouts automatically use the existing generic transformer.

--- a/rust/otap-dataflow/crates/contrib-nodes/Cargo.toml
+++ b/rust/otap-dataflow/crates/contrib-nodes/Cargo.toml
@@ -144,6 +144,7 @@ clickhouse-exporter = [
     "dep:itoa",
     "dep:ryu",
 ]
+clickhouse-exporter-bench = ["clickhouse-exporter"]
 geneva-exporter = [
     "dep:geneva-uploader",
     "dep:opentelemetry-proto",
@@ -215,6 +216,12 @@ name = "azure_monitor_transformer"
 path = "benches/exporters/azure_monitor_exporter/transformer.rs"
 harness = false
 required-features = ["azure-monitor-exporter"]
+
+[[bench]]
+name = "clickhouse_logs_transformer"
+path = "benches/exporters/clickhouse_exporter/logs_transformer.rs"
+harness = false
+required-features = ["clickhouse-exporter-bench"]
 
 [[bench]]
 name = "azure_monitor_gzip_batcher"

--- a/rust/otap-dataflow/crates/contrib-nodes/benches/exporters/clickhouse_exporter/logs_transformer.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/benches/exporters/clickhouse_exporter/logs_transformer.rs
@@ -7,7 +7,7 @@ use std::hint::black_box;
 
 use arrow::ipc::writer::StreamWriter;
 use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
-use otap_df_contrib_nodes::exporters::clickhouse_exporter::benchmark::LogsTransformBenchmark;
+use otap_df_contrib_nodes::exporters::clickhouse_exporter::bench_support::LogsTransformBenchmark;
 use otap_df_pdata::testing::{fixtures, round_trip::encode_logs};
 
 const LOGS_PER_BATCH: usize = 8192;

--- a/rust/otap-dataflow/crates/contrib-nodes/benches/exporters/clickhouse_exporter/logs_transformer.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/benches/exporters/clickhouse_exporter/logs_transformer.rs
@@ -1,0 +1,56 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Compares generic and specialized OTAP logs transformation for the ClickHouse exporter.
+
+use std::hint::black_box;
+
+use arrow::ipc::writer::StreamWriter;
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
+use otap_df_contrib_nodes::exporters::clickhouse_exporter::benchmark::LogsTransformBenchmark;
+use otap_df_pdata::testing::{fixtures, round_trip::encode_logs};
+
+const LOGS_PER_BATCH: usize = 8192;
+
+fn bench_logs_transform(c: &mut Criterion) {
+    let mut records = encode_logs(&fixtures::logs_with_varying_attributes_and_properties(
+        LOGS_PER_BATCH,
+    ));
+    records
+        .decode_transport_optimized_ids()
+        .expect("decode transport-optimized IDs");
+
+    let mut group = c.benchmark_group("clickhouse_logs_transform");
+    _ = group.throughput(Throughput::Elements(LOGS_PER_BATCH as u64));
+
+    let mut generic = LogsTransformBenchmark::default();
+    _ = group.bench_function("generic/8192", |b| {
+        b.iter_batched(
+            || records.clone(),
+            |input| black_box(generic.transform_generic(input)),
+            BatchSize::SmallInput,
+        );
+    });
+
+    let mut fast = LogsTransformBenchmark::default();
+    _ = group.bench_function("specialized/8192", |b| {
+        b.iter(|| black_box(fast.transform_fast(black_box(&records))));
+    });
+
+    let output = fast.transform_fast(&records);
+    _ = group.bench_function("arrow_stream/8192", |b| {
+        b.iter(|| {
+            let mut bytes = Vec::new();
+            let mut writer = StreamWriter::try_new(&mut bytes, output.schema_ref())
+                .expect("create ArrowStream writer");
+            writer.write(&output).expect("encode ClickHouse batch");
+            writer.finish().expect("finish ArrowStream");
+            black_box(bytes)
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_logs_transform);
+criterion_main!(benches);

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/README.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/README.md
@@ -78,7 +78,8 @@ At runtime the exporter does the following:
    tables if enabled
 3. Receives `OtapPdata` messages from the engine
 4. Converts payloads into `OtapArrowRecords`
-5. Runs the transform pipeline across supported payload types
+5. Uses the specialized transformer for canonical OTAP logs, with the generic
+   transform pipeline as a fallback and for other inputs
 6. Returns only signal batches (`Logs`, `Spans`) from the transformer
 7. Inserts those batches into the destination tables
 
@@ -178,6 +179,12 @@ Nested attribute values (Map/Slice) are transcoded from binary/CBOR into a JSON
 string stored as the map value.
 
 ## Transform Pipeline
+
+Canonical OTAP log batches use a specialized transformation path that preserves
+the generic transformer's ClickHouse schema and values. If an input layout is
+not supported by that path, the exporter automatically falls back to the
+generic transformer. OTLP logs, traces, and other supported payloads continue
+to use the generic pipeline.
 
 The transform pipeline has two stages per payload:
 

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/bench_support.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/bench_support.rs
@@ -2,6 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Benchmark-only access to the ClickHouse logs transformation implementations.
+//!
+//! Criterion benchmarks are compiled as separate crates, so they cannot access the exporter's
+//! crate-private transformers directly. This feature-gated bridge exposes only the operations
+//! needed to compare the generic and specialized implementations without making those
+//! implementation details part of the production API.
 
 use arrow::array::RecordBatch;
 use otap_df_pdata::OtapArrowRecords;

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/benchmark.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/benchmark.rs
@@ -1,0 +1,45 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Benchmark-only access to the ClickHouse logs transformation implementations.
+
+use arrow::array::RecordBatch;
+use otap_df_pdata::OtapArrowRecords;
+use otap_df_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
+
+use super::transform::logs_fast::{LogsFastTransform, LogsFastTransformer};
+use super::transform::transform_batch::BatchTransformer;
+
+/// Owns reusable state for comparing the generic and specialized logs transformers.
+#[derive(Default)]
+pub struct LogsTransformBenchmark {
+    generic: BatchTransformer,
+    fast: LogsFastTransformer,
+}
+
+impl LogsTransformBenchmark {
+    /// Transform one logs batch with the generic transformation plan.
+    #[must_use]
+    pub fn transform_generic(&mut self, records: OtapArrowRecords) -> RecordBatch {
+        self.generic
+            .apply_plan(records)
+            .expect("generic ClickHouse logs transform")
+            .remove(&ArrowPayloadType::Logs)
+            .expect("generic transform produced a logs batch")
+    }
+
+    /// Transform one decoded canonical OTAP logs batch with the specialized path.
+    #[must_use]
+    pub fn transform_fast(&mut self, records: &OtapArrowRecords) -> RecordBatch {
+        match self
+            .fast
+            .try_apply(records)
+            .expect("specialized ClickHouse logs transform")
+        {
+            LogsFastTransform::Applied(batch) => batch,
+            LogsFastTransform::NotApplicable(reason) => {
+                panic!("benchmark input is not supported by the specialized transform: {reason}")
+            }
+        }
+    }
+}

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/metrics.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/metrics.rs
@@ -24,7 +24,7 @@ pub struct ClickhouseExporterMetrics {
     #[metric(unit = "{batch}")]
     pub log_fast_path_batches: Counter<u64>,
 
-    /// Total number of OTAP log batches sent through the generic transform fallback.
+    /// Total number of log batches sent through the generic transform fallback.
     #[metric(unit = "{batch}")]
     pub log_transform_fallback_batches: Counter<u64>,
 }
@@ -44,7 +44,7 @@ impl ClickhouseExporterMetrics {
         self.log_fast_path_batches.inc();
     }
 
-    /// Records one log batch transformed by the generic fallback path.
+    /// Records one log batch sent through the generic fallback path.
     pub fn record_log_transform_fallback(&mut self) {
         self.log_transform_fallback_batches.inc();
     }

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/metrics.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/metrics.rs
@@ -19,6 +19,14 @@ pub struct ClickhouseExporterMetrics {
     /// Total number of trace rows written successfully into clickhouse
     #[metric(unit = "{row}")]
     pub trace_rows_written: Counter<u64>,
+
+    /// Total number of OTAP log batches transformed by the specialized path.
+    #[metric(unit = "{batch}")]
+    pub log_fast_path_batches: Counter<u64>,
+
+    /// Total number of OTAP log batches sent through the generic transform fallback.
+    #[metric(unit = "{batch}")]
+    pub log_transform_fallback_batches: Counter<u64>,
 }
 
 impl ClickhouseExporterMetrics {
@@ -30,12 +38,24 @@ impl ClickhouseExporterMetrics {
             _ => {}
         }
     }
+
+    /// Records one log batch transformed by the specialized path.
+    pub fn record_log_fast_path(&mut self) {
+        self.log_fast_path_batches.inc();
+    }
+
+    /// Records one log batch transformed by the generic fallback path.
+    pub fn record_log_transform_fallback(&mut self) {
+        self.log_transform_fallback_batches.inc();
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// Scenario: a successful log insert reports its row count.
+    /// Guarantees: log rows increment only the log row counter.
     #[test]
     fn add_logs_increments_log_rows_counter() {
         let mut m = ClickhouseExporterMetrics::default();
@@ -44,6 +64,8 @@ mod tests {
         assert_eq!(m.trace_rows_written.get(), 0);
     }
 
+    /// Scenario: a successful span insert reports its row count.
+    /// Guarantees: span rows increment only the trace row counter.
     #[test]
     fn add_spans_increments_trace_rows_counter() {
         let mut m = ClickhouseExporterMetrics::default();
@@ -52,6 +74,8 @@ mod tests {
         assert_eq!(m.log_rows_written.get(), 0);
     }
 
+    /// Scenario: a non-signal Arrow payload reports written rows.
+    /// Guarantees: unsupported payload types leave both signal row counters unchanged.
     #[test]
     fn add_unknown_payload_type_is_noop() {
         let mut m = ClickhouseExporterMetrics::default();
@@ -60,6 +84,8 @@ mod tests {
         assert_eq!(m.trace_rows_written.get(), 0);
     }
 
+    /// Scenario: a successful insert contains zero rows.
+    /// Guarantees: adding zero leaves the selected row counter unchanged.
     #[test]
     fn add_zero_rows_does_not_change_counter() {
         let mut m = ClickhouseExporterMetrics::default();
@@ -67,6 +93,8 @@ mod tests {
         assert_eq!(m.log_rows_written.get(), 0);
     }
 
+    /// Scenario: several successful log inserts complete.
+    /// Guarantees: row metrics accumulate every reported log row count.
     #[test]
     fn add_accumulates_across_multiple_calls() {
         let mut m = ClickhouseExporterMetrics::default();
@@ -76,6 +104,8 @@ mod tests {
         assert_eq!(m.log_rows_written.get(), 60);
     }
 
+    /// Scenario: log and span inserts both complete successfully.
+    /// Guarantees: each signal updates its independent row counter.
     #[test]
     fn counters_are_independent() {
         let mut m = ClickhouseExporterMetrics::default();
@@ -85,10 +115,25 @@ mod tests {
         assert_eq!(m.trace_rows_written.get(), 2);
     }
 
+    /// Scenario: ClickHouse exporter metrics are newly registered.
+    /// Guarantees: all written-row counters start at zero.
     #[test]
     fn default_counters_are_zero() {
         let m = ClickhouseExporterMetrics::default();
         assert_eq!(m.log_rows_written.get(), 0);
         assert_eq!(m.trace_rows_written.get(), 0);
+    }
+
+    /// Scenario: specialized and fallback log transforms are both observed.
+    /// Guarantees: each transform path increments only its dedicated batch counter.
+    #[test]
+    fn transform_path_counters_are_independent() {
+        let mut metrics = ClickhouseExporterMetrics::default();
+        metrics.record_log_fast_path();
+        metrics.record_log_transform_fallback();
+        metrics.record_log_transform_fallback();
+
+        assert_eq!(metrics.log_fast_path_batches.get(), 1);
+        assert_eq!(metrics.log_transform_fallback_batches.get(), 2);
     }
 }

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/mod.rs
@@ -355,6 +355,9 @@ impl Exporter<OtapPdata> for ClickhouseExporter {
                             Err(error) => Err(error),
                         }
                     } else {
+                        if signal_type == SignalType::Logs {
+                            self.ch_metrics.record_log_transform_fallback();
+                        }
                         batch_transformer.apply_plan(arrow_records)
                     };
 

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/mod.rs
@@ -69,7 +69,7 @@ use crate::exporters::clickhouse_exporter::writer::ClickHouseWriter;
 mod arrays;
 #[cfg(feature = "clickhouse-exporter-bench")]
 #[doc(hidden)]
-pub mod benchmark;
+pub mod bench_support;
 mod config;
 mod consts;
 mod error;

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/mod.rs
@@ -348,13 +348,8 @@ impl Exporter<OtapPdata> for ClickhouseExporter {
                                 self.ch_metrics.record_log_fast_path();
                                 Ok(HashMap::from([(ArrowPayloadType::Logs, batch)]))
                             }
-                            Ok(LogsFastTransform::NotApplicable(reason)) => {
+                            Ok(LogsFastTransform::NotApplicable(_)) => {
                                 self.ch_metrics.record_log_transform_fallback();
-                                otap_df_telemetry::otel_debug!(
-                                    "clickhouse.exporter.transform.fallback",
-                                    message = "Using generic ClickHouse transform for OTAP logs.",
-                                    reason = reason,
-                                );
                                 batch_transformer.apply_plan(arrow_records)
                             }
                             Err(error) => Err(error),

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/mod.rs
@@ -32,6 +32,7 @@ use futures::future::LocalBoxFuture;
 use linkme::distributed_slice;
 use otap_df_config::node::NodeUserConfig;
 use otap_df_config::validation::validate_typed_config;
+use otap_df_config::{SignalFormat, SignalType};
 use otap_df_engine::ExporterFactory;
 use otap_df_engine::config::ExporterConfig;
 use otap_df_engine::context::PipelineContext;
@@ -51,6 +52,7 @@ use otap_df_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
 use otap_df_telemetry::common_attributes::{Outcome, SignalOutcomeAttributes};
 use otap_df_telemetry::metrics::MetricSetHandler;
 use otap_df_telemetry::metrics::{MeasurementMetricSet, MetricSet};
+use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -58,10 +60,16 @@ use std::time::{Duration, Instant};
 use crate::exporters::clickhouse_exporter::config::{Config, ConfigPatch};
 use crate::exporters::clickhouse_exporter::in_flight::{CompletedWrite, InFlightWrites};
 use crate::exporters::clickhouse_exporter::metrics::ClickhouseExporterMetrics;
+use crate::exporters::clickhouse_exporter::transform::logs_fast::{
+    LogsFastTransform, LogsFastTransformer,
+};
 use crate::exporters::clickhouse_exporter::transform::transform_batch::BatchTransformer;
 use crate::exporters::clickhouse_exporter::writer::ClickHouseWriter;
 
 mod arrays;
+#[cfg(feature = "clickhouse-exporter-bench")]
+#[doc(hidden)]
+pub mod benchmark;
 mod config;
 mod consts;
 mod error;
@@ -222,6 +230,7 @@ impl Exporter<OtapPdata> for ClickhouseExporter {
         );
 
         let mut batch_transformer = BatchTransformer::new();
+        let mut logs_fast_transformer = LogsFastTransformer::default();
         let clickhouse_writer =
             Rc::new(ClickHouseWriter::new(&self.config).await.map_err(|e| {
                 Error::ExporterError {
@@ -286,6 +295,7 @@ impl Exporter<OtapPdata> for ClickhouseExporter {
                 }
                 Message::PData(pdata) => {
                     let signal_type = pdata.signal_type();
+                    let signal_format = pdata.signal_format();
 
                     let (_context, payload) = pdata.into_parts();
 
@@ -330,7 +340,30 @@ impl Exporter<OtapPdata> for ClickhouseExporter {
                             }
                         })?;
 
-                    let write_batches = match batch_transformer.apply_plan(arrow_records) {
+                    let transform_result = if signal_type == SignalType::Logs
+                        && signal_format == SignalFormat::OtapRecords
+                    {
+                        match logs_fast_transformer.try_apply(&arrow_records) {
+                            Ok(LogsFastTransform::Applied(batch)) => {
+                                self.ch_metrics.record_log_fast_path();
+                                Ok(HashMap::from([(ArrowPayloadType::Logs, batch)]))
+                            }
+                            Ok(LogsFastTransform::NotApplicable(reason)) => {
+                                self.ch_metrics.record_log_transform_fallback();
+                                otap_df_telemetry::otel_debug!(
+                                    "clickhouse.exporter.transform.fallback",
+                                    message = "Using generic ClickHouse transform for OTAP logs.",
+                                    reason = reason,
+                                );
+                                batch_transformer.apply_plan(arrow_records)
+                            }
+                            Err(error) => Err(error),
+                        }
+                    } else {
+                        batch_transformer.apply_plan(arrow_records)
+                    };
+
+                    let write_batches = match transform_result {
                         Ok(batches) => batches,
                         Err(e) => {
                             self.pdata_metrics

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/logs_fast.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/logs_fast.rs
@@ -1,0 +1,629 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Specialized transformation of canonical OTAP log batches into ClickHouse columns.
+//!
+//! # Applicability
+//!
+//! The exporter attempts this fast path only for log signals whose original format is
+//! `SignalFormat::OtapRecords`. It applies when a `Logs` batch is present and its optional
+//! `resource`, `scope`, and `body` columns use the canonical struct layout. Parent IDs must be
+//! `UInt16` when the corresponding resource, scope, or log attribute payload is present. Missing
+//! optional columns and attribute payloads do not prevent fast-path use.
+//!
+//! The fast path is not attempted for raw OTLP protobuf (`SignalFormat::OtlpBytes`), traces, or
+//! metrics; those inputs use the generic transformation plan directly. If an OTAP logs batch is
+//! eligible for an attempt but has an unsupported layout, this transformer returns
+//! [`LogsFastTransform::NotApplicable`] and the caller falls back to the generic plan.
+//!
+//! # Approach
+//!
+//! The generic transformer interprets a reusable transformation plan that supports several
+//! signals and input layouts. This transformer recognizes the canonical OTAP logs layout and
+//! constructs the equivalent ClickHouse `RecordBatch` directly:
+//!
+//! - compatible Arrow arrays are shared with the output; only columns that require conversion or
+//!   joining are materialized
+//! - compact resource, scope, and log attribute payloads are joined to their parent log rows, with
+//!   resource and scope joins using a dense ID-to-row lookup
+//! - `service.name` is extracted while resource attributes are copied, avoiding another map scan
+//! - output columns are sorted to match the generic transformer's stable lexical ordering
+//! - the most recently used output schema is cached and reused for batches with the same layout
+//!
+//! # ClickHouse-compatible Arrow RecordBatch
+//!
+//! The output contains one row per input log row. Columns are assembled as follows (`LC` means
+//! `LowCardinality`):
+//!
+//! ```text
+//! +--------------------+--------------------------------------+--------------------------+
+//! | Output column      | OTAP source / operation              | ClickHouse type          |
+//! +--------------------+--------------------------------------+--------------------------+
+//! | Body               | body -> stringify AnyValue           | String                   |
+//! | EventName          | event_name -> reuse                  | String                   |
+//! | LogAttributes      | LogAttrs joined on Logs.id           | Map(LC(String), String)  |
+//! | ResourceAttributes | ResourceAttrs joined on resource.id  | Map(LC(String), String)  |
+//! | ResourceSchemaUrl  | resource.schema_url -> reuse         | LC(String)               |
+//! | ScopeAttributes    | ScopeAttrs joined on scope.id        | Map(LC(String), String)  |
+//! | ScopeName          | scope.name -> reuse                  | String                   |
+//! | ScopeSchemaUrl     | scope.schema_url -> reuse            | LC(String)               |
+//! | ScopeVersion       | scope.version -> reuse               | LC(String)               |
+//! | ServiceName        | extract service.name from resource   | LC(String)               |
+//! | SeverityNumber     | severity_number -> cast to UInt8     | UInt8                    |
+//! | SeverityText       | severity_text -> reuse               | LC(String)               |
+//! | SpanId             | span_id -> lowercase hex string      | String                   |
+//! | Timestamp          | time_unix_nano -> reuse              | DateTime64(9)            |
+//! | TraceFlags         | span_flags -> reuse                  | UInt8                    |
+//! | TraceId            | trace_id -> lowercase hex string     | String                   |
+//! +--------------------+--------------------------------------+--------------------------+
+//! ```
+//!
+//! ```text
+//!                      +--------------------------------+
+//! all output arrays -->| sort columns lexically         |
+//!                      | build/reuse cached Arrow schema |
+//!                      +---------------+----------------+
+//!                                      |
+//!                                      v
+//!                      +--------------------------------+
+//!                      | RecordBatch                    |
+//!                      +---------------+----------------+
+//!                                      |
+//!                                      | FORMAT ArrowStream
+//!                                      v
+//!                      +--------------------------------+
+//!                      | ClickHouse otel_logs table      |
+//!                      +--------------------------------+
+//! ```
+//!
+//! An unsupported input shape returns [`LogsFastTransform::NotApplicable`] without modifying the
+//! input, allowing the caller to use the generic transformer. Conversion and Arrow errors are
+//! propagated instead of falling back, so malformed data is not silently handled differently.
+//! Equivalence tests compare the specialized output with the generic transformation plan.
+
+use std::sync::Arc;
+
+use arrow::array::{
+    Array, ArrayRef, MapArray, MapBuilder, RecordBatch, StringArray, StringBuilder, StructArray,
+    UInt16Array, UInt32Array,
+};
+use arrow::compute::cast;
+use arrow::datatypes::{DataType, Field, Schema, UInt8Type};
+use otap_df_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
+use otap_df_pdata::{OtapArrowRecords, schema::consts};
+
+use crate::exporters::clickhouse_exporter::arrays::StructColumnAccessor;
+use crate::exporters::clickhouse_exporter::consts as ch_consts;
+use crate::exporters::clickhouse_exporter::error::ClickhouseExporterError;
+use crate::exporters::clickhouse_exporter::transform::transform_attributes::{
+    group_attributes_to_map_str, inline_attributes_to_parent,
+};
+use crate::exporters::clickhouse_exporter::transform::transform_column::{
+    fixed_binary_to_hex_string, struct_column_to_string,
+};
+
+const OTAP_SPAN_FLAGS: &str = "span_flags";
+const SERVICE_NAME_KEY: &str = "service.name";
+const MISSING_INDEX: u32 = u32::MAX;
+
+/// Result of attempting the specialized transformation.
+pub(crate) enum LogsFastTransform {
+    /// The canonical logs layout was transformed successfully.
+    Applied(RecordBatch),
+    /// The input layout is valid but not supported by this specialized path.
+    NotApplicable(&'static str),
+}
+
+/// Specialized transformer with a one-entry output schema cache.
+#[derive(Default)]
+pub(crate) struct LogsFastTransformer {
+    cached_schema: Option<(Vec<(&'static str, DataType)>, Arc<Schema>)>,
+}
+
+impl LogsFastTransformer {
+    /// Transform a decoded canonical OTAP logs batch or decline it without modifying the input.
+    pub(crate) fn try_apply(
+        &mut self,
+        records: &OtapArrowRecords,
+    ) -> Result<LogsFastTransform, ClickhouseExporterError> {
+        let Some(logs) = records.get(ArrowPayloadType::Logs) else {
+            return Ok(LogsFastTransform::NotApplicable("missing logs payload"));
+        };
+
+        let resource = match logs.column_by_name(consts::RESOURCE) {
+            Some(array) => match array.as_any().downcast_ref::<StructArray>() {
+                Some(array) => Some(array),
+                None => {
+                    return Ok(LogsFastTransform::NotApplicable(
+                        "resource column is not a struct",
+                    ));
+                }
+            },
+            None => None,
+        };
+        let scope = match logs.column_by_name(consts::SCOPE) {
+            Some(array) => match array.as_any().downcast_ref::<StructArray>() {
+                Some(array) => Some(array),
+                None => {
+                    return Ok(LogsFastTransform::NotApplicable(
+                        "scope column is not a struct",
+                    ));
+                }
+            },
+            None => None,
+        };
+        let body = match logs.column_by_name(consts::BODY) {
+            Some(array) => match array.as_any().downcast_ref::<StructArray>() {
+                Some(array) => Some(array),
+                None => {
+                    return Ok(LogsFastTransform::NotApplicable(
+                        "body column is not a struct",
+                    ));
+                }
+            },
+            None => None,
+        };
+
+        let resource_attrs = grouped_attributes(records, ArrowPayloadType::ResourceAttrs)?;
+        let scope_attrs = grouped_attributes(records, ArrowPayloadType::ScopeAttrs)?;
+        let log_attrs = records.get(ArrowPayloadType::LogAttrs);
+
+        let mut columns: Vec<(&'static str, ArrayRef)> = Vec::with_capacity(16);
+        if let Some(body) = body {
+            let Some(body_types) = StructColumnAccessor::new(body)
+                .primitive_column_op::<UInt8Type>(consts::ATTRIBUTE_TYPE)?
+            else {
+                return Ok(LogsFastTransform::NotApplicable(
+                    "body type column is not UInt8",
+                ));
+            };
+            columns.push((
+                ch_consts::CH_BODY,
+                struct_column_to_string(body_types, &StructColumnAccessor::new(body))?,
+            ));
+        }
+        if let Some(column) = logs.column_by_name(consts::EVENT_NAME) {
+            columns.push((ch_consts::CH_EVENT_NAME, column.clone()));
+        }
+
+        if let Some(attributes_batch) = log_attrs {
+            let Some(log_ids) = u16_column(logs, consts::ID) else {
+                return Ok(LogsFastTransform::NotApplicable(
+                    "log id column is not UInt16",
+                ));
+            };
+            if let Some(attributes) = inline_attributes_to_parent(attributes_batch, log_ids)? {
+                columns.push((ch_consts::CH_LOG_ATTRIBUTES, Arc::new(attributes)));
+            }
+        }
+
+        if let Some(compact) = resource_attrs.as_ref() {
+            let Some(resource_ids) =
+                resource.and_then(|array| struct_u16_column(array, consts::ID))
+            else {
+                return Ok(LogsFastTransform::NotApplicable(
+                    "resource id column is not UInt16",
+                ));
+            };
+            let (attributes, service_name) = inline_attributes(resource_ids, compact, true)?;
+            columns.push((ch_consts::CH_RESOURCE_ATTRIBUTES, attributes));
+            columns.push((
+                ch_consts::CH_SERVICE_NAME,
+                service_name.expect("service name requested"),
+            ));
+        }
+
+        if let Some(resource_schema_url) =
+            resource.and_then(|array| array.column_by_name(consts::SCHEMA_URL))
+        {
+            columns.push((
+                ch_consts::CH_RESOURCE_SCHEMA_URL,
+                resource_schema_url.clone(),
+            ));
+        }
+
+        if let Some(compact) = scope_attrs.as_ref() {
+            let Some(scope_ids) = scope.and_then(|array| struct_u16_column(array, consts::ID))
+            else {
+                return Ok(LogsFastTransform::NotApplicable(
+                    "scope id column is not UInt16",
+                ));
+            };
+            let (attributes, _) = inline_attributes(scope_ids, compact, false)?;
+            columns.push((ch_consts::CH_SCOPE_ATTRIBUTES, attributes));
+        }
+
+        if let Some(scope) = scope {
+            for (source, destination) in [
+                (consts::NAME, ch_consts::CH_SCOPE_NAME),
+                (consts::SCHEMA_URL, ch_consts::CH_SCOPE_SCHEMA_URL),
+                (consts::VERSION, ch_consts::CH_SCOPE_VERSION),
+            ] {
+                if let Some(column) = scope.column_by_name(source) {
+                    columns.push((destination, column.clone()));
+                }
+            }
+        }
+
+        if let Some(column) = logs.column_by_name(consts::SEVERITY_NUMBER) {
+            columns.push((
+                ch_consts::CH_SEVERITY_NUMBER,
+                cast(column, &DataType::UInt8)?,
+            ));
+        }
+        if let Some(column) = logs.column_by_name(consts::SEVERITY_TEXT) {
+            columns.push((ch_consts::CH_SEVERITY_TEXT, column.clone()));
+        }
+        if let Some(column) = logs.column_by_name(consts::SPAN_ID) {
+            columns.push((ch_consts::CH_SPAN_ID, fixed_binary_to_hex_string(column)?));
+        }
+        if let Some(column) = logs.column_by_name(consts::TIME_UNIX_NANO) {
+            columns.push((ch_consts::CH_TIMESTAMP, column.clone()));
+        }
+        if let Some(column) = logs.column_by_name(OTAP_SPAN_FLAGS) {
+            columns.push((ch_consts::CH_TRACE_FLAGS, column.clone()));
+        }
+        if let Some(column) = logs.column_by_name(consts::TRACE_ID) {
+            columns.push((ch_consts::CH_TRACE_ID, fixed_binary_to_hex_string(column)?));
+        }
+
+        if columns.is_empty() {
+            return Ok(LogsFastTransform::NotApplicable(
+                "logs payload has no ClickHouse columns",
+            ));
+        }
+
+        // The generic transformer emits columns in lexical order. Matching that order makes the
+        // specialized output directly comparable and keeps ArrowStream schemas stable.
+        columns.sort_unstable_by_key(|(name, _)| *name);
+        let schema = self.schema_for(&columns);
+        let arrays = columns.into_iter().map(|(_, array)| array).collect();
+        let batch = RecordBatch::try_new(schema, arrays)?;
+
+        Ok(LogsFastTransform::Applied(batch))
+    }
+
+    fn schema_for(&mut self, columns: &[(&'static str, ArrayRef)]) -> Arc<Schema> {
+        let key: Vec<_> = columns
+            .iter()
+            .map(|(name, array)| (*name, array.data_type().clone()))
+            .collect();
+        if let Some((cached_key, schema)) = &self.cached_schema
+            && cached_key == &key
+        {
+            return schema.clone();
+        }
+
+        let fields = key
+            .iter()
+            .map(|(name, data_type)| Field::new(*name, data_type.clone(), true))
+            .collect::<Vec<_>>();
+        let schema = Arc::new(Schema::new(fields));
+        self.cached_schema = Some((key, schema.clone()));
+        schema
+    }
+}
+
+fn u16_column<'a>(batch: &'a RecordBatch, name: &str) -> Option<&'a UInt16Array> {
+    batch
+        .column_by_name(name)?
+        .as_any()
+        .downcast_ref::<UInt16Array>()
+}
+
+fn struct_u16_column<'a>(array: &'a StructArray, name: &str) -> Option<&'a UInt16Array> {
+    array
+        .column_by_name(name)?
+        .as_any()
+        .downcast_ref::<UInt16Array>()
+}
+
+fn grouped_attributes(
+    records: &OtapArrowRecords,
+    payload_type: ArrowPayloadType,
+) -> Result<Option<(UInt32Array, MapArray)>, ClickhouseExporterError> {
+    let Some(batch) = records.get(payload_type) else {
+        return Ok(None);
+    };
+    group_attributes_to_map_str(batch)
+}
+
+fn inline_attributes(
+    parent_ids: &UInt16Array,
+    compact: &(UInt32Array, MapArray),
+    extract_service_name: bool,
+) -> Result<(ArrayRef, Option<ArrayRef>), ClickhouseExporterError> {
+    let (compact_ids, compact_maps) = compact;
+    let keys = compact_maps
+        .keys()
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or_else(|| ClickhouseExporterError::CoercionError {
+            error: "attribute map keys are not strings".into(),
+        })?;
+    let values = compact_maps
+        .values()
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or_else(|| ClickhouseExporterError::CoercionError {
+            error: "attribute map values are not strings".into(),
+        })?;
+
+    let max_id = compact_ids.iter().flatten().max().unwrap_or(0) as usize;
+    let mut dense_remap = vec![MISSING_INDEX; max_id.saturating_add(1)];
+    for (index, id) in compact_ids.iter().enumerate() {
+        if let Some(id) = id
+            && let Some(slot) = dense_remap.get_mut(id as usize)
+        {
+            *slot = index as u32;
+        }
+    }
+
+    let mut map_builder = MapBuilder::with_capacity(
+        None,
+        StringBuilder::new(),
+        StringBuilder::new(),
+        parent_ids.len(),
+    );
+    let mut service_builder = extract_service_name.then(|| {
+        StringBuilder::with_capacity(parent_ids.len(), parent_ids.len().saturating_mul(16))
+    });
+    let offsets = compact_maps.offsets();
+
+    for row in 0..parent_ids.len() {
+        let compact_index = if parent_ids.is_valid(row) {
+            dense_remap
+                .get(parent_ids.value(row) as usize)
+                .copied()
+                .filter(|index| *index != MISSING_INDEX)
+                .map(|index| index as usize)
+        } else {
+            None
+        };
+        let mut service_name = None;
+
+        if let Some(compact_index) = compact_index {
+            let start = offsets[compact_index] as usize;
+            let end = offsets[compact_index + 1] as usize;
+            for index in start..end {
+                let key = keys.value(index);
+                map_builder.keys().append_value(key);
+                if values.is_null(index) {
+                    map_builder.values().append_null();
+                } else {
+                    let value = values.value(index);
+                    map_builder.values().append_value(value);
+                    if service_name.is_none() && key == SERVICE_NAME_KEY {
+                        service_name = Some(value);
+                    }
+                }
+            }
+        }
+
+        map_builder.append(true)?;
+        if let Some(builder) = &mut service_builder {
+            builder.append_value(service_name.unwrap_or(""));
+        }
+    }
+
+    Ok((
+        Arc::new(map_builder.finish()),
+        service_builder.map(|mut builder| Arc::new(builder.finish()) as ArrayRef),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::UInt32Builder;
+    use otap_df_pdata::proto::opentelemetry::common::v1::{
+        AnyValue, InstrumentationScope, KeyValue,
+    };
+    use otap_df_pdata::proto::opentelemetry::logs::v1::{
+        LogRecord, LogRecordFlags, LogsData, ResourceLogs, ScopeLogs, SeverityNumber,
+    };
+    use otap_df_pdata::proto::opentelemetry::resource::v1::Resource;
+    use otap_df_pdata::testing::{fixtures, round_trip::encode_logs};
+
+    use crate::exporters::clickhouse_exporter::transform::transform_batch::BatchTransformer;
+
+    fn decoded_logs(logs: LogsData) -> OtapArrowRecords {
+        let mut records = encode_logs(&logs);
+        records
+            .decode_transport_optimized_ids()
+            .expect("decode IDs");
+        records
+    }
+
+    fn assert_matches_generic(records: OtapArrowRecords) {
+        let mut generic = BatchTransformer::new();
+        let expected = generic
+            .apply_plan(records.clone())
+            .expect("generic transform")
+            .remove(&ArrowPayloadType::Logs)
+            .expect("generic logs output");
+        let actual = match LogsFastTransformer::default()
+            .try_apply(&records)
+            .expect("fast transform")
+        {
+            LogsFastTransform::Applied(batch) => batch,
+            LogsFastTransform::NotApplicable(reason) => {
+                panic!("canonical logs unexpectedly declined: {reason}")
+            }
+        };
+        assert_eq!(actual, expected);
+    }
+
+    fn rich_logs() -> LogsData {
+        LogsData::new(vec![ResourceLogs::new(
+            Resource::build()
+                .attributes(vec![
+                    KeyValue::new("service.name", AnyValue::new_string("fast-path-service")),
+                    KeyValue::new("resource.int", AnyValue::new_int(42)),
+                ])
+                .finish(),
+            vec![ScopeLogs::new(
+                InstrumentationScope::build()
+                    .name("fast-path-scope".to_string())
+                    .version("1.2.3".to_string())
+                    .attributes(vec![KeyValue::new("scope.bool", AnyValue::new_bool(true))])
+                    .finish(),
+                vec![
+                    LogRecord::build()
+                        .time_unix_nano(1_000u64)
+                        .severity_number(SeverityNumber::Info)
+                        .severity_text("INFO")
+                        .body(AnyValue::new_string("message"))
+                        .attributes(vec![KeyValue::new("log.double", AnyValue::new_double(1.5))])
+                        .flags(LogRecordFlags::TraceFlagsMask)
+                        .trace_id(vec![0x11; 16])
+                        .span_id(vec![0x22; 8])
+                        .event_name("rich-event")
+                        .finish(),
+                ],
+            )],
+        )])
+    }
+
+    /// Scenario: canonical logs contain resource, scope, and log attributes.
+    /// Guarantees: the fast path produces the exact same ClickHouse batch as the generic path.
+    #[test]
+    fn full_logs_match_generic_transform() {
+        assert_matches_generic(decoded_logs(fixtures::logs_with_full_resource_and_scope()));
+    }
+
+    /// Scenario: canonical logs omit all resource, scope, and log attributes.
+    /// Guarantees: the fast path preserves the generic path's omitted attribute columns.
+    #[test]
+    fn logs_without_attributes_match_generic_transform() {
+        assert_matches_generic(decoded_logs(fixtures::logs_with_no_attributes()));
+    }
+
+    /// Scenario: canonical logs contain multiple resources and scopes with mixed content.
+    /// Guarantees: fixed-layout joins preserve row ordering and values from the generic path.
+    #[test]
+    fn mixed_resources_and_scopes_match_generic_transform() {
+        assert_matches_generic(decoded_logs(
+            fixtures::logs_multiple_resources_mixed_content(),
+        ));
+    }
+
+    /// Scenario: canonical logs exercise every transformed ClickHouse field and attribute level.
+    /// Guarantees: service extraction, ID hex encoding, body conversion, and maps match generic output.
+    #[test]
+    fn rich_logs_match_generic_transform() {
+        assert_matches_generic(decoded_logs(rich_logs()));
+    }
+
+    /// Scenario: the same canonical logs layout is transformed more than once.
+    /// Guarantees: the specialized transformer reuses its cached output schema.
+    #[test]
+    fn repeated_layout_reuses_cached_schema() {
+        let records = decoded_logs(rich_logs());
+        let mut transformer = LogsFastTransformer::default();
+        let first = match transformer.try_apply(&records).expect("first transform") {
+            LogsFastTransform::Applied(batch) => batch,
+            LogsFastTransform::NotApplicable(reason) => {
+                panic!("canonical logs unexpectedly declined: {reason}")
+            }
+        };
+        let second = match transformer.try_apply(&records).expect("second transform") {
+            LogsFastTransform::Applied(batch) => batch,
+            LogsFastTransform::NotApplicable(reason) => {
+                panic!("canonical logs unexpectedly declined: {reason}")
+            }
+        };
+
+        assert!(Arc::ptr_eq(first.schema_ref(), second.schema_ref()));
+    }
+
+    /// Scenario: parent rows contain sparse, null, known, and unknown attribute IDs.
+    /// Guarantees: maps preserve parent order and service names default when no match exists.
+    #[test]
+    fn inline_attributes_handles_sparse_and_null_parent_ids() {
+        let mut map_builder = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
+        map_builder.keys().append_value(SERVICE_NAME_KEY);
+        map_builder.values().append_value("checkout");
+        map_builder.keys().append_value("nullable");
+        map_builder.values().append_null();
+        map_builder.append(true).expect("first compact map");
+        map_builder.keys().append_value("other");
+        map_builder.values().append_value("value");
+        map_builder.append(true).expect("second compact map");
+        let compact = (UInt32Array::from(vec![2_u32, 7_u32]), map_builder.finish());
+        let parent_ids = UInt16Array::from(vec![Some(7_u16), None, Some(2_u16), Some(9_u16)]);
+
+        let (attributes, service_names) =
+            inline_attributes(&parent_ids, &compact, true).expect("inline compact attributes");
+        let attributes = attributes
+            .as_any()
+            .downcast_ref::<MapArray>()
+            .expect("attribute map output");
+        let keys = attributes
+            .keys()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("string keys");
+        let values = attributes
+            .values()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("string values");
+        let service_names = service_names
+            .expect("service names requested")
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("service name strings")
+            .clone();
+
+        assert_eq!(attributes.value_offsets(), &[0, 1, 1, 3, 3]);
+        assert_eq!(keys.value(0), "other");
+        assert_eq!(keys.value(1), SERVICE_NAME_KEY);
+        assert_eq!(keys.value(2), "nullable");
+        assert_eq!(values.value(0), "value");
+        assert_eq!(values.value(1), "checkout");
+        assert!(values.is_null(2));
+        assert_eq!(
+            service_names.iter().collect::<Vec<_>>(),
+            vec![Some(""), Some(""), Some("checkout"), Some("")]
+        );
+    }
+
+    /// Scenario: a compact attribute map uses a non-string key or value type.
+    /// Guarantees: the specialized inliner reports coercion errors instead of reading invalid data.
+    #[test]
+    fn inline_attributes_rejects_non_string_map_entries() {
+        let mut map_builder = MapBuilder::new(None, UInt32Builder::new(), StringBuilder::new());
+        map_builder.keys().append_value(1);
+        map_builder.values().append_value("value");
+        map_builder.append(true).expect("compact map");
+        let compact = (UInt32Array::from(vec![1_u32]), map_builder.finish());
+        let parent_ids = UInt16Array::from(vec![1_u16]);
+
+        let error = inline_attributes(&parent_ids, &compact, false)
+            .expect_err("non-string keys must be rejected");
+
+        assert!(error.to_string().contains("keys are not strings"));
+
+        let mut map_builder = MapBuilder::new(None, StringBuilder::new(), UInt32Builder::new());
+        map_builder.keys().append_value("key");
+        map_builder.values().append_value(1);
+        map_builder.append(true).expect("compact map");
+        let compact = (UInt32Array::from(vec![1_u32]), map_builder.finish());
+        let error = inline_attributes(&parent_ids, &compact, false)
+            .expect_err("non-string values must be rejected");
+
+        assert!(error.to_string().contains("values are not strings"));
+    }
+
+    /// Scenario: an OTAP logs envelope contains no root logs record batch.
+    /// Guarantees: the fast path declines the input so normal exporter handling remains available.
+    #[test]
+    fn missing_logs_payload_is_declined_for_generic_fallback() {
+        let records = encode_logs(&fixtures::empty_logs());
+        let result = LogsFastTransformer::default()
+            .try_apply(&records)
+            .expect("applicability check");
+        assert!(matches!(result, LogsFastTransform::NotApplicable(_)));
+    }
+}

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/logs_fast.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/logs_fast.rs
@@ -363,6 +363,8 @@ fn inline_attributes(
         }
     }
 
+    // Bulk range copies with MutableArrayData did not improve typical batches in benchmarks.
+    // Revisit that approach for high-cardinality attributes, where the setup cost may amortize.
     let mut map_builder = MapBuilder::with_capacity(
         None,
         StringBuilder::new(),

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/logs_fast.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/logs_fast.rs
@@ -88,11 +88,11 @@ use arrow::array::{
     UInt16Array, UInt32Array,
 };
 use arrow::compute::cast;
-use arrow::datatypes::{DataType, Field, Schema, UInt8Type};
+use arrow::datatypes::{DataType, Field, Schema, UInt8Type, UInt16Type};
 use otap_df_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
 use otap_df_pdata::{OtapArrowRecords, schema::consts};
 
-use crate::exporters::clickhouse_exporter::arrays::StructColumnAccessor;
+use crate::exporters::clickhouse_exporter::arrays::{StructColumnAccessor, get_u16_array_opt};
 use crate::exporters::clickhouse_exporter::consts as ch_consts;
 use crate::exporters::clickhouse_exporter::error::ClickhouseExporterError;
 use crate::exporters::clickhouse_exporter::transform::transform_attributes::{
@@ -187,7 +187,7 @@ impl LogsFastTransformer {
         }
 
         if let Some(attributes_batch) = log_attrs {
-            let Some(log_ids) = u16_column(logs, consts::ID) else {
+            let Some(log_ids) = fast_path_u16_column(logs, consts::ID) else {
                 return Ok(LogsFastTransform::NotApplicable(
                     "log id column is not UInt16",
                 ));
@@ -199,7 +199,7 @@ impl LogsFastTransformer {
 
         if let Some(compact) = resource_attrs.as_ref() {
             let Some(resource_ids) =
-                resource.and_then(|array| struct_u16_column(array, consts::ID))
+                resource.and_then(|array| fast_path_struct_u16_column(array, consts::ID))
             else {
                 return Ok(LogsFastTransform::NotApplicable(
                     "resource id column is not UInt16",
@@ -223,7 +223,8 @@ impl LogsFastTransformer {
         }
 
         if let Some(compact) = scope_attrs.as_ref() {
-            let Some(scope_ids) = scope.and_then(|array| struct_u16_column(array, consts::ID))
+            let Some(scope_ids) =
+                scope.and_then(|array| fast_path_struct_u16_column(array, consts::ID))
             else {
                 return Ok(LogsFastTransform::NotApplicable(
                     "scope id column is not UInt16",
@@ -304,18 +305,19 @@ impl LogsFastTransformer {
     }
 }
 
-fn u16_column<'a>(batch: &'a RecordBatch, name: &str) -> Option<&'a UInt16Array> {
-    batch
-        .column_by_name(name)?
-        .as_any()
-        .downcast_ref::<UInt16Array>()
+fn fast_path_u16_column<'a>(batch: &'a RecordBatch, name: &str) -> Option<&'a UInt16Array> {
+    // Missing and mistyped columns both mean that this specialized layout does not apply. The
+    // generic transformer remains responsible for deciding whether the input itself is invalid.
+    get_u16_array_opt(batch, name).ok().flatten()
 }
 
-fn struct_u16_column<'a>(array: &'a StructArray, name: &str) -> Option<&'a UInt16Array> {
-    array
-        .column_by_name(name)?
-        .as_any()
-        .downcast_ref::<UInt16Array>()
+fn fast_path_struct_u16_column<'a>(array: &'a StructArray, name: &str) -> Option<&'a UInt16Array> {
+    // Preserve the same applicability policy while delegating Arrow access and type checking to
+    // the exporter's shared accessor.
+    StructColumnAccessor::new(array)
+        .primitive_column_op::<UInt16Type>(name)
+        .ok()
+        .flatten()
 }
 
 fn grouped_attributes(
@@ -535,6 +537,53 @@ mod tests {
         };
 
         assert!(Arc::ptr_eq(first.schema_ref(), second.schema_ref()));
+    }
+
+    /// Scenario: a root log ID is present as UInt16, absent, or encoded with another type.
+    /// Guarantees: the shared accessor is reused while unsupported layouts remain fallback cases.
+    #[test]
+    fn root_log_id_accessor_preserves_fast_path_fallback_policy() {
+        let batch = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("valid_id", DataType::UInt16, false),
+                Field::new("wrong_id", DataType::UInt32, false),
+            ])),
+            vec![
+                Arc::new(UInt16Array::from(vec![7_u16])),
+                Arc::new(UInt32Array::from(vec![7_u32])),
+            ],
+        )
+        .expect("ID test batch");
+
+        assert_eq!(
+            fast_path_u16_column(&batch, "valid_id").map(|ids| ids.value(0)),
+            Some(7)
+        );
+        assert!(fast_path_u16_column(&batch, "missing_id").is_none());
+        assert!(fast_path_u16_column(&batch, "wrong_id").is_none());
+    }
+
+    /// Scenario: a resource or scope ID is present as UInt16, absent, or has another type.
+    /// Guarantees: nested ID access reuses StructColumnAccessor and preserves generic fallback.
+    #[test]
+    fn nested_parent_id_accessor_preserves_fast_path_fallback_policy() {
+        let array = StructArray::from(vec![
+            (
+                Arc::new(Field::new("valid_id", DataType::UInt16, false)),
+                Arc::new(UInt16Array::from(vec![11_u16])) as ArrayRef,
+            ),
+            (
+                Arc::new(Field::new("wrong_id", DataType::UInt32, false)),
+                Arc::new(UInt32Array::from(vec![11_u32])) as ArrayRef,
+            ),
+        ]);
+
+        assert_eq!(
+            fast_path_struct_u16_column(&array, "valid_id").map(|ids| ids.value(0)),
+            Some(11)
+        );
+        assert!(fast_path_struct_u16_column(&array, "missing_id").is_none());
+        assert!(fast_path_struct_u16_column(&array, "wrong_id").is_none());
     }
 
     /// Scenario: parent rows contain sparse, null, known, and unknown attribute IDs.

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/logs_fast.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/logs_fast.rs
@@ -111,7 +111,9 @@ pub(crate) enum LogsFastTransform {
     /// The canonical logs layout was transformed successfully.
     Applied(RecordBatch),
     /// The input layout is valid but not supported by this specialized path.
-    NotApplicable(&'static str),
+    ///
+    /// The reason is retained for benchmark and test diagnostics; production records a counter.
+    NotApplicable(#[allow(dead_code)] &'static str),
 }
 
 /// Specialized transformer with a one-entry output schema cache.

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/mod.rs
@@ -7,6 +7,7 @@ use crate::exporters::clickhouse_exporter::SUPPORTED_ARROW_PAYLOAD_TYPES;
 use crate::exporters::clickhouse_exporter::transform::transform_plan::TransformationPlan;
 use otap_df_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
 
+pub(crate) mod logs_fast;
 mod transform_attributes;
 pub(crate) mod transform_batch;
 mod transform_column;
@@ -26,6 +27,8 @@ mod tests {
     use super::*;
     use std::collections::HashSet;
 
+    /// Scenario: the ClickHouse transform map is constructed for exporter startup.
+    /// Guarantees: every supported payload type receives its configured transformation plan.
     #[test]
     fn build_payload_transform_map_has_all_supported_keys_and_expected_values() {
         let m = build_payload_transform_map();

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/transform_attributes.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/transform_attributes.rs
@@ -23,7 +23,10 @@
 //! for rewriting foreign keys in parent signal batches.
 use std::collections::HashMap;
 
-use arrow::array::{Array, MapBuilder, StringBuilder, UInt16Array, UInt32Builder};
+use arrow::array::{
+    Array, BinaryArray, BooleanArray, Float64Array, MapBuilder, StringBuilder, UInt8Array,
+    UInt16Array, UInt32Builder,
+};
 use arrow::array::{RecordBatch, UInt32Array};
 use arrow::compute::cast;
 use arrow::datatypes::DataType;
@@ -180,6 +183,170 @@ fn parent_ids_as_u16(batch: &RecordBatch) -> Result<Option<UInt16Array>, Clickho
         .clone();
 
     Ok(Some(ids))
+}
+
+struct AttributeMapEncoder<'a> {
+    types: &'a UInt8Array,
+    keys: StringArrayAccessor<'a>,
+    strings: Option<StringArrayAccessor<'a>>,
+    integers: Option<Int64ArrayAccessor<'a>>,
+    doubles: Option<&'a Float64Array>,
+    booleans: Option<&'a BooleanArray>,
+    bytes: Option<&'a BinaryArray>,
+    serialized: Option<ByteArrayAccessor<'a>>,
+}
+
+impl<'a> AttributeMapEncoder<'a> {
+    fn try_new(batch: &'a RecordBatch) -> Result<Self, ClickhouseExporterError> {
+        Ok(Self {
+            types: get_u8_array(batch, consts::ATTRIBUTE_TYPE)?,
+            keys: StringArrayAccessor::try_new_for_column(batch, consts::ATTRIBUTE_KEY)?,
+            strings: get_array_op(batch, consts::ATTRIBUTE_STR)
+                .map(StringArrayAccessor::try_new)
+                .transpose()?,
+            integers: get_array_op(batch, consts::ATTRIBUTE_INT)
+                .map(Int64ArrayAccessor::try_new)
+                .transpose()?,
+            doubles: get_f64_array_opt(batch, consts::ATTRIBUTE_DOUBLE)?,
+            booleans: get_bool_array_opt(batch, consts::ATTRIBUTE_BOOL)?,
+            bytes: get_binary_array_opt(batch, consts::ATTRIBUTE_BYTES)?,
+            serialized: get_array_op(batch, consts::ATTRIBUTE_SER)
+                .map(ByteArrayAccessor::try_new)
+                .transpose()?,
+        })
+    }
+
+    fn append_row(&self, row: usize, builder: &mut MapBuilder<StringBuilder, StringBuilder>) {
+        let Some(key) = self.keys.str_at(row) else {
+            return;
+        };
+        builder.keys().append_value(key);
+
+        let attribute_type = self.types.value(row);
+        match attribute_type {
+            value if value == AttributeValueType::Empty as u8 => {
+                builder.values().append_value("");
+            }
+            value if value == AttributeValueType::Str as u8 => {
+                builder.values().append_value(
+                    self.strings
+                        .as_ref()
+                        .and_then(|a| a.str_at(row))
+                        .unwrap_or(""),
+                );
+            }
+            value if value == AttributeValueType::Int as u8 => {
+                if let Some(value) = self.integers.as_ref().and_then(|a| a.value_at(row)) {
+                    let mut buffer = itoa::Buffer::new();
+                    builder.values().append_value(buffer.format(value));
+                } else {
+                    builder.values().append_value("");
+                }
+            }
+            value if value == AttributeValueType::Double as u8 => {
+                if let Some(value) = self.doubles.and_then(|a| a.value_at(row)) {
+                    let mut buffer = ryu::Buffer::new();
+                    builder.values().append_value(buffer.format(value));
+                } else {
+                    builder.values().append_value("");
+                }
+            }
+            value if value == AttributeValueType::Bool as u8 => {
+                if let Some(value) = self.booleans.and_then(|a| a.value_at(row)) {
+                    builder
+                        .values()
+                        .append_value(if value { "true" } else { "false" });
+                } else {
+                    builder.values().append_value("");
+                }
+            }
+            value if value == AttributeValueType::Bytes as u8 => {
+                if let Some(bytes) = self.bytes.filter(|a| a.is_valid(row)) {
+                    builder.values().append_value(
+                        base64::engine::general_purpose::STANDARD.encode(bytes.value(row)),
+                    );
+                } else {
+                    builder.values().append_value("");
+                }
+            }
+            value
+                if value == AttributeValueType::Map as u8
+                    || value == AttributeValueType::Slice as u8 =>
+            {
+                let json = self
+                    .serialized
+                    .as_ref()
+                    .and_then(|a| a.slice_at(row))
+                    .and_then(|value| {
+                        let mut buffer = Vec::with_capacity(value.len() * 2);
+                        append_cbor_as_json(&mut buffer, value)
+                            .ok()
+                            .and_then(|()| String::from_utf8(buffer).ok())
+                    })
+                    .unwrap_or_default();
+                builder.values().append_value(json);
+            }
+            _ => builder.values().append_value(""),
+        }
+    }
+}
+
+/// Inline an attribute payload directly into an existing parent row order.
+pub(crate) fn inline_attributes_to_parent(
+    batch: &RecordBatch,
+    parent_ids: &UInt16Array,
+) -> Result<Option<MapArray>, ClickhouseExporterError> {
+    let Some(attribute_parent_ids) = parent_ids_as_u16(batch)? else {
+        return Ok(None);
+    };
+
+    // OTAP attribute rows are sorted by type/key/value for compression, so their parent IDs are
+    // commonly non-contiguous. Build a compact row index in two linear passes instead of creating
+    // a hash entry and a separately allocated Vec for every parent.
+    let max_id = attribute_parent_ids
+        .iter()
+        .chain(parent_ids.iter())
+        .flatten()
+        .max()
+        .unwrap_or(0) as usize;
+    let mut offsets = vec![0_u32; max_id.saturating_add(2)];
+    for id in attribute_parent_ids.iter().flatten() {
+        offsets[id as usize + 1] += 1;
+    }
+    for index in 1..offsets.len() {
+        offsets[index] += offsets[index - 1];
+    }
+    let mut cursors = offsets[..offsets.len() - 1].to_vec();
+    let mut grouped_rows = vec![0_u32; attribute_parent_ids.len()];
+    for (row, id) in attribute_parent_ids.iter().enumerate() {
+        let Some(id) = id else {
+            continue;
+        };
+        let cursor = &mut cursors[id as usize];
+        grouped_rows[*cursor as usize] = row as u32;
+        *cursor += 1;
+    }
+
+    let encoder = AttributeMapEncoder::try_new(batch)?;
+    let mut builder = MapBuilder::with_capacity(
+        None,
+        StringBuilder::new(),
+        StringBuilder::new(),
+        parent_ids.len(),
+    );
+    for row in 0..parent_ids.len() {
+        if parent_ids.is_valid(row) {
+            let id = parent_ids.value(row) as usize;
+            let start = offsets[id] as usize;
+            let end = offsets[id + 1] as usize;
+            for &attribute_row in &grouped_rows[start..end] {
+                encoder.append_row(attribute_row as usize, &mut builder);
+            }
+        }
+        builder.append(true)?;
+    }
+
+    Ok(Some(builder.finish()))
 }
 
 /// For Clickhouse Map(str, str) attribute columns, we group the rows by parent_id and represent the set as an array of dicts.
@@ -409,6 +576,8 @@ mod tests_group_attributes {
         out
     }
 
+    /// Scenario: an attribute batch has no parent ID column.
+    /// Guarantees: grouping reports no attribute map instead of fabricating parent associations.
     #[test]
     fn map_returns_none_when_parent_id_missing() {
         let batch = build_batch(
@@ -427,6 +596,8 @@ mod tests_group_attributes {
         assert!(got.is_none());
     }
 
+    /// Scenario: attribute rows share parent IDs and one row has a null key.
+    /// Guarantees: values are grouped by parent while null-keyed attributes are omitted.
     #[test]
     fn map_groups_by_parent_id_and_skips_null_keys() {
         // rows:
@@ -459,6 +630,8 @@ mod tests_group_attributes {
         assert_eq!(by_id[&20], vec![("b".into(), "y".into())]);
     }
 
+    /// Scenario: parent IDs use dictionary-encoded UInt32 values.
+    /// Guarantees: grouping accepts the canonical encoded ID layout and preserves associations.
     #[test]
     fn map_groups_dictionary_encoded_u32_parent_ids() {
         let fields = vec![
@@ -504,6 +677,8 @@ mod tests_group_attributes {
         assert_eq!(by_id[&99], vec![("c".into(), "z".into())]);
     }
 
+    /// Scenario: attributes contain scalar values, nulls, and missing value columns.
+    /// Guarantees: values use the expected strings and absent values become empty strings.
     #[test]
     fn map_formats_non_string_types_to_string_and_defaults_to_empty_on_null_or_missing_column() {
         // 6 rows for same parent, each different type.
@@ -557,6 +732,8 @@ mod tests_group_attributes {
         );
     }
 
+    /// Scenario: serialized map and slice values are missing or invalid CBOR.
+    /// Guarantees: failed serialization falls back to an empty string for each attribute.
     #[test]
     fn map_and_slice_types_use_attribute_ser_and_default_to_empty_on_decode_failure() {
         // If you can easily generate real CBOR bytes used by append_cbor_as_json,

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/transform_attributes.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/transform_attributes.rs
@@ -358,26 +358,7 @@ pub(crate) fn group_attributes_to_map_str(
         return Ok(None);
     };
     let groups = group_rows_by_id(&id_col);
-    let types = get_u8_array(batch, consts::ATTRIBUTE_TYPE)?;
-    let key_accessor = StringArrayAccessor::try_new_for_column(batch, consts::ATTRIBUTE_KEY)?;
-
-    // Build all value accessors once up front rather than per row. The accessors borrow the batch
-    // columns, so they are valid for the whole grouping loop below.
-    let str_accessor = match get_array_op(batch, consts::ATTRIBUTE_STR) {
-        Some(col) => Some(StringArrayAccessor::try_new(col)?),
-        None => None,
-    };
-    let int_accessor = match get_array_op(batch, consts::ATTRIBUTE_INT) {
-        Some(col) => Some(Int64ArrayAccessor::try_new(col)?),
-        None => None,
-    };
-    let double_col = get_f64_array_opt(batch, consts::ATTRIBUTE_DOUBLE)?;
-    let bool_col = get_bool_array_opt(batch, consts::ATTRIBUTE_BOOL)?;
-    let bytes_col = get_binary_array_opt(batch, consts::ATTRIBUTE_BYTES)?;
-    let ser_accessor = match get_array_op(batch, consts::ATTRIBUTE_SER) {
-        Some(col) => Some(ByteArrayAccessor::try_new(col)?),
-        None => None,
-    };
+    let encoder = AttributeMapEncoder::try_new(batch)?;
 
     let mut map_builder = MapBuilder::with_capacity(
         None,
@@ -389,96 +370,7 @@ pub(crate) fn group_attributes_to_map_str(
 
     for (id, rows) in groups {
         for row in rows.iter() {
-            let Some(key) = key_accessor.str_at(row) else {
-                // No key, skip it
-                continue;
-            };
-            map_builder.keys().append_value(key);
-
-            let t = types.value(row);
-            match t {
-                t if t == AttributeValueType::Empty as u8 => {
-                    // No value, default for type
-                    map_builder.values().append_value("");
-                }
-
-                t if t == AttributeValueType::Str as u8 => {
-                    if let Some(str_accessor) = &str_accessor {
-                        if let Some(v) = str_accessor.str_at(row) {
-                            map_builder.values().append_value(v);
-                            continue;
-                        }
-                    }
-                    map_builder.values().append_value("");
-                }
-
-                t if t == AttributeValueType::Int as u8 => {
-                    if let Some(int_accessor) = &int_accessor {
-                        if let Some(v) = int_accessor.value_at(row) {
-                            let mut itoa_buf = itoa::Buffer::new();
-                            map_builder.values().append_value(itoa_buf.format(v));
-                            continue;
-                        }
-                    }
-                    map_builder.values().append_value("");
-                }
-
-                t if t == AttributeValueType::Double as u8 => {
-                    if let Some(col) = double_col {
-                        if !col.is_null(row) {
-                            let mut r_buf = ryu::Buffer::new();
-                            map_builder
-                                .values()
-                                .append_value(r_buf.format(col.value(row)));
-                            continue;
-                        }
-                    }
-                    map_builder.values().append_value("");
-                }
-
-                t if t == AttributeValueType::Bool as u8 => {
-                    if let Some(col) = bool_col {
-                        if !col.is_null(row) {
-                            if col.value(row) {
-                                map_builder.values().append_value("true");
-                                continue;
-                            } else {
-                                map_builder.values().append_value("false");
-                                continue;
-                            }
-                        }
-                    }
-                    map_builder.values().append_value("");
-                }
-
-                t if t == AttributeValueType::Bytes as u8 => {
-                    if let Some(col) = bytes_col {
-                        if !col.is_null(row) {
-                            let bytes = col.value(row);
-                            let v = base64::engine::general_purpose::STANDARD.encode(bytes);
-                            map_builder.values().append_value(v);
-                            continue;
-                        }
-                    }
-                    map_builder.values().append_value("");
-                }
-
-                t if t == AttributeValueType::Map as u8 || t == AttributeValueType::Slice as u8 => {
-                    if let Some(byte_accessor) = &ser_accessor {
-                        if let Some(v) = byte_accessor.slice_at(row) {
-                            let mut buf = Vec::with_capacity(v.len() * 2);
-                            if append_cbor_as_json(&mut buf, v).is_ok() {
-                                if let Ok(json) = String::from_utf8(buf) {
-                                    map_builder.values().append_value(json);
-                                    continue;
-                                }
-                            }
-                        }
-                    }
-                    map_builder.values().append_value("");
-                }
-                _ => map_builder.values().append_value(""),
-            };
+            encoder.append_row(row, &mut map_builder);
         }
         map_builder.append(true)?; // true = row is not null
         id_builder.append_value(id as u32);

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/transform_attributes.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/transform_attributes.rs
@@ -358,7 +358,26 @@ pub(crate) fn group_attributes_to_map_str(
         return Ok(None);
     };
     let groups = group_rows_by_id(&id_col);
-    let encoder = AttributeMapEncoder::try_new(batch)?;
+    let types = get_u8_array(batch, consts::ATTRIBUTE_TYPE)?;
+    let key_accessor = StringArrayAccessor::try_new_for_column(batch, consts::ATTRIBUTE_KEY)?;
+
+    // Build all value accessors once up front rather than per row. The accessors borrow the batch
+    // columns, so they are valid for the whole grouping loop below.
+    let str_accessor = match get_array_op(batch, consts::ATTRIBUTE_STR) {
+        Some(col) => Some(StringArrayAccessor::try_new(col)?),
+        None => None,
+    };
+    let int_accessor = match get_array_op(batch, consts::ATTRIBUTE_INT) {
+        Some(col) => Some(Int64ArrayAccessor::try_new(col)?),
+        None => None,
+    };
+    let double_col = get_f64_array_opt(batch, consts::ATTRIBUTE_DOUBLE)?;
+    let bool_col = get_bool_array_opt(batch, consts::ATTRIBUTE_BOOL)?;
+    let bytes_col = get_binary_array_opt(batch, consts::ATTRIBUTE_BYTES)?;
+    let ser_accessor = match get_array_op(batch, consts::ATTRIBUTE_SER) {
+        Some(col) => Some(ByteArrayAccessor::try_new(col)?),
+        None => None,
+    };
 
     let mut map_builder = MapBuilder::with_capacity(
         None,
@@ -370,7 +389,96 @@ pub(crate) fn group_attributes_to_map_str(
 
     for (id, rows) in groups {
         for row in rows.iter() {
-            encoder.append_row(row, &mut map_builder);
+            let Some(key) = key_accessor.str_at(row) else {
+                // No key, skip it
+                continue;
+            };
+            map_builder.keys().append_value(key);
+
+            let t = types.value(row);
+            match t {
+                t if t == AttributeValueType::Empty as u8 => {
+                    // No value, default for type
+                    map_builder.values().append_value("");
+                }
+
+                t if t == AttributeValueType::Str as u8 => {
+                    if let Some(str_accessor) = &str_accessor {
+                        if let Some(v) = str_accessor.str_at(row) {
+                            map_builder.values().append_value(v);
+                            continue;
+                        }
+                    }
+                    map_builder.values().append_value("");
+                }
+
+                t if t == AttributeValueType::Int as u8 => {
+                    if let Some(int_accessor) = &int_accessor {
+                        if let Some(v) = int_accessor.value_at(row) {
+                            let mut itoa_buf = itoa::Buffer::new();
+                            map_builder.values().append_value(itoa_buf.format(v));
+                            continue;
+                        }
+                    }
+                    map_builder.values().append_value("");
+                }
+
+                t if t == AttributeValueType::Double as u8 => {
+                    if let Some(col) = double_col {
+                        if !col.is_null(row) {
+                            let mut r_buf = ryu::Buffer::new();
+                            map_builder
+                                .values()
+                                .append_value(r_buf.format(col.value(row)));
+                            continue;
+                        }
+                    }
+                    map_builder.values().append_value("");
+                }
+
+                t if t == AttributeValueType::Bool as u8 => {
+                    if let Some(col) = bool_col {
+                        if !col.is_null(row) {
+                            if col.value(row) {
+                                map_builder.values().append_value("true");
+                                continue;
+                            } else {
+                                map_builder.values().append_value("false");
+                                continue;
+                            }
+                        }
+                    }
+                    map_builder.values().append_value("");
+                }
+
+                t if t == AttributeValueType::Bytes as u8 => {
+                    if let Some(col) = bytes_col {
+                        if !col.is_null(row) {
+                            let bytes = col.value(row);
+                            let v = base64::engine::general_purpose::STANDARD.encode(bytes);
+                            map_builder.values().append_value(v);
+                            continue;
+                        }
+                    }
+                    map_builder.values().append_value("");
+                }
+
+                t if t == AttributeValueType::Map as u8 || t == AttributeValueType::Slice as u8 => {
+                    if let Some(byte_accessor) = &ser_accessor {
+                        if let Some(v) = byte_accessor.slice_at(row) {
+                            let mut buf = Vec::with_capacity(v.len() * 2);
+                            if append_cbor_as_json(&mut buf, v).is_ok() {
+                                if let Ok(json) = String::from_utf8(buf) {
+                                    map_builder.values().append_value(json);
+                                    continue;
+                                }
+                            }
+                        }
+                    }
+                    map_builder.values().append_value("");
+                }
+                _ => map_builder.values().append_value(""),
+            };
         }
         map_builder.append(true)?; // true = row is not null
         id_builder.append_value(id as u32);


### PR DESCRIPTION
# Change Summary

Optimizes the ClickHouse exporter transformation path for canonical OTAP log batches.

The exporter now uses a specialized, shape-preserving transformer that produces the same ClickHouse schema and values as the existing generic transformation pipeline while avoiding its general-purpose overhead.

Unsupported OTAP layouts automatically fall back to the existing generic transformer. OTLP logs, traces, and other payloads continue to use the generic path.

This PR is stacked on #3709.

## Performance impact

The change was benchmarked against #3709 using:

- 8,192-log batches
- synchronous ClickHouse inserts
- `max_in_flight: 10`
- one df_engine core
- six ClickHouse cores
- twelve traffic-generator cores
- ClickHouse 25.6
- three 60-second repetitions per scenario

Median results for canonical DFE OTAP logs:

| Metric | #3709 baseline | This change | Impact |
| --- | --- | --- | --- |
| Written throughput at maximum load | 682,597 logs/s | 885,655 logs/s | +29.7% / 1.30x |
| DFE CPU at approximately 100,000 logs/s | 28.46% | 20.72% | -27.2% |

Written throughput at the fixed offered load remained approximately 100,000 logs/s, as expected.

These results indicate that canonical OTAP log workloads can gain approximately 30% maximum throughput while using approximately 27% less DFE CPU at 100,000 logs/s. Actual gains depend on the input layout, workload, and ClickHouse capacity. Inputs that do not match the canonical layout use the generic fallback path.

## What issue does this PR close?

- Related to #3512
- Implements the OTAP transformation optimization identified by the ClickHouse exporter benchmarks in #3512

## How are these changes tested?

Automated tests verify:

- exact output parity between the specialized and generic transformers
- logs with complete and omitted attribute sets
- multiple resources and scopes with mixed content
- service-name extraction, ID encoding, body conversion, and attribute maps
- automatic fallback when the canonical logs payload is unavailable
- dictionary-encoded attribute parent IDs
- null, missing, scalar, map, and slice attribute values
- independent specialized-path and fallback telemetry counters

## Are there any user-facing changes?

Yes. Canonical OTAP log batches are transformed more efficiently before insertion into ClickHouse.

There is no new configuration and no expected change to the generated ClickHouse schema or values. Unsupported input layouts automatically use the existing generic transformer.

### Changelog

- [X] Added a `.chloggen/*.yaml` entry
- [ ] This PR is a chore (indicated in title)
- [ ] This is a documentation-only PR.