### PR TITLE
docs(auth extensions): describe the design, not its delivery status

### DIFF
--- a/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/design.md
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/azure_identity_auth/design.md
@@ -2,17 +2,15 @@
 
 <!-- markdownlint-disable MD013 -->
 
-**Status:** Draft
-
 **Extension URN:** `urn:microsoft:extension:azure_identity_auth`
 
 **Capability exposed:** `BearerTokenProvider`
 
 **Execution model:** Active + Shared
 
-**Target crate:** `crates/contrib-extensions`
+**Crate:** `crates/contrib-extensions`
 
-**Target module:** `crates/contrib-extensions/src/azure_identity_auth/`
+**Module:** `crates/contrib-extensions/src/azure_identity_auth/`
 
 This document describes the design of the **Azure Identity Auth extension**
 (`azure_identity_auth`) for the OTAP dataflow engine. The extension acquires and
@@ -32,12 +30,13 @@ It builds on the extension system foundations:
 ## Problem
 
 Several nodes need to authenticate to Azure services using OAuth bearer tokens.
-Today each owns its own authentication: the Azure Monitor exporter constructs an
-Azure credential, acquires a token, and refreshes it inline, and the Parquet
-exporter independently builds an `Arc<dyn TokenCredential>` (via
-`cloud_auth::azure::from_auth_method`) and wraps it in an `object_store`
-`CredentialProvider` (`AzureTokenCredentialProvider`) for blob-storage writes.
-This couples authentication to each node and has several drawbacks:
+Without a shared token source each owns its own authentication: the Azure
+Monitor exporter constructs an Azure credential, acquires a token, and refreshes
+it inline, and the Parquet exporter independently builds an
+`Arc<dyn TokenCredential>` (via `cloud_auth::azure::from_auth_method`) and wraps
+it in an `object_store` `CredentialProvider` (`AzureTokenCredentialProvider`)
+for blob-storage writes. Coupling authentication to each node has several
+drawbacks:
 
 - **Duplication.** Every Azure-authenticating node must re-implement credential
   construction, token caching, refresh scheduling, and failure handling.
@@ -85,8 +84,8 @@ path free of authentication plumbing.
 - A general-purpose capability framework. `BearerTokenProvider` is a single,
   purpose-built capability trait (defined via the engine's `#[capability]`
   proc macro, see
-  [Extension System Architecture](../../../../docs/extension-system-architecture.md)) introduced
-  alongside this extension; this design adds no capability machinery beyond it.
+  [Extension System Architecture](../../../../docs/extension-system-architecture.md));
+  this design adds no capability machinery beyond it.
 - General-purpose OAuth/OIDC support. This extension is Azure-specific.
 - Per-request, per-tenant token selection. One extension instance serves one
   configured identity + scope.
@@ -97,14 +96,14 @@ path free of authentication plumbing.
 
 | Decision | Choice |
 | --- | --- |
-| Component shape | Standalone extension in a new `otap-df-contrib-extensions` crate; the Azure SDK dependency is isolated behind a feature flag. |
+| Component shape | Standalone extension in the `otap-df-contrib-extensions` crate; the Azure SDK dependency is isolated behind a feature flag. |
 | Capability surface | `BearerTokenProvider`: `get_token()` (cached fast path / single coalesced slow path) + `token_stream()` (refresh subscription). A single purpose-built capability trait, not a general framework. |
 | Execution model | `Active + Shared`. Shared serves both `require_shared()` and `require_local()` consumers; Active drives the background refresh loop. |
 | Startup gating | Opt into the engine readiness probe; `signal_ready()` after the first token publish so the engine holds data-path node startup until a token exists (bounded by the probe timeout). |
 | Sharing model | All state behind `Arc<Inner>`; every clone (consumers + background task) observes one token cache. At pipeline scope this is per pipeline instance (per core). |
 | Token cache | `tokio::sync::watch<Option<BearerToken>>` - lock-free fast-path read + pub/sub for `token_stream()`. |
 | Slow-path coalescing | An async `fetch_lock` with double-checked caching so concurrent cache-miss callers - and the background refresh - share one in-flight credential call. |
-| Auth methods (v1) | `managed_identity` (system- or user-assigned), `development` (local dev tooling), and `workload_identity` (federated ServiceAccount token). |
+| Auth methods | `managed_identity` (system- or user-assigned), `development` (local dev tooling), and `workload_identity` (federated ServiceAccount token). |
 | Refresh tuning | Fixed constants (skew before expiry, exponential-backoff-with-jitter retry, min cadence, refresh jitter); not user-configurable. |
 | Expiry handling | Absolute UNIX expiry converted once to a monotonic `Instant`, immune to wall-clock jumps thereafter. |
 | Registration | `#[distributed_slice(OTAP_EXTENSION_FACTORIES)]` link-time discovery, same mechanism as nodes. |
@@ -112,10 +111,9 @@ path free of authentication plumbing.
 
 ## Capability: `BearerTokenProvider`
 
-The extension implements the `BearerTokenProvider` capability - a small engine
-trait introduced alongside this work. The trait (generated via the
-`#[capability]` proc macro into `local::` and `shared::` variants) exposes two
-methods:
+The extension implements the `BearerTokenProvider` capability, a small engine
+trait. The trait (generated via the `#[capability]` proc macro into `local::`
+and `shared::` variants) exposes two methods:
 
 ```rust
 /// A per-consumer subscription to token refreshes. Boxed to hide the concrete
@@ -318,8 +316,7 @@ that does not apply to the selected method (`tenant_id`/`token_file_path` are
      control channel is polled even while a refresh is in flight, so a shutdown
      arriving mid-acquisition cancels the in-progress token call rather than
      letting a slow request run past the shutdown deadline.
-   - `Config` - currently a no-op; refresh cadence is governed by token
-     lifetime.
+   - `Config` - a no-op; refresh cadence is governed by token lifetime.
    - `CollectTelemetry` - best-effort flush of the metric set to the reporter,
      serviced without interrupting an in-flight refresh.
 2. **Refresh timer** (`sleep_until(next_refresh)`):
@@ -367,11 +364,10 @@ source.
 
 ### Azure Monitor exporter
 
-The Azure Monitor exporter is refactored to **consume** the capability rather
-than own authentication:
+The Azure Monitor exporter **consumes** the capability rather than owning
+authentication, so it carries no credential construction, token cache, refresh
+schedule, or auth-specific config, errors, and metrics of its own:
 
-- Its `auth.rs`, `AuthConfig`, auth-specific error variants, and auth metrics
-  are removed.
 - At factory time it resolves the capability:
   `capabilities.require_local::<BearerTokenProvider>()`.
 - Cold start needs no exporter-side wait: the readiness probe (see
@@ -379,8 +375,7 @@ than own authentication:
   spawned. If a later refresh fails and the cached token expires, the exporter
   falls back to a **"no token, no pdata"** state: it stops accepting pdata
   (`inbox.recv_when(false)`), applying backpressure upstream via the bounded
-  inbox channel until a fresh token arrives - the same pattern the current Azure
-  Monitor exporter uses (pdata is paused, not dropped).
+  inbox channel until a fresh token arrives (pdata is paused, not dropped).
 
 ### Parquet exporter (object_store)
 
@@ -388,12 +383,11 @@ The Parquet exporter (`urn:otel:exporter:parquet`) writes to Azure Blob Storage
 through the `object_store` crate, which expects an `object_store`
 `CredentialProvider` rather than the engine's `BearerTokenProvider`. The bridge
 is `AzureTokenCredentialProvider` (`crates/otap/src/object_store/azure.rs`): it
-is re-sourced to hold the resolved `BearerTokenProvider` handle instead of
-constructing its own credential, and implements `get_credential()` by calling
-`get_token()` and mapping the result to `AzureCredential::BearerToken`. Token
-caching and refresh move out of the exporter and into the extension; the
-`cloud_auth::azure` credential-construction path is no longer needed on this
-route.
+holds the resolved `BearerTokenProvider` handle rather than constructing its own
+credential, and implements `get_credential()` by calling `get_token()` and
+mapping the result to `AzureCredential::BearerToken`. Token caching and refresh
+belong to the extension, not the exporter, so the `cloud_auth::azure`
+credential-construction path is not used on this route.
 
 - The exporter binds the storage-scoped extension instance
   (`scope: https://storage.azure.com/.default`).
@@ -404,22 +398,19 @@ route.
 
 ### OTLP HTTP exporter
 
-The OTLP HTTP (`urn:otel:exporter:otlp_http`) exporter today supports only
-static request headers (e.g. a fixed `Authorization` header) and performs no
-token refresh. It **optionally** consumes `BearerTokenProvider`: when the
-capability is bound, the exporter resolves it at factory time
-(`optional_local()`) and subscribes to `token_stream()`. It rebuilds and caches
-the `Authorization: Bearer <token>` header once per refresh, then clones the
-cached header onto each outgoing request, so credentials refresh without a
-restart and the export hot loop never performs a credential read, header
-formatting, or a blocking token fetch. Subscribing rather than calling
+The OTLP HTTP (`urn:otel:exporter:otlp_http`) exporter **optionally** consumes
+`BearerTokenProvider`: when the capability is bound, the exporter resolves it at
+factory time (`optional_local()`) and subscribes to `token_stream()`. It rebuilds
+and caches the `Authorization: Bearer <token>` header once per refresh, then
+clones the cached header onto each outgoing request, so credentials refresh
+without a restart and the export hot loop never performs a credential read,
+header formatting, or a blocking token fetch. Subscribing rather than calling
 `get_token()` per request keeps all credential work off the data path
 (`get_token()`'s coalesced slow path can otherwise block the export loop on a
 token-endpoint call during a refresh failure). Until the provider publishes its
 first token the exporter applies backpressure with a retryable NACK rather than
-sending an unauthenticated request. Its factory already receives a
-`capabilities` argument, so this is additive and does not change the default
-(no-auth) behavior.
+sending an unauthenticated request. With no provider bound the exporter uses its
+statically configured request headers and performs no token refresh.
 
 ## Telemetry
 
@@ -475,10 +466,10 @@ Metrics are recorded in both the background refresh loop and the slow-path
 
 The extension is reconfigured over the extension system's own control channel
 (`ExtensionControlMsg`), independent of pipeline-node reconfiguration
-(`NodeControlMsg::Config`). In v1, `ExtensionControlMsg::Config` is a no-op:
+(`NodeControlMsg::Config`). `ExtensionControlMsg::Config` is a no-op:
 refresh cadence is governed by token lifetime, and changing identity/scope is
-treated as an extension restart rather than an in-place swap. Promoting
-identity/scope to hot-swappable config is possible future work.
+treated as an extension restart rather than an in-place swap (see
+[Open Questions](#open-questions)).
 
 ### Cargo features
 
@@ -573,7 +564,7 @@ registration takes effect.
 
 Validation focuses on user-facing scenarios.
 
-First useful end-to-end scenario (local development):
+End-to-end scenario (local development):
 
 - A pipeline declares the extension with `method: development` and binds it to
   the Azure Monitor exporter via `capabilities: { bearer_token_provider: ... }`.
@@ -606,20 +597,19 @@ Additional scenario coverage:
 
 ## Open Questions
 
-1. **Identity/scope hot-swap.** v1 treats an identity or scope change as an
+1. **Identity/scope hot-swap.** An identity or scope change is treated as an
    extension restart. Should `ExtensionControlMsg::Config` instead support
    swapping the credential in place (rebuilding `Auth` and forcing a refresh)
    without dropping the published token? The tradeoff is added complexity in the
    refresh loop versus a brief miss window on restart.
-2. **`AuthMethod` shape.** v1 uses a flat config struct with optional
-   per-method fields (`client_id`, `tenant_id`, `token_file_path`). Now that
+2. **`AuthMethod` shape.** The config is a flat struct with optional
+   per-method fields (`client_id`, `tenant_id`, `token_file_path`). Because
    `workload_identity` adds method-specific fields, should `AuthMethod` become
    an enum whose variants carry those fields, so required fields validate
-   structurally? This refactor was explicitly deferred during
-   [PR #3337](https://github.com/open-telemetry/otel-arrow/pull/3337).
+   structurally?
 3. **Multi-resource tokens.** A node targeting more than one Azure resource
-   needs more than one scope. v1's answer is "declare one extension instance per
-   scope and bind each"; is a single multi-scope instance worth the extra
+   needs more than one scope. The answer here is "declare one extension instance
+   per scope and bind each"; is a single multi-scope instance worth the extra
    capability surface?
 
 ## Future Work
@@ -627,8 +617,8 @@ Additional scenario coverage:
 - **`AuthMethod` enum refactor.** Promote the flat config struct to an
   `AuthMethod` enum so required per-method fields validate structurally (see
   [Open Questions](#open-questions)).
-- **Broader extension scope.** Hoist the extension to group/engine scope (Phase
-  2) for genuine cross-core token-cache sharing, so a single token cache and
+- **Broader extension scope.** Hoist the extension to group/engine scope for
+  genuine cross-core token-cache sharing, so a single token cache and
   refresh loop serve every core (see
   [Extension Scopes](../../../../docs/extension-requirements.md#extension-scopes)).
 
@@ -639,4 +629,3 @@ Additional scenario coverage:
 - [Design Principles and Constraints](../../../../docs/design-principles.md)
 - [Architecture](../../../../docs/architecture.md)
 - [URN Format](../../../../docs/urns.md)
-- [PR #3337 - Workload Identity Federation for Azure Monitor exporter (merged)](https://github.com/open-telemetry/otel-arrow/pull/3337)

--- a/rust/otap-dataflow/crates/contrib-extensions/src/oauth2_client_auth/design.md
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/oauth2_client_auth/design.md
@@ -2,17 +2,15 @@
 
 <!-- markdownlint-disable MD013 -->
 
-**Status:** Draft
-
 **Extension URN:** `urn:otel:extension:oauth2_client_auth`
 
 **Capability exposed:** `BearerTokenProvider`
 
 **Execution model:** Active + Shared
 
-**Target crate:** `crates/contrib-extensions`
+**Crate:** `crates/contrib-extensions`
 
-**Target module:** `crates/contrib-extensions/src/oauth2_client_auth/`
+**Module:** `crates/contrib-extensions/src/oauth2_client_auth/`
 
 This document describes the design of the **OAuth 2.0 Client Auth extension**
 (`oauth2_client_auth`) for the OTAP dataflow engine. The extension acquires and
@@ -36,13 +34,14 @@ It builds on the extension system foundations:
 
 ## Problem
 
-The OTLP exporters (`urn:otel:exporter:otlp_grpc`, `urn:otel:exporter:otlp_http`)
-today support only **static** request headers. A fixed `Authorization` header
-cannot express an OAuth 2.0 flow, cannot refresh a token before it expires, and
-forces credentials into every node's config. Any node authenticating to an
-OAuth-protected endpoint (an OTLP backend, a vendor gateway) must either use a
-long-lived static token or re-implement client-credentials acquisition, caching,
-and refresh inline on its data path.
+Absent a token-provider capability, the only credential an OTLP exporter
+(`urn:otel:exporter:otlp_grpc`, `urn:otel:exporter:otlp_http`) can carry is a
+**static** request header. A fixed `Authorization` header cannot express an
+OAuth 2.0 flow, cannot refresh a token before it expires, and forces credentials
+into every node's config. Any node authenticating to an OAuth-protected endpoint
+(an OTLP backend, a vendor gateway) would have to either use a long-lived static
+token or re-implement client-credentials acquisition, caching, and refresh
+inline on its data path.
 
 The extension system lets us factor this out into a **shared, cross-cutting
 capability** that any node binds to, while keeping the data path free of
@@ -70,7 +69,7 @@ standard OAuth 2.0 endpoints rather than Azure identity flows.
 ## Non-Goals
 
 - A new capability. This extension **reuses** the `BearerTokenProvider`
-  capability introduced with the
+  capability defined by the engine and documented under the
   [Azure Identity Auth extension](../azure_identity_auth/design.md#capability-bearertokenprovider);
   it adds no capability machinery.
 - Provider-specific identity flows (Managed Identity, Workload Identity). Those
@@ -94,7 +93,7 @@ standard OAuth 2.0 endpoints rather than Azure identity flows.
 | Sharing model | All state behind `Arc<Inner>`; every clone (consumers + background task) observes one token cache. At pipeline scope this is per pipeline instance (per core). |
 | Token cache | `tokio::sync::watch<Option<BearerToken>>` - lock-free fast-path read + pub/sub for `token_stream()`. |
 | Slow-path coalescing | An async `fetch_lock` with double-checked caching so concurrent cache-miss callers - and the background refresh - share one in-flight token request. |
-| Grant types (v1) | `client_credentials` (client secret) and `jwt-bearer` (RFC 7523 section 2.1 authorization grant; the signed JWT is sent as the `assertion` parameter). |
+| Grant types | `client_credentials` (client secret) and `jwt-bearer` (RFC 7523 section 2.1 authorization grant; the signed JWT is sent as the `assertion` parameter). |
 | Credential rotation | `client_id` / `client_secret` / signing key may be supplied inline or via `*_file` paths re-read on each acquisition; the file form takes precedence. |
 | Refresh tuning | `expiry_buffer` is user-configurable; the usability margin, min cadence, refresh jitter, and exponential-backoff-with-jitter retry are fixed constants. |
 | Transport security | Token endpoint reached over TLS via the shared `TlsClientConfig` (custom CA, mTLS). `https://` recommended; `http://` allowed but warned. Finite request and connect timeouts bound every acquisition by default. |
@@ -352,7 +351,7 @@ runs (control channel + refresh timer); only the `TokenSource` acquisition call
 and the `expiry_buffer` value differ:
 
 1. **Control channel** (`ctrl.recv()`): `Shutdown` returns the final metric
-   snapshot as the terminal state; `Config` is a no-op in v1; `CollectTelemetry`
+   snapshot as the terminal state; `Config` is a no-op; `CollectTelemetry`
    flushes the metric set. The control channel is polled even while a refresh is
    in flight, so a shutdown arriving mid-acquisition cancels the in-progress
    token call rather than letting a slow request run past the shutdown deadline,
@@ -447,16 +446,15 @@ backs the capability, and can consume it two ways: a cached fast-path read via
 `get_token()`, or a subscription to `token_stream()` that pushes each refreshed
 token.
 
-The primary consumers are the **OTLP HTTP and gRPC exporters**. The OTLP HTTP
-exporter subscribes to `token_stream()` and caches a
-pre-built `Authorization: Bearer <token>` header that it clones onto each
-outgoing request, so credential work stays off the export hot path and tokens
-rotate without a restart. The refreshed bearer **overrides** any statically
-configured `authorization` header, and the cached token is marked **sensitive**
-(redacted in `Debug`, excluded from HPACK indexing). Until a token is available
-(startup or an auth outage) the exporter withholds export rather than sending
-unauthenticated data. The OTLP gRPC exporter integration follows the same pattern
-and is planned. Any other `BearerTokenProvider` consumer works unchanged.
+The primary consumers are the **OTLP HTTP and gRPC exporters**. Both subscribe
+to `token_stream()` and cache a pre-built `Authorization: Bearer <token>` header
+that they clone onto each outgoing request, so credential work stays off the
+export hot path and tokens rotate without a restart. The refreshed bearer
+**overrides** any statically configured `authorization` header, and the cached
+token is marked **sensitive** (redacted in `Debug`, excluded from HPACK
+indexing). Until a token is available (startup or an auth outage) the exporter
+withholds export rather than sending unauthenticated data. Any other
+`BearerTokenProvider` consumer works unchanged.
 
 ## Telemetry
 
@@ -509,13 +507,13 @@ Metrics are recorded in the background refresh loop and the slow-path
 
 The extension is reconfigured over the extension system's own control channel
 (`ExtensionControlMsg`), independent of pipeline-node reconfiguration
-(`NodeControlMsg::Config`). In v1, `ExtensionControlMsg::Config` is a no-op:
+(`NodeControlMsg::Config`). `ExtensionControlMsg::Config` is a no-op:
 refresh cadence is governed by token lifetime and `expiry_buffer`, and changing
 the client, grant, or scopes is treated as an extension restart rather than an
 in-place swap. Credential *values* still rotate without a restart when supplied
 via the `*_file` fields, since those are re-read on each acquisition (see
-[Configuration](#config-schema)). Promoting the client/grant/scopes to
-hot-swappable config is possible future work (see [Open Questions](#open-questions)).
+[Configuration](#config-schema)). Whether the client, grant, and scopes should
+become hot-swappable is an open question (see [Open Questions](#open-questions)).
 
 ### Cargo features
 
@@ -664,9 +662,9 @@ OAuth-specific coverage:
 
 ## Open Questions
 
-1. **Grant coverage.** v1 ships `client_credentials` and `jwt-bearer`. Is there
-   demand for password or refresh-token grants, or should those stay out of
-   scope as non-machine-to-machine flows?
+1. **Grant coverage.** The extension supports `client_credentials` and
+   `jwt-bearer`. Is there demand for password or refresh-token grants, or should
+   those stay out of scope as non-machine-to-machine flows?
 2. **Multi-scope / multi-endpoint.** As with the Azure extension, one instance
    serves one client + scope set; a node needing multiple audiences declares one
    instance per audience. Is a single multi-scope instance worth the added
@@ -679,7 +677,7 @@ OAuth-specific coverage:
 
 ## Future Work
 
-- **Broader extension scope.** Hoist to group/engine scope (Phase 2) for genuine
+- **Broader extension scope.** Hoist to group/engine scope for genuine
   cross-core token-cache sharing (see
   [Extension Scopes](../../../../docs/extension-requirements.md#extension-scopes)).
 


### PR DESCRIPTION
# Change Summary

Both auth extension design docs mixed design with work status, so they read as stale the moment something landed: a Draft status header, "target" crate and module, "v1" scoping, "today" comparisons against the pre-extension code, a consumer section written as a refactor ("is refactored to", "are removed", "re-sourced"), an integration described as planned that has since shipped, and open questions annotated with the PR that deferred them.

State the design in the present tense throughout. Scope statements that were phrased as "v1 does X" now say what the extension does; the problem statements say what is impossible without a shared token source rather than what the code looked like before; consumer sections describe the end state; and Open Questions and Future Work keep the design boundaries without the tracking references.

## What issue does this PR close?

n/a

## How are these changes tested?

n/a

## Are there any user-facing changes?

no

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [ ] Added a `.chloggen/*.yaml` entry
* [ ] This PR is a `chore` (indicated in title)
* [x] This is a documentation-only PR.
