### PR TITLE
chore(repo): Add chore PR template and make default more compact

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/chore.md
+++ b/.github/PULL_REQUEST_TEMPLATE/chore.md
@@ -1,0 +1,7 @@
+# Chore Summary
+
+<!-- Briefly describe the maintenance work in this PR. -->
+
+## Related issue
+
+<!-- Link the related issue if one exists. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-# Summary
+# Change summary
 
 > Chore PR? Open **Preview**, then [use the chore template](?template=chore.md).
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,27 +1,19 @@
-# Change Summary
+# Summary
+
+> Opening a chore PR? [Use the chore PR template](?template=chore.md).
 
 <!--Replace with a brief summary of the change in this PR-->
 
-## What issue does this PR close?
+## Related issue
 
 <!--We highly recommend correlation of every PR to an issue-->
 
 * Closes #NNN
 
-## How are these changes tested?
+## Validation
 
-## Are there any user-facing changes?
+<!--How did you confirm your change has intended effect?-->
 
- <!-- If yes, provide further info below -->
+## User-facing changes
 
-### Changelog
-
-<!--
-User-facing changes need a .chloggen/*.yaml entry. Copy the TEMPLATE.yaml
-in go/.chloggen/ or rust/otap-dataflow/.chloggen/ and fill in the fields.
-If not required, include `chore` in the PR title.
--->
-
-* [ ] Added a `.chloggen/*.yaml` entry
-* [ ] This PR is a `chore` (indicated in title)
-* [ ] This is a documentation-only PR.
+<!-- Describe the impact, or write `None`. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 # Summary
 
-> Opening a chore PR? [Use the chore PR template](?template=chore.md).
+> Chore PR? Open **Preview**, then [use the chore template](?template=chore.md).
 
 <!--Replace with a brief summary of the change in this PR-->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,8 +12,12 @@
 
 ## Validation
 
-<!--How did you confirm your change has intended effect?-->
+<!--How did you confirm your change has the intended effect?-->
 
 ## User-facing changes
 
-<!-- Describe the impact, or write `None`. -->
+<!--
+Describe the impact, or write `None`.
+User-facing changes require a `.chloggen/*.yaml` entry. If no entry is needed,
+include `chore` in the PR title. Documentation-only changes are exempt.
+-->


### PR DESCRIPTION
# Chore summary

Minor improvements to the default PR template and adding a `chore` template
- `Changelog` section in PR description with 3 list entries causes GitHub to render `1/3 tasks`, leading to possible confusion
    <img width="706" height="80" alt="image" src="https://github.com/user-attachments/assets/f1853f01-60f0-4614-ba60-718756aabd0c" />
- Chore PRs don't need other headers
- `changelog` workflow automation already captures a lot of the same info automatically

## Related issue

N/A