### PR TITLE
Optimize raw OTLP log transformation in the ClickHouse exporter

### DIFF
--- a/rust/otap-dataflow/.chloggen/clickhouse-exporter-optimize-otlp-logs.yaml
+++ b/rust/otap-dataflow/.chloggen/clickhouse-exporter-optimize-otlp-logs.yaml
@@ -1,0 +1,9 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+change_type: enhancement
+component: pipeline
+note: "Reduce CPU used to export raw OTLP logs to ClickHouse."
+issues: [3512]
+subtext: |
+  Raw OTLP log requests now build ClickHouse columns directly. Inputs that cannot use the direct path automatically use the existing conversion path.

--- a/rust/otap-dataflow/crates/contrib-nodes/benches/exporters/clickhouse_exporter/logs_transformer.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/benches/exporters/clickhouse_exporter/logs_transformer.rs
@@ -6,19 +6,27 @@
 use std::hint::black_box;
 
 use arrow::ipc::writer::StreamWriter;
+use bytes::Bytes;
 use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
 use otap_df_contrib_nodes::exporters::clickhouse_exporter::bench_support::LogsTransformBenchmark;
+use otap_df_pdata::proto::opentelemetry::collector::logs::v1::ExportLogsServiceRequest;
 use otap_df_pdata::testing::{fixtures, round_trip::encode_logs};
+use prost::Message;
 
 const LOGS_PER_BATCH: usize = 8192;
 
 fn bench_logs_transform(c: &mut Criterion) {
-    let mut records = encode_logs(&fixtures::logs_with_varying_attributes_and_properties(
-        LOGS_PER_BATCH,
-    ));
+    let logs = fixtures::logs_with_varying_attributes_and_properties(LOGS_PER_BATCH);
+    let mut records = encode_logs(&logs);
     records
         .decode_transport_optimized_ids()
         .expect("decode transport-optimized IDs");
+    let request = Bytes::from(
+        ExportLogsServiceRequest {
+            resource_logs: logs.resource_logs,
+        }
+        .encode_to_vec(),
+    );
 
     let mut group = c.benchmark_group("clickhouse_logs_transform");
     _ = group.throughput(Throughput::Elements(LOGS_PER_BATCH as u64));
@@ -45,6 +53,34 @@ fn bench_logs_transform(c: &mut Criterion) {
                 .expect("create ArrowStream writer");
             writer.write(&output).expect("encode ClickHouse batch");
             writer.finish().expect("finish ArrowStream");
+            black_box(bytes)
+        });
+    });
+
+    let mut otlp_legacy = LogsTransformBenchmark::default();
+    _ = group.bench_function("otlp_legacy/8192", |b| {
+        b.iter_batched(
+            || request.clone(),
+            |input| black_box(otlp_legacy.transform_otlp_legacy(input)),
+            BatchSize::SmallInput,
+        );
+    });
+
+    let mut otlp_direct = LogsTransformBenchmark::default();
+    _ = group.bench_function("otlp_direct/8192", |b| {
+        b.iter(|| black_box(otlp_direct.transform_otlp_direct(black_box(&request))));
+    });
+
+    let direct_output = otlp_direct.transform_otlp_direct(&request);
+    _ = group.bench_function("otlp_direct_arrow_stream/8192", |b| {
+        b.iter(|| {
+            let mut bytes = Vec::new();
+            let mut writer = StreamWriter::try_new(&mut bytes, direct_output.schema_ref())
+                .expect("create direct ArrowStream writer");
+            writer
+                .write(&direct_output)
+                .expect("encode direct ClickHouse batch");
+            writer.finish().expect("finish direct ArrowStream");
             black_box(bytes)
         });
     });

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/README.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/README.md
@@ -1,9 +1,9 @@
 # ClickHouse Exporter
 
-This exporter accepts OTAP Arrow payloads, reshapes them into
-ClickHouse-compatible Arrow `RecordBatch`es, and inserts them into ClickHouse
-over HTTP using the official ClickHouse Rust client (`clickhouse` +
-`clickhouse-ext-arrow`, `FORMAT ArrowStream`).
+This exporter accepts OTAP Arrow payloads and serialized OTLP requests,
+reshapes them into ClickHouse-compatible Arrow `RecordBatch`es, and inserts
+them into ClickHouse over HTTP using the official ClickHouse Rust client
+(`clickhouse` + `clickhouse-ext-arrow`, `FORMAT ArrowStream`).
 
 The current architecture is intentionally simple:
 
@@ -77,9 +77,10 @@ At runtime the exporter does the following:
 2. Connects to ClickHouse and creates the target database and configured
    tables if enabled
 3. Receives `OtapPdata` messages from the engine
-4. Converts payloads into `OtapArrowRecords`
-5. Uses the specialized transformer for canonical OTAP logs, with the generic
-   transform pipeline as a fallback and for other inputs
+4. Transforms serialized OTLP logs directly into ClickHouse columns; if that
+   path cannot handle an input, converts it into `OtapArrowRecords`
+5. Uses a second specialized transformer for canonical OTAP logs, with the
+   generic transform pipeline as a fallback and for other inputs
 6. Returns only signal batches (`Logs`, `Spans`) from the transformer
 7. Inserts those batches into the destination tables
 
@@ -175,16 +176,18 @@ Inline attributes are stored as:
 Map(LowCardinality(String), String)
 ```
 
-Nested attribute values (Map/Slice) are transcoded from binary/CBOR into a JSON
-string stored as the map value.
+Nested attribute values (Map/Slice) are stored as a JSON string. The raw OTLP
+path serializes them directly, while OTAP inputs transcode their CBOR values.
 
 ## Transform Pipeline
 
-Canonical OTAP log batches use a specialized transformation path that preserves
-the generic transformer's ClickHouse schema and values. If an input layout is
-not supported by that path, the exporter automatically falls back to the
-generic transformer. OTLP logs, traces, and other supported payloads continue
-to use the generic pipeline.
+Serialized OTLP log requests build the final ClickHouse columns directly from
+the protobuf byte view, avoiding an intermediate OTAP Arrow batch. Canonical
+OTAP log batches use a separate specialized transformation path. Both paths
+preserve the generic transformer's ClickHouse values. Raw OTLP transformation
+errors use the legacy conversion path, while unsupported OTAP layouts use the
+generic transformer. Traces and other supported payloads continue to use the
+generic pipeline.
 
 The transform pipeline has two stages per payload:
 

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/README.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/README.md
@@ -134,13 +134,93 @@ Table config supports:
 
 ## Schema Shape
 
-The current implementation follows the clickhouse-exporter in
-opentelemetry-collector-contrib defined by
+The exporter creates one row per log record in the configured logs table
+(`otel_logs` by default) and one row per span in the configured traces table
+(`otel_traces` by default). Both table names can be overridden under `tables`.
+All columns are non-nullable; when a transformed Arrow batch omits an optional
+column, ClickHouse supplies that column type's default value.
+
+The schema follows the clickhouse-exporter in opentelemetry-collector-contrib
+where practical, based on
 [the Go exporter's SQL templates](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/clickhouseexporter/internal/sqltemplates).
 
-Snapshots of the current structure are generated in the
-[table_snapshots](./table_snapshots/) directory. There is currently no
-automated testing to ensure schema drift relative to the go collector.
+### Logs table
+
+<!-- markdownlint-disable MD013 -->
+
+| Column | ClickHouse type | OTLP meaning |
+| --- | --- | --- |
+| `Timestamp` | `DateTime64(9)` | Log record `time_unix_nano` |
+| `TraceId` | `String` | Lowercase hexadecimal trace ID |
+| `SpanId` | `String` | Lowercase hexadecimal span ID |
+| `TraceFlags` | `UInt8` | Trace-flags portion of the log flags |
+| `SeverityText` | `LowCardinality(String)` | Original severity text |
+| `SeverityNumber` | `UInt8` | OTLP severity number |
+| `ServiceName` | `LowCardinality(String)` | First `service.name` resource attribute |
+| `Body` | `String` | Stringified log body; complex values use JSON |
+| `ResourceSchemaUrl` | `LowCardinality(String)` | Resource-logs schema URL |
+| `ResourceAttributes` | `Map(LowCardinality(String), String)` | Resource attributes flattened onto each log row |
+| `ScopeSchemaUrl` | `LowCardinality(String)` | Scope-logs schema URL |
+| `ScopeName` | `String` | Instrumentation scope name |
+| `ScopeVersion` | `LowCardinality(String)` | Instrumentation scope version |
+| `ScopeAttributes` | `Map(LowCardinality(String), String)` | Scope attributes flattened onto each log row |
+| `LogAttributes` | `Map(LowCardinality(String), String)` | Log-record attributes |
+| `EventName` | `String` | Log-record event name |
+
+<!-- markdownlint-enable MD013 -->
+
+### Traces table
+
+<!-- markdownlint-disable MD013 -->
+
+| Column | ClickHouse type | OTLP meaning |
+| --- | --- | --- |
+| `Timestamp` | `DateTime64(9)` | Span start time |
+| `TraceId` | `String` | Lowercase hexadecimal trace ID |
+| `SpanId` | `String` | Lowercase hexadecimal span ID |
+| `ParentSpanId` | `String` | Lowercase hexadecimal parent span ID |
+| `TraceState` | `String` | W3C trace state |
+| `SpanName` | `LowCardinality(String)` | Span name |
+| `SpanKind` | `LowCardinality(String)` | String representation of the OTLP span kind |
+| `ServiceName` | `LowCardinality(String)` | First `service.name` resource attribute |
+| `ResourceAttributes` | `Map(LowCardinality(String), String)` | Resource attributes flattened onto each span row |
+| `ScopeName` | `String` | Instrumentation scope name |
+| `ScopeVersion` | `LowCardinality(String)` | Instrumentation scope version |
+| `SpanAttributes` | `Map(LowCardinality(String), String)` | Span attributes |
+| `Duration` | `UInt64` | Span duration in nanoseconds |
+| `StatusCode` | `LowCardinality(String)` | String representation of the OTLP status code |
+| `StatusMessage` | `String` | Span status message |
+| `Events.Timestamp` | `Array(DateTime64(9))` | Event timestamps |
+| `Events.Name` | `Array(LowCardinality(String))` | Event names |
+| `Events.Attributes` | `Array(Map(LowCardinality(String), String))` | One attribute map per event |
+| `Links.TraceId` | `Array(String)` | Lowercase hexadecimal linked trace IDs |
+| `Links.SpanId` | `Array(String)` | Lowercase hexadecimal linked span IDs |
+| `Links.TraceState` | `Array(String)` | Linked trace states |
+| `Links.Attributes` | `Array(Map(LowCardinality(String), String))` | One attribute map per link |
+
+<!-- markdownlint-enable MD013 -->
+
+The three `Events.*` arrays have matching positions: element `i` in each array
+describes the same event. The four `Links.*` arrays follow the same rule for a
+link. Events and links therefore remain embedded in the span row rather than
+being written to child tables.
+
+### Storage layout and indexes
+
+The default tables use `MergeTree`, partition by `toDate(Timestamp)`, and use
+an index granularity of 8192. Logs are ordered by five-minute timestamp bucket,
+service name, and timestamp. Traces are ordered by service name, span name, and
+second-resolution timestamp. Both tables have a trace-ID bloom-filter index and
+bloom-filter indexes for resource attribute keys and values. Logs add scope and
+log attribute bloom filters plus a token bloom filter over lowercase body text;
+traces add span attribute bloom filters and a min-max duration index.
+
+String-like columns use ZSTD compression, and timestamps use Delta plus ZSTD.
+Configuration can override the table engine and add a TTL. Exact generated DDL
+is snapshot-tested in
+[table_snapshots](./table_snapshots/); `schema.rs` and `tables.rs` are the source
+of truth. There is currently no automated test for drift from the Go Collector
+schema.
 
 ## Verified Arrow -> ClickHouse Type Mapping
 
@@ -151,6 +231,8 @@ in `transform/transform_batch.rs` (inserting the realistic fixtures and reading
 every column back). Columns bind **by name**, so column order is irrelevant,
 missing columns are server-defaulted, and an unknown column name errors on
 `end()`.
+
+<!-- markdownlint-disable MD013 -->
 
 | Emitted Arrow type | ClickHouse column type | Example columns |
 | --- | --- | --- |
@@ -165,6 +247,8 @@ missing columns are server-defaulted, and an unknown column name errors on
 | `List<Timestamp(ns)>` | `Array(DateTime64(9))` | Events.Timestamp |
 | `List<hex Utf8>` | `Array(String)` | Links.TraceId, Links.SpanId (and event equivalents), hex-encoded like the top-level ids |
 | `List<Map<Utf8,Utf8>>` | `Array(Map(LowCardinality(String), String))` | Events.Attributes, Links.Attributes (one map per event/link) |
+
+<!-- markdownlint-enable MD013 -->
 
 No special `input_format_arrow_*` settings were required for a clean insert.
 

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/bench_support.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/bench_support.rs
@@ -9,10 +9,12 @@
 //! implementation details part of the production API.
 
 use arrow::array::RecordBatch;
-use otap_df_pdata::OtapArrowRecords;
+use bytes::Bytes;
 use otap_df_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
+use otap_df_pdata::{OtapArrowRecords, OtapPayload, OtlpProtoBytes, TryIntoWithOptions};
 
 use super::transform::logs_fast::{LogsFastTransform, LogsFastTransformer};
+use super::transform::logs_otlp::OtlpLogsTransformer;
 use super::transform::transform_batch::BatchTransformer;
 
 /// Owns reusable state for comparing the generic and specialized logs transformers.
@@ -20,6 +22,7 @@ use super::transform::transform_batch::BatchTransformer;
 pub struct LogsTransformBenchmark {
     generic: BatchTransformer,
     fast: LogsFastTransformer,
+    otlp: OtlpLogsTransformer,
 }
 
 impl LogsTransformBenchmark {
@@ -46,5 +49,27 @@ impl LogsTransformBenchmark {
                 panic!("benchmark input is not supported by the specialized transform: {reason}")
             }
         }
+    }
+
+    /// Transform raw OTLP logs through the legacy OTAP Arrow conversion path.
+    #[must_use]
+    pub fn transform_otlp_legacy(&mut self, request: Bytes) -> RecordBatch {
+        let payload: OtapPayload = OtlpProtoBytes::ExportLogsRequest(request).into();
+        let mut records: OtapArrowRecords = payload
+            .try_into_with_default()
+            .expect("convert benchmark OTLP logs to OTAP Arrow");
+        records
+            .decode_transport_optimized_ids()
+            .expect("decode benchmark transport-optimized IDs");
+        self.transform_generic(records)
+    }
+
+    /// Transform raw OTLP logs directly to ClickHouse columns.
+    #[must_use]
+    pub fn transform_otlp_direct(&mut self, request: &[u8]) -> RecordBatch {
+        self.otlp
+            .transform(request)
+            .expect("direct ClickHouse OTLP logs transform")
+            .expect("benchmark input contains logs")
     }
 }

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/metrics.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/metrics.rs
@@ -27,6 +27,14 @@ pub struct ClickhouseExporterMetrics {
     /// Total number of log batches sent through the generic transform fallback.
     #[metric(unit = "{batch}")]
     pub log_transform_fallback_batches: Counter<u64>,
+
+    /// Total number of raw OTLP log batches transformed directly to ClickHouse columns.
+    #[metric(unit = "{batch}")]
+    pub log_otlp_direct_path_batches: Counter<u64>,
+
+    /// Total number of raw OTLP log batches sent through the legacy transform fallback.
+    #[metric(unit = "{batch}")]
+    pub log_otlp_transform_fallback_batches: Counter<u64>,
 }
 
 impl ClickhouseExporterMetrics {
@@ -47,6 +55,16 @@ impl ClickhouseExporterMetrics {
     /// Records one log batch sent through the generic fallback path.
     pub fn record_log_transform_fallback(&mut self) {
         self.log_transform_fallback_batches.inc();
+    }
+
+    /// Records one raw OTLP log batch transformed directly to ClickHouse columns.
+    pub fn record_log_otlp_direct_path(&mut self) {
+        self.log_otlp_direct_path_batches.inc();
+    }
+
+    /// Records one raw OTLP log batch transformed by the legacy fallback path.
+    pub fn record_log_otlp_transform_fallback(&mut self) {
+        self.log_otlp_transform_fallback_batches.inc();
     }
 }
 
@@ -135,5 +153,20 @@ mod tests {
 
         assert_eq!(metrics.log_fast_path_batches.get(), 1);
         assert_eq!(metrics.log_transform_fallback_batches.get(), 2);
+    }
+
+    /// Scenario: direct and fallback raw OTLP log transforms are both observed.
+    /// Guarantees: each raw OTLP transform path increments only its dedicated counter.
+    #[test]
+    fn otlp_transform_path_counters_are_independent() {
+        let mut metrics = ClickhouseExporterMetrics::default();
+        metrics.record_log_otlp_direct_path();
+        metrics.record_log_otlp_direct_path();
+        metrics.record_log_otlp_transform_fallback();
+
+        assert_eq!(metrics.log_otlp_direct_path_batches.get(), 2);
+        assert_eq!(metrics.log_otlp_transform_fallback_batches.get(), 1);
+        assert_eq!(metrics.log_fast_path_batches.get(), 0);
+        assert_eq!(metrics.log_transform_fallback_batches.get(), 0);
     }
 }

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/mod.rs
@@ -46,6 +46,7 @@ use otap_df_engine::terminal_state::TerminalState;
 use otap_df_otap::OTAP_EXPORTER_FACTORIES;
 use otap_df_otap::metrics::ExporterPDataExportMetrics;
 use otap_df_otap::pdata::OtapPdata;
+use otap_df_pdata::error::Error as PdataError;
 use otap_df_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
 use otap_df_pdata::{OtapArrowRecords, OtapPayload, OtlpProtoBytes, TryIntoWithOptions};
 use otap_df_telemetry::common_attributes::{Outcome, SignalOutcomeAttributes};
@@ -199,6 +200,13 @@ fn transform_raw_otlp_logs(
     }
 }
 
+fn is_invalid_protobuf(error: &error::ClickhouseExporterError) -> bool {
+    matches!(
+        error,
+        error::ClickhouseExporterError::Child(PdataError::InvalidProtobufWireFormat)
+    )
+}
+
 /// Register Clickhouse exporter with the OTAP exporter factory
 ///
 /// Unsafe code is temporarily used here to allow the use of `distributed_slice` macro
@@ -324,6 +332,21 @@ impl Exporter<OtapPdata> for ClickhouseExporter {
                                             })
                                             .unwrap_or_default(),
                                     )
+                                }
+                                Err(error) if is_invalid_protobuf(&error) => {
+                                    self.pdata_metrics
+                                        .with(SignalOutcomeAttributes {
+                                            signal: signal_type,
+                                            outcome: Outcome::Failure,
+                                        })
+                                        .messages
+                                        .inc();
+                                    otap_df_telemetry::otel_warn!(
+                                        "clickhouse.exporter.otlp.invalid_protobuf",
+                                        message = "Rejecting malformed raw OTLP logs.",
+                                        error = error.to_string(),
+                                    );
+                                    continue;
                                 }
                                 Err(error) => {
                                     self.ch_metrics.record_log_otlp_transform_fallback();
@@ -465,5 +488,21 @@ mod tests {
 
         assert!(transform_raw_otlp_logs(&logs, &mut transformer).is_some());
         assert!(transform_raw_otlp_logs(&traces, &mut transformer).is_none());
+    }
+
+    /// Scenario: a raw OTLP logs request has malformed nested protobuf framing.
+    /// Guarantees: the routing layer classifies it as invalid instead of using legacy fallback.
+    #[test]
+    fn malformed_raw_otlp_logs_are_not_fallback_candidates() {
+        let logs =
+            OtapPayload::OtlpBytes(OtlpProtoBytes::ExportLogsRequest(Bytes::from_static(&[
+                0x0a, 0x03, 0x1a, 0x05, 0x00,
+            ])));
+        let mut transformer = OtlpLogsTransformer::default();
+        let error = transform_raw_otlp_logs(&logs, &mut transformer)
+            .expect("raw logs should select direct transformation")
+            .expect_err("malformed nested protobuf must fail");
+
+        assert!(is_invalid_protobuf(&error));
     }
 }

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/mod.rs
@@ -46,9 +46,8 @@ use otap_df_engine::terminal_state::TerminalState;
 use otap_df_otap::OTAP_EXPORTER_FACTORIES;
 use otap_df_otap::metrics::ExporterPDataExportMetrics;
 use otap_df_otap::pdata::OtapPdata;
-use otap_df_pdata::OtapArrowRecords;
-use otap_df_pdata::TryIntoWithOptions;
 use otap_df_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
+use otap_df_pdata::{OtapArrowRecords, OtapPayload, OtlpProtoBytes, TryIntoWithOptions};
 use otap_df_telemetry::common_attributes::{Outcome, SignalOutcomeAttributes};
 use otap_df_telemetry::metrics::MetricSetHandler;
 use otap_df_telemetry::metrics::{MeasurementMetricSet, MetricSet};
@@ -63,6 +62,7 @@ use crate::exporters::clickhouse_exporter::metrics::ClickhouseExporterMetrics;
 use crate::exporters::clickhouse_exporter::transform::logs_fast::{
     LogsFastTransform, LogsFastTransformer,
 };
+use crate::exporters::clickhouse_exporter::transform::logs_otlp::OtlpLogsTransformer;
 use crate::exporters::clickhouse_exporter::transform::transform_batch::BatchTransformer;
 use crate::exporters::clickhouse_exporter::writer::ClickHouseWriter;
 
@@ -187,6 +187,18 @@ impl ClickhouseExporter {
     }
 }
 
+fn transform_raw_otlp_logs(
+    payload: &OtapPayload,
+    transformer: &mut OtlpLogsTransformer,
+) -> Option<Result<Option<arrow::array::RecordBatch>, error::ClickhouseExporterError>> {
+    match payload {
+        OtapPayload::OtlpBytes(OtlpProtoBytes::ExportLogsRequest(bytes)) => {
+            Some(transformer.transform(bytes))
+        }
+        _ => None,
+    }
+}
+
 /// Register Clickhouse exporter with the OTAP exporter factory
 ///
 /// Unsafe code is temporarily used here to allow the use of `distributed_slice` macro
@@ -231,6 +243,7 @@ impl Exporter<OtapPdata> for ClickhouseExporter {
 
         let mut batch_transformer = BatchTransformer::new();
         let mut logs_fast_transformer = LogsFastTransformer::default();
+        let mut otlp_logs_transformer = OtlpLogsTransformer::default();
         let clickhouse_writer =
             Rc::new(ClickHouseWriter::new(&self.config).await.map_err(|e| {
                 Error::ExporterError {
@@ -299,85 +312,117 @@ impl Exporter<OtapPdata> for ClickhouseExporter {
 
                     let (_context, payload) = pdata.into_parts();
 
-                    let mut arrow_records: OtapArrowRecords = match payload.try_into_with_default()
-                    {
-                        Ok(arrow_records) => arrow_records,
-                        Err(e) => {
-                            self.pdata_metrics
-                                .with(SignalOutcomeAttributes {
-                                    signal: signal_type,
-                                    outcome: Outcome::Failure,
-                                })
-                                .messages
-                                .inc();
-                            otap_df_telemetry::otel_warn!(
-                                "clickhouse.exporter.convert.error",
-                                message =
-                                    format!("Failed to convert payload to OtapArrowRecords: {e:?}"),
-                                signal_type = format!("{:?}", signal_type),
-                            );
-                            continue;
-                        }
-                    };
+                    let direct_otlp_batches =
+                        match transform_raw_otlp_logs(&payload, &mut otlp_logs_transformer) {
+                            Some(result) => match result {
+                                Ok(batch) => {
+                                    self.ch_metrics.record_log_otlp_direct_path();
+                                    Some(
+                                        batch
+                                            .map(|batch| {
+                                                HashMap::from([(ArrowPayloadType::Logs, batch)])
+                                            })
+                                            .unwrap_or_default(),
+                                    )
+                                }
+                                Err(error) => {
+                                    self.ch_metrics.record_log_otlp_transform_fallback();
+                                    otap_df_telemetry::otel_debug!(
+                                        "clickhouse.exporter.otlp.transform.fallback",
+                                        message =
+                                            "Using the legacy ClickHouse transform for OTLP logs.",
+                                        reason = error.to_string(),
+                                    );
+                                    None
+                                }
+                            },
+                            _ => None,
+                        };
 
-                    // decode the transport optimized IDs before joining payloads against them.
-                    arrow_records
-                        .decode_transport_optimized_ids()
-                        .map_err(|e| {
-                            self.pdata_metrics
-                                .with(SignalOutcomeAttributes {
-                                    signal: signal_type,
-                                    outcome: Outcome::Failure,
-                                })
-                                .messages
-                                .inc();
-                            let source_detail = format_error_sources(&e);
-                            Error::ExporterError {
-                                exporter: exporter_id.clone(),
-                                kind: ExporterErrorKind::Other,
-                                error: format!("Failed to decode transport optimized IDs: {e}"),
-                                source_detail,
-                            }
-                        })?;
-
-                    let transform_result = if signal_type == SignalType::Logs
-                        && signal_format == SignalFormat::OtapRecords
-                    {
-                        match logs_fast_transformer.try_apply(&arrow_records) {
-                            Ok(LogsFastTransform::Applied(batch)) => {
-                                self.ch_metrics.record_log_fast_path();
-                                Ok(HashMap::from([(ArrowPayloadType::Logs, batch)]))
-                            }
-                            Ok(LogsFastTransform::NotApplicable(_)) => {
-                                self.ch_metrics.record_log_transform_fallback();
-                                batch_transformer.apply_plan(arrow_records)
-                            }
-                            Err(error) => Err(error),
-                        }
+                    let write_batches = if let Some(batches) = direct_otlp_batches {
+                        batches
                     } else {
-                        if signal_type == SignalType::Logs {
-                            self.ch_metrics.record_log_transform_fallback();
-                        }
-                        batch_transformer.apply_plan(arrow_records)
-                    };
+                        let mut arrow_records: OtapArrowRecords =
+                            match payload.try_into_with_default() {
+                                Ok(arrow_records) => arrow_records,
+                                Err(e) => {
+                                    self.pdata_metrics
+                                        .with(SignalOutcomeAttributes {
+                                            signal: signal_type,
+                                            outcome: Outcome::Failure,
+                                        })
+                                        .messages
+                                        .inc();
+                                    otap_df_telemetry::otel_warn!(
+                                        "clickhouse.exporter.convert.error",
+                                        message = format!(
+                                            "Failed to convert payload to OtapArrowRecords: {e:?}"
+                                        ),
+                                        signal_type = format!("{:?}", signal_type),
+                                    );
+                                    continue;
+                                }
+                            };
 
-                    let write_batches = match transform_result {
-                        Ok(batches) => batches,
-                        Err(e) => {
-                            self.pdata_metrics
-                                .with(SignalOutcomeAttributes {
-                                    signal: signal_type,
-                                    outcome: Outcome::Failure,
-                                })
-                                .messages
-                                .inc();
-                            otap_df_telemetry::otel_warn!(
-                                "clickhouse.exporter.transform.error",
-                                message = "Error transforming batch for export.",
-                                error = e.to_string(),
-                                signal_type = format!("{:?}", signal_type),
-                            );
-                            continue;
+                        // Decode transport-optimized IDs before joining payloads against them.
+                        arrow_records
+                            .decode_transport_optimized_ids()
+                            .map_err(|e| {
+                                self.pdata_metrics
+                                    .with(SignalOutcomeAttributes {
+                                        signal: signal_type,
+                                        outcome: Outcome::Failure,
+                                    })
+                                    .messages
+                                    .inc();
+                                let source_detail = format_error_sources(&e);
+                                Error::ExporterError {
+                                    exporter: exporter_id.clone(),
+                                    kind: ExporterErrorKind::Other,
+                                    error: format!("Failed to decode transport optimized IDs: {e}"),
+                                    source_detail,
+                                }
+                            })?;
+
+                        let transform_result = if signal_type == SignalType::Logs
+                            && signal_format == SignalFormat::OtapRecords
+                        {
+                            match logs_fast_transformer.try_apply(&arrow_records) {
+                                Ok(LogsFastTransform::Applied(batch)) => {
+                                    self.ch_metrics.record_log_fast_path();
+                                    Ok(HashMap::from([(ArrowPayloadType::Logs, batch)]))
+                                }
+                                Ok(LogsFastTransform::NotApplicable(_)) => {
+                                    self.ch_metrics.record_log_transform_fallback();
+                                    batch_transformer.apply_plan(arrow_records)
+                                }
+                                Err(error) => Err(error),
+                            }
+                        } else {
+                            if signal_type == SignalType::Logs {
+                                self.ch_metrics.record_log_transform_fallback();
+                            }
+                            batch_transformer.apply_plan(arrow_records)
+                        };
+
+                        match transform_result {
+                            Ok(batches) => batches,
+                            Err(e) => {
+                                self.pdata_metrics
+                                    .with(SignalOutcomeAttributes {
+                                        signal: signal_type,
+                                        outcome: Outcome::Failure,
+                                    })
+                                    .messages
+                                    .inc();
+                                otap_df_telemetry::otel_warn!(
+                                    "clickhouse.exporter.transform.error",
+                                    message = "Error transforming batch for export.",
+                                    error = e.to_string(),
+                                    signal_type = format!("{:?}", signal_type),
+                                );
+                                continue;
+                            }
                         }
                     };
                     let writer = Rc::clone(&clickhouse_writer);
@@ -401,11 +446,24 @@ impl Exporter<OtapPdata> for ClickhouseExporter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bytes::Bytes;
 
     /// Scenario: the ClickHouse exporter is registered with its public component URN.
     /// Guarantees: configuration references continue to resolve to the exporter factory.
     #[test]
     fn test_urn_constant() {
         assert_eq!(CLICKHOUSE_EXPORTER_URN, "urn:otel:exporter:clickhouse");
+    }
+
+    /// Scenario: the exporter receives serialized OTLP logs or another payload representation.
+    /// Guarantees: only serialized OTLP log requests are selected for direct transformation.
+    #[test]
+    fn raw_otlp_log_routing_is_signal_and_format_specific() {
+        let logs = OtapPayload::OtlpBytes(OtlpProtoBytes::ExportLogsRequest(Bytes::new()));
+        let traces = OtapPayload::OtlpBytes(OtlpProtoBytes::ExportTracesRequest(Bytes::new()));
+        let mut transformer = OtlpLogsTransformer::default();
+
+        assert!(transform_raw_otlp_logs(&logs, &mut transformer).is_some());
+        assert!(transform_raw_otlp_logs(&traces, &mut transformer).is_none());
     }
 }

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/mod.rs
@@ -490,18 +490,17 @@ mod tests {
         assert!(transform_raw_otlp_logs(&traces, &mut transformer).is_none());
     }
 
-    /// Scenario: a raw OTLP logs request has malformed nested protobuf framing.
+    /// Scenario: a raw OTLP logs request has malformed top-level protobuf framing.
     /// Guarantees: the routing layer classifies it as invalid instead of using legacy fallback.
     #[test]
     fn malformed_raw_otlp_logs_are_not_fallback_candidates() {
-        let logs =
-            OtapPayload::OtlpBytes(OtlpProtoBytes::ExportLogsRequest(Bytes::from_static(&[
-                0x0a, 0x03, 0x1a, 0x05, 0x00,
-            ])));
+        let logs = OtapPayload::OtlpBytes(OtlpProtoBytes::ExportLogsRequest(Bytes::from_static(
+            b"\xff",
+        )));
         let mut transformer = OtlpLogsTransformer::default();
         let error = transform_raw_otlp_logs(&logs, &mut transformer)
             .expect("raw logs should select direct transformation")
-            .expect_err("malformed nested protobuf must fail");
+            .expect_err("malformed top-level protobuf must fail");
 
         assert!(is_invalid_protobuf(&error));
     }

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/logs_otlp.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/logs_otlp.rs
@@ -26,6 +26,11 @@ use crate::exporters::clickhouse_exporter::error::ClickhouseExporterError;
 
 const SERVICE_NAME_KEY: &[u8] = b"service.name";
 const INITIAL_STRING_BYTES_PER_ROW: usize = 16;
+const MAX_PREALLOCATED_ROWS: usize = 16 * 1024;
+
+fn bounded_row_capacity(row_count: usize) -> usize {
+    row_count.min(MAX_PREALLOCATED_ROWS)
+}
 
 /// Direct OTLP logs transformer with reusable sizing and serialization state.
 #[derive(Default)]
@@ -215,6 +220,7 @@ struct LogsBuilders {
 
 impl LogsBuilders {
     fn new(row_capacity: usize) -> Self {
+        let row_capacity = bounded_row_capacity(row_capacity);
         let string_capacity = row_capacity.saturating_mul(INITIAL_STRING_BYTES_PER_ROW);
         let string_builder = || StringBuilder::with_capacity(row_capacity, string_capacity);
         let map_builder = || {
@@ -854,14 +860,37 @@ mod tests {
     }
 
     /// Scenario: a raw OTLP request has invalid top-level protobuf framing.
-    /// Guarantees: the direct path returns an error so exporter routing can use the legacy path.
+    /// Guarantees: the direct path returns an error so exporter routing can reject the request.
     #[test]
-    fn malformed_request_is_rejected_for_legacy_fallback() {
+    fn malformed_request_is_rejected() {
         let error = OtlpLogsTransformer::default()
             .transform(b"\xff")
             .expect_err("malformed protobuf must be rejected");
 
         assert!(matches!(error, ClickhouseExporterError::Child(_)));
+    }
+
+    /// Scenario: a nested OTLP field declares a length beyond its enclosing message.
+    /// Guarantees: the direct transformer returns an error before traversing malformed ranges.
+    #[test]
+    fn malformed_nested_request_is_rejected() {
+        let error = OtlpLogsTransformer::default()
+            .transform(&[0x0a, 0x03, 0x1a, 0x05, 0x00])
+            .expect_err("malformed nested protobuf must be rejected");
+
+        assert!(matches!(error, ClickhouseExporterError::Child(_)));
+    }
+
+    /// Scenario: the previous OTLP request reports an arbitrarily large row count.
+    /// Guarantees: speculative Arrow builder capacity remains capped at a bounded row count.
+    #[test]
+    fn reusable_row_preallocation_is_bounded() {
+        assert_eq!(bounded_row_capacity(8_192), 8_192);
+        assert_eq!(
+            bounded_row_capacity(MAX_PREALLOCATED_ROWS),
+            MAX_PREALLOCATED_ROWS
+        );
+        assert_eq!(bounded_row_capacity(usize::MAX), MAX_PREALLOCATED_ROWS);
     }
 
     #[derive(clickhouse::Row, serde::Deserialize)]

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/logs_otlp.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/logs_otlp.rs
@@ -2,6 +2,146 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Direct transformation of serialized OTLP logs into ClickHouse Arrow columns.
+//!
+//! # Purpose
+//!
+//! The legacy raw-OTLP path first converts an `ExportLogsServiceRequest` into the canonical OTAP
+//! Arrow representation and then runs the generic ClickHouse transformation plan. This module
+//! avoids both intermediate stages. It reads the serialized protobuf through borrowed
+//! [`RawLogsData`] views and builds the final ClickHouse-compatible [`RecordBatch`] directly.
+//! Protobuf messages are not decoded into an owned Rust object tree and no intermediate OTAP
+//! batches are created.
+//!
+//! Unlike the specialized OTAP transformer in `logs_fast`, this path cannot share input arrays
+//! with its output because its input is a byte buffer rather than Arrow data. Its main savings
+//! come from traversing the protobuf once, materializing only the final arrays, and reusing
+//! allocation and schema state between requests.
+//!
+//! # Applicability and routing
+//!
+//! The ClickHouse exporter attempts this transformer only for raw
+//! `OtlpProtoBytes::ExportLogsRequest` payloads. It is not used for OTAP records, OTLP traces,
+//! OTLP metrics, or already transformed Arrow batches. The routing and fallback policy lives in
+//! the parent `clickhouse_exporter` module:
+//!
+//! - a successful non-empty transformation is written as the logs payload
+//! - a valid request with no log records returns `None`, so no empty insert is issued
+//! - invalid protobuf wire framing is rejected and is not sent through the legacy path
+//! - other conversion or Arrow errors are returned to the caller, which may attempt the legacy
+//!   OTLP-to-OTAP transformation
+//!
+//! This module does not perform fallback itself. Keeping that decision at the exporter boundary
+//! makes direct-path and fallback telemetry account for the complete request.
+//!
+//! # Processing model
+//!
+//! `OtlpLogsTransformer::transform` follows the OTLP ownership hierarchy. Resource and scope data
+//! is collected once and replayed for each child log, while log-local fields are appended directly
+//! to the Arrow builders:
+//!
+//! ```text
+//! ExportLogsServiceRequest bytes
+//!                 |
+//!                 v
+//!       RawLogsData::try_new
+//!       - validate wire framing
+//!       - expose borrowed views
+//!                 |
+//!                 v
+//!       ResourceLogs (0..n)
+//!       - resource schema URL
+//!       - resource attributes + service.name
+//!                 |
+//!                 v
+//!         ScopeLogs (0..n)
+//!         - scope name/version/attributes
+//!                 |
+//!                 v
+//!         LogRecord (0..n) --------> append one output row
+//!                                     - scalar fields
+//!                                     - body and attributes
+//!                                     - trace/span IDs
+//!                                               |
+//!                                               v
+//!                                   sort columns by name
+//!                                   build/reuse Arrow schema
+//!                                               |
+//!                                               v
+//!                                   ClickHouse RecordBatch
+//! ```
+//!
+//! Traversal order is resource, then scope, then log order. That order is the output row order and
+//! must remain stable. Resource and scope attributes are copied into every child log row because
+//! the ClickHouse logs table stores flattened rows rather than the nested OTLP hierarchy.
+//!
+//! # Column mapping
+//!
+//! One output row represents one OTLP `LogRecord`. The transformer currently builds these
+//! columns, then sorts them lexically to preserve the generic transformer's stable output order:
+//!
+//! ```text
+//! +--------------------+--------------------------------------+-----------------------+
+//! | Output column      | Raw OTLP source / operation          | Arrow representation  |
+//! +--------------------+--------------------------------------+-----------------------+
+//! | Timestamp          | LogRecord.time_unix_nano             | TimestampNanosecond   |
+//! | ResourceSchemaUrl  | ResourceLogs.schema_url              | Utf8                  |
+//! | ResourceAttributes | Resource.attributes -> string map    | Map(Utf8, Utf8)       |
+//! | ServiceName        | first resource attr `service.name`   | Utf8                  |
+//! | ScopeName          | InstrumentationScope.name            | Utf8                  |
+//! | ScopeVersion       | InstrumentationScope.version         | Utf8                  |
+//! | ScopeAttributes    | InstrumentationScope.attributes      | Map(Utf8, Utf8)       |
+//! | LogAttributes      | LogRecord.attributes                 | Map(Utf8, Utf8)       |
+//! | Body               | LogRecord.body -> string             | Utf8                  |
+//! | EventName          | LogRecord.event_name                 | Utf8                  |
+//! | SeverityNumber     | LogRecord.severity_number -> UInt8   | UInt8                 |
+//! | SeverityText       | LogRecord.severity_text              | Utf8                  |
+//! | TraceId            | LogRecord.trace_id -> lowercase hex  | Utf8                  |
+//! | SpanId             | LogRecord.span_id -> lowercase hex   | Utf8                  |
+//! +--------------------+--------------------------------------+-----------------------+
+//! ```
+//!
+//! Fields not listed in this table are not emitted by this transformer. In particular, the
+//! current implementation does not emit `ScopeSchemaUrl` or `TraceFlags`; extending the mapping
+//! requires updating the builders, presence tracking, parity tests, and live ClickHouse binding
+//! test together.
+//!
+//! # Value conversion
+//!
+//! ClickHouse attribute columns are maps of strings, so OTLP `AnyValue` values use the same
+//! logical conversion as the legacy transformer:
+//!
+//! - strings remain strings; booleans, integers, and doubles use their textual form
+//! - a top-level byte value is standard base64 text
+//! - arrays and key-value lists are JSON; byte values nested in JSON use the serializer's byte
+//!   array representation
+//! - a missing attribute value becomes an empty string
+//! - an empty or missing body becomes null
+//! - trace and span IDs become lowercase hexadecimal strings
+//!
+//! String-bearing OTLP fields must contain valid UTF-8, and a severity number must fit in `UInt8`.
+//! Violations are conversion errors rather than silent truncation or replacement.
+//!
+//! # Optional columns and defaults
+//!
+//! [`ColumnPresence`] records whether an optional field appears anywhere in the request. A column
+//! is omitted from the batch when it is absent from every row, matching the generic transformer's
+//! use of ClickHouse defaults. When a column is present for only some rows, its builders retain
+//! nulls or empty maps at the other row positions. `Timestamp` is always emitted and a missing
+//! OTLP timestamp becomes zero. `ResourceAttributes` and `ServiceName` are emitted together when
+//! at least one resource attribute exists; an absent `service.name` becomes an empty string.
+//!
+//! # Reused state and allocation bounds
+//!
+//! [`OtlpLogsTransformer`] is owned by one exporter task and is reused sequentially. It retains:
+//!
+//! - the previous request's row count as the next request's builder-capacity hint, capped at 16K
+//!   rows to prevent one unusually large request from causing persistent over-allocation
+//! - a scratch byte buffer used for `AnyValue` text/JSON conversion and ID encoding
+//! - a one-entry schema cache keyed by the sorted output column names and Arrow data types
+//!
+//! The Arrow builders themselves are request-local and are finalized into the returned batch.
+//! Changes to conversion, column presence, or sorting must preserve logical parity with the
+//! legacy path; the tests below compare names, row order, null placement, and values.
 
 use std::sync::Arc;
 
@@ -24,24 +164,56 @@ use serde::ser::{Error as SerError, SerializeMap, SerializeSeq, Serializer};
 use crate::exporters::clickhouse_exporter::consts as ch_consts;
 use crate::exporters::clickhouse_exporter::error::ClickhouseExporterError;
 
+/// Raw resource-attribute key whose first value populates the dedicated `ServiceName` column.
 const SERVICE_NAME_KEY: &[u8] = b"service.name";
+
+/// Initial payload-byte estimate used for each row in an Arrow string builder.
+///
+/// Builders grow automatically, so this affects allocation behavior but never truncates values.
 const INITIAL_STRING_BYTES_PER_ROW: usize = 16;
+
+/// Maximum number of rows for which a new request speculatively reserves builder capacity.
+///
+/// The output itself is not capped. Requests larger than this value continue growing their
+/// builders normally; only the capacity hint learned for the next request is bounded.
 const MAX_PREALLOCATED_ROWS: usize = 16 * 1024;
 
+/// Clamp a previous request's row count before using it as the next capacity hint.
 fn bounded_row_capacity(row_count: usize) -> usize {
     row_count.min(MAX_PREALLOCATED_ROWS)
 }
 
-/// Direct OTLP logs transformer with reusable sizing and serialization state.
+/// Stateful converter from serialized OTLP log requests to ClickHouse Arrow batches.
+///
+/// The exporter keeps one instance per task and calls it sequentially. Only allocation hints,
+/// serialization scratch space, and the most recently used schema survive between calls; no
+/// payload data is retained after [`Self::transform`] returns.
 #[derive(Default)]
 pub(crate) struct OtlpLogsTransformer {
+    /// Last schema and the ordered `(name, data_type)` key that uniquely describes it.
     cached_schema: Option<(Vec<(&'static str, DataType)>, Arc<Schema>)>,
+    /// Reusable buffer for scalar text, JSON, base64, and hexadecimal representations.
     json_scratch: Vec<u8>,
+    /// Completed row count from the previous request, used only as a capacity estimate.
     previous_row_count: usize,
 }
 
 impl OtlpLogsTransformer {
     /// Transform serialized `ExportLogsServiceRequest` bytes directly to a ClickHouse batch.
+    ///
+    /// The method validates the protobuf framing, walks resources/scopes/logs in wire order, and
+    /// appends one Arrow row for each log record. Parent resource and scope values are flattened
+    /// into every child row. Output columns are selected from request-wide presence information
+    /// and sorted by name before schema construction.
+    ///
+    /// Returns `Ok(None)` when the request is valid but contains no log records. The caller treats
+    /// that as a successful no-op rather than issuing an empty ClickHouse insert.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for invalid protobuf framing, invalid UTF-8, unsupported value coercions,
+    /// or Arrow builder/schema failures. The exporter, not this method, decides whether an error
+    /// is rejected or offered to the legacy transformation path.
     pub(crate) fn transform(
         &mut self,
         request: &[u8],
@@ -164,6 +336,10 @@ impl OtlpLogsTransformer {
         Ok(Some(RecordBatch::try_new(schema, arrays)?))
     }
 
+    /// Return a cached schema when column names and types match, or build and cache a new one.
+    ///
+    /// Column order is part of the cache key. Callers must sort columns before invoking this
+    /// method so equivalent request shapes produce the same schema identity.
     fn schema_for(&mut self, columns: &[(&'static str, ArrayRef)]) -> Arc<Schema> {
         let key = columns
             .iter()
@@ -185,6 +361,11 @@ impl OtlpLogsTransformer {
     }
 }
 
+/// Request-wide presence flags controlling which optional arrays enter the output batch.
+///
+/// Builders append a value or null for every row even before a field is known to occur. At
+/// finalization, these flags discard arrays that were absent from all rows, preserving the legacy
+/// transformer's conditional-column behavior and allowing ClickHouse defaults to apply.
 #[derive(Default)]
 struct ColumnPresence {
     body: bool,
@@ -201,6 +382,10 @@ struct ColumnPresence {
     trace_id: bool,
 }
 
+/// Request-local Arrow builders kept in row lockstep while the protobuf hierarchy is flattened.
+///
+/// Every builder receives exactly one logical entry per output row. [`Self::finish`] may omit an
+/// optional array, but any array it returns must have the same length as `timestamp`.
 struct LogsBuilders {
     body: StringBuilder,
     event_name: StringBuilder,
@@ -219,6 +404,11 @@ struct LogsBuilders {
 }
 
 impl LogsBuilders {
+    /// Create all builders using a bounded estimate of the request's eventual row count.
+    ///
+    /// String payload capacity uses a small per-row estimate. Map child builders intentionally
+    /// start without a value-count estimate because attribute cardinality is independent of log
+    /// row count.
     fn new(row_capacity: usize) -> Self {
         let row_capacity = bounded_row_capacity(row_capacity);
         let string_capacity = row_capacity.saturating_mul(INITIAL_STRING_BYTES_PER_ROW);
@@ -249,6 +439,11 @@ impl LogsBuilders {
         }
     }
 
+    /// Finalize required arrays and only those optional arrays observed in the request.
+    ///
+    /// `Timestamp` is unconditional. `ResourceAttributes` and `ServiceName` are a pair because
+    /// the service name is derived while scanning the resource map. Sorting is deliberately left
+    /// to the caller so this method can focus on presence policy and builder finalization.
     fn finish(mut self, presence: ColumnPresence) -> Vec<(&'static str, ArrayRef)> {
         let mut columns = Vec::with_capacity(14);
         if presence.body {
@@ -332,6 +527,11 @@ impl LogsBuilders {
     }
 }
 
+/// Materialize one resource's string map and extract its first `service.name` value.
+///
+/// Resource attributes must be replayed for every descendant log, so they are owned here rather
+/// than repeatedly traversed through borrowed protobuf views. Attribute order and duplicate keys
+/// are preserved. The first `service.name` wins to match the generic ClickHouse transformation.
 fn collect_resource_attributes<R: ResourceView>(
     resource: R,
     scratch: &mut Vec<u8>,
@@ -351,6 +551,10 @@ fn collect_resource_attributes<R: ResourceView>(
     Ok((attributes, service_name.unwrap_or_default()))
 }
 
+/// Materialize a reusable string-map representation of parent-level attributes.
+///
+/// This is used for scope attributes, which are converted once per scope and copied into every
+/// descendant log row. Attribute order and duplicate keys are preserved.
 fn collect_attributes<I, A>(
     attributes: I,
     scratch: &mut Vec<u8>,
@@ -368,6 +572,10 @@ where
     Ok(collected)
 }
 
+/// Append one borrowed attribute to the current map row without an intermediate owned pair.
+///
+/// Callers are responsible for closing the map row with `MapBuilder::append` after all of that
+/// log record's attributes have been added.
 fn append_attribute<A: AttributeView>(
     builder: &mut MapBuilder<StringBuilder, StringBuilder>,
     attribute: A,
@@ -379,6 +587,11 @@ fn append_attribute<A: AttributeView>(
     Ok(())
 }
 
+/// Replay a materialized parent attribute map and close exactly one Arrow map row.
+///
+/// Calling this with an empty slice appends a valid empty map, not a null map. That distinction
+/// keeps all builders aligned while request-wide presence tracking decides whether the complete
+/// column is emitted.
 fn append_attribute_map(
     builder: &mut MapBuilder<StringBuilder, StringBuilder>,
     attributes: &[(String, String)],
@@ -391,6 +604,10 @@ fn append_attribute_map(
     Ok(())
 }
 
+/// Replace `scratch` with the string-map representation of an optional OTLP value.
+///
+/// A missing value intentionally produces an empty string because ClickHouse attribute maps use
+/// string values and this matches the legacy transformer's coercion.
 fn stringify_optional_any_value<'a, V: AnyValueView<'a> + 'a>(
     value: Option<V>,
     scratch: &mut Vec<u8>,
@@ -402,6 +619,11 @@ fn stringify_optional_any_value<'a, V: AnyValueView<'a> + 'a>(
     Ok(())
 }
 
+/// Replace `scratch` with the ClickHouse string representation of an OTLP `AnyValue`.
+///
+/// Scalar values avoid general-purpose JSON serialization. Arrays and key-value lists delegate
+/// to serde so nesting is preserved. A top-level byte value is base64, whereas a byte value
+/// nested inside JSON follows serde's byte-sequence representation.
 fn stringify_any_value<'a, V: AnyValueView<'a> + 'a>(
     value: V,
     scratch: &mut Vec<u8>,
@@ -457,12 +679,16 @@ fn stringify_any_value<'a, V: AnyValueView<'a> + 'a>(
     Ok(())
 }
 
+/// Describe an inconsistent view whose declared `ValueType` has no matching payload accessor.
 fn invalid_any_value(expected: &str) -> ClickhouseExporterError {
     ClickhouseExporterError::CoercionError {
         error: format!("OTLP AnyValue declared {expected} but did not contain a valid value"),
     }
 }
 
+/// Adapter that lets a borrowed [`AnyValueView`] participate in recursive serde serialization.
+///
+/// Keeping the view borrowed avoids building a second owned tree solely for nested JSON values.
 struct AnyValueSerializerWrapper<T>(T);
 
 impl<'a, T> Serialize for AnyValueSerializerWrapper<T>
@@ -477,6 +703,11 @@ where
     }
 }
 
+/// Recursively serialize an OTLP value with JSON-compatible scalar, sequence, and map semantics.
+///
+/// This function is serializer-generic so recursion can use normal serde APIs; production calls
+/// it through `serde_json::to_writer` in [`stringify_any_value`]. Missing nested attribute values
+/// become JSON nulls, unlike missing top-level string-map values, which become empty strings.
 fn serialize_any_value<'a, T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
 where
     T: AnyValueView<'a> + 'a,
@@ -541,18 +772,21 @@ where
     }
 }
 
+/// Validate and own an optional protobuf string that must outlive its borrowed parent view.
 fn optional_utf8(value: Option<&[u8]>) -> Result<Option<String>, ClickhouseExporterError> {
     value
         .map(|value| utf8(value).map(ToOwned::to_owned))
         .transpose()
 }
 
+/// Interpret protobuf string bytes as UTF-8 and normalize failures to an exporter coercion error.
 fn utf8(value: &[u8]) -> Result<&str, ClickhouseExporterError> {
     std::str::from_utf8(value).map_err(|error| ClickhouseExporterError::CoercionError {
         error: format!("invalid UTF-8 in OTLP string: {error}"),
     })
 }
 
+/// Append an optional validated string while preserving a null for an absent row value.
 fn append_optional_string(builder: &mut StringBuilder, value: Option<&str>) {
     match value {
         Some(value) => builder.append_value(value),
@@ -560,6 +794,10 @@ fn append_optional_string(builder: &mut StringBuilder, value: Option<&str>) {
     }
 }
 
+/// Validate and append an optional protobuf string, recording request-wide column presence.
+///
+/// The presence flag changes only for `Some`, even when the present string is empty. This lets an
+/// explicitly empty OTLP value remain distinguishable from a field omitted in every row.
 fn append_optional_bytes_as_string(
     builder: &mut StringBuilder,
     value: Option<&[u8]>,
@@ -575,6 +813,10 @@ fn append_optional_bytes_as_string(
     Ok(())
 }
 
+/// Append optional binary identifier bytes as lowercase hexadecimal text.
+///
+/// Hex output is written into the shared scratch buffer without allocating a temporary `String`.
+/// As with other optional helpers, `present` records field presence across the entire request.
 fn append_optional_hex(
     builder: &mut StringBuilder,
     value: Option<&[u8]>,

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/logs_otlp.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/logs_otlp.rs
@@ -14,8 +14,8 @@
 //!
 //! Unlike the specialized OTAP transformer in `logs_fast`, this path cannot share input arrays
 //! with its output because its input is a byte buffer rather than Arrow data. Its main savings
-//! come from traversing the protobuf once, materializing only the final arrays, and reusing
-//! allocation and schema state between requests.
+//! come from traversing the nested protobuf hierarchy once, materializing only the final arrays,
+//! and reusing allocation and schema state between requests.
 //!
 //! # Applicability and routing
 //!
@@ -26,7 +26,8 @@
 //!
 //! - a successful non-empty transformation is written as the logs payload
 //! - a valid request with no log records returns `None`, so no empty insert is issued
-//! - invalid protobuf wire framing is rejected and is not sent through the legacy path
+//! - invalid top-level protobuf wire framing is rejected and is not sent through the legacy path
+//! - malformed or wrongly typed nested fields follow the raw views' lazy best-effort behavior
 //! - other conversion or Arrow errors are returned to the caller, which may attempt the legacy
 //!   OTLP-to-OTAP transformation
 //!
@@ -44,7 +45,7 @@
 //!                 |
 //!                 v
 //!       RawLogsData::try_new
-//!       - validate wire framing
+//!       - validate top-level framing
 //!       - expose borrowed views
 //!                 |
 //!                 v
@@ -211,9 +212,9 @@ impl OtlpLogsTransformer {
     ///
     /// # Errors
     ///
-    /// Returns an error for invalid protobuf framing, invalid UTF-8, unsupported value coercions,
-    /// or Arrow builder/schema failures. The exporter, not this method, decides whether an error
-    /// is rejected or offered to the legacy transformation path.
+    /// Returns an error for invalid top-level protobuf framing, invalid UTF-8, unsupported value
+    /// coercions, or Arrow builder/schema failures. The exporter, not this method, decides whether
+    /// an error is rejected or offered to the legacy transformation path.
     pub(crate) fn transform(
         &mut self,
         request: &[u8],
@@ -1160,14 +1161,14 @@ mod tests {
     }
 
     /// Scenario: a nested OTLP field declares a length beyond its enclosing message.
-    /// Guarantees: the direct transformer returns an error before traversing malformed ranges.
+    /// Guarantees: lazy traversal ignores the malformed field instead of rejecting the request.
     #[test]
-    fn malformed_nested_request_is_rejected() {
-        let error = OtlpLogsTransformer::default()
+    fn malformed_nested_request_uses_best_effort_view() {
+        let batch = OtlpLogsTransformer::default()
             .transform(&[0x0a, 0x03, 0x1a, 0x05, 0x00])
-            .expect_err("malformed nested protobuf must be rejected");
+            .expect("top-level framing is valid");
 
-        assert!(matches!(error, ClickhouseExporterError::Child(_)));
+        assert!(batch.is_none());
     }
 
     /// Scenario: the previous OTLP request reports an arbitrarily large row count.

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/logs_otlp.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/logs_otlp.rs
@@ -1,0 +1,928 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Direct transformation of serialized OTLP logs into ClickHouse Arrow columns.
+
+use std::sync::Arc;
+
+use arrow::array::{
+    ArrayRef, MapBuilder, RecordBatch, StringBuilder, TimestampNanosecondBuilder, UInt8Builder,
+};
+use arrow::datatypes::{DataType, Field, Schema};
+use base64::Engine;
+use otap_df_pdata::views::otlp::bytes::logs::RawLogsData;
+use otap_df_pdata_views::views::common::{
+    AnyValueView, AttributeView, InstrumentationScopeView, ValueType,
+};
+use otap_df_pdata_views::views::logs::{
+    LogRecordView, LogsDataView, ResourceLogsView, ScopeLogsView,
+};
+use otap_df_pdata_views::views::resource::ResourceView;
+use serde::Serialize;
+use serde::ser::{Error as SerError, SerializeMap, SerializeSeq, Serializer};
+
+use crate::exporters::clickhouse_exporter::consts as ch_consts;
+use crate::exporters::clickhouse_exporter::error::ClickhouseExporterError;
+
+const SERVICE_NAME_KEY: &[u8] = b"service.name";
+const INITIAL_STRING_BYTES_PER_ROW: usize = 16;
+
+/// Direct OTLP logs transformer with reusable sizing and serialization state.
+#[derive(Default)]
+pub(crate) struct OtlpLogsTransformer {
+    cached_schema: Option<(Vec<(&'static str, DataType)>, Arc<Schema>)>,
+    json_scratch: Vec<u8>,
+    previous_row_count: usize,
+}
+
+impl OtlpLogsTransformer {
+    /// Transform serialized `ExportLogsServiceRequest` bytes directly to a ClickHouse batch.
+    pub(crate) fn transform(
+        &mut self,
+        request: &[u8],
+    ) -> Result<Option<RecordBatch>, ClickhouseExporterError> {
+        let logs = RawLogsData::try_new(request)?;
+        let mut builders = LogsBuilders::new(self.previous_row_count);
+        let mut presence = ColumnPresence::default();
+        let mut row_count = 0;
+
+        for resource_logs in logs.resources() {
+            let resource_schema_url = optional_utf8(resource_logs.schema_url())?;
+            let (resource_attributes, service_name) = match resource_logs.resource() {
+                Some(resource) => collect_resource_attributes(resource, &mut self.json_scratch)?,
+                None => (Vec::new(), String::new()),
+            };
+            presence.resource_schema_url |= resource_schema_url.is_some();
+            presence.resource_attributes |= !resource_attributes.is_empty();
+
+            for scope_logs in resource_logs.scopes() {
+                let (scope_name, scope_version, scope_attributes) = match scope_logs.scope() {
+                    Some(scope) => {
+                        let name = optional_utf8(scope.name())?;
+                        let version = optional_utf8(scope.version())?;
+                        let attributes =
+                            collect_attributes(scope.attributes(), &mut self.json_scratch)?;
+                        (name, version, attributes)
+                    }
+                    None => (None, None, Vec::new()),
+                };
+                presence.scope_name |= scope_name.is_some();
+                presence.scope_version |= scope_version.is_some();
+                presence.scope_attributes |= !scope_attributes.is_empty();
+
+                for log in scope_logs.log_records() {
+                    row_count += 1;
+                    builders
+                        .timestamp
+                        .append_value(log.time_unix_nano().unwrap_or(0) as i64);
+                    append_optional_string(
+                        &mut builders.resource_schema_url,
+                        resource_schema_url.as_deref(),
+                    );
+                    append_attribute_map(&mut builders.resource_attributes, &resource_attributes)?;
+                    builders.service_name.append_value(&service_name);
+                    append_optional_string(&mut builders.scope_name, scope_name.as_deref());
+                    append_optional_string(&mut builders.scope_version, scope_version.as_deref());
+                    append_attribute_map(&mut builders.scope_attributes, &scope_attributes)?;
+
+                    let mut has_log_attributes = false;
+                    for attribute in log.attributes() {
+                        append_attribute(
+                            &mut builders.log_attributes,
+                            attribute,
+                            &mut self.json_scratch,
+                        )?;
+                        has_log_attributes = true;
+                    }
+                    builders.log_attributes.append(true)?;
+                    presence.log_attributes |= has_log_attributes;
+
+                    match log.body() {
+                        Some(body) if body.value_type() != ValueType::Empty => {
+                            stringify_any_value(body, &mut self.json_scratch)?;
+                            builders.body.append_value(utf8(&self.json_scratch)?);
+                            presence.body = true;
+                        }
+                        _ => builders.body.append_null(),
+                    }
+
+                    append_optional_bytes_as_string(
+                        &mut builders.event_name,
+                        log.event_name(),
+                        &mut presence.event_name,
+                    )?;
+                    append_optional_bytes_as_string(
+                        &mut builders.severity_text,
+                        log.severity_text(),
+                        &mut presence.severity_text,
+                    )?;
+                    match log.severity_number() {
+                        Some(value) => {
+                            let value = u8::try_from(value).map_err(|_| {
+                                ClickhouseExporterError::CoercionError {
+                                    error: format!(
+                                        "OTLP log severity number {value} cannot be represented as UInt8"
+                                    ),
+                                }
+                            })?;
+                            builders.severity_number.append_value(value);
+                            presence.severity_number = true;
+                        }
+                        None => builders.severity_number.append_null(),
+                    }
+
+                    append_optional_hex(
+                        &mut builders.span_id,
+                        log.span_id().map(|id| id.as_slice()),
+                        &mut presence.span_id,
+                        &mut self.json_scratch,
+                    );
+                    append_optional_hex(
+                        &mut builders.trace_id,
+                        log.trace_id().map(|id| id.as_slice()),
+                        &mut presence.trace_id,
+                        &mut self.json_scratch,
+                    );
+                }
+            }
+        }
+
+        self.previous_row_count = row_count;
+        if row_count == 0 {
+            return Ok(None);
+        }
+
+        let mut columns = builders.finish(presence);
+        columns.sort_unstable_by_key(|(name, _)| *name);
+        let schema = self.schema_for(&columns);
+        let arrays = columns.into_iter().map(|(_, array)| array).collect();
+        Ok(Some(RecordBatch::try_new(schema, arrays)?))
+    }
+
+    fn schema_for(&mut self, columns: &[(&'static str, ArrayRef)]) -> Arc<Schema> {
+        let key = columns
+            .iter()
+            .map(|(name, array)| (*name, array.data_type().clone()))
+            .collect::<Vec<_>>();
+        if let Some((cached_key, schema)) = &self.cached_schema
+            && cached_key == &key
+        {
+            return schema.clone();
+        }
+
+        let fields = key
+            .iter()
+            .map(|(name, data_type)| Field::new(*name, data_type.clone(), true))
+            .collect::<Vec<_>>();
+        let schema = Arc::new(Schema::new(fields));
+        self.cached_schema = Some((key, schema.clone()));
+        schema
+    }
+}
+
+#[derive(Default)]
+struct ColumnPresence {
+    body: bool,
+    event_name: bool,
+    log_attributes: bool,
+    resource_attributes: bool,
+    resource_schema_url: bool,
+    scope_attributes: bool,
+    scope_name: bool,
+    scope_version: bool,
+    severity_number: bool,
+    severity_text: bool,
+    span_id: bool,
+    trace_id: bool,
+}
+
+struct LogsBuilders {
+    body: StringBuilder,
+    event_name: StringBuilder,
+    log_attributes: MapBuilder<StringBuilder, StringBuilder>,
+    resource_attributes: MapBuilder<StringBuilder, StringBuilder>,
+    resource_schema_url: StringBuilder,
+    scope_attributes: MapBuilder<StringBuilder, StringBuilder>,
+    scope_name: StringBuilder,
+    scope_version: StringBuilder,
+    service_name: StringBuilder,
+    severity_number: UInt8Builder,
+    severity_text: StringBuilder,
+    span_id: StringBuilder,
+    timestamp: TimestampNanosecondBuilder,
+    trace_id: StringBuilder,
+}
+
+impl LogsBuilders {
+    fn new(row_capacity: usize) -> Self {
+        let string_capacity = row_capacity.saturating_mul(INITIAL_STRING_BYTES_PER_ROW);
+        let string_builder = || StringBuilder::with_capacity(row_capacity, string_capacity);
+        let map_builder = || {
+            MapBuilder::with_capacity(
+                None,
+                StringBuilder::new(),
+                StringBuilder::new(),
+                row_capacity,
+            )
+        };
+        Self {
+            body: string_builder(),
+            event_name: string_builder(),
+            log_attributes: map_builder(),
+            resource_attributes: map_builder(),
+            resource_schema_url: string_builder(),
+            scope_attributes: map_builder(),
+            scope_name: string_builder(),
+            scope_version: string_builder(),
+            service_name: string_builder(),
+            severity_number: UInt8Builder::with_capacity(row_capacity),
+            severity_text: string_builder(),
+            span_id: string_builder(),
+            timestamp: TimestampNanosecondBuilder::with_capacity(row_capacity),
+            trace_id: string_builder(),
+        }
+    }
+
+    fn finish(mut self, presence: ColumnPresence) -> Vec<(&'static str, ArrayRef)> {
+        let mut columns = Vec::with_capacity(14);
+        if presence.body {
+            columns.push((ch_consts::CH_BODY, Arc::new(self.body.finish()) as ArrayRef));
+        }
+        if presence.event_name {
+            columns.push((
+                ch_consts::CH_EVENT_NAME,
+                Arc::new(self.event_name.finish()) as ArrayRef,
+            ));
+        }
+        if presence.log_attributes {
+            columns.push((
+                ch_consts::CH_LOG_ATTRIBUTES,
+                Arc::new(self.log_attributes.finish()) as ArrayRef,
+            ));
+        }
+        if presence.resource_attributes {
+            columns.push((
+                ch_consts::CH_RESOURCE_ATTRIBUTES,
+                Arc::new(self.resource_attributes.finish()) as ArrayRef,
+            ));
+            columns.push((
+                ch_consts::CH_SERVICE_NAME,
+                Arc::new(self.service_name.finish()) as ArrayRef,
+            ));
+        }
+        if presence.resource_schema_url {
+            columns.push((
+                ch_consts::CH_RESOURCE_SCHEMA_URL,
+                Arc::new(self.resource_schema_url.finish()) as ArrayRef,
+            ));
+        }
+        if presence.scope_attributes {
+            columns.push((
+                ch_consts::CH_SCOPE_ATTRIBUTES,
+                Arc::new(self.scope_attributes.finish()) as ArrayRef,
+            ));
+        }
+        if presence.scope_name {
+            columns.push((
+                ch_consts::CH_SCOPE_NAME,
+                Arc::new(self.scope_name.finish()) as ArrayRef,
+            ));
+        }
+        if presence.scope_version {
+            columns.push((
+                ch_consts::CH_SCOPE_VERSION,
+                Arc::new(self.scope_version.finish()) as ArrayRef,
+            ));
+        }
+        if presence.severity_number {
+            columns.push((
+                ch_consts::CH_SEVERITY_NUMBER,
+                Arc::new(self.severity_number.finish()) as ArrayRef,
+            ));
+        }
+        if presence.severity_text {
+            columns.push((
+                ch_consts::CH_SEVERITY_TEXT,
+                Arc::new(self.severity_text.finish()) as ArrayRef,
+            ));
+        }
+        if presence.span_id {
+            columns.push((
+                ch_consts::CH_SPAN_ID,
+                Arc::new(self.span_id.finish()) as ArrayRef,
+            ));
+        }
+        columns.push((
+            ch_consts::CH_TIMESTAMP,
+            Arc::new(self.timestamp.finish()) as ArrayRef,
+        ));
+        if presence.trace_id {
+            columns.push((
+                ch_consts::CH_TRACE_ID,
+                Arc::new(self.trace_id.finish()) as ArrayRef,
+            ));
+        }
+        columns
+    }
+}
+
+fn collect_resource_attributes<R: ResourceView>(
+    resource: R,
+    scratch: &mut Vec<u8>,
+) -> Result<(Vec<(String, String)>, String), ClickhouseExporterError> {
+    let mut attributes = Vec::new();
+    let mut service_name = None;
+    for attribute in resource.attributes() {
+        let key_bytes = attribute.key();
+        let key = utf8(key_bytes)?.to_owned();
+        stringify_optional_any_value(attribute.value(), scratch)?;
+        let value = utf8(scratch)?.to_owned();
+        if service_name.is_none() && key_bytes == SERVICE_NAME_KEY {
+            service_name = Some(value.clone());
+        }
+        attributes.push((key, value));
+    }
+    Ok((attributes, service_name.unwrap_or_default()))
+}
+
+fn collect_attributes<I, A>(
+    attributes: I,
+    scratch: &mut Vec<u8>,
+) -> Result<Vec<(String, String)>, ClickhouseExporterError>
+where
+    I: Iterator<Item = A>,
+    A: AttributeView,
+{
+    let mut collected = Vec::new();
+    for attribute in attributes {
+        let key = utf8(attribute.key())?.to_owned();
+        stringify_optional_any_value(attribute.value(), scratch)?;
+        collected.push((key, utf8(scratch)?.to_owned()));
+    }
+    Ok(collected)
+}
+
+fn append_attribute<A: AttributeView>(
+    builder: &mut MapBuilder<StringBuilder, StringBuilder>,
+    attribute: A,
+    scratch: &mut Vec<u8>,
+) -> Result<(), ClickhouseExporterError> {
+    builder.keys().append_value(utf8(attribute.key())?);
+    stringify_optional_any_value(attribute.value(), scratch)?;
+    builder.values().append_value(utf8(scratch)?);
+    Ok(())
+}
+
+fn append_attribute_map(
+    builder: &mut MapBuilder<StringBuilder, StringBuilder>,
+    attributes: &[(String, String)],
+) -> Result<(), ClickhouseExporterError> {
+    for (key, value) in attributes {
+        builder.keys().append_value(key);
+        builder.values().append_value(value);
+    }
+    builder.append(true)?;
+    Ok(())
+}
+
+fn stringify_optional_any_value<'a, V: AnyValueView<'a> + 'a>(
+    value: Option<V>,
+    scratch: &mut Vec<u8>,
+) -> Result<(), ClickhouseExporterError> {
+    scratch.clear();
+    if let Some(value) = value {
+        stringify_any_value(value, scratch)?;
+    }
+    Ok(())
+}
+
+fn stringify_any_value<'a, V: AnyValueView<'a> + 'a>(
+    value: V,
+    scratch: &mut Vec<u8>,
+) -> Result<(), ClickhouseExporterError> {
+    scratch.clear();
+    match value.value_type() {
+        ValueType::Empty => {}
+        ValueType::String => scratch.extend_from_slice(
+            value
+                .as_string()
+                .ok_or_else(|| invalid_any_value("string"))?,
+        ),
+        ValueType::Bool => scratch.extend_from_slice(
+            if value.as_bool().ok_or_else(|| invalid_any_value("bool"))? {
+                b"true"
+            } else {
+                b"false"
+            },
+        ),
+        ValueType::Int64 => {
+            let mut buffer = itoa::Buffer::new();
+            scratch.extend_from_slice(
+                buffer
+                    .format(value.as_int64().ok_or_else(|| invalid_any_value("int64"))?)
+                    .as_bytes(),
+            );
+        }
+        ValueType::Double => {
+            let mut buffer = ryu::Buffer::new();
+            scratch.extend_from_slice(
+                buffer
+                    .format(
+                        value
+                            .as_double()
+                            .ok_or_else(|| invalid_any_value("double"))?,
+                    )
+                    .as_bytes(),
+            );
+        }
+        ValueType::Bytes => {
+            let encoded = base64::engine::general_purpose::STANDARD
+                .encode(value.as_bytes().ok_or_else(|| invalid_any_value("bytes"))?);
+            scratch.extend_from_slice(encoded.as_bytes());
+        }
+        ValueType::Array | ValueType::KeyValueList => {
+            serde_json::to_writer(&mut *scratch, &AnyValueSerializerWrapper(value)).map_err(
+                |error| ClickhouseExporterError::CoercionError {
+                    error: format!("failed to serialize OTLP AnyValue as JSON: {error}"),
+                },
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn invalid_any_value(expected: &str) -> ClickhouseExporterError {
+    ClickhouseExporterError::CoercionError {
+        error: format!("OTLP AnyValue declared {expected} but did not contain a valid value"),
+    }
+}
+
+struct AnyValueSerializerWrapper<T>(T);
+
+impl<'a, T> Serialize for AnyValueSerializerWrapper<T>
+where
+    T: AnyValueView<'a> + 'a,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serialize_any_value(&self.0, serializer)
+    }
+}
+
+fn serialize_any_value<'a, T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    T: AnyValueView<'a> + 'a,
+    S: Serializer,
+{
+    match value.value_type() {
+        ValueType::Empty => serializer.serialize_none(),
+        ValueType::String => serializer.serialize_str(
+            std::str::from_utf8(
+                value
+                    .as_string()
+                    .ok_or_else(|| S::Error::custom("missing OTLP string value"))?,
+            )
+            .map_err(S::Error::custom)?,
+        ),
+        ValueType::Bool => serializer.serialize_bool(
+            value
+                .as_bool()
+                .ok_or_else(|| S::Error::custom("missing OTLP bool value"))?,
+        ),
+        ValueType::Int64 => serializer.serialize_i64(
+            value
+                .as_int64()
+                .ok_or_else(|| S::Error::custom("missing OTLP int64 value"))?,
+        ),
+        ValueType::Double => serializer.serialize_f64(
+            value
+                .as_double()
+                .ok_or_else(|| S::Error::custom("missing OTLP double value"))?,
+        ),
+        ValueType::Bytes => serializer.serialize_bytes(
+            value
+                .as_bytes()
+                .ok_or_else(|| S::Error::custom("missing OTLP bytes value"))?,
+        ),
+        ValueType::Array => {
+            let mut sequence = serializer.serialize_seq(None)?;
+            for child in value
+                .as_array()
+                .ok_or_else(|| S::Error::custom("missing OTLP array value"))?
+            {
+                sequence.serialize_element(&AnyValueSerializerWrapper(child))?;
+            }
+            sequence.end()
+        }
+        ValueType::KeyValueList => {
+            let mut map = serializer.serialize_map(None)?;
+            for attribute in value
+                .as_kvlist()
+                .ok_or_else(|| S::Error::custom("missing OTLP map value"))?
+            {
+                let key = std::str::from_utf8(attribute.key()).map_err(S::Error::custom)?;
+                match attribute.value() {
+                    Some(child) => {
+                        map.serialize_entry(key, &AnyValueSerializerWrapper(child))?;
+                    }
+                    None => map.serialize_entry(key, &Option::<()>::None)?,
+                }
+            }
+            map.end()
+        }
+    }
+}
+
+fn optional_utf8(value: Option<&[u8]>) -> Result<Option<String>, ClickhouseExporterError> {
+    value
+        .map(|value| utf8(value).map(ToOwned::to_owned))
+        .transpose()
+}
+
+fn utf8(value: &[u8]) -> Result<&str, ClickhouseExporterError> {
+    std::str::from_utf8(value).map_err(|error| ClickhouseExporterError::CoercionError {
+        error: format!("invalid UTF-8 in OTLP string: {error}"),
+    })
+}
+
+fn append_optional_string(builder: &mut StringBuilder, value: Option<&str>) {
+    match value {
+        Some(value) => builder.append_value(value),
+        None => builder.append_null(),
+    }
+}
+
+fn append_optional_bytes_as_string(
+    builder: &mut StringBuilder,
+    value: Option<&[u8]>,
+    present: &mut bool,
+) -> Result<(), ClickhouseExporterError> {
+    match value {
+        Some(value) => {
+            builder.append_value(utf8(value)?);
+            *present = true;
+        }
+        None => builder.append_null(),
+    }
+    Ok(())
+}
+
+fn append_optional_hex(
+    builder: &mut StringBuilder,
+    value: Option<&[u8]>,
+    present: &mut bool,
+    scratch: &mut Vec<u8>,
+) {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    match value {
+        Some(value) => {
+            scratch.clear();
+            scratch.reserve(value.len() * 2);
+            for byte in value {
+                scratch.push(HEX[(byte >> 4) as usize]);
+                scratch.push(HEX[(byte & 0x0f) as usize]);
+            }
+            builder.append_value(
+                std::str::from_utf8(scratch).expect("lowercase hexadecimal is valid UTF-8"),
+            );
+            *present = true;
+        }
+        None => builder.append_null(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::HashMap;
+
+    use arrow::array::Array;
+    use arrow::util::display::array_value_to_string;
+    use bytes::Bytes;
+    use otap_df_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
+    use otap_df_pdata::proto::opentelemetry::collector::logs::v1::ExportLogsServiceRequest;
+    use otap_df_pdata::proto::opentelemetry::common::v1::{
+        AnyValue, InstrumentationScope, KeyValue,
+    };
+    use otap_df_pdata::proto::opentelemetry::logs::v1::{
+        LogRecord, LogsData, ResourceLogs, ScopeLogs, SeverityNumber,
+    };
+    use otap_df_pdata::proto::opentelemetry::resource::v1::Resource;
+    use otap_df_pdata::testing::fixtures;
+    use otap_df_pdata::{OtapArrowRecords, OtapPayload, OtlpProtoBytes, TryIntoWithOptions};
+    use prost::Message;
+
+    use crate::exporters::clickhouse_exporter::transform::transform_batch::BatchTransformer;
+    use crate::exporters::clickhouse_exporter::{
+        config::Config,
+        writer::{ClickHouseWriter, build_client},
+    };
+
+    fn request_bytes(logs: LogsData) -> Bytes {
+        Bytes::from(
+            ExportLogsServiceRequest {
+                resource_logs: logs.resource_logs,
+            }
+            .encode_to_vec(),
+        )
+    }
+
+    fn legacy_batch(bytes: &Bytes) -> Option<RecordBatch> {
+        let payload: OtapPayload = OtlpProtoBytes::ExportLogsRequest(bytes.clone()).into();
+        let mut records: OtapArrowRecords = payload
+            .try_into_with_default()
+            .expect("convert raw OTLP logs through OTAP Arrow");
+        records
+            .decode_transport_optimized_ids()
+            .expect("decode transport optimized IDs");
+        BatchTransformer::new()
+            .apply_plan(records)
+            .expect("apply legacy ClickHouse transform")
+            .remove(&ArrowPayloadType::Logs)
+    }
+
+    fn logical_values(array: &dyn Array) -> Vec<Option<String>> {
+        if matches!(array.data_type(), DataType::Binary)
+            || matches!(
+                array.data_type(),
+                DataType::Dictionary(_, value) if **value == DataType::Binary
+            )
+        {
+            let binary = arrow::compute::cast(array, &DataType::Binary)
+                .expect("cast dictionary-encoded binary values")
+                .as_any()
+                .downcast_ref::<arrow::array::BinaryArray>()
+                .expect("binary array")
+                .clone();
+            return (0..binary.len())
+                .map(|row| {
+                    (!binary.is_null(row)).then(|| {
+                        std::str::from_utf8(binary.value(row))
+                            .expect("ClickHouse string bytes are UTF-8")
+                            .to_owned()
+                    })
+                })
+                .collect();
+        }
+
+        (0..array.len())
+            .map(|row| {
+                (!array.is_null(row)).then(|| {
+                    array_value_to_string(array, row).expect("format Arrow value for comparison")
+                })
+            })
+            .collect()
+    }
+
+    fn assert_matches_legacy(logs: LogsData) {
+        let bytes = request_bytes(logs);
+        let expected = legacy_batch(&bytes);
+        let actual = OtlpLogsTransformer::default()
+            .transform(&bytes)
+            .expect("transform raw OTLP logs directly");
+
+        match (actual, expected) {
+            (Some(actual), Some(expected)) => {
+                let actual_names = actual
+                    .schema()
+                    .fields()
+                    .iter()
+                    .map(|field| field.name().clone())
+                    .collect::<Vec<_>>();
+                let expected_names = expected
+                    .schema()
+                    .fields()
+                    .iter()
+                    .map(|field| field.name().clone())
+                    .collect::<Vec<_>>();
+                assert_eq!(actual_names, expected_names);
+                assert_eq!(actual.num_rows(), expected.num_rows());
+                for (actual, expected) in actual.columns().iter().zip(expected.columns()) {
+                    assert_eq!(
+                        logical_values(actual.as_ref()),
+                        logical_values(expected.as_ref())
+                    );
+                }
+            }
+            (None, None) => {}
+            (actual, expected) => panic!(
+                "direct and legacy transforms disagree about output presence: direct={}, legacy={}",
+                actual.is_some(),
+                expected.is_some()
+            ),
+        }
+    }
+
+    fn logs_with_all_value_types() -> LogsData {
+        let nested = AnyValue::new_kvlist(vec![
+            KeyValue::new("nested.string", AnyValue::new_string("value")),
+            KeyValue::new(
+                "nested.array",
+                AnyValue::new_array(vec![
+                    AnyValue::new_bool(false),
+                    AnyValue::new_int(-7),
+                    AnyValue::new_bytes([1_u8, 2, 3]),
+                ]),
+            ),
+        ]);
+        LogsData::new(vec![ResourceLogs {
+            resource: Some(
+                Resource::build()
+                    .attributes(vec![
+                        KeyValue::new("service.name", AnyValue::new_string("first")),
+                        KeyValue::new("service.name", AnyValue::new_string("second")),
+                        KeyValue::new("resource.map", nested.clone()),
+                    ])
+                    .finish(),
+            ),
+            scope_logs: vec![ScopeLogs {
+                scope: Some(
+                    InstrumentationScope::build()
+                        .name("raw-scope")
+                        .version("1.0")
+                        .attributes(vec![KeyValue::new(
+                            "scope.array",
+                            AnyValue::new_array(vec![AnyValue::new_double(1.5)]),
+                        )])
+                        .finish(),
+                ),
+                log_records: vec![
+                    LogRecord::build()
+                        .time_unix_nano(123_u64)
+                        .severity_number(SeverityNumber::Error)
+                        .severity_text("ERROR")
+                        .body(nested)
+                        .attributes(vec![
+                            KeyValue::new("empty", AnyValue::default()),
+                            KeyValue::new("string", AnyValue::new_string("text")),
+                            KeyValue::new("int", AnyValue::new_int(-42)),
+                            KeyValue::new("double", AnyValue::new_double(3.25)),
+                            KeyValue::new("bool", AnyValue::new_bool(true)),
+                        ])
+                        .trace_id([0x11; 16])
+                        .span_id([0x22; 8])
+                        .event_name("raw-event")
+                        .finish(),
+                ],
+                schema_url: "https://scope.example/v1".to_string(),
+            }],
+            schema_url: "https://resource.example/v1".to_string(),
+        }])
+    }
+
+    /// Scenario: raw OTLP logs contain resource, scope, and log attributes plus scalar fields.
+    /// Guarantees: the direct path preserves the legacy transform's columns, row order, and values.
+    #[test]
+    fn full_logs_match_legacy_transform() {
+        assert_matches_legacy(fixtures::logs_with_full_resource_and_scope());
+    }
+
+    /// Scenario: raw OTLP logs omit every resource, scope, and log attribute.
+    /// Guarantees: the direct path omits the same attribute columns as the legacy transform.
+    #[test]
+    fn logs_without_attributes_match_legacy_transform() {
+        assert_matches_legacy(fixtures::logs_with_no_attributes());
+    }
+
+    /// Scenario: raw OTLP logs span resources and scopes with mixed optional content.
+    /// Guarantees: direct traversal preserves legacy row order, nulls, and conditional columns.
+    #[test]
+    fn mixed_resources_and_scopes_match_legacy_transform() {
+        assert_matches_legacy(fixtures::logs_multiple_resources_mixed_content());
+    }
+
+    /// Scenario: raw OTLP logs exercise scalar, nested, ID, and schema fields.
+    /// Guarantees: direct JSON and scalar conversion exactly preserve legacy logical values.
+    #[test]
+    fn nested_value_types_match_legacy_transform() {
+        assert_matches_legacy(logs_with_all_value_types());
+    }
+
+    /// Scenario: a raw OTLP log attribute contains an arbitrary byte sequence.
+    /// Guarantees: the direct path stores the attribute using standard base64 encoding.
+    #[test]
+    fn bytes_attribute_is_base64_encoded() {
+        let logs = LogsData::new(vec![ResourceLogs::new(
+            Resource::default(),
+            vec![ScopeLogs::new(
+                InstrumentationScope::default(),
+                vec![
+                    LogRecord::build()
+                        .attributes(vec![KeyValue::new(
+                            "bytes",
+                            AnyValue::new_bytes([0_u8, 1, 2, 255]),
+                        )])
+                        .finish(),
+                ],
+            )],
+        )]);
+        let bytes = request_bytes(logs);
+        let batch = OtlpLogsTransformer::default()
+            .transform(&bytes)
+            .expect("transform byte attribute")
+            .expect("logs batch");
+        let attributes = batch
+            .column_by_name(ch_consts::CH_LOG_ATTRIBUTES)
+            .expect("log attributes")
+            .as_any()
+            .downcast_ref::<arrow::array::MapArray>()
+            .expect("map column");
+        let keys = attributes
+            .keys()
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .expect("map keys");
+        let values = attributes
+            .values()
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .expect("map values");
+
+        assert_eq!(keys.value(0), "bytes");
+        assert_eq!(values.value(0), "AAEC/w==");
+    }
+
+    /// Scenario: an OTLP export request contains no log records.
+    /// Guarantees: the direct path produces no ClickHouse write batch, matching legacy behavior.
+    #[test]
+    fn empty_logs_produce_no_batch() {
+        assert_matches_legacy(fixtures::empty_logs());
+        assert_matches_legacy(fixtures::logs_with_empty_log_records());
+    }
+
+    /// Scenario: a raw OTLP request has invalid top-level protobuf framing.
+    /// Guarantees: the direct path returns an error so exporter routing can use the legacy path.
+    #[test]
+    fn malformed_request_is_rejected_for_legacy_fallback() {
+        let error = OtlpLogsTransformer::default()
+            .transform(b"\xff")
+            .expect_err("malformed protobuf must be rejected");
+
+        assert!(matches!(error, ClickhouseExporterError::Child(_)));
+    }
+
+    #[derive(clickhouse::Row, serde::Deserialize)]
+    struct RawLogSummary {
+        row_count: u64,
+        service_name: String,
+        body: String,
+    }
+
+    /// Scenario: a direct raw OTLP batch is inserted into a live ClickHouse logs table.
+    /// Guarantees: emitted Arrow types bind by name and preserve rows, service extraction, and body JSON.
+    #[tokio::test]
+    #[ignore = "requires a live ClickHouse; run with --ignored e2e"]
+    async fn e2e_raw_otlp_logs_insert_roundtrips_through_clickhouse_schema() {
+        otap_df_otap::crypto::ensure_crypto_provider();
+        let endpoint =
+            std::env::var("CLICKHOUSE_URL").unwrap_or_else(|_| "http://localhost:8123".into());
+        let username = std::env::var("CLICKHOUSE_USER").unwrap_or_else(|_| "default".into());
+        let password = std::env::var("CLICKHOUSE_PASSWORD").unwrap_or_else(|_| "test".into());
+        let patch = serde_json::from_value(serde_json::json!({
+            "endpoint": endpoint,
+            "database": "otap_e2e_raw_otlp_logs",
+            "username": username,
+            "password": password,
+            "async_insert": false,
+        }))
+        .expect("valid ClickHouse config");
+        let config = Config::from_patch(patch);
+        build_client(&config, "default")
+            .query("DROP DATABASE IF EXISTS otap_e2e_raw_otlp_logs")
+            .execute()
+            .await
+            .expect("drop pre-existing test database");
+
+        let bytes = request_bytes(logs_with_all_value_types());
+        let batch = OtlpLogsTransformer::default()
+            .transform(&bytes)
+            .expect("transform raw OTLP logs")
+            .expect("logs batch");
+        let batches = HashMap::from([(ArrowPayloadType::Logs, batch)]);
+        let writer = ClickHouseWriter::new(&config)
+            .await
+            .expect("create ClickHouse schema");
+        _ = writer
+            .write_batches(&batches)
+            .await
+            .expect("insert raw OTLP logs batch");
+
+        let summary = build_client(&config, &config.database)
+            .query(
+                "SELECT count() AS row_count, CAST(any(ServiceName) AS String) AS service_name, \
+                 any(Body) AS body FROM otap_e2e_raw_otlp_logs.otel_logs",
+            )
+            .fetch_one::<RawLogSummary>()
+            .await
+            .expect("read raw OTLP logs back");
+        assert_eq!(summary.row_count, 1);
+        assert_eq!(summary.service_name, "first");
+        assert_eq!(
+            summary.body,
+            "{\"nested.string\":\"value\",\"nested.array\":[false,-7,[1,2,3]]}"
+        );
+    }
+}

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/logs_otlp.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/logs_otlp.rs
@@ -859,10 +859,13 @@ mod tests {
         LogRecord, LogsData, ResourceLogs, ScopeLogs, SeverityNumber,
     };
     use otap_df_pdata::proto::opentelemetry::resource::v1::Resource;
-    use otap_df_pdata::testing::fixtures;
+    use otap_df_pdata::testing::{fixtures, round_trip::encode_logs};
     use otap_df_pdata::{OtapArrowRecords, OtapPayload, OtlpProtoBytes, TryIntoWithOptions};
     use prost::Message;
 
+    use crate::exporters::clickhouse_exporter::transform::logs_fast::{
+        LogsFastTransform, LogsFastTransformer,
+    };
     use crate::exporters::clickhouse_exporter::transform::transform_batch::BatchTransformer;
     use crate::exporters::clickhouse_exporter::{
         config::Config,
@@ -890,6 +893,22 @@ mod tests {
             .apply_plan(records)
             .expect("apply legacy ClickHouse transform")
             .remove(&ArrowPayloadType::Logs)
+    }
+
+    fn otap_fast_batch(logs: &LogsData) -> RecordBatch {
+        let mut records = encode_logs(logs);
+        records
+            .decode_transport_optimized_ids()
+            .expect("decode transport optimized IDs");
+        match LogsFastTransformer::default()
+            .try_apply(&records)
+            .expect("transform canonical OTAP logs through the fast path")
+        {
+            LogsFastTransform::Applied(batch) => batch,
+            LogsFastTransform::NotApplicable(reason) => {
+                panic!("nested canonical logs unexpectedly declined: {reason}")
+            }
+        }
     }
 
     fn logical_values(array: &dyn Array) -> Vec<Option<String>> {
@@ -1002,13 +1021,14 @@ mod tests {
                         .time_unix_nano(123_u64)
                         .severity_number(SeverityNumber::Error)
                         .severity_text("ERROR")
-                        .body(nested)
+                        .body(nested.clone())
                         .attributes(vec![
                             KeyValue::new("empty", AnyValue::default()),
                             KeyValue::new("string", AnyValue::new_string("text")),
                             KeyValue::new("int", AnyValue::new_int(-42)),
                             KeyValue::new("double", AnyValue::new_double(3.25)),
                             KeyValue::new("bool", AnyValue::new_bool(true)),
+                            KeyValue::new("nested", nested),
                         ])
                         .trace_id([0x11; 16])
                         .span_id([0x22; 8])
@@ -1047,6 +1067,33 @@ mod tests {
     #[test]
     fn nested_value_types_match_legacy_transform() {
         assert_matches_legacy(logs_with_all_value_types());
+    }
+
+    /// Scenario: identical nested OTLP values take the direct and canonical OTAP fast paths.
+    /// Guarantees: every direct-path ClickHouse column has the same rows and logical values.
+    #[test]
+    fn nested_values_match_otap_fast_path() {
+        let logs = logs_with_all_value_types();
+        let bytes = request_bytes(logs.clone());
+        let direct = OtlpLogsTransformer::default()
+            .transform(&bytes)
+            .expect("transform raw OTLP logs directly")
+            .expect("direct logs batch");
+        let fast = otap_fast_batch(&logs);
+
+        assert_eq!(direct.num_rows(), fast.num_rows());
+        for field in direct.schema().fields() {
+            let name = field.name();
+            let direct_column = direct.column_by_name(name).expect("direct column");
+            let fast_column = fast
+                .column_by_name(name)
+                .unwrap_or_else(|| panic!("OTAP fast-path batch is missing {name}"));
+            assert_eq!(
+                logical_values(direct_column.as_ref()),
+                logical_values(fast_column.as_ref()),
+                "direct and OTAP fast-path values differ for {name}",
+            );
+        }
     }
 
     /// Scenario: a raw OTLP log attribute contains an arbitrary byte sequence.

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/mod.rs
@@ -8,6 +8,7 @@ use crate::exporters::clickhouse_exporter::transform::transform_plan::Transforma
 use otap_df_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
 
 pub(crate) mod logs_fast;
+pub(crate) mod logs_otlp;
 mod transform_attributes;
 pub(crate) mod transform_batch;
 mod transform_column;

--- a/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/decode.rs
+++ b/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/decode.rs
@@ -187,15 +187,15 @@ pub(crate) fn field_value_range(buf: &[u8], wire_type: u64, pos: usize) -> Optio
 
         wire_types::LEN => {
             let (len, p) = read_varint(buf, pos)?;
-            let end = p.checked_add(len as usize)?;
+            let end = p.checked_add(usize::try_from(len).ok()?)?;
             (p, end)
         }
-        wire_types::FIXED64 => (pos, pos + 8),
-        wire_types::FIXED32 => (pos, pos + 4),
+        wire_types::FIXED64 => (pos, pos.checked_add(8)?),
+        wire_types::FIXED32 => (pos, pos.checked_add(4)?),
         _ => return None,
     };
 
-    Some(range)
+    (range.1 <= buf.len()).then_some(range)
 }
 
 /// `RepeatedFieldProtoBytesParser` is an iterator over byte slices for some field (represented by

--- a/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/logs.rs
+++ b/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/logs.rs
@@ -24,31 +24,19 @@
 //!
 //! # Validation and lazy access
 //!
-//! [`RawLogsData::try_new`] performs an allocation-free validation pass before exposing the view.
-//! It validates protobuf framing, the wire types of known fields, and the complete known nested
-//! logs hierarchy. Unknown fields retain protobuf forward compatibility: their framing is checked,
-//! but length-delimited unknown payloads remain opaque. Semantic constraints such as UTF-8 and ID
-//! lengths are left to typed accessors and consumers.
+//! [`RawLogsData::try_new`] performs an allocation-free validation pass over the top-level message
+//! before exposing the view. It validates top-level protobuf framing, while length-delimited nested
+//! messages remain opaque until a consumer accesses them. Unknown fields retain protobuf forward
+//! compatibility and are skipped according to their framing.
 //!
-//! After validation, child views use [`ProtoBytesParser`] to discover fields lazily. Parser clones
-//! and repeated-field iterators share scan progress and cached byte ranges through `Rc<Cell<_>>`.
-//! This avoids eagerly indexing every field, but means these views are intentionally not `Send`
-//! and are not designed for concurrent access. A validated request therefore incurs one framing
-//! scan followed by lazy field scans, while still avoiding an owned decoded representation.
+//! Child views use [`ProtoBytesParser`] to discover fields lazily. Parser clones and repeated-field
+//! iterators share scan progress and cached byte ranges through `Rc<Cell<_>>`. This avoids eagerly
+//! indexing every field, but means these views are intentionally not `Send` and are not designed
+//! for concurrent access. Malformed or wrongly typed nested fields may appear absent or stop the
+//! affected iterator, matching the best-effort behavior of the other raw OTLP byte views.
 //!
 //! [`RawLogsData::new`] and [`RawLogRecord::new`] are unchecked constructors for trusted or
-//! already validated internal bytes. Untrusted serialized requests should enter through
-//! [`RawLogsData::try_new`]; otherwise malformed nested fields can appear indistinguishable from
-//! absent fields to the optional view accessors.
-//!
-//! # Schema-aware wire validation
-//!
-//! Protobuf's length-delimited wire type is shared by strings, bytes, and embedded messages, so
-//! wire framing alone cannot determine which payloads require recursive validation.
-//! [`MessageKind`] supplies that schema context. For each known field it records the expected wire
-//! type and, for embedded messages, the kind to validate recursively. This table duplicates the
-//! portion of the OTLP protobuf schema traversed by these raw views and must stay synchronized with
-//! `logs.proto`, `common.proto`, `resource.proto`, and the accessors below.
+//! internal bytes when the caller does not need top-level framing validation.
 
 use std::cell::Cell;
 use std::num::NonZeroUsize;
@@ -63,7 +51,6 @@ use crate::proto::consts::field_num::logs::{
     RESOURCE_LOGS_SCHEMA_URL, RESOURCE_LOGS_SCOPE_LOGS, SCOPE_LOG_SCOPE, SCOPE_LOGS_LOG_RECORDS,
     SCOPE_LOGS_SCHEMA_URL,
 };
-use crate::proto::consts::field_num::{common as common_fields, resource as resource_fields};
 use crate::proto::consts::wire_types;
 use crate::schema::{SpanId, TraceId};
 use crate::views::otlp::bytes::common::{
@@ -78,140 +65,6 @@ use crate::views::otlp::bytes::resource::RawResource;
 use otap_df_pdata_views::views::logs::{
     LogRecordView, LogsDataView, ResourceLogsView, ScopeLogsView,
 };
-
-/// Maximum number of embedded known messages accepted by recursive wire validation.
-const MAX_NESTED_MESSAGE_DEPTH: usize = 64;
-
-/// Schema context for one protobuf message reachable from an OTLP logs request.
-///
-/// This is not a protobuf field value or an OTLP signal discriminator. It tells
-/// [`validate_message`] how to interpret field numbers whose wire representation alone is
-/// ambiguous. See [`Self::field_spec`] for the schema table.
-#[derive(Clone, Copy)]
-enum MessageKind {
-    /// `LogsData` or the wire-compatible `ExportLogsServiceRequest` envelope.
-    LogsData,
-    /// One `ResourceLogs` message.
-    ResourceLogs,
-    /// One `Resource` message from `resource.proto`.
-    Resource,
-    /// One `ScopeLogs` message.
-    ScopeLogs,
-    /// One `InstrumentationScope` message from `common.proto`.
-    InstrumentationScope,
-    /// One `LogRecord` message.
-    LogRecord,
-    /// One attribute `KeyValue` message from `common.proto`.
-    KeyValue,
-    /// One `AnyValue` message from `common.proto`.
-    AnyValue,
-    /// The embedded message used by the `AnyValue.array_value` variant.
-    ArrayValue,
-    /// The embedded message used by the `AnyValue.kvlist_value` variant.
-    KeyValueList,
-}
-
-impl MessageKind {
-    /// Return the expected wire type and optional nested message kind for a known field.
-    ///
-    /// `None` means the field number is unknown in this message and is accepted after generic
-    /// framing validation. `Some((wire_type, None))` identifies a known scalar, string, or byte
-    /// field. `Some((wire_type, Some(kind)))` identifies an embedded message whose contents must
-    /// be recursively validated as `kind`.
-    fn field_spec(self, field_num: u64) -> Option<(u64, Option<Self>)> {
-        use MessageKind::{
-            AnyValue, ArrayValue, InstrumentationScope, KeyValue, KeyValueList, LogRecord,
-            Resource, ResourceLogs, ScopeLogs,
-        };
-
-        let spec = match (self, field_num) {
-            (Self::LogsData, LOGS_DATA_RESOURCE) => (wire_types::LEN, Some(ResourceLogs)),
-            (ResourceLogs, RESOURCE_LOGS_RESOURCE) => (wire_types::LEN, Some(Resource)),
-            (ResourceLogs, RESOURCE_LOGS_SCOPE_LOGS) => (wire_types::LEN, Some(ScopeLogs)),
-            (ResourceLogs, RESOURCE_LOGS_SCHEMA_URL) => (wire_types::LEN, None),
-            (Resource, resource_fields::RESOURCE_ATTRIBUTES) => (wire_types::LEN, Some(KeyValue)),
-            (Resource, resource_fields::RESOURCE_DROPPED_ATTRIBUTES_COUNT) => {
-                (wire_types::VARINT, None)
-            }
-            (ScopeLogs, SCOPE_LOG_SCOPE) => (wire_types::LEN, Some(InstrumentationScope)),
-            (ScopeLogs, SCOPE_LOGS_LOG_RECORDS) => (wire_types::LEN, Some(LogRecord)),
-            (ScopeLogs, SCOPE_LOGS_SCHEMA_URL) => (wire_types::LEN, None),
-            (InstrumentationScope, common_fields::INSTRUMENTATION_SCOPE_NAME)
-            | (InstrumentationScope, common_fields::INSTRUMENTATION_SCOPE_VERSION) => {
-                (wire_types::LEN, None)
-            }
-            (InstrumentationScope, common_fields::INSTRUMENTATION_SCOPE_ATTRIBUTES) => {
-                (wire_types::LEN, Some(KeyValue))
-            }
-            (InstrumentationScope, common_fields::INSTRUMENTATION_DROPPED_ATTRIBUTES_COUNT) => {
-                (wire_types::VARINT, None)
-            }
-            (LogRecord, LOG_RECORD_TIME_UNIX_NANO)
-            | (LogRecord, LOG_RECORD_OBSERVED_TIME_UNIX_NANO) => (wire_types::FIXED64, None),
-            (LogRecord, LOG_RECORD_SEVERITY_NUMBER)
-            | (LogRecord, LOG_RECORD_DROPPED_ATTRIBUTES_COUNT) => (wire_types::VARINT, None),
-            (LogRecord, LOG_RECORD_SEVERITY_TEXT)
-            | (LogRecord, LOG_RECORD_TRACE_ID)
-            | (LogRecord, LOG_RECORD_SPAN_ID)
-            | (LogRecord, LOG_RECORD_EVENT_NAME) => (wire_types::LEN, None),
-            (LogRecord, LOG_RECORD_BODY) => (wire_types::LEN, Some(AnyValue)),
-            (LogRecord, LOG_RECORD_ATTRIBUTES) => (wire_types::LEN, Some(KeyValue)),
-            (LogRecord, LOG_RECORD_FLAGS) => (wire_types::FIXED32, None),
-            (KeyValue, common_fields::KEY_VALUE_KEY) => (wire_types::LEN, None),
-            (KeyValue, common_fields::KEY_VALUE_VALUE) => (wire_types::LEN, Some(AnyValue)),
-            (AnyValue, common_fields::ANY_VALUE_STRING_VALUE)
-            | (AnyValue, common_fields::ANY_VALUE_BYTES_VALUE) => (wire_types::LEN, None),
-            (AnyValue, common_fields::ANY_VALUE_BOOL_VALUE)
-            | (AnyValue, common_fields::ANY_VALUE_INT_VALUE) => (wire_types::VARINT, None),
-            (AnyValue, common_fields::ANY_VALUE_DOUBLE_VALUE) => (wire_types::FIXED64, None),
-            (AnyValue, common_fields::ANY_VALUE_ARRAY_VALUE) => (wire_types::LEN, Some(ArrayValue)),
-            (AnyValue, common_fields::ANY_VALUE_KVLIST_VALUE) => {
-                (wire_types::LEN, Some(KeyValueList))
-            }
-            (ArrayValue, common_fields::ARRAY_VALUE_VALUES) => (wire_types::LEN, Some(AnyValue)),
-            (KeyValueList, common_fields::KEY_VALUE_LIST_VALUES) => {
-                (wire_types::LEN, Some(KeyValue))
-            }
-            _ => return None,
-        };
-        Some(spec)
-    }
-}
-
-/// Recursively validate framing and known-field wire types for one serialized message.
-///
-/// The walk allocates no heap data and rejects invalid tags, truncated values, unsupported wire
-/// types, known fields encoded with the wrong wire type, and excessive known-message nesting.
-/// Unknown fields are skipped according to their encoded wire type.
-fn validate_message(buf: &[u8], message: MessageKind, depth: usize) -> Result<(), Error> {
-    if depth > MAX_NESTED_MESSAGE_DEPTH {
-        return Err(Error::InvalidProtobufWireFormat);
-    }
-
-    let mut pos = 0;
-    while pos < buf.len() {
-        let (tag, next) = read_varint(buf, pos).ok_or(Error::InvalidProtobufWireFormat)?;
-        let field_num = tag >> 3;
-        let wire_type = tag & 7;
-        if field_num == 0 {
-            return Err(Error::InvalidProtobufWireFormat);
-        }
-
-        let (start, end) =
-            crate::views::otlp::bytes::decode::field_value_range(buf, wire_type, next)
-                .ok_or(Error::InvalidProtobufWireFormat)?;
-        if let Some((expected_wire_type, nested_message)) = message.field_spec(field_num) {
-            if wire_type != expected_wire_type {
-                return Err(Error::InvalidProtobufWireFormat);
-            }
-            if let Some(nested_message) = nested_message {
-                validate_message(&buf[start..end], nested_message, depth + 1)?;
-            }
-        }
-        pos = end;
-    }
-    Ok(())
-}
 
 /// Root borrowed view over a serialized OTLP logs request.
 ///
@@ -232,13 +85,45 @@ impl<'a> RawLogsData<'a> {
         Self { buf }
     }
 
-    /// Construct a [`RawLogsData`] after validating protobuf wire framing.
+    /// Construct a [`RawLogsData`] after validating top-level protobuf wire framing.
     ///
-    /// The recursive, allocation-free validation walk covers the known OTLP logs hierarchy.
-    /// Unknown fields remain opaque but their wire framing is validated. Nesting is capped to
-    /// keep stack usage bounded.
+    /// Cost: a single linear walk of `buf` with no allocations. Each top-level field tag is
+    /// decoded, and each value is bounds-checked against the end of `buf`. Length-delimited nested
+    /// messages are not recursively validated; their fields are interpreted lazily on access.
     pub fn try_new(buf: &'a [u8]) -> Result<Self, Error> {
-        validate_message(buf, MessageKind::LogsData, 0)?;
+        let mut pos = 0;
+        while pos < buf.len() {
+            let (tag, next) = read_varint(buf, pos).ok_or(Error::InvalidProtobufWireFormat)?;
+            let field_num = tag >> 3;
+            let wire_type = tag & 7;
+
+            if field_num == 0 {
+                return Err(Error::InvalidProtobufWireFormat);
+            }
+
+            pos = match wire_type {
+                wire_types::VARINT => {
+                    let (_, end) =
+                        read_varint(buf, next).ok_or(Error::InvalidProtobufWireFormat)?;
+                    end
+                }
+                wire_types::LEN => {
+                    let (_, end) =
+                        read_len_delim(buf, next).ok_or(Error::InvalidProtobufWireFormat)?;
+                    end
+                }
+                wire_types::FIXED64 => next
+                    .checked_add(8)
+                    .filter(|end| *end <= buf.len())
+                    .ok_or(Error::InvalidProtobufWireFormat)?,
+                wire_types::FIXED32 => next
+                    .checked_add(4)
+                    .filter(|end| *end <= buf.len())
+                    .ok_or(Error::InvalidProtobufWireFormat)?,
+                _ => return Err(Error::InvalidProtobufWireFormat),
+            };
+        }
+
         Ok(Self { buf })
     }
 }
@@ -709,24 +594,6 @@ impl LogRecordView for RawLogRecord<'_> {
 mod tests {
     use super::*;
 
-    fn length_delimited_field(tag: u8, payload: &[u8]) -> Vec<u8> {
-        let mut encoded = vec![tag];
-        let mut len = payload.len();
-        loop {
-            let mut byte = (len & 0x7f) as u8;
-            len >>= 7;
-            if len != 0 {
-                byte |= 0x80;
-            }
-            encoded.push(byte);
-            if len == 0 {
-                break;
-            }
-        }
-        encoded.extend_from_slice(payload);
-        encoded
-    }
-
     /// Scenario: an empty byte slice represents an empty OTLP logs request.
     /// Guarantees: validation accepts the request and exposes no resources.
     #[test]
@@ -782,39 +649,21 @@ mod tests {
         assert!(RawLogsData::try_new(&[0xa2, 0x06, 0x00]).is_ok());
     }
 
-    /// Scenario: a ResourceLogs string declares a length beyond its nested message boundary.
-    /// Guarantees: validation rejects malformed nested framing instead of exposing unsafe ranges.
+    /// Scenario: a nested ScopeLogs field declares a length beyond its ResourceLogs boundary.
+    /// Guarantees: top-level construction succeeds and lazy scope traversal ignores the field.
     #[test]
-    fn try_new_rejects_truncated_nested_field() {
-        assert!(matches!(
-            RawLogsData::try_new(&[0x0a, 0x03, 0x1a, 0x05, 0x00]),
-            Err(Error::InvalidProtobufWireFormat)
-        ));
+    fn try_new_accepts_truncated_nested_field() {
+        let logs = RawLogsData::try_new(&[0x0a, 0x03, 0x1a, 0x05, 0x00])
+            .expect("top-level framing is valid");
+        let resource_logs = logs.resources().next().expect("resource logs");
+
+        assert_eq!(resource_logs.scopes().count(), 0);
     }
 
     /// Scenario: a known nested ResourceLogs field uses the wrong protobuf wire type.
-    /// Guarantees: validation rejects data that the typed raw view cannot interpret faithfully.
+    /// Guarantees: top-level construction defers interpretation to the lazy nested view.
     #[test]
-    fn try_new_rejects_wrong_wire_type_for_known_field() {
-        assert!(matches!(
-            RawLogsData::try_new(&[0x0a, 0x02, 0x08, 0x01]),
-            Err(Error::InvalidProtobufWireFormat)
-        ));
-    }
-
-    /// Scenario: recursive AnyValue arrays exceed the validation nesting limit.
-    /// Guarantees: validation rejects excessive nesting before stack use can grow without bound.
-    #[test]
-    fn validation_rejects_excessive_message_nesting() {
-        let mut any_value = Vec::new();
-        for _ in 0..=MAX_NESTED_MESSAGE_DEPTH {
-            let array_value = length_delimited_field(0x0a, &any_value);
-            any_value = length_delimited_field(0x2a, &array_value);
-        }
-
-        assert!(matches!(
-            validate_message(&any_value, MessageKind::AnyValue, 0),
-            Err(Error::InvalidProtobufWireFormat)
-        ));
+    fn try_new_accepts_wrong_wire_type_for_nested_field() {
+        assert!(RawLogsData::try_new(&[0x0a, 0x02, 0x08, 0x01]).is_ok());
     }
 }

--- a/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/logs.rs
+++ b/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/logs.rs
@@ -1,8 +1,54 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//! This module contains the implementation of the pdata View traits for serialized OTLP protobuf
-//! bytes for messages defined in logs.proto
+//! Borrowed pdata views over serialized OTLP log protobuf messages.
+//!
+//! # Purpose
+//!
+//! The types in this module expose the pdata log view traits without first decoding the protobuf
+//! into an owned Prost object tree. Field values remain slices of the caller-owned byte buffer,
+//! and nested messages are represented by lightweight borrowed views. This is useful on paths
+//! that only need selected fields or want to transform OTLP bytes directly into another format.
+//!
+//! The view hierarchy follows the OTLP logs schema:
+//!
+//! ```text
+//! RawLogsData
+//!   `- ResourceLogsIter -> RawResourceLogs
+//!        `- ScopeLogsIter -> RawScopeLogs
+//!             `- LogRecordsIter -> RawLogRecord
+//! ```
+//!
+//! Resource, instrumentation-scope, attribute, and `AnyValue` submessages reuse the raw views in
+//! the sibling `resource` and `common` modules.
+//!
+//! # Validation and lazy access
+//!
+//! [`RawLogsData::try_new`] performs an allocation-free validation pass before exposing the view.
+//! It validates protobuf framing, the wire types of known fields, and the complete known nested
+//! logs hierarchy. Unknown fields retain protobuf forward compatibility: their framing is checked,
+//! but length-delimited unknown payloads remain opaque. Semantic constraints such as UTF-8 and ID
+//! lengths are left to typed accessors and consumers.
+//!
+//! After validation, child views use [`ProtoBytesParser`] to discover fields lazily. Parser clones
+//! and repeated-field iterators share scan progress and cached byte ranges through `Rc<Cell<_>>`.
+//! This avoids eagerly indexing every field, but means these views are intentionally not `Send`
+//! and are not designed for concurrent access. A validated request therefore incurs one framing
+//! scan followed by lazy field scans, while still avoiding an owned decoded representation.
+//!
+//! [`RawLogsData::new`] and [`RawLogRecord::new`] are unchecked constructors for trusted or
+//! already validated internal bytes. Untrusted serialized requests should enter through
+//! [`RawLogsData::try_new`]; otherwise malformed nested fields can appear indistinguishable from
+//! absent fields to the optional view accessors.
+//!
+//! # Schema-aware wire validation
+//!
+//! Protobuf's length-delimited wire type is shared by strings, bytes, and embedded messages, so
+//! wire framing alone cannot determine which payloads require recursive validation.
+//! [`MessageKind`] supplies that schema context. For each known field it records the expected wire
+//! type and, for embedded messages, the kind to validate recursively. This table duplicates the
+//! portion of the OTLP protobuf schema traversed by these raw views and must stay synchronized with
+//! `logs.proto`, `common.proto`, `resource.proto`, and the accessors below.
 
 use std::cell::Cell;
 use std::num::NonZeroUsize;
@@ -33,23 +79,45 @@ use otap_df_pdata_views::views::logs::{
     LogRecordView, LogsDataView, ResourceLogsView, ScopeLogsView,
 };
 
+/// Maximum number of embedded known messages accepted by recursive wire validation.
 const MAX_NESTED_MESSAGE_DEPTH: usize = 64;
 
+/// Schema context for one protobuf message reachable from an OTLP logs request.
+///
+/// This is not a protobuf field value or an OTLP signal discriminator. It tells
+/// [`validate_message`] how to interpret field numbers whose wire representation alone is
+/// ambiguous. See [`Self::field_spec`] for the schema table.
 #[derive(Clone, Copy)]
 enum MessageKind {
+    /// `LogsData` or the wire-compatible `ExportLogsServiceRequest` envelope.
     LogsData,
+    /// One `ResourceLogs` message.
     ResourceLogs,
+    /// One `Resource` message from `resource.proto`.
     Resource,
+    /// One `ScopeLogs` message.
     ScopeLogs,
+    /// One `InstrumentationScope` message from `common.proto`.
     InstrumentationScope,
+    /// One `LogRecord` message.
     LogRecord,
+    /// One attribute `KeyValue` message from `common.proto`.
     KeyValue,
+    /// One `AnyValue` message from `common.proto`.
     AnyValue,
+    /// The embedded message used by the `AnyValue.array_value` variant.
     ArrayValue,
+    /// The embedded message used by the `AnyValue.kvlist_value` variant.
     KeyValueList,
 }
 
 impl MessageKind {
+    /// Return the expected wire type and optional nested message kind for a known field.
+    ///
+    /// `None` means the field number is unknown in this message and is accepted after generic
+    /// framing validation. `Some((wire_type, None))` identifies a known scalar, string, or byte
+    /// field. `Some((wire_type, Some(kind)))` identifies an embedded message whose contents must
+    /// be recursively validated as `kind`.
     fn field_spec(self, field_num: u64) -> Option<(u64, Option<Self>)> {
         use MessageKind::{
             AnyValue, ArrayValue, InstrumentationScope, KeyValue, KeyValueList, LogRecord,
@@ -110,6 +178,11 @@ impl MessageKind {
     }
 }
 
+/// Recursively validate framing and known-field wire types for one serialized message.
+///
+/// The walk allocates no heap data and rejects invalid tags, truncated values, unsupported wire
+/// types, known fields encoded with the wrong wire type, and excessive known-message nesting.
+/// Unknown fields are skipped according to their encoded wire type.
 fn validate_message(buf: &[u8], message: MessageKind, depth: usize) -> Result<(), Error> {
     if depth > MAX_NESTED_MESSAGE_DEPTH {
         return Err(Error::InvalidProtobufWireFormat);
@@ -140,16 +213,20 @@ fn validate_message(buf: &[u8], message: MessageKind, depth: usize) -> Result<()
     Ok(())
 }
 
-/// Implementation of `LogsDataView` backed by protobuf serialized `LogsData` message
+/// Root borrowed view over a serialized OTLP logs request.
 ///
-/// TODO: Rename OtlpLogsView similar to OtapLogsView for consistency?
+/// `LogsData` and `ExportLogsServiceRequest` have the same top-level repeated resource-logs field,
+/// so this view accepts either wire representation. It owns no payload data.
 pub struct RawLogsData<'a> {
-    /// bytes of the serialized message
+    /// Bytes of the serialized message.
     buf: &'a [u8],
 }
 
 impl<'a> RawLogsData<'a> {
-    /// Create a new instance of `RawLogsData`
+    /// Create a root view without validating the serialized message.
+    ///
+    /// This constructor is intended only for trusted or already validated internal data. Prefer
+    /// [`Self::try_new`] at an ingestion boundary.
     #[must_use]
     pub const fn new(buf: &'a [u8]) -> Self {
         Self { buf }
@@ -157,9 +234,9 @@ impl<'a> RawLogsData<'a> {
 
     /// Construct a [`RawLogsData`] after validating protobuf wire framing.
     ///
-    /// Cost: a recursive, allocation-free walk of the known OTLP logs message hierarchy. Unknown
-    /// fields remain opaque but their wire framing is validated. Nesting is capped to keep
-    /// validation stack usage bounded.
+    /// The recursive, allocation-free validation walk covers the known OTLP logs hierarchy.
+    /// Unknown fields remain opaque but their wire framing is validated. Nesting is capped to
+    /// keep stack usage bounded.
     pub fn try_new(buf: &'a [u8]) -> Result<Self, Error> {
         validate_message(buf, MessageKind::LogsData, 0)?;
         Ok(Self { buf })
@@ -177,12 +254,14 @@ impl<'a> TryFrom<&'a OtlpProtoBytes> for RawLogsData<'a> {
     }
 }
 
-/// Implementation of `ResourceLogsView` backed by protobuf serialized `ResourceLogs` message
+/// Borrowed `ResourceLogsView` backed by a serialized `ResourceLogs` message.
 pub struct RawResourceLogs<'a> {
     byte_parser: ProtoBytesParser<'a, ResourceLogsFieldOffsets>,
 }
 
-/// Known field offsets within byte buffer for fields in ResourceLogs message
+/// Lazily cached byte ranges for fields used from a `ResourceLogs` message.
+///
+/// Only the first repeated `scope_logs` range is cached; its iterator scans subsequent values.
 pub struct ResourceLogsFieldOffsets {
     resource: Cell<Option<(NonZeroUsize, NonZeroUsize)>>,
     schema_url: Cell<Option<(NonZeroUsize, NonZeroUsize)>>,
@@ -228,12 +307,14 @@ impl FieldRanges for ResourceLogsFieldOffsets {
     }
 }
 
-/// Implementation of `ScopeLogsView` backed by protobuf serialized `ScopeLogs` message
+/// Borrowed `ScopeLogsView` backed by a serialized `ScopeLogs` message.
 pub struct RawScopeLogs<'a> {
     byte_parser: ProtoBytesParser<'a, ScopeLogsFieldOffsets>,
 }
 
-/// Known field offsets within byte buffer for fields in ResourceLogs message
+/// Lazily cached byte ranges for fields used from a `ScopeLogs` message.
+///
+/// Only the first repeated log-record range is cached; its iterator scans subsequent values.
 pub struct ScopeLogsFieldOffsets {
     scope: Cell<Option<(NonZeroUsize, NonZeroUsize)>>,
     schema_url: Cell<Option<(NonZeroUsize, NonZeroUsize)>>,
@@ -278,15 +359,17 @@ impl FieldRanges for ScopeLogsFieldOffsets {
     }
 }
 
-/// Implementation of `LogRecordView` backed by protobuf serialized `LogRecord` message
+/// Borrowed `LogRecordView` backed by a serialized `LogRecord` message.
 pub struct RawLogRecord<'a> {
     bytes_parser: ProtoBytesParser<'a, LogFieldOffsets>,
 }
 
 impl<'a> RawLogRecord<'a> {
-    /// Create a new instance of `RawLogRecord`. This is exposed
-    /// specifically for interpreting internally generated log records
-    /// which encode body and attributes as OTLP bytes.
+    /// Create an unchecked view of an internally generated serialized log record.
+    ///
+    /// This is exposed specifically for records that encode body and attributes as OTLP bytes.
+    /// External request bytes should be validated through [`RawLogsData::try_new`] before child
+    /// views are constructed.
     #[must_use]
     pub fn new(buf: &'a [u8]) -> Self {
         Self {
@@ -295,7 +378,10 @@ impl<'a> RawLogRecord<'a> {
     }
 }
 
-/// Known field offsets within byte buffer for fields in ResourceLogs message
+/// Lazily cached byte ranges for fields used from a `LogRecord` message.
+///
+/// Scalar ranges share a field-number-indexed array. Only the first attribute range is cached;
+/// the attribute iterator continues scanning subsequent values as needed.
 pub struct LogFieldOffsets {
     scalar_fields: [Cell<Option<(NonZeroUsize, NonZeroUsize)>>; 13],
     first_attribute: Cell<Option<(NonZeroUsize, NonZeroUsize)>>,
@@ -359,8 +445,7 @@ impl FieldRanges for LogFieldOffsets {
 
 /* ----------------------------- ADAPTER ITERATORS ----------------------- */
 
-/// Iterator of ResourceLogs - produces implementation of `ResourceLogs` view from byte array
-/// containing a serialized LogsData message
+/// Iterator of borrowed resource-log views in their protobuf wire order.
 pub struct ResourceLogsIter<'a> {
     buf: &'a [u8],
     pos: usize,
@@ -388,8 +473,7 @@ impl<'a> Iterator for ResourceLogsIter<'a> {
     }
 }
 
-/// Iterator of ScopeLogs - produces implementation of `ScopeLogs` view from byte array
-/// containing a serialized ResourceLogs message
+/// Iterator of borrowed scope-log views in their parent resource's protobuf wire order.
 pub struct ScopeLogsIter<'a> {
     byte_parser: RepeatedFieldProtoBytesParser<'a, ResourceLogsFieldOffsets>,
 }
@@ -406,8 +490,7 @@ impl<'a> Iterator for ScopeLogsIter<'a> {
     }
 }
 
-/// Iterator of LogsRecord - produces implementation of `LogRecord` view from byte array
-/// containing a serialized ScopeLogs message
+/// Iterator of borrowed log-record views in their parent scope's protobuf wire order.
 pub struct LogRecordsIter<'a> {
     byte_parser: RepeatedFieldProtoBytesParser<'a, ScopeLogsFieldOffsets>,
 }

--- a/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/logs.rs
+++ b/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/logs.rs
@@ -17,6 +17,7 @@ use crate::proto::consts::field_num::logs::{
     RESOURCE_LOGS_SCHEMA_URL, RESOURCE_LOGS_SCOPE_LOGS, SCOPE_LOG_SCOPE, SCOPE_LOGS_LOG_RECORDS,
     SCOPE_LOGS_SCHEMA_URL,
 };
+use crate::proto::consts::field_num::{common as common_fields, resource as resource_fields};
 use crate::proto::consts::wire_types;
 use crate::schema::{SpanId, TraceId};
 use crate::views::otlp::bytes::common::{
@@ -31,6 +32,113 @@ use crate::views::otlp::bytes::resource::RawResource;
 use otap_df_pdata_views::views::logs::{
     LogRecordView, LogsDataView, ResourceLogsView, ScopeLogsView,
 };
+
+const MAX_NESTED_MESSAGE_DEPTH: usize = 64;
+
+#[derive(Clone, Copy)]
+enum MessageKind {
+    LogsData,
+    ResourceLogs,
+    Resource,
+    ScopeLogs,
+    InstrumentationScope,
+    LogRecord,
+    KeyValue,
+    AnyValue,
+    ArrayValue,
+    KeyValueList,
+}
+
+impl MessageKind {
+    fn field_spec(self, field_num: u64) -> Option<(u64, Option<Self>)> {
+        use MessageKind::{
+            AnyValue, ArrayValue, InstrumentationScope, KeyValue, KeyValueList, LogRecord,
+            Resource, ResourceLogs, ScopeLogs,
+        };
+
+        let spec = match (self, field_num) {
+            (Self::LogsData, LOGS_DATA_RESOURCE) => (wire_types::LEN, Some(ResourceLogs)),
+            (ResourceLogs, RESOURCE_LOGS_RESOURCE) => (wire_types::LEN, Some(Resource)),
+            (ResourceLogs, RESOURCE_LOGS_SCOPE_LOGS) => (wire_types::LEN, Some(ScopeLogs)),
+            (ResourceLogs, RESOURCE_LOGS_SCHEMA_URL) => (wire_types::LEN, None),
+            (Resource, resource_fields::RESOURCE_ATTRIBUTES) => (wire_types::LEN, Some(KeyValue)),
+            (Resource, resource_fields::RESOURCE_DROPPED_ATTRIBUTES_COUNT) => {
+                (wire_types::VARINT, None)
+            }
+            (ScopeLogs, SCOPE_LOG_SCOPE) => (wire_types::LEN, Some(InstrumentationScope)),
+            (ScopeLogs, SCOPE_LOGS_LOG_RECORDS) => (wire_types::LEN, Some(LogRecord)),
+            (ScopeLogs, SCOPE_LOGS_SCHEMA_URL) => (wire_types::LEN, None),
+            (InstrumentationScope, common_fields::INSTRUMENTATION_SCOPE_NAME)
+            | (InstrumentationScope, common_fields::INSTRUMENTATION_SCOPE_VERSION) => {
+                (wire_types::LEN, None)
+            }
+            (InstrumentationScope, common_fields::INSTRUMENTATION_SCOPE_ATTRIBUTES) => {
+                (wire_types::LEN, Some(KeyValue))
+            }
+            (InstrumentationScope, common_fields::INSTRUMENTATION_DROPPED_ATTRIBUTES_COUNT) => {
+                (wire_types::VARINT, None)
+            }
+            (LogRecord, LOG_RECORD_TIME_UNIX_NANO)
+            | (LogRecord, LOG_RECORD_OBSERVED_TIME_UNIX_NANO) => (wire_types::FIXED64, None),
+            (LogRecord, LOG_RECORD_SEVERITY_NUMBER)
+            | (LogRecord, LOG_RECORD_DROPPED_ATTRIBUTES_COUNT) => (wire_types::VARINT, None),
+            (LogRecord, LOG_RECORD_SEVERITY_TEXT)
+            | (LogRecord, LOG_RECORD_TRACE_ID)
+            | (LogRecord, LOG_RECORD_SPAN_ID)
+            | (LogRecord, LOG_RECORD_EVENT_NAME) => (wire_types::LEN, None),
+            (LogRecord, LOG_RECORD_BODY) => (wire_types::LEN, Some(AnyValue)),
+            (LogRecord, LOG_RECORD_ATTRIBUTES) => (wire_types::LEN, Some(KeyValue)),
+            (LogRecord, LOG_RECORD_FLAGS) => (wire_types::FIXED32, None),
+            (KeyValue, common_fields::KEY_VALUE_KEY) => (wire_types::LEN, None),
+            (KeyValue, common_fields::KEY_VALUE_VALUE) => (wire_types::LEN, Some(AnyValue)),
+            (AnyValue, common_fields::ANY_VALUE_STRING_VALUE)
+            | (AnyValue, common_fields::ANY_VALUE_BYTES_VALUE) => (wire_types::LEN, None),
+            (AnyValue, common_fields::ANY_VALUE_BOOL_VALUE)
+            | (AnyValue, common_fields::ANY_VALUE_INT_VALUE) => (wire_types::VARINT, None),
+            (AnyValue, common_fields::ANY_VALUE_DOUBLE_VALUE) => (wire_types::FIXED64, None),
+            (AnyValue, common_fields::ANY_VALUE_ARRAY_VALUE) => (wire_types::LEN, Some(ArrayValue)),
+            (AnyValue, common_fields::ANY_VALUE_KVLIST_VALUE) => {
+                (wire_types::LEN, Some(KeyValueList))
+            }
+            (ArrayValue, common_fields::ARRAY_VALUE_VALUES) => (wire_types::LEN, Some(AnyValue)),
+            (KeyValueList, common_fields::KEY_VALUE_LIST_VALUES) => {
+                (wire_types::LEN, Some(KeyValue))
+            }
+            _ => return None,
+        };
+        Some(spec)
+    }
+}
+
+fn validate_message(buf: &[u8], message: MessageKind, depth: usize) -> Result<(), Error> {
+    if depth > MAX_NESTED_MESSAGE_DEPTH {
+        return Err(Error::InvalidProtobufWireFormat);
+    }
+
+    let mut pos = 0;
+    while pos < buf.len() {
+        let (tag, next) = read_varint(buf, pos).ok_or(Error::InvalidProtobufWireFormat)?;
+        let field_num = tag >> 3;
+        let wire_type = tag & 7;
+        if field_num == 0 {
+            return Err(Error::InvalidProtobufWireFormat);
+        }
+
+        let (start, end) =
+            crate::views::otlp::bytes::decode::field_value_range(buf, wire_type, next)
+                .ok_or(Error::InvalidProtobufWireFormat)?;
+        if let Some((expected_wire_type, nested_message)) = message.field_spec(field_num) {
+            if wire_type != expected_wire_type {
+                return Err(Error::InvalidProtobufWireFormat);
+            }
+            if let Some(nested_message) = nested_message {
+                validate_message(&buf[start..end], nested_message, depth + 1)?;
+            }
+        }
+        pos = end;
+    }
+    Ok(())
+}
 
 /// Implementation of `LogsDataView` backed by protobuf serialized `LogsData` message
 ///
@@ -47,64 +155,13 @@ impl<'a> RawLogsData<'a> {
         Self { buf }
     }
 
-    /// Construct a [`RawLogsData`] after validating top-level protobuf wire framing.
+    /// Construct a [`RawLogsData`] after validating protobuf wire framing.
     ///
-    /// Cost: a single linear walk of `buf` with no allocations. Each field tag is decoded,
-    /// and each length-delimited or fixed-width field is bounds-checked against the end of
-    /// `buf`. Length-delimited payloads are not recursively decoded as messages; nested
-    /// `ResourceLogs`, `ScopeLogs`, and `LogRecord` content is interpreted lazily on access
-    /// via the view APIs.
+    /// Cost: a recursive, allocation-free walk of the known OTLP logs message hierarchy. Unknown
+    /// fields remain opaque but their wire framing is validated. Nesting is capped to keep
+    /// validation stack usage bounded.
     pub fn try_new(buf: &'a [u8]) -> Result<Self, Error> {
-        let mut pos = 0;
-        while pos < buf.len() {
-            let (tag, next) = read_varint(buf, pos).ok_or(Error::InvalidProtobufWireFormat)?;
-            let field_num = tag >> 3;
-            let wire_type = tag & 7;
-
-            if field_num == 0 {
-                return Err(Error::InvalidProtobufWireFormat);
-            }
-
-            pos = match wire_type {
-                wire_types::VARINT => {
-                    let (_, p) = read_varint(buf, next).ok_or(Error::InvalidProtobufWireFormat)?;
-                    p
-                }
-                wire_types::LEN => {
-                    let (len, p) =
-                        read_varint(buf, next).ok_or(Error::InvalidProtobufWireFormat)?;
-                    let end = p
-                        .checked_add(
-                            usize::try_from(len).map_err(|_| Error::InvalidProtobufWireFormat)?,
-                        )
-                        .ok_or(Error::InvalidProtobufWireFormat)?;
-                    if end > buf.len() {
-                        return Err(Error::InvalidProtobufWireFormat);
-                    }
-                    end
-                }
-                wire_types::FIXED64 => {
-                    let end = next
-                        .checked_add(8)
-                        .ok_or(Error::InvalidProtobufWireFormat)?;
-                    if end > buf.len() {
-                        return Err(Error::InvalidProtobufWireFormat);
-                    }
-                    end
-                }
-                wire_types::FIXED32 => {
-                    let end = next
-                        .checked_add(4)
-                        .ok_or(Error::InvalidProtobufWireFormat)?;
-                    if end > buf.len() {
-                        return Err(Error::InvalidProtobufWireFormat);
-                    }
-                    end
-                }
-                _ => return Err(Error::InvalidProtobufWireFormat),
-            };
-        }
-
+        validate_message(buf, MessageKind::LogsData, 0)?;
         Ok(Self { buf })
     }
 }
@@ -569,12 +626,34 @@ impl LogRecordView for RawLogRecord<'_> {
 mod tests {
     use super::*;
 
+    fn length_delimited_field(tag: u8, payload: &[u8]) -> Vec<u8> {
+        let mut encoded = vec![tag];
+        let mut len = payload.len();
+        loop {
+            let mut byte = (len & 0x7f) as u8;
+            len >>= 7;
+            if len != 0 {
+                byte |= 0x80;
+            }
+            encoded.push(byte);
+            if len == 0 {
+                break;
+            }
+        }
+        encoded.extend_from_slice(payload);
+        encoded
+    }
+
+    /// Scenario: an empty byte slice represents an empty OTLP logs request.
+    /// Guarantees: validation accepts the request and exposes no resources.
     #[test]
     fn try_new_accepts_valid_empty_request() {
         let logs = RawLogsData::try_new(&[]).expect("empty request is valid protobuf");
         assert_eq!(logs.resources().count(), 0);
     }
 
+    /// Scenario: a top-level protobuf tag is an unterminated varint.
+    /// Guarantees: validation rejects malformed top-level wire framing.
     #[test]
     fn try_new_rejects_malformed_varint() {
         assert!(matches!(
@@ -583,6 +662,8 @@ mod tests {
         ));
     }
 
+    /// Scenario: a top-level length-delimited field extends beyond the request buffer.
+    /// Guarantees: validation rejects the truncated field before a view can traverse it.
     #[test]
     fn try_new_rejects_truncated_length_delimited_field() {
         assert!(matches!(
@@ -591,6 +672,8 @@ mod tests {
         ));
     }
 
+    /// Scenario: a top-level varint value is truncated at the end of the request.
+    /// Guarantees: validation rejects trailing partial values.
     #[test]
     fn try_new_rejects_trailing_partial_varint() {
         assert!(matches!(
@@ -599,6 +682,8 @@ mod tests {
         ));
     }
 
+    /// Scenario: a protobuf tag uses the reserved field number zero.
+    /// Guarantees: validation rejects invalid field numbers.
     #[test]
     fn try_new_rejects_field_number_zero() {
         assert!(matches!(
@@ -607,8 +692,46 @@ mod tests {
         ));
     }
 
+    /// Scenario: a valid unknown top-level length-delimited field is present.
+    /// Guarantees: validation preserves protobuf forward compatibility for unknown fields.
     #[test]
     fn try_new_accepts_unknown_fields() {
         assert!(RawLogsData::try_new(&[0xa2, 0x06, 0x00]).is_ok());
+    }
+
+    /// Scenario: a ResourceLogs string declares a length beyond its nested message boundary.
+    /// Guarantees: validation rejects malformed nested framing instead of exposing unsafe ranges.
+    #[test]
+    fn try_new_rejects_truncated_nested_field() {
+        assert!(matches!(
+            RawLogsData::try_new(&[0x0a, 0x03, 0x1a, 0x05, 0x00]),
+            Err(Error::InvalidProtobufWireFormat)
+        ));
+    }
+
+    /// Scenario: a known nested ResourceLogs field uses the wrong protobuf wire type.
+    /// Guarantees: validation rejects data that the typed raw view cannot interpret faithfully.
+    #[test]
+    fn try_new_rejects_wrong_wire_type_for_known_field() {
+        assert!(matches!(
+            RawLogsData::try_new(&[0x0a, 0x02, 0x08, 0x01]),
+            Err(Error::InvalidProtobufWireFormat)
+        ));
+    }
+
+    /// Scenario: recursive AnyValue arrays exceed the validation nesting limit.
+    /// Guarantees: validation rejects excessive nesting before stack use can grow without bound.
+    #[test]
+    fn validation_rejects_excessive_message_nesting() {
+        let mut any_value = Vec::new();
+        for _ in 0..=MAX_NESTED_MESSAGE_DEPTH {
+            let array_value = length_delimited_field(0x0a, &any_value);
+            any_value = length_delimited_field(0x2a, &array_value);
+        }
+
+        assert!(matches!(
+            validate_message(&any_value, MessageKind::AnyValue, 0),
+            Err(Error::InvalidProtobufWireFormat)
+        ));
     }
 }

--- a/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/logs.rs
+++ b/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/logs.rs
@@ -22,12 +22,7 @@
 //! Resource, instrumentation-scope, attribute, and `AnyValue` submessages reuse the raw views in
 //! the sibling `resource` and `common` modules.
 //!
-//! # Validation and lazy access
-//!
-//! [`RawLogsData::try_new`] performs an allocation-free validation pass over the top-level message
-//! before exposing the view. It validates top-level protobuf framing, while length-delimited nested
-//! messages remain opaque until a consumer accesses them. Unknown fields retain protobuf forward
-//! compatibility and are skipped according to their framing.
+//! # Lazy access
 //!
 //! Child views use [`ProtoBytesParser`] to discover fields lazily. Parser clones and repeated-field
 //! iterators share scan progress and cached byte ranges through `Rc<Cell<_>>`. This avoids eagerly

--- a/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/logs.rs
+++ b/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/logs.rs
@@ -103,23 +103,40 @@ impl<'a> RawLogsData<'a> {
 
             pos = match wire_type {
                 wire_types::VARINT => {
-                    let (_, end) =
-                        read_varint(buf, next).ok_or(Error::InvalidProtobufWireFormat)?;
-                    end
+                    let (_, p) = read_varint(buf, next).ok_or(Error::InvalidProtobufWireFormat)?;
+                    p
                 }
                 wire_types::LEN => {
-                    let (_, end) =
-                        read_len_delim(buf, next).ok_or(Error::InvalidProtobufWireFormat)?;
+                    let (len, p) =
+                        read_varint(buf, next).ok_or(Error::InvalidProtobufWireFormat)?;
+                    let end = p
+                        .checked_add(
+                            usize::try_from(len).map_err(|_| Error::InvalidProtobufWireFormat)?,
+                        )
+                        .ok_or(Error::InvalidProtobufWireFormat)?;
+                    if end > buf.len() {
+                        return Err(Error::InvalidProtobufWireFormat);
+                    }
                     end
                 }
-                wire_types::FIXED64 => next
-                    .checked_add(8)
-                    .filter(|end| *end <= buf.len())
-                    .ok_or(Error::InvalidProtobufWireFormat)?,
-                wire_types::FIXED32 => next
-                    .checked_add(4)
-                    .filter(|end| *end <= buf.len())
-                    .ok_or(Error::InvalidProtobufWireFormat)?,
+                wire_types::FIXED64 => {
+                    let end = next
+                        .checked_add(8)
+                        .ok_or(Error::InvalidProtobufWireFormat)?;
+                    if end > buf.len() {
+                        return Err(Error::InvalidProtobufWireFormat);
+                    }
+                    end
+                }
+                wire_types::FIXED32 => {
+                    let end = next
+                        .checked_add(4)
+                        .ok_or(Error::InvalidProtobufWireFormat)?;
+                    if end > buf.len() {
+                        return Err(Error::InvalidProtobufWireFormat);
+                    }
+                    end
+                }
                 _ => return Err(Error::InvalidProtobufWireFormat),
             };
         }
@@ -618,6 +635,16 @@ mod tests {
     fn try_new_rejects_truncated_length_delimited_field() {
         assert!(matches!(
             RawLogsData::try_new(&[0x0a, 0x05, 0x00]),
+            Err(Error::InvalidProtobufWireFormat)
+        ));
+    }
+
+    /// Scenario: a top-level field declares a length larger than a 32-bit address space.
+    /// Guarantees: validation rejects lengths that overflow `usize` or exceed the input buffer.
+    #[test]
+    fn try_new_rejects_oversized_length_delimited_field() {
+        assert!(matches!(
+            RawLogsData::try_new(&[0x0a, 0x80, 0x80, 0x80, 0x80, 0x10]),
             Err(Error::InvalidProtobufWireFormat)
         ));
     }

--- a/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/logs.rs
+++ b/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/logs.rs
@@ -66,20 +66,16 @@ use otap_df_pdata_views::views::logs::{
     LogRecordView, LogsDataView, ResourceLogsView, ScopeLogsView,
 };
 
-/// Root borrowed view over a serialized OTLP logs request.
+/// Implementation of `LogsDataView` backed by protobuf serialized `LogsData` message
 ///
-/// `LogsData` and `ExportLogsServiceRequest` have the same top-level repeated resource-logs field,
-/// so this view accepts either wire representation. It owns no payload data.
+/// TODO: Rename OtlpLogsView similar to OtapLogsView for consistency?
 pub struct RawLogsData<'a> {
-    /// Bytes of the serialized message.
+    /// bytes of the serialized message
     buf: &'a [u8],
 }
 
 impl<'a> RawLogsData<'a> {
-    /// Create a root view without validating the serialized message.
-    ///
-    /// This constructor is intended only for trusted or already validated internal data. Prefer
-    /// [`Self::try_new`] at an ingestion boundary.
+    /// Create a new instance of `RawLogsData`
     #[must_use]
     pub const fn new(buf: &'a [u8]) -> Self {
         Self { buf }
@@ -87,9 +83,11 @@ impl<'a> RawLogsData<'a> {
 
     /// Construct a [`RawLogsData`] after validating top-level protobuf wire framing.
     ///
-    /// Cost: a single linear walk of `buf` with no allocations. Each top-level field tag is
-    /// decoded, and each value is bounds-checked against the end of `buf`. Length-delimited nested
-    /// messages are not recursively validated; their fields are interpreted lazily on access.
+    /// Cost: a single linear walk of `buf` with no allocations. Each field tag is decoded,
+    /// and each length-delimited or fixed-width field is bounds-checked against the end of
+    /// `buf`. Length-delimited payloads are not recursively decoded as messages; nested
+    /// `ResourceLogs`, `ScopeLogs`, and `LogRecord` content is interpreted lazily on access
+    /// via the view APIs.
     pub fn try_new(buf: &'a [u8]) -> Result<Self, Error> {
         let mut pos = 0;
         while pos < buf.len() {
@@ -156,14 +154,12 @@ impl<'a> TryFrom<&'a OtlpProtoBytes> for RawLogsData<'a> {
     }
 }
 
-/// Borrowed `ResourceLogsView` backed by a serialized `ResourceLogs` message.
+/// Implementation of `ResourceLogsView` backed by protobuf serialized `ResourceLogs` message
 pub struct RawResourceLogs<'a> {
     byte_parser: ProtoBytesParser<'a, ResourceLogsFieldOffsets>,
 }
 
-/// Lazily cached byte ranges for fields used from a `ResourceLogs` message.
-///
-/// Only the first repeated `scope_logs` range is cached; its iterator scans subsequent values.
+/// Known field offsets within byte buffer for fields in ResourceLogs message
 pub struct ResourceLogsFieldOffsets {
     resource: Cell<Option<(NonZeroUsize, NonZeroUsize)>>,
     schema_url: Cell<Option<(NonZeroUsize, NonZeroUsize)>>,
@@ -209,14 +205,12 @@ impl FieldRanges for ResourceLogsFieldOffsets {
     }
 }
 
-/// Borrowed `ScopeLogsView` backed by a serialized `ScopeLogs` message.
+/// Implementation of `ScopeLogsView` backed by protobuf serialized `ScopeLogs` message
 pub struct RawScopeLogs<'a> {
     byte_parser: ProtoBytesParser<'a, ScopeLogsFieldOffsets>,
 }
 
-/// Lazily cached byte ranges for fields used from a `ScopeLogs` message.
-///
-/// Only the first repeated log-record range is cached; its iterator scans subsequent values.
+/// Known field offsets within byte buffer for fields in ResourceLogs message
 pub struct ScopeLogsFieldOffsets {
     scope: Cell<Option<(NonZeroUsize, NonZeroUsize)>>,
     schema_url: Cell<Option<(NonZeroUsize, NonZeroUsize)>>,
@@ -261,17 +255,15 @@ impl FieldRanges for ScopeLogsFieldOffsets {
     }
 }
 
-/// Borrowed `LogRecordView` backed by a serialized `LogRecord` message.
+/// Implementation of `LogRecordView` backed by protobuf serialized `LogRecord` message
 pub struct RawLogRecord<'a> {
     bytes_parser: ProtoBytesParser<'a, LogFieldOffsets>,
 }
 
 impl<'a> RawLogRecord<'a> {
-    /// Create an unchecked view of an internally generated serialized log record.
-    ///
-    /// This is exposed specifically for records that encode body and attributes as OTLP bytes.
-    /// External request bytes should be validated through [`RawLogsData::try_new`] before child
-    /// views are constructed.
+    /// Create a new instance of `RawLogRecord`. This is exposed
+    /// specifically for interpreting internally generated log records
+    /// which encode body and attributes as OTLP bytes.
     #[must_use]
     pub fn new(buf: &'a [u8]) -> Self {
         Self {
@@ -280,10 +272,7 @@ impl<'a> RawLogRecord<'a> {
     }
 }
 
-/// Lazily cached byte ranges for fields used from a `LogRecord` message.
-///
-/// Scalar ranges share a field-number-indexed array. Only the first attribute range is cached;
-/// the attribute iterator continues scanning subsequent values as needed.
+/// Known field offsets within byte buffer for fields in ResourceLogs message
 pub struct LogFieldOffsets {
     scalar_fields: [Cell<Option<(NonZeroUsize, NonZeroUsize)>>; 13],
     first_attribute: Cell<Option<(NonZeroUsize, NonZeroUsize)>>,
@@ -347,7 +336,8 @@ impl FieldRanges for LogFieldOffsets {
 
 /* ----------------------------- ADAPTER ITERATORS ----------------------- */
 
-/// Iterator of borrowed resource-log views in their protobuf wire order.
+/// Iterator of ResourceLogs - produces implementation of `ResourceLogs` view from byte array
+/// containing a serialized LogsData message
 pub struct ResourceLogsIter<'a> {
     buf: &'a [u8],
     pos: usize,
@@ -375,7 +365,8 @@ impl<'a> Iterator for ResourceLogsIter<'a> {
     }
 }
 
-/// Iterator of borrowed scope-log views in their parent resource's protobuf wire order.
+/// Iterator of ScopeLogs - produces implementation of `ScopeLogs` view from byte array
+/// containing a serialized ResourceLogs message
 pub struct ScopeLogsIter<'a> {
     byte_parser: RepeatedFieldProtoBytesParser<'a, ResourceLogsFieldOffsets>,
 }
@@ -392,7 +383,8 @@ impl<'a> Iterator for ScopeLogsIter<'a> {
     }
 }
 
-/// Iterator of borrowed log-record views in their parent scope's protobuf wire order.
+/// Iterator of LogsRecord - produces implementation of `LogRecord` view from byte array
+/// containing a serialized ScopeLogs message
 pub struct LogRecordsIter<'a> {
     byte_parser: RepeatedFieldProtoBytesParser<'a, ScopeLogsFieldOffsets>,
 }


### PR DESCRIPTION
# Change Summary

Optimizes the ClickHouse exporter transformation path for raw OTLP log
requests.

The exporter now builds the final ClickHouse Arrow columns directly from the
serialized OTLP protobuf view, avoiding the intermediate conversion into OTAP
Arrow records and the subsequent generic transformation pipeline.

If the direct path cannot process an input, the exporter automatically attempts
the existing OTLP-to-OTAP conversion path. OTAP logs, traces, and other payload
types continue to use their existing paths.

This PR builds on the specialized OTAP path merged in #3711 and has been rebased
onto current `main`.

## Performance impact

### End-to-end saturation benchmark

Benchmark params:

- 8,192-log batches
- synchronous ClickHouse inserts
- `max_in_flight: 10`
- one df_engine core
- six ClickHouse cores
- twelve traffic-generator cores
- ClickHouse 25.6
- three 60-second repetitions per scenario

Median results for DFE OTLP logs:

| Metric | Current `main` | This change | Impact |
| --- | ---: | ---: | ---: |
| Max written throughput | 432,568 logs/s | 543,418 logs/s | +25.6% / 1.26x |
| DFE CPU at approximately 100,000 logs/s | 35.21% | 31.04% | -11.8% |

Written throughput at the fixed offered load remained approximately 100,000
logs/s, as expected. Capacity throughput CV was 4.63% for `main` and 1.01% for
this change. Final post-drain validation found no lost logs in any saturation
repetition.

These saturation results indicate that raw OTLP log workloads can gain
approximately 26% maximum throughput while using approximately 12% less DFE CPU
at 100,000 logs/s. 

### Transformation microbenchmark

The 8,192-log Criterion benchmark was run on a
pinned CPU with 50 samples, a 2-second warm-up, and a 5-second measurement
period:

| Path | Median time | Throughput |
| --- | ---: | ---: |
| Legacy OTLP-to-OTAP transformation | 5.682 ms | 1.44M logs/s |
| Direct OTLP transformation | 2.510 ms | 3.26M logs/s |
| Impact | -55.8% | 2.26x |

This microbenchmark measures transformation only and excludes ClickHouse I/O.

## What issue does this PR close?

- Related to #3512

## How are these changes tested?

Automated tests verify:

- logical output parity with the existing path, including column names, row
  order, and values
- logs with complete and omitted attribute sets
- multiple resources and scopes with mixed content
- nested map and slice attribute values
- byte attributes encoded as base64
- empty OTLP requests
- malformed protobuf rejection by the direct transformer so the exporter can
  attempt the existing path
- raw OTLP routing being limited to the appropriate payload format
- independent direct-path and fallback telemetry counters
- Arrow-to-ClickHouse binding through an ignored test that requires a live
  ClickHouse instance

## Are there any user-facing changes?

Yes. Raw OTLP log requests are transformed more efficiently before insertion
into ClickHouse.

There is no new configuration and no expected change to the ClickHouse table
schema or logical values. Inputs that cannot use the direct path automatically
attempt the existing conversion path.

### Changelog

- [x] Added a `.chloggen/*.yaml` entry
- [ ] This PR is a `chore` (indicated in title)
- [ ] This is a documentation-only PR.
