### PR TITLE
chore: [query-engine] Refactor ArrayValueMut & MapValueMut retain APIs

### DIFF
--- a/rust/experimental/query_engine/engine-recordset/src/primitives/value_mut.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/primitives/value_mut.rs
@@ -57,36 +57,7 @@ pub trait ArrayValueMut: ArrayValue {
 
     fn remove(&mut self, index: usize) -> ValueMutRemoveResult;
 
-    fn retain(&mut self, item_callback: &mut dyn IndexValueMutCallback);
-}
-
-pub trait IndexValueMutCallback {
-    fn next(&mut self, index: usize, value: &mut (dyn AsStaticValueMut + 'static)) -> bool;
-}
-
-pub struct IndexValueMutClosureCallback<F>
-where
-    F: FnMut(usize, &mut (dyn AsStaticValueMut + 'static)) -> bool,
-{
-    callback: F,
-}
-
-impl<F> IndexValueMutClosureCallback<F>
-where
-    F: FnMut(usize, &mut (dyn AsStaticValueMut + 'static)) -> bool,
-{
-    pub fn new(callback: F) -> IndexValueMutClosureCallback<F> {
-        Self { callback }
-    }
-}
-
-impl<F> IndexValueMutCallback for IndexValueMutClosureCallback<F>
-where
-    F: FnMut(usize, &mut (dyn AsStaticValueMut + 'static)) -> bool,
-{
-    fn next(&mut self, index: usize, value: &mut (dyn AsStaticValueMut + 'static)) -> bool {
-        (self.callback)(index, value)
-    }
+    fn retain(&mut self, item_callback: &mut dyn FnMut(usize, &mut (dyn AsStaticValueMut + 'static)) -> bool);
 }
 
 pub trait MapValueMut: MapValue {
@@ -98,36 +69,7 @@ pub trait MapValueMut: MapValue {
 
     fn remove(&mut self, key: &str) -> ValueMutRemoveResult;
 
-    fn retain(&mut self, item_callback: &mut dyn KeyValueMutCallback);
-}
-
-pub trait KeyValueMutCallback {
-    fn next(&mut self, key: &str, value: &mut (dyn AsStaticValueMut + 'static)) -> bool;
-}
-
-pub struct KeyValueMutClosureCallback<F>
-where
-    F: FnMut(&str, &mut (dyn AsStaticValueMut + 'static)) -> bool,
-{
-    callback: F,
-}
-
-impl<F> KeyValueMutClosureCallback<F>
-where
-    F: FnMut(&str, &mut (dyn AsStaticValueMut + 'static)) -> bool,
-{
-    pub fn new(callback: F) -> KeyValueMutClosureCallback<F> {
-        Self { callback }
-    }
-}
-
-impl<F> KeyValueMutCallback for KeyValueMutClosureCallback<F>
-where
-    F: FnMut(&str, &mut (dyn AsStaticValueMut + 'static)) -> bool,
-{
-    fn next(&mut self, key: &str, value: &mut (dyn AsStaticValueMut + 'static)) -> bool {
-        (self.callback)(key, value)
-    }
+    fn retain(&mut self, item_callback: &mut dyn FnMut(&str, &mut (dyn AsStaticValueMut + 'static)) -> bool);
 }
 
 pub trait StringValueMut: StringValue {

--- a/rust/experimental/query_engine/engine-recordset/src/primitives/value_mut.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/primitives/value_mut.rs
@@ -57,7 +57,10 @@ pub trait ArrayValueMut: ArrayValue {
 
     fn remove(&mut self, index: usize) -> ValueMutRemoveResult;
 
-    fn retain(&mut self, item_callback: &mut dyn FnMut(usize, &mut (dyn AsStaticValueMut + 'static)) -> bool);
+    fn retain(
+        &mut self,
+        item_callback: &mut dyn FnMut(usize, &mut (dyn AsStaticValueMut + 'static)) -> bool,
+    );
 }
 
 pub trait MapValueMut: MapValue {
@@ -69,7 +72,10 @@ pub trait MapValueMut: MapValue {
 
     fn remove(&mut self, key: &str) -> ValueMutRemoveResult;
 
-    fn retain(&mut self, item_callback: &mut dyn FnMut(&str, &mut (dyn AsStaticValueMut + 'static)) -> bool);
+    fn retain(
+        &mut self,
+        item_callback: &mut dyn FnMut(&str, &mut (dyn AsStaticValueMut + 'static)) -> bool,
+    );
 }
 
 pub trait StringValueMut: StringValue {

--- a/rust/experimental/query_engine/engine-recordset/src/primitives/value_storage.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/primitives/value_storage.rs
@@ -400,10 +400,10 @@ impl<T: EnumerableValueSource<T>> ArrayValueMut for ArrayValueStorage<T> {
         ValueMutRemoveResult::Removed(old.into())
     }
 
-    fn retain(&mut self, item_callback: &mut dyn IndexValueMutCallback) {
+    fn retain(&mut self, item_callback: &mut dyn FnMut(usize, &mut (dyn AsStaticValueMut + 'static)) -> bool) {
         let mut index = 0;
         self.values.retain_mut(|v| {
-            let r = item_callback.next(index, v);
+            let r = (item_callback)(index, v);
             index += 1;
             r
         });
@@ -515,8 +515,8 @@ impl<T: EnumerableValueSource<T>> MapValueMut for MapValueStorage<T> {
         }
     }
 
-    fn retain(&mut self, item_callback: &mut dyn KeyValueMutCallback) {
-        self.values.retain(|k, v| item_callback.next(k, v));
+    fn retain(&mut self, item_callback: &mut dyn FnMut(&str, &mut (dyn AsStaticValueMut + 'static)) -> bool) {
+        self.values.retain(|k, v| (item_callback)(k, v));
     }
 }
 

--- a/rust/experimental/query_engine/engine-recordset/src/primitives/value_storage.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/primitives/value_storage.rs
@@ -400,7 +400,10 @@ impl<T: EnumerableValueSource<T>> ArrayValueMut for ArrayValueStorage<T> {
         ValueMutRemoveResult::Removed(old.into())
     }
 
-    fn retain(&mut self, item_callback: &mut dyn FnMut(usize, &mut (dyn AsStaticValueMut + 'static)) -> bool) {
+    fn retain(
+        &mut self,
+        item_callback: &mut dyn FnMut(usize, &mut (dyn AsStaticValueMut + 'static)) -> bool,
+    ) {
         let mut index = 0;
         self.values.retain_mut(|v| {
             let r = (item_callback)(index, v);
@@ -515,7 +518,10 @@ impl<T: EnumerableValueSource<T>> MapValueMut for MapValueStorage<T> {
         }
     }
 
-    fn retain(&mut self, item_callback: &mut dyn FnMut(&str, &mut (dyn AsStaticValueMut + 'static)) -> bool) {
+    fn retain(
+        &mut self,
+        item_callback: &mut dyn FnMut(&str, &mut (dyn AsStaticValueMut + 'static)) -> bool,
+    ) {
         self.values.retain(|k, v| (item_callback)(k, v));
     }
 }

--- a/rust/experimental/query_engine/engine-recordset/src/test_helpers.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/test_helpers.rs
@@ -177,7 +177,7 @@ impl MapValueMut for TestRecord {
         }
     }
 
-    fn retain(&mut self, item_callback: &mut dyn KeyValueMutCallback) {
-        self.values.retain(|k, v| item_callback.next(k, v));
+    fn retain(&mut self, item_callback: &mut dyn FnMut(&str, &mut (dyn AsStaticValueMut + 'static)) -> bool) {
+        self.values.retain(|k, v| (item_callback)(k, v));
     }
 }

--- a/rust/experimental/query_engine/engine-recordset/src/test_helpers.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/test_helpers.rs
@@ -177,7 +177,10 @@ impl MapValueMut for TestRecord {
         }
     }
 
-    fn retain(&mut self, item_callback: &mut dyn FnMut(&str, &mut (dyn AsStaticValueMut + 'static)) -> bool) {
+    fn retain(
+        &mut self,
+        item_callback: &mut dyn FnMut(&str, &mut (dyn AsStaticValueMut + 'static)) -> bool,
+    ) {
         self.values.retain(|k, v| (item_callback)(k, v));
     }
 }

--- a/rust/experimental/query_engine/engine-recordset/src/transform/reduce_map_transform_expression.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/transform/reduce_map_transform_expression.rs
@@ -33,7 +33,7 @@ pub fn execute_map_reduce_transform_expression<'a, TRecord: Record>(
             let target = execute_mutable_value_expression(execution_context, target)?;
 
             if let Some(ResolvedValueMut::Map(mut m)) = target {
-                m.retain(&mut KeyValueMutClosureCallback::new(|k, v| {
+                m.retain(&mut |k, v| {
                     for p in &reduction.key_patterns {
                         if p.get_value().is_match(k) {
                             execution_context.add_diagnostic_if_enabled(
@@ -82,7 +82,7 @@ pub fn execute_map_reduce_transform_expression<'a, TRecord: Record>(
                     }
 
                     true
-                }));
+                });
             } else {
                 execution_context.add_diagnostic_if_enabled(
                     RecordSetEngineDiagnosticLevel::Warn,
@@ -107,7 +107,7 @@ pub fn execute_map_reduce_transform_expression<'a, TRecord: Record>(
             let target = execute_mutable_value_expression(execution_context, target)?;
 
             if let Some(ResolvedValueMut::Map(mut m)) = target {
-                m.retain(&mut KeyValueMutClosureCallback::new(|k, v| {
+                m.retain(&mut |k, v| {
                     for p in &reduction.key_patterns {
                         if p.get_value().is_match(k) {
                             return true;
@@ -148,7 +148,7 @@ pub fn execute_map_reduce_transform_expression<'a, TRecord: Record>(
                     );
 
                     false
-                }));
+                });
             } else {
                 execution_context.add_diagnostic_if_enabled(
                     RecordSetEngineDiagnosticLevel::Warn,
@@ -389,7 +389,7 @@ fn remove_from_map<'a, TRecord: Record + 'static>(
     map: &mut dyn MapValueMut,
     reduction: &MapReduction<'_>,
 ) {
-    map.retain(&mut KeyValueMutClosureCallback::new(|k, v| {
+    map.retain(&mut |k, v| {
         if !reduction.key_patterns.is_empty() {
             for p in &reduction.key_patterns {
                 if p.get_value().is_match(k) {
@@ -439,7 +439,7 @@ fn remove_from_map<'a, TRecord: Record + 'static>(
             }
         }
         true
-    }));
+    });
 }
 
 fn remove_from_array<'a, TRecord: Record + 'static>(
@@ -472,7 +472,7 @@ fn remove_from_array<'a, TRecord: Record + 'static>(
         }
     }
 
-    array.retain(&mut IndexValueMutClosureCallback::new(|i, v| {
+    array.retain(&mut |i, v| {
         if let Some(inner_reduction) = elements.get(&i) {
             let v = v.to_static_value_mut();
             let remove = match v {
@@ -510,7 +510,7 @@ fn remove_from_array<'a, TRecord: Record + 'static>(
         }
 
         true
-    }));
+    });
 }
 
 fn keep_in_map<'a, TRecord: Record + 'static>(
@@ -519,7 +519,7 @@ fn keep_in_map<'a, TRecord: Record + 'static>(
     map: &mut dyn MapValueMut,
     reduction: &MapReduction<'_>,
 ) {
-    map.retain(&mut KeyValueMutClosureCallback::new(|k, v| {
+    map.retain(&mut |k, v| {
         if !reduction.key_patterns.is_empty() {
             for p in &reduction.key_patterns {
                 if p.get_value().is_match(k) {
@@ -562,7 +562,7 @@ fn keep_in_map<'a, TRecord: Record + 'static>(
         );
 
         false
-    }));
+    });
 }
 
 fn keep_in_array<'a, TRecord: Record + 'static>(
@@ -595,7 +595,7 @@ fn keep_in_array<'a, TRecord: Record + 'static>(
         }
     }
 
-    array.retain(&mut IndexValueMutClosureCallback::new(|i, v| {
+    array.retain(&mut |i, v| {
         if let Some(inner_reduction) = elements.get(&i) {
             let v = v.to_static_value_mut();
             match v {
@@ -630,7 +630,7 @@ fn keep_in_array<'a, TRecord: Record + 'static>(
         );
 
         false
-    }));
+    });
 }
 
 #[cfg(test)]

--- a/rust/experimental/query_engine/engine-recordset/src/transform/transform_expressions.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/transform/transform_expressions.rs
@@ -420,7 +420,7 @@ pub fn execute_transform_expression<'a, TRecord: Record>(
                             let s: String = key.to_value().convert_to_string().into();
                             key_map.insert(s.into());
                         }
-                        target_map.retain(&mut KeyValueMutClosureCallback::new(|k, v| {
+                        target_map.retain(&mut |k, v| {
                             if key_map.contains(k) {
                                 return true;
                             }
@@ -436,7 +436,7 @@ pub fn execute_transform_expression<'a, TRecord: Record>(
                                 },
                             );
                             false
-                        }));
+                        });
                     }
                     None => {
                         execution_context.add_diagnostic_if_enabled(

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/logs.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/logs.rs
@@ -402,52 +402,55 @@ impl MapValueMut for LogRecord {
         }
     }
 
-    fn retain(&mut self, item_callback: &mut dyn KeyValueMutCallback) {
+    fn retain(
+        &mut self,
+        item_callback: &mut dyn FnMut(&str, &mut (dyn AsStaticValueMut + 'static)) -> bool,
+    ) {
         if let Some(v) = &mut self.timestamp {
-            if !item_callback.next("time_unix_nano", v) {
+            if !(item_callback)("time_unix_nano", v) {
                 self.timestamp = None;
             }
         }
         if let Some(v) = &mut self.observed_timestamp {
-            if !item_callback.next("observed_time_unix_nano", v) {
+            if !(item_callback)("observed_time_unix_nano", v) {
                 self.observed_timestamp = None;
             }
         }
         if let Some(v) = &mut self.severity_number {
-            if !item_callback.next("severity_number", v) {
+            if !(item_callback)("severity_number", v) {
                 self.severity_number = None;
             }
         }
         if let Some(v) = &mut self.severity_text {
-            if !item_callback.next("severity_text", v) {
+            if !(item_callback)("severity_text", v) {
                 self.severity_text = None;
             }
         }
         if let Some(v) = &mut self.body {
-            if !item_callback.next("body", v) {
+            if !(item_callback)("body", v) {
                 self.body = None;
             }
         }
-        if !item_callback.next("attributes", &mut self.attributes) {
+        if !(item_callback)("attributes", &mut self.attributes) {
             self.attributes = MapValueStorage::new(HashMap::new());
         }
         if let Some(v) = &mut self.flags {
-            if !item_callback.next("flags", v) {
+            if !(item_callback)("flags", v) {
                 self.flags = None;
             }
         }
         if let Some(v) = &mut self.trace_id {
-            if !item_callback.next("trace_id", v) {
+            if !(item_callback)("trace_id", v) {
                 self.trace_id = None;
             }
         }
         if let Some(v) = &mut self.span_id {
-            if !item_callback.next("span_id", v) {
+            if !(item_callback)("span_id", v) {
                 self.span_id = None;
             }
         }
         if let Some(v) = &mut self.event_name {
-            if !item_callback.next("event_name", v) {
+            if !(item_callback)("event_name", v) {
                 self.event_name = None;
             }
         }

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/proto/common.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/proto/common.rs
@@ -315,10 +315,13 @@ impl ArrayValueMut for ByteArrayValueStorage {
         )))
     }
 
-    fn retain(&mut self, item_callback: &mut dyn IndexValueMutCallback) {
+    fn retain(
+        &mut self,
+        item_callback: &mut dyn FnMut(usize, &mut (dyn AsStaticValueMut + 'static)) -> bool,
+    ) {
         let mut index = 0;
         self.values.retain_mut(|v| {
-            let r = item_callback.next(index, v);
+            let r = (item_callback)(index, v);
             index += 1;
             r
         });


### PR DESCRIPTION
Relates to #3681

# Changes

* Replace custom traits\structs on `ArrayValueMut` & `MapValueMut` `retain` APIs with more vanilla `&mut dyn FnMut(...)` contracts

# Details

This PR cleans up the mutable APIs with the same change done on #3681 for immutable APIs.