### PR TITLE
ci: update and manage Weaver CLI versions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,6 +25,16 @@
     "config:best-practices",
     "helpers:pinGitHubActionDigestsToSemver"
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update Weaver CLI versions in GitHub workflows",
+      "managerFilePatterns": ["/^\\.github/workflows/.*\\.ya?ml$/"],
+      "matchStrings": ["WEAVER_VERSION:\\s*(?<currentValue>v?\\d+\\.\\d+\\.\\d+)"],
+      "depNameTemplate": "open-telemetry/weaver",
+      "datasourceTemplate": "github-releases"
+    }
+  ],
   // NOTE: Rule ordering matters here
   // Later rules will override earlier rules
   "packageRules": [

--- a/.github/workflows/df-engine-internal-observability.yml
+++ b/.github/workflows/df-engine-internal-observability.yml
@@ -32,7 +32,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  WEAVER_VERSION: v0.24.0
+  WEAVER_VERSION: v0.25.1
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -73,8 +73,8 @@ jobs:
         working-directory: ./rust/otap-dataflow
       # Weaver listener lifecycle (start, readiness probe, /stop, report
       # capture, artifact upload) is owned by the upstream composite
-      # actions below. Pinned to the published v0.24.0 release, which is
-      # the first tag to ship these actions.
+      # actions below. The CLI and actions are pinned to v0.25.1, which
+      # fixes a race that could truncate the report returned by /stop.
       - name: Start weaver live-check listener
         id: weaver-start
         uses: open-telemetry/weaver/.github/actions/weaver-live-check-start@26c685ff52b925056ff1d53476c6022638c01220 # v0.25.1

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -732,7 +732,7 @@ jobs:
   host-metrics-weaver-live-check:
     runs-on: ubuntu-latest
     env:
-      WEAVER_VERSION: v0.24.0
+      WEAVER_VERSION: v0.25.1
       # Semantic-conventions tag to validate against. Keep in sync with
       # the `VERSION` constant in
       # rust/otap-dataflow/crates/core-nodes/src/receivers/host_metrics_receiver/semconv.rs


### PR DESCRIPTION
Upgrade the Weaver CLI used by the df-engine internal observability and host-metrics workflows from v0.24.0 to v0.25.1.

v0.25.1 includes open-telemetry/weaver#1632, which fixes a race in HTTP output shutdown that could truncate the live-check report returned by /stop. The workflows already pin the accompanying GitHub Actions to v0.25.1.

Add a Renovate regex manager for WEAVER_VERSION variables in GitHub workflows. Future Weaver CLI releases will now be detected and grouped with the repository's workflow dependency updates.

This prevents intermittent JSON parsing failures and keeps the Weaver CLI pins current. No runtime behavior is changed.