### PR TITLE
feat(engine): expose component inventory via `dfctl components` + admin endpoint (RFC 0001)

### DIFF
--- a/rust/otap-dataflow/.chloggen/dfctl-components.yaml
+++ b/rust/otap-dataflow/.chloggen/dfctl-components.yaml
@@ -1,0 +1,23 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: engine
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `dfctl components` and a `GET /api/v1/components` admin endpoint to report the running engine's component inventory (RFC 0001)
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [3610]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The admin server (running in the df_engine process) serves its own
+  COMPONENT_INVENTORY slice, so the report reflects exactly the components
+  linked into the running binary, including feature/platform-gated ones. The
+  dfctl command uses the standard --output human|json|yaml|agent-json flag.

--- a/rust/otap-dataflow/components-baseline.json
+++ b/rust/otap-dataflow/components-baseline.json
@@ -96,6 +96,12 @@
     "attributes": {}
   },
   {
+    "id": "urn:otel:extension:oauth2_client_auth",
+    "category": "Extension",
+    "description": null,
+    "attributes": {}
+  },
+  {
     "id": "urn:otel:processor:attribute",
     "category": "Processor",
     "description": null,

--- a/rust/otap-dataflow/crates/admin-api/src/client.rs
+++ b/rust/otap-dataflow/crates/admin-api/src/client.rs
@@ -5,7 +5,7 @@
 
 use crate::endpoint::{AdminAuth, AdminEndpoint};
 use crate::http_backend::HttpBackend;
-use crate::{Error, config, engine, groups, operations, pipelines, telemetry};
+use crate::{Error, components, config, engine, groups, operations, pipelines, telemetry};
 use async_trait::async_trait;
 use std::sync::Arc;
 use std::time::Duration;
@@ -225,6 +225,47 @@ impl AdminClient {
         TelemetryClient {
             backend: self.backend.as_ref(),
         }
+    }
+
+    /// Returns the component-inventory resource client (RFC 0001).
+    #[must_use]
+    pub fn components(&self) -> ComponentsClient<'_> {
+        ComponentsClient {
+            backend: self.backend.as_ref(),
+        }
+    }
+}
+
+/// Component-inventory admin client.
+#[derive(Clone, Copy)]
+pub struct ComponentsClient<'a> {
+    backend: &'a dyn AdminBackend,
+}
+
+impl ComponentsClient<'_> {
+    /// Returns the running engine's component inventory (RFC 0001).
+    ///
+    /// This reports exactly the components linked into the engine binary,
+    /// including feature- and platform-gated ones.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use otap_df_admin_api::{AdminClient, AdminEndpoint, HttpAdminClientSettings};
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let client = AdminClient::builder()
+    /// #     .http(HttpAdminClientSettings::new(AdminEndpoint::http(
+    /// #         "engine-a.internal.example",
+    /// #         8080,
+    /// #     )))
+    /// #     .build()?;
+    /// let inventory = client.components().list().await?;
+    /// println!("components={}", inventory.components.len());
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn list(&self) -> Result<components::ComponentsResponse, Error> {
+        self.backend.components().await
     }
 }
 
@@ -935,6 +976,7 @@ impl TelemetryClient<'_> {
 
 #[async_trait]
 pub(crate) trait AdminBackend: Send + Sync {
+    async fn components(&self) -> Result<components::ComponentsResponse, Error>;
     async fn engine_status(&self) -> Result<engine::Status, Error>;
     async fn engine_livez(&self) -> Result<engine::ProbeResponse, Error>;
     async fn engine_readyz(&self) -> Result<engine::ProbeResponse, Error>;

--- a/rust/otap-dataflow/crates/admin-api/src/http_backend.rs
+++ b/rust/otap-dataflow/crates/admin-api/src/http_backend.rs
@@ -5,7 +5,7 @@
 
 use crate::client::{AdminBackend, HttpAdminClientSettings};
 use crate::endpoint::{AdminAuth, AdminEndpoint, AdminScheme};
-use crate::{Error, config, engine, groups, operations, pipelines, telemetry};
+use crate::{Error, components, config, engine, groups, operations, pipelines, telemetry};
 use async_trait::async_trait;
 use reqwest::{Certificate, ClientBuilder, Identity, Method, Url};
 use serde::de::DeserializeOwned;
@@ -163,6 +163,12 @@ impl HttpBackend {
 
 #[async_trait]
 impl AdminBackend for HttpBackend {
+    async fn components(&self) -> Result<components::ComponentsResponse, Error> {
+        self.request_json(Method::GET, &["api", "v1", "components"], &[], &[200])
+            .await
+            .map(|(_, body)| body)
+    }
+
     async fn engine_status(&self) -> Result<engine::Status, Error> {
         self.request_json(Method::GET, &["api", "v1", "status"], &[], &[200])
             .await
@@ -829,7 +835,7 @@ fn ensure_crypto_provider() -> Result<(), Error> {
 mod tests {
     use super::*;
     use crate::config::tls::{TlsClientConfig, TlsConfig};
-    use crate::{AdminClient, engine, groups, operations, pipelines, telemetry};
+    use crate::{AdminClient, components, engine, groups, operations, pipelines, telemetry};
     use otap_test_tls_certs::{ExtendedKeyUsage, generate_ca};
     use rustls_pki_types::{CertificateDer, PrivateKeyDer, pem::PemObject};
     use serde_json::json;
@@ -964,6 +970,40 @@ mod tests {
             .await
             .expect("status should decode");
         assert_eq!(response.generated_at, "2026-01-01T00:00:00Z");
+    }
+
+    /// Scenario: the SDK requests the component inventory and the engine returns
+    /// a components response with one factory entry.
+    /// Guarantees: the client GETs `/api/v1/components` and decodes the
+    /// `ComponentsResponse` (generated_at + entries) from the body.
+    #[tokio::test]
+    async fn components_list_decodes_json() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/components"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                components::ComponentsResponse {
+                    generated_at: "2026-01-01T00:00:00Z".to_string(),
+                    components: vec![components::ComponentEntry {
+                        id: "urn:otel:receiver:otlp".to_string(),
+                        category: "Receiver".to_string(),
+                        description: Some("OTLP receiver".to_string()),
+                        attributes: Default::default(),
+                    }],
+                },
+            ))
+            .mount(&server)
+            .await;
+
+        let response = client(&server)
+            .components()
+            .list()
+            .await
+            .expect("components should decode");
+        assert_eq!(response.generated_at, "2026-01-01T00:00:00Z");
+        assert_eq!(response.components.len(), 1);
+        assert_eq!(response.components[0].id, "urn:otel:receiver:otlp");
+        assert_eq!(response.components[0].category, "Receiver");
     }
 
     #[tokio::test]

--- a/rust/otap-dataflow/crates/admin-api/src/lib.rs
+++ b/rust/otap-dataflow/crates/admin-api/src/lib.rs
@@ -11,13 +11,13 @@ mod client;
 #[cfg(feature = "http-client")]
 mod http_backend;
 
-pub use otap_df_admin_types::{engine, groups, operations, pipelines, telemetry};
+pub use otap_df_admin_types::{components, engine, groups, operations, pipelines, telemetry};
 pub use otap_df_config as config;
 
 #[cfg(feature = "http-client")]
 pub use crate::client::{
-    AdminClient, AdminClientBuilder, EngineClient, GroupsClient, HttpAdminClientSettings,
-    PipelinesClient, TelemetryClient,
+    AdminClient, AdminClientBuilder, ComponentsClient, EngineClient, GroupsClient,
+    HttpAdminClientSettings, PipelinesClient, TelemetryClient,
 };
 pub use crate::endpoint::{AdminAuth, AdminEndpoint, AdminScheme};
 pub use crate::error::{EndpointError, Error};

--- a/rust/otap-dataflow/crates/admin-types/src/components.rs
+++ b/rust/otap-dataflow/crates/admin-types/src/components.rs
@@ -1,0 +1,100 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared component-inventory admin models.
+//!
+//! Wire types for the `GET /api/v1/components` admin endpoint, which reports the
+//! running engine's component inventory (RFC 0001). The [`ComponentEntry`] shape
+//! mirrors `components-baseline.json` (id, PascalCase category, description,
+//! attributes map) so operators can diff endpoint output against the committed
+//! baseline. Source `file`/`line` are intentionally omitted (they are not part
+//! of the baseline and change frequently).
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// Response for `GET /api/v1/components`: the engine's component inventory.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ComponentsResponse {
+    /// RFC 3339 timestamp when the inventory snapshot was generated.
+    pub generated_at: String,
+    /// Inventory entries, one per linked component.
+    pub components: Vec<ComponentEntry>,
+}
+
+/// One security-relevant component in the engine's inventory.
+///
+/// Mirrors an entry in `components-baseline.json`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ComponentEntry {
+    /// Component URN, e.g. `urn:otel:receiver:otlp`.
+    pub id: String,
+    /// Component category in PascalCase, e.g. `Receiver` (matches the baseline).
+    pub category: String,
+    /// Short human-readable description, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Free-form key/value attributes (e.g. `listen_port`, `protocol`, `auth`).
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub attributes: BTreeMap<String, String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::de::DeserializeOwned;
+    use serde_json::{Value, json};
+
+    fn assert_roundtrip<T>(value: Value)
+    where
+        T: DeserializeOwned + Serialize,
+    {
+        let parsed: T = serde_json::from_value(value.clone()).expect("fixture should deserialize");
+        let serialized = serde_json::to_value(parsed).expect("model should serialize");
+        assert_eq!(serialized, value);
+    }
+
+    /// Scenario: a full components response with a factory entry (attributes +
+    /// description) and a non-factory entry (empty attributes, no description)
+    /// is deserialized and re-serialized.
+    /// Guarantees: the wire shape round-trips exactly, including `generatedAt`
+    /// camelCase, PascalCase `category`, and omission of empty
+    /// `attributes`/absent `description`.
+    #[test]
+    fn components_response_roundtrips_current_wire_shape() {
+        assert_roundtrip::<ComponentsResponse>(json!({
+            "generatedAt": "2026-01-01T00:00:00Z",
+            "components": [
+                {
+                    "id": "urn:otel:receiver:otlp",
+                    "category": "Receiver",
+                    "description": "OTLP receiver",
+                    "attributes": { "listen_port": "4317", "protocol": "gRPC" }
+                },
+                {
+                    "id": "urn:otel:controller:main",
+                    "category": "Controller"
+                }
+            ]
+        }));
+    }
+
+    /// Scenario: an entry with no attributes and no description is serialized.
+    /// Guarantees: empty `attributes` and absent `description` are omitted from
+    /// the wire form (so the output matches the baseline's minimal entries).
+    #[test]
+    fn empty_attributes_and_description_are_omitted() {
+        let entry = ComponentEntry {
+            id: "urn:otel:safety:memory_limiter".to_string(),
+            category: "Safety".to_string(),
+            description: None,
+            attributes: BTreeMap::new(),
+        };
+        let value = serde_json::to_value(&entry).expect("serialize");
+        assert_eq!(
+            value,
+            json!({ "id": "urn:otel:safety:memory_limiter", "category": "Safety" })
+        );
+    }
+}

--- a/rust/otap-dataflow/crates/admin-types/src/lib.rs
+++ b/rust/otap-dataflow/crates/admin-types/src/lib.rs
@@ -3,6 +3,7 @@
 
 //! Shared admin request, response, query, and model types.
 
+pub mod components;
 pub mod engine;
 pub mod groups;
 pub mod operations;

--- a/rust/otap-dataflow/crates/admin/src/components.rs
+++ b/rust/otap-dataflow/crates/admin/src/components.rs
@@ -1,0 +1,112 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Component inventory endpoint (RFC 0001).
+//!
+//! - GET `/api/v1/components` - list the components linked into this engine
+//!   binary, from the `COMPONENT_INVENTORY` link-time slice.
+//!
+//! The admin server runs inside the `df_engine` process, so this reports the
+//! *running engine's* inventory (exactly what was compiled/linked, including
+//! feature- and platform-gated components), not a source-level scan.
+
+use crate::AppState;
+use axum::routing::get;
+use axum::{Json, Router};
+use chrono::Utc;
+use otap_df_admin_types::components::{ComponentEntry, ComponentsResponse};
+use otap_df_engine::inventory::{self, ComponentMeta};
+
+/// Routes for the component inventory endpoint.
+pub(crate) fn routes() -> Router<AppState> {
+    Router::new().route("/components", get(list_components))
+}
+
+/// GET `/api/v1/components`: the engine's component inventory.
+pub async fn list_components() -> Json<ComponentsResponse> {
+    let components = inventory::components().iter().map(to_entry).collect();
+    Json(ComponentsResponse {
+        generated_at: Utc::now().to_rfc3339(),
+        components,
+    })
+}
+
+/// Convert a link-time [`ComponentMeta`] into the owned wire entry.
+///
+/// Uses `Category::ident_str()` for the PascalCase category (matching the
+/// `components-baseline.json` shape) and drops the source `file`/`line`.
+fn to_entry(meta: &ComponentMeta) -> ComponentEntry {
+    ComponentEntry {
+        id: meta.id.to_string(),
+        category: meta.category.ident_str().to_string(),
+        description: meta.description.map(str::to_string),
+        attributes: meta
+            .attributes
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    /// Scenario: the live engine inventory is serialized through the endpoint's
+    /// conversion for every linked component.
+    /// Guarantees: every entry carries a non-empty `id` and a category string
+    /// that is one of the known PascalCase category identifiers (so the wire
+    /// output stays consistent with the baseline vocabulary).
+    #[test]
+    fn every_linked_component_converts_to_a_valid_entry() {
+        const KNOWN: &[&str] = &[
+            "Receiver",
+            "Exporter",
+            "Processor",
+            "Extension",
+            "Admin",
+            "Controller",
+            "Cli",
+            "Subsystem",
+            "Safety",
+        ];
+        for meta in inventory::components() {
+            let entry = to_entry(meta);
+            assert!(!entry.id.is_empty(), "component id must not be empty");
+            assert!(
+                KNOWN.contains(&entry.category.as_str()),
+                "unexpected category `{}` for {}",
+                entry.category,
+                entry.id
+            );
+        }
+    }
+
+    /// Scenario: a `ComponentMeta` with attributes and a description is converted.
+    /// Guarantees: `id`, PascalCase `category`, `description`, and the full
+    /// attribute map are carried into the owned `ComponentEntry` unchanged.
+    #[test]
+    fn to_entry_preserves_fields_and_attributes() {
+        use otap_df_engine::inventory::Category;
+        let meta = ComponentMeta {
+            id: "urn:otel:receiver:otlp",
+            category: Category::Receiver,
+            description: Some("OTLP receiver"),
+            file: "file.rs",
+            line: 1,
+            attributes: &[("listen_port", "4317"), ("protocol", "gRPC")],
+        };
+        let entry = to_entry(&meta);
+        assert_eq!(entry.id, "urn:otel:receiver:otlp");
+        assert_eq!(entry.category, "Receiver");
+        assert_eq!(entry.description.as_deref(), Some("OTLP receiver"));
+        let expected: BTreeMap<String, String> = [
+            ("listen_port".to_string(), "4317".to_string()),
+            ("protocol".to_string(), "gRPC".to_string()),
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(entry.attributes, expected);
+    }
+}

--- a/rust/otap-dataflow/crates/admin/src/lib.rs
+++ b/rust/otap-dataflow/crates/admin/src/lib.rs
@@ -3,6 +3,7 @@
 
 //! HTTP server for exposing admin endpoints.
 
+mod components;
 mod convert;
 mod dashboard;
 mod debug;
@@ -342,6 +343,7 @@ pub async fn run(
     };
 
     let api_routes = Router::new()
+        .merge(components::routes())
         .merge(debug::routes())
         .merge(health::routes())
         .merge(telemetry::routes())

--- a/rust/otap-dataflow/crates/contrib-extensions/src/oauth2_client_auth/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/oauth2_client_auth/mod.rs
@@ -96,6 +96,7 @@ fn create(
 
 /// Factory registration for the OAuth 2.0 Client Auth extension.
 #[allow(unsafe_code)]
+#[otap_df_engine::component_inventory(category = Extension)]
 #[distributed_slice(OTAP_EXTENSION_FACTORIES)]
 pub static OAUTH2_CLIENT_AUTH_EXTENSION: ExtensionFactory = ExtensionFactory {
     name: OAUTH2_CLIENT_AUTH_URN,

--- a/rust/otap-dataflow/crates/ctl/src/args.rs
+++ b/rust/otap-dataflow/crates/ctl/src/args.rs
@@ -280,6 +280,7 @@ pub enum Command {
     Groups(GroupsArgs),
     Pipelines(PipelinesArgs),
     Telemetry(TelemetryArgs),
+    Components(ComponentsArgs),
 }
 
 impl Command {
@@ -299,6 +300,7 @@ impl Command {
             Command::Groups(args) => apply_group_agent_output_default(args),
             Command::Pipelines(args) => apply_pipeline_agent_output_default(args),
             Command::Telemetry(args) => apply_telemetry_agent_output_default(args),
+            Command::Components(args) => args.output.output = ReadOutput::AgentJson,
         }
     }
 }
@@ -463,6 +465,13 @@ pub enum EngineCommand {
     Status(ReadOutputArgs),
     Livez(ReadOutputArgs),
     Readyz(ReadOutputArgs),
+}
+
+/// Arguments for `components`: list the running engine's component inventory.
+#[derive(Args, Debug, Clone)]
+pub struct ComponentsArgs {
+    #[command(flatten)]
+    pub output: ReadOutputArgs,
 }
 
 /// Arguments for group-level commands that operate across pipeline groups.

--- a/rust/otap-dataflow/crates/ctl/src/commands/catalog.rs
+++ b/rust/otap-dataflow/crates/ctl/src/commands/catalog.rs
@@ -452,6 +452,7 @@ fn curated_examples(path: &[String]) -> Vec<String> {
         ["engine", "status"] => vec![command_example("engine status --output json")],
         ["engine", "livez"] => vec![command_example("engine livez")],
         ["engine", "readyz"] => vec![command_example("engine readyz")],
+        ["components"] => vec![command_example("components --output json")],
         ["groups", "status"] => vec![command_example("groups status")],
         ["groups", "describe"] => vec![command_example("groups describe")],
         ["groups", "events", "get"] => vec![command_example("groups events get --tail 20")],

--- a/rust/otap-dataflow/crates/ctl/src/commands/components.rs
+++ b/rust/otap-dataflow/crates/ctl/src/commands/components.rs
@@ -1,0 +1,29 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Component-inventory command runner (RFC 0001).
+//!
+//! Implements `dfctl components`, which reports the running engine's component
+//! inventory (`GET /api/v1/components`) as a human table or a machine-readable
+//! format, using the shared read-output plumbing.
+
+use crate::args::ComponentsArgs;
+use crate::commands::output::write_read_command_output;
+use crate::error::CliError;
+use crate::render::render_components;
+use crate::style::HumanStyle;
+use otap_df_admin_api::AdminClient;
+use std::io::Write;
+
+/// Execute the `components` command.
+pub(crate) async fn run(
+    client: &AdminClient,
+    stdout: &mut dyn Write,
+    human_style: HumanStyle,
+    args: ComponentsArgs,
+) -> Result<(), CliError> {
+    let response = client.components().list().await?;
+    write_read_command_output(stdout, args.output.output, &response, || {
+        Ok(render_components(&human_style, &response))
+    })
+}

--- a/rust/otap-dataflow/crates/ctl/src/commands/mod.rs
+++ b/rust/otap-dataflow/crates/ctl/src/commands/mod.rs
@@ -11,6 +11,7 @@
 
 pub(crate) mod catalog;
 pub(crate) mod completions;
+pub(crate) mod components;
 pub(crate) mod config;
 pub(crate) mod engine;
 pub(crate) mod fetch;

--- a/rust/otap-dataflow/crates/ctl/src/commands/tests.rs
+++ b/rust/otap-dataflow/crates/ctl/src/commands/tests.rs
@@ -70,6 +70,75 @@ async fn engine_status_json_command_hits_expected_route() {
     assert!(output.contains("\"generatedAt\""));
 }
 
+/// Scenario: the CLI runs `dfctl components --output json` against an admin
+/// endpoint.
+/// Guarantees: the command hits the committed `/api/v1/components` route and
+/// emits the decoded inventory response as JSON.
+#[tokio::test]
+async fn components_json_command_hits_expected_route() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/v1/components"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "generatedAt": "2026-01-01T00:00:00Z",
+            "components": [
+                {
+                    "id": "urn:otel:receiver:otlp",
+                    "category": "Receiver",
+                    "description": "OTLP receiver",
+                    "attributes": { "listen_port": "4317" }
+                }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let cli = Cli::try_parse_from([
+        "dfctl",
+        "--url",
+        &server.uri(),
+        "components",
+        "--output",
+        "json",
+    ])
+    .expect("parse");
+
+    let mut stdout = Vec::new();
+    run(cli, &mut stdout).await.expect("run");
+
+    let output = String::from_utf8(stdout).expect("utf8");
+    assert!(output.contains("\"urn:otel:receiver:otlp\""));
+    assert!(output.contains("\"Receiver\""));
+}
+
+/// Scenario: the CLI runs `dfctl components` with the default human output.
+/// Guarantees: the human table renders the category, id, and a component count
+/// so operators get a readable inventory without a format flag.
+#[tokio::test]
+async fn components_human_command_renders_table() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/v1/components"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "generatedAt": "2026-01-01T00:00:00Z",
+            "components": [
+                { "id": "urn:otel:receiver:otlp", "category": "Receiver" }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let cli = Cli::try_parse_from(["dfctl", "--url", &server.uri(), "components"]).expect("parse");
+
+    let mut stdout = Vec::new();
+    run(cli, &mut stdout).await.expect("run");
+
+    let output = String::from_utf8(stdout).expect("utf8");
+    assert!(output.contains("urn:otel:receiver:otlp"));
+    assert!(output.contains("Receiver"));
+    assert!(output.contains("components"));
+}
+
 /// Scenario: the CLI runs a one-shot read command in agent JSON mode.
 /// Guarantees: the output includes a stable dfctl envelope with provenance and
 /// the SDK response nested under `data`.

--- a/rust/otap-dataflow/crates/ctl/src/lib.rs
+++ b/rust/otap-dataflow/crates/ctl/src/lib.rs
@@ -162,6 +162,9 @@ pub async fn run_with_terminal_and_diagnostics(
         Command::Telemetry(args) => {
             commands::telemetry::run(&client, stdout, human_style, args).await
         }
+        Command::Components(args) => {
+            commands::components::run(&client, stdout, human_style, args).await
+        }
     }
 }
 

--- a/rust/otap-dataflow/crates/ctl/src/render.rs
+++ b/rust/otap-dataflow/crates/ctl/src/render.rs
@@ -16,11 +16,11 @@ mod output;
 mod table;
 
 pub use human::{
-    render_diagnosis, render_engine_probe, render_engine_status, render_event_line, render_events,
-    render_group_shutdown_watch, render_groups_describe, render_groups_shutdown,
-    render_groups_status, render_log_line, render_logs, render_metrics_compact,
-    render_metrics_full, render_pipeline_describe, render_pipeline_details, render_pipeline_probe,
-    render_pipeline_status, render_rollout_status, render_shutdown_status,
+    render_components, render_diagnosis, render_engine_probe, render_engine_status,
+    render_event_line, render_events, render_group_shutdown_watch, render_groups_describe,
+    render_groups_shutdown, render_groups_status, render_log_line, render_logs,
+    render_metrics_compact, render_metrics_full, render_pipeline_describe, render_pipeline_details,
+    render_pipeline_probe, render_pipeline_status, render_rollout_status, render_shutdown_status,
 };
 pub use output::{
     write_agent_output, write_bundle_output, write_event_output, write_human, write_log_event,

--- a/rust/otap-dataflow/crates/ctl/src/render/human.rs
+++ b/rust/otap-dataflow/crates/ctl/src/render/human.rs
@@ -14,7 +14,7 @@ use crate::troubleshoot::{
     DiagnosisFinding, DiagnosisReport, GroupShutdownWatchSnapshot, GroupsDescribeReport,
     NormalizedEvent, PipelineDescribeReport,
 };
-use otap_df_admin_api::{engine, groups, pipelines, telemetry};
+use otap_df_admin_api::{components, engine, groups, pipelines, telemetry};
 use std::collections::BTreeMap;
 
 /// Renders engine status as human-readable fields and a pipeline table.
@@ -26,6 +26,39 @@ pub fn render_engine_status(style: &HumanStyle, status: &engine::Status) -> Stri
     if !status.pipelines.is_empty() {
         lines.push(String::new());
         lines.push(render_pipeline_summary_table(style, &status.pipelines));
+    }
+    lines.join("\n")
+}
+
+/// Renders the engine's component inventory as human-readable fields and a
+/// table sorted by category then id.
+pub fn render_components(style: &HumanStyle, response: &components::ComponentsResponse) -> String {
+    let mut lines = vec![
+        field(style, "generated_at", response.generated_at.to_string()),
+        field(style, "components", response.components.len().to_string()),
+    ];
+    if !response.components.is_empty() {
+        let mut sorted: Vec<&components::ComponentEntry> = response.components.iter().collect();
+        sorted.sort_by(|a, b| a.category.cmp(&b.category).then_with(|| a.id.cmp(&b.id)));
+        lines.push(String::new());
+        lines.push(render_table(
+            style,
+            &[
+                TableColumn::left("category"),
+                TableColumn::left("id"),
+                TableColumn::left("description"),
+            ],
+            sorted
+                .iter()
+                .map(|entry| {
+                    vec![
+                        terminal_safe(&entry.category),
+                        terminal_safe(&entry.id),
+                        terminal_safe(entry.description.as_deref().unwrap_or("")),
+                    ]
+                })
+                .collect(),
+        ));
     }
     lines.join("\n")
 }


### PR DESCRIPTION
# Change Summary

Adds a **`dfctl components`** subcommand that reports the **running engine's**
component inventory (RFC 0001), plus the admin endpoint it queries.

```
dfctl components                 # human table (default)
dfctl components --output json   # machine-readable (pipe to jq)
dfctl components --output yaml
dfctl components --output agent-json
```

Closes #3610.

## Why an admin endpoint (not in-process)

`COMPONENT_INVENTORY` is a **link-time** distributed slice — it reflects the
components linked into the binary that reads it. `dfctl` is a **separate binary**
from `df_engine` and does **not** link the node crates, so reading its own
`otap_df_engine::inventory::components()` would report an empty/incorrect
inventory. The admin server runs **inside the `df_engine` process** and already
depends on `otap-df-engine`, so a new endpoint reads the engine's own slice
directly (stateless, no `AppState` change). This reports exactly what the running
binary contains, including feature/platform-gated components.

## Changes (four small layers)

- **admin-types** — new `components` module: `ComponentsResponse` /
  `ComponentEntry` (serde), mirroring `components-baseline.json` (id, PascalCase
  category, description, attributes). Source `file`/`line` are intentionally
  omitted. Round-trip tests.
- **admin** — new `GET /api/v1/components` endpoint that serializes
  `otap_df_engine::inventory::components()` via `Category::ident_str()`. Stateless.
- **admin-api** — `AdminClient::components().list()` backed by a new
  `AdminBackend`/`HttpBackend` method hitting `/api/v1/components`; wiremock test.
- **ctl** — `dfctl components` using the standard
  `--output human|json|yaml|agent-json` flag (consistent with `engine status`,
  etc.; `human` is the table), a `render_table` human view
  (category / id / description), dispatch wiring, a catalog example, and command
  tests (json route + human table).

## Drive-by: restore the inventory baseline

The `oauth2_client_auth` extension landed upstream (#3657) **without** a
`#[component_inventory]` annotation, so `cargo xtask component-inventory --check`
(wired into `cargo xtask check`) is currently **failing on `main`**. This PR
annotates that factory (`category = Extension`, matching its
`urn:otel:extension:oauth2_client_auth`) and regenerates
`components-baseline.json`, restoring a clean check. (Happy to split this into a
separate PR if preferred, but `xtask check` can't pass without it.)

## How are these changes tested?

- Unit/round-trip tests in `admin-types`; converter tests in `admin`; wiremock
  backend test in `admin-api`; wiremock command tests in `ctl` (json + human).
- All documented with `Scenario:` / `Guarantees:`.
- `cargo xtask check` passes (structure, component-inventory baseline, fmt,
  clippy `-D warnings`, no_std build, `cargo test --workspace`); `sanitycheck.py`
  clean.

## Are there any user-facing changes?

Yes — a new `dfctl components` command and a new `GET /api/v1/components` admin
endpoint. A `.chloggen` entry is included (`component: engine`).

Part of RFC 0001 (component inventory); tracking issue #3435.

### Changelog

- [x] Added a `.chloggen/*.yaml` entry
