### PR TITLE
chore: [query-engine] Use type aliasing to improve code quality in iterator APIs

### DIFF
--- a/rust/experimental/query_engine/engine-recordset/src/primitives/resolved_value.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/primitives/resolved_value.rs
@@ -440,7 +440,7 @@ impl ArrayValue for List<'_> {
     fn get_item_range<'a>(
         &'a self,
         range: ArrayRange,
-        item_callback: &mut dyn FnMut(usize, Value<'a>) -> bool,
+        item_callback: &mut ArrayValueIteratorCallback<'a, '_>,
     ) -> bool {
         for (index, value) in range.get_slice(&self.values).iter().enumerate() {
             if !(item_callback)(index, value.to_value()) {
@@ -517,7 +517,7 @@ impl ArrayValue for ArraySlice<'_> {
     fn get_item_range<'a>(
         &'a self,
         range: ArrayRange,
-        item_callback: &mut dyn FnMut(usize, Value<'a>) -> bool,
+        item_callback: &mut ArrayValueIteratorCallback<'a, '_>,
     ) -> bool {
         let start = range
             .get_start_range_inclusize()
@@ -674,7 +674,7 @@ impl ArrayValue for Sequence<'_> {
     fn get_item_range<'a>(
         &'a self,
         range: ArrayRange,
-        item_callback: &mut dyn FnMut(usize, Value<'a>) -> bool,
+        item_callback: &mut ArrayValueIteratorCallback<'a, '_>,
     ) -> bool {
         let len = self.len();
 
@@ -1044,7 +1044,7 @@ impl ArrayValue for ResolvedArrayValue<'_> {
     fn get_item_range<'a>(
         &'a self,
         range: ArrayRange,
-        item_callback: &mut dyn FnMut(usize, Value<'a>) -> bool,
+        item_callback: &mut ArrayValueIteratorCallback<'a, '_>,
     ) -> bool {
         self.get_array().get_item_range(range, item_callback)
     }
@@ -1204,7 +1204,7 @@ impl MapValue for ResolvedMapValue<'_> {
         self.get_map().get_static(key)
     }
 
-    fn get_items<'a>(&'a self, item_callback: &mut dyn FnMut(&str, Value<'a>) -> bool) -> bool {
+    fn get_items<'a>(&'a self, item_callback: &mut MapValueIteratorCallback<'a, '_>) -> bool {
         self.get_map().get_items(item_callback)
     }
 }

--- a/rust/experimental/query_engine/engine-recordset/src/primitives/value_mut.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/primitives/value_mut.rs
@@ -57,11 +57,11 @@ pub trait ArrayValueMut: ArrayValue {
 
     fn remove(&mut self, index: usize) -> ValueMutRemoveResult;
 
-    fn retain(
-        &mut self,
-        item_callback: &mut dyn FnMut(usize, &mut (dyn AsStaticValueMut + 'static)) -> bool,
-    );
+    fn retain(&mut self, item_callback: &mut ArrayValueMutIteratorCallback<'_>);
 }
+
+pub type ArrayValueMutIteratorCallback<'a> =
+    dyn FnMut(usize, &mut (dyn AsStaticValueMut + 'static)) -> bool + 'a;
 
 pub trait MapValueMut: MapValue {
     fn get_mut(&mut self, key: &str) -> ValueMutGetResult<'_>;
@@ -72,11 +72,11 @@ pub trait MapValueMut: MapValue {
 
     fn remove(&mut self, key: &str) -> ValueMutRemoveResult;
 
-    fn retain(
-        &mut self,
-        item_callback: &mut dyn FnMut(&str, &mut (dyn AsStaticValueMut + 'static)) -> bool,
-    );
+    fn retain(&mut self, item_callback: &mut MapValueMutIteratorCallback<'_>);
 }
+
+pub type MapValueMutIteratorCallback<'a> =
+    dyn FnMut(&str, &mut (dyn AsStaticValueMut + 'static)) -> bool + 'a;
 
 pub trait StringValueMut: StringValue {
     fn get_value_mut(&mut self) -> &mut String;

--- a/rust/experimental/query_engine/engine-recordset/src/primitives/value_storage.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/primitives/value_storage.rs
@@ -400,7 +400,7 @@ impl<T: EnumerableValueSource<T>> ArrayValueMut for ArrayValueStorage<T> {
         ValueMutRemoveResult::Removed(old.into())
     }
 
-    fn retain(&mut self, item_callback: &mut ArrayValueMutIteratorCallback) {
+    fn retain(&mut self, item_callback: &mut ArrayValueMutIteratorCallback<'_>) {
         let mut index = 0;
         self.values.retain_mut(|v| {
             let r = (item_callback)(index, v);
@@ -515,7 +515,7 @@ impl<T: EnumerableValueSource<T>> MapValueMut for MapValueStorage<T> {
         }
     }
 
-    fn retain(&mut self, item_callback: &mut MapValueMutIteratorCallback) {
+    fn retain(&mut self, item_callback: &mut MapValueMutIteratorCallback<'_>) {
         self.values.retain(|k, v| (item_callback)(k, v));
     }
 }

--- a/rust/experimental/query_engine/engine-recordset/src/primitives/value_storage.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/primitives/value_storage.rs
@@ -331,7 +331,7 @@ impl<T: EnumerableValueSource<T>> ArrayValue for ArrayValueStorage<T> {
     fn get_item_range<'a>(
         &'a self,
         range: ArrayRange,
-        item_callback: &mut dyn FnMut(usize, Value<'a>) -> bool,
+        item_callback: &mut ArrayValueIteratorCallback<'a, '_>,
     ) -> bool {
         for (index, value) in range.get_slice(&self.values).iter().enumerate() {
             if !(item_callback)(index, value.to_value()) {
@@ -400,10 +400,7 @@ impl<T: EnumerableValueSource<T>> ArrayValueMut for ArrayValueStorage<T> {
         ValueMutRemoveResult::Removed(old.into())
     }
 
-    fn retain(
-        &mut self,
-        item_callback: &mut dyn FnMut(usize, &mut (dyn AsStaticValueMut + 'static)) -> bool,
-    ) {
+    fn retain(&mut self, item_callback: &mut ArrayValueMutIteratorCallback) {
         let mut index = 0;
         self.values.retain_mut(|v| {
             let r = (item_callback)(index, v);
@@ -463,7 +460,7 @@ impl<T: EnumerableValueSource<T>> MapValue for MapValueStorage<T> {
         Ok(self.values.get(key).map(|v| v as &dyn AsStaticValue))
     }
 
-    fn get_items<'a>(&'a self, item_callback: &mut dyn FnMut(&str, Value<'a>) -> bool) -> bool {
+    fn get_items<'a>(&'a self, item_callback: &mut MapValueIteratorCallback<'a, '_>) -> bool {
         for (key, value) in self.values.iter() {
             if !(item_callback)(key, value.to_value()) {
                 return false;
@@ -518,10 +515,7 @@ impl<T: EnumerableValueSource<T>> MapValueMut for MapValueStorage<T> {
         }
     }
 
-    fn retain(
-        &mut self,
-        item_callback: &mut dyn FnMut(&str, &mut (dyn AsStaticValueMut + 'static)) -> bool,
-    ) {
+    fn retain(&mut self, item_callback: &mut MapValueMutIteratorCallback) {
         self.values.retain(|k, v| (item_callback)(k, v));
     }
 }

--- a/rust/experimental/query_engine/engine-recordset/src/test_helpers.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/test_helpers.rs
@@ -177,7 +177,7 @@ impl MapValueMut for TestRecord {
         }
     }
 
-    fn retain(&mut self, item_callback: &mut MapValueMutIteratorCallback) {
+    fn retain(&mut self, item_callback: &mut MapValueMutIteratorCallback<'_>) {
         self.values.retain(|k, v| (item_callback)(k, v));
     }
 }

--- a/rust/experimental/query_engine/engine-recordset/src/test_helpers.rs
+++ b/rust/experimental/query_engine/engine-recordset/src/test_helpers.rs
@@ -136,7 +136,7 @@ impl MapValue for TestRecord {
         Ok(self.values.get(key).map(|v| v as &dyn AsStaticValue))
     }
 
-    fn get_items<'a>(&'a self, item_callback: &mut dyn FnMut(&str, Value<'a>) -> bool) -> bool {
+    fn get_items<'a>(&'a self, item_callback: &mut MapValueIteratorCallback<'a, '_>) -> bool {
         for (k, v) in &self.values {
             if !(item_callback)(k, v.to_value()) {
                 return false;
@@ -177,10 +177,7 @@ impl MapValueMut for TestRecord {
         }
     }
 
-    fn retain(
-        &mut self,
-        item_callback: &mut dyn FnMut(&str, &mut (dyn AsStaticValueMut + 'static)) -> bool,
-    ) {
+    fn retain(&mut self, item_callback: &mut MapValueMutIteratorCallback) {
         self.values.retain(|k, v| (item_callback)(k, v));
     }
 }

--- a/rust/experimental/query_engine/expressions/src/primitives/array_value.rs
+++ b/rust/experimental/query_engine/expressions/src/primitives/array_value.rs
@@ -18,14 +18,14 @@ pub trait ArrayValue: Debug {
     // of support for this method
     fn get_static(&self, index: usize) -> Result<Option<&(dyn AsStaticValue + 'static)>, String>;
 
-    fn get_items<'a>(&'a self, item_callback: &mut dyn FnMut(usize, Value<'a>) -> bool) -> bool {
+    fn get_items<'a>(&'a self, item_callback: &mut ArrayValueIteratorCallback<'a, '_>) -> bool {
         self.get_item_range((..).into(), item_callback)
     }
 
     fn get_item_range<'a>(
         &'a self,
         range: ArrayRange,
-        item_callback: &mut dyn FnMut(usize, Value<'a>) -> bool,
+        item_callback: &mut ArrayValueIteratorCallback<'a, '_>,
     ) -> bool;
 
     fn to_string(&self) -> ValueString<'_> {
@@ -39,6 +39,8 @@ pub trait ArrayValue: Debug {
         ValueString::Owned(serde_json::Value::Array(values).to_string())
     }
 }
+
+pub type ArrayValueIteratorCallback<'a, 'b> = dyn FnMut(usize, Value<'a>) -> bool + 'b;
 
 #[derive(Debug)]
 pub struct ArrayRange {

--- a/rust/experimental/query_engine/expressions/src/primitives/map_value.rs
+++ b/rust/experimental/query_engine/expressions/src/primitives/map_value.rs
@@ -20,7 +20,7 @@ pub trait MapValue: Debug {
     // of support for this method
     fn get_static(&self, key: &str) -> Result<Option<&(dyn AsStaticValue + 'static)>, String>;
 
-    fn get_items<'a>(&'a self, item_callback: &mut dyn FnMut(&str, Value<'a>) -> bool) -> bool;
+    fn get_items<'a>(&'a self, item_callback: &mut MapValueIteratorCallback<'a, '_>) -> bool;
 
     fn to_string(&self) -> ValueString<'_> {
         let mut values = serde_json::Map::new();
@@ -33,6 +33,8 @@ pub trait MapValue: Debug {
         ValueString::Owned(serde_json::Value::Object(values).to_string())
     }
 }
+
+pub type MapValueIteratorCallback<'a, 'b> = dyn FnMut(&str, Value<'a>) -> bool + 'b;
 
 pub(crate) fn equal_to(
     query_location: &QueryLocation,

--- a/rust/experimental/query_engine/expressions/src/scalars/statics/array_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/statics/array_scalar_expression.rs
@@ -55,7 +55,7 @@ impl ArrayValue for ArrayScalarExpression {
     fn get_item_range<'a>(
         &'a self,
         range: ArrayRange,
-        item_callback: &mut dyn FnMut(usize, Value<'a>) -> bool,
+        item_callback: &mut ArrayValueIteratorCallback<'a, '_>,
     ) -> bool {
         for (index, value) in range.get_slice(&self.values).iter().enumerate() {
             if !(item_callback)(index, value.to_value()) {

--- a/rust/experimental/query_engine/expressions/src/scalars/statics/map_scalar_expression.rs
+++ b/rust/experimental/query_engine/expressions/src/scalars/statics/map_scalar_expression.rs
@@ -58,7 +58,7 @@ impl MapValue for MapScalarExpression {
         Ok(self.values.get(key).map(|v| v as &dyn AsStaticValue))
     }
 
-    fn get_items<'a>(&'a self, item_callback: &mut dyn FnMut(&str, Value<'a>) -> bool) -> bool {
+    fn get_items<'a>(&'a self, item_callback: &mut MapValueIteratorCallback<'a, '_>) -> bool {
         for (key, value) in &self.values {
             if !(item_callback)(key, value.to_value()) {
                 return false;

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/attached_records.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/attached_records.rs
@@ -61,7 +61,7 @@ impl MapValue for Resource {
         Ok(None)
     }
 
-    fn get_items<'a>(&'a self, item_callback: &mut dyn FnMut(&str, Value<'a>) -> bool) -> bool {
+    fn get_items<'a>(&'a self, item_callback: &mut MapValueIteratorCallback<'a, '_>) -> bool {
         (item_callback)("Attributes", Value::Map(&self.attributes))
     }
 }
@@ -98,7 +98,7 @@ impl MapValue for InstrumentationScope {
         })
     }
 
-    fn get_items<'a>(&'a self, item_callback: &mut dyn FnMut(&str, Value<'a>) -> bool) -> bool {
+    fn get_items<'a>(&'a self, item_callback: &mut MapValueIteratorCallback<'a, '_>) -> bool {
         if let Some(v) = &self.name {
             if !(item_callback)("Name", Value::String(v)) {
                 return false;

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/logs.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/logs.rs
@@ -402,7 +402,7 @@ impl MapValueMut for LogRecord {
         }
     }
 
-    fn retain(&mut self, item_callback: &mut MapValueMutIteratorCallback) {
+    fn retain(&mut self, item_callback: &mut MapValueMutIteratorCallback<'_>) {
         if let Some(v) = &mut self.timestamp {
             if !(item_callback)("time_unix_nano", v) {
                 self.timestamp = None;

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/logs.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/logs.rs
@@ -107,7 +107,7 @@ impl MapValue for LogRecord {
         })
     }
 
-    fn get_items<'a>(&'a self, item_callback: &mut dyn FnMut(&str, Value<'a>) -> bool) -> bool {
+    fn get_items<'a>(&'a self, item_callback: &mut MapValueIteratorCallback<'a, '_>) -> bool {
         if let Some(v) = &self.timestamp {
             if !(item_callback)("time_unix_nano", Value::DateTime(v)) {
                 return false;
@@ -402,10 +402,7 @@ impl MapValueMut for LogRecord {
         }
     }
 
-    fn retain(
-        &mut self,
-        item_callback: &mut dyn FnMut(&str, &mut (dyn AsStaticValueMut + 'static)) -> bool,
-    ) {
+    fn retain(&mut self, item_callback: &mut MapValueMutIteratorCallback) {
         if let Some(v) = &mut self.timestamp {
             if !(item_callback)("time_unix_nano", v) {
                 self.timestamp = None;

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/proto/common.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/proto/common.rs
@@ -228,7 +228,7 @@ impl ArrayValue for ByteArrayValueStorage {
     fn get_item_range<'a>(
         &'a self,
         range: ArrayRange,
-        item_callback: &mut dyn FnMut(usize, Value<'a>) -> bool,
+        item_callback: &mut ArrayValueIteratorCallback<'a, '_>,
     ) -> bool {
         for (index, value) in range.get_slice(&self.values).iter().enumerate() {
             if !(item_callback)(index, Value::Integer(value)) {
@@ -315,10 +315,7 @@ impl ArrayValueMut for ByteArrayValueStorage {
         )))
     }
 
-    fn retain(
-        &mut self,
-        item_callback: &mut dyn FnMut(usize, &mut (dyn AsStaticValueMut + 'static)) -> bool,
-    ) {
+    fn retain(&mut self, item_callback: &mut ArrayValueMutIteratorCallback) {
         let mut index = 0;
         self.values.retain_mut(|v| {
             let r = (item_callback)(index, v);

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/proto/common.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/proto/common.rs
@@ -315,7 +315,7 @@ impl ArrayValueMut for ByteArrayValueStorage {
         )))
     }
 
-    fn retain(&mut self, item_callback: &mut ArrayValueMutIteratorCallback) {
+    fn retain(&mut self, item_callback: &mut ArrayValueMutIteratorCallback<'_>) {
         let mut index = 0;
         self.values.retain_mut(|v| {
             let r = (item_callback)(index, v);


### PR DESCRIPTION
Relates to #3681
Relates to #3727

Follow-up for https://github.com/open-telemetry/otel-arrow/pull/3727#discussion_r3764073226

# Changes

* Implement suggestion from @utpilla to improve code quality
