### PR TITLE
feat(opamp): accept YAML remote configuration

### DIFF
--- a/rust/otap-dataflow/.chloggen/opamp-yaml-remote-config.yaml
+++ b/rust/otap-dataflow/.chloggen/opamp-yaml-remote-config.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: observability
+note: Accept JSON and YAML engine configuration from OpAMP servers.
+issues: [3387]
+subtext: YAML is selected by its content type or detected when the OpAMP config file omits a content type, as the opamp-go example server does.

--- a/rust/otap-dataflow/Cargo.lock
+++ b/rust/otap-dataflow/Cargo.lock
@@ -7490,6 +7490,7 @@ dependencies = [
  "prost 0.14.4",
  "serde",
  "serde_json",
+ "serde_yaml",
  "smallvec",
  "sysinfo",
  "thiserror 2.0.19",

--- a/rust/otap-dataflow/crates/controller/Cargo.toml
+++ b/rust/otap-dataflow/crates/controller/Cargo.toml
@@ -37,6 +37,7 @@ chrono = { workspace = true }
 futures-util = { workspace = true }
 prost = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 serde = { workspace = true }
 tokio-tungstenite = { workspace = true }
 humantime-serde = { workspace = true }

--- a/rust/otap-dataflow/crates/controller/src/extension/opamp/README.md
+++ b/rust/otap-dataflow/crates/controller/src/extension/opamp/README.md
@@ -41,6 +41,10 @@ box, and hit Save. Remote configuration is complete desired state, not a patch,
 so this payload preserves both pipelines from the startup config while changing
 `signals_per_second` from `10` to `20`:
 
+The extension accepts JSON and YAML remote configuration. The opamp-go example
+UI does not send a content type, so the extension detects either format. Other
+servers should set `application/json`, `application/yaml`, or `text/yaml`.
+
 ```json
 {
   "version": "otel_dataflow/v1",
@@ -115,9 +119,9 @@ Expected sequence, visible in the server log and the engine log:
    updates the traffic generator to 20 signals per second.
 3. The next reply reports `RemoteConfigStatus=APPLIED` and `Healthy=true`.
 
-Pushing an invalid config (for example malformed JSON) is reported back as
-`RemoteConfigStatus=FAILED` with an error message, and the previously running
-pipelines are left untouched.
+Pushing an invalid config (for example malformed JSON or YAML) is reported back
+as `RemoteConfigStatus=FAILED` with an error message, and the previously
+running pipelines are left untouched.
 
 ### 4. Clean up
 

--- a/rust/otap-dataflow/crates/controller/src/extension/opamp/mod.rs
+++ b/rust/otap-dataflow/crates/controller/src/extension/opamp/mod.rs
@@ -880,12 +880,14 @@ fn handle_server_to_agent_message(
                                     config_hash: remote_config.config_hash,
                                 })
                             }
-                            Err(e) => {
-                                let message = "Remote configuration was rejected; the current engine configuration remains active".to_string();
+                            Err(error) => {
+                                let message = format!(
+                                    "Remote configuration was rejected: {error}; the current engine configuration remains active"
+                                );
                                 otel_error!(
                                     "opamp.controller_extension.message.invalid_config",
                                     message = message,
-                                    error =? e,
+                                    error = error,
                                 );
                                 reply.reply_error = Some(ReplyError {
                                     message,
@@ -1921,9 +1923,17 @@ mod test {
         let applied = &requests[1];
         let status = applied.remote_config_status.as_ref().unwrap();
         assert_eq!(status.status, RemoteConfigStatuses::Failed as i32);
-        assert_eq!(
-            status.error_message,
-            "Remote configuration was rejected; the current engine configuration remains active"
+        assert!(
+            status.error_message.contains("expected value at line"),
+            "status should include the JSON parser error: {}",
+            status.error_message
+        );
+        assert!(
+            status
+                .error_message
+                .ends_with("the current engine configuration remains active"),
+            "status should explain that the existing config remains active: {}",
+            status.error_message
         );
     }
 

--- a/rust/otap-dataflow/crates/controller/src/extension/opamp/mod.rs
+++ b/rust/otap-dataflow/crates/controller/src/extension/opamp/mod.rs
@@ -699,6 +699,31 @@ struct ReplyError {
     config_hash: Vec<u8>,
 }
 
+fn parse_remote_engine_config(content_type: &str, body: &[u8]) -> Result<OtelDataflowSpec, String> {
+    let media_type = content_type
+        .split(';')
+        .next()
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase();
+    match media_type.as_str() {
+        "application/json" => serde_json::from_slice(body).map_err(|error| error.to_string()),
+        "application/yaml" | "application/x-yaml" | "text/yaml" | "text/x-yaml" => {
+            serde_yaml::from_slice(body).map_err(|error| error.to_string())
+        }
+        // Preserve the historical empty-as-JSON behavior, then support servers such as
+        // opamp-go that omit the content type for YAML payloads.
+        "" => serde_json::from_slice(body).or_else(|json_error| {
+            serde_yaml::from_slice(body).map_err(|yaml_error| {
+                format!("could not parse as JSON ({json_error}) or YAML ({yaml_error})")
+            })
+        }),
+        other => Err(format!(
+            "unsupported content type `{other}`; expected JSON or YAML"
+        )),
+    }
+}
+
 /// Decide what must be done with the ServerToAgent message
 fn handle_server_to_agent_message(
     message: ServerToAgent,
@@ -843,51 +868,36 @@ fn handle_server_to_agent_message(
                     .config_map
                     .get(&config.remote_config_key)
                 {
-                    // assume empty content type to be JSON
-                    if config_file.content_type == "application/json"
-                        || config_file.content_type.is_empty()
-                    {
-                        if !config_file.body.is_empty() {
-                            match serde_json::from_slice::<OtelDataflowSpec>(&config_file.body) {
-                                Ok(engine_config) => {
-                                    otel_debug!(
-                                        "opamp.controller_extension.remote_config.accepted"
-                                    );
-                                    updates.engine_config = Some(EngineConfigUpdate {
-                                        engine_config,
-                                        config_hash: remote_config.config_hash,
-                                    })
-                                }
-                                Err(e) => {
-                                    let message = "Remote configuration was rejected; the current engine configuration remains active".to_string();
-                                    otel_error!(
-                                        "opamp.controller_extension.message.invalid_config_json",
-                                        message = message,
-                                        error =? e,
-                                    );
-                                    reply.reply_error = Some(ReplyError {
-                                        message,
-                                        config_hash: remote_config.config_hash,
-                                    })
-                                }
+                    if !config_file.body.is_empty() {
+                        match parse_remote_engine_config(
+                            &config_file.content_type,
+                            &config_file.body,
+                        ) {
+                            Ok(engine_config) => {
+                                otel_debug!("opamp.controller_extension.remote_config.accepted");
+                                updates.engine_config = Some(EngineConfigUpdate {
+                                    engine_config,
+                                    config_hash: remote_config.config_hash,
+                                })
                             }
-                        } else {
-                            otel_debug!(
-                                "opamp.controller_extension.remote_config.empty",
-                                message = "Ignoring empty remote configuration body"
-                            );
+                            Err(e) => {
+                                let message = "Remote configuration was rejected; the current engine configuration remains active".to_string();
+                                otel_error!(
+                                    "opamp.controller_extension.message.invalid_config",
+                                    message = message,
+                                    error =? e,
+                                );
+                                reply.reply_error = Some(ReplyError {
+                                    message,
+                                    config_hash: remote_config.config_hash,
+                                })
+                            }
                         }
                     } else {
-                        let message = "Invalid content type. expected application/json".to_string();
-                        otel_error!(
-                            "opamp.controller_extension.message.invalid_serialized_config",
-                            message = message,
-                            received = config_file.content_type,
+                        otel_debug!(
+                            "opamp.controller_extension.remote_config.empty",
+                            message = "Ignoring empty remote configuration body"
                         );
-                        reply.reply_error = Some(ReplyError {
-                            message,
-                            config_hash: remote_config.config_hash,
-                        })
                     }
                 } else {
                     otel_warn!(
@@ -1602,6 +1612,7 @@ fn pipeline_status_custom_message(
 mod test {
     use std::{borrow::Cow, sync::Arc};
 
+    use otap_df_admin::ControlPlane;
     use otap_df_config::{
         extension::{ExtensionUrn, ExtensionUserConfig},
         observed_state::ObservedStateSettings,
@@ -1913,6 +1924,101 @@ mod test {
         assert_eq!(
             status.error_message,
             "Remote configuration was rejected; the current engine configuration remains active"
+        );
+    }
+
+    /// Scenario: an OpAMP config file declares a standard YAML media type.
+    /// Guarantees: all supported YAML media types deserialize the engine config.
+    #[test]
+    fn test_parse_remote_yaml_content_types() {
+        let body = serde_yaml::to_string(&test_config()).expect("test config should serialize");
+
+        for content_type in [
+            "application/yaml",
+            "application/x-yaml",
+            "text/yaml",
+            "text/x-yaml; charset=utf-8",
+        ] {
+            let parsed = parse_remote_engine_config(content_type, body.as_bytes())
+                .expect("YAML remote config should parse");
+            assert_eq!(parsed.version, "otel_dataflow/v1");
+        }
+    }
+
+    /// Scenario: an OpAMP config file contains JSON and omits its content type.
+    /// Guarantees: format detection preserves the historical JSON behavior.
+    #[test]
+    fn test_parse_remote_json_without_content_type() {
+        let body = serde_json::to_vec(&test_config()).expect("test config should serialize");
+
+        let parsed = parse_remote_engine_config("", &body)
+            .expect("JSON remote config without a content type should parse");
+
+        assert_eq!(parsed.version, "otel_dataflow/v1");
+    }
+
+    /// Scenario: an OpAMP config file declares an unsupported media type or malformed YAML.
+    /// Guarantees: parsing rejects the payload with an actionable format error.
+    #[test]
+    fn test_parse_remote_config_rejects_unsupported_or_malformed_payload() {
+        let unsupported = parse_remote_engine_config("text/plain", b"version: otel_dataflow/v1")
+            .expect_err("unsupported media type should fail");
+        assert!(unsupported.contains("unsupported content type `text/plain`"));
+
+        let malformed = parse_remote_engine_config("application/yaml", b"version: [")
+            .expect_err("malformed YAML should fail");
+        assert!(!malformed.is_empty());
+    }
+
+    /// Scenario: the opamp-go example UI sends YAML without a content type.
+    /// Guarantees: the agent detects YAML, reconciles it, and reports the config as applied.
+    #[tokio::test]
+    async fn test_yaml_config_without_content_type_is_applied() {
+        let control_plane = Arc::new(MockControlPlane::new(empty_engine_config()));
+        let desired = test_config();
+        let body = serde_yaml::to_string(&desired).expect("test config should serialize");
+        let responses = vec![
+            Some(ServerToAgent {
+                remote_config: Some(AgentRemoteConfig {
+                    config_hash: vec![5, 1, 4],
+                    config: Some(AgentConfigMap {
+                        config_map: HashMap::from_iter([(
+                            "".into(),
+                            AgentConfigFile {
+                                content_type: String::new(),
+                                body: body.into_bytes(),
+                            },
+                        )]),
+                    }),
+                }),
+                instance_uid: EXPECTED_INSTANCE_UID_BYTES.to_vec(),
+                ..Default::default()
+            }),
+            None,
+        ];
+        let config: Config = serde_json::from_value(serde_json::json!({
+            "instance_uid": EXPECTED_INSTANCE_UID_STR,
+            "endpoint": "",
+        }))
+        .expect("OpAMP test config should parse");
+
+        let requests =
+            run_web_socket_test_with_config(responses, Arc::clone(&control_plane), 3, config).await;
+
+        assert_eq!(requests.len(), 3);
+        assert_eq!(
+            requests[2]
+                .remote_config_status
+                .as_ref()
+                .expect("applied response should include remote config status")
+                .status,
+            RemoteConfigStatuses::Applied as i32
+        );
+        assert_eq!(
+            control_plane
+                .engine_config_snapshot()
+                .expect("effective config should be available"),
+            desired
         );
     }
 


### PR DESCRIPTION
Accept YAML engine configuration from OpAMP servers in addition to JSON.

Support standard YAML media types and detect JSON or YAML when the config file omits its content type, as the opamp-go example server does. Effective configuration reporting remains canonical JSON.