### PR TITLE
chore(metrics): encode OTLP metric metadata before data points

### DIFF
--- a/rust/otap-dataflow/crates/telemetry/src/metrics/otlp.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/metrics/otlp.rs
@@ -98,6 +98,10 @@
 //! use `BoundedBuf::encode_len_delimited`, and the trusted pre-encoded resource
 //! field shared with internal logs is copied directly into `ResourceMetrics`.
 //!
+//! Protobuf field order is semantically insignificant. The encoder nevertheless
+//! writes scalar aggregation metadata before repeated data points to keep the
+//! wire layout stable and place context before potentially long repeated fields.
+//!
 //! Production encoding does not construct generated OTLP messages or traverse
 //! a Prost object tree. Tests decode the emitted bytes with Prost as an
 //! independent compatibility oracle.
@@ -896,6 +900,8 @@ fn encode_metric(
     encode_string(buffer, METRIC_DESCRIPTION, metric.description)?;
     encode_string(buffer, METRIC_UNIT, metric.field.unit)?;
 
+    // Sum and histogram messages intentionally place scalar aggregation metadata
+    // before repeated data points; protobuf decoding itself is order-independent.
     match metric.field.instrument {
         Instrument::Gauge => {
             buffer.encode_len_delimited(METRIC_GAUGE, |buffer| {

--- a/rust/otap-dataflow/crates/telemetry/src/metrics/otlp.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/metrics/otlp.rs
@@ -1602,11 +1602,11 @@ mod tests {
             .unwrap_or_else(|| panic!("missing message field {field_number}"))
     }
 
-    fn metric_data_fields(
+    fn metric_data_field_numbers(
         encoded: &OtlpProtoBytes,
-        metric_index: usize,
+        metric_name: &str,
         data_field: u64,
-    ) -> Vec<(u64, u64, &[u8])> {
+    ) -> Vec<u64> {
         let resource_metrics = message_field(encoded.as_bytes(), METRICS_DATA_RESOURCE_METRICS);
         let scope_metrics = message_field(resource_metrics, RESOURCE_METRICS_SCOPE_METRICS);
         let metric = protobuf_fields(scope_metrics)
@@ -1614,9 +1614,12 @@ mod tests {
             .filter_map(|(number, wire_type, payload)| {
                 (number == SCOPE_METRICS_METRICS && wire_type == wire_types::LEN).then_some(payload)
             })
-            .nth(metric_index)
-            .unwrap_or_else(|| panic!("missing metric at index {metric_index}"));
+            .find(|metric| message_field(metric, METRIC_NAME) == metric_name.as_bytes())
+            .unwrap_or_else(|| panic!("missing metric named {metric_name}"));
         protobuf_fields(message_field(metric, data_field))
+            .into_iter()
+            .map(|(number, _, _)| number)
+            .collect()
     }
 
     fn only_scope(request: &ExportMetricsServiceRequest) -> &ScopeMetrics {
@@ -2439,10 +2442,7 @@ mod tests {
             .expect("mixed metrics batch should produce a request");
 
         assert_eq!(
-            metric_data_fields(&encoded, 0, METRIC_SUM)
-                .iter()
-                .map(|(number, _, _)| *number)
-                .collect::<Vec<_>>(),
+            metric_data_field_numbers(&encoded, "counter.delta", METRIC_SUM),
             vec![
                 SUM_AGGREGATION_TEMPORALITY,
                 SUM_IS_MONOTONIC,
@@ -2451,10 +2451,7 @@ mod tests {
             ]
         );
         assert_eq!(
-            metric_data_fields(&encoded, 2, METRIC_SUM)
-                .iter()
-                .map(|(number, _, _)| *number)
-                .collect::<Vec<_>>(),
+            metric_data_field_numbers(&encoded, "up_down.delta", METRIC_SUM),
             vec![
                 SUM_AGGREGATION_TEMPORALITY,
                 SUM_DATA_POINTS,
@@ -2462,10 +2459,7 @@ mod tests {
             ]
         );
         assert_eq!(
-            metric_data_fields(&encoded, 4, METRIC_HISTOGRAM)
-                .iter()
-                .map(|(number, _, _)| *number)
-                .collect::<Vec<_>>(),
+            metric_data_field_numbers(&encoded, "histogram.mmsc", METRIC_HISTOGRAM),
             vec![
                 HISTOGRAM_AGGREGATION_TEMPORALITY,
                 HISTOGRAM_DATA_POINTS,
@@ -2518,10 +2512,11 @@ mod tests {
             .expect("exponential histogram batch should produce a request");
 
         assert_eq!(
-            metric_data_fields(&encoded, 0, METRIC_EXPONENTIAL_HISTOGRAM)
-                .iter()
-                .map(|(number, _, _)| *number)
-                .collect::<Vec<_>>(),
+            metric_data_field_numbers(
+                &encoded,
+                "histogram.distribution",
+                METRIC_EXPONENTIAL_HISTOGRAM,
+            ),
             vec![
                 EXPONENTIAL_HISTOGRAM_AGGREGATION_TEMPORALITY,
                 EXPONENTIAL_HISTOGRAM_DATA_POINTS,

--- a/rust/otap-dataflow/crates/telemetry/src/metrics/otlp.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/metrics/otlp.rs
@@ -912,6 +912,12 @@ fn encode_metric(
                 metric: metric.field.name,
             })?;
             buffer.encode_len_delimited(METRIC_SUM, |buffer| {
+                buffer.encode_field_tag(SUM_AGGREGATION_TEMPORALITY, wire_types::VARINT)?;
+                buffer.encode_varint(encode_temporality(temporality))?;
+                if matches!(metric.field.instrument, Instrument::Counter) {
+                    buffer.encode_field_tag(SUM_IS_MONOTONIC, wire_types::VARINT)?;
+                    buffer.encode_varint(1)?;
+                }
                 for point in &metric.points {
                     let start_time_unix_nano = match temporality {
                         Temporality::Delta => point.metric_set.delta_start_time_unix_nano,
@@ -926,39 +932,33 @@ fn encode_metric(
                         )
                     })?;
                 }
-                buffer.encode_field_tag(SUM_AGGREGATION_TEMPORALITY, wire_types::VARINT)?;
-                buffer.encode_varint(encode_temporality(temporality))?;
-                if matches!(metric.field.instrument, Instrument::Counter) {
-                    buffer.encode_field_tag(SUM_IS_MONOTONIC, wire_types::VARINT)?;
-                    buffer.encode_varint(1)?;
-                }
                 Ok::<(), Error>(())
             })?;
         }
         Instrument::Mmsc => {
             buffer.encode_len_delimited(METRIC_HISTOGRAM, |buffer| {
+                buffer.encode_field_tag(HISTOGRAM_AGGREGATION_TEMPORALITY, wire_types::VARINT)?;
+                buffer.encode_varint(encode_temporality(Temporality::Delta))?;
                 for point in &metric.points {
                     buffer.encode_len_delimited(HISTOGRAM_DATA_POINTS, |buffer| {
                         encode_mmsc_data_point(buffer, point, time_unix_nano)
                     })?;
                 }
-                buffer.encode_field_tag(HISTOGRAM_AGGREGATION_TEMPORALITY, wire_types::VARINT)?;
-                buffer.encode_varint(encode_temporality(Temporality::Delta))?;
                 Ok::<(), Error>(())
             })?;
         }
         Instrument::ExponentialHistogram => {
             buffer.encode_len_delimited(METRIC_EXPONENTIAL_HISTOGRAM, |buffer| {
-                for point in &metric.points {
-                    buffer.encode_len_delimited(EXPONENTIAL_HISTOGRAM_DATA_POINTS, |buffer| {
-                        encode_exponential_histogram_data_point(buffer, point, time_unix_nano)
-                    })?;
-                }
                 buffer.encode_field_tag(
                     EXPONENTIAL_HISTOGRAM_AGGREGATION_TEMPORALITY,
                     wire_types::VARINT,
                 )?;
                 buffer.encode_varint(encode_temporality(Temporality::Delta))?;
+                for point in &metric.points {
+                    buffer.encode_len_delimited(EXPONENTIAL_HISTOGRAM_DATA_POINTS, |buffer| {
+                        encode_exponential_histogram_data_point(buffer, point, time_unix_nano)
+                    })?;
+                }
                 Ok::<(), Error>(())
             })?;
         }
@@ -1594,6 +1594,23 @@ mod tests {
                 (number == field_number && wire_type == wire_types::LEN).then_some(payload)
             })
             .unwrap_or_else(|| panic!("missing message field {field_number}"))
+    }
+
+    fn metric_data_fields(
+        encoded: &OtlpProtoBytes,
+        metric_index: usize,
+        data_field: u64,
+    ) -> Vec<(u64, u64, &[u8])> {
+        let resource_metrics = message_field(encoded.as_bytes(), METRICS_DATA_RESOURCE_METRICS);
+        let scope_metrics = message_field(resource_metrics, RESOURCE_METRICS_SCOPE_METRICS);
+        let metric = protobuf_fields(scope_metrics)
+            .into_iter()
+            .filter_map(|(number, wire_type, payload)| {
+                (number == SCOPE_METRICS_METRICS && wire_type == wire_types::LEN).then_some(payload)
+            })
+            .nth(metric_index)
+            .unwrap_or_else(|| panic!("missing metric at index {metric_index}"));
+        protobuf_fields(message_field(metric, data_field))
     }
 
     fn only_scope(request: &ExportMetricsServiceRequest) -> &ScopeMetrics {
@@ -2372,6 +2389,139 @@ mod tests {
         assert_eq!(point.max, Some(9.0));
         assert!(point.explicit_bounds.is_empty());
         assert!(point.bucket_counts.is_empty());
+    }
+
+    /// Scenario: Direct encoding emits aggregation metadata and two ordered data points for every
+    /// sum and histogram message kind.
+    /// Guarantees: Metadata physically precedes repeated data points, false monotonicity remains
+    /// omitted, and repeated data-point order is preserved.
+    #[test]
+    fn encodes_aggregation_metadata_before_ordered_data_points() {
+        let attributes = empty_attributes();
+        let mut first = metric_set(
+            &ALL_METRICS_DESCRIPTOR,
+            attributes.clone(),
+            vec![
+                MetricValue::U64(1),
+                MetricValue::U64(2),
+                MetricValue::F64(-1.0),
+                MetricValue::F64(3.0),
+                mmsc_value(1.0, 2.0, 3.0, 2),
+            ],
+        );
+        first.item_attributes = vec![("bucket".to_owned(), "first".to_owned())];
+        let mut second = metric_set(
+            &ALL_METRICS_DESCRIPTOR,
+            attributes.clone(),
+            vec![
+                MetricValue::U64(4),
+                MetricValue::U64(5),
+                MetricValue::F64(-2.0),
+                MetricValue::F64(6.0),
+                mmsc_value(3.0, 4.0, 7.0, 2),
+            ],
+        );
+        second.item_attributes = vec![("bucket".to_owned(), "second".to_owned())];
+        let batch = MetricExportBatch {
+            time_unix_nano: COLLECTION_TIME,
+            metric_sets: vec![first, second],
+        };
+
+        let encoded = empty_resource_encoder()
+            .encode(&batch)
+            .expect("mixed metrics batch should encode")
+            .expect("mixed metrics batch should produce a request");
+
+        assert_eq!(
+            metric_data_fields(&encoded, 0, METRIC_SUM)
+                .iter()
+                .map(|(number, _, _)| *number)
+                .collect::<Vec<_>>(),
+            vec![
+                SUM_AGGREGATION_TEMPORALITY,
+                SUM_IS_MONOTONIC,
+                SUM_DATA_POINTS,
+                SUM_DATA_POINTS,
+            ]
+        );
+        assert_eq!(
+            metric_data_fields(&encoded, 2, METRIC_SUM)
+                .iter()
+                .map(|(number, _, _)| *number)
+                .collect::<Vec<_>>(),
+            vec![
+                SUM_AGGREGATION_TEMPORALITY,
+                SUM_DATA_POINTS,
+                SUM_DATA_POINTS,
+            ]
+        );
+        assert_eq!(
+            metric_data_fields(&encoded, 4, METRIC_HISTOGRAM)
+                .iter()
+                .map(|(number, _, _)| *number)
+                .collect::<Vec<_>>(),
+            vec![
+                HISTOGRAM_AGGREGATION_TEMPORALITY,
+                HISTOGRAM_DATA_POINTS,
+                HISTOGRAM_DATA_POINTS,
+            ]
+        );
+
+        let request = decode_request(encoded);
+        let Some(metric::Data::Sum(sum)) = metric_named(only_scope(&request), "counter.delta")
+            .data
+            .as_ref()
+        else {
+            panic!("expected sum metric")
+        };
+        assert_eq!(sum.data_points.len(), 2);
+        assert!(matches!(
+            sum.data_points[0].attributes[0]
+                .value
+                .as_ref()
+                .and_then(|value| value.value.as_ref()),
+            Some(any_value::Value::StringValue(value)) if value == "first"
+        ));
+        assert!(matches!(
+            sum.data_points[1].attributes[0]
+                .value
+                .as_ref()
+                .and_then(|value| value.value.as_ref()),
+            Some(any_value::Value::StringValue(value)) if value == "second"
+        ));
+
+        let mut first = metric_set(
+            &DISTRIBUTION_ONLY_DESCRIPTOR,
+            attributes.clone(),
+            vec![MetricValue::from(normal_distribution(&[1.0, 2.0]))],
+        );
+        first.item_attributes = vec![("bucket".to_owned(), "first".to_owned())];
+        let mut second = metric_set(
+            &DISTRIBUTION_ONLY_DESCRIPTOR,
+            attributes,
+            vec![MetricValue::from(normal_distribution(&[4.0, 8.0]))],
+        );
+        second.item_attributes = vec![("bucket".to_owned(), "second".to_owned())];
+        let batch = MetricExportBatch {
+            time_unix_nano: COLLECTION_TIME,
+            metric_sets: vec![first, second],
+        };
+        let encoded = empty_resource_encoder()
+            .encode(&batch)
+            .expect("exponential histogram batch should encode")
+            .expect("exponential histogram batch should produce a request");
+
+        assert_eq!(
+            metric_data_fields(&encoded, 0, METRIC_EXPONENTIAL_HISTOGRAM)
+                .iter()
+                .map(|(number, _, _)| *number)
+                .collect::<Vec<_>>(),
+            vec![
+                EXPONENTIAL_HISTOGRAM_AGGREGATION_TEMPORALITY,
+                EXPONENTIAL_HISTOGRAM_DATA_POINTS,
+                EXPONENTIAL_HISTOGRAM_DATA_POINTS,
+            ]
+        );
     }
 
     /// Scenario: A batch contains populated and empty MMSC fields and sets.

--- a/rust/otap-dataflow/crates/telemetry/src/metrics/otlp.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/metrics/otlp.rs
@@ -2400,12 +2400,12 @@ mod tests {
         assert!(point.bucket_counts.is_empty());
     }
 
-    /// Scenario: Direct encoding emits aggregation metadata and two ordered data points for every
-    /// sum and histogram message kind.
+    /// Scenario: Direct encoding emits aggregation metadata and two ordered data points for sum
+    /// and explicit-boundary histogram messages.
     /// Guarantees: Metadata physically precedes repeated data points, false monotonicity remains
     /// omitted, and repeated data-point order is preserved.
     #[test]
-    fn encodes_aggregation_metadata_before_ordered_data_points() {
+    fn encodes_sum_and_histogram_metadata_before_ordered_data_points() {
         let attributes = empty_attributes();
         let mut first = metric_set(
             &ALL_METRICS_DESCRIPTOR,
@@ -2475,21 +2475,23 @@ mod tests {
             panic!("expected sum metric")
         };
         assert_eq!(sum.data_points.len(), 2);
-        assert!(matches!(
-            sum.data_points[0].attributes[0]
-                .value
-                .as_ref()
-                .and_then(|value| value.value.as_ref()),
-            Some(any_value::Value::StringValue(value)) if value == "first"
-        ));
-        assert!(matches!(
-            sum.data_points[1].attributes[0]
-                .value
-                .as_ref()
-                .and_then(|value| value.value.as_ref()),
-            Some(any_value::Value::StringValue(value)) if value == "second"
-        ));
+        assert_eq!(
+            sum.data_points[0].attributes[0].value,
+            Some(AnyValue::new_string("first"))
+        );
+        assert_eq!(
+            sum.data_points[1].attributes[0].value,
+            Some(AnyValue::new_string("second"))
+        );
+    }
 
+    /// Scenario: Direct encoding emits aggregation metadata and two data points for an
+    /// exponential-histogram message.
+    /// Guarantees: Exponential-histogram temporality physically precedes every repeated data
+    /// point.
+    #[test]
+    fn encodes_exponential_histogram_metadata_before_data_points() {
+        let attributes = empty_attributes();
         let mut first = metric_set(
             &DISTRIBUTION_ONLY_DESCRIPTOR,
             attributes.clone(),


### PR DESCRIPTION
# Change Summary

Encode OTLP aggregation metadata before repeated data points in the direct ITS metrics encoder.
 
For `Sum`, aggregation temporality and monotonicity are now written before data points. For `Histogram` and `ExponentialHistogram`, aggregation temporality is written before data points.
 
This changes only physical protobuf wire-field order. It preserves decoded semantics, encoded size, default-field omission, allocation behavior, traversal count, and data-point order. This is a follow-up to #3714.
 
## What issue does this PR close?

* Closes #3751

## How are these changes tested?

- Added separate wire-level regression coverage for `Sum`/`Histogram` and `ExponentialHistogram` field order.
- Located encoded metrics by their wire-level `METRIC_NAME`, preventing descriptor reordering from silently retargeting assertions.
- Verified non-monotonic sums continue to omit the default `is_monotonic = false` field.
- Verified repeated `Sum` data-point order is preserved.
- `cargo test -p otap-df-telemetry`
- `cargo check -p otap-df-telemetry`
- `cargo clippy -p otap-df-telemetry --all-targets -- -D warnings`

## Are there any user-facing changes?

No. Protobuf field order is semantically insignificant, and decoded OTLP output remains unchanged.

### Changelog

* [ ] Added a `.chloggen/*.yaml` entry
* [X] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
