### PR TITLE
docs: correct link to phase1 benchmarks

### DIFF
--- a/docs/project-phases.md
+++ b/docs/project-phases.md
@@ -49,7 +49,7 @@ compression results.
   with OpenTelemetry metrics data model
   ([design](./multivariate-design.md))
 - Benchmark suite comparing CPU/memory/compression performance against
-  OTLP ([results](./benchmarks.md))
+  OTLP ([results](./benchmarks-phase1.md))
 - Unit tests and validation tools (this repository)
 - OpenTelemetry Collector-contrib
   [exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/otelarrowexporter/README.md)


### PR DESCRIPTION
# Change Summary

<!--Replace with a brief summary of the change in this PR-->

corrects link to benchmark results for phase 1 in the project phases documentation. This link was pointing at the phase 2 benchmarks

## What issue does this PR close?

<!--We highly recommend correlation of every PR to an issue-->

* Closes #NNN

## How are these changes tested?

## Are there any user-facing changes?

 <!-- If yes, provide further info below -->

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [x] This is a documentation-only PR.
