### PR TITLE
docs: shorten ClickHouse chart tooltips

### DIFF
--- a/docs/benchmarks/nightly/clickhouse/index.html
+++ b/docs/benchmarks/nightly/clickhouse/index.html
@@ -263,7 +263,8 @@
               afterTitle: items => {
                 const point = points[items[0].index];
                 const user = point.commit.committer.username || point.commit.committer.name;
-                return '\n' + point.commit.message + '\n\n' + point.commit.timestamp + ' committed by @' + user + '\n';
+                const message = point.commit.message.split('\n')[0] || point.commit.id.slice(0, 7);
+                return '\n' + message + '\n\n' + point.commit.timestamp + ' committed by @' + user + '\n';
               },
               label: item => item.value + ' ' + (points[item.index].bench.unit || ''),
               afterLabel: item => points[item.index].bench.extra ? '\n' + points[item.index].bench.extra : ''


### PR DESCRIPTION
## Summary

- show only the first line of the commit message in ClickHouse chart tooltips
- fall back to the short commit ID when the commit subject is empty
- match the tooltip behavior used by the syslog and other nightly dashboards

## Validation

- verified against generated ClickHouse benchmark data
- verified multiline commit bodies are omitted from the tooltip
- `git diff --check`
