### PR TITLE
chore(deps): Isolate go and rust patch version updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -50,6 +50,24 @@
       ]
     },
     {
+      // keep Go patch updates separate from other ecosystems
+      "groupName": "go patch versions",
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["patch"],
+      "schedule": [
+        "before 8am on Monday"
+      ]
+    },
+    {
+      // keep Rust patch updates separate from other ecosystems
+      "groupName": "rust patch versions",
+      "matchManagers": ["cargo"],
+      "matchUpdateTypes": ["patch"],
+      "schedule": [
+        "before 8am on Monday"
+      ]
+    },
+    {
       // avoids these Renovate PRs from trickling in throughout the week
       // (consolidating the review process)
       "matchUpdateTypes": [


### PR DESCRIPTION
# Change Summary

Inspired by #3784 

Since we have separate changelog attribution for `go/` and `rust`, I think the dependency upgrade PRs should be isolated.

## What issue does this PR close?

N/A

## How are these changes tested?

N/A

## Are there any user-facing changes?

N/A

### Changelog

<!--
User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
If not required, include `chore` in the PR title.
-->

* [ ] Added a `.chloggen/*.yaml` entry
* [x] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
