### PR TITLE
refactor(metrics): migrate signal_type_router telemetry to MeasurementMetricSet

### DIFF
--- a/rust/otap-dataflow/.chloggen/signal-type-router-metrics-refactor.yaml
+++ b/rust/otap-dataflow/.chloggen/signal-type-router-metrics-refactor.yaml
@@ -3,4 +3,4 @@ component: pipeline
 note: "Refactor signal_type_router telemetry to use standard outcome-and-reason enum attributes instead of discrete named metrics."
 issues: [3716]
 subtext: |
-  Migration: The `processor.signal_type_router.signals.*` discrete metrics have been removed. Use `processor.signal_type_router.signals.decision` (with `outcome` and `reason` attributes) instead.
+  Migration: The `processor.type_router.signals.*` discrete metrics have been removed. Use `processor.type_router.signals.decision` (with `outcome` and `reason` attributes) instead.

--- a/rust/otap-dataflow/.chloggen/signal-type-router-metrics-refactor.yaml
+++ b/rust/otap-dataflow/.chloggen/signal-type-router-metrics-refactor.yaml
@@ -3,4 +3,4 @@ component: pipeline
 note: "Refactor signal_type_router telemetry to use standard outcome-and-reason enum attributes instead of discrete named metrics."
 issues: [3716]
 subtext: |
-  Migration: The `processor.type_router.signals.*` discrete metrics have been removed. Use `processor.type_router.signals.decision` (with `outcome` and `reason` attributes) instead.
+  Migration: The `processor.type_router.signals.*` discrete metrics have been removed. Use `processor.type_router.signals.decision` (with `signal`, `outcome`, and `reason` attributes) instead.

--- a/rust/otap-dataflow/.chloggen/signal-type-router-metrics-refactor.yaml
+++ b/rust/otap-dataflow/.chloggen/signal-type-router-metrics-refactor.yaml
@@ -1,0 +1,6 @@
+change_type: breaking
+component: pipeline
+note: "Refactor signal_type_router telemetry to use standard outcome-and-reason enum attributes instead of discrete named metrics."
+issues: [3716]
+subtext: |
+  Migration: The `processor.signal_type_router.signals.*` discrete metrics have been removed. Use `processor.signal_type_router.signals.decision` (with `outcome` and `reason` attributes) instead.

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/signal_type_router/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/signal_type_router/README.md
@@ -154,7 +154,7 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
 | --- | --- | --- |
 | `processor.type_router.signals.decision` | `{message}` | Number of messages with a given routing outcome. |
 
-The `signals.decision` metric includes `outcome` and `reason` attributes to describe the terminal routing result:
+The `signals.decision` metric includes `signal`, `outcome`, and `reason` attributes to describe the terminal routing result:
 
 | Terminal routing result | `outcome` | `reason` |
 | --- | --- | --- |

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/signal_type_router/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/signal_type_router/README.md
@@ -133,15 +133,7 @@ subscription across the topic hop, while `disabled` does not.
 
 ## Observability
 
-The signal type router exposes per-signal counters for:
-
-- received messages
-- messages routed to named routes
-- messages routed to the default output
-- route-local NACKed messages
-- dropped messages
-- selected-route full rejections
-- selected-route closed rejections
+The signal type router exposes a single `signals.decision` measurement metric, broken down by `signal`, `outcome`, and `reason` attributes.
 
 Selected-route NACKs include a machine-readable `NackCause`:
 
@@ -156,31 +148,22 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
 
 ### Metric Sets
 
-#### `processor.signal_type_router`
+#### `processor.type_router`
 
 | Metric | Unit | Description |
 | --- | --- | --- |
-| `processor.signal_type_router.signals_received_logs` | `{msg}` | Number of log messages received by the router. |
-| `processor.signal_type_router.signals_received_metrics` | `{msg}` | Number of metric messages received by the router. |
-| `processor.signal_type_router.signals_received_traces` | `{msg}` | Number of trace messages received by the router. |
-| `processor.signal_type_router.signals_routed_named_logs` | `{msg}` | Number of log messages routed to a named port. |
-| `processor.signal_type_router.signals_routed_named_metrics` | `{msg}` | Number of metric messages routed to a named port. |
-| `processor.signal_type_router.signals_routed_named_traces` | `{msg}` | Number of trace messages routed to a named port. |
-| `processor.signal_type_router.signals_routed_default_logs` | `{msg}` | Number of log messages routed via the default port. |
-| `processor.signal_type_router.signals_routed_default_metrics` | `{msg}` | Number of metric messages routed via the default port. |
-| `processor.signal_type_router.signals_routed_default_traces` | `{msg}` | Number of trace messages routed via the default port. |
-| `processor.signal_type_router.signals_nacked_logs` | `{msg}` | Number of log messages NACKed due to route-local rejection. |
-| `processor.signal_type_router.signals_nacked_metrics` | `{msg}` | Number of metric messages NACKed due to route-local rejection. |
-| `processor.signal_type_router.signals_nacked_traces` | `{msg}` | Number of trace messages NACKed due to route-local rejection. |
-| `processor.signal_type_router.signals_rejected_route_full_logs` | `{msg}` | Number of log messages rejected because the selected route was full. |
-| `processor.signal_type_router.signals_rejected_route_full_metrics` | `{msg}` | Number of metric messages rejected because the selected route was full. |
-| `processor.signal_type_router.signals_rejected_route_full_traces` | `{msg}` | Number of trace messages rejected because the selected route was full. |
-| `processor.signal_type_router.signals_rejected_route_closed_logs` | `{msg}` | Number of log messages rejected because the selected route was closed. |
-| `processor.signal_type_router.signals_rejected_route_closed_metrics` | `{msg}` | Number of metric messages rejected because the selected route was closed. |
-| `processor.signal_type_router.signals_rejected_route_closed_traces` | `{msg}` | Number of trace messages rejected because the selected route was closed. |
-| `processor.signal_type_router.signals_dropped_logs` | `{msg}` | Number of log messages dropped due to routing failure. |
-| `processor.signal_type_router.signals_dropped_metrics` | `{msg}` | Number of metric messages dropped due to routing failure. |
-| `processor.signal_type_router.signals_dropped_traces` | `{msg}` | Number of trace messages dropped due to routing failure. |
+| `processor.type_router.signals.decision` | `{message}` | Number of messages with a given routing outcome. |
+
+The `signals.decision` metric includes `outcome` and `reason` attributes to describe the terminal routing result:
+
+| Terminal routing result | `outcome` | `reason` |
+| --- | --- | --- |
+| Named signal output accepted | `success` | `named_route` |
+| Default accepted because the named output is unwired | `success` | `default_route_unwired` |
+| Selected output is full | `refused` | `route_full` |
+| Selected output is closed | `refused` | `route_closed` |
+| Neither the named nor default output exists | `failure` | `no_available_route` |
+| Shutdown cancels parked work | `failure` | `node_shutdown` |
 
 ### Events
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/signal_type_router/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/signal_type_router/mod.rs
@@ -59,10 +59,11 @@ use otap_df_engine::{
 };
 use otap_df_otap::OTAP_PROCESSOR_FACTORIES;
 use otap_df_otap::pdata::OtapPdata;
+use otap_df_telemetry::common_attributes::Outcome;
 use otap_df_telemetry::instrument::Counter;
 use otap_df_telemetry::metrics::MeasurementMetricSet;
-use otap_df_telemetry::common_attributes::SignalAttributes;
-use otap_df_telemetry_macros::metric_set;
+use otap_df_telemetry::reporter::MetricsReporter;
+use otap_df_telemetry_macros::{AttributeEnum, attribute_set, metric_set};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -83,39 +84,86 @@ pub const PORT_METRICS: &str = "metrics";
 /// Name of the output port used for log signals
 pub const PORT_LOGS: &str = "logs";
 
-/// Metrics for the SignalTypeRouter processor.
-#[metric_set(name = "processor.signal_type_router", measurement_attributes = SignalAttributes)]
-#[derive(Debug, Default, Clone)]
-pub struct SignalTypeRouterMetrics {
-    /// Number of messages received by the router.
-    #[metric(name = "signals.received", unit = "{msg}")]
-    pub signals_received: Counter<u64>,
-
-    /// Number of messages routed to a named port.
-    #[metric(name = "signals.routed.named", unit = "{msg}")]
-    pub signals_routed_named: Counter<u64>,
-
-    /// Number of messages routed via the default port.
-    #[metric(name = "signals.routed.default", unit = "{msg}")]
-    pub signals_routed_default: Counter<u64>,
-
-    /// Number of messages NACKed due to route-local rejection.
-    #[metric(name = "signals.nacked", unit = "{msg}")]
-    pub signals_nacked: Counter<u64>,
-
-    /// Number of messages rejected because the selected route was full.
-    #[metric(name = "signals.rejected.route.full", unit = "{msg}")]
-    pub signals_rejected_route_full: Counter<u64>,
-
-    /// Number of messages rejected because the selected route was closed.
-    #[metric(name = "signals.rejected.route.closed", unit = "{msg}")]
-    pub signals_rejected_route_closed: Counter<u64>,
-
-    /// Number of messages dropped due to routing failure.
-    #[metric(name = "signals.dropped", unit = "{msg}")]
-    pub signals_dropped: Counter<u64>,
+/// Specific reasons for SignalTypeRouter outcomes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, AttributeEnum)]
+pub enum SignalTypeRouterReason {
+    /// Routed to a named port.
+    MatchedRoute,
+    /// Routed to default because named port was not connected.
+    DefaultRouteNoMatch,
+    /// NACKed because the selected route was full.
+    RouteFull,
+    /// NACKed because the selected route was closed.
+    RouteClosed,
+    /// Dropped because no matching named or default route exists.
+    NoMatchingRoute,
+    /// NACKed because the node was shutting down.
+    NodeShutdown,
 }
 
+/// Attributes for SignalTypeRouter outcome metric.
+#[attribute_set(item, measurement)]
+#[derive(Debug, Clone, Copy)]
+pub struct SignalTypeRouterAttributes {
+    /// The telemetry signal type.
+    pub signal: otap_df_config::SignalType,
+    /// General outcome of the routing decision.
+    pub outcome: Outcome,
+    /// Specific reason for the outcome.
+    pub reason: SignalTypeRouterReason,
+}
+
+/// Measurement metrics for the SignalTypeRouter processor.
+#[metric_set(
+    name = "processor.signal_type_router",
+    measurement_attributes = SignalTypeRouterAttributes
+)]
+#[derive(Debug, Default, Clone)]
+pub struct SignalTypeRouterMeasurementMetrics {
+    /// Number of messages with this outcome.
+    #[metric(name = "signals.decision", unit = "{msg}")]
+    pub messages: Counter<u64>,
+}
+
+/// Metrics for the SignalTypeRouter processor.
+pub struct SignalTypeRouterMetrics {
+    /// Measurement metric set for outcomes.
+    pub metrics: MeasurementMetricSet<SignalTypeRouterMeasurementMetrics>,
+}
+
+impl SignalTypeRouterMetrics {
+    /// Creates a new SignalTypeRouterMetrics.
+    pub fn new(pipeline_ctx: &PipelineContext) -> Self {
+        Self {
+            metrics: SignalTypeRouterMeasurementMetrics::register(pipeline_ctx),
+        }
+    }
+
+    /// Reports the metrics.
+    pub fn report(
+        &mut self,
+        reporter: &mut MetricsReporter,
+    ) -> Result<(), otap_df_telemetry::error::Error> {
+        reporter.report_measurement(&mut self.metrics)
+    }
+
+    /// Records a specific outcome and reason.
+    pub fn record(
+        &mut self,
+        signal: otap_df_config::SignalType,
+        outcome: Outcome,
+        reason: SignalTypeRouterReason,
+    ) {
+        self.metrics
+            .with(SignalTypeRouterAttributes {
+                signal,
+                outcome,
+                reason,
+            })
+            .messages
+            .inc();
+    }
+}
 
 /// Minimal configuration for the SignalTypeRouter processor
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -148,7 +196,7 @@ pub struct SignalTypeRouter {
     /// Selected-route admission scheduler.
     admission: ExclusiveRouteScheduler<OtapPdata, SelectedRouteContext>,
     /// Telemetry metrics for this router (optional when constructed without PipelineContext)
-    metrics: Option<MeasurementMetricSet<SignalTypeRouterMetrics>>,
+    metrics: Option<SignalTypeRouterMetrics>,
 }
 
 impl SignalTypeRouter {
@@ -168,7 +216,7 @@ impl SignalTypeRouter {
         pipeline_ctx: PipelineContext,
         config: SignalTypeRouterConfig,
     ) -> Self {
-        let metrics = SignalTypeRouterMetrics::register(&pipeline_ctx);
+        let metrics = SignalTypeRouterMetrics::new(&pipeline_ctx);
         let mut router = Self::new(config);
         router.metrics = Some(metrics);
         router
@@ -181,8 +229,16 @@ impl SignalTypeRouter {
     fn record_forwarded_route(&mut self, context: SelectedRouteContext) {
         if let Some(m) = self.metrics.as_mut() {
             match context.route_kind {
-                SelectedRouteKind::Named => m.with(SignalAttributes { signal: context.signal_type }).signals_routed_named.inc(),
-                SelectedRouteKind::Default => m.with(SignalAttributes { signal: context.signal_type }).signals_routed_default.inc(),
+                SelectedRouteKind::Named => m.record(
+                    context.signal_type,
+                    Outcome::Success,
+                    SignalTypeRouterReason::MatchedRoute,
+                ),
+                SelectedRouteKind::Default => m.record(
+                    context.signal_type,
+                    Outcome::Success,
+                    SignalTypeRouterReason::DefaultRouteNoMatch,
+                ),
             }
         }
     }
@@ -242,8 +298,11 @@ impl SignalTypeRouter {
         data: OtapPdata,
     ) -> Result<(), EngineError> {
         if let Some(m) = self.metrics.as_mut() {
-            m.with(SignalAttributes { signal: signal_type }).signals_nacked.inc();
-            m.with(SignalAttributes { signal: signal_type }).signals_rejected_route_full.inc();
+            m.record(
+                signal_type,
+                Outcome::Refused,
+                SignalTypeRouterReason::RouteFull,
+            );
         }
 
         effect_handler
@@ -265,8 +324,11 @@ impl SignalTypeRouter {
         data: OtapPdata,
     ) -> Result<(), EngineError> {
         if let Some(m) = self.metrics.as_mut() {
-            m.with(SignalAttributes { signal: signal_type }).signals_nacked.inc();
-            m.with(SignalAttributes { signal: signal_type }).signals_rejected_route_closed.inc();
+            m.record(
+                signal_type,
+                Outcome::Refused,
+                SignalTypeRouterReason::RouteClosed,
+            );
         }
 
         effect_handler
@@ -290,7 +352,11 @@ impl SignalTypeRouter {
         reason: &str,
     ) -> Result<(), EngineError> {
         if let Some(m) = self.metrics.as_mut() {
-            m.with(SignalAttributes { signal: signal_type }).signals_nacked.inc();
+            m.record(
+                signal_type,
+                Outcome::Failure,
+                SignalTypeRouterReason::NodeShutdown,
+            );
         }
 
         effect_handler
@@ -429,7 +495,7 @@ impl local::Processor<OtapPdata> for SignalTypeRouter {
                     mut metrics_reporter,
                 } => {
                     if let Some(m) = self.metrics.as_mut() {
-                        let _ = metrics_reporter.report_measurement(m);
+                        let _ = m.report(&mut metrics_reporter);
                     }
                     Ok(())
                 }
@@ -448,9 +514,8 @@ impl local::Processor<OtapPdata> for SignalTypeRouter {
             },
             Message::PData(data) => {
                 let st = data.signal_type();
-                if let Some(m) = self.metrics.as_mut() {
-                    m.with(SignalAttributes { signal: st }).signals_received.inc();
-                }
+                // Notice: we do NOT record received here in Outcome based recording,
+                // received count is derived from summing all outcomes.
 
                 // Resolve the preferred named route first. Falling back is only
                 // allowed when the named port is not wired at all, not when the
@@ -547,7 +612,11 @@ impl local::Processor<OtapPdata> for SignalTypeRouter {
                         ),
                         Err(e) => {
                             if let Some(m) = self.metrics.as_mut() {
-                                m.with(SignalAttributes { signal: st }).signals_dropped.inc();
+                                m.record(
+                                    st,
+                                    Outcome::Failure,
+                                    SignalTypeRouterReason::NoMatchingRoute,
+                                );
                             }
                             Err(e.into())
                         }
@@ -1156,7 +1225,6 @@ mod tests {
                     }
                     for (field, value) in iter {
                         let key = format!("{}{}", field.name, dp_str);
-                        println!("DEBUG METRIC MAP: {} = {}", key, value.to_u64_lossy());
                         let _ = out.insert(key, value.to_u64_lossy());
                     }
                 },
@@ -1305,49 +1373,62 @@ mod tests {
             let signal = signal_name(st);
             assert_eq!(
                 metrics
-                    .get(format!("signals.received signal={signal}").as_str())
-                    .copied()
-                    .unwrap_or(0),
-                1
-            );
-            assert_eq!(
-                metrics
-                    .get(format!("signals.routed.named signal={signal}").as_str())
-                    .copied()
-                    .unwrap_or(0),
-                0
-            );
-            assert_eq!(
-                metrics
-                    .get(format!("signals.routed.default signal={signal}").as_str())
+                    .get(
+                        format!(
+                            "signals.decision outcome=Success reason=MatchedRoute signal={signal}"
+                        )
+                        .as_str()
+                    )
                     .copied()
                     .unwrap_or(0),
                 0
             );
             assert_eq!(
                 metrics
-                    .get(format!("signals.nacked signal={signal}").as_str())
-                    .copied()
-                    .unwrap_or(0),
-                1
-            );
-            assert_eq!(
-                metrics
-                    .get(format!("signals.rejected.route.full signal={signal}").as_str())
-                    .copied()
-                    .unwrap_or(0),
-                1
-            );
-            assert_eq!(
-                metrics
-                    .get(format!("signals.rejected.route.closed signal={signal}").as_str())
+                    .get(format!("signals.decision outcome=Success reason=DefaultRouteNoMatch signal={signal}").as_str())
                     .copied()
                     .unwrap_or(0),
                 0
             );
             assert_eq!(
                 metrics
-                    .get(format!("signals.dropped signal={signal}").as_str())
+                    .get(
+                        format!(
+                            "signals.decision outcome=Failure reason=NodeShutdown signal={signal}"
+                        )
+                        .as_str()
+                    )
+                    .copied()
+                    .unwrap_or(0),
+                1
+            );
+            assert_eq!(
+                metrics
+                    .get(
+                        format!(
+                            "signals.decision outcome=Refused reason=RouteFull signal={signal}"
+                        )
+                        .as_str()
+                    )
+                    .copied()
+                    .unwrap_or(0),
+                1
+            );
+            assert_eq!(
+                metrics
+                    .get(
+                        format!(
+                            "signals.decision outcome=Refused reason=RouteClosed signal={signal}"
+                        )
+                        .as_str()
+                    )
+                    .copied()
+                    .unwrap_or(0),
+                0
+            );
+            assert_eq!(
+                metrics
+                    .get(format!("signals.decision outcome=Failure reason=NoMatchingRoute signal={signal}").as_str())
                     .copied()
                     .unwrap_or(0),
                 0
@@ -1408,24 +1489,33 @@ mod tests {
 
                 let metrics = collect_metrics_map(&telemetry_registry);
                 assert_eq!(
-                    metrics.get("signals.received signal=logs").copied().unwrap_or(0),
-                    1
-                );
-                assert_eq!(
                     metrics
-                        .get("signals.routed.named signal=logs")
+                        .get("signals.received signal=logs")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.routed.default signal=logs")
+                        .get("signals.decision outcome=Success reason=MatchedRoute signal=logs")
+                        .copied()
+                        .unwrap_or(0),
+                    1
+                );
+                assert_eq!(
+                    metrics
+                        .get("signals.decision outcome=Success reason=DefaultRouteNoMatch signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
-                assert_eq!(metrics.get("signals.dropped signal=logs").copied().unwrap_or(0), 0);
+                assert_eq!(
+                    metrics
+                        .get("signals.decision outcome=Failure reason=NoMatchingRoute signal=logs")
+                        .copied()
+                        .unwrap_or(0),
+                    0
+                );
 
                 // shutdown collector
                 stop_telemetry(reporter, collector_task);
@@ -1496,39 +1586,54 @@ mod tests {
 
                 let metrics = collect_metrics_map(&telemetry_registry);
                 assert_eq!(
-                    metrics.get("signals.received signal=logs").copied().unwrap_or(0),
-                    1
-                );
-                assert_eq!(
                     metrics
-                        .get("signals.routed.named signal=logs")
-                        .copied()
-                        .unwrap_or(0),
-                    0
-                );
-                assert_eq!(
-                    metrics
-                        .get("signals.routed.default signal=logs")
-                        .copied()
-                        .unwrap_or(0),
-                    0
-                );
-                assert_eq!(metrics.get("signals.nacked signal=logs").copied().unwrap_or(0), 1);
-                assert_eq!(
-                    metrics
-                        .get("signals.rejected.route.full signal=logs")
-                        .copied()
-                        .unwrap_or(0),
-                    0
-                );
-                assert_eq!(
-                    metrics
-                        .get("signals.rejected.route.closed signal=logs")
+                        .get("signals.received signal=logs")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
-                assert_eq!(metrics.get("signals.dropped signal=logs").copied().unwrap_or(0), 0);
+                assert_eq!(
+                    metrics
+                        .get("signals.decision outcome=Success reason=MatchedRoute signal=logs")
+                        .copied()
+                        .unwrap_or(0),
+                    0
+                );
+                assert_eq!(
+                    metrics
+                        .get("signals.decision outcome=Success reason=DefaultRouteNoMatch signal=logs")
+                        .copied()
+                        .unwrap_or(0),
+                    0
+                );
+                assert_eq!(
+                    metrics
+                        .get("signals.decision outcome=Failure reason=NodeShutdown signal=logs")
+                        .copied()
+                        .unwrap_or(0),
+                    1
+                );
+                assert_eq!(
+                    metrics
+                        .get("signals.decision outcome=Refused reason=RouteFull signal=logs")
+                        .copied()
+                        .unwrap_or(0),
+                    0
+                );
+                assert_eq!(
+                    metrics
+                        .get("signals.decision outcome=Refused reason=RouteClosed signal=logs")
+                        .copied()
+                        .unwrap_or(0),
+                    1
+                );
+                assert_eq!(
+                    metrics
+                        .get("signals.decision outcome=Failure reason=NoMatchingRoute signal=logs")
+                        .copied()
+                        .unwrap_or(0),
+                    0
+                );
 
                 stop_telemetry(reporter, collector_task);
             }));
@@ -1594,24 +1699,33 @@ mod tests {
 
                 let metrics = collect_metrics_map(&telemetry_registry);
                 assert_eq!(
-                    metrics.get("signals.received signal=logs").copied().unwrap_or(0),
+                    metrics
+                        .get("signals.received signal=logs")
+                        .copied()
+                        .unwrap_or(0),
                     1
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.routed.named signal=logs")
+                        .get("signals.decision outcome=Success reason=MatchedRoute signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.routed.default signal=logs")
+                        .get("signals.decision outcome=Success reason=DefaultRouteNoMatch signal=logs")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
-                assert_eq!(metrics.get("signals.dropped signal=logs").copied().unwrap_or(0), 0);
+                assert_eq!(
+                    metrics
+                        .get("signals.decision outcome=Failure reason=NoMatchingRoute signal=logs")
+                        .copied()
+                        .unwrap_or(0),
+                    0
+                );
 
                 stop_telemetry(reporter, collector_task);
             }));
@@ -1679,39 +1793,54 @@ mod tests {
 
                 let metrics = collect_metrics_map(&telemetry_registry);
                 assert_eq!(
-                    metrics.get("signals.received signal=logs").copied().unwrap_or(0),
-                    1
-                );
-                assert_eq!(
                     metrics
-                        .get("signals.routed.named signal=logs")
-                        .copied()
-                        .unwrap_or(0),
-                    0
-                );
-                assert_eq!(
-                    metrics
-                        .get("signals.routed.default signal=logs")
-                        .copied()
-                        .unwrap_or(0),
-                    0
-                );
-                assert_eq!(metrics.get("signals.nacked signal=logs").copied().unwrap_or(0), 1);
-                assert_eq!(
-                    metrics
-                        .get("signals.rejected.route.full signal=logs")
-                        .copied()
-                        .unwrap_or(0),
-                    0
-                );
-                assert_eq!(
-                    metrics
-                        .get("signals.rejected.route.closed signal=logs")
+                        .get("signals.received signal=logs")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
-                assert_eq!(metrics.get("signals.dropped signal=logs").copied().unwrap_or(0), 0);
+                assert_eq!(
+                    metrics
+                        .get("signals.decision outcome=Success reason=MatchedRoute signal=logs")
+                        .copied()
+                        .unwrap_or(0),
+                    0
+                );
+                assert_eq!(
+                    metrics
+                        .get("signals.decision outcome=Success reason=DefaultRouteNoMatch signal=logs")
+                        .copied()
+                        .unwrap_or(0),
+                    0
+                );
+                assert_eq!(
+                    metrics
+                        .get("signals.decision outcome=Failure reason=NodeShutdown signal=logs")
+                        .copied()
+                        .unwrap_or(0),
+                    1
+                );
+                assert_eq!(
+                    metrics
+                        .get("signals.decision outcome=Refused reason=RouteFull signal=logs")
+                        .copied()
+                        .unwrap_or(0),
+                    0
+                );
+                assert_eq!(
+                    metrics
+                        .get("signals.decision outcome=Refused reason=RouteClosed signal=logs")
+                        .copied()
+                        .unwrap_or(0),
+                    1
+                );
+                assert_eq!(
+                    metrics
+                        .get("signals.decision outcome=Failure reason=NoMatchingRoute signal=logs")
+                        .copied()
+                        .unwrap_or(0),
+                    0
+                );
 
                 stop_telemetry(reporter, collector_task);
             }));
@@ -1813,7 +1942,10 @@ mod tests {
                     flush_metrics(&mut router, &mut eh, reporter.clone(), &telemetry_registry)
                         .await;
                 assert_eq!(
-                    metrics.get("signals.received signal=logs").copied().unwrap_or(0),
+                    metrics
+                        .get("signals.received signal=logs")
+                        .copied()
+                        .unwrap_or(0),
                     1
                 );
                 assert_eq!(
@@ -1825,29 +1957,46 @@ mod tests {
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.routed.named signal=logs")
+                        .get("signals.decision outcome=Success reason=MatchedRoute signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.routed.named signal=metrics")
+                        .get("signals.decision outcome=Success reason=MatchedRoute signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
-                assert_eq!(metrics.get("signals.nacked signal=logs").copied().unwrap_or(0), 1);
                 assert_eq!(
                     metrics
-                        .get("signals.rejected.route.full signal=logs")
+                        .get("signals.decision outcome=Failure reason=NodeShutdown signal=logs")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
-                assert_eq!(metrics.get("signals.dropped signal=logs").copied().unwrap_or(0), 0);
                 assert_eq!(
-                    metrics.get("signals.dropped signal=metrics").copied().unwrap_or(0),
+                    metrics
+                        .get("signals.decision outcome=Refused reason=RouteFull signal=logs")
+                        .copied()
+                        .unwrap_or(0),
+                    1
+                );
+                assert_eq!(
+                    metrics
+                        .get("signals.decision outcome=Failure reason=NoMatchingRoute signal=logs")
+                        .copied()
+                        .unwrap_or(0),
+                    0
+                );
+                assert_eq!(
+                    metrics
+                        .get(
+                            "signals.decision outcome=Failure reason=NoMatchingRoute signal=metrics"
+                        )
+                        .copied()
+                        .unwrap_or(0),
                     0
                 );
 
@@ -1897,16 +2046,26 @@ mod tests {
                 tokio::time::sleep(Duration::from_millis(50)).await;
 
                 let m = collect_metrics_map(&telemetry_registry);
-                assert_eq!(m.get("signals.received signal=traces").copied().unwrap_or(0), 1);
                 assert_eq!(
-                    m.get("signals.routed.named signal=traces").copied().unwrap_or(0),
+                    m.get("signals.decision outcome=Success reason=MatchedRoute signal=traces")
+                        .copied()
+                        .unwrap_or(0),
                     1
                 );
                 assert_eq!(
-                    m.get("signals.routed.default signal=traces").copied().unwrap_or(0),
+                    m.get(
+                        "signals.decision outcome=Success reason=DefaultRouteNoMatch signal=traces"
+                    )
+                    .copied()
+                    .unwrap_or(0),
                     0
                 );
-                assert_eq!(m.get("signals.dropped signal=traces").copied().unwrap_or(0), 0);
+                assert_eq!(
+                    m.get("signals.decision outcome=Failure reason=NoMatchingRoute signal=traces")
+                        .copied()
+                        .unwrap_or(0),
+                    0
+                );
 
                 stop_telemetry(reporter, collector_task);
             }));
@@ -1957,29 +2116,44 @@ mod tests {
                 tokio::time::sleep(Duration::from_millis(50)).await;
 
                 let m = collect_metrics_map(&telemetry_registry);
-                assert_eq!(m.get("signals.received signal=traces").copied().unwrap_or(0), 1);
                 assert_eq!(
-                    m.get("signals.routed.named signal=traces").copied().unwrap_or(0),
-                    0
-                );
-                assert_eq!(
-                    m.get("signals.routed.default signal=traces").copied().unwrap_or(0),
-                    0
-                );
-                assert_eq!(m.get("signals.nacked signal=traces").copied().unwrap_or(0), 1);
-                assert_eq!(
-                    m.get("signals.rejected.route.full signal=traces")
+                    m.get("signals.decision outcome=Success reason=MatchedRoute signal=traces")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
-                    m.get("signals.rejected.route.closed signal=traces")
+                    m.get(
+                        "signals.decision outcome=Success reason=DefaultRouteNoMatch signal=traces"
+                    )
+                    .copied()
+                    .unwrap_or(0),
+                    0
+                );
+                assert_eq!(
+                    m.get("signals.decision outcome=Failure reason=NodeShutdown signal=traces")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
-                assert_eq!(m.get("signals.dropped signal=traces").copied().unwrap_or(0), 0);
+                assert_eq!(
+                    m.get("signals.decision outcome=Refused reason=RouteFull signal=traces")
+                        .copied()
+                        .unwrap_or(0),
+                    0
+                );
+                assert_eq!(
+                    m.get("signals.decision outcome=Refused reason=RouteClosed signal=traces")
+                        .copied()
+                        .unwrap_or(0),
+                    1
+                );
+                assert_eq!(
+                    m.get("signals.decision outcome=Failure reason=NoMatchingRoute signal=traces")
+                        .copied()
+                        .unwrap_or(0),
+                    0
+                );
 
                 stop_telemetry(reporter, collector_task);
             }));
@@ -2041,16 +2215,26 @@ mod tests {
                 tokio::time::sleep(Duration::from_millis(50)).await;
 
                 let m = collect_metrics_map(&telemetry_registry);
-                assert_eq!(m.get("signals.received signal=traces").copied().unwrap_or(0), 1);
                 assert_eq!(
-                    m.get("signals.routed.named signal=traces").copied().unwrap_or(0),
+                    m.get("signals.decision outcome=Success reason=MatchedRoute signal=traces")
+                        .copied()
+                        .unwrap_or(0),
                     0
                 );
                 assert_eq!(
-                    m.get("signals.routed.default signal=traces").copied().unwrap_or(0),
+                    m.get(
+                        "signals.decision outcome=Success reason=DefaultRouteNoMatch signal=traces"
+                    )
+                    .copied()
+                    .unwrap_or(0),
                     1
                 );
-                assert_eq!(m.get("signals.dropped signal=traces").copied().unwrap_or(0), 0);
+                assert_eq!(
+                    m.get("signals.decision outcome=Failure reason=NoMatchingRoute signal=traces")
+                        .copied()
+                        .unwrap_or(0),
+                    0
+                );
 
                 stop_telemetry(reporter, collector_task);
             }));
@@ -2101,29 +2285,44 @@ mod tests {
                 tokio::time::sleep(Duration::from_millis(50)).await;
 
                 let m = collect_metrics_map(&telemetry_registry);
-                assert_eq!(m.get("signals.received signal=traces").copied().unwrap_or(0), 1);
                 assert_eq!(
-                    m.get("signals.routed.named signal=traces").copied().unwrap_or(0),
-                    0
-                );
-                assert_eq!(
-                    m.get("signals.routed.default signal=traces").copied().unwrap_or(0),
-                    0
-                );
-                assert_eq!(m.get("signals.nacked signal=traces").copied().unwrap_or(0), 1);
-                assert_eq!(
-                    m.get("signals.rejected.route.full signal=traces")
+                    m.get("signals.decision outcome=Success reason=MatchedRoute signal=traces")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
-                    m.get("signals.rejected.route.closed signal=traces")
+                    m.get(
+                        "signals.decision outcome=Success reason=DefaultRouteNoMatch signal=traces"
+                    )
+                    .copied()
+                    .unwrap_or(0),
+                    0
+                );
+                assert_eq!(
+                    m.get("signals.decision outcome=Failure reason=NodeShutdown signal=traces")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
-                assert_eq!(m.get("signals.dropped signal=traces").copied().unwrap_or(0), 0);
+                assert_eq!(
+                    m.get("signals.decision outcome=Refused reason=RouteFull signal=traces")
+                        .copied()
+                        .unwrap_or(0),
+                    0
+                );
+                assert_eq!(
+                    m.get("signals.decision outcome=Refused reason=RouteClosed signal=traces")
+                        .copied()
+                        .unwrap_or(0),
+                    1
+                );
+                assert_eq!(
+                    m.get("signals.decision outcome=Failure reason=NoMatchingRoute signal=traces")
+                        .copied()
+                        .unwrap_or(0),
+                    0
+                );
 
                 stop_telemetry(reporter, collector_task);
             }));
@@ -2186,18 +2385,26 @@ mod tests {
                 tokio::time::sleep(Duration::from_millis(50)).await;
 
                 let m = collect_metrics_map(&telemetry_registry);
-                assert_eq!(m.get("signals.received signal=metrics").copied().unwrap_or(0), 1);
                 assert_eq!(
-                    m.get("signals.routed.named signal=metrics").copied().unwrap_or(0),
+                    m.get("signals.decision outcome=Success reason=MatchedRoute signal=metrics")
+                        .copied()
+                        .unwrap_or(0),
                     1
                 );
                 assert_eq!(
-                    m.get("signals.routed.default signal=metrics")
+                    m.get(
+                        "signals.decision outcome=Success reason=DefaultRouteNoMatch signal=metrics"
+                    )
+                    .copied()
+                    .unwrap_or(0),
+                    0
+                );
+                assert_eq!(
+                    m.get("signals.decision outcome=Failure reason=NoMatchingRoute signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
-                assert_eq!(m.get("signals.dropped signal=metrics").copied().unwrap_or(0), 0);
 
                 stop_telemetry(reporter, collector_task);
             }));
@@ -2248,31 +2455,44 @@ mod tests {
                 tokio::time::sleep(Duration::from_millis(50)).await;
 
                 let m = collect_metrics_map(&telemetry_registry);
-                assert_eq!(m.get("signals.received signal=metrics").copied().unwrap_or(0), 1);
                 assert_eq!(
-                    m.get("signals.routed.named signal=metrics").copied().unwrap_or(0),
-                    0
-                );
-                assert_eq!(
-                    m.get("signals.routed.default signal=metrics")
-                        .copied()
-                        .unwrap_or(0),
-                    0
-                );
-                assert_eq!(m.get("signals.nacked signal=metrics").copied().unwrap_or(0), 1);
-                assert_eq!(
-                    m.get("signals.rejected.route.full signal=metrics")
+                    m.get("signals.decision outcome=Success reason=MatchedRoute signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
-                    m.get("signals.rejected.route.closed signal=metrics")
+                    m.get(
+                        "signals.decision outcome=Success reason=DefaultRouteNoMatch signal=metrics"
+                    )
+                    .copied()
+                    .unwrap_or(0),
+                    0
+                );
+                assert_eq!(
+                    m.get("signals.decision outcome=Failure reason=NodeShutdown signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
-                assert_eq!(m.get("signals.dropped signal=metrics").copied().unwrap_or(0), 0);
+                assert_eq!(
+                    m.get("signals.decision outcome=Refused reason=RouteFull signal=metrics")
+                        .copied()
+                        .unwrap_or(0),
+                    0
+                );
+                assert_eq!(
+                    m.get("signals.decision outcome=Refused reason=RouteClosed signal=metrics")
+                        .copied()
+                        .unwrap_or(0),
+                    1
+                );
+                assert_eq!(
+                    m.get("signals.decision outcome=Failure reason=NoMatchingRoute signal=metrics")
+                        .copied()
+                        .unwrap_or(0),
+                    0
+                );
 
                 stop_telemetry(reporter, collector_task);
             }));
@@ -2334,18 +2554,26 @@ mod tests {
                 tokio::time::sleep(Duration::from_millis(50)).await;
 
                 let m = collect_metrics_map(&telemetry_registry);
-                assert_eq!(m.get("signals.received signal=metrics").copied().unwrap_or(0), 1);
                 assert_eq!(
-                    m.get("signals.routed.named signal=metrics").copied().unwrap_or(0),
+                    m.get("signals.decision outcome=Success reason=MatchedRoute signal=metrics")
+                        .copied()
+                        .unwrap_or(0),
                     0
                 );
                 assert_eq!(
-                    m.get("signals.routed.default signal=metrics")
-                        .copied()
-                        .unwrap_or(0),
+                    m.get(
+                        "signals.decision outcome=Success reason=DefaultRouteNoMatch signal=metrics"
+                    )
+                    .copied()
+                    .unwrap_or(0),
                     1
                 );
-                assert_eq!(m.get("signals.dropped signal=metrics").copied().unwrap_or(0), 0);
+                assert_eq!(
+                    m.get("signals.decision outcome=Failure reason=NoMatchingRoute signal=metrics")
+                        .copied()
+                        .unwrap_or(0),
+                    0
+                );
 
                 stop_telemetry(reporter, collector_task);
             }));
@@ -2396,31 +2624,44 @@ mod tests {
                 tokio::time::sleep(Duration::from_millis(50)).await;
 
                 let m = collect_metrics_map(&telemetry_registry);
-                assert_eq!(m.get("signals.received signal=metrics").copied().unwrap_or(0), 1);
                 assert_eq!(
-                    m.get("signals.routed.named signal=metrics").copied().unwrap_or(0),
-                    0
-                );
-                assert_eq!(
-                    m.get("signals.routed.default signal=metrics")
-                        .copied()
-                        .unwrap_or(0),
-                    0
-                );
-                assert_eq!(m.get("signals.nacked signal=metrics").copied().unwrap_or(0), 1);
-                assert_eq!(
-                    m.get("signals.rejected.route.full signal=metrics")
+                    m.get("signals.decision outcome=Success reason=MatchedRoute signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
-                    m.get("signals.rejected.route.closed signal=metrics")
+                    m.get(
+                        "signals.decision outcome=Success reason=DefaultRouteNoMatch signal=metrics"
+                    )
+                    .copied()
+                    .unwrap_or(0),
+                    0
+                );
+                assert_eq!(
+                    m.get("signals.decision outcome=Failure reason=NodeShutdown signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
-                assert_eq!(m.get("signals.dropped signal=metrics").copied().unwrap_or(0), 0);
+                assert_eq!(
+                    m.get("signals.decision outcome=Refused reason=RouteFull signal=metrics")
+                        .copied()
+                        .unwrap_or(0),
+                    0
+                );
+                assert_eq!(
+                    m.get("signals.decision outcome=Refused reason=RouteClosed signal=metrics")
+                        .copied()
+                        .unwrap_or(0),
+                    1
+                );
+                assert_eq!(
+                    m.get("signals.decision outcome=Failure reason=NoMatchingRoute signal=metrics")
+                        .copied()
+                        .unwrap_or(0),
+                    0
+                );
 
                 stop_telemetry(reporter, collector_task);
             }));

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/signal_type_router/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/signal_type_router/mod.rs
@@ -1400,7 +1400,7 @@ mod tests {
                     )
                     .copied()
                     .unwrap_or(0),
-                1
+                0
             );
             assert_eq!(
                 metrics
@@ -1488,14 +1488,8 @@ mod tests {
                 tokio::time::sleep(Duration::from_millis(50)).await;
 
                 let metrics = collect_metrics_map(&telemetry_registry);
-                assert_eq!(
-                    metrics
-                        .get("signals.received signal=logs")
-                        .copied()
-                        .unwrap_or(0),
-                    1
-                );
-                assert_eq!(
+
+assert_eq!(
                     metrics
                         .get("signals.decision outcome=Success reason=MatchedRoute signal=logs")
                         .copied()
@@ -1585,14 +1579,8 @@ mod tests {
                 tokio::time::sleep(Duration::from_millis(50)).await;
 
                 let metrics = collect_metrics_map(&telemetry_registry);
-                assert_eq!(
-                    metrics
-                        .get("signals.received signal=logs")
-                        .copied()
-                        .unwrap_or(0),
-                    1
-                );
-                assert_eq!(
+
+assert_eq!(
                     metrics
                         .get("signals.decision outcome=Success reason=MatchedRoute signal=logs")
                         .copied()
@@ -1698,14 +1686,8 @@ mod tests {
                 tokio::time::sleep(Duration::from_millis(50)).await;
 
                 let metrics = collect_metrics_map(&telemetry_registry);
-                assert_eq!(
-                    metrics
-                        .get("signals.received signal=logs")
-                        .copied()
-                        .unwrap_or(0),
-                    1
-                );
-                assert_eq!(
+
+assert_eq!(
                     metrics
                         .get("signals.decision outcome=Success reason=MatchedRoute signal=logs")
                         .copied()
@@ -1792,14 +1774,8 @@ mod tests {
                 tokio::time::sleep(Duration::from_millis(50)).await;
 
                 let metrics = collect_metrics_map(&telemetry_registry);
-                assert_eq!(
-                    metrics
-                        .get("signals.received signal=logs")
-                        .copied()
-                        .unwrap_or(0),
-                    1
-                );
-                assert_eq!(
+
+assert_eq!(
                     metrics
                         .get("signals.decision outcome=Success reason=MatchedRoute signal=logs")
                         .copied()
@@ -1941,20 +1917,7 @@ mod tests {
                 let metrics =
                     flush_metrics(&mut router, &mut eh, reporter.clone(), &telemetry_registry)
                         .await;
-                assert_eq!(
-                    metrics
-                        .get("signals.received signal=logs")
-                        .copied()
-                        .unwrap_or(0),
-                    1
-                );
-                assert_eq!(
-                    metrics
-                        .get("signals.received signal=metrics")
-                        .copied()
-                        .unwrap_or(0),
-                    1
-                );
+
                 assert_eq!(
                     metrics
                         .get("signals.decision outcome=Success reason=MatchedRoute signal=logs")
@@ -2134,7 +2097,7 @@ mod tests {
                     m.get("signals.decision outcome=Failure reason=NodeShutdown signal=traces")
                         .copied()
                         .unwrap_or(0),
-                    1
+                    0
                 );
                 assert_eq!(
                     m.get("signals.decision outcome=Refused reason=RouteFull signal=traces")
@@ -2303,7 +2266,7 @@ mod tests {
                     m.get("signals.decision outcome=Failure reason=NodeShutdown signal=traces")
                         .copied()
                         .unwrap_or(0),
-                    1
+                    0
                 );
                 assert_eq!(
                     m.get("signals.decision outcome=Refused reason=RouteFull signal=traces")
@@ -2473,7 +2436,7 @@ mod tests {
                     m.get("signals.decision outcome=Failure reason=NodeShutdown signal=metrics")
                         .copied()
                         .unwrap_or(0),
-                    1
+                    0
                 );
                 assert_eq!(
                     m.get("signals.decision outcome=Refused reason=RouteFull signal=metrics")
@@ -2642,7 +2605,7 @@ mod tests {
                     m.get("signals.decision outcome=Failure reason=NodeShutdown signal=metrics")
                         .copied()
                         .unwrap_or(0),
-                    1
+                    0
                 );
                 assert_eq!(
                     m.get("signals.decision outcome=Refused reason=RouteFull signal=metrics")

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/signal_type_router/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/signal_type_router/mod.rs
@@ -88,15 +88,15 @@ pub const PORT_LOGS: &str = "logs";
 #[derive(Debug, Clone, Copy, PartialEq, Eq, AttributeEnum)]
 pub enum SignalTypeRouterReason {
     /// Routed to a named port.
-    MatchedRoute,
+    NamedRoute,
     /// Routed to default because named port was not connected.
-    DefaultRouteNoMatch,
+    DefaultRouteUnwired,
     /// NACKed because the selected route was full.
     RouteFull,
     /// NACKed because the selected route was closed.
     RouteClosed,
     /// Dropped because no matching named or default route exists.
-    NoMatchingRoute,
+    NoAvailableRoute,
     /// NACKed because the node was shutting down.
     NodeShutdown,
 }
@@ -115,13 +115,13 @@ pub struct SignalTypeRouterAttributes {
 
 /// Measurement metrics for the SignalTypeRouter processor.
 #[metric_set(
-    name = "processor.signal_type_router",
+    name = "processor.type_router",
     measurement_attributes = SignalTypeRouterAttributes
 )]
 #[derive(Debug, Default, Clone)]
 pub struct SignalTypeRouterMeasurementMetrics {
     /// Number of messages with this outcome.
-    #[metric(name = "signals.decision", unit = "{msg}")]
+    #[metric(name = "signals.decision", unit = "{message}")]
     pub messages: Counter<u64>,
 }
 
@@ -232,12 +232,12 @@ impl SignalTypeRouter {
                 SelectedRouteKind::Named => m.record(
                     context.signal_type,
                     Outcome::Success,
-                    SignalTypeRouterReason::MatchedRoute,
+                    SignalTypeRouterReason::NamedRoute,
                 ),
                 SelectedRouteKind::Default => m.record(
                     context.signal_type,
                     Outcome::Success,
-                    SignalTypeRouterReason::DefaultRouteNoMatch,
+                    SignalTypeRouterReason::DefaultRouteUnwired,
                 ),
             }
         }
@@ -515,7 +515,7 @@ impl local::Processor<OtapPdata> for SignalTypeRouter {
             Message::PData(data) => {
                 let st = data.signal_type();
                 // Notice: we do NOT record received here in Outcome based recording,
-                // received count is derived from summing all outcomes.
+                // prefer using the node consumed metric instead.
 
                 // Resolve the preferred named route first. Falling back is only
                 // allowed when the named port is not wired at all, not when the
@@ -615,7 +615,7 @@ impl local::Processor<OtapPdata> for SignalTypeRouter {
                                 m.record(
                                     st,
                                     Outcome::Failure,
-                                    SignalTypeRouterReason::NoMatchingRoute,
+                                    SignalTypeRouterReason::NoAvailableRoute,
                                 );
                             }
                             Err(e.into())
@@ -1375,7 +1375,7 @@ mod tests {
                 metrics
                     .get(
                         format!(
-                            "signals.decision outcome=success reason=matched_route signal={signal}"
+                            "signals.decision outcome=success reason=named_route signal={signal}"
                         )
                         .as_str()
                     )
@@ -1385,7 +1385,7 @@ mod tests {
             );
             assert_eq!(
                 metrics
-                    .get(format!("signals.decision outcome=success reason=default_route_no_match signal={signal}").as_str())
+                    .get(format!("signals.decision outcome=success reason=default_route_unwired signal={signal}").as_str())
                     .copied()
                     .unwrap_or(0),
                 0
@@ -1428,7 +1428,7 @@ mod tests {
             );
             assert_eq!(
                 metrics
-                    .get(format!("signals.decision outcome=failure reason=no_matching_route signal={signal}").as_str())
+                    .get(format!("signals.decision outcome=failure reason=no_available_route signal={signal}").as_str())
                     .copied()
                     .unwrap_or(0),
                 0
@@ -1491,21 +1491,21 @@ mod tests {
 
 assert_eq!(
                     metrics
-                        .get("signals.decision outcome=success reason=matched_route signal=logs")
+                        .get("signals.decision outcome=success reason=named_route signal=logs")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.decision outcome=success reason=default_route_no_match signal=logs")
+                        .get("signals.decision outcome=success reason=default_route_unwired signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.decision outcome=failure reason=no_matching_route signal=logs")
+                        .get("signals.decision outcome=failure reason=no_available_route signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
@@ -1582,14 +1582,14 @@ assert_eq!(
 
 assert_eq!(
                     metrics
-                        .get("signals.decision outcome=success reason=matched_route signal=logs")
+                        .get("signals.decision outcome=success reason=named_route signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.decision outcome=success reason=default_route_no_match signal=logs")
+                        .get("signals.decision outcome=success reason=default_route_unwired signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
@@ -1617,7 +1617,7 @@ assert_eq!(
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.decision outcome=failure reason=no_matching_route signal=logs")
+                        .get("signals.decision outcome=failure reason=no_available_route signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
@@ -1689,21 +1689,21 @@ assert_eq!(
 
 assert_eq!(
                     metrics
-                        .get("signals.decision outcome=success reason=matched_route signal=logs")
+                        .get("signals.decision outcome=success reason=named_route signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.decision outcome=success reason=default_route_no_match signal=logs")
+                        .get("signals.decision outcome=success reason=default_route_unwired signal=logs")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.decision outcome=failure reason=no_matching_route signal=logs")
+                        .get("signals.decision outcome=failure reason=no_available_route signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
@@ -1777,14 +1777,14 @@ assert_eq!(
 
 assert_eq!(
                     metrics
-                        .get("signals.decision outcome=success reason=matched_route signal=logs")
+                        .get("signals.decision outcome=success reason=named_route signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.decision outcome=success reason=default_route_no_match signal=logs")
+                        .get("signals.decision outcome=success reason=default_route_unwired signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
@@ -1812,7 +1812,7 @@ assert_eq!(
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.decision outcome=failure reason=no_matching_route signal=logs")
+                        .get("signals.decision outcome=failure reason=no_available_route signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
@@ -1920,14 +1920,14 @@ assert_eq!(
 
                 assert_eq!(
                     metrics
-                        .get("signals.decision outcome=success reason=matched_route signal=logs")
+                        .get("signals.decision outcome=success reason=named_route signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.decision outcome=success reason=matched_route signal=metrics")
+                        .get("signals.decision outcome=success reason=named_route signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     1
@@ -1948,7 +1948,7 @@ assert_eq!(
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.decision outcome=failure reason=no_matching_route signal=logs")
+                        .get("signals.decision outcome=failure reason=no_available_route signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
@@ -1956,7 +1956,7 @@ assert_eq!(
                 assert_eq!(
                     metrics
                         .get(
-                            "signals.decision outcome=failure reason=no_matching_route signal=metrics"
+                            "signals.decision outcome=failure reason=no_available_route signal=metrics"
                         )
                         .copied()
                         .unwrap_or(0),
@@ -2010,21 +2010,21 @@ assert_eq!(
 
                 let m = collect_metrics_map(&telemetry_registry);
                 assert_eq!(
-                    m.get("signals.decision outcome=success reason=matched_route signal=traces")
+                    m.get("signals.decision outcome=success reason=named_route signal=traces")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
                 assert_eq!(
                     m.get(
-                        "signals.decision outcome=success reason=default_route_no_match signal=traces"
+                        "signals.decision outcome=success reason=default_route_unwired signal=traces"
                     )
                     .copied()
                     .unwrap_or(0),
                     0
                 );
                 assert_eq!(
-                    m.get("signals.decision outcome=failure reason=no_matching_route signal=traces")
+                    m.get("signals.decision outcome=failure reason=no_available_route signal=traces")
                         .copied()
                         .unwrap_or(0),
                     0
@@ -2080,14 +2080,14 @@ assert_eq!(
 
                 let m = collect_metrics_map(&telemetry_registry);
                 assert_eq!(
-                    m.get("signals.decision outcome=success reason=matched_route signal=traces")
+                    m.get("signals.decision outcome=success reason=named_route signal=traces")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
                     m.get(
-                        "signals.decision outcome=success reason=default_route_no_match signal=traces"
+                        "signals.decision outcome=success reason=default_route_unwired signal=traces"
                     )
                     .copied()
                     .unwrap_or(0),
@@ -2112,7 +2112,7 @@ assert_eq!(
                     1
                 );
                 assert_eq!(
-                    m.get("signals.decision outcome=failure reason=no_matching_route signal=traces")
+                    m.get("signals.decision outcome=failure reason=no_available_route signal=traces")
                         .copied()
                         .unwrap_or(0),
                     0
@@ -2179,21 +2179,21 @@ assert_eq!(
 
                 let m = collect_metrics_map(&telemetry_registry);
                 assert_eq!(
-                    m.get("signals.decision outcome=success reason=matched_route signal=traces")
+                    m.get("signals.decision outcome=success reason=named_route signal=traces")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
                     m.get(
-                        "signals.decision outcome=success reason=default_route_no_match signal=traces"
+                        "signals.decision outcome=success reason=default_route_unwired signal=traces"
                     )
                     .copied()
                     .unwrap_or(0),
                     1
                 );
                 assert_eq!(
-                    m.get("signals.decision outcome=failure reason=no_matching_route signal=traces")
+                    m.get("signals.decision outcome=failure reason=no_available_route signal=traces")
                         .copied()
                         .unwrap_or(0),
                     0
@@ -2249,14 +2249,14 @@ assert_eq!(
 
                 let m = collect_metrics_map(&telemetry_registry);
                 assert_eq!(
-                    m.get("signals.decision outcome=success reason=matched_route signal=traces")
+                    m.get("signals.decision outcome=success reason=named_route signal=traces")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
                     m.get(
-                        "signals.decision outcome=success reason=default_route_no_match signal=traces"
+                        "signals.decision outcome=success reason=default_route_unwired signal=traces"
                     )
                     .copied()
                     .unwrap_or(0),
@@ -2281,7 +2281,7 @@ assert_eq!(
                     1
                 );
                 assert_eq!(
-                    m.get("signals.decision outcome=failure reason=no_matching_route signal=traces")
+                    m.get("signals.decision outcome=failure reason=no_available_route signal=traces")
                         .copied()
                         .unwrap_or(0),
                     0
@@ -2349,21 +2349,21 @@ assert_eq!(
 
                 let m = collect_metrics_map(&telemetry_registry);
                 assert_eq!(
-                    m.get("signals.decision outcome=success reason=matched_route signal=metrics")
+                    m.get("signals.decision outcome=success reason=named_route signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
                 assert_eq!(
                     m.get(
-                        "signals.decision outcome=success reason=default_route_no_match signal=metrics"
+                        "signals.decision outcome=success reason=default_route_unwired signal=metrics"
                     )
                     .copied()
                     .unwrap_or(0),
                     0
                 );
                 assert_eq!(
-                    m.get("signals.decision outcome=failure reason=no_matching_route signal=metrics")
+                    m.get("signals.decision outcome=failure reason=no_available_route signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     0
@@ -2419,14 +2419,14 @@ assert_eq!(
 
                 let m = collect_metrics_map(&telemetry_registry);
                 assert_eq!(
-                    m.get("signals.decision outcome=success reason=matched_route signal=metrics")
+                    m.get("signals.decision outcome=success reason=named_route signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
                     m.get(
-                        "signals.decision outcome=success reason=default_route_no_match signal=metrics"
+                        "signals.decision outcome=success reason=default_route_unwired signal=metrics"
                     )
                     .copied()
                     .unwrap_or(0),
@@ -2451,7 +2451,7 @@ assert_eq!(
                     1
                 );
                 assert_eq!(
-                    m.get("signals.decision outcome=failure reason=no_matching_route signal=metrics")
+                    m.get("signals.decision outcome=failure reason=no_available_route signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     0
@@ -2518,21 +2518,21 @@ assert_eq!(
 
                 let m = collect_metrics_map(&telemetry_registry);
                 assert_eq!(
-                    m.get("signals.decision outcome=success reason=matched_route signal=metrics")
+                    m.get("signals.decision outcome=success reason=named_route signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
                     m.get(
-                        "signals.decision outcome=success reason=default_route_no_match signal=metrics"
+                        "signals.decision outcome=success reason=default_route_unwired signal=metrics"
                     )
                     .copied()
                     .unwrap_or(0),
                     1
                 );
                 assert_eq!(
-                    m.get("signals.decision outcome=failure reason=no_matching_route signal=metrics")
+                    m.get("signals.decision outcome=failure reason=no_available_route signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     0
@@ -2588,14 +2588,14 @@ assert_eq!(
 
                 let m = collect_metrics_map(&telemetry_registry);
                 assert_eq!(
-                    m.get("signals.decision outcome=success reason=matched_route signal=metrics")
+                    m.get("signals.decision outcome=success reason=named_route signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
                     m.get(
-                        "signals.decision outcome=success reason=default_route_no_match signal=metrics"
+                        "signals.decision outcome=success reason=default_route_unwired signal=metrics"
                     )
                     .copied()
                     .unwrap_or(0),
@@ -2620,7 +2620,7 @@ assert_eq!(
                     1
                 );
                 assert_eq!(
-                    m.get("signals.decision outcome=failure reason=no_matching_route signal=metrics")
+                    m.get("signals.decision outcome=failure reason=no_available_route signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     0

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/signal_type_router/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/signal_type_router/mod.rs
@@ -105,12 +105,12 @@ pub enum SignalTypeRouterReason {
 #[attribute_set(item, measurement)]
 #[derive(Debug, Clone, Copy)]
 pub struct SignalTypeRouterAttributes {
-    /// The telemetry signal type.
-    pub signal: otap_df_config::SignalType,
     /// General outcome of the routing decision.
     pub outcome: Outcome,
     /// Specific reason for the outcome.
     pub reason: SignalTypeRouterReason,
+    /// The telemetry signal type.
+    pub signal: otap_df_config::SignalType,
 }
 
 /// Measurement metrics for the SignalTypeRouter processor.
@@ -1375,7 +1375,7 @@ mod tests {
                 metrics
                     .get(
                         format!(
-                            "signals.decision outcome=Success reason=MatchedRoute signal={signal}"
+                            "signals.decision outcome=success reason=matched_route signal={signal}"
                         )
                         .as_str()
                     )
@@ -1385,7 +1385,7 @@ mod tests {
             );
             assert_eq!(
                 metrics
-                    .get(format!("signals.decision outcome=Success reason=DefaultRouteNoMatch signal={signal}").as_str())
+                    .get(format!("signals.decision outcome=success reason=default_route_no_match signal={signal}").as_str())
                     .copied()
                     .unwrap_or(0),
                 0
@@ -1394,7 +1394,7 @@ mod tests {
                 metrics
                     .get(
                         format!(
-                            "signals.decision outcome=Failure reason=NodeShutdown signal={signal}"
+                            "signals.decision outcome=failure reason=node_shutdown signal={signal}"
                         )
                         .as_str()
                     )
@@ -1406,7 +1406,7 @@ mod tests {
                 metrics
                     .get(
                         format!(
-                            "signals.decision outcome=Refused reason=RouteFull signal={signal}"
+                            "signals.decision outcome=refused reason=route_full signal={signal}"
                         )
                         .as_str()
                     )
@@ -1418,7 +1418,7 @@ mod tests {
                 metrics
                     .get(
                         format!(
-                            "signals.decision outcome=Refused reason=RouteClosed signal={signal}"
+                            "signals.decision outcome=refused reason=route_closed signal={signal}"
                         )
                         .as_str()
                     )
@@ -1428,7 +1428,7 @@ mod tests {
             );
             assert_eq!(
                 metrics
-                    .get(format!("signals.decision outcome=Failure reason=NoMatchingRoute signal={signal}").as_str())
+                    .get(format!("signals.decision outcome=failure reason=no_matching_route signal={signal}").as_str())
                     .copied()
                     .unwrap_or(0),
                 0
@@ -1491,21 +1491,21 @@ mod tests {
 
 assert_eq!(
                     metrics
-                        .get("signals.decision outcome=Success reason=MatchedRoute signal=logs")
+                        .get("signals.decision outcome=success reason=matched_route signal=logs")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.decision outcome=Success reason=DefaultRouteNoMatch signal=logs")
+                        .get("signals.decision outcome=success reason=default_route_no_match signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.decision outcome=Failure reason=NoMatchingRoute signal=logs")
+                        .get("signals.decision outcome=failure reason=no_matching_route signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
@@ -1582,42 +1582,42 @@ assert_eq!(
 
 assert_eq!(
                     metrics
-                        .get("signals.decision outcome=Success reason=MatchedRoute signal=logs")
+                        .get("signals.decision outcome=success reason=matched_route signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.decision outcome=Success reason=DefaultRouteNoMatch signal=logs")
+                        .get("signals.decision outcome=success reason=default_route_no_match signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.decision outcome=Failure reason=NodeShutdown signal=logs")
+                        .get("signals.decision outcome=failure reason=node_shutdown signal=logs")
+                        .copied()
+                        .unwrap_or(0),
+                    0
+                );
+                assert_eq!(
+                    metrics
+                        .get("signals.decision outcome=refused reason=route_full signal=logs")
+                        .copied()
+                        .unwrap_or(0),
+                    0
+                );
+                assert_eq!(
+                    metrics
+                        .get("signals.decision outcome=refused reason=route_closed signal=logs")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.decision outcome=Refused reason=RouteFull signal=logs")
-                        .copied()
-                        .unwrap_or(0),
-                    0
-                );
-                assert_eq!(
-                    metrics
-                        .get("signals.decision outcome=Refused reason=RouteClosed signal=logs")
-                        .copied()
-                        .unwrap_or(0),
-                    1
-                );
-                assert_eq!(
-                    metrics
-                        .get("signals.decision outcome=Failure reason=NoMatchingRoute signal=logs")
+                        .get("signals.decision outcome=failure reason=no_matching_route signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
@@ -1689,21 +1689,21 @@ assert_eq!(
 
 assert_eq!(
                     metrics
-                        .get("signals.decision outcome=Success reason=MatchedRoute signal=logs")
+                        .get("signals.decision outcome=success reason=matched_route signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.decision outcome=Success reason=DefaultRouteNoMatch signal=logs")
+                        .get("signals.decision outcome=success reason=default_route_no_match signal=logs")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.decision outcome=Failure reason=NoMatchingRoute signal=logs")
+                        .get("signals.decision outcome=failure reason=no_matching_route signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
@@ -1777,42 +1777,42 @@ assert_eq!(
 
 assert_eq!(
                     metrics
-                        .get("signals.decision outcome=Success reason=MatchedRoute signal=logs")
+                        .get("signals.decision outcome=success reason=matched_route signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.decision outcome=Success reason=DefaultRouteNoMatch signal=logs")
+                        .get("signals.decision outcome=success reason=default_route_no_match signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.decision outcome=Failure reason=NodeShutdown signal=logs")
+                        .get("signals.decision outcome=failure reason=node_shutdown signal=logs")
+                        .copied()
+                        .unwrap_or(0),
+                    0
+                );
+                assert_eq!(
+                    metrics
+                        .get("signals.decision outcome=refused reason=route_full signal=logs")
+                        .copied()
+                        .unwrap_or(0),
+                    0
+                );
+                assert_eq!(
+                    metrics
+                        .get("signals.decision outcome=refused reason=route_closed signal=logs")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.decision outcome=Refused reason=RouteFull signal=logs")
-                        .copied()
-                        .unwrap_or(0),
-                    0
-                );
-                assert_eq!(
-                    metrics
-                        .get("signals.decision outcome=Refused reason=RouteClosed signal=logs")
-                        .copied()
-                        .unwrap_or(0),
-                    1
-                );
-                assert_eq!(
-                    metrics
-                        .get("signals.decision outcome=Failure reason=NoMatchingRoute signal=logs")
+                        .get("signals.decision outcome=failure reason=no_matching_route signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
@@ -1920,35 +1920,35 @@ assert_eq!(
 
                 assert_eq!(
                     metrics
-                        .get("signals.decision outcome=Success reason=MatchedRoute signal=logs")
+                        .get("signals.decision outcome=success reason=matched_route signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.decision outcome=Success reason=MatchedRoute signal=metrics")
+                        .get("signals.decision outcome=success reason=matched_route signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.decision outcome=Failure reason=NodeShutdown signal=logs")
+                        .get("signals.decision outcome=failure reason=node_shutdown signal=logs")
+                        .copied()
+                        .unwrap_or(0),
+                    0
+                );
+                assert_eq!(
+                    metrics
+                        .get("signals.decision outcome=refused reason=route_full signal=logs")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.decision outcome=Refused reason=RouteFull signal=logs")
-                        .copied()
-                        .unwrap_or(0),
-                    1
-                );
-                assert_eq!(
-                    metrics
-                        .get("signals.decision outcome=Failure reason=NoMatchingRoute signal=logs")
+                        .get("signals.decision outcome=failure reason=no_matching_route signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
@@ -1956,7 +1956,7 @@ assert_eq!(
                 assert_eq!(
                     metrics
                         .get(
-                            "signals.decision outcome=Failure reason=NoMatchingRoute signal=metrics"
+                            "signals.decision outcome=failure reason=no_matching_route signal=metrics"
                         )
                         .copied()
                         .unwrap_or(0),
@@ -2010,21 +2010,21 @@ assert_eq!(
 
                 let m = collect_metrics_map(&telemetry_registry);
                 assert_eq!(
-                    m.get("signals.decision outcome=Success reason=MatchedRoute signal=traces")
+                    m.get("signals.decision outcome=success reason=matched_route signal=traces")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
                 assert_eq!(
                     m.get(
-                        "signals.decision outcome=Success reason=DefaultRouteNoMatch signal=traces"
+                        "signals.decision outcome=success reason=default_route_no_match signal=traces"
                     )
                     .copied()
                     .unwrap_or(0),
                     0
                 );
                 assert_eq!(
-                    m.get("signals.decision outcome=Failure reason=NoMatchingRoute signal=traces")
+                    m.get("signals.decision outcome=failure reason=no_matching_route signal=traces")
                         .copied()
                         .unwrap_or(0),
                     0
@@ -2080,39 +2080,39 @@ assert_eq!(
 
                 let m = collect_metrics_map(&telemetry_registry);
                 assert_eq!(
-                    m.get("signals.decision outcome=Success reason=MatchedRoute signal=traces")
+                    m.get("signals.decision outcome=success reason=matched_route signal=traces")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
                     m.get(
-                        "signals.decision outcome=Success reason=DefaultRouteNoMatch signal=traces"
+                        "signals.decision outcome=success reason=default_route_no_match signal=traces"
                     )
                     .copied()
                     .unwrap_or(0),
                     0
                 );
                 assert_eq!(
-                    m.get("signals.decision outcome=Failure reason=NodeShutdown signal=traces")
+                    m.get("signals.decision outcome=failure reason=node_shutdown signal=traces")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
-                    m.get("signals.decision outcome=Refused reason=RouteFull signal=traces")
+                    m.get("signals.decision outcome=refused reason=route_full signal=traces")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
-                    m.get("signals.decision outcome=Refused reason=RouteClosed signal=traces")
+                    m.get("signals.decision outcome=refused reason=route_closed signal=traces")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
                 assert_eq!(
-                    m.get("signals.decision outcome=Failure reason=NoMatchingRoute signal=traces")
+                    m.get("signals.decision outcome=failure reason=no_matching_route signal=traces")
                         .copied()
                         .unwrap_or(0),
                     0
@@ -2179,21 +2179,21 @@ assert_eq!(
 
                 let m = collect_metrics_map(&telemetry_registry);
                 assert_eq!(
-                    m.get("signals.decision outcome=Success reason=MatchedRoute signal=traces")
+                    m.get("signals.decision outcome=success reason=matched_route signal=traces")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
                     m.get(
-                        "signals.decision outcome=Success reason=DefaultRouteNoMatch signal=traces"
+                        "signals.decision outcome=success reason=default_route_no_match signal=traces"
                     )
                     .copied()
                     .unwrap_or(0),
                     1
                 );
                 assert_eq!(
-                    m.get("signals.decision outcome=Failure reason=NoMatchingRoute signal=traces")
+                    m.get("signals.decision outcome=failure reason=no_matching_route signal=traces")
                         .copied()
                         .unwrap_or(0),
                     0
@@ -2249,39 +2249,39 @@ assert_eq!(
 
                 let m = collect_metrics_map(&telemetry_registry);
                 assert_eq!(
-                    m.get("signals.decision outcome=Success reason=MatchedRoute signal=traces")
+                    m.get("signals.decision outcome=success reason=matched_route signal=traces")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
                     m.get(
-                        "signals.decision outcome=Success reason=DefaultRouteNoMatch signal=traces"
+                        "signals.decision outcome=success reason=default_route_no_match signal=traces"
                     )
                     .copied()
                     .unwrap_or(0),
                     0
                 );
                 assert_eq!(
-                    m.get("signals.decision outcome=Failure reason=NodeShutdown signal=traces")
+                    m.get("signals.decision outcome=failure reason=node_shutdown signal=traces")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
-                    m.get("signals.decision outcome=Refused reason=RouteFull signal=traces")
+                    m.get("signals.decision outcome=refused reason=route_full signal=traces")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
-                    m.get("signals.decision outcome=Refused reason=RouteClosed signal=traces")
+                    m.get("signals.decision outcome=refused reason=route_closed signal=traces")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
                 assert_eq!(
-                    m.get("signals.decision outcome=Failure reason=NoMatchingRoute signal=traces")
+                    m.get("signals.decision outcome=failure reason=no_matching_route signal=traces")
                         .copied()
                         .unwrap_or(0),
                     0
@@ -2349,21 +2349,21 @@ assert_eq!(
 
                 let m = collect_metrics_map(&telemetry_registry);
                 assert_eq!(
-                    m.get("signals.decision outcome=Success reason=MatchedRoute signal=metrics")
+                    m.get("signals.decision outcome=success reason=matched_route signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
                 assert_eq!(
                     m.get(
-                        "signals.decision outcome=Success reason=DefaultRouteNoMatch signal=metrics"
+                        "signals.decision outcome=success reason=default_route_no_match signal=metrics"
                     )
                     .copied()
                     .unwrap_or(0),
                     0
                 );
                 assert_eq!(
-                    m.get("signals.decision outcome=Failure reason=NoMatchingRoute signal=metrics")
+                    m.get("signals.decision outcome=failure reason=no_matching_route signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     0
@@ -2419,39 +2419,39 @@ assert_eq!(
 
                 let m = collect_metrics_map(&telemetry_registry);
                 assert_eq!(
-                    m.get("signals.decision outcome=Success reason=MatchedRoute signal=metrics")
+                    m.get("signals.decision outcome=success reason=matched_route signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
                     m.get(
-                        "signals.decision outcome=Success reason=DefaultRouteNoMatch signal=metrics"
+                        "signals.decision outcome=success reason=default_route_no_match signal=metrics"
                     )
                     .copied()
                     .unwrap_or(0),
                     0
                 );
                 assert_eq!(
-                    m.get("signals.decision outcome=Failure reason=NodeShutdown signal=metrics")
+                    m.get("signals.decision outcome=failure reason=node_shutdown signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
-                    m.get("signals.decision outcome=Refused reason=RouteFull signal=metrics")
+                    m.get("signals.decision outcome=refused reason=route_full signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
-                    m.get("signals.decision outcome=Refused reason=RouteClosed signal=metrics")
+                    m.get("signals.decision outcome=refused reason=route_closed signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
                 assert_eq!(
-                    m.get("signals.decision outcome=Failure reason=NoMatchingRoute signal=metrics")
+                    m.get("signals.decision outcome=failure reason=no_matching_route signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     0
@@ -2518,21 +2518,21 @@ assert_eq!(
 
                 let m = collect_metrics_map(&telemetry_registry);
                 assert_eq!(
-                    m.get("signals.decision outcome=Success reason=MatchedRoute signal=metrics")
+                    m.get("signals.decision outcome=success reason=matched_route signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
                     m.get(
-                        "signals.decision outcome=Success reason=DefaultRouteNoMatch signal=metrics"
+                        "signals.decision outcome=success reason=default_route_no_match signal=metrics"
                     )
                     .copied()
                     .unwrap_or(0),
                     1
                 );
                 assert_eq!(
-                    m.get("signals.decision outcome=Failure reason=NoMatchingRoute signal=metrics")
+                    m.get("signals.decision outcome=failure reason=no_matching_route signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     0
@@ -2588,39 +2588,39 @@ assert_eq!(
 
                 let m = collect_metrics_map(&telemetry_registry);
                 assert_eq!(
-                    m.get("signals.decision outcome=Success reason=MatchedRoute signal=metrics")
+                    m.get("signals.decision outcome=success reason=matched_route signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
                     m.get(
-                        "signals.decision outcome=Success reason=DefaultRouteNoMatch signal=metrics"
+                        "signals.decision outcome=success reason=default_route_no_match signal=metrics"
                     )
                     .copied()
                     .unwrap_or(0),
                     0
                 );
                 assert_eq!(
-                    m.get("signals.decision outcome=Failure reason=NodeShutdown signal=metrics")
+                    m.get("signals.decision outcome=failure reason=node_shutdown signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
-                    m.get("signals.decision outcome=Refused reason=RouteFull signal=metrics")
+                    m.get("signals.decision outcome=refused reason=route_full signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
-                    m.get("signals.decision outcome=Refused reason=RouteClosed signal=metrics")
+                    m.get("signals.decision outcome=refused reason=route_closed signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
                 assert_eq!(
-                    m.get("signals.decision outcome=Failure reason=NoMatchingRoute signal=metrics")
+                    m.get("signals.decision outcome=failure reason=no_matching_route signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     0

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/signal_type_router/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/signal_type_router/mod.rs
@@ -60,7 +60,8 @@ use otap_df_engine::{
 use otap_df_otap::OTAP_PROCESSOR_FACTORIES;
 use otap_df_otap::pdata::OtapPdata;
 use otap_df_telemetry::instrument::Counter;
-use otap_df_telemetry::metrics::MetricSet;
+use otap_df_telemetry::metrics::MeasurementMetricSet;
+use otap_df_telemetry::common_attributes::SignalAttributes;
 use otap_df_telemetry_macros::metric_set;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -83,131 +84,38 @@ pub const PORT_METRICS: &str = "metrics";
 pub const PORT_LOGS: &str = "logs";
 
 /// Metrics for the SignalTypeRouter processor.
-#[metric_set(name = "processor.signal_type_router")]
+#[metric_set(name = "processor.signal_type_router", measurement_attributes = SignalAttributes)]
 #[derive(Debug, Default, Clone)]
 pub struct SignalTypeRouterMetrics {
-    /// Number of log messages received by the router.
-    #[metric(unit = "{msg}")]
-    pub signals_received_logs: Counter<u64>,
-    /// Number of metric messages received by the router.
-    #[metric(unit = "{msg}")]
-    pub signals_received_metrics: Counter<u64>,
-    /// Number of trace messages received by the router.
-    #[metric(unit = "{msg}")]
-    pub signals_received_traces: Counter<u64>,
+    /// Number of messages received by the router.
+    #[metric(name = "signals.received", unit = "{msg}")]
+    pub signals_received: Counter<u64>,
 
-    /// Number of log messages routed to a named port.
-    #[metric(unit = "{msg}")]
-    pub signals_routed_named_logs: Counter<u64>,
-    /// Number of metric messages routed to a named port.
-    #[metric(unit = "{msg}")]
-    pub signals_routed_named_metrics: Counter<u64>,
-    /// Number of trace messages routed to a named port.
-    #[metric(unit = "{msg}")]
-    pub signals_routed_named_traces: Counter<u64>,
+    /// Number of messages routed to a named port.
+    #[metric(name = "signals.routed.named", unit = "{msg}")]
+    pub signals_routed_named: Counter<u64>,
 
-    /// Number of log messages routed via the default port.
-    #[metric(unit = "{msg}")]
-    pub signals_routed_default_logs: Counter<u64>,
-    /// Number of metric messages routed via the default port.
-    #[metric(unit = "{msg}")]
-    pub signals_routed_default_metrics: Counter<u64>,
-    /// Number of trace messages routed via the default port.
-    #[metric(unit = "{msg}")]
-    pub signals_routed_default_traces: Counter<u64>,
+    /// Number of messages routed via the default port.
+    #[metric(name = "signals.routed.default", unit = "{msg}")]
+    pub signals_routed_default: Counter<u64>,
 
-    /// Number of log messages NACKed due to route-local rejection.
-    #[metric(unit = "{msg}")]
-    pub signals_nacked_logs: Counter<u64>,
-    /// Number of metric messages NACKed due to route-local rejection.
-    #[metric(unit = "{msg}")]
-    pub signals_nacked_metrics: Counter<u64>,
-    /// Number of trace messages NACKed due to route-local rejection.
-    #[metric(unit = "{msg}")]
-    pub signals_nacked_traces: Counter<u64>,
+    /// Number of messages NACKed due to route-local rejection.
+    #[metric(name = "signals.nacked", unit = "{msg}")]
+    pub signals_nacked: Counter<u64>,
 
-    /// Number of log messages rejected because the selected route was full.
-    #[metric(unit = "{msg}")]
-    pub signals_rejected_route_full_logs: Counter<u64>,
-    /// Number of metric messages rejected because the selected route was full.
-    #[metric(unit = "{msg}")]
-    pub signals_rejected_route_full_metrics: Counter<u64>,
-    /// Number of trace messages rejected because the selected route was full.
-    #[metric(unit = "{msg}")]
-    pub signals_rejected_route_full_traces: Counter<u64>,
+    /// Number of messages rejected because the selected route was full.
+    #[metric(name = "signals.rejected.route.full", unit = "{msg}")]
+    pub signals_rejected_route_full: Counter<u64>,
 
-    /// Number of log messages rejected because the selected route was closed.
-    #[metric(unit = "{msg}")]
-    pub signals_rejected_route_closed_logs: Counter<u64>,
-    /// Number of metric messages rejected because the selected route was closed.
-    #[metric(unit = "{msg}")]
-    pub signals_rejected_route_closed_metrics: Counter<u64>,
-    /// Number of trace messages rejected because the selected route was closed.
-    #[metric(unit = "{msg}")]
-    pub signals_rejected_route_closed_traces: Counter<u64>,
+    /// Number of messages rejected because the selected route was closed.
+    #[metric(name = "signals.rejected.route.closed", unit = "{msg}")]
+    pub signals_rejected_route_closed: Counter<u64>,
 
-    /// Number of log messages dropped due to routing failure.
-    #[metric(unit = "{msg}")]
-    pub signals_dropped_logs: Counter<u64>,
-    /// Number of metric messages dropped due to routing failure.
-    #[metric(unit = "{msg}")]
-    pub signals_dropped_metrics: Counter<u64>,
-    /// Number of trace messages dropped due to routing failure.
-    #[metric(unit = "{msg}")]
-    pub signals_dropped_traces: Counter<u64>,
+    /// Number of messages dropped due to routing failure.
+    #[metric(name = "signals.dropped", unit = "{msg}")]
+    pub signals_dropped: Counter<u64>,
 }
 
-impl SignalTypeRouterMetrics {
-    const fn inc_received(&mut self, st: otap_df_config::SignalType) {
-        match st {
-            otap_df_config::SignalType::Logs => self.signals_received_logs.inc(),
-            otap_df_config::SignalType::Metrics => self.signals_received_metrics.inc(),
-            otap_df_config::SignalType::Traces => self.signals_received_traces.inc(),
-        }
-    }
-    const fn inc_routed_named(&mut self, st: otap_df_config::SignalType) {
-        match st {
-            otap_df_config::SignalType::Logs => self.signals_routed_named_logs.inc(),
-            otap_df_config::SignalType::Metrics => self.signals_routed_named_metrics.inc(),
-            otap_df_config::SignalType::Traces => self.signals_routed_named_traces.inc(),
-        }
-    }
-    const fn inc_routed_default(&mut self, st: otap_df_config::SignalType) {
-        match st {
-            otap_df_config::SignalType::Logs => self.signals_routed_default_logs.inc(),
-            otap_df_config::SignalType::Metrics => self.signals_routed_default_metrics.inc(),
-            otap_df_config::SignalType::Traces => self.signals_routed_default_traces.inc(),
-        }
-    }
-    const fn inc_nacked(&mut self, st: otap_df_config::SignalType) {
-        match st {
-            otap_df_config::SignalType::Logs => self.signals_nacked_logs.inc(),
-            otap_df_config::SignalType::Metrics => self.signals_nacked_metrics.inc(),
-            otap_df_config::SignalType::Traces => self.signals_nacked_traces.inc(),
-        }
-    }
-    const fn inc_rejected_route_full(&mut self, st: otap_df_config::SignalType) {
-        match st {
-            otap_df_config::SignalType::Logs => self.signals_rejected_route_full_logs.inc(),
-            otap_df_config::SignalType::Metrics => self.signals_rejected_route_full_metrics.inc(),
-            otap_df_config::SignalType::Traces => self.signals_rejected_route_full_traces.inc(),
-        }
-    }
-    const fn inc_rejected_route_closed(&mut self, st: otap_df_config::SignalType) {
-        match st {
-            otap_df_config::SignalType::Logs => self.signals_rejected_route_closed_logs.inc(),
-            otap_df_config::SignalType::Metrics => self.signals_rejected_route_closed_metrics.inc(),
-            otap_df_config::SignalType::Traces => self.signals_rejected_route_closed_traces.inc(),
-        }
-    }
-    const fn inc_dropped(&mut self, st: otap_df_config::SignalType) {
-        match st {
-            otap_df_config::SignalType::Logs => self.signals_dropped_logs.inc(),
-            otap_df_config::SignalType::Metrics => self.signals_dropped_metrics.inc(),
-            otap_df_config::SignalType::Traces => self.signals_dropped_traces.inc(),
-        }
-    }
-}
 
 /// Minimal configuration for the SignalTypeRouter processor
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -240,7 +148,7 @@ pub struct SignalTypeRouter {
     /// Selected-route admission scheduler.
     admission: ExclusiveRouteScheduler<OtapPdata, SelectedRouteContext>,
     /// Telemetry metrics for this router (optional when constructed without PipelineContext)
-    metrics: Option<MetricSet<SignalTypeRouterMetrics>>,
+    metrics: Option<MeasurementMetricSet<SignalTypeRouterMetrics>>,
 }
 
 impl SignalTypeRouter {
@@ -260,7 +168,7 @@ impl SignalTypeRouter {
         pipeline_ctx: PipelineContext,
         config: SignalTypeRouterConfig,
     ) -> Self {
-        let metrics = pipeline_ctx.register_metrics::<SignalTypeRouterMetrics>();
+        let metrics = SignalTypeRouterMetrics::register(&pipeline_ctx);
         let mut router = Self::new(config);
         router.metrics = Some(metrics);
         router
@@ -273,8 +181,8 @@ impl SignalTypeRouter {
     fn record_forwarded_route(&mut self, context: SelectedRouteContext) {
         if let Some(m) = self.metrics.as_mut() {
             match context.route_kind {
-                SelectedRouteKind::Named => m.inc_routed_named(context.signal_type),
-                SelectedRouteKind::Default => m.inc_routed_default(context.signal_type),
+                SelectedRouteKind::Named => m.with(SignalAttributes { signal: context.signal_type }).signals_routed_named.inc(),
+                SelectedRouteKind::Default => m.with(SignalAttributes { signal: context.signal_type }).signals_routed_default.inc(),
             }
         }
     }
@@ -334,8 +242,8 @@ impl SignalTypeRouter {
         data: OtapPdata,
     ) -> Result<(), EngineError> {
         if let Some(m) = self.metrics.as_mut() {
-            m.inc_nacked(signal_type);
-            m.inc_rejected_route_full(signal_type);
+            m.with(SignalAttributes { signal: signal_type }).signals_nacked.inc();
+            m.with(SignalAttributes { signal: signal_type }).signals_rejected_route_full.inc();
         }
 
         effect_handler
@@ -357,8 +265,8 @@ impl SignalTypeRouter {
         data: OtapPdata,
     ) -> Result<(), EngineError> {
         if let Some(m) = self.metrics.as_mut() {
-            m.inc_nacked(signal_type);
-            m.inc_rejected_route_closed(signal_type);
+            m.with(SignalAttributes { signal: signal_type }).signals_nacked.inc();
+            m.with(SignalAttributes { signal: signal_type }).signals_rejected_route_closed.inc();
         }
 
         effect_handler
@@ -382,7 +290,7 @@ impl SignalTypeRouter {
         reason: &str,
     ) -> Result<(), EngineError> {
         if let Some(m) = self.metrics.as_mut() {
-            m.inc_nacked(signal_type);
+            m.with(SignalAttributes { signal: signal_type }).signals_nacked.inc();
         }
 
         effect_handler
@@ -521,7 +429,7 @@ impl local::Processor<OtapPdata> for SignalTypeRouter {
                     mut metrics_reporter,
                 } => {
                     if let Some(m) = self.metrics.as_mut() {
-                        let _ = metrics_reporter.report(m);
+                        let _ = metrics_reporter.report_measurement(m);
                     }
                     Ok(())
                 }
@@ -541,7 +449,7 @@ impl local::Processor<OtapPdata> for SignalTypeRouter {
             Message::PData(data) => {
                 let st = data.signal_type();
                 if let Some(m) = self.metrics.as_mut() {
-                    m.inc_received(st);
+                    m.with(SignalAttributes { signal: st }).signals_received.inc();
                 }
 
                 // Resolve the preferred named route first. Falling back is only
@@ -639,7 +547,7 @@ impl local::Processor<OtapPdata> for SignalTypeRouter {
                         ),
                         Err(e) => {
                             if let Some(m) = self.metrics.as_mut() {
-                                m.inc_dropped(st);
+                                m.with(SignalAttributes { signal: st }).signals_dropped.inc();
                             }
                             Err(e.into())
                         }
@@ -1240,11 +1148,20 @@ mod tests {
             telemetry_registry: &TelemetryRegistryHandle,
         ) -> HashMap<String, u64> {
             let mut out = HashMap::new();
-            telemetry_registry.visit_current_metrics(|_desc, _attrs, iter| {
-                for (field, value) in iter {
-                    let _ = out.insert(field.name.to_string(), value.to_u64_lossy());
-                }
-            });
+            telemetry_registry.visit_current_metrics_with_item_attrs(
+                |_desc, _attrs, dp, iter| {
+                    let mut dp_str = String::new();
+                    for (k, v) in dp {
+                        dp_str.push_str(&format!(" {}={}", k, v));
+                    }
+                    for (field, value) in iter {
+                        let key = format!("{}{}", field.name, dp_str);
+                        println!("DEBUG METRIC MAP: {} = {}", key, value.to_u64_lossy());
+                        let _ = out.insert(key, value.to_u64_lossy());
+                    }
+                },
+                false,
+            );
             out
         }
 
@@ -1388,49 +1305,49 @@ mod tests {
             let signal = signal_name(st);
             assert_eq!(
                 metrics
-                    .get(format!("signals.received.{signal}").as_str())
+                    .get(format!("signals.received signal={signal}").as_str())
                     .copied()
                     .unwrap_or(0),
                 1
             );
             assert_eq!(
                 metrics
-                    .get(format!("signals.routed.named.{signal}").as_str())
+                    .get(format!("signals.routed.named signal={signal}").as_str())
                     .copied()
                     .unwrap_or(0),
                 0
             );
             assert_eq!(
                 metrics
-                    .get(format!("signals.routed.default.{signal}").as_str())
+                    .get(format!("signals.routed.default signal={signal}").as_str())
                     .copied()
                     .unwrap_or(0),
                 0
             );
             assert_eq!(
                 metrics
-                    .get(format!("signals.nacked.{signal}").as_str())
+                    .get(format!("signals.nacked signal={signal}").as_str())
                     .copied()
                     .unwrap_or(0),
                 1
             );
             assert_eq!(
                 metrics
-                    .get(format!("signals.rejected.route.full.{signal}").as_str())
+                    .get(format!("signals.rejected.route.full signal={signal}").as_str())
                     .copied()
                     .unwrap_or(0),
                 1
             );
             assert_eq!(
                 metrics
-                    .get(format!("signals.rejected.route.closed.{signal}").as_str())
+                    .get(format!("signals.rejected.route.closed signal={signal}").as_str())
                     .copied()
                     .unwrap_or(0),
                 0
             );
             assert_eq!(
                 metrics
-                    .get(format!("signals.dropped.{signal}").as_str())
+                    .get(format!("signals.dropped signal={signal}").as_str())
                     .copied()
                     .unwrap_or(0),
                 0
@@ -1491,24 +1408,24 @@ mod tests {
 
                 let metrics = collect_metrics_map(&telemetry_registry);
                 assert_eq!(
-                    metrics.get("signals.received.logs").copied().unwrap_or(0),
+                    metrics.get("signals.received signal=logs").copied().unwrap_or(0),
                     1
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.routed.named.logs")
+                        .get("signals.routed.named signal=logs")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.routed.default.logs")
+                        .get("signals.routed.default signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
-                assert_eq!(metrics.get("signals.dropped.logs").copied().unwrap_or(0), 0);
+                assert_eq!(metrics.get("signals.dropped signal=logs").copied().unwrap_or(0), 0);
 
                 // shutdown collector
                 stop_telemetry(reporter, collector_task);
@@ -1579,39 +1496,39 @@ mod tests {
 
                 let metrics = collect_metrics_map(&telemetry_registry);
                 assert_eq!(
-                    metrics.get("signals.received.logs").copied().unwrap_or(0),
+                    metrics.get("signals.received signal=logs").copied().unwrap_or(0),
                     1
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.routed.named.logs")
+                        .get("signals.routed.named signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.routed.default.logs")
+                        .get("signals.routed.default signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
-                assert_eq!(metrics.get("signals.nacked.logs").copied().unwrap_or(0), 1);
+                assert_eq!(metrics.get("signals.nacked signal=logs").copied().unwrap_or(0), 1);
                 assert_eq!(
                     metrics
-                        .get("signals.rejected.route.full.logs")
+                        .get("signals.rejected.route.full signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.rejected.route.closed.logs")
+                        .get("signals.rejected.route.closed signal=logs")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
-                assert_eq!(metrics.get("signals.dropped.logs").copied().unwrap_or(0), 0);
+                assert_eq!(metrics.get("signals.dropped signal=logs").copied().unwrap_or(0), 0);
 
                 stop_telemetry(reporter, collector_task);
             }));
@@ -1677,24 +1594,24 @@ mod tests {
 
                 let metrics = collect_metrics_map(&telemetry_registry);
                 assert_eq!(
-                    metrics.get("signals.received.logs").copied().unwrap_or(0),
+                    metrics.get("signals.received signal=logs").copied().unwrap_or(0),
                     1
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.routed.named.logs")
+                        .get("signals.routed.named signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.routed.default.logs")
+                        .get("signals.routed.default signal=logs")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
-                assert_eq!(metrics.get("signals.dropped.logs").copied().unwrap_or(0), 0);
+                assert_eq!(metrics.get("signals.dropped signal=logs").copied().unwrap_or(0), 0);
 
                 stop_telemetry(reporter, collector_task);
             }));
@@ -1762,39 +1679,39 @@ mod tests {
 
                 let metrics = collect_metrics_map(&telemetry_registry);
                 assert_eq!(
-                    metrics.get("signals.received.logs").copied().unwrap_or(0),
+                    metrics.get("signals.received signal=logs").copied().unwrap_or(0),
                     1
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.routed.named.logs")
+                        .get("signals.routed.named signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.routed.default.logs")
+                        .get("signals.routed.default signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
-                assert_eq!(metrics.get("signals.nacked.logs").copied().unwrap_or(0), 1);
+                assert_eq!(metrics.get("signals.nacked signal=logs").copied().unwrap_or(0), 1);
                 assert_eq!(
                     metrics
-                        .get("signals.rejected.route.full.logs")
+                        .get("signals.rejected.route.full signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.rejected.route.closed.logs")
+                        .get("signals.rejected.route.closed signal=logs")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
-                assert_eq!(metrics.get("signals.dropped.logs").copied().unwrap_or(0), 0);
+                assert_eq!(metrics.get("signals.dropped signal=logs").copied().unwrap_or(0), 0);
 
                 stop_telemetry(reporter, collector_task);
             }));
@@ -1896,41 +1813,41 @@ mod tests {
                     flush_metrics(&mut router, &mut eh, reporter.clone(), &telemetry_registry)
                         .await;
                 assert_eq!(
-                    metrics.get("signals.received.logs").copied().unwrap_or(0),
+                    metrics.get("signals.received signal=logs").copied().unwrap_or(0),
                     1
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.received.metrics")
+                        .get("signals.received signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.routed.named.logs")
+                        .get("signals.routed.named signal=logs")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
                     metrics
-                        .get("signals.routed.named.metrics")
+                        .get("signals.routed.named signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
-                assert_eq!(metrics.get("signals.nacked.logs").copied().unwrap_or(0), 1);
+                assert_eq!(metrics.get("signals.nacked signal=logs").copied().unwrap_or(0), 1);
                 assert_eq!(
                     metrics
-                        .get("signals.rejected.route.full.logs")
+                        .get("signals.rejected.route.full signal=logs")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
-                assert_eq!(metrics.get("signals.dropped.logs").copied().unwrap_or(0), 0);
+                assert_eq!(metrics.get("signals.dropped signal=logs").copied().unwrap_or(0), 0);
                 assert_eq!(
-                    metrics.get("signals.dropped.metrics").copied().unwrap_or(0),
+                    metrics.get("signals.dropped signal=metrics").copied().unwrap_or(0),
                     0
                 );
 
@@ -1980,16 +1897,16 @@ mod tests {
                 tokio::time::sleep(Duration::from_millis(50)).await;
 
                 let m = collect_metrics_map(&telemetry_registry);
-                assert_eq!(m.get("signals.received.traces").copied().unwrap_or(0), 1);
+                assert_eq!(m.get("signals.received signal=traces").copied().unwrap_or(0), 1);
                 assert_eq!(
-                    m.get("signals.routed.named.traces").copied().unwrap_or(0),
+                    m.get("signals.routed.named signal=traces").copied().unwrap_or(0),
                     1
                 );
                 assert_eq!(
-                    m.get("signals.routed.default.traces").copied().unwrap_or(0),
+                    m.get("signals.routed.default signal=traces").copied().unwrap_or(0),
                     0
                 );
-                assert_eq!(m.get("signals.dropped.traces").copied().unwrap_or(0), 0);
+                assert_eq!(m.get("signals.dropped signal=traces").copied().unwrap_or(0), 0);
 
                 stop_telemetry(reporter, collector_task);
             }));
@@ -2040,29 +1957,29 @@ mod tests {
                 tokio::time::sleep(Duration::from_millis(50)).await;
 
                 let m = collect_metrics_map(&telemetry_registry);
-                assert_eq!(m.get("signals.received.traces").copied().unwrap_or(0), 1);
+                assert_eq!(m.get("signals.received signal=traces").copied().unwrap_or(0), 1);
                 assert_eq!(
-                    m.get("signals.routed.named.traces").copied().unwrap_or(0),
+                    m.get("signals.routed.named signal=traces").copied().unwrap_or(0),
                     0
                 );
                 assert_eq!(
-                    m.get("signals.routed.default.traces").copied().unwrap_or(0),
+                    m.get("signals.routed.default signal=traces").copied().unwrap_or(0),
                     0
                 );
-                assert_eq!(m.get("signals.nacked.traces").copied().unwrap_or(0), 1);
+                assert_eq!(m.get("signals.nacked signal=traces").copied().unwrap_or(0), 1);
                 assert_eq!(
-                    m.get("signals.rejected.route.full.traces")
+                    m.get("signals.rejected.route.full signal=traces")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
-                    m.get("signals.rejected.route.closed.traces")
+                    m.get("signals.rejected.route.closed signal=traces")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
-                assert_eq!(m.get("signals.dropped.traces").copied().unwrap_or(0), 0);
+                assert_eq!(m.get("signals.dropped signal=traces").copied().unwrap_or(0), 0);
 
                 stop_telemetry(reporter, collector_task);
             }));
@@ -2124,16 +2041,16 @@ mod tests {
                 tokio::time::sleep(Duration::from_millis(50)).await;
 
                 let m = collect_metrics_map(&telemetry_registry);
-                assert_eq!(m.get("signals.received.traces").copied().unwrap_or(0), 1);
+                assert_eq!(m.get("signals.received signal=traces").copied().unwrap_or(0), 1);
                 assert_eq!(
-                    m.get("signals.routed.named.traces").copied().unwrap_or(0),
+                    m.get("signals.routed.named signal=traces").copied().unwrap_or(0),
                     0
                 );
                 assert_eq!(
-                    m.get("signals.routed.default.traces").copied().unwrap_or(0),
+                    m.get("signals.routed.default signal=traces").copied().unwrap_or(0),
                     1
                 );
-                assert_eq!(m.get("signals.dropped.traces").copied().unwrap_or(0), 0);
+                assert_eq!(m.get("signals.dropped signal=traces").copied().unwrap_or(0), 0);
 
                 stop_telemetry(reporter, collector_task);
             }));
@@ -2184,29 +2101,29 @@ mod tests {
                 tokio::time::sleep(Duration::from_millis(50)).await;
 
                 let m = collect_metrics_map(&telemetry_registry);
-                assert_eq!(m.get("signals.received.traces").copied().unwrap_or(0), 1);
+                assert_eq!(m.get("signals.received signal=traces").copied().unwrap_or(0), 1);
                 assert_eq!(
-                    m.get("signals.routed.named.traces").copied().unwrap_or(0),
+                    m.get("signals.routed.named signal=traces").copied().unwrap_or(0),
                     0
                 );
                 assert_eq!(
-                    m.get("signals.routed.default.traces").copied().unwrap_or(0),
+                    m.get("signals.routed.default signal=traces").copied().unwrap_or(0),
                     0
                 );
-                assert_eq!(m.get("signals.nacked.traces").copied().unwrap_or(0), 1);
+                assert_eq!(m.get("signals.nacked signal=traces").copied().unwrap_or(0), 1);
                 assert_eq!(
-                    m.get("signals.rejected.route.full.traces")
+                    m.get("signals.rejected.route.full signal=traces")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
-                    m.get("signals.rejected.route.closed.traces")
+                    m.get("signals.rejected.route.closed signal=traces")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
-                assert_eq!(m.get("signals.dropped.traces").copied().unwrap_or(0), 0);
+                assert_eq!(m.get("signals.dropped signal=traces").copied().unwrap_or(0), 0);
 
                 stop_telemetry(reporter, collector_task);
             }));
@@ -2269,18 +2186,18 @@ mod tests {
                 tokio::time::sleep(Duration::from_millis(50)).await;
 
                 let m = collect_metrics_map(&telemetry_registry);
-                assert_eq!(m.get("signals.received.metrics").copied().unwrap_or(0), 1);
+                assert_eq!(m.get("signals.received signal=metrics").copied().unwrap_or(0), 1);
                 assert_eq!(
-                    m.get("signals.routed.named.metrics").copied().unwrap_or(0),
+                    m.get("signals.routed.named signal=metrics").copied().unwrap_or(0),
                     1
                 );
                 assert_eq!(
-                    m.get("signals.routed.default.metrics")
+                    m.get("signals.routed.default signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
-                assert_eq!(m.get("signals.dropped.metrics").copied().unwrap_or(0), 0);
+                assert_eq!(m.get("signals.dropped signal=metrics").copied().unwrap_or(0), 0);
 
                 stop_telemetry(reporter, collector_task);
             }));
@@ -2331,31 +2248,31 @@ mod tests {
                 tokio::time::sleep(Duration::from_millis(50)).await;
 
                 let m = collect_metrics_map(&telemetry_registry);
-                assert_eq!(m.get("signals.received.metrics").copied().unwrap_or(0), 1);
+                assert_eq!(m.get("signals.received signal=metrics").copied().unwrap_or(0), 1);
                 assert_eq!(
-                    m.get("signals.routed.named.metrics").copied().unwrap_or(0),
+                    m.get("signals.routed.named signal=metrics").copied().unwrap_or(0),
                     0
                 );
                 assert_eq!(
-                    m.get("signals.routed.default.metrics")
+                    m.get("signals.routed.default signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
-                assert_eq!(m.get("signals.nacked.metrics").copied().unwrap_or(0), 1);
+                assert_eq!(m.get("signals.nacked signal=metrics").copied().unwrap_or(0), 1);
                 assert_eq!(
-                    m.get("signals.rejected.route.full.metrics")
+                    m.get("signals.rejected.route.full signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
-                    m.get("signals.rejected.route.closed.metrics")
+                    m.get("signals.rejected.route.closed signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
-                assert_eq!(m.get("signals.dropped.metrics").copied().unwrap_or(0), 0);
+                assert_eq!(m.get("signals.dropped signal=metrics").copied().unwrap_or(0), 0);
 
                 stop_telemetry(reporter, collector_task);
             }));
@@ -2417,18 +2334,18 @@ mod tests {
                 tokio::time::sleep(Duration::from_millis(50)).await;
 
                 let m = collect_metrics_map(&telemetry_registry);
-                assert_eq!(m.get("signals.received.metrics").copied().unwrap_or(0), 1);
+                assert_eq!(m.get("signals.received signal=metrics").copied().unwrap_or(0), 1);
                 assert_eq!(
-                    m.get("signals.routed.named.metrics").copied().unwrap_or(0),
+                    m.get("signals.routed.named signal=metrics").copied().unwrap_or(0),
                     0
                 );
                 assert_eq!(
-                    m.get("signals.routed.default.metrics")
+                    m.get("signals.routed.default signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
-                assert_eq!(m.get("signals.dropped.metrics").copied().unwrap_or(0), 0);
+                assert_eq!(m.get("signals.dropped signal=metrics").copied().unwrap_or(0), 0);
 
                 stop_telemetry(reporter, collector_task);
             }));
@@ -2479,31 +2396,31 @@ mod tests {
                 tokio::time::sleep(Duration::from_millis(50)).await;
 
                 let m = collect_metrics_map(&telemetry_registry);
-                assert_eq!(m.get("signals.received.metrics").copied().unwrap_or(0), 1);
+                assert_eq!(m.get("signals.received signal=metrics").copied().unwrap_or(0), 1);
                 assert_eq!(
-                    m.get("signals.routed.named.metrics").copied().unwrap_or(0),
+                    m.get("signals.routed.named signal=metrics").copied().unwrap_or(0),
                     0
                 );
                 assert_eq!(
-                    m.get("signals.routed.default.metrics")
+                    m.get("signals.routed.default signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
-                assert_eq!(m.get("signals.nacked.metrics").copied().unwrap_or(0), 1);
+                assert_eq!(m.get("signals.nacked signal=metrics").copied().unwrap_or(0), 1);
                 assert_eq!(
-                    m.get("signals.rejected.route.full.metrics")
+                    m.get("signals.rejected.route.full signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     0
                 );
                 assert_eq!(
-                    m.get("signals.rejected.route.closed.metrics")
+                    m.get("signals.rejected.route.closed signal=metrics")
                         .copied()
                         .unwrap_or(0),
                     1
                 );
-                assert_eq!(m.get("signals.dropped.metrics").copied().unwrap_or(0), 0);
+                assert_eq!(m.get("signals.dropped signal=metrics").copied().unwrap_or(0), 0);
 
                 stop_telemetry(reporter, collector_task);
             }));


### PR DESCRIPTION
**Description :-**

This PR contributes to the "Heavyweight" Metric Migrations (part of #3530) by focusing strictly on refactoring the `signal_type_router` processor to use the standardized enum-attribute macros.

As requested by maintainers, this is a clean, split PR containing only the `signal_type_router` changes to ensure ease of review and proper changelog attribution.

Changes Made:

`signal_type_router`:
- Migrated metrics in `SignalTypeRouterMetrics` to utilize the new `MeasurementMetricSet` macro.
- Eliminated duplicated, signal-specific metric properties (e.g., `signals_received_logs`, `signals_received_metrics`) in favor of dynamic `SignalAttributes` (e.g., `signals.received signal=logs`).
- Updated telemetry unit tests to correctly format and assert against the new metric attribute formats.

Metric Outcomes Table:
The `signals.decision` metric includes `signal`, `outcome`, and `reason` attributes to describe the terminal routing result.

| Terminal routing result | `outcome` | `reason` |
| --- | --- | --- |
| Named signal output accepted | `success` | `named_route` |
| Default accepted because the named output is unwired | `success` | `default_route_unwired` |
| Selected output is full | `refused` | `route_full` |
| Selected output is closed | `refused` | `route_closed` |
| Neither the named nor default output exists | `failure` | `no_available_route` |
| Shutdown cancels parked work | `failure` | `node_shutdown` |

Related Links

Part of Enum-attribute instrumentation migration #3530