### PR TITLE
[otap-dataflow] Improve OTAP batch processor throughput

### DIFF
--- a/rust/otap-dataflow/.chloggen/batch-processor-improve-otap-throughput.yaml
+++ b/rust/otap-dataflow/.chloggen/batch-processor-improve-otap-throughput.yaml
@@ -1,0 +1,9 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+change_type: enhancement
+component: pipeline
+note: "Increase OTAP batch processor throughput for both already-sized and merged payloads."
+issues: [3172]
+subtext: |
+  Already-sized OTAP payloads pass through without copying, while compatible payloads use a faster guarded merge path.

--- a/rust/otap-dataflow/benchmarks/Cargo.toml
+++ b/rust/otap-dataflow/benchmarks/Cargo.toml
@@ -101,6 +101,10 @@ name = "item_count"
 harness = false
 
 [[bench]]
+name = "batch_processor"
+harness = false
+
+[[bench]]
 name = "internal_metrics_bridge"
 harness = false
 

--- a/rust/otap-dataflow/benchmarks/benches/batch_processor/main.rs
+++ b/rust/otap-dataflow/benchmarks/benches/batch_processor/main.rs
@@ -5,10 +5,14 @@
 
 //! Benchmarks for OTAP batch-processor flush work.
 
+use arrow::array::RecordBatch;
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use otap_df_config::SignalType;
 use otap_df_pdata::OtapArrowRecords;
 use otap_df_pdata::otap::batching::make_item_batches;
+use otap_df_pdata::otap::transform::concatenate::concatenate;
+use otap_df_pdata::otap::transform::reindex::reindex;
+use otap_df_pdata::otap::{Logs, OtapBatchStore};
 use otap_df_pdata::proto::OtlpProtoMessage;
 use otap_df_pdata::testing::fixtures::{DataGenerator, LogsConfig};
 use otap_df_pdata::testing::round_trip::otlp_to_otap;
@@ -35,13 +39,24 @@ fn logs_batch(item_count: usize) -> OtapArrowRecords {
     otlp_to_otap(&OtlpProtoMessage::Logs(logs))
 }
 
+fn logs_store(item_count: usize) -> [Option<RecordBatch>; Logs::COUNT] {
+    let OtapArrowRecords::Logs(logs) = logs_batch(item_count) else {
+        unreachable!("logs generator must produce logs")
+    };
+    logs.into_batches()
+}
+
 fn bench_otap_logs_flush(c: &mut Criterion) {
     let mut group = c.benchmark_group("batch_processor/otap_logs_flush");
     _ = group.sample_size(30);
 
-    for (input_batches, items_per_batch, max_items) in
-        [(1, 8192, None), (8, 1024, None), (8, 1024, Some(2048))]
-    {
+    for (input_batches, items_per_batch, max_items) in [
+        (1, 8192, None),
+        (2, 4096, None),
+        (8, 1024, None),
+        (32, 256, None),
+        (8, 1024, Some(2048)),
+    ] {
         let input = vec![logs_batch(items_per_batch); input_batches];
         let total_items = input_batches * items_per_batch;
         let name = match max_items {
@@ -71,5 +86,35 @@ fn bench_otap_logs_flush(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_otap_logs_flush);
+fn bench_otap_logs_stages(c: &mut Criterion) {
+    let mut group = c.benchmark_group("batch_processor/otap_logs_stages/8x1024");
+    _ = group.sample_size(30);
+    _ = group.throughput(Throughput::Elements(8192));
+
+    let input = vec![logs_store(1024); 8];
+    _ = group.bench_function("reindex", |b| {
+        b.iter_batched(
+            || input.clone(),
+            |mut pending| {
+                reindex(&mut pending).expect("reindexing must succeed");
+                black_box(pending)
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    let mut reindexed = input;
+    reindex(&mut reindexed).expect("reindexing must succeed");
+    _ = group.bench_function("concatenate", |b| {
+        b.iter_batched(
+            || reindexed.clone(),
+            |mut pending| black_box(concatenate(&mut pending).expect("concatenation must succeed")),
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_otap_logs_flush, bench_otap_logs_stages);
 criterion_main!(benches);

--- a/rust/otap-dataflow/benchmarks/benches/batch_processor/main.rs
+++ b/rust/otap-dataflow/benchmarks/benches/batch_processor/main.rs
@@ -1,0 +1,75 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(missing_docs)]
+
+//! Benchmarks for OTAP batch-processor flush work.
+
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use otap_df_config::SignalType;
+use otap_df_pdata::OtapArrowRecords;
+use otap_df_pdata::otap::batching::make_item_batches;
+use otap_df_pdata::proto::OtlpProtoMessage;
+use otap_df_pdata::testing::fixtures::{DataGenerator, LogsConfig};
+use otap_df_pdata::testing::round_trip::otlp_to_otap;
+use std::hint::black_box;
+use std::num::NonZeroU64;
+
+#[cfg(not(windows))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(not(windows))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
+fn logs_batch(item_count: usize) -> OtapArrowRecords {
+    let logs = DataGenerator::with_logs_config(
+        LogsConfig::new(item_count)
+            .with_resources(1)
+            .with_scopes_per_resource(1)
+            .with_resource_attrs(4)
+            .with_scope_attrs(2)
+            .with_log_attrs(4),
+    )
+    .generate_logs_from_config();
+    otlp_to_otap(&OtlpProtoMessage::Logs(logs))
+}
+
+fn bench_otap_logs_flush(c: &mut Criterion) {
+    let mut group = c.benchmark_group("batch_processor/otap_logs_flush");
+    _ = group.sample_size(30);
+
+    for (input_batches, items_per_batch, max_items) in
+        [(1, 8192, None), (8, 1024, None), (8, 1024, Some(2048))]
+    {
+        let input = vec![logs_batch(items_per_batch); input_batches];
+        let total_items = input_batches * items_per_batch;
+        let name = match max_items {
+            None => format!("{input_batches}x{items_per_batch}/unbounded"),
+            Some(max_items) => format!("{input_batches}x{items_per_batch}/max_{max_items}"),
+        };
+
+        _ = group.throughput(Throughput::Elements(total_items as u64));
+        _ = group.bench_with_input(BenchmarkId::from_parameter(name), &input, |b, input| {
+            b.iter_batched(
+                || input.clone(),
+                |pending| {
+                    black_box(
+                        make_item_batches(
+                            SignalType::Logs,
+                            max_items.and_then(NonZeroU64::new),
+                            pending,
+                        )
+                        .expect("OTAP logs batching must succeed"),
+                    )
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_otap_logs_flush);
+criterion_main!(benches);

--- a/rust/otap-dataflow/crates/pdata/src/otap/batching.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/batching.rs
@@ -7,8 +7,13 @@ use super::{OtapArrowRecords, error::Result, groups::RecordsGroup};
 use otap_df_config::SignalType;
 use std::num::NonZeroU64;
 
-/// Rebatch records to the appropriate size in a single pass, measured
-/// in items.  Requires all inputs have the same signal type.
+/// Rebatch records to the appropriate size in a single pass, measured in
+/// items. Requires all inputs to have the same signal type.
+///
+/// A single non-empty input within the configured limit is returned unchanged.
+/// Besides avoiding grouping work, this preserves every Arrow buffer and schema
+/// `Arc`; that is the dominant batch-processor case when upstream batches are
+/// already sized appropriately.
 pub fn make_item_batches(
     signal: SignalType,
     max_items: Option<NonZeroU64>,

--- a/rust/otap-dataflow/crates/pdata/src/otap/batching.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/batching.rs
@@ -14,6 +14,29 @@ pub fn make_item_batches(
     max_items: Option<NonZeroU64>,
     records: Vec<OtapArrowRecords>,
 ) -> Result<Vec<OtapArrowRecords>> {
+    // A single non-empty payload already satisfying the output limit requires
+    // neither splitting nor concatenation. Keep its Arrow arrays intact and
+    // avoid converting through RecordsGroup only to reconstruct the same
+    // payload. Empty payloads retain the existing behavior of being dropped,
+    // regardless of their signal variant.
+    if let [record] = records.as_slice() {
+        let item_count = record.num_items();
+        if item_count == 0 {
+            return Ok(Vec::new());
+        }
+        if record.signal_type() != signal {
+            return Err(super::error::Error::MixedSignals);
+        }
+
+        let within_limit = max_items.is_none_or(|limit| {
+            let effective_limit = limit.get().min(u32::MAX as u64);
+            u64::try_from(item_count).is_ok_and(|count| count <= effective_limit)
+        });
+        if within_limit {
+            return Ok(records);
+        }
+    }
+
     // Separate by signal type.
     let mut records = match signal {
         SignalType::Logs => RecordsGroup::separate_logs(records),

--- a/rust/otap-dataflow/crates/pdata/src/otap/batching_tests.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/batching_tests.rs
@@ -9,7 +9,9 @@ use crate::testing::equiv::assert_equivalent;
 use crate::testing::fixtures::{DataGenerator, MetricsConfig};
 use crate::testing::round_trip::otap_to_otlp;
 use crate::testing::round_trip::otlp_to_otap;
+use otap_df_config::SignalType;
 use std::num::NonZeroU64;
+use std::sync::Arc;
 
 /// A test case for batching metrics with specific configurations
 #[derive(Debug, Clone)]
@@ -298,6 +300,37 @@ fn test_batching(
 
     // Check OTLP equivalence
     assert_equivalent(&inputs_otlp, &outputs_otlp);
+}
+
+/// Scenario: one non-empty OTAP payload is flushed without an output limit or
+/// with a limit larger than its item count.
+/// Guarantees: Batching returns the original Arrow arrays without copying or
+/// rebuilding an already-sized payload.
+#[test]
+fn test_single_sized_payload_is_zero_copy() {
+    let mut datagen = DataGenerator::new(1);
+    let input = otlp_to_otap(&datagen.generate_logs().into());
+    let root_column = Arc::clone(
+        input
+            .root_record_batch()
+            .expect("logs root batch")
+            .column(0),
+    );
+    let item_count = input.num_items();
+
+    for max_items in [None, NonZeroU64::new(item_count as u64 + 1)] {
+        let outputs = make_item_batches(SignalType::Logs, max_items, vec![input.clone()])
+            .expect("batching should succeed");
+
+        assert_eq!(outputs.len(), 1);
+        assert!(Arc::ptr_eq(
+            &root_column,
+            outputs[0]
+                .root_record_batch()
+                .expect("logs root batch")
+                .column(0)
+        ));
+    }
 }
 
 /// Count the total number of metrics in a MetricsData batch

--- a/rust/otap-dataflow/crates/pdata/src/otap/groups.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/groups.rs
@@ -242,9 +242,10 @@ fn generic_concatenate<const N: usize>(
     batches: Vec<[Option<RecordBatch>; N]>,
     max_items: Option<NonZeroU64>,
 ) -> Result<Vec<[Option<RecordBatch>; N]>> {
-    let mut result = Vec::new();
+    let input_count = batches.len();
+    let mut result = Vec::with_capacity(if max_items.is_none() { 1 } else { input_count });
 
-    let mut current = Vec::new();
+    let mut current = Vec::with_capacity(input_count);
     let mut current_num_items = 0;
 
     for input in batches {

--- a/rust/otap-dataflow/crates/pdata/src/otap/groups.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/groups.rs
@@ -16,7 +16,7 @@ use crate::{
 use arrow::array::RecordBatch;
 use otap_df_config::SignalType;
 
-use super::transform::{concatenate::concatenate, split};
+use super::transform::split;
 
 /// Represents a sequence of OtapArrowRecords that all share exactly
 /// the same signal.  Invarients:
@@ -270,8 +270,7 @@ fn concatenate_emitter<const N: usize>(
     current: &mut Vec<[Option<RecordBatch>; N]>,
     result: &mut Vec<[Option<RecordBatch>; N]>,
 ) -> Result<()> {
-    super::transform::reindex::reindex(current)?;
-    result.push(concatenate(current)?);
+    result.push(super::transform::reindex::reindex_and_concatenate(current)?);
     assert_all_empty(current);
     current.clear();
     Ok(())

--- a/rust/otap-dataflow/crates/pdata/src/otap/groups.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/groups.rs
@@ -243,6 +243,9 @@ fn generic_concatenate<const N: usize>(
     max_items: Option<NonZeroU64>,
 ) -> Result<Vec<[Option<RecordBatch>; N]>> {
     let input_count = batches.len();
+    // With no limit, all inputs produce exactly one output. With a limit, one
+    // output per input is the conservative upper bound. Reserving both vectors
+    // avoids growth while fragments are collected and emitted.
     let mut result = Vec::with_capacity(if max_items.is_none() { 1 } else { input_count });
 
     let mut current = Vec::with_capacity(input_count);
@@ -270,6 +273,10 @@ fn concatenate_emitter<const N: usize>(
     current: &mut Vec<[Option<RecordBatch>; N]>,
     result: &mut Vec<[Option<RecordBatch>; N]>,
 ) -> Result<()> {
+    // Relationship reindexing and physical concatenation share one planner so
+    // offset-compatible inputs do not allocate intermediate ID columns. The
+    // function consumes every `Some(RecordBatch)` only after its selected path
+    // succeeds, which preserves the ownership contract checked below.
     result.push(super::transform::reindex::reindex_and_concatenate(current)?);
     assert_all_empty(current);
     current.clear();

--- a/rust/otap-dataflow/crates/pdata/src/otap/transform/concatenate.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/transform/concatenate.rs
@@ -39,38 +39,48 @@ const MAX_U16_CARDINALITY: usize = 65535;
 
 /// Concatenate the provided OtapArrowRecords into a single batch.
 ///
-/// # Preconditions
+/// # Relationship preconditions
 ///
-/// Currently the caller is responsible for satisfying the following:
+/// This low-level function does not change OTAP relationship IDs. Its caller is
+/// responsible for satisfying the following:
 ///
 ///   1. Remove the transport optimized encodings from the columns, if any
 ///   2. Reindex the ID columns so that the parent child relationships are
 ///      consistent after the concatenation
 ///
-/// These will be handled internally in the future as we refine the API, see
-/// https://github.com/open-telemetry/otel-arrow/issues/1926.
+/// The batch processor satisfies these requirements through
+/// `reindex_and_concatenate`, which can fuse reindexing with this operation.
 ///
 /// # General Algorithm
 ///
-/// Concatenating multiple OtapArrowRecords involves three steps:
+/// The general schema-reconciliation path involves three steps:
 ///
-///   1. Reindexing the ID columns so that the parent child relationships are
-///      consistent after the concatenation
-///   2. Selecting a common schema and converting every record batch to that
+///   1. Selecting a common schema and converting every record batch to that
 ///      schema. This includes several steps:
 ///         * Indexing all fields for the same ArrowPayloadType across every batch
 ///         * Selecting a safe key type for each dictionary field from the
 ///           physical number of dictionary values that Arrow may concatenate.
 ///         * Determining nullability for each field in the final batch
-///   3. Casting every record batch to the final schema, including casting individual
+///   2. Casting every record batch to the final schema, including casting individual
 ///      arrays as well as reordering the columns to match the schema.
+///   3. Coalescing the converted batches into one output batch per payload type.
+///
+/// # Fast paths
+///
+/// - Zero inputs produce an empty result and one input transfers its existing
+///   batches without copying Arrow buffers.
+/// - Inputs with identical schemas and sufficient dictionary key capacity use
+///   Arrow's `concat_batches` directly, skipping field indexing, schema
+///   selection, and conversion.
+/// - The higher-level OTAP-aware path reuses the same-schema eligibility check
+///   and can apply relationship offsets while copying final ID buffers.
+///
+/// Equal dictionary data types do not by themselves make direct concatenation
+/// safe: Arrow appends each input's physical dictionary values, even when
+/// logical values overlap. The capacity preflight therefore sums physical
+/// lengths before retaining a narrow key type.
 ///
 /// # Future optimizations
-///
-/// - TODO: Re-indexing probably should not be a separate operation. We should decide
-///   within this function whether or not to do it and ensure it happens if required.
-///   This is deferred until we totally remove the old implementation in groups.rs
-///   due to interface incompatibility.
 ///
 /// - TODO: Consider using new_unchecked for record batch construction if we're
 ///   confident in it. We mostly unwrap those operations a lot, so skipping the
@@ -129,10 +139,10 @@ fn concatenate_with_def<const N: usize>(
         };
 
         let shared_schema = first.schema_ref();
-        if select_all(items, i).flatten().all(|batch| {
-            Arc::ptr_eq(batch.schema_ref(), shared_schema) || batch.schema_ref() == shared_schema
-        }) && dictionary_keys_have_capacity(items, i, first)?
-        {
+        // Most batches produced by one OTAP stream already share a schema.
+        // Avoiding the general path here removes repeated field indexing,
+        // schema construction, casts, and RecordBatch reconstruction.
+        if batches_share_concatenable_schema(items, i)? {
             let shared_schema = Arc::clone(shared_schema);
             let batches = select_all_mut(items, i)
                 .filter_map(Option::take)
@@ -184,6 +194,26 @@ fn concatenate_with_def<const N: usize>(
     }
 
     Ok(result)
+}
+
+/// Returns whether one payload slot can bypass schema reconciliation.
+///
+/// Pointer equality handles the common shared-`Arc` case cheaply; structural
+/// equality also accepts independently allocated but identical schemas. The
+/// dictionary check is separate because schema equality says nothing about the
+/// combined physical value count. This predicate is shared with the OTAP-aware
+/// copy-and-offset kernel so both fast paths have identical safety boundaries.
+pub(crate) fn batches_share_concatenable_schema<const N: usize>(
+    items: &[[Option<RecordBatch>; N]],
+    payload_index: usize,
+) -> Result<bool> {
+    let Some(first) = select_all(items, payload_index).flatten().next() else {
+        return Ok(true);
+    };
+    let shared_schema = first.schema_ref();
+    Ok(select_all(items, payload_index).flatten().all(|batch| {
+        Arc::ptr_eq(batch.schema_ref(), shared_schema) || batch.schema_ref() == shared_schema
+    }) && dictionary_keys_have_capacity(items, payload_index, first)?)
 }
 
 /// Returns whether coalescing batches that share a schema can retain every

--- a/rust/otap-dataflow/crates/pdata/src/otap/transform/concatenate.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/transform/concatenate.rs
@@ -133,22 +133,14 @@ fn concatenate_with_def<const N: usize>(
             Arc::ptr_eq(batch.schema_ref(), shared_schema) || batch.schema_ref() == shared_schema
         }) && dictionary_keys_have_capacity(items, i, first)?
         {
-            let row_count = select_all(items, i)
-                .flatten()
-                .map(RecordBatch::num_rows)
-                .sum();
-            let mut batcher = arrow::compute::BatchCoalescer::new(shared_schema.clone(), row_count);
-            for payload in select_all_mut(items, i) {
-                if let Some(batch) = payload.take() {
-                    batcher
-                        .push_batch(batch)
-                        .map_err(|source| Error::Batching { source })?;
-                }
-            }
-            batcher
-                .finish_buffered_batch()
-                .map_err(|source| Error::Batching { source })?;
-            result[i] = batcher.next_completed_batch();
+            let shared_schema = Arc::clone(shared_schema);
+            let batches = select_all_mut(items, i)
+                .filter_map(Option::take)
+                .collect::<Vec<_>>();
+            result[i] = Some(
+                arrow::compute::concat_batches(&shared_schema, batches.iter())
+                    .map_err(|source| Error::Batching { source })?,
+            );
             continue;
         }
 

--- a/rust/otap-dataflow/crates/pdata/src/otap/transform/concatenate.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/transform/concatenate.rs
@@ -124,6 +124,34 @@ fn concatenate_with_def<const N: usize>(
 
     #[allow(clippy::needless_range_loop)]
     for i in 0..N {
+        let Some(first) = select_all(items, i).flatten().next() else {
+            continue;
+        };
+
+        let shared_schema = first.schema_ref();
+        if select_all(items, i).flatten().all(|batch| {
+            Arc::ptr_eq(batch.schema_ref(), shared_schema) || batch.schema_ref() == shared_schema
+        }) && dictionary_keys_have_capacity(items, i, first)?
+        {
+            let row_count = select_all(items, i)
+                .flatten()
+                .map(RecordBatch::num_rows)
+                .sum();
+            let mut batcher = arrow::compute::BatchCoalescer::new(shared_schema.clone(), row_count);
+            for payload in select_all_mut(items, i) {
+                if let Some(batch) = payload.take() {
+                    batcher
+                        .push_batch(batch)
+                        .map_err(|source| Error::Batching { source })?;
+                }
+            }
+            batcher
+                .finish_buffered_batch()
+                .map_err(|source| Error::Batching { source })?;
+            result[i] = batcher.next_completed_batch();
+            continue;
+        }
+
         let payload_def = get_def(i);
 
         let index = index_records(select_all(items, i))?;
@@ -164,6 +192,73 @@ fn concatenate_with_def<const N: usize>(
     }
 
     Ok(result)
+}
+
+/// Returns whether coalescing batches that share a schema can retain every
+/// dictionary's current key width. Arrow appends physical dictionary value
+/// arrays while coalescing, so their summed lengths are the safe bound even
+/// when values overlap.
+fn dictionary_keys_have_capacity<const N: usize>(
+    batches: &[[Option<RecordBatch>; N]],
+    payload_index: usize,
+    first: &RecordBatch,
+) -> Result<bool> {
+    for column_index in 0..first.num_columns() {
+        match first.column(column_index).data_type() {
+            DataType::Dictionary(key_type, _) => {
+                let arrays = select_all(batches, payload_index)
+                    .flatten()
+                    .map(|batch| batch.column(column_index));
+                if !dictionary_value_lengths_fit(arrays, key_type)? {
+                    return Ok(false);
+                }
+            }
+            DataType::Struct(fields) => {
+                for field_index in 0..fields.len() {
+                    let DataType::Dictionary(key_type, _) = first
+                        .column(column_index)
+                        .as_struct()
+                        .column(field_index)
+                        .data_type()
+                    else {
+                        continue;
+                    };
+                    let arrays = select_all(batches, payload_index)
+                        .flatten()
+                        .map(|batch| batch.column(column_index).as_struct().column(field_index));
+                    if !dictionary_value_lengths_fit(arrays, key_type)? {
+                        return Ok(false);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(true)
+}
+
+fn dictionary_value_lengths_fit<'a>(
+    arrays: impl Iterator<Item = &'a ArrayRef>,
+    key_type: &DataType,
+) -> Result<bool> {
+    let capacity = match key_type {
+        DataType::UInt8 => MAX_U8_CARDINALITY,
+        DataType::UInt16 => MAX_U16_CARDINALITY,
+        actual => {
+            return Err(Error::UnsupportedDictionaryKeyType {
+                expect_oneof: vec![DataType::UInt8, DataType::UInt16],
+                actual: actual.clone(),
+            });
+        }
+    };
+    let mut physical_values = 0usize;
+    for array in arrays {
+        physical_values = physical_values.saturating_add(get_dictionary_values(array)?.len());
+        if physical_values > capacity {
+            return Ok(false);
+        }
+    }
+    Ok(true)
 }
 
 /// Convert the columns from one schema to another. The arguments deal in

--- a/rust/otap-dataflow/crates/pdata/src/otap/transform/reindex.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/transform/reindex.rs
@@ -79,8 +79,8 @@ use std::ops::{Add, AddAssign, Range, Sub, SubAssign};
 use std::sync::Arc;
 
 use arrow::array::{
-    Array, ArrayRef, ArrowNativeTypeOp, ArrowPrimitiveType, AsArray, DictionaryArray,
-    PrimitiveArray, RecordBatch,
+    Array, ArrayRef, ArrowNativeTypeOp, ArrowPrimitiveType, AsArray, DictionaryArray, NullArray,
+    PrimitiveArray, RecordBatch, StructArray,
 };
 use arrow::buffer::ScalarBuffer;
 use arrow::datatypes::{
@@ -89,10 +89,11 @@ use arrow::datatypes::{
 };
 
 use crate::error::{Error, Result};
+use crate::otap::transform::concatenate::concatenate;
 use crate::otap::transform::transport_optimize::remove_transport_optimized_encodings;
 use crate::otap::transform::util::{
     extract_id_column, payload_to_idx, remove_record_batch_ranges, replace_column,
-    sort_record_batch_by_indices,
+    sort_record_batch_by_indices, struct_column_name,
 };
 use crate::otap::{Logs, Metrics, OtapBatchStore, Traces};
 use crate::proto::opentelemetry::arrow::v1::ArrowPayloadType;
@@ -116,6 +117,28 @@ pub fn reindex<const N: usize>(batches: &mut [[Option<RecordBatch>; N]]) -> Resu
         Logs::COUNT => reindex_logs::<{ N }>(batches),
         Metrics::COUNT => reindex_metrics::<{ N }>(batches),
         Traces::COUNT => reindex_traces::<{ N }>(batches),
+        _ => unreachable!(),
+    }
+}
+
+/// Reindex and concatenate OTAP batches, applying offset-only reindexing to the
+/// final coalesced buffers when the relation columns support it.
+pub(crate) fn reindex_and_concatenate<const N: usize>(
+    batches: &mut [[Option<RecordBatch>; N]],
+) -> Result<[Option<RecordBatch>; N]> {
+    if batches.len() <= 1 {
+        return concatenate(batches);
+    }
+    // Planning costs more than the avoided allocations for a two-batch merge.
+    if batches.len() == 2 {
+        reindex(batches)?;
+        return concatenate(batches);
+    }
+
+    match N {
+        Logs::COUNT => reindex_and_concatenate_store::<Logs, N>(batches),
+        Metrics::COUNT => reindex_and_concatenate_store::<Metrics, N>(batches),
+        Traces::COUNT => reindex_and_concatenate_store::<Traces, N>(batches),
         _ => unreachable!(),
     }
 }
@@ -194,6 +217,15 @@ where
         store.remove_transport_optimized_encodings(*payload_type)?;
     }
 
+    reindex_decoded_batch_store(store)
+}
+
+fn reindex_decoded_batch_store<S, const N: usize>(
+    store: &mut MultiBatchStore<'_, S, N>,
+) -> Result<()>
+where
+    S: OtapBatchStore,
+{
     for &payload_type in S::allowed_payload_types() {
         let info = payload_relations(payload_type);
 
@@ -229,6 +261,402 @@ where
         }
     }
 
+    Ok(())
+}
+
+fn reindex_and_concatenate_store<S, const N: usize>(
+    batches: &mut [[Option<RecordBatch>; N]],
+) -> Result<[Option<RecordBatch>; N]>
+where
+    S: OtapBatchStore,
+{
+    let plan = {
+        let mut store = MultiBatchStore::<S, N>::new(batches);
+        for payload_type in S::allowed_payload_types() {
+            store.remove_transport_optimized_encodings(*payload_type)?;
+        }
+        try_build_fused_reindex_plan(&store)?
+    };
+
+    if let Some(plan) = plan {
+        let mut result = concatenate(batches)?;
+        plan.apply(&mut result)?;
+        return Ok(result);
+    }
+
+    let mut store = MultiBatchStore::<S, N>::new(batches);
+    reindex_decoded_batch_store(&mut store)?;
+    concatenate(batches)
+}
+
+#[derive(Debug, Default)]
+struct FusedReindexPlan {
+    columns: Vec<PlannedColumn>,
+}
+
+#[derive(Debug)]
+struct PlannedColumn {
+    payload_index: usize,
+    column_path: &'static str,
+    id_type: IdColumnType,
+    offsets: Vec<PlannedOffset>,
+}
+
+#[derive(Debug)]
+struct PlannedOffset {
+    range: Range<usize>,
+    offset: u64,
+    sign: Sign,
+}
+
+impl FusedReindexPlan {
+    fn push(
+        &mut self,
+        payload_index: usize,
+        column_path: &'static str,
+        id_type: IdColumnType,
+        range: Range<usize>,
+        offset: u64,
+        sign: Sign,
+    ) {
+        if range.is_empty() || offset == 0 {
+            return;
+        }
+
+        if let Some(column) = self.columns.iter_mut().find(|column| {
+            column.payload_index == payload_index && column.column_path == column_path
+        }) {
+            column.offsets.push(PlannedOffset {
+                range,
+                offset,
+                sign,
+            });
+            return;
+        }
+
+        self.columns.push(PlannedColumn {
+            payload_index,
+            column_path,
+            id_type,
+            offsets: vec![PlannedOffset {
+                range,
+                offset,
+                sign,
+            }],
+        });
+    }
+
+    fn apply<const N: usize>(self, result: &mut [Option<RecordBatch>; N]) -> Result<()> {
+        for (payload_index, result_batch) in result.iter_mut().enumerate() {
+            if !self
+                .columns
+                .iter()
+                .any(|column| column.payload_index == payload_index)
+            {
+                continue;
+            }
+
+            let batch = result_batch
+                .take()
+                .ok_or_else(|| Error::UnexpectedRecordBatchState {
+                    reason: format!(
+                        "Fused reindex output is missing payload index {payload_index}"
+                    ),
+                })?;
+            let (schema, mut columns, _) = batch.into_parts();
+            for column in self
+                .columns
+                .iter()
+                .filter(|column| column.payload_index == payload_index)
+            {
+                apply_planned_column(schema.as_ref(), &mut columns, column)?;
+            }
+            *result_batch = Some(RecordBatch::try_new(schema, columns).map_err(|source| {
+                Error::UnexpectedRecordBatchState {
+                    reason: format!("Failed to rebuild fused reindex output: {source}"),
+                }
+            })?);
+        }
+
+        Ok(())
+    }
+}
+
+fn try_build_fused_reindex_plan<S, const N: usize>(
+    store: &MultiBatchStore<'_, S, N>,
+) -> Result<Option<FusedReindexPlan>>
+where
+    S: OtapBatchStore,
+{
+    let mut running_rows = [0usize; N];
+    let row_ranges = store
+        .batches
+        .iter()
+        .map(|batch| {
+            std::array::from_fn(|payload_index| {
+                let start = running_rows[payload_index];
+                running_rows[payload_index] += batch[payload_index]
+                    .as_ref()
+                    .map_or(0, RecordBatch::num_rows);
+                start..running_rows[payload_index]
+            })
+        })
+        .collect::<Vec<[_; N]>>();
+
+    let mut plan = FusedReindexPlan::default();
+    for &payload_type in S::allowed_payload_types() {
+        let info = payload_relations(payload_type);
+        if let Some(ref primary_id_info) = info.primary_id {
+            check_primary_id_for_overflow(store, payload_type, primary_id_info)?;
+        }
+
+        for relation in info.relations {
+            let is_primary = Some(relation.key_col) == info.primary_id.as_ref().map(|id| id.name);
+            let supported = match relation.size {
+                IdColumnType::U16 => try_plan_offset_reindex::<UInt16Type, S, N>(
+                    store,
+                    &row_ranges,
+                    &mut plan,
+                    payload_type,
+                    relation.child_types,
+                    relation.key_col,
+                    is_primary,
+                    relation.size,
+                )?,
+                IdColumnType::U32 => try_plan_offset_reindex::<UInt32Type, S, N>(
+                    store,
+                    &row_ranges,
+                    &mut plan,
+                    payload_type,
+                    relation.child_types,
+                    relation.key_col,
+                    is_primary,
+                    relation.size,
+                )?,
+            };
+            if !supported {
+                return Ok(None);
+            }
+        }
+    }
+
+    Ok(Some(plan))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn try_plan_offset_reindex<T, S, const N: usize>(
+    store: &MultiBatchStore<'_, S, N>,
+    row_ranges: &[[Range<usize>; N]],
+    plan: &mut FusedReindexPlan,
+    parent_payload_type: ArrowPayloadType,
+    child_payload_types: &[ArrowPayloadType],
+    id_column_path: &'static str,
+    is_primary: bool,
+    id_type: IdColumnType,
+) -> Result<bool>
+where
+    T: ArrowNumericType,
+    T::Native: Ord
+        + Copy
+        + Add<Output = T::Native>
+        + Sub<Output = T::Native>
+        + From<u8>
+        + ArrowNativeTypeOp,
+    S: OtapBatchStore,
+{
+    let stats = gather_column_stats::<T, S, N>(
+        store,
+        parent_payload_type,
+        child_payload_types,
+        id_column_path,
+        is_primary,
+    )?;
+
+    let total_ids_needed = stats
+        .iter()
+        .filter_map(Option::as_ref)
+        .map(|stat| stat.max_ids_needed as u64)
+        .sum::<u64>();
+    if total_ids_needed > id_type.max()
+        || stats
+            .iter()
+            .flatten()
+            .any(|stat| stat.strategy == ReindexStrategy::CompactOnly)
+    {
+        return Ok(false);
+    }
+
+    let parent_index = payload_to_idx(parent_payload_type);
+    let mut offset = T::Native::from(0);
+    for (batch_index, stat) in stats.iter().enumerate() {
+        let Some(stat) = stat else {
+            continue;
+        };
+
+        let parent_batch = store.batches[batch_index][parent_index]
+            .as_ref()
+            .expect("batch must exist for non-None stat");
+        if !plain_non_null_id_column::<T>(parent_batch, id_column_path) {
+            return Ok(false);
+        }
+        for &child_payload_type in child_payload_types {
+            let child_index = payload_to_idx(child_payload_type);
+            if let Some(child_batch) = &store.batches[batch_index][child_index]
+                && !plain_non_null_id_column::<T>(child_batch, PARENT_ID)
+            {
+                return Ok(false);
+            }
+        }
+
+        let (adjustment, sign) = if stat.min <= offset {
+            (offset - stat.min, Sign::Positive)
+        } else {
+            (stat.min - offset, Sign::Negative)
+        };
+        let span = stat.max - stat.min + T::Native::from(1);
+
+        if adjustment != T::Native::from(0) {
+            plan.push(
+                parent_index,
+                id_column_path,
+                id_type,
+                row_ranges[batch_index][parent_index].clone(),
+                adjustment.as_usize() as u64,
+                sign,
+            );
+            for &child_payload_type in child_payload_types {
+                let child_index = payload_to_idx(child_payload_type);
+                if store.batches[batch_index][child_index].is_some() {
+                    plan.push(
+                        child_index,
+                        PARENT_ID,
+                        id_type,
+                        row_ranges[batch_index][child_index].clone(),
+                        adjustment.as_usize() as u64,
+                        sign,
+                    );
+                }
+            }
+        }
+
+        offset = offset + span;
+    }
+
+    Ok(true)
+}
+
+fn plain_non_null_id_column<T>(batch: &RecordBatch, column_path: &str) -> bool
+where
+    T: ArrowPrimitiveType,
+{
+    extract_id_column(batch, column_path)
+        .is_ok_and(|column| column.data_type() == &T::DATA_TYPE && column.null_count() == 0)
+}
+
+fn apply_planned_column(
+    schema: &arrow_schema::Schema,
+    columns: &mut [ArrayRef],
+    plan: &PlannedColumn,
+) -> Result<()> {
+    if let Some(struct_name) = struct_column_name(plan.column_path) {
+        let struct_index = schema
+            .index_of(struct_name)
+            .map_err(|_| Error::ColumnNotFound {
+                name: plan.column_path.to_string(),
+            })?;
+        let original = take_array(&mut columns[struct_index]);
+        let struct_array = original.as_struct().clone();
+        drop(original);
+        let struct_len = struct_array.len();
+        let (fields, mut struct_columns, nulls) = struct_array.into_parts();
+        let (id_index, _) = fields.find(ID).ok_or_else(|| Error::ColumnNotFound {
+            name: plan.column_path.to_string(),
+        })?;
+        let id_column = take_array(&mut struct_columns[id_index]);
+        struct_columns[id_index] = apply_planned_offsets(id_column, plan)?;
+        columns[struct_index] = Arc::new(
+            StructArray::try_new_with_length(fields, struct_columns, nulls, struct_len)
+                .map_err(|source| Error::Batching { source })?,
+        );
+        return Ok(());
+    }
+
+    let column_index = schema
+        .index_of(plan.column_path)
+        .map_err(|_| Error::ColumnNotFound {
+            name: plan.column_path.to_string(),
+        })?;
+    let column = take_array(&mut columns[column_index]);
+    columns[column_index] = apply_planned_offsets(column, plan)?;
+    Ok(())
+}
+
+fn take_array(array: &mut ArrayRef) -> ArrayRef {
+    std::mem::replace(array, Arc::new(NullArray::new(0)))
+}
+
+fn apply_planned_offsets(array: ArrayRef, plan: &PlannedColumn) -> Result<ArrayRef> {
+    match plan.id_type {
+        IdColumnType::U16 => apply_planned_primitive_offsets::<UInt16Type>(array, &plan.offsets),
+        IdColumnType::U32 => apply_planned_primitive_offsets::<UInt32Type>(array, &plan.offsets),
+    }
+}
+
+fn apply_planned_primitive_offsets<T>(
+    array: ArrayRef,
+    offsets: &[PlannedOffset],
+) -> Result<ArrayRef>
+where
+    T: ArrowPrimitiveType,
+    T::Native: AddAssign + SubAssign + Copy + ArrowNativeType,
+{
+    if array.data_type() != &T::DATA_TYPE {
+        return Err(Error::ColumnDataTypeMismatch {
+            name: ID.to_string(),
+            expect: T::DATA_TYPE,
+            actual: array.data_type().clone(),
+        });
+    }
+
+    let primitive = array.as_primitive::<T>().clone();
+    drop(array);
+    match primitive.into_builder() {
+        Ok(mut builder) => {
+            apply_offset_ranges(builder.values_slice_mut(), offsets)?;
+            Ok(Arc::new(builder.finish()))
+        }
+        Err(primitive) => {
+            let mut values = primitive.values().to_vec();
+            apply_offset_ranges(&mut values, offsets)?;
+            Ok(Arc::new(PrimitiveArray::<T>::new(
+                ScalarBuffer::from(values),
+                primitive.nulls().cloned(),
+            )))
+        }
+    }
+}
+
+fn apply_offset_ranges<T>(values: &mut [T], offsets: &[PlannedOffset]) -> Result<()>
+where
+    T: AddAssign + SubAssign + Copy + ArrowNativeType,
+{
+    for planned in offsets {
+        let values_len = values.len();
+        let range = values.get_mut(planned.range.clone()).ok_or_else(|| {
+            Error::UnexpectedRecordBatchState {
+                reason: format!(
+                    "Fused reindex range {:?} exceeds ID column length {values_len}",
+                    planned.range
+                ),
+            }
+        })?;
+        let offset = T::from_usize(planned.offset as usize).ok_or_else(|| {
+            Error::UnexpectedRecordBatchState {
+                reason: format!("Fused reindex offset {} does not fit", planned.offset),
+            }
+        })?;
+        apply_uniform_offset(range, offset, planned.sign);
+    }
     Ok(())
 }
 
@@ -1369,6 +1797,227 @@ mod tests {
                 (ResourceAttrs, ("parent_id", UInt16, child_ids.clone()))
             ),
         ]);
+    }
+
+    /// Scenario: overlapping plain log, resource, and scope IDs are merged from
+    /// multiple batches using uniform offsets.
+    /// Guarantees: The fused path is selected and produces exactly the same
+    /// root and child IDs as the legacy reindex-then-concatenate sequence.
+    #[test]
+    fn test_fused_reindex_and_concatenate_matches_legacy_logs() {
+        let stores = vec![
+            logs!(
+                (
+                    Logs,
+                    ("id", UInt16, vec![0u16, 1]),
+                    ("resource.id", UInt16, vec![0u16, 0]),
+                    ("scope.id", UInt16, vec![0u16, 0])
+                ),
+                (LogAttrs, ("parent_id", UInt16, vec![0u16, 1])),
+                (ResourceAttrs, ("parent_id", UInt16, vec![0u16, 0])),
+                (ScopeAttrs, ("parent_id", UInt16, vec![0u16, 0]))
+            ),
+            logs!(
+                (
+                    Logs,
+                    ("id", UInt16, vec![0u16, 1]),
+                    ("resource.id", UInt16, vec![0u16, 0]),
+                    ("scope.id", UInt16, vec![0u16, 0])
+                ),
+                (LogAttrs, ("parent_id", UInt16, vec![0u16, 1])),
+                (ResourceAttrs, ("parent_id", UInt16, vec![0u16, 0])),
+                (ScopeAttrs, ("parent_id", UInt16, vec![0u16, 0]))
+            ),
+            logs!(
+                (
+                    Logs,
+                    ("id", UInt16, vec![0u16, 1]),
+                    ("resource.id", UInt16, vec![0u16, 0]),
+                    ("scope.id", UInt16, vec![0u16, 0])
+                ),
+                (LogAttrs, ("parent_id", UInt16, vec![0u16, 1])),
+                (ResourceAttrs, ("parent_id", UInt16, vec![0u16, 0])),
+                (ScopeAttrs, ("parent_id", UInt16, vec![0u16, 0]))
+            ),
+        ];
+        let batches = stores
+            .into_iter()
+            .map(OtapBatchStore::into_batches)
+            .collect::<Vec<_>>();
+
+        let mut planned = batches.clone();
+        let plan = {
+            let mut store = MultiBatchStore::<Logs, { Logs::COUNT }>::new(&mut planned);
+            for payload_type in Logs::allowed_payload_types() {
+                store
+                    .remove_transport_optimized_encodings(*payload_type)
+                    .unwrap();
+            }
+            try_build_fused_reindex_plan(&store).unwrap()
+        };
+        assert!(plan.is_some());
+
+        let mut legacy = batches.clone();
+        reindex(&mut legacy).unwrap();
+        let expected = concatenate(&mut legacy).unwrap();
+
+        let mut fused = batches;
+        let actual = reindex_and_concatenate(&mut fused).unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    /// Scenario: a log child contains parent IDs outside its parent ID range.
+    /// Guarantees: Fused offset planning declines the batch and the fallback
+    /// preserves legacy compaction and orphan-row removal exactly.
+    #[test]
+    fn test_fused_reindex_falls_back_for_orphan_parent_ids() {
+        let stores = vec![
+            logs!(
+                (Logs, ("id", UInt16, vec![1u16, 2, 4])),
+                (LogAttrs, ("parent_id", UInt16, vec![0u16, 1, 2, 3, 4, 5]))
+            ),
+            logs!(
+                (Logs, ("id", UInt16, vec![1u16, 2, 4])),
+                (LogAttrs, ("parent_id", UInt16, vec![1u16, 2, 4]))
+            ),
+        ];
+        let batches = stores
+            .into_iter()
+            .map(OtapBatchStore::into_batches)
+            .collect::<Vec<_>>();
+
+        let mut planned = batches.clone();
+        let plan = {
+            let mut store = MultiBatchStore::<Logs, { Logs::COUNT }>::new(&mut planned);
+            for payload_type in Logs::allowed_payload_types() {
+                store
+                    .remove_transport_optimized_encodings(*payload_type)
+                    .unwrap();
+            }
+            try_build_fused_reindex_plan(&store).unwrap()
+        };
+        assert!(plan.is_none());
+
+        let mut legacy = batches.clone();
+        reindex(&mut legacy).unwrap();
+        let expected = concatenate(&mut legacy).unwrap();
+
+        let mut fused = batches;
+        let actual = reindex_and_concatenate(&mut fused).unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    /// Scenario: a UInt32 child relation uses dictionary-encoded parent IDs.
+    /// Guarantees: Fused primitive-buffer planning declines the relation and
+    /// the fallback preserves dictionary reindexing and concatenation exactly.
+    #[test]
+    fn test_fused_reindex_falls_back_for_dictionary_parent_ids() {
+        let stores = vec![
+            metrics!(
+                (UnivariateMetrics, ("id", UInt16, vec![0u16, 1])),
+                (
+                    NumberDataPoints,
+                    ("id", UInt32, vec![0u32, 1]),
+                    ("parent_id", UInt16, vec![0u16, 1])
+                ),
+                (
+                    NumberDpAttrs,
+                    ("parent_id", (UInt8, UInt32), (vec![0u8, 1], vec![0u32, 1]))
+                )
+            ),
+            metrics!(
+                (UnivariateMetrics, ("id", UInt16, vec![0u16, 1])),
+                (
+                    NumberDataPoints,
+                    ("id", UInt32, vec![0u32, 1]),
+                    ("parent_id", UInt16, vec![0u16, 1])
+                ),
+                (
+                    NumberDpAttrs,
+                    ("parent_id", (UInt8, UInt32), (vec![0u8, 1], vec![0u32, 1]))
+                )
+            ),
+        ];
+        let batches = stores
+            .into_iter()
+            .map(OtapBatchStore::into_batches)
+            .collect::<Vec<_>>();
+
+        let mut planned = batches.clone();
+        let plan = {
+            let mut store = MultiBatchStore::<Metrics, { Metrics::COUNT }>::new(&mut planned);
+            for payload_type in Metrics::allowed_payload_types() {
+                store
+                    .remove_transport_optimized_encodings(*payload_type)
+                    .unwrap();
+            }
+            try_build_fused_reindex_plan(&store).unwrap()
+        };
+        assert!(plan.is_none());
+
+        let mut legacy = batches.clone();
+        reindex(&mut legacy).unwrap();
+        let expected = concatenate(&mut legacy).unwrap();
+
+        let mut fused = batches;
+        let actual = reindex_and_concatenate(&mut fused).unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    /// Scenario: a plain primary ID column contains a null value.
+    /// Guarantees: Fused in-place offset planning declines nullable ID buffers
+    /// and the fallback preserves the legacy null semantics exactly.
+    #[test]
+    fn test_fused_reindex_falls_back_for_nullable_ids() {
+        let stores = vec![
+            logs!((Logs, ("id", UInt16, vec![Some(0u16), None]))),
+            logs!((Logs, ("id", UInt16, vec![Some(0u16), Some(1)]))),
+        ];
+        let batches = stores
+            .into_iter()
+            .map(OtapBatchStore::into_batches)
+            .collect::<Vec<_>>();
+
+        let mut planned = batches.clone();
+        let plan = {
+            let mut store = MultiBatchStore::<Logs, { Logs::COUNT }>::new(&mut planned);
+            for payload_type in Logs::allowed_payload_types() {
+                store
+                    .remove_transport_optimized_encodings(*payload_type)
+                    .unwrap();
+            }
+            try_build_fused_reindex_plan(&store).unwrap()
+        };
+        assert!(plan.is_none());
+
+        let mut legacy = batches.clone();
+        reindex(&mut legacy).unwrap();
+        let expected = concatenate(&mut legacy).unwrap();
+
+        let mut fused = batches;
+        let actual = reindex_and_concatenate(&mut fused).unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    /// Scenario: a uniquely owned coalesced primitive ID buffer receives a
+    /// planned offset for one input-batch range.
+    /// Guarantees: Offsets are applied correctly while retaining the original
+    /// values-buffer allocation.
+    #[test]
+    fn test_fused_offset_reuses_primitive_values_buffer() {
+        let array = Arc::new(PrimitiveArray::<UInt16Type>::from(vec![0u16, 1, 0, 1])) as ArrayRef;
+        let original_values = array.as_primitive::<UInt16Type>().values().as_ptr();
+        let offsets = [PlannedOffset {
+            range: 2..4,
+            offset: 2,
+            sign: Sign::Positive,
+        }];
+
+        let result = apply_planned_primitive_offsets::<UInt16Type>(array, &offsets).unwrap();
+        let result = result.as_primitive::<UInt16Type>();
+
+        assert_eq!(result.values(), &[0u16, 1, 2, 3]);
+        assert_eq!(result.values().as_ptr(), original_values);
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/pdata/src/otap/transform/reindex.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/transform/reindex.rs
@@ -83,7 +83,6 @@ use arrow::array::{
     PrimitiveArray, RecordBatch,
 };
 use arrow::buffer::ScalarBuffer;
-use arrow::compute::kernels::aggregate::{max_array, min_array};
 use arrow::datatypes::{
     ArrowDictionaryKeyType, ArrowNativeType, ArrowNumericType, DataType, UInt8Type, UInt16Type,
     UInt32Type,
@@ -365,16 +364,20 @@ where
 fn id_column_min_max<T>(col: &dyn Array) -> Result<Option<(T::Native, T::Native)>>
 where
     T: ArrowNumericType,
-    T::Native: ArrowNativeTypeOp,
+    T::Native: ArrowNativeTypeOp + Ord + Copy,
 {
     let values = materialize_id_values::<T>(col)?;
-    let Some(min) = min_array::<T, _>(values) else {
-        return Ok(None);
-    };
-    // SAFETY: presence of a min value implies at least one non-null element,
-    // so max must also be Some.
-    let max = max_array::<T, _>(values).expect("max must exist when min exists");
-    Ok(Some((min, max)))
+    if values.null_count() == 0 {
+        return Ok(min_max_values(values.values().iter().copied()));
+    }
+    Ok(min_max_values(values.iter().flatten()))
+}
+
+fn min_max_values<T: Ord + Copy>(mut values: impl Iterator<Item = T>) -> Option<(T, T)> {
+    let first = values.next()?;
+    Some(values.fold((first, first), |(min, max), value| {
+        (min.min(value), max.max(value))
+    }))
 }
 
 /// Fast path: apply a uniform offset to the ID column and all child parent_id
@@ -405,6 +408,16 @@ where
         + ArrowNativeTypeOp,
     S: OtapBatchStore,
 {
+    let (off, sign) = if min <= offset {
+        (offset - min, Sign::Positive)
+    } else {
+        (min - offset, Sign::Negative)
+    };
+    let span = max - min + T::Native::from(1);
+    if off == T::Native::from(0) {
+        return Ok(offset + span);
+    }
+
     let parent_idx = payload_to_idx(parent_payload_type);
     let parent_rb = store.get_mut(batch_index)[parent_idx]
         .take()
@@ -412,12 +425,6 @@ where
 
     let id_col = extract_id_column(&parent_rb, id_column_path)?;
     let id_values = materialize_id_values::<T>(id_col.as_ref())?;
-
-    let (off, sign) = if min <= offset {
-        (offset - min, Sign::Positive)
-    } else {
-        (min - offset, Sign::Negative)
-    };
 
     let mut ids = id_values.values().to_vec();
     apply_uniform_offset(&mut ids, off, sign);
@@ -432,7 +439,6 @@ where
         }
     }
 
-    let span = max - min + T::Native::from(1);
     Ok(offset + span)
 }
 

--- a/rust/otap-dataflow/crates/pdata/src/otap/transform/reindex.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/transform/reindex.rs
@@ -852,7 +852,7 @@ where
         .expect("batch must exist for non-None stat");
 
     let id_col = extract_id_column(&parent_rb, id_column_path)?;
-    let id_values = materialize_id_values::<T>(id_col.as_ref())?;
+    let id_values = materialize_id_values::<T>(id_col)?;
 
     let mut ids = id_values.values().to_vec();
     apply_uniform_offset(&mut ids, off, sign);
@@ -900,7 +900,7 @@ where
         .expect("batch must exist for non-None stat");
 
     let id_col = extract_id_column(&parent_rb, id_column_path)?;
-    let id_values = materialize_id_values::<T>(id_col.as_ref())?;
+    let id_values = materialize_id_values::<T>(id_col)?;
     let mut ids = id_values.values().to_vec();
 
     let (mappings, new_offset) = if ids.is_sorted() {
@@ -952,7 +952,7 @@ where
     let Ok(child_col) = extract_id_column(child_batch, PARENT_ID) else {
         return Ok(true);
     };
-    let Some((child_min, child_max)) = id_column_min_max::<T>(child_col.as_ref())? else {
+    let Some((child_min, child_max)) = id_column_min_max::<T>(child_col)? else {
         return Ok(true);
     };
     Ok(child_min >= parent_min && child_max <= parent_max)
@@ -982,7 +982,7 @@ where
     T::Native: Ord + Copy + AddAssign + SubAssign + ArrowNativeType,
 {
     let id_col = extract_id_column(&rb, column_path)?;
-    let id_values = materialize_id_values::<T>(id_col.as_ref())?;
+    let id_values = materialize_id_values::<T>(id_col)?;
     let mut new_values = id_values.values().to_vec();
     apply_uniform_offset(&mut new_values, offset, sign);
     replace_id_column::<T>(rb, column_path, new_values)
@@ -1004,7 +1004,7 @@ where
     // Materialize the id values. In the case of a dictionary this is the
     // values array and does not include the keys.
     let id_col = extract_id_column(&rb, column_path)?;
-    let id_values = materialize_id_values::<T>(id_col.as_ref())?;
+    let id_values = materialize_id_values::<T>(id_col)?;
     let mut id_values = id_values.values().to_vec();
 
     let value_sort_indices = sort_vec_to_indices(&id_values);
@@ -1029,14 +1029,12 @@ where
             DataType::Dictionary(key_type, _) => {
                 // Determine which value violations correspond to actual rows.
                 let key_redactions = match key_type.as_ref() {
-                    DataType::UInt8 => map_value_redactions_to_key_redactions::<UInt8Type>(
-                        id_col.as_ref(),
-                        &violations,
-                    ),
-                    DataType::UInt16 => map_value_redactions_to_key_redactions::<UInt16Type>(
-                        id_col.as_ref(),
-                        &violations,
-                    ),
+                    DataType::UInt8 => {
+                        map_value_redactions_to_key_redactions::<UInt8Type>(id_col, &violations)
+                    }
+                    DataType::UInt16 => {
+                        map_value_redactions_to_key_redactions::<UInt16Type>(id_col, &violations)
+                    }
                     _ => {
                         return Err(Error::UnsupportedDictionaryKeyType {
                             expect_oneof: vec![DataType::UInt8, DataType::UInt16],
@@ -1052,7 +1050,7 @@ where
                 let rb = if !key_redactions.is_empty() {
                     // Genuine violations - sort batch by the same key order
                     // used to produce the key redaction ranges, then remove.
-                    let sort_indices = arrow::compute::sort_to_indices(&id_col, None, None)
+                    let sort_indices = arrow::compute::sort_to_indices(id_col, None, None)
                         .map_err(|e| Error::Batching { source: e })?;
                     let rb = sort_record_batch_by_indices(rb, &sort_indices)?;
                     remove_record_batch_ranges(&rb, &key_redactions)
@@ -1216,10 +1214,9 @@ where
     T: ArrowPrimitiveType,
     T::Native: ArrowNativeType,
 {
-    let id_col = extract_id_column(&rb, column_path)?;
     let new_ids_array = PrimitiveArray::<T>::new(ScalarBuffer::from(new_ids), None);
+    let new_column = replace_ids::<T>(extract_id_column(&rb, column_path)?, new_ids_array);
     let (schema, mut columns, _) = rb.into_parts();
-    let new_column = replace_ids::<T>(id_col.as_ref(), new_ids_array);
     replace_column(column_path, None, &schema, &mut columns, new_column);
     let rb =
         RecordBatch::try_new(schema, columns).map_err(|e| Error::UnexpectedRecordBatchState {
@@ -1373,12 +1370,12 @@ where
             }
         };
 
-        let Some((min, max)) = id_column_min_max::<T>(id_col.as_ref())? else {
+        let Some((min, max)) = id_column_min_max::<T>(id_col)? else {
             stats.push(None);
             continue;
         };
 
-        let id_values = materialize_id_values::<T>(id_col.as_ref())?;
+        let id_values = materialize_id_values::<T>(id_col)?;
         let len = id_values.len();
         let span = max.as_usize() - min.as_usize() + 1;
 

--- a/rust/otap-dataflow/crates/pdata/src/otap/transform/reindex.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/transform/reindex.rs
@@ -8,10 +8,10 @@ they can be safely concatenated together.
 # Reindexing strategies
 
 There are two reindexing strategies we can take. The first is a
-naive offset where we just apply some fixed number to the ids to move the
-range out of the way of the previous. For example if we have a batches with
-ids [1, 2] and [1, 2, 3] we can "bump" the second batch out of the way by
-adding 2 to all of the ids.
+naive offset where we just apply some fixed number to the IDs to move the
+range out of the way of the previous batches. For example, if we have batches
+with IDs [1, 2] and [1, 2, 3] we can "bump" the second batch out of the way by
+adding 2 to all of the IDs.
 
 The problem with naive offset is that if the second batch has holes then we
 "use up" more ids than we need. For example if the second batch is [1, 3]
@@ -32,7 +32,7 @@ violations. Suppose we have corresponding id and parent id pairs like this:
 
 id: [1, 2]  parent_id: [1, 3]
 
-parent_id has a referential integrgity violation. We compute the mappings
+parent_id has a referential integrity violation. We compute the mappings
 and next offset based on the id column only, so 3 is dangling over into the
 range that the next otap batch will use and we can accidentally associate
 the row with `id = 3` with some record batch not in this otap batch.
@@ -73,23 +73,79 @@ The only way we can save id space is by choosing compaction and seeing if
 we end up with less ids than the upper bound. We keep choosing compaction
 until we've saved enough ids that we can use the optimal available strategy
 for the rest of the record batches.
+
+# Batch-processor fast paths
+
+The batch processor usually needs to make relationship IDs unique and then
+concatenate each OTAP payload table. Performing those operations literally
+copies a relationship column once to reindex each input and again to build the
+concatenated output. It can also spend time reconciling schemas that are
+already identical.
+
+The optimized path avoids that work in layers:
+
+1. The batching entry point returns one in-limit record unchanged.
+2. Removing transport encoding returns shared Arrow arrays unchanged when the
+   relevant ID fields are already plain.
+3. For three or more input records, `reindex_and_concatenate` first builds a
+   read-only plan of uniform ID offsets. Two inputs retain the legacy path
+   because measurements showed that planning costs more than it saves there.
+4. When schemas and dictionary widths already match, the OTAP-aware kernel
+   copies each planned ID column directly into its final output buffer and
+   applies that input's offset during the copy. Other columns use Arrow's
+   normal concatenation kernel.
+5. When the custom kernel cannot be used but uniform offsets are still safe,
+   generic concatenation runs first and the plan adjusts only the final merged
+   relationship buffers. A uniquely owned Arrow buffer can be adjusted in
+   place.
+
+The flow for three or more inputs is:
+
+```text
+decode transport encodings
+          |
+          v
+can every relationship use a uniform offset?
+          | yes                         | no
+          v                             v
+build an offset plan              legacy reindex
+          |                             |
+          v                             v
+same schemas and safe dictionaries?  generic concatenate
+          | yes             | no
+          v                 v
+copy + offset kernel    generic concatenate
+                             |
+                             v
+                      apply offsets once
+```
+
+Planning deliberately rejects relationship columns containing nulls or using
+dictionary encoding, compaction, insufficient ID headroom, and
+referential-integrity cases that require row removal. Those cases continue
+through the original reindexing implementation. The custom kernel additionally
+requires identical schemas and enough capacity in every dictionary key type.
+It completes all validation and builds every output before consuming the input
+`Option<RecordBatch>` values, so declining the optimization leaves the legacy
+fallback with intact inputs.
 */
 
 use std::ops::{Add, AddAssign, Range, Sub, SubAssign};
 use std::sync::Arc;
 
+use arrow::array::builder::BooleanBufferBuilder;
 use arrow::array::{
     Array, ArrayRef, ArrowNativeTypeOp, ArrowPrimitiveType, AsArray, DictionaryArray, NullArray,
     PrimitiveArray, RecordBatch, StructArray,
 };
-use arrow::buffer::ScalarBuffer;
+use arrow::buffer::{NullBuffer, ScalarBuffer};
 use arrow::datatypes::{
     ArrowDictionaryKeyType, ArrowNativeType, ArrowNumericType, DataType, UInt8Type, UInt16Type,
     UInt32Type,
 };
 
 use crate::error::{Error, Result};
-use crate::otap::transform::concatenate::concatenate;
+use crate::otap::transform::concatenate::{batches_share_concatenable_schema, concatenate};
 use crate::otap::transform::transport_optimize::remove_transport_optimized_encodings;
 use crate::otap::transform::util::{
     extract_id_column, payload_to_idx, remove_record_batch_ranges, replace_column,
@@ -105,9 +161,9 @@ use super::util::{IdColumnType, PrimaryIdInfo, payload_relations};
 /// for each payload type across all batches. This makes it safe to concatenate
 /// these record batches.
 ///
-/// Note: reindex also removes the transport optimized encoding.
-/// Note: There are opportunities for optimization here, some of which are captured
-/// in https://github.com/open-telemetry/otel-arrow/issues/1926
+/// This is the general standalone path and also removes transport-optimized
+/// encodings. Batch processing should use `reindex_and_concatenate` so
+/// offset-only cases can avoid intermediate relationship buffers.
 pub fn reindex<const N: usize>(batches: &mut [[Option<RecordBatch>; N]]) -> Result<()> {
     if batches.is_empty() || batches.len() == 1 {
         return Ok(());
@@ -121,8 +177,15 @@ pub fn reindex<const N: usize>(batches: &mut [[Option<RecordBatch>; N]]) -> Resu
     }
 }
 
-/// Reindex and concatenate OTAP batches, applying offset-only reindexing to the
-/// final coalesced buffers when the relation columns support it.
+/// Reindexes and concatenates OTAP batches while avoiding redundant ID-buffer
+/// copies when uniform offsets are sufficient.
+///
+/// Three or more inputs use a read-only planning pass. A supported plan is
+/// executed either by the same-schema copy-and-offset kernel or, when schemas
+/// require reconciliation, by applying offsets after generic concatenation.
+/// Compaction and other unsupported layouts retain the original
+/// reindex-then-concatenate behavior. Two inputs skip planning because its
+/// fixed cost exceeded the allocation savings in benchmarks.
 pub(crate) fn reindex_and_concatenate<const N: usize>(
     batches: &mut [[Option<RecordBatch>; N]],
 ) -> Result<[Option<RecordBatch>; N]> {
@@ -270,6 +333,9 @@ fn reindex_and_concatenate_store<S, const N: usize>(
 where
     S: OtapBatchStore,
 {
+    // Transport decoding must precede planning because encoded deltas do not
+    // expose the logical min/max values used to compute safe offsets. The
+    // decoder itself is zero-copy for already-plain root relationship IDs.
     let plan = {
         let mut store = MultiBatchStore::<S, N>::new(batches);
         for payload_type in S::allowed_payload_types() {
@@ -279,11 +345,21 @@ where
     };
 
     if let Some(plan) = plan {
+        // Prefer the narrowest path. The custom kernel removes both the
+        // per-input reindex copies and the post-concatenation ID adjustment.
+        if let Some(result) = plan.try_concatenate(batches)? {
+            return Ok(result);
+        }
+        // Schema conversion or dictionary widening still needs the generic
+        // concatenator. Applying the plan afterward retains the larger win of
+        // not rebuilding every input relationship column separately.
         let mut result = concatenate(batches)?;
         plan.apply(&mut result)?;
         return Ok(result);
     }
 
+    // A plan is absent only when correctness requires behavior that a uniform
+    // offset cannot express, such as compaction or orphan-row removal.
     let mut store = MultiBatchStore::<S, N>::new(batches);
     reindex_decoded_batch_store(&mut store)?;
     concatenate(batches)
@@ -291,21 +367,29 @@ where
 
 #[derive(Debug, Default)]
 struct FusedReindexPlan {
+    /// Relationship columns and the output row ranges that need adjustment.
     columns: Vec<PlannedColumn>,
 }
 
 #[derive(Debug)]
 struct PlannedColumn {
+    /// Payload-table slot containing the relationship column.
     payload_index: usize,
+    /// Top-level or nested path, such as `parent_id` or `resource.id`.
     column_path: &'static str,
+    /// Physical integer width that must be preserved by the fast path.
     id_type: IdColumnType,
+    /// Non-zero adjustments, ordered by their final concatenated row ranges.
     offsets: Vec<PlannedOffset>,
 }
 
 #[derive(Debug)]
 struct PlannedOffset {
+    /// Rows occupied by one input batch in the final concatenated column.
     range: Range<usize>,
+    /// Magnitude of the uniform adjustment.
     offset: u64,
+    /// Whether to add or subtract the magnitude.
     sign: Sign,
 }
 
@@ -346,6 +430,12 @@ impl FusedReindexPlan {
         });
     }
 
+    /// Applies a supported offset plan after generic schema-aware concatenation.
+    ///
+    /// This fallback is useful when relationship semantics permit uniform
+    /// offsets but schema conversion prevents the custom concatenation kernel.
+    /// `apply_planned_primitive_offsets` reuses a uniquely owned Arrow values
+    /// buffer when possible and otherwise copies only that final ID column.
     fn apply<const N: usize>(self, result: &mut [Option<RecordBatch>; N]) -> Result<()> {
         for (payload_index, result_batch) in result.iter_mut().enumerate() {
             if !self
@@ -380,14 +470,263 @@ impl FusedReindexPlan {
 
         Ok(())
     }
+
+    /// Concatenates same-schema inputs while applying relationship offsets as
+    /// their values are copied into final buffers.
+    ///
+    /// Returns `Ok(None)` when schema reconciliation or dictionary widening is
+    /// required. Every eligibility check happens before inputs are taken, and
+    /// output batches are built from shared references. Inputs are cleared only
+    /// after every planned column has been found and every output has been
+    /// constructed, keeping fallback behavior atomic.
+    fn try_concatenate<const N: usize>(
+        &self,
+        batches: &mut [[Option<RecordBatch>; N]],
+    ) -> Result<Option<[Option<RecordBatch>; N]>> {
+        if self.columns.is_empty() {
+            return Ok(None);
+        }
+        // This uses the same eligibility predicate as generic concatenation's
+        // same-schema path. In particular, equal dictionary schemas are not
+        // enough when concatenated physical values outgrow their key widths.
+        for payload_index in 0..N {
+            if !batches_share_concatenable_schema(batches, payload_index)? {
+                return Ok(None);
+            }
+        }
+
+        let mut result = [const { None }; N];
+        let mut applied_columns = 0usize;
+        for (payload_index, result_batch) in result.iter_mut().enumerate() {
+            let input_batches = batches
+                .iter()
+                .filter_map(|batch| batch[payload_index].as_ref())
+                .collect::<Vec<_>>();
+            let Some(first) = input_batches.first() else {
+                continue;
+            };
+            let schema = Arc::clone(first.schema_ref());
+            let mut columns = Vec::with_capacity(schema.fields().len());
+            for (column_index, field) in schema.fields().iter().enumerate() {
+                let arrays = input_batches
+                    .iter()
+                    .map(|batch| batch.column(column_index).as_ref())
+                    .collect::<Vec<_>>();
+                let column = if let Some(plan) = self.columns.iter().find(|plan| {
+                    plan.payload_index == payload_index && plan.column_path == field.name()
+                }) {
+                    applied_columns += 1;
+                    concatenate_planned_column(&arrays, plan)?
+                } else if let Some(plan) = self.columns.iter().find(|plan| {
+                    plan.payload_index == payload_index
+                        && struct_column_name(plan.column_path) == Some(field.name())
+                }) {
+                    applied_columns += 1;
+                    concatenate_planned_struct(&arrays, plan)?
+                } else {
+                    arrow::compute::concat(&arrays).map_err(|source| Error::Batching { source })?
+                };
+                columns.push(column);
+            }
+            *result_batch = Some(RecordBatch::try_new(schema, columns).map_err(|source| {
+                Error::UnexpectedRecordBatchState {
+                    reason: format!("Failed to build OTAP-aware concatenated batch: {source}"),
+                }
+            })?);
+        }
+        if applied_columns != self.columns.len() {
+            return Err(Error::UnexpectedRecordBatchState {
+                reason: format!(
+                    "OTAP-aware concatenation applied {applied_columns} of {} planned columns",
+                    self.columns.len()
+                ),
+            });
+        }
+
+        // Delay ownership transfer until the complete result is known valid.
+        for batch in batches {
+            for payload in batch {
+                *payload = None;
+            }
+        }
+        Ok(Some(result))
+    }
 }
 
+fn concatenate_planned_column(arrays: &[&dyn Array], plan: &PlannedColumn) -> Result<ArrayRef> {
+    match plan.id_type {
+        IdColumnType::U16 => concatenate_planned_primitive::<UInt16Type>(arrays, &plan.offsets),
+        IdColumnType::U32 => concatenate_planned_primitive::<UInt32Type>(arrays, &plan.offsets),
+    }
+}
+
+/// Concatenates an OTAP resource/scope struct without losing outer validity.
+///
+/// Only the nested `id` child is relationship-aware. Other children retain
+/// Arrow's generic concatenation semantics, and the parent struct's null bits
+/// are appended independently from its child buffers.
+fn concatenate_planned_struct(arrays: &[&dyn Array], plan: &PlannedColumn) -> Result<ArrayRef> {
+    let Some(first) = arrays.first() else {
+        return Err(Error::UnexpectedRecordBatchState {
+            reason: format!(
+                "OTAP-aware concatenation has no inputs for {}",
+                plan.column_path
+            ),
+        });
+    };
+    let DataType::Struct(fields) = first.data_type() else {
+        return Err(Error::UnexpectedRecordBatchState {
+            reason: format!(
+                "OTAP-aware concatenation expected a struct for {}, found {}",
+                plan.column_path,
+                first.data_type()
+            ),
+        });
+    };
+    let structs = arrays
+        .iter()
+        .map(|array| array.as_struct())
+        .collect::<Vec<_>>();
+    let len = structs.iter().map(|array| array.len()).sum();
+    let nulls = structs
+        .iter()
+        .any(|array| array.null_count() != 0)
+        .then(|| {
+            let mut builder = BooleanBufferBuilder::new(len);
+            for array in &structs {
+                match array.nulls() {
+                    Some(nulls) => builder.append_buffer(nulls.inner()),
+                    None => builder.append_n(array.len(), true),
+                }
+            }
+            NullBuffer::new(builder.finish())
+        });
+
+    let (id_index, _) = fields.find(ID).ok_or_else(|| Error::ColumnNotFound {
+        name: plan.column_path.to_string(),
+    })?;
+    let mut columns = Vec::with_capacity(fields.len());
+    for column_index in 0..fields.len() {
+        let child_arrays = structs
+            .iter()
+            .map(|array| array.column(column_index).as_ref())
+            .collect::<Vec<_>>();
+        let column = if column_index == id_index {
+            concatenate_planned_column(&child_arrays, plan)?
+        } else {
+            arrow::compute::concat(&child_arrays).map_err(|source| Error::Batching { source })?
+        };
+        columns.push(column);
+    }
+
+    Ok(Arc::new(
+        StructArray::try_new_with_length(fields.clone(), columns, nulls, len)
+            .map_err(|source| Error::Batching { source })?,
+    ))
+}
+
+/// Copies primitive ID arrays into one final buffer and adjusts planned input
+/// ranges during that copy.
+///
+/// A conventional reindex-then-concatenate sequence allocates an adjusted
+/// buffer per input and then copies those buffers again. This kernel allocates
+/// exactly the final values buffer. Unplanned ranges use `extend_from_slice`;
+/// planned ranges perform the signed adjustment while extending. The planner
+/// guarantees one range per complete input array, and the alignment checks
+/// below protect that contract from future planner changes.
+fn concatenate_planned_primitive<T>(
+    arrays: &[&dyn Array],
+    offsets: &[PlannedOffset],
+) -> Result<ArrayRef>
+where
+    T: ArrowPrimitiveType,
+    T::Native: AddAssign + SubAssign + Copy + ArrowNativeType,
+{
+    let total_len = arrays.iter().map(|array| array.len()).sum();
+    let mut values = Vec::with_capacity(total_len);
+    let mut output_start = 0usize;
+    let mut next_offset = offsets.iter().peekable();
+
+    for array in arrays {
+        if array.data_type() != &T::DATA_TYPE {
+            return Err(Error::ColumnDataTypeMismatch {
+                name: ID.to_string(),
+                expect: T::DATA_TYPE,
+                actual: array.data_type().clone(),
+            });
+        }
+        if array.null_count() != 0 {
+            return Err(Error::UnexpectedRecordBatchState {
+                reason: "OTAP-aware concatenation received a nullable planned ID column"
+                    .to_string(),
+            });
+        }
+        let primitive = array.as_primitive::<T>();
+        let output_end = output_start + primitive.len();
+        let output_range = output_start..output_end;
+        match next_offset.peek() {
+            Some(planned) if planned.range == output_range => {
+                let offset = T::Native::from_usize(planned.offset as usize).ok_or_else(|| {
+                    Error::UnexpectedRecordBatchState {
+                        reason: format!("Fused reindex offset {} does not fit", planned.offset),
+                    }
+                })?;
+                match planned.sign {
+                    Sign::Positive => values.extend(primitive.values().iter().map(|value| {
+                        let mut value = *value;
+                        value += offset;
+                        value
+                    })),
+                    Sign::Negative => values.extend(primitive.values().iter().map(|value| {
+                        let mut value = *value;
+                        value -= offset;
+                        value
+                    })),
+                }
+                let _ = next_offset.next();
+            }
+            Some(planned) if planned.range.start < output_end => {
+                return Err(Error::UnexpectedRecordBatchState {
+                    reason: format!(
+                        "Fused reindex range {:?} does not align with concatenated input range {:?}",
+                        planned.range, output_range
+                    ),
+                });
+            }
+            _ => values.extend_from_slice(primitive.values()),
+        }
+        output_start = output_end;
+    }
+
+    if let Some(planned) = next_offset.next() {
+        return Err(Error::UnexpectedRecordBatchState {
+            reason: format!(
+                "Fused reindex range {:?} exceeds concatenated column length {total_len}",
+                planned.range
+            ),
+        });
+    }
+
+    Ok(Arc::new(PrimitiveArray::<T>::new(
+        ScalarBuffer::from(values),
+        None,
+    )))
+}
+
+/// Builds a non-mutating uniform-offset plan for every OTAP relationship.
+///
+/// Returns `Ok(None)` as soon as any relationship needs the general reindexer;
+/// partial plans are never executed. Overflow remains an error, matching the
+/// general path rather than silently declining the optimization.
 fn try_build_fused_reindex_plan<S, const N: usize>(
     store: &MultiBatchStore<'_, S, N>,
 ) -> Result<Option<FusedReindexPlan>>
 where
     S: OtapBatchStore,
 {
+    // Translate each input table into its future output row range once. Plans
+    // store these ranges rather than batch indices so they can be applied both
+    // to a generic concatenated column and while the custom kernel is copying.
     let mut running_rows = [0usize; N];
     let row_ranges = store
         .batches
@@ -443,6 +782,12 @@ where
     Ok(Some(plan))
 }
 
+/// Adds uniform adjustments for one parent/child relationship to `plan`.
+///
+/// `Ok(false)` is an expected fast-path rejection, not malformed data. It means
+/// the relationship needs compaction, exceeds its ID width, is nullable or
+/// dictionary encoded, or otherwise cannot be represented as one adjustment
+/// per input. The caller then executes the original reindexing algorithm.
 #[allow(clippy::too_many_arguments)]
 fn try_plan_offset_reindex<T, S, const N: usize>(
     store: &MultiBatchStore<'_, S, N>,
@@ -591,6 +936,10 @@ fn apply_planned_column(
     Ok(())
 }
 
+/// Takes an array while leaving a disposable placeholder in its column slot.
+///
+/// Dropping the surrounding `ArrayRef` aliases before `into_builder` gives
+/// Arrow the opportunity to reuse a uniquely owned primitive values buffer.
 fn take_array(array: &mut ArrayRef) -> ArrayRef {
     std::mem::replace(array, Arc::new(NullArray::new(0)))
 }
@@ -602,6 +951,11 @@ fn apply_planned_offsets(array: ArrayRef, plan: &PlannedColumn) -> Result<ArrayR
     }
 }
 
+/// Applies offsets to a final concatenated primitive column.
+///
+/// This is the plan's schema-reconciliation fallback. It first attempts
+/// `into_builder` to mutate a uniquely owned Arrow buffer; shared buffers copy
+/// only once into a replacement final column.
 fn apply_planned_primitive_offsets<T>(
     array: ArrayRef,
     offsets: &[PlannedOffset],
@@ -795,6 +1149,9 @@ where
     T::Native: ArrowNativeTypeOp + Ord + Copy,
 {
     let values = materialize_id_values::<T>(col)?;
+    // Scan once instead of invoking Arrow's independent min and max kernels.
+    // The common non-null case can also iterate the contiguous values buffer
+    // without checking validity for every element.
     if values.null_count() == 0 {
         return Ok(min_max_values(values.values().iter().copied()));
     }
@@ -842,6 +1199,8 @@ where
         (min - offset, Sign::Negative)
     };
     let span = max - min + T::Native::from(1);
+    // A batch already starting at the desired offset needs no data mutation.
+    // Returning before taking the RecordBatch preserves all Arrow buffers.
     if off == T::Native::from(0) {
         return Ok(offset + span);
     }
@@ -1563,7 +1922,8 @@ mod tests {
     use super::*;
     use std::collections::HashSet;
 
-    use arrow::array::RecordBatch;
+    use arrow::array::{RecordBatch, StringArray};
+    use arrow::datatypes::{Field, Fields, Schema};
 
     use crate::error::Error;
     use crate::otap::transform::testing::{assert_no_id_overlaps, extract_relation_fingerprints};
@@ -1798,8 +2158,8 @@ mod tests {
 
     /// Scenario: overlapping plain log, resource, and scope IDs are merged from
     /// multiple batches using uniform offsets.
-    /// Guarantees: The fused path is selected and produces exactly the same
-    /// root and child IDs as the legacy reindex-then-concatenate sequence.
+    /// Guarantees: The OTAP-aware concatenation kernel is selected and produces
+    /// exactly the same root and child IDs as the legacy sequence.
     #[test]
     fn test_fused_reindex_and_concatenate_matches_legacy_logs() {
         let stores = vec![
@@ -1837,10 +2197,26 @@ mod tests {
                 (ScopeAttrs, ("parent_id", UInt16, vec![0u16, 0]))
             ),
         ];
-        let batches = stores
+        let mut batches = stores
             .into_iter()
             .map(OtapBatchStore::into_batches)
             .collect::<Vec<_>>();
+        for payload_index in 0..Logs::COUNT {
+            let Some(schema) = batches[0][payload_index]
+                .as_ref()
+                .map(|batch| Arc::clone(batch.schema_ref()))
+            else {
+                continue;
+            };
+            for batch in batches.iter_mut().skip(1) {
+                let Some(record_batch) = batch[payload_index].take() else {
+                    continue;
+                };
+                let (_, columns, _) = record_batch.into_parts();
+                batch[payload_index] =
+                    Some(RecordBatch::try_new(Arc::clone(&schema), columns).unwrap());
+            }
+        }
 
         let mut planned = batches.clone();
         let plan = {
@@ -1851,16 +2227,162 @@ mod tests {
                     .unwrap();
             }
             try_build_fused_reindex_plan(&store).unwrap()
-        };
-        assert!(plan.is_some());
+        }
+        .expect("uniform plain IDs should produce a fused plan");
 
         let mut legacy = batches.clone();
         reindex(&mut legacy).unwrap();
         let expected = concatenate(&mut legacy).unwrap();
 
+        let kernel = plan
+            .try_concatenate(&mut planned)
+            .unwrap()
+            .expect("same-schema batches should use the OTAP-aware kernel");
+        assert_eq!(kernel, expected);
+
         let mut fused = batches;
         let actual = reindex_and_concatenate(&mut fused).unwrap();
         assert_eq!(actual, expected);
+    }
+
+    /// Scenario: nested OTAP IDs are concatenated through structs that contain
+    /// outer nulls and unrelated child columns.
+    /// Guarantees: The kernel preserves struct validity and non-ID children
+    /// while applying offsets to the nested ID buffer.
+    #[test]
+    fn test_otap_kernel_preserves_nested_struct_nulls() {
+        let fields = Fields::from(vec![
+            Arc::new(Field::new(ID, DataType::UInt16, false)),
+            Arc::new(Field::new("name", DataType::Utf8, false)),
+        ]);
+        let first = StructArray::new(
+            fields.clone(),
+            vec![
+                Arc::new(PrimitiveArray::<UInt16Type>::from(vec![0u16, 1])),
+                Arc::new(StringArray::from(vec!["a", "b"])),
+            ],
+            Some(NullBuffer::from(vec![true, false])),
+        );
+        let second = StructArray::new(
+            fields,
+            vec![
+                Arc::new(PrimitiveArray::<UInt16Type>::from(vec![0u16, 1])),
+                Arc::new(StringArray::from(vec!["c", "d"])),
+            ],
+            Some(NullBuffer::from(vec![false, true])),
+        );
+        let plan = PlannedColumn {
+            payload_index: 0,
+            column_path: "resource.id",
+            id_type: IdColumnType::U16,
+            offsets: vec![PlannedOffset {
+                range: 2..4,
+                offset: 2,
+                sign: Sign::Positive,
+            }],
+        };
+
+        let arrays = [&first as &dyn Array, &second as &dyn Array];
+        let result = concatenate_planned_struct(&arrays, &plan).unwrap();
+        let result = result.as_struct();
+
+        assert_eq!(
+            result.nulls().unwrap().iter().collect::<Vec<_>>(),
+            [true, false, false, true]
+        );
+        assert_eq!(
+            result
+                .column_by_name(ID)
+                .unwrap()
+                .as_primitive::<UInt16Type>()
+                .values(),
+            &[0u16, 1, 2, 3]
+        );
+        assert_eq!(
+            result
+                .column_by_name("name")
+                .unwrap()
+                .as_string::<i32>()
+                .iter()
+                .collect::<Vec<_>>(),
+            [Some("a"), Some("b"), Some("c"), Some("d")]
+        );
+    }
+
+    /// Scenario: UInt32 relationship IDs require both positive and negative
+    /// adjustments while being copied from multiple input arrays.
+    /// Guarantees: The primitive kernel applies each signed adjustment to the
+    /// correct input range without disturbing earlier values.
+    #[test]
+    fn test_otap_kernel_concatenates_u32_with_signed_offsets() {
+        let first = PrimitiveArray::<UInt32Type>::from(vec![0u32, 1]);
+        let second = PrimitiveArray::<UInt32Type>::from(vec![0u32, 1]);
+        let third = PrimitiveArray::<UInt32Type>::from(vec![10u32, 11]);
+        let arrays = [
+            &first as &dyn Array,
+            &second as &dyn Array,
+            &third as &dyn Array,
+        ];
+        let offsets = [
+            PlannedOffset {
+                range: 2..4,
+                offset: 2,
+                sign: Sign::Positive,
+            },
+            PlannedOffset {
+                range: 4..6,
+                offset: 6,
+                sign: Sign::Negative,
+            },
+        ];
+
+        let result = concatenate_planned_primitive::<UInt32Type>(&arrays, &offsets).unwrap();
+
+        assert_eq!(
+            result.as_primitive::<UInt32Type>().values(),
+            &[0u32, 1, 2, 3, 4, 5]
+        );
+    }
+
+    /// Scenario: otherwise compatible input batches carry different schemas.
+    /// Guarantees: The OTAP-aware kernel declines atomically and leaves every
+    /// input available to the schema-conversion fallback.
+    #[test]
+    fn test_otap_kernel_schema_mismatch_leaves_inputs_untouched() {
+        let first_schema = Arc::new(Schema::new(vec![Field::new(ID, DataType::UInt16, false)]));
+        let second_schema = Arc::new(Schema::new(vec![
+            Field::new(ID, DataType::UInt16, false)
+                .with_metadata([("encoding".to_string(), "alternate".to_string())].into()),
+        ]));
+        let make_batch = |schema| {
+            RecordBatch::try_new(
+                schema,
+                vec![Arc::new(PrimitiveArray::<UInt16Type>::from(vec![0u16, 1]))],
+            )
+            .unwrap()
+        };
+        let mut batches = vec![
+            [Some(make_batch(Arc::clone(&first_schema)))],
+            [Some(make_batch(Arc::clone(&second_schema)))],
+            [Some(make_batch(first_schema))],
+        ];
+        let plan = FusedReindexPlan {
+            columns: vec![PlannedColumn {
+                payload_index: 0,
+                column_path: ID,
+                id_type: IdColumnType::U16,
+                offsets: vec![PlannedOffset {
+                    range: 2..4,
+                    offset: 2,
+                    sign: Sign::Positive,
+                }],
+            }],
+        };
+
+        let result = plan.try_concatenate(&mut batches).unwrap();
+
+        assert!(result.is_none());
+        assert!(batches.iter().all(|batch| batch[0].is_some()));
     }
 
     /// Scenario: a log child contains parent IDs outside its parent ID range.

--- a/rust/otap-dataflow/crates/pdata/src/otap/transform/transport_optimize.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/transform/transport_optimize.rs
@@ -928,7 +928,9 @@ pub fn remove_transport_optimized_encodings(
         | ArrowPayloadType::UnivariateMetrics
         | ArrowPayloadType::MultivariateMetrics
         | ArrowPayloadType::Spans => {
-            // remove delta encoding from ID column on struct arrays ..
+            // Root batches are frequently already plain after local processing.
+            // Inspect field metadata before cloning the columns/schema vectors;
+            // `RecordBatch::clone` then retains all Arrow buffers by `Arc`.
             let schema = record_batch.schema_ref();
             if [RESOURCE_ID_COL_PATH, SCOPE_ID_COL_PATH, consts::ID]
                 .iter()

--- a/rust/otap-dataflow/crates/pdata/src/otap/transform/transport_optimize.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/transform/transport_optimize.rs
@@ -930,6 +930,13 @@ pub fn remove_transport_optimized_encodings(
         | ArrowPayloadType::Spans => {
             // remove delta encoding from ID column on struct arrays ..
             let schema = record_batch.schema_ref();
+            if [RESOURCE_ID_COL_PATH, SCOPE_ID_COL_PATH, consts::ID]
+                .iter()
+                .all(|path| is_column_encoded(path, schema) != Some(true))
+            {
+                return Ok(record_batch.clone());
+            }
+
             let mut columns = record_batch.columns().to_vec();
             let mut fields = schema.fields.to_vec();
             for struct_id_path in [RESOURCE_ID_COL_PATH, SCOPE_ID_COL_PATH] {
@@ -1261,6 +1268,40 @@ mod test {
     use crate::schema::FieldExt;
 
     use super::*;
+
+    /// Scenario: all ID fields in an OTAP root batch are already marked with
+    /// plain encoding.
+    /// Guarantees: Removing transport encodings is a zero-copy no-op for both
+    /// the schema and columns.
+    #[test]
+    fn test_remove_transport_encodings_plain_root_is_zero_copy() {
+        let id_fields: Fields =
+            vec![Field::new(consts::ID, DataType::UInt16, true).with_plain_encoding()].into();
+        let root_schema = Arc::new(Schema::new(vec![
+            Field::new(consts::ID, DataType::UInt16, true).with_plain_encoding(),
+            Field::new(consts::RESOURCE, DataType::Struct(id_fields.clone()), true),
+            Field::new(consts::SCOPE, DataType::Struct(id_fields.clone()), true),
+        ]));
+        let root_ids = Arc::new(UInt16Array::from_iter_values([0, 1])) as ArrayRef;
+        let resource = Arc::new(StructArray::new(
+            id_fields.clone(),
+            vec![Arc::new(UInt16Array::from_iter_values([0, 0]))],
+            None,
+        )) as ArrayRef;
+        let scope = Arc::new(StructArray::new(
+            id_fields,
+            vec![Arc::new(UInt16Array::from_iter_values([0, 0]))],
+            None,
+        )) as ArrayRef;
+        let input = RecordBatch::try_new(root_schema.clone(), vec![root_ids, resource, scope])
+            .expect("valid root batch");
+
+        let result = remove_transport_optimized_encodings(ArrowPayloadType::Logs, &input)
+            .expect("plain root should remain valid");
+
+        assert!(Arc::ptr_eq(result.schema_ref(), &root_schema));
+        assert!(Arc::ptr_eq(result.column(0), input.column(0)));
+    }
 
     #[test]
     fn test_access_column_basic() {

--- a/rust/otap-dataflow/crates/pdata/src/otap/transform/util.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/transform/util.rs
@@ -309,6 +309,10 @@ fn sort_two_columns_packed<T: ArrowNativeType>(
 }
 
 /// Borrows an ID column from a record batch.
+///
+/// Reindex planning only scans these arrays, so cloning an `ArrayRef` would add
+/// unnecessary atomic reference-count traffic for every relationship in every
+/// input batch. Mutation paths explicitly clone or replace the array later.
 pub(crate) fn extract_id_column<'a>(
     rb: &'a RecordBatch,
     column_path: &str,
@@ -356,6 +360,9 @@ pub(crate) fn access_column(path: &str, schema: &Schema, columns: &[ArrayRef]) -
 }
 
 /// Borrows the column associated with a possibly nested path.
+///
+/// This is the read-only counterpart to `access_column`; keep both helpers so
+/// callers that only inspect schema/statistics do not clone an `ArrayRef`.
 pub(crate) fn access_column_ref<'a>(
     path: &str,
     schema: &Schema,

--- a/rust/otap-dataflow/crates/pdata/src/otap/transform/util.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/transform/util.rs
@@ -308,10 +308,15 @@ fn sort_two_columns_packed<T: ArrowNativeType>(
     sort_record_batch_by_indices(rb, &indices_arr)
 }
 
-/// Extracts an ID column from a record batch
-pub(crate) fn extract_id_column(rb: &RecordBatch, column_path: &str) -> Result<ArrayRef> {
-    access_column(column_path, &rb.schema(), rb.columns()).ok_or_else(|| Error::ColumnNotFound {
-        name: column_path.to_string(),
+/// Borrows an ID column from a record batch.
+pub(crate) fn extract_id_column<'a>(
+    rb: &'a RecordBatch,
+    column_path: &str,
+) -> Result<&'a dyn Array> {
+    access_column_ref(column_path, rb.schema_ref(), rb.columns()).ok_or_else(|| {
+        Error::ColumnNotFound {
+            name: column_path.to_string(),
+        }
     })
 }
 
@@ -348,6 +353,22 @@ pub(crate) fn access_column(path: &str, schema: &Schema, columns: &[ArrayRef]) -
     // otherwise just return column by name
     let (column_idx, _) = schema.fields.find(path)?;
     columns.get(column_idx).cloned()
+}
+
+/// Borrows the column associated with a possibly nested path.
+pub(crate) fn access_column_ref<'a>(
+    path: &str,
+    schema: &Schema,
+    columns: &'a [ArrayRef],
+) -> Option<&'a dyn Array> {
+    if let Some(struct_col_name) = struct_column_name(path) {
+        let struct_col_idx = schema.index_of(struct_col_name).ok()?;
+        let struct_col = columns.get(struct_col_idx)?.as_struct();
+        return struct_col.column_by_name(ID).map(AsRef::as_ref);
+    }
+
+    let (column_idx, _) = schema.fields.find(path)?;
+    columns.get(column_idx).map(AsRef::as_ref)
 }
 
 /// if configured to encode the ID column in the nested resource/scope struct array, this


### PR DESCRIPTION
## Change summary

- Return a single in-limit OTAP payload unchanged, avoiding unnecessary copying.
- Fuse relationship-ID reindex planning with concatenation so relationship columns are not processed twice.
- Add an OTAP-aware concatenation kernel that applies planned ID offsets while copying directly into the final Arrow buffers.
- Reuse eligible Arrow buffers and reduce temporary allocations, reference-count operations, and schema reconciliation work.
- Preserve generic fallback paths for schema differences, dictionary or nullable relationship columns, compaction, referential-integrity repairs, and capacity limits.
- Keep input consumption atomic: input batches remain untouched if the optimized path cannot produce a complete result.
- Add Criterion benchmarks and detailed implementation comments explaining the fast paths, safety conditions, and fallback rationale.

**Measured performance impact**
On representative in-memory OTAP log traffic, 8 input batches of 1,024 records, each containing one resource, one scope, 4 resource attributes, 2 scope attributes, and 4 log attributes, merged into one 8,192-record output, the median complete flush benchmark fell from **142.6 us** at the pre-optimization baseline (`5abeaf8e`) to **66.5 us** at the optimized tip (`9af9345a`). This is a **53.3% reduction in processing time**, equivalent to **2.14x batch-flush throughput** (+114%). The gain comes primarily from replacing separate reindexing and concatenation passes with one planned copy.

## What issues does this PR close?

- Closes #3172

## How are these changes tested?

- Added Criterion scenarios covering different input batch sizes, bounded output batches, and individual reindex/concatenation stages.
- `cargo xtask check`

Performance was measured in release mode with jemalloc on an Intel Xeon Gold 6154, with both revisions pinned to the same CPU. Each revision was run in 10 alternating processes; each process reported the median of 31 samples of 30 flushes after 100 warm-up iterations. The reported values are the median across those process-level results.

This measures the in-memory OTAP batch-processing path, not complete collector throughput. End-to-end gains depend on the proportion of pipeline time spent receiving, decoding, encoding, compressing, and exporting.

## Are there any user-facing changes?

No

### Changelog

* [x] Added a `.chloggen/*.yaml` entry
* [ ] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
