### PR TITLE
fix: preserve multiple nightly runs per day

### DIFF
--- a/docs/benchmarks/nightly/backpressure/index.html
+++ b/docs/benchmarks/nightly/backpressure/index.html
@@ -257,7 +257,7 @@
 
       for (const entry of entries) {
         const { commit, date, tool, benches } = entry;
-        const dateStr = new Date(date).toISOString().slice(0, 10); // YYYY-MM-DD
+        const dateStr = new Date(date).toISOString();
 
         if (!dates.includes(dateStr)) {
           dates.push(dateStr);
@@ -295,7 +295,7 @@
 
       for (const entry of entries) {
         const { commit, date, tool, benches } = entry;
-        const dateStr = new Date(date).toISOString().slice(0, 10); // YYYY-MM-DD
+        const dateStr = new Date(date).toISOString();
 
         if (!dates.includes(dateStr)) {
           dates.push(dateStr);
@@ -387,7 +387,7 @@
       results.sort((a, b) => a.name.localeCompare(b.name));
 
       const data = {
-        labels: dates,
+        labels: dates.map(timestamp => timestamp.slice(0, 16).replace('T', ' ')),
         datasets: results.map(({ name, dataset }, index) => {
           const color = COLORS[index % COLORS.length];
           return {

--- a/docs/benchmarks/nightly/batch-processor/index.html
+++ b/docs/benchmarks/nightly/batch-processor/index.html
@@ -411,7 +411,7 @@
 
       for (const entry of entries) {
         const { commit, date, tool, benches } = entry;
-        const dateStr = new Date(date).toISOString().slice(0, 10); // YYYY-MM-DD
+        const dateStr = new Date(date).toISOString();
 
         if (!dates.includes(dateStr)) {
           dates.push(dateStr);
@@ -449,7 +449,7 @@
 
       for (const entry of entries) {
         const { commit, date, tool, benches } = entry;
-        const dateStr = new Date(date).toISOString().slice(0, 10); // YYYY-MM-DD
+        const dateStr = new Date(date).toISOString();
 
         if (!dates.includes(dateStr)) {
           dates.push(dateStr);
@@ -543,7 +543,7 @@
       const datasetTags = results.map(r => parseTestNameTags(r.name));
 
       const data = {
-        labels: dates,
+        labels: dates.map(timestamp => timestamp.slice(0, 16).replace('T', ' ')),
         datasets: results.map(({ name, dataset }, index) => {
           const color = COLORS[index % COLORS.length];
           return {

--- a/docs/benchmarks/nightly/filter/index.html
+++ b/docs/benchmarks/nightly/filter/index.html
@@ -257,7 +257,7 @@
 
       for (const entry of entries) {
         const { commit, date, tool, benches } = entry;
-        const dateStr = new Date(date).toISOString().slice(0, 10); // YYYY-MM-DD
+        const dateStr = new Date(date).toISOString();
 
         if (!dates.includes(dateStr)) {
           dates.push(dateStr);
@@ -295,7 +295,7 @@
 
       for (const entry of entries) {
         const { commit, date, tool, benches } = entry;
-        const dateStr = new Date(date).toISOString().slice(0, 10); // YYYY-MM-DD
+        const dateStr = new Date(date).toISOString();
 
         if (!dates.includes(dateStr)) {
           dates.push(dateStr);
@@ -387,7 +387,7 @@
       results.sort((a, b) => a.name.localeCompare(b.name));
 
       const data = {
-        labels: dates,
+        labels: dates.map(timestamp => timestamp.slice(0, 16).replace('T', ' ')),
         datasets: results.map(({ name, dataset }, index) => {
           const color = COLORS[index % COLORS.length];
           return {

--- a/docs/benchmarks/nightly/saturation/index.html
+++ b/docs/benchmarks/nightly/saturation/index.html
@@ -247,7 +247,7 @@
 
       for (const entry of entries) {
         const { commit, date, tool, benches } = entry;
-        const dateStr = new Date(date).toISOString().slice(0, 10); // YYYY-MM-DD
+        const dateStr = new Date(date).toISOString();
 
         if (!dates.includes(dateStr)) {
           dates.push(dateStr);
@@ -285,7 +285,7 @@
 
       for (const entry of entries) {
         const { commit, date, tool, benches } = entry;
-        const dateStr = new Date(date).toISOString().slice(0, 10); // YYYY-MM-DD
+        const dateStr = new Date(date).toISOString();
 
         if (!dates.includes(dateStr)) {
           dates.push(dateStr);
@@ -377,7 +377,7 @@
       results.sort((a, b) => a.name.localeCompare(b.name));
 
       const data = {
-        labels: dates,
+        labels: dates.map(timestamp => timestamp.slice(0, 16).replace('T', ' ')),
         datasets: results.map(({ name, dataset }, index) => {
           const color = COLORS[index % COLORS.length];
           return {

--- a/docs/benchmarks/nightly/scaling-efficiency/index.html
+++ b/docs/benchmarks/nightly/scaling-efficiency/index.html
@@ -247,7 +247,7 @@
 
       for (const entry of entries) {
         const { commit, date, tool, benches } = entry;
-        const dateStr = new Date(date).toISOString().slice(0, 10); // YYYY-MM-DD
+        const dateStr = new Date(date).toISOString();
 
         if (!dates.includes(dateStr)) {
           dates.push(dateStr);
@@ -285,7 +285,7 @@
 
       for (const entry of entries) {
         const { commit, date, tool, benches } = entry;
-        const dateStr = new Date(date).toISOString().slice(0, 10); // YYYY-MM-DD
+        const dateStr = new Date(date).toISOString();
 
         if (!dates.includes(dateStr)) {
           dates.push(dateStr);
@@ -377,7 +377,7 @@
       results.sort((a, b) => a.name.localeCompare(b.name));
 
       const data = {
-        labels: dates,
+        labels: dates.map(timestamp => timestamp.slice(0, 16).replace('T', ' ')),
         datasets: results.map(({ name, dataset }, index) => {
           const color = COLORS[index % COLORS.length];
           return {

--- a/docs/benchmarks/nightly/standardload-batch-size/index.html
+++ b/docs/benchmarks/nightly/standardload-batch-size/index.html
@@ -247,7 +247,7 @@
 
       for (const entry of entries) {
         const { commit, date, tool, benches } = entry;
-        const dateStr = new Date(date).toISOString().slice(0, 10); // YYYY-MM-DD
+        const dateStr = new Date(date).toISOString();
 
         if (!dates.includes(dateStr)) {
           dates.push(dateStr);
@@ -285,7 +285,7 @@
 
       for (const entry of entries) {
         const { commit, date, tool, benches } = entry;
-        const dateStr = new Date(date).toISOString().slice(0, 10); // YYYY-MM-DD
+        const dateStr = new Date(date).toISOString();
 
         if (!dates.includes(dateStr)) {
           dates.push(dateStr);
@@ -377,7 +377,7 @@
       results.sort((a, b) => a.name.localeCompare(b.name));
 
       const data = {
-        labels: dates,
+        labels: dates.map(timestamp => timestamp.slice(0, 16).replace('T', ' ')),
         datasets: results.map(({ name, dataset }, index) => {
           const color = COLORS[index % COLORS.length];
           return {

--- a/docs/benchmarks/nightly/syslog-tcp-otelcol/index.html
+++ b/docs/benchmarks/nightly/syslog-tcp-otelcol/index.html
@@ -260,7 +260,7 @@
 
       for (const entry of entries) {
         const { commit, date, tool, benches } = entry;
-        const dateStr = new Date(date).toISOString().slice(0, 10); // YYYY-MM-DD
+        const dateStr = new Date(date).toISOString();
 
         if (!dates.includes(dateStr)) {
           dates.push(dateStr);
@@ -298,7 +298,7 @@
 
       for (const entry of entries) {
         const { commit, date, tool, benches } = entry;
-        const dateStr = new Date(date).toISOString().slice(0, 10); // YYYY-MM-DD
+        const dateStr = new Date(date).toISOString();
 
         if (!dates.includes(dateStr)) {
           dates.push(dateStr);
@@ -390,7 +390,7 @@
       results.sort((a, b) => a.name.localeCompare(b.name));
 
       const data = {
-        labels: dates,
+        labels: dates.map(timestamp => timestamp.slice(0, 16).replace('T', ' ')),
         datasets: results.map(({ name, dataset }, index) => {
           const color = COLORS[index % COLORS.length];
           return {

--- a/docs/benchmarks/nightly/syslog-tcp/index.html
+++ b/docs/benchmarks/nightly/syslog-tcp/index.html
@@ -247,7 +247,7 @@
 
       for (const entry of entries) {
         const { commit, date, tool, benches } = entry;
-        const dateStr = new Date(date).toISOString().slice(0, 10); // YYYY-MM-DD
+        const dateStr = new Date(date).toISOString();
 
         if (!dates.includes(dateStr)) {
           dates.push(dateStr);
@@ -285,7 +285,7 @@
 
       for (const entry of entries) {
         const { commit, date, tool, benches } = entry;
-        const dateStr = new Date(date).toISOString().slice(0, 10); // YYYY-MM-DD
+        const dateStr = new Date(date).toISOString();
 
         if (!dates.includes(dateStr)) {
           dates.push(dateStr);
@@ -377,7 +377,7 @@
       results.sort((a, b) => a.name.localeCompare(b.name));
 
       const data = {
-        labels: dates,
+        labels: dates.map(timestamp => timestamp.slice(0, 16).replace('T', ' ')),
         datasets: results.map(({ name, dataset }, index) => {
           const color = COLORS[index % COLORS.length];
           return {

--- a/docs/benchmarks/nightly/syslog/index.html
+++ b/docs/benchmarks/nightly/syslog/index.html
@@ -269,7 +269,7 @@
 
       for (const entry of entries) {
         const { commit, date, tool, benches } = entry;
-        const dateStr = new Date(date).toISOString().slice(0, 10); // YYYY-MM-DD
+        const dateStr = new Date(date).toISOString();
 
         if (!dates.includes(dateStr)) {
           dates.push(dateStr);
@@ -307,7 +307,7 @@
 
       for (const entry of entries) {
         const { commit, date, tool, benches } = entry;
-        const dateStr = new Date(date).toISOString().slice(0, 10); // YYYY-MM-DD
+        const dateStr = new Date(date).toISOString();
 
         if (!dates.includes(dateStr)) {
           dates.push(dateStr);
@@ -399,7 +399,7 @@
       results.sort((a, b) => a.name.localeCompare(b.name));
 
       const data = {
-        labels: dates,
+        labels: dates.map(timestamp => timestamp.slice(0, 16).replace('T', ' ')),
         datasets: results.map(({ name, dataset }, index) => {
           const color = COLORS[index % COLORS.length];
           return {


### PR DESCRIPTION
## Summary

- preserve multiple nightly benchmark runs that occur on the same UTC day
- use full ISO timestamps as internal chart keys instead of truncating keys to `YYYY-MM-DD`
- keep x-axis labels readable at minute precision

The previous date-keyed maps silently replaced earlier same-day runs with the last run from that day.

## Validation

- reproduced with current syslog data: 100 stored runs rendered as only 52 date keys
- verified the fixed syslog page renders all 100 points
- verified all nine affected current datasets retain 100/100 run timestamps
- compared deployed and fixed pages in the browser
- `git diff --check`
