### PR TITLE
feat(console): add actionable exporter metrics

### DIFF
--- a/rust/otap-dataflow/.chloggen/console-exporter-actionable-metrics.yaml
+++ b/rust/otap-dataflow/.chloggen/console-exporter-actionable-metrics.yaml
@@ -1,0 +1,21 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: pipeline
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add bounded outcome and actionable error type metrics to the console exporter.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [3300]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries. Breaking entries must include a `Migration:`
+# section with the specific action consumers must take. Keep notes to 200
+# characters and subtext to 300 characters.
+subtext:

--- a/rust/otap-dataflow/.chloggen/console-exporter-actionable-metrics.yaml
+++ b/rust/otap-dataflow/.chloggen/console-exporter-actionable-metrics.yaml
@@ -8,7 +8,7 @@ change_type: enhancement
 component: pipeline
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add bounded outcome and actionable error type metrics to the console exporter.
+note: Add bounded outcome and error type metrics to the console exporter, with actionable warnings for unsupported signals.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [3300]

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/README.md
@@ -190,9 +190,20 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
 
 ### Metric Sets
 
-| Metric | Unit | Description |
-| --- | --- | --- |
-| *None* | N/A | This node does not register a node-specific metric set. |
+| Metric | Unit | Attributes | Description |
+| --- | --- | --- | --- |
+| `exporter.pdata.exports.messages` | `{message}` | `signal`, `outcome` | PData messages whose console export reached a terminal outcome. A successful outcome means formatting and the stdout write completed without an error. |
+| `exporter.console.failures.messages` | `{message}` | `format`, `signal`, `error.type` | Failed console exports classified by selected output format and actionable error type. |
+
+`error.type` is one of `otlp_view_creation`, `otap_view_creation`,
+`unsupported_signal`, `formatting`, or `write`. The `format` attribute is fixed
+when the metric set is registered; `signal` and `error.type` are bounded
+per-measurement attributes.
+
+Console output remains best effort. The exporter ACKs a message after the
+attempt even when `outcome="failure"`, so `node.consumer.consumed.messages`
+describes pipeline completion while `exporter.pdata.exports.messages` describes
+the actual console export result.
 
 ### Events
 

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/README.md
@@ -211,8 +211,7 @@ the actual console export result.
 | --- | --- | --- |
 | `console.logs_view.otlp_create_failed` | `error` | Failed to create an OTLP logs view for console output. |
 | `console.logs_view.otap_create_failed` | `error` | Failed to create an OTAP logs view for console output. |
-| `console.traces.not_implemented` | `error` | The exporter received traces, which are not currently rendered. |
-| `console.metrics.not_implemented` | `error` | The exporter received metrics, which are not currently rendered. |
+| `console.message.unsupported_signal` | `warn` | The exporter received an unsupported `metrics` or `traces` signal; use `processor:debug` followed by `exporter:noop` to inspect it. |
 | `console.format_failed` | `error` | Failed to format a payload for console output. |
 | `console.write_failed` | `error` | Failed to write rendered output to stdout. |
 
@@ -223,6 +222,8 @@ the actual console export result.
 - Formatting and writes are best effort. Payloads are ACKed after the export
   attempt, including when formatting or writing fails.
 - Traces and metrics are not currently rendered in either format.
+- To inspect traces or metrics, use `processor:debug` and terminate the pipeline
+  with `exporter:noop`.
 - OTAP views do not currently expose every scope field. In particular, scope
   name and version can be absent from `record_json` after conversion to OTAP,
   while scope attributes remain available.

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/metrics.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/metrics.rs
@@ -1,0 +1,266 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Metrics for the Console Exporter node.
+
+use super::ConsoleOutputFormat;
+use otap_df_config::SignalType;
+use otap_df_engine::context::PipelineContext;
+use otap_df_otap::metrics::ExporterPDataExportMetrics;
+use otap_df_telemetry::common_attributes::{Outcome, SignalOutcomeAttributes};
+use otap_df_telemetry::error::Error as TelemetryError;
+use otap_df_telemetry::instrument::Counter;
+use otap_df_telemetry::metrics::{MeasurementMetricSet, MetricSetSnapshot};
+use otap_df_telemetry::reporter::MetricsReporter;
+use otap_df_telemetry_macros::{AttributeEnum, attribute_set, metric_set};
+
+/// Actionable category for a failed console export operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, AttributeEnum)]
+pub(super) enum ConsoleExportErrorType {
+    /// An OTLP byte payload could not be exposed as a logs view.
+    OtlpViewCreation,
+    /// An OTAP Arrow payload could not be exposed as a logs view.
+    OtapViewCreation,
+    /// The exporter received a signal that it cannot render.
+    UnsupportedSignal,
+    /// The selected output formatter could not encode the logs payload.
+    Formatting,
+    /// The rendered output could not be written to stdout.
+    Write,
+}
+
+/// Fixed output-format context for console exporter failure metrics.
+#[attribute_set(item, registration)]
+#[derive(Debug, Clone, Copy)]
+struct ConsoleFormatAttributes {
+    format: ConsoleOutputFormat,
+}
+
+/// Signal and error dimensions for failed console export operations.
+#[attribute_set(item, measurement)]
+#[derive(Debug, Clone, Copy)]
+struct ConsoleFailureAttributes {
+    signal: SignalType,
+    #[attribute_key = "error.type"]
+    error_type: ConsoleExportErrorType,
+}
+
+/// Failed console exports grouped by signal and actionable error type.
+#[metric_set(
+    name = "exporter.console.failures",
+    registration_attributes = ConsoleFormatAttributes,
+    measurement_attributes = ConsoleFailureAttributes
+)]
+#[derive(Debug, Default, Clone)]
+struct ConsoleExporterFailureMetrics {
+    /// Number of PData messages that failed for the classified reason.
+    #[metric(unit = "{message}")]
+    messages: Counter<u64>,
+}
+
+/// Metric sets emitted directly by a console exporter.
+pub(super) struct ConsoleExporterMetrics {
+    export_metrics: MeasurementMetricSet<ExporterPDataExportMetrics>,
+    failure_metrics: MeasurementMetricSet<ConsoleExporterFailureMetrics>,
+}
+
+impl ConsoleExporterMetrics {
+    /// Registers console exporter metrics with the selected output format.
+    pub(super) fn register(pipeline_ctx: &PipelineContext, format: ConsoleOutputFormat) -> Self {
+        Self {
+            export_metrics: ExporterPDataExportMetrics::register(pipeline_ctx),
+            failure_metrics: ConsoleExporterFailureMetrics::register(
+                pipeline_ctx,
+                &ConsoleFormatAttributes { format },
+            ),
+        }
+    }
+
+    /// Reports all console exporter metric sets.
+    pub(super) fn report(&mut self, reporter: &mut MetricsReporter) -> Result<(), TelemetryError> {
+        reporter
+            .report_measurement(&mut self.export_metrics)
+            .and_then(|()| reporter.report_measurement(&mut self.failure_metrics))
+    }
+
+    /// Takes terminal snapshots of every touched metric bucket.
+    #[must_use]
+    pub(super) fn terminal_snapshots(&mut self) -> Vec<MetricSetSnapshot> {
+        let mut snapshots = self.export_metrics.terminal_snapshots();
+        snapshots.extend(self.failure_metrics.terminal_snapshots());
+        snapshots
+    }
+
+    /// Records one successfully rendered and written PData message.
+    #[inline]
+    pub(super) fn record_success(&mut self, signal: SignalType) {
+        self.export_metrics
+            .with(SignalOutcomeAttributes {
+                signal,
+                outcome: Outcome::Success,
+            })
+            .messages
+            .inc();
+    }
+
+    /// Records one failed PData message and its diagnostic category.
+    #[inline]
+    pub(super) fn record_failure(
+        &mut self,
+        signal: SignalType,
+        error_type: ConsoleExportErrorType,
+    ) {
+        self.export_metrics
+            .with(SignalOutcomeAttributes {
+                signal,
+                outcome: Outcome::Failure,
+            })
+            .messages
+            .inc();
+        self.failure_metrics
+            .with(ConsoleFailureAttributes { signal, error_type })
+            .messages
+            .inc();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use otap_df_engine::context::ControllerContext;
+    use otap_df_telemetry::registry::TelemetryRegistryHandle;
+
+    fn new_test_metrics(format: ConsoleOutputFormat) -> ConsoleExporterMetrics {
+        new_test_metrics_with_registry(format).1
+    }
+
+    fn new_test_metrics_with_registry(
+        format: ConsoleOutputFormat,
+    ) -> (TelemetryRegistryHandle, ConsoleExporterMetrics) {
+        let registry = TelemetryRegistryHandle::new();
+        let controller = ControllerContext::new(registry.clone());
+        let pipeline_ctx =
+            controller.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+        (
+            registry,
+            ConsoleExporterMetrics::register(&pipeline_ctx, format),
+        )
+    }
+
+    /// Scenario: Console exports succeed and fail for different telemetry signals.
+    /// Guarantees: Outcomes and actionable failure types are counted in isolated buckets.
+    #[test]
+    fn export_outcomes_and_failures_are_bucketed_consistently() {
+        let mut metrics = new_test_metrics(ConsoleOutputFormat::RecordJson);
+        metrics.record_success(SignalType::Logs);
+        metrics.record_success(SignalType::Logs);
+        metrics.record_failure(SignalType::Logs, ConsoleExportErrorType::OtlpViewCreation);
+        metrics.record_failure(
+            SignalType::Metrics,
+            ConsoleExportErrorType::UnsupportedSignal,
+        );
+
+        assert_eq!(
+            metrics
+                .export_metrics
+                .get(SignalOutcomeAttributes {
+                    signal: SignalType::Logs,
+                    outcome: Outcome::Success,
+                })
+                .messages
+                .get(),
+            2
+        );
+        assert_eq!(
+            metrics
+                .export_metrics
+                .get(SignalOutcomeAttributes {
+                    signal: SignalType::Logs,
+                    outcome: Outcome::Failure,
+                })
+                .messages
+                .get(),
+            1
+        );
+        assert_eq!(
+            metrics
+                .failure_metrics
+                .get(ConsoleFailureAttributes {
+                    signal: SignalType::Logs,
+                    error_type: ConsoleExportErrorType::OtlpViewCreation,
+                })
+                .messages
+                .get(),
+            1
+        );
+        assert_eq!(
+            metrics
+                .failure_metrics
+                .get(ConsoleFailureAttributes {
+                    signal: SignalType::Metrics,
+                    error_type: ConsoleExportErrorType::UnsupportedSignal,
+                })
+                .messages
+                .get(),
+            1
+        );
+        assert_eq!(
+            metrics
+                .failure_metrics
+                .get(ConsoleFailureAttributes {
+                    signal: SignalType::Logs,
+                    error_type: ConsoleExportErrorType::Write,
+                })
+                .messages
+                .get(),
+            0
+        );
+    }
+
+    /// Scenario: A failed console export is handed off during terminal shutdown twice.
+    /// Guarantees: Outcome and diagnostic buckets have stable attributes, emit once, and drain.
+    #[test]
+    fn terminal_snapshots_emit_touched_buckets_once() {
+        let (registry, mut metrics) = new_test_metrics_with_registry(ConsoleOutputFormat::Pretty);
+        metrics.record_failure(
+            SignalType::Traces,
+            ConsoleExportErrorType::UnsupportedSignal,
+        );
+
+        let snapshots = metrics.terminal_snapshots();
+        assert_eq!(snapshots.len(), 2);
+        assert!(snapshots.iter().any(|snapshot| {
+            snapshot.descriptor().name == "exporter.pdata.exports"
+                && snapshot.measurement_attribute_value("signal") == Some("traces")
+                && snapshot.measurement_attribute_value("outcome") == Some("failure")
+        }));
+        assert!(snapshots.iter().any(|snapshot| {
+            snapshot.descriptor().name == "exporter.console.failures"
+                && snapshot.measurement_attribute_value("signal") == Some("traces")
+                && snapshot.measurement_attribute_value("error.type") == Some("unsupported_signal")
+        }));
+
+        for snapshot in &snapshots {
+            registry.accumulate_metric_set_snapshot(
+                snapshot.key(),
+                snapshot.bucket(),
+                snapshot.get_metrics(),
+            );
+        }
+        let export_batch = registry.drain_metric_export_batch();
+        let failure_export = export_batch
+            .metric_sets
+            .iter()
+            .find(|metric_set| metric_set.descriptor.name == "exporter.console.failures")
+            .expect("console failure metric set");
+        assert_eq!(
+            failure_export.item_attributes,
+            [
+                ("format".to_owned(), "pretty".to_owned()),
+                ("signal".to_owned(), "traces".to_owned()),
+                ("error.type".to_owned(), "unsupported_signal".to_owned()),
+            ]
+        );
+        assert!(metrics.terminal_snapshots().is_empty());
+    }
+}

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/mod.rs
@@ -31,8 +31,8 @@ use otap_df_pdata_views::views::logs::{
     LogRecordView, LogsDataView, ResourceLogsView, ScopeLogsView,
 };
 use otap_df_pdata_views::views::resource::ResourceView;
-use otap_df_telemetry::otel_error;
 use otap_df_telemetry::self_tracing::{AnsiCode, ColorMode, LOG_BUFFER_SIZE, StyledBufWriter};
+use otap_df_telemetry::{otel_error, otel_warn};
 use otap_df_telemetry_macros::AttributeEnum;
 use std::io::Write;
 use std::sync::Arc;
@@ -254,8 +254,8 @@ impl ConsoleExporter {
     async fn export(&self, payload: &OtapPayload) -> Result<(), ConsoleExportErrorType> {
         match payload.signal_type() {
             SignalType::Logs => self.export_logs(payload).await,
-            SignalType::Traces => self.export_traces(payload).await,
-            SignalType::Metrics => self.export_metrics(payload).await,
+            SignalType::Traces => self.unsupported_signal("traces"),
+            SignalType::Metrics => self.unsupported_signal("metrics"),
         }
     }
 
@@ -278,20 +278,11 @@ impl ConsoleExporter {
         }
     }
 
-    async fn export_traces(&self, _payload: &OtapPayload) -> Result<(), ConsoleExportErrorType> {
-        // TODO: Implement traces formatting.
-        otel_error!(
-            "console.traces.not_implemented",
-            message = "Traces formatting not yet implemented"
-        );
-        Err(ConsoleExportErrorType::UnsupportedSignal)
-    }
-
-    async fn export_metrics(&self, _payload: &OtapPayload) -> Result<(), ConsoleExportErrorType> {
-        // TODO: Implement metrics formatting.
-        otel_error!(
-            "console.metrics.not_implemented",
-            message = "Metrics formatting not yet implemented"
+    fn unsupported_signal(&self, signal: &'static str) -> Result<(), ConsoleExportErrorType> {
+        otel_warn!(
+            "console.message.unsupported_signal",
+            signal = signal,
+            message = "Console exporter supports logs only; use processor:debug followed by exporter:noop to inspect metrics or traces"
         );
         Err(ConsoleExportErrorType::UnsupportedSignal)
     }

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/mod.rs
@@ -3,6 +3,7 @@
 
 //! Console exporter that prints OTLP data in human-readable or structured formats.
 
+mod metrics;
 mod record_json;
 
 use async_trait::async_trait;
@@ -32,17 +33,19 @@ use otap_df_pdata_views::views::logs::{
 use otap_df_pdata_views::views::resource::ResourceView;
 use otap_df_telemetry::otel_error;
 use otap_df_telemetry::self_tracing::{AnsiCode, ColorMode, LOG_BUFFER_SIZE, StyledBufWriter};
+use otap_df_telemetry_macros::AttributeEnum;
 use std::io::Write;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, Instant, SystemTime};
 
+use self::metrics::{ConsoleExportErrorType, ConsoleExporterMetrics};
 use self::record_json::RecordJsonFormatter;
 
 /// The URN for the console exporter
 pub const CONSOLE_EXPORTER_URN: &str = "urn:otel:exporter:console";
 
 /// Output formats supported by the console exporter.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Deserialize, AttributeEnum)]
 #[serde(rename_all = "snake_case")]
 pub enum ConsoleOutputFormat {
     /// Human-readable hierarchical output intended for interactive inspection.
@@ -164,12 +167,14 @@ const fn default_record_json_scope() -> bool {
 /// Console exporter that prints OTLP data to stdout.
 pub struct ConsoleExporter {
     formatter: ConsoleFormatter,
+    metrics: ConsoleExporterMetrics,
 }
 
 impl ConsoleExporter {
     /// Create a new console exporter with the given configuration.
     #[must_use]
-    pub const fn new(config: ConsoleExporterConfig) -> Self {
+    pub fn new(pipeline_ctx: &PipelineContext, config: ConsoleExporterConfig) -> Self {
+        let metrics = ConsoleExporterMetrics::register(pipeline_ctx, config.format);
         let formatter = match config.format {
             ConsoleOutputFormat::Pretty => {
                 ConsoleFormatter::Pretty(HierarchicalFormatter::new(config.color, config.unicode))
@@ -178,7 +183,11 @@ impl ConsoleExporter {
                 ConsoleFormatter::RecordJson(RecordJsonFormatter::new(config.record_json))
             }
         };
-        Self { formatter }
+        Self { formatter, metrics }
+    }
+
+    fn terminal_state(&mut self, deadline: Instant) -> TerminalState {
+        TerminalState::new(deadline, self.metrics.terminal_snapshots())
     }
 }
 
@@ -188,7 +197,7 @@ impl ConsoleExporter {
 #[distributed_slice(OTAP_EXPORTER_FACTORIES)]
 pub static CONSOLE_EXPORTER: ExporterFactory<OtapPdata> = ExporterFactory {
     name: CONSOLE_EXPORTER_URN,
-    create: |_pipeline: PipelineContext,
+    create: |pipeline: PipelineContext,
              node: NodeId,
              node_config: Arc<NodeUserConfig>,
              exporter_config: &ExporterConfig,
@@ -198,7 +207,7 @@ pub static CONSOLE_EXPORTER: ExporterFactory<OtapPdata> = ExporterFactory {
                 error: format!("Failed to parse console exporter config: {}", e),
             })?;
         Ok(ExporterWrapper::local(
-            ConsoleExporter::new(config),
+            ConsoleExporter::new(&pipeline, config),
             node,
             node_config,
             exporter_config,
@@ -211,15 +220,26 @@ pub static CONSOLE_EXPORTER: ExporterFactory<OtapPdata> = ExporterFactory {
 #[async_trait(?Send)]
 impl Exporter<OtapPdata> for ConsoleExporter {
     async fn start(
-        self: Box<Self>,
+        mut self: Box<Self>,
         mut msg_chan: ExporterInbox<OtapPdata>,
         effect_handler: EffectHandler<OtapPdata>,
     ) -> Result<TerminalState, Error> {
         loop {
             match msg_chan.recv().await? {
-                Message::Control(NodeControlMsg::Shutdown { .. }) => break,
+                Message::Control(NodeControlMsg::CollectTelemetry {
+                    mut metrics_reporter,
+                }) => {
+                    _ = self.metrics.report(&mut metrics_reporter);
+                }
+                Message::Control(NodeControlMsg::Shutdown { deadline, .. }) => {
+                    return Ok(self.terminal_state(deadline));
+                }
                 Message::PData(data) => {
-                    self.export(data.payload_ref()).await;
+                    let signal = data.signal_type();
+                    match self.export(data.payload_ref()).await {
+                        Ok(()) => self.metrics.record_success(signal),
+                        Err(error_type) => self.metrics.record_failure(signal, error_type),
+                    }
                     effect_handler.notify_ack(AckMsg::new(data)).await?;
                 }
                 _ => {
@@ -227,13 +247,11 @@ impl Exporter<OtapPdata> for ConsoleExporter {
                 }
             }
         }
-
-        Ok(TerminalState::default())
     }
 }
 
 impl ConsoleExporter {
-    async fn export(&self, payload: &OtapPayload) {
+    async fn export(&self, payload: &OtapPayload) -> Result<(), ConsoleExportErrorType> {
         match payload.signal_type() {
             SignalType::Logs => self.export_logs(payload).await,
             SignalType::Traces => self.export_traces(payload).await,
@@ -241,41 +259,41 @@ impl ConsoleExporter {
         }
     }
 
-    async fn export_logs(&self, payload: &OtapPayload) {
+    async fn export_logs(&self, payload: &OtapPayload) -> Result<(), ConsoleExportErrorType> {
         match payload {
             OtapPayload::OtlpBytes(bytes) => match RawLogsData::try_from(bytes) {
-                Ok(logs_view) => {
-                    self.formatter.print_logs_data(&logs_view).await;
-                }
+                Ok(logs_view) => self.formatter.print_logs_data(&logs_view).await,
                 Err(e) => {
                     otel_error!("console.logs_view.otlp_create_failed", error = ?e, message = "Failed to create OTLP logs view");
+                    Err(ConsoleExportErrorType::OtlpViewCreation)
                 }
             },
             OtapPayload::OtapArrowRecords(records) => match OtapLogsView::try_from(records) {
-                Ok(logs_view) => {
-                    self.formatter.print_logs_data(&logs_view).await;
-                }
+                Ok(logs_view) => self.formatter.print_logs_data(&logs_view).await,
                 Err(e) => {
                     otel_error!("console.logs_view.otap_create_failed", error = ?e, message = "Failed to create OTAP logs view");
+                    Err(ConsoleExportErrorType::OtapViewCreation)
                 }
             },
         }
     }
 
-    async fn export_traces(&self, _payload: &OtapPayload) {
+    async fn export_traces(&self, _payload: &OtapPayload) -> Result<(), ConsoleExportErrorType> {
         // TODO: Implement traces formatting.
         otel_error!(
             "console.traces.not_implemented",
             message = "Traces formatting not yet implemented"
         );
+        Err(ConsoleExportErrorType::UnsupportedSignal)
     }
 
-    async fn export_metrics(&self, _payload: &OtapPayload) {
+    async fn export_metrics(&self, _payload: &OtapPayload) -> Result<(), ConsoleExportErrorType> {
         // TODO: Implement metrics formatting.
         otel_error!(
             "console.metrics.not_implemented",
             message = "Metrics formatting not yet implemented"
         );
+        Err(ConsoleExportErrorType::UnsupportedSignal)
     }
 }
 
@@ -287,7 +305,10 @@ enum ConsoleFormatter {
 
 impl ConsoleFormatter {
     /// Format logs and write the complete payload to stdout.
-    async fn print_logs_data<L: LogsDataView>(&self, logs_data: &L) {
+    async fn print_logs_data<L: LogsDataView>(
+        &self,
+        logs_data: &L,
+    ) -> Result<(), ConsoleExportErrorType> {
         let mut output = Vec::new();
         let format_result = match self {
             Self::Pretty(formatter) => {
@@ -303,7 +324,7 @@ impl ConsoleFormatter {
                 error = ?err,
                 message = "Could not format console output"
             );
-            return;
+            return Err(ConsoleExportErrorType::Formatting);
         }
 
         // Note: each per-core exporter currently creates a new Tokio stdout handle for every
@@ -316,7 +337,10 @@ impl ConsoleFormatter {
         use tokio::io::AsyncWriteExt;
         if let Err(err) = tokio::io::stdout().write_all(&output).await {
             otel_error!("console.write_failed", error = ?err, message = "Could not write to console");
+            return Err(ConsoleExportErrorType::Write);
         }
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
# Change Summary

Refactors the Console Exporter's internal instrumentation to use bounded enum-based attributes and measurement metric sets.

The exporter now:
- Reports terminal export results through `exporter.pdata.exports.messages`, partitioned by `signal` and `outcome`.
- Reports actionable failures through `exporter.console.failures.messages`, partitioned by the fixed output `format`, `signal`, and bounded `error.type`.
- Classifies failures as OTLP view creation, OTAP view creation, unsupported signal, formatting, or stdout write failures.
- Reports metrics during periodic collection and includes touched buckets in terminal shutdown snapshots.
- Preserves the existing best-effort ACK behavior, including when console formatting or output fails.
- Avoids duplicating input-volume metrics already provided by engine-owned channel instrumentation.

## What issue does this PR close?

* Related to #3300

## How are these changes tested?

- Added unit tests verifying that successful and failed exports are isolated by signal and outcome.
- Added unit tests verifying actionable failure classification and deterministic attribute ordering.
- Added terminal snapshot tests verifying that only touched buckets are emitted and that they are drained exactly once.
- `cargo xtask check` 

## Are there any user-facing changes?

Yes. The Console Exporter now exposes bounded internal telemetry for terminal export outcomes and actionable failure reasons:

- `exporter.pdata.exports.messages{signal,outcome}`
- `exporter.console.failures.messages{format,signal,error.type}`

Console output and ACK behavior are unchanged.

### Changelog

* [x] Added a `.chloggen/*.yaml` entry
* [ ] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.