### PR TITLE
feat: extend OPL type hierarchy to include metric types

### DIFF
--- a/rust/otap-dataflow/.chloggen/opl-metrics-concrete-types.yaml
+++ b/rust/otap-dataflow/.chloggen/opl-metrics-concrete-types.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: query-engine
+note: Add support for concrete metric types in OPL type hierarchy
+issues: [3721]

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use data_engine_expressions::{Expression, PipelineExpression};
+use data_engine_expressions::Expression;
 use data_engine_kql_parser::{KqlParser, Parser};
 use linkme::distributed_slice;
 use otap_df_config::{SignalType, error::Error as ConfigError, node::NodeUserConfig};
@@ -99,22 +99,48 @@ enum SignalScope {
     Signal(SignalType),
 }
 
-impl TryFrom<&PipelineExpression> for SignalScope {
-    type Error = ConfigError;
-
-    fn try_from(pipeline_expr: &PipelineExpression) -> Result<Self, Self::Error> {
+impl SignalScope {
+    fn try_from_kql_query(query: &str) -> Result<Self, ConfigError> {
         // Current logic looks at the start of the pipeline and expects it to be in a form like
         // "logs | ..." or "traces | ...", etc.
-        //
-        // TODO the logic here wouldn't be safe for languages other than Kql. We might want to have
-        //  the pipeline expression be able to return name of the source
-        let query = pipeline_expr.get_query_slice(pipeline_expr.get_query_location());
         let query = query.trim_start();
         Ok(if query.starts_with("logs") {
             Self::Signal(SignalType::Logs)
         } else if query.starts_with("traces") {
             Self::Signal(SignalType::Traces)
         } else if query.starts_with("metrics") {
+            Self::Signal(SignalType::Metrics)
+        } else if query.starts_with("signal") {
+            Self::All
+        } else {
+            return Err(ConfigError::InvalidUserConfig {
+                error: "could not determine signal type from query".into(),
+            });
+        })
+    }
+
+    fn try_from_opl_query(query: &str) -> Result<Self, ConfigError> {
+        // Current logic looks at the start of the pipeline and expects it to be in a form like
+        // "logs | ..." or "traces | ...", etc.
+        //
+        // The OPL Parser will inspect the source during parsing and if it sees the source is the
+        // plural form of some concrete metric type (gauges, sums, histograms, etc.), it creates a
+        // query plan that will select for processing only these batch types and only rows having
+        // the specified metric type. All other batches / rows are treated as passthrough. This is
+        // why for OPL only we allow these identifiers to the the query source
+        //
+        let query = query.trim_start();
+        Ok(if query.starts_with("logs") {
+            Self::Signal(SignalType::Logs)
+        } else if query.starts_with("traces") {
+            Self::Signal(SignalType::Traces)
+        } else if query.starts_with("metrics")
+            | query.starts_with("gauges")
+            | query.starts_with("sums")
+            | query.starts_with("histograms")
+            | query.starts_with("exponential_histograms")
+            | query.starts_with("summaries")
+        {
             Self::Signal(SignalType::Metrics)
         } else if query.starts_with("signal") {
             Self::All
@@ -152,7 +178,9 @@ impl TransformProcessor {
                 let pipeline_expr = KqlParser::parse_with_options(query, parser_options)
                     .map_err(map_parser_err)?
                     .pipeline;
-                let signal_scope = SignalScope::try_from(&pipeline_expr)?;
+                let signal_scope = SignalScope::try_from_kql_query(
+                    &pipeline_expr.get_query_slice(pipeline_expr.get_query_location()),
+                )?;
                 (
                     vec![Transform {
                         pipeline: Pipeline::new_with_options(pipeline_expr, pipeline_options),
@@ -165,7 +193,9 @@ impl TransformProcessor {
                 let pipeline_expr = OplParser::parse_with_options(query, parser_options)
                     .map_err(map_parser_err)?
                     .pipeline;
-                let signal_scope = SignalScope::try_from(&pipeline_expr)?;
+                let signal_scope = SignalScope::try_from_opl_query(
+                    &pipeline_expr.get_query_slice(pipeline_expr.get_query_location()),
+                )?;
                 (
                     vec![Transform {
                         pipeline: Pipeline::new_with_options(pipeline_expr, pipeline_options),
@@ -692,7 +722,9 @@ mod test {
                 arrow::v1::ArrowPayloadType,
                 common::v1::{AnyValue, InstrumentationScope, KeyValue},
                 logs::v1::{LogRecord, LogsData, ResourceLogs, ScopeLogs},
-                metrics::v1::{Metric, MetricsData, ResourceMetrics, ScopeMetrics},
+                metrics::v1::{
+                    Gauge, Histogram, Metric, MetricsData, ResourceMetrics, ScopeMetrics, Sum,
+                },
                 resource::v1::Resource,
                 trace::v1::{ResourceSpans, ScopeSpans, Span, Status, TracesData},
             },
@@ -2823,6 +2855,104 @@ mod test {
                     }
                     _ => panic!("unexpected payload type"),
                 }
+            })
+            .validate(|_ctx| async move {})
+    }
+
+    #[test]
+    fn test_process_histogram_concrete_data_types() {
+        let runtime = TestRuntime::<OtapPdata>::new();
+        let query = "histograms | set name = \"new_histogram_name\"";
+        let processor = try_create_with_opl_query(query, &runtime).expect("created processor");
+
+        runtime
+            .set_processor(processor)
+            .run_test(|mut ctx| async move {
+                let gauge_metric = Metric::build()
+                    .name("gauge_name")
+                    .data_gauge(Gauge::default())
+                    .finish();
+
+                let histogram_metric = Metric::build()
+                    .name("histogram_metric")
+                    .data_histogram(Histogram::default())
+                    .finish();
+
+                let input_batch1 = vec![gauge_metric.clone(), histogram_metric.clone()];
+                let otap_batch1 = otlp_to_otap(&OtlpProtoMessage::Metrics(MetricsData {
+                    resource_metrics: vec![ResourceMetrics::new(
+                        Resource::default(),
+                        vec![ScopeMetrics::new(
+                            InstrumentationScope::default(),
+                            input_batch1.clone(),
+                        )],
+                    )],
+                }));
+                let pdata_batch1 = OtapPdata::new(
+                    Context::default(),
+                    OtapPayload::OtapArrowRecords(otap_batch1),
+                );
+                ctx.process(Message::PData(pdata_batch1)).await.unwrap();
+
+                // check it still processes correctly metrics batches even if they don't have
+                // any of the specific metric type selected by the query
+                let sum_metric = Metric::build()
+                    .name("sum_metric")
+                    .data_sum(Sum::default())
+                    .finish();
+
+                let input_batch2 = vec![sum_metric.clone()];
+                let otap_batch2 = otlp_to_otap(&OtlpProtoMessage::Metrics(MetricsData {
+                    resource_metrics: vec![ResourceMetrics::new(
+                        Resource::default(),
+                        vec![ScopeMetrics::new(
+                            InstrumentationScope::default(),
+                            input_batch2.clone(),
+                        )],
+                    )],
+                }));
+                let pdata_batch2 = OtapPdata::new(
+                    Context::default(),
+                    OtapPayload::OtapArrowRecords(otap_batch2),
+                );
+                ctx.process(Message::PData(pdata_batch2)).await.unwrap();
+
+                let output = ctx.drain_pdata().await;
+                assert_eq!(output.len(), 2);
+
+                let mut outputs = output.into_iter();
+                let mut result1 = outputs.next().unwrap();
+                let mut result2 = outputs.next().unwrap();
+
+                let payload1: OtapArrowRecords =
+                    result1.take_payload().try_into_with_default().unwrap();
+                let OtlpProtoMessage::Metrics(metrics_result1) = otap_to_otlp(&payload1) else {
+                    panic!("invalid signal type result")
+                };
+                assert_eq!(metrics_result1.resource_metrics.len(), 1);
+                assert_eq!(metrics_result1.resource_metrics[0].scope_metrics.len(), 1);
+                assert_eq!(
+                    metrics_result1.resource_metrics[0].scope_metrics[0].metrics,
+                    vec![
+                        gauge_metric.clone(),
+                        Metric::build()
+                            .name("new_histogram_name")
+                            .data_histogram(Histogram::default())
+                            .finish()
+                    ]
+                );
+
+                let payload2: OtapArrowRecords =
+                    result2.take_payload().try_into_with_default().unwrap();
+                let OtlpProtoMessage::Metrics(metrics_result2) = otap_to_otlp(&payload2) else {
+                    panic!("invalid signal type result")
+                };
+                assert_eq!(metrics_result2.resource_metrics.len(), 1);
+                assert_eq!(metrics_result2.resource_metrics[0].scope_metrics.len(), 1);
+                assert_eq!(
+                    metrics_result2.resource_metrics[0].scope_metrics[0].metrics,
+                    vec![sum_metric.clone()]
+                );
             })
             .validate(|_ctx| async move {})
     }

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
@@ -179,7 +179,7 @@ impl TransformProcessor {
                     .map_err(map_parser_err)?
                     .pipeline;
                 let signal_scope = SignalScope::try_from_kql_query(
-                    &pipeline_expr.get_query_slice(pipeline_expr.get_query_location()),
+                    pipeline_expr.get_query_slice(pipeline_expr.get_query_location()),
                 )?;
                 (
                     vec![Transform {
@@ -194,7 +194,7 @@ impl TransformProcessor {
                     .map_err(map_parser_err)?
                     .pipeline;
                 let signal_scope = SignalScope::try_from_opl_query(
-                    &pipeline_expr.get_query_slice(pipeline_expr.get_query_location()),
+                    pipeline_expr.get_query_slice(pipeline_expr.get_query_location()),
                 )?;
                 (
                     vec![Transform {

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
@@ -127,7 +127,7 @@ impl SignalScope {
         // plural form of some concrete metric type (gauges, sums, histograms, etc.), it creates a
         // query plan that will select for processing only these batch types and only rows having
         // the specified metric type. All other batches / rows are treated as passthrough. This is
-        // why for OPL only we allow these identifiers to the the query source
+        // why for OPL only we allow these identifiers to the query source
         //
         let query = query.trim_start();
         Ok(if query.starts_with("logs") {
@@ -135,11 +135,11 @@ impl SignalScope {
         } else if query.starts_with("traces") {
             Self::Signal(SignalType::Traces)
         } else if query.starts_with("metrics")
-            | query.starts_with("gauges")
-            | query.starts_with("sums")
-            | query.starts_with("histograms")
-            | query.starts_with("exponential_histograms")
-            | query.starts_with("summaries")
+            || query.starts_with("gauges")
+            || query.starts_with("sums")
+            || query.starts_with("histograms")
+            || query.starts_with("exponential_histograms")
+            || query.starts_with("summaries")
         {
             Self::Signal(SignalType::Metrics)
         } else if query.starts_with("signal") {
@@ -2859,6 +2859,9 @@ mod test {
             .validate(|_ctx| async move {})
     }
 
+    /// Scenario: Process metrics with an OPL pipeline sourced from some specific metric type.
+    /// Guarantees: Only selected metric type are modified; rows w/out this metric type and batches
+    /// without of the selected metric type pass through unchanged.
     #[test]
     fn test_process_histogram_concrete_data_types() {
         let runtime = TestRuntime::<OtapPdata>::new();

--- a/rust/otap-dataflow/crates/pdata/src/error.rs
+++ b/rust/otap-dataflow/crates/pdata/src/error.rs
@@ -57,9 +57,7 @@ pub enum Error {
     },
 
     #[error("Cannot recognize metric type name: {metric_type_name}")]
-    UnrecognizedMetricTypeName {
-        metric_type_name: String
-    },
+    UnrecognizedMetricTypeName { metric_type_name: String },
 
     #[error("Unable to handle empty metric type")]
     EmptyMetricType,

--- a/rust/otap-dataflow/crates/pdata/src/error.rs
+++ b/rust/otap-dataflow/crates/pdata/src/error.rs
@@ -56,6 +56,11 @@ pub enum Error {
         error: TryFromPrimitiveError<MetricType>,
     },
 
+    #[error("Cannot recognize metric type name: {metric_type_name}")]
+    UnrecognizedMetricTypeName {
+        metric_type_name: String
+    },
+
     #[error("Unable to handle empty metric type")]
     EmptyMetricType,
 

--- a/rust/otap-dataflow/crates/pdata/src/otlp/metrics.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/metrics.rs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::str::FromStr;
+
 use crate::arrays::{
     Int32ArrayAccessor, MaybeDictArrayAccessor, NullableArrayAccessor, StringArrayAccessor,
     get_bool_array_opt, get_u8_array, get_u16_array,
@@ -56,6 +58,23 @@ pub enum MetricType {
     Histogram = 3,
     ExponentialHistogram = 4,
     Summary = 5,
+}
+
+impl FromStr for MetricType {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "Empty" => Ok(Self::Empty),
+            "Gauge" => Ok(Self::Gauge),
+            "Sum" => Ok(Self::Sum),
+            "Histogram" => Ok(Self::Histogram),
+            "ExponentialHistogram" => Ok(Self::ExponentialHistogram),
+            other => Err(Error::UnrecognizedMetricTypeName {
+                metric_type_name: other.to_string(),
+            }),
+        }
+    }
 }
 
 pub(crate) struct MetricsArrays<'a> {

--- a/rust/otap-dataflow/crates/pdata/src/otlp/metrics.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/metrics.rs
@@ -70,6 +70,7 @@ impl FromStr for MetricType {
             "Sum" => Ok(Self::Sum),
             "Histogram" => Ok(Self::Histogram),
             "ExponentialHistogram" => Ok(Self::ExponentialHistogram),
+            "Summary" => Ok(Self::Summary),
             other => Err(Error::UnrecognizedMetricTypeName {
                 metric_type_name: other.to_string(),
             }),

--- a/rust/otap-dataflow/crates/query-engine-languages/docs/opl-user-guide/src/flow_control.md
+++ b/rust/otap-dataflow/crates/query-engine-languages/docs/opl-user-guide/src/flow_control.md
@@ -162,7 +162,7 @@ This syntax can also be used to process only certain types of metrics:
 - `is Sum` -- matches only rows from metrics batch sum metrics
 - `is Histogram` -- matches only rows from metrics batch histogram
   metrics
-- `is ExponentialHistogram` -- matches only rows from metrics batch 
+- `is ExponentialHistogram` -- matches only rows from metrics batch
   exponential metrics
 - `is Sum` -- matches only rows from metrics batch sum metrics
 

--- a/rust/otap-dataflow/crates/query-engine-languages/docs/opl-user-guide/src/flow_control.md
+++ b/rust/otap-dataflow/crates/query-engine-languages/docs/opl-user-guide/src/flow_control.md
@@ -156,6 +156,26 @@ if (is Metric) {
 }
 ```
 
+This syntax can also be used to process only certain types of metrics:
+
+- `is Gauge` -- matches only rows from metrics batch gauge metrics
+- `is Sum` -- matches only rows from metrics batch sum metrics
+- `is Histogram` -- matches only rows from metrics batch histogram
+  metrics
+- `is ExponentialHistogram` -- matches only rows from metrics batch 
+  exponential metrics
+- `is Sum` -- matches only rows from metrics batch sum metrics
+
+```text
+// keep only sum and guage metrics
+signals | where is Sum or is Gauge
+
+// apply processing to only histogram metrics
+metrics | is (is Histogram) {
+    // ...
+}
+```
+
 ## Route Output (`route_to`)
 
 The `route_to` operator sends the current batch to a named output port instead

--- a/rust/otap-dataflow/crates/query-engine-languages/docs/opl-user-guide/src/introduction.md
+++ b/rust/otap-dataflow/crates/query-engine-languages/docs/opl-user-guide/src/introduction.md
@@ -69,6 +69,16 @@ The source keyword determines which signal types the pipeline processes:
 - `metrics` -- metric data points
 - `signals` -- all signal types
 
+The following sources can also be used to process only some specific type of
+metric. Non-metric batches (logs/traces) and rows containing unselected metric
+types will be ignored by the program:
+
+- `gauges` - gauge metrics
+- `sums` - sum metrics
+- `histograms`- histogram metrics
+- `exponential_histograms` - exponential histogram metrics
+- `summaries` - summary metrics
+
 ## Guide Overview
 
 This guide covers the currently implemented OPL operators and functions:

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/opl.pest
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/opl.pest
@@ -152,6 +152,11 @@ type_name = {
     "Log"
   | "Metric"
   | "Span"
+  | "Gauge"
+  | "Sum"
+  | "Histogram"
+  | "ExponentialHistogram"
+  | "Summary"
 }
 
 type_check_op = @{ "is" }
@@ -200,7 +205,7 @@ assignment_expression = {
     (member_expression | identifier_expression) ~ "=" ~ expression
 }
 
-rename_pair = {
+rename_pair = { 
     string_literal ~ "as" ~ string_literal
 }
 

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/opl.pest
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/opl.pest
@@ -153,10 +153,10 @@ type_name = {
   | "Metric"
   | "Span"
   | "Gauge"
+  | "Summary"
   | "Sum"
   | "Histogram"
   | "ExponentialHistogram"
-  | "Summary"
 }
 
 type_check_op = @{ "is" }

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/opl.pest
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/opl.pest
@@ -178,8 +178,17 @@ expression = {
     or_expression
 }
 
+metric_type_source = {
+    "gauges"
+  | "sums"
+  | "histograms"
+  | "exponential_histograms"
+  | "summaries"
+}
+
 source = {
-    "logs"
+  metric_type_source
+  | "logs"
   | "metrics"
   | "traces"
   | "signals"

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/opl.pest
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/opl.pest
@@ -187,7 +187,7 @@ metric_type_source = {
 }
 
 source = {
-  metric_type_source
+    metric_type_source
   | "logs"
   | "metrics"
   | "traces"

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/opl.pest
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/opl.pest
@@ -205,7 +205,7 @@ assignment_expression = {
     (member_expression | identifier_expression) ~ "=" ~ expression
 }
 
-rename_pair = { 
+rename_pair = {
     string_literal ~ "as" ~ string_literal
 }
 

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser.rs
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser.rs
@@ -370,6 +370,9 @@ mod test {
         }
     }
 
+    /// Scenario: Parse OPL pipelines that use plural concrete metric types as source.
+     /// Guarantees: The parser produces a query plan that only processes rows that have the
+     /// selected metric type
     #[test]
     fn test_parses_program_for_metrics_types() {
         let test_cases = [

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser.rs
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser.rs
@@ -371,8 +371,8 @@ mod test {
     }
 
     /// Scenario: Parse OPL pipelines that use plural concrete metric types as source.
-     /// Guarantees: The parser produces a query plan that only processes rows that have the
-     /// selected metric type
+    /// Guarantees: The parser produces a query plan that only processes rows that have the
+    /// selected metric type
     #[test]
     fn test_parses_program_for_metrics_types() {
         let test_cases = [

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser.rs
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser.rs
@@ -143,10 +143,11 @@ pub(crate) fn invalid_child_rule_error(
 #[cfg(test)]
 mod test {
     use data_engine_expressions::{
-        DataExpression, DiscardDataExpression, EqualToLogicalExpression, LogicalExpression,
-        MatchesLogicalExpression, NotLogicalExpression, QueryLocation, RegexScalarExpression,
-        ScalarExpression, SourceScalarExpression, StaticScalarExpression, StringScalarExpression,
-        ValueAccessor,
+        BooleanScalarExpression, BranchDataExpression, DataExpression, DataExpressionBranch,
+        DiscardDataExpression, EqualToLogicalExpression, GetRecordTypeScalarExpression,
+        LogicalExpression, MatchesLogicalExpression, NotLogicalExpression, QueryLocation,
+        RegexScalarExpression, ScalarExpression, SourceScalarExpression, StaticScalarExpression,
+        StringScalarExpression, ValueAccessor,
     };
     use data_engine_parser_abstractions::Parser;
     use regex::Regex;
@@ -366,6 +367,58 @@ mod test {
                 pretty_assertions::assert_eq!(&branch_exprs[0], &expected);
             }
             other => panic!("expected Conditional, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_parses_program_for_metrics_types() {
+        let test_cases = [
+            ("gauges", "Gauge"),
+            ("sums", "Sum"),
+            ("histograms", "Histogram"),
+            ("exponential_histograms", "ExponentialHistogram"),
+            ("summaries", "Summary"),
+        ];
+
+        for (source, metric_type_name) in test_cases {
+            let query = format!("{source} | where true");
+            let pipeline = OplParser::parse(&query).unwrap().pipeline;
+            let expressions = pipeline.get_expressions();
+            assert_eq!(expressions.len(), 1);
+            pretty_assertions::assert_eq!(
+                expressions[0],
+                DataExpression::Branch(
+                    BranchDataExpression::new(QueryLocation::new_fake(), true).with_branch(
+                        DataExpressionBranch::new(
+                            QueryLocation::new_fake(),
+                            Some(LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                                QueryLocation::new_fake(),
+                                ScalarExpression::GetRecordType(
+                                    GetRecordTypeScalarExpression::new(QueryLocation::new_fake())
+                                ),
+                                ScalarExpression::Static(StaticScalarExpression::String(
+                                    StringScalarExpression::new(
+                                        QueryLocation::new_fake(),
+                                        metric_type_name
+                                    )
+                                )),
+                                false
+                            ))),
+                            vec![DataExpression::Discard(
+                                DiscardDataExpression::new(QueryLocation::new_fake())
+                                    .with_predicate(LogicalExpression::Scalar(
+                                        ScalarExpression::Static(StaticScalarExpression::Boolean(
+                                            BooleanScalarExpression::new(
+                                                QueryLocation::new_fake(),
+                                                false
+                                            )
+                                        ))
+                                    ))
+                            )]
+                        )
+                    )
+                )
+            )
         }
     }
 }

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser/pipeline.rs
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser/pipeline.rs
@@ -126,7 +126,7 @@ pub(crate) fn parse_pipeline(
                     continue;
                 };
                 let source_query_location = to_query_location(&source_rule);
-                
+
                 // try to determine the type of metrics selected by this pipeline.
                 // for example, if the caller supplies a query like: "gauges | ... "
                 // we should only execute on metrics batches and only on the rows
@@ -168,7 +168,7 @@ pub(crate) fn parse_pipeline(
 
     // if the source was some concrete metric type, create a single condition selecting the only
     // rows containing this metric type. Effectively, this transforms the query into something like:
-    // signals | if (is <metric type name>) { <... pipeline ...> } 
+    // signals | if (is <metric type name>) { <... pipeline ...> }
     if let Some((source_query_location, metric_type_name)) = metric_concrete_type_condition {
         let branch_expr = BranchDataExpression::new(pipeline_query_location.clone(), true)
             .with_branch(DataExpressionBranch::new(

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser/pipeline.rs
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser/pipeline.rs
@@ -3,7 +3,11 @@
 
 use std::collections::HashMap;
 
-use data_engine_expressions::{DataExpression, PipelineFunction};
+use data_engine_expressions::{
+    BranchDataExpression, DataExpression, DataExpressionBranch, EqualToLogicalExpression,
+    GetRecordTypeScalarExpression, LogicalExpression, PipelineFunction, ScalarExpression,
+    StaticScalarExpression, StringScalarExpression,
+};
 use data_engine_parser_abstractions::{
     ParserError, ParserFunction, ParserScope, ParserState, to_query_location,
 };
@@ -111,13 +115,43 @@ pub(crate) fn parse_pipeline(
     rule: Pair<'_, Rule>,
     state: &mut ParserState,
 ) -> Result<(), ParserError> {
+    let pipeline_query_location = to_query_location(&rule);
+    let mut metric_concrete_type_condition = None;
+    let mut root_pipeline_builder = RootPipelineBuilder::new(state);
+    let mut inner_pipeline_builder = InnerPipelineBuilder::new(&mut root_pipeline_builder);
     for rule in rule.into_inner() {
         match rule.as_rule() {
             Rule::source => {
-                // ignore for now
+                let Some(source_rule) = rule.into_inner().next() else {
+                    continue;
+                };
+                let source_query_location = to_query_location(&source_rule);
+                
+                // try to determine the type of metrics selected by this pipeline.
+                // for example, if the caller supplies a query like: "gauges | ... "
+                // we should only execute on metrics batches and only on the rows
+                // that contain gauges, ignoring other batches and non gauge rows
+                if matches!(source_rule.as_rule(), Rule::metric_type_source) {
+                    let metric_type_name = match source_rule.as_str() {
+                        "gauges" => "Gauge",
+                        "sums" => "Sum",
+                        "histograms" => "Histogram",
+                        "exponential_histograms" => "ExponentialHistogram",
+                        "summaries" => "Summary",
+                        _ => {
+                            return Err(ParserError::SyntaxNotSupported(
+                                source_query_location,
+                                format!("Unknown source identifier {:?}", source_rule.as_str()),
+                            ));
+                        }
+                    };
+
+                    metric_concrete_type_condition =
+                        Some((source_query_location, metric_type_name));
+                }
             }
             Rule::pipeline_stage => {
-                parse_pipeline_stage(rule, &mut RootPipelineBuilder::new(state))?
+                parse_pipeline_stage(rule, &mut inner_pipeline_builder)?;
             }
             invalid_rule => {
                 let query_location = to_query_location(&rule);
@@ -129,6 +163,38 @@ pub(crate) fn parse_pipeline(
             }
         }
     }
+
+    let (exprs, _) = inner_pipeline_builder.into_parts();
+
+    // if the source was some concrete metric type, create a single condition selecting the only
+    // rows containing this metric type. Effectively, this transforms the query into something like:
+    // signals | if (is <metric type name>) { <... pipeline ...> } 
+    if let Some((source_query_location, metric_type_name)) = metric_concrete_type_condition {
+        let branch_expr = BranchDataExpression::new(pipeline_query_location.clone(), true)
+            .with_branch(DataExpressionBranch::new(
+                pipeline_query_location.clone(),
+                Some(LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+                    source_query_location.clone(),
+                    ScalarExpression::GetRecordType(GetRecordTypeScalarExpression::new(
+                        source_query_location.clone(),
+                    )),
+                    ScalarExpression::Static(StaticScalarExpression::String(
+                        StringScalarExpression::new(
+                            source_query_location.clone(),
+                            metric_type_name,
+                        ),
+                    )),
+                    false,
+                ))),
+                exprs,
+            ));
+        root_pipeline_builder.push_data_expression(DataExpression::Branch(branch_expr));
+    } else {
+        exprs
+            .into_iter()
+            .for_each(|expr| root_pipeline_builder.push_data_expression(expr));
+    }
+
     Ok(())
 }
 

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline.rs
@@ -543,8 +543,8 @@ mod test {
     }
 
     /// Scenario: Run a pipeline sourced from a concrete metric type over mixed inputs.
-     /// Guarantees: Only gauge metric rows are transformed; other metric types and other signals
-     /// pass through unchanged.
+    /// Guarantees: Only gauge metric rows are transformed; other metric types and other signals
+    /// pass through unchanged.
     #[tokio::test]
     async fn test_pipelines_selecting_concrete_metrics_type_skip_exec_only_on_selected_rows() {
         let logs_batch = vec![

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline.rs
@@ -260,6 +260,8 @@ impl Default for PipelineOptions {
     }
 }
 
+
+
 /// The main entrypoint for transform pipeline execution
 pub struct Pipeline {
     /// The expression tree (AST) defining this pipeline

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline.rs
@@ -260,8 +260,6 @@ impl Default for PipelineOptions {
     }
 }
 
-
-
 /// The main entrypoint for transform pipeline execution
 pub struct Pipeline {
     /// The expression tree (AST) defining this pipeline
@@ -544,8 +542,6 @@ mod test {
         assert_eq!(result2_logs, &input2_logs.slice(2, 1));
     }
 
-    // TODO should we have an equivalent test for this that also checks we don't process the signal
-    // for source != the signal type?
     #[tokio::test]
     async fn test_pipelines_selecting_concrete_metrics_type_skip_exec_only_on_selected_rows() {
         let logs_batch = vec![
@@ -555,7 +551,7 @@ mod test {
         let spans_batch = vec![Span::build().finish()];
 
         let gauge_metric = Metric::build()
-            .name("guage_matric")
+            .name("gauge_metric")
             .data_gauge(Gauge::default())
             .finish();
 

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline.rs
@@ -384,10 +384,13 @@ mod test {
     use otap_df_pdata::proto::OtlpProtoMessage;
     use otap_df_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
     use otap_df_pdata::proto::opentelemetry::logs::v1::{LogRecord, LogsData};
-    use otap_df_pdata::proto::opentelemetry::metrics::v1::MetricsData;
-    use otap_df_pdata::proto::opentelemetry::trace::v1::TracesData;
-    use otap_df_pdata::testing::round_trip::{otlp_to_otap, to_otap_logs};
+    use otap_df_pdata::proto::opentelemetry::metrics::v1::{Gauge, Metric, MetricsData, Sum};
+    use otap_df_pdata::proto::opentelemetry::trace::v1::{Span, TracesData};
+    use otap_df_pdata::testing::round_trip::{
+        otap_to_otlp, otlp_to_otap, to_otap_logs, to_otap_metrics, to_otap_traces,
+    };
     use otap_df_pdata::{OtapPayload, OtlpProtoBytes};
+    use otap_df_query_engine_languages::opl::parser::OplParser;
     use prost::Message;
 
     use crate::parser::default_parser_options;
@@ -537,5 +540,56 @@ mod test {
         let result2 = pipeline.execute(otap_batch2).await.unwrap();
         let result2_logs = result2.get(ArrowPayloadType::Logs).unwrap();
         assert_eq!(result2_logs, &input2_logs.slice(2, 1));
+    }
+
+    // TODO should we have an equivalent test for this that also checks we don't process the signal
+    // for source != the signal type?
+    #[tokio::test]
+    async fn test_pipelines_selecting_concrete_metrics_type_skip_exec_only_on_selected_rows() {
+        let logs_batch = vec![
+            LogRecord::build().event_name("event1").finish(),
+            LogRecord::build().event_name("event2").finish(),
+        ];
+        let spans_batch = vec![Span::build().finish()];
+
+        let gauge_metric = Metric::build()
+            .name("guage_matric")
+            .data_gauge(Gauge::default())
+            .finish();
+
+        let sum_metric = Metric::build()
+            .name("sum_metric")
+            .data_sum(Sum::default())
+            .finish();
+
+        let query = "gauges | set name =\"gauge_name_updated\"";
+        let parser_result = OplParser::parse(query).unwrap();
+        let mut pipeline = Pipeline::new(parser_result.pipeline);
+
+        let logs_input = to_otap_logs(logs_batch);
+        let result = pipeline.execute(logs_input.clone()).await.unwrap();
+        pretty_assertions::assert_eq!(result, logs_input);
+
+        let traces_input = to_otap_traces(spans_batch);
+        let result = pipeline.execute(traces_input.clone()).await.unwrap();
+        pretty_assertions::assert_eq!(result, traces_input);
+
+        let metrics_input = to_otap_metrics(vec![gauge_metric.clone(), sum_metric.clone()]);
+        let result = pipeline.execute(metrics_input).await.unwrap();
+        let OtlpProtoMessage::Metrics(metrics_result) = otap_to_otlp(&result) else {
+            panic!("invalid signal type result")
+        };
+        assert_eq!(metrics_result.resource_metrics.len(), 1);
+        assert_eq!(metrics_result.resource_metrics[0].scope_metrics.len(), 1);
+        pretty_assertions::assert_eq!(
+            metrics_result.resource_metrics[0].scope_metrics[0].metrics,
+            vec![
+                Metric::build()
+                    .name("gauge_name_updated")
+                    .data_gauge(Gauge::default())
+                    .finish(),
+                sum_metric.clone(),
+            ]
+        );
     }
 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline.rs
@@ -542,6 +542,9 @@ mod test {
         assert_eq!(result2_logs, &input2_logs.slice(2, 1));
     }
 
+    /// Scenario: Run a pipeline sourced from a concrete metric type over mixed inputs.
+     /// Guarantees: Only gauge metric rows are transformed; other metric types and other signals
+     /// pass through unchanged.
     #[tokio::test]
     async fn test_pipelines_selecting_concrete_metrics_type_skip_exec_only_on_selected_rows() {
         let logs_batch = vec![

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/conditional.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/conditional.rs
@@ -149,8 +149,6 @@ impl PipelineStage for ConditionalPipelineStage {
                 .condition
                 .execute_as_value(&otap_batch, session_ctx)?;
 
-            // TODO - there's an optimization we can maybe make here if the thing returned a scalar?
-
             let predicate_selection_vec = match predicate_result {
                 None => BooleanArray::new(BooleanBuffer::new_unset(root_batch.num_rows()), None),
                 Some(scoped_value) => {
@@ -167,13 +165,13 @@ impl PipelineStage for ConditionalPipelineStage {
             };
 
             let branch_selection_vec = and(&predicate_selection_vec, &not(&already_selected_vec)?)?;
-            
+
             // update the list of rows that were already selected by branches
             already_selected_vec = or(&already_selected_vec, &predicate_selection_vec)?;
 
             if branch_selection_vec.true_count() == 0 {
                 // no rows selected - no sense executing the branch on zero rows
-                continue
+                continue;
             }
 
             // create a batch with only the rows that match the condition

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/conditional.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/conditional.rs
@@ -166,8 +166,6 @@ impl PipelineStage for ConditionalPipelineStage {
                 }
             };
 
-            println!("predicate_selection_vec = {:?}", predicate_selection_vec);
-
             let branch_selection_vec = and(&predicate_selection_vec, &not(&already_selected_vec)?)?;
             
             // update the list of rows that were already selected by branches

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/conditional.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/conditional.rs
@@ -149,6 +149,8 @@ impl PipelineStage for ConditionalPipelineStage {
                 .condition
                 .execute_as_value(&otap_batch, session_ctx)?;
 
+            // TODO - there's an optimization we can maybe make here if the thing returned a scalar?
+
             let predicate_selection_vec = match predicate_result {
                 None => BooleanArray::new(BooleanBuffer::new_unset(root_batch.num_rows()), None),
                 Some(scoped_value) => {
@@ -164,10 +166,17 @@ impl PipelineStage for ConditionalPipelineStage {
                 }
             };
 
-            let branch_selection_vec = and(&predicate_selection_vec, &not(&already_selected_vec)?)?;
+            println!("predicate_selection_vec = {:?}", predicate_selection_vec);
 
+            let branch_selection_vec = and(&predicate_selection_vec, &not(&already_selected_vec)?)?;
+            
             // update the list of rows that were already selected by branches
             already_selected_vec = or(&already_selected_vec, &predicate_selection_vec)?;
+
+            if branch_selection_vec.true_count() == 0 {
+                // no rows selected - no sense executing the branch on zero rows
+                continue
+            }
 
             // create a batch with only the rows that match the condition
             //

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
@@ -365,9 +365,6 @@ impl ExprPlanner {
                 let left = left_planned.expr;
                 let right = right_planned.expr;
 
-                println!("{left:?}");
-                println!("{right:?}");
-                println!("{combined_scope:?}");
                 if let Some(combined_scope) = combined_scope
                     && !matches!(combined_scope, DataScope::AttributesAll(_))
                 {

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
@@ -1591,8 +1591,8 @@ impl ExprPlanner {
                     "Span" => SignalType::Traces,
                     other if let Ok(metric_type) = MetricType::from_str(other) => {
                         // produce plan equivalent to "is Metric and type == <metric_type>"
-                        // where metric_type is the OTAP metric type determinant (e.g. 0 = Empty,
-                        // 1 = Gauge, etc. see OTAP spec for all values)
+                        // where metric_type is the OTAP metric type determinant (e.g.  1 = Gauge,
+                        // 2 = Sum, 3 = Histogram, etc.  see OTAP spec for all values)
                         return Ok(Some(ScopedExpr::JoinAndEval {
                             children: vec![
                                 ScopedExpr::Eval {

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
@@ -1590,31 +1590,17 @@ impl ExprPlanner {
                     "Metric" => SignalType::Metrics,
                     "Span" => SignalType::Traces,
                     other if let Ok(metric_type) = MetricType::from_str(other) => {
-                        // produce plan equivalent to "is Metric and type == <metric_type>"
-                        // where metric_type is the OTAP metric type determinant (e.g.  1 = Gauge,
-                        // 2 = Sum, 3 = Histogram, etc.  see OTAP spec for all values)
-                        return Ok(Some(ScopedExpr::JoinAndEval {
-                            children: vec![
-                                ScopedExpr::Eval {
-                                    scope: DataScope::Root,
-                                    eval: LeafEval::BatchPredicate(Box::new(
-                                        SignalTypePredicate::new(SignalType::Metrics),
-                                    )),
-                                },
-                                ScopedExpr::Eval {
-                                    scope: DataScope::Root,
-                                    eval: LeafEval::new_df_expr(
-                                        col(consts::METRIC_TYPE).eq(lit(metric_type as u8)),
-                                        false,
-                                    )?,
-                                },
-                            ],
+                        // produce a plan that simply checks if the value in the "type" column
+                        // is equivalent to the metric type discriminant. This will always quickly
+                        // evaluate to `None` for non-metrics batches because projection will not
+                        // find such a column and the result will  be interpreted as `false` in a
+                        // filtering scenario
+                        return Ok(Some(ScopedExpr::Eval {
+                            scope: DataScope::Root,
                             eval: LeafEval::new_df_expr(
-                                col(arg_column_name(0)).and(col(arg_column_name(1))),
+                                col(consts::METRIC_TYPE).eq(lit(metric_type as u8)),
                                 false,
                             )?,
-                            align_children_to_root: false,
-                            default_null_children: false,
                         }));
                     }
                     _ => {

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
@@ -5,6 +5,7 @@
 //! into `ScopedExpr` execution trees.
 
 use std::borrow::Cow;
+use std::str::FromStr;
 use std::sync::Arc;
 
 use arrow::datatypes::DataType;
@@ -31,6 +32,7 @@ use datafusion::logical_expr::simplify::{ExprSimplifyResult, SimplifyContext};
 use datafusion::logical_expr::{BinaryExpr, Expr, Operator, ScalarUDF, col, lit, not};
 use datafusion::prelude::{binary_expr, lit_timestamp_nano};
 use otap_df_config::SignalType;
+use otap_df_pdata::otlp::metrics::MetricType;
 use otap_df_pdata::schema::consts;
 
 #[cfg(feature = "sha1-hash")]
@@ -358,9 +360,14 @@ impl ExprPlanner {
                     expr_type: ExprLogicalType::Boolean,
                     requires_dict_downcast: false,
                 };
+
                 let combined_scope = try_combine_scopes(&left_planned, &right_planned);
                 let left = left_planned.expr;
                 let right = right_planned.expr;
+
+                println!("{left:?}");
+                println!("{right:?}");
+                println!("{combined_scope:?}");
                 if let Some(combined_scope) = combined_scope
                     && !matches!(combined_scope, DataScope::AttributesAll(_))
                 {
@@ -1586,6 +1593,34 @@ impl ExprPlanner {
                     "Log" => SignalType::Logs,
                     "Metric" => SignalType::Metrics,
                     "Span" => SignalType::Traces,
+                    other if let Ok(metric_type) = MetricType::from_str(other) => {
+                        // produce plan equivalent to "is Metric and type == <metric_type>"
+                        // where metric_type is the OTAP metric type determinant (e.g. 0 = Empty,
+                        // 1 = Gauge, etc. see OTAP spec for all values)
+                        return Ok(Some(ScopedExpr::JoinAndEval {
+                            children: vec![
+                                ScopedExpr::Eval {
+                                    scope: DataScope::Root,
+                                    eval: LeafEval::BatchPredicate(Box::new(
+                                        SignalTypePredicate::new(SignalType::Metrics),
+                                    )),
+                                },
+                                ScopedExpr::Eval {
+                                    scope: DataScope::Root,
+                                    eval: LeafEval::new_df_expr(
+                                        col(consts::METRIC_TYPE).eq(lit(metric_type as u8)),
+                                        false,
+                                    )?,
+                                },
+                            ],
+                            eval: LeafEval::new_df_expr(
+                                col(arg_column_name(0)).and(col(arg_column_name(1))),
+                                false,
+                            )?,
+                            align_children_to_root: false,
+                            default_null_children: false,
+                        }));
+                    }
                     _ => {
                         return Err(Error::InvalidPipelineError {
                             cause: format!("Unknown stream type name {type_name}"),

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
@@ -364,7 +364,6 @@ impl ExprPlanner {
                 let combined_scope = try_combine_scopes(&left_planned, &right_planned);
                 let left = left_planned.expr;
                 let right = right_planned.expr;
-
                 if let Some(combined_scope) = combined_scope
                     && !matches!(combined_scope, DataScope::AttributesAll(_))
                 {

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
@@ -399,6 +399,7 @@ mod test {
     use crate::pipeline::{Pipeline, PipelineOptions};
 
     use super::*;
+    use otap_df_pdata::OtapPayloadHelpers;
     use otap_df_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
     use otap_df_pdata::schema::consts;
 
@@ -5780,6 +5781,37 @@ mod test {
         let query = "metrics | where is Summary";
         let result = exec_metrics_pipeline::<OplParser>(query, input.clone()).await;
         assert_results(result, vec![summary_metric.clone()]);
+    }
+
+    #[tokio::test]
+    async fn test_filter_check_signal_type_as_concrete_metric_type() {
+        let logs_batch = vec![LogRecord::build().finish()];
+        let spans_batch = vec![Span::build().finish()];
+        let metrics_batch = vec![Metric::build().data_gauge(Gauge::default()).finish()];
+
+        let query = "signals | where is Gauge";
+        let parser_result = OplParser::parse(query).unwrap();
+        let mut pipeline = Pipeline::new(parser_result.pipeline);
+
+        let logs_result = pipeline.execute(to_otap_logs(logs_batch)).await.unwrap();
+        assert!(logs_result.is_empty());
+
+        let spans_result = pipeline.execute(to_otap_traces(spans_batch)).await.unwrap();
+        assert!(spans_result.is_empty());
+
+        let metrics_result = pipeline
+            .execute(to_otap_metrics(metrics_batch.clone()))
+            .await
+            .unwrap();
+        let OtlpProtoMessage::Metrics(result) = otap_to_otlp(&metrics_result) else {
+            panic!("invalid signal type after conversion")
+        };
+        assert_eq!(result.resource_metrics.len(), 1);
+        assert_eq!(result.resource_metrics[0].scope_metrics.len(), 1);
+        pretty_assertions::assert_eq!(
+            result.resource_metrics[0].scope_metrics[0].metrics,
+            metrics_batch
+        );
     }
 
     #[tokio::test]

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
@@ -5703,6 +5703,8 @@ mod test {
         assert_eq!(traces_input, traces_ouptut);
     }
 
+    /// Scenario: Filter a metrics stream using `is <MetricType>` predicates.
+    /// Guarantees: Only metrics of the requested concrete type remain after filtering.
     #[tokio::test]
     async fn test_filter_check_metric_type() {
         let gauge_metric = Metric::build()
@@ -5783,6 +5785,9 @@ mod test {
         assert_results(result, vec![summary_metric.clone()]);
     }
 
+    /// Scenario: Run selecting some concrete metric type against a mixed stream of batches of
+    /// various signal types
+    /// Guarantees: Only rows from metrics batches having the selected metric type remain
     #[tokio::test]
     async fn test_filter_check_signal_type_as_concrete_metric_type() {
         let logs_batch = vec![LogRecord::build().finish()];

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
@@ -423,19 +423,20 @@ mod test {
     use otap_df_pdata::proto::opentelemetry::metrics::v1::exponential_histogram_data_point::Buckets;
     use otap_df_pdata::proto::opentelemetry::metrics::v1::{
         Exemplar, ExponentialHistogram, ExponentialHistogramDataPoint, Gauge, Histogram,
-        HistogramDataPoint, Metric, NumberDataPoint, Summary, SummaryDataPoint,
+        HistogramDataPoint, Metric, MetricsData, NumberDataPoint, Sum, Summary, SummaryDataPoint,
     };
     use otap_df_pdata::proto::opentelemetry::resource::v1::Resource;
     use otap_df_pdata::proto::opentelemetry::trace::v1::span::{Event, Link};
     use otap_df_pdata::proto::opentelemetry::trace::v1::{Span, Status};
     use otap_df_pdata::testing::round_trip::{
-        otap_to_otlp, otlp_to_otap, to_logs_data, to_otap_logs, to_otap_metrics, to_otap_traces,
-        to_traces_data,
+        otap_to_otlp, otlp_to_otap, to_logs_data, to_metrics_data, to_otap_logs, to_otap_metrics,
+        to_otap_traces, to_traces_data,
     };
     use otap_df_query_engine_languages::opl::parser::OplParser;
 
     use crate::pipeline::test::{
-        exec_logs_pipeline, otap_to_logs_data, otap_to_metrics_data, otap_to_traces_data,
+        exec_logs_pipeline, exec_metrics_pipeline, otap_to_logs_data, otap_to_metrics_data,
+        otap_to_traces_data,
     };
 
     async fn test_simple_filter<P: Parser, F: Fn(&str) -> String>(date_time_formatter: F) {
@@ -5697,6 +5698,42 @@ mod test {
         let traces_ouptut = pipeline.execute(traces_input.clone()).await.unwrap();
 
         assert_eq!(traces_input, traces_ouptut);
+    }
+
+    #[tokio::test]
+    async fn test_filter_check_metric_type() {
+        let gauge_metric = Metric::build()
+            .name("gauge_metric")
+            .data_gauge(Gauge {
+                data_points: vec![NumberDataPoint::build().finish()],
+            })
+            .finish();
+        let sum_metric = Metric::build()
+            .name("sum_metric")
+            .data_sum(Sum {
+                data_points: vec![NumberDataPoint::build().finish()],
+                ..Default::default()
+            })
+            .finish();
+
+        let assert_results = |result: MetricsData, expected| {
+            assert_eq!(result.resource_metrics.len(), 1);
+            assert_eq!(result.resource_metrics[0].scope_metrics.len(), 1);
+            assert_eq!(
+                result.resource_metrics[0].scope_metrics[0].metrics,
+                expected
+            );
+        };
+
+        let input = to_metrics_data(vec![gauge_metric.clone(), sum_metric.clone()]);
+
+        let query = "metrics | where is Gauge";
+        let result = exec_metrics_pipeline::<OplParser>(query, input.clone()).await;
+        assert_results(result, vec![gauge_metric.clone()]);
+
+        let query = "metrics | where is Sum";
+        let result = exec_metrics_pipeline::<OplParser>(query, input.clone()).await;
+        assert_results(result, vec![sum_metric.clone()]);
     }
 
     #[tokio::test]

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
@@ -420,10 +420,12 @@ mod test {
     use otap_df_pdata::proto::opentelemetry::logs::v1::{
         LogRecord, LogsData, ResourceLogs, ScopeLogs,
     };
+
     use otap_df_pdata::proto::opentelemetry::metrics::v1::exponential_histogram_data_point::Buckets;
     use otap_df_pdata::proto::opentelemetry::metrics::v1::{
-        Exemplar, ExponentialHistogram, ExponentialHistogramDataPoint, Gauge, Histogram,
-        HistogramDataPoint, Metric, MetricsData, NumberDataPoint, Sum, Summary, SummaryDataPoint,
+        AggregationTemporality, Exemplar, ExponentialHistogram, ExponentialHistogramDataPoint,
+        Gauge, Histogram, HistogramDataPoint, Metric, MetricsData, NumberDataPoint, Sum, Summary,
+        SummaryDataPoint,
     };
     use otap_df_pdata::proto::opentelemetry::resource::v1::Resource;
     use otap_df_pdata::proto::opentelemetry::trace::v1::span::{Event, Link};
@@ -5715,17 +5717,49 @@ mod test {
                 ..Default::default()
             })
             .finish();
+        let histogram_metric = Metric::build()
+            .name("histogram_metric")
+            .data_histogram(Histogram {
+                data_points: vec![HistogramDataPoint::build().finish()],
+                aggregation_temporality: AggregationTemporality::Unspecified as i32,
+            })
+            .finish();
+        let exp_histogram_metric = Metric::build()
+            .name("exp_histogram_metric")
+            .data_exponential_histogram(ExponentialHistogram {
+                data_points: vec![
+                    ExponentialHistogramDataPoint::build()
+                        .positive(Buckets::default())
+                        .negative(Buckets::default())
+                        .finish(),
+                ],
+                aggregation_temporality: AggregationTemporality::Unspecified as i32,
+            })
+            .finish();
+        let summary_metric = Metric::build()
+            .name("summary_metric")
+            .data_summary(Summary {
+                data_points: vec![SummaryDataPoint::build().finish()],
+            })
+            .finish();
 
+        let input = to_metrics_data(vec![
+            gauge_metric.clone(),
+            sum_metric.clone(),
+            histogram_metric.clone(),
+            exp_histogram_metric.clone(),
+            summary_metric.clone(),
+        ]);
+
+        // helper to assert on which metrics were present after filtering
         let assert_results = |result: MetricsData, expected| {
             assert_eq!(result.resource_metrics.len(), 1);
             assert_eq!(result.resource_metrics[0].scope_metrics.len(), 1);
-            assert_eq!(
+            pretty_assertions::assert_eq!(
                 result.resource_metrics[0].scope_metrics[0].metrics,
                 expected
             );
         };
-
-        let input = to_metrics_data(vec![gauge_metric.clone(), sum_metric.clone()]);
 
         let query = "metrics | where is Gauge";
         let result = exec_metrics_pipeline::<OplParser>(query, input.clone()).await;
@@ -5734,6 +5768,18 @@ mod test {
         let query = "metrics | where is Sum";
         let result = exec_metrics_pipeline::<OplParser>(query, input.clone()).await;
         assert_results(result, vec![sum_metric.clone()]);
+
+        let query = "metrics | where is Histogram";
+        let result = exec_metrics_pipeline::<OplParser>(query, input.clone()).await;
+        assert_results(result, vec![histogram_metric.clone()]);
+
+        let query = "metrics | where is ExponentialHistogram";
+        let result = exec_metrics_pipeline::<OplParser>(query, input.clone()).await;
+        assert_results(result, vec![exp_histogram_metric.clone()]);
+
+        let query = "metrics | where is Summary";
+        let result = exec_metrics_pipeline::<OplParser>(query, input.clone()).await;
+        assert_results(result, vec![summary_metric.clone()]);
     }
 
     #[tokio::test]


### PR DESCRIPTION
# Change Summary

Extends the type hierarchy of OPL to make various types of metrics concrete types of the `Metric` signal:

```
Signal
|- Log
|- Span
|- Metric
    |- Gauge
    |- Sum
    |- Hisotgram
    |- ExponentialHistogram
    |- Summary
```

Allows writing expressions such as:

```
// keep only histogram metrics
metrics | where is Histogram

// only apply transformation to gaueges or sums
metrics | if (is Gauge or is Sum) {
 // ...
}
```

```
// note - this is also allowed if the stream type is not `Metrics` e.g.
signals | if (is Gauge) { /* ... */ }
// is equivalent to
signals | if (is Metric and is Gauge) { /* ... */ }
// is equivalent to
signals | if (is Metric) { if (is Gauge) { /* ... */ } }
```

Adds a syntax sugar for applying pipelines directly to some specifig metric type. E.g. the "source" of an OPL program can be `guages`, `sums`, `hisotgrams`, `exponential_hisotgrams` or `summaries` and the pipeline will be applied only to rows containing a metric of this type, others are passthrough.

e.g.
```
gauges | // ... pipeline

// is equivalent to

signals | if (is Gauge) {
  // ... pipeline
}
```

Changes:
- adds support for this soucr in transform process for OPL only
- OPL parser support for metric type names and source identifiers
- implementation of query-engine expression planner
- various tests

Note: we don't have the same sugar in KQL parser to identify metrics type by the source name, so in transform processor it continues to only allow KQL programs where the source is `logs`, `metrics`, `traces`

<!--Replace with a brief summary of the change in this PR-->

## What issue does this PR close?

<!--We highly recommend correlation of every PR to an issue-->

* Closes #3721

## How are these changes tested?

Unit tests

## Are there any user-facing changes?

Yes, this new syntax is available in configuraiton for the transform processor

 <!-- If yes, provide further info below -->

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] Added a `.chloggen/*.yaml` entry

