### PR TITLE
feat(metrics): Add durable_buffer.loss bytes metric

### DIFF
--- a/rust/otap-dataflow/.chloggen/durable-buffer-loss-bytes.yaml
+++ b/rust/otap-dataflow/.chloggen/durable-buffer-loss-bytes.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: pipeline
+note: Report persisted bytes removed by durable-buffer runtime retention.
+issues: [2884]
+subtext: The new `processor.durable_buffer.loss.bytes` counter is partitioned by `reason=drop_oldest|expired`.

--- a/rust/otap-dataflow/configs/trafficgen-durable-buffer-loss.yaml
+++ b/rust/otap-dataflow/configs/trafficgen-durable-buffer-loss.yaml
@@ -1,0 +1,115 @@
+version: otel_dataflow/v1
+
+# Exercises both durable-buffer runtime retention loss paths against unreachable
+# OTLP exporters. Each pipeline writes to its own storage directory.
+#
+# Build:
+#   cargo build --release
+#
+# Reset prior data:
+#   rm -rf /tmp/otap-durable-buffer-loss
+#
+# Run from rust/otap-dataflow:
+#   ./target/release/df_engine --config configs/trafficgen-durable-buffer-loss.yaml --num-cores 1
+#
+# Query durable-buffer utilization, used bytes, and loss metrics:
+#   curl -fsS 'http://127.0.0.1:8080/api/v1/metrics?format=json_compact' | jq '.metric_sets[] | select(.name == "processor.durable_buffer" or .name == "processor.durable_buffer.loss")'
+#
+# Expected:
+# - `segments`, `bundles`, `bytes`, and signal-specific `items` appear.
+# - reason="drop_oldest" increases after the minimum valid 192 MiB cap is reached.
+# - reason="expired" begins increasing after finalized segments are 5 seconds old.
+
+engine:
+  http_admin:
+    bind_address: 127.0.0.1:8080
+  telemetry:
+    reporting_interval: 1s
+    logs:
+      level: info
+
+groups:
+  loss_metrics:
+    pipelines:
+      drop_oldest:
+        policies:
+          channel_capacity:
+            control:
+              node: 100
+              pipeline: 100
+            pdata: 128
+
+        nodes:
+          receiver:
+            type: receiver:traffic_generator
+            config:
+              traffic_config:
+                max_signal_count: null
+                max_batch_size: 1000
+                signals_per_second: 50000
+                log_weight: 100
+
+          durable_buffer:
+            type: processor:durable_buffer
+            config:
+              path: /tmp/otap-durable-buffer-loss/drop-oldest
+              poll_interval: 100ms
+              retention_size_cap: "192 MiB"
+              size_cap_policy: drop_oldest
+              max_segment_open_duration: 1s
+              initial_retry_interval: 1s
+              max_retry_interval: 5s
+
+          broken_exporter:
+            type: exporter:otlp_grpc
+            config:
+              grpc_endpoint: "http://127.0.0.1:14318"
+              timeout: 1s
+
+        connections:
+          - from: receiver
+            to: durable_buffer
+          - from: durable_buffer
+            to: broken_exporter
+
+      expired:
+        policies:
+          channel_capacity:
+            control:
+              node: 100
+              pipeline: 100
+            pdata: 128
+
+        nodes:
+          receiver:
+            type: receiver:traffic_generator
+            config:
+              traffic_config:
+                max_signal_count: null
+                max_batch_size: 100
+                signals_per_second: 1000
+                log_weight: 100
+
+          durable_buffer:
+            type: processor:durable_buffer
+            config:
+              path: /tmp/otap-durable-buffer-loss/expired
+              poll_interval: 100ms
+              max_age: 5s
+              retention_size_cap: "192 MiB"
+              size_cap_policy: backpressure
+              max_segment_open_duration: 1s
+              initial_retry_interval: 1s
+              max_retry_interval: 5s
+
+          broken_exporter:
+            type: exporter:otlp_grpc
+            config:
+              grpc_endpoint: "http://127.0.0.1:14319"
+              timeout: 1s
+
+        connections:
+          - from: receiver
+            to: durable_buffer
+          - from: durable_buffer
+            to: broken_exporter

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/README.md
@@ -110,7 +110,7 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
 | `processor.durable_buffer.bundles` | `resolved` | `outcome=acked\|deferred\|permanently_rejected` |
 | `processor.durable_buffer.ingest` | `failures` | `failure=error\|backpressure` |
 | `processor.durable_buffer.items` | `rejected`, `consumed`, `produced`, `requeued`, `queued` | `signal=traces\|metrics\|logs` |
-| `processor.durable_buffer.loss` | `segments`, `bundles` | `reason=drop_oldest\|expired` |
+| `processor.durable_buffer.loss` | `segments`, `bundles`, `bytes` | `reason=drop_oldest\|expired` |
 | `processor.durable_buffer.loss` | `items` | `signal=traces\|metrics\|logs`, `reason=drop_oldest\|expired` |
 
 ### Events

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/metrics.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/metrics.rs
@@ -124,7 +124,7 @@ pub(super) struct LossAttributes {
     pub(super) reason: LossReason,
 }
 
-/// Segment and bundle loss metrics partitioned by retention reason.
+/// Loss metrics partitioned by retention reason.
 #[metric_set(
     name = "processor.durable_buffer.loss",
     measurement_attributes = LossAttributes
@@ -137,6 +137,9 @@ pub(super) struct DurableBufferLossMetrics {
     /// Number of bundles lost.
     #[metric(unit = "{bundle}")]
     pub(super) bundles: Counter<u64>,
+    /// Persisted segment bytes lost.
+    #[metric(unit = "By")]
+    pub(super) bytes: Counter<u64>,
 }
 
 #[attribute_set(item, measurement)]

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
@@ -264,6 +264,7 @@ fn retention_loss_delta(
             segments: current.segments.saturating_sub(previous.segments),
             bundles: current.bundles.saturating_sub(previous.bundles),
             items: current.items.saturating_sub(previous.items),
+            bytes: current.bytes.saturating_sub(previous.bytes),
         }
     }
 
@@ -798,10 +799,12 @@ impl DurableBuffer {
         let dropped = self.metrics.loss_for(LossReason::DropOldest);
         dropped.segments.add(loss_delta.drop_oldest.segments);
         dropped.bundles.add(loss_delta.drop_oldest.bundles);
+        dropped.bytes.add(loss_delta.drop_oldest.bytes);
 
         let expired = self.metrics.loss_for(LossReason::Expired);
         expired.segments.add(loss_delta.expired.segments);
         expired.bundles.add(loss_delta.expired.bundles);
+        expired.bytes.add(loss_delta.expired.bytes);
 
         // Classify Quiver's opaque slot shapes in the OTAP layer, where signal
         // semantics are known.
@@ -2900,7 +2903,7 @@ mod tests {
         assert_eq!(sample(&mut processor), (4, 0));
     }
 
-    /// Scenario: Segment and bundle loss occur in separate reporting intervals.
+    /// Scenario: Segment, bundle, and byte loss occur in separate reporting intervals.
     /// Guarantees: Each reason-only aggregate counter reports its delta and resets after export.
     #[tokio::test]
     async fn test_aggregate_loss_metrics_are_delta_counters() {
@@ -2913,11 +2916,19 @@ mod tests {
             let dropped = processor.metrics.loss_metrics.get(LossAttributes {
                 reason: LossReason::DropOldest,
             });
-            let dropped_values = (dropped.segments.get(), dropped.bundles.get());
+            let dropped_values = (
+                dropped.segments.get(),
+                dropped.bundles.get(),
+                dropped.bytes.get(),
+            );
             let expired = processor.metrics.loss_metrics.get(LossAttributes {
                 reason: LossReason::Expired,
             });
-            let expired_values = (expired.segments.get(), expired.bundles.get());
+            let expired_values = (
+                expired.segments.get(),
+                expired.bundles.get(),
+                expired.bytes.get(),
+            );
 
             reporter
                 .report_measurement(&mut processor.metrics.loss_metrics)
@@ -2932,22 +2943,45 @@ mod tests {
             .await
             .expect("ingest dropped bundle");
         engine.flush().await.expect("flush dropped bundle");
+        let dropped_bytes = engine
+            .segment_store()
+            .segment_sequences()
+            .into_iter()
+            .min()
+            .map(|seq| {
+                engine
+                    .segment_store()
+                    .segment_file_size(seq)
+                    .expect("segment file size")
+            })
+            .expect("oldest segment");
         assert_eq!(engine.force_drop_oldest_pending_segments(), 1);
-        assert_eq!(sample(&mut processor), ((1, 1), (0, 0)));
+        assert_eq!(sample(&mut processor), ((1, 1, dropped_bytes), (0, 0, 0)));
 
         engine
             .ingest(&make_simple_bundle(SlotId::new(30), 3))
             .await
             .expect("ingest expired bundle");
         engine.flush().await.expect("flush expired bundle");
+        let expired_bytes = engine
+            .segment_store()
+            .segment_sequences()
+            .into_iter()
+            .map(|seq| {
+                engine
+                    .segment_store()
+                    .segment_file_size(seq)
+                    .expect("segment file size")
+            })
+            .sum::<u64>();
         tokio::time::sleep(Duration::from_millis(20)).await;
         assert_eq!(
             engine.cleanup_expired_segments().expect("expire segment"),
             1
         );
-        assert_eq!(sample(&mut processor), ((0, 0), (1, 1)));
+        assert_eq!(sample(&mut processor), ((0, 0, 0), (1, 1, expired_bytes)));
 
-        assert_eq!(sample(&mut processor), ((0, 0), (0, 0)));
+        assert_eq!(sample(&mut processor), ((0, 0, 0), (0, 0, 0)));
     }
 
     /// Scenario: DropOldest removes a metrics bundle containing 42 items.

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/telemetry.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/telemetry.md
@@ -16,7 +16,7 @@ OpenTelemetry attributes rather than encoded in instrument names.
 | `processor.durable_buffer.bundles` | `resolved` | `outcome=acked\|deferred\|permanently_rejected` | Bundle resolution by downstream outcome. |
 | `processor.durable_buffer.ingest` | `failures` | `failure=error\|backpressure` | Failed ingest attempts by failure kind. |
 | `processor.durable_buffer.items` | `rejected`, `consumed`, `produced`, `requeued`, `queued` | `signal=traces\|metrics\|logs` | Item operations and queued gauges by OpenTelemetry signal. |
-| `processor.durable_buffer.loss` | `segments`, `bundles` | `reason=drop_oldest\|expired` | Segment and bundle retention loss. |
+| `processor.durable_buffer.loss` | `segments`, `bundles`, `bytes` | `reason=drop_oldest\|expired` | Runtime retention loss, including full persisted segment-file bytes. |
 | `processor.durable_buffer.loss` | `items` | `signal=traces\|metrics\|logs`, `reason=drop_oldest\|expired` | Item retention loss. |
 
 ## Logs

--- a/rust/otap-dataflow/crates/quiver/src/engine.rs
+++ b/rust/otap-dataflow/crates/quiver/src/engine.rs
@@ -76,6 +76,8 @@ pub struct RetentionLossCounts {
     pub bundles: u64,
     /// Number of logical items stored in the removed segments.
     pub items: u64,
+    /// Persisted bytes stored in the removed segment files.
+    pub bytes: u64,
 }
 
 /// Cumulative retention-loss totals for the current engine lifetime.
@@ -133,6 +135,8 @@ pub struct QuiverEngine {
     force_dropped_bundles: AtomicU64,
     /// Count of individual data items lost due to force-dropped segments.
     force_dropped_items: AtomicU64,
+    /// Count of persisted bytes lost due to force-dropped segments.
+    force_dropped_bytes: AtomicU64,
     /// Pending dropped items grouped by slot shape, for per-signal tracking.
     /// Keyed by sorted slot_ids to bound memory by unique bundle shapes.
     dropped_items_by_shape: RwLock<HashMap<Vec<crate::record_bundle::SlotId>, u64>>,
@@ -142,6 +146,8 @@ pub struct QuiverEngine {
     expired_bundles: AtomicU64,
     /// Count of individual data items lost due to expired segments.
     expired_items: AtomicU64,
+    /// Count of persisted bytes lost due to expired segments.
+    expired_bytes: AtomicU64,
     /// Pending expired items grouped by slot shape, for per-signal tracking.
     /// Keyed by sorted slot_ids to bound memory by unique bundle shapes.
     expired_items_by_shape: RwLock<HashMap<Vec<crate::record_bundle::SlotId>, u64>>,
@@ -432,10 +438,12 @@ impl QuiverEngine {
             force_dropped_segments: AtomicU64::new(0),
             force_dropped_bundles: AtomicU64::new(0),
             force_dropped_items: AtomicU64::new(0),
+            force_dropped_bytes: AtomicU64::new(0),
             dropped_items_by_shape: RwLock::new(HashMap::new()),
             expired_segments: AtomicU64::new(0),
             expired_bundles: AtomicU64::new(0),
             expired_items: AtomicU64::new(0),
+            expired_bytes: AtomicU64::new(0),
             expired_items_by_shape: RwLock::new(HashMap::new()),
             segment_store,
             registry: registry.clone(),
@@ -541,11 +549,13 @@ impl QuiverEngine {
                 segments: self.force_dropped_segments(),
                 bundles: self.force_dropped_bundles(),
                 items: self.force_dropped_items(),
+                bytes: self.force_dropped_bytes.load(Ordering::Relaxed),
             },
             expired: RetentionLossCounts {
                 segments: self.expired_segments(),
                 bundles: self.expired_bundles(),
                 items: self.expired_items(),
+                bytes: self.expired_bytes.load(Ordering::Relaxed),
             },
         }
     }
@@ -1414,12 +1424,14 @@ impl QuiverEngine {
         let mut deleted = 0;
         let mut bundles_dropped: u64 = 0;
         let mut items_dropped: u64 = 0;
+        let mut bytes_dropped: u64 = 0;
         for seq in &to_drop {
             // Count bundles and items before deleting (single lock acquisition)
             if let Ok((bundles, items)) = self.segment_store.segment_drop_counts(*seq) {
                 bundles_dropped += bundles as u64;
                 items_dropped += items;
             }
+            let file_size = self.segment_store.segment_file_size(*seq);
             match self.segment_store.bundle_metadata(*seq) {
                 Ok(metadata) => {
                     let mut map = self.dropped_items_by_shape.write();
@@ -1442,6 +1454,9 @@ impl QuiverEngine {
             if let Err(e) = self.segment_store.delete_segment(*seq) {
                 otel_warn!("quiver.segment.drop", segment = seq.raw(), error = %e, error_type = "io", reason = "force_drop");
             } else {
+                if let Ok(bytes) = file_size {
+                    bytes_dropped += bytes;
+                }
                 otel_info!(
                     "quiver.segment.drop",
                     segment = seq.raw(),
@@ -1461,6 +1476,9 @@ impl QuiverEngine {
         let _ = self
             .force_dropped_items
             .fetch_add(items_dropped, Ordering::Relaxed);
+        let _ = self
+            .force_dropped_bytes
+            .fetch_add(bytes_dropped, Ordering::Relaxed);
 
         // Clean up registry internal state
         if let Some(&max_dropped) = to_drop.iter().max() {
@@ -1502,12 +1520,14 @@ impl QuiverEngine {
         let mut deleted = 0;
         let mut bundles_expired: u64 = 0;
         let mut items_expired: u64 = 0;
+        let mut bytes_expired: u64 = 0;
         for seq in &expired_segments {
             // Count bundles and items before deleting (single lock acquisition)
             if let Ok((bundles, items)) = self.segment_store.segment_drop_counts(*seq) {
                 bundles_expired += bundles as u64;
                 items_expired += items;
             }
+            let file_size = self.segment_store.segment_file_size(*seq);
             match self.segment_store.bundle_metadata(*seq) {
                 Ok(metadata) => {
                     let mut map = self.expired_items_by_shape.write();
@@ -1537,6 +1557,9 @@ impl QuiverEngine {
                     reason = "expired",
                 );
             } else {
+                if let Ok(bytes) = file_size {
+                    bytes_expired += bytes;
+                }
                 otel_info!(
                     "quiver.segment.drop",
                     segment = seq.raw(),
@@ -1565,6 +1588,11 @@ impl QuiverEngine {
             let _ = self
                 .expired_items
                 .fetch_add(items_expired, Ordering::Relaxed);
+        }
+        if bytes_expired > 0 {
+            let _ = self
+                .expired_bytes
+                .fetch_add(bytes_expired, Ordering::Relaxed);
         }
 
         Ok(deleted)
@@ -3504,7 +3532,7 @@ mod tests {
     }
 
     /// Scenario: DropOldest removes one pending segment without active readers.
-    /// Guarantees: The typed loss snapshot reports the cumulative segment and bundle loss.
+    /// Guarantees: The loss snapshot reports its exact segment, bundle, and persisted-byte totals.
     #[tokio::test]
     async fn force_drop_oldest_drops_pending_segments_without_readers() {
         let temp_dir = tempdir().expect("tempdir");
@@ -3545,6 +3573,16 @@ mod tests {
         // Verify we have some segments pending
         let initial_count = engine.segment_store.segment_count();
         assert!(initial_count >= 2, "should have multiple segments");
+        let oldest = engine
+            .segment_store()
+            .segment_sequences()
+            .into_iter()
+            .min()
+            .expect("oldest segment");
+        let oldest_file_size = engine
+            .segment_store()
+            .segment_file_size(oldest)
+            .expect("segment file size");
 
         // Do NOT consume any bundles - they're all pending
         // But we also have no claimed bundles (no active reads)
@@ -3561,6 +3599,7 @@ mod tests {
         let loss = engine.retention_loss_snapshot();
         assert_eq!(loss.drop_oldest.segments, 1);
         assert!(loss.drop_oldest.bundles > 0);
+        assert_eq!(loss.drop_oldest.bytes, oldest_file_size);
         assert_eq!(loss.expired, RetentionLossCounts::default());
 
         // Segment count should decrease
@@ -4313,7 +4352,7 @@ mod tests {
     }
 
     /// Scenario: All finalized segments are older than the configured max_age.
-    /// Guarantees: Expiry removes them and the typed loss snapshot reports their totals.
+    /// Guarantees: Expiry reports their exact segment, bundle, and persisted-byte totals.
     #[tokio::test]
     async fn cleanup_expired_segments_deletes_old_segments() {
         let dir = tempdir().expect("tempdir");
@@ -4348,6 +4387,17 @@ mod tests {
             initial_segment_count >= 1,
             "should have at least one segment"
         );
+        let expected_bytes = engine
+            .segment_store()
+            .segment_sequences()
+            .into_iter()
+            .map(|seq| {
+                engine
+                    .segment_store()
+                    .segment_file_size(seq)
+                    .expect("segment file size")
+            })
+            .sum::<u64>();
 
         // Backdate segments so they appear older than max_age
         engine
@@ -4370,6 +4420,7 @@ mod tests {
         let loss = engine.retention_loss_snapshot();
         assert_eq!(loss.expired.segments, initial_segment_count as u64);
         assert_eq!(loss.expired.bundles, 5);
+        assert_eq!(loss.expired.bytes, expected_bytes);
         assert_eq!(loss.drop_oldest, RetentionLossCounts::default());
     }
 

--- a/rust/otap-dataflow/crates/quiver/src/engine.rs
+++ b/rust/otap-dataflow/crates/quiver/src/engine.rs
@@ -1451,19 +1451,18 @@ impl QuiverEngine {
                     );
                 }
             }
-            if let Err(e) = self.segment_store.delete_segment(*seq) {
-                otel_warn!("quiver.segment.drop", segment = seq.raw(), error = %e, error_type = "io", reason = "force_drop");
-            } else {
-                if let Ok(bytes) = file_size {
-                    bytes_dropped += bytes;
-                }
-                otel_info!(
-                    "quiver.segment.drop",
-                    segment = seq.raw(),
-                    reason = "force_drop",
-                );
-                deleted += 1;
+            self.segment_store
+                .delete_segment(*seq)
+                .expect("physical deletion failures are deferred");
+            if let Ok(bytes) = file_size {
+                bytes_dropped += bytes;
             }
+            otel_info!(
+                "quiver.segment.drop",
+                segment = seq.raw(),
+                reason = "force_drop",
+            );
+            deleted += 1;
         }
 
         // Update the force-dropped counters
@@ -1548,26 +1547,19 @@ impl QuiverEngine {
                 }
             }
 
-            if let Err(e) = self.segment_store.delete_segment(*seq) {
-                otel_warn!(
-                    "quiver.segment.drop",
-                    segment = seq.raw(),
-                    error = %e,
-                    error_type = "io",
-                    reason = "expired",
-                );
-            } else {
-                if let Ok(bytes) = file_size {
-                    bytes_expired += bytes;
-                }
-                otel_info!(
-                    "quiver.segment.drop",
-                    segment = seq.raw(),
-                    max_age_secs = max_age.as_secs(),
-                    reason = "expired",
-                );
-                deleted += 1;
+            self.segment_store
+                .delete_segment(*seq)
+                .expect("physical deletion failures are deferred");
+            if let Ok(bytes) = file_size {
+                bytes_expired += bytes;
             }
+            otel_info!(
+                "quiver.segment.drop",
+                segment = seq.raw(),
+                max_age_secs = max_age.as_secs(),
+                reason = "expired",
+            );
+            deleted += 1;
         }
 
         // Clean up registry internal state for deleted segments

--- a/rust/otap-dataflow/crates/quiver/src/segment_store.rs
+++ b/rust/otap-dataflow/crates/quiver/src/segment_store.rs
@@ -744,6 +744,15 @@ impl SegmentStore {
         self.segments.read().keys().copied().collect()
     }
 
+    /// Returns the finalized segment file size in bytes.
+    pub fn segment_file_size(&self, segment_seq: SegmentSeq) -> Result<u64> {
+        self.segments
+            .read()
+            .get(&segment_seq)
+            .map(|handle| handle.file_size_bytes)
+            .ok_or_else(|| SubscriberError::segment_not_found(segment_seq.raw()))
+    }
+
     /// Returns segments that were finalized more than `max_age` ago.
     ///
     /// This is used for age-based retention to identify segments that have


### PR DESCRIPTION
# Change Summary

Add `processor.durable_buffer.loss.bytes{reason}` for persisted bytes removed by durable-buffer runtime retention.

The durable buffer already reports lost segments and bundles by retention reason and lost items by reason and signal. Those counts do not show the persisted volume discarded when the buffer applies DropOldest or max-age expiry.

Bytes are aggregate rather than signal-specific because a segment may contain bundles from multiple signals. The value includes the complete persisted file representation, including metadata and encoding overhead.

### Validation

Running the sample config:

```text
processor.durable_buffer.loss.segments{reason}
processor.durable_buffer.loss.bundles{reason}
processor.durable_buffer.loss.bytes{reason}
processor.durable_buffer.loss.items{reason,signal}
```

An unreachable-exporter run exercised both runtime retention paths:

| Pipeline | Traffic | Retention |
| --- | --- | --- |
| DropOldest | 50,000 logs/s, batches up to 1,000 | 192 MiB cap with `drop_oldest` |
| Max age | 1,000 logs/s, batches up to 100 | 5-second max age with a 192 MiB cap |

The admin accumulator was reset, then sampled and reset again five seconds later. Loss values are deltas for that window; storage used and utilization are point-in-time gauges at the end of the window.

| Pipeline | Reason | Utilization | Storage used | Segments lost | Bundles lost | Items lost | Storage lost |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| DropOldest | `drop_oldest` | 82.66% | 158.70 MiB | 30 | 175 | 175,000 | 62.73 MiB |
| Max age | `expired` | 14.54% | 27.92 MiB | 48 | 50 | 5,000 | 2.04 MiB |

## What issue does this PR close?

<!--We highly recommend correlation of every PR to an issue-->

* Follow-up to:
  * #3516
  * #3705

## How are these changes tested?

Unit tests and local engine runs

## Are there any user-facing changes?

Yes, added a new `loss.bytes` metric.

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry
* [ ] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
