### PR TITLE
feat(metrics): Migrate temporal_reaggregation processor telemetry to enum attributes

### DIFF
--- a/rust/otap-dataflow/.chloggen/temporal-reaggregation-measurement-metrics.yaml
+++ b/rust/otap-dataflow/.chloggen/temporal-reaggregation-measurement-metrics.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: pipeline
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: >-
+  Migrated temporal reaggregation processor telemetry from three flat counters to three
+  dimensioned metric populations: `operations`, `failures{error.type}`, and
+  `flushes{outcome,reason}`.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [3530]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries. Breaking entries must include a `Migration:`
+# section with the specific action consumers must take.
+subtext: |
+  Migration:
+    - flushes_timer -> flushes{reason="timer"}
+    - flushes_overflow -> flushes{reason=~"id_overflow|stream_cardinality_exceeded"}
+    - batches_rejected -> failures{error.type=~"view_creation|id_overflow|stream_cardinality_exceeded"}
+    Note: `flushes` counts non-empty attempts.

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/README.md
@@ -84,13 +84,52 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
 
 ### Metric Sets
 
-#### `processor.temporal_reaggregation.pdata`
+#### `processor.temporal_reaggregation`
+
+Three separate populations are tracked.
+
+**`operations`** - one terminal result per metrics PData input:
 
 | Metric | Unit | Description |
 | --- | --- | --- |
-| `processor.temporal_reaggregation.pdata.flushes_timer` | `{flush}` | Number of flushes triggered by the regular timer. |
-| `processor.temporal_reaggregation.pdata.flushes_overflow` | `{flush}` | Number of flushes triggered by exceeding the maximum stream count. |
-| `processor.temporal_reaggregation.pdata.batches_rejected` | `{batch}` | Number of incoming batches rejected because they individually exceed some specified limit or fail to be processed into a view. |
+| `processor.temporal_reaggregation.operations` | `{operation}` | Number of input operations. Success means data was staged or passed through; failure means local processing or immediate downstream handoff failed. |
+
+**`failures`** - one entry per failed input, with actionable cause:
+
+| Metric | Attributes | Description |
+| --- | --- | --- |
+| `processor.temporal_reaggregation.failures` | `error.type` | Number of failed input operations, broken down by cause. |
+
+| `error.type` value | Description |
+| --- | --- |
+| `view_creation` | Could not decode the input records into a metrics view. |
+| `id_overflow` | Batch was too large to aggregate even after an overflow flush. |
+| `stream_cardinality_exceeded` | Batch was too large to aggregate even after an overflow flush. |
+| `output_send` | An immediate downstream send failed. |
+| `internal` | Internal scheduling or processor state handling failed. |
+
+**`flushes`** - one entry per non-empty flush attempt, recorded after the result is known:
+
+| Metric | Attributes | Description |
+| --- | --- | --- |
+| `processor.temporal_reaggregation.flushes` | `outcome`, `reason` | Number of non-empty flushes and their result. Empty flushes are not counted. |
+
+| `outcome` value | Description |
+| --- | --- |
+| `success` | Flush was sent downstream without error. |
+| `failure` | Sending the flush downstream returned an error. |
+
+| `reason` value | Description |
+| --- | --- |
+| `timer` | Regular collection-period timer fired. |
+| `id_overflow` | ID counter overflow triggered an early flush. |
+| `stream_cardinality_exceeded` | Stream cardinality limit triggered an early flush. |
+| `shutdown` | Processor is shutting down; remaining data was flushed. |
+
+An input operation is counted as successful when the data is either staged in
+the aggregation buffer or passed through to the next node. Delayed downstream
+acknowledgements (ACKs/NACKs on the flushed output) do not change the local
+operation outcome recorded here.
 
 ### Events
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/mod.rs
@@ -50,7 +50,7 @@ use otel_arrow_dfe_pdata_views::views::metrics::{
     SummaryDataPointView, SummaryView,
 };
 use otel_arrow_dfe_pdata_views::views::resource::ResourceView;
-use otel_arrow_dfe_telemetry::metrics::MetricSet;
+use otel_arrow_dfe_telemetry::common_attributes::Outcome;
 
 mod builder;
 mod config;
@@ -63,7 +63,7 @@ use self::identity::{
     HashBuffer, MetricId, MetricIdRef, ResourceId, ScopeId, ScopeIdRef, StreamId, StreamIdRef,
     metric_id_of, resource_id_of, scope_id_of, stream_id_of,
 };
-use self::telemetry::TemporalReaggregationMetrics;
+use self::telemetry::{ErrorType, FlushReason, TemporalReaggregationMetrics};
 
 /// Errors that can occur during view processing.
 #[derive(thiserror::Error, Debug)]
@@ -211,7 +211,7 @@ const FLUSH_WAKEUP_SLOT: WakeupSlot = WakeupSlot(0);
 /// [`OtapArrowRecords`] batch.
 pub struct TemporalReaggregationProcessor {
     /// Processor metrics
-    metrics: MetricSet<TemporalReaggregationMetrics>,
+    metrics: TemporalReaggregationMetrics,
 
     /// The collection period for aggregating metrics before emitting a batch
     collection_period: Duration,
@@ -296,19 +296,21 @@ impl local::Processor<OtapPdata> for TemporalReaggregationProcessor {
                 NodeControlMsg::Wakeup { revision, .. } => {
                     if self.wakeup_revision == Some(revision) {
                         self.wakeup_revision = None;
-                        self.metrics.flushes_timer.inc();
-                        self.flush(effect_handler, None).await?;
+                        self.flush(effect_handler, None, FlushReason::Timer).await?;
                     }
 
                     Ok(())
                 }
                 NodeControlMsg::Ack(msg) => self.handle_ack(effect_handler, msg).await,
                 NodeControlMsg::Nack(msg) => self.handle_nack(effect_handler, msg).await,
-                NodeControlMsg::Shutdown { .. } => self.flush(effect_handler, None).await,
+                NodeControlMsg::Shutdown { .. } => {
+                    self.flush(effect_handler, None, FlushReason::Shutdown)
+                        .await
+                }
                 NodeControlMsg::CollectTelemetry {
                     mut metrics_reporter,
                 } => {
-                    _ = metrics_reporter.report(&mut self.metrics);
+                    _ = self.metrics.report(&mut metrics_reporter);
                     Ok(())
                 }
                 _ => Ok(()),
@@ -349,7 +351,7 @@ impl TemporalReaggregationProcessor {
         pipeline_ctx: PipelineContext,
         config: &serde_json::Value,
     ) -> Result<Self, ConfigError> {
-        let metrics = pipeline_ctx.register_metrics::<TemporalReaggregationMetrics>();
+        let metrics = TemporalReaggregationMetrics::new(&pipeline_ctx);
         let config: Config =
             serde_json::from_value(config.clone()).map_err(|e| ConfigError::InvalidUserConfig {
                 error: e.to_string(),
@@ -628,7 +630,8 @@ impl TemporalReaggregationProcessor {
                 Ok(view) => self.process_view(effect_handler, &view).await,
                 Err(e) => {
                     otel_warn!(telemetry::VIEW_CREATION_FAILED_EVENT, error = %e);
-                    self.metrics.batches_rejected.inc();
+                    // local failure, not a downstream refusal
+                    self.metrics.record_failure(ErrorType::ViewCreation);
                     let msg = format!("Failed to create view: {:#}", e);
                     effect_handler
                         .notify_nack(NackMsg::new_permanent(msg, pdata))
@@ -646,7 +649,13 @@ impl TemporalReaggregationProcessor {
         match result {
             Ok(agg_result) => match agg_result {
                 AggregationResult::NoAggregations => {
-                    Ok(effect_handler.send_message_with_source_node(pdata).await?)
+                    let send_res = effect_handler.send_message_with_source_node(pdata).await;
+                    if send_res.is_ok() {
+                        self.metrics.record_success();
+                    } else {
+                        self.metrics.record_failure(ErrorType::OutputSend);
+                    }
+                    Ok(send_res?)
                 }
                 AggregationResult::SomeAggregations(records) => {
                     // The aggregated portion of this input has been folded into
@@ -657,13 +666,19 @@ impl TemporalReaggregationProcessor {
                     // metrics unwinding depends on the inbound context.
                     let (inbound_ctx, _) = pdata.into_parts();
                     if !inbound_ctx.needs_completion_tracking() {
-                        self.ensure_wakeup_scheduled(effect_handler)?;
+                        if let Err(e) = self.ensure_wakeup_scheduled(effect_handler) {
+                            self.metrics.record_failure(ErrorType::Internal);
+                            return Err(e);
+                        }
                         let pt_pdata = OtapPdata::new(inbound_ctx, OtapPayload::from(records));
 
-                        effect_handler
-                            .send_message_with_source_node(pt_pdata)
-                            .await?;
-                        return Ok(());
+                        let send_res = effect_handler.send_message_with_source_node(pt_pdata).await;
+                        if send_res.is_ok() {
+                            self.metrics.record_success();
+                        } else {
+                            self.metrics.record_failure(ErrorType::OutputSend);
+                        }
+                        return Ok(send_res?);
                     }
 
                     // The partial-passthrough output represents exactly one
@@ -678,8 +693,15 @@ impl TemporalReaggregationProcessor {
                         flushed: false,
                     };
 
-                    let inbound_calldata: CallData =
-                        self.record_pending_and_handle_wakeup(effect_handler, tracker)?;
+                    let inbound_calldata_res =
+                        self.record_pending_and_handle_wakeup(effect_handler, tracker);
+                    let inbound_calldata: CallData = match inbound_calldata_res {
+                        Ok(call_data) => call_data,
+                        Err(e) => {
+                            self.metrics.record_failure(ErrorType::Internal);
+                            return Err(e);
+                        }
+                    };
 
                     // safety: See [`TemporalReaggregationProcessor::accept_pdata`].
                     // We always expect one inbound and three outbound slots available
@@ -701,9 +723,13 @@ impl TemporalReaggregationProcessor {
                         &mut pt_pdata,
                     );
 
-                    Ok(effect_handler
-                        .send_message_with_source_node(pt_pdata)
-                        .await?)
+                    let send_res = effect_handler.send_message_with_source_node(pt_pdata).await;
+                    if send_res.is_ok() {
+                        self.metrics.record_success();
+                    } else {
+                        self.metrics.record_failure(ErrorType::OutputSend);
+                    }
+                    Ok(send_res?)
                 }
                 AggregationResult::AllAggregated => {
                     // The full input was folded into the in-progress builder;
@@ -713,7 +739,11 @@ impl TemporalReaggregationProcessor {
                     // the inbound context, only schedule the aggregate flush.
                     let (inbound_ctx, _) = pdata.into_parts();
                     if !inbound_ctx.needs_completion_tracking() {
-                        self.ensure_wakeup_scheduled(effect_handler)?;
+                        if let Err(e) = self.ensure_wakeup_scheduled(effect_handler) {
+                            self.metrics.record_failure(ErrorType::Internal);
+                            return Err(e);
+                        }
+                        self.metrics.record_success();
                         return Ok(());
                     }
 
@@ -725,8 +755,12 @@ impl TemporalReaggregationProcessor {
                         flushed: false,
                     };
 
-                    _ = self.record_pending_and_handle_wakeup(effect_handler, tracker)?;
+                    if let Err(e) = self.record_pending_and_handle_wakeup(effect_handler, tracker) {
+                        self.metrics.record_failure(ErrorType::Internal);
+                        return Err(e);
+                    }
 
+                    self.metrics.record_success();
                     Ok(())
                 }
             },
@@ -734,11 +768,17 @@ impl TemporalReaggregationProcessor {
                 // Engine errors are fatal, we propagate those up the stack
                 ProcessingError::Engine { source } => Err(source),
 
-                // This is our classic "bad data" case where even after flushing
-                // the current batch, it failed on retry due to being oversized
-                // in some way. We can't handle it, so it gets a nack.
+                // Classic "bad data" case: even after flushing the current batch
+                // and retrying, the input is still too large to aggregate.
+                // Record the actionable error cause from source, not the control-flow reason.
                 ProcessingError::AggregationRetryFailed { source } => {
-                    self.metrics.batches_rejected.inc();
+                    let error_type = match source {
+                        AggregationError::IdOverflow => ErrorType::IdOverflow,
+                        AggregationError::StreamCardinalityExceeded => {
+                            ErrorType::StreamCardinalityExceeded
+                        }
+                    };
+                    self.metrics.record_failure(error_type);
                     let msg = format!("Failed to aggregate batch: {:#}", source);
                     effect_handler
                         .notify_nack(NackMsg::new_permanent(msg, pdata))
@@ -756,10 +796,15 @@ impl TemporalReaggregationProcessor {
     /// the data appended before the checkpoint is clean and should be sent
     /// downstream, while the partial data from the failed call is discarded
     /// by slicing the record batches.
+    /// Flush accumulated metrics up to the given checkpoint.
+    ///
+    /// Records a `flushes` metric only when records are actually emitted (non-empty flush).
+    /// The metric is recorded after the send result is known so that outcome is accurate.
     async fn flush(
         &mut self,
         effect_handler: &mut local::EffectHandler<OtapPdata>,
         checkpoint: Option<Checkpoint>,
+        reason: FlushReason,
     ) -> Result<(), Error> {
         let records = self.builder.finish(checkpoint);
         // Snapshot the merged peer_addr from every input that contributed to
@@ -771,6 +816,7 @@ impl TemporalReaggregationProcessor {
         // scheduled whenever we start aggregating a new batch
         self.cancel_current_wakeup(effect_handler);
 
+        // Empty flush - nothing to emit, skip the metric entirely
         if records.is_empty() {
             return Ok(());
         }
@@ -784,8 +830,14 @@ impl TemporalReaggregationProcessor {
             if let Some(addr) = merged_peer {
                 pdata.set_peer_addr(addr);
             }
-            effect_handler.send_message_with_source_node(pdata).await?;
-            return Ok(());
+            let res = effect_handler.send_message_with_source_node(pdata).await;
+            let outcome = if res.is_ok() {
+                Outcome::Success
+            } else {
+                Outcome::Failure
+            };
+            self.metrics.record_flush(outcome, reason);
+            return Ok(res?);
         }
 
         // safety: See [`TemporalReaggregationProcessor::accept_pdata`].
@@ -817,8 +869,14 @@ impl TemporalReaggregationProcessor {
             &mut pdata,
         );
 
-        effect_handler.send_message_with_source_node(pdata).await?;
-        Ok(())
+        let res = effect_handler.send_message_with_source_node(pdata).await;
+        let outcome = if res.is_ok() {
+            Outcome::Success
+        } else {
+            Outcome::Failure
+        };
+        self.metrics.record_flush(outcome, reason);
+        Ok(res?)
     }
 
     async fn process_view<V: MetricsView>(
@@ -839,9 +897,30 @@ impl TemporalReaggregationProcessor {
                 // data back into a fresh one. This prevents complex ack/nack
                 // scenarios where a single input batch has representation in
                 // multiple output batches.
-                AggregationError::IdOverflow | AggregationError::StreamCardinalityExceeded => {
-                    self.metrics.flushes_overflow.inc();
-                    self.flush(effect_handler, Some(checkpoint)).await?;
+                AggregationError::IdOverflow => {
+                    // Flush first with the correct reason, metric is recorded inside flush()
+                    // after the send result is known - not before.
+                    let flush_reason = FlushReason::IdOverflow;
+                    if let Err(e) = self
+                        .flush(effect_handler, Some(checkpoint), flush_reason)
+                        .await
+                    {
+                        self.metrics.record_failure(ErrorType::OutputSend);
+                        return Err(e.into());
+                    }
+                    Ok(self
+                        .aggregate_view(view)
+                        .inspect_err(|_| self.clear_state())?)
+                }
+                AggregationError::StreamCardinalityExceeded => {
+                    let flush_reason = FlushReason::StreamCardinalityExceeded;
+                    if let Err(e) = self
+                        .flush(effect_handler, Some(checkpoint), flush_reason)
+                        .await
+                    {
+                        self.metrics.record_failure(ErrorType::OutputSend);
+                        return Err(e.into());
+                    }
                     Ok(self
                         .aggregate_view(view)
                         .inspect_err(|_| self.clear_state())?)
@@ -1518,7 +1597,7 @@ mod tests {
     #[test]
     fn test_gauge_correlation() {
         // Two batches with the same gauge stream. The later timestamp wins.
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             #[rustfmt::skip]
             let batch1 = OtapArrowRecords::Metrics(metrics!(
                 (UnivariateMetrics,
@@ -1567,7 +1646,7 @@ mod tests {
     fn test_cumulative_sum_correlation() {
         // Two batches with the same cumulative monotonic sum. The later
         // timestamp wins.
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             #[rustfmt::skip]
             let batch1 = OtapArrowRecords::Metrics(metrics!(
                 (UnivariateMetrics,
@@ -1619,7 +1698,7 @@ mod tests {
     #[test]
     fn test_cumulative_histogram_correlation() {
         // Two batches with the same cumulative histogram. The later timestamp wins.
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             let batch1 = make_otlp_pdata(MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
                 vec![ScopeMetrics::new(
@@ -1682,7 +1761,7 @@ mod tests {
     fn test_cumulative_exp_histogram_correlation() {
         // Two batches with the same cumulative exp histogram. The later
         // timestamp wins.
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             let batch1 = make_otlp_pdata(MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
                 vec![ScopeMetrics::new(
@@ -1746,7 +1825,7 @@ mod tests {
     #[test]
     fn test_summary_correlation() {
         // Two batches with the same summary stream. The later timestamp wins.
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             let batch1 = make_otlp_pdata(MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
                 vec![ScopeMetrics::new(
@@ -1807,7 +1886,7 @@ mod tests {
     fn test_different_resources_preserved() {
         // Two gauges with different resource attributes should be treated as
         // separate streams and both preserved.
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             #[rustfmt::skip]
             let batch1 = OtapArrowRecords::Metrics(metrics!(
                 (UnivariateMetrics,
@@ -1865,7 +1944,7 @@ mod tests {
     fn test_different_scope_attributes_preserved() {
         // Two gauges with the same resource but different scope attributes
         // should both be preserved.
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             #[rustfmt::skip]
             let input = OtapArrowRecords::Metrics(metrics!(
                 (UnivariateMetrics,
@@ -1901,7 +1980,7 @@ mod tests {
     fn test_different_scope_name_preserved() {
         // Two gauges with the same resource but different scope names should
         // both be preserved.
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             #[rustfmt::skip]
             let batch1 = OtapArrowRecords::Metrics(metrics!(
                 (UnivariateMetrics,
@@ -1961,7 +2040,7 @@ mod tests {
     fn test_different_metric_name_preserved() {
         // Two gauges with the same resource/scope but different metric names
         // should both be preserved.
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             #[rustfmt::skip]
             let input = OtapArrowRecords::Metrics(metrics!(
                 (UnivariateMetrics,
@@ -1992,7 +2071,7 @@ mod tests {
     fn test_different_metric_type_preserved() {
         // A gauge and a cumulative sum with the same name should be treated as
         // different metrics and both preserved.
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             #[rustfmt::skip]
             let input = OtapArrowRecords::Metrics(metrics!(
                 (UnivariateMetrics,
@@ -2025,7 +2104,7 @@ mod tests {
     fn test_different_dp_attributes_preserved() {
         // One gauge with two data points that have different DP attributes
         // should treat them as distinct streams and preserve both.
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             #[rustfmt::skip]
             let input = OtapArrowRecords::Metrics(metrics!(
                 (UnivariateMetrics,
@@ -2061,7 +2140,7 @@ mod tests {
     fn test_mixed_metric_types_in_single_batch() {
         // A batch containing both a gauge and a cumulative sum should preserve
         // both in the output.
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             #[rustfmt::skip]
             let input = OtapArrowRecords::Metrics(metrics!(
                 (UnivariateMetrics,
@@ -2136,6 +2215,23 @@ mod tests {
                 assert_eq!(output.len(), 2, "expected early flush + wakeup flush");
                 assert_output_metric_count(&output[0], max_metrics);
                 assert_output_metric_count(&output[1], 2);
+
+                let snaps = collect_telemetry(&mut ctx).await;
+                assert_eq!(
+                    metric_count(&snaps, "operations", Some("success"), None, None),
+                    2
+                );
+                assert_eq!(metric_count(&snaps, "failures", None, None, None), 0);
+                assert_eq!(
+                    metric_count(
+                        &snaps,
+                        "flushes",
+                        Some("success"),
+                        Some("id_overflow"),
+                        None
+                    ),
+                    1
+                );
             },
         );
     }
@@ -2169,6 +2265,23 @@ mod tests {
                 let output3 = ctx.drain_pdata().await;
                 assert_eq!(output3.len(), 1, "expected wakeup flush of second batch");
                 assert_output_otlp_equivalent(&output3[0], data2);
+
+                let snaps = collect_telemetry(&mut ctx).await;
+                assert_eq!(
+                    metric_count(&snaps, "operations", Some("success"), None, None),
+                    2
+                );
+                assert_eq!(metric_count(&snaps, "failures", None, None, None), 0);
+                assert_eq!(
+                    metric_count(
+                        &snaps,
+                        "flushes",
+                        Some("success"),
+                        Some("stream_cardinality_exceeded"),
+                        None
+                    ),
+                    1
+                );
             },
         );
     }
@@ -2216,7 +2329,7 @@ mod tests {
     #[test]
     fn test_otlp_gauge_correlation() {
         // Two OTLP gauge batches with the same stream. The later timestamp wins.
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             let batch1 = make_otlp_bytes_pdata(MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
                 vec![ScopeMetrics::new(
@@ -2256,7 +2369,7 @@ mod tests {
     #[test]
     fn test_otlp_cumulative_sum_correlation() {
         // Two OTLP cumulative monotonic sum batches. The later timestamp wins.
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             let batch1 = make_otlp_bytes_pdata(MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
                 vec![ScopeMetrics::new(
@@ -2300,7 +2413,7 @@ mod tests {
     #[test]
     fn test_otlp_histogram_correlation() {
         // Two OTLP cumulative histogram batches. The later timestamp wins.
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             let batch1 = make_otlp_bytes_pdata(MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
                 vec![ScopeMetrics::new(
@@ -2346,7 +2459,7 @@ mod tests {
     #[test]
     fn test_otlp_exp_histogram_correlation() {
         // Two OTLP cumulative exponential histogram batches. Later timestamp wins.
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             let batch1 = make_otlp_bytes_pdata(MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
                 vec![ScopeMetrics::new(
@@ -2393,7 +2506,7 @@ mod tests {
     #[test]
     fn test_otlp_summary_correlation() {
         // Two OTLP summary batches. The later timestamp wins.
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             let batch1 = make_otlp_bytes_pdata(MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
                 vec![ScopeMetrics::new(
@@ -2454,7 +2567,7 @@ mod tests {
     fn test_otlp_different_resources_preserved() {
         // Two OTLP gauges with different resource attributes should be treated
         // as separate streams.
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             let batch1 = make_otlp_bytes_pdata(MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build()
                     .attributes(vec![KeyValue::new("env", AnyValue::new_string("prod"))])
@@ -2503,7 +2616,7 @@ mod tests {
     fn test_otlp_different_dp_attributes_preserved() {
         // One OTLP gauge with two data points that have different DP
         // attributes should treat them as distinct streams.
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             let batch = make_otlp_bytes_pdata(MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
                 vec![ScopeMetrics::new(
@@ -2577,7 +2690,7 @@ mod tests {
     fn test_mixed_otap_otlp_gauge_correlation() {
         // One OTAP batch and one OTLP bytes batch for the same gauge stream.
         // They should be correlated and the later timestamp wins.
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             // First batch via OTAP encoding.
             let otap_batch = make_otlp_pdata(MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
@@ -2620,7 +2733,7 @@ mod tests {
     fn test_full_passthrough_delta_sum() {
         // A batch containing only a delta sum (non-aggregatable) should be
         // passed through immediately without waiting for a wakeup.
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             let input_data = MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
                 vec![ScopeMetrics::new(
@@ -2652,6 +2765,13 @@ mod tests {
             let output = ctx.drain_pdata().await;
             assert_eq!(output.len(), 1, "delta sum should pass through immediately");
             assert_output_otlp_equivalent(&output[0], input_data);
+
+            let snaps = collect_telemetry(&mut ctx).await;
+            assert_eq!(
+                metric_count(&snaps, "operations", Some("success"), None, None),
+                1
+            );
+            assert_eq!(metric_count(&snaps, "failures", None, None, None), 0);
         });
     }
 
@@ -2659,7 +2779,7 @@ mod tests {
     fn test_full_passthrough_non_monotonic_cumulative_sum() {
         // A non-monotonic cumulative sum is not aggregatable and should pass
         // through immediately.
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             let input_data = MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
                 vec![ScopeMetrics::new(
@@ -2698,7 +2818,7 @@ mod tests {
     #[test]
     fn test_full_passthrough_delta_histogram() {
         // A delta histogram should pass through immediately.
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             let input_data = MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
                 vec![ScopeMetrics::new(
@@ -2737,7 +2857,7 @@ mod tests {
         // delta sum (passthrough) in the same resource and scope. The delta
         // sum should be passed through immediately while the cumulative sum
         // should be buffered.
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             let aggregatable = make_sum("requests.total", true, 100, vec![]);
             let passthrough = make_sum("requests.delta", false, 50, vec![]);
 
@@ -2790,7 +2910,7 @@ mod tests {
     fn test_passthrough_all_aggregated_no_immediate_output() {
         // When a batch contains only aggregatable metrics, nothing should be
         // emitted until a wakeup.
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             let pdata = make_otlp_pdata(MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
                 vec![ScopeMetrics::new(
@@ -2806,13 +2926,20 @@ mod tests {
                 output.is_empty(),
                 "all-aggregatable batch should not emit anything immediately"
             );
+
+            let _ = ctx.fire_wakeup().await.unwrap();
+            let snaps = collect_telemetry(&mut ctx).await;
+            assert_eq!(
+                metric_count(&snaps, "flushes", Some("success"), Some("timer"), None),
+                1
+            );
         });
     }
 
     #[test]
     fn test_passthrough_delta_exp_histogram() {
         // A delta exponential histogram should pass through.
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             let input_data = MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
                 vec![ScopeMetrics::new(
@@ -2854,7 +2981,7 @@ mod tests {
         // Multiple exemplars on a single data point should all survive
         // the passthrough path, exercising the exemplar loop and ID
         // allocation in append_number_dp_exemplars.
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             let input_data = MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
                 vec![ScopeMetrics::new(
@@ -2908,7 +3035,7 @@ mod tests {
     fn test_mixed_batch_all_passthrough_types_with_exemplars() {
         // A mixed batch forces the slow path through the builder so all three
         // exemplar append functions are exercised.
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             let aggregatable_sum = make_sum("requests.total", true, 100, vec![]);
 
             let delta_sum = make_sum(
@@ -3008,7 +3135,7 @@ mod tests {
     fn test_mixed_resources_passthrough_and_aggregate() {
         // Two different resources: one with only aggregatable metrics, the
         // other with only passthrough metrics.
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             let passthrough = make_sum("requests.delta", false, 10, vec![]);
 
             let input_data = MetricsData::new(vec![
@@ -3065,7 +3192,7 @@ mod tests {
         // The gauge data point should be aggregated and flushed on timer.
         // We use OTLP bytes encoding because the OTAP encoder normalizes
         // None resources, but the raw bytes view preserves the None.
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             let input_data = MetricsData::new(vec![resource_metrics_without_resource(vec![
                 ScopeMetrics::new(
                     InstrumentationScope::build().finish(),
@@ -3094,7 +3221,7 @@ mod tests {
     #[test]
     fn test_none_scope_aggregation() {
         // A batch with scope=None should still be processed.
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             let input_data = MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
                 vec![scope_metrics_without_scope(vec![make_gauge("mem", 1024.0)])],
@@ -3118,7 +3245,7 @@ mod tests {
         // A delta sum under a None resource should pass through immediately.
         // This uses OTLP bytes encoding and the full passthrough path forwards
         // the original pdata unchanged (still as OTLP bytes, not OTAP records).
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             let input_data = MetricsData::new(vec![resource_metrics_without_resource(vec![
                 ScopeMetrics::new(
                     InstrumentationScope::build().finish(),
@@ -3143,7 +3270,7 @@ mod tests {
     #[test]
     fn test_none_resource_and_scope() {
         // Both resource=None and scope=None should still work.
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             let input_data = MetricsData::new(vec![resource_metrics_without_resource(vec![
                 scope_metrics_without_scope(vec![make_gauge("temp", 98.6)]),
             ])]);
@@ -3442,6 +3569,54 @@ mod tests {
         run_test(config, actions);
     }
 
+    /// Scenario: A single input batch is too large to aggregate and exceeds the cardinality limit.
+    /// Guarantees: The batch is permanently rejected, recording exactly one failed operation
+    /// and one `stream_cardinality_exceeded` failure diagnostic.
+    #[test]
+    fn test_telemetry_batch_rejected_cardinality_limit() {
+        let too_many = u16::MAX as usize + 1;
+        run_processor_test(json!({}), move |mut ctx| async move {
+            let payload = make_otlp_payload_from_metrics(make_n_gauge_metrics(too_many));
+            let context = Context::with_capacity(1);
+            let pdata = OtapPdata::new(context, payload);
+
+            // This will return Ok(()) but generate a NackMsg internally and record failure metrics
+            ctx.process(Message::PData(pdata)).await.unwrap();
+
+            let snaps = collect_telemetry(&mut ctx).await;
+
+            // Should have 1 failed operation
+            assert_eq!(
+                metric_count(&snaps, "operations", Some("failure"), None, None),
+                1
+            );
+            assert_eq!(
+                metric_count(&snaps, "operations", Some("success"), None, None),
+                0
+            );
+
+            // Should have exactly 1 diagnostic matching the failure
+            assert_eq!(
+                metric_count(
+                    &snaps,
+                    "failures",
+                    None,
+                    None,
+                    Some("stream_cardinality_exceeded")
+                ),
+                1
+            );
+            assert_eq!(
+                metric_count(&snaps, "failures", None, None, Some("id_overflow")),
+                0
+            );
+            assert_eq!(
+                metric_count(&snaps, "failures", None, None, Some("view_creation")),
+                0
+            );
+        });
+    }
+
     /// Sending an ack whose calldata has the wrong number of elements
     /// (0 or 2 instead of exactly 1) should be silently ignored.
     #[test]
@@ -3613,13 +3788,19 @@ mod tests {
     /// `Ok(false)` because no wakeup was ever scheduled.
     #[test]
     fn test_no_wakeup_scheduled_when_idle() {
-        run_processor_test(json!({}), |mut ctx| async move {
+        run_processor_test(json!({}), move |mut ctx| async move {
             let fired = ctx.fire_wakeup().await.unwrap();
             assert!(
                 !fired,
                 "fire_wakeup should return false when no data has been sent"
             );
             assert!(ctx.drain_pdata().await.is_empty());
+
+            let snaps = collect_telemetry(&mut ctx).await;
+            assert_eq!(
+                metric_count(&snaps, "flushes", None, Some("timer"), None),
+                0
+            );
         });
     }
 
@@ -3714,5 +3895,97 @@ mod tests {
             },
         ];
         run_test(config, actions);
+    }
+
+    // --- Telemetry Tests ---
+
+    use otel_arrow_dfe_telemetry::reporter::MetricsReporter;
+
+    /// Helper to collect current telemetry snapshots from the processor.
+    async fn collect_telemetry(
+        ctx: &mut TestContext<OtapPdata>,
+    ) -> Vec<otel_arrow_dfe_telemetry::metrics::MetricSetSnapshot> {
+        let (metrics_rx, reporter) = MetricsReporter::create_new_and_receiver(10);
+        ctx.process(Message::Control(NodeControlMsg::CollectTelemetry {
+            metrics_reporter: reporter,
+        }))
+        .await
+        .unwrap();
+
+        let mut snaps = Vec::new();
+        while let Ok(snap) = metrics_rx.try_recv() {
+            snaps.push(snap);
+        }
+        snaps
+    }
+
+    /// Helper to count the occurrences of a metric with specific attribute values.
+    fn metric_count(
+        snaps: &[otel_arrow_dfe_telemetry::metrics::MetricSetSnapshot],
+        metric_name: &str,
+        outcome: Option<&str>,
+        reason: Option<&str>,
+        error_type: Option<&str>,
+    ) -> u64 {
+        let mut total = 0;
+        for s in snaps {
+            if s.descriptor().name != "processor.temporal_reaggregation" {
+                continue;
+            }
+            if let Some(idx) = s
+                .descriptor()
+                .metrics
+                .iter()
+                .position(|f| f.name == metric_name)
+            {
+                let mut match_outcome = true;
+                let mut match_reason = true;
+                let mut match_error = true;
+
+                if let Some(o) = outcome {
+                    if s.measurement_attribute_value("outcome") != Some(o) {
+                        match_outcome = false;
+                    }
+                }
+                if let Some(r) = reason {
+                    if s.measurement_attribute_value("reason") != Some(r) {
+                        match_reason = false;
+                    }
+                }
+                if let Some(e) = error_type {
+                    if s.measurement_attribute_value("error.type") != Some(e) {
+                        match_error = false;
+                    }
+                }
+
+                if match_outcome && match_reason && match_error {
+                    total += s.get_metrics()[idx].to_u64_lossy();
+                }
+            }
+        }
+        total
+    }
+
+    /// Scenario: An aggregatable metrics batch remains buffered when shutdown begins.
+    /// Guarantees: Shutdown emits one non-empty successful flush with the `shutdown` reason.
+    #[test]
+    fn test_shutdown_flush() {
+        run_processor_test(json!({}), move |mut ctx| async move {
+            let batch = make_otlp_bytes_pdata(make_n_gauge_metrics(1));
+            ctx.process(Message::PData(batch)).await.unwrap();
+
+            ctx.process(Message::Control(NodeControlMsg::Shutdown {
+                deadline: Instant::now() + Duration::from_secs(5),
+                reason: "test".to_string(),
+            }))
+            .await
+            .unwrap();
+
+            let snaps = collect_telemetry(&mut ctx).await;
+            assert_eq!(
+                metric_count(&snaps, "flushes", Some("success"), Some("shutdown"), None),
+                1
+            );
+        });
     }
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/mod.rs
@@ -649,13 +649,8 @@ impl TemporalReaggregationProcessor {
         match result {
             Ok(agg_result) => match agg_result {
                 AggregationResult::NoAggregations => {
-                    let send_res = effect_handler.send_message_with_source_node(pdata).await;
-                    if send_res.is_ok() {
-                        self.metrics.record_success();
-                    } else {
-                        self.metrics.record_failure(ErrorType::OutputSend);
-                    }
-                    Ok(send_res?)
+                    self.try_send_message_with_metrics(effect_handler, pdata)
+                        .await
                 }
                 AggregationResult::SomeAggregations(records) => {
                     // The aggregated portion of this input has been folded into
@@ -672,13 +667,9 @@ impl TemporalReaggregationProcessor {
                         }
                         let pt_pdata = OtapPdata::new(inbound_ctx, OtapPayload::from(records));
 
-                        let send_res = effect_handler.send_message_with_source_node(pt_pdata).await;
-                        if send_res.is_ok() {
-                            self.metrics.record_success();
-                        } else {
-                            self.metrics.record_failure(ErrorType::OutputSend);
-                        }
-                        return Ok(send_res?);
+                        return self
+                            .try_send_message_with_metrics(effect_handler, pt_pdata)
+                            .await;
                     }
 
                     // The partial-passthrough output represents exactly one
@@ -723,13 +714,8 @@ impl TemporalReaggregationProcessor {
                         &mut pt_pdata,
                     );
 
-                    let send_res = effect_handler.send_message_with_source_node(pt_pdata).await;
-                    if send_res.is_ok() {
-                        self.metrics.record_success();
-                    } else {
-                        self.metrics.record_failure(ErrorType::OutputSend);
-                    }
-                    Ok(send_res?)
+                    self.try_send_message_with_metrics(effect_handler, pt_pdata)
+                        .await
                 }
                 AggregationResult::AllAggregated => {
                     // The full input was folded into the in-progress builder;
@@ -796,8 +782,21 @@ impl TemporalReaggregationProcessor {
     /// the data appended before the checkpoint is clean and should be sent
     /// downstream, while the partial data from the failed call is discarded
     /// by slicing the record batches.
-    /// Flush accumulated metrics up to the given checkpoint.
     ///
+    async fn try_send_message_with_metrics(
+        &mut self,
+        effect_handler: &mut local::EffectHandler<OtapPdata>,
+        pdata: OtapPdata,
+    ) -> Result<(), Error> {
+        let send_res = effect_handler.send_message_with_source_node(pdata).await;
+        if send_res.is_ok() {
+            self.metrics.record_success();
+        } else {
+            self.metrics.record_failure(ErrorType::OutputSend);
+        }
+        Ok(send_res?)
+    }
+
     /// Records a `flushes` metric only when records are actually emitted (non-empty flush).
     /// The metric is recorded after the send result is known so that outcome is accurate.
     async fn flush(
@@ -1597,7 +1596,7 @@ mod tests {
     #[test]
     fn test_gauge_correlation() {
         // Two batches with the same gauge stream. The later timestamp wins.
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             #[rustfmt::skip]
             let batch1 = OtapArrowRecords::Metrics(metrics!(
                 (UnivariateMetrics,
@@ -1646,7 +1645,7 @@ mod tests {
     fn test_cumulative_sum_correlation() {
         // Two batches with the same cumulative monotonic sum. The later
         // timestamp wins.
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             #[rustfmt::skip]
             let batch1 = OtapArrowRecords::Metrics(metrics!(
                 (UnivariateMetrics,
@@ -1698,7 +1697,7 @@ mod tests {
     #[test]
     fn test_cumulative_histogram_correlation() {
         // Two batches with the same cumulative histogram. The later timestamp wins.
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             let batch1 = make_otlp_pdata(MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
                 vec![ScopeMetrics::new(
@@ -1761,7 +1760,7 @@ mod tests {
     fn test_cumulative_exp_histogram_correlation() {
         // Two batches with the same cumulative exp histogram. The later
         // timestamp wins.
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             let batch1 = make_otlp_pdata(MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
                 vec![ScopeMetrics::new(
@@ -1825,7 +1824,7 @@ mod tests {
     #[test]
     fn test_summary_correlation() {
         // Two batches with the same summary stream. The later timestamp wins.
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             let batch1 = make_otlp_pdata(MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
                 vec![ScopeMetrics::new(
@@ -1886,7 +1885,7 @@ mod tests {
     fn test_different_resources_preserved() {
         // Two gauges with different resource attributes should be treated as
         // separate streams and both preserved.
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             #[rustfmt::skip]
             let batch1 = OtapArrowRecords::Metrics(metrics!(
                 (UnivariateMetrics,
@@ -1944,7 +1943,7 @@ mod tests {
     fn test_different_scope_attributes_preserved() {
         // Two gauges with the same resource but different scope attributes
         // should both be preserved.
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             #[rustfmt::skip]
             let input = OtapArrowRecords::Metrics(metrics!(
                 (UnivariateMetrics,
@@ -1980,7 +1979,7 @@ mod tests {
     fn test_different_scope_name_preserved() {
         // Two gauges with the same resource but different scope names should
         // both be preserved.
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             #[rustfmt::skip]
             let batch1 = OtapArrowRecords::Metrics(metrics!(
                 (UnivariateMetrics,
@@ -2040,7 +2039,7 @@ mod tests {
     fn test_different_metric_name_preserved() {
         // Two gauges with the same resource/scope but different metric names
         // should both be preserved.
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             #[rustfmt::skip]
             let input = OtapArrowRecords::Metrics(metrics!(
                 (UnivariateMetrics,
@@ -2071,7 +2070,7 @@ mod tests {
     fn test_different_metric_type_preserved() {
         // A gauge and a cumulative sum with the same name should be treated as
         // different metrics and both preserved.
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             #[rustfmt::skip]
             let input = OtapArrowRecords::Metrics(metrics!(
                 (UnivariateMetrics,
@@ -2104,7 +2103,7 @@ mod tests {
     fn test_different_dp_attributes_preserved() {
         // One gauge with two data points that have different DP attributes
         // should treat them as distinct streams and preserve both.
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             #[rustfmt::skip]
             let input = OtapArrowRecords::Metrics(metrics!(
                 (UnivariateMetrics,
@@ -2140,7 +2139,7 @@ mod tests {
     fn test_mixed_metric_types_in_single_batch() {
         // A batch containing both a gauge and a cumulative sum should preserve
         // both in the output.
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             #[rustfmt::skip]
             let input = OtapArrowRecords::Metrics(metrics!(
                 (UnivariateMetrics,
@@ -2329,7 +2328,7 @@ mod tests {
     #[test]
     fn test_otlp_gauge_correlation() {
         // Two OTLP gauge batches with the same stream. The later timestamp wins.
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             let batch1 = make_otlp_bytes_pdata(MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
                 vec![ScopeMetrics::new(
@@ -2369,7 +2368,7 @@ mod tests {
     #[test]
     fn test_otlp_cumulative_sum_correlation() {
         // Two OTLP cumulative monotonic sum batches. The later timestamp wins.
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             let batch1 = make_otlp_bytes_pdata(MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
                 vec![ScopeMetrics::new(
@@ -2413,7 +2412,7 @@ mod tests {
     #[test]
     fn test_otlp_histogram_correlation() {
         // Two OTLP cumulative histogram batches. The later timestamp wins.
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             let batch1 = make_otlp_bytes_pdata(MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
                 vec![ScopeMetrics::new(
@@ -2459,7 +2458,7 @@ mod tests {
     #[test]
     fn test_otlp_exp_histogram_correlation() {
         // Two OTLP cumulative exponential histogram batches. Later timestamp wins.
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             let batch1 = make_otlp_bytes_pdata(MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
                 vec![ScopeMetrics::new(
@@ -2506,7 +2505,7 @@ mod tests {
     #[test]
     fn test_otlp_summary_correlation() {
         // Two OTLP summary batches. The later timestamp wins.
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             let batch1 = make_otlp_bytes_pdata(MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
                 vec![ScopeMetrics::new(
@@ -2567,7 +2566,7 @@ mod tests {
     fn test_otlp_different_resources_preserved() {
         // Two OTLP gauges with different resource attributes should be treated
         // as separate streams.
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             let batch1 = make_otlp_bytes_pdata(MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build()
                     .attributes(vec![KeyValue::new("env", AnyValue::new_string("prod"))])
@@ -2616,7 +2615,7 @@ mod tests {
     fn test_otlp_different_dp_attributes_preserved() {
         // One OTLP gauge with two data points that have different DP
         // attributes should treat them as distinct streams.
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             let batch = make_otlp_bytes_pdata(MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
                 vec![ScopeMetrics::new(
@@ -2690,7 +2689,7 @@ mod tests {
     fn test_mixed_otap_otlp_gauge_correlation() {
         // One OTAP batch and one OTLP bytes batch for the same gauge stream.
         // They should be correlated and the later timestamp wins.
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             // First batch via OTAP encoding.
             let otap_batch = make_otlp_pdata(MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
@@ -2733,7 +2732,7 @@ mod tests {
     fn test_full_passthrough_delta_sum() {
         // A batch containing only a delta sum (non-aggregatable) should be
         // passed through immediately without waiting for a wakeup.
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             let input_data = MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
                 vec![ScopeMetrics::new(
@@ -2779,7 +2778,7 @@ mod tests {
     fn test_full_passthrough_non_monotonic_cumulative_sum() {
         // A non-monotonic cumulative sum is not aggregatable and should pass
         // through immediately.
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             let input_data = MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
                 vec![ScopeMetrics::new(
@@ -2818,7 +2817,7 @@ mod tests {
     #[test]
     fn test_full_passthrough_delta_histogram() {
         // A delta histogram should pass through immediately.
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             let input_data = MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
                 vec![ScopeMetrics::new(
@@ -2857,7 +2856,7 @@ mod tests {
         // delta sum (passthrough) in the same resource and scope. The delta
         // sum should be passed through immediately while the cumulative sum
         // should be buffered.
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             let aggregatable = make_sum("requests.total", true, 100, vec![]);
             let passthrough = make_sum("requests.delta", false, 50, vec![]);
 
@@ -2910,7 +2909,7 @@ mod tests {
     fn test_passthrough_all_aggregated_no_immediate_output() {
         // When a batch contains only aggregatable metrics, nothing should be
         // emitted until a wakeup.
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             let pdata = make_otlp_pdata(MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
                 vec![ScopeMetrics::new(
@@ -2939,7 +2938,7 @@ mod tests {
     #[test]
     fn test_passthrough_delta_exp_histogram() {
         // A delta exponential histogram should pass through.
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             let input_data = MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
                 vec![ScopeMetrics::new(
@@ -2981,7 +2980,7 @@ mod tests {
         // Multiple exemplars on a single data point should all survive
         // the passthrough path, exercising the exemplar loop and ID
         // allocation in append_number_dp_exemplars.
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             let input_data = MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
                 vec![ScopeMetrics::new(
@@ -3035,7 +3034,7 @@ mod tests {
     fn test_mixed_batch_all_passthrough_types_with_exemplars() {
         // A mixed batch forces the slow path through the builder so all three
         // exemplar append functions are exercised.
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             let aggregatable_sum = make_sum("requests.total", true, 100, vec![]);
 
             let delta_sum = make_sum(
@@ -3135,7 +3134,7 @@ mod tests {
     fn test_mixed_resources_passthrough_and_aggregate() {
         // Two different resources: one with only aggregatable metrics, the
         // other with only passthrough metrics.
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             let passthrough = make_sum("requests.delta", false, 10, vec![]);
 
             let input_data = MetricsData::new(vec![
@@ -3192,7 +3191,7 @@ mod tests {
         // The gauge data point should be aggregated and flushed on timer.
         // We use OTLP bytes encoding because the OTAP encoder normalizes
         // None resources, but the raw bytes view preserves the None.
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             let input_data = MetricsData::new(vec![resource_metrics_without_resource(vec![
                 ScopeMetrics::new(
                     InstrumentationScope::build().finish(),
@@ -3221,7 +3220,7 @@ mod tests {
     #[test]
     fn test_none_scope_aggregation() {
         // A batch with scope=None should still be processed.
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             let input_data = MetricsData::new(vec![ResourceMetrics::new(
                 Resource::build().finish(),
                 vec![scope_metrics_without_scope(vec![make_gauge("mem", 1024.0)])],
@@ -3245,7 +3244,7 @@ mod tests {
         // A delta sum under a None resource should pass through immediately.
         // This uses OTLP bytes encoding and the full passthrough path forwards
         // the original pdata unchanged (still as OTLP bytes, not OTAP records).
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             let input_data = MetricsData::new(vec![resource_metrics_without_resource(vec![
                 ScopeMetrics::new(
                     InstrumentationScope::build().finish(),
@@ -3270,7 +3269,7 @@ mod tests {
     #[test]
     fn test_none_resource_and_scope() {
         // Both resource=None and scope=None should still work.
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             let input_data = MetricsData::new(vec![resource_metrics_without_resource(vec![
                 scope_metrics_without_scope(vec![make_gauge("temp", 98.6)]),
             ])]);
@@ -3788,7 +3787,7 @@ mod tests {
     /// `Ok(false)` because no wakeup was ever scheduled.
     #[test]
     fn test_no_wakeup_scheduled_when_idle() {
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             let fired = ctx.fire_wakeup().await.unwrap();
             assert!(
                 !fired,
@@ -3970,7 +3969,7 @@ mod tests {
     /// Guarantees: Shutdown emits one non-empty successful flush with the `shutdown` reason.
     #[test]
     fn test_shutdown_flush() {
-        run_processor_test(json!({}), move |mut ctx| async move {
+        run_processor_test(json!({}), |mut ctx| async move {
             let batch = make_otlp_bytes_pdata(make_n_gauge_metrics(1));
             ctx.process(Message::PData(batch)).await.unwrap();
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/telemetry.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/telemetry.rs
@@ -3,8 +3,12 @@
 
 //! Telemetry definitions for the temporal reaggregation processor.
 
+use otel_arrow_dfe_engine::context::PipelineContext;
+use otel_arrow_dfe_telemetry::common_attributes::{Outcome, OutcomeAttributes};
 use otel_arrow_dfe_telemetry::instrument::Counter;
-use otel_arrow_dfe_telemetry_macros::metric_set;
+use otel_arrow_dfe_telemetry::metrics::MeasurementMetricSet;
+use otel_arrow_dfe_telemetry::reporter::MetricsReporter;
+use otel_arrow_dfe_telemetry_macros::{AttributeEnum, attribute_set, metric_set};
 
 /// Emitted when creating a view fails so we cannot process the data
 pub const VIEW_CREATION_FAILED_EVENT: &str = "temporal_reaggregation.view.creation_failed";
@@ -19,20 +23,152 @@ pub const INVALID_CALLDATA_EVENT: &str = "temporal_reaggregation.calldata.invali
 /// Emitted when there is an erroneous ack/nack event
 pub const ERRONEOUS_ACK_EVENT: &str = "temporal_reaggregation.ack.erroneous";
 
-/// Metrics for the temporal reaggregation processor.
-#[metric_set(name = "processor.temporal_reaggregation.pdata")]
+/// Actionable cause for a failed input operation.
+/// These map directly to the `error.type` attribute on the `failures` metric.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, AttributeEnum)]
+pub enum ErrorType {
+    /// A view could not be created over the input records.
+    ViewCreation,
+    /// The batch was too large even after a flush; ID counter would overflow.
+    IdOverflow,
+    /// The batch was too large even after a flush; stream cardinality limit hit.
+    StreamCardinalityExceeded,
+    /// Failed to send output downstream.
+    OutputSend,
+    /// Internal scheduling or other fatal error.
+    Internal,
+}
+
+/// What triggered a flush. Used as the `reason` attribute on the `flushes` metric.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, AttributeEnum)]
+pub enum FlushReason {
+    /// Regular collection-period timer fired.
+    Timer,
+    /// ID overflow caused an early flush before the timer.
+    IdOverflow,
+    /// Stream cardinality limit caused an early flush before the timer.
+    StreamCardinalityExceeded,
+    /// Processor is shutting down; flush remaining data.
+    Shutdown,
+}
+
+/// Attributes carried on each `failures` data point.
+#[attribute_set(item, measurement)]
+#[derive(Debug, Clone, Copy)]
+pub struct FailureAttributes {
+    /// The actionable cause of the failure.
+    #[attribute_key = "error.type"]
+    pub error_type: ErrorType,
+}
+
+/// Attributes carried on each `flushes` data point.
+#[attribute_set(item, measurement)]
+#[derive(Debug, Clone, Copy)]
+pub struct FlushAttributes {
+    /// Whether the flush itself succeeded or failed.
+    pub outcome: Outcome,
+    /// What triggered this flush.
+    pub reason: FlushReason,
+}
+
+/// Counts one terminal outcome per metrics PData input.
+///
+/// Incremented exactly once per input, regardless of how many overflow flushes
+/// happen internally while processing it.
+#[metric_set(
+    name = "processor.temporal_reaggregation",
+    measurement_attributes = OutcomeAttributes
+)]
 #[derive(Debug, Default, Clone)]
+pub struct OperationMetrics {
+    #[metric(unit = "{operation}")]
+    pub operations: Counter<u64>,
+}
+
+/// Counts failed input operations broken down by actionable cause.
+///
+/// Always incremented alongside a corresponding `operations` failure so that
+/// `sum(failures)` == number of failed `operations`.
+#[metric_set(
+    name = "processor.temporal_reaggregation",
+    measurement_attributes = FailureAttributes
+)]
+#[derive(Debug, Default, Clone)]
+pub struct FailureMetrics {
+    #[metric(unit = "{operation}")]
+    pub failures: Counter<u64>,
+}
+
+/// Counts non-empty flush attempts.
+///
+/// Empty flushes (no data accumulated) are not recorded here.
+#[metric_set(
+    name = "processor.temporal_reaggregation",
+    measurement_attributes = FlushAttributes
+)]
+#[derive(Debug, Default, Clone)]
+pub struct FlushMetrics {
+    #[metric(unit = "{flush}")]
+    pub flushes: Counter<u64>,
+}
+
+/// All metrics for the temporal reaggregation processor.
 pub struct TemporalReaggregationMetrics {
-    /// Number of flushes triggered by the regular timer.
-    #[metric(unit = "{flush}")]
-    pub flushes_timer: Counter<u64>,
+    operations: MeasurementMetricSet<OperationMetrics>,
+    failures: MeasurementMetricSet<FailureMetrics>,
+    flushes: MeasurementMetricSet<FlushMetrics>,
+}
 
-    /// Number of flushes triggered by exceeding the maximum stream count.
-    #[metric(unit = "{flush}")]
-    pub flushes_overflow: Counter<u64>,
+impl TemporalReaggregationMetrics {
+    pub fn new(pipeline_ctx: &PipelineContext) -> Self {
+        Self {
+            operations: OperationMetrics::register(pipeline_ctx),
+            failures: FailureMetrics::register(pipeline_ctx),
+            flushes: FlushMetrics::register(pipeline_ctx),
+        }
+    }
 
-    /// Number of incoming batches rejected because they individually exceed some
-    /// specified limit or fail to be processed into a view.
-    #[metric(unit = "{batch}")]
-    pub batches_rejected: Counter<u64>,
+    /// Record one successful input operation.
+    pub fn record_success(&mut self) {
+        self.operations
+            .with(OutcomeAttributes {
+                outcome: Outcome::Success,
+            })
+            .operations
+            .inc();
+    }
+
+    /// Record one failed input operation with the actionable cause.
+    pub fn record_failure(&mut self, error_type: ErrorType) {
+        self.operations
+            .with(OutcomeAttributes {
+                outcome: Outcome::Failure,
+            })
+            .operations
+            .inc();
+        self.failures
+            .with(FailureAttributes { error_type })
+            .failures
+            .inc();
+    }
+
+    /// Record a non-empty flush attempt.
+    ///
+    /// Do not call this for empty flushes (when `builder.finish()` returns
+    /// nothing) - those are intentionally silent.
+    pub fn record_flush(&mut self, outcome: Outcome, reason: FlushReason) {
+        self.flushes
+            .with(FlushAttributes { outcome, reason })
+            .flushes
+            .inc();
+    }
+
+    pub fn report(
+        &mut self,
+        reporter: &mut MetricsReporter,
+    ) -> Result<(), otel_arrow_dfe_telemetry::error::Error> {
+        reporter.report_measurement(&mut self.operations)?;
+        reporter.report_measurement(&mut self.failures)?;
+        reporter.report_measurement(&mut self.flushes)
+    }
 }


### PR DESCRIPTION
Migrates the `temporal_reaggregation` processor telemetry to use the new `MeasurementMetricSet` with enum attributes, following the `operations`/`failures`/`flushes` model (similar to the transform processor).

### Changes:
- **Telemetry split into 3 distinct populations:**
  - `processor.temporal_reaggregation.pdata.operations`: Records one terminal outcome (`success` or `failure`) per metrics PData input.
  - `processor.temporal_reaggregation.pdata.failures`: Records actionable causes (`error.type` like `view_creation`, `id_overflow`, `stream_cardinality_exceeded`) alongside failed operations.
  - `processor.temporal_reaggregation.pdata.flushes`: Records non-empty flush attempts and their results (with `outcome` and `reason`).
- **Deferred flush measurement:** Flush success is now recorded *only* when the result is explicitly known (`Emitted`), ensuring empty flushes aren't erroneously counted.
- **Testing:** Added robust telemetry tests covering 5 different scenarios (passthrough, overflow, timer flushes, empty flushes, and shutdown flushes) with `Scenario:` and `Guarantees:` comments.
- **Documentation:** Updated `README.md` to cleanly document the 3 semantic populations, and added an explicit migration mapping in the changelog.

Part of the enum-attribute instrumentation migration tracked in #3530