### PR TITLE
feat(telemetry): apply log level during reconciliation

### DIFF
--- a/rust/otap-dataflow/.chloggen/apply-log-level-before-reconciliation.yaml
+++ b/rust/otap-dataflow/.chloggen/apply-log-level-before-reconciliation.yaml
@@ -2,4 +2,4 @@ change_type: enhancement
 component: observability
 note: Apply reconciled internal log levels before pipeline rewiring begins.
 issues: [3387]
-subtext: Pipeline startup, readiness, draining, and cutover use the requested verbosity. Failed reconciliation restores the previous filter.
+subtext: Pipeline startup, readiness, draining, and cutover use the requested verbosity. Failed reconciliation restores the previous directives.

--- a/rust/otap-dataflow/.chloggen/apply-log-level-before-reconciliation.yaml
+++ b/rust/otap-dataflow/.chloggen/apply-log-level-before-reconciliation.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: observability
+note: Apply reconciled internal log levels before pipeline rewiring begins.
+issues: [3387]
+subtext: Pipeline startup, readiness, draining, and cutover use the requested verbosity. Failed reconciliation restores the previous filter.

--- a/rust/otap-dataflow/crates/controller/src/live_control/planning.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control/planning.rs
@@ -1563,7 +1563,7 @@ impl<
             .into_iter()
             .filter(|pipeline| pipeline.role == ResolvedPipelineRole::Regular)
         {
-            _ = self.assigned_cores_for_resolved(&pipeline)?;
+            _ = self.pipeline_placement_for_resolved_with_reserved(&pipeline, &BTreeSet::new())?;
         }
 
         let state = self

--- a/rust/otap-dataflow/crates/controller/src/live_control/planning.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control/planning.rs
@@ -1550,22 +1550,16 @@ impl<
         state.config_revision += 1;
     }
 
+    // Rejects conflicting concurrent operations before the desired log level is
+    // applied. Placement feasibility is validated per pipeline by the planning
+    // loop below, which is reservation-aware; repeating a reservation-free
+    // placement check here would only duplicate it.
     fn preflight_engine_reconciliation(
         &self,
-        desired_config: &OtelDataflowSpec,
         desired_pipeline_keys: &HashSet<PipelineKey>,
         delete_missing: bool,
         engine_operation_id: &str,
     ) -> Result<(), ControlPlaneError> {
-        for pipeline in desired_config
-            .resolve()
-            .pipelines
-            .into_iter()
-            .filter(|pipeline| pipeline.role == ResolvedPipelineRole::Regular)
-        {
-            _ = self.pipeline_placement_for_resolved_with_reserved(&pipeline, &BTreeSet::new())?;
-        }
-
         let state = self
             .state
             .lock()
@@ -2051,7 +2045,6 @@ impl<
             .collect();
 
         self.preflight_engine_reconciliation(
-            &desired_config,
             &desired_key_set,
             request.delete_missing,
             guard.operation_id(),

--- a/rust/otap-dataflow/crates/controller/src/live_control/planning.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control/planning.rs
@@ -1519,8 +1519,6 @@ impl<
     }
 
     fn apply_reconcile_success(&self, desired_config: &OtelDataflowSpec, delete_missing: bool) {
-        self.log_filter_handle
-            .apply(&desired_config.engine.telemetry.logs.level);
         let mut state = self
             .state
             .lock()
@@ -1550,6 +1548,38 @@ impl<
             }
         }
         state.config_revision += 1;
+    }
+
+    fn preflight_engine_reconciliation(
+        &self,
+        desired_config: &OtelDataflowSpec,
+        desired_pipeline_keys: &HashSet<PipelineKey>,
+        delete_missing: bool,
+        engine_operation_id: &str,
+    ) -> Result<(), ControlPlaneError> {
+        for pipeline in desired_config
+            .resolve()
+            .pipelines
+            .into_iter()
+            .filter(|pipeline| pipeline.role == ResolvedPipelineRole::Regular)
+        {
+            _ = self.assigned_cores_for_resolved(&pipeline)?;
+        }
+
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let conflicts = |pipeline_key: &PipelineKey| {
+            desired_pipeline_keys.contains(pipeline_key) || delete_missing
+        };
+        if !Self::engine_operation_allows(&state, Some(engine_operation_id))
+            || state.active_rollouts.keys().any(conflicts)
+            || state.active_shutdowns.keys().any(conflicts)
+        {
+            return Err(ControlPlaneError::RolloutConflict);
+        }
+        Ok(())
     }
 
     fn live_pipeline_keys(&self) -> Vec<PipelineKey> {
@@ -2020,6 +2050,16 @@ impl<
             .map(|(pipeline_key, _)| pipeline_key.clone())
             .collect();
 
+        self.preflight_engine_reconciliation(
+            &desired_config,
+            &desired_key_set,
+            request.delete_missing,
+            guard.operation_id(),
+        )?;
+        let log_filter_update = self
+            .log_filter_handle
+            .apply_transactionally(&desired_config.engine.telemetry.logs.level);
+
         let mut projected_exclusive_core_ids = BTreeSet::new();
         let mut projected_controller_chosen_core_ids = BTreeSet::new();
         let mut rollout_plans = Vec::new();
@@ -2164,6 +2204,7 @@ impl<
         }
 
         self.apply_reconcile_success(&desired_config, request.delete_missing);
+        log_filter_update.commit();
         status.state = EngineConfigReconcileState::Succeeded;
         status.updated_at = timestamp_now();
         Ok(status)

--- a/rust/otap-dataflow/crates/controller/src/live_control_tests.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control_tests.rs
@@ -28,6 +28,7 @@ use otap_df_telemetry::log_filter::{RuntimeLogFilter, RuntimeLogFilterHandle};
 use otap_df_telemetry::metrics::MetricSetSnapshot;
 use otap_df_telemetry::tracing_init::ProviderSetup;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Condvar, Mutex, OnceLock};
 use tokio_util::sync::CancellationToken;
 use tracing::{Event, Subscriber};
 use tracing_subscriber::Registry;
@@ -66,6 +67,65 @@ fn test_receiver_create(
     _capabilities: &otap_df_engine::capability::registry::Capabilities,
 ) -> Result<ReceiverWrapper<()>, otap_df_config::error::Error> {
     panic!("test receiver factory should not be constructed")
+}
+
+#[derive(Default)]
+struct BlockingReceiverState {
+    entered: bool,
+    release: bool,
+}
+
+fn blocking_receiver_state() -> &'static (Mutex<BlockingReceiverState>, Condvar) {
+    static STATE: OnceLock<(Mutex<BlockingReceiverState>, Condvar)> = OnceLock::new();
+    STATE.get_or_init(|| (Mutex::new(BlockingReceiverState::default()), Condvar::new()))
+}
+
+fn block_test_component_creation() {
+    let (state, changed) = blocking_receiver_state();
+    let mut state = state
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    state.entered = true;
+    changed.notify_all();
+    while !state.release {
+        state = changed
+            .wait(state)
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+    }
+}
+
+fn blocking_test_receiver_create(
+    pipeline_ctx: PipelineContext,
+    node: otap_df_engine::node::NodeId,
+    node_config: Arc<NodeUserConfig>,
+    receiver_config: &ReceiverConfig,
+    capabilities: &otap_df_engine::capability::registry::Capabilities,
+) -> Result<ReceiverWrapper<()>, otap_df_config::error::Error> {
+    block_test_component_creation();
+    test_receiver_create(
+        pipeline_ctx,
+        node,
+        node_config,
+        receiver_config,
+        capabilities,
+    )
+}
+
+fn blocking_test_exporter_create(
+    pipeline_ctx: PipelineContext,
+    node: otap_df_engine::node::NodeId,
+    node_config: Arc<NodeUserConfig>,
+    exporter_config: &ExporterConfig,
+    capabilities: &otap_df_engine::capability::registry::Capabilities,
+) -> Result<ExporterWrapper<()>, otap_df_config::error::Error> {
+    block_test_component_creation();
+    test_exporter_create(
+        pipeline_ctx,
+        node,
+        node_config,
+        exporter_config,
+        capabilities,
+    )
 }
 
 fn test_exporter_create(
@@ -226,6 +286,61 @@ static TEST_PIPELINE_FACTORY: PipelineFactory<()> = PipelineFactory::new(
     TEST_RECEIVER_FACTORIES,
     TEST_PROCESSOR_FACTORIES,
     TEST_EXPORTER_FACTORIES,
+    &[],
+);
+
+static BLOCKING_TEST_RECEIVER_FACTORIES: &[ReceiverFactory<()>] = &[
+    ReceiverFactory {
+        name: "urn:test:receiver:example",
+        create: blocking_test_receiver_create,
+        wiring_contract: WiringContract::UNRESTRICTED,
+        validate_config: test_validate_config,
+    },
+    ReceiverFactory {
+        name: "urn:otel:receiver:topic",
+        create: test_receiver_create,
+        wiring_contract: WiringContract::UNRESTRICTED,
+        validate_config: test_validate_config,
+    },
+    ReceiverFactory {
+        name: "urn:otel:receiver:internal_telemetry",
+        create: test_receiver_create,
+        wiring_contract: WiringContract::UNRESTRICTED,
+        validate_config: test_validate_config,
+    },
+];
+
+static BLOCKING_TEST_EXPORTER_FACTORIES: &[ExporterFactory<()>] = &[
+    ExporterFactory {
+        name: "urn:test:exporter:example",
+        create: blocking_test_exporter_create,
+        wiring_contract: WiringContract::UNRESTRICTED,
+        validate_config: test_validate_config,
+    },
+    ExporterFactory {
+        name: "urn:otel:exporter:topic",
+        create: test_exporter_create,
+        wiring_contract: WiringContract::UNRESTRICTED,
+        validate_config: test_validate_config,
+    },
+    ExporterFactory {
+        name: "urn:otel:exporter:console",
+        create: test_exporter_create,
+        wiring_contract: WiringContract::UNRESTRICTED,
+        validate_config: test_validate_config,
+    },
+    ExporterFactory {
+        name: "urn:otel:exporter:noop",
+        create: test_exporter_create,
+        wiring_contract: WiringContract::UNRESTRICTED,
+        validate_config: test_validate_config,
+    },
+];
+
+static BLOCKING_TEST_PIPELINE_FACTORY: PipelineFactory<()> = PipelineFactory::new(
+    BLOCKING_TEST_RECEIVER_FACTORIES,
+    TEST_PROCESSOR_FACTORIES,
+    BLOCKING_TEST_EXPORTER_FACTORIES,
     &[],
 );
 
@@ -3979,6 +4094,76 @@ fn reconcile_engine_config_applies_runtime_log_level() {
     assert_eq!(status.state, EngineConfigReconcileState::Succeeded);
     assert_eq!(log_filter_handle.configured_level().as_str(), "warn");
     tracing::dispatcher::with_default(&dispatch, emit_info);
+    assert_eq!(event_count.load(Ordering::SeqCst), 0);
+}
+
+/// Scenario: full-config reconciliation raises the log level while pipeline construction is blocked and then fails.
+/// Guarantees: the candidate level is active during rollout, then the prior filter and committed config are restored.
+#[test]
+fn reconcile_engine_config_rolls_back_log_level_after_pipeline_failure() {
+    let mut config = empty_engine_config();
+    config.engine.telemetry.logs.level =
+        serde_json::from_value(serde_json::json!("warn")).expect("warn level should parse");
+    let (runtime, log_filter_handle, log_filter) =
+        test_runtime_with_log_filter(&config, &BLOCKING_TEST_PIPELINE_FACTORY);
+    let event_count = Arc::new(AtomicUsize::new(0));
+    let dispatch = tracing::Dispatch::new(
+        Registry::default()
+            .with(log_filter.layer())
+            .with(CountingLayer(Arc::clone(&event_count))),
+    );
+    let mut desired = engine_config_with_pipeline(simple_pipeline_yaml());
+    desired.engine.telemetry.logs.level =
+        serde_json::from_value(serde_json::json!("info")).expect("info level should parse");
+    let (blocking_state, changed) = blocking_receiver_state();
+    {
+        let mut state = blocking_state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.entered = false;
+        state.release = false;
+    }
+
+    let reconcile_runtime = Arc::clone(&runtime);
+    let reconcile = thread::spawn(move || {
+        reconcile_runtime
+            .reconcile_engine_config(reconcile_request(desired, true))
+            .expect("pipeline failure should return terminal status")
+    });
+
+    let state = blocking_state
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let (mut state, wait) = changed
+        .wait_timeout_while(state, Duration::from_secs(5), |state| !state.entered)
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert!(!wait.timed_out(), "pipeline construction did not start");
+    assert_eq!(log_filter_handle.configured_level().as_str(), "info");
+    tracing::dispatcher::with_default(&dispatch, || {
+        otel_info!("test.controller.runtime_filter_during_reconcile");
+    });
+    assert_eq!(event_count.swap(0, Ordering::SeqCst), 1);
+
+    state.release = true;
+    changed.notify_all();
+    drop(state);
+    let status = reconcile.join().expect("reconciliation thread should join");
+
+    assert_eq!(status.state, EngineConfigReconcileState::Failed);
+    assert_eq!(log_filter_handle.configured_level().as_str(), "warn");
+    assert_eq!(
+        runtime
+            .engine_config_snapshot()
+            .engine
+            .telemetry
+            .logs
+            .level
+            .as_str(),
+        "warn"
+    );
+    tracing::dispatcher::with_default(&dispatch, || {
+        otel_info!("test.controller.runtime_filter_after_failed_reconcile");
+    });
     assert_eq!(event_count.load(Ordering::SeqCst), 0);
 }
 

--- a/rust/otap-dataflow/crates/controller/src/live_control_tests.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control_tests.rs
@@ -4167,6 +4167,108 @@ fn reconcile_engine_config_rolls_back_log_level_after_pipeline_failure() {
     assert_eq!(event_count.load(Ordering::SeqCst), 0);
 }
 
+/// Scenario: reconciliation raises the log level and then aborts with a planning error
+/// (core relocation conflict) raised after the level was already applied.
+/// Guarantees: the previous log level and committed engine config are restored when
+/// planning rejects the request instead of returning a terminal rollout status.
+#[test]
+fn reconcile_engine_config_rolls_back_log_level_after_planning_error() {
+    let mut config = engine_config_with_pipeline(
+        r#"
+        policies:
+          resources:
+            core_allocation:
+              type: core_count
+              count: 2
+        nodes:
+          receiver:
+            type: "urn:test:receiver:example"
+            config: null
+          exporter:
+            type: "urn:test:exporter:example"
+            config: null
+        connections:
+          - from: receiver
+            to: exporter
+"#,
+    );
+    config.engine.telemetry.logs.level =
+        serde_json::from_value(serde_json::json!("warn")).expect("warn level should parse");
+    let (runtime, log_filter_handle, _log_filter) =
+        test_runtime_with_log_filter(&config, &TEST_PIPELINE_FACTORY);
+    register_existing_pipeline(&runtime, &config);
+
+    let mut desired = OtelDataflowSpec::from_yaml(
+        r#"
+version: otel_dataflow/v1
+groups:
+  g1:
+    pipelines:
+      p1:
+        policies:
+          resources:
+            core_allocation:
+              type: core_set
+              set:
+                - start: 2
+                  end: 3
+        nodes:
+          receiver:
+            type: "urn:test:receiver:example"
+            config: null
+          exporter:
+            type: "urn:test:exporter:example"
+            config: null
+        connections:
+          - from: receiver
+            to: exporter
+      p2:
+        policies:
+          resources:
+            core_allocation:
+              type: core_set
+              set:
+                - start: 0
+                  end: 1
+        nodes:
+          receiver:
+            type: "urn:test:receiver:example"
+            config: null
+          exporter:
+            type: "urn:test:exporter:example"
+            config: null
+        connections:
+          - from: receiver
+            to: exporter
+"#,
+    )
+    .expect("desired config should parse");
+    desired.engine.telemetry.logs.level =
+        serde_json::from_value(serde_json::json!("info")).expect("info level should parse");
+
+    let err = runtime
+        .reconcile_engine_config(reconcile_request(desired, true))
+        .expect_err("reconcile should reject vacate-before-claim placement");
+
+    match err {
+        ControlPlaneError::InvalidRequest { message } => {
+            assert!(message.contains("conflicts with committed or in-flight"));
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+    assert_eq!(log_filter_handle.configured_level().as_str(), "warn");
+    assert_eq!(
+        runtime
+            .engine_config_snapshot()
+            .engine
+            .telemetry
+            .logs
+            .level
+            .as_str(),
+        "warn"
+    );
+}
+
 /// Scenario: a full-config reconciliation request omits live stopped
 /// resources with `delete_missing` enabled.
 /// Guarantees: reconciliation deletes the omitted pipeline and then the

--- a/rust/otap-dataflow/crates/controller/src/live_control_tests.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control_tests.rs
@@ -4098,7 +4098,7 @@ fn reconcile_engine_config_applies_runtime_log_level() {
 }
 
 /// Scenario: full-config reconciliation raises the log level while pipeline construction is blocked and then fails.
-/// Guarantees: the candidate level is active during rollout, then the prior filter and committed config are restored.
+/// Guarantees: the candidate level is active during rollout, then the prior directives and committed config are restored.
 #[test]
 fn reconcile_engine_config_rolls_back_log_level_after_pipeline_failure() {
     let mut config = empty_engine_config();

--- a/rust/otap-dataflow/crates/telemetry/README.md
+++ b/rust/otap-dataflow/crates/telemetry/README.md
@@ -120,7 +120,7 @@ The `engine.telemetry.logs.level` field accepts either a severity such as
 preflight succeed, reconciliation applies the requested level before pipeline
 rewiring starts. This lets an OpAMP or admin control plane observe pipeline
 startup, readiness, draining, and cutover without restarting the engine. If the
-pipeline work fails, reconciliation restores the previous filter.
+pipeline work fails, reconciliation restores the previous filter directives.
 
 `EnvFilter` target directives use prefix matching. A directive for
 `<namespace>.<kind>.<name>` also matches another component whose target begins
@@ -155,7 +155,9 @@ never pushes them onto its scope stack. A reconciled span directive applies to
 matching spans created after the update, including spans created by replacement
 pipeline threads. Events inside a long-lived `pipeline_thread` span that was
 already entered fall back to the new filter's non-span directives until that
-pipeline thread and its span are recreated.
+pipeline thread and its span are recreated. This also applies when a failed
+reconciliation restores the previous directives: active span state is not
+reconstructed during rollback.
 The non-span part of the reconciled `logs.level` takes effect immediately.
 
 There are four aspects that can be configured:

--- a/rust/otap-dataflow/crates/telemetry/README.md
+++ b/rust/otap-dataflow/crates/telemetry/README.md
@@ -116,10 +116,11 @@ parts of the code.
 
 All modes use a [`tracing_subscriber::EnvFilter`](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html).
 The `engine.telemetry.logs.level` field accepts either a severity such as
-`warn` or a complete target directive string. Successful full-engine
-reconciliation applies changes to this field to existing tracing subscribers,
-so an OpAMP or admin control plane can temporarily increase verbosity without
-restarting the engine. Failed reconciliation preserves the active filter.
+`warn` or a complete target directive string. After full-config validation and
+preflight succeed, reconciliation applies the requested level before pipeline
+rewiring starts. This lets an OpAMP or admin control plane observe pipeline
+startup, readiness, draining, and cutover without restarting the engine. If the
+pipeline work fails, reconciliation restores the previous filter.
 
 `EnvFilter` target directives use prefix matching. A directive for
 `<namespace>.<kind>.<name>` also matches another component whose target begins
@@ -135,10 +136,9 @@ warn,otel.receiver.otlp=debug,otap-df-otap=debug
 ```
 
 At startup, a valid `RUST_LOG` environment variable takes precedence over
-`logs.level`. After startup, a successful full-engine reconciliation makes the
-reconciled `logs.level` authoritative and replaces the environment-derived
-filter. This lets an OpAMP or admin control plane reliably change verbosity
-even when the process was launched with `RUST_LOG`.
+`logs.level`. A preflighted reconciliation temporarily replaces that startup
+filter while applying pipeline changes. Success makes the reconciled
+`logs.level` authoritative; failure restores the environment-derived filter.
 
 ### Limitation: active span state is not reconstructed
 

--- a/rust/otap-dataflow/crates/telemetry/src/log_filter.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/log_filter.rs
@@ -186,25 +186,16 @@ impl RuntimeLogFilterHandle {
     /// stays empty for them. Such directives still work when supplied at
     /// startup. See the crate README for operator-facing details.
     pub fn apply(&self, level: &LogLevel) {
-        let filter =
-            EnvFilter::try_new(level.as_str()).expect("logs.level must be validated before use");
-        let mut layers = self
-            .shared
-            .layers
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if self.shared.configured_level.load().as_ref() == level
-            && !self.shared.startup_override_active.load(Ordering::Acquire)
-        {
-            return;
-        }
-        self.publish(&mut layers, level.clone(), false, filter);
-        _ = self.shared.revision.fetch_add(1, Ordering::AcqRel);
-        drop(layers);
-        tracing::callsite::rebuild_interest_cache();
+        self.apply_transactionally(level).commit();
     }
 
     /// Applies a candidate level that is rolled back unless the returned guard is committed.
+    ///
+    /// Callers must serialize updates: at most one guard may be outstanding at a
+    /// time. The engine reconciliation path enforces this through the
+    /// engine-operation guard. If another update lands before an outstanding
+    /// guard is dropped, that newer update wins and the stale guard skips its
+    /// rollback rather than clobbering the newer configuration.
     #[must_use]
     pub fn apply_transactionally(&self, level: &LogLevel) -> RuntimeLogFilterUpdateGuard {
         let filter =

--- a/rust/otap-dataflow/crates/telemetry/src/log_filter.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/log_filter.rs
@@ -3,7 +3,7 @@
 
 //! Runtime-reloadable filtering for internal telemetry logs.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, Weak};
 
 use arc_swap::ArcSwap;
@@ -20,8 +20,15 @@ struct SharedState {
     configured_level: ArcSwap<LogLevel>,
     // The first reconciliation must replace RUST_LOG even when logs.level is unchanged.
     startup_override_active: AtomicBool,
+    revision: AtomicU64,
     template: ArcSwap<EnvFilter>,
     layers: Mutex<Vec<Weak<ArcSwap<EnvFilter>>>>,
+}
+
+struct FilterSnapshot {
+    configured_level: LogLevel,
+    startup_override_active: bool,
+    filter: EnvFilter,
 }
 
 /// One dispatcher-local layer managed by a [`RuntimeLogFilter`].
@@ -62,6 +69,13 @@ pub struct RuntimeLogFilterHandle {
     shared: Arc<SharedState>,
 }
 
+/// Restores the previous filter state unless the candidate update is committed.
+pub struct RuntimeLogFilterUpdateGuard {
+    shared: Arc<SharedState>,
+    previous: Option<FilterSnapshot>,
+    applied_revision: u64,
+}
+
 impl RuntimeLogFilter {
     /// Creates a filter and its update handle from the configured log level.
     #[must_use]
@@ -89,6 +103,7 @@ impl RuntimeLogFilter {
         let shared = Arc::new(SharedState {
             configured_level: ArcSwap::from_pointee(level.clone()),
             startup_override_active: AtomicBool::new(startup_override_active),
+            revision: AtomicU64::new(0),
             template: ArcSwap::from_pointee(filter),
             layers: Mutex::new(Vec::new()),
         });
@@ -106,6 +121,7 @@ impl RuntimeLogFilter {
             shared: Arc::new(SharedState {
                 configured_level: ArcSwap::from_pointee(level),
                 startup_override_active: AtomicBool::new(false),
+                revision: AtomicU64::new(0),
                 template: ArcSwap::from_pointee(filter),
                 layers: Mutex::new(Vec::new()),
             }),
@@ -139,31 +155,17 @@ impl RuntimeLogFilter {
 }
 
 impl RuntimeLogFilterHandle {
-    /// Replaces the active level/target directives and refreshes all callsites.
-    ///
-    /// Severity and target directives take effect immediately. Span-scoped
-    /// directives such as `[pipeline_thread]=debug` do not apply to spans that
-    /// were entered before this call: the replacement `EnvFilter` never
-    /// observed their `on_new_span`/`on_enter` callbacks, so its scope stack
-    /// stays empty for them. Such directives still work when supplied at
-    /// startup. See the crate README for operator-facing details.
-    pub fn apply(&self, level: &LogLevel) {
-        if self.shared.configured_level.load().as_ref() == level
-            && !self.shared.startup_override_active.load(Ordering::Acquire)
-        {
-            return;
-        }
-        let filter =
-            EnvFilter::try_new(level.as_str()).expect("logs.level must be validated before use");
-        let mut layers = self
-            .shared
-            .layers
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        self.shared.configured_level.store(Arc::new(level.clone()));
+    fn publish(
+        &self,
+        layers: &mut Vec<Weak<ArcSwap<EnvFilter>>>,
+        level: LogLevel,
+        startup_override_active: bool,
+        filter: EnvFilter,
+    ) {
+        self.shared.configured_level.store(Arc::new(level));
         self.shared
             .startup_override_active
-            .store(false, Ordering::Release);
+            .store(startup_override_active, Ordering::Release);
         self.shared.template.store(Arc::new(filter.clone()));
         layers.retain(|layer| {
             if let Some(layer) = layer.upgrade() {
@@ -173,8 +175,68 @@ impl RuntimeLogFilterHandle {
                 false
             }
         });
+    }
+
+    /// Replaces the active level/target directives and refreshes all callsites.
+    ///
+    /// Severity and target directives take effect immediately. Span-scoped
+    /// directives such as `[pipeline_thread]=debug` do not apply to spans that
+    /// were entered before this call: the replacement `EnvFilter` never
+    /// observed their `on_new_span`/`on_enter` callbacks, so its scope stack
+    /// stays empty for them. Such directives still work when supplied at
+    /// startup. See the crate README for operator-facing details.
+    pub fn apply(&self, level: &LogLevel) {
+        let filter =
+            EnvFilter::try_new(level.as_str()).expect("logs.level must be validated before use");
+        let mut layers = self
+            .shared
+            .layers
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if self.shared.configured_level.load().as_ref() == level
+            && !self.shared.startup_override_active.load(Ordering::Acquire)
+        {
+            return;
+        }
+        self.publish(&mut layers, level.clone(), false, filter);
+        _ = self.shared.revision.fetch_add(1, Ordering::AcqRel);
         drop(layers);
         tracing::callsite::rebuild_interest_cache();
+    }
+
+    /// Applies a candidate level that is rolled back unless the returned guard is committed.
+    #[must_use]
+    pub fn apply_transactionally(&self, level: &LogLevel) -> RuntimeLogFilterUpdateGuard {
+        let filter =
+            EnvFilter::try_new(level.as_str()).expect("logs.level must be validated before use");
+        let mut layers = self
+            .shared
+            .layers
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if self.shared.configured_level.load().as_ref() == level
+            && !self.shared.startup_override_active.load(Ordering::Acquire)
+        {
+            return RuntimeLogFilterUpdateGuard {
+                shared: Arc::clone(&self.shared),
+                previous: None,
+                applied_revision: self.shared.revision.load(Ordering::Acquire),
+            };
+        }
+        let previous = FilterSnapshot {
+            configured_level: self.shared.configured_level.load().as_ref().clone(),
+            startup_override_active: self.shared.startup_override_active.load(Ordering::Acquire),
+            filter: self.shared.template.load().as_ref().clone(),
+        };
+        self.publish(&mut layers, level.clone(), false, filter);
+        let applied_revision = self.shared.revision.fetch_add(1, Ordering::AcqRel) + 1;
+        drop(layers);
+        tracing::callsite::rebuild_interest_cache();
+        RuntimeLogFilterUpdateGuard {
+            shared: Arc::clone(&self.shared),
+            previous: Some(previous),
+            applied_revision,
+        }
     }
 
     /// Returns the desired configuration value.
@@ -184,6 +246,41 @@ impl RuntimeLogFilterHandle {
     #[must_use]
     pub fn configured_level(&self) -> LogLevel {
         self.shared.configured_level.load().as_ref().clone()
+    }
+}
+
+impl RuntimeLogFilterUpdateGuard {
+    /// Keeps the candidate filter as the new configured state.
+    pub fn commit(mut self) {
+        self.previous = None;
+    }
+}
+
+impl Drop for RuntimeLogFilterUpdateGuard {
+    fn drop(&mut self) {
+        let Some(previous) = self.previous.take() else {
+            return;
+        };
+        let handle = RuntimeLogFilterHandle {
+            shared: Arc::clone(&self.shared),
+        };
+        let mut layers = self
+            .shared
+            .layers
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if self.shared.revision.load(Ordering::Acquire) != self.applied_revision {
+            return;
+        }
+        handle.publish(
+            &mut layers,
+            previous.configured_level,
+            previous.startup_override_active,
+            previous.filter,
+        );
+        _ = self.shared.revision.fetch_add(1, Ordering::AcqRel);
+        drop(layers);
+        tracing::callsite::rebuild_interest_cache();
     }
 }
 
@@ -410,6 +507,67 @@ mod tests {
             });
 
             assert_eq!(handle.configured_level().as_str(), "info");
+        });
+    }
+
+    /// Scenario: a candidate reconciliation level temporarily replaces startup RUST_LOG and then fails.
+    /// Guarantees: dropping the update guard restores the exact environment-derived filter and configured level.
+    #[test]
+    fn transactional_update_rolls_back_rust_log_startup_filter() {
+        crate::with_rust_log(Some("error"), || {
+            let count = Arc::new(AtomicUsize::new(0));
+            let (filter, handle) = RuntimeLogFilter::new(&level("warn"));
+            let subscriber = Registry::default()
+                .with(filter.layer())
+                .with(CountingLayer(Arc::clone(&count)));
+
+            tracing::subscriber::with_default(subscriber, || {
+                let update = handle.apply_transactionally(&level("info"));
+                tracing::info!("candidate level permits this event");
+                assert_eq!(count.swap(0, Ordering::SeqCst), 1);
+
+                drop(update);
+                tracing::warn!("restored RUST_LOG blocks this event");
+                assert_eq!(count.swap(0, Ordering::SeqCst), 0);
+            });
+
+            assert_eq!(handle.configured_level().as_str(), "warn");
+        });
+    }
+
+    /// Scenario: a candidate reconciliation level succeeds.
+    /// Guarantees: committing the update guard keeps the candidate filter active.
+    #[test]
+    fn transactional_update_commit_keeps_candidate_filter() {
+        crate::with_cleared_rust_log(|| {
+            let count = Arc::new(AtomicUsize::new(0));
+            let (filter, handle) = RuntimeLogFilter::new(&level("warn"));
+            let subscriber = Registry::default()
+                .with(filter.layer())
+                .with(CountingLayer(Arc::clone(&count)));
+
+            handle.apply_transactionally(&level("info")).commit();
+            tracing::subscriber::with_default(subscriber, || {
+                tracing::info!("committed candidate permits this event");
+            });
+
+            assert_eq!(count.load(Ordering::SeqCst), 1);
+            assert_eq!(handle.configured_level().as_str(), "info");
+        });
+    }
+
+    /// Scenario: another update supersedes an uncommitted candidate level.
+    /// Guarantees: dropping the stale guard does not overwrite the newer filter.
+    #[test]
+    fn transactional_update_does_not_roll_back_newer_update() {
+        crate::with_cleared_rust_log(|| {
+            let (_filter, handle) = RuntimeLogFilter::new(&level("warn"));
+
+            let update = handle.apply_transactionally(&level("info"));
+            handle.apply(&level("debug"));
+            drop(update);
+
+            assert_eq!(handle.configured_level().as_str(), "debug");
         });
     }
 

--- a/rust/otap-dataflow/crates/telemetry/src/log_filter.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/log_filter.rs
@@ -69,7 +69,7 @@ pub struct RuntimeLogFilterHandle {
     shared: Arc<SharedState>,
 }
 
-/// Restores the previous filter state unless the candidate update is committed.
+/// Restores the previous filter directives unless the candidate update is committed.
 pub struct RuntimeLogFilterUpdateGuard {
     shared: Arc<SharedState>,
     previous: Option<FilterSnapshot>,
@@ -532,6 +532,32 @@ mod tests {
             });
 
             assert_eq!(handle.configured_level().as_str(), "warn");
+        });
+    }
+
+    /// Scenario: a candidate level replaces the filter while a matching span remains entered.
+    /// Guarantees: rollback restores directives but cannot reconstruct the existing span's dynamic filter state.
+    #[test]
+    fn transactional_update_rollback_does_not_reconstruct_active_span_state() {
+        crate::with_cleared_rust_log(|| {
+            let count = Arc::new(AtomicUsize::new(0));
+            let (filter, handle) = RuntimeLogFilter::new(&level("warn,[rollback_span]=debug"));
+            let subscriber = Registry::default()
+                .with(filter.layer())
+                .with(CountingLayer(Arc::clone(&count)));
+
+            tracing::subscriber::with_default(subscriber, || {
+                let span = tracing::info_span!("rollback_span");
+                let _entered = span.enter();
+                tracing::debug!("original span directive permits this event");
+                assert_eq!(count.swap(0, Ordering::SeqCst), 1);
+
+                let update = handle.apply_transactionally(&level("warn"));
+                drop(update);
+
+                tracing::debug!("restored directives have no state for the existing span");
+                assert_eq!(count.load(Ordering::SeqCst), 0);
+            });
         });
     }
 


### PR DESCRIPTION
Apply the requested internal log level after full-config preflight and before pipeline rewiring begins. This makes pipeline startup, readiness, draining, and cutover observable at the requested verbosity.

If reconciliation fails, restore the previous filter directives and startup `RUST_LOG` authority. Active span state is not reconstructed. Successful reconciliation commits the candidate level as before.

Follow up from https://github.com/open-telemetry/otel-arrow/pull/3613