### PR TITLE
ci: link unified ClickHouse benchmark dashboard

### DIFF
--- a/.github/workflows/pipeline-perf-test-nightly.yml
+++ b/.github/workflows/pipeline-perf-test-nightly.yml
@@ -338,6 +338,7 @@ jobs:
         run: |
           echo "### Benchmark Results" >> $GITHUB_STEP_SUMMARY
           echo "[View the benchmark results here](https://open-telemetry.github.io/otel-arrow/benchmarks/nightly/)" >> $GITHUB_STEP_SUMMARY
+          echo "[View the unified ClickHouse benchmarks](https://open-telemetry.github.io/otel-arrow/benchmarks/nightly/clickhouse/)" >> $GITHUB_STEP_SUMMARY
 
       # Bare-metal host cleanup: remove only the Docker artifacts created by
       # this job. Avoid broad commands (e.g. rm -rf /tmp/*) per the shared
@@ -723,6 +724,7 @@ jobs:
         run: |
           echo "### Benchmark Results" >> $GITHUB_STEP_SUMMARY
           echo "[View the benchmark results here](https://open-telemetry.github.io/otel-arrow/benchmarks/nightly/)" >> $GITHUB_STEP_SUMMARY
+          echo "[View the unified ClickHouse benchmarks](https://open-telemetry.github.io/otel-arrow/benchmarks/nightly/clickhouse/)" >> $GITHUB_STEP_SUMMARY
 
   workflow-notification:
     permissions:


### PR DESCRIPTION
## Summary

- add a direct unified ClickHouse dashboard link to the pipeline performance job summary
- add the same direct link to the benchmark publication job summary

The dashboard itself is published separately from the `benchmarks` branch. This change does not modify benchmark execution or data generation.

## Validation

- workflow YAML parsing
- `python3 tools/sanitycheck.py`
- `git diff --check`

No changelog entry: this is a CI link-only change.
