### PR TITLE
chore(engine): add local delayed-resume identity

### DIFF
--- a/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
@@ -1245,7 +1245,7 @@ impl local::Processor<OtapPdata> for BatchProcessor {
 
                         Ok(())
                     }
-                    NodeControlMsg::DelayedData { data, when } => {
+                    NodeControlMsg::DelayedData { data, when, .. } => {
                         let signal = data.signal_type();
 
                         match self.format_for_signal_format(data.signal_format()) {

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/retry_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/retry_processor/mod.rs
@@ -640,7 +640,7 @@ impl Processor<OtapPdata> for RetryProcessor {
             Message::Control(control_msg) => match control_msg {
                 NodeControlMsg::Ack(ack) => self.handle_ack(ack, effect_handler).await,
                 NodeControlMsg::Nack(nack) => self.handle_nack(nack, effect_handler).await,
-                NodeControlMsg::DelayedData { when, data } => {
+                NodeControlMsg::DelayedData { when, data, .. } => {
                     if let Some(calldata) = data.source_route() {
                         let _rstate: RetryState = calldata.calldata.try_into()?;
                         self.handle_delayed(when, data, effect_handler).await?;

--- a/rust/otap-dataflow/crates/engine/src/control.rs
+++ b/rust/otap-dataflow/crates/engine/src/control.rs
@@ -96,6 +96,23 @@ pub struct WakeupSlot(pub u128);
 /// current wakeup from a stale delivery for the same slot.
 pub type WakeupRevision = u64;
 
+/// Correlation id assigned to one processor-local delayed resume.
+///
+/// IDs are unique within one node-local scheduler instance. They are returned
+/// by `requeue_later` and carried back on [`NodeControlMsg::DelayedData`] so a
+/// processor can correlate a resumed payload with local state kept outside the
+/// payload. Runtime-global delayed data has no local resume id.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct LocalResumeId(u64);
+
+impl LocalResumeId {
+    /// Creates an id from a node-local scheduler sequence.
+    pub(crate) const fn new(sequence: u64) -> Self {
+        Self(sequence)
+    }
+}
+
 /// Engine-managed call data envelope. Wraps the CallData with an envelope
 /// containing timestamp. Lives on the forward path (in context stack frames).
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -315,6 +332,10 @@ pub enum NodeControlMsg<PData> {
 
         /// The data.
         data: Box<PData>,
+
+        /// Scheduler-assigned identity for node-local delayed requeue, or
+        /// `None` for runtime-global delayed data.
+        resume_id: Option<LocalResumeId>,
     },
 
     /// Announces a process-wide memory pressure transition to receiver-local admission state.

--- a/rust/otap-dataflow/crates/engine/src/effect_handler.rs
+++ b/rust/otap-dataflow/crates/engine/src/effect_handler.rs
@@ -8,8 +8,8 @@ use crate::completion_emission_metrics::CompletionEmissionMetricsHandle;
 #[cfg(any(test, feature = "test-utils"))]
 use crate::control::WakeupRevision;
 use crate::control::{
-    AckMsg, NackMsg, PipelineCompletionMsg, PipelineCompletionMsgSender, RuntimeControlMsg,
-    RuntimeCtrlMsgSender, WakeupSlot,
+    AckMsg, LocalResumeId, NackMsg, PipelineCompletionMsg, PipelineCompletionMsgSender,
+    RuntimeControlMsg, RuntimeCtrlMsgSender, WakeupSlot,
 };
 use crate::error::Error;
 use crate::node::NodeId;
@@ -422,7 +422,10 @@ impl<PData> EffectHandlerCore<PData> {
     }
 
     /// Requeue retained pdata onto this node later.
-    pub fn requeue_later(&self, when: Instant, data: Box<PData>) -> Result<(), PData> {
+    ///
+    /// Returns the scheduler-assigned identity that will accompany the
+    /// corresponding [`crate::control::NodeControlMsg::DelayedData`].
+    pub fn requeue_later(&self, when: Instant, data: Box<PData>) -> Result<LocalResumeId, PData> {
         self.local_scheduler
             .as_ref()
             // Safety: processor runtime preparation installs the node-local scheduler

--- a/rust/otap-dataflow/crates/engine/src/local/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/local/processor.rs
@@ -587,7 +587,11 @@ impl<PData> EffectHandler<PData> {
     }
 
     /// Requeue retained pdata onto this node later.
-    pub fn requeue_later(&self, when: Instant, data: Box<PData>) -> Result<(), PData> {
+    pub fn requeue_later(
+        &self,
+        when: Instant,
+        data: Box<PData>,
+    ) -> Result<crate::control::LocalResumeId, PData> {
         self.core.requeue_later(when, data)
     }
 

--- a/rust/otap-dataflow/crates/engine/src/message.rs
+++ b/rust/otap-dataflow/crates/engine/src/message.rs
@@ -915,12 +915,13 @@ mod tests {
     /// Scenario: a processor-local delayed resume is scheduled for immediate
     /// delivery while the processor inbox is otherwise idle.
     /// Guarantees: the inbox surfaces the due retained payload as
-    /// `NodeControlMsg::DelayedData` with the original deadline and payload.
+    /// `NodeControlMsg::DelayedData` with the original deadline, payload, and
+    /// scheduler-assigned resume id.
     #[tokio::test]
     async fn processor_inbox_emits_due_delayed_resume_as_control_message() {
         let (_control_tx, _pdata_tx, scheduler, mut inbox) = local_processor_inbox(4);
         let when = Instant::now();
-        scheduler
+        let resume_id = scheduler
             .requeue_later(when, Box::new(TestMsg::new("delayed")))
             .expect("delayed resume should schedule");
 
@@ -930,8 +931,13 @@ mod tests {
             .expect("message should arrive");
         assert!(matches!(
             message,
-            Message::Control(NodeControlMsg::DelayedData { when: observed, data })
-                if observed == when && *data == TestMsg::new("delayed")
+            Message::Control(NodeControlMsg::DelayedData {
+                when: observed,
+                data,
+                resume_id: observed_id,
+            }) if observed == when
+                && *data == TestMsg::new("delayed")
+                && observed_id == Some(resume_id)
         ));
     }
 
@@ -976,7 +982,7 @@ mod tests {
             .expect("pdata should enqueue");
         let when = Instant::now();
         for idx in 0..40 {
-            scheduler
+            let _resume_id = scheduler
                 .requeue_later(when, Box::new(TestMsg::new(format!("delayed-{idx}"))))
                 .expect("delayed resume should schedule");
         }
@@ -1165,12 +1171,13 @@ mod tests {
     /// Scenario: shutdown is latched while the processor-local scheduler still
     /// holds a future delayed resume.
     /// Guarantees: pending delayed resumes become immediately available as
-    /// `DelayedData` control traffic before the latched shutdown is delivered.
+    /// `DelayedData` control traffic with their original resume ids before the
+    /// latched shutdown is delivered.
     #[tokio::test]
     async fn processor_inbox_returns_pending_delayed_resumes_on_shutdown_latch() {
         let (control_tx, _pdata_tx, scheduler, mut inbox) = local_processor_inbox(4);
         let original_when = Instant::now() + Duration::from_secs(60);
-        scheduler
+        let resume_id = scheduler
             .requeue_later(original_when, Box::new(TestMsg::new("delayed")))
             .expect("delayed resume should schedule");
         control_tx
@@ -1202,8 +1209,13 @@ mod tests {
             .expect("delayed resume should return immediately during shutdown");
         assert!(matches!(
             resumed,
-            Message::Control(NodeControlMsg::DelayedData { when, data })
-                if when < original_when && *data == TestMsg::new("delayed")
+            Message::Control(NodeControlMsg::DelayedData {
+                when,
+                data,
+                resume_id: observed_id,
+            }) if when < original_when
+                && *data == TestMsg::new("delayed")
+                && observed_id == Some(resume_id)
         ));
 
         let shutdown = inbox

--- a/rust/otap-dataflow/crates/engine/src/node_local_scheduler.rs
+++ b/rust/otap-dataflow/crates/engine/src/node_local_scheduler.rs
@@ -22,7 +22,7 @@
 //! the older runtime-global delayed-data path for processor-local retry work.
 
 use crate::clock;
-use crate::control::{NodeControlMsg, WakeupRevision, WakeupSlot};
+use crate::control::{LocalResumeId, NodeControlMsg, WakeupRevision, WakeupSlot};
 use crate::entity_context::current_node_telemetry_handle;
 use crate::indexed_min_heap::IndexedMinHeap;
 use otap_df_telemetry::error::Error as TelemetryError;
@@ -230,7 +230,7 @@ impl<PData> NodeLocalScheduler<PData> {
     /// Allocates the next delayed-resume FIFO sequence number.
     fn next_sequence(&mut self) -> u64 {
         let next = self.next_sequence;
-        self.next_sequence = self.next_sequence.saturating_add(1);
+        self.next_sequence += 1;
         next
     }
 
@@ -251,10 +251,18 @@ impl<PData> NodeLocalScheduler<PData> {
 
     /// Stores a retained payload for later delivery to this processor.
     ///
-    /// Returns the original payload on capacity pressure or after shutdown is
+    /// Returns the scheduler-assigned identity on success. Returns the original
+    /// payload on capacity pressure, identity exhaustion, or after shutdown is
     /// latched so callers never lose ownership on rejection.
-    fn requeue_later(&mut self, when: Instant, data: Box<PData>) -> Result<(), Box<PData>> {
-        if self.shutting_down || self.delayed_resumes.len() >= self.delayed_resume_capacity {
+    fn requeue_later(
+        &mut self,
+        when: Instant,
+        data: Box<PData>,
+    ) -> Result<LocalResumeId, Box<PData>> {
+        if self.shutting_down
+            || self.delayed_resumes.len() >= self.delayed_resume_capacity
+            || self.next_sequence == u64::MAX
+        {
             return Err(data);
         }
 
@@ -264,7 +272,7 @@ impl<PData> NodeLocalScheduler<PData> {
             sequence,
             data,
         });
-        Ok(())
+        Ok(LocalResumeId::new(sequence))
     }
 
     /// Inserts or replaces a lightweight keyed wakeup.
@@ -391,6 +399,7 @@ impl<PData> NodeLocalScheduler<PData> {
             return Some(NodeControlMsg::DelayedData {
                 when: resume.when,
                 data: resume.data,
+                resume_id: Some(LocalResumeId::new(resume.sequence)),
             });
         }
 
@@ -448,6 +457,7 @@ impl<PData> NodeLocalScheduler<PData> {
             self.due_now.push_back(NodeControlMsg::DelayedData {
                 when: now,
                 data: resume.data,
+                resume_id: Some(LocalResumeId::new(resume.sequence)),
             });
         }
 
@@ -515,7 +525,11 @@ impl<PData> NodeLocalSchedulerHandle<PData> {
         f(&mut guard)
     }
 
-    pub(crate) fn requeue_later(&self, when: Instant, data: Box<PData>) -> Result<(), Box<PData>> {
+    pub(crate) fn requeue_later(
+        &self,
+        when: Instant,
+        data: Box<PData>,
+    ) -> Result<LocalResumeId, Box<PData>> {
         let result = self.with_scheduler(|scheduler| scheduler.requeue_later(when, data));
         if result.is_ok() {
             self.notify.notify_one();
@@ -596,11 +610,17 @@ mod tests {
         msg: Option<NodeControlMsg<i32>>,
         expected_when: Instant,
         expected_data: i32,
+        expected_resume_id: LocalResumeId,
     ) {
         match msg {
-            Some(NodeControlMsg::DelayedData { when, data }) => {
+            Some(NodeControlMsg::DelayedData {
+                when,
+                data,
+                resume_id,
+            }) => {
                 assert_eq!(when, expected_when);
                 assert_eq!(*data, expected_data);
+                assert_eq!(resume_id, Some(expected_resume_id));
             }
             _ => panic!("expected delayed data"),
         }
@@ -629,21 +649,24 @@ mod tests {
     /// Scenario: a retained payload is scheduled through the processor-local
     /// delayed-resume queue and then becomes due.
     /// Guarantees: the scheduler emits the original payload as
-    /// `NodeControlMsg::DelayedData` and clears the delayed-resume deadline.
+    /// `NodeControlMsg::DelayedData` with the returned resume id and clears the
+    /// delayed-resume deadline.
     #[test]
     fn requeue_later_emits_the_stored_payload() {
         let mut scheduler = NodeLocalScheduler::<i32>::new(2, 2);
         let when = Instant::now() + Duration::from_secs(1);
 
-        assert_eq!(scheduler.requeue_later(when, Box::new(17)), Ok(()));
-        expect_delayed(scheduler.pop_due(when), when, 17);
+        let resume_id = scheduler
+            .requeue_later(when, Box::new(17))
+            .expect("delayed resume should schedule");
+        expect_delayed(scheduler.pop_due(when), when, 17, resume_id);
         assert_eq!(scheduler.next_expiry(), None);
     }
 
     /// Scenario: multiple delayed resumes are scheduled at different times,
     /// including two with the same due time.
     /// Guarantees: due resumes are emitted by due time, with FIFO ordering for
-    /// equal deadlines.
+    /// equal deadlines and distinct resume ids for distinct payloads.
     #[test]
     fn delayed_resumes_preserve_due_time_ordering() {
         let mut scheduler = NodeLocalScheduler::new(4, 2);
@@ -653,15 +676,26 @@ mod tests {
         let same_time_a = now + Duration::from_secs(2);
         let same_time_b = same_time_a;
 
-        assert_eq!(scheduler.requeue_later(later, Box::new(3)), Ok(()));
-        assert_eq!(scheduler.requeue_later(same_time_a, Box::new(1)), Ok(()));
-        assert_eq!(scheduler.requeue_later(same_time_b, Box::new(2)), Ok(()));
-        assert_eq!(scheduler.requeue_later(sooner, Box::new(0)), Ok(()));
+        let later_id = scheduler.requeue_later(later, Box::new(3)).unwrap();
+        let same_time_a_id = scheduler.requeue_later(same_time_a, Box::new(1)).unwrap();
+        let same_time_b_id = scheduler.requeue_later(same_time_b, Box::new(2)).unwrap();
+        let sooner_id = scheduler.requeue_later(sooner, Box::new(0)).unwrap();
 
-        expect_delayed(scheduler.pop_due(sooner), sooner, 0);
-        expect_delayed(scheduler.pop_due(same_time_a), same_time_a, 1);
-        expect_delayed(scheduler.pop_due(same_time_b), same_time_b, 2);
-        expect_delayed(scheduler.pop_due(later), later, 3);
+        assert_ne!(same_time_a_id, same_time_b_id);
+        expect_delayed(scheduler.pop_due(sooner), sooner, 0, sooner_id);
+        expect_delayed(
+            scheduler.pop_due(same_time_a),
+            same_time_a,
+            1,
+            same_time_a_id,
+        );
+        expect_delayed(
+            scheduler.pop_due(same_time_b),
+            same_time_b,
+            2,
+            same_time_b_id,
+        );
+        expect_delayed(scheduler.pop_due(later), later, 3, later_id);
     }
 
     /// Scenario: the delayed-resume heap has reached its configured capacity.
@@ -672,7 +706,9 @@ mod tests {
         let mut scheduler = NodeLocalScheduler::new(1, 1);
         let when = Instant::now() + Duration::from_secs(1);
 
-        assert_eq!(scheduler.requeue_later(when, Box::new(1)), Ok(()));
+        let _accepted_id = scheduler
+            .requeue_later(when, Box::new(1))
+            .expect("first delayed resume should schedule");
         let rejected = scheduler
             .requeue_later(when, Box::new(2))
             .expect_err("capacity should reject");
@@ -695,26 +731,43 @@ mod tests {
         assert_eq!(*rejected, 99);
     }
 
+    /// Scenario: the node-local scheduler has exhausted its resume-id space.
+    /// Guarantees: a new delayed resume is rejected with its original payload
+    /// instead of accepting work with a reused identity.
+    #[test]
+    fn exhausted_resume_ids_reject_the_original_payload() {
+        let mut scheduler = NodeLocalScheduler::new(2, 1);
+        scheduler.next_sequence = u64::MAX;
+
+        let rejected = scheduler
+            .requeue_later(Instant::now(), Box::new(99))
+            .expect_err("exhausted resume ids should reject");
+        assert_eq!(*rejected, 99);
+        assert!(scheduler.delayed_resumes.is_empty());
+    }
+
     /// Scenario: shutdown begins while future delayed resumes are still pending
     /// in the processor-local scheduler.
     /// Guarantees: pending delayed resumes are converted into immediate
-    /// `DelayedData` delivery using the shutdown-start timestamp.
+    /// `DelayedData` delivery using the shutdown-start timestamp while
+    /// preserving their assigned resume ids.
     #[test]
     fn shutdown_makes_pending_delayed_resumes_due_immediately() {
         let mut scheduler = NodeLocalScheduler::new(4, 2);
         let now = Instant::now();
         let later = now + Duration::from_secs(30);
 
-        assert_eq!(scheduler.requeue_later(later, Box::new(11)), Ok(()));
-        assert_eq!(
-            scheduler.requeue_later(later + Duration::from_secs(1), Box::new(12)),
-            Ok(())
-        );
+        let first_id = scheduler
+            .requeue_later(later, Box::new(11))
+            .expect("first delayed resume should schedule");
+        let second_id = scheduler
+            .requeue_later(later + Duration::from_secs(1), Box::new(12))
+            .expect("second delayed resume should schedule");
 
         scheduler.begin_shutdown(now);
 
-        expect_delayed(scheduler.pop_due(now), now, 11);
-        expect_delayed(scheduler.pop_due(now), now, 12);
+        expect_delayed(scheduler.pop_due(now), now, 11, first_id);
+        expect_delayed(scheduler.pop_due(now), now, 12, second_id);
         assert!(scheduler.pop_due(now).is_none());
     }
 

--- a/rust/otap-dataflow/crates/engine/src/pipeline_ctrl.rs
+++ b/rust/otap-dataflow/crates/engine/src/pipeline_ctrl.rs
@@ -701,6 +701,7 @@ impl<PData> RuntimeCtrlMsgManager<PData> {
                                     NodeControlMsg::DelayedData {
                                         when: now,
                                         data,
+                                        resume_id: None,
                                     },
                                 );
                                 self.runtime_control_metrics
@@ -845,6 +846,7 @@ impl<PData> RuntimeCtrlMsgManager<PData> {
                 NodeControlMsg::DelayedData {
                     when,
                     data: delayed.data,
+                    resume_id: None,
                 },
             );
             flushed += 1;
@@ -894,6 +896,7 @@ impl<PData> RuntimeCtrlMsgManager<PData> {
                 NodeControlMsg::DelayedData {
                     when: delayed.when,
                     data: delayed.data,
+                    resume_id: None,
                 },
             ));
             delayed_data_count += 1;
@@ -2314,6 +2317,10 @@ mod tests {
         assert!(delayed_heap.is_empty());
     }
 
+    /// Scenario: runtime-global delayed data reaches its target after the
+    /// requested deadline.
+    /// Guarantees: global delivery preserves the deadline and payload and does
+    /// not claim a node-local resume identity.
     #[tokio::test]
     async fn test_delay_data_integration() {
         let local = LocalSet::new();
@@ -2342,9 +2349,14 @@ mod tests {
                 let delayed_result = async { receiver.recv().await };
 
                 match delayed_result.await {
-                    Ok(NodeControlMsg::DelayedData { when, data }) => {
+                    Ok(NodeControlMsg::DelayedData {
+                        when,
+                        data,
+                        resume_id,
+                    }) => {
                         assert_eq!(*data, *test_data);
                         assert_eq!(when, delay_time);
+                        assert_eq!(resume_id, None);
                     }
                     Ok(other) => panic!("Expected DelayedData, got {other:?}"),
                     Err(e) => panic!("Failed to receive message: {e:?}"),
@@ -3022,9 +3034,10 @@ mod tests {
             .await;
     }
 
-    // DelayData submitted after draining begins represents retry work that
-    // should not stay hidden behind the delayed-data heap. The manager returns
-    // it to the origin node immediately so the node can decide what to do next.
+    /// Scenario: runtime-global delayed data is submitted after draining has
+    /// started.
+    /// Guarantees: the payload is returned immediately with a rewritten
+    /// deadline and without a node-local resume identity.
     #[tokio::test]
     async fn test_new_delay_data_returned_immediately_during_draining() {
         let local = LocalSet::new();
@@ -3068,8 +3081,13 @@ mod tests {
                     .expect("processor control channel should stay open");
 
                 match msg {
-                    NodeControlMsg::DelayedData { when, data } => {
+                    NodeControlMsg::DelayedData {
+                        when,
+                        data,
+                        resume_id,
+                    } => {
                         assert_eq!(*data, "drain_retry");
+                        assert_eq!(resume_id, None);
                         assert!(
                             when < original_when,
                             "DelayedData should be returned immediately, not at its original wake time"
@@ -3085,9 +3103,9 @@ mod tests {
             .await;
     }
 
-    // Draining must also flush retry work that was already queued before
-    // shutdown. Once draining starts, delayed data is returned immediately
-    // rather than waiting for its original wake time.
+    /// Scenario: runtime-global delayed data is queued before draining starts.
+    /// Guarantees: drain flushes the payload immediately with a rewritten
+    /// deadline and without a node-local resume identity.
     #[tokio::test]
     async fn test_queued_delayed_data_flushed_when_draining_begins() {
         let local = LocalSet::new();
@@ -3125,8 +3143,13 @@ mod tests {
                     .expect("Queued delayed data should flush when draining begins")
                     .expect("processor control channel should stay open");
                 match msg {
-                    NodeControlMsg::DelayedData { when, data } => {
+                    NodeControlMsg::DelayedData {
+                        when,
+                        data,
+                        resume_id,
+                    } => {
                         assert_eq!(*data, "queued_retry");
+                        assert_eq!(resume_id, None);
                         assert!(
                             when < original_when,
                             "Queued delayed data should be flushed immediately during shutdown"

--- a/rust/otap-dataflow/crates/engine/src/shared/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/shared/processor.rs
@@ -609,7 +609,11 @@ impl<PData> EffectHandler<PData> {
     }
 
     /// Requeue retained pdata onto this node later.
-    pub fn requeue_later(&self, when: Instant, data: Box<PData>) -> Result<(), PData> {
+    pub fn requeue_later(
+        &self,
+        when: Instant,
+        data: Box<PData>,
+    ) -> Result<crate::control::LocalResumeId, PData> {
         self.core.requeue_later(when, data)
     }
 


### PR DESCRIPTION
## Summary

- add an opaque scheduler-local `LocalResumeId` to local delayed-work delivery
- return the assigned ID from successful `requeue_later` calls and preserve it through due and shutdown delivery
- keep runtime-global delayed delivery explicitly identified with `resume_id: None`
- preserve existing ordering, capacity, drain, shutdown, and processor behavior

This is a generic delayed-work identity change. It does not add memory accounting, metrics, configuration, tenant behavior, or enforcement.

## Validation

Passed:

- `cargo fmt --all -- --check`
- `cargo check -p otap-df-engine`
- `cargo check -p otap-df-core-nodes`
- focused node-local scheduler, processor inbox, pipeline delay/drain, and retry processor tests
- `cargo clippy -p otap-df-engine -p otap-df-core-nodes --all-targets -- -D warnings`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `python3 tools/sanitycheck.py`

`cargo xtask check` was run but stopped at the initial component-inventory gate because current `main` is missing an inventory annotation for `OTAP_EXTENSION_FACTORIES` in `crates/contrib-extensions/src/oauth2_client_auth/mod.rs`. This file is outside this PR. The full workspace clippy and test stages were run separately and passed.