### PR TITLE
chore: remove Prost from the ITS metrics path

### DIFF
--- a/rust/otap-dataflow/benchmarks/benches/internal_metrics_bridge/main.rs
+++ b/rust/otap-dataflow/benchmarks/benches/internal_metrics_bridge/main.rs
@@ -132,8 +132,7 @@ impl BridgeBenchmark {
         )
         .expect("benchmark telemetry system should initialize");
         let resource_bytes = telemetry.internal_telemetry_settings().resource_field_bytes;
-        let encoder = MetricsOtlpEncoder::new_with_views(&resource_bytes, views)
-            .expect("resource bytes should be valid");
+        let encoder = MetricsOtlpEncoder::new_with_views(&resource_bytes, views);
         let collector = telemetry.collector();
         let reporter = telemetry.reporter();
         let metric_sets = (0..entity_count)

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/internal_telemetry_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/internal_telemetry_receiver/mod.rs
@@ -331,13 +331,10 @@ impl local::Receiver<OtapPdata> for InternalTelemetryReceiver {
                 .into_iter()
                 .map(MetricView::from)
                 .collect();
-            Some(
-                MetricsOtlpEncoder::new_with_views(&internal.resource_field_bytes, views).map_err(
-                    |error| Error::PdataConversionError {
-                        error: error.to_string(),
-                    },
-                )?,
-            )
+            Some(MetricsOtlpEncoder::new_with_views(
+                &internal.resource_field_bytes,
+                views,
+            ))
         } else {
             None
         };
@@ -798,8 +795,7 @@ mod tests {
                 0,
                 &[otap_df_telemetry::metrics::MetricValue::U64(9)],
             );
-            let encoder = MetricsOtlpEncoder::new(&ResourceLogs::default().encode_to_vec())
-                .expect("valid empty OTLP resource");
+            let encoder = MetricsOtlpEncoder::new(&ResourceLogs::default().encode_to_vec());
 
             let (output_tx, output_rx) = create_not_send_channel(1);
             drop(output_rx);

--- a/rust/otap-dataflow/crates/engine/Cargo.toml
+++ b/rust/otap-dataflow/crates/engine/Cargo.toml
@@ -40,7 +40,6 @@ bitflags = { workspace = true }
 bytemuck = { workspace = true }
 smallvec = { workspace = true }
 socket2 = { workspace = true }
-prost = { workspace = true }
 cpu-time = { workspace = true }
 memory-stats = { workspace = true }
 nix = { workspace = true, features = ["resource"] }
@@ -58,6 +57,7 @@ async-trait = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "time", "test-util"] }
+prost = { workspace = true }
 
 [target.'cfg(not(windows))'.dev-dependencies]
 tikv-jemallocator = { workspace = true }

--- a/rust/otap-dataflow/crates/engine/src/error.rs
+++ b/rust/otap-dataflow/crates/engine/src/error.rs
@@ -489,13 +489,6 @@ pub enum Error {
         reason: String,
     },
 
-    /// Error from the prost encoder.
-    #[error("Prost encode error: {}", reason)]
-    ProtoEncodeError {
-        /// Prost error string
-        reason: String,
-    },
-
     /// No default output port is configured when multiple ports are connected.
     #[error(
         "Ambiguous default output port for node {node}: multiple ports connected and no default configured"
@@ -615,7 +608,6 @@ impl Error {
             Error::RuntimeMsgError { .. } => "RuntimeMsgError",
             Error::ProcessorAlreadyExists { .. } => "ProcessorAlreadyExists",
             Error::ProcessorError { .. } => "ProcessorError",
-            Error::ProtoEncodeError { .. } => "ProtoEncodeError",
             Error::ReceiverAlreadyExists { .. } => "ReceiverAlreadyExists",
             Error::ReceiverError { .. } => "ReceiverError",
             Error::SpmcSharedNotSupported { .. } => "SpmcSharedNotSupported",
@@ -690,14 +682,6 @@ pub fn error_summary_from(err: &Error) -> ErrorSummary {
             message: err.to_string(),
             source: None,
         },
-    }
-}
-
-impl From<prost::EncodeError> for Error {
-    fn from(e: prost::EncodeError) -> Self {
-        Self::ProtoEncodeError {
-            reason: e.to_string(),
-        }
     }
 }
 

--- a/rust/otap-dataflow/crates/engine/tests/enum_attribute_metrics.rs
+++ b/rust/otap-dataflow/crates/engine/tests/enum_attribute_metrics.rs
@@ -400,7 +400,7 @@ fn measurement_metric_set_its_export_preserves_bucket_points() {
 
     let batch = registry.drain_metric_export_batch();
     assert_eq!(batch.metric_sets.len(), 2);
-    let encoder = MetricsOtlpEncoder::new(&ResourceLogs::default().encode_to_vec()).unwrap();
+    let encoder = MetricsOtlpEncoder::new(&ResourceLogs::default().encode_to_vec());
     let encoded = encoder.encode(&batch).unwrap().expect("non-empty metrics");
     let OtlpProtoBytes::ExportMetricsRequest(bytes) = encoded else {
         panic!("expected an OTLP metrics request");

--- a/rust/otap-dataflow/crates/otap/src/pdata_conversions.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata_conversions.rs
@@ -9,6 +9,11 @@ impl TryFrom<OtlpProtoMessage> for OtapPdata {
     type Error = Error;
 
     fn try_from(value: OtlpProtoMessage) -> Result<Self, Self::Error> {
-        Ok(OtapPdata::new_todo_context(value.try_into()?))
+        let payload = value
+            .try_into()
+            .map_err(|error: prost::EncodeError| Error::PDataError {
+                reason: error.to_string(),
+            })?;
+        Ok(OtapPdata::new_todo_context(payload))
     }
 }

--- a/rust/otap-dataflow/crates/telemetry/Cargo.toml
+++ b/rust/otap-dataflow/crates/telemetry/Cargo.toml
@@ -34,7 +34,6 @@ serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 slotmap = { workspace = true }
 parking_lot = { workspace = true }
-prost = { workspace = true }
 serde = { workspace = true }
 smallvec = { workspace = true }
 arc-swap = { workspace = true }
@@ -50,6 +49,7 @@ criterion = { workspace = true }
 temp-env = { workspace = true }
 tempfile = { workspace = true }
 otap-df-pdata = { workspace = true, features = ["testing"] }
+prost = { workspace = true }
 
 [[bench]]
 name = "distribution_record"

--- a/rust/otap-dataflow/crates/telemetry/src/metrics/exphist.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/metrics/exphist.rs
@@ -12,9 +12,11 @@
 //! All points are emitted with delta temporality by the caller; these
 //! functions only build the per-point payload.
 
-use crate::instrument::DistributionValue;
+#[cfg(test)]
 use otap_df_expohisto::HistogramView;
+#[cfg(test)]
 use otap_df_pdata::proto::opentelemetry::common::v1::KeyValue;
+#[cfg(test)]
 use otap_df_pdata::proto::opentelemetry::metrics::v1::{
     ExponentialHistogramDataPoint, exponential_histogram_data_point::Buckets,
 };
@@ -54,6 +56,7 @@ pub(crate) fn otlp_histogram_sum(count: u64, sum: f64, min: f64) -> Option<f64> 
 /// sum for non-negative populations so consumers can treat it as monotonic,
 /// for compatibility with OpenMetrics, which is the same rule the MMSC
 /// encoder applies.
+#[cfg(test)]
 pub(crate) fn exponential_histogram_data_point<const N: usize>(
     view: &HistogramView<'_, N>,
     start_time_unix_nano: u64,
@@ -86,36 +89,6 @@ pub(crate) fn exponential_histogram_data_point<const N: usize>(
     }
 
     builder.finish()
-}
-
-/// Projects a [`DistributionValue`] onto an OTLP `ExponentialHistogramDataPoint`,
-/// dispatching each bucketed tier onto the matching primitive.
-///
-/// The caller validates that this function is used only for a true
-/// exponential-histogram instrument.
-pub(crate) fn distribution_exponential_histogram_data_point(
-    distribution: &DistributionValue,
-    start_time_unix_nano: u64,
-    time_unix_nano: u64,
-    attributes: &[KeyValue],
-) -> ExponentialHistogramDataPoint {
-    match distribution {
-        DistributionValue::Basic(_) => {
-            unreachable!("basic MMSC distributions use explicit-boundary histograms")
-        }
-        DistributionValue::Normal(hist) => exponential_histogram_data_point(
-            &hist.view(),
-            start_time_unix_nano,
-            time_unix_nano,
-            attributes,
-        ),
-        DistributionValue::Detailed(hist) => exponential_histogram_data_point(
-            &hist.view(),
-            start_time_unix_nano,
-            time_unix_nano,
-            attributes,
-        ),
-    }
 }
 
 #[cfg(test)]

--- a/rust/otap-dataflow/crates/telemetry/src/metrics/otlp.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/metrics/otlp.rs
@@ -1034,7 +1034,6 @@ fn encode_exponential_histogram_view<const N: usize>(
 ) -> Result<(), Error> {
     let stats = view.stats();
     let positive = view.positive();
-    let zero_count = view.scan_buckets(|_| {}).zero_count;
     encode_datapoint_attributes(buffer, point, EXP_HISTOGRAM_DP_ATTRIBUTES)?;
     encode_fixed64_if_nonzero(
         buffer,
@@ -1050,9 +1049,7 @@ fn encode_exponential_histogram_view<const N: usize>(
         buffer.encode_field_tag(EXP_HISTOGRAM_DP_SCALE, wire_types::VARINT)?;
         buffer.encode_sint32(view.scale())?;
     }
-    if zero_count != 0 {
-        encode_fixed64(buffer, EXP_HISTOGRAM_DP_ZERO_COUNT, zero_count)?;
-    }
+    let mut positive_total = 0_u64;
     if !positive.is_empty() {
         buffer.encode_len_delimited(EXP_HISTOGRAM_DP_POSITIVE, |buffer| {
             if positive.offset() != 0 {
@@ -1061,11 +1058,16 @@ fn encode_exponential_histogram_view<const N: usize>(
             }
             buffer.encode_len_delimited(EXP_HISTOGRAM_BUCKET_BUCKET_COUNTS, |buffer| {
                 for count in positive.iter() {
+                    positive_total = positive_total.saturating_add(count);
                     buffer.encode_varint(count)?;
                 }
                 Ok::<(), Error>(())
             })
         })?;
+    }
+    let zero_count = stats.count.saturating_sub(positive_total);
+    if zero_count != 0 {
+        encode_fixed64(buffer, EXP_HISTOGRAM_DP_ZERO_COUNT, zero_count)?;
     }
     encode_double(buffer, EXP_HISTOGRAM_DP_MIN, stats.min)?;
     encode_double(buffer, EXP_HISTOGRAM_DP_MAX, stats.max)
@@ -2104,8 +2106,8 @@ mod tests {
 
     /// Scenario: A direct-encoded exponential histogram uses zero timestamps,
     /// packed buckets, a negative integer attribute, and a nested map.
-    /// Guarantees: Scalar defaults are absent, recursive values decode, and
-    /// bucket counts use one packed length-delimited field.
+    /// Guarantees: Scalar defaults are absent, recursive values decode, bucket
+    /// counts use one packed field, and zero plus positive counts equal count.
     #[test]
     fn direct_wire_encoding_omits_defaults_and_packs_buckets() {
         let nested = BTreeMap::from([(
@@ -2188,6 +2190,11 @@ mod tests {
             .as_ref()
             .expect("positive buckets");
         assert!(!positive.bucket_counts.is_empty());
+        assert_eq!(histogram.data_points[0].zero_count, 1);
+        assert_eq!(
+            histogram.data_points[0].count,
+            histogram.data_points[0].zero_count + positive.bucket_counts.iter().sum::<u64>()
+        );
 
         let resource_metrics = message_field(&direct_bytes, METRICS_DATA_RESOURCE_METRICS);
         let scope_metrics = message_field(resource_metrics, RESOURCE_METRICS_SCOPE_METRICS);

--- a/rust/otap-dataflow/crates/telemetry/src/metrics/otlp.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/metrics/otlp.rs
@@ -122,7 +122,7 @@ use bytes::Bytes;
 use otap_df_config::pipeline::telemetry::AttributeValue as ConfigAttributeValue;
 use otap_df_expohisto::HistogramView;
 use otap_df_pdata::OtlpProtoBytes;
-use otap_df_pdata::otlp::common::{BoundedBuf, Dropped, ProtoBuffer};
+use otap_df_pdata::otlp::common::{BoundedBuf, Dropped, MAX_OTLP_SIZE_LIMIT, ProtoBuffer};
 use otap_df_pdata::proto::consts::field_num::common::{
     ANY_VALUE_BOOL_VALUE, ANY_VALUE_DOUBLE_VALUE, ANY_VALUE_INT_VALUE, ANY_VALUE_KVLIST_VALUE,
     ANY_VALUE_STRING_VALUE, INSTRUMENTATION_SCOPE_ATTRIBUTES, INSTRUMENTATION_SCOPE_NAME,
@@ -201,13 +201,18 @@ pub enum Error {
     },
 
     /// The encoded request exceeded the protobuf buffer limit.
-    #[error("internal telemetry metrics request exceeded the OTLP size limit")]
-    RequestTooLarge,
+    #[error("internal telemetry metrics request exceeded the OTLP size limit of {limit} bytes")]
+    RequestTooLarge {
+        /// Maximum encoded request size accepted by the protobuf buffer.
+        limit: usize,
+    },
 }
 
 impl From<Dropped> for Error {
     fn from(_: Dropped) -> Self {
-        Self::RequestTooLarge
+        Self::RequestTooLarge {
+            limit: MAX_OTLP_SIZE_LIMIT,
+        }
     }
 }
 
@@ -1259,6 +1264,19 @@ mod tests {
     const DELTA_START: u64 = 10;
     const CUMULATIVE_START: u64 = 5;
     const COLLECTION_TIME: u64 = 20;
+
+    /// Scenario: Direct protobuf encoding reports that its buffer limit was exceeded.
+    /// Guarantees: The diagnostic includes the exact maximum accepted OTLP request size.
+    #[test]
+    fn request_too_large_error_reports_the_buffer_limit() {
+        assert_eq!(
+            Error::from(Dropped).to_string(),
+            format!(
+                "internal telemetry metrics request exceeded the OTLP size limit of \
+                 {MAX_OTLP_SIZE_LIMIT} bytes"
+            )
+        );
+    }
 
     /// Builds a basic-tier distribution value from raw Mmsc fields.
     fn mmsc_value(min: f64, max: f64, sum: f64, count: u64) -> MetricValue {

--- a/rust/otap-dataflow/crates/telemetry/src/metrics/otlp.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/metrics/otlp.rs
@@ -257,6 +257,12 @@ pub struct MetricViewStream {
 }
 
 /// Reusable OTLP encoder holding the trusted pre-encoded process resource.
+///
+/// Constructor resource fragments must come from the internal telemetry
+/// resource encoder rather than external input.
+///
+/// TODO: Consider an opaque resource-fragment type if this API gains external
+/// producers that cannot uphold this invariant.
 #[derive(Debug, Clone)]
 pub struct MetricsOtlpEncoder {
     resource_fragment: Bytes,

--- a/rust/otap-dataflow/crates/telemetry/src/metrics/otlp.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/metrics/otlp.rs
@@ -57,7 +57,7 @@
 //! Entity attributes are placed on `InstrumentationScope` rather than repeated
 //! on every data point. Measurement and registration attributes identify a
 //! metric-set bucket and are attached to its data points. Resource attributes
-//! come from the process-level `ResourceMetrics` prototype retained by
+//! come from the process-level pre-encoded resource field retained by
 //! [`MetricsOtlpEncoder`].
 //!
 //! # Instrument mapping
@@ -92,29 +92,15 @@
 //!
 //! # Encoding strategy
 //!
-//! This module materializes a full prost object tree
-//! (`ExportMetricsServiceRequest` -> `ResourceMetrics` -> `ScopeMetrics` ->
-//! `Metric` -> data point) and serializes it with `encode_to_vec` at the end.
-//! The internal-logs path in [`crate::self_tracing::encoder`] instead writes
-//! OTLP wire bytes directly into a `ProtoBuffer`, allocating nothing per
-//! record.
+//! Semantic preparation resolves views, collisions, coalescing, and effective
+//! OTLP streams into a lightweight borrowed representation. The encoder then
+//! writes the complete request directly into a `ProtoBuffer`. Nested messages
+//! use `BoundedBuf::encode_len_delimited`, and the trusted pre-encoded resource
+//! field shared with internal logs is copied directly into `ResourceMetrics`.
 //!
-//! TODO: move this path to direct `ProtoBuffer` writes as well. The tree costs
-//! a per-cycle allocation for every descriptor string that is already
-//! `&'static str`, a deep clone of the data-point attributes, a one-element
-//! `Vec` per metric, a heap `Vec<u64>` for bucket counts that already live in
-//! a fixed-size array, a clone of the resource prototype, and then a second
-//! full traversal in `encode_to_vec` to compute lengths and serialize. Because
-//! this is self-telemetry, that churn is attributed to the process whose
-//! allocation behaviour these very metrics report.
-//!
-//! The nesting that makes this awkward is already handled by
-//! `BoundedBuf::encode_len_delimited`, which writes a length placeholder,
-//! encodes the submessage body, and patches the length afterwards. The real
-//! work is that views, metric-set coalescing, and name-collision detection
-//! currently operate on the object tree and would need to run before or during
-//! a single encoding pass. The existing tests decode the emitted bytes with
-//! prost, so they carry over unchanged as a correctness net.
+//! Production encoding does not construct generated OTLP messages or traverse
+//! a Prost object tree. Tests decode the emitted bytes with Prost as an
+//! independent compatibility oracle.
 //!
 //! # Transitional design
 //!
@@ -130,17 +116,34 @@
 use crate::attributes::{AttributeSetHandler, AttributeValue};
 use crate::descriptor::{Instrument, MetricsField, Temporality};
 use crate::entity::EntityAttributeSet;
+use crate::instrument::DistributionValue;
 use crate::metrics::{MetricExportBatch, MetricSetExport, MetricValue};
 use bytes::Bytes;
 use otap_df_config::pipeline::telemetry::AttributeValue as ConfigAttributeValue;
+use otap_df_expohisto::HistogramView;
 use otap_df_pdata::OtlpProtoBytes;
-use otap_df_pdata::proto::opentelemetry::collector::metrics::v1::ExportMetricsServiceRequest;
-use otap_df_pdata::proto::opentelemetry::common::v1::{AnyValue, InstrumentationScope, KeyValue};
-use otap_df_pdata::proto::opentelemetry::metrics::v1::{
-    AggregationTemporality, ExponentialHistogram, Gauge, Histogram, HistogramDataPoint, Metric,
-    NumberDataPoint, ResourceMetrics, ScopeMetrics, Sum, metric,
+use otap_df_pdata::otlp::common::{BoundedBuf, Dropped, ProtoBuffer};
+use otap_df_pdata::proto::consts::field_num::common::{
+    ANY_VALUE_BOOL_VALUE, ANY_VALUE_DOUBLE_VALUE, ANY_VALUE_INT_VALUE, ANY_VALUE_KVLIST_VALUE,
+    ANY_VALUE_STRING_VALUE, INSTRUMENTATION_SCOPE_ATTRIBUTES, INSTRUMENTATION_SCOPE_NAME,
+    KEY_VALUE_KEY, KEY_VALUE_LIST_VALUES, KEY_VALUE_VALUE,
 };
-use prost::Message;
+use otap_df_pdata::proto::consts::field_num::metrics::{
+    EXP_HISTOGRAM_BUCKET_BUCKET_COUNTS, EXP_HISTOGRAM_BUCKET_OFFSET, EXP_HISTOGRAM_DP_ATTRIBUTES,
+    EXP_HISTOGRAM_DP_COUNT, EXP_HISTOGRAM_DP_MAX, EXP_HISTOGRAM_DP_MIN, EXP_HISTOGRAM_DP_POSITIVE,
+    EXP_HISTOGRAM_DP_SCALE, EXP_HISTOGRAM_DP_START_TIME_UNIX_NANO, EXP_HISTOGRAM_DP_SUM,
+    EXP_HISTOGRAM_DP_TIME_UNIX_NANO, EXP_HISTOGRAM_DP_ZERO_COUNT,
+    EXPONENTIAL_HISTOGRAM_AGGREGATION_TEMPORALITY, EXPONENTIAL_HISTOGRAM_DATA_POINTS,
+    GAUGE_DATA_POINTS, HISTOGRAM_AGGREGATION_TEMPORALITY, HISTOGRAM_DATA_POINTS,
+    HISTOGRAM_DP_ATTRIBUTES, HISTOGRAM_DP_COUNT, HISTOGRAM_DP_MAX, HISTOGRAM_DP_MIN,
+    HISTOGRAM_DP_START_TIME_UNIX_NANO, HISTOGRAM_DP_SUM, HISTOGRAM_DP_TIME_UNIX_NANO,
+    METRIC_DESCRIPTION, METRIC_EXPONENTIAL_HISTOGRAM, METRIC_GAUGE, METRIC_HISTOGRAM, METRIC_NAME,
+    METRIC_SUM, METRIC_UNIT, METRICS_DATA_RESOURCE_METRICS, NUMBER_DP_AS_DOUBLE, NUMBER_DP_AS_INT,
+    NUMBER_DP_ATTRIBUTES, NUMBER_DP_START_TIME_UNIX_NANO, NUMBER_DP_TIME_UNIX_NANO,
+    RESOURCE_METRICS_SCOPE_METRICS, SCOPE_METRICS_METRICS, SCOPE_METRICS_SCOPE,
+    SUM_AGGREGATION_TEMPORALITY, SUM_DATA_POINTS, SUM_IS_MONOTONIC,
+};
+use otap_df_pdata::proto::consts::wire_types;
 use smallvec::SmallVec;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
@@ -149,10 +152,6 @@ use std::sync::Arc;
 /// Errors produced while encoding registry metrics as OTLP.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    /// The pre-encoded resource fragment was invalid.
-    #[error("invalid internal telemetry resource: {0}")]
-    InvalidResource(#[from] prost::DecodeError),
-
     /// A sum-like metric did not declare its aggregation temporality.
     #[error("sum metric '{metric}' is missing aggregation temporality")]
     MissingTemporality {
@@ -200,6 +199,16 @@ pub enum Error {
         /// Output name produced for the second field.
         second_name: String,
     },
+
+    /// The encoded request exceeded the protobuf buffer limit.
+    #[error("internal telemetry metrics request exceeded the OTLP size limit")]
+    RequestTooLarge,
+}
+
+impl From<Dropped> for Error {
+    fn from(_: Dropped) -> Self {
+        Self::RequestTooLarge
+    }
 }
 
 /// A supported subset of metric view behavior.
@@ -247,10 +256,10 @@ pub struct MetricViewStream {
     pub description: Option<String>,
 }
 
-/// Reusable OTLP encoder holding the process resource prototype.
+/// Reusable OTLP encoder holding the trusted pre-encoded process resource.
 #[derive(Debug, Clone)]
 pub struct MetricsOtlpEncoder {
-    resource_metrics: ResourceMetrics,
+    resource_fragment: Bytes,
     views: Vec<MetricView>,
 }
 
@@ -302,6 +311,28 @@ type ProjectedSources<'a> = SmallVec<[ProjectedStream<'a>; 1]>;
 type ScopeStreams<'a> = HashMap<CaseInsensitiveName<'a>, ProjectedSources<'a>>;
 type CollisionIndex<'a> = HashMap<ScopeIdentity, ScopeStreams<'a>>;
 
+/// One resolved OTLP metric stream with one or more data points.
+struct PreparedMetric<'a> {
+    field: &'static MetricsField,
+    name: &'a str,
+    description: &'a str,
+    points: SmallVec<[PreparedPoint<'a>; 1]>,
+}
+
+/// One data point and the source timing/attribute context needed to encode it.
+#[derive(Clone, Copy)]
+struct PreparedPoint<'a> {
+    value: &'a MetricValue,
+    metric_set: &'a MetricSetExport,
+}
+
+/// One effective OTLP instrumentation scope.
+struct PreparedScope<'a> {
+    name: &'static str,
+    attributes: &'a EntityAttributeSet,
+    metrics: Vec<PreparedMetric<'a>>,
+}
+
 /// Exact source identity that must become one OTLP instrumentation scope.
 #[derive(Hash, PartialEq, Eq)]
 struct MetricSetIdentity<'a> {
@@ -331,7 +362,8 @@ impl MetricsOtlpEncoder {
     /// `ResourceLogs` and `ResourceMetrics` use the same field numbers for
     /// `resource` and `schema_url`, so the pre-encoded fragment is valid for
     /// either message type.
-    pub fn new(resource_fragment: &[u8]) -> Result<Self, Error> {
+    #[must_use]
+    pub fn new(resource_fragment: &[u8]) -> Self {
         Self::new_with_views(resource_fragment, Vec::new())
     }
 
@@ -345,84 +377,86 @@ impl MetricsOtlpEncoder {
     /// [`Self::encode`] reports an [`Error::MetricNameCollision`] when that
     /// occurs. This includes fields supplied by separate metric-set exports
     /// whose scope names and entity attributes are equal.
-    pub fn new_with_views(resource_fragment: &[u8], views: Vec<MetricView>) -> Result<Self, Error> {
-        Ok(Self {
-            resource_metrics: ResourceMetrics::decode(resource_fragment)?,
+    #[must_use]
+    pub fn new_with_views(resource_fragment: &[u8], views: Vec<MetricView>) -> Self {
+        Self {
+            resource_fragment: Bytes::copy_from_slice(resource_fragment),
             views,
-        })
+        }
     }
 
     /// Encodes a registry export batch. Empty batches produce no pdata.
     pub fn encode(&self, batch: &MetricExportBatch) -> Result<Option<OtlpProtoBytes>, Error> {
-        let scope_metrics = if batch
+        let scopes = if batch
             .metric_sets
             .iter()
             .any(|metric_set| metric_set.identity_may_repeat)
         {
             let metric_sets = coalesce_metric_sets(&batch.metric_sets)?;
-            self.encode_metric_sets(
+            let scopes = self.prepare_metric_sets(
                 metric_sets.iter().map(CoalescedMetricSet::as_metric_set),
                 metric_sets.len(),
+            )?;
+            if scopes.is_empty() {
+                return Ok(None);
+            }
+            let mut buffer = ProtoBuffer::with_capacity(1024);
+            encode_request(
+                &mut buffer,
+                &self.resource_fragment,
+                &scopes,
                 batch.time_unix_nano,
-            )?
+            )?;
+            return Ok(Some(OtlpProtoBytes::ExportMetricsRequest(
+                buffer.into_bytes(),
+            )));
         } else {
-            self.encode_metric_sets(
-                batch.metric_sets.iter(),
-                batch.metric_sets.len(),
-                batch.time_unix_nano,
-            )?
+            self.prepare_metric_sets(batch.metric_sets.iter(), batch.metric_sets.len())?
         };
 
-        if scope_metrics.is_empty() {
+        if scopes.is_empty() {
             return Ok(None);
         }
 
-        let mut resource_metrics = self.resource_metrics.clone();
-        resource_metrics.scope_metrics = scope_metrics;
-        let request = ExportMetricsServiceRequest::new(vec![resource_metrics]);
-        Ok(Some(OtlpProtoBytes::ExportMetricsRequest(Bytes::from(
-            request.encode_to_vec(),
-        ))))
+        let mut buffer = ProtoBuffer::with_capacity(1024);
+        encode_request(
+            &mut buffer,
+            &self.resource_fragment,
+            &scopes,
+            batch.time_unix_nano,
+        )?;
+        Ok(Some(OtlpProtoBytes::ExportMetricsRequest(
+            buffer.into_bytes(),
+        )))
     }
 
-    fn encode_metric_sets<'a>(
-        &self,
-        metric_sets: impl Iterator<Item = &'a MetricSetExport>,
+    fn prepare_metric_sets<'batch, 'view>(
+        &'view self,
+        metric_sets: impl Iterator<Item = &'batch MetricSetExport>,
         metric_set_count: usize,
-        time_unix_nano: u64,
-    ) -> Result<Vec<ScopeMetrics>, Error> {
-        let mut scope_metrics = Vec::with_capacity(metric_set_count);
+    ) -> Result<Vec<PreparedScope<'batch>>, Error>
+    where
+        'view: 'batch,
+    {
+        let mut scopes = Vec::with_capacity(metric_set_count);
         let mut scope_identities = HashMap::with_capacity(metric_set_count);
         if self.views.is_empty() {
             for metric_set in metric_sets {
-                if let Some(scope) = encode_metric_set_without_views(metric_set, time_unix_nano)? {
-                    append_scope_metrics(
-                        &mut scope_metrics,
-                        &mut scope_identities,
-                        metric_set,
-                        scope,
-                    );
+                if let Some(scope) = prepare_metric_set_without_views(metric_set)? {
+                    append_prepared_scope(&mut scopes, &mut scope_identities, metric_set, scope);
                 }
             }
         } else {
             let mut collisions = CollisionIndex::with_capacity(metric_set_count);
             for metric_set in metric_sets {
-                if let Some(scope) = encode_metric_set_with_views(
-                    metric_set,
-                    time_unix_nano,
-                    &self.views,
-                    &mut collisions,
-                )? {
-                    append_scope_metrics(
-                        &mut scope_metrics,
-                        &mut scope_identities,
-                        metric_set,
-                        scope,
-                    );
+                if let Some(scope) =
+                    prepare_metric_set_with_views(metric_set, &self.views, &mut collisions)?
+                {
+                    append_prepared_scope(&mut scopes, &mut scope_identities, metric_set, scope);
                 }
             }
         }
-        Ok(scope_metrics)
+        Ok(scopes)
     }
 }
 
@@ -430,80 +464,45 @@ impl MetricsOtlpEncoder {
 /// their values. Distinct data-point attributes therefore remain distinct OTLP
 /// points, while independently registered producers with the same attributes
 /// have already been numerically coalesced above this layer.
-fn append_scope_metrics(
-    scope_metrics: &mut Vec<ScopeMetrics>,
+fn append_prepared_scope<'a>(
+    scopes: &mut Vec<PreparedScope<'a>>,
     identities: &mut HashMap<(usize, usize), usize>,
-    metric_set: &MetricSetExport,
-    incoming: ScopeMetrics,
+    metric_set: &'a MetricSetExport,
+    incoming: PreparedScope<'a>,
 ) {
     let identity = (
         std::ptr::from_ref(metric_set.descriptor) as usize,
         Arc::as_ptr(&metric_set.attributes) as usize,
     );
     if let Some(index) = identities.get(&identity).copied() {
-        merge_scope_metric_points(&mut scope_metrics[index], incoming);
+        merge_prepared_scope(&mut scopes[index], incoming);
     } else {
-        let index = scope_metrics.len();
+        let index = scopes.len();
         let _ = identities.insert(identity, index);
-        scope_metrics.push(incoming);
+        scopes.push(incoming);
     }
 }
 
-fn merge_scope_metric_points(target: &mut ScopeMetrics, incoming: ScopeMetrics) {
+fn merge_prepared_scope<'a>(target: &mut PreparedScope<'a>, incoming: PreparedScope<'a>) {
     for incoming_metric in incoming.metrics {
         let target_metric = target.metrics.iter_mut().find(|target_metric| {
             // TODO: Is this compatibility checking needed? can't imagine how
             // a single SDK would reach a point of having a disagreement.
             target_metric.name == incoming_metric.name
                 && target_metric.description == incoming_metric.description
-                && target_metric.unit == incoming_metric.unit
-                && metric_data_compatible(target_metric, &incoming_metric)
+                && target_metric.field.unit == incoming_metric.field.unit
+                && metric_data_compatible(target_metric.field, incoming_metric.field)
         });
         if let Some(target_metric) = target_metric {
-            append_metric_points(target_metric, incoming_metric);
+            target_metric.points.extend(incoming_metric.points);
         } else {
             target.metrics.push(incoming_metric);
         }
     }
 }
 
-fn metric_data_compatible(left: &Metric, right: &Metric) -> bool {
-    match (left.data.as_ref(), right.data.as_ref()) {
-        (Some(metric::Data::Gauge(_)), Some(metric::Data::Gauge(_))) => true,
-        (Some(metric::Data::Sum(left)), Some(metric::Data::Sum(right))) => {
-            left.aggregation_temporality == right.aggregation_temporality
-                && left.is_monotonic == right.is_monotonic
-        }
-        (Some(metric::Data::Histogram(left)), Some(metric::Data::Histogram(right))) => {
-            left.aggregation_temporality == right.aggregation_temporality
-        }
-        (
-            Some(metric::Data::ExponentialHistogram(left)),
-            Some(metric::Data::ExponentialHistogram(right)),
-        ) => left.aggregation_temporality == right.aggregation_temporality,
-        _ => false,
-    }
-}
-
-fn append_metric_points(target: &mut Metric, incoming: Metric) {
-    match (target.data.as_mut(), incoming.data) {
-        (Some(metric::Data::Gauge(target)), Some(metric::Data::Gauge(mut incoming))) => {
-            target.data_points.append(&mut incoming.data_points);
-        }
-        (Some(metric::Data::Sum(target)), Some(metric::Data::Sum(mut incoming))) => {
-            target.data_points.append(&mut incoming.data_points);
-        }
-        (Some(metric::Data::Histogram(target)), Some(metric::Data::Histogram(mut incoming))) => {
-            target.data_points.append(&mut incoming.data_points);
-        }
-        (
-            Some(metric::Data::ExponentialHistogram(target)),
-            Some(metric::Data::ExponentialHistogram(mut incoming)),
-        ) => {
-            target.data_points.append(&mut incoming.data_points);
-        }
-        _ => unreachable!("metric stream compatibility was checked before merging"),
-    }
+fn metric_data_compatible(left: &MetricsField, right: &MetricsField) -> bool {
+    left.instrument == right.instrument && left.temporality == right.temporality
 }
 
 /// Coalesces independently registered keys that map to the same OTLP scope.
@@ -588,26 +587,16 @@ fn merge_metric_set(target: &mut MetricSetExport, incoming: &MetricSetExport) {
     }
 }
 
-/// Expands one metric set without paying any view-resolution bookkeeping.
-fn encode_metric_set_without_views(
+/// Prepares one metric set without paying any view-resolution bookkeeping.
+fn prepare_metric_set_without_views(
     metric_set: &MetricSetExport,
-    time_unix_nano: u64,
-) -> Result<Option<ScopeMetrics>, Error> {
+) -> Result<Option<PreparedScope<'_>>, Error> {
     validate_value_count(metric_set)?;
 
     let mut metrics = Vec::with_capacity(metric_set.values.len());
-    let datapoint_attributes = encode_datapoint_attributes(metric_set);
     for (field, value) in metric_set.descriptor.metrics.iter().zip(&metric_set.values) {
         validate_value_kind(field, value)?;
-        if let Some(metric) = encode_metric(
-            field,
-            value,
-            metric_set,
-            time_unix_nano,
-            field.name,
-            field.brief,
-            &datapoint_attributes,
-        )? {
+        if let Some(metric) = prepare_metric(field, value, metric_set, field.name, field.brief)? {
             metrics.push(metric);
         }
     }
@@ -615,20 +604,21 @@ fn encode_metric_set_without_views(
     if metrics.is_empty() {
         return Ok(None);
     }
-    Ok(Some(build_scope_metrics(metric_set, metrics)))
+    Ok(Some(build_prepared_scope(metric_set, metrics)))
 }
 
-/// Expands one metric set after resolving views and checking stream collisions.
-fn encode_metric_set_with_views<'a>(
-    metric_set: &MetricSetExport,
-    time_unix_nano: u64,
-    views: &'a [MetricView],
-    collisions: &mut CollisionIndex<'a>,
-) -> Result<Option<ScopeMetrics>, Error> {
+/// Prepares one metric set after resolving views and checking stream collisions.
+fn prepare_metric_set_with_views<'batch, 'view>(
+    metric_set: &'batch MetricSetExport,
+    views: &'view [MetricView],
+    collisions: &mut CollisionIndex<'view>,
+) -> Result<Option<PreparedScope<'batch>>, Error>
+where
+    'view: 'batch,
+{
     validate_value_count(metric_set)?;
 
     let mut metrics = Vec::with_capacity(metric_set.values.len());
-    let datapoint_attributes = encode_datapoint_attributes(metric_set);
     // Scope selectors are invariant across all fields in this metric set, so
     // evaluate them once before resolving the per-instrument selectors.
     let scope_views = views
@@ -644,15 +634,9 @@ fn encode_metric_set_with_views<'a>(
     for (field, value) in metric_set.descriptor.metrics.iter().zip(&metric_set.values) {
         validate_value_kind(field, value)?;
         for stream in resolve_views(field, &scope_views) {
-            if let Some(metric) = encode_metric(
-                field,
-                value,
-                metric_set,
-                time_unix_nano,
-                stream.name,
-                stream.description,
-                &datapoint_attributes,
-            )? {
+            if let Some(metric) =
+                prepare_metric(field, value, metric_set, stream.name, stream.description)?
+            {
                 register_projected_stream(
                     scope_streams,
                     metric_set.descriptor.name,
@@ -667,7 +651,7 @@ fn encode_metric_set_with_views<'a>(
     if metrics.is_empty() {
         return Ok(None);
     }
-    Ok(Some(build_scope_metrics(metric_set, metrics)))
+    Ok(Some(build_prepared_scope(metric_set, metrics)))
 }
 
 /// Matches the dimensions that are common to every field in a metric set.
@@ -725,25 +709,15 @@ fn validate_value_count(metric_set: &MetricSetExport) -> Result<(), Error> {
     }
 }
 
-fn build_scope_metrics(metric_set: &MetricSetExport, metrics: Vec<Metric>) -> ScopeMetrics {
-    let attributes: Vec<KeyValue> = metric_set
-        .attributes
-        .iter_attributes()
-        .map(|(key, value)| KeyValue::new(key, encode_attribute_value(value)))
-        .collect();
-    let scope = InstrumentationScope::build()
-        .name(metric_set.descriptor.name)
-        .attributes(attributes)
-        .finish();
-    ScopeMetrics::new(scope, metrics)
-}
-
-fn encode_datapoint_attributes(metric_set: &MetricSetExport) -> Vec<KeyValue> {
-    metric_set
-        .item_attributes
-        .iter()
-        .map(|(key, value)| KeyValue::new(key.clone(), AnyValue::new_string(value.clone())))
-        .collect()
+fn build_prepared_scope<'a>(
+    metric_set: &'a MetricSetExport,
+    metrics: Vec<PreparedMetric<'a>>,
+) -> PreparedScope<'a> {
+    PreparedScope {
+        name: metric_set.descriptor.name,
+        attributes: &metric_set.attributes,
+        metrics,
+    }
 }
 
 /// Adds one stream to the collision index for its effective scope.
@@ -820,53 +794,30 @@ fn resolve_views<'a>(
     streams
 }
 
-/// Projects one multivariate metric field into its univariate OTLP data type.
-fn encode_metric(
+/// Prepares one multivariate metric field as a univariate OTLP stream.
+fn prepare_metric<'a>(
     field: &'static MetricsField,
-    value: &MetricValue,
-    metric_set: &MetricSetExport,
-    time_unix_nano: u64,
-    name: &str,
-    description: &str,
-    datapoint_attributes: &[KeyValue],
-) -> Result<Option<Metric>, Error> {
-    let data = match field.instrument {
+    value: &'a MetricValue,
+    metric_set: &'a MetricSetExport,
+    name: &'a str,
+    description: &'a str,
+) -> Result<Option<PreparedMetric<'a>>, Error> {
+    match field.instrument {
         Instrument::Counter | Instrument::UpDownCounter => {
-            let temporality = field
+            let _ = field
                 .temporality
                 .ok_or(Error::MissingTemporality { metric: field.name })?;
-            let start_time = match temporality {
-                Temporality::Delta => metric_set.delta_start_time_unix_nano,
-                Temporality::Cumulative => metric_set.cumulative_start_time_unix_nano,
-            };
-            let point = number_data_point(value, start_time, time_unix_nano, datapoint_attributes);
-            metric::Data::Sum(Sum::new(
-                encode_temporality(temporality),
-                matches!(field.instrument, Instrument::Counter),
-                vec![point],
-            ))
-        }
-        Instrument::Gauge => {
-            let point = number_data_point(value, 0, time_unix_nano, datapoint_attributes);
-            metric::Data::Gauge(Gauge::new(vec![point]))
         }
         Instrument::Mmsc => {
             let MetricValue::Distribution(distribution) = value else {
                 unreachable!("metric value kind was validated before encoding")
             };
-            let crate::instrument::DistributionValue::Basic(mmsc) = distribution else {
+            let DistributionValue::Basic(mmsc) = distribution else {
                 unreachable!("metric value kind was validated before encoding")
             };
             if mmsc.count == 0 {
                 return Ok(None);
             }
-            let point = mmsc_histogram_data_point(
-                mmsc,
-                metric_set.delta_start_time_unix_nano,
-                time_unix_nano,
-                datapoint_attributes,
-            );
-            metric::Data::Histogram(Histogram::new(AggregationTemporality::Delta, vec![point]))
         }
         Instrument::ExponentialHistogram => {
             let MetricValue::Distribution(distribution) = value else {
@@ -875,26 +826,336 @@ fn encode_metric(
             if distribution.is_empty() {
                 return Ok(None);
             }
-            let point = crate::metrics::exphist::distribution_exponential_histogram_data_point(
-                distribution,
-                metric_set.delta_start_time_unix_nano,
-                time_unix_nano,
-                datapoint_attributes,
-            );
-            metric::Data::ExponentialHistogram(ExponentialHistogram::new(
-                AggregationTemporality::Delta,
-                vec![point],
-            ))
         }
+        Instrument::Gauge => {}
     };
 
-    Ok(Some(Metric {
-        name: name.to_owned(),
-        description: description.to_owned(),
-        unit: field.unit.to_owned(),
-        metadata: Vec::new(),
-        data: Some(data),
+    Ok(Some(PreparedMetric {
+        field,
+        name,
+        description,
+        points: SmallVec::from_buf([PreparedPoint { value, metric_set }]),
     }))
+}
+
+fn encode_request(
+    buffer: &mut ProtoBuffer,
+    resource_fragment: &[u8],
+    scopes: &[PreparedScope<'_>],
+    time_unix_nano: u64,
+) -> Result<(), Error> {
+    buffer.encode_len_delimited(METRICS_DATA_RESOURCE_METRICS, |buffer| {
+        buffer.extend_from_slice(resource_fragment)?;
+        for scope in scopes {
+            buffer.encode_len_delimited(RESOURCE_METRICS_SCOPE_METRICS, |buffer| {
+                encode_scope(buffer, scope, time_unix_nano)
+            })?;
+        }
+        Ok(())
+    })
+}
+
+fn encode_scope(
+    buffer: &mut ProtoBuffer,
+    scope: &PreparedScope<'_>,
+    time_unix_nano: u64,
+) -> Result<(), Error> {
+    buffer.encode_len_delimited(SCOPE_METRICS_SCOPE, |buffer| {
+        encode_string(buffer, INSTRUMENTATION_SCOPE_NAME, scope.name)?;
+        for (key, value) in scope.attributes.iter_attributes() {
+            encode_key_value(buffer, INSTRUMENTATION_SCOPE_ATTRIBUTES, key, value)?;
+        }
+        Ok::<(), Error>(())
+    })?;
+
+    for metric in &scope.metrics {
+        buffer.encode_len_delimited(SCOPE_METRICS_METRICS, |buffer| {
+            encode_metric(buffer, metric, time_unix_nano)
+        })?;
+    }
+    Ok::<(), Error>(())
+}
+
+fn encode_metric(
+    buffer: &mut ProtoBuffer,
+    metric: &PreparedMetric<'_>,
+    time_unix_nano: u64,
+) -> Result<(), Error> {
+    encode_string(buffer, METRIC_NAME, metric.name)?;
+    encode_string(buffer, METRIC_DESCRIPTION, metric.description)?;
+    encode_string(buffer, METRIC_UNIT, metric.field.unit)?;
+
+    match metric.field.instrument {
+        Instrument::Gauge => {
+            buffer.encode_len_delimited(METRIC_GAUGE, |buffer| {
+                for point in &metric.points {
+                    buffer.encode_len_delimited(GAUGE_DATA_POINTS, |buffer| {
+                        encode_number_data_point(buffer, point, 0, time_unix_nano)
+                    })?;
+                }
+                Ok::<(), Error>(())
+            })?;
+        }
+        Instrument::Counter | Instrument::UpDownCounter => {
+            let temporality = metric.field.temporality.ok_or(Error::MissingTemporality {
+                metric: metric.field.name,
+            })?;
+            buffer.encode_len_delimited(METRIC_SUM, |buffer| {
+                for point in &metric.points {
+                    let start_time_unix_nano = match temporality {
+                        Temporality::Delta => point.metric_set.delta_start_time_unix_nano,
+                        Temporality::Cumulative => point.metric_set.cumulative_start_time_unix_nano,
+                    };
+                    buffer.encode_len_delimited(SUM_DATA_POINTS, |buffer| {
+                        encode_number_data_point(
+                            buffer,
+                            point,
+                            start_time_unix_nano,
+                            time_unix_nano,
+                        )
+                    })?;
+                }
+                buffer.encode_field_tag(SUM_AGGREGATION_TEMPORALITY, wire_types::VARINT)?;
+                buffer.encode_varint(encode_temporality(temporality))?;
+                if matches!(metric.field.instrument, Instrument::Counter) {
+                    buffer.encode_field_tag(SUM_IS_MONOTONIC, wire_types::VARINT)?;
+                    buffer.encode_varint(1)?;
+                }
+                Ok::<(), Error>(())
+            })?;
+        }
+        Instrument::Mmsc => {
+            buffer.encode_len_delimited(METRIC_HISTOGRAM, |buffer| {
+                for point in &metric.points {
+                    buffer.encode_len_delimited(HISTOGRAM_DATA_POINTS, |buffer| {
+                        encode_mmsc_data_point(buffer, point, time_unix_nano)
+                    })?;
+                }
+                buffer.encode_field_tag(HISTOGRAM_AGGREGATION_TEMPORALITY, wire_types::VARINT)?;
+                buffer.encode_varint(encode_temporality(Temporality::Delta))?;
+                Ok::<(), Error>(())
+            })?;
+        }
+        Instrument::ExponentialHistogram => {
+            buffer.encode_len_delimited(METRIC_EXPONENTIAL_HISTOGRAM, |buffer| {
+                for point in &metric.points {
+                    buffer.encode_len_delimited(EXPONENTIAL_HISTOGRAM_DATA_POINTS, |buffer| {
+                        encode_exponential_histogram_data_point(buffer, point, time_unix_nano)
+                    })?;
+                }
+                buffer.encode_field_tag(
+                    EXPONENTIAL_HISTOGRAM_AGGREGATION_TEMPORALITY,
+                    wire_types::VARINT,
+                )?;
+                buffer.encode_varint(encode_temporality(Temporality::Delta))?;
+                Ok::<(), Error>(())
+            })?;
+        }
+    }
+    Ok(())
+}
+
+fn encode_number_data_point(
+    buffer: &mut ProtoBuffer,
+    point: &PreparedPoint<'_>,
+    start_time_unix_nano: u64,
+    time_unix_nano: u64,
+) -> Result<(), Error> {
+    encode_datapoint_attributes(buffer, point, NUMBER_DP_ATTRIBUTES)?;
+    encode_fixed64_if_nonzero(buffer, NUMBER_DP_START_TIME_UNIX_NANO, start_time_unix_nano)?;
+    encode_fixed64_if_nonzero(buffer, NUMBER_DP_TIME_UNIX_NANO, time_unix_nano)?;
+    match point.value {
+        MetricValue::U64(value) => {
+            encode_fixed64(buffer, NUMBER_DP_AS_INT, saturating_i64(*value) as u64)?
+        }
+        MetricValue::F64(value) => encode_double(buffer, NUMBER_DP_AS_DOUBLE, *value)?,
+        MetricValue::Distribution(_) => {
+            unreachable!("metric value kind was validated before encoding")
+        }
+    }
+    Ok(())
+}
+
+fn encode_mmsc_data_point(
+    buffer: &mut ProtoBuffer,
+    point: &PreparedPoint<'_>,
+    time_unix_nano: u64,
+) -> Result<(), Error> {
+    let MetricValue::Distribution(DistributionValue::Basic(mmsc)) = point.value else {
+        unreachable!("metric value kind was validated before encoding")
+    };
+    encode_datapoint_attributes(buffer, point, HISTOGRAM_DP_ATTRIBUTES)?;
+    encode_fixed64_if_nonzero(
+        buffer,
+        HISTOGRAM_DP_START_TIME_UNIX_NANO,
+        point.metric_set.delta_start_time_unix_nano,
+    )?;
+    encode_fixed64_if_nonzero(buffer, HISTOGRAM_DP_TIME_UNIX_NANO, time_unix_nano)?;
+    encode_fixed64_if_nonzero(buffer, HISTOGRAM_DP_COUNT, mmsc.count)?;
+    if let Some(sum) = super::exphist::otlp_histogram_sum(mmsc.count, mmsc.sum, mmsc.min) {
+        encode_double(buffer, HISTOGRAM_DP_SUM, sum)?;
+    }
+    encode_double(buffer, HISTOGRAM_DP_MIN, mmsc.min)?;
+    encode_double(buffer, HISTOGRAM_DP_MAX, mmsc.max)
+}
+
+fn encode_exponential_histogram_data_point(
+    buffer: &mut ProtoBuffer,
+    point: &PreparedPoint<'_>,
+    time_unix_nano: u64,
+) -> Result<(), Error> {
+    let MetricValue::Distribution(distribution) = point.value else {
+        unreachable!("metric value kind was validated before encoding")
+    };
+    match distribution {
+        DistributionValue::Basic(_) => {
+            unreachable!("basic MMSC distributions use explicit-boundary histograms")
+        }
+        DistributionValue::Normal(histogram) => {
+            encode_exponential_histogram_view(buffer, &histogram.view(), point, time_unix_nano)
+        }
+        DistributionValue::Detailed(histogram) => {
+            encode_exponential_histogram_view(buffer, &histogram.view(), point, time_unix_nano)
+        }
+    }
+}
+
+fn encode_exponential_histogram_view<const N: usize>(
+    buffer: &mut ProtoBuffer,
+    view: &HistogramView<'_, N>,
+    point: &PreparedPoint<'_>,
+    time_unix_nano: u64,
+) -> Result<(), Error> {
+    let stats = view.stats();
+    let positive = view.positive();
+    let zero_count = view.scan_buckets(|_| {}).zero_count;
+    encode_datapoint_attributes(buffer, point, EXP_HISTOGRAM_DP_ATTRIBUTES)?;
+    encode_fixed64_if_nonzero(
+        buffer,
+        EXP_HISTOGRAM_DP_START_TIME_UNIX_NANO,
+        point.metric_set.delta_start_time_unix_nano,
+    )?;
+    encode_fixed64_if_nonzero(buffer, EXP_HISTOGRAM_DP_TIME_UNIX_NANO, time_unix_nano)?;
+    encode_fixed64_if_nonzero(buffer, EXP_HISTOGRAM_DP_COUNT, stats.count)?;
+    if let Some(sum) = super::exphist::otlp_histogram_sum(stats.count, stats.sum, stats.min) {
+        encode_double(buffer, EXP_HISTOGRAM_DP_SUM, sum)?;
+    }
+    if view.scale() != 0 {
+        buffer.encode_field_tag(EXP_HISTOGRAM_DP_SCALE, wire_types::VARINT)?;
+        buffer.encode_sint32(view.scale())?;
+    }
+    if zero_count != 0 {
+        encode_fixed64(buffer, EXP_HISTOGRAM_DP_ZERO_COUNT, zero_count)?;
+    }
+    if !positive.is_empty() {
+        buffer.encode_len_delimited(EXP_HISTOGRAM_DP_POSITIVE, |buffer| {
+            if positive.offset() != 0 {
+                buffer.encode_field_tag(EXP_HISTOGRAM_BUCKET_OFFSET, wire_types::VARINT)?;
+                buffer.encode_sint32(positive.offset())?;
+            }
+            buffer.encode_len_delimited(EXP_HISTOGRAM_BUCKET_BUCKET_COUNTS, |buffer| {
+                for count in positive.iter() {
+                    buffer.encode_varint(count)?;
+                }
+                Ok::<(), Error>(())
+            })
+        })?;
+    }
+    encode_double(buffer, EXP_HISTOGRAM_DP_MIN, stats.min)?;
+    encode_double(buffer, EXP_HISTOGRAM_DP_MAX, stats.max)
+}
+
+fn encode_datapoint_attributes(
+    buffer: &mut ProtoBuffer,
+    point: &PreparedPoint<'_>,
+    field_number: u64,
+) -> Result<(), Error> {
+    for (key, value) in &point.metric_set.item_attributes {
+        buffer.encode_len_delimited(field_number, |buffer| {
+            encode_string(buffer, KEY_VALUE_KEY, key)?;
+            buffer.encode_len_delimited(KEY_VALUE_VALUE, |buffer| -> Result<(), Error> {
+                buffer.encode_string(ANY_VALUE_STRING_VALUE, value)?;
+                Ok(())
+            })
+        })?;
+    }
+    Ok(())
+}
+
+fn encode_key_value(
+    buffer: &mut ProtoBuffer,
+    outer_field: u64,
+    key: &str,
+    value: &AttributeValue,
+) -> Result<(), Error> {
+    buffer.encode_len_delimited(outer_field, |buffer| {
+        encode_string(buffer, KEY_VALUE_KEY, key)?;
+        buffer.encode_len_delimited(KEY_VALUE_VALUE, |buffer| {
+            encode_attribute_value(buffer, value)
+        })
+    })
+}
+
+fn encode_attribute_value(buffer: &mut ProtoBuffer, value: &AttributeValue) -> Result<(), Error> {
+    match value {
+        AttributeValue::String(value) => {
+            buffer.encode_string(ANY_VALUE_STRING_VALUE, value)?;
+        }
+        AttributeValue::Int(value) => {
+            buffer.encode_field_tag(ANY_VALUE_INT_VALUE, wire_types::VARINT)?;
+            buffer.encode_varint(*value as u64)?;
+        }
+        AttributeValue::UInt(value) => {
+            buffer.encode_field_tag(ANY_VALUE_INT_VALUE, wire_types::VARINT)?;
+            buffer.encode_varint(saturating_i64(*value) as u64)?;
+        }
+        AttributeValue::Double(value) => {
+            encode_double(buffer, ANY_VALUE_DOUBLE_VALUE, *value)?;
+        }
+        AttributeValue::Boolean(value) => {
+            buffer.encode_field_tag(ANY_VALUE_BOOL_VALUE, wire_types::VARINT)?;
+            buffer.encode_varint(u64::from(*value))?;
+        }
+        AttributeValue::Map(values) => {
+            buffer.encode_len_delimited(ANY_VALUE_KVLIST_VALUE, |buffer| {
+                for (key, value) in values {
+                    encode_key_value(buffer, KEY_VALUE_LIST_VALUES, key, value)?;
+                }
+                Ok::<(), Error>(())
+            })?;
+        }
+    }
+    Ok(())
+}
+
+fn encode_fixed64(buffer: &mut ProtoBuffer, field_number: u64, value: u64) -> Result<(), Error> {
+    buffer.encode_field_tag(field_number, wire_types::FIXED64)?;
+    buffer.extend_from_slice(&value.to_le_bytes())?;
+    Ok(())
+}
+
+fn encode_fixed64_if_nonzero(
+    buffer: &mut ProtoBuffer,
+    field_number: u64,
+    value: u64,
+) -> Result<(), Error> {
+    if value != 0 {
+        encode_fixed64(buffer, field_number, value)?;
+    }
+    Ok(())
+}
+
+fn encode_string(buffer: &mut ProtoBuffer, field_number: u64, value: &str) -> Result<(), Error> {
+    if !value.is_empty() {
+        buffer.encode_string(field_number, value)?;
+    }
+    Ok(())
+}
+
+fn encode_double(buffer: &mut ProtoBuffer, field_number: u64, value: f64) -> Result<(), Error> {
+    buffer.encode_field_tag(field_number, wire_types::FIXED64)?;
+    buffer.extend_from_slice(&value.to_le_bytes())?;
+    Ok(())
 }
 
 /// Validates the descriptor/value pairing before any lossy projection occurs.
@@ -910,10 +1171,9 @@ fn validate_value_kind(field: &MetricsField, value: &MetricValue) -> Result<(), 
     let actual = match value {
         MetricValue::U64(_) => "u64",
         MetricValue::F64(_) => "f64",
-        MetricValue::Distribution(crate::instrument::DistributionValue::Basic(_)) => "mmsc",
+        MetricValue::Distribution(DistributionValue::Basic(_)) => "mmsc",
         MetricValue::Distribution(
-            crate::instrument::DistributionValue::Normal(_)
-            | crate::instrument::DistributionValue::Detailed(_),
+            DistributionValue::Normal(_) | DistributionValue::Detailed(_),
         ) => "exponential histogram",
     };
 
@@ -928,70 +1188,10 @@ fn validate_value_kind(field: &MetricsField, value: &MetricValue) -> Result<(), 
     }
 }
 
-/// Creates a scalar OTLP point, saturating unsigned values to OTLP's signed range.
-fn number_data_point(
-    value: &MetricValue,
-    start_time_unix_nano: u64,
-    time_unix_nano: u64,
-    datapoint_attributes: &[KeyValue],
-) -> NumberDataPoint {
-    let builder = NumberDataPoint::build()
-        .attributes(datapoint_attributes.to_vec())
-        .start_time_unix_nano(start_time_unix_nano)
-        .time_unix_nano(time_unix_nano);
-    match value {
-        MetricValue::U64(value) => builder.value_int(saturating_i64(*value)).finish(),
-        MetricValue::F64(value) => builder.value_double(*value).finish(),
-        MetricValue::Distribution(_) => {
-            unreachable!("metric value kind was validated before encoding")
-        }
-    }
-}
-
-/// Encodes an MMSC summary. This uses the OTLP explicit boundary histogram
-/// without buckets, which is a valid way to encode MMSC by the spec:
-/// https://opentelemetry.io/docs/specs/otel/metrics/data-model/#histogram
-fn mmsc_histogram_data_point(
-    mmsc: &crate::instrument::Mmsc,
-    start_time_unix_nano: u64,
-    time_unix_nano: u64,
-    datapoint_attributes: &[KeyValue],
-) -> HistogramDataPoint {
-    let mut point = HistogramDataPoint::build()
-        .attributes(datapoint_attributes.to_vec())
-        .start_time_unix_nano(start_time_unix_nano)
-        .time_unix_nano(time_unix_nano)
-        .count(mmsc.count);
-    if mmsc.count > 0 {
-        point = point.min(mmsc.min).max(mmsc.max);
-    }
-    if let Some(sum) = super::exphist::otlp_histogram_sum(mmsc.count, mmsc.sum, mmsc.min) {
-        point = point.sum(sum);
-    }
-    point.finish()
-}
-
-const fn encode_temporality(temporality: Temporality) -> AggregationTemporality {
+const fn encode_temporality(temporality: Temporality) -> u64 {
     match temporality {
-        Temporality::Delta => AggregationTemporality::Delta,
-        Temporality::Cumulative => AggregationTemporality::Cumulative,
-    }
-}
-
-/// Preserves internal attribute types in their corresponding OTLP value forms.
-fn encode_attribute_value(value: &AttributeValue) -> AnyValue {
-    match value {
-        AttributeValue::String(value) => AnyValue::new_string(value.clone()),
-        AttributeValue::Int(value) => AnyValue::new_int(*value),
-        AttributeValue::UInt(value) => AnyValue::new_int(saturating_i64(*value)),
-        AttributeValue::Double(value) => AnyValue::new_double(*value),
-        AttributeValue::Boolean(value) => AnyValue::new_bool(*value),
-        AttributeValue::Map(values) => AnyValue::new_kvlist(
-            values
-                .iter()
-                .map(|(key, value)| KeyValue::new(key, encode_attribute_value(value)))
-                .collect::<Vec<_>>(),
-        ),
+        Temporality::Delta => 1,
+        Temporality::Cumulative => 2,
     }
 }
 
@@ -1009,7 +1209,7 @@ mod tests {
 
     /// Builds a normal-tier snapshot by recording through its instrument,
     /// which is the only way a distribution is populated.
-    fn normal_distribution(observations: &[f64]) -> crate::instrument::DistributionValue {
+    fn normal_distribution(observations: &[f64]) -> DistributionValue {
         let mut histogram = crate::instrument::HistogramNormal::default();
         for &value in observations {
             histogram.record(value);
@@ -1024,9 +1224,15 @@ mod tests {
         MetricsDescriptor,
     };
     use crate::entity::{EntityAttributeSet, EntityRegistry};
-    use otap_df_pdata::proto::opentelemetry::common::v1::{KeyValueList, any_value};
+    use otap_df_pdata::proto::opentelemetry::collector::metrics::v1::ExportMetricsServiceRequest;
+    use otap_df_pdata::proto::opentelemetry::common::v1::{
+        AnyValue, KeyValue, KeyValueList, any_value,
+    };
     use otap_df_pdata::proto::opentelemetry::logs::v1::ResourceLogs;
-    use otap_df_pdata::proto::opentelemetry::metrics::v1::{metric, number_data_point};
+    use otap_df_pdata::proto::opentelemetry::metrics::v1::{
+        AggregationTemporality, Metric, NumberDataPoint, ScopeMetrics, Sum, metric,
+        number_data_point,
+    };
     use otap_df_pdata::proto::opentelemetry::resource::v1::Resource;
     use otap_df_pdata::views::otap::OtapMetricsView;
     use otap_df_pdata::{OtapArrowRecords, OtapPayload, TryIntoWithOptions};
@@ -1038,6 +1244,7 @@ mod tests {
         ResourceMetricsView, ScopeMetricsView, SumView, Value,
     };
     use otap_df_pdata_views::views::resource::ResourceView;
+    use prost::Message;
     use std::collections::BTreeMap;
     use std::sync::Arc;
 
@@ -1307,7 +1514,6 @@ mod tests {
 
     fn empty_resource_encoder() -> MetricsOtlpEncoder {
         MetricsOtlpEncoder::new(&ResourceLogs::default().encode_to_vec())
-            .expect("valid resource fragment")
     }
 
     fn decode_request(encoded: OtlpProtoBytes) -> ExportMetricsServiceRequest {
@@ -1315,6 +1521,53 @@ mod tests {
             panic!("encoder returned the wrong OTLP signal")
         };
         ExportMetricsServiceRequest::decode(bytes).expect("valid metrics request")
+    }
+
+    fn protobuf_fields(mut bytes: &[u8]) -> Vec<(u64, u64, &[u8])> {
+        fn varint(bytes: &[u8]) -> (u64, usize) {
+            let mut value = 0_u64;
+            for (index, byte) in bytes.iter().copied().enumerate() {
+                value |= u64::from(byte & 0x7f) << (index * 7);
+                if byte & 0x80 == 0 {
+                    return (value, index + 1);
+                }
+            }
+            panic!("truncated varint")
+        }
+
+        let mut fields = Vec::new();
+        while !bytes.is_empty() {
+            let (key, key_len) = varint(bytes);
+            bytes = &bytes[key_len..];
+            let wire_type = key & 7;
+            let payload_len = match wire_type {
+                wire_types::VARINT => varint(bytes).1,
+                wire_types::FIXED64 => 8,
+                wire_types::LEN => {
+                    let (len, prefix_len) = varint(bytes);
+                    let len = usize::try_from(len).expect("field length fits usize");
+                    let payload = &bytes[prefix_len..prefix_len + len];
+                    fields.push((key >> 3, wire_type, payload));
+                    bytes = &bytes[prefix_len + len..];
+                    continue;
+                }
+                wire_types::FIXED32 => 4,
+                other => panic!("unsupported wire type {other}"),
+            };
+            let payload = &bytes[..payload_len];
+            fields.push((key >> 3, wire_type, payload));
+            bytes = &bytes[payload_len..];
+        }
+        fields
+    }
+
+    fn message_field(bytes: &[u8], field_number: u64) -> &[u8] {
+        protobuf_fields(bytes)
+            .into_iter()
+            .find_map(|(number, wire_type, payload)| {
+                (number == field_number && wire_type == wire_types::LEN).then_some(payload)
+            })
+            .unwrap_or_else(|| panic!("missing message field {field_number}"))
     }
 
     fn only_scope(request: &ExportMetricsServiceRequest) -> &ScopeMetrics {
@@ -1345,6 +1598,9 @@ mod tests {
         (point, sum)
     }
 
+    /// Scenario: No configured view matches a metric field.
+    /// Guarantees: The descriptor-defined name, description, and unit are
+    /// preserved in the emitted OTLP stream.
     #[test]
     fn unmatched_views_preserve_the_descriptor_defined_stream() {
         let views = vec![MetricView {
@@ -1359,8 +1615,7 @@ mod tests {
             },
         }];
         let encoder =
-            MetricsOtlpEncoder::new_with_views(&ResourceLogs::default().encode_to_vec(), views)
-                .expect("valid resource fragment");
+            MetricsOtlpEncoder::new_with_views(&ResourceLogs::default().encode_to_vec(), views);
         let batch = MetricExportBatch {
             time_unix_nano: COLLECTION_TIME,
             metric_sets: vec![metric_set(
@@ -1385,6 +1640,9 @@ mod tests {
         assert_eq!(metric.unit, "1");
     }
 
+    /// Scenario: A view selects a scope by several exact scalar attributes.
+    /// Guarantees: The view applies only when every configured key, type, and
+    /// value matches the metric-set entity.
     #[test]
     fn scope_attribute_selectors_require_all_exact_scalar_matches() {
         let attributes = shared_attributes(
@@ -1426,8 +1684,7 @@ mod tests {
             let encoder = MetricsOtlpEncoder::new_with_views(
                 &ResourceLogs::default().encode_to_vec(),
                 vec![view_for(scope_attributes)],
-            )
-            .expect("valid resource fragment");
+            );
             let batch = MetricExportBatch {
                 time_unix_nano: COLLECTION_TIME,
                 metric_sets: vec![metric_set(
@@ -1477,6 +1734,8 @@ mod tests {
         }
     }
 
+    /// Scenario: Several matching views produce case variants of one stream.
+    /// Guarantees: One stream is emitted and retains the longest description.
     #[test]
     fn matching_views_deduplicate_names_case_insensitively_and_keep_longest_description() {
         let renamed_stream = MetricViewStream {
@@ -1538,8 +1797,7 @@ mod tests {
             },
         ];
         let encoder =
-            MetricsOtlpEncoder::new_with_views(&ResourceLogs::default().encode_to_vec(), views)
-                .expect("valid resource fragment");
+            MetricsOtlpEncoder::new_with_views(&ResourceLogs::default().encode_to_vec(), views);
         let batch = MetricExportBatch {
             time_unix_nano: COLLECTION_TIME,
             metric_sets: vec![metric_set(
@@ -1574,6 +1832,8 @@ mod tests {
         assert_eq!(point.value, Some(number_data_point::Value::AsDouble(3.5)));
     }
 
+    /// Scenario: Views map two fields in one metric set to the same name.
+    /// Guarantees: Encoding rejects the ambiguous case-insensitive collision.
     #[test]
     fn rejects_view_name_collisions_between_fields_in_one_metric_set() {
         let views = vec![
@@ -1601,8 +1861,7 @@ mod tests {
             },
         ];
         let encoder =
-            MetricsOtlpEncoder::new_with_views(&ResourceLogs::default().encode_to_vec(), views)
-                .expect("valid resource fragment");
+            MetricsOtlpEncoder::new_with_views(&ResourceLogs::default().encode_to_vec(), views);
         let batch = MetricExportBatch {
             time_unix_nano: COLLECTION_TIME,
             metric_sets: vec![metric_set(
@@ -1629,6 +1888,8 @@ mod tests {
         ));
     }
 
+    /// Scenario: Views map fields from equal effective scopes to one name.
+    /// Guarantees: Collision detection spans separate metric-set exports.
     #[test]
     fn rejects_view_name_collisions_across_metric_sets_with_the_same_scope_identity() {
         let views = vec![
@@ -1656,8 +1917,7 @@ mod tests {
             },
         ];
         let encoder =
-            MetricsOtlpEncoder::new_with_views(&ResourceLogs::default().encode_to_vec(), views)
-                .expect("valid resource fragment");
+            MetricsOtlpEncoder::new_with_views(&ResourceLogs::default().encode_to_vec(), views);
         let attributes = empty_attributes();
         let batch = MetricExportBatch {
             time_unix_nano: COLLECTION_TIME,
@@ -1689,6 +1949,8 @@ mod tests {
         ));
     }
 
+    /// Scenario: Descriptor-defined fields already differ only by name case.
+    /// Guarantees: The no-view path preserves both pre-existing streams.
     #[test]
     fn preserves_preexisting_no_view_name_collision_behavior() {
         let batch = MetricExportBatch {
@@ -1834,6 +2096,158 @@ mod tests {
         assert_eq!(point.start_time_unix_nano, DELTA_START);
     }
 
+    /// Scenario: A direct-encoded exponential histogram uses zero timestamps,
+    /// packed buckets, a negative integer attribute, and a nested map.
+    /// Guarantees: Scalar defaults are absent, recursive values decode, and
+    /// bucket counts use one packed length-delimited field.
+    #[test]
+    fn direct_wire_encoding_omits_defaults_and_packs_buckets() {
+        let nested = BTreeMap::from([(
+            "inner".to_owned(),
+            AttributeValue::Map(BTreeMap::from([(
+                "delta".to_owned(),
+                AttributeValue::Int(-9),
+            )])),
+        )]);
+        let attributes = shared_attributes(
+            &FULL_ATTRIBUTES_DESCRIPTOR,
+            vec![
+                AttributeValue::String("worker-a".to_owned()),
+                AttributeValue::Int(-2),
+                AttributeValue::UInt(7),
+                AttributeValue::Double(0.75),
+                AttributeValue::Boolean(false),
+                AttributeValue::Map(nested),
+            ],
+        );
+        let mut metric_set = metric_set(
+            &DISTRIBUTION_ONLY_DESCRIPTOR,
+            attributes,
+            vec![MetricValue::from(normal_distribution(&[0.0, 1.0, 4.0]))],
+        );
+        metric_set.delta_start_time_unix_nano = 0;
+        let batch = MetricExportBatch {
+            time_unix_nano: 0,
+            metric_sets: vec![metric_set],
+        };
+
+        let encoded = empty_resource_encoder()
+            .encode(&batch)
+            .expect("direct encoding succeeds")
+            .expect("distribution produces a request");
+        let direct_bytes = encoded.as_bytes().to_vec();
+        let request = decode_request(encoded);
+
+        let scope = only_scope(&request);
+        let delta = scope
+            .scope
+            .as_ref()
+            .expect("scope")
+            .attributes
+            .iter()
+            .find(|attribute| attribute.key == "worker.delta")
+            .and_then(|attribute| attribute.value.as_ref())
+            .and_then(|value| value.value.as_ref());
+        assert_eq!(delta, Some(&any_value::Value::IntValue(-2)));
+        let nested_delta = scope
+            .scope
+            .as_ref()
+            .expect("scope")
+            .attributes
+            .iter()
+            .find(|attribute| attribute.key == "worker.labels")
+            .and_then(|attribute| attribute.value.as_ref())
+            .and_then(|value| value.value.as_ref())
+            .and_then(|value| match value {
+                any_value::Value::KvlistValue(values) => values.values.first(),
+                _ => None,
+            })
+            .and_then(|attribute| attribute.value.as_ref())
+            .and_then(|value| value.value.as_ref())
+            .and_then(|value| match value {
+                any_value::Value::KvlistValue(values) => values.values.first(),
+                _ => None,
+            })
+            .and_then(|attribute| attribute.value.as_ref())
+            .and_then(|value| value.value.as_ref());
+        assert_eq!(nested_delta, Some(&any_value::Value::IntValue(-9)));
+
+        let Some(metric::Data::ExponentialHistogram(histogram)) =
+            metric_named(scope, "histogram.distribution").data.as_ref()
+        else {
+            panic!("expected exponential histogram")
+        };
+        let positive = histogram.data_points[0]
+            .positive
+            .as_ref()
+            .expect("positive buckets");
+        assert!(!positive.bucket_counts.is_empty());
+
+        let resource_metrics = message_field(&direct_bytes, METRICS_DATA_RESOURCE_METRICS);
+        let scope_metrics = message_field(resource_metrics, RESOURCE_METRICS_SCOPE_METRICS);
+        let metric = message_field(scope_metrics, SCOPE_METRICS_METRICS);
+        let exponential_histogram = message_field(metric, METRIC_EXPONENTIAL_HISTOGRAM);
+        let point = message_field(exponential_histogram, EXPONENTIAL_HISTOGRAM_DATA_POINTS);
+        let point_fields = protobuf_fields(point);
+        assert!(
+            point_fields
+                .iter()
+                .all(|(number, _, _)| !matches!(*number, 2 | 3))
+        );
+        let positive = message_field(point, EXP_HISTOGRAM_DP_POSITIVE);
+        let bucket_fields = protobuf_fields(positive)
+            .into_iter()
+            .filter(|(number, _, _)| *number == EXP_HISTOGRAM_BUCKET_BUCKET_COUNTS)
+            .collect::<Vec<_>>();
+        assert_eq!(bucket_fields.len(), 1);
+        assert_eq!(bucket_fields[0].1, wire_types::LEN);
+    }
+
+    /// Scenario: Two bucket-local gauge values share a scope and stream but
+    /// have distinct item attributes.
+    /// Guarantees: Direct encoding emits one metric with two attributed data
+    /// points instead of merging values or duplicating the metric stream.
+    #[test]
+    fn merges_distinct_item_attribute_buckets_into_multiple_stream_points() {
+        let attributes = empty_attributes();
+        let mut first = metric_set(
+            &F64_GAUGE_DESCRIPTOR,
+            attributes.clone(),
+            vec![MetricValue::F64(1.5)],
+        );
+        first.item_attributes = vec![("bucket".to_owned(), "first".to_owned())];
+        let mut second = metric_set(
+            &F64_GAUGE_DESCRIPTOR,
+            attributes,
+            vec![MetricValue::F64(2.5)],
+        );
+        second.item_attributes = vec![("bucket".to_owned(), "second".to_owned())];
+        let batch = MetricExportBatch {
+            time_unix_nano: COLLECTION_TIME,
+            metric_sets: vec![first, second],
+        };
+
+        let request = decode_request(
+            empty_resource_encoder()
+                .encode(&batch)
+                .expect("bucketed gauges encode")
+                .expect("bucketed gauges produce a request"),
+        );
+        let scope = only_scope(&request);
+        let [metric] = scope.metrics.as_slice() else {
+            panic!("expected one merged metric stream")
+        };
+        let Some(metric::Data::Gauge(gauge)) = metric.data.as_ref() else {
+            panic!("expected gauge data")
+        };
+        assert_eq!(gauge.data_points.len(), 2);
+        assert_eq!(gauge.data_points[0].attributes[0].key, "bucket");
+        assert_eq!(gauge.data_points[1].attributes[0].key, "bucket");
+    }
+
+    /// Scenario: Every supported instrument kind is encoded in one batch.
+    /// Guarantees: Values, timing, temporality, monotonicity, saturation, and
+    /// bucketless MMSC statistics retain their OTLP semantics.
     #[test]
     fn encodes_all_instrument_kinds_with_otlp_semantics() {
         let encoder = empty_resource_encoder();
@@ -1929,6 +2343,9 @@ mod tests {
         assert!(point.bucket_counts.is_empty());
     }
 
+    /// Scenario: A batch contains populated and empty MMSC fields and sets.
+    /// Guarantees: Empty distributions are omitted without suppressing other
+    /// metrics or populated scopes.
     #[test]
     fn emits_multiple_scopes_while_omitting_empty_mmsc_fields_and_sets() {
         let empty_mmsc = mmsc_value(0.0, 0.0, 0.0, 0);
@@ -1989,6 +2406,9 @@ mod tests {
         assert_eq!(second.metrics[0].name, "histogram.empty");
     }
 
+    /// Scenario: Dirty scalar instruments contain numeric zero values.
+    /// Guarantees: Their oneof values remain present rather than being omitted
+    /// as protobuf defaults.
     #[test]
     fn emits_meaningful_zero_scalar_values() {
         let batch = MetricExportBatch {
@@ -2068,6 +2488,8 @@ mod tests {
         assert!(point.bucket_counts.is_empty());
     }
 
+    /// Scenario: An empty batch or an all-empty MMSC batch is encoded.
+    /// Guarantees: Neither case emits an empty OTLP request.
     #[test]
     fn omits_empty_mmsc_and_empty_batches() {
         let encoder = empty_resource_encoder();
@@ -2098,6 +2520,10 @@ mod tests {
         );
     }
 
+    /// Scenario: Resource and entity attributes include every internal value
+    /// type, saturation, and a map.
+    /// Guarantees: The trusted resource fragment and native scope attribute
+    /// values survive direct wire encoding.
     #[test]
     fn attaches_native_attributes_to_scope_and_preserves_resource() {
         let resource = Resource {
@@ -2114,7 +2540,7 @@ mod tests {
             schema_url: "https://resource.example/schema".to_owned(),
         }
         .encode_to_vec();
-        let encoder = MetricsOtlpEncoder::new(&fragment).expect("valid log resource fragment");
+        let encoder = MetricsOtlpEncoder::new(&fragment);
 
         let mut labels = BTreeMap::new();
         let _ = labels.insert("overflow".to_owned(), AttributeValue::UInt(u64::MAX));
@@ -2213,13 +2639,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn rejects_invalid_resource_fragment() {
-        let error = MetricsOtlpEncoder::new(&[0x0a, 0x02, 0x08])
-            .expect_err("truncated nested resource must fail");
-        assert!(matches!(error, Error::InvalidResource(_)));
-    }
-
+    /// Scenario: A metric set supplies too few or too many values.
+    /// Guarantees: Encoding rejects the batch instead of truncating the
+    /// descriptor/value pairing.
     #[test]
     fn rejects_metric_set_value_count_mismatches() {
         for actual in [0, 2] {
@@ -2312,6 +2734,8 @@ mod tests {
         }
     }
 
+    /// Scenario: A sum-like descriptor omits aggregation temporality.
+    /// Guarantees: Encoding reports the missing semantic requirement.
     #[test]
     fn rejects_sum_without_temporality() {
         let batch = MetricExportBatch {
@@ -2333,6 +2757,9 @@ mod tests {
         ));
     }
 
+    /// Scenario: Directly encoded metrics enter the OTAP conversion path.
+    /// Guarantees: Resources, scopes, attributes, and metric data remain
+    /// consumable after conversion to Arrow records.
     #[test]
     fn encoded_metrics_are_consumable_by_the_otap_export_path() {
         let resource = Resource {
@@ -2350,8 +2777,7 @@ mod tests {
                 schema_url: "https://resource.example/schema".to_owned(),
             }
             .encode_to_vec(),
-        )
-        .expect("valid resource fragment");
+        );
         let mut labels = BTreeMap::new();
         let _ = labels.insert(
             "region".to_owned(),


### PR DESCRIPTION
# Change Summary

Replace Prost-based ITS metrics serialization with direct OTLP protobuf encoding through `ProtoBuffer`, matching the existing logs path. Prost is now used only by tests to decode and verify emitted bytes.

## What issue does this PR close?

* Closes #3668 

## How are these changes tested?

- `cargo test -p otap-df-telemetry`
- `cargo test -p otap-df-core-nodes internal_telemetry_receiver`
- `cargo test -p otap-df-engine --test enum_attributes_metrics`
- `cargo test -p otap-df-otap --test enum_attributes_metrics`
- `cargo check` for the affected telemetry, engine, OTAP, and core-nodes crates
- `cargo clippy` for the affected crates with warnings denied 
- Internal metrics bridge benchmark

The full `cargo xtask check` is currently blocked by pre-existing component inventory drift.

## Performance

Measured with:

```console
cargo bench -p benchmarks --bench internal_metrics_bridge
```

| Workload | Before | After | Time reduction | Throughput improvement |
| --- | ---: | ---: | ---: | ---: |
| 100 entities, no views | 299.71 us | 98.03 us | 67.2% | 3.05x |
| 100 entities, six views | 357.92 us | 179.59 us | 51.3% | 2.05x |
| 1,000 entities, no views | 3.074 ms | 1.119 ms | 64.3% | 2.80x |
| 1,000 entities, six views | 3.872 ms | 1.903 ms | 50.9% | 2.04x |

All comparisons were statistically significant (`p < 0.05`). Direct protobuf encoding reduces bridge execution time by approximately **51-67%**, increasing throughput by approximately **2.0-3.1x**.


## Are there any user-facing changes?

No. This is an internal serialization and dependency cleanup that preserves the existing OTLP output and configuration behavior.

### Changelog

* [ ] Added a `.chloggen/*.yaml` entry
* [X] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
