### PR TITLE
chore(release): Avoid edge case race conditions during Release prep and push

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -21,6 +21,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -32,12 +33,38 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'merge_group' }}
     steps:
-      - run: echo "Changelog validation passed on the pull request."
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Identify pull request in merge group
+        id: merge_group
+        env:
+          HEAD_REF: ${{ github.event.merge_group.head_ref }}
+        run: |
+          if [[ "$HEAD_REF" =~ /pr-([0-9]+)- ]]; then
+            echo "pr_number=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+          else
+            echo "Error: Could not identify the pull request from merge group ref: $HEAD_REF"
+            exit 1
+          fi
+      - name: Block merge during active release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./.github/workflows/scripts/check-release-freeze.sh "${{ steps.merge_group.outputs.pr_number }}"
+
+  changelog-bot-pull-request:
+    name: changelog
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && (github.actor == 'dependabot[bot]' || github.actor == 'renovate[bot]' || github.actor == 'otelbot-arrow[bot]') }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Block merge during active release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./.github/workflows/scripts/check-release-freeze.sh "${{ github.event.pull_request.number }}"
 
   changelog-validation:
     name: changelog
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && github.actor != 'otelbot' }}
+    if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && github.actor != 'otelbot-arrow[bot]' }}
     env:
       PR_HEAD: ${{ github.event.pull_request.head.sha }}
 
@@ -68,6 +95,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: ${{ steps.detect_bypass.outputs.skip == 'true' && '1' || '0' }}
+
+      - name: Block merge during active release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./.github/workflows/scripts/check-release-freeze.sh "${{ github.event.pull_request.number }}"
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         if: ${{ steps.detect_bypass.outputs.skip != 'true' }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -15,11 +15,13 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   prepare-release:
     permissions:
       contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     environment: release
     steps:
@@ -61,6 +63,10 @@ jobs:
 
       - name: Validate inputs
         run: ./.github/workflows/scripts/validate-version.sh "${{ inputs.version }}"
+
+      - name: Record release base commit
+        id: release_base
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Get last released version
         id: last_version
@@ -199,7 +205,12 @@ jobs:
 
       - name: Create release branch and commit changes
         if: "!inputs.dry_run"
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
+          ./.github/workflows/scripts/verify-release-window.sh \
+            "${{ steps.release_base.outputs.sha }}"
+
           # Configure git for otelbot
           git config user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
           git config user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
@@ -258,6 +269,14 @@ jobs:
               --base main \
               --label release
           fi
+
+      - name: Verify release window remains stable
+        if: "!inputs.dry_run"
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ./.github/workflows/scripts/verify-release-window.sh \
+            "${{ steps.release_base.outputs.sha }}"
 
       - name: Summary
         run: |

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -66,8 +66,9 @@ jobs:
 
       - name: Record release base commit
         id: release_base
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
+        run: |
+          git fetch --quiet origin main
+          echo "sha=$(git rev-parse origin/main)" >> "$GITHUB_OUTPUT"
       - name: Get last released version
         id: last_version
         run: |

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -15,11 +15,13 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   push-release:
     permissions:
       contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     environment: release
     steps:
@@ -63,6 +65,35 @@ jobs:
             exit 1
           fi
 
+      - name: Resolve release pull request commit
+        id: release
+        env:
+          GH_TOKEN: ${{ inputs.dry_run && github.token || steps.app-token.outputs.token }}
+        run: |
+          BRANCH="otelbot/release-v${{ inputs.version }}"
+          RELEASE_PRS=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/pulls?state=closed&base=main&head=${GITHUB_REPOSITORY_OWNER}:${BRANCH}&per_page=100" \
+            --jq '[.[] | select(.merged_at != null)]')
+          RELEASE_PR_COUNT=$(jq 'length' <<< "$RELEASE_PRS")
+
+          if [ "$RELEASE_PR_COUNT" -ne 1 ]; then
+            echo "Error: Expected exactly one merged release PR from ${BRANCH}, found ${RELEASE_PR_COUNT}"
+            echo "Make sure the Prepare Release PR for v${{ inputs.version }} has been merged"
+            exit 1
+          fi
+
+          RELEASE_PR=$(jq -r '.[0].number' <<< "$RELEASE_PRS")
+          RELEASE_SHA=$(jq -r '.[0].merge_commit_sha' <<< "$RELEASE_PRS")
+
+          echo "pr_number=$RELEASE_PR" >> "$GITHUB_OUTPUT"
+          echo "sha=$RELEASE_SHA" >> "$GITHUB_OUTPUT"
+          echo "Resolved release PR #${RELEASE_PR} to commit ${RELEASE_SHA}"
+
+      - name: Check out release pull request commit
+        run: |
+          git fetch --quiet origin main --tags
+          git checkout --detach "${{ steps.release.outputs.sha }}"
+
       - name: Verify release preparation
         run: |
           # Check if the version is already in go/CHANGELOG.md.
@@ -77,6 +108,11 @@ jobs:
           if [ -n "$(git status --porcelain)" ]; then
             echo "Error: Repository has uncommitted changes"
             git status
+            exit 1
+          fi
+
+          if [ "$(git rev-parse HEAD)" != "${{ steps.release.outputs.sha }}" ]; then
+            echo "Error: Checkout does not match the resolved release PR commit"
             exit 1
           fi
 
@@ -174,6 +210,8 @@ jobs:
 
           ## Planned Operations
           - **Version to tag**: `v${{ inputs.version }}`
+          - **Release PR**: `#${{ steps.release.outputs.pr_number }}`
+          - **Commit to tag**: `${{ steps.release.outputs.sha }}`
           - **Last version**: `v${{ steps.last_version.outputs.last_version }}`
 
           ## Git Tags to Create
@@ -217,13 +255,13 @@ jobs:
           git config user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
 
           # Create main release tag
-          git tag -a "v${{ inputs.version }}" -m "Release v${{ inputs.version }}"
+          git tag -a "v${{ inputs.version }}" "${{ steps.release.outputs.sha }}" -m "Release v${{ inputs.version }}"
 
           # Create Go module tags
-          git tag -a "go/v${{ inputs.version }}" -m "Release go/v${{ inputs.version }}"
+          git tag -a "go/v${{ inputs.version }}" "${{ steps.release.outputs.sha }}" -m "Release go/v${{ inputs.version }}"
 
           # Create Rust workspace tag (git-tag only; no crates.io publish yet)
-          git tag -a "rust/otap-dataflow/v${{ inputs.version }}" -m "Release rust/otap-dataflow/v${{ inputs.version }}"
+          git tag -a "rust/otap-dataflow/v${{ inputs.version }}" "${{ steps.release.outputs.sha }}" -m "Release rust/otap-dataflow/v${{ inputs.version }}"
 
           echo "Created tags:"
           git tag --list "v${{ inputs.version }}"
@@ -275,6 +313,8 @@ jobs:
             echo ""
             echo "Release details:"
             echo "- Version: v${{ inputs.version }}"
+            echo "- Release PR: #${{ steps.release.outputs.pr_number }}"
+            echo "- Tagged commit: ${{ steps.release.outputs.sha }}"
             echo "- GitHub release: https://github.com/open-telemetry/otel-arrow/releases/tag/v${{ inputs.version }}"
             echo ""
             echo "Git tags created:"

--- a/.github/workflows/scripts/check-release-freeze.sh
+++ b/.github/workflows/scripts/check-release-freeze.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <pull-request-number>"
+    exit 1
+fi
+
+PR_NUMBER="$1"
+REPOSITORY="${GITHUB_REPOSITORY:-$(gh repo view --json nameWithOwner --jq '.nameWithOwner')}"
+PR=$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}")
+PR_HEAD=$(jq -r '.head.ref' <<< "$PR")
+IS_RELEASE_PR=$(jq -r 'any(.labels[]; .name == "release")' <<< "$PR")
+
+if [[ "$PR_HEAD" == otelbot/release-v* && "$IS_RELEASE_PR" == "true" ]]; then
+    OWNER="${REPOSITORY%/*}"
+    NAME="${REPOSITORY#*/}"
+    OTHER_QUEUED_PRS=$(gh api graphql \
+        -f query='
+          query($owner: String!, $name: String!) {
+            repository(owner: $owner, name: $name) {
+              mergeQueue {
+                entries(first: 100) {
+                  nodes {
+                    pullRequest {
+                      number
+                      url
+                    }
+                  }
+                }
+              }
+            }
+          }' \
+        -f owner="$OWNER" \
+        -f name="$NAME" \
+        --jq ".data.repository.mergeQueue.entries.nodes | map(select(.pullRequest.number != ${PR_NUMBER}))")
+
+    if [ "$(jq 'length' <<< "$OTHER_QUEUED_PRS")" -ne 0 ]; then
+        echo "Error: Release PR #${PR_NUMBER} cannot merge while other pull requests are queued:"
+        jq -r '.[] | "  - #\(.pullRequest.number) \(.pullRequest.url)"' <<< "$OTHER_QUEUED_PRS"
+        echo "Wait for the queue to drain, then rerun Prepare Release if main changed."
+        exit 1
+    fi
+
+    BASE_REF=$(jq -r '.base.ref' <<< "$PR")
+    HEAD_SHA=$(jq -r '.head.sha' <<< "$PR")
+    COMPARE_STATUS=$(gh api \
+        "repos/${REPOSITORY}/compare/${BASE_REF}...${HEAD_SHA}" \
+        --jq '.status')
+
+    if [[ "$COMPARE_STATUS" != "ahead" && "$COMPARE_STATUS" != "identical" ]]; then
+        echo "Error: Release PR #${PR_NUMBER} is not based on the latest main commit."
+        echo "Re-run Prepare Release so its changelog includes every preceding merge."
+        exit 1
+    fi
+
+    echo "Release PR #${PR_NUMBER} may merge during its release window."
+    exit 0
+fi
+
+ACTIVE_RELEASES=$(gh pr list \
+    --repo "$REPOSITORY" \
+    --state open \
+    --base main \
+    --label release \
+    --limit 100 \
+    --json number,headRefName,url \
+    --jq '[.[] | select(.headRefName | startswith("otelbot/release-v"))]')
+
+if [ "$(jq 'length' <<< "$ACTIVE_RELEASES")" -eq 0 ]; then
+    echo "No active release PR; merge may proceed."
+    exit 0
+fi
+
+echo "Error: Merges are paused while a release PR is open:"
+jq -r '.[] | "  - #\(.number) \(.url)"' <<< "$ACTIVE_RELEASES"
+echo "Retry after the release PR has merged or closed."
+exit 1

--- a/.github/workflows/scripts/verify-release-window.sh
+++ b/.github/workflows/scripts/verify-release-window.sh
@@ -33,7 +33,17 @@ QUEUE=$(gh api graphql \
     -f name="$NAME" \
     --jq '.data.repository.mergeQueue.entries')
 
-QUEUE_COUNT=$(jq -r '.totalCount' <<< "$QUEUE")
+if [ -z "$QUEUE" ] || [ "$QUEUE" = "null" ]; then
+    echo "Error: Could not read merge queue state (is merge queue enabled and GH_TOKEN authorized?)."
+    exit 1
+fi
+
+QUEUE_COUNT=$(jq -r '.totalCount // empty' <<< "$QUEUE")
+if [[ -z "$QUEUE_COUNT" || ! "$QUEUE_COUNT" =~ ^[0-9]+$ ]]; then
+    echo "Error: Could not parse merge queue response."
+    exit 1
+fi
+
 if [ "$QUEUE_COUNT" -ne 0 ]; then
     echo "Error: Cannot prepare a release while pull requests are in the merge queue:"
     jq -r '.nodes[] | "  - #\(.pullRequest.number) \(.pullRequest.url)"' <<< "$QUEUE"

--- a/.github/workflows/scripts/verify-release-window.sh
+++ b/.github/workflows/scripts/verify-release-window.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <expected-main-sha>"
+    exit 1
+fi
+
+EXPECTED_MAIN_SHA="$1"
+REPOSITORY="${GITHUB_REPOSITORY:-$(gh repo view --json nameWithOwner --jq '.nameWithOwner')}"
+OWNER="${REPOSITORY%/*}"
+NAME="${REPOSITORY#*/}"
+
+QUEUE=$(gh api graphql \
+    -f query='
+      query($owner: String!, $name: String!) {
+        repository(owner: $owner, name: $name) {
+          mergeQueue {
+            entries(first: 100) {
+              totalCount
+              nodes {
+                pullRequest {
+                  number
+                  url
+                }
+              }
+            }
+          }
+        }
+      }' \
+    -f owner="$OWNER" \
+    -f name="$NAME" \
+    --jq '.data.repository.mergeQueue.entries')
+
+QUEUE_COUNT=$(jq -r '.totalCount' <<< "$QUEUE")
+if [ "$QUEUE_COUNT" -ne 0 ]; then
+    echo "Error: Cannot prepare a release while pull requests are in the merge queue:"
+    jq -r '.nodes[] | "  - #\(.pullRequest.number) \(.pullRequest.url)"' <<< "$QUEUE"
+    echo "Wait for the merge queue to drain, then rerun Prepare Release."
+    exit 1
+fi
+
+git fetch --quiet origin main
+CURRENT_MAIN_SHA=$(git rev-parse origin/main)
+
+if [ "$CURRENT_MAIN_SHA" != "$EXPECTED_MAIN_SHA" ]; then
+    echo "Error: main changed while Prepare Release was running."
+    echo "Expected: $EXPECTED_MAIN_SHA"
+    echo "Current:  $CURRENT_MAIN_SHA"
+    echo "Rerun Prepare Release so the changelog is rendered from the latest main commit."
+    exit 1
+fi
+
+echo "Merge queue is empty and main remains at ${EXPECTED_MAIN_SHA}."

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -85,6 +85,8 @@ Before making actual changes, run the workflow in dry-run mode:
 1. Run the workflow again with "Dry run mode" set to `false`.
 2. The workflow will:
    - Validate the version format and increment.
+   - Verify that the merge queue is empty and that `main` does not change
+     while the release contents are generated.
    - Auto-generate umbrella chloggen entries summarizing renovate[bot]
      and dependabot[bot] PRs merged since the last release tag (one per
      tree, skipped if none).
@@ -104,7 +106,8 @@ Before making actual changes, run the workflow in dry-run mode:
      the expected entries.
    - `rust/otap-dataflow/Cargo.toml` reflects the new version.
 3. Ensure all CI checks pass.
-4. Merge the pull request.
+4. Merge the pull request. While it is open, the required `changelog` check
+   blocks every other pull request from merging.
 
 ### Step 6: Run Push Release Workflow
 
@@ -129,9 +132,16 @@ Before publishing the release, run the push workflow in dry-run mode:
 
 1. Run the push release workflow again with "Dry run mode" set to `false`.
 2. The workflow will:
+   - Resolve the merged `otelbot/release-vX.Y.Z` pull request and use its
+     merge commit as the release commit.
    - Create git tags for the main release, the Go modules, and the Rust
-     workspace.
+     workspace at that release commit.
    - Publish the GitHub release with the combined changelog content.
+
+Changes merged into `main` after the release pull request are not included in
+these tags. Their `.chloggen/` entries remain pending and are rendered into the
+next release. Normal pull request merges resume after the release pull request
+merges, even if the tags have not been created yet.
 
 The following git tags are created:
 


### PR DESCRIPTION
# Change Summary

Protect the release window from changelog gaps.

The release process previously rendered the changelog at Prepare Release time but created tags from the current `main` tip later. A pull request merged during that window could therefore be included in the release tags without appearing in that release's changelog.

This change closes the gap at three points:

1. **Before and after opening the release PR:** Prepare Release records its starting `main` commit and verifies that the merge queue is empty and `main` has not moved. If the first check fails, no PR is opened. If the second check fails, the release PR remains open to freeze merges and Prepare Release must be rerun to update it from the latest `main`.
2. **While the release PR is open:** The required `changelog` check rejects every other pull request and merge-group entry. The release PR is allowed only when no other PR remains queued and its branch contains the latest `main`.
3. **When creating the release:** Push Release resolves the uniquely merged `otelbot/release-v<VERSION>` PR and creates all release tags at that PR's merge commit rather than the current `main` tip.

```mermaid
sequenceDiagram
    participant MQ as Merge queue
    participant Prep as Prepare Release
    participant Main as main
    participant RP as Release PR
    participant Push as Push Release

    Prep->>Main: Record starting commit
    Prep->>MQ: Require empty queue
    Prep->>Main: Require unchanged commit
    Prep->>RP: Open otelbot/release-vX.Y.Z
    Prep->>MQ: Recheck empty queue
    Prep->>Main: Recheck unchanged commit

    Note over RP,MQ: Required changelog check freezes unrelated merges
    RP->>MQ: Require no other queued PRs
    RP->>Main: Merge prepared changelog and versions

    Push->>RP: Resolve merged release PR
    Push->>Main: Tag the release PR merge commit
    Note over Main,Push: Later main commits remain pending for the next release
```

## What issue does this PR close?

<!--We highly recommend correlation of every PR to an issue-->

N/A

## How are these changes tested?

N/A

## Are there any user-facing changes?

No

### Changelog

* [x] This PR is a `chore` (indicated in title)
