### PR TITLE
fix(quiver): Report exact loss metrics during engine startup

### DIFF
--- a/rust/otap-dataflow/.chloggen/durable-buffer-startup-loss-accounting.yaml
+++ b/rust/otap-dataflow/.chloggen/durable-buffer-startup-loss-accounting.yaml
@@ -1,7 +1,7 @@
 change_type: bug_fix
 component: pipeline
 note: Report exact item and signal loss when finalized segments or WAL-only bundles expire during durable buffer startup.
-issues: [3705]
+issues: [3728]
 subtext: |
   Current-format finalized segments avoid payload reads; older segments use full validation when exact accounting is available.
-  Newly written segment and WAL formats require the current or a later version; downgrade after new data is written is unsupported.
+  No segment or WAL format changes are required; existing data remains readable across upgrades and rollbacks.

--- a/rust/otap-dataflow/.chloggen/durable-buffer-startup-loss-accounting.yaml
+++ b/rust/otap-dataflow/.chloggen/durable-buffer-startup-loss-accounting.yaml
@@ -1,0 +1,7 @@
+change_type: bug_fix
+component: pipeline
+note: Report exact item and signal loss when finalized segments or WAL-only bundles expire during durable buffer startup.
+issues: [3705]
+subtext: |
+  Current-format finalized segments avoid payload reads; older segments use full validation when exact accounting is available.
+  Newly written segment and WAL formats require the current or a later version; downgrade after new data is written is unsupported.

--- a/rust/otap-dataflow/.chloggen/durable-buffer-startup-loss-accounting.yaml
+++ b/rust/otap-dataflow/.chloggen/durable-buffer-startup-loss-accounting.yaml
@@ -1,7 +1,7 @@
 change_type: bug_fix
 component: pipeline
-note: Report exact item and signal loss when finalized segments or WAL-only bundles expire during durable buffer startup.
-issues: [3728]
+note: Report durable-buffer loss when finalized segments or WAL-only bundles expire during startup.
+issues: [3705]
 subtext: |
-  Current-format finalized segments avoid payload reads; older segments use full validation when exact accounting is available.
-  No segment or WAL format changes are required; existing data remains readable across upgrades and rollbacks.
+  Startup validates existing segment files and decodes expired WAL entries without changing on-disk formats.
+  Finalized-segment loss includes persisted bytes; WAL-only expiry reports bundle, item, and signal counts.

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/bundle_adapter.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/bundle_adapter.rs
@@ -514,6 +514,37 @@ fn extract_otlp_bytes(
     Ok(OtlpProtoBytes::new_from_bytes(signal_type, bytes))
 }
 
+/// Recovers the logical item count from a decoded Quiver bundle.
+///
+/// This is used only for WAL entries that expire during startup, where the
+/// existing WAL format does not persist `RecordBundle::item_count()`.
+pub fn recover_item_count(bundle: &dyn RecordBundle) -> Option<u64> {
+    let payloads = bundle
+        .descriptor()
+        .slots
+        .iter()
+        .filter_map(|slot| {
+            bundle
+                .payload(slot.id)
+                .map(|payload| (slot.id, payload.batch.clone()))
+        })
+        .collect::<HashMap<_, _>>();
+
+    if let Some((signal_type, batch)) = find_otlp_slot(&payloads) {
+        return extract_otlp_bytes(signal_type, batch)
+            .ok()
+            .map(|bytes| bytes.num_items() as u64);
+    }
+
+    let signal_type = determine_signal_type(&payloads).ok()?;
+    let records = match signal_type {
+        SignalType::Logs => create_records::<Logs>(&payloads).ok()?,
+        SignalType::Traces => create_records::<Traces>(&payloads).ok()?,
+        SignalType::Metrics => create_records::<Metrics>(&payloads).ok()?,
+    };
+    Some(records.num_items() as u64)
+}
+
 /// Convert a ReconstructedBundle back to OtapPdata.
 ///
 /// This reconstructs the original OTAP telemetry data from Quiver's storage format.
@@ -703,6 +734,30 @@ mod tests {
         let spans_slot = to_slot_id(SignalType::Traces, ArrowPayloadType::Spans);
         let payload = adapter.payload(spans_slot);
         assert!(payload.is_none());
+    }
+
+    /// Scenario: A decoded Arrow logs bundle is inspected during WAL expiry.
+    /// Guarantees: The counter reconstructs the original logical record count.
+    #[test]
+    fn recover_item_count_from_arrow_bundle() {
+        let records = OtapArrowRecords::Logs(logs!((Logs, ("id", UInt16, vec![1u16, 2, 3]))));
+        let adapter = OtapRecordBundleAdapter::new(records);
+
+        assert_eq!(recover_item_count(&adapter), Some(3));
+    }
+
+    /// Scenario: A decoded OTLP pass-through bundle is inspected during WAL expiry.
+    /// Guarantees: The counter uses the same protobuf item scan as live ingestion.
+    #[test]
+    fn recover_item_count_from_otlp_bundle() {
+        let otlp =
+            OtlpProtoBytes::new_from_bytes(SignalType::Logs, b"test OTLP protobuf data".to_vec());
+        let adapter = OtlpBytesAdapter::new(otlp).map_err(|(e, _)| e).unwrap();
+
+        assert_eq!(
+            recover_item_count(&adapter),
+            Some(adapter.cached_item_count())
+        );
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
@@ -99,7 +99,8 @@ use otap_df_otap::pdata::OtapPdata;
 use otap_df_pdata::TryIntoWithOptions;
 
 use bundle_adapter::{
-    OtapRecordBundleAdapter, OtlpBytesAdapter, convert_bundle_to_pdata, signal_type_from_slot_id,
+    OtapRecordBundleAdapter, OtlpBytesAdapter, convert_bundle_to_pdata, recover_item_count,
+    signal_type_from_slot_id,
 };
 pub use config::{DurableBufferConfig, OtlpHandling, SizeCapPolicy};
 use deferred_retry_state::DeferredRetryState;
@@ -889,6 +890,7 @@ impl DurableBuffer {
         // Build the Quiver engine
         let engine = QuiverEngine::builder(quiver_config)
             .with_budget(budget)
+            .with_wal_item_counter(Arc::new(recover_item_count))
             .build()
             .await
             .map_err(|e| Error::InternalError {

--- a/rust/otap-dataflow/crates/quiver/ARCHITECTURE.md
+++ b/rust/otap-dataflow/crates/quiver/ARCHITECTURE.md
@@ -820,7 +820,7 @@ future versions to extend the footer without breaking backwards compatibility:
 +-------------------------------------------------------------------------+
 |                         Batch Manifest                                  |
 |  Encoded as Arrow IPC (self-describing schema)                          |
-|  Columns: bundle_index, slot_refs (List<Struct>)                        |
+|  Columns: bundle_index, item_count, slot_refs (List<Struct>)            |
 +-------------------------------------------------------------------------+
 |                         Footer (variable size, version-dependent)       |
 |  Version 1 (34 bytes):                                                  |

--- a/rust/otap-dataflow/crates/quiver/Cargo.toml
+++ b/rust/otap-dataflow/crates/quiver/Cargo.toml
@@ -55,3 +55,7 @@ harness = false
 [[bench]]
 name = "segment"
 harness = false
+
+[[bench]]
+name = "startup"
+harness = false

--- a/rust/otap-dataflow/crates/quiver/benches/startup.rs
+++ b/rust/otap-dataflow/crates/quiver/benches/startup.rs
@@ -1,0 +1,498 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Criterion benchmarks for startup retention accounting.
+//!
+//! Fixture creation is excluded from the timed region. The benchmarks measure:
+//! - validation, accounting, and deletion of expired finalized segments
+//! - decoding, item counting, and skipping of expired WAL entries
+
+#![allow(missing_docs)]
+#![allow(unused_results)]
+
+use std::num::NonZeroU64;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+use arrow_array::RecordBatch;
+use arrow_array::builder::{Int64Builder, StringBuilder};
+use arrow_schema::{DataType, Field, Schema};
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use quiver::budget::DiskBudget;
+use quiver::config::{DurabilityMode, QuiverConfig, RetentionConfig, SegmentConfig, WalConfig};
+use quiver::engine::{QuiverEngine, WalItemCounter};
+use quiver::record_bundle::{BundleDescriptor, PayloadRef, RecordBundle, SlotDescriptor, SlotId};
+use quiver::segment::{OpenSegment, SegmentSeq, SegmentWriter};
+use tempfile::TempDir;
+use tokio::runtime::Runtime;
+
+const EXPIRED_AGE: Duration = Duration::from_secs(3_600);
+const MAX_AGE: Duration = Duration::from_secs(60);
+
+struct BenchBundle {
+    descriptor: BundleDescriptor,
+    batch: RecordBatch,
+    ingestion_time: SystemTime,
+}
+
+impl BenchBundle {
+    fn with_rows(num_rows: usize, ingestion_time: SystemTime) -> Self {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("timestamp", DataType::Int64, false),
+            Field::new("value", DataType::Int64, false),
+            Field::new("message", DataType::Utf8, false),
+        ]));
+
+        let mut timestamp = Int64Builder::with_capacity(num_rows);
+        let mut value = Int64Builder::with_capacity(num_rows);
+        let mut message = StringBuilder::with_capacity(num_rows, num_rows * 64);
+        for i in 0..num_rows {
+            timestamp.append_value(1_700_000_000_000_i64 + i as i64);
+            value.append_value(i as i64);
+            message.append_value(format!(
+                "startup retention benchmark telemetry payload row {i:08}"
+            ));
+        }
+
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(timestamp.finish()),
+                Arc::new(value.finish()),
+                Arc::new(message.finish()),
+            ],
+        )
+        .expect("valid benchmark batch");
+
+        Self {
+            descriptor: BundleDescriptor::new(vec![SlotDescriptor::new(SlotId::new(0), "Logs")]),
+            batch,
+            ingestion_time,
+        }
+    }
+}
+
+impl RecordBundle for BenchBundle {
+    fn descriptor(&self) -> &BundleDescriptor {
+        &self.descriptor
+    }
+
+    fn ingestion_time(&self) -> SystemTime {
+        self.ingestion_time
+    }
+
+    fn payload(&self, slot: SlotId) -> Option<PayloadRef<'_>> {
+        (slot == SlotId::new(0)).then_some(PayloadRef {
+            schema_fingerprint: [0; 32],
+            batch: &self.batch,
+        })
+    }
+
+    fn item_count(&self) -> u64 {
+        self.batch.num_rows() as u64
+    }
+}
+
+fn bench_tempdir() -> TempDir {
+    let home = std::env::var("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| std::env::current_dir().unwrap_or_else(|_| ".".into()));
+    let base_dir = home.join(".quiver-benchmarks");
+    std::fs::create_dir_all(&base_dir).expect("create benchmark base dir");
+    tempfile::Builder::new()
+        .prefix("startup-")
+        .tempdir_in(&base_dir)
+        .expect("create benchmark temp dir")
+}
+
+fn unlimited_budget() -> Arc<DiskBudget> {
+    Arc::new(DiskBudget::unlimited())
+}
+
+fn sync_fixture_dir(path: &Path) {
+    for entry in std::fs::read_dir(path).expect("read fixture directory") {
+        let entry = entry.expect("fixture directory entry");
+        if entry.file_type().expect("fixture file type").is_file() {
+            std::fs::File::open(entry.path())
+                .expect("open fixture file")
+                .sync_all()
+                .expect("sync fixture file");
+        }
+    }
+
+    #[cfg(unix)]
+    std::fs::File::open(path)
+        .expect("open fixture directory")
+        .sync_all()
+        .expect("sync fixture directory");
+}
+
+fn segment_config(data_dir: &Path, max_age: Option<Duration>) -> QuiverConfig {
+    QuiverConfig::builder()
+        .data_dir(data_dir)
+        .durability(DurabilityMode::SegmentOnly)
+        .segment(SegmentConfig {
+            target_size_bytes: NonZeroU64::new(1024 * 1024 * 1024).expect("non-zero"),
+            max_open_duration: Duration::from_secs(3_600),
+            ..Default::default()
+        })
+        .retention(RetentionConfig { max_age })
+        .build()
+        .expect("valid segment benchmark config")
+}
+
+fn wal_config(data_dir: &Path, max_age: Option<Duration>) -> QuiverConfig {
+    QuiverConfig::builder()
+        .data_dir(data_dir)
+        .wal(WalConfig {
+            max_size_bytes: NonZeroU64::new(1024 * 1024 * 1024).expect("non-zero"),
+            rotation_target_bytes: NonZeroU64::new(256 * 1024 * 1024).expect("non-zero"),
+            flush_interval: Duration::from_secs(3_600),
+            ..Default::default()
+        })
+        .segment(SegmentConfig {
+            target_size_bytes: NonZeroU64::new(1024 * 1024 * 1024).expect("non-zero"),
+            max_open_duration: Duration::from_secs(3_600),
+            ..Default::default()
+        })
+        .retention(RetentionConfig { max_age })
+        .build()
+        .expect("valid WAL benchmark config")
+}
+
+fn prepare_segments(
+    rt: &Runtime,
+    segment_count: usize,
+    bundles_per_segment: usize,
+    rows_per_bundle: usize,
+    expired: bool,
+) -> (TempDir, QuiverConfig, u64, u64) {
+    let temp_dir = bench_tempdir();
+    let segment_dir = temp_dir.path().join("segments");
+    std::fs::create_dir_all(&segment_dir).expect("create segment directory");
+
+    let bundle = BenchBundle::with_rows(rows_per_bundle, SystemTime::now() - EXPIRED_AGE);
+    let mut total_bytes = 0;
+    for raw_seq in 0..segment_count as u64 {
+        let seq = SegmentSeq::new(raw_seq);
+        let mut segment = OpenSegment::new();
+        for _ in 0..bundles_per_segment {
+            segment.append(&bundle).expect("append benchmark bundle");
+        }
+        let path = segment_dir.join(format!("{}.qseg", seq.to_filename_component()));
+        let writer = SegmentWriter::new(seq, false);
+        rt.block_on(writer.write_segment(&path, segment))
+            .expect("write benchmark segment");
+        total_bytes += std::fs::metadata(path)
+            .expect("benchmark segment metadata")
+            .len();
+    }
+    sync_fixture_dir(&segment_dir);
+
+    let max_age = if expired {
+        // Segment expiry uses file modification time, so make the positive
+        // max_age boundary unambiguous outside the measured region.
+        std::thread::sleep(Duration::from_millis(2));
+        Duration::from_nanos(1)
+    } else {
+        MAX_AGE
+    };
+    let config = segment_config(temp_dir.path(), Some(max_age));
+    let total_items = (segment_count * bundles_per_segment * rows_per_bundle) as u64;
+    (temp_dir, config, total_bytes, total_items)
+}
+
+fn prepare_wal(
+    rt: &Runtime,
+    entry_count: usize,
+    rows_per_entry: usize,
+    expired: bool,
+) -> (TempDir, QuiverConfig, u64, u64) {
+    let temp_dir = bench_tempdir();
+    let write_config = wal_config(temp_dir.path(), None);
+    let ingestion_time = if expired {
+        SystemTime::now() - EXPIRED_AGE
+    } else {
+        SystemTime::now()
+    };
+    let bundle = BenchBundle::with_rows(rows_per_entry, ingestion_time);
+
+    rt.block_on(async {
+        let engine = QuiverEngine::open(write_config, unlimited_budget())
+            .await
+            .expect("open WAL fixture engine");
+        for _ in 0..entry_count {
+            engine.ingest(&bundle).await.expect("write WAL fixture");
+        }
+        drop(engine);
+    });
+
+    let wal_dir = temp_dir.path().join("wal");
+    sync_fixture_dir(&wal_dir);
+    let wal_bytes = std::fs::read_dir(&wal_dir)
+        .expect("read WAL directory")
+        .map(|entry| {
+            entry
+                .expect("WAL directory entry")
+                .metadata()
+                .expect("WAL metadata")
+                .len()
+        })
+        .sum();
+    let config = wal_config(temp_dir.path(), Some(MAX_AGE));
+    let total_items = (entry_count * rows_per_entry) as u64;
+    (temp_dir, config, wal_bytes, total_items)
+}
+
+fn startup_empty(c: &mut Criterion) {
+    let rt = Runtime::new().expect("tokio runtime");
+    c.bench_function("startup_empty", |b| {
+        b.iter_batched(
+            || {
+                let temp_dir = bench_tempdir();
+                let config = segment_config(temp_dir.path(), Some(MAX_AGE));
+                (temp_dir, config)
+            },
+            |(temp_dir, config)| {
+                let engine = rt
+                    .block_on(QuiverEngine::open(config, unlimited_budget()))
+                    .expect("open empty engine");
+                drop((engine, temp_dir));
+            },
+            BatchSize::PerIteration,
+        );
+    });
+}
+
+fn startup_segments(c: &mut Criterion) {
+    let mut group = c.benchmark_group("startup_segments");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(5));
+    let rt = Runtime::new().expect("tokio runtime");
+
+    for expired in [false, true] {
+        for (segment_count, bundles_per_segment, rows_per_bundle) in
+            [(1, 16, 1_000), (4, 16, 1_000), (1, 16, 8_192)]
+        {
+            let probe = prepare_segments(
+                &rt,
+                segment_count,
+                bundles_per_segment,
+                rows_per_bundle,
+                expired,
+            );
+            let total_bytes = probe.2;
+            drop(probe);
+
+            group.throughput(Throughput::Bytes(total_bytes));
+            let state = if expired { "expired" } else { "fresh" };
+            let id = format!(
+                "{state}/{segment_count}_segments/{bundles_per_segment}_bundles/{rows_per_bundle}_rows"
+            );
+            group.bench_function(BenchmarkId::new("open", id), |b| {
+                b.iter_batched(
+                    || {
+                        prepare_segments(
+                            &rt,
+                            segment_count,
+                            bundles_per_segment,
+                            rows_per_bundle,
+                            expired,
+                        )
+                    },
+                    |(temp_dir, config, _, expected_items)| {
+                        let engine = rt
+                            .block_on(QuiverEngine::open(config, unlimited_budget()))
+                            .expect("open engine with benchmark segments");
+                        let loss = engine.retention_loss_snapshot().expired;
+                        if expired {
+                            assert_eq!(loss.segments, segment_count as u64);
+                            assert_eq!(loss.items, expected_items);
+                        } else {
+                            assert_eq!(loss.segments, 0);
+                            assert_eq!(loss.items, 0);
+                        }
+                        drop((engine, temp_dir));
+                    },
+                    BatchSize::PerIteration,
+                );
+            });
+        }
+    }
+
+    group.finish();
+}
+
+fn startup_segments_large(c: &mut Criterion) {
+    let mut group = c.benchmark_group("startup_segments_large");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(500));
+    group.measurement_time(Duration::from_secs(1));
+    let rt = Runtime::new().expect("tokio runtime");
+
+    for expired in [false, true] {
+        for (segment_count, bundles_per_segment, rows_per_bundle) in
+            [(32, 16, 1_000), (8, 16, 8_192)]
+        {
+            let probe = prepare_segments(
+                &rt,
+                segment_count,
+                bundles_per_segment,
+                rows_per_bundle,
+                expired,
+            );
+            let total_bytes = probe.2;
+            drop(probe);
+
+            group.throughput(Throughput::Bytes(total_bytes));
+            let state = if expired { "expired" } else { "fresh" };
+            let id = format!(
+                "{state}/{segment_count}_segments/{bundles_per_segment}_bundles/{rows_per_bundle}_rows"
+            );
+            group.bench_function(BenchmarkId::new("open", id), |b| {
+                b.iter_batched(
+                    || {
+                        prepare_segments(
+                            &rt,
+                            segment_count,
+                            bundles_per_segment,
+                            rows_per_bundle,
+                            expired,
+                        )
+                    },
+                    |(temp_dir, config, _, expected_items)| {
+                        let engine = rt
+                            .block_on(QuiverEngine::open(config, unlimited_budget()))
+                            .expect("open engine with large benchmark segments");
+                        let loss = engine.retention_loss_snapshot().expired;
+                        if expired {
+                            assert_eq!(loss.segments, segment_count as u64);
+                            assert_eq!(loss.items, expected_items);
+                        } else {
+                            assert_eq!(loss.segments, 0);
+                            assert_eq!(loss.items, 0);
+                        }
+                        drop((engine, temp_dir));
+                    },
+                    BatchSize::PerIteration,
+                );
+            });
+        }
+    }
+
+    group.finish();
+}
+
+fn startup_wal(c: &mut Criterion) {
+    let mut group = c.benchmark_group("startup_wal");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(5));
+    let rt = Runtime::new().expect("tokio runtime");
+    let counter: WalItemCounter = Arc::new(|bundle| {
+        bundle
+            .payload(SlotId::new(0))
+            .map(|payload| payload.batch.num_rows() as u64)
+    });
+
+    for expired in [false, true] {
+        for (entry_count, rows_per_entry) in [(100, 100), (100, 1_000), (1_000, 100)] {
+            let probe = prepare_wal(&rt, entry_count, rows_per_entry, expired);
+            let total_bytes = probe.2;
+            drop(probe);
+
+            group.throughput(Throughput::Bytes(total_bytes));
+            let state = if expired { "expired" } else { "fresh" };
+            let id = format!("{state}/{entry_count}_entries/{rows_per_entry}_rows");
+            group.bench_function(BenchmarkId::new("open", id), |b| {
+                b.iter_batched(
+                    || prepare_wal(&rt, entry_count, rows_per_entry, expired),
+                    |(temp_dir, config, _, expected_items)| {
+                        let engine = rt
+                            .block_on(
+                                QuiverEngine::builder(config)
+                                    .with_budget(unlimited_budget())
+                                    .with_wal_item_counter(Arc::clone(&counter))
+                                    .build(),
+                            )
+                            .expect("open engine with benchmark WAL");
+                        let loss = engine.retention_loss_snapshot().expired;
+                        if expired {
+                            assert_eq!(loss.bundles, entry_count as u64);
+                            assert_eq!(loss.items, expected_items);
+                        } else {
+                            assert_eq!(loss.bundles, 0);
+                            assert_eq!(loss.items, 0);
+                        }
+                        drop((engine, temp_dir));
+                    },
+                    BatchSize::PerIteration,
+                );
+            });
+        }
+    }
+
+    group.finish();
+}
+
+fn startup_wal_large(c: &mut Criterion) {
+    let mut group = c.benchmark_group("startup_wal_large");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(500));
+    group.measurement_time(Duration::from_secs(1));
+    let rt = Runtime::new().expect("tokio runtime");
+    let counter: WalItemCounter = Arc::new(|bundle| {
+        bundle
+            .payload(SlotId::new(0))
+            .map(|payload| payload.batch.num_rows() as u64)
+    });
+
+    for expired in [false, true] {
+        for (entry_count, rows_per_entry) in [(1_000, 1_000), (10_000, 100)] {
+            let probe = prepare_wal(&rt, entry_count, rows_per_entry, expired);
+            let total_bytes = probe.2;
+            drop(probe);
+
+            group.throughput(Throughput::Bytes(total_bytes));
+            let state = if expired { "expired" } else { "fresh" };
+            let id = format!("{state}/{entry_count}_entries/{rows_per_entry}_rows");
+            group.bench_function(BenchmarkId::new("open", id), |b| {
+                b.iter_batched(
+                    || prepare_wal(&rt, entry_count, rows_per_entry, expired),
+                    |(temp_dir, config, _, expected_items)| {
+                        let engine = rt
+                            .block_on(
+                                QuiverEngine::builder(config)
+                                    .with_budget(unlimited_budget())
+                                    .with_wal_item_counter(Arc::clone(&counter))
+                                    .build(),
+                            )
+                            .expect("open engine with large benchmark WAL");
+                        let loss = engine.retention_loss_snapshot().expired;
+                        if expired {
+                            assert_eq!(loss.bundles, entry_count as u64);
+                            assert_eq!(loss.items, expected_items);
+                        } else {
+                            assert_eq!(loss.bundles, 0);
+                            assert_eq!(loss.items, 0);
+                        }
+                        drop((engine, temp_dir));
+                    },
+                    BatchSize::PerIteration,
+                );
+            });
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    startup_empty,
+    startup_segments,
+    startup_segments_large,
+    startup_wal,
+    startup_wal_large,
+);
+criterion_main!(benches);

--- a/rust/otap-dataflow/crates/quiver/src/engine.rs
+++ b/rust/otap-dataflow/crates/quiver/src/engine.rs
@@ -93,6 +93,9 @@ pub struct RetentionLossSnapshot {
     pub expired: RetentionLossCounts,
 }
 
+/// Counts the logical items in a decoded WAL bundle during startup expiry.
+pub type WalItemCounter = Arc<dyn Fn(&dyn RecordBundle) -> Option<u64> + Send + Sync + 'static>;
+
 /// Primary entry point for the persistence engine.
 ///
 /// The engine coordinates:
@@ -197,10 +200,23 @@ pub struct QuiverEngine {
 ///     Ok(())
 /// }
 /// ```
-#[derive(Debug)]
 pub struct QuiverEngineBuilder {
     config: QuiverConfig,
     budget: Option<Arc<crate::budget::DiskBudget>>,
+    wal_item_counter: Option<WalItemCounter>,
+}
+
+impl std::fmt::Debug for QuiverEngineBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("QuiverEngineBuilder")
+            .field("config", &self.config)
+            .field("budget", &self.budget)
+            .field(
+                "wal_item_counter",
+                &self.wal_item_counter.as_ref().map(|_| "<counter>"),
+            )
+            .finish()
+    }
 }
 
 impl QuiverEngineBuilder {
@@ -212,6 +228,7 @@ impl QuiverEngineBuilder {
         Self {
             config,
             budget: None,
+            wal_item_counter: None,
         }
     }
 
@@ -226,6 +243,13 @@ impl QuiverEngineBuilder {
         self
     }
 
+    /// Sets the counter used to recover exact item counts for expired WAL bundles.
+    #[must_use]
+    pub fn with_wal_item_counter(mut self, counter: WalItemCounter) -> Self {
+        self.wal_item_counter = Some(counter);
+        self
+    }
+
     /// Builds the engine asynchronously, returning an `Arc<QuiverEngine>`.
     ///
     /// # Errors
@@ -236,7 +260,7 @@ impl QuiverEngineBuilder {
         let budget = self
             .budget
             .unwrap_or_else(|| Arc::new(crate::budget::DiskBudget::unlimited()));
-        QuiverEngine::open(self.config, budget).await
+        QuiverEngine::open_with_wal_item_counter(self.config, budget, self.wal_item_counter).await
     }
 }
 
@@ -282,6 +306,14 @@ impl QuiverEngine {
     pub async fn open(
         config: QuiverConfig,
         budget: Arc<crate::budget::DiskBudget>,
+    ) -> Result<Arc<Self>> {
+        Self::open_with_wal_item_counter(config, budget, None).await
+    }
+
+    async fn open_with_wal_item_counter(
+        config: QuiverConfig,
+        budget: Arc<crate::budget::DiskBudget>,
+        wal_item_counter: Option<WalItemCounter>,
     ) -> Result<Arc<Self>> {
         config.validate()?;
 
@@ -362,19 +394,16 @@ impl QuiverEngine {
             budget.clone(),
         ));
 
-        // Scan for existing segments from previous runs (recovery).
-        // Pass max_age to skip loading segments that are already expired -
-        // they'll be deleted during scan without the overhead of parsing them.
+        // Scan for existing segments from previous runs. Expired segments are
+        // validated and accounted for before deletion, but are not registered.
         let mut next_segment_seq = 0u64;
         let mut deleted_during_scan = Vec::new();
+        let mut startup_expired = RetentionLossCounts::default();
+        let mut startup_expired_items_by_shape = HashMap::new();
         match segment_store.scan_existing_with_max_age(config.retention.max_age) {
             Ok(scan_result) => {
-                // Determine next sequence from the highest loaded OR deleted segment.
-                // This prevents sequence reuse when all segments are expired and deleted.
-                let highest_found = scan_result.found.last().map(|(seq, _)| seq.raw());
-                let highest_deleted = scan_result.deleted.last().map(|seq| seq.raw());
-                if let Some(highest) = highest_found.into_iter().chain(highest_deleted).max() {
-                    next_segment_seq = highest + 1;
+                if let Some(highest) = scan_result.highest_seen {
+                    next_segment_seq = highest.raw() + 1;
                 }
 
                 if !scan_result.found.is_empty() {
@@ -392,7 +421,18 @@ impl QuiverEngine {
                         next_segment_seq,
                     );
                 }
-                deleted_during_scan = scan_result.deleted;
+                for (seq, bytes, summary) in scan_result.deleted {
+                    startup_expired.segments += 1;
+                    startup_expired.bytes += bytes;
+                    if let Some(summary) = summary {
+                        startup_expired.bundles += summary.bundles;
+                        startup_expired.items += summary.items;
+                        for (shape, items) in summary.items_by_shape {
+                            *startup_expired_items_by_shape.entry(shape).or_insert(0) += items;
+                        }
+                    }
+                    deleted_during_scan.push(seq);
+                }
             }
             Err(e) => {
                 otel_error!(
@@ -440,11 +480,11 @@ impl QuiverEngine {
             force_dropped_items: AtomicU64::new(0),
             force_dropped_bytes: AtomicU64::new(0),
             dropped_items_by_shape: RwLock::new(HashMap::new()),
-            expired_segments: AtomicU64::new(0),
-            expired_bundles: AtomicU64::new(0),
-            expired_items: AtomicU64::new(0),
-            expired_bytes: AtomicU64::new(0),
-            expired_items_by_shape: RwLock::new(HashMap::new()),
+            expired_segments: AtomicU64::new(startup_expired.segments),
+            expired_bundles: AtomicU64::new(startup_expired.bundles),
+            expired_items: AtomicU64::new(startup_expired.items),
+            expired_bytes: AtomicU64::new(startup_expired.bytes),
+            expired_items_by_shape: RwLock::new(startup_expired_items_by_shape),
             segment_store,
             registry: registry.clone(),
             budget: budget.clone(),
@@ -461,7 +501,7 @@ impl QuiverEngine {
 
         // Replay WAL entries that weren't finalized to segments before shutdown/crash
         // This uses the same ingest path as live ingestion (minus WAL writes)
-        let replayed = engine.replay_wal().await?;
+        let replayed = engine.replay_wal(wal_item_counter.as_ref()).await?;
         if replayed > 0 {
             otel_info!("quiver.wal.replay", replayed,);
         }
@@ -773,7 +813,7 @@ impl QuiverEngine {
     ///
     /// The number of WAL entries replayed.
     #[must_use = "the replay count indicates recovery status and should be logged"]
-    async fn replay_wal(&self) -> Result<usize> {
+    async fn replay_wal(&self, wal_item_counter: Option<&WalItemCounter>) -> Result<usize> {
         let wal_path = wal_path(&self.config);
 
         // Load cursor sidecar to find where we left off
@@ -932,6 +972,47 @@ impl QuiverEngine {
                 };
                 if entry_time < cutoff {
                     skipped_expired += 1;
+                    if let Some(counter) = wal_item_counter {
+                        match ReplayBundle::from_wal_entry(&entry) {
+                            Some(bundle) => match counter(&bundle) {
+                                Some(item_count) => {
+                                    let _ =
+                                        self.expired_items.fetch_add(item_count, Ordering::Relaxed);
+                                    if item_count > 0 {
+                                        let mut slot_ids = entry
+                                            .slots
+                                            .iter()
+                                            .map(|slot| slot.slot_id)
+                                            .collect::<Vec<_>>();
+                                        slot_ids.sort_unstable();
+                                        *self
+                                            .expired_items_by_shape
+                                            .write()
+                                            .entry(slot_ids)
+                                            .or_insert(0) += item_count;
+                                    }
+                                }
+                                None => {
+                                    otel_warn!(
+                                        "quiver.wal.expiry.accounting",
+                                        sequence = entry.sequence,
+                                        slot_count = entry.slots.len(),
+                                        reason = "item_count_unavailable",
+                                        message = "deleting expired WAL entry without item loss accounting because the item counter returned no count",
+                                    );
+                                }
+                            },
+                            None => {
+                                otel_warn!(
+                                    "quiver.wal.expiry.accounting",
+                                    sequence = entry.sequence,
+                                    slot_count = entry.slots.len(),
+                                    reason = "decode_failed",
+                                    message = "deleting expired WAL entry without item loss accounting because bundle decoding failed",
+                                );
+                            }
+                        }
+                    }
                     // Advance cursor past this entry so it won't be retried.
                     let cursor = WalConsumerCursor::after(&entry);
                     {
@@ -943,7 +1024,7 @@ impl QuiverEngine {
             }
 
             // Decode WAL entry into a ReplayBundle
-            let bundle = match ReplayBundle::from_wal_entry(&entry) {
+            let mut bundle = match ReplayBundle::from_wal_entry(&entry) {
                 Some(b) => b,
                 None => {
                     // Decode failure logged by from_wal_entry with slot details
@@ -962,6 +1043,21 @@ impl QuiverEngine {
                     continue;
                 }
             };
+
+            if let Some(counter) = wal_item_counter {
+                match counter(&bundle) {
+                    Some(item_count) => bundle.set_item_count(item_count),
+                    None => {
+                        otel_warn!(
+                            "quiver.wal.replay.accounting",
+                            sequence = entry.sequence,
+                            slot_count = entry.slots.len(),
+                            reason = "item_count_unavailable",
+                            message = "replaying WAL entry without an item count; future segment loss accounting may be incomplete",
+                        );
+                    }
+                }
+            }
 
             // Replay through the normal ingest path (minus WAL write)
             let cursor = WalConsumerCursor::after(&entry);
@@ -1921,6 +2017,10 @@ mod tests {
                 None
             }
         }
+
+        fn item_count(&self) -> u64 {
+            self.batch.num_rows() as u64
+        }
     }
 
     /// A bundle wrapper that returns a fixed ingestion time instead of `now()`.
@@ -1950,6 +2050,10 @@ mod tests {
 
         fn payload(&self, slot: SlotId) -> Option<PayloadRef<'_>> {
             self.inner.payload(slot)
+        }
+
+        fn item_count(&self) -> u64 {
+            self.inner.item_count()
         }
     }
 
@@ -4663,12 +4767,10 @@ mod tests {
         );
     }
 
-    /// Test that expired segments are deleted during startup scan without loading them.
-    ///
-    /// This verifies that `scan_existing_with_max_age()` deletes expired segments
-    /// based on file mtime alone, without the overhead of opening and parsing them.
+    /// Scenario: Finalized segments expire while the engine is stopped.
+    /// Guarantees: Startup deletion reports exact expired segment, bundle, item, and slot totals.
     #[tokio::test]
-    async fn startup_deletes_expired_segments_without_loading() {
+    async fn startup_deletes_expired_segments_with_exact_loss() {
         let dir = tempdir().expect("tempdir");
 
         // Phase 1: Create segments with a long max_age config
@@ -4686,6 +4788,7 @@ mod tests {
             .expect("config");
 
         let segments_created;
+        let expired_bytes;
         {
             let engine = QuiverEngine::open(config_long_age, test_budget())
                 .await
@@ -4700,6 +4803,17 @@ mod tests {
 
             segments_created = engine.segment_store().segment_count();
             assert!(segments_created >= 1, "should create at least one segment");
+            expired_bytes = engine
+                .segment_store()
+                .segment_sequences()
+                .into_iter()
+                .map(|seq| {
+                    engine
+                        .segment_store()
+                        .segment_file_size(seq)
+                        .expect("segment file size")
+                })
+                .sum::<u64>();
         }
 
         // Backdate segment files so they appear older than our short max_age
@@ -4724,6 +4838,97 @@ mod tests {
             engine2.segment_store().segment_count(),
             0,
             "expired segments should be deleted during startup, not loaded"
+        );
+
+        let loss = engine2.retention_loss_snapshot();
+        let expired_by_shape = engine2.drain_expired_items_by_shape();
+        assert_eq!(
+            (loss.expired, expired_by_shape),
+            (
+                RetentionLossCounts {
+                    segments: segments_created as u64,
+                    bundles: 5,
+                    items: 250,
+                    bytes: expired_bytes,
+                },
+                vec![(vec![SlotId::new(0)], 250)],
+            ),
+            "startup expiry should report the finalized data deleted during recovery"
+        );
+    }
+
+    /// Scenario: An expired finalized segment fails whole-file validation at startup.
+    /// Guarantees: Startup warns, deletes the file, and reports only the trusted segment loss.
+    #[tokio::test]
+    async fn startup_deletes_expired_corrupt_segment_without_item_totals() {
+        let dir = tempdir().expect("tempdir");
+        let segment_config = SegmentConfig {
+            target_size_bytes: NonZeroU64::new(100).unwrap(),
+            ..Default::default()
+        };
+
+        {
+            let config = QuiverConfig::builder()
+                .data_dir(dir.path())
+                .segment(segment_config.clone())
+                .build()
+                .expect("config");
+            let engine = QuiverEngine::open(config, test_budget())
+                .await
+                .expect("engine");
+            engine
+                .ingest(&DummyBundle::with_rows(50))
+                .await
+                .expect("ingest");
+            engine.flush().await.expect("flush");
+        }
+
+        let segment_path = fs::read_dir(dir.path().join("segments"))
+            .expect("read segments")
+            .map(|entry| entry.expect("entry").path())
+            .find(|path| path.extension().is_some_and(|ext| ext == "qseg"))
+            .expect("segment file");
+        let segment_metadata = fs::metadata(&segment_path).expect("metadata");
+        let segment_bytes = segment_metadata.len();
+        let original_permissions = segment_metadata.permissions();
+        if original_permissions.readonly() {
+            let mut writable = original_permissions.clone();
+            #[allow(clippy::permissions_set_readonly_false)]
+            writable.set_readonly(false);
+            fs::set_permissions(&segment_path, writable).expect("make writable");
+        }
+        let mut bytes = fs::read(&segment_path).expect("read segment");
+        bytes[0] ^= 0xFF;
+        fs::write(&segment_path, bytes).expect("corrupt segment payload");
+        if original_permissions.readonly() {
+            fs::set_permissions(&segment_path, original_permissions).expect("restore permissions");
+        }
+        backdate_segment_files(dir.path(), Duration::from_secs(1));
+
+        let config = QuiverConfig::builder()
+            .data_dir(dir.path())
+            .segment(segment_config)
+            .retention(RetentionConfig {
+                max_age: Some(Duration::from_millis(10)),
+            })
+            .build()
+            .expect("config");
+        let engine = QuiverEngine::open(config, test_budget())
+            .await
+            .expect("engine");
+
+        assert!(
+            !segment_path.exists(),
+            "corrupt expired segment should be deleted"
+        );
+        assert_eq!(
+            engine.retention_loss_snapshot().expired,
+            RetentionLossCounts {
+                segments: 1,
+                bundles: 0,
+                items: 0,
+                bytes: segment_bytes,
+            }
         );
     }
 
@@ -5295,10 +5500,10 @@ mod tests {
         );
     }
 
+    /// Scenario: WAL replay exceeds the segment threshold, then those finalized segments expire.
+    /// Guarantees: Replayed bundles retain exact item counts through later segment expiry.
     #[tokio::test]
-    async fn wal_replay_finalizes_segments_if_threshold_exceeded() {
-        // Test that WAL replay properly finalizes segments if the replayed data
-        // exceeds the segment size threshold
+    async fn wal_replay_finalized_segments_preserve_item_counts_for_expiry() {
         let dir = tempdir().expect("tempdir");
 
         // Segment threshold for replay: 5KB
@@ -5358,9 +5563,20 @@ mod tests {
             );
         }
 
+        let counter: WalItemCounter = Arc::new(|bundle| {
+            bundle
+                .payload(SlotId::new(0))
+                .map(|payload| payload.batch.num_rows() as u64)
+        });
+
         // Second run: reopen with SMALL segment size - replay should trigger finalization
+        let finalized_segment_count;
+        let finalized_segment_bytes;
         {
-            let engine = QuiverEngine::open(config, test_budget())
+            let engine = QuiverEngine::builder(config)
+                .with_budget(test_budget())
+                .with_wal_item_counter(Arc::clone(&counter))
+                .build()
                 .await
                 .expect("engine reopen");
 
@@ -5386,7 +5602,66 @@ mod tests {
                 bundles_remaining,
                 bundles_in_open_segment
             );
+
+            engine.flush().await.expect("finalize replay remainder");
+            finalized_segment_count = engine.segment_store().segment_count();
+            finalized_segment_bytes = engine
+                .segment_store()
+                .segment_sequences()
+                .into_iter()
+                .map(|seq| {
+                    engine
+                        .segment_store()
+                        .segment_file_size(seq)
+                        .expect("segment file size")
+                })
+                .sum::<u64>();
+            assert!(
+                finalized_segment_count >= segments_written as usize,
+                "flush should retain replay-finalized segments"
+            );
         }
+
+        backdate_segment_files(dir.path(), Duration::from_secs(1));
+
+        // Third run: expire the replay-finalized segments and verify their persisted counts.
+        let expiry_config = QuiverConfig::builder()
+            .data_dir(dir.path())
+            .segment(SegmentConfig {
+                target_size_bytes: NonZeroU64::new(replay_segment_threshold).unwrap(),
+                ..Default::default()
+            })
+            .retention(RetentionConfig {
+                max_age: Some(Duration::from_millis(10)),
+            })
+            .build()
+            .expect("expiry config");
+        let engine = QuiverEngine::builder(expiry_config)
+            .with_budget(test_budget())
+            .with_wal_item_counter(counter)
+            .build()
+            .await
+            .expect("expiry reopen");
+
+        assert_eq!(engine.segment_store().segment_count(), 0);
+        assert_eq!(
+            (
+                engine.retention_loss_snapshot().expired,
+                engine.drain_expired_items_by_shape(),
+            ),
+            (
+                RetentionLossCounts {
+                    segments: finalized_segment_count as u64,
+                    bundles: bundles_to_ingest as u64,
+                    items: (bundles_to_ingest * rows_per_bundle) as u64,
+                    bytes: finalized_segment_bytes,
+                },
+                vec![(
+                    vec![SlotId::new(0)],
+                    (bundles_to_ingest * rows_per_bundle) as u64,
+                )],
+            )
+        );
     }
 
     #[tokio::test]
@@ -5755,11 +6030,10 @@ mod tests {
         }
     }
 
+    /// Scenario: WAL-only bundles expire while the engine is stopped.
+    /// Guarantees: Replay skips expired bundles and reports their exact item and slot totals.
     #[tokio::test]
     async fn wal_replay_skips_expired_entries() {
-        // Test that WAL replay filters out entries older than max_age,
-        // preventing expired data from being replayed into new segments
-        // (which would reset its age and retain it longer than intended).
         let dir = tempdir().expect("tempdir");
 
         let max_age = Duration::from_secs(60); // 1 minute
@@ -5819,7 +6093,15 @@ mod tests {
                 .build()
                 .expect("config");
 
-            let engine = QuiverEngine::open(config, test_budget())
+            let counter: WalItemCounter = Arc::new(|bundle| {
+                bundle
+                    .payload(SlotId::new(0))
+                    .map(|payload| payload.batch.num_rows() as u64)
+            });
+            let engine = QuiverEngine::builder(config)
+                .with_budget(test_budget())
+                .with_wal_item_counter(counter)
+                .build()
                 .await
                 .expect("engine");
 
@@ -5831,11 +6113,21 @@ mod tests {
                 fresh_bundles, recovered
             );
 
-            // The expired_bundles counter should reflect the skipped entries
+            // The expired loss snapshot should reflect the skipped entries.
+            let loss = engine.retention_loss_snapshot();
+            let expired_by_shape = engine.drain_expired_items_by_shape();
             assert_eq!(
-                engine.expired_bundles(),
-                old_bundles as u64,
-                "expired_bundles counter should track skipped WAL entries"
+                (loss.expired, expired_by_shape),
+                (
+                    RetentionLossCounts {
+                        segments: 0,
+                        bundles: old_bundles as u64,
+                        items: (old_bundles * 10) as u64,
+                        bytes: 0,
+                    },
+                    vec![(vec![SlotId::new(0)], (old_bundles * 10) as u64)],
+                ),
+                "WAL startup expiry should report the skipped logical data"
             );
         }
     }

--- a/rust/otap-dataflow/crates/quiver/src/engine.rs
+++ b/rust/otap-dataflow/crates/quiver/src/engine.rs
@@ -1523,28 +1523,38 @@ impl QuiverEngine {
         let mut bytes_dropped: u64 = 0;
         for seq in &to_drop {
             // Count bundles and items before deleting (single lock acquisition)
-            if let Ok((bundles, items)) = self.segment_store.segment_drop_counts(*seq) {
-                bundles_dropped += bundles as u64;
-                items_dropped += items;
-            }
-            let file_size = self.segment_store.segment_file_size(*seq);
-            match self.segment_store.bundle_metadata(*seq) {
-                Ok(metadata) => {
-                    let mut map = self.dropped_items_by_shape.write();
-                    for bundle in metadata {
-                        let mut key = bundle.slot_ids;
-                        key.sort_unstable();
-                        *map.entry(key).or_insert(0) += bundle.item_count;
+            let has_exact_item_counts =
+                if let Ok((bundles, items)) = self.segment_store.retention_drop_counts(*seq) {
+                    bundles_dropped += bundles as u64;
+                    if let Some(items) = items {
+                        items_dropped += items;
+                        true
+                    } else {
+                        false
                     }
-                }
-                Err(e) => {
-                    otel_warn!(
-                        "quiver.segment.drop_metadata_failed",
-                        segment = seq.raw(),
-                        error = %e,
-                        error_type = "io",
-                        reason = "force_drop"
-                    );
+                } else {
+                    false
+                };
+            let file_size = self.segment_store.segment_file_size(*seq);
+            if has_exact_item_counts {
+                match self.segment_store.bundle_metadata(*seq) {
+                    Ok(metadata) => {
+                        let mut map = self.dropped_items_by_shape.write();
+                        for bundle in metadata {
+                            let mut key = bundle.slot_ids;
+                            key.sort_unstable();
+                            *map.entry(key).or_insert(0) += bundle.item_count;
+                        }
+                    }
+                    Err(e) => {
+                        otel_warn!(
+                            "quiver.segment.drop_metadata_failed",
+                            segment = seq.raw(),
+                            error = %e,
+                            error_type = "io",
+                            reason = "force_drop"
+                        );
+                    }
                 }
             }
             self.segment_store
@@ -1618,28 +1628,38 @@ impl QuiverEngine {
         let mut bytes_expired: u64 = 0;
         for seq in &expired_segments {
             // Count bundles and items before deleting (single lock acquisition)
-            if let Ok((bundles, items)) = self.segment_store.segment_drop_counts(*seq) {
-                bundles_expired += bundles as u64;
-                items_expired += items;
-            }
-            let file_size = self.segment_store.segment_file_size(*seq);
-            match self.segment_store.bundle_metadata(*seq) {
-                Ok(metadata) => {
-                    let mut map = self.expired_items_by_shape.write();
-                    for bundle in metadata {
-                        let mut key = bundle.slot_ids;
-                        key.sort_unstable();
-                        *map.entry(key).or_insert(0) += bundle.item_count;
+            let has_exact_item_counts =
+                if let Ok((bundles, items)) = self.segment_store.retention_drop_counts(*seq) {
+                    bundles_expired += bundles as u64;
+                    if let Some(items) = items {
+                        items_expired += items;
+                        true
+                    } else {
+                        false
                     }
-                }
-                Err(e) => {
-                    otel_warn!(
-                        "quiver.segment.drop_metadata_failed",
-                        segment = seq.raw(),
-                        error = %e,
-                        error_type = "io",
-                        reason = "expired"
-                    );
+                } else {
+                    false
+                };
+            let file_size = self.segment_store.segment_file_size(*seq);
+            if has_exact_item_counts {
+                match self.segment_store.bundle_metadata(*seq) {
+                    Ok(metadata) => {
+                        let mut map = self.expired_items_by_shape.write();
+                        for bundle in metadata {
+                            let mut key = bundle.slot_ids;
+                            key.sort_unstable();
+                            *map.entry(key).or_insert(0) += bundle.item_count;
+                        }
+                    }
+                    Err(e) => {
+                        otel_warn!(
+                            "quiver.segment.drop_metadata_failed",
+                            segment = seq.raw(),
+                            error = %e,
+                            error_type = "io",
+                            reason = "expired"
+                        );
+                    }
                 }
             }
 
@@ -5662,6 +5682,154 @@ mod tests {
                 )],
             )
         );
+    }
+
+    /// Scenario: A fresh WAL entry is replayed without an item counter and later expires.
+    /// Guarantees: Replay preserves the data while expiry reports bundles without inventing item totals.
+    #[tokio::test]
+    async fn wal_replay_without_item_counter_preserves_unknown_count() {
+        let dir = tempdir().expect("tempdir");
+        let wal_only_config = QuiverConfig::builder()
+            .data_dir(dir.path())
+            .segment(SegmentConfig {
+                target_size_bytes: NonZeroU64::new(100 * 1024 * 1024).unwrap(),
+                max_open_duration: Duration::from_secs(3600),
+                ..Default::default()
+            })
+            .build()
+            .expect("WAL-only config");
+
+        {
+            let engine = QuiverEngine::open(wal_only_config, test_budget())
+                .await
+                .expect("initial engine");
+            engine
+                .ingest(&DummyBundle::with_rows(10))
+                .await
+                .expect("ingest");
+            assert_eq!(engine.total_segments_written(), 0);
+        }
+
+        let replay_config = QuiverConfig::builder()
+            .data_dir(dir.path())
+            .segment(SegmentConfig {
+                target_size_bytes: NonZeroU64::new(1).unwrap(),
+                ..Default::default()
+            })
+            .build()
+            .expect("replay config");
+        let finalized_segment_bytes;
+        {
+            let engine = QuiverEngine::open(replay_config, test_budget())
+                .await
+                .expect("replay engine");
+            assert_eq!(engine.segment_store().segment_count(), 1);
+            finalized_segment_bytes = engine
+                .segment_store()
+                .segment_sequences()
+                .into_iter()
+                .map(|seq| {
+                    engine
+                        .segment_store()
+                        .segment_file_size(seq)
+                        .expect("segment file size")
+                })
+                .sum::<u64>();
+        }
+
+        backdate_segment_files(dir.path(), Duration::from_secs(1));
+
+        let expiry_config = QuiverConfig::builder()
+            .data_dir(dir.path())
+            .retention(RetentionConfig {
+                max_age: Some(Duration::from_millis(10)),
+            })
+            .build()
+            .expect("expiry config");
+        let engine = QuiverEngine::open(expiry_config, test_budget())
+            .await
+            .expect("expiry engine");
+
+        assert_eq!(engine.segment_store().segment_count(), 0);
+        assert_eq!(
+            engine.retention_loss_snapshot().expired,
+            RetentionLossCounts {
+                segments: 1,
+                bundles: 1,
+                items: 0,
+                bytes: finalized_segment_bytes,
+            }
+        );
+        assert!(engine.drain_expired_items_by_shape().is_empty());
+    }
+
+    /// Scenario: A replayed segment with an unknown item count expires while the engine is running.
+    /// Guarantees: Runtime retention reports the segment and bundle without inventing item or shape totals.
+    #[tokio::test]
+    async fn runtime_expiry_omits_unknown_replay_item_count() {
+        let dir = tempdir().expect("tempdir");
+        let wal_only_config = QuiverConfig::builder()
+            .data_dir(dir.path())
+            .segment(SegmentConfig {
+                target_size_bytes: NonZeroU64::new(100 * 1024 * 1024).unwrap(),
+                max_open_duration: Duration::from_secs(3600),
+                ..Default::default()
+            })
+            .build()
+            .expect("WAL-only config");
+
+        {
+            let engine = QuiverEngine::open(wal_only_config, test_budget())
+                .await
+                .expect("initial engine");
+            engine
+                .ingest(&DummyBundle::with_rows(10))
+                .await
+                .expect("ingest");
+            assert_eq!(engine.total_segments_written(), 0);
+        }
+
+        let replay_config = QuiverConfig::builder()
+            .data_dir(dir.path())
+            .segment(SegmentConfig {
+                target_size_bytes: NonZeroU64::new(1).unwrap(),
+                ..Default::default()
+            })
+            .retention(RetentionConfig {
+                max_age: Some(Duration::from_secs(3600)),
+            })
+            .build()
+            .expect("replay config");
+        let engine = QuiverEngine::open(replay_config, test_budget())
+            .await
+            .expect("replay engine");
+        assert_eq!(engine.segment_store().segment_count(), 1);
+        let finalized_segment_bytes = engine
+            .segment_store()
+            .segment_sequences()
+            .into_iter()
+            .map(|seq| {
+                engine
+                    .segment_store()
+                    .segment_file_size(seq)
+                    .expect("segment file size")
+            })
+            .sum::<u64>();
+
+        engine
+            .segment_store()
+            .backdate_all_segments(Duration::from_secs(7200));
+        assert_eq!(engine.cleanup_expired_segments().expect("cleanup"), 1);
+        assert_eq!(
+            engine.retention_loss_snapshot().expired,
+            RetentionLossCounts {
+                segments: 1,
+                bundles: 1,
+                items: 0,
+                bytes: finalized_segment_bytes,
+            }
+        );
+        assert!(engine.drain_expired_items_by_shape().is_empty());
     }
 
     #[tokio::test]

--- a/rust/otap-dataflow/crates/quiver/src/engine.rs
+++ b/rust/otap-dataflow/crates/quiver/src/engine.rs
@@ -1962,6 +1962,7 @@ mod tests {
     use crate::record_bundle::{
         BundleDescriptor, PayloadRef, RecordBundle, SlotDescriptor, SlotId,
     };
+    use crate::segment_store::SegmentReadMode;
     use crate::subscriber::SubscriberId;
     use crate::wal::{CURSOR_SIDECAR_FILENAME, WalReader};
     use arrow_array::builder::Int64Builder;
@@ -4891,6 +4892,7 @@ mod tests {
             let config = QuiverConfig::builder()
                 .data_dir(dir.path())
                 .segment(segment_config.clone())
+                .read_mode(SegmentReadMode::Standard)
                 .build()
                 .expect("config");
             let engine = QuiverEngine::open(config, test_budget())

--- a/rust/otap-dataflow/crates/quiver/src/lib.rs
+++ b/rust/otap-dataflow/crates/quiver/src/lib.rs
@@ -133,7 +133,8 @@ pub use config::{
     DurabilityMode, QuiverConfig, RetentionConfig, RetentionPolicy, SegmentConfig, WalConfig,
 };
 pub use engine::{
-    MaintenanceStats, QuiverEngine, QuiverEngineBuilder, RetentionLossCounts, RetentionLossSnapshot,
+    MaintenanceStats, QuiverEngine, QuiverEngineBuilder, RetentionLossCounts,
+    RetentionLossSnapshot, WalItemCounter,
 };
 pub use error::{QuiverError, Result};
 

--- a/rust/otap-dataflow/crates/quiver/src/record_bundle.rs
+++ b/rust/otap-dataflow/crates/quiver/src/record_bundle.rs
@@ -229,14 +229,16 @@ pub trait RecordBundle {
     /// metric data points, or spans obtained by scanning the protobuf
     /// wire format.
     ///
-    /// Returns `0` if the item count is unknown (e.g. WAL replay bundles
-    /// whose format pre-dates this field).
-    ///
-    /// **Implementors:** override this to return a meaningful value;
-    /// the default `0` will cause item-level metrics to under-count.
+    /// Returns `0` if the item count is unavailable.
     #[must_use]
     fn item_count(&self) -> u64 {
         0
+    }
+
+    /// Returns whether [`Self::item_count`] is authoritative.
+    #[must_use]
+    fn item_count_is_known(&self) -> bool {
+        true
     }
 }
 

--- a/rust/otap-dataflow/crates/quiver/src/segment/mod.rs
+++ b/rust/otap-dataflow/crates/quiver/src/segment/mod.rs
@@ -85,7 +85,7 @@ mod writer;
 
 pub use error::SegmentError;
 pub use open_segment::{OpenSegment, OpenSegmentBundleSummary};
-pub use reader::{ReconstructedBundle, SegmentReader};
+pub use reader::{ReconstructedBundle, SegmentLossSummary, SegmentReader};
 pub use stream_accumulator::StreamAccumulator;
 pub use types::{
     ChunkIndex, ManifestEntry, SegmentSeq, SlotChunkRef, StreamId, StreamKey, StreamMetadata,

--- a/rust/otap-dataflow/crates/quiver/src/segment/open_segment.rs
+++ b/rust/otap-dataflow/crates/quiver/src/segment/open_segment.rs
@@ -163,7 +163,8 @@ impl OpenSegment {
         }
 
         let bundle_index = self.manifest.len() as u32;
-        let mut entry = ManifestEntry::new(bundle_index, bundle.item_count());
+        let item_count = bundle.item_count_is_known().then(|| bundle.item_count());
+        let mut entry = ManifestEntry::new_with_item_count(bundle_index, item_count);
 
         // Iterate over all slots defined in the bundle's descriptor
         for slot_desc in &bundle.descriptor().slots {

--- a/rust/otap-dataflow/crates/quiver/src/segment/reader.rs
+++ b/rust/otap-dataflow/crates/quiver/src/segment/reader.rs
@@ -59,12 +59,12 @@ use super::types::{
 };
 use crate::record_bundle::{ArrowPrimitive, SlotId};
 
-/// Exact logical loss represented by one finalized segment.
+/// Trusted logical loss metadata represented by one finalized segment.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SegmentLossSummary {
     /// Number of bundles stored in the segment.
     pub bundles: u64,
-    /// Number of logical telemetry items stored in the segment.
+    /// Number of logical telemetry items, or 0 when exact counts are unavailable.
     pub items: u64,
     /// Logical item totals grouped by each bundle's sorted slot IDs.
     pub items_by_shape: Vec<(Vec<SlotId>, u64)>,
@@ -355,7 +355,7 @@ impl std::fmt::Debug for SegmentReader {
 }
 
 impl SegmentReader {
-    /// Opens and validates a segment, then recovers its exact logical loss.
+    /// Opens and validates a segment, then recovers its trusted logical loss metadata.
     pub(crate) fn read_loss_summary(
         path: impl AsRef<Path>,
     ) -> Result<SegmentLossSummary, SegmentError> {
@@ -363,7 +363,7 @@ impl SegmentReader {
         Self::loss_summary_from_reader(&reader)
     }
 
-    /// Memory-maps and validates a segment, then recovers its exact logical loss.
+    /// Memory-maps and validates a segment, then recovers its trusted logical loss metadata.
     #[cfg(feature = "mmap")]
     pub(crate) fn read_loss_summary_mmap(
         path: impl AsRef<Path>,
@@ -374,8 +374,9 @@ impl SegmentReader {
 
     fn loss_summary_from_reader(reader: &Self) -> Result<SegmentLossSummary, SegmentError> {
         if !reader.manifest_has_item_count {
-            return Err(SegmentError::InvalidFormat {
-                message: "segment manifest has no exact item counts".to_string(),
+            return Ok(SegmentLossSummary {
+                bundles: reader.manifest().len() as u64,
+                ..Default::default()
             });
         }
         Self::summarize_loss(&reader.streams, reader.manifest())
@@ -421,17 +422,24 @@ impl SegmentReader {
             }
             shape.sort_unstable();
 
-            items = items.checked_add(entry.item_count()).ok_or_else(|| {
-                SegmentError::InvalidFormat {
+            let item_count =
+                entry
+                    .exact_item_count()
+                    .ok_or_else(|| SegmentError::InvalidFormat {
+                        message: "segment manifest has no exact item counts".to_string(),
+                    })?;
+            items = items
+                .checked_add(item_count)
+                .ok_or_else(|| SegmentError::InvalidFormat {
                     message: "segment item count overflow".to_string(),
-                }
-            })?;
+                })?;
             let shape_items = items_by_shape.entry(shape).or_insert(0);
-            *shape_items = shape_items.checked_add(entry.item_count()).ok_or_else(|| {
-                SegmentError::InvalidFormat {
-                    message: "segment shape item count overflow".to_string(),
-                }
-            })?;
+            *shape_items =
+                shape_items
+                    .checked_add(item_count)
+                    .ok_or_else(|| SegmentError::InvalidFormat {
+                        message: "segment shape item count overflow".to_string(),
+                    })?;
         }
 
         let mut items_by_shape = items_by_shape.into_iter().collect::<Vec<_>>();
@@ -1002,7 +1010,7 @@ impl SegmentReader {
     /// Arrow IPC file with schema:
     ///
     /// - `bundle_index`: UInt32
-    /// - `item_count`: UInt64 (optional; defaults to 0 for legacy segments)
+    /// - `item_count`: nullable UInt64 (optional for legacy segments)
     /// - `slot_refs`: List<Struct<slot_id: UInt16, stream_id: UInt32, chunk_index: UInt32>>
     ///
     /// Each row represents one [`ManifestEntry`] describing which stream chunks
@@ -1034,8 +1042,21 @@ impl SegmentReader {
             Self::get_primitive_column::<arrow_array::types::UInt32Type>(&batch, "bundle_index")?;
 
         // item_count is optional for backward compatibility with legacy segments.
-        let item_counts: Option<Vec<u64>> =
-            Self::get_primitive_column::<arrow_array::types::UInt64Type>(&batch, "item_count").ok();
+        // Null values preserve bundles replayed without an authoritative count.
+        let item_counts = batch
+            .column_by_name("item_count")
+            .and_then(|column| column.as_primitive_opt::<arrow_array::types::UInt64Type>())
+            .map(|array| {
+                (0..array.len())
+                    .map(|index| {
+                        if array.is_null(index) {
+                            None
+                        } else {
+                            Some(array.value(index))
+                        }
+                    })
+                    .collect::<Vec<_>>()
+            });
 
         // Get the slot_refs list column
         let slot_refs_col =
@@ -1067,8 +1088,8 @@ impl SegmentReader {
 
         let mut entries = Vec::with_capacity(batch.num_rows());
         for (i, &bundle_index) in bundle_indices.iter().enumerate() {
-            let item_count = item_counts.as_ref().map(|counts| counts[i]).unwrap_or(0);
-            let mut entry = ManifestEntry::new(bundle_index, item_count);
+            let item_count = item_counts.as_ref().and_then(|counts| counts[i]);
+            let mut entry = ManifestEntry::new_with_item_count(bundle_index, item_count);
 
             // Get the struct array for this bundle's slot refs
             let slot_refs_for_bundle = slot_refs_list.value(i);
@@ -1124,7 +1145,10 @@ impl SegmentReader {
             entries.push(entry);
         }
 
-        Ok((entries, item_counts.is_some()))
+        let manifest_has_item_count = item_counts
+            .as_ref()
+            .is_some_and(|counts| counts.iter().all(Option::is_some));
+        Ok((entries, manifest_has_item_count))
     }
 
     /// Extracts a primitive column from a RecordBatch as a Vec.

--- a/rust/otap-dataflow/crates/quiver/src/segment/reader.rs
+++ b/rust/otap-dataflow/crates/quiver/src/segment/reader.rs
@@ -59,6 +59,17 @@ use super::types::{
 };
 use crate::record_bundle::{ArrowPrimitive, SlotId};
 
+/// Exact logical loss represented by one finalized segment.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SegmentLossSummary {
+    /// Number of bundles stored in the segment.
+    pub bundles: u64,
+    /// Number of logical telemetry items stored in the segment.
+    pub items: u64,
+    /// Logical item totals grouped by each bundle's sorted slot IDs.
+    pub items_by_shape: Vec<(Vec<SlotId>, u64)>,
+}
+
 // -----------------------------------------------------------------------------
 // ReconstructedBundle
 // -----------------------------------------------------------------------------
@@ -323,6 +334,8 @@ pub struct SegmentReader {
     stream_by_id: HashMap<StreamId, usize>,
     /// Batch manifest (parsed on open).
     manifest: Vec<ManifestEntry>,
+    /// Whether the manifest persisted authoritative logical item counts.
+    manifest_has_item_count: bool,
     /// Cached stream decoders for efficient repeated reads.
     /// Lazily populated on first access to each stream.
     stream_decoders: RwLock<HashMap<StreamId, StreamDecoder>>,
@@ -342,6 +355,94 @@ impl std::fmt::Debug for SegmentReader {
 }
 
 impl SegmentReader {
+    /// Opens and validates a segment, then recovers its exact logical loss.
+    pub(crate) fn read_loss_summary(
+        path: impl AsRef<Path>,
+    ) -> Result<SegmentLossSummary, SegmentError> {
+        let reader = Self::open(path)?;
+        Self::loss_summary_from_reader(&reader)
+    }
+
+    /// Memory-maps and validates a segment, then recovers its exact logical loss.
+    #[cfg(feature = "mmap")]
+    pub(crate) fn read_loss_summary_mmap(
+        path: impl AsRef<Path>,
+    ) -> Result<SegmentLossSummary, SegmentError> {
+        let reader = Self::open_mmap(path)?;
+        Self::loss_summary_from_reader(&reader)
+    }
+
+    fn loss_summary_from_reader(reader: &Self) -> Result<SegmentLossSummary, SegmentError> {
+        if !reader.manifest_has_item_count {
+            return Err(SegmentError::InvalidFormat {
+                message: "segment manifest has no exact item counts".to_string(),
+            });
+        }
+        Self::summarize_loss(&reader.streams, reader.manifest())
+    }
+
+    fn summarize_loss(
+        streams: &[StreamMetadata],
+        manifest: &[ManifestEntry],
+    ) -> Result<SegmentLossSummary, SegmentError> {
+        let streams_by_id = streams
+            .iter()
+            .map(|stream| (stream.id, stream))
+            .collect::<HashMap<_, _>>();
+        if streams_by_id.len() != streams.len() {
+            return Err(SegmentError::InvalidFormat {
+                message: "stream directory contains duplicate stream IDs".to_string(),
+            });
+        }
+
+        let mut items = 0u64;
+        let mut items_by_shape = HashMap::<Vec<SlotId>, u64>::new();
+        for (expected_index, entry) in manifest.iter().enumerate() {
+            if entry.bundle_index != expected_index as u32 {
+                return Err(SegmentError::InvalidFormat {
+                    message: "manifest bundle indices are not contiguous".to_string(),
+                });
+            }
+
+            let mut shape = Vec::with_capacity(entry.slot_count());
+            for (slot_id, chunk_ref) in entry.slots() {
+                let stream = streams_by_id.get(&chunk_ref.stream_id).ok_or_else(|| {
+                    SegmentError::InvalidFormat {
+                        message: "manifest references an unknown stream".to_string(),
+                    }
+                })?;
+                if stream.slot_id != slot_id || chunk_ref.chunk_index.raw() >= stream.chunk_count {
+                    return Err(SegmentError::InvalidFormat {
+                        message: "manifest slot reference does not match the stream directory"
+                            .to_string(),
+                    });
+                }
+                shape.push(slot_id);
+            }
+            shape.sort_unstable();
+
+            items = items.checked_add(entry.item_count()).ok_or_else(|| {
+                SegmentError::InvalidFormat {
+                    message: "segment item count overflow".to_string(),
+                }
+            })?;
+            let shape_items = items_by_shape.entry(shape).or_insert(0);
+            *shape_items = shape_items.checked_add(entry.item_count()).ok_or_else(|| {
+                SegmentError::InvalidFormat {
+                    message: "segment shape item count overflow".to_string(),
+                }
+            })?;
+        }
+
+        let mut items_by_shape = items_by_shape.into_iter().collect::<Vec<_>>();
+        items_by_shape.sort_by(|left, right| left.0.cmp(&right.0));
+        Ok(SegmentLossSummary {
+            bundles: manifest.len() as u64,
+            items,
+            items_by_shape,
+        })
+    }
+
     /// Opens a segment file by reading it into memory.
     ///
     /// This allocates a buffer and reads the entire file.
@@ -514,7 +615,7 @@ impl SegmentReader {
             streams.iter().enumerate().map(|(i, s)| (s.id, i)).collect();
 
         // 6. Read batch manifest
-        let manifest = Self::read_manifest(
+        let (manifest, manifest_has_item_count) = Self::read_manifest(
             &buffer,
             footer.manifest_offset as usize,
             footer.manifest_length as usize,
@@ -526,6 +627,7 @@ impl SegmentReader {
             streams,
             stream_by_id,
             manifest,
+            manifest_has_item_count,
             stream_decoders: RwLock::new(HashMap::new()),
         })
     }
@@ -911,7 +1013,7 @@ impl SegmentReader {
         buffer: &Buffer,
         offset: usize,
         length: usize,
-    ) -> Result<Vec<ManifestEntry>, SegmentError> {
+    ) -> Result<(Vec<ManifestEntry>, bool), SegmentError> {
         let ipc_buffer = buffer.slice_with_length(offset, length);
         let decoder = StreamDecoder::new(ipc_buffer)?;
 
@@ -1022,7 +1124,7 @@ impl SegmentReader {
             entries.push(entry);
         }
 
-        Ok(entries)
+        Ok((entries, item_counts.is_some()))
     }
 
     /// Extracts a primitive column from a RecordBatch as a Vec.
@@ -1158,6 +1260,8 @@ mod tests {
         }
     }
 
+    /// Scenario: A segment written in the current format is opened normally.
+    /// Guarantees: The reader exposes the expected counts and current format version.
     #[tokio::test]
     async fn reader_opens_valid_segment() {
         let seg = TestSegment::new().await;
@@ -1441,6 +1545,40 @@ mod tests {
 
         let result = SegmentReader::open(&seg.path);
         assert!(matches!(result, Err(SegmentError::ChecksumMismatch { .. })));
+    }
+
+    /// Scenario: Segment manifest bytes are corrupt during startup loss recovery.
+    /// Guarantees: Whole-file validation rejects the summary instead of publishing partial loss.
+    #[tokio::test]
+    async fn loss_summary_rejects_corrupt_metadata() {
+        let seg = TestSegment::new().await;
+        let reader = SegmentReader::open(&seg.path).expect("open");
+        let manifest_offset = reader.footer.manifest_offset as usize;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let permissions = std::fs::Permissions::from_mode(0o644);
+            std::fs::set_permissions(&seg.path, permissions).expect("set permissions");
+        }
+        #[cfg(not(unix))]
+        {
+            let mut permissions = std::fs::metadata(&seg.path)
+                .expect("metadata")
+                .permissions();
+            #[allow(clippy::permissions_set_readonly_false)]
+            permissions.set_readonly(false);
+            std::fs::set_permissions(&seg.path, permissions).expect("set permissions");
+        }
+
+        let mut bytes = std::fs::read(&seg.path).expect("read");
+        bytes[manifest_offset] ^= 0xFF;
+        std::fs::write(&seg.path, bytes).expect("write");
+
+        assert!(matches!(
+            SegmentReader::read_loss_summary(&seg.path),
+            Err(SegmentError::ChecksumMismatch { .. })
+        ));
     }
 
     #[tokio::test]

--- a/rust/otap-dataflow/crates/quiver/src/segment/types.rs
+++ b/rust/otap-dataflow/crates/quiver/src/segment/types.rs
@@ -303,8 +303,8 @@ pub struct ManifestEntry {
     ///
     /// For Arrow bundles this is `num_rows()`, for OTLP pass-through
     /// bundles this is the count of log records, metric data points,
-    /// or spans. Zero if unknown (e.g. legacy segments without this field).
-    item_count: u64,
+    /// or spans. `None` means the count is unknown.
+    item_count: Option<u64>,
     /// Mapping from slot to the stream/chunk containing that slot's data.
     slot_refs: HashMap<SlotId, SlotChunkRef>,
 }
@@ -313,6 +313,11 @@ impl ManifestEntry {
     /// Creates a new manifest entry for the given bundle index and item count.
     #[must_use]
     pub fn new(bundle_index: u32, item_count: u64) -> Self {
+        Self::new_with_item_count(bundle_index, Some(item_count))
+    }
+
+    /// Creates a manifest entry with an optional authoritative item count.
+    pub(crate) fn new_with_item_count(bundle_index: u32, item_count: Option<u64>) -> Self {
         Self {
             bundle_index,
             item_count,
@@ -321,8 +326,18 @@ impl ManifestEntry {
     }
 
     /// Returns the number of logical data items in this bundle.
+    ///
+    /// Returns 0 when the count is unavailable.
     #[must_use]
     pub const fn item_count(&self) -> u64 {
+        match self.item_count {
+            Some(item_count) => item_count,
+            None => 0,
+        }
+    }
+
+    /// Returns the authoritative item count when available.
+    pub(crate) const fn exact_item_count(&self) -> Option<u64> {
         self.item_count
     }
 

--- a/rust/otap-dataflow/crates/quiver/src/segment/writer.rs
+++ b/rust/otap-dataflow/crates/quiver/src/segment/writer.rs
@@ -74,10 +74,10 @@ use std::io::{BufWriter, Write};
 use std::path::Path;
 use std::sync::Arc;
 
-use arrow_array::RecordBatch;
 use arrow_array::builder::{
     FixedSizeBinaryBuilder, ListBuilder, StructBuilder, UInt16Builder, UInt32Builder, UInt64Builder,
 };
+use arrow_array::{ArrayRef, RecordBatch};
 use arrow_ipc::writer::FileWriter;
 use arrow_schema::{DataType, Field, Fields, Schema};
 use crc32fast::Hasher;
@@ -474,20 +474,24 @@ impl SegmentWriter {
             Field::new("chunk_index", ChunkIndex::arrow_data_type(), false),
         ]);
 
-        // Note: The list item field must be nullable to match what ListBuilder produces
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("bundle_index", DataType::UInt32, false),
-            Field::new("item_count", DataType::UInt64, false),
-            Field::new(
-                "slot_refs",
-                DataType::List(Arc::new(Field::new_struct(
-                    "item",
-                    slot_ref_fields.clone(),
-                    true,
-                ))),
-                false,
-            ),
-        ]));
+        let has_item_counts = entries
+            .iter()
+            .all(|entry| entry.exact_item_count().is_some());
+        let mut fields = vec![Field::new("bundle_index", DataType::UInt32, false)];
+        if has_item_counts {
+            fields.push(Field::new("item_count", DataType::UInt64, false));
+        }
+        // Note: The list item field must be nullable to match what ListBuilder produces.
+        fields.push(Field::new(
+            "slot_refs",
+            DataType::List(Arc::new(Field::new_struct(
+                "item",
+                slot_ref_fields.clone(),
+                true,
+            ))),
+            false,
+        ));
+        let schema = Arc::new(Schema::new(fields));
 
         let mut bundle_index_builder = UInt32Builder::with_capacity(entries.len());
         let mut item_count_builder = UInt64Builder::with_capacity(entries.len());
@@ -501,7 +505,9 @@ impl SegmentWriter {
 
         for entry in entries {
             bundle_index_builder.append_value(entry.bundle_index);
-            item_count_builder.append_value(entry.item_count());
+            if let Some(item_count) = entry.exact_item_count() {
+                item_count_builder.append_value(item_count);
+            }
 
             // Get the struct builder from the list builder
             let struct_builder = slot_refs_builder.values();
@@ -528,15 +534,13 @@ impl SegmentWriter {
             slot_refs_builder.append(true);
         }
 
-        let batch = RecordBatch::try_new(
-            schema.clone(),
-            vec![
-                Arc::new(bundle_index_builder.finish()),
-                Arc::new(item_count_builder.finish()),
-                Arc::new(slot_refs_builder.finish()),
-            ],
-        )
-        .map_err(|e| SegmentError::Arrow { source: e })?;
+        let mut columns: Vec<ArrayRef> = vec![Arc::new(bundle_index_builder.finish())];
+        if has_item_counts {
+            columns.push(Arc::new(item_count_builder.finish()));
+        }
+        columns.push(Arc::new(slot_refs_builder.finish()));
+        let batch = RecordBatch::try_new(schema.clone(), columns)
+            .map_err(|e| SegmentError::Arrow { source: e })?;
 
         encode_as_ipc(&batch)
     }
@@ -952,6 +956,25 @@ mod tests {
         let batches: Vec<_> = reader.map(|r| r.unwrap()).collect();
         assert_eq!(batches.len(), 1);
         assert_eq!(batches[0].num_rows(), 2);
+    }
+
+    /// Scenario: A segment contains a bundle whose logical item count is unknown.
+    /// Guarantees: The manifest omits the count column instead of persisting a zero estimate.
+    #[test]
+    fn encode_manifest_omits_unknown_item_counts() {
+        let entries = vec![
+            ManifestEntry::new(0, 10),
+            ManifestEntry::new_with_item_count(1, None),
+        ];
+
+        let ipc_bytes = SegmentWriter::encode_manifest(&entries).unwrap();
+
+        use arrow_ipc::reader::FileReader;
+        use std::io::Cursor;
+        let cursor = Cursor::new(&ipc_bytes);
+        let mut reader = FileReader::try_new(cursor, None).expect("valid IPC");
+        let batch = reader.next().expect("manifest batch").expect("valid batch");
+        assert!(batch.column_by_name("item_count").is_none());
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/quiver/src/segment_store.rs
+++ b/rust/otap-dataflow/crates/quiver/src/segment_store.rs
@@ -112,8 +112,8 @@ struct SegmentHandle {
     reader: SegmentReader,
     /// Number of bundles in this segment.
     bundle_count: u32,
-    /// Total number of logical data items across all bundles.
-    total_item_count: u64,
+    /// Authoritative total number of logical data items across all bundles.
+    total_item_count: Option<u64>,
     /// Size of the segment file in bytes.
     file_size_bytes: u64,
     /// Time when the segment was finalized (from file modification time).
@@ -142,11 +142,11 @@ impl SegmentHandle {
         })?;
 
         let bundle_count = reader.manifest().len() as u32;
-        let total_item_count = reader
-            .manifest()
-            .iter()
-            .map(|entry| entry.item_count())
-            .sum::<u64>();
+        let total_item_count = reader.manifest().iter().try_fold(0u64, |total, entry| {
+            entry
+                .exact_item_count()
+                .and_then(|count| total.checked_add(count))
+        });
 
         Ok(Self {
             seq,
@@ -827,6 +827,18 @@ impl SegmentStore {
             .collect()
     }
 
+    /// Returns bundle count and authoritative item count for retention accounting.
+    pub(crate) fn retention_drop_counts(
+        &self,
+        segment_seq: SegmentSeq,
+    ) -> Result<(u32, Option<u64>)> {
+        let segments = self.segments.read();
+        let handle = segments
+            .get(&segment_seq)
+            .ok_or_else(|| SubscriberError::segment_not_found(segment_seq.raw()))?;
+        Ok((handle.bundle_count, handle.total_item_count))
+    }
+
     /// Subtracts `offset` from every segment's `finalized_at` timestamp,
     /// making them appear older for expiration tests without sleeping.
     #[cfg(test)]
@@ -855,7 +867,7 @@ impl SegmentProvider for SegmentStore {
         let segments = self.segments.read();
         segments
             .get(&segment_seq)
-            .map(|h| h.total_item_count)
+            .map(|h| h.total_item_count.unwrap_or(0))
             .ok_or_else(|| SubscriberError::segment_not_found(segment_seq.raw()))
     }
 
@@ -898,7 +910,7 @@ impl SegmentProvider for SegmentStore {
         let handle = segments
             .get(&segment_seq)
             .ok_or_else(|| SubscriberError::segment_not_found(segment_seq.raw()))?;
-        Ok((handle.bundle_count, handle.total_item_count))
+        Ok((handle.bundle_count, handle.total_item_count.unwrap_or(0)))
     }
 
     fn read_bundle(&self, bundle_ref: BundleRef) -> Result<ReconstructedBundle> {

--- a/rust/otap-dataflow/crates/quiver/src/segment_store.rs
+++ b/rust/otap-dataflow/crates/quiver/src/segment_store.rs
@@ -16,7 +16,7 @@ use parking_lot::{Mutex, RwLock};
 
 use crate::budget::DiskBudget;
 use crate::logging::{otel_debug, otel_error, otel_warn};
-use crate::segment::{ReconstructedBundle, SegmentReader, SegmentSeq};
+use crate::segment::{ReconstructedBundle, SegmentLossSummary, SegmentReader, SegmentSeq};
 use crate::subscriber::{BundleIndex, BundleRef, SegmentProvider, SubscriberError};
 
 /// Maximum number of maintenance cycles a pending delete is retried before
@@ -66,8 +66,10 @@ pub struct ScanResult {
     /// Segments that were found and registered, sorted by sequence number.
     /// Each entry contains the segment sequence and its bundle count.
     pub found: Vec<(SegmentSeq, u32)>,
-    /// Segment sequences that were deleted during scan (e.g., expired by max_age).
-    pub deleted: Vec<SegmentSeq>,
+    /// Expired segments deleted during scan, their persisted bytes, and any exact loss summaries.
+    pub deleted: Vec<(SegmentSeq, u64, Option<SegmentLossSummary>)>,
+    /// Highest valid segment sequence observed, including retained corrupt files.
+    pub highest_seen: Option<SegmentSeq>,
 }
 
 /// Type alias for subscriber-related results.
@@ -630,17 +632,18 @@ impl SegmentStore {
     }
 
     /// Scans the segment directory and loads existing segments, optionally
-    /// filtering out expired segments without loading them.
+    /// validating, accounting for, and deleting expired segments.
     ///
     /// When `max_age` is provided, segment files whose modification time
-    /// exceeds the age limit are deleted without being loaded into memory.
-    /// This is more efficient than loading all segments and then calling
+    /// exceeds the age limit are validated using the configured read mode,
+    /// summarized for loss accounting, and deleted without being registered.
+    /// This is more efficient than registering all segments and then calling
     /// [`cleanup_expired_segments`](crate::QuiverEngine::cleanup_expired_segments).
     ///
     /// # Arguments
     ///
-    /// * `max_age` - If provided, segments older than this duration are deleted
-    ///   without being loaded.
+    /// * `max_age` - If provided, segments older than this duration are validated,
+    ///   accounted for, and deleted.
     ///
     /// # Errors
     ///
@@ -648,6 +651,7 @@ impl SegmentStore {
     pub fn scan_existing_with_max_age(&self, max_age: Option<Duration>) -> Result<ScanResult> {
         let mut found = Vec::new();
         let mut deleted = Vec::new();
+        let mut highest_seen = None;
         let now = SystemTime::now();
 
         // Pre-compute cutoff time: segments modified before this are expired.
@@ -668,11 +672,47 @@ impl SegmentStore {
             let path = entry.path();
             if path.extension().is_some_and(|ext| ext == "qseg") {
                 if let Some(seq) = Self::parse_segment_filename(&path) {
-                    // Check if segment is expired before loading
+                    highest_seen =
+                        Some(highest_seen.map_or(seq, |highest: SegmentSeq| highest.max(seq)));
+                    // Check if the segment is expired before registering it.
                     if let Some(cutoff) = cutoff {
                         if Self::is_file_before_cutoff(&path, cutoff) {
-                            // Delete expired segment without loading it.
-                            // No budget release needed - file was never registered.
+                            let file_size = match std::fs::metadata(&path) {
+                                Ok(metadata) => metadata.len(),
+                                Err(e) => {
+                                    otel_warn!(
+                                        "quiver.segment.scan",
+                                        path = %path.display(),
+                                        error = %e,
+                                        error_type = "io",
+                                        message = "expired segment byte loss cannot be reported because file metadata could not be read",
+                                    );
+                                    0
+                                }
+                            };
+                            let summary_result = match self.read_mode {
+                                SegmentReadMode::Standard => {
+                                    SegmentReader::read_loss_summary(&path)
+                                }
+                                #[cfg(feature = "mmap")]
+                                SegmentReadMode::Mmap => {
+                                    SegmentReader::read_loss_summary_mmap(&path)
+                                }
+                            };
+                            let summary = match summary_result {
+                                Ok(summary) => Some(summary),
+                                Err(e) => {
+                                    otel_warn!(
+                                        "quiver.segment.scan",
+                                        path = %path.display(),
+                                        error = %e,
+                                        error_type = "invalid_metadata",
+                                        message = "deleting expired segment without bundle or item loss accounting because exact metadata could not be recovered",
+                                    );
+                                    None
+                                }
+                            };
+                            // No budget release is needed because the file was never registered.
                             if let Err(e) = Self::remove_readonly_file(&path) {
                                 otel_warn!(
                                     "quiver.segment.scan",
@@ -682,7 +722,7 @@ impl SegmentStore {
                                 );
                             } else {
                                 otel_debug!("quiver.segment.scan", segment = seq.raw(),);
-                                deleted.push(seq);
+                                deleted.push((seq, file_size, summary));
                             }
                             continue;
                         }
@@ -706,9 +746,13 @@ impl SegmentStore {
 
         // Sort by sequence number
         found.sort_by_key(|(seq, _)| *seq);
-        deleted.sort();
+        deleted.sort_by_key(|(seq, _, _)| *seq);
 
-        Ok(ScanResult { found, deleted })
+        Ok(ScanResult {
+            found,
+            deleted,
+            highest_seen,
+        })
     }
 
     /// Checks if a file's modification time is before the cutoff time.

--- a/rust/otap-dataflow/crates/quiver/src/wal/replay.rs
+++ b/rust/otap-dataflow/crates/quiver/src/wal/replay.rs
@@ -29,7 +29,7 @@ pub(crate) struct ReplayBundle {
     /// The ingestion timestamp from the WAL entry.
     ingestion_time: SystemTime,
     /// Logical item count recovered by the caller's WAL item counter.
-    item_count: u64,
+    item_count: Option<u64>,
     /// Decoded slots with their Arrow RecordBatch data.
     slots: Vec<ReplaySlot>,
 }
@@ -106,14 +106,14 @@ impl ReplayBundle {
         Some(Self {
             descriptor: BundleDescriptor::new(descriptors),
             ingestion_time,
-            item_count: 0,
+            item_count: None,
             slots,
         })
     }
 
     /// Sets the logical item count recovered by the caller's WAL item counter.
     pub(crate) const fn set_item_count(&mut self, item_count: u64) {
-        self.item_count = item_count;
+        self.item_count = Some(item_count);
     }
 }
 
@@ -137,7 +137,11 @@ impl RecordBundle for ReplayBundle {
     }
 
     fn item_count(&self) -> u64 {
-        self.item_count
+        self.item_count.unwrap_or(0)
+    }
+
+    fn item_count_is_known(&self) -> bool {
+        self.item_count.is_some()
     }
 }
 

--- a/rust/otap-dataflow/crates/quiver/src/wal/replay.rs
+++ b/rust/otap-dataflow/crates/quiver/src/wal/replay.rs
@@ -28,6 +28,8 @@ pub(crate) struct ReplayBundle {
     descriptor: BundleDescriptor,
     /// The ingestion timestamp from the WAL entry.
     ingestion_time: SystemTime,
+    /// Logical item count recovered by the caller's WAL item counter.
+    item_count: u64,
     /// Decoded slots with their Arrow RecordBatch data.
     slots: Vec<ReplaySlot>,
 }
@@ -104,8 +106,14 @@ impl ReplayBundle {
         Some(Self {
             descriptor: BundleDescriptor::new(descriptors),
             ingestion_time,
+            item_count: 0,
             slots,
         })
+    }
+
+    /// Sets the logical item count recovered by the caller's WAL item counter.
+    pub(crate) const fn set_item_count(&mut self, item_count: u64) {
+        self.item_count = item_count;
     }
 }
 
@@ -126,6 +134,10 @@ impl RecordBundle for ReplayBundle {
                 schema_fingerprint: s.schema_fingerprint,
                 batch: &s.batch,
             })
+    }
+
+    fn item_count(&self) -> u64 {
+        self.item_count
     }
 }
 

--- a/rust/otap-dataflow/crates/quiver/src/wal/tests.rs
+++ b/rust/otap-dataflow/crates/quiver/src/wal/tests.rs
@@ -106,6 +106,12 @@ impl RecordBundle for FixtureBundle {
                 batch: &slot.batch,
             })
     }
+
+    fn item_count(&self) -> u64 {
+        self.slots
+            .first()
+            .map_or(0, |slot| slot.batch.num_rows() as u64)
+    }
 }
 
 fn build_batch(values: &[i64]) -> RecordBatch {


### PR DESCRIPTION
# Change Summary

Report exact durable-buffer loss for finalized segments and WAL-only bundles removed by startup max-age retention.

Startup cleanup currently deletes expired segment files before loading them, so their loss is omitted. WAL replay counts expired bundles but cannot report their item or signal totals.

A finalized segment is an immutable `.qseg` file containing multiple bundles that have been grouped and written from the in-memory open segment. It stores their payload streams and a manifest describing which bundles and items they contain.

The WAL is an append-only recovery log for bundles accepted since the last segment was finalized. Each entry contains the bundle timestamp, populated slots, and encoded payload needed to rebuild it after an unexpected shutdown.

An initial solution considered adding fields to the segment and WAL formats. That would make older binaries unable to read newly written data after a rollback, so this change instead recovers counts from the existing formats.

### How it works

Previously, startup removed expired data from both paths without fully reporting its logical item count and signal.

#### Finalized segments

- Startup validates each expired file, reads its manifest totals, reports the loss, and deletes the file. If validation or exact counting fails, startup warns, reports only the segment loss, and still deletes the file.
- **Performance implication:** Validation must inspect the full file, so startup cost grows with the number and size of expired segments. Memory mapping avoids a payload-sized heap copy but does not avoid reading the data.

#### WAL-only bundles

- Startup decodes each expired entry, counts its Arrow or OTLP items through the durable-buffer adapter, reports the loss, advances the replay cursor, and skips the bundle.
- **Performance implication:** Startup must decode and count every expired entry, then durably persist the replay cursor. At larger scales, skipping normal segment reconstruction can offset part of this work.

No segment or WAL format changes are required, so existing data remains readable across upgrades and rollbacks.

### Performance tradeoff

Exact startup accounting requires reading expired finalized segments and decoding expired WAL bundles. This work occurs only for data that exceeded `max_age` while the process was stopped.

Results:

| Fixture | Fresh data | Expired data | Expiry overhead | Increase |
| --- | ---: | ---: | ---: | ---: |
| 1 segment, 16 x 1,000-row bundles | 2.22 ms | 2.94 ms | 0.72 ms | 32.4% |
| 4 segments, 16 x 1,000-row bundles each | 3.28 ms | 5.08 ms | 1.81 ms | 55.2% |
| 1 segment, 16 x 8,192-row bundles | 4.88 ms | 7.01 ms | 2.13 ms | 43.7% |
| 32 segments, 16 x 1,000-row bundles each | 13.31 ms | 20.25 ms | 6.94 ms | 52.2% |
| 8 segments, 16 x 8,192-row bundles each | 19.53 ms | 32.47 ms | 12.94 ms | 66.3% |
| 100 WAL entries x 100 rows | 3.53 ms | 15.74 ms | 12.21 ms | 346.0% |
| 100 WAL entries x 1,000 rows | 10.50 ms | 22.10 ms | 11.59 ms | 110.4% |
| 1,000 WAL entries x 100 rows | 18.77 ms | 21.94 ms | 3.17 ms | 16.9% |
| 1,000 WAL entries x 1,000 rows | 96.64 ms | 106.72 ms | 10.08 ms | 10.4% |
| 10,000 WAL entries x 100 rows | 174.07 ms | 149.68 ms | -24.39 ms | -14.0% |

- Empty startup establishes a 1.60 ms initialization baseline.
- Segment expiry overhead continues to scale with file count and payload bytes.
- WAL expiry adds roughly 10-12 ms at smaller scales, primarily from persisting its crash-safe replay cursor.
- At 10,000 WAL entries, skipping segment reconstruction outweighs the fixed cursor cost.
- WAL timings vary with filesystem sync latency, so absolute cost is more informative than percentage increase over a small baseline.
- Cold-disk startup can be slower than these warm-cache results.

## What issue does this PR close?

* Closes #3728

## How are these changes tested?

Unit tests and benchmarks

## Are there any user-facing changes?

Yes, more accurate loss metrics from `durable_buffer_processor`

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry
* [ ] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
