### PR TITLE
feat(wasm): add experimental WASM host support to df_engine with cargo feature

### DIFF
--- a/rust/otap-dataflow/.chloggen/wasm-host-df-engine-wiring.yaml
+++ b/rust/otap-dataflow/.chloggen/wasm-host-df-engine-wiring.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: pipeline
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Operators can now build the df_engine binary with experimental wasm processor plugin support by enabling the `wasm` Cargo feature (`--features wasm`)
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [2973, 3227]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries. Breaking entries must include a `Migration:`
+# section with the specific action consumers must take. Keep notes to 200
+# characters and subtext to 300 characters.
+subtext: |
+  The `wasm` cargo feature is still off by default; enabling it force-links
+  `otap-df-wasm-host` into `df_engine` and registers the `wasm_processor`
+  factory (URN `urn:otel:processor:wasm_processor`). No wasmtime dependency
+  is pulled into the default build.

--- a/rust/otap-dataflow/Cargo.lock
+++ b/rust/otap-dataflow/Cargo.lock
@@ -7234,6 +7234,7 @@ dependencies = [
  "otap-df-core-nodes",
  "otap-df-engine",
  "otap-df-otap",
+ "otap-df-wasm-host",
  "tikv-jemallocator",
 ]
 

--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -42,6 +42,7 @@ otap-df-controller.workspace = true
 otap-df-core-nodes.workspace = true
 otap-df-engine.workspace = true
 otap-df-otap.workspace = true
+otap-df-wasm-host = { workspace = true, optional = true }
 clap.workspace = true
 mimalloc = { workspace = true, optional = true }
 dhat = { workspace = true, optional = true }
@@ -360,6 +361,12 @@ recordset-kql-processor = ["otap-df-contrib-nodes/recordset-kql-processor"]
 resource-validator-processor = ["otap-df-contrib-nodes/resource-validator-processor"]
 # Contrib receivers (opt-in) - Windows-only
 etw-receiver = ["otap-df-contrib-nodes/etw-receiver"]
+
+# Experimental WASM host-kernel processor plugin runtime (opt-in). Off by
+# default; enabling this pulls in wasmtime and registers the
+# `wasm_processor` factory (URN `urn:otel:processor:wasm_processor`). The WIT
+# contract and host surface are unstable, see crates/wasm-host/README.md.
+wasm = ["dep:otap-df-wasm-host", "otap-df-wasm-host/wasm"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }

--- a/rust/otap-dataflow/crates/wasm-host/README.md
+++ b/rust/otap-dataflow/crates/wasm-host/README.md
@@ -87,8 +87,8 @@ cargo build -p otap-df --features wasm
 ```
 
 Without `--features wasm`, `df_engine` compiles with no wasmtime dependency
-and rejects any pipeline config referencing `processor:wasm_processor` as an
-unknown component.
+and rejects any pipeline config referencing `processor:wasm_processor` with
+`Unknown processor plugin urn:otel:processor:wasm_processor`.
 
 ## Configuration
 

--- a/rust/otap-dataflow/crates/wasm-host/README.md
+++ b/rust/otap-dataflow/crates/wasm-host/README.md
@@ -75,6 +75,21 @@ Current experimental behavior is intentionally narrow:
   process calls, guest process errors, guest-driven drops, kernel invocation
   counters, and per-signal `records_in`/`records_out`.
 
+## Enabling in `df_engine`
+
+The shipping `df_engine` binary (`rust/otap-dataflow`) does not currently link
+this crate by default. Opt in with the top-level `wasm` cargo feature, which
+force-links `otap-df-wasm-host` (registering the `wasm_processor` factory)
+and pulls in wasmtime:
+
+```sh
+cargo build -p otap-df --features wasm
+```
+
+Without `--features wasm`, `df_engine` compiles with no wasmtime dependency
+and rejects any pipeline config referencing `processor:wasm_processor` as an
+unknown component.
+
 ## Configuration
 
 ```yaml

--- a/rust/otap-dataflow/deny.toml
+++ b/rust/otap-dataflow/deny.toml
@@ -97,6 +97,7 @@ allow = [
     "MIT",
     "MIT-0",
     "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
     "Unicode-3.0",
     "BSD-2-Clause",
     "BSD-3-Clause",

--- a/rust/otap-dataflow/src/main.rs
+++ b/rust/otap-dataflow/src/main.rs
@@ -20,6 +20,12 @@ use otap_df_controller::{BuildInfo, Controller, ControllerRunOptions};
 // in `OTAP_PIPELINE_FACTORY` at runtime.
 use otap_df_core_nodes as _;
 use otap_df_otap::OTAP_PIPELINE_FACTORY;
+// Keep this side-effect import so the experimental wasm-host crate is linked
+// and its `linkme` distributed-slice registration (the `wasm_processor`
+// factory) is visible in `OTAP_PIPELINE_FACTORY` at runtime. Off by default;
+// only present when the `wasm` cargo feature is enabled.
+#[cfg(feature = "wasm")]
+use otap_df_wasm_host as _;
 /// Project license text (Apache-2.0), embedded at compile time.
 const LICENSE_TEXT: &str = include_str!("../LICENSE");
 


### PR DESCRIPTION
# Change Summary

Add opt-in experimental WASM processor support to the `df_engine` binary. Building with the Cargo feature `wasm` links `otap-df-wasm-host`, registers the `wasm_processor` factory, and enables wasmtime. Default builds remain unchanged.

## What issue does this PR close?

- Related to #2973

## How are these changes tested?

Validated that `otap-df-wasm-host` is included only when the `wasm` feature is included in `cargo build`.

## Are there any user-facing changes?

Yes. Operators can build `df_engine` with experimental WASM processor support:

`cargo build -p otap-df --features wasm`

### Changelog

* [x] Added a `.chloggen/*.yaml` entry
* [ ] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
